### PR TITLE
ci: fix CLA status on bot-authored docs PRs

### DIFF
--- a/.github/workflows/update-generated-docs.yml
+++ b/.github/workflows/update-generated-docs.yml
@@ -24,6 +24,10 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+      # Required by the "Set CLA status for bot author" step below, which
+      # POSTs a commit status. GITHUB_TOKEN cannot trigger the CLA workflow
+      # on bot-authored PRs, so we set the status directly instead.
+      statuses: write
     env:
       BRANCH: automated/update-generated-docs
     steps:


### PR DESCRIPTION
Daily `update-generated-docs` PRs stay blocked because their `cla-assistant` status is never posted.

The workflow already compensates for `GITHUB_TOKEN` not triggering the CLA Assistant workflow by POSTing the status in a "Set CLA status for bot author" step. That step failed every run with HTTP 403 because the job lacked `statuses: write`. This grants it.

Diagnosed on #37504, whose status was set manually to unblock it.