### PR TITLE
adapter: Commit single-peek transactions in the session task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8763,6 +8763,7 @@ dependencies = [
  "mz-dyncfg",
  "mz-dyncfgs",
  "mz-ore",
+ "mz-persist",
  "mz-persist-client",
  "mz-persist-types",
  "mz-proto",

--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -235,6 +235,32 @@ keep the change invisible to session-visible catalog reads (name resolution,
 planning). Otherwise sessions serve stale catalogs where today they would see
 the change.
 
+### Session-local commit must stay a no-op on the Coordinator
+
+`SessionClient::end_transaction` commits a single-statement transaction whose
+only statement was a frontend-sequenced plain `SELECT` in the session task,
+without a `Command::Commit` round-trip (behind the
+`enable_session_local_commit` dyncfg). This is correct only because such a
+transaction leaves no per-connection state in the Coordinator that is cleaned
+up at transaction end, so `Coordinator::clear_connection` would find nothing
+to do. Eligibility is tracked by
+`TransactionOps::Peeks::allow_session_local_commit`, which any sequencing path
+that does leave such state must set to false. Two known examples:
+
+- The Coordinator peek sequencing stores transaction read holds in
+  `Coordinator::txn_read_holds` even for single-statement transactions, and
+  `store_transaction_read_holds` merges into an existing entry. A wrongly
+  eligible transaction would therefore silently accumulate read holds on a
+  pooled connection, stalling compaction.
+- `COPY TO` registers an active compute sink that transaction end retires.
+
+At strict serializable isolation, commit must additionally not return before
+the oracle read timestamp has passed the peek's timestamp. The session-local
+path only handles the no-wait case: `chosen_ts <= oracle_ts` already held when
+the peek's timestamp was determined, and the oracle only advances. Actual
+waits, and strong session serializable's oracle `apply_write` at commit, fall
+back to `Command::Commit`.
+
 ## Rejected Optimizations
 
 This section records specific optimizations that have been attempted and found

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -246,6 +246,11 @@ def get_variable_system_parameters(
             ["true", "false"],
         ),
         VariableSystemParameter(
+            "enable_session_local_commit",
+            "true" if version >= MzVersion.parse_mz("v26.34.0-dev") else "false",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
             "enable_scoped_system_parameters",
             "false",
             ["true", "false"],

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1678,6 +1678,7 @@ class FlipFlagsAction(Action):
             "true",
             "false",
         ]
+        self.flags_with_values["enable_session_local_commit"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_case_literal_transform"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_cast_elimination"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_fixed_correlated_cte_lowering"] = (

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -101,6 +101,14 @@ pub const ENABLE_FRONTEND_SUBSCRIBES: Config<bool> = Config::new(
     "Enable sending subscribes down the new frontend-peek path.",
 );
 
+/// Enable committing single-peek transactions in the session task, without a
+/// Coordinator round-trip.
+pub const ENABLE_SESSION_LOCAL_COMMIT: Config<bool> = Config::new(
+    "enable_session_local_commit",
+    false,
+    "Enable committing single-peek transactions in the session task, without a Coordinator round-trip.",
+);
+
 /// The plan insights notice will not investigate fast path clusters if plan optimization took longer than this.
 pub const PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION: Config<Duration> = Config::new(
     "plan_insights_notice_fast_path_clusters_optimize_duration",
@@ -362,6 +370,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
         .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
         .add(&ENABLE_FRONTEND_SUBSCRIBES)
+        .add(&ENABLE_SESSION_LOCAL_COMMIT)
         .add(&PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION)
         .add(&ENABLE_EXPRESSION_CACHE)
         .add(&ENABLE_PASSWORD_AUTH)

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -42,7 +42,7 @@ use mz_sql::session::hint::ApplicationNameHint;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::user::SUPPORT_USER;
 use mz_sql::session::vars::{
-    CLUSTER, ENABLE_FRONTEND_PEEK_SEQUENCING, OwnedVarInput, SystemVars, Var,
+    CLUSTER, ENABLE_FRONTEND_PEEK_SEQUENCING, IsolationLevel, OwnedVarInput, SystemVars, Var,
 };
 use mz_sql_parser::parser::{ParserStatementError, StatementParseResult};
 use prometheus::Histogram;
@@ -61,7 +61,8 @@ use crate::coord::{Coordinator, ExecuteContextGuard};
 use crate::error::AdapterError;
 use crate::metrics::{self, Metrics};
 use crate::session::{
-    EndTransactionAction, PreparedStatement, Session, SessionConfig, StateRevision, TransactionId,
+    EndTransactionAction, PreparedStatement, RequireLinearization, Session, SessionConfig,
+    StateRevision, TransactionId, TransactionOps, TransactionStatus,
 };
 use crate::statement_logging::{StatementEndedExecutionReason, StatementExecutionStrategy};
 use crate::telemetry::{self, EventDetails, SegmentClientExt, StatementFailureType};
@@ -1092,6 +1093,17 @@ impl SessionClient {
         &mut self,
         action: EndTransactionAction,
     ) -> Result<ExecuteResponse, AdapterError> {
+        if self.commit_is_session_local(&action) {
+            // This matches what the `Command::Commit` path does for such a
+            // transaction: `Session::clear_transaction` in
+            // `sequence_end_transaction_inner`, and `SessionVars::end_transaction`
+            // when building the response.
+            let session = self.session.as_mut().expect("session invariant violated");
+            let _ = session.clear_transaction();
+            let params = session.vars_mut().end_transaction(action);
+            return Ok(ExecuteResponse::TransactionCommitted { params });
+        }
+
         let res = self
             .send(|tx, session| Command::Commit {
                 action,
@@ -1104,6 +1116,59 @@ impl SessionClient {
         // any data that the Coordinator must act on for correctness.
         let _ = self.session().clear_transaction();
         res
+    }
+
+    /// Whether [`SessionClient::end_transaction`] can commit the current
+    /// transaction in the session task, without a `Command::Commit`
+    /// round-trip to the Coordinator.
+    ///
+    /// This is the case for a single-statement transaction whose only
+    /// statement was a peek sequenced by the frontend peek sequencing. Such a
+    /// transaction has no Coordinator-side state that gets cleaned up when the
+    /// transaction ends (see `TransactionOps::Peeks::allow_session_local_commit`),
+    /// so committing consists only of session-local steps. The exception is
+    /// isolation levels whose commit involves the timestamp oracle, where we
+    /// fall back to the Coordinator path:
+    /// - At strict serializable, a peek whose timestamp is ahead of the oracle
+    ///   read timestamp must wait for the oracle to pass it before the commit
+    ///   may return, see `Coordinator::message_linearize_reads`. We commit
+    ///   locally only when
+    ///   [`TimestampContext::requires_oracle_wait`](crate::coord::timestamp_selection::TimestampContext::requires_oracle_wait)
+    ///   shows that no wait is needed.
+    /// - At strong session serializable, commit applies the peek timestamp to
+    ///   the session's oracle.
+    fn commit_is_session_local(&self, action: &EndTransactionAction) -> bool {
+        if !matches!(action, EndTransactionAction::Commit) {
+            return false;
+        }
+        let session = self.session.as_ref().expect("session invariant violated");
+        // `Started` transactions are guaranteed single-statement (see its doc
+        // comment), so the transaction consists of exactly the peeks checked
+        // below. Everything else, including explicit and multi-statement
+        // implicit transactions (whose read holds are stored in the
+        // Coordinator) and failed transactions, falls back.
+        let TransactionStatus::Started(txn) = session.transaction() else {
+            return false;
+        };
+        let TransactionOps::Peeks {
+            determination,
+            requires_linearization,
+            allow_session_local_commit: true,
+            ..
+        } = &txn.ops
+        else {
+            return false;
+        };
+        match (
+            session.vars().transaction_isolation(),
+            requires_linearization,
+        ) {
+            (IsolationLevel::StrictSerializable, RequireLinearization::Required) => {
+                !determination.timestamp_context.requires_oracle_wait()
+            }
+            (IsolationLevel::StrongSessionSerializable, RequireLinearization::Required) => false,
+            _ => true,
+        }
     }
 
     /// Fails a transaction.

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -1078,53 +1078,44 @@ impl Coordinator {
         let mut cached_oracle_ts = BTreeMap::new();
 
         for (conn_id, mut read_txn) in std::mem::take(&mut self.pending_linearize_read_txns) {
-            if let TimestampContext::TimelineTimestamp {
+            if !read_txn.timestamp_context().requires_oracle_wait() {
+                // No oracle timestamp, or the chosen timestamp already
+                // trailed the oracle timestamp when it was determined, so no
+                // need to delay.
+                ready_txns.push(read_txn);
+                continue;
+            }
+            let TimestampContext::TimelineTimestamp {
                 timeline,
                 chosen_ts,
-                oracle_ts,
+                ..
             } = read_txn.timestamp_context()
-            {
-                let oracle_ts = match oracle_ts {
-                    Some(oracle_ts) => oracle_ts,
-                    None => {
-                        // There was no oracle timestamp, so no need to delay.
-                        ready_txns.push(read_txn);
-                        continue;
-                    }
-                };
+            else {
+                unreachable!("requires_oracle_wait implies a timeline timestamp");
+            };
 
-                if chosen_ts <= oracle_ts {
-                    // Chosen ts was already <= the oracle ts, so we're good
-                    // to go!
-                    ready_txns.push(read_txn);
-                    continue;
+            // See what the oracle timestamp is now and delay when needed.
+            let current_oracle_ts = cached_oracle_ts.entry(timeline.clone());
+            let current_oracle_ts = match current_oracle_ts {
+                btree_map::Entry::Vacant(entry) => {
+                    let timestamp_oracle = self.get_timestamp_oracle(timeline);
+                    let read_ts = timestamp_oracle.read_ts().await;
+                    entry.insert(read_ts.clone());
+                    read_ts
                 }
+                btree_map::Entry::Occupied(entry) => entry.get().clone(),
+            };
 
-                // See what the oracle timestamp is now and delay when needed.
-                let current_oracle_ts = cached_oracle_ts.entry(timeline.clone());
-                let current_oracle_ts = match current_oracle_ts {
-                    btree_map::Entry::Vacant(entry) => {
-                        let timestamp_oracle = self.get_timestamp_oracle(timeline);
-                        let read_ts = timestamp_oracle.read_ts().await;
-                        entry.insert(read_ts.clone());
-                        read_ts
-                    }
-                    btree_map::Entry::Occupied(entry) => entry.get().clone(),
-                };
-
-                if *chosen_ts <= current_oracle_ts {
-                    ready_txns.push(read_txn);
-                } else {
-                    let wait =
-                        Duration::from_millis(chosen_ts.saturating_sub(current_oracle_ts).into());
-                    if wait < shortest_wait {
-                        shortest_wait = wait;
-                    }
-                    read_txn.num_requeues += 1;
-                    self.pending_linearize_read_txns.insert(conn_id, read_txn);
-                }
-            } else {
+            if *chosen_ts <= current_oracle_ts {
                 ready_txns.push(read_txn);
+            } else {
+                let wait =
+                    Duration::from_millis(chosen_ts.saturating_sub(current_oracle_ts).into());
+                if wait < shortest_wait {
+                    shortest_wait = wait;
+                }
+                read_txn.num_requeues += 1;
+                self.pending_linearize_read_txns.insert(conn_id, read_txn);
             }
         }
 

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -1118,11 +1118,15 @@ impl Coordinator {
         // necessary to support PG's `BEGIN` semantics, whose behavior can
         // depend on whether or not reads have occurred in the txn.
         let mut transaction_determination = determination.clone();
+        // No session-local commit for Coordinator-sequenced peeks: we stored
+        // transaction read holds above, which `Command::Commit` releases.
+        let allow_session_local_commit = false;
         if when.is_transactional() {
             session.add_transaction_ops(TransactionOps::Peeks {
                 determination: transaction_determination,
                 cluster_id,
                 requires_linearization,
+                allow_session_local_commit,
             })?;
         } else if matches!(session.transaction(), &TransactionStatus::InTransaction(_)) {
             // If the query uses AS OF, then ignore the timestamp.
@@ -1131,6 +1135,7 @@ impl Coordinator {
                 determination: transaction_determination,
                 cluster_id,
                 requires_linearization,
+                allow_session_local_commit,
             })?;
         };
 

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -225,6 +225,12 @@ impl Coordinator {
     ///
     /// Returns a notify that resolves once any `mz_subscriptions` retractions
     /// caused by cleanup are durable.
+    ///
+    /// NOTE: `SessionClient::end_transaction` commits eligible single-peek
+    /// transactions session-locally, skipping this cleanup on the grounds
+    /// that it is a no-op for them. When adding cleanup here for state that
+    /// the frontend peek sequencing of a plain `SELECT` can create, revisit
+    /// `TransactionOps::Peeks::allow_session_local_commit`.
     pub(crate) async fn clear_connection(
         &mut self,
         conn_id: &ConnectionId,

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -110,6 +110,28 @@ impl TimestampContext {
         }
     }
 
+    /// Whether a strict serializable read at this timestamp context may have
+    /// to wait for the timestamp oracle before its results are released.
+    ///
+    /// This is the case when the chosen timestamp ran ahead of the oracle
+    /// read timestamp at the time the timestamp was determined. The oracle
+    /// only advances, so a `false` result remains valid: results can be
+    /// released without consulting the oracle.
+    pub fn requires_oracle_wait(&self) -> bool {
+        match self {
+            Self::TimelineTimestamp {
+                chosen_ts,
+                oracle_ts: Some(oracle_ts),
+                ..
+            } => chosen_ts > oracle_ts,
+            // No oracle timestamp to wait for.
+            Self::TimelineTimestamp {
+                oracle_ts: None, ..
+            }
+            | Self::NoTimestamp => false,
+        }
+    }
+
     /// The timestamp belonging to this context, or a sensible default if one does not exists.
     pub fn timestamp_or_default(&self) -> Timestamp {
         match self {

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use itertools::Itertools;
-use mz_adapter_types::dyncfgs::ENABLE_FRONTEND_SUBSCRIBES;
+use mz_adapter_types::dyncfgs::{ENABLE_FRONTEND_SUBSCRIBES, ENABLE_SESSION_LOCAL_COMMIT};
 use mz_compute_types::ComputeInstanceId;
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_controller_types::ClusterId;
@@ -804,6 +804,10 @@ impl PeekClient {
         // necessary to support PG's `BEGIN` semantics, whose behavior can
         // depend on whether or not reads have occurred in the txn.
         let requires_linearization = (&explain_ctx).into();
+        // Only plain SELECTs qualify. COPY TO leaves Coordinator-side state,
+        // see the field's doc comment.
+        let allow_session_local_commit = matches!(query_plan, QueryPlan::Select(..))
+            && ENABLE_SESSION_LOCAL_COMMIT.get(catalog.system_config().dyncfgs());
         let mut transaction_determination = determination.clone();
         match query_plan {
             QueryPlan::Subscribe { .. } => {
@@ -817,6 +821,7 @@ impl PeekClient {
                         determination: transaction_determination,
                         cluster_id: target_cluster_id,
                         requires_linearization,
+                        allow_session_local_commit,
                     })?;
                 } else if matches!(session.transaction(), &TransactionStatus::InTransaction(_)) {
                     // If the query uses AS OF, then ignore the timestamp.
@@ -825,6 +830,7 @@ impl PeekClient {
                         determination: transaction_determination,
                         cluster_id: target_cluster_id,
                         requires_linearization,
+                        allow_session_local_commit,
                     })?;
                 }
             }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1321,12 +1321,16 @@ impl TransactionStatus {
                         determination,
                         cluster_id,
                         requires_linearization,
+                        allow_session_local_commit,
                     } => match add_ops {
                         TransactionOps::Peeks {
                             determination: add_timestamp_determination,
                             cluster_id: add_cluster_id,
                             requires_linearization: add_requires_linearization,
+                            allow_session_local_commit: add_allow_session_local_commit,
                         } => {
+                            *allow_session_local_commit =
+                                *allow_session_local_commit && add_allow_session_local_commit;
                             assert_eq!(*cluster_id, add_cluster_id);
                             match (
                                 &determination.timestamp_context,
@@ -1577,6 +1581,19 @@ pub enum TransactionOps {
         cluster_id: ClusterId,
         /// Whether this peek needs to be linearized.
         requires_linearization: RequireLinearization,
+        /// Whether `SessionClient::end_transaction` may commit this
+        /// transaction in the session task, without a `Command::Commit`
+        /// round-trip to the Coordinator.
+        ///
+        /// Contract: only set this to true if sequencing left no
+        /// per-connection state in the Coordinator that gets cleaned up when
+        /// the transaction ends (see `Coordinator::clear_connection`, e.g.
+        /// stored transaction read holds, active compute sinks). The frontend
+        /// peek sequencing of a plain `SELECT` satisfies this. The Coordinator
+        /// peek sequencing does not (it stores transaction read holds even for
+        /// single-statement transactions), and neither does `COPY TO`, whose
+        /// active sink is retired on transaction end.
+        allow_session_local_commit: bool,
     },
     /// This transaction has done a `SUBSCRIBE` and must do nothing else.
     Subscribe,

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -4130,3 +4130,149 @@ fn test_grant_all_on_view_suppresses_non_applicable_notice() {
         );
     }
 }
+
+/// Test that a single-peek transaction commits in the session task, without a
+/// `Command::Commit` round-trip to the Coordinator (the `command-commit`
+/// message), when `enable_session_local_commit` is on.
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // too slow
+#[allow(clippy::disallowed_methods)]
+fn test_session_local_commit() {
+    let server = test_util::TestHarness::default()
+        .with_system_parameter_default(
+            "enable_session_local_commit".to_string(),
+            "true".to_string(),
+        )
+        .with_system_parameter_default("enable_refresh_every_mvs".to_string(), "true".to_string())
+        .start_blocking();
+    let mut client = server.connect(postgres::NoTls).unwrap();
+
+    // The number of `command-commit` Coordinator messages processed so far.
+    let command_commits = || {
+        server
+            .metrics_registry()
+            .gather()
+            .into_iter()
+            .find(|metric_family| metric_family.name() == "mz_slow_message_handling")
+            .map(|metric_family| {
+                metric_family
+                    .get_metric()
+                    .iter()
+                    .filter(|metric| {
+                        metric
+                            .get_label()
+                            .iter()
+                            .any(|label| label.value() == "command-commit")
+                    })
+                    .map(|metric| metric.get_histogram().get_sample_count())
+                    .sum::<u64>()
+            })
+            .unwrap_or(0)
+    };
+
+    client.batch_execute("CREATE TABLE t (a int)").unwrap();
+    client
+        .batch_execute("INSERT INTO t VALUES (1), (2)")
+        .unwrap();
+
+    // Use prepared statements so each execution is a single Bind/Execute/Sync
+    // round. An unprepared `query` additionally sends a Parse/Describe/Sync
+    // round, whose Sync commits an *empty* implicit transaction, and empty
+    // transactions (not being single-peek transactions) still commit via the
+    // Coordinator.
+    let select_one = client.prepare("SELECT 1").unwrap();
+    let select_t = client.prepare("SELECT * FROM t").unwrap();
+
+    // Constant peeks have no timestamp, so they are eligible under any
+    // isolation level, including the default strict serializable.
+    let before = command_commits();
+    for _ in 0..10 {
+        let rows = client.query(&select_one, &[]).unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+    assert_eq!(
+        command_commits(),
+        before,
+        "autocommit constant SELECTs must not send command-commit"
+    );
+
+    // Non-constant peeks: run under serializable isolation, where eligibility
+    // doesn't depend on the timestamp the peek happened to choose. (Under
+    // strict serializable, a peek whose timestamp is ahead of the oracle falls
+    // back to the Coordinator commit path, so counting there would be racy.)
+    client
+        .batch_execute("SET transaction_isolation = serializable")
+        .unwrap();
+    let before = command_commits();
+    for _ in 0..10 {
+        let rows = client.query(&select_t, &[]).unwrap();
+        assert_eq!(rows.len(), 2);
+    }
+    assert_eq!(
+        command_commits(),
+        before,
+        "autocommit SELECTs must not send command-commit"
+    );
+    client.batch_execute("RESET transaction_isolation").unwrap();
+
+    // The metric is observed after the Coordinator sends the response the
+    // client is waiting on, so retry briefly when asserting growth.
+    let assert_command_commits_grow = |before: u64, what: &str| {
+        let grew = Retry::default()
+            .max_duration(Duration::from_secs(10))
+            .retry(|_| {
+                if command_commits() > before {
+                    Ok(())
+                } else {
+                    Err("no command-commit observed yet")
+                }
+            });
+        assert!(grew.is_ok(), "{what}: expected a command-commit message");
+    };
+
+    // Autocommit writes still commit via the Coordinator.
+    let before = command_commits();
+    client.batch_execute("INSERT INTO t VALUES (3)").unwrap();
+    assert_command_commits_grow(before, "autocommit write");
+
+    // Smoke test that with the flag on, a multi-statement transaction still
+    // takes the Coordinator fall-back path successfully. (Its COMMIT is a
+    // regular executed statement, not a `command-commit` message, so there is
+    // nothing to count here.)
+    let mut txn = client.transaction().unwrap();
+    let rows = txn.query("SELECT * FROM t", &[]).unwrap();
+    assert_eq!(rows.len(), 3);
+    let rows = txn.query("SELECT a FROM t WHERE a = 1", &[]).unwrap();
+    assert_eq!(rows.len(), 1);
+    txn.commit().unwrap();
+
+    // A strict serializable peek whose timestamp is ahead of the oracle read
+    // timestamp must fall back to the Coordinator commit path: the commit is
+    // what gates releasing the results until the oracle passes the peek's
+    // timestamp (`Coordinator::message_linearize_reads`). A REFRESH AT
+    // materialized view whose first refresh is in the near future forces such
+    // a timestamp.
+    client
+        .batch_execute(
+            "CREATE MATERIALIZED VIEW refresh_mv \
+             WITH (REFRESH AT mz_now()::text::int8 + 2000) AS SELECT 1",
+        )
+        .unwrap();
+    let refresh_mv_select = client.prepare("SELECT * FROM refresh_mv").unwrap();
+    let before = command_commits();
+    // Blocks for ~2s, until the timestamp oracle passes the refresh time.
+    let rows = client.query(&refresh_mv_select, &[]).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_command_commits_grow(before, "peek with a linearize wait");
+
+    // Turning the flag off takes effect for subsequent statements: commits go
+    // back through the Coordinator.
+    let mut internal_client = server.connect_internal(postgres::NoTls).unwrap();
+    internal_client
+        .batch_execute("ALTER SYSTEM SET enable_session_local_commit = false")
+        .unwrap();
+    let before = command_commits();
+    let rows = client.query("SELECT 1", &[]).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_command_commits_grow(before, "autocommit SELECT with the flag off");
+}

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -45,5 +45,8 @@ tokio-stream.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 
+[dev-dependencies]
+mz-persist = { path = "../persist" }
+
 [features]
 default = []

--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -1737,6 +1737,12 @@ where
         .collect()
 }
 
+/// Number of updates to add to a persist batch between yields in
+/// [`monotonic_append`]. Encoding one update takes single-digit
+/// microseconds, so this bounds the poll time of the append future to a
+/// few milliseconds.
+const MONOTONIC_APPEND_YIELD_INTERVAL: usize = 1024;
+
 async fn monotonic_append(
     write_handle: &mut WriteHandle<SourceData, (), Timestamp, StorageDiff>,
     updates: Vec<TimestamplessUpdate>,
@@ -1757,23 +1763,60 @@ async fn monotonic_append(
 
         let lower = std::cmp::max(upper, at_least);
         let new_upper = lower.step_forward();
-        let updates = updates
-            .iter()
-            .map(|TimestamplessUpdate { row, diff }| {
-                ((SourceData(Ok(row.clone())), ()), lower, diff.into_inner())
-            })
-            .collect::<Vec<_>>();
+
+        // Build the batch incrementally, yielding regularly. Encoding an
+        // update is pure CPU and `BatchBuilder::add` has no await points
+        // until a part reaches `blob_target_size`. Statement logging can
+        // produce batches of hundreds of thousands of updates here, and
+        // encoding all of them in a single poll blocks this tokio worker
+        // for hundreds of milliseconds, starving tasks that are pinned to
+        // it (for example a task sitting in the worker's LIFO slot, which
+        // other workers cannot steal).
+        //
+        // TODO: The hazard is general to `WriteHandle::batch`, which encodes
+        // whole batches in one poll for every `compare_and_append` caller.
+        // If persist ever yields periodically while building batches, this
+        // can go back to a plain `compare_and_append` call.
+        // The batch description must span exactly [expected upper, new
+        // upper), like `compare_and_append` would use. The updates
+        // themselves are timestamped with `lower`, which lies within that
+        // span.
+        let mut builder = write_handle.builder(Antichain::from_elem(upper));
+        for (i, TimestamplessUpdate { row, diff }) in updates.iter().enumerate() {
+            if i > 0 && i % MONOTONIC_APPEND_YIELD_INTERVAL == 0 {
+                tokio::task::yield_now().await;
+            }
+            builder
+                .add(
+                    &SourceData(Ok(row.clone())),
+                    &(),
+                    &lower,
+                    &diff.into_inner(),
+                )
+                .await
+                .expect("valid usage");
+        }
+        let mut batch = builder
+            .finish(Antichain::from_elem(new_upper))
+            .await
+            .expect("valid usage");
+
         let res = write_handle
-            .compare_and_append(
-                updates,
+            .compare_and_append_batch(
+                &mut [&mut batch],
                 Antichain::from_elem(upper),
                 Antichain::from_elem(new_upper),
+                true,
             )
             .await
             .expect("valid usage");
         match res {
             Ok(()) => return,
             Err(err) => {
+                // The batch's updates are timestamped with `lower`, which
+                // is now wrong. Delete the batch and rebuild it with
+                // timestamps based on the actual upper.
+                batch.delete().await;
                 expected_upper = err.current;
                 continue;
             }
@@ -2069,5 +2112,146 @@ mod tests {
             ns_datum.1.unwrap_map().iter().next().unwrap(),
             ("thing", Datum::String("error"))
         );
+    }
+
+    /// Exercises `monotonic_append` against real persist state: a batch large
+    /// enough to take the periodic-yield path, and a deterministic upper
+    /// mismatch that forces the delete-and-rebuild retry. Verifies that every
+    /// update lands exactly once and that retried updates are re-timestamped
+    /// to the actual upper.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // too slow
+    async fn test_monotonic_append_yield_and_upper_mismatch_retry() {
+        use mz_ore::metrics::MetricsRegistry;
+        use mz_persist::location::{Blob, Consensus};
+        use mz_persist::mem::{MemBlob, MemBlobConfig, MemConsensus};
+        use mz_persist_client::async_runtime::IsolatedRuntime;
+        use mz_persist_client::cache::StateCache;
+        use mz_persist_client::cfg::PersistConfig;
+        use mz_persist_client::metrics::Metrics as PersistMetrics;
+        use mz_persist_client::rpc::PubSubClientConnection;
+        use mz_persist_client::{Diagnostics, PersistClient, ShardId};
+        use mz_persist_types::codec_impls::UnitSchema;
+        use mz_repr::{RelationDesc, SqlScalarType};
+
+        let cfg = PersistConfig::new_for_tests();
+        let blob: Arc<dyn Blob> = Arc::new(MemBlob::open(MemBlobConfig::default()));
+        let consensus: Arc<dyn Consensus> = Arc::new(MemConsensus::default());
+        let metrics = Arc::new(PersistMetrics::new(&cfg, &MetricsRegistry::new()));
+        // Two clients over the same backing storage with separate state
+        // caches, so that appends through one client are not reflected in the
+        // other's cached upper.
+        let new_client = || {
+            let pubsub_sender = PubSubClientConnection::noop().sender;
+            PersistClient::new(
+                cfg.clone(),
+                Arc::clone(&blob),
+                Arc::clone(&consensus),
+                Arc::clone(&metrics),
+                Arc::new(IsolatedRuntime::new_for_tests()),
+                Arc::new(StateCache::new(
+                    &cfg,
+                    Arc::clone(&metrics),
+                    Arc::clone(&pubsub_sender),
+                )),
+                pubsub_sender,
+            )
+            .expect("valid client")
+        };
+
+        let shard = ShardId::new();
+        let relation_desc = RelationDesc::builder()
+            .with_column("a", SqlScalarType::UInt64.nullable(false))
+            .finish();
+        let updates = |range: std::ops::Range<u64>| {
+            range
+                .map(|i| TimestamplessUpdate {
+                    row: Row::pack_slice(&[Datum::UInt64(i)]),
+                    diff: Diff::ONE,
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let client1 = new_client();
+        let mut write1 = client1
+            .open_writer::<SourceData, (), Timestamp, StorageDiff>(
+                shard,
+                Arc::new(relation_desc.clone()),
+                Arc::new(UnitSchema),
+                Diagnostics::for_tests(),
+            )
+            .await
+            .expect("valid usage");
+
+        // More rows than MONOTONIC_APPEND_YIELD_INTERVAL, so the append
+        // yields several times while building the batch. The shard's initial
+        // upper is 0, so the rows land at max(0, 1) = 1 and the upper becomes
+        // 2.
+        monotonic_append(&mut write1, updates(0..3000), Timestamp::from(1)).await;
+
+        // Advance the upper through a second client. Its writer is opened at
+        // the current upper 2, so this appends at max(2, 10) = 10 and moves
+        // the upper to 11.
+        let client2 = new_client();
+        let mut write2 = client2
+            .open_writer::<SourceData, (), Timestamp, StorageDiff>(
+                shard,
+                Arc::new(relation_desc.clone()),
+                Arc::new(UnitSchema),
+                Diagnostics::for_tests(),
+            )
+            .await
+            .expect("valid usage");
+        monotonic_append(&mut write2, updates(3000..3005), Timestamp::from(10)).await;
+
+        // `write1` still caches upper 2 while the shard's actual upper is 11,
+        // so this append's first compare_and_append attempt (at
+        // lower = max(2, 5) = 5) is guaranteed to hit an upper mismatch and
+        // take the delete-and-rebuild retry, re-timestamping the updates to
+        // the actual upper 11.
+        assert_eq!(
+            write1.shared_upper(),
+            Antichain::from_elem(Timestamp::from(2)),
+            "write1's cached upper must be stale for this test to exercise the retry",
+        );
+        assert_eq!(
+            write2.shared_upper(),
+            Antichain::from_elem(Timestamp::from(11)),
+        );
+        monotonic_append(&mut write1, updates(3005..3010), Timestamp::from(5)).await;
+
+        let mut read = client1
+            .open_leased_reader::<SourceData, (), Timestamp, StorageDiff>(
+                shard,
+                Arc::new(relation_desc),
+                Arc::new(UnitSchema),
+                Diagnostics::for_tests(),
+                true,
+            )
+            .await
+            .expect("valid usage");
+
+        // A snapshot advances all timestamps to its `as_of`, so per-update
+        // timestamps are verified by which updates are visible at which
+        // `as_of`. Every update must appear exactly once, with diff 1.
+        for (as_of, expected_rows) in [(1, 3000), (10, 3005), (11, 3010)] {
+            let contents = read
+                .snapshot_and_fetch(Antichain::from_elem(Timestamp::from(as_of)))
+                .await
+                .expect("as_of available");
+            let mut seen = BTreeSet::new();
+            for ((key, _val), _ts, diff) in contents {
+                let SourceData(data) = key;
+                let row = data.expect("valid data");
+                let a = row.iter().next().unwrap().unwrap_uint64();
+                assert_eq!(diff, 1, "row {a} duplicated or retracted");
+                assert!(seen.insert(a), "row {a} appeared twice");
+            }
+            assert_eq!(
+                seen,
+                (0..expected_rows).collect(),
+                "unexpected contents at time {as_of}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Further QPS improvement, the second item in https://github.com/MaterializeInc/database-issues/issues/9593's "Further performance optimizations" section. Stacked on #37606, which fixes a pre-existing statement-logging latency hazard that this PR's higher QPS surfaced; only the last commit belongs to this PR.

Eliminate the Command::Commit Coordinator round-trip for single-statement transactions whose only statement was a peek sequenced by the frontend peek sequencing. For such a transaction the Coordinator-side transaction cleanup (Coordinator::clear_connection) is a no-op, so the commit consists only of session-local steps, which SessionClient::end_transaction now performs directly.

Eligibility is tracked by a new field on TransactionOps::Peeks, allow_session_local_commit, set only by the frontend sequencing of plain SELECTs. The Coordinator peek sequencing sets it to false because it stores transaction read holds even for single-statement transactions, and so does the frontend COPY TO, whose active sink is retired on transaction end. Isolation levels whose commit involves the timestamp oracle also fall back to the Coordinator path: strict serializable when the peek's timestamp is ahead of the oracle read timestamp (the commit must wait for the oracle), and strong session serializable (the commit applies the peek timestamp to the session oracle). The oracle wait is rare in practice: ~1000 `EXPLAIN TIMESTAMP` probes across all user and built-in objects in a busy QA environment never showed the query timestamp ahead of the oracle, leaving the fall-back to corner cases like `REFRESH` materialized views and real-time recency.

The fast path is gated behind the new enable_session_local_commit dyncfg, off by default, on by default in mzcompose-based tests, and flipped randomly by the parallel-workload FlipFlagsAction.

Testing: `test_session_local_commit` counts `command-commit` Coordinator messages via the `mz_slow_message_handling` metric. Eligible peeks commit without one; writes, the flag-off case, and a strict serializable peek that needs a linearize wait (a `REFRESH AT` materialized view, where the Coordinator commit gates the results on the oracle) still produce one. `materialized_views.slt` also exercises the linearize wait end-to-end with the flag on in CI.

Note: extended-protocol clients that re-prepare each statement issue a separate Parse/Describe/Sync round whose Sync commits an empty implicit transaction, and that commit still goes through the Coordinator. Committing empty transactions session-locally would require tracking that nothing in the transaction reached the Coordinator (for example a single-statement DDL leaves ops None but holds the Coordinator's deferred lock), so it is left as a follow-up.

Nightly: https://buildkite.com/materialize/nightly/builds/17188



