### PR TITLE
interchange, repr: Prevent deep Protobuf and jsonb stack overflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7338,6 +7338,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-reflect",
+ "prost-types",
  "seahash",
  "serde",
  "serde_json",

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -2749,7 +2749,7 @@ impl AggregateFunc {
         let nullable = match self {
             AggregateFunc::Count => false,
             // Use the nullability of the underlying column being aggregated, not the Records wrapping it
-            AggregateFunc::StringAgg { .. } => match input_type.scalar_type {
+            AggregateFunc::StringAgg { .. } => match &input_type.scalar_type {
                 // The outer Record wraps the input in the first position, and any ORDER BY expressions afterwards
                 SqlScalarType::Record { fields, .. } => match &fields[0].1.scalar_type {
                     // The inner Record is a (value, separator) tuple

--- a/src/expr/src/scalar/func/impls/record.rs
+++ b/src/expr/src/scalar/func/impls/record.rs
@@ -192,7 +192,7 @@ impl LazyUnaryFunc for RecordGet {
     }
 
     fn output_sql_type(&self, input_type: SqlColumnType) -> SqlColumnType {
-        match input_type.scalar_type {
+        match &input_type.scalar_type {
             SqlScalarType::Record { fields, .. } => {
                 let (_name, ty) = &fields[self.0];
                 let mut ty = ty.clone();

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -42,6 +42,7 @@ uuid = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 criterion.workspace = true
+prost-types.workspace = true
 tokio.workspace = true
 
 [build-dependencies]

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -26,7 +26,7 @@ maplit.workspace = true
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-glue-schema-registry = { path = "../aws-glue-schema-registry" }
 mz-ccsr = { path = "../ccsr" }
-mz-ore = { path = "../ore", features = ["network", "cli"] }
+mz-ore = { path = "../ore", features = ["network", "cli", "stack"] }
 mz-repr = { path = "../repr" }
 mz-pgrepr = { path = "../pgrepr" }
 ordered-float.workspace = true

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -82,12 +82,27 @@ impl DecodedDescriptors {
     }
 }
 
+/// Message decoding takes the plain stack when the message's relation type
+/// nests at most this deep, which holds for any realistic schema. Deeper
+/// messages get a dedicated stack sized by their nesting depth, see
+/// [`Decoder::decode`].
+const MAX_PLAIN_STACK_MESSAGE_DEPTH: usize = 128;
+
+/// Stack bytes reserved per nesting level when decoding a deeply nested
+/// message: a generous upper bound on the stack that prost-reflect's
+/// recursive decoding and the message tree's drop glue use per level,
+/// including in debug builds.
+const DECODE_STACK_BYTES_PER_LEVEL: usize = 4096;
+
 /// Decodes a particular Protobuf message from its wire format.
 #[derive(Debug)]
 pub struct Decoder {
     descriptors: DecodedDescriptors,
     row: Row,
     confluent_wire_format: bool,
+    /// The nesting depth of the message's relation type, used to size the
+    /// decoding stack for deeply nested schemas.
+    nesting_depth: usize,
 }
 
 impl Decoder {
@@ -97,6 +112,7 @@ impl Decoder {
         confluent_wire_format: bool,
     ) -> Result<Self, anyhow::Error> {
         Ok(Decoder {
+            nesting_depth: type_nesting_depth(descriptors.columns()),
             descriptors,
             row: Row::default(),
             confluent_wire_format,
@@ -125,11 +141,57 @@ impl Decoder {
             let (_schema_id, adjusted_bytes) = crate::confluent::extract_protobuf_header(bytes)?;
             bytes = adjusted_bytes;
         }
+        // `DynamicMessage::decode`, and the drop of the decoded message tree,
+        // recurse once per nesting level inside prost-reflect, which we
+        // cannot instrument with `maybe_grow`. A message nests only as deeply
+        // as its schema, so schemas nested deeper than the plain stack safely
+        // handles get a dedicated stack sized by their depth. The message
+        // must also drop within that scope, so the whole decode runs there.
+        if self.nesting_depth > MAX_PLAIN_STACK_MESSAGE_DEPTH {
+            let stack_size = self.nesting_depth * DECODE_STACK_BYTES_PER_LEVEL;
+            mz_ore::stack::grow(stack_size, || self.decode_message(bytes))
+        } else {
+            self.decode_message(bytes)
+        }
+    }
+
+    fn decode_message(&mut self, bytes: &[u8]) -> Result<Option<Row>, anyhow::Error> {
         let message = DynamicMessage::decode(self.descriptors.message_descriptor.clone(), bytes)?;
         let mut packer = self.row.packer();
         pack_message(&mut packer, &message)?;
         Ok(Some(self.row.clone()))
     }
+}
+
+/// Returns the maximum nesting depth of the given column types.
+///
+/// Iterative, so safe to call on arbitrarily deeply nested types.
+fn type_nesting_depth(columns: &[(ColumnName, SqlColumnType)]) -> usize {
+    let mut max_depth = 1;
+    let mut todo: Vec<(&SqlScalarType, usize)> = columns
+        .iter()
+        .map(|(_name, ty)| (&ty.scalar_type, 1))
+        .collect();
+    while let Some((ty, depth)) = todo.pop() {
+        max_depth = max_depth.max(depth);
+        match ty {
+            SqlScalarType::Array(ty)
+            | SqlScalarType::List {
+                element_type: ty, ..
+            }
+            | SqlScalarType::Map { value_type: ty, .. }
+            | SqlScalarType::Range { element_type: ty } => todo.push((ty, depth + 1)),
+            SqlScalarType::Record { fields, .. } => {
+                todo.extend(
+                    fields
+                        .iter()
+                        .map(|(_name, ty)| (&ty.scalar_type, depth + 1)),
+                );
+            }
+            _ => {}
+        }
+    }
+    max_depth
 }
 
 fn derive_column_type(
@@ -496,49 +558,54 @@ fn pack_value(
     field_desc: &FieldDescriptor,
     value: &Value,
 ) -> Result<(), anyhow::Error> {
-    match value {
-        Value::Bool(false) => packer.push(Datum::False),
-        Value::Bool(true) => packer.push(Datum::True),
-        Value::I32(i) => packer.push(Datum::Int32(*i)),
-        Value::I64(i) => packer.push(Datum::Int64(*i)),
-        Value::U32(i) => packer.push(Datum::UInt32(*i)),
-        Value::U64(i) => packer.push(Datum::UInt64(*i)),
-        Value::F32(f) => packer.push(Datum::Float32((*f).into())),
-        Value::F64(f) => packer.push(Datum::Float64((*f).into())),
-        Value::String(s) => packer.push(Datum::String(s)),
-        Value::Bytes(s) => packer.push(Datum::Bytes(s)),
-        Value::EnumNumber(i) => {
-            let kind = field_desc.kind();
-            let enum_desc = kind.as_enum().ok_or_else(|| {
-                anyhow!(
-                    "internal error: decoding protobuf: field {} missing enum descriptor",
-                    field_desc.name()
-                )
-            })?;
-            let value = enum_desc.get_value(*i).ok_or_else(|| {
-                anyhow!(
-                    "error decoding protobuf: unknown enum value {} while decoding field {}",
-                    i,
-                    field_desc.name()
-                )
-            })?;
-            packer.push(Datum::String(value.name()));
+    // A value nests as deeply as its message type, which can be arbitrarily
+    // deep, so grow the stack on demand. Every packing recursion cycle
+    // (including the one through `pack_message`) passes through here.
+    mz_ore::stack::maybe_grow(|| {
+        match value {
+            Value::Bool(false) => packer.push(Datum::False),
+            Value::Bool(true) => packer.push(Datum::True),
+            Value::I32(i) => packer.push(Datum::Int32(*i)),
+            Value::I64(i) => packer.push(Datum::Int64(*i)),
+            Value::U32(i) => packer.push(Datum::UInt32(*i)),
+            Value::U64(i) => packer.push(Datum::UInt64(*i)),
+            Value::F32(f) => packer.push(Datum::Float32((*f).into())),
+            Value::F64(f) => packer.push(Datum::Float64((*f).into())),
+            Value::String(s) => packer.push(Datum::String(s)),
+            Value::Bytes(s) => packer.push(Datum::Bytes(s)),
+            Value::EnumNumber(i) => {
+                let kind = field_desc.kind();
+                let enum_desc = kind.as_enum().ok_or_else(|| {
+                    anyhow!(
+                        "internal error: decoding protobuf: field {} missing enum descriptor",
+                        field_desc.name()
+                    )
+                })?;
+                let value = enum_desc.get_value(*i).ok_or_else(|| {
+                    anyhow!(
+                        "error decoding protobuf: unknown enum value {} while decoding field {}",
+                        i,
+                        field_desc.name()
+                    )
+                })?;
+                packer.push(Datum::String(value.name()));
+            }
+            Value::Message(m) => packer.push_list_with(|packer| pack_message(packer, m))?,
+            Value::List(values) => {
+                packer.push_list_with(|packer| {
+                    for value in values {
+                        pack_value(packer, field_desc, value)?;
+                    }
+                    Ok::<_, anyhow::Error>(())
+                })?;
+            }
+            Value::Map(_) => bail!(
+                "internal error: unexpected value while decoding protobuf message: {:?}",
+                value
+            ),
         }
-        Value::Message(m) => packer.push_list_with(|packer| pack_message(packer, m))?,
-        Value::List(values) => {
-            packer.push_list_with(|packer| {
-                for value in values {
-                    pack_value(packer, field_desc, value)?;
-                }
-                Ok::<_, anyhow::Error>(())
-            })?;
-        }
-        Value::Map(_) => bail!(
-            "internal error: unexpected value while decoding protobuf message: {:?}",
-            value
-        ),
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 #[cfg(test)]
@@ -555,7 +622,7 @@ mod stack_overflow_verification {
         DescriptorProto, FieldDescriptorProto, FileDescriptorProto, FileDescriptorSet, FileOptions,
     };
 
-    use super::{DecodedDescriptors, MAX_DESCRIPTOR_WIRE_NESTING_DEPTH};
+    use super::{DecodedDescriptors, Decoder, MAX_DESCRIPTOR_WIRE_NESTING_DEPTH};
 
     fn deep_chain_fds(n: usize) -> Vec<u8> {
         let message_type = (0..n)
@@ -595,20 +662,60 @@ mod stack_overflow_verification {
         FileDescriptorSet { file: vec![file] }.encode_to_vec()
     }
 
+    /// Returns the wire encoding of a message of the type derived from
+    /// `deep_chain_fds(n)`: `n - 1` nested length-delimited frames of field 1,
+    /// with an empty innermost message.
+    fn deep_chain_payload(n: usize) -> Vec<u8> {
+        use prost::encoding::{WireType, encode_key, encode_varint, encoded_len_varint};
+
+        let key_len = {
+            let mut probe = vec![];
+            encode_key(1, WireType::LengthDelimited, &mut probe);
+            probe.len()
+        };
+        let mut lens = vec![0usize; n];
+        for k in 1..n {
+            let inner = lens[k - 1];
+            lens[k] = key_len + encoded_len_varint(u64::try_from(inner).unwrap()) + inner;
+        }
+        let mut payload = Vec::with_capacity(lens[n - 1]);
+        for k in (1..n).rev() {
+            encode_key(1, WireType::LengthDelimited, &mut payload);
+            encode_varint(u64::try_from(lens[k - 1]).unwrap(), &mut payload);
+        }
+        payload
+    }
+
     #[mz_ore::test]
     fn deep_chain_does_not_overflow() {
-        // A chain far deeper than a fixed stack could recurse over, but shallow
-        // enough that the resulting nested record type is itself well-behaved.
-        // Before the fix `derive_inner_type` recursed once per message on a
-        // fixed stack and aborted the process here; it now grows the stack on
-        // demand, so the chain resolves to a nested record type.
-        let bytes = deep_chain_fds(1_000);
-        let res = DecodedDescriptors::from_bytes(&bytes, ".test.m0".to_string());
-        assert!(
-            res.is_ok(),
-            "expected a deep message chain to decode, got: {:?}",
-            res.err()
-        );
+        // A chain far deeper than a fixed stack could recurse over. Before the
+        // fix `derive_inner_type` recursed once per message on a fixed stack
+        // and aborted the process here; it now grows the stack on demand, so
+        // the chain resolves to a nested record type. Everything downstream of
+        // the derivation that recurses over the resulting type (clone, message
+        // decoding, drop) grows its stack as well, which this test exercises
+        // end to end.
+        const DEPTH: usize = 50_000;
+        let bytes = deep_chain_fds(DEPTH);
+        let descriptors = DecodedDescriptors::from_bytes(&bytes, ".test.m0".to_string())
+            .expect("deep message chain must decode");
+        assert_eq!(super::type_nesting_depth(descriptors.columns()), DEPTH);
+
+        // Cloning the derived type recurses once per nesting level.
+        let cloned_columns = descriptors.columns().to_vec();
+
+        // Decoding a conforming (deeply nested) message recurses once per
+        // nesting level, both in `DynamicMessage::decode` and while packing
+        // the decoded values into a row.
+        let payload = deep_chain_payload(DEPTH);
+        let mut decoder = Decoder::new(descriptors, false).expect("valid descriptors");
+        let row = decoder.decode(&payload).expect("deep message must decode");
+        assert!(row.is_some());
+
+        // Dropping the derived type (and its clone) also recurses once per
+        // nesting level, via the manual `Drop` impls.
+        drop(cloned_columns);
+        drop(decoder);
     }
 
     /// The `type_name` reference chain above is flat on the wire, so it stresses

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -208,22 +208,118 @@ fn derive_inner_type(
     }
 }
 
-/// Rejects a `FileDescriptorSet` whose wire encoding nests message or group
-/// fields deeper than [`MAX_DESCRIPTOR_WIRE_NESTING_DEPTH`], which would
-/// otherwise overflow the stack inside `DescriptorPool::decode`.
+/// The `descriptor.proto` message type that a region of the wire is being
+/// parsed as. [`check_descriptor_set_nesting_depth`] uses it to descend only
+/// into fields that are message-typed, mirroring what `DescriptorPool::decode`
+/// recurses into.
+#[derive(Clone, Copy)]
+enum WireCtx {
+    FileDescriptorSet,
+    FileDescriptorProto,
+    DescriptorProto,
+    ExtensionRange,
+    FieldDescriptorProto,
+    OneofDescriptorProto,
+    EnumDescriptorProto,
+    EnumValueDescriptorProto,
+    ServiceDescriptorProto,
+    MethodDescriptorProto,
+    /// Any of the `*Options` messages. The only message-typed field they carry
+    /// that matters here is `uninterpreted_option` (tag 999).
+    Options,
+    UninterpretedOption,
+    SourceCodeInfo,
+    /// A message with no message-typed fields, or an opaque group region. Only
+    /// nested groups increase depth from here.
+    Leaf,
+}
+
+impl WireCtx {
+    /// Returns the context in which to parse the payload of the message-typed
+    /// field with the given `tag`, or `None` if the field is not message-typed
+    /// in this context (a scalar, `string`, `bytes`, or unknown field), in which
+    /// case the scan treats the payload as an opaque leaf.
+    ///
+    /// This encodes the message structure of the `descriptor.proto` schema that
+    /// `prost-reflect` decodes. `DescriptorPool::decode` recurses into exactly
+    /// these fields, so mirroring them keeps the scan's depth in lockstep with
+    /// the decoder's recursion depth.
+    fn child(self, tag: u32) -> Option<WireCtx> {
+        use WireCtx::*;
+        Some(match (self, tag) {
+            (FileDescriptorSet, 1) => FileDescriptorProto,
+            (FileDescriptorProto, 4) => DescriptorProto,
+            (FileDescriptorProto, 5) => EnumDescriptorProto,
+            (FileDescriptorProto, 6) => ServiceDescriptorProto,
+            (FileDescriptorProto, 7) => FieldDescriptorProto,
+            (FileDescriptorProto, 8) => Options,
+            (FileDescriptorProto, 9) => SourceCodeInfo,
+            (DescriptorProto, 2) => FieldDescriptorProto,
+            (DescriptorProto, 3) => DescriptorProto,
+            (DescriptorProto, 4) => EnumDescriptorProto,
+            (DescriptorProto, 5) => ExtensionRange,
+            (DescriptorProto, 6) => FieldDescriptorProto,
+            (DescriptorProto, 7) => Options,
+            (DescriptorProto, 8) => OneofDescriptorProto,
+            (DescriptorProto, 9) => Leaf, // ReservedRange
+            (ExtensionRange, 3) => Options,
+            (FieldDescriptorProto, 8) => Options,
+            (OneofDescriptorProto, 2) => Options,
+            (EnumDescriptorProto, 2) => EnumValueDescriptorProto,
+            (EnumDescriptorProto, 3) => Options,
+            (EnumDescriptorProto, 4) => Leaf, // EnumReservedRange
+            (EnumValueDescriptorProto, 3) => Options,
+            (ServiceDescriptorProto, 2) => MethodDescriptorProto,
+            (ServiceDescriptorProto, 3) => Options,
+            (MethodDescriptorProto, 4) => Options,
+            (Options, 999) => UninterpretedOption,
+            (UninterpretedOption, 2) => Leaf, // NamePart
+            (SourceCodeInfo, 1) => Leaf,      // Location
+            _ => return None,
+        })
+    }
+}
+
+/// Rejects a `FileDescriptorSet` whose wire encoding nests messages or groups
+/// deeper than [`MAX_DESCRIPTOR_WIRE_NESTING_DEPTH`], which would otherwise
+/// overflow the stack inside `DescriptorPool::decode`.
 ///
-/// The scan is iterative (it tracks open regions on an explicit stack), so it
-/// cannot itself overflow. It descends into every length-delimited field and
-/// every group, which is a superset of what Prost recurses into while decoding,
-/// so any input that would drive Prost past the limit is rejected here first. A
-/// length-delimited field that is not actually a nested message (a string or a
-/// packed field) fails to parse as one within a few bytes and is skipped as an
-/// opaque leaf, so realistic descriptor sets are not rejected.
+/// `DescriptorPool::decode` recurses in exactly two ways, both unbounded because
+/// the workspace builds Prost with `no-recursion-limit`:
+///
+///  * It recursively decodes message-typed fields. In `descriptor.proto` the
+///    only self-referential message field is `DescriptorProto.nested_type`, so a
+///    `nested_type` chain drives this recursion arbitrarily deep.
+///  * It skips unknown group fields recursively (`prost::encoding::skip_field`
+///    recurses once per level of nested group), so a chain of `StartGroup` keys
+///    drives the recursion arbitrarily deep as well.
+///
+/// The scan mirrors that recursion with an explicit stack, so it cannot itself
+/// overflow. It is schema-aware: it descends only into length-delimited fields
+/// that are message-typed according to `descriptor.proto` (tracked by
+/// [`WireCtx`]) and into groups. A length-delimited field that is a `string`,
+/// `bytes`, or unknown field is skipped as an opaque leaf, because
+/// `DescriptorPool::decode` does not parse its contents as a message either.
+///
+/// Treating opaque payloads as leaves is essential, not just an optimization: a
+/// `string` may contain byte sequences that are valid protobuf keys (an option
+/// string of `0x4b` bytes reads as a chain of `StartGroup` keys), so a scan that
+/// parsed string contents as nested protobuf would reject valid, shallow
+/// descriptors.
+///
+/// Because the scan descends into every message-typed field the decoder decodes
+/// and into every group the decoder skips, any input that would drive the
+/// decoder past the limit trips the limit here first.
 fn check_descriptor_set_nesting_depth(bytes: &[u8]) -> Result<(), anyhow::Error> {
     use bytes::Buf;
     use prost::encoding::{WireType, decode_key, decode_varint};
 
-    enum Frame {
+    struct Frame {
+        kind: FrameKind,
+        /// The context in which fields inside this frame are parsed.
+        ctx: WireCtx,
+    }
+    enum FrameKind {
         /// A length-delimited region that ends once `buf.remaining()` has
         /// dropped to this value.
         Len(usize),
@@ -236,7 +332,7 @@ fn check_descriptor_set_nesting_depth(bytes: &[u8]) -> Result<(), anyhow::Error>
     // length-delimited region to recover into, in which case scanning must stop.
     let recover = |frames: &mut Vec<Frame>, buf: &mut &[u8]| -> bool {
         while let Some(frame) = frames.pop() {
-            if let Frame::Len(end_remaining) = frame {
+            if let FrameKind::Len(end_remaining) = frame.kind {
                 let skip = buf.remaining().saturating_sub(end_remaining);
                 buf.advance(skip);
                 return true;
@@ -250,7 +346,11 @@ fn check_descriptor_set_nesting_depth(bytes: &[u8]) -> Result<(), anyhow::Error>
 
     loop {
         // Close every length-delimited region that ends at the current position.
-        while let Some(Frame::Len(end_remaining)) = frames.last() {
+        while let Some(Frame {
+            kind: FrameKind::Len(end_remaining),
+            ..
+        }) = frames.last()
+        {
             if buf.remaining() <= *end_remaining {
                 frames.pop();
             } else {
@@ -263,6 +363,12 @@ fn check_descriptor_set_nesting_depth(bytes: &[u8]) -> Result<(), anyhow::Error>
             // way.
             return Ok(());
         }
+
+        // The context for the field about to be read is that of the innermost
+        // open frame, or the root `FileDescriptorSet` at the top level.
+        let ctx = frames
+            .last()
+            .map_or(WireCtx::FileDescriptorSet, |frame| frame.ctx);
 
         let (tag, wire_type) = match decode_key(&mut buf) {
             Ok(key) => key,
@@ -313,14 +419,27 @@ fn check_descriptor_set_nesting_depth(bytes: &[u8]) -> Result<(), anyhow::Error>
                     }
                     return Ok(());
                 }
-                if frames.len() >= MAX_DESCRIPTOR_WIRE_NESTING_DEPTH {
-                    bail!(
-                        "Protobuf descriptor set nesting depth exceeds limit of {}",
-                        MAX_DESCRIPTOR_WIRE_NESTING_DEPTH
-                    );
+                match ctx.child(tag) {
+                    // A message-typed field: descend, mirroring the decoder
+                    // recursing into the nested message.
+                    Some(child) => {
+                        if frames.len() >= MAX_DESCRIPTOR_WIRE_NESTING_DEPTH {
+                            bail!(
+                                "Protobuf descriptor set nesting depth exceeds limit of {}",
+                                MAX_DESCRIPTOR_WIRE_NESTING_DEPTH
+                            );
+                        }
+                        let end_remaining = buf.remaining() - len as usize;
+                        frames.push(Frame {
+                            kind: FrameKind::Len(end_remaining),
+                            ctx: child,
+                        });
+                    }
+                    // A string, bytes, scalar, or unknown field. The decoder does
+                    // not parse its contents as a message, so skip it as an
+                    // opaque leaf rather than recursing into it.
+                    None => buf.advance(len as usize),
                 }
-                let end_remaining = buf.remaining() - len as usize;
-                frames.push(Frame::Len(end_remaining));
             }
             WireType::StartGroup => {
                 if frames.len() >= MAX_DESCRIPTOR_WIRE_NESTING_DEPTH {
@@ -329,10 +448,18 @@ fn check_descriptor_set_nesting_depth(bytes: &[u8]) -> Result<(), anyhow::Error>
                         MAX_DESCRIPTOR_WIRE_NESTING_DEPTH
                     );
                 }
-                frames.push(Frame::Group(tag));
+                // Group contents are skipped as unknown wire data by the decoder,
+                // so only further nested groups increase depth from here.
+                frames.push(Frame {
+                    kind: FrameKind::Group(tag),
+                    ctx: WireCtx::Leaf,
+                });
             }
             WireType::EndGroup => match frames.last() {
-                Some(Frame::Group(open_tag)) if *open_tag == tag => {
+                Some(Frame {
+                    kind: FrameKind::Group(open_tag),
+                    ..
+                }) if *open_tag == tag => {
                     frames.pop();
                 }
                 _ => {
@@ -427,10 +554,10 @@ mod stack_overflow_verification {
     use prost::Message;
     use prost_types::field_descriptor_proto::{Label, Type};
     use prost_types::{
-        DescriptorProto, FieldDescriptorProto, FileDescriptorProto, FileDescriptorSet,
+        DescriptorProto, FieldDescriptorProto, FileDescriptorProto, FileDescriptorSet, FileOptions,
     };
 
-    use super::DecodedDescriptors;
+    use super::{DecodedDescriptors, MAX_DESCRIPTOR_WIRE_NESTING_DEPTH};
 
     fn deep_chain_fds(n: usize) -> Vec<u8> {
         let message_type = (0..n)
@@ -539,6 +666,73 @@ mod stack_overflow_verification {
         assert!(
             res.is_err(),
             "expected a nesting-depth error for a deeply nested descriptor"
+        );
+    }
+
+    /// A valid, shallow descriptor whose `FileOptions.java_package` is a long
+    /// string of `0x4b` ('K') bytes. Each `0x4b` is a valid protobuf key
+    /// (`StartGroup`, tag 9), so a scanner that parsed opaque string contents as
+    /// nested protobuf would count one level of phantom nesting per byte and
+    /// reject this descriptor once the string exceeds the depth limit.
+    fn message_like_option_bytes_fds() -> Vec<u8> {
+        let options = FileOptions {
+            java_package: Some("K".repeat(MAX_DESCRIPTOR_WIRE_NESTING_DEPTH * 2)),
+            ..Default::default()
+        };
+        let file = FileDescriptorProto {
+            name: Some("test.proto".into()),
+            package: Some("test".into()),
+            message_type: vec![DescriptorProto {
+                name: Some("m0".into()),
+                ..Default::default()
+            }],
+            options: Some(options),
+            syntax: Some("proto2".into()),
+            ..Default::default()
+        };
+        FileDescriptorSet { file: vec![file] }.encode_to_vec()
+    }
+
+    #[mz_ore::test]
+    fn message_like_option_bytes_accepted() {
+        let bytes = message_like_option_bytes_fds();
+        // The wire scan must treat `java_package` as an opaque string, not
+        // recurse into it, so this valid shallow descriptor is accepted just as
+        // `DescriptorPool::decode` accepts it.
+        let res = DecodedDescriptors::from_bytes(&bytes, ".test.m0".to_string());
+        assert!(
+            res.is_ok(),
+            "valid descriptor with message-like option bytes must be accepted, got: {:?}",
+            res.err()
+        );
+    }
+
+    /// A chain of `depth` bare `StartGroup` keys at the top level of the
+    /// descriptor set. `DescriptorPool::decode` skips unknown groups recursively
+    /// (`skip_field`), so this drives that recursion `depth` levels deep.
+    fn deep_group_fds(depth: usize) -> Vec<u8> {
+        use prost::encoding::{WireType, encode_key};
+
+        let mut fds = vec![];
+        // Tag 2 is not a field of `FileDescriptorSet` (which defines only field
+        // 1), so the decoder skips it via `skip_field`, which recurses per nested
+        // group. The scan bounds depth by the number of open groups regardless of
+        // their tags.
+        for _ in 0..depth {
+            encode_key(2, WireType::StartGroup, &mut fds);
+        }
+        fds
+    }
+
+    #[mz_ore::test]
+    fn deep_group_does_not_overflow() {
+        let bytes = deep_group_fds(50_000);
+        // Must return an error (wire nesting-depth limit), not abort with a stack
+        // overflow inside `skip_field`'s recursive group skipping.
+        let res = DecodedDescriptors::from_bytes(&bytes, ".test.m0".to_string());
+        assert!(
+            res.is_err(),
+            "expected a nesting-depth error for a deeply nested group chain"
         );
     }
 }

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -17,12 +17,6 @@ use prost_reflect::{
     ReflectMessage, Value,
 };
 
-/// Maximum Protobuf message nesting depth accepted when deriving a relation
-/// type. A message nested deeper than this is rejected rather than recursed
-/// into, so that a pathological (non-cyclic) message chain cannot overflow the
-/// stack while deriving the source's `RelationDesc`.
-const MAX_MESSAGE_NESTING_DEPTH: usize = 128;
-
 /// Maximum Protobuf wire nesting depth accepted when decoding a
 /// `FileDescriptorSet`.
 ///
@@ -35,10 +29,9 @@ const MAX_MESSAGE_NESTING_DEPTH: usize = 128;
 /// overflow before any of our own validation runs.
 ///
 /// We therefore reject descriptor sets nested deeper than this on the wire,
-/// before decoding them. This is distinct from [`MAX_MESSAGE_NESTING_DEPTH`],
-/// which bounds how far message *type references* (`m0 -> m1 -> ...` by name)
-/// are followed while deriving the relation type. Those references are a flat
-/// list on the wire, so a reference chain does not nest here.
+/// before decoding them. Message *type references* (`m0 -> m1 -> ...` by name)
+/// do not count toward this limit. Those references are a flat list on the wire,
+/// and relation type derivation grows its stack on demand as it follows them.
 const MAX_DESCRIPTOR_WIRE_NESTING_DEPTH: usize = 128;
 
 /// A decoded description of the schema of a Protobuf message.
@@ -165,7 +158,14 @@ fn derive_inner_type(
     seen_messages: &mut BTreeSet<String>,
     ty: Kind,
 ) -> Result<SqlColumnType, anyhow::Error> {
-    match ty {
+    // A message field can reference another message, and that chain can be
+    // arbitrarily long (though non-cyclic, which `seen_messages` enforces), so
+    // this recurses once per level. Grow the stack on demand instead of
+    // bounding the depth, so deriving the relation type from a deeply nested
+    // schema does not overflow the stack. This mirrors the jsonb recursion in
+    // `mz_repr`, and keeps schemas that a prior version already accepted and
+    // persisted decodable on re-render.
+    mz_ore::stack::maybe_grow(move || match ty {
         Kind::Bool => Ok(SqlScalarType::Bool.nullable(false)),
         Kind::Int32 | Kind::Sint32 | Kind::Sfixed32 => Ok(SqlScalarType::Int32.nullable(false)),
         Kind::Int64 | Kind::Sint64 | Kind::Sfixed64 => Ok(SqlScalarType::Int64.nullable(false)),
@@ -179,17 +179,6 @@ fn derive_inner_type(
         Kind::Message(m) => {
             if seen_messages.contains(m.name()) {
                 bail!("Recursive types are not supported: {}", m.name());
-            }
-            // `seen_messages` holds the ancestor messages currently being
-            // resolved, so its length is the current nesting depth. Bounding it
-            // prevents a stack overflow from a deeply nested (but non-cyclic)
-            // message chain, whose descriptor set is a flat, cheap-to-encode
-            // list of messages that reference each other by name.
-            if seen_messages.len() >= MAX_MESSAGE_NESTING_DEPTH {
-                bail!(
-                    "Protobuf message nesting depth exceeds limit of {}",
-                    MAX_MESSAGE_NESTING_DEPTH
-                );
             }
             seen_messages.insert(m.name().to_owned());
             let mut fields = Vec::with_capacity(m.fields().len());
@@ -205,7 +194,7 @@ fn derive_inner_type(
             };
             Ok(ty.nullable(true))
         }
-    }
+    })
 }
 
 /// The `descriptor.proto` message type that a region of the wire is being
@@ -413,7 +402,16 @@ fn check_descriptor_set_nesting_depth(bytes: &[u8]) -> Result<(), anyhow::Error>
                         return Ok(());
                     }
                 };
-                if len > buf.remaining() as u64 {
+                let len = match usize::try_from(len) {
+                    Ok(len) => len,
+                    Err(_) => {
+                        if recover(&mut frames, &mut buf) {
+                            continue;
+                        }
+                        return Ok(());
+                    }
+                };
+                if len > buf.remaining() {
                     if recover(&mut frames, &mut buf) {
                         continue;
                     }
@@ -429,7 +427,7 @@ fn check_descriptor_set_nesting_depth(bytes: &[u8]) -> Result<(), anyhow::Error>
                                 MAX_DESCRIPTOR_WIRE_NESTING_DEPTH
                             );
                         }
-                        let end_remaining = buf.remaining() - len as usize;
+                        let end_remaining = buf.remaining() - len;
                         frames.push(Frame {
                             kind: FrameKind::Len(end_remaining),
                             ctx: child,
@@ -438,7 +436,7 @@ fn check_descriptor_set_nesting_depth(bytes: &[u8]) -> Result<(), anyhow::Error>
                     // A string, bytes, scalar, or unknown field. The decoder does
                     // not parse its contents as a message, so skip it as an
                     // opaque leaf rather than recursing into it.
-                    None => buf.advance(len as usize),
+                    None => buf.advance(len),
                 }
             }
             WireType::StartGroup => {
@@ -548,9 +546,9 @@ mod stack_overflow_verification {
     // Regression test: a deep, non-cyclic protobuf message chain
     // (`m0 -> m1 -> ... -> mN`) must not overflow the stack while deriving the
     // relation type in `DecodedDescriptors::from_bytes` (reached during
-    // `CREATE SOURCE ... FORMAT PROTOBUF`). `derive_inner_type` bounds the
-    // nesting depth, so this returns a graceful error rather than aborting the
-    // process with a stack overflow.
+    // `CREATE SOURCE ... FORMAT PROTOBUF`). `derive_inner_type` grows the stack
+    // on demand, so this succeeds rather than aborting the process with a stack
+    // overflow.
     use prost::Message;
     use prost_types::field_descriptor_proto::{Label, Type};
     use prost_types::{
@@ -599,13 +597,17 @@ mod stack_overflow_verification {
 
     #[mz_ore::test]
     fn deep_chain_does_not_overflow() {
-        let bytes = deep_chain_fds(50_000);
-        // Must return an error (nesting-depth limit), not abort with a stack
-        // overflow. Before the fix this recursed once per message and aborted.
+        // A chain far deeper than a fixed stack could recurse over, but shallow
+        // enough that the resulting nested record type is itself well-behaved.
+        // Before the fix `derive_inner_type` recursed once per message on a
+        // fixed stack and aborted the process here; it now grows the stack on
+        // demand, so the chain resolves to a nested record type.
+        let bytes = deep_chain_fds(1_000);
         let res = DecodedDescriptors::from_bytes(&bytes, ".test.m0".to_string());
         assert!(
-            res.is_err(),
-            "expected a nesting-depth error for a deep message chain"
+            res.is_ok(),
+            "expected a deep message chain to decode, got: {:?}",
+            res.err()
         );
     }
 
@@ -617,6 +619,10 @@ mod stack_overflow_verification {
     /// overflows the stack.
     fn deep_nested_type_fds(depth: usize) -> Vec<u8> {
         use prost::encoding::{WireType, encode_key, encode_varint, encoded_len_varint};
+
+        fn wire_len(len: usize) -> u64 {
+            u64::try_from(len).expect("test descriptor length must fit in u64")
+        }
 
         // Build the wire encoding directly. Materializing the nested
         // `DescriptorProto` values would overflow Prost's *encoder* (and the
@@ -633,25 +639,25 @@ mod stack_overflow_verification {
         };
         let mut lens = vec![0usize; depth + 1];
         for k in 1..=depth {
-            lens[k] = key_len + encoded_len_varint(lens[k - 1] as u64) + lens[k - 1];
+            lens[k] = key_len + encoded_len_varint(wire_len(lens[k - 1])) + lens[k - 1];
         }
 
         let mut dp = Vec::with_capacity(lens[depth]);
         for k in (1..=depth).rev() {
             encode_key(NESTED_TYPE_FIELD, WireType::LengthDelimited, &mut dp);
-            encode_varint(lens[k - 1] as u64, &mut dp);
+            encode_varint(wire_len(lens[k - 1]), &mut dp);
         }
 
         // Wrap the chain: FileDescriptorProto.message_type (field 4), then
         // FileDescriptorSet.file (field 1).
         let mut fdp = vec![];
         encode_key(4, WireType::LengthDelimited, &mut fdp);
-        encode_varint(dp.len() as u64, &mut fdp);
+        encode_varint(wire_len(dp.len()), &mut fdp);
         fdp.extend_from_slice(&dp);
 
         let mut fds = vec![];
         encode_key(1, WireType::LengthDelimited, &mut fds);
-        encode_varint(fdp.len() as u64, &mut fds);
+        encode_varint(wire_len(fdp.len()), &mut fds);
         fds.extend_from_slice(&fdp);
         fds
     }

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -23,6 +23,24 @@ use prost_reflect::{
 /// stack while deriving the source's `RelationDesc`.
 const MAX_MESSAGE_NESTING_DEPTH: usize = 128;
 
+/// Maximum Protobuf wire nesting depth accepted when decoding a
+/// `FileDescriptorSet`.
+///
+/// `DescriptorPool::decode` decodes the descriptor set recursively, descending
+/// once per level of wire nesting. `DescriptorProto.nested_type` is
+/// self-referential and unknown group fields are skipped recursively, so a
+/// deeply nested (but cheap to encode) descriptor set drives that recursion
+/// arbitrarily deep. The workspace builds Prost with `no-recursion-limit`, so
+/// the recursion is unbounded and such input aborts the process with a stack
+/// overflow before any of our own validation runs.
+///
+/// We therefore reject descriptor sets nested deeper than this on the wire,
+/// before decoding them. This is distinct from [`MAX_MESSAGE_NESTING_DEPTH`],
+/// which bounds how far message *type references* (`m0 -> m1 -> ...` by name)
+/// are followed while deriving the relation type. Those references are a flat
+/// list on the wire, so a reference chain does not nest here.
+const MAX_DESCRIPTOR_WIRE_NESTING_DEPTH: usize = 128;
+
 /// A decoded description of the schema of a Protobuf message.
 #[derive(Debug, PartialEq)]
 pub struct DecodedDescriptors {
@@ -35,6 +53,10 @@ impl DecodedDescriptors {
     /// Builds a `DecodedDescriptors` from an encoded `FileDescriptorSet` and
     /// the fully qualified name of a message inside that file descriptor set.
     pub fn from_bytes(bytes: &[u8], message_name: String) -> Result<Self, anyhow::Error> {
+        // Reject pathologically nested input before `DescriptorPool::decode`
+        // recurses into it and overflows the stack. See
+        // `MAX_DESCRIPTOR_WIRE_NESTING_DEPTH`.
+        check_descriptor_set_nesting_depth(bytes)?;
         let fds = DescriptorPool::decode(bytes).context("decoding file descriptor set")?;
         let message_descriptor = fds.get_message_by_name(&message_name).ok_or_else(|| {
             anyhow!(
@@ -186,6 +208,144 @@ fn derive_inner_type(
     }
 }
 
+/// Rejects a `FileDescriptorSet` whose wire encoding nests message or group
+/// fields deeper than [`MAX_DESCRIPTOR_WIRE_NESTING_DEPTH`], which would
+/// otherwise overflow the stack inside `DescriptorPool::decode`.
+///
+/// The scan is iterative (it tracks open regions on an explicit stack), so it
+/// cannot itself overflow. It descends into every length-delimited field and
+/// every group, which is a superset of what Prost recurses into while decoding,
+/// so any input that would drive Prost past the limit is rejected here first. A
+/// length-delimited field that is not actually a nested message (a string or a
+/// packed field) fails to parse as one within a few bytes and is skipped as an
+/// opaque leaf, so realistic descriptor sets are not rejected.
+fn check_descriptor_set_nesting_depth(bytes: &[u8]) -> Result<(), anyhow::Error> {
+    use bytes::Buf;
+    use prost::encoding::{WireType, decode_key, decode_varint};
+
+    enum Frame {
+        /// A length-delimited region that ends once `buf.remaining()` has
+        /// dropped to this value.
+        Len(usize),
+        /// A group that ends at an `EndGroup` key carrying this tag.
+        Group(u32),
+    }
+
+    // Skips the remainder of the innermost length-delimited region, treating it
+    // as opaque bytes. Returns `false` when there is no enclosing
+    // length-delimited region to recover into, in which case scanning must stop.
+    let recover = |frames: &mut Vec<Frame>, buf: &mut &[u8]| -> bool {
+        while let Some(frame) = frames.pop() {
+            if let Frame::Len(end_remaining) = frame {
+                let skip = buf.remaining().saturating_sub(end_remaining);
+                buf.advance(skip);
+                return true;
+            }
+        }
+        false
+    };
+
+    let mut buf: &[u8] = bytes;
+    let mut frames: Vec<Frame> = Vec::new();
+
+    loop {
+        // Close every length-delimited region that ends at the current position.
+        while let Some(Frame::Len(end_remaining)) = frames.last() {
+            if buf.remaining() <= *end_remaining {
+                frames.pop();
+            } else {
+                break;
+            }
+        }
+        if !buf.has_remaining() {
+            // Any frames still open mean truncated input, which
+            // `DescriptorPool::decode` will reject. The depth is bounded either
+            // way.
+            return Ok(());
+        }
+
+        let (tag, wire_type) = match decode_key(&mut buf) {
+            Ok(key) => key,
+            Err(_) => {
+                if recover(&mut frames, &mut buf) {
+                    continue;
+                }
+                return Ok(());
+            }
+        };
+
+        match wire_type {
+            WireType::Varint => {
+                if decode_varint(&mut buf).is_err() {
+                    if recover(&mut frames, &mut buf) {
+                        continue;
+                    }
+                    return Ok(());
+                }
+            }
+            WireType::SixtyFourBit | WireType::ThirtyTwoBit => {
+                let width = if wire_type == WireType::SixtyFourBit {
+                    8
+                } else {
+                    4
+                };
+                if buf.remaining() < width {
+                    if recover(&mut frames, &mut buf) {
+                        continue;
+                    }
+                    return Ok(());
+                }
+                buf.advance(width);
+            }
+            WireType::LengthDelimited => {
+                let len = match decode_varint(&mut buf) {
+                    Ok(len) => len,
+                    Err(_) => {
+                        if recover(&mut frames, &mut buf) {
+                            continue;
+                        }
+                        return Ok(());
+                    }
+                };
+                if len > buf.remaining() as u64 {
+                    if recover(&mut frames, &mut buf) {
+                        continue;
+                    }
+                    return Ok(());
+                }
+                if frames.len() >= MAX_DESCRIPTOR_WIRE_NESTING_DEPTH {
+                    bail!(
+                        "Protobuf descriptor set nesting depth exceeds limit of {}",
+                        MAX_DESCRIPTOR_WIRE_NESTING_DEPTH
+                    );
+                }
+                let end_remaining = buf.remaining() - len as usize;
+                frames.push(Frame::Len(end_remaining));
+            }
+            WireType::StartGroup => {
+                if frames.len() >= MAX_DESCRIPTOR_WIRE_NESTING_DEPTH {
+                    bail!(
+                        "Protobuf descriptor set nesting depth exceeds limit of {}",
+                        MAX_DESCRIPTOR_WIRE_NESTING_DEPTH
+                    );
+                }
+                frames.push(Frame::Group(tag));
+            }
+            WireType::EndGroup => match frames.last() {
+                Some(Frame::Group(open_tag)) if *open_tag == tag => {
+                    frames.pop();
+                }
+                _ => {
+                    if recover(&mut frames, &mut buf) {
+                        continue;
+                    }
+                    return Ok(());
+                }
+            },
+        }
+    }
+}
+
 fn pack_message(packer: &mut RowPacker, message: &DynamicMessage) -> Result<(), anyhow::Error> {
     for field_desc in message.descriptor().fields() {
         if !message.has_field(&field_desc) {
@@ -319,6 +479,66 @@ mod stack_overflow_verification {
         assert!(
             res.is_err(),
             "expected a nesting-depth error for a deep message chain"
+        );
+    }
+
+    /// The `type_name` reference chain above is flat on the wire, so it stresses
+    /// the relation-type derivation. A `DescriptorProto.nested_type` chain is
+    /// instead recursive on the wire, so it stresses `DescriptorPool::decode`
+    /// itself, which decodes the descriptor set recursively without a depth
+    /// limit (`no-recursion-limit`). This must be rejected before that decode
+    /// overflows the stack.
+    fn deep_nested_type_fds(depth: usize) -> Vec<u8> {
+        use prost::encoding::{WireType, encode_key, encode_varint, encoded_len_varint};
+
+        // Build the wire encoding directly. Materializing the nested
+        // `DescriptorProto` values would overflow Prost's *encoder* (and the
+        // recursive `Drop`) for the same reason we are guarding the decoder.
+        //
+        // `lens[k]` is the encoded size of the `DescriptorProto` nested `k`
+        // levels deep. Level 0 is an empty message (0 bytes); each further level
+        // wraps the previous one in a single `nested_type` field (field 3).
+        const NESTED_TYPE_FIELD: u32 = 3;
+        let key_len = {
+            let mut probe = vec![];
+            encode_key(NESTED_TYPE_FIELD, WireType::LengthDelimited, &mut probe);
+            probe.len()
+        };
+        let mut lens = vec![0usize; depth + 1];
+        for k in 1..=depth {
+            lens[k] = key_len + encoded_len_varint(lens[k - 1] as u64) + lens[k - 1];
+        }
+
+        let mut dp = Vec::with_capacity(lens[depth]);
+        for k in (1..=depth).rev() {
+            encode_key(NESTED_TYPE_FIELD, WireType::LengthDelimited, &mut dp);
+            encode_varint(lens[k - 1] as u64, &mut dp);
+        }
+
+        // Wrap the chain: FileDescriptorProto.message_type (field 4), then
+        // FileDescriptorSet.file (field 1).
+        let mut fdp = vec![];
+        encode_key(4, WireType::LengthDelimited, &mut fdp);
+        encode_varint(dp.len() as u64, &mut fdp);
+        fdp.extend_from_slice(&dp);
+
+        let mut fds = vec![];
+        encode_key(1, WireType::LengthDelimited, &mut fds);
+        encode_varint(fdp.len() as u64, &mut fds);
+        fds.extend_from_slice(&fdp);
+        fds
+    }
+
+    #[mz_ore::test]
+    fn deep_nested_type_does_not_overflow() {
+        let bytes = deep_nested_type_fds(50_000);
+        // Must return an error (wire nesting-depth limit), not abort with a
+        // stack overflow. Before the fix `DescriptorPool::decode` recursed once
+        // per `nested_type` level and aborted the process.
+        let res = DecodedDescriptors::from_bytes(&bytes, ".test.m0".to_string());
+        assert!(
+            res.is_err(),
+            "expected a nesting-depth error for a deeply nested descriptor"
         );
     }
 }

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -17,6 +17,12 @@ use prost_reflect::{
     ReflectMessage, Value,
 };
 
+/// Maximum Protobuf message nesting depth accepted when deriving a relation
+/// type. A message nested deeper than this is rejected rather than recursed
+/// into, so that a pathological (non-cyclic) message chain cannot overflow the
+/// stack while deriving the source's `RelationDesc`.
+const MAX_MESSAGE_NESTING_DEPTH: usize = 128;
+
 /// A decoded description of the schema of a Protobuf message.
 #[derive(Debug, PartialEq)]
 pub struct DecodedDescriptors {
@@ -152,6 +158,17 @@ fn derive_inner_type(
             if seen_messages.contains(m.name()) {
                 bail!("Recursive types are not supported: {}", m.name());
             }
+            // `seen_messages` holds the ancestor messages currently being
+            // resolved, so its length is the current nesting depth. Bounding it
+            // prevents a stack overflow from a deeply nested (but non-cyclic)
+            // message chain, whose descriptor set is a flat, cheap-to-encode
+            // list of messages that reference each other by name.
+            if seen_messages.len() >= MAX_MESSAGE_NESTING_DEPTH {
+                bail!(
+                    "Protobuf message nesting depth exceeds limit of {}",
+                    MAX_MESSAGE_NESTING_DEPTH
+                );
+            }
             seen_messages.insert(m.name().to_owned());
             let mut fields = Vec::with_capacity(m.fields().len());
             for field in m.fields() {
@@ -237,4 +254,71 @@ fn pack_value(
         ),
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod stack_overflow_verification {
+    // Regression test: a deep, non-cyclic protobuf message chain
+    // (`m0 -> m1 -> ... -> mN`) must not overflow the stack while deriving the
+    // relation type in `DecodedDescriptors::from_bytes` (reached during
+    // `CREATE SOURCE ... FORMAT PROTOBUF`). `derive_inner_type` bounds the
+    // nesting depth, so this returns a graceful error rather than aborting the
+    // process with a stack overflow.
+    use prost::Message;
+    use prost_types::field_descriptor_proto::{Label, Type};
+    use prost_types::{
+        DescriptorProto, FieldDescriptorProto, FileDescriptorProto, FileDescriptorSet,
+    };
+
+    use super::DecodedDescriptors;
+
+    fn deep_chain_fds(n: usize) -> Vec<u8> {
+        let message_type = (0..n)
+            .map(|i| {
+                let field = if i + 1 < n {
+                    FieldDescriptorProto {
+                        name: Some("f".into()),
+                        number: Some(1),
+                        label: Some(Label::Optional.into()),
+                        r#type: Some(Type::Message.into()),
+                        type_name: Some(format!(".test.m{}", i + 1)),
+                        ..Default::default()
+                    }
+                } else {
+                    FieldDescriptorProto {
+                        name: Some("f".into()),
+                        number: Some(1),
+                        label: Some(Label::Optional.into()),
+                        r#type: Some(Type::Int32.into()),
+                        ..Default::default()
+                    }
+                };
+                DescriptorProto {
+                    name: Some(format!("m{}", i)),
+                    field: vec![field],
+                    ..Default::default()
+                }
+            })
+            .collect();
+        let file = FileDescriptorProto {
+            name: Some("test.proto".into()),
+            package: Some("test".into()),
+            message_type,
+            syntax: Some("proto2".into()),
+            ..Default::default()
+        };
+        FileDescriptorSet { file: vec![file] }.encode_to_vec()
+    }
+
+    #[mz_ore::test]
+    fn deep_chain_does_not_overflow() {
+        let bytes = deep_chain_fds(50_000);
+        // Must return an error (nesting-depth limit), not abort with a stack
+        // overflow. Before the fix this recursed once per message and aborted.
+        let res = DecodedDescriptors::from_bytes(&bytes, ".test.m0".to_string());
+        assert!(
+            res.is_err(),
+            "expected a nesting-depth error for a deep message chain"
+        );
+    }
 }

--- a/src/ore/src/stack.rs
+++ b/src/ore/src/stack.rs
@@ -107,6 +107,23 @@ where
     stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, f)
 }
 
+/// Runs `f` on a stack with at least `stack_size` bytes of available space,
+/// allocating a new stack of that size if the current one is smaller.
+///
+/// Unlike [`maybe_grow`], which is called at each level of a recursion and
+/// grows the stack in fixed increments on demand, this function is for
+/// delegating into recursive code that cannot be instrumented per level (e.g.
+/// generated Protobuf encode/decode, or dropping a deeply nested foreign
+/// type). The callee gets a single stack allocation, so `stack_size` must be
+/// chosen large enough for the deepest recursion the delegated code can
+/// reach. The allocation is virtual memory; pages are only backed once used.
+pub fn grow<F, R>(stack_size: usize, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    stacker::maybe_grow(stack_size, stack_size, f)
+}
+
 /// A trait for types which support bounded recursion to prevent stack overflow.
 ///
 /// The rather odd design of this trait allows checked recursion to be added to

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -586,42 +586,46 @@ impl Serialize for JsonbDatum<'_> {
     where
         S: Serializer,
     {
-        match self.0 {
-            Datum::JsonNull => serializer.serialize_none(),
-            Datum::True => serializer.serialize_bool(true),
-            Datum::False => serializer.serialize_bool(false),
-            Datum::Numeric(n) => {
-                // To serialize an arbitrary-precision number, we present
-                // serde_json with the following magic struct:
-                //
-                //     struct $serde_json::private::Number {
-                //          $serde_json::private::Number: <NUMBER VALUE>,
-                //     }
-                //
-                let mut s = serializer.serialize_struct(SERDE_JSON_NUMBER_TOKEN, 1)?;
-                s.serialize_field(
-                    SERDE_JSON_NUMBER_TOKEN,
-                    &n.into_inner().to_standard_notation_string(),
-                )?;
-                s.end()
-            }
-            Datum::String(s) => serializer.serialize_str(s),
-            Datum::List(list) => {
-                let mut seq = serializer.serialize_seq(None)?;
-                for e in list.iter() {
-                    seq.serialize_element(&JsonbDatum(e))?;
+        // Grow the stack as needed: a jsonb value can be arbitrarily deeply
+        // nested, and this serializes it recursively.
+        mz_ore::stack::maybe_grow(move || {
+            match self.0 {
+                Datum::JsonNull => serializer.serialize_none(),
+                Datum::True => serializer.serialize_bool(true),
+                Datum::False => serializer.serialize_bool(false),
+                Datum::Numeric(n) => {
+                    // To serialize an arbitrary-precision number, we present
+                    // serde_json with the following magic struct:
+                    //
+                    //     struct $serde_json::private::Number {
+                    //          $serde_json::private::Number: <NUMBER VALUE>,
+                    //     }
+                    //
+                    let mut s = serializer.serialize_struct(SERDE_JSON_NUMBER_TOKEN, 1)?;
+                    s.serialize_field(
+                        SERDE_JSON_NUMBER_TOKEN,
+                        &n.into_inner().to_standard_notation_string(),
+                    )?;
+                    s.end()
                 }
-                seq.end()
-            }
-            Datum::Map(dict) => {
-                let mut map = serializer.serialize_map(None)?;
-                for (k, v) in dict.iter() {
-                    map.serialize_entry(k, &JsonbDatum(v))?;
+                Datum::String(s) => serializer.serialize_str(s),
+                Datum::List(list) => {
+                    let mut seq = serializer.serialize_seq(None)?;
+                    for e in list.iter() {
+                        seq.serialize_element(&JsonbDatum(e))?;
+                    }
+                    seq.end()
                 }
-                map.end()
+                Datum::Map(dict) => {
+                    let mut map = serializer.serialize_map(None)?;
+                    for (k, v) in dict.iter() {
+                        map.serialize_entry(k, &JsonbDatum(v))?;
+                    }
+                    map.end()
+                }
+                d => unreachable!("not a json-compatible datum: {:?}", d),
             }
-            d => unreachable!("not a json-compatible datum: {:?}", d),
-        }
+        })
     }
 }
 

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1611,19 +1611,12 @@ impl fmt::Display for Datum<'_> {
 ///
 /// There is an indirect correspondence between `Datum` variants and `SqlScalarType`
 /// variants: every `Datum` variant belongs to one or more `SqlScalarType` variants.
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    Ord,
-    PartialOrd,
-    Hash,
-    EnumKind,
-    MzReflect
-)]
+///
+/// `Clone`, `Drop`, `Serialize`, and `Deserialize` are implemented manually
+/// because values can be nested arbitrarily deeply (e.g. record types derived
+/// from Protobuf schemas), and the derived impls recurse once per nesting
+/// level on a fixed stack. The manual impls grow the stack on demand instead.
+#[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Hash, EnumKind, MzReflect)]
 #[enum_kind(SqlScalarBaseType, derive(PartialOrd, Ord, Hash))]
 pub enum SqlScalarType {
     /// The type of [`Datum::True`] and [`Datum::False`].
@@ -1766,6 +1759,202 @@ pub enum SqlScalarType {
     AclItem,
 }
 
+/// Serialization mirror of [`SqlScalarType`], used by the manual
+/// `Serialize`/`Deserialize` impls below (see [`serde(remote)`]).
+///
+/// This must list the exact variants of `SqlScalarType` in the same order, so
+/// that the derived wire format, in particular the variant indices used by
+/// index-based formats like bincode, is identical to what a derive on
+/// `SqlScalarType` itself would produce.
+///
+/// [`serde(remote)`]: https://serde.rs/remote-derive.html
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "SqlScalarType")]
+enum SqlScalarTypeDef {
+    Bool,
+    Int16,
+    Int32,
+    Int64,
+    UInt16,
+    UInt32,
+    UInt64,
+    Float32,
+    Float64,
+    Numeric {
+        max_scale: Option<NumericMaxScale>,
+    },
+    Date,
+    Time,
+    Timestamp {
+        precision: Option<TimestampPrecision>,
+    },
+    TimestampTz {
+        precision: Option<TimestampPrecision>,
+    },
+    Interval,
+    PgLegacyChar,
+    PgLegacyName,
+    Bytes,
+    String,
+    Char {
+        length: Option<CharLength>,
+    },
+    VarChar {
+        max_length: Option<VarCharMaxLength>,
+    },
+    Jsonb,
+    Uuid,
+    Array(Box<SqlScalarType>),
+    List {
+        element_type: Box<SqlScalarType>,
+        custom_id: Option<CatalogItemId>,
+    },
+    Record {
+        fields: Box<[(ColumnName, SqlColumnType)]>,
+        custom_id: Option<CatalogItemId>,
+    },
+    Oid,
+    Map {
+        value_type: Box<SqlScalarType>,
+        custom_id: Option<CatalogItemId>,
+    },
+    RegProc,
+    RegType,
+    RegClass,
+    Int2Vector,
+    MzTimestamp,
+    Range {
+        element_type: Box<SqlScalarType>,
+    },
+    MzAclItem,
+    AclItem,
+}
+
+impl Serialize for SqlScalarType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Serializing a nested type recurses once per nesting level, so grow
+        // the stack on demand. The `SqlScalarTypeDef` mirror keeps the format
+        // identical to a derived impl.
+        mz_ore::stack::maybe_grow(|| SqlScalarTypeDef::serialize(self, serializer))
+    }
+}
+
+impl<'de> Deserialize<'de> for SqlScalarType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // See the `Serialize` impl for why this grows the stack.
+        mz_ore::stack::maybe_grow(|| SqlScalarTypeDef::deserialize(deserializer))
+    }
+}
+
+impl Clone for SqlScalarType {
+    fn clone(&self) -> Self {
+        match self {
+            // Cloning a nested variant recurses once per nesting level, so
+            // grow the stack on demand.
+            SqlScalarType::Array(element_type) => {
+                mz_ore::stack::maybe_grow(|| SqlScalarType::Array(element_type.clone()))
+            }
+            SqlScalarType::List {
+                element_type,
+                custom_id,
+            } => mz_ore::stack::maybe_grow(|| SqlScalarType::List {
+                element_type: element_type.clone(),
+                custom_id: *custom_id,
+            }),
+            SqlScalarType::Record { fields, custom_id } => {
+                mz_ore::stack::maybe_grow(|| SqlScalarType::Record {
+                    fields: fields.clone(),
+                    custom_id: *custom_id,
+                })
+            }
+            SqlScalarType::Map {
+                value_type,
+                custom_id,
+            } => mz_ore::stack::maybe_grow(|| SqlScalarType::Map {
+                value_type: value_type.clone(),
+                custom_id: *custom_id,
+            }),
+            SqlScalarType::Range { element_type } => {
+                mz_ore::stack::maybe_grow(|| SqlScalarType::Range {
+                    element_type: element_type.clone(),
+                })
+            }
+            SqlScalarType::Bool => SqlScalarType::Bool,
+            SqlScalarType::Int16 => SqlScalarType::Int16,
+            SqlScalarType::Int32 => SqlScalarType::Int32,
+            SqlScalarType::Int64 => SqlScalarType::Int64,
+            SqlScalarType::UInt16 => SqlScalarType::UInt16,
+            SqlScalarType::UInt32 => SqlScalarType::UInt32,
+            SqlScalarType::UInt64 => SqlScalarType::UInt64,
+            SqlScalarType::Float32 => SqlScalarType::Float32,
+            SqlScalarType::Float64 => SqlScalarType::Float64,
+            SqlScalarType::Numeric { max_scale } => SqlScalarType::Numeric {
+                max_scale: *max_scale,
+            },
+            SqlScalarType::Date => SqlScalarType::Date,
+            SqlScalarType::Time => SqlScalarType::Time,
+            SqlScalarType::Timestamp { precision } => SqlScalarType::Timestamp {
+                precision: *precision,
+            },
+            SqlScalarType::TimestampTz { precision } => SqlScalarType::TimestampTz {
+                precision: *precision,
+            },
+            SqlScalarType::Interval => SqlScalarType::Interval,
+            SqlScalarType::PgLegacyChar => SqlScalarType::PgLegacyChar,
+            SqlScalarType::PgLegacyName => SqlScalarType::PgLegacyName,
+            SqlScalarType::Bytes => SqlScalarType::Bytes,
+            SqlScalarType::String => SqlScalarType::String,
+            SqlScalarType::Char { length } => SqlScalarType::Char { length: *length },
+            SqlScalarType::VarChar { max_length } => SqlScalarType::VarChar {
+                max_length: *max_length,
+            },
+            SqlScalarType::Jsonb => SqlScalarType::Jsonb,
+            SqlScalarType::Uuid => SqlScalarType::Uuid,
+            SqlScalarType::Oid => SqlScalarType::Oid,
+            SqlScalarType::RegProc => SqlScalarType::RegProc,
+            SqlScalarType::RegType => SqlScalarType::RegType,
+            SqlScalarType::RegClass => SqlScalarType::RegClass,
+            SqlScalarType::Int2Vector => SqlScalarType::Int2Vector,
+            SqlScalarType::MzTimestamp => SqlScalarType::MzTimestamp,
+            SqlScalarType::MzAclItem => SqlScalarType::MzAclItem,
+            SqlScalarType::AclItem => SqlScalarType::AclItem,
+        }
+    }
+}
+
+impl Drop for SqlScalarType {
+    fn drop(&mut self) {
+        match self {
+            // Extract the nested value and drop it on a grown stack, so that
+            // dropping a deeply nested type does not overflow. The extracted
+            // value's own drop passes through here again, once per nesting
+            // level. The replacement leaf value left behind is dropped by the
+            // compiler-generated glue without further recursion.
+            SqlScalarType::Array(element_type)
+            | SqlScalarType::List { element_type, .. }
+            | SqlScalarType::Map {
+                value_type: element_type,
+                ..
+            }
+            | SqlScalarType::Range { element_type } => {
+                let element_type = std::mem::replace(element_type.as_mut(), SqlScalarType::Bool);
+                mz_ore::stack::maybe_grow(|| drop(element_type));
+            }
+            SqlScalarType::Record { fields, .. } => {
+                let fields = std::mem::take(fields);
+                mz_ore::stack::maybe_grow(|| drop(fields));
+            }
+            _ => (),
+        }
+    }
+}
+
 impl RustType<ProtoRecordField> for (ColumnName, SqlColumnType) {
     fn into_proto(&self) -> ProtoRecordField {
         ProtoRecordField {
@@ -1791,7 +1980,14 @@ impl RustType<ProtoScalarType> for SqlScalarType {
         use crate::relation_and_scalar::proto_scalar_type::Kind::*;
         use crate::relation_and_scalar::proto_scalar_type::*;
 
-        ProtoScalarType {
+        // Converting a nested type recurses once per nesting level, and the
+        // nesting can be arbitrarily deep, so grow the stack on demand.
+        //
+        // NOTE: the returned proto tree drops (and is typically encoded by
+        // prost) with unguarded recursion, so deeply nested types must be
+        // converted and consumed within a sufficiently large stack scope, see
+        // `mz_ore::stack::grow`.
+        mz_ore::stack::maybe_grow(|| ProtoScalarType {
             kind: Some(match self {
                 SqlScalarType::Bool => Bool(()),
                 SqlScalarType::Int16 => Int16(()),
@@ -1857,7 +2053,7 @@ impl RustType<ProtoScalarType> for SqlScalarType {
                 SqlScalarType::MzAclItem => MzAclItem(()),
                 SqlScalarType::AclItem => AclItem(()),
             }),
-        }
+        })
     }
 
     fn from_proto(proto: ProtoScalarType) -> Result<Self, TryFromProtoError> {
@@ -1867,7 +2063,8 @@ impl RustType<ProtoScalarType> for SqlScalarType {
             .kind
             .ok_or_else(|| TryFromProtoError::missing_field("ProtoScalarType::Kind"))?;
 
-        match kind {
+        // See `into_proto` for why this grows the stack.
+        mz_ore::stack::maybe_grow(|| match kind {
             Bool(()) => Ok(SqlScalarType::Bool),
             Int16(()) => Ok(SqlScalarType::Int16),
             Int32(()) => Ok(SqlScalarType::Int32),
@@ -1942,7 +2139,7 @@ impl RustType<ProtoScalarType> for SqlScalarType {
             }),
             MzAclItem(()) => Ok(SqlScalarType::MzAclItem),
             AclItem(()) => Ok(SqlScalarType::AclItem),
-        }
+        })
     }
 }
 
@@ -3589,9 +3786,12 @@ impl SqlScalarType {
     /// Panics if called on anything other than a [`SqlScalarType::Array`] or
     /// [`SqlScalarType::Int2Vector`].
     pub fn unwrap_array_element_type(&self) -> &SqlScalarType {
+        // A named static because `SqlScalarType` implements `Drop`, which
+        // rules out const-promotion of `&SqlScalarType::Int16`.
+        static INT16: SqlScalarType = SqlScalarType::Int16;
         match self {
             SqlScalarType::Array(s) => &**s,
-            SqlScalarType::Int2Vector => &SqlScalarType::Int16,
+            SqlScalarType::Int2Vector => &INT16,
             _ => panic!(
                 "SqlScalarType::unwrap_array_element_type called on {:?}",
                 self
@@ -3607,9 +3807,10 @@ impl SqlScalarType {
     /// Panics if called on anything other than a [`SqlScalarType::Array`],
     /// [`SqlScalarType::Int2Vector`], or [`SqlScalarType::List`].
     pub fn unwrap_collection_element_type(&self) -> &SqlScalarType {
+        static INT16: SqlScalarType = SqlScalarType::Int16;
         match self {
             SqlScalarType::Array(element_type) => element_type,
-            SqlScalarType::Int2Vector => &SqlScalarType::Int16,
+            SqlScalarType::Int2Vector => &INT16,
             SqlScalarType::List { element_type, .. } => element_type,
             _ => panic!(
                 "SqlScalarType::unwrap_collection_element_type called on {:?}",
@@ -3696,10 +3897,13 @@ impl SqlScalarType {
     /// Note that if adding any near matches besides unsigned ints, consider
     /// extending/generalizing how `guess_best_common_type` uses this function.
     pub fn near_match(&self) -> Option<&'static SqlScalarType> {
+        static INT32: SqlScalarType = SqlScalarType::Int32;
+        static INT64: SqlScalarType = SqlScalarType::Int64;
+        static NUMERIC: SqlScalarType = SqlScalarType::Numeric { max_scale: None };
         match self {
-            SqlScalarType::UInt16 => Some(&SqlScalarType::Int32),
-            SqlScalarType::UInt32 => Some(&SqlScalarType::Int64),
-            SqlScalarType::UInt64 => Some(&SqlScalarType::Numeric { max_scale: None }),
+            SqlScalarType::UInt16 => Some(&INT32),
+            SqlScalarType::UInt32 => Some(&INT64),
+            SqlScalarType::UInt64 => Some(&NUMERIC),
             _ => None,
         }
     }
@@ -4357,7 +4561,10 @@ impl SqlScalarType {
     pub fn enumerate() -> &'static [Self] {
         // TODO: Is there a compile-time way to make sure any new
         // non-parameterized types get added here?
-        &[
+        //
+        // A named static because `SqlScalarType` implements `Drop`, which
+        // rules out const-promotion of the array literal.
+        static ENUMERATED: &[SqlScalarType] = &[
             SqlScalarType::Bool,
             SqlScalarType::Int16,
             SqlScalarType::Int32,
@@ -4425,14 +4632,21 @@ impl SqlScalarType {
                 element_type: todo!(),
             }
             */
-        ]
+        ];
+        ENUMERATED
     }
 
     /// Returns the appropriate element type for making a [`SqlScalarType::Array`] whose elements are
     /// of `self`.
     ///
     /// If the type is not compatible with making an array, returns in the error position.
-    pub fn array_of_self_elem_type(self) -> Result<SqlScalarType, SqlScalarType> {
+    pub fn array_of_self_elem_type(mut self) -> Result<SqlScalarType, SqlScalarType> {
+        // Take the element out through the box: `self` cannot be destructured
+        // by value because `SqlScalarType` implements `Drop`.
+        if let SqlScalarType::Array(elem) = &mut self {
+            let elem = std::mem::replace(elem.as_mut(), SqlScalarType::Bool);
+            return elem.array_of_self_elem_type();
+        }
         match self {
             t @ (SqlScalarType::AclItem
             | SqlScalarType::Bool
@@ -4467,7 +4681,7 @@ impl SqlScalarType {
             | SqlScalarType::Range { .. }
             | SqlScalarType::MzAclItem { .. }) => Ok(t),
 
-            SqlScalarType::Array(elem) => Ok(elem.array_of_self_elem_type()?),
+            SqlScalarType::Array(_) => unreachable!("handled above"),
 
             // https://github.com/MaterializeInc/database-issues/issues/2360
             t @ (SqlScalarType::Char { .. }
@@ -4725,7 +4939,11 @@ impl Arbitrary for ReprScalarType {
 ///
 /// It is important that any new variants for this enum be added to the `Arbitrary` instance
 /// and the `union` method.
-#[derive(Clone, Debug, EnumKind, Serialize, Deserialize, MzReflect)]
+///
+/// `Clone`, `Drop`, `Serialize`, and `Deserialize` are implemented manually
+/// because values can be nested arbitrarily deeply, see the
+/// [`SqlScalarType`] docs.
+#[derive(Debug, EnumKind, MzReflect)]
 #[enum_kind(ReprScalarBaseType, derive(PartialOrd, Ord, Hash))]
 pub enum ReprScalarType {
     Bool,
@@ -4757,6 +4975,142 @@ pub enum ReprScalarType {
     Range { element_type: Box<ReprScalarType> },
     MzAclItem,
     AclItem,
+}
+
+/// Serialization mirror of [`ReprScalarType`], see [`SqlScalarTypeDef`].
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "ReprScalarType")]
+enum ReprScalarTypeDef {
+    Bool,
+    Int16,
+    Int32,
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Float32,
+    Float64,
+    Numeric,
+    Date,
+    Time,
+    Timestamp,
+    TimestampTz,
+    MzTimestamp,
+    Interval,
+    Bytes,
+    Jsonb,
+    String,
+    Uuid,
+    Array(Box<ReprScalarType>),
+    Int2Vector,
+    List { element_type: Box<ReprScalarType> },
+    Record { fields: Box<[ReprColumnType]> },
+    Map { value_type: Box<ReprScalarType> },
+    Range { element_type: Box<ReprScalarType> },
+    MzAclItem,
+    AclItem,
+}
+
+impl Serialize for ReprScalarType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Serializing a nested type recurses once per nesting level, so grow
+        // the stack on demand. The `ReprScalarTypeDef` mirror keeps the
+        // format identical to a derived impl.
+        mz_ore::stack::maybe_grow(|| ReprScalarTypeDef::serialize(self, serializer))
+    }
+}
+
+impl<'de> Deserialize<'de> for ReprScalarType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // See the `Serialize` impl for why this grows the stack.
+        mz_ore::stack::maybe_grow(|| ReprScalarTypeDef::deserialize(deserializer))
+    }
+}
+
+impl Clone for ReprScalarType {
+    fn clone(&self) -> Self {
+        match self {
+            // Cloning a nested variant recurses once per nesting level, so
+            // grow the stack on demand.
+            ReprScalarType::Array(element_type) => {
+                mz_ore::stack::maybe_grow(|| ReprScalarType::Array(element_type.clone()))
+            }
+            ReprScalarType::List { element_type } => {
+                mz_ore::stack::maybe_grow(|| ReprScalarType::List {
+                    element_type: element_type.clone(),
+                })
+            }
+            ReprScalarType::Record { fields } => {
+                mz_ore::stack::maybe_grow(|| ReprScalarType::Record {
+                    fields: fields.clone(),
+                })
+            }
+            ReprScalarType::Map { value_type } => {
+                mz_ore::stack::maybe_grow(|| ReprScalarType::Map {
+                    value_type: value_type.clone(),
+                })
+            }
+            ReprScalarType::Range { element_type } => {
+                mz_ore::stack::maybe_grow(|| ReprScalarType::Range {
+                    element_type: element_type.clone(),
+                })
+            }
+            ReprScalarType::Bool => ReprScalarType::Bool,
+            ReprScalarType::Int16 => ReprScalarType::Int16,
+            ReprScalarType::Int32 => ReprScalarType::Int32,
+            ReprScalarType::Int64 => ReprScalarType::Int64,
+            ReprScalarType::UInt8 => ReprScalarType::UInt8,
+            ReprScalarType::UInt16 => ReprScalarType::UInt16,
+            ReprScalarType::UInt32 => ReprScalarType::UInt32,
+            ReprScalarType::UInt64 => ReprScalarType::UInt64,
+            ReprScalarType::Float32 => ReprScalarType::Float32,
+            ReprScalarType::Float64 => ReprScalarType::Float64,
+            ReprScalarType::Numeric => ReprScalarType::Numeric,
+            ReprScalarType::Date => ReprScalarType::Date,
+            ReprScalarType::Time => ReprScalarType::Time,
+            ReprScalarType::Timestamp => ReprScalarType::Timestamp,
+            ReprScalarType::TimestampTz => ReprScalarType::TimestampTz,
+            ReprScalarType::MzTimestamp => ReprScalarType::MzTimestamp,
+            ReprScalarType::Interval => ReprScalarType::Interval,
+            ReprScalarType::Bytes => ReprScalarType::Bytes,
+            ReprScalarType::Jsonb => ReprScalarType::Jsonb,
+            ReprScalarType::String => ReprScalarType::String,
+            ReprScalarType::Uuid => ReprScalarType::Uuid,
+            ReprScalarType::Int2Vector => ReprScalarType::Int2Vector,
+            ReprScalarType::MzAclItem => ReprScalarType::MzAclItem,
+            ReprScalarType::AclItem => ReprScalarType::AclItem,
+        }
+    }
+}
+
+impl Drop for ReprScalarType {
+    fn drop(&mut self) {
+        match self {
+            // See the `Drop` impl for `SqlScalarType` for why this extracts
+            // the nested value and drops it on a grown stack.
+            ReprScalarType::Array(element_type)
+            | ReprScalarType::List { element_type }
+            | ReprScalarType::Map {
+                value_type: element_type,
+            }
+            | ReprScalarType::Range { element_type } => {
+                let element_type = std::mem::replace(element_type.as_mut(), ReprScalarType::Bool);
+                mz_ore::stack::maybe_grow(|| drop(element_type));
+            }
+            ReprScalarType::Record { fields } => {
+                let fields = std::mem::take(fields);
+                mz_ore::stack::maybe_grow(|| drop(fields));
+            }
+            _ => (),
+        }
+    }
 }
 
 impl PartialEq for ReprScalarType {
@@ -5014,7 +5368,9 @@ impl ReprScalarType {
 
 impl From<&SqlScalarType> for ReprScalarType {
     fn from(typ: &SqlScalarType) -> Self {
-        match typ {
+        // Converting a nested type recurses once per nesting level, and the
+        // nesting can be arbitrarily deep, so grow the stack on demand.
+        mz_ore::stack::maybe_grow(|| match typ {
             SqlScalarType::Bool => ReprScalarType::Bool,
             SqlScalarType::Int16 => ReprScalarType::Int16,
             SqlScalarType::Int32 => ReprScalarType::Int32,
@@ -5070,7 +5426,7 @@ impl From<&SqlScalarType> for ReprScalarType {
             },
             SqlScalarType::MzAclItem => ReprScalarType::MzAclItem,
             SqlScalarType::AclItem => ReprScalarType::AclItem,
-        }
+        })
     }
 }
 
@@ -5095,7 +5451,9 @@ impl SqlScalarType {
     /// assert_eq!(sql_rt, SqlScalarType::String);
     /// ```
     pub fn from_repr(repr: &ReprScalarType) -> Self {
-        match repr {
+        // Converting a nested type recurses once per nesting level, and the
+        // nesting can be arbitrarily deep, so grow the stack on demand.
+        mz_ore::stack::maybe_grow(|| match repr {
             ReprScalarType::Bool => SqlScalarType::Bool,
             ReprScalarType::Int16 => SqlScalarType::Int16,
             ReprScalarType::Int32 => SqlScalarType::Int32,
@@ -5148,7 +5506,7 @@ impl SqlScalarType {
             },
             ReprScalarType::MzAclItem => SqlScalarType::MzAclItem,
             ReprScalarType::AclItem => SqlScalarType::AclItem,
-        }
+        })
     }
 }
 
@@ -5333,7 +5691,9 @@ pub fn arb_datum_for_column(column_type: SqlColumnType) -> impl Strategy<Value =
 /// Generates an arbitrary [`PropDatum`] for the provided [`SqlScalarType`].
 #[cfg(any(test, feature = "proptest"))]
 pub fn arb_datum_for_scalar(scalar_type: SqlScalarType) -> impl Strategy<Value = PropDatum> {
-    match scalar_type {
+    // Match on a reference: `SqlScalarType` implements `Drop`, so its fields
+    // cannot be moved out of a value.
+    match &scalar_type {
         SqlScalarType::Bool => any::<bool>().prop_map(PropDatum::Bool).boxed(),
         SqlScalarType::Int16 => any::<i16>().prop_map(PropDatum::Int16).boxed(),
         SqlScalarType::Int32 => any::<i32>().prop_map(PropDatum::Int32).boxed(),
@@ -5399,17 +5759,21 @@ pub fn arb_datum_for_scalar(scalar_type: SqlScalarType) -> impl Strategy<Value =
         SqlScalarType::MzAclItem => any::<MzAclItem>().prop_map(PropDatum::MzAclItem).boxed(),
         SqlScalarType::Range { element_type } => {
             let data_strat = (
-                arb_datum_for_scalar(*element_type.clone()),
-                arb_datum_for_scalar(*element_type),
+                arb_datum_for_scalar((**element_type).clone()),
+                arb_datum_for_scalar((**element_type).clone()),
             );
             arb_range(data_strat).prop_map(PropDatum::Range).boxed()
         }
-        SqlScalarType::List { element_type, .. } => arb_list(arb_datum_for_scalar(*element_type))
-            .prop_map(PropDatum::List)
-            .boxed(),
-        SqlScalarType::Array(element_type) => arb_array(arb_datum_for_scalar(*element_type))
-            .prop_map(PropDatum::Array)
-            .boxed(),
+        SqlScalarType::List { element_type, .. } => {
+            arb_list(arb_datum_for_scalar((**element_type).clone()))
+                .prop_map(PropDatum::List)
+                .boxed()
+        }
+        SqlScalarType::Array(element_type) => {
+            arb_array(arb_datum_for_scalar((**element_type).clone()))
+                .prop_map(PropDatum::Array)
+                .boxed()
+        }
         SqlScalarType::Int2Vector => {
             // `int2vector` is, by definition, a 1-dimensional array of `int2`
             // values (matching PostgreSQL's `int2vector` and Materialize's
@@ -5431,9 +5795,11 @@ pub fn arb_datum_for_scalar(scalar_type: SqlScalarType) -> impl Strategy<Value =
                 })
                 .boxed()
         }
-        SqlScalarType::Map { value_type, .. } => arb_dict(arb_datum_for_scalar(*value_type))
-            .prop_map(PropDatum::Map)
-            .boxed(),
+        SqlScalarType::Map { value_type, .. } => {
+            arb_dict(arb_datum_for_scalar((**value_type).clone()))
+                .prop_map(PropDatum::Map)
+                .boxed()
+        }
         SqlScalarType::Record { fields, .. } => {
             let field_strats = fields.iter().map(|(name, ty)| {
                 (
@@ -5926,6 +6292,66 @@ mod tests {
         }
         let deep = row.unpack_first();
         assert!(deep.is_instance_of_sql(&SqlScalarType::Jsonb.nullable(true)));
+    }
+
+    // Regression: operations on a deeply nested type (e.g. a record type
+    // derived from a Protobuf schema) must not overflow the stack. Clone,
+    // drop, the proto conversions, and the SQL<->repr conversions each
+    // recurse once per nesting level and grow the stack on demand.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // too slow
+    fn deeply_nested_type_ops_do_not_overflow() {
+        const DEPTH: usize = 50_000;
+
+        // Iterative construction, which needs no stack guard.
+        let mut ty = SqlScalarType::Int32;
+        for _ in 0..DEPTH {
+            ty = SqlScalarType::Record {
+                fields: vec![(ColumnName::from("f"), ty.nullable(true))].into(),
+                custom_id: None,
+            };
+        }
+
+        // Iterative depth measurement, likewise. The derived `PartialEq` still
+        // recurses on a fixed stack, so equality assertions are off limits
+        // here.
+        fn depth(mut ty: &SqlScalarType) -> usize {
+            let mut depth = 0;
+            while let SqlScalarType::Record { fields, .. } = ty {
+                depth += 1;
+                ty = &fields[0].1.scalar_type;
+            }
+            depth
+        }
+
+        let clone = ty.clone();
+        assert_eq!(depth(&clone), DEPTH);
+        drop(clone);
+
+        let repr = ReprScalarType::from(&ty);
+        let repr_clone = repr.clone();
+        drop(repr_clone);
+        let sql = SqlScalarType::from_repr(&repr);
+        assert_eq!(depth(&sql), DEPTH);
+        drop(sql);
+        drop(repr);
+
+        // Serde serialization (e.g. for the bincode cluster transport)
+        // recurses once per nesting level in both directions.
+        let bytes = bincode::serialize(&ty).expect("deep type serializes");
+        let deserialized: SqlScalarType =
+            bincode::deserialize(&bytes).expect("deep type deserializes");
+        assert_eq!(depth(&deserialized), DEPTH);
+
+        // The `RustType` conversions grow the stack themselves, but the proto
+        // tree they produce is prost-generated and drops with unguarded
+        // recursion, so it must live and die within a `grow` scope, as in
+        // `SourceData::encode_schema`.
+        let roundtripped = mz_ore::stack::grow(1 << 28, || {
+            let proto = ty.into_proto();
+            SqlScalarType::from_proto(proto).expect("valid proto")
+        });
+        assert_eq!(depth(&roundtripped), DEPTH);
     }
 
     proptest! {

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1139,130 +1139,135 @@ impl<'a> Datum<'a> {
     /// See [`Datum<'a>::is_instance_of`] for comparing `Datum`s to `ReprColumnType`s.
     pub fn is_instance_of_sql(self, column_type: &SqlColumnType) -> bool {
         fn is_instance_of_scalar(datum: Datum, scalar_type: &SqlScalarType) -> bool {
-            if let SqlScalarType::Jsonb = scalar_type {
-                // json type checking
-                match datum {
-                    Datum::Dummy => false,
-                    Datum::JsonNull
-                    | Datum::False
-                    | Datum::True
-                    | Datum::Numeric(_)
-                    | Datum::String(_) => true,
-                    Datum::List(list) => list
-                        .iter()
-                        .all(|elem| is_instance_of_scalar(elem, scalar_type)),
-                    Datum::Map(dict) => dict
-                        .iter()
-                        .all(|(_key, val)| is_instance_of_scalar(val, scalar_type)),
-                    _ => false,
-                }
-            } else {
-                // sql type checking
-                match (datum, scalar_type) {
-                    (Datum::Dummy, _) => false,
-                    (Datum::Null, _) => false,
-                    (Datum::False, SqlScalarType::Bool) => true,
-                    (Datum::False, _) => false,
-                    (Datum::True, SqlScalarType::Bool) => true,
-                    (Datum::True, _) => false,
-                    (Datum::Int16(_), SqlScalarType::Int16) => true,
-                    (Datum::Int16(_), _) => false,
-                    (Datum::Int32(_), SqlScalarType::Int32) => true,
-                    (Datum::Int32(_), _) => false,
-                    (Datum::Int64(_), SqlScalarType::Int64) => true,
-                    (Datum::Int64(_), _) => false,
-                    (Datum::UInt8(_), SqlScalarType::PgLegacyChar) => true,
-                    (Datum::UInt8(_), _) => false,
-                    (Datum::UInt16(_), SqlScalarType::UInt16) => true,
-                    (Datum::UInt16(_), _) => false,
-                    (Datum::UInt32(_), SqlScalarType::Oid) => true,
-                    (Datum::UInt32(_), SqlScalarType::RegClass) => true,
-                    (Datum::UInt32(_), SqlScalarType::RegProc) => true,
-                    (Datum::UInt32(_), SqlScalarType::RegType) => true,
-                    (Datum::UInt32(_), SqlScalarType::UInt32) => true,
-                    (Datum::UInt32(_), _) => false,
-                    (Datum::UInt64(_), SqlScalarType::UInt64) => true,
-                    (Datum::UInt64(_), _) => false,
-                    (Datum::Float32(_), SqlScalarType::Float32) => true,
-                    (Datum::Float32(_), _) => false,
-                    (Datum::Float64(_), SqlScalarType::Float64) => true,
-                    (Datum::Float64(_), _) => false,
-                    (Datum::Date(_), SqlScalarType::Date) => true,
-                    (Datum::Date(_), _) => false,
-                    (Datum::Time(_), SqlScalarType::Time) => true,
-                    (Datum::Time(_), _) => false,
-                    (Datum::Timestamp(_), SqlScalarType::Timestamp { .. }) => true,
-                    (Datum::Timestamp(_), _) => false,
-                    (Datum::TimestampTz(_), SqlScalarType::TimestampTz { .. }) => true,
-                    (Datum::TimestampTz(_), _) => false,
-                    (Datum::Interval(_), SqlScalarType::Interval) => true,
-                    (Datum::Interval(_), _) => false,
-                    (Datum::Bytes(_), SqlScalarType::Bytes) => true,
-                    (Datum::Bytes(_), _) => false,
-                    (Datum::String(_), SqlScalarType::String)
-                    | (Datum::String(_), SqlScalarType::VarChar { .. })
-                    | (Datum::String(_), SqlScalarType::Char { .. })
-                    | (Datum::String(_), SqlScalarType::PgLegacyName) => true,
-                    (Datum::String(_), _) => false,
-                    (Datum::Uuid(_), SqlScalarType::Uuid) => true,
-                    (Datum::Uuid(_), _) => false,
-                    (Datum::Array(array), SqlScalarType::Array(t)) => {
-                        array.elements.iter().all(|e| match e {
-                            Datum::Null => true,
-                            _ => is_instance_of_scalar(e, t),
-                        })
+            // Grow the stack as needed: `jsonb` (and nested list/map/record/range)
+            // values can be arbitrarily deep, and this checks them recursively.
+            mz_ore::stack::maybe_grow(|| {
+                if let SqlScalarType::Jsonb = scalar_type {
+                    // json type checking
+                    match datum {
+                        Datum::Dummy => false,
+                        Datum::JsonNull
+                        | Datum::False
+                        | Datum::True
+                        | Datum::Numeric(_)
+                        | Datum::String(_) => true,
+                        Datum::List(list) => list
+                            .iter()
+                            .all(|elem| is_instance_of_scalar(elem, scalar_type)),
+                        Datum::Map(dict) => dict
+                            .iter()
+                            .all(|(_key, val)| is_instance_of_scalar(val, scalar_type)),
+                        _ => false,
                     }
-                    (Datum::Array(array), SqlScalarType::Int2Vector) => {
-                        array.has_int2vector_dims()
-                            && array
-                                .elements
-                                .iter()
-                                .all(|e| is_instance_of_scalar(e, &SqlScalarType::Int16))
-                    }
-                    (Datum::Array(_), _) => false,
-                    (Datum::List(list), SqlScalarType::List { element_type, .. }) => list
-                        .iter()
-                        .all(|e| e.is_null() || is_instance_of_scalar(e, element_type)),
-                    (Datum::List(list), SqlScalarType::Record { fields, .. }) => {
-                        if list.iter().count() != fields.len() {
-                            return false;
+                } else {
+                    // sql type checking
+                    match (datum, scalar_type) {
+                        (Datum::Dummy, _) => false,
+                        (Datum::Null, _) => false,
+                        (Datum::False, SqlScalarType::Bool) => true,
+                        (Datum::False, _) => false,
+                        (Datum::True, SqlScalarType::Bool) => true,
+                        (Datum::True, _) => false,
+                        (Datum::Int16(_), SqlScalarType::Int16) => true,
+                        (Datum::Int16(_), _) => false,
+                        (Datum::Int32(_), SqlScalarType::Int32) => true,
+                        (Datum::Int32(_), _) => false,
+                        (Datum::Int64(_), SqlScalarType::Int64) => true,
+                        (Datum::Int64(_), _) => false,
+                        (Datum::UInt8(_), SqlScalarType::PgLegacyChar) => true,
+                        (Datum::UInt8(_), _) => false,
+                        (Datum::UInt16(_), SqlScalarType::UInt16) => true,
+                        (Datum::UInt16(_), _) => false,
+                        (Datum::UInt32(_), SqlScalarType::Oid) => true,
+                        (Datum::UInt32(_), SqlScalarType::RegClass) => true,
+                        (Datum::UInt32(_), SqlScalarType::RegProc) => true,
+                        (Datum::UInt32(_), SqlScalarType::RegType) => true,
+                        (Datum::UInt32(_), SqlScalarType::UInt32) => true,
+                        (Datum::UInt32(_), _) => false,
+                        (Datum::UInt64(_), SqlScalarType::UInt64) => true,
+                        (Datum::UInt64(_), _) => false,
+                        (Datum::Float32(_), SqlScalarType::Float32) => true,
+                        (Datum::Float32(_), _) => false,
+                        (Datum::Float64(_), SqlScalarType::Float64) => true,
+                        (Datum::Float64(_), _) => false,
+                        (Datum::Date(_), SqlScalarType::Date) => true,
+                        (Datum::Date(_), _) => false,
+                        (Datum::Time(_), SqlScalarType::Time) => true,
+                        (Datum::Time(_), _) => false,
+                        (Datum::Timestamp(_), SqlScalarType::Timestamp { .. }) => true,
+                        (Datum::Timestamp(_), _) => false,
+                        (Datum::TimestampTz(_), SqlScalarType::TimestampTz { .. }) => true,
+                        (Datum::TimestampTz(_), _) => false,
+                        (Datum::Interval(_), SqlScalarType::Interval) => true,
+                        (Datum::Interval(_), _) => false,
+                        (Datum::Bytes(_), SqlScalarType::Bytes) => true,
+                        (Datum::Bytes(_), _) => false,
+                        (Datum::String(_), SqlScalarType::String)
+                        | (Datum::String(_), SqlScalarType::VarChar { .. })
+                        | (Datum::String(_), SqlScalarType::Char { .. })
+                        | (Datum::String(_), SqlScalarType::PgLegacyName) => true,
+                        (Datum::String(_), _) => false,
+                        (Datum::Uuid(_), SqlScalarType::Uuid) => true,
+                        (Datum::Uuid(_), _) => false,
+                        (Datum::Array(array), SqlScalarType::Array(t)) => {
+                            array.elements.iter().all(|e| match e {
+                                Datum::Null => true,
+                                _ => is_instance_of_scalar(e, t),
+                            })
                         }
+                        (Datum::Array(array), SqlScalarType::Int2Vector) => {
+                            array.has_int2vector_dims()
+                                && array
+                                    .elements
+                                    .iter()
+                                    .all(|e| is_instance_of_scalar(e, &SqlScalarType::Int16))
+                        }
+                        (Datum::Array(_), _) => false,
+                        (Datum::List(list), SqlScalarType::List { element_type, .. }) => list
+                            .iter()
+                            .all(|e| e.is_null() || is_instance_of_scalar(e, element_type)),
+                        (Datum::List(list), SqlScalarType::Record { fields, .. }) => {
+                            if list.iter().count() != fields.len() {
+                                return false;
+                            }
 
-                        list.iter().zip_eq(fields).all(|(e, (_, t))| {
-                            (e.is_null() && t.nullable) || is_instance_of_scalar(e, &t.scalar_type)
-                        })
-                    }
-                    (Datum::List(_), _) => false,
-                    (Datum::Map(map), SqlScalarType::Map { value_type, .. }) => map
-                        .iter()
-                        .all(|(_k, v)| v.is_null() || is_instance_of_scalar(v, value_type)),
-                    (Datum::Map(_), _) => false,
-                    (Datum::JsonNull, _) => false,
-                    (Datum::Numeric(_), SqlScalarType::Numeric { .. }) => true,
-                    (Datum::Numeric(_), _) => false,
-                    (Datum::MzTimestamp(_), SqlScalarType::MzTimestamp) => true,
-                    (Datum::MzTimestamp(_), _) => false,
-                    (Datum::Range(Range { inner }), SqlScalarType::Range { element_type }) => {
-                        match inner {
-                            None => true,
-                            Some(inner) => {
-                                true && match inner.lower.bound {
-                                    None => true,
-                                    Some(b) => is_instance_of_scalar(b.datum(), element_type),
-                                } && match inner.upper.bound {
-                                    None => true,
-                                    Some(b) => is_instance_of_scalar(b.datum(), element_type),
+                            list.iter().zip_eq(fields).all(|(e, (_, t))| {
+                                (e.is_null() && t.nullable)
+                                    || is_instance_of_scalar(e, &t.scalar_type)
+                            })
+                        }
+                        (Datum::List(_), _) => false,
+                        (Datum::Map(map), SqlScalarType::Map { value_type, .. }) => map
+                            .iter()
+                            .all(|(_k, v)| v.is_null() || is_instance_of_scalar(v, value_type)),
+                        (Datum::Map(_), _) => false,
+                        (Datum::JsonNull, _) => false,
+                        (Datum::Numeric(_), SqlScalarType::Numeric { .. }) => true,
+                        (Datum::Numeric(_), _) => false,
+                        (Datum::MzTimestamp(_), SqlScalarType::MzTimestamp) => true,
+                        (Datum::MzTimestamp(_), _) => false,
+                        (Datum::Range(Range { inner }), SqlScalarType::Range { element_type }) => {
+                            match inner {
+                                None => true,
+                                Some(inner) => {
+                                    true && match inner.lower.bound {
+                                        None => true,
+                                        Some(b) => is_instance_of_scalar(b.datum(), element_type),
+                                    } && match inner.upper.bound {
+                                        None => true,
+                                        Some(b) => is_instance_of_scalar(b.datum(), element_type),
+                                    }
                                 }
                             }
                         }
+                        (Datum::Range(_), _) => false,
+                        (Datum::MzAclItem(_), SqlScalarType::MzAclItem) => true,
+                        (Datum::MzAclItem(_), _) => false,
+                        (Datum::AclItem(_), SqlScalarType::AclItem) => true,
+                        (Datum::AclItem(_), _) => false,
                     }
-                    (Datum::Range(_), _) => false,
-                    (Datum::MzAclItem(_), SqlScalarType::MzAclItem) => true,
-                    (Datum::MzAclItem(_), _) => false,
-                    (Datum::AclItem(_), SqlScalarType::AclItem) => true,
-                    (Datum::AclItem(_), _) => false,
                 }
-            }
+            })
         }
         if column_type.nullable {
             if let Datum::Null = self {
@@ -5906,6 +5911,22 @@ mod tests {
     use mz_proto::protobuf_roundtrip;
 
     use super::*;
+
+    // Regression: type-checking a deeply nested jsonb value must not overflow the
+    // stack (STACK-8). `is_instance_of_sql` recurses per nesting level.
+    #[mz_ore::test]
+    fn is_instance_of_deep_jsonb_does_not_overflow() {
+        // Build a value nested 50k deep. `push_list` byte-copies the inner value,
+        // so constructing the deep value does not itself recurse.
+        let mut row = crate::Row::pack_slice(&[Datum::JsonNull]);
+        for _ in 0..50_000 {
+            let mut next = crate::Row::default();
+            next.packer().push_list([row.unpack_first()]);
+            row = next;
+        }
+        let deep = row.unpack_first();
+        assert!(deep.is_instance_of_sql(&SqlScalarType::Jsonb.nullable(true)));
+    }
 
     proptest! {
        #[mz_ore::test]

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1612,11 +1612,12 @@ impl fmt::Display for Datum<'_> {
 /// There is an indirect correspondence between `Datum` variants and `SqlScalarType`
 /// variants: every `Datum` variant belongs to one or more `SqlScalarType` variants.
 ///
-/// `Clone`, `Drop`, `Serialize`, and `Deserialize` are implemented manually
-/// because values can be nested arbitrarily deeply (e.g. record types derived
-/// from Protobuf schemas), and the derived impls recurse once per nesting
-/// level on a fixed stack. The manual impls grow the stack on demand instead.
-#[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Hash, EnumKind, MzReflect)]
+/// `Clone`, `Drop`, `Serialize`, `Deserialize`, the comparison and hashing
+/// traits, and `Debug` are implemented manually because values can be nested
+/// arbitrarily deeply (e.g. record types derived from Protobuf schemas), and
+/// the derived impls recurse once per nesting level on a fixed stack. The
+/// manual impls grow the stack on demand instead.
+#[derive(EnumKind, MzReflect)]
 #[enum_kind(SqlScalarBaseType, derive(PartialOrd, Ord, Hash))]
 pub enum SqlScalarType {
     /// The type of [`Datum::True`] and [`Datum::False`].
@@ -1951,6 +1952,246 @@ impl Drop for SqlScalarType {
                 mz_ore::stack::maybe_grow(|| drop(fields));
             }
             _ => (),
+        }
+    }
+}
+
+// The comparison, hashing, and formatting traits are implemented by hand rather
+// than derived because a `SqlScalarType` derived from a deep Protobuf message
+// chain can nest arbitrarily deep, and the derived impls would recurse once per
+// nesting level on a fixed stack and overflow. Each recursive arm grows the
+// stack on demand, matching the `Clone`/serde treatment above. The recursion
+// always passes through one of these methods exactly once per level, so
+// downstream types that merely contain a `SqlScalarType` (`SqlColumnType`,
+// `SqlRelationType`, `RelationDesc`) can keep their derived impls.
+
+impl fmt::Debug for SqlScalarType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use SqlScalarType::*;
+        match self {
+            Array(element_type) => {
+                mz_ore::stack::maybe_grow(|| f.debug_tuple("Array").field(element_type).finish())
+            }
+            List {
+                element_type,
+                custom_id,
+            } => mz_ore::stack::maybe_grow(|| {
+                f.debug_struct("List")
+                    .field("element_type", element_type)
+                    .field("custom_id", custom_id)
+                    .finish()
+            }),
+            Record { fields, custom_id } => mz_ore::stack::maybe_grow(|| {
+                f.debug_struct("Record")
+                    .field("fields", fields)
+                    .field("custom_id", custom_id)
+                    .finish()
+            }),
+            Map {
+                value_type,
+                custom_id,
+            } => mz_ore::stack::maybe_grow(|| {
+                f.debug_struct("Map")
+                    .field("value_type", value_type)
+                    .field("custom_id", custom_id)
+                    .finish()
+            }),
+            Range { element_type } => mz_ore::stack::maybe_grow(|| {
+                f.debug_struct("Range")
+                    .field("element_type", element_type)
+                    .finish()
+            }),
+            Bool => f.write_str("Bool"),
+            Int16 => f.write_str("Int16"),
+            Int32 => f.write_str("Int32"),
+            Int64 => f.write_str("Int64"),
+            UInt16 => f.write_str("UInt16"),
+            UInt32 => f.write_str("UInt32"),
+            UInt64 => f.write_str("UInt64"),
+            Float32 => f.write_str("Float32"),
+            Float64 => f.write_str("Float64"),
+            Numeric { max_scale } => f
+                .debug_struct("Numeric")
+                .field("max_scale", max_scale)
+                .finish(),
+            Date => f.write_str("Date"),
+            Time => f.write_str("Time"),
+            Timestamp { precision } => f
+                .debug_struct("Timestamp")
+                .field("precision", precision)
+                .finish(),
+            TimestampTz { precision } => f
+                .debug_struct("TimestampTz")
+                .field("precision", precision)
+                .finish(),
+            Interval => f.write_str("Interval"),
+            PgLegacyChar => f.write_str("PgLegacyChar"),
+            PgLegacyName => f.write_str("PgLegacyName"),
+            Bytes => f.write_str("Bytes"),
+            String => f.write_str("String"),
+            Char { length } => f.debug_struct("Char").field("length", length).finish(),
+            VarChar { max_length } => f
+                .debug_struct("VarChar")
+                .field("max_length", max_length)
+                .finish(),
+            Jsonb => f.write_str("Jsonb"),
+            Uuid => f.write_str("Uuid"),
+            Oid => f.write_str("Oid"),
+            RegProc => f.write_str("RegProc"),
+            RegType => f.write_str("RegType"),
+            RegClass => f.write_str("RegClass"),
+            Int2Vector => f.write_str("Int2Vector"),
+            MzTimestamp => f.write_str("MzTimestamp"),
+            MzAclItem => f.write_str("MzAclItem"),
+            AclItem => f.write_str("AclItem"),
+        }
+    }
+}
+
+impl PartialEq for SqlScalarType {
+    fn eq(&self, other: &Self) -> bool {
+        use SqlScalarType::*;
+        match (self, other) {
+            (Array(a), Array(b)) => mz_ore::stack::maybe_grow(|| a == b),
+            (
+                List {
+                    element_type: a,
+                    custom_id: a_id,
+                },
+                List {
+                    element_type: b,
+                    custom_id: b_id,
+                },
+            ) => a_id == b_id && mz_ore::stack::maybe_grow(|| a == b),
+            (
+                Record {
+                    fields: a,
+                    custom_id: a_id,
+                },
+                Record {
+                    fields: b,
+                    custom_id: b_id,
+                },
+            ) => a_id == b_id && mz_ore::stack::maybe_grow(|| a == b),
+            (
+                Map {
+                    value_type: a,
+                    custom_id: a_id,
+                },
+                Map {
+                    value_type: b,
+                    custom_id: b_id,
+                },
+            ) => a_id == b_id && mz_ore::stack::maybe_grow(|| a == b),
+            (Range { element_type: a }, Range { element_type: b }) => {
+                mz_ore::stack::maybe_grow(|| a == b)
+            }
+            // Non-recursive variants that carry data compare that data directly.
+            (Numeric { max_scale: a }, Numeric { max_scale: b }) => a == b,
+            (Timestamp { precision: a }, Timestamp { precision: b }) => a == b,
+            (TimestampTz { precision: a }, TimestampTz { precision: b }) => a == b,
+            (Char { length: a }, Char { length: b }) => a == b,
+            (VarChar { max_length: a }, VarChar { max_length: b }) => a == b,
+            // Any remaining pair is equal exactly when the discriminants match.
+            // A new data-carrying variant must be given its own arm above, or
+            // its payload would be silently ignored here.
+            _ => SqlScalarBaseType::from(self) == SqlScalarBaseType::from(other),
+        }
+    }
+}
+impl Eq for SqlScalarType {}
+
+impl PartialOrd for SqlScalarType {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SqlScalarType {
+    fn cmp(&self, other: &Self) -> Ordering {
+        use SqlScalarType::*;
+        // Fields are compared in declaration order, matching a derived `Ord`.
+        match (self, other) {
+            (Array(a), Array(b)) => mz_ore::stack::maybe_grow(|| a.cmp(b)),
+            (
+                List {
+                    element_type: a,
+                    custom_id: a_id,
+                },
+                List {
+                    element_type: b,
+                    custom_id: b_id,
+                },
+            ) => mz_ore::stack::maybe_grow(|| a.cmp(b)).then_with(|| a_id.cmp(b_id)),
+            (
+                Record {
+                    fields: a,
+                    custom_id: a_id,
+                },
+                Record {
+                    fields: b,
+                    custom_id: b_id,
+                },
+            ) => mz_ore::stack::maybe_grow(|| a.cmp(b)).then_with(|| a_id.cmp(b_id)),
+            (
+                Map {
+                    value_type: a,
+                    custom_id: a_id,
+                },
+                Map {
+                    value_type: b,
+                    custom_id: b_id,
+                },
+            ) => mz_ore::stack::maybe_grow(|| a.cmp(b)).then_with(|| a_id.cmp(b_id)),
+            (Range { element_type: a }, Range { element_type: b }) => {
+                mz_ore::stack::maybe_grow(|| a.cmp(b))
+            }
+            (Numeric { max_scale: a }, Numeric { max_scale: b }) => a.cmp(b),
+            (Timestamp { precision: a }, Timestamp { precision: b }) => a.cmp(b),
+            (TimestampTz { precision: a }, TimestampTz { precision: b }) => a.cmp(b),
+            (Char { length: a }, Char { length: b }) => a.cmp(b),
+            (VarChar { max_length: a }, VarChar { max_length: b }) => a.cmp(b),
+            // Any remaining pair orders by discriminant. As with `PartialEq`, a
+            // new data-carrying variant must be given its own arm above.
+            _ => SqlScalarBaseType::from(self).cmp(&SqlScalarBaseType::from(other)),
+        }
+    }
+}
+
+impl Hash for SqlScalarType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        use SqlScalarType::*;
+        // Hash the discriminant, then the payload, so that distinct variants
+        // rarely collide. Only the payload can recurse, so only it grows.
+        SqlScalarBaseType::from(self).hash(state);
+        match self {
+            Array(a) => mz_ore::stack::maybe_grow(|| a.hash(state)),
+            List {
+                element_type,
+                custom_id,
+            } => {
+                mz_ore::stack::maybe_grow(|| element_type.hash(state));
+                custom_id.hash(state);
+            }
+            Record { fields, custom_id } => {
+                mz_ore::stack::maybe_grow(|| fields.hash(state));
+                custom_id.hash(state);
+            }
+            Map {
+                value_type,
+                custom_id,
+            } => {
+                mz_ore::stack::maybe_grow(|| value_type.hash(state));
+                custom_id.hash(state);
+            }
+            Range { element_type } => mz_ore::stack::maybe_grow(|| element_type.hash(state)),
+            Numeric { max_scale } => max_scale.hash(state),
+            Timestamp { precision } => precision.hash(state),
+            TimestampTz { precision } => precision.hash(state),
+            Char { length } => length.hash(state),
+            VarChar { max_length } => max_length.hash(state),
+            // Fieldless variants are fully described by the discriminant.
+            _ => {}
         }
     }
 }
@@ -4940,10 +5181,10 @@ impl Arbitrary for ReprScalarType {
 /// It is important that any new variants for this enum be added to the `Arbitrary` instance
 /// and the `union` method.
 ///
-/// `Clone`, `Drop`, `Serialize`, and `Deserialize` are implemented manually
-/// because values can be nested arbitrarily deeply, see the
-/// [`SqlScalarType`] docs.
-#[derive(Debug, EnumKind, MzReflect)]
+/// `Clone`, `Drop`, `Serialize`, `Deserialize`, the comparison and hashing
+/// traits, `Debug`, and `Display` are implemented manually because values can
+/// be nested arbitrarily deeply, see the [`SqlScalarType`] docs.
+#[derive(EnumKind, MzReflect)]
 #[enum_kind(ReprScalarBaseType, derive(PartialOrd, Ord, Hash))]
 pub enum ReprScalarType {
     Bool,
@@ -5115,25 +5356,31 @@ impl Drop for ReprScalarType {
 
 impl PartialEq for ReprScalarType {
     fn eq(&self, other: &Self) -> bool {
+        // Comparing a nested variant recurses once per nesting level, so grow
+        // the stack on demand.
         match (self, other) {
-            (ReprScalarType::Array(a), ReprScalarType::Array(b)) => a.eq(b),
+            (ReprScalarType::Array(a), ReprScalarType::Array(b)) => {
+                mz_ore::stack::maybe_grow(|| a.eq(b))
+            }
             (
                 ReprScalarType::List { element_type: a },
                 ReprScalarType::List { element_type: b },
-            ) => a.eq(b),
+            ) => mz_ore::stack::maybe_grow(|| a.eq(b)),
             (ReprScalarType::Record { fields: a }, ReprScalarType::Record { fields: b }) => {
                 a.len() == b.len()
-                    && a.iter()
-                        .zip_eq(b.iter())
-                        .all(|(af, bf)| af.scalar_type.eq(&bf.scalar_type))
+                    && mz_ore::stack::maybe_grow(|| {
+                        a.iter()
+                            .zip_eq(b.iter())
+                            .all(|(af, bf)| af.scalar_type.eq(&bf.scalar_type))
+                    })
             }
             (ReprScalarType::Map { value_type: a }, ReprScalarType::Map { value_type: b }) => {
-                a.eq(b)
+                mz_ore::stack::maybe_grow(|| a.eq(b))
             }
             (
                 ReprScalarType::Range { element_type: a },
                 ReprScalarType::Range { element_type: b },
-            ) => a.eq(b),
+            ) => mz_ore::stack::maybe_grow(|| a.eq(b)),
             _ => ReprScalarBaseType::from(self) == ReprScalarBaseType::from(other),
         }
     }
@@ -5142,16 +5389,20 @@ impl Eq for ReprScalarType {}
 
 impl Hash for ReprScalarType {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Hashing a nested variant recurses once per nesting level, so grow the
+        // stack on demand.
         match self {
-            ReprScalarType::Array(a) => a.hash(state),
-            ReprScalarType::List { element_type: a } => a.hash(state),
-            ReprScalarType::Record { fields: a } => {
+            ReprScalarType::Array(a) => mz_ore::stack::maybe_grow(|| a.hash(state)),
+            ReprScalarType::List { element_type: a } => mz_ore::stack::maybe_grow(|| a.hash(state)),
+            ReprScalarType::Record { fields: a } => mz_ore::stack::maybe_grow(|| {
                 for field in a {
                     field.scalar_type.hash(state);
                 }
+            }),
+            ReprScalarType::Map { value_type: a } => mz_ore::stack::maybe_grow(|| a.hash(state)),
+            ReprScalarType::Range { element_type: a } => {
+                mz_ore::stack::maybe_grow(|| a.hash(state))
             }
-            ReprScalarType::Map { value_type: a } => a.hash(state),
-            ReprScalarType::Range { element_type: a } => a.hash(state),
             _ => ReprScalarBaseType::from(self).hash(state),
         }
     }
@@ -5165,42 +5416,105 @@ impl PartialOrd for ReprScalarType {
 
 impl Ord for ReprScalarType {
     fn cmp(&self, other: &Self) -> Ordering {
+        // Comparing a nested variant recurses once per nesting level, so grow
+        // the stack on demand.
         match (self, other) {
-            (ReprScalarType::Array(a), ReprScalarType::Array(b)) => a.cmp(b),
+            (ReprScalarType::Array(a), ReprScalarType::Array(b)) => {
+                mz_ore::stack::maybe_grow(|| a.cmp(b))
+            }
             (
                 ReprScalarType::List { element_type: a },
                 ReprScalarType::List { element_type: b },
-            ) => a.cmp(b),
+            ) => mz_ore::stack::maybe_grow(|| a.cmp(b)),
             (ReprScalarType::Record { fields: a }, ReprScalarType::Record { fields: b }) => {
                 let len_ordering = a.len().cmp(&b.len());
                 if len_ordering != Ordering::Equal {
                     return len_ordering;
                 }
 
-                // NB ignoring nullability
-                for (af, bf) in a.iter().zip_eq(b.iter()) {
-                    let scalar_type_ordering = af.scalar_type.cmp(&bf.scalar_type);
-                    if scalar_type_ordering != Ordering::Equal {
-                        return scalar_type_ordering;
+                mz_ore::stack::maybe_grow(|| {
+                    // NB ignoring nullability
+                    for (af, bf) in a.iter().zip_eq(b.iter()) {
+                        let scalar_type_ordering = af.scalar_type.cmp(&bf.scalar_type);
+                        if scalar_type_ordering != Ordering::Equal {
+                            return scalar_type_ordering;
+                        }
                     }
-                }
 
-                Ordering::Equal
+                    Ordering::Equal
+                })
             }
             (ReprScalarType::Map { value_type: a }, ReprScalarType::Map { value_type: b }) => {
-                a.cmp(b)
+                mz_ore::stack::maybe_grow(|| a.cmp(b))
             }
             (
                 ReprScalarType::Range { element_type: a },
                 ReprScalarType::Range { element_type: b },
-            ) => a.cmp(b),
+            ) => mz_ore::stack::maybe_grow(|| a.cmp(b)),
             _ => ReprScalarBaseType::from(self).cmp(&ReprScalarBaseType::from(other)),
+        }
+    }
+}
+
+impl fmt::Debug for ReprScalarType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ReprScalarType::*;
+        // Formatting a nested variant recurses once per nesting level, so grow
+        // the stack on demand.
+        match self {
+            Array(element_type) => {
+                mz_ore::stack::maybe_grow(|| f.debug_tuple("Array").field(element_type).finish())
+            }
+            List { element_type } => mz_ore::stack::maybe_grow(|| {
+                f.debug_struct("List")
+                    .field("element_type", element_type)
+                    .finish()
+            }),
+            Record { fields } => mz_ore::stack::maybe_grow(|| {
+                f.debug_struct("Record").field("fields", fields).finish()
+            }),
+            Map { value_type } => mz_ore::stack::maybe_grow(|| {
+                f.debug_struct("Map")
+                    .field("value_type", value_type)
+                    .finish()
+            }),
+            Range { element_type } => mz_ore::stack::maybe_grow(|| {
+                f.debug_struct("Range")
+                    .field("element_type", element_type)
+                    .finish()
+            }),
+            Bool => f.write_str("Bool"),
+            Int16 => f.write_str("Int16"),
+            Int32 => f.write_str("Int32"),
+            Int64 => f.write_str("Int64"),
+            UInt8 => f.write_str("UInt8"),
+            UInt16 => f.write_str("UInt16"),
+            UInt32 => f.write_str("UInt32"),
+            UInt64 => f.write_str("UInt64"),
+            Float32 => f.write_str("Float32"),
+            Float64 => f.write_str("Float64"),
+            Numeric => f.write_str("Numeric"),
+            Date => f.write_str("Date"),
+            Time => f.write_str("Time"),
+            Timestamp => f.write_str("Timestamp"),
+            TimestampTz => f.write_str("TimestampTz"),
+            MzTimestamp => f.write_str("MzTimestamp"),
+            Interval => f.write_str("Interval"),
+            Bytes => f.write_str("Bytes"),
+            Jsonb => f.write_str("Jsonb"),
+            String => f.write_str("String"),
+            Uuid => f.write_str("Uuid"),
+            Int2Vector => f.write_str("Int2Vector"),
+            MzAclItem => f.write_str("MzAclItem"),
+            AclItem => f.write_str("AclItem"),
         }
     }
 }
 
 impl std::fmt::Display for ReprScalarType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Formatting a nested variant recurses once per nesting level, so grow
+        // the stack on demand.
         match self {
             ReprScalarType::Bool => write!(f, "r_bool"),
             ReprScalarType::Int16 => write!(f, "r_int16"),
@@ -5223,15 +5537,23 @@ impl std::fmt::Display for ReprScalarType {
             ReprScalarType::Jsonb => write!(f, "r_jsonb"),
             ReprScalarType::String => write!(f, "r_string"),
             ReprScalarType::Uuid => write!(f, "r_uuid"),
-            ReprScalarType::Array(element_type) => write!(f, "r_array({element_type})"),
+            ReprScalarType::Array(element_type) => {
+                mz_ore::stack::maybe_grow(|| write!(f, "r_array({element_type})"))
+            }
             ReprScalarType::Int2Vector => write!(f, "r_int2vector"),
-            ReprScalarType::List { element_type } => write!(f, "r_list({element_type})"),
-            ReprScalarType::Record { fields } => {
+            ReprScalarType::List { element_type } => {
+                mz_ore::stack::maybe_grow(|| write!(f, "r_list({element_type})"))
+            }
+            ReprScalarType::Record { fields } => mz_ore::stack::maybe_grow(|| {
                 let fields = separated(", ", fields.iter());
                 write!(f, "r_record({fields})")
+            }),
+            ReprScalarType::Map { value_type } => {
+                mz_ore::stack::maybe_grow(|| write!(f, "r_map({value_type})"))
             }
-            ReprScalarType::Map { value_type } => write!(f, "r_map({value_type})"),
-            ReprScalarType::Range { element_type } => write!(f, "r_range({element_type})"),
+            ReprScalarType::Range { element_type } => {
+                mz_ore::stack::maybe_grow(|| write!(f, "r_range({element_type})"))
+            }
             ReprScalarType::MzAclItem => write!(f, "r_mz_acl_item"),
             ReprScalarType::AclItem => write!(f, "r_acl_item"),
         }
@@ -6296,8 +6618,9 @@ mod tests {
 
     // Regression: operations on a deeply nested type (e.g. a record type
     // derived from a Protobuf schema) must not overflow the stack. Clone,
-    // drop, the proto conversions, and the SQL<->repr conversions each
-    // recurse once per nesting level and grow the stack on demand.
+    // drop, the proto conversions, the SQL<->repr conversions, and the
+    // comparison, hashing, and formatting traits each recurse once per nesting
+    // level and grow the stack on demand.
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // too slow
     fn deeply_nested_type_ops_do_not_overflow() {
@@ -6312,9 +6635,7 @@ mod tests {
             };
         }
 
-        // Iterative depth measurement, likewise. The derived `PartialEq` still
-        // recurses on a fixed stack, so equality assertions are off limits
-        // here.
+        // Iterative depth measurement, likewise.
         fn depth(mut ty: &SqlScalarType) -> usize {
             let mut depth = 0;
             while let SqlScalarType::Record { fields, .. } = ty {
@@ -6324,12 +6645,31 @@ mod tests {
             depth
         }
 
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            use std::hash::Hasher;
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut hasher);
+            hasher.finish()
+        }
+
         let clone = ty.clone();
         assert_eq!(depth(&clone), DEPTH);
+
+        // Comparison, hashing, and formatting recurse over every level. The
+        // equal case recurses all the way to the leaf, so it is the deepest.
+        assert!(ty == clone);
+        assert_eq!(ty.cmp(&clone), Ordering::Equal);
+        assert_eq!(hash_of(&ty), hash_of(&clone));
+        assert!(!format!("{ty:?}").is_empty());
         drop(clone);
 
         let repr = ReprScalarType::from(&ty);
         let repr_clone = repr.clone();
+        assert!(repr == repr_clone);
+        assert_eq!(repr.cmp(&repr_clone), Ordering::Equal);
+        assert_eq!(hash_of(&repr), hash_of(&repr_clone));
+        assert!(!format!("{repr:?}").is_empty());
+        assert!(!format!("{repr}").is_empty());
         drop(repr_clone);
         let sql = SqlScalarType::from_repr(&repr);
         assert_eq!(depth(&sql), DEPTH);
@@ -6352,6 +6692,33 @@ mod tests {
             SqlScalarType::from_proto(proto).expect("valid proto")
         });
         assert_eq!(depth(&roundtripped), DEPTH);
+    }
+
+    // The hand-written `Debug` impls must reproduce the format a
+    // `#[derive(Debug)]` would produce, one shape per variant kind.
+    #[mz_ore::test]
+    fn manual_debug_matches_derived_format() {
+        // Unit, tuple, and struct variants of `SqlScalarType`.
+        assert_eq!(format!("{:?}", SqlScalarType::Int32), "Int32");
+        assert_eq!(
+            format!("{:?}", SqlScalarType::Array(Box::new(SqlScalarType::Int32))),
+            "Array(Int32)"
+        );
+        assert_eq!(
+            format!("{:?}", SqlScalarType::Numeric { max_scale: None }),
+            "Numeric { max_scale: None }"
+        );
+        // Unit and struct variants of `ReprScalarType`.
+        assert_eq!(format!("{:?}", ReprScalarType::Bool), "Bool");
+        assert_eq!(
+            format!(
+                "{:?}",
+                ReprScalarType::List {
+                    element_type: Box::new(ReprScalarType::Bool)
+                }
+            ),
+            "List { element_type: Bool }"
+        );
     }
 
     proptest! {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -5469,8 +5469,8 @@ fn array_to_string(
     ecx: &ExprContext,
     exprs: Vec<HirScalarExpr>,
 ) -> Result<HirScalarExpr, PlanError> {
-    let elem_type = match ecx.scalar_type(&exprs[0]) {
-        SqlScalarType::Array(elem_type) => *elem_type,
+    let elem_type = match &ecx.scalar_type(&exprs[0]) {
+        SqlScalarType::Array(elem_type) => (**elem_type).clone(),
         _ => unreachable!("array_to_string is guaranteed to receive array as first argument"),
     };
     Ok(HirScalarExpr::call_variadic(

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -1566,7 +1566,7 @@ impl AggregateFunc {
                 custom_id: None,
             },
             AggregateFunc::ArrayConcat { .. } | AggregateFunc::ListConcat { .. } => {
-                match input_type.scalar_type {
+                match &input_type.scalar_type {
                     // The input is wrapped in a Record if there's an ORDER BY, so extract it out.
                     SqlScalarType::Record { fields, .. } => fields[0].1.scalar_type.clone(),
                     _ => unreachable!(),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3693,11 +3693,12 @@ fn expand_select_item<'a>(
             // uncommon operation and the PostgreSQL docs have a warning that
             // this operation is slow in Postgres too.
             let expr = plan_expr(ecx, sql_expr)?.type_as_any(ecx)?;
-            let fields = match ecx.scalar_type(&expr) {
-                SqlScalarType::Record { fields, .. } => fields,
+            let ty = ecx.scalar_type(&expr);
+            let fields = match &ty {
+                SqlScalarType::Record { fields, .. } => fields.clone(),
                 ty => sql_bail!(
                     "type {} is not composite",
-                    ecx.humanize_sql_scalar_type(&ty, false)
+                    ecx.humanize_sql_scalar_type(ty, false)
                 ),
             };
             let mut skip_cols: BTreeSet<ColumnName> = BTreeSet::new();

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -1179,7 +1179,10 @@ pub fn to_string(ecx: &ExprContext, expr: HirScalarExpr) -> Result<HirScalarExpr
 pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> Result<HirScalarExpr, PlanError> {
     use SqlScalarType::*;
 
-    Ok(match ecx.scalar_type(&expr) {
+    // Match on a reference: `SqlScalarType` implements `Drop`, so its fields
+    // cannot be moved out of a value.
+    let scalar_type = ecx.scalar_type(&expr);
+    Ok(match &scalar_type {
         Bool | Jsonb | Numeric { .. } => {
             expr.call_unary(UnaryFunc::CastJsonbableToJsonb(func::CastJsonbableToJsonb))
         }
@@ -1206,10 +1209,7 @@ pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> Result<HirScalarExpr,
             }
             HirScalarExpr::call_variadic(JsonbBuildObject, exprs)
         }
-        ref ty @ List {
-            ref element_type, ..
-        }
-        | ref ty @ Array(ref element_type) => {
+        ty @ List { element_type, .. } | ty @ Array(element_type) => {
             // Construct a new expression context with one column whose type
             // is the container's element type.
             let qcx = QueryContext::root(ecx.qcx.scx, ecx.qcx.lifetime);
@@ -1551,15 +1551,18 @@ pub fn plan_cast(
     //   src/backend/parser/parse_coerce.c#L3205-L3223
     let from_category = TypeCategory::from_type(&from);
     let to_category = TypeCategory::from_type(to);
+    // A named local because `SqlScalarType` implements `Drop`, which rules
+    // out promoting `&SqlScalarType::String` beyond its statement.
+    let string_type = SqlScalarType::String;
     if from_category == TypeCategory::String && to_category != TypeCategory::String {
         // Converting from stringlike to something non-stringlike. Handle as if
         // `from` were a `SqlScalarType::String.
-        cast_inner(&SqlScalarType::String, to, expr)
+        cast_inner(&string_type, to, expr)
     } else if from_category != TypeCategory::String && to_category == TypeCategory::String {
         // Converting from non-stringlike to something stringlike. Convert to a
         // `SqlScalarType::String` and then to the desired type.
-        let expr = cast_inner(&from, &SqlScalarType::String, expr)?;
-        cast_inner(&SqlScalarType::String, to, expr)
+        let expr = cast_inner(&from, &string_type, expr)?;
+        cast_inner(&string_type, to, expr)
     } else {
         // Standard cast.
         cast_inner(&from, to, expr)

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -42,7 +42,7 @@ mz-dyncfg = { path = "../dyncfg" }
 mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
-mz-ore = { path = "../ore", features = ["async", "tracing"] }
+mz-ore = { path = "../ore", features = ["async", "stack", "tracing"] }
 mz-mysql-util = { path = "../mysql-util" }
 mz-persist-types = { path = "../persist-types" }
 mz-pgcopy = { path = "../pgcopy" }

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1136,14 +1136,30 @@ impl Codec for SourceData {
     }
 
     fn encode_schema(schema: &Self::Schema) -> Bytes {
-        schema.into_proto().encode_to_vec().into()
+        // A `RelationDesc` can contain arbitrarily deeply nested record types
+        // (e.g. derived from Protobuf schemas). The `RustType` conversions
+        // grow the stack on demand, but prost's generated encode/decode and
+        // the drop of the intermediate proto tree recurse once per nesting
+        // level without doing so. Give them one large stack up front. The
+        // size supports nesting depths in the millions, far deeper than any
+        // schema that fits through the SQL or schema-registry entry points.
+        mz_ore::stack::grow(SCHEMA_CODEC_STACK_SIZE, || {
+            schema.into_proto().encode_to_vec().into()
+        })
     }
 
     fn decode_schema(buf: &Bytes) -> Self::Schema {
-        let proto = ProtoRelationDesc::decode(buf.as_ref()).expect("valid schema");
-        proto.into_rust().expect("valid schema")
+        // See `encode_schema` for why this grows the stack.
+        mz_ore::stack::grow(SCHEMA_CODEC_STACK_SIZE, || {
+            let proto = ProtoRelationDesc::decode(buf.as_ref()).expect("valid schema");
+            proto.into_rust().expect("valid schema")
+        })
     }
 }
+
+/// Stack size for [`SourceData::encode_schema`] and
+/// [`SourceData::decode_schema`], see there for rationale.
+const SCHEMA_CODEC_STACK_SIZE: usize = 1 << 30;
 
 /// Given a [`RelationDesc`] returns an arbitrary [`SourceData`].
 #[cfg(any(test, feature = "proptest"))]
@@ -1730,8 +1746,9 @@ mod tests {
     use mz_persist_types::schema::{Migration, backward_compatible};
     use mz_persist_types::stats::{PartStats, PartStatsMetrics};
     use mz_repr::{
-        ColumnIndex, DatumVec, PropRelationDescDiff, ProtoRelationDesc, RelationDescBuilder,
-        RowArena, SqlScalarType, arb_relation_desc_diff, arb_relation_desc_projection,
+        ColumnIndex, ColumnName, DatumVec, PropRelationDescDiff, ProtoRelationDesc,
+        RelationDescBuilder, RowArena, SqlScalarType, arb_relation_desc_diff,
+        arb_relation_desc_projection,
     };
     use proptest::prelude::*;
     use proptest::strategy::{Union, ValueTree};
@@ -1739,6 +1756,47 @@ mod tests {
     use crate::stats::RelationPartStats;
 
     use super::*;
+
+    // Regression: a `RelationDesc` with a deeply nested record type (e.g.
+    // derived from a Protobuf schema) must roundtrip through
+    // `{encode,decode}_schema` without overflowing the stack. Prost's
+    // generated encode/decode and the proto tree's drop glue recurse once per
+    // nesting level, so both functions run on a dedicated large stack.
+    //
+    // The depth is more modest than in the related mz-repr and mz-interchange
+    // tests only because prost recomputes nested lengths at every level, so
+    // encoding is quadratic in the nesting depth and a deeper test spends
+    // minutes of CPU. The stack guard itself is depth-independent.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // too slow
+    fn deeply_nested_schema_roundtrips() {
+        const DEPTH: usize = 5_000;
+
+        // Iterative construction, which needs no stack guard.
+        let mut ty = SqlScalarType::Int32;
+        for _ in 0..DEPTH {
+            ty = SqlScalarType::Record {
+                fields: vec![(ColumnName::from("f"), ty.nullable(true))].into(),
+                custom_id: None,
+            };
+        }
+        let desc = RelationDesc::builder()
+            .with_column("c", ty.nullable(true))
+            .finish();
+
+        let encoded = SourceData::encode_schema(&desc);
+        let roundtripped = SourceData::decode_schema(&encoded);
+
+        // Iterative depth check; the derived `PartialEq` would recurse on a
+        // fixed stack, so no equality assertion on the whole desc here.
+        let mut ty = &roundtripped.typ().column_types[0].scalar_type;
+        let mut depth = 0;
+        while let SqlScalarType::Record { fields, .. } = ty {
+            depth += 1;
+            ty = &fields[0].1.scalar_type;
+        }
+        assert_eq!(depth, DEPTH);
+    }
 
     #[mz_ore::test]
     fn test_timeline_parsing() {


### PR DESCRIPTION
## Motivation

Materialize recursively processes Protobuf schemas when deriving source relation types and when Prost decodes wire-nested descriptor messages or unknown groups. Deep but inexpensive inputs can exhaust the environmentd stack and abort the process during `CREATE SOURCE`. Deeply nested `jsonb` values can likewise exhaust the stack during SQL type validation or serialization.

A fixed limit on Protobuf message reference chains is not upgrade-safe. Materialize can re-render sources whose catalogs already contain schemas beyond a newly introduced limit. Those schemas must remain decodable.

After this change, existing deeply nested Protobuf schemas continue to work during upgrades and re-renders, deeply nested `jsonb` values no longer crash Materialize in these paths, and pathological wire-nested descriptor sets produce an error instead of aborting the process.

## Description

- Grow the stack on demand while deriving relation types from Protobuf message reference chains. This preserves support for schemas accepted and persisted by earlier versions.
- Grow the stack during recursive `jsonb` type validation and serialization.
- Scan a Protobuf `FileDescriptorSet` iteratively before `DescriptorPool::decode` and reject message or group wire nesting deeper than 128 levels.
- Make the wire scan schema-aware so it descends only into message-typed fields and groups. Strings, bytes, scalars, and unknown length-delimited fields remain opaque, matching Prost decoding and avoiding false rejections.

## Verification

Adds Protobuf regression coverage for deep non-cyclic message reference chains, deeply wire-nested descriptor messages, deeply nested unknown groups, and valid option strings containing message-like bytes. Also adds a regression test for type-checking deeply nested `jsonb` values without overflowing the stack.

Closes: [SS-342](https://linear.app/materializeinc/issue/SS-342)