### PR TITLE
ci: Nightly fixes (2026-07-11), enable upsert v2 by default

### DIFF
--- a/src/aws-glue-schema-registry/src/client.rs
+++ b/src/aws-glue-schema-registry/src/client.rs
@@ -720,6 +720,7 @@ mod tests {
     /// Glue validates versions asynchronously, so callers gate on it before
     /// using a version's id.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `sha256_compress` on OS `linux`
     async fn write_methods_surface_lifecycle_status() {
         let register = mock!(aws_sdk_glue::Client::register_schema_version).then_output(|| {
             RegisterSchemaVersionOutput::builder()

--- a/src/storage-client/src/sink.rs
+++ b/src/storage-client/src/sink.rs
@@ -528,6 +528,7 @@ mod tests {
     /// A version that registers as `Pending` is polled until Glue reports it
     /// `Available`.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `sha256_compress` on OS `linux`
     async fn publish_glue_schema_waits_for_pending_version() {
         let lookup = definition_not_found();
         let register = register_returns(SchemaVersionStatus::Pending);
@@ -557,6 +558,7 @@ mod tests {
     /// A version whose asynchronous compatibility check fails surfaces an
     /// error instead of an id that consumers could never resolve.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `sha256_compress` on OS `linux`
     async fn publish_glue_schema_errors_on_failed_compatibility_check() {
         let lookup = definition_not_found();
         let register = register_returns(SchemaVersionStatus::Pending);
@@ -579,6 +581,7 @@ mod tests {
     /// A definition match in `Available` state is reused as-is, with no
     /// registration and no status polling.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `sha256_compress` on OS `linux`
     async fn publish_glue_schema_reuses_available_definition_match() {
         let lookup = mock!(aws_sdk_glue::Client::get_schema_by_definition).then_output(|| {
             GetSchemaByDefinitionOutput::builder()
@@ -596,6 +599,7 @@ mod tests {
     /// A definition match whose version failed its compatibility check is not
     /// reused: the definition is registered anew.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `sha256_compress` on OS `linux`
     async fn publish_glue_schema_skips_failed_definition_match() {
         let lookup = mock!(aws_sdk_glue::Client::get_schema_by_definition).then_output(|| {
             GetSchemaByDefinitionOutput::builder()

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -351,7 +351,7 @@ pub const STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT: Config<bool> = Config::new(
 /// Whether to use the v2 upsert operator.
 pub const ENABLE_UPSERT_V2: Config<bool> = Config::new(
     "enable_upsert_v2",
-    false,
+    true,
     "Whether to use the v2 upsert operator.",
 );
 

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -549,7 +549,6 @@ KNOWN_CROSS_ENV_DIVERGENCES: set[str] = set("""
     enable_notices_for_index_too_wide_for_literal_constraints
     enable_refresh_every_mvs
     enable_upsert_paged_spill
-    enable_upsert_v2
     enable_variadic_left_join_lowering
     grpc_client_http2_keep_alive_timeout
     max_connections

--- a/test/sqllogictest/cockroach/builtin_function.slt
+++ b/test/sqllogictest/cockroach/builtin_function.slt
@@ -1762,7 +1762,7 @@ timestamptz
 bytes
 int[]
 
-# TODO(def-): Reenable after database-issues#6599 is fixed
+# TODO(def-): Reenable after DB-165 is fixed
 # query T
 # VALUES (format_type('anyelement'::regtype, -1)),
 #        (format_type('bit'::regtype, -1)),


### PR DESCRIPTION
(same as in Cloud already)

Based on https://buildkite.com/materialize/nightly/builds/17148