### PR TITLE
sql: Guard pre-decorrelation HIR walks against deep relation trees

### DIFF
--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -2008,8 +2008,12 @@ impl HirRelationExpr {
         F: FnMut(&'a Self, usize) -> Result<(), E>,
     {
         #[allow(deprecated)]
-        self.visit1(depth, |e: &HirRelationExpr, depth: usize| {
-            e.visit_fallible(depth, f)
+        // Grow the stack: this recurses over the relation tree, whose depth is
+        // user-controlled (e.g. a long JOIN chain or a chain of CTEs).
+        stack::maybe_grow(|| {
+            self.visit1(depth, |e: &HirRelationExpr, depth: usize| {
+                e.visit_fallible(depth, f)
+            })
         })?;
         f(self, depth)
     }

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -2099,8 +2099,12 @@ impl HirRelationExpr {
         F: FnMut(&mut Self, usize) -> Result<(), E>,
     {
         #[allow(deprecated)]
-        self.visit1_mut(depth, |e: &mut HirRelationExpr, depth: usize| {
-            e.visit_mut_fallible(depth, f)
+        // Grow the stack: this recurses over the relation tree, whose depth is
+        // user-controlled (e.g. a long JOIN chain or a chain of CTEs).
+        stack::maybe_grow(|| {
+            self.visit1_mut(depth, |e: &mut HirRelationExpr, depth: usize| {
+                e.visit_mut_fallible(depth, f)
+            })
         })?;
         f(self, depth)
     }

--- a/src/sql/src/plan/transform_hir.rs
+++ b/src/sql/src/plan/transform_hir.rs
@@ -171,66 +171,77 @@ pub fn try_simplify_quantified_comparisons(
     expr: &mut HirRelationExpr,
     simplify_join_on: bool,
 ) -> Result<(), RecursionLimitError> {
+    // There is nothing to simplify unless the query contains a subquery. Bail
+    // early in that common case: `walk_relation` recomputes `input.typ()` at
+    // every level, which is O(depth^2) over a deep relation tree (e.g. a long
+    // JOIN or CTE chain) and would wedge the coordinator.
+    if !relation_contains_subquery(expr) {
+        return Ok(());
+    }
+
     fn walk_relation(
         expr: &mut HirRelationExpr,
         outers: &[SqlRelationType],
         simplify_join_on: bool,
     ) -> Result<(), RecursionLimitError> {
-        match expr {
-            HirRelationExpr::Map { scalars, input } => {
-                walk_relation(input, outers, simplify_join_on)?;
-                let mut outers = outers.to_vec();
-                outers.insert(0, input.typ(&outers, &NO_PARAMS));
-                for scalar in scalars {
-                    walk_scalar(scalar, &outers, false, simplify_join_on)?;
-                    let (inner, outers) = outers
-                        .split_first_mut()
-                        .expect("outers known to have at least one element");
-                    let scalar_type = scalar.typ(outers, inner, &NO_PARAMS);
-                    inner.column_types.push(scalar_type);
+        // Grow the stack: recurses over a user-controlled-depth relation tree.
+        mz_ore::stack::maybe_grow(|| {
+            match expr {
+                HirRelationExpr::Map { scalars, input } => {
+                    walk_relation(input, outers, simplify_join_on)?;
+                    let mut outers = outers.to_vec();
+                    outers.insert(0, input.typ(&outers, &NO_PARAMS));
+                    for scalar in scalars {
+                        walk_scalar(scalar, &outers, false, simplify_join_on)?;
+                        let (inner, outers) = outers
+                            .split_first_mut()
+                            .expect("outers known to have at least one element");
+                        let scalar_type = scalar.typ(outers, inner, &NO_PARAMS);
+                        inner.column_types.push(scalar_type);
+                    }
+                }
+                HirRelationExpr::Filter { predicates, input } => {
+                    walk_relation(input, outers, simplify_join_on)?;
+                    let mut outers = outers.to_vec();
+                    outers.insert(0, input.typ(&outers, &NO_PARAMS));
+                    for pred in predicates {
+                        walk_scalar(pred, &outers, true, simplify_join_on)?;
+                    }
+                }
+                HirRelationExpr::CallTable { exprs, .. } => {
+                    let mut outers = outers.to_vec();
+                    outers.insert(0, SqlRelationType::empty());
+                    for scalar in exprs {
+                        walk_scalar(scalar, &outers, false, simplify_join_on)?;
+                    }
+                }
+                HirRelationExpr::Join {
+                    left, right, on, ..
+                } => {
+                    walk_relation(left, outers, simplify_join_on)?;
+                    let left_type = left.typ(outers, &NO_PARAMS);
+                    let mut outers = outers.to_vec();
+                    outers.insert(0, left_type);
+                    walk_relation(right, &outers, simplify_join_on)?;
+                    if simplify_join_on {
+                        // Build outers with the full join output type, since the
+                        // ON clause can reference columns from both sides.
+                        let right_type = right.typ(&outers, &NO_PARAMS);
+                        let mut join_columns = outers[0].column_types.clone();
+                        join_columns.extend(right_type.column_types);
+                        outers[0] = SqlRelationType::new(join_columns);
+                        walk_scalar(on, &outers, true, simplify_join_on)?;
+                    }
+                }
+                expr => {
+                    #[allow(deprecated)]
+                    let _ = expr.visit1_mut(0, &mut |expr, _| -> Result<(), RecursionLimitError> {
+                        walk_relation(expr, outers, simplify_join_on)
+                    });
                 }
             }
-            HirRelationExpr::Filter { predicates, input } => {
-                walk_relation(input, outers, simplify_join_on)?;
-                let mut outers = outers.to_vec();
-                outers.insert(0, input.typ(&outers, &NO_PARAMS));
-                for pred in predicates {
-                    walk_scalar(pred, &outers, true, simplify_join_on)?;
-                }
-            }
-            HirRelationExpr::CallTable { exprs, .. } => {
-                let mut outers = outers.to_vec();
-                outers.insert(0, SqlRelationType::empty());
-                for scalar in exprs {
-                    walk_scalar(scalar, &outers, false, simplify_join_on)?;
-                }
-            }
-            HirRelationExpr::Join {
-                left, right, on, ..
-            } => {
-                walk_relation(left, outers, simplify_join_on)?;
-                let left_type = left.typ(outers, &NO_PARAMS);
-                let mut outers = outers.to_vec();
-                outers.insert(0, left_type);
-                walk_relation(right, &outers, simplify_join_on)?;
-                if simplify_join_on {
-                    // Build outers with the full join output type, since the
-                    // ON clause can reference columns from both sides.
-                    let right_type = right.typ(&outers, &NO_PARAMS);
-                    let mut join_columns = outers[0].column_types.clone();
-                    join_columns.extend(right_type.column_types);
-                    outers[0] = SqlRelationType::new(join_columns);
-                    walk_scalar(on, &outers, true, simplify_join_on)?;
-                }
-            }
-            expr => {
-                #[allow(deprecated)]
-                let _ = expr.visit1_mut(0, &mut |expr, _| -> Result<(), RecursionLimitError> {
-                    walk_relation(expr, outers, simplify_join_on)
-                });
-            }
-        }
-        Ok(())
+            Ok(())
+        })
     }
 
     fn walk_scalar(
@@ -504,6 +515,32 @@ fn resolve_local_columns(expr: &HirScalarExpr, env: &[HirScalarExpr]) -> Option<
         }
     });
     ok.then_some(expr)
+}
+
+/// Returns whether `expr` contains any subquery (`HirScalarExpr::Exists` or
+/// `HirScalarExpr::Select`). The relation tree is traversed iteratively so this
+/// is stack-safe on deeply nested inputs; the per-scalar walk is bounded by the
+/// parser's expression-depth limit.
+fn relation_contains_subquery(expr: &HirRelationExpr) -> bool {
+    fn scalar_contains_subquery(s: &HirScalarExpr) -> bool {
+        if matches!(s, HirScalarExpr::Exists(..) | HirScalarExpr::Select(..)) {
+            return true;
+        }
+        let mut found = false;
+        VisitChildren::<HirScalarExpr>::visit_children(s, |c| {
+            found = found || scalar_contains_subquery(c);
+        });
+        found
+    }
+    let mut found = false;
+    expr.visit_post(&mut |r: &HirRelationExpr| {
+        if !found {
+            VisitChildren::<HirScalarExpr>::visit_children(r, |s| {
+                found = found || scalar_contains_subquery(s);
+            });
+        }
+    });
+    found
 }
 
 /// An empty parameter type map.
@@ -970,4 +1007,35 @@ pub fn fuse_window_functions(
         }
         Ok(())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A deeply nested, subquery-free relation tree must plan without
+    /// overflowing the stack. The pre-decorrelation HIR walks
+    /// (`split_subquery_predicates`, `try_simplify_quantified_comparisons`)
+    /// recurse over its full, user-controlled depth, and the latter would
+    /// otherwise recompute `input.typ()` at every level (O(depth^2)).
+    #[mz_ore::test]
+    fn deep_relation_chain_does_not_overflow() {
+        const DEPTH: usize = 100_000;
+        let mut expr = HirRelationExpr::constant(vec![], SqlRelationType::empty());
+        for _ in 0..DEPTH {
+            expr = HirRelationExpr::Filter {
+                predicates: vec![],
+                input: Box::new(expr),
+            };
+        }
+
+        split_subquery_predicates(&mut expr).unwrap();
+        try_simplify_quantified_comparisons(&mut expr, false).unwrap();
+
+        // Dismantle iteratively: dropping the deep tree recursively would itself
+        // overflow the stack.
+        while let HirRelationExpr::Filter { input, .. } = expr {
+            expr = *input;
+        }
+    }
 }

--- a/src/sql/src/plan/transform_hir.rs
+++ b/src/sql/src/plan/transform_hir.rs
@@ -18,7 +18,7 @@ use mz_expr::WindowFrame;
 use mz_expr::func::variadic::RecordCreate;
 use mz_expr::visit::{Visit, VisitChildren};
 use mz_expr::{ColumnOrder, UnaryFunc, VariadicFunc};
-use mz_ore::stack::RecursionLimitError;
+use mz_ore::stack::{RecursionLimitError, maybe_grow};
 use mz_repr::{ColumnName, SqlColumnType, SqlRelationType, SqlScalarType};
 
 use crate::plan::hir::{
@@ -185,7 +185,7 @@ pub fn try_simplify_quantified_comparisons(
         simplify_join_on: bool,
     ) -> Result<(), RecursionLimitError> {
         // Grow the stack: recurses over a user-controlled-depth relation tree.
-        mz_ore::stack::maybe_grow(|| {
+        maybe_grow(|| {
             match expr {
                 HirRelationExpr::Map { scalars, input } => {
                     walk_relation(input, outers, simplify_join_on)?;
@@ -518,25 +518,23 @@ fn resolve_local_columns(expr: &HirScalarExpr, env: &[HirScalarExpr]) -> Option<
 }
 
 /// Returns whether `expr` contains any subquery (`HirScalarExpr::Exists` or
-/// `HirScalarExpr::Select`). The relation tree is traversed iteratively so this
-/// is stack-safe on deeply nested inputs; the per-scalar walk is bounded by the
-/// parser's expression-depth limit.
+/// `HirScalarExpr::Select`). Both the relation tree and the per-node scalars are
+/// traversed iteratively, so this is stack-safe on deeply nested inputs: a long
+/// JOIN/CTE chain grows the relation tree, and a flat `CASE` with many arms
+/// lowers to a deep right-nested `If` chain in a single scalar. `visit_pre` on
+/// `HirScalarExpr` stops at `Exists`/`Select` (they are scalar leaves), so the
+/// scan never descends into subquery bodies. The relation walk already yields
+/// those bodies as its own children.
 fn relation_contains_subquery(expr: &HirRelationExpr) -> bool {
-    fn scalar_contains_subquery(s: &HirScalarExpr) -> bool {
-        if matches!(s, HirScalarExpr::Exists(..) | HirScalarExpr::Select(..)) {
-            return true;
-        }
-        let mut found = false;
-        VisitChildren::<HirScalarExpr>::visit_children(s, |c| {
-            found = found || scalar_contains_subquery(c);
-        });
-        found
-    }
     let mut found = false;
     expr.visit_post(&mut |r: &HirRelationExpr| {
         if !found {
             VisitChildren::<HirScalarExpr>::visit_children(r, |s| {
-                found = found || scalar_contains_subquery(s);
+                s.visit_pre(&mut |e: &HirScalarExpr| {
+                    if matches!(e, HirScalarExpr::Exists(..) | HirScalarExpr::Select(..)) {
+                        found = true;
+                    }
+                });
             });
         }
     });
@@ -1019,6 +1017,7 @@ mod tests {
     /// recurse over its full, user-controlled depth, and the latter would
     /// otherwise recompute `input.typ()` at every level (O(depth^2)).
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
     fn deep_relation_chain_does_not_overflow() {
         const DEPTH: usize = 100_000;
         let mut expr = HirRelationExpr::constant(vec![], SqlRelationType::empty());
@@ -1037,5 +1036,86 @@ mod tests {
         while let HirRelationExpr::Filter { input, .. } = expr {
             expr = *input;
         }
+    }
+
+    /// A shallow relation whose scalar is a deeply nested `If` chain must plan
+    /// without overflowing the stack. A flat `CASE` with many arms consumes no
+    /// per-arm parser recursion but lowers to a right-nested `If` chain of that
+    /// depth, so the subquery scan in `try_simplify_quantified_comparisons` must
+    /// scan the scalar iteratively, not once per `If` node.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    fn deep_scalar_if_chain_does_not_overflow() {
+        const DEPTH: usize = 100_000;
+        let mut scalar = HirScalarExpr::literal_true();
+        for _ in 0..DEPTH {
+            scalar = HirScalarExpr::if_then_else(
+                HirScalarExpr::literal_true(),
+                HirScalarExpr::literal_true(),
+                scalar,
+            );
+        }
+        let mut expr = HirRelationExpr::Map {
+            input: Box::new(HirRelationExpr::constant(vec![], SqlRelationType::empty())),
+            scalars: vec![scalar],
+        };
+
+        try_simplify_quantified_comparisons(&mut expr, false).unwrap();
+
+        // Dismantle the `If` chain iteratively: dropping it recursively would
+        // itself overflow the stack.
+        let HirRelationExpr::Map { mut scalars, .. } = expr else {
+            unreachable!()
+        };
+        let mut scalar = scalars.pop().unwrap();
+        while let HirScalarExpr::If { els, .. } = scalar {
+            scalar = *els;
+        }
+    }
+
+    /// Once a subquery defeats the early bail in
+    /// `try_simplify_quantified_comparisons`, `walk_relation` recurses over the
+    /// full depth of the relation tree and must not overflow.
+    ///
+    /// The depth stays modest because `walk_relation` recomputes `input.typ()`
+    /// at every level, which is O(depth^2). Running on a thread whose stack is
+    /// smaller than `mz_ore::stack::STACK_RED_ZONE` is what makes the walk's
+    /// `maybe_grow` load-bearing at that depth: without it, the walk overflows.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    fn deep_relation_chain_with_subquery_does_not_overflow() {
+        const DEPTH: usize = 3_000;
+        const THREAD_STACK_SIZE: usize = 256 << 10;
+
+        std::thread::Builder::new()
+            .stack_size(THREAD_STACK_SIZE)
+            .spawn(|| {
+                let mut expr = HirRelationExpr::constant(vec![], SqlRelationType::empty());
+                for _ in 0..DEPTH {
+                    expr = HirRelationExpr::Filter {
+                        predicates: vec![],
+                        input: Box::new(expr),
+                    };
+                }
+                // A single subquery anywhere in the tree is enough to make the
+                // full-depth walk run.
+                expr = HirRelationExpr::Filter {
+                    predicates: vec![
+                        HirRelationExpr::constant(vec![], SqlRelationType::empty()).exists(),
+                    ],
+                    input: Box::new(expr),
+                };
+
+                try_simplify_quantified_comparisons(&mut expr, false).unwrap();
+
+                // Dismantle iteratively: dropping the deep tree recursively
+                // would itself overflow this thread's small stack.
+                while let HirRelationExpr::Filter { input, .. } = expr {
+                    expr = *input;
+                }
+            })
+            .unwrap()
+            .join()
+            .unwrap();
     }
 }

--- a/src/sql/src/plan/transform_hir.rs
+++ b/src/sql/src/plan/transform_hir.rs
@@ -518,25 +518,23 @@ fn resolve_local_columns(expr: &HirScalarExpr, env: &[HirScalarExpr]) -> Option<
 }
 
 /// Returns whether `expr` contains any subquery (`HirScalarExpr::Exists` or
-/// `HirScalarExpr::Select`). The relation tree is traversed iteratively so this
-/// is stack-safe on deeply nested inputs; the per-scalar walk is bounded by the
-/// parser's expression-depth limit.
+/// `HirScalarExpr::Select`). Both the relation tree and the per-node scalars are
+/// traversed iteratively, so this is stack-safe on deeply nested inputs: a long
+/// JOIN/CTE chain grows the relation tree, and a flat `CASE` with many arms
+/// lowers to a deep right-nested `If` chain in a single scalar. `visit_pre` on
+/// `HirScalarExpr` stops at `Exists`/`Select` (they are scalar leaves), so the
+/// scan never descends into subquery bodies. The relation walk already yields
+/// those bodies as its own children.
 fn relation_contains_subquery(expr: &HirRelationExpr) -> bool {
-    fn scalar_contains_subquery(s: &HirScalarExpr) -> bool {
-        if matches!(s, HirScalarExpr::Exists(..) | HirScalarExpr::Select(..)) {
-            return true;
-        }
-        let mut found = false;
-        VisitChildren::<HirScalarExpr>::visit_children(s, |c| {
-            found = found || scalar_contains_subquery(c);
-        });
-        found
-    }
     let mut found = false;
     expr.visit_post(&mut |r: &HirRelationExpr| {
         if !found {
             VisitChildren::<HirScalarExpr>::visit_children(r, |s| {
-                found = found || scalar_contains_subquery(s);
+                s.visit_pre(&mut |e: &HirScalarExpr| {
+                    if matches!(e, HirScalarExpr::Exists(..) | HirScalarExpr::Select(..)) {
+                        found = true;
+                    }
+                });
             });
         }
     });
@@ -1036,6 +1034,40 @@ mod tests {
         // overflow the stack.
         while let HirRelationExpr::Filter { input, .. } = expr {
             expr = *input;
+        }
+    }
+
+    /// A shallow relation whose scalar is a deeply nested `If` chain must plan
+    /// without overflowing the stack. A flat `CASE` with many arms consumes no
+    /// per-arm parser recursion but lowers to a right-nested `If` chain of that
+    /// depth, so the subquery scan in `try_simplify_quantified_comparisons` must
+    /// scan the scalar iteratively, not once per `If` node.
+    #[mz_ore::test]
+    fn deep_scalar_if_chain_does_not_overflow() {
+        const DEPTH: usize = 100_000;
+        let mut scalar = HirScalarExpr::literal_true();
+        for _ in 0..DEPTH {
+            scalar = HirScalarExpr::if_then_else(
+                HirScalarExpr::literal_true(),
+                HirScalarExpr::literal_true(),
+                scalar,
+            );
+        }
+        let mut expr = HirRelationExpr::Map {
+            input: Box::new(HirRelationExpr::constant(vec![], SqlRelationType::empty())),
+            scalars: vec![scalar],
+        };
+
+        try_simplify_quantified_comparisons(&mut expr, false).unwrap();
+
+        // Dismantle the `If` chain iteratively: dropping it recursively would
+        // itself overflow the stack.
+        let HirRelationExpr::Map { mut scalars, .. } = expr else {
+            unreachable!()
+        };
+        let mut scalar = scalars.pop().unwrap();
+        while let HirScalarExpr::If { els, .. } = scalar {
+            scalar = *els;
         }
     }
 }


### PR DESCRIPTION
The HIR transforms that run before decorrelation recurse over the relation tree, whose depth is user-controlled (a long JOIN chain or a chain of CTEs). Two of them were unguarded:

* `HirRelationExpr::visit_mut_fallible` (used by `split_subquery_predicates`) self-recursed with no stack growth, overflowing on a deep tree.

* `try_simplify_quantified_comparisons::walk_relation` likewise recursed unguarded, and additionally recomputed `input.typ()` at every level, which is O(depth^2) and wedges the coordinator on deep inputs.

Wrap both recursions in `maybe_grow`, and short-circuit `try_simplify_quantified_comparisons` when the query contains no subquery: in that common case there is nothing to simplify, so we skip the expensive walk entirely (the detection itself is an iterative, stack-safe traversal).

Note: a flat N-way join is also super-linear to *plan* (building the left-deep HIR in `plan_join`); that separate cost is not addressed here.

Closes: [SQL-512](https://linear.app/materializeinc/issue/SQL-512)