### PR TITLE
Move temporal bucketing into the merge batcher

### DIFF
--- a/doc/developer/design/20260711_temporal_bucketing_batcher.md
+++ b/doc/developer/design/20260711_temporal_bucketing_batcher.md
@@ -1,0 +1,361 @@
+# Temporal bucketing inside the merge batcher
+
+- Associated:
+  [materialize#37589](https://github.com/MaterializeInc/materialize/pull/37589) (implementation),
+  [materialize#36427](https://github.com/MaterializeInc/materialize/pull/36427) (earlier draft),
+  [materialize#36644](https://github.com/MaterializeInc/materialize/pull/36644) (operator coverage in the lowering),
+  [20210426_temporal_filters](./20210426_temporal_filters.md)
+
+## Summary
+
+Move temporal bucketing from a standalone dataflow operator into the merge
+batcher that every arrangement already contains. Each batcher decides at
+every seal (the frontier advance at which the batcher emits newly ready
+updates), based on the data it actually holds, whether to park far-future
+updates in a bucket chain. This replaces the lowering's static analysis
+of where bucketing *may* be needed with a free runtime check of where it
+*is* needed. It applies uniformly to every arrangement that dataflow
+rendering builds on a totally ordered timestamp, and it lets us later
+delete the standalone operator and its plan-level plumbing. A feature
+flag switches between the old and new mechanism during rollout.
+
+## The Problem
+
+Temporal filters produce updates whose timestamps lie days or weeks in the
+future (a row's scheduled retraction at `ts + window`). The plain merge
+batcher re-merges and re-extracts everything it holds at every seal, so an
+update sitting at distance `d` from the frontier is re-walked `d / tick`
+times before it matures. The whole future tail is thus re-walked at
+every tick for the entire retention window, which makes arrangement
+maintenance the dominant cost of temporal workloads.
+
+The current mitigation is the `temporal_bucket` operator: a separate
+operator that holds far-future updates in a `BucketChain` (buckets of
+geometrically growing time spans, amortized `O(log distance)` per record)
+and releases them shortly before they mature. Because it is a separate
+operator, the MIR-to-LIR lowering must decide where to insert it, by
+propagating a static may-analysis ("may this collection carry future
+updates?") through the plan.
+
+The main cost is complexity, smeared through the lowering. The analysis
+must find every merge batcher (its invariant is "bucketing sits
+immediately upstream of every batcher that may see future updates"), it
+needs absorption conventions so bucket operators do not stack, and every
+new rendering feature must reason about the invariant again.
+materialize#36644 fixed missed sites at Reduce, TopK, and consolidating
+Unions. The plumbing (`has_future_updates` propagation,
+`ArrangementStrategy`, EXPLAIN annotations) exists at the plan level to
+serve what is a runtime property of the data.
+
+The static placement also has performance costs in both directions:
+
+- The operator cannot run where the analysis cannot see future updates.
+  Updates run ahead of a batcher's frontier without any temporal filter:
+  multi-input operators and worker skew deliver data early, all the more
+  when a dataflow lags. Those batchers pay the plain re-merging cost.
+- Where the operator does run, it duplicates machinery the arrangement
+  already has: it exchanges the data (a second shuffle on top of the
+  arrangement's own exchange) and holds it in its own bucket chains, and
+  matured updates then enter the arrangement's batcher to be merged again.
+  Relatedly, the operator's hydration cost depends on whether it is
+  scheduled before or after the snapshot arrives, while a batcher, sealed
+  only when the frontier moves, is deterministic.
+
+## The Design
+
+### The observation is free
+
+The plain batcher's seal already partitions every held update against the
+seal's `upper` (that is what its extract does, and where its `kept` updates
+come from). Deciding "does this batcher hold far-future data right now?"
+therefore costs one extra comparison inside a loop that already compares
+every record against the upper. The batcher can make the bucketing decision
+empirically, per seal, per arrangement instance, at no extra cost.
+
+Three consequences, one per cost above:
+
+1. The complexity is localized. Everything about bucketing lives inside the
+   merge batcher instead of being smeared across the lowering: there is no
+   site to find and nothing to absorb (each batcher holds only its own
+   data, which it must hold anyway), and the plan-level plumbing can be
+   deleted.
+2. Coverage is decided by the data, not the plan. Future updates are parked
+   wherever they actually show up, including the skew-delivered kind no
+   static analysis can see, and a batcher whose future tail drains reverts
+   to plain behavior automatically.
+3. The duplicated machinery disappears: no second exchange, no second set
+   of chains, and the hydration cost no longer depends on when an operator
+   happens to be scheduled.
+
+### The batcher
+
+`TemporalBucketingMergeBatcher` (`mz_timely_util::merge_batcher`) is a
+drop-in implementation of differential's `Batcher` trait. It is generic
+over a `TemporalMerger`, the chain-merging engine: differential's `Merger`
+role plus a three-way, bounds-tracking extract. In sketch:
+
+```text
+trait TemporalMerger {
+    type Time;
+    type Chunk;   // chain entries, possibly offloaded
+    type Output;  // the container pushed into and emitted by the batcher
+    fn absorb(Output) -> Chunk;
+    fn materialize(Chunk) -> Output;
+    fn merge(chain, chain) -> chain;  // consolidating
+    fn extract_time_partitioned(chain, split_lo, split_hi, track_before)
+        -> { before, within, beyond: chains with attained time bounds };
+}
+```
+
+Two implementations exist,
+one over the paged column chains of the `ColumnMergeBatcher` family and
+one wrapping our columnation-based `ColInternalMerger`. Both engines'
+record-walking loops live in this repository rather than in the
+differential-dataflow dependency, so the three-way extract needs no fork
+or vendoring, and the temporal logic itself exists exactly once.
+
+The paged engine is the primary target, but the columnation adapter is
+what carries the rollout: it is the default engine everywhere and the only
+one with builders for every arrangement family (see "Rollout and
+alternatives").
+
+The batcher's state is the plain batcher's flat chains plus a
+`BucketChain` of `MergeBucket`s for far-future data. The `BucketChain` is
+the same shared module the operator uses (`mz_timely_util::temporal`).
+
+At every seal, one extract walk partitions the merged flat chains three
+ways against the seal's `upper` and `upper + θ`, where θ is a configurable
+near/far threshold (next section):
+
+- ready (`t < upper`): emitted, exactly like the plain batcher,
+- near (`upper <= t < upper + θ`): returned to the flat chains, exactly
+  like the plain batcher's `kept` handling,
+- far (`upper + θ <= t`): routed into the bucket chain.
+
+The seal then peels matured buckets (entirely below `upper`), merges them
+into the emitted output, and lets the chain restore its shape under a fuel
+budget. When the batcher holds no far-future data, the bucket chain is
+never touched and the seal is the plain batcher's code plus one branch.
+Parity with plain in that case is a benchmarked requirement, not a
+best-effort goal.
+
+### The near/far threshold θ
+
+θ (dyncfg `compute_temporal_bucketing_summary`, default 2s, shared with the
+operator) exists because data slightly ahead of the frontier is normal and
+cheap for the plain batcher: in-flight updates race a tick or two ahead,
+and multi-input dataflows see worker and input skew. A record at distance
+`d` costs about `d / tick` flat re-merges, so `θ / tick` is the maximum
+number of rescans we accept before bucketing takes over. Sharing the
+config with the operator also shares the behavior: the operator releases
+within-summary data immediately, so under either mechanism such data ends
+up in the arrangement's plain flat chains.
+
+The knob is forgiving, since both misconfiguration directions cost a small
+constant per record. It is read once per batcher from a process-global
+installed by `apply_worker_config`, so a config change takes effect on
+newly built batchers without a restart.
+
+### Bucket bounds
+
+Every bucket carries the `(min, max)` times of its contents, established
+during the extract walks that move the data anyway. Bounds exist if and
+only if the bucket holds data. There is deliberately no unknown state with
+a scan fallback: a fallback would turn a bounds-maintenance bug into
+silent performance degradation, while without one such bugs surface as
+invariant violations, caught by the test-only validator, the protocol
+proptest, and the frontier guard below.
+
+Importantly, splits whose midpoint falls outside a bucket's bounds move
+the bucket wholesale without touching records. This is the load-bearing
+performance detail: it is what keeps large frontier jumps cheap, most
+importantly a batcher's first seal after hydration (see "The first seal"
+under Performance).
+
+Consolidation inside a bucket can cancel the records that attained a
+bound, so bounds are conservative (possibly wider than the data) but
+always within the bucket's time range, and a bucket whose contents cancel
+entirely drops its content outright.
+
+### Frontier semantics and the arrange protocol
+
+Differential's arrange operator downgrades its capabilities to
+`batcher.frontier()` after each seal and uses the capability's time as the
+hint from which downstream trace imports mint their capabilities. The
+contract this imposes: the reported frontier must never fall below a
+sealed upper, else the arrange holds a capability below the trace upper
+and the import panics.
+
+The batcher meets the contract by construction. It reports the minimum of
+the near data's lower bound (at least `upper` by classification) and the
+lowest non-empty bucket's bound (at least the bucket's range start, which
+peeling keeps at or above `upper`).
+
+A proptest simulates this protocol end to end, with updates that can
+cancel, and a cheap runtime guard soft-panics with full bucket state if
+the invariant is ever violated.
+
+### Wiring: uniform coverage
+
+When `enable_compute_temporal_bucketing_batcher` is on, every merge
+batcher in dataflow rendering that runs on a totally ordered timestamp is
+a temporal-bucketing batcher, and
+the `temporal_bucket` operator is suppressed at all of its insertion sites,
+ignoring the lowering's `ArrangementStrategy`. There is deliberately no
+reasoning about which sites need bucketing. The fast path makes unnecessary
+coverage free, so uniform coverage replaces the per-site analysis, which
+was the point of the exercise.
+
+Batcher selection dispatches per render timestamp through a
+`MaybeTemporalArrange` trait (mirroring `MaybeBucketByTime`):
+`mz_repr::Timestamp` honors the flag, the iterative-scope
+`Product<Timestamp, PointStamp>` ignores it, since partially ordered
+timestamps cannot be bucketed by a totally ordered chain. Covered sites are
+the ArrangeBy ok and err arrangements, all Reduce input arrangements and
+the monotonic consolidation, all TopK arrangements and consolidations,
+Threshold, the linear join stages, consolidating Unions, LetRec
+consolidations, and index exports. Delta joins build no batchers of their
+own: both their lookup side and their update streams read the input
+arrangements, so covering
+those covers delta joins transitively, including the half-join operators'
+internal buffers, which only ever see updates the input arrangements have
+released. Introspection (logging) dataflows keep plain batchers: they are
+built outside the rendering path and their updates carry no future
+timestamps.
+
+## Performance
+
+There are three data regimes, and each is compared against what would
+actually run there today. Parity or better across all of them is what
+makes running the batcher everywhere safe.
+
+1. No future data (almost every batcher): the baseline is the plain
+   batcher, the incumbent at these sites. The requirement is parity, and
+   criterion benchmarks measure a temporal-to-plain runtime ratio of
+   0.98-0.99, at or marginally better than parity.
+2. Data within θ of the frontier: the threshold split makes the batcher
+   behave identically to plain, which is also how the operator treats such
+   data. The operator's summary and the batcher's θ are the same config,
+   `compute_temporal_bucketing_summary`, so parity holds against either
+   comparator by construction.
+3. Genuine far-future data, split by what produces it:
+   - Temporal-filter workloads: the baseline is the operator, today's
+     mechanism for exactly these. Measured: parity (the temporal-filter
+     feature benchmarks), with the operator's duplicated machinery (the
+     second exchange, the second set of chains, the scheduling-dependent
+     hydration cost) removed structurally.
+   - Future data the planner cannot see (worker skew, multi-input
+     operators, lagging dataflows): the baseline is the plain batcher,
+     the only thing that runs there. Criterion benchmarks measure
+     steady-state gains of more than an order of magnitude. A dataflow
+     lagging by L can accumulate skew-delivered data up to L ahead of its
+     frontier, and the plain batcher re-walks all of it at every seal.
+     The batcher parks the beyond-θ part at a constant number of touches
+     independent of L.
+
+### The first seal
+
+A batcher's first seal after hydration absorbs the entire future tail,
+call it F records, at once, and the bucket chain then bisects from the
+whole time domain down to the frontier, so it is natural to worry that
+this one seal touches each record many times. We have both theoretical
+arguments that the cost stays a small multiple of F and simulations of
+the bucket chain's mechanics that confirm them across data distributions.
+Three things bound the seal:
+
+- `suppress_early_progress` holds back progress on source imports until
+  the input passes the as_of, so arranges see no intermediate frontiers.
+  The snapshot ships in the same single seal, without a detour through the
+  bucket chain, and only the genuine future tail enters the chain.
+- The attained bucket bounds let every bisection step whose midpoint
+  misses the data move the bucket wholesale, without touching records.
+  Only splits that genuinely cut through data walk it. In simulation this
+  is the difference between roughly 3 F and roughly 34 F record-touches.
+- Within the seal, only the peel share (about 1.1 F) runs synchronously.
+  The restore share is fuel-capped and trickles out over subsequent seals.
+
+For an interval-shaped tail the bisection is a halving cascade: each
+genuine cut splits off a part that the seal does not touch again, so the
+touches form a geometric series summing to about 2 F. Simulations across
+data shapes (uniform tails over various window sizes, growing and
+shrinking tables, batch-load spikes, random frontier alignments) confirm
+2-4 F record-touches in total, recouped within seconds against the plain
+batcher's F per tick.
+
+The adversarial ceiling is
+`O(F log F)`, reachable only by distributions that place equal mass at
+every distance scale from the frontier. The peel runs unfueled, so the
+ceiling also bounds the synchronous share of a single seal, but the same
+reasoning applies there too: the threshold split excises the realistic
+routes to it (in the worst simulated case, nearly all of
+that mass sits within θ of the frontier and never enters the chain). The
+ceiling is also not a new asymptotic class: it is the bucket chain's
+designed amortized `O(log distance)` per-record lifetime cost,
+front-loaded into one seal.
+
+## Observability
+
+The batcher counts records touched by bucket-chain operations: a cumulative
+counter plus a per-seal high-water mark recorded with that seal's held
+count (never an average, which would dilute the one expensive hydration
+seal across thousands of cheap ones). A `tracing::debug!` line reports any
+seal that performed bucket-chain work. Bucket contents flow into
+`BatcherEvent` logging so arrangement-size introspection does not
+under-report exactly the workloads that hold weeks of retractions.
+
+## Correctness and testing
+
+- Unit tests plus a model-based proptest: emitted batches must equal the
+  not-yet-emitted updates below each upper, consolidated, and the reported
+  frontier must match a reference.
+- A protocol proptest simulating the arrange operator's capability handling
+  against a downstream trace import, with cancelling updates. This caught a
+  real bug (a fully cancelled bucket retaining stale bounds, reported as a
+  frontier below the seal upper, panicking trace imports). The
+  drop-content-outright rule under "Bucket bounds" closes exactly this
+  case.
+- An expensive `validate_bounds_invariant()` walk (bounds contain exactly
+  the bucket's data, counts consistent, no empty content) called from tests
+  only, never on production paths.
+- Criterion benchmarks for parity (regimes 1 and 2) and wins (regime 3).
+- End-to-end sqllogictests, and CI runs entirely in batcher mode via the
+  minimal system parameters. The flag-off production configurations (the
+  standalone operator, and plain batchers) keep deterministic coverage
+  through a dedicated sqllogictest that is deleted with the flags.
+  Parameter-randomized CI runs additionally flip the flag.
+
+## Rollout and alternatives
+
+`enable_compute_temporal_bucketing_batcher` (default off) selects the new
+mechanism at dataflow build time and takes precedence over the operator
+flag. Off means bit-for-bit today's behavior. The #36644 plumbing stays
+untouched during the transition and is deleted in a later cleanup PR
+(operator, `ArrangementStrategy`, `has_future_updates` propagation, EXPLAIN
+annotations). EXPLAIN loses its bucketing annotations. The replacement is
+runtime introspection of where bucketing actually engaged, which is more
+truthful than where the planner guessed.
+
+Of the two engines, the paged one is the primary target: it composes with
+`enable_column_paged_batcher` (with both flags on, the affected
+arrangements run temporal bucketing over paged chains), and the far-future
+tail is the ideal spill candidate, since it is touched again only when
+buckets split or mature. The columnation adapter is nonetheless what
+carries the rollout: the columnation engine is the default everywhere and
+CI runs it nearly exclusively, and paged builders exist only for the
+row-row and val-row arrangement families, so uniform coverage of every
+batcher site is only expressible on the columnation engine today. The
+adapter is a small delegation wrapper plus that engine's extract walk, and
+it is deleted together with the engine.
+
+Alternatives considered:
+
+- Keep the operator and extend the lowering's coverage. Rejected: the
+  coverage invariant is exactly the recurring cost we want to remove, and
+  the operator cannot adapt to the data at runtime.
+- Per-site selection of which batchers get the temporal variant. Rejected:
+  it recreates the same shielding analysis inside rendering that we are
+  removing from the lowering.
+- Dataflow-granularity fallback (one scan of the finalized dataflow for
+  temporal predicates, one bool into rendering) remains available if
+  always-on turns out too aggressive, and still deletes the lowering
+  complexity.

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -101,6 +101,9 @@ def get_minimal_system_parameters(
         "enable_statement_lifecycle_logging": "true",
         "enable_storage_introspection_logs": "true",
         "enable_compute_temporal_bucketing": "true",
+        "enable_compute_temporal_bucketing_batcher": (
+            "true" if version >= MzVersion.parse_mz("v26.34.0-dev") else "false"
+        ),
         "enable_variadic_left_join_lowering": "true",
         "enable_worker_core_affinity": "true",
         "grpc_client_http2_keep_alive_timeout": "5s",
@@ -371,6 +374,15 @@ def get_variable_system_parameters(
             (
                 ["true", "false"]
                 if version > MzVersion.parse_mz("v0.127.0-dev")
+                else ["false"]
+            ),
+        ),
+        VariableSystemParameter(
+            "enable_compute_temporal_bucketing_batcher",
+            ("true" if version >= MzVersion.parse_mz("v26.34.0-dev") else "false"),
+            (
+                ["true", "false"]
+                if version >= MzVersion.parse_mz("v26.34.0-dev")
                 else ["false"]
             ),
         ),

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1654,6 +1654,9 @@ class FlipFlagsAction(Action):
         self.flags_with_values["enable_compute_temporal_bucketing"] = (
             BOOLEAN_FLAG_VALUES
         )
+        self.flags_with_values["enable_compute_temporal_bucketing_batcher"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_alter_table_add_column"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_arrangement_dictionary_compression_alpha"] = (
             BOOLEAN_FLAG_VALUES

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -162,10 +162,28 @@ pub const ENABLE_COMPUTE_TEMPORAL_BUCKETING: Config<bool> = Config::new(
 );
 
 /// The summary to apply to the frontier in temporal bucketing in compute.
+/// Also the near/far threshold of the temporal-bucketing merge batcher (see
+/// [`ENABLE_COMPUTE_TEMPORAL_BUCKETING_BATCHER`]): data within this distance
+/// of a seal's upper stays in the batcher's flat chains.
 pub const TEMPORAL_BUCKETING_SUMMARY: Config<Duration> = Config::new(
     "compute_temporal_bucketing_summary",
     Duration::from_secs(2),
     "The summary to apply to frontiers in temporal bucketing in compute.",
+);
+
+/// Perform temporal bucketing inside arrangement merge batchers instead of
+/// via the standalone bucketing operator. When `true`, takes precedence over
+/// [`ENABLE_COMPUTE_TEMPORAL_BUCKETING`]: the operator is not inserted and
+/// batchers park far-future updates in a bucket chain based on the data they
+/// actually observe, regardless of the lowering's `ArrangementStrategy`.
+/// Composes with `enable_column_paged_batcher`: with both set, the affected
+/// arrangements use the temporal-bucketing batcher over paged chains.
+/// Read at dataflow construction time.
+pub const ENABLE_COMPUTE_TEMPORAL_BUCKETING_BATCHER: Config<bool> = Config::new(
+    "enable_compute_temporal_bucketing_batcher",
+    false,
+    "Perform temporal bucketing inside arrangement merge batchers instead of via the \
+     standalone bucketing operator.",
 );
 
 /// The yielding behavior with which linear joins should be rendered.
@@ -496,6 +514,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&CORRECTION_V2_CHAIN_PROPORTIONALITY)
         .add(&CORRECTION_V2_CHUNK_SIZE)
         .add(&ENABLE_COMPUTE_TEMPORAL_BUCKETING)
+        .add(&ENABLE_COMPUTE_TEMPORAL_BUCKETING_BATCHER)
         .add(&TEMPORAL_BUCKETING_SUMMARY)
         .add(&LINEAR_JOIN_YIELDING)
         .add(&ENABLE_LGALLOC)

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -155,6 +155,18 @@ pub const CORRECTION_V2_CHUNK_SIZE: Config<usize> = Config::new(
 );
 
 /// Whether to enable temporal bucketing in compute.
+///
+/// NOTE: When removing this flag, remove the operator-mode section of
+/// test/sqllogictest/temporal_bucketing_legacy.slt, which exercises it
+/// (the file as a whole is deleted only together with
+/// `enable_compute_temporal_bucketing_batcher`, since its plain-mode
+/// section outlives this flag), and revisit
+/// test/sqllogictest/temporal_bucketing.slt: it tests details of the
+/// lowering machinery the operator needs (`temporal_bucketing_strategy`
+/// EXPLAIN annotations, `input_bucketing_strategy` plumbing). The EXPLAIN
+/// tests asserting on the strategy annotations can go with the plumbing,
+/// and the remaining tests' comments must stop referring to the deleted
+/// code.
 pub const ENABLE_COMPUTE_TEMPORAL_BUCKETING: Config<bool> = Config::new(
     "enable_compute_temporal_bucketing",
     false,
@@ -179,6 +191,10 @@ pub const TEMPORAL_BUCKETING_SUMMARY: Config<Duration> = Config::new(
 /// Composes with `enable_column_paged_batcher`: with both set, the affected
 /// arrangements use the temporal-bucketing batcher over paged chains.
 /// Read at dataflow construction time.
+///
+/// NOTE: CI runs with this flag on. The flag-off production configurations
+/// are covered by test/sqllogictest/temporal_bucketing_legacy.slt, which
+/// should be deleted when the flag is removed.
 pub const ENABLE_COMPUTE_TEMPORAL_BUCKETING_BATCHER: Config<bool> = Config::new(
     "enable_compute_temporal_bucketing_batcher",
     false,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -308,6 +308,18 @@ impl ComputeState {
             std::sync::atomic::Ordering::Relaxed,
         );
 
+        // The temporal-bucketing merge batcher reads its near/far threshold
+        // from a process-global at construction time; keep that global in
+        // sync with the dyncfg.
+        mz_timely_util::merge_batcher::TEMPORAL_THRESHOLD_MS.store(
+            TEMPORAL_BUCKETING_SUMMARY
+                .get(config)
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+
         // NB: arrangement dictionary compression is deliberately NOT applied here. Unlike the
         // settings above, it is captured once at replica creation (see `handle_create_instance`
         // and `InstanceConfig::arrangement_dictionary_compression`) and held fixed, so that

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -8,20 +8,33 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::BTreeMap;
+use std::hash::Hash;
 use std::rc::{Rc, Weak};
 
+use columnation::Columnation;
 use differential_dataflow::difference::Semigroup;
+use differential_dataflow::dynamic::pointstamp::PointStamp;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::arrangement::arrange_core;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::trace::implementations::spine_fueled::Spine;
 use differential_dataflow::trace::{Batch, Batcher, Builder, Trace, TraceReader};
 use differential_dataflow::{Collection, Data, ExchangeData, Hashable, VecCollection};
+use mz_repr::{Diff, Row};
+use mz_row_spine::{RowRowBuilder, RowRowColPagedBuilder};
+use mz_timely_util::columnar::builder::ColumnBuilder;
+use mz_timely_util::columnar::{
+    Col2ValBatcher, Col2ValPagedBatcher, Col2ValPagedTemporalBatcher, Col2ValTemporalBatcher,
+    Column, batcher, columnar_exchange,
+};
+use mz_timely_util::columnation::{ColumnationChunker, ColumnationStack};
+use mz_timely_util::operator::CollectionExt;
 use timely::Container;
 use timely::container::{ContainerBuilder, PushInto};
 use timely::dataflow::Stream;
-use timely::dataflow::channels::pact::{Exchange, ParallelizationContract, Pipeline};
+use timely::dataflow::channels::pact::{Exchange, ExchangeCore, ParallelizationContract, Pipeline};
 use timely::dataflow::operators::Operator;
+use timely::order::Product;
 use timely::progress::Timestamp;
 
 use crate::logging::compute::{
@@ -29,7 +42,8 @@ use crate::logging::compute::{
     ArrangementHeapSizeOperator, ComputeEvent, ComputeEventBuilder,
 };
 use crate::typedefs::{
-    KeyAgent, KeyValAgent, MzArrangeData, MzData, MzTimestamp, RowAgent, RowRowAgent, RowValAgent,
+    KeyAgent, KeyBatcher, KeyValAgent, KeyValBatcher, MzArrangeData, MzData, MzTimestamp, RowAgent,
+    RowRowAgent, RowRowSpine, RowValAgent,
 };
 
 /// Extension trait to arrange data.
@@ -465,4 +479,183 @@ where
             (size, capacity, allocations)
         })
     }
+}
+
+/// Arrangement and consolidation construction with a per-timestamp batcher
+/// choice.
+///
+/// The temporal-bucketing batcher requires a totally ordered timestamp, which
+/// is not a general property of a render timestamp, so the dispatch lives in
+/// its own trait (mirroring `MaybeBucketByTime`): `mz_repr::Timestamp` honors
+/// `use_temporal`, the iterative-scope `Product` timestamp ignores it.
+pub trait MaybeTemporalArrange: MzTimestamp + Default {
+    /// Arrange a row-row stream into a [`RowRowAgent`], choosing the batcher
+    /// by the given flags. The flags compose: with both set, the batcher is
+    /// temporal-bucketing over paged chains.
+    ///
+    /// Warning: The default body ignores `use_temporal`, appropriate for
+    /// partially ordered timestamps, which are not bucketable.
+    fn arrange_row_row<'scope>(
+        stream: Stream<'scope, Self, Column<((Row, Row), Self, Diff)>>,
+        name: &str,
+        use_paged: bool,
+        _use_temporal: bool,
+    ) -> Arranged<'scope, RowRowAgent<Self, Diff>> {
+        let exchange = ExchangeCore::<ColumnBuilder<_>, _>::new_core(
+            columnar_exchange::<Row, Row, Self, Diff>,
+        );
+        if use_paged {
+            stream.mz_arrange_core::<
+                _,
+                batcher::ColumnChunker<_>,
+                Col2ValPagedBatcher<_, _, _, _>,
+                RowRowColPagedBuilder<_, _>,
+                RowRowSpine<_, _>,
+            >(exchange, name)
+        } else {
+            stream.mz_arrange_core::<
+                _,
+                batcher::Chunker<_>,
+                Col2ValBatcher<_, _, _, _>,
+                RowRowBuilder<_, _>,
+                RowRowSpine<_, _>,
+            >(exchange, name)
+        }
+    }
+
+    /// `mz_arrange` a `(key, val)` collection into `Tr` with the
+    /// [`KeyValBatcher`] family, using the temporal-bucketing
+    /// batcher when both `use_temporal` and the timestamp allow it.
+    ///
+    /// Warning: The default body ignores `use_temporal`.
+    fn mz_arrange_maybe_temporal<'scope, K, V, R, Bu, Tr>(
+        collection: VecCollection<'scope, Self, (K, V), R>,
+        name: &str,
+        _use_temporal: bool,
+    ) -> Arranged<'scope, TraceAgent<Tr>>
+    where
+        K: ExchangeData + Hashable + Columnation + Ord,
+        V: ExchangeData + Columnation + Ord,
+        R: ExchangeData + Semigroup + Default + Columnation,
+        Bu: Builder<Time = Self, Input = ColumnationStack<((K, V), Self, R)>, Output = Tr::Batch>,
+        Tr: Trace + TraceReader<Time = Self> + 'static,
+        Tr::Batch: Batch,
+        Arranged<'scope, TraceAgent<Tr>>: ArrangementSize,
+    {
+        collection.mz_arrange::<ColumnationChunker<_>, KeyValBatcher<K, V, Self, R>, Bu, Tr>(name)
+    }
+
+    /// `consolidate_named_if` with the [`KeyBatcher`]
+    /// family, using the temporal-bucketing batcher when both `use_temporal`
+    /// and the timestamp allow it.
+    ///
+    /// Warning: The default body ignores `use_temporal`.
+    fn consolidate_maybe_temporal<'scope, D, R>(
+        collection: VecCollection<'scope, Self, D, R>,
+        must_consolidate: bool,
+        name: &str,
+        _use_temporal: bool,
+    ) -> VecCollection<'scope, Self, D, R>
+    where
+        D: ExchangeData + Hash + Columnation + Ord,
+        R: ExchangeData + Semigroup + Default + Columnation,
+    {
+        collection.consolidate_named_if::<KeyBatcher<D, Self, R>>(must_consolidate, name)
+    }
+}
+
+impl MaybeTemporalArrange for mz_repr::Timestamp {
+    fn arrange_row_row<'scope>(
+        stream: Stream<'scope, Self, Column<((Row, Row), Self, Diff)>>,
+        name: &str,
+        use_paged: bool,
+        use_temporal: bool,
+    ) -> Arranged<'scope, RowRowAgent<Self, Diff>> {
+        let exchange = ExchangeCore::<ColumnBuilder<_>, _>::new_core(
+            columnar_exchange::<Row, Row, Self, Diff>,
+        );
+        if use_temporal && use_paged {
+            stream.mz_arrange_core::<
+                _,
+                batcher::ColumnChunker<_>,
+                Col2ValPagedTemporalBatcher<_, _, _, _>,
+                RowRowColPagedBuilder<_, _>,
+                RowRowSpine<_, _>,
+            >(exchange, name)
+        } else if use_temporal {
+            stream.mz_arrange_core::<
+                _,
+                batcher::Chunker<_>,
+                Col2ValTemporalBatcher<_, _, _, _>,
+                RowRowBuilder<_, _>,
+                RowRowSpine<_, _>,
+            >(exchange, name)
+        } else if use_paged {
+            stream.mz_arrange_core::<
+                _,
+                batcher::ColumnChunker<_>,
+                Col2ValPagedBatcher<_, _, _, _>,
+                RowRowColPagedBuilder<_, _>,
+                RowRowSpine<_, _>,
+            >(exchange, name)
+        } else {
+            stream.mz_arrange_core::<
+                _,
+                batcher::Chunker<_>,
+                Col2ValBatcher<_, _, _, _>,
+                RowRowBuilder<_, _>,
+                RowRowSpine<_, _>,
+            >(exchange, name)
+        }
+    }
+
+    fn mz_arrange_maybe_temporal<'scope, K, V, R, Bu, Tr>(
+        collection: VecCollection<'scope, Self, (K, V), R>,
+        name: &str,
+        use_temporal: bool,
+    ) -> Arranged<'scope, TraceAgent<Tr>>
+    where
+        K: ExchangeData + Hashable + Columnation + Ord,
+        V: ExchangeData + Columnation + Ord,
+        R: ExchangeData + Semigroup + Default + Columnation,
+        Bu: Builder<Time = Self, Input = ColumnationStack<((K, V), Self, R)>, Output = Tr::Batch>,
+        Tr: Trace + TraceReader<Time = Self> + 'static,
+        Tr::Batch: Batch,
+        Arranged<'scope, TraceAgent<Tr>>: ArrangementSize,
+    {
+        if use_temporal {
+            collection
+                .mz_arrange::<ColumnationChunker<_>, Col2ValTemporalBatcher<K, V, Self, R>, Bu, Tr>(
+                    name,
+                )
+        } else {
+            collection
+                .mz_arrange::<ColumnationChunker<_>, KeyValBatcher<K, V, Self, R>, Bu, Tr>(name)
+        }
+    }
+
+    fn consolidate_maybe_temporal<'scope, D, R>(
+        collection: VecCollection<'scope, Self, D, R>,
+        must_consolidate: bool,
+        name: &str,
+        use_temporal: bool,
+    ) -> VecCollection<'scope, Self, D, R>
+    where
+        D: ExchangeData + Hash + Columnation + Ord,
+        R: ExchangeData + Semigroup + Default + Columnation,
+    {
+        if use_temporal {
+            collection.consolidate_named_if::<Col2ValTemporalBatcher<D, (), Self, R>>(
+                must_consolidate,
+                name,
+            )
+        } else {
+            collection.consolidate_named_if::<KeyBatcher<D, Self, R>>(must_consolidate, name)
+        }
+    }
+}
+
+impl MaybeTemporalArrange for Product<mz_repr::Timestamp, PointStamp<u64>> {
+    // Iterative scope: the timestamp is partially ordered and not bucketable,
+    // so the defaults, which ignore `use_temporal`, apply.
 }

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -124,7 +124,8 @@ use mz_compute_types::dataflows::{DataflowDescription, IndexDesc};
 use mz_compute_types::dyncfgs::{
     COMPUTE_APPLY_COLUMN_DEMANDS, COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK,
     COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES, ENABLE_COMPUTE_LOGICAL_BACKPRESSURE,
-    ENABLE_COMPUTE_TEMPORAL_BUCKETING, SUBSCRIBE_SNAPSHOT_OPTIMIZATION, TEMPORAL_BUCKETING_SUMMARY,
+    ENABLE_COMPUTE_TEMPORAL_BUCKETING, ENABLE_COMPUTE_TEMPORAL_BUCKETING_BATCHER,
+    SUBSCRIBE_SNAPSHOT_OPTIMIZATION, TEMPORAL_BUCKETING_SUMMARY,
 };
 use mz_compute_types::plan::render_plan::{
     self, BindStage, LetBind, LetFreePlan, RecBind, RenderPlan,
@@ -138,8 +139,7 @@ use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, ReprRelationType, Row, RowArena, SharedRow};
 use mz_storage_operators::persist_source;
 use mz_storage_types::controller::CollectionMetadata;
-use mz_timely_util::columnation::ColumnationChunker;
-use mz_timely_util::operator::{CollectionExt, StreamExt};
+use mz_timely_util::operator::StreamExt;
 use mz_timely_util::probe::{Handle as MzProbeHandle, ProbeNotify};
 use mz_timely_util::scope_label::ScopeExt;
 use timely::PartialOrder;
@@ -157,7 +157,7 @@ use timely::worker::Worker as TimelyWorker;
 
 use crate::arrangement::manager::TraceBundle;
 use crate::compute_state::ComputeState;
-use crate::extensions::arrange::{KeyCollection, MzArrange};
+use crate::extensions::arrange::MaybeTemporalArrange;
 use crate::extensions::reduce::MzReduce;
 use crate::extensions::temporal_bucket::TemporalBucketing;
 use crate::logging::compute::{
@@ -165,8 +165,8 @@ use crate::logging::compute::{
 };
 use crate::render::context::{ArrangementFlavor, Context};
 use crate::render::errors::DataflowErrorSer;
-use crate::typedefs::{ErrBatcher, ErrBuilder, ErrSpine, KeyBatcher, MzTimestamp};
-use mz_row_spine::{DatumSeq, RowRowBatcher, RowRowBuilder};
+use crate::typedefs::{ErrBuilder, ErrSpine, MzTimestamp, RowRowSpine};
+use mz_row_spine::{DatumSeq, RowRowBuilder};
 
 pub mod context;
 pub(crate) mod errors;
@@ -790,24 +790,32 @@ where
                 // TODO: The following as_collection/leave/arrange sequence could be optimized.
                 //   * Combine as_collection and leave into a single function.
                 //   * Use columnar to extract columns from the batches to implement leave.
-                let mut oks = oks
-                    .as_collection(|k, v| (k.to_row(), v.to_row()))
-                    .leave(outer)
-                    .mz_arrange::<
-                        ColumnationChunker<_>,
-                        RowRowBatcher<_, _>,
-                        RowRowBuilder<_, _>,
-                        _,
-                    >(
-                        "Arrange export iterative",
-                    );
+                let use_temporal = self.temporal_batcher;
+                let mut oks = mz_repr::Timestamp::mz_arrange_maybe_temporal::<
+                    _,
+                    _,
+                    _,
+                    RowRowBuilder<_, _>,
+                    RowRowSpine<_, _>,
+                >(
+                    oks.as_collection(|k, v| (k.to_row(), v.to_row()))
+                        .leave(outer),
+                    "Arrange export iterative",
+                    use_temporal,
+                );
 
-                let mut errs = errs
-                    .as_collection(|k, v| (k.clone(), v.clone()))
-                    .leave(outer)
-                    .mz_arrange::<ColumnationChunker<_>, ErrBatcher<_, _>, ErrBuilder<_, _>, _>(
-                        "Arrange export iterative err",
-                    );
+                let mut errs = mz_repr::Timestamp::mz_arrange_maybe_temporal::<
+                    _,
+                    _,
+                    _,
+                    ErrBuilder<_, _>,
+                    ErrSpine<_, _>,
+                >(
+                    errs.as_collection(|k, v| (k.clone(), v.clone()))
+                        .leave(outer),
+                    "Arrange export iterative err",
+                    use_temporal,
+                );
 
                 // Ensure that the frontier does not advance past the expiration time, if set.
                 // Otherwise, we might write down incorrect data.
@@ -938,10 +946,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 let (oks_v, err_v) = variables.remove(&Id::Local(id)).unwrap();
 
                 // Set oks variable to `oks` but consolidated to ensure iteration ceases at fixed point.
-                let mut oks = CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(
-                    oks,
-                    "LetRecConsolidation",
-                );
+                let mut oks = self.consolidate(oks, true, "LetRecConsolidation");
 
                 if let Some(limit) = limit {
                     // We swallow the results of the `max_iter`th iteration, because
@@ -968,14 +973,9 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // say if the limit of `oks` has an error. This would result in non-terminating rather
                 // than a clean report of the error. The trade-off is that we lose information about
                 // multiplicities of errors, but .. this seems to be the better call.
-                let err: KeyCollection<_, _, _> = err.into();
-                let errs = err
-                    .mz_arrange::<
-                        ColumnationChunker<_>,
-                        ErrBatcher<_, _>,
-                        ErrBuilder<_, _>,
-                        ErrSpine<_, _>,
-                    >(
+                let errs = self
+                    .arrange_key::<_, _, ErrBuilder<_, _>, ErrSpine<_, _>>(
+                        err,
                         "Arrange recursive err",
                     )
                     .mz_reduce_abelian::<_, ErrBuilder<_, _>, ErrSpine<_, _>>(
@@ -1005,7 +1005,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
     }
 }
 
-impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
+impl<'scope, T: RenderTimestamp + MaybeBucketByTime + MaybeTemporalArrange> Context<'scope, T> {
     /// Renders a non-recursive plan to a differential dataflow, producing the collection of
     /// results.
     ///
@@ -1339,13 +1339,9 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                     // Apply per-input temporal bucketing. No-op for `Direct`.
                     // Only consolidating Unions carry non-`Direct` strategies;
                     // see the `Union` arm of `lower_mir_expr_stack_safe`.
-                    let os = if matches!(strategy, ArrangementStrategy::TemporalBucketing)
-                        && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(&self.config_set)
+                    let os = if let Some(summary) =
+                        operator_bucketing_summary(&self.config_set, strategy)
                     {
-                        let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
-                            .get(&self.config_set)
-                            .try_into()
-                            .expect("must fit");
                         T::maybe_apply_temporal_bucketing(
                             os.inner,
                             self.as_of_frontier.clone(),
@@ -1359,10 +1355,7 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                 }
                 let mut oks = differential_dataflow::collection::concatenate(self.scope, oks);
                 if consolidate_output {
-                    oks = CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(
-                        oks,
-                        "UnionConsolidation",
-                    )
+                    oks = self.consolidate(oks, true, "UnionConsolidation")
                 }
                 let errs = differential_dataflow::collection::concatenate(self.scope, errs);
                 CollectionBundle::from_collections(oks, errs)
@@ -1532,6 +1525,26 @@ pub trait RenderTimestamp: MzTimestamp + Default + Refines<mz_repr::Timestamp> {
     /// Steps the timestamp back so that logical compaction to the output will
     /// not conflate `self` with any historical times.
     fn step_back(&self) -> Self;
+}
+
+/// The summary for the standalone temporal bucketing operator, or `None`
+/// when the operator must not be inserted: the lowering did not select
+/// bucketing for this site, the operator flag is off, or batcher-mode
+/// bucketing (`enable_compute_temporal_bucketing_batcher`, which performs
+/// the same work inside every merge batcher) supersedes it.
+pub(crate) fn operator_bucketing_summary(
+    config_set: &mz_dyncfg::ConfigSet,
+    strategy: ArrangementStrategy,
+) -> Option<mz_repr::Timestamp> {
+    let apply = matches!(strategy, ArrangementStrategy::TemporalBucketing)
+        && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(config_set)
+        && !ENABLE_COMPUTE_TEMPORAL_BUCKETING_BATCHER.get(config_set);
+    apply.then(|| {
+        TEMPORAL_BUCKETING_SUMMARY
+            .get(config_set)
+            .try_into()
+            .expect("must fit")
+    })
 }
 
 /// Apply temporal bucketing to a stream when the timestamp type supports it.

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -13,15 +13,17 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use columnation::Columnation;
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
-use differential_dataflow::operators::arrange::Arranged;
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::trace::implementations::BatchContainer;
-use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
-use differential_dataflow::{AsCollection, Data, VecCollection};
+use differential_dataflow::trace::{Batch, BatchReader, Builder, Cursor, Trace, TraceReader};
+use differential_dataflow::{AsCollection, Data, ExchangeData, Hashable, VecCollection};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::{
     ENABLE_COLUMN_PAGED_BATCHER, ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION,
-    ENABLE_COMPUTE_TEMPORAL_BUCKETING, TEMPORAL_BUCKETING_SUMMARY,
+    ENABLE_COMPUTE_TEMPORAL_BUCKETING_BATCHER,
 };
 use mz_compute_types::plan::scalar::{LirScalarExpr, mfp_mir_to_lir_plan, mfp_plan_lir_to_mir};
 use mz_compute_types::plan::{ArrangementStrategy, AvailableCollections};
@@ -30,14 +32,13 @@ use mz_expr::{Eval, Id, MfpPlan};
 use mz_ore::soft_assert_or_log;
 use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, DatumVecBorrow, Diff, GlobalId, Row, RowArena, SharedRow};
+use mz_row_spine::DatumSeq;
 use mz_storage_types::controller::CollectionMetadata;
-use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
-use mz_timely_util::columnar::{Col2ValBatcher, Col2ValPagedBatcher, columnar_exchange};
-use mz_timely_util::columnation::ColumnationChunker;
+use mz_timely_util::columnation::ColumnationStack;
 use timely::ContainerBuilder;
 use timely::container::{CapacityContainerBuilder, PushInto};
-use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
+use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Capability;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::{OutputBuilder, OutputBuilderSession};
@@ -46,13 +47,10 @@ use timely::progress::operate::FrontierInterest;
 use timely::progress::{Antichain, Timestamp};
 
 use crate::compute_state::ComputeState;
-use crate::extensions::arrange::{KeyCollection, MzArrange, MzArrangeCore};
+use crate::extensions::arrange::{ArrangementSize, MaybeTemporalArrange};
 use crate::render::errors::{DataflowErrorSer, ErrorLogger};
 use crate::render::{LinearJoinSpec, MaybeBucketByTime, RenderTimestamp};
-use crate::typedefs::{
-    ErrAgent, ErrBatcher, ErrBuilder, ErrEnter, ErrSpine, RowRowAgent, RowRowEnter, RowRowSpine,
-};
-use mz_row_spine::{DatumSeq, RowRowBuilder, RowRowColPagedBuilder};
+use crate::typedefs::{ErrAgent, ErrBuilder, ErrEnter, ErrSpine, RowRowAgent, RowRowEnter};
 
 /// Dataflow-local collections and arrangements.
 ///
@@ -91,6 +89,9 @@ pub struct Context<'scope, T: RenderTimestamp> {
     pub dataflow_expiration: Antichain<mz_repr::Timestamp>,
     /// The config set for this context.
     pub config_set: Rc<ConfigSet>,
+    /// Whether merge batchers should perform temporal bucketing
+    /// (`enable_compute_temporal_bucketing_batcher`).
+    pub(super) temporal_batcher: bool,
 }
 
 impl<'scope, T: RenderTimestamp> Context<'scope, T> {
@@ -131,12 +132,70 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
             compute_logger,
             linear_join_spec: compute_state.linear_join_spec,
             dataflow_expiration,
+            temporal_batcher: ENABLE_COMPUTE_TEMPORAL_BUCKETING_BATCHER
+                .get(&compute_state.worker_config),
             config_set: Rc::clone(&compute_state.worker_config),
         }
     }
 }
 
 impl<'scope, T: RenderTimestamp> Context<'scope, T> {
+    /// `mz_arrange` a `(key, val)` collection, using the temporal-bucketing
+    /// batcher when `enable_compute_temporal_bucketing_batcher` is set and
+    /// the timestamp allows it.
+    pub(crate) fn arrange<'s, K, V, R, Bu, Tr>(
+        &self,
+        collection: VecCollection<'s, T, (K, V), R>,
+        name: &str,
+    ) -> Arranged<'s, TraceAgent<Tr>>
+    where
+        T: MaybeTemporalArrange,
+        K: ExchangeData + Hashable + Columnation + Ord,
+        V: ExchangeData + Columnation + Ord,
+        R: ExchangeData + Semigroup + Default + Columnation,
+        Bu: Builder<Time = T, Input = ColumnationStack<((K, V), T, R)>, Output = Tr::Batch>,
+        Tr: Trace + TraceReader<Time = T> + 'static,
+        Tr::Batch: Batch,
+        Arranged<'s, TraceAgent<Tr>>: ArrangementSize,
+    {
+        T::mz_arrange_maybe_temporal::<K, V, R, Bu, Tr>(collection, name, self.temporal_batcher)
+    }
+
+    /// [`Self::arrange`] for key-only collections.
+    pub(crate) fn arrange_key<'s, K, R, Bu, Tr>(
+        &self,
+        collection: VecCollection<'s, T, K, R>,
+        name: &str,
+    ) -> Arranged<'s, TraceAgent<Tr>>
+    where
+        T: MaybeTemporalArrange,
+        K: ExchangeData + Hashable + Columnation + Ord,
+        R: ExchangeData + Semigroup + Default + Columnation,
+        Bu: Builder<Time = T, Input = ColumnationStack<((K, ()), T, R)>, Output = Tr::Batch>,
+        Tr: Trace + TraceReader<Time = T> + 'static,
+        Tr::Batch: Batch,
+        Arranged<'s, TraceAgent<Tr>>: ArrangementSize,
+    {
+        self.arrange::<K, (), R, Bu, Tr>(collection.map(|k| (k, ())), name)
+    }
+
+    /// `consolidate_named_if`, using the temporal-bucketing batcher when
+    /// `enable_compute_temporal_bucketing_batcher` is set and the timestamp
+    /// allows it.
+    pub(crate) fn consolidate<'s, D, R>(
+        &self,
+        collection: VecCollection<'s, T, D, R>,
+        must_consolidate: bool,
+        name: &str,
+    ) -> VecCollection<'s, T, D, R>
+    where
+        T: MaybeTemporalArrange,
+        D: ExchangeData + std::hash::Hash + Columnation + Ord,
+        R: ExchangeData + Semigroup + Default + Columnation,
+    {
+        T::consolidate_maybe_temporal(collection, must_consolidate, name, self.temporal_batcher)
+    }
+
     /// Insert a collection bundle by an identifier.
     ///
     /// This is expected to be used to install external collections (sources, indexes, other views),
@@ -206,6 +265,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
             linear_join_spec: self.linear_join_spec.clone(),
             bindings,
             dataflow_expiration: self.dataflow_expiration.clone(),
+            temporal_batcher: self.temporal_batcher,
             config_set: Rc::clone(&self.config_set),
         }
     }
@@ -1025,11 +1085,15 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         strategy: ArrangementStrategy,
     ) -> Self
     where
-        T: MaybeBucketByTime,
+        T: MaybeBucketByTime + MaybeTemporalArrange,
     {
         if collections == Default::default() {
             return self;
         }
+        // In batcher mode, temporal bucketing happens inside the arrangement
+        // merge batchers based on the data they observe, and the standalone
+        // bucketing operator is suppressed regardless of `strategy`.
+        let use_temporal_batcher = ENABLE_COMPUTE_TEMPORAL_BUCKETING_BATCHER.get(config_set);
         // Cache collection to avoid reforming it each time.
         //
         // TODO(mcsherry): In theory this could be faster run out of another arrangement,
@@ -1070,13 +1134,9 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
             } else {
                 ArrangementStrategy::Direct
             };
-            let oks = if matches!(effective_strategy, ArrangementStrategy::TemporalBucketing)
-                && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(config_set)
+            let oks = if let Some(summary) =
+                crate::render::operator_bucketing_summary(config_set, effective_strategy)
             {
-                let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
-                    .get(config_set)
-                    .try_into()
-                    .expect("must fit");
                 bucketed = true;
                 T::maybe_apply_temporal_bucketing(oks.inner, as_of.clone(), summary)
             } else {
@@ -1102,13 +1162,9 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 } else {
                     strategy
                 };
-                let oks = if matches!(effective_strategy, ArrangementStrategy::TemporalBucketing)
-                    && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(config_set)
+                let oks = if let Some(summary) =
+                    crate::render::operator_bucketing_summary(config_set, effective_strategy)
                 {
-                    let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
-                        .get(config_set)
-                        .try_into()
-                        .expect("must fit");
                     bucketed = true;
                     T::maybe_apply_temporal_bucketing(oks.inner, as_of.clone(), summary)
                 } else {
@@ -1121,18 +1177,21 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     key.clone(),
                     thinning.clone(),
                     use_paged_path,
+                    use_temporal_batcher,
                 );
-                let errs_concat: KeyCollection<_, _, _> = errs.clone().concat(errs_keyed).into();
+                let errs_concat = errs.clone().concat(errs_keyed).map(|e| (e, ()));
                 self.collection = Some((passthrough, errs));
-                let errs =
-                    errs_concat.mz_arrange::<
-                        ColumnationChunker<_>,
-                        ErrBatcher<_, _>,
-                        ErrBuilder<_, _>,
-                        ErrSpine<_, _>,
-                    >(
-                        &format!("{}-errors", name),
-                    );
+                let errs = T::mz_arrange_maybe_temporal::<
+                    _,
+                    _,
+                    _,
+                    ErrBuilder<T, Diff>,
+                    ErrSpine<T, Diff>,
+                >(
+                    errs_concat,
+                    &format!("{}-errors", name),
+                    use_temporal_batcher,
+                );
                 self.arranged
                     .insert(key, ArrangementFlavor::Local(oks, errs));
             }
@@ -1156,11 +1215,15 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         key: Vec<LirScalarExpr>,
         thinning: Vec<usize>,
         use_paged_path: bool,
+        use_temporal_batcher: bool,
     ) -> (
         Arranged<'scope, RowRowAgent<T, Diff>>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
         VecCollection<'scope, T, Row, Diff>,
-    ) {
+    )
+    where
+        T: MaybeTemporalArrange,
+    {
         // This operator implements a `map_fallible`, but produces columnar updates for the ok
         // stream. The `map_fallible` cannot be used here because the closure cannot return
         // references, which is what we need to push into columnar streams. Instead, we use a
@@ -1209,25 +1272,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
             }
         });
 
-        let exchange =
-            ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, T, Diff>);
-        let oks = if use_paged_path {
-            ok_stream.mz_arrange_core::<
-                _,
-                batcher::ColumnChunker<_>,
-                Col2ValPagedBatcher<_, _, _, _>,
-                RowRowColPagedBuilder<_, _>,
-                RowRowSpine<_, _>,
-            >(exchange, name)
-        } else {
-            ok_stream.mz_arrange_core::<
-                _,
-                batcher::Chunker<_>,
-                Col2ValBatcher<_, _, _, _>,
-                RowRowBuilder<_, _>,
-                RowRowSpine<_, _>,
-            >(exchange, name)
-        };
+        let oks = T::arrange_row_row(ok_stream, name, use_paged_path, use_temporal_batcher);
         (
             oks,
             err_stream.as_collection(),

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -27,21 +27,18 @@ use mz_dyncfg::ConfigSet;
 use mz_expr::Eval;
 use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, Diff, Row, RowArena, SharedRow};
-use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
-use mz_timely_util::columnar::{Col2ValBatcher, Col2ValPagedBatcher, columnar_exchange};
 use mz_timely_util::operator::{CollectionExt, StreamExt};
 use timely::dataflow::Scope;
-use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
+use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::OkErr;
 
-use crate::extensions::arrange::MzArrangeCore;
+use crate::extensions::arrange::MaybeTemporalArrange;
 use crate::render::RenderTimestamp;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::render::join::mz_join_core::mz_join_core;
 use crate::typedefs::{RowRowAgent, RowRowEnter};
-use mz_row_spine::{RowRowBuilder, RowRowColPagedBuilder, RowRowSpine};
 
 /// Available linear join implementations.
 ///
@@ -196,7 +193,7 @@ enum JoinedFlavor<'scope, T: RenderTimestamp> {
 
 impl<'scope, T> Context<'scope, T>
 where
-    T: Lattice + RenderTimestamp,
+    T: Lattice + RenderTimestamp + MaybeTemporalArrange,
 {
     pub(crate) fn render_join(
         &self,
@@ -384,26 +381,12 @@ where
 
             errors.push(errs.as_collection());
 
-            let exchange = ExchangeCore::<ColumnBuilder<_>, _>::new_core(
-                columnar_exchange::<Row, Row, T, Diff>,
+            let arranged = T::arrange_row_row(
+                keyed,
+                "JoinStage",
+                ENABLE_COLUMN_PAGED_BATCHER.get(&self.config_set),
+                self.temporal_batcher,
             );
-            let arranged = if ENABLE_COLUMN_PAGED_BATCHER.get(&self.config_set) {
-                keyed.mz_arrange_core::<
-                    _,
-                    batcher::ColumnChunker<_>,
-                    Col2ValPagedBatcher<_, _, _, _>,
-                    RowRowColPagedBuilder<_, _>,
-                    RowRowSpine<_, _>,
-                >(exchange, "JoinStage")
-            } else {
-                keyed.mz_arrange_core::<
-                    _,
-                    batcher::Chunker<_>,
-                    Col2ValBatcher<_, _, _, _>,
-                    RowRowBuilder<_, _>,
-                    RowRowSpine<_, _>,
-                >(exchange, "JoinStage")
-            };
             joined = JoinedFlavor::Local(arranged);
         }
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -25,7 +25,6 @@ use differential_dataflow::trace::implementations::BatchContainer;
 use differential_dataflow::trace::{Builder, Trace};
 use differential_dataflow::{Data, VecCollection};
 use itertools::Itertools;
-use mz_compute_types::dyncfgs::{ENABLE_COMPUTE_TEMPORAL_BUCKETING, TEMPORAL_BUCKETING_SUMMARY};
 use mz_compute_types::plan::ArrangementStrategy;
 use mz_compute_types::plan::reduce::{
     AccumulablePlan, BasicPlan, BucketedPlan, HierarchicalPlan, KeyValPlan, LirAggregateExpr,
@@ -37,7 +36,7 @@ use mz_ore::cast::CastLossy;
 use mz_repr::adt::numeric::{self, Numeric, NumericAgg};
 use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{Datum, DatumVec, Diff, Row, RowArena, SharedRow};
-use mz_timely_util::columnation::ColumnationChunker;
+use mz_row_spine::{DatumSeq, RowBuilder, RowRowBuilder, RowValBuilder};
 use mz_timely_util::operator::CollectionExt;
 use num_traits::Float;
 use serde::{Deserialize, Serialize};
@@ -45,7 +44,7 @@ use timely::Container;
 use timely::container::{CapacityContainerBuilder, PushInto};
 use tracing::warn;
 
-use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
+use crate::extensions::arrange::{ArrangementSize, MaybeTemporalArrange};
 use crate::extensions::reduce::{ClearContainer, MzReduce};
 use crate::render::context::{CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
@@ -53,14 +52,11 @@ use crate::render::errors::MaybeValidatingRow;
 use crate::render::reduce::monoids::{ReductionMonoid, get_monoid};
 use crate::render::{ArrangementFlavor, Pairer, RenderTimestamp};
 use crate::typedefs::{
-    ErrBatcher, ErrBuilder, KeyBatcher, RowErrBuilder, RowErrSpine, RowRowAgent, RowRowArrangement,
-    RowRowSpine, RowSpine, RowValSpine,
-};
-use mz_row_spine::{
-    DatumSeq, RowBatcher, RowBuilder, RowRowBatcher, RowRowBuilder, RowValBatcher, RowValBuilder,
+    ErrBuilder, ErrSpine, RowErrBuilder, RowErrSpine, RowRowAgent, RowRowArrangement, RowRowSpine,
+    RowSpine, RowValSpine,
 };
 
-impl<'scope, T: RenderTimestamp> Context<'scope, T> {
+impl<'scope, T: RenderTimestamp + MaybeTemporalArrange> Context<'scope, T> {
     /// Renders a `MirRelationExpr::Reduce` using various non-obvious techniques to
     /// minimize worst-case incremental update times and memory footprint.
     pub fn render_reduce(
@@ -159,15 +155,11 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
             // `ensure_collections`, so the strategy is plumbed through `PlanNode::Reduce`
             // rather than inferred at the arrangement site. No-op for `Direct`.
             let key_val_collection = key_val_input.as_collection();
-            let key_val_collection = if matches!(
-                temporal_bucketing_strategy,
-                ArrangementStrategy::TemporalBucketing
-            ) && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(&self.config_set)
-            {
-                let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
-                    .get(&self.config_set)
-                    .try_into()
-                    .expect("must fit");
+            let key_val_collection = if let Some(summary) =
+                crate::render::operator_bucketing_summary(
+                    &self.config_set,
+                    temporal_bucketing_strategy,
+                ) {
                 T::maybe_apply_temporal_bucketing(
                     key_val_collection.inner,
                     self.as_of_frontier.clone(),
@@ -199,12 +191,13 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         let mut errors = Default::default();
         let arrangement =
             self.render_reduce_plan_inner(plan, collection, &mut errors, key_arity, mfp_after);
-        let errs: KeyCollection<_, _, _> = err_input.concatenate(errors).into();
+        let errs = err_input.concatenate(errors);
         CollectionBundle::from_columns(
             0..key_arity,
             ArrangementFlavor::Local(
                 arrangement,
-                errs.mz_arrange::<ColumnationChunker<_>, ErrBatcher<_, _>, ErrBuilder<_, _>, _>(
+                self.arrange_key::<_, _, ErrBuilder<_, _>, ErrSpine<_, _>>(
+                    errs,
                     "Arrange bundle err",
                 ),
             ),
@@ -294,15 +287,10 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         let mfp_after1 = mfp_after.clone();
         let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
 
-        let arranged = collection
-            .mz_arrange::<
-                ColumnationChunker<_>,
-                RowRowBatcher<_, _>,
-                RowRowBuilder<_, _>,
-                RowRowSpine<_, _>,
-            >(
-                "Arranged DistinctBy",
-            );
+        let arranged = self.arrange::<_, _, _, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+            collection,
+            "Arranged DistinctBy",
+        );
         let output = arranged
             .clone()
             .mz_reduce_abelian::<_, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
@@ -404,13 +392,8 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         let mfp_after1 = mfp_after.clone();
         let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
 
-        let arranged = differential_dataflow::collection::concatenate(input.scope(), to_collect)
-            .mz_arrange::<
-                ColumnationChunker<_>,
-                RowValBatcher<_, _, _>,
-                RowValBuilder<_, _, _>,
-                RowValSpine<_, _, _>,
-            >(
+        let arranged = self.arrange::<_, _, _, RowValBuilder<_, _, _>, RowValSpine<_, _, _>>(
+            differential_dataflow::collection::concatenate(input.scope(), to_collect),
             "Arranged ReduceFuseBasic input",
         );
 
@@ -564,15 +547,10 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         } else {
             "FusedReduceUnnestList"
         };
-        let arranged = partial
-            .mz_arrange::<
-                ColumnationChunker<_>,
-                RowRowBatcher<_, _>,
-                RowRowBuilder<_, _>,
-                RowRowSpine<_, _>,
-            >(&format!(
-                "Arranged {name}"
-            ));
+        let arranged = self.arrange::<_, _, _, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+            partial,
+            &format!("Arranged {name}"),
+        );
         let oks = if !fused_unnest_list {
             arranged
                 .clone()
@@ -792,31 +770,25 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
             name_tag.unwrap_or_default()
         );
 
-        let input: KeyCollection<_, _, _> = input.into();
-        input
-            .mz_arrange::<
-                ColumnationChunker<_>,
-                RowBatcher<_, _>,
-                RowBuilder<_, _>,
-                RowSpine<_, _>,
-            >(
-                "Arranged ReduceInaccumulable Distinct [val: empty]",
-            )
-            .mz_reduce_abelian::<_, Bu, Tr>(&output_name, move |_, source, t| {
-                if let Some(err) = Tr::ValOwn::into_error() {
-                    for (value, count) in source.iter() {
-                        if count.is_positive() {
-                            continue;
-                        }
-
-                        let message = "Non-positive accumulation in ReduceInaccumulable DISTINCT";
-                        error_logger.log(message, &format!("value={value:?}, count={count}"));
-                        t.push((err(message.to_string()), Diff::ONE));
-                        return;
+        self.arrange_key::<_, _, RowBuilder<_, _>, RowSpine<_, _>>(
+            input,
+            "Arranged ReduceInaccumulable Distinct [val: empty]",
+        )
+        .mz_reduce_abelian::<_, Bu, Tr>(&output_name, move |_, source, t| {
+            if let Some(err) = Tr::ValOwn::into_error() {
+                for (value, count) in source.iter() {
+                    if count.is_positive() {
+                        continue;
                     }
+
+                    let message = "Non-positive accumulation in ReduceInaccumulable DISTINCT";
+                    error_logger.log(message, &format!("value={value:?}, count={count}"));
+                    t.push((err(message.to_string()), Diff::ONE));
+                    return;
                 }
-                t.push((Tr::ValOwn::ok(()), Diff::ONE))
-            })
+            }
+            t.push((Tr::ValOwn::ok(()), Diff::ONE))
+        })
     }
 
     /// Build the dataflow to compute and arrange multiple hierarchical aggregations
@@ -928,15 +900,10 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 let error_logger = self.error_logger();
                 // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
                 // view mz_introspection.mz_expected_group_size_advice.
-                let arranged = partial
-                    .mz_arrange::<
-                        ColumnationChunker<_>,
-                        RowRowBatcher<_, _>,
-                        RowRowBuilder<_, _>,
-                        RowRowSpine<_, _>,
-                    >(
-                        "Arrange ReduceMinsMaxes",
-                    );
+                let arranged = self.arrange::<_, _, _, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+                    partial,
+                    "Arrange ReduceMinsMaxes",
+                );
                 // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
                 // but we then wouldn't be able to do this error check conditionally.  See its documentation
                 // for the rationale around using a second reduction here.
@@ -1138,15 +1105,10 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         let error_logger = self.error_logger();
         // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
         // view mz_introspection.mz_expected_group_size_advice.
-        let arranged_input = input
-            .mz_arrange::<
-                ColumnationChunker<_>,
-                RowRowBatcher<_, _>,
-                RowRowBuilder<_, _>,
-                RowRowSpine<_, _>,
-            >(
-                "Arranged MinsMaxesHierarchical input",
-            );
+        let arranged_input = self.arrange::<_, _, _, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+            input,
+            "Arranged MinsMaxesHierarchical input",
+        );
 
         // Scratch buffer for decoding the input values (one column per aggregate) into the
         // arena, so the aggregates iterate arena-resident datums rather than the packed bytes.
@@ -1226,22 +1188,22 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
     ) {
         let aggregations = aggr_funcs.len();
         // Gather the relevant values into a vec of rows ordered by aggregation_index
-        let collection = collection
-            .map(move |(key, row)| {
-                let mut row_builder = SharedRow::get();
-                let mut values = Vec::with_capacity(aggregations);
-                values.extend(
-                    row.iter()
-                        .take(aggregations)
-                        .map(|v| row_builder.pack_using(std::iter::once(v))),
-                );
-
-                (key, values)
-            })
-            .consolidate_named_if::<KeyBatcher<_, _, _>>(
-                must_consolidate,
-                "Consolidated ReduceMonotonic input",
+        let collection = collection.map(move |(key, row)| {
+            let mut row_builder = SharedRow::get();
+            let mut values = Vec::with_capacity(aggregations);
+            values.extend(
+                row.iter()
+                    .take(aggregations)
+                    .map(|v| row_builder.pack_using(std::iter::once(v))),
             );
+
+            (key, values)
+        });
+        let collection = self.consolidate(
+            collection,
+            must_consolidate,
+            "Consolidated ReduceMonotonic input",
+        );
 
         // It should be now possible to ensure that we have a monotonic collection.
         let error_logger = self.error_logger();
@@ -1272,16 +1234,11 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         let mfp_after1 = mfp_after.clone();
         let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
 
-        let partial: KeyCollection<_, _, _> = partial.into();
-        let arranged = partial
-            .mz_arrange::<
-                ColumnationChunker<_>,
-                RowBatcher<_, _>,
-                RowBuilder<_, _>,
-                RowSpine<_, Vec<ReductionMonoid>>,
-            >(
-                "ArrangeMonotonic [val: empty]",
-            );
+        type MonotonicSpine<T> = RowSpine<T, Vec<ReductionMonoid>>;
+        let arranged = self.arrange_key::<_, _, RowBuilder<_, _>, MonotonicSpine<T>>(
+            partial,
+            "ArrangeMonotonic [val: empty]",
+        );
         let output = arranged
             .clone()
             .mz_reduce_abelian::<_, RowRowBuilder<_, _>, RowRowSpine<_, _>>("ReduceMonotonic", {
@@ -1418,18 +1375,13 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         // Next, collect all aggregations that require distinctness.
         for (datum_index, aggr) in distinct_aggrs.into_iter() {
             let pairer = Pairer::new(key_arity);
-            let collection = collection
-                .clone()
-                .map(move |(key, row)| {
-                    let value = row.iter().nth(datum_index).unwrap();
-                    (pairer.merge(&key, std::iter::once(value)), ())
-                })
-                .mz_arrange::<
-                    ColumnationChunker<_>,
-                    RowBatcher<_, _>,
-                    RowBuilder<_, _>,
-                    RowSpine<_, _>,
-                >(
+            let keyed = collection.clone().map(move |(key, row)| {
+                let value = row.iter().nth(datum_index).unwrap();
+                (pairer.merge(&key, std::iter::once(value)), ())
+            });
+            let collection = self
+                .arrange::<_, _, _, RowBuilder<_, _>, RowSpine<_, _>>(
+                    keyed,
                     "Arranged Accumulable Distinct [val: empty]",
                 )
                 .mz_reduce_abelian::<_, RowBuilder<_, _>, RowSpine<_, _>>(
@@ -1466,15 +1418,10 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
 
         let error_logger = self.error_logger();
         let err_full_aggrs = full_aggrs.clone();
-        let arranged = collection
-            .mz_arrange::<
-                ColumnationChunker<_>,
-                RowBatcher<_, _>,
-                RowBuilder<_, _>,
-                RowSpine<_, (Vec<Accum>, Diff)>,
-            >(
-                "ArrangeAccumulable [val: empty]",
-            );
+        let arranged = self.arrange::<_, _, _, RowBuilder<_, _>, RowSpine<_, (Vec<Accum>, Diff)>>(
+            collection,
+            "ArrangeAccumulable [val: empty]",
+        );
         let arranged_output = arranged
             .clone()
             .mz_reduce_abelian::<_, RowRowBuilder<_, _>, RowRowSpine<_, _>>("ReduceAccumulable", {

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -18,16 +18,15 @@ use differential_dataflow::trace::{Builder, Trace, TraceReader};
 use mz_compute_types::plan::scalar::LirScalarExpr;
 use mz_compute_types::plan::threshold::{BasicThresholdPlan, ThresholdPlan};
 use mz_repr::Diff;
-use mz_timely_util::columnation::ColumnationChunker;
+use mz_row_spine::RowRowBuilder;
 use timely::Container;
 use timely::container::PushInto;
 
-use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
+use crate::extensions::arrange::{ArrangementSize, MaybeTemporalArrange};
 use crate::extensions::reduce::{ClearContainer, MzReduce};
 use crate::render::RenderTimestamp;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
-use crate::typedefs::{ErrBatcher, ErrBuilder, MzData, MzTimestamp};
-use mz_row_spine::RowRowBuilder;
+use crate::typedefs::{ErrBuilder, ErrSpine, MzData, MzTimestamp};
 
 /// Shared function to compute an arrangement of values matching `logic`.
 fn threshold_arrangement<'scope, Ts, T1, Bu2, T2, L>(
@@ -79,10 +78,14 @@ where
 ///
 /// This implementation maintains rows in the output, i.e. all rows that have a count greater than
 /// zero. It returns a [CollectionBundle] populated from a local arrangement.
-pub fn build_threshold_basic<'scope, T: RenderTimestamp>(
+pub fn build_threshold_basic<'scope, T>(
     input: CollectionBundle<'scope, T>,
     key: Vec<LirScalarExpr>,
-) -> CollectionBundle<'scope, T> {
+    use_temporal: bool,
+) -> CollectionBundle<'scope, T>
+where
+    T: RenderTimestamp + MaybeTemporalArrange,
+{
     let arrangement = input
         .arrangement(&key)
         .expect("Arrangement ensured to exist");
@@ -101,17 +104,18 @@ pub fn build_threshold_basic<'scope, T: RenderTimestamp>(
                 "Threshold trace",
                 |count| count.is_positive(),
             );
-            let errs: KeyCollection<_, _, _> = errs.as_collection(|k, _| k.clone()).into();
-            let errs = errs
-                .mz_arrange::<ColumnationChunker<_>, ErrBatcher<_, _>, ErrBuilder<_, _>, _>(
-                    "Arrange threshold basic err",
-                );
+            let errs = errs.as_collection(|k, _| (k.clone(), ()));
+            let errs = T::mz_arrange_maybe_temporal::<_, _, _, ErrBuilder<_, _>, ErrSpine<_, _>>(
+                errs,
+                "Arrange threshold basic err",
+                use_temporal,
+            );
             CollectionBundle::from_expressions(key, ArrangementFlavor::Local(oks, errs))
         }
     }
 }
 
-impl<'scope, T: RenderTimestamp> Context<'scope, T> {
+impl<'scope, T: RenderTimestamp + MaybeTemporalArrange> Context<'scope, T> {
     pub(crate) fn render_threshold(
         &self,
         input: CollectionBundle<'scope, T>,
@@ -124,7 +128,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 // We do not need to apply the permutation here,
                 // since threshold doesn't inspect the values, but only
                 // their counts.
-                build_threshold_basic(input, key)
+                build_threshold_basic(input, key, self.temporal_batcher)
             }
         }
     }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -23,7 +23,6 @@ use differential_dataflow::operators::iterate::Variable as SemigroupVariable;
 use differential_dataflow::trace::implementations::BatchContainer;
 use differential_dataflow::trace::{Builder, Trace};
 use differential_dataflow::{Data, VecCollection};
-use mz_compute_types::dyncfgs::{ENABLE_COMPUTE_TEMPORAL_BUCKETING, TEMPORAL_BUCKETING_SUMMARY};
 use mz_compute_types::plan::ArrangementStrategy;
 use mz_compute_types::plan::scalar::LirScalarExpr;
 use mz_compute_types::plan::top_k::{
@@ -35,27 +34,27 @@ use mz_ore::cast::CastFrom;
 use mz_ore::soft_assert_or_log;
 use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{Datum, DatumVec, Diff, ReprScalarType, Row, SharedRow};
-use mz_timely_util::columnation::ColumnationChunker;
+use mz_row_spine::{DatumSeq, RowBuilder, RowRowBuilder, RowValBuilder, RowValSpine};
 use mz_timely_util::operator::CollectionExt;
 use timely::Container;
 use timely::container::{CapacityContainerBuilder, PushInto};
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Operator;
 
-use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
+use crate::extensions::arrange::ArrangementSize;
 use crate::extensions::reduce::{ClearContainer, MzReduce};
 use crate::render::Pairer;
 use crate::render::context::{CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::render::errors::MaybeValidatingRow;
-use crate::typedefs::{KeyBatcher, MzTimestamp, RowRowSpine, RowSpine};
-use mz_row_spine::{
-    DatumSeq, RowBatcher, RowBuilder, RowRowBatcher, RowRowBuilder, RowValBuilder, RowValSpine,
-};
+use crate::typedefs::{MzTimestamp, RowRowSpine, RowSpine};
 
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
-impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTime>
-    Context<'scope, T>
+impl<'scope, T> Context<'scope, T>
+where
+    T: crate::render::RenderTimestamp
+        + crate::render::MaybeBucketByTime
+        + crate::extensions::arrange::MaybeTemporalArrange,
 {
     pub(crate) fn render_topk(
         &self,
@@ -98,15 +97,9 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                  `mz_now()` has been const-folded and no temporal bucketing is set",
             );
         }
-        let ok_input = if matches!(
-            temporal_bucketing_strategy,
-            ArrangementStrategy::TemporalBucketing
-        ) && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(&self.config_set)
+        let ok_input = if let Some(summary) =
+            crate::render::operator_bucketing_summary(&self.config_set, temporal_bucketing_strategy)
         {
-            let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
-                .get(&self.config_set)
-                .try_into()
-                .expect("must fit");
             T::maybe_apply_temporal_bucketing(ok_input.inner, self.as_of_frontier.clone(), summary)
         } else {
             ok_input
@@ -186,18 +179,18 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     // Map the group key along with the row and consolidate if required to do so.
                     let mut datum_vec = mz_repr::DatumVec::new();
                     let ok_scope = ok_input.scope();
-                    let collection = ok_input
-                        .map(move |row| {
-                            let group_row = {
-                                let datums = datum_vec.borrow_with(&row);
-                                SharedRow::pack(group_key.iter().map(|i| datums[*i]))
-                            };
-                            (group_row, row)
-                        })
-                        .consolidate_named_if::<KeyBatcher<_, _, _>>(
-                            must_consolidate,
-                            "Consolidated MonotonicTopK input",
-                        );
+                    let collection = ok_input.map(move |row| {
+                        let group_row = {
+                            let datums = datum_vec.borrow_with(&row);
+                            SharedRow::pack(group_key.iter().map(|i| datums[*i]))
+                        };
+                        (group_row, row)
+                    });
+                    let collection = self.consolidate(
+                        collection,
+                        must_consolidate,
+                        "Consolidated MonotonicTopK input",
+                    );
 
                     // It should be now possible to ensure that we have a monotonic collection.
                     let error_logger = self.error_logger();
@@ -254,10 +247,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     let (result, errs) =
                         self.build_topk_stage(thinned, order_key, 1u64, 0, limit, arity, false);
                     // Consolidate the output of `build_topk_stage` because it's not guaranteed to be.
-                    let result = CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(
-                        result,
-                        "Monotonic TopK final consolidate",
-                    );
+                    let result = self.consolidate(result, true, "Monotonic TopK final consolidate");
                     retractions_var.set(collection.concat(result.clone().negate()));
                     soft_assert_or_log!(
                         errs.is_none(),
@@ -388,8 +378,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
             collection, order_key, 1u64, offset, limit, arity, validating,
         );
         // Consolidate the output of `build_topk_stage` because it's not guaranteed to be.
-        let oks =
-            CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(oks, "TopK final consolidate");
+        let oks = self.consolidate(oks, true, "TopK final consolidate");
         collection = oks;
         if validating {
             err_collection = errs;
@@ -461,7 +450,14 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                 T,
                 RowValBuilder<_, _, _>,
                 RowValSpine<Result<Row, Row>, _, _>,
-            >(&input, order_key, offset, limit, arity);
+            >(
+                &input,
+                order_key,
+                offset,
+                limit,
+                arity,
+                self.temporal_batcher,
+            );
             let stage = stage.as_collection(|k, v| (k.to_row(), v.clone()));
 
             // Demux oks and errors.
@@ -486,7 +482,12 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
             // Build non-validating topk stage.
             let (input, stage) =
                 build_topk_negated_stage::<T, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
-                    &input, order_key, offset, limit, arity,
+                    &input,
+                    order_key,
+                    offset,
+                    limit,
+                    arity,
+                    self.temporal_batcher,
                 );
             // Turn arrangement into collection.
             let stage = stage.as_collection(|k, v| (k.to_row(), v.to_row()));
@@ -511,22 +512,22 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         // corresponding to evaluating our aggregate, instead of having to do a hierarchical
         // reduction. We start by mapping the group key along with the row and consolidating
         // if required to do so.
-        let collection = collection
-            .map({
-                let mut datum_vec = mz_repr::DatumVec::new();
-                move |row| {
-                    // Scoped to allow borrow of `row` to drop.
-                    let group_key = {
-                        let datums = datum_vec.borrow_with(&row);
-                        SharedRow::pack(group_key.iter().map(|i| datums[*i]))
-                    };
-                    (group_key, row)
-                }
-            })
-            .consolidate_named_if::<KeyBatcher<_, _, _>>(
-                must_consolidate,
-                "Consolidated MonotonicTop1 input",
-            );
+        let collection = collection.map({
+            let mut datum_vec = mz_repr::DatumVec::new();
+            move |row| {
+                // Scoped to allow borrow of `row` to drop.
+                let group_key = {
+                    let datums = datum_vec.borrow_with(&row);
+                    SharedRow::pack(group_key.iter().map(|i| datums[*i]))
+                };
+                (group_key, row)
+            }
+        });
+        let collection = self.consolidate(
+            collection,
+            must_consolidate,
+            "Consolidated MonotonicTop1 input",
+        );
 
         // It should be now possible to ensure that we have a monotonic collection and process it.
         let error_logger = self.error_logger();
@@ -538,24 +539,18 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
             let m = "tried to build monotonic top-1 on non-monotonic input".into();
             (EvalError::Internal(m).into(), Diff::ONE)
         });
-        let partial: KeyCollection<_, _, _> = partial
-            .explode_one(move |(group_key, row)| {
-                (
-                    group_key,
-                    monoids::Top1Monoid {
-                        row,
-                        order_key: order_key.clone(),
-                    },
-                )
-            })
-            .into();
-        let result = partial
-            .mz_arrange::<
-                ColumnationChunker<_>,
-                RowBatcher<_, _>,
-                RowBuilder<_, _>,
-                RowSpine<_, _>,
-            >(
+        let partial = partial.explode_one(move |(group_key, row)| {
+            (
+                group_key,
+                monoids::Top1Monoid {
+                    row,
+                    order_key: order_key.clone(),
+                },
+            )
+        });
+        let result = self
+            .arrange_key::<_, _, RowBuilder<_, _>, RowSpine<_, _>>(
+                partial,
                 "Arranged MonotonicTop1 partial [val: empty]",
             )
             .mz_reduce_abelian::<_, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
@@ -583,12 +578,13 @@ fn build_topk_negated_stage<'s, T, Bu, Tr>(
     offset: usize,
     limit: Option<LirScalarExpr>,
     arity: usize,
+    use_temporal: bool,
 ) -> (
     Arranged<'s, TraceAgent<RowRowSpine<T, Diff>>>,
     Arranged<'s, TraceAgent<Tr>>,
 )
 where
-    T: MzTimestamp,
+    T: MzTimestamp + crate::extensions::arrange::MaybeTemporalArrange,
     Bu: Builder<
             Time = T,
             Input: Container + ClearContainer + PushInto<((Row, Tr::ValOwn), T, Diff)>,
@@ -609,16 +605,11 @@ where
     // such that `input.concat(&negated_output)` yields the correct TopK
     // NOTE(vmarcos): The arranged input operator name below is used in the tuning advice
     // built-in view mz_introspection.mz_expected_group_size_advice.
-    let arranged = input
-        .clone()
-        .mz_arrange::<
-            ColumnationChunker<_>,
-            RowRowBatcher<_, _>,
-            RowRowBuilder<_, _>,
-            RowRowSpine<_, _>,
-        >(
-            "Arranged TopK input",
-        );
+    let arranged = T::mz_arrange_maybe_temporal::<_, _, _, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+        input.clone(),
+        "Arranged TopK input",
+        use_temporal,
+    );
 
     // Eagerly evaluate literal limits.
     let limit = limit.map(|l| match l.as_literal() {

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -198,6 +198,14 @@ impl BucketTimestamp for Timestamp {
     }
 }
 
+impl mz_timely_util::merge_batcher::TemporalThreshold for Timestamp {
+    fn temporal_threshold() -> Self {
+        mz_timely_util::merge_batcher::TEMPORAL_THRESHOLD_MS
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .into()
+    }
+}
+
 pub trait TimestampManipulation:
     timely::progress::Timestamp
     + timely::order::TotalOrder

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -29,6 +29,10 @@ harness = false
 name = "column_pager"
 harness = false
 
+[[bench]]
+name = "temporal_merge_batcher"
+harness = false
+
 [dependencies]
 ahash.workspace = true
 bincode.workspace = true

--- a/src/timely-util/benches/temporal_merge_batcher.rs
+++ b/src/timely-util/benches/temporal_merge_batcher.rs
@@ -1,0 +1,202 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Plain vs temporal merge batcher across the three workload regimes that
+//! decide whether the temporal batcher can be enabled everywhere:
+//!
+//! 1. `all_past`: no future updates. The temporal batcher must be at parity
+//!    with the plain batcher (its fast path is the plain code plus a branch).
+//! 2. `raced_ahead`: data one tick ahead of the frontier, within the
+//!    threshold. Both batchers treat it identically (flat re-merge), so
+//!    parity is expected here too.
+//! 3. `hydration`/`near_heavy`/`steady_tail`: genuine far-future data
+//!    (temporal-filter retraction tails). The plain batcher re-walks the held
+//!    tail at every seal; the temporal batcher parks it in the bucket chain.
+//!
+//! A third arm (the standalone temporal-bucket *operator* feeding a plain
+//! batcher, today's production mechanism for temporal workloads) lives in
+//! mz-compute and needs a dataflow harness; it is intentionally not
+//! replicated here.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use differential_dataflow::consolidation::consolidate_updates;
+use differential_dataflow::trace::Batcher;
+use differential_dataflow::trace::implementations::merge_batcher::MergeBatcher;
+use mz_timely_util::columnation::{ColInternalMerger, ColTemporalMerger, ColumnationStack};
+use mz_timely_util::merge_batcher::TemporalBucketingMergeBatcher;
+use timely::container::PushInto;
+use timely::progress::Antichain;
+
+type Update = (u64, u64, i64);
+type Merger = ColInternalMerger<u64, u64, i64>;
+type Plain = MergeBatcher<Merger>;
+type Temporal = TemporalBucketingMergeBatcher<ColTemporalMerger<u64, u64, i64>>;
+
+/// ~2026-07-11 in milliseconds since the epoch.
+const NOW: u64 = 1_752_192_000_000;
+const TICK: u64 = 1_000;
+const WINDOW: u64 = 45 * 24 * 3_600 * 1_000;
+/// Mirrors the chunk sizes the production chunker emits.
+const CHUNK: usize = 8_192;
+
+/// One seal's worth of work: chunks to push, then a seal at `upper`.
+struct Step {
+    chunks: Vec<ColumnationStack<Update>>,
+    upper: u64,
+}
+
+fn steps(raw: Vec<(Vec<Update>, u64)>) -> Vec<Step> {
+    raw.into_iter()
+        .map(|(mut updates, upper)| {
+            consolidate_updates(&mut updates);
+            let chunks = updates
+                .chunks(CHUNK)
+                .map(|slice| {
+                    let mut chunk = ColumnationStack::default();
+                    for update in slice {
+                        chunk.push_into(*update);
+                    }
+                    chunk
+                })
+                .collect();
+            Step { chunks, upper }
+        })
+        .collect()
+}
+
+/// Drive a batcher through `steps` plus a final flush; returns emitted
+/// records as a sink the optimizer can't discard.
+fn run<B>(steps: &[Step]) -> usize
+where
+    B: Batcher<Time = u64, Output = ColumnationStack<Update>> + PushInto<ColumnationStack<Update>>,
+{
+    let mut batcher = B::new(None, 0);
+    let mut emitted = 0;
+    for step in steps {
+        for chunk in &step.chunks {
+            batcher.push_into(chunk.clone());
+        }
+        let (chain, _description) = batcher.seal(Antichain::from_elem(step.upper));
+        emitted += chain.iter().map(|c| c[..].len()).sum::<usize>();
+    }
+    let (chain, _description) = batcher.seal(Antichain::new());
+    emitted += chain.iter().map(|c| c[..].len()).sum::<usize>();
+    emitted
+}
+
+/// Regime 1: all data at the current tick, no future updates.
+fn all_past(ticks: u64, per_tick: u64) -> Vec<Step> {
+    let mut raw = Vec::new();
+    for tick in 0..ticks {
+        let upper = NOW + (tick + 1) * TICK;
+        let updates = (0..per_tick)
+            .map(|i| (tick * per_tick + i, upper - 1, 1))
+            .collect();
+        raw.push((updates, upper));
+    }
+    steps(raw)
+}
+
+/// Regime 2: every record one tick ahead of the seal upper (within the 2s
+/// default threshold), re-merged once before release, in both batchers.
+fn raced_ahead(ticks: u64, per_tick: u64) -> Vec<Step> {
+    let mut raw = Vec::new();
+    for tick in 0..ticks {
+        let upper = NOW + (tick + 1) * TICK;
+        let updates = (0..per_tick)
+            .map(|i| (tick * per_tick + i, upper + TICK, 1))
+            .collect();
+        raw.push((updates, upper));
+    }
+    steps(raw)
+}
+
+/// Regime 3, hydration shape: a snapshot below the upper plus a
+/// temporal-filter retraction tail uniform over the window, all sealed once,
+/// followed by quiet ticks.
+fn hydration(records: u64, ticks: u64) -> Vec<Step> {
+    let mut updates = Vec::new();
+    for i in 0..records {
+        updates.push((i, NOW - 1 - (i % 1_000), 1));
+        updates.push((i, NOW + 1 + i * (WINDOW / records), -1));
+    }
+    let mut raw = vec![(updates, NOW)];
+    for tick in 1..=ticks {
+        raw.push((Vec::new(), NOW + tick * TICK));
+    }
+    steps(raw)
+}
+
+/// Regime 3, adversarial: tail mass geometrically concentrated near the
+/// frontier at every scale (the worst distribution the simulation found).
+fn near_heavy(records: u64, ticks: u64) -> Vec<Step> {
+    let mut updates = Vec::new();
+    for i in 0..records {
+        updates.push((i, NOW - 1 - (i % 1_000), 1));
+        let distance = (1_u64 << (i % 33)).min(WINDOW) + (i % 977);
+        updates.push((i, NOW + distance, -1));
+    }
+    let mut raw = vec![(updates, NOW)];
+    for tick in 1..=ticks {
+        raw.push((Vec::new(), NOW + tick * TICK));
+    }
+    steps(raw)
+}
+
+/// Regime 3, steady state: a held tail plus per-tick current data and a
+/// trickle of new far-future retractions, over many ticks. This is where the
+/// plain batcher pays O(held) per seal and the temporal batcher does not.
+fn steady_tail(tail: u64, ticks: u64, per_tick: u64) -> Vec<Step> {
+    let mut updates = Vec::new();
+    for i in 0..tail {
+        updates.push((i, NOW + 1 + i * (WINDOW / tail), -1));
+    }
+    let mut raw = vec![(updates, NOW)];
+    for tick in 1..=ticks {
+        let upper = NOW + tick * TICK;
+        let mut updates: Vec<Update> = (0..per_tick)
+            .map(|i| (tail + tick * per_tick + i, upper - 1, 1))
+            .collect();
+        updates.push((tail + tick, upper - 1 + WINDOW, -1));
+        raw.push((updates, upper));
+    }
+    steps(raw)
+}
+
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("temporal_merge_batcher");
+    group.sample_size(10);
+
+    let scenarios: Vec<(&str, Vec<Step>)> = vec![
+        ("all_past", all_past(256, 2_048)),
+        ("raced_ahead", raced_ahead(256, 2_048)),
+        ("hydration", hydration(262_144, 10)),
+        ("near_heavy", near_heavy(262_144, 10)),
+        ("steady_tail", steady_tail(65_536, 512, 512)),
+    ];
+
+    for (name, steps) in &scenarios {
+        group.bench_function(format!("{name}/plain"), |b| {
+            b.iter(|| std::hint::black_box(run::<Plain>(steps)))
+        });
+        group.bench_function(format!("{name}/temporal"), |b| {
+            b.iter(|| std::hint::black_box(run::<Temporal>(steps)))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/src/timely-util/proptest-regressions/merge_batcher.txt
+++ b/src/timely-util/proptest-regressions/merge_batcher.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 8525c91df69b8a4e5bbcbf97feea34d607f5e8a825863d73b778e5490d1dfb2e # shrinks to threshold = 4, steps = [(3, [(1, 11, false)], 7), (0, [(1, 7, true)], 2), (0, [], 6)]

--- a/src/timely-util/src/column_pager.rs
+++ b/src/timely-util/src/column_pager.rs
@@ -42,6 +42,7 @@ use std::sync::{Arc, LazyLock, RwLock};
 use columnar::Columnar;
 use lz4_flex::frame::{FrameDecoder, FrameEncoder};
 use mz_ore::pager::{self, Backend, Handle};
+use timely::Accountable;
 use timely::bytes::arc::BytesMut;
 use timely::dataflow::channels::ContainerBytes;
 
@@ -134,6 +135,8 @@ pub trait PagingPolicy: Send + Sync {
 pub struct Meta {
     /// Uncompressed body size in bytes.
     pub len_bytes: usize,
+    /// Number of records in the column.
+    pub records: usize,
 }
 
 /// A column whose body may be resident, paged out, or paged out and compressed.
@@ -172,6 +175,18 @@ pub enum PagedColumn<C: Columnar> {
         /// Sizing metadata.
         meta: Meta,
     },
+}
+
+impl<C: Columnar> PagedColumn<C> {
+    /// Number of records in the column, without materializing it.
+    pub fn record_count(&self) -> usize {
+        match self {
+            PagedColumn::Resident(col, _) => {
+                usize::try_from(col.record_count()).expect("non-negative")
+            }
+            PagedColumn::Paged { meta, .. } | PagedColumn::Compressed { meta, .. } => meta.records,
+        }
+    }
 }
 
 /// Drop guard that returns budget to a [`PagingPolicy`] when a
@@ -413,7 +428,10 @@ impl ColumnPager {
             }
             PageDecision::Page { backend, codec } => (backend, codec),
         };
-        let meta = Meta { len_bytes };
+        let meta = Meta {
+            len_bytes,
+            records: usize::try_from(col.record_count()).expect("non-negative"),
+        };
 
         match codec {
             None => {
@@ -759,13 +777,19 @@ mod tests {
 
     #[mz_ore::test]
     fn align_variant_fast_path() {
-        // Construct an Align column directly to exercise the move-only raw path.
+        // Construct an Align column to exercise the raw path that moves the
+        // aligned allocation into the pager without a copy. The body must be
+        // a real serialized column: `page` reads the record count from it.
         let policy = TestPolicy::new(PageDecision::Page {
             backend: Backend::Swap,
             codec: None,
         });
         let cp = ColumnPager::new(as_dyn(&policy));
-        let body: Vec<u64> = (1u64..=512).collect();
+        let body: Vec<u64> = {
+            let mut buf = Vec::new();
+            sample_typed().into_bytes(&mut buf);
+            bytemuck::allocation::pod_collect_to_vec(&buf)
+        };
         let mut col: Column<i64> = Column::Align(body.clone());
         let paged = cp.page(&mut col);
         assert!(matches!(paged, PagedColumn::Paged { .. }));

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -37,7 +37,7 @@ use timely::bytes::arc::Bytes;
 use timely::container::{DrainContainer, PushInto, SizableContainer};
 use timely::dataflow::channels::ContainerBytes;
 
-use crate::columnation::ColInternalMerger;
+use crate::columnation::{ColInternalMerger, ColTemporalMerger};
 
 /// A batcher for columnar storage.
 ///
@@ -48,6 +48,12 @@ use crate::columnation::ColInternalMerger;
 pub type Col2ValBatcher<K, V, T, R> = MergeBatcher<ColInternalMerger<(K, V), T, R>>;
 /// A batcher for columnar storage with unit values.
 pub type Col2KeyBatcher<K, T, R> = Col2ValBatcher<K, (), T, R>;
+
+/// Temporal-bucketing counterpart of [`Col2ValBatcher`]: same chunks and
+/// merger, but far-future updates are held in a bucket chain instead of
+/// being re-merged at every seal.
+pub type Col2ValTemporalBatcher<K, V, T, R> =
+    crate::merge_batcher::TemporalBucketingMergeBatcher<ColTemporalMerger<(K, V), T, R>>;
 
 /// Pageable counterpart to [`Col2ValBatcher`]. Routes every chunk produced
 /// by chunking, merging, or extract through a [`crate::column_pager::ColumnPager`],

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -62,6 +62,14 @@ pub type Col2KeyBatcher<K, T, R> = Col2ValBatcher<K, (), T, R>;
 /// real one via [`merge_batcher::ColumnMergeBatcher::set_pager`].
 pub type Col2ValPagedBatcher<K, V, T, R> = merge_batcher::ColumnMergeBatcher<(K, V), T, R>;
 
+/// Temporal-bucketing counterpart of [`Col2ValPagedBatcher`]: paged chains
+/// plus far-future updates held in a bucket chain instead of being re-merged
+/// at every seal.
+pub type Col2ValPagedTemporalBatcher<K, V, T, R> =
+    crate::merge_batcher::TemporalBucketingMergeBatcher<
+        merge_batcher::PagedColumnMerger<(K, V), T, R>,
+    >;
+
 /// A container based on a columnar store, encoded in aligned bytes.
 ///
 /// The type can represent typed data, bytes from Timely, or an aligned allocation. The name

--- a/src/timely-util/src/columnar/merge_batcher.rs
+++ b/src/timely-util/src/columnar/merge_batcher.rs
@@ -30,9 +30,9 @@
 
 use std::collections::VecDeque;
 
-use columnar::{Columnar, Index, Len};
+use columnar::{Borrow, Columnar, Container, Index, Len};
 use differential_dataflow::difference::Semigroup;
-use differential_dataflow::logging::{BatcherEvent, Logger};
+use differential_dataflow::logging::Logger;
 use differential_dataflow::trace::{Batcher, Description};
 use timely::Accountable;
 use timely::PartialOrder;
@@ -165,25 +165,12 @@ where
     /// Emit a single `BatcherEvent` summing resident accounting across
     /// `chain` with the given sign. No-op when no logger is attached.
     fn emit_account(&self, chain: &VecDeque<PagedColumn<(D, T, R)>>, diff: isize) {
-        let Some(logger) = &self.logger else {
-            return;
-        };
-        let (mut records, mut size, mut capacity, mut allocations) =
-            (0isize, 0isize, 0isize, 0isize);
-        for entry in chain {
-            let (r, s, c, a) = account_chunk(entry);
-            records = records.saturating_add_unsigned(r);
-            size = size.saturating_add_unsigned(s);
-            capacity = capacity.saturating_add_unsigned(c);
-            allocations = allocations.saturating_add_unsigned(a);
-        }
-        logger.log(BatcherEvent {
-            operator: self.operator_id,
-            records_diff: records.saturating_mul(diff),
-            size_diff: size.saturating_mul(diff),
-            capacity_diff: capacity.saturating_mul(diff),
-            allocations_diff: allocations.saturating_mul(diff),
-        });
+        crate::merge_batcher::log_batcher_event(
+            &self.logger,
+            self.operator_id,
+            chain.iter().map(account_chunk),
+            diff,
+        );
     }
 }
 
@@ -667,6 +654,213 @@ pub fn extract_chain<D, T, R, SinkShip, SinkKeep>(
         ship(pager.page(&mut ship_buf));
     } else {
         recycle_capped(ship_buf, stash);
+    }
+}
+
+use crate::merge_batcher::{TemporalMerger, TimePartitioned, update_bounds};
+
+/// [`TemporalMerger`] over paged column chains: the temporal-bucketing
+/// counterpart of [`ColumnMergeBatcher`]'s engine. Chain entries are
+/// [`PagedColumn`]s, so both the flat chains and the far-future bucket chain
+/// can spill under memory pressure. The far tail is the natural spill
+/// candidate: it is touched again only when buckets split or mature.
+///
+/// Resolves its pager lazily per call via [`column_pager::global_pager`],
+/// like [`ColumnMergeBatcher`]. Tests may pin one via [`Self::set_pager`].
+pub struct PagedColumnMerger<D, T, R>
+where
+    (D, T, R): Columnar,
+{
+    /// Recycled empty `Column::Typed` chunks, kept across calls within one
+    /// seal cycle and dropped in `seal_done`.
+    stash: Vec<Column<(D, T, R)>>,
+    /// Optional override; `None` reads the process-global pager per use.
+    pager_override: Option<ColumnPager>,
+}
+
+impl<D, T, R> Default for PagedColumnMerger<D, T, R>
+where
+    (D, T, R): Columnar,
+{
+    fn default() -> Self {
+        Self {
+            stash: Vec::new(),
+            pager_override: None,
+        }
+    }
+}
+
+impl<D, T, R> PagedColumnMerger<D, T, R>
+where
+    (D, T, R): Columnar,
+{
+    /// Pin the pager this merger uses, overriding the process-global lookup.
+    /// Mainly for tests.
+    pub fn set_pager(&mut self, pager: ColumnPager) {
+        self.pager_override = Some(pager);
+    }
+
+    fn pager(&self) -> ColumnPager {
+        self.pager_override
+            .clone()
+            .unwrap_or_else(column_pager::global_pager)
+    }
+}
+
+impl<D, T, R> TemporalMerger for PagedColumnMerger<D, T, R>
+where
+    D: Columnar,
+    for<'a> columnar::Ref<'a, D>: Copy + Ord,
+    T: Columnar + Default + Clone + Ord + PartialOrder,
+    for<'a> columnar::Ref<'a, T>: Copy + Ord,
+    R: Columnar + Default + Semigroup + for<'a> Semigroup<columnar::Ref<'a, R>>,
+{
+    type Time = T;
+    type Chunk = PagedColumn<(D, T, R)>;
+    type Output = Column<(D, T, R)>;
+
+    fn absorb(&mut self, mut input: Self::Output) -> Self::Chunk {
+        self.pager().page(&mut input)
+    }
+
+    fn materialize(&mut self, chunk: Self::Chunk) -> Self::Output {
+        self.pager().take(chunk)
+    }
+
+    fn merge(
+        &mut self,
+        list1: Vec<Self::Chunk>,
+        list2: Vec<Self::Chunk>,
+        output: &mut Vec<Self::Chunk>,
+    ) {
+        let pager = self.pager();
+        merge_chains(
+            FetchIter::new(VecDeque::from(list1), &pager),
+            FetchIter::new(VecDeque::from(list2), &pager),
+            |paged| output.push(paged),
+            &mut self.stash,
+        );
+    }
+
+    fn chunk_len(chunk: &Self::Chunk) -> usize {
+        chunk.record_count()
+    }
+
+    fn chunk_time_bounds(chunk: &Self::Chunk) -> Option<(T, T)> {
+        // Offloaded chunks cannot be inspected in place; validation callers
+        // pin an always-resident pager.
+        let PagedColumn::Resident(col, _) = chunk else {
+            return None;
+        };
+        let mut bounds = None;
+        let mut owned_t = T::default();
+        let view = col.borrow();
+        for i in 0..view.len() {
+            let (_, time, _) = view.get(i);
+            T::copy_from(&mut owned_t, time);
+            update_bounds(&mut bounds, &owned_t);
+        }
+        bounds
+    }
+
+    fn extract_time_partitioned(
+        &mut self,
+        merged: Vec<Self::Chunk>,
+        split_lo: AntichainRef<'_, T>,
+        split_hi: AntichainRef<'_, T>,
+        track_before: bool,
+    ) -> TimePartitioned<Self::Chunk, T> {
+        let pager = self.pager();
+        let stash = &mut self.stash;
+        let mut result = TimePartitioned {
+            before: Vec::new(),
+            before_bounds: None,
+            within: Vec::new(),
+            within_bounds: None,
+            beyond: Vec::new(),
+            beyond_bounds: None,
+            records: 0,
+        };
+        let mut before: Column<(D, T, R)> = empty_chunk(stash);
+        // The `within` and `beyond` parts are often empty (any seal without
+        // future updates); allocate their builders lazily so such extracts
+        // pay exactly the two-way extract's allocations.
+        let mut within: Option<Column<(D, T, R)>> = None;
+        let mut beyond: Option<Column<(D, T, R)>> = None;
+
+        let mut owned_t = T::default();
+        for buffer in FetchIter::new(VecDeque::from(merged), &pager) {
+            let view = buffer.borrow();
+            let len = view.len();
+            result.records += len;
+            for i in 0..len {
+                let (_, time, _) = view.get(i);
+                T::copy_from(&mut owned_t, time);
+                // NOTE: chunks are sorted data-major, so times arrive in no
+                // particular order and every record updates the bounds.
+                // Testing `before` first keeps the dominant case (ready
+                // data) at the two-way extract's single comparison.
+                let (out, chunks, bounds, tracked) = if !split_lo.less_equal(&owned_t) {
+                    (
+                        &mut before,
+                        &mut result.before,
+                        &mut result.before_bounds,
+                        track_before,
+                    )
+                } else if split_hi.less_equal(&owned_t) {
+                    (
+                        beyond.get_or_insert_with(|| empty_chunk(stash)),
+                        &mut result.beyond,
+                        &mut result.beyond_bounds,
+                        true,
+                    )
+                } else {
+                    (
+                        within.get_or_insert_with(|| empty_chunk(stash)),
+                        &mut result.within,
+                        &mut result.within_bounds,
+                        true,
+                    )
+                };
+                if tracked {
+                    update_bounds(bounds, &owned_t);
+                }
+                let Column::Typed(out_c) = out else {
+                    unreachable!("builder chunks are always Column::Typed");
+                };
+                out_c.extend_from_self(view, i..i + 1);
+                if crate::columnar::at_serialized_capacity(&out_c.borrow()) {
+                    let mut full = std::mem::replace(out, empty_chunk(stash));
+                    chunks.push(pager.page(&mut full));
+                    recycle_capped(full, stash);
+                }
+            }
+            recycle_capped(buffer, stash);
+        }
+
+        for (builder, out) in [
+            (Some(before), &mut result.before),
+            (within, &mut result.within),
+            (beyond, &mut result.beyond),
+        ] {
+            if let Some(mut builder) = builder {
+                if builder.is_empty() {
+                    recycle_capped(builder, stash);
+                } else {
+                    out.push(pager.page(&mut builder));
+                    recycle_capped(builder, stash);
+                }
+            }
+        }
+        result
+    }
+
+    fn account(chunk: &Self::Chunk) -> (usize, usize, usize, usize) {
+        account_chunk(chunk)
+    }
+
+    fn seal_done(&mut self) {
+        self.stash.clear();
     }
 }
 

--- a/src/timely-util/src/columnation.rs
+++ b/src/timely-util/src/columnation.rs
@@ -785,3 +785,168 @@ where
         (chunk[..].len(), size, capacity, allocations)
     }
 }
+
+use crate::merge_batcher::{TemporalMerger, TimePartitioned, update_bounds};
+
+/// The columnation-based [`TemporalMerger`]: [`ColInternalMerger`] plus the
+/// recycled-chunk stash that differential's merge batcher would otherwise
+/// carry. Chunks pass through unchanged, there is no offloaded
+/// representation.
+pub struct ColTemporalMerger<D, T, R>
+where
+    D: Columnation,
+    T: Columnation,
+    R: Columnation,
+{
+    inner: ColInternalMerger<D, T, R>,
+    stash: Vec<ColumnationStack<(D, T, R)>>,
+}
+
+impl<D, T, R> Default for ColTemporalMerger<D, T, R>
+where
+    D: Columnation,
+    T: Columnation,
+    R: Columnation,
+{
+    fn default() -> Self {
+        Self {
+            inner: ColInternalMerger::default(),
+            stash: Vec::new(),
+        }
+    }
+}
+
+impl<D, T, R> TemporalMerger for ColTemporalMerger<D, T, R>
+where
+    D: Ord + Columnation + Clone + 'static,
+    T: Ord + Columnation + Clone + PartialOrder + 'static,
+    R: Default + Semigroup + Columnation + Clone + 'static,
+{
+    type Time = T;
+    type Chunk = ColumnationStack<(D, T, R)>;
+    type Output = ColumnationStack<(D, T, R)>;
+
+    fn absorb(&mut self, input: Self::Output) -> Self::Chunk {
+        input
+    }
+
+    fn materialize(&mut self, chunk: Self::Chunk) -> Self::Output {
+        chunk
+    }
+
+    fn merge(
+        &mut self,
+        list1: Vec<Self::Chunk>,
+        list2: Vec<Self::Chunk>,
+        output: &mut Vec<Self::Chunk>,
+    ) {
+        Merger::merge(&mut self.inner, list1, list2, output, &mut self.stash);
+    }
+
+    fn chunk_len(chunk: &Self::Chunk) -> usize {
+        chunk[..].len()
+    }
+
+    fn chunk_time_bounds(chunk: &Self::Chunk) -> Option<(T, T)> {
+        let mut bounds = None;
+        for (_, time, _) in &chunk[..] {
+            update_bounds(&mut bounds, time);
+        }
+        bounds
+    }
+
+    fn account(chunk: &Self::Chunk) -> (usize, usize, usize, usize) {
+        <ColInternalMerger<D, T, R> as Merger>::account(chunk)
+    }
+
+    fn seal_done(&mut self) {
+        self.stash.clear();
+    }
+
+    fn extract_time_partitioned(
+        &mut self,
+        merged: Vec<Self::Chunk>,
+        split_lo: AntichainRef<'_, T>,
+        split_hi: AntichainRef<'_, T>,
+        track_before: bool,
+    ) -> TimePartitioned<Self::Chunk, T> {
+        let stash = &mut self.stash;
+        let mut result = TimePartitioned {
+            before: Vec::new(),
+            before_bounds: None,
+            within: Vec::new(),
+            within_bounds: None,
+            beyond: Vec::new(),
+            beyond_bounds: None,
+            records: 0,
+        };
+        let mut before = ColInternalMerger::<D, T, R>::empty(stash);
+        // The `within` and `beyond` parts are often empty (any seal without
+        // future updates); allocate their builders lazily so such extracts
+        // pay exactly the plain extract's allocations.
+        let mut within: Option<Self::Chunk> = None;
+        let mut beyond: Option<Self::Chunk> = None;
+
+        for chunk in merged {
+            let len = chunk[..].len();
+            for i in 0..len {
+                let (data, time, diff) = &chunk[i];
+                result.records += 1;
+                // NOTE: chunks are sorted data-major, so times arrive in no
+                // particular order and every record updates the bounds.
+                // Testing `before` first keeps the dominant case (ready
+                // data) at the plain extract's single comparison.
+                if !split_lo.less_equal(time) {
+                    if track_before {
+                        update_bounds(&mut result.before_bounds, time);
+                    }
+                    before.copy_destructured(data, time, diff);
+                    if before.at_capacity() {
+                        result.before.push(std::mem::replace(
+                            &mut before,
+                            ColInternalMerger::<D, T, R>::empty(stash),
+                        ));
+                    }
+                } else if split_hi.less_equal(time) {
+                    update_bounds(&mut result.beyond_bounds, time);
+                    let builder =
+                        beyond.get_or_insert_with(|| ColInternalMerger::<D, T, R>::empty(stash));
+                    builder.copy_destructured(data, time, diff);
+                    if builder.at_capacity() {
+                        result.beyond.push(std::mem::replace(
+                            builder,
+                            ColInternalMerger::<D, T, R>::empty(stash),
+                        ));
+                    }
+                } else {
+                    update_bounds(&mut result.within_bounds, time);
+                    let builder =
+                        within.get_or_insert_with(|| ColInternalMerger::<D, T, R>::empty(stash));
+                    builder.copy_destructured(data, time, diff);
+                    if builder.at_capacity() {
+                        result.within.push(std::mem::replace(
+                            builder,
+                            ColInternalMerger::<D, T, R>::empty(stash),
+                        ));
+                    }
+                }
+            }
+            ColInternalMerger::<D, T, R>::recycle(chunk, stash);
+        }
+
+        for (builder, out) in [
+            (Some(before), &mut result.before),
+            (within, &mut result.within),
+            (beyond, &mut result.beyond),
+        ] {
+            if let Some(builder) = builder {
+                if builder[..].is_empty() {
+                    ColInternalMerger::<D, T, R>::recycle(builder, stash);
+                } else {
+                    out.push(builder);
+                }
+            }
+        }
+        result
+    }
+}

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -24,6 +24,7 @@ pub mod columnar;
 pub mod columnation;
 pub mod containers;
 pub mod hash;
+pub mod merge_batcher;
 pub mod operator;
 pub mod order;
 pub mod pact;

--- a/src/timely-util/src/merge_batcher.rs
+++ b/src/timely-util/src/merge_batcher.rs
@@ -1,0 +1,1239 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A merge batcher that holds back far-future updates in a [`BucketChain`].
+//!
+//! [`TemporalBucketingMergeBatcher`] is a drop-in replacement for
+//! differential's `MergeBatcher` that avoids the quadratic behavior the plain
+//! batcher exhibits on future-stamped updates. The plain batcher re-merges and
+//! re-extracts every held update at every seal, so an update at time `t` costs
+//! work proportional to the number of seals until the frontier passes `t`.
+//! Temporal filters produce updates days or weeks ahead of the frontier, which
+//! turns that into `O(updates x seals)`.
+//!
+//! This batcher instead decides *empirically* at each seal, based on the data
+//! it actually holds. The seal's single extract walk partitions updates three
+//! ways against the seal `upper` and `upper + threshold`:
+//!
+//! * ready (`t < upper`): emitted, exactly like the plain batcher;
+//! * near (`upper <= t < upper + threshold`): returned to the flat chains,
+//!   exactly like the plain batcher's `kept` handling. Data raced a tick or
+//!   two ahead of the frontier is re-merged a bounded number of times, which
+//!   is cheaper than bucket bookkeeping;
+//! * far (`upper + threshold <= t`): parked in a [`BucketChain`] and only
+//!   touched again when splits or peels require it, amortized logarithmic in
+//!   the update's distance from the frontier.
+//!
+//! When no far-future data is present the bucket chain is never touched and
+//! the batcher's behavior and cost are the plain batcher's plus one branch.
+//!
+//! Every bucket carries the `(min, max)` times of its contents. Bounds exist
+//! if and only if the bucket holds data, there is no "unknown" state. This is
+//! what makes bucket splits cheap: a split whose midpoint falls outside a
+//! bucket's bounds moves the bucket wholesale without touching records.
+//! Bounds are established during the extract walks that move data anyway, so
+//! maintaining them costs no extra passes. Consolidation inside a bucket can
+//! cancel the records that attained a bound, so bounds are conservative
+//! (possibly wider than the data) but always within the bucket's time range.
+//! As a byproduct, [`differential_dataflow::trace::Batcher::frontier`] is
+//! bucket-bound precise (the lowest non-empty bucket's minimum bound, exact
+//! absent cancellation) rather than coarsened to bucket boundaries. The
+//! arrange operator requires that it never falls below a sealed upper, which
+//! bucket ranges guarantee: peels leave no bucket range, and hence no bound,
+//! below the seal upper.
+
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use differential_dataflow::logging::{BatcherEvent, Logger};
+use differential_dataflow::trace::{Batcher, Description};
+use mz_ore::cast::CastFrom;
+use mz_ore::soft_panic_or_log;
+use timely::PartialOrder;
+use timely::container::PushInto;
+use timely::progress::frontier::{Antichain, AntichainRef};
+use timely::progress::{PathSummary, Timestamp};
+
+use crate::temporal::{Bucket, BucketChain, BucketTimestamp};
+
+/// Fuel for [`BucketChain::restore`] per seal. Restoration work beyond this
+/// budget is deferred to subsequent seals; `peel` tolerates chains that are
+/// not well-formed, at the cost of extra splits.
+const RESTORE_FUEL: i64 = 1_000_000;
+
+/// The threshold by which a timestamp type advances seal uppers to separate
+/// "near" from "far" future updates. See the module documentation.
+pub trait TemporalThreshold: Timestamp {
+    /// The current threshold. Read once per batcher at construction time.
+    fn temporal_threshold() -> Self::Summary;
+}
+
+/// Process-global near/far threshold in milliseconds, shared by the
+/// [`TemporalThreshold`] impls of millisecond-based timestamp types (`u64`
+/// here, `mz_repr::Timestamp` in its own crate). Installed from the worker
+/// configuration; batchers read it at construction time.
+pub static TEMPORAL_THRESHOLD_MS: AtomicU64 = AtomicU64::new(2_000);
+
+impl TemporalThreshold for u64 {
+    fn temporal_threshold() -> u64 {
+        TEMPORAL_THRESHOLD_MS.load(Ordering::Relaxed)
+    }
+}
+
+/// The chain-merging engine a [`TemporalBucketingMergeBatcher`] is built on:
+/// differential's
+/// [`Merger`](differential_dataflow::trace::implementations::merge_batcher::Merger)
+/// role plus time partitioning with attained bounds, self-contained so chain
+/// entries need not be the containers the
+/// batcher exchanges with the outside (the paged implementation absorbs
+/// resident columns into pager-managed entries and materializes them back on
+/// the way out).
+///
+/// The bounds are what enable [`MergeBucket`] splits to short-circuit, and
+/// they must be *attained*: for each non-empty part, `min` and `max` are times
+/// that actually occur in the part, and every time `t` in the part satisfies
+/// `min <= t <= max`. Implementations compute them during the extract walks
+/// they perform anyway. Consolidation may later cancel a bound's attaining
+/// record, so consumers treat bounds as conservative.
+///
+/// Implementations carry their own scratch state (recycled chunk buffers),
+/// released via [`Self::seal_done`] at the end of every seal.
+pub trait TemporalMerger: Default {
+    /// The type of time used in frontiers.
+    type Time;
+    /// The chain-entry representation held by the batcher.
+    type Chunk;
+    /// The chunk type the batcher exchanges with the outside: pushed chunks
+    /// arrive as it and the seal emits it ([`Batcher`] requires the two to
+    /// coincide).
+    type Output: Default;
+
+    /// Convert a pushed chunk into a chain entry.
+    fn absorb(&mut self, input: Self::Output) -> Self::Chunk;
+
+    /// Convert a readied chain entry into seal output.
+    fn materialize(&mut self, chunk: Self::Chunk) -> Self::Output;
+
+    /// Merge two sorted, consolidated chains into one, consolidating.
+    fn merge(
+        &mut self,
+        list1: Vec<Self::Chunk>,
+        list2: Vec<Self::Chunk>,
+        output: &mut Vec<Self::Chunk>,
+    );
+
+    /// The number of updates in the chunk. Must be cheap, in particular it
+    /// must not require materializing an offloaded chunk.
+    fn chunk_len(chunk: &Self::Chunk) -> usize;
+
+    /// The attained `(min, max)` times in the chunk, or `None` if it is
+    /// empty or the implementation cannot inspect it in place. Intended for
+    /// validation, not hot paths.
+    fn chunk_time_bounds(chunk: &Self::Chunk) -> Option<(Self::Time, Self::Time)>;
+
+    /// Partition `merged`, a sorted and consolidated chain, into three parts:
+    /// `before` (`t` not in advance of `split_lo`), `beyond` (`t` in advance
+    /// of `split_hi`), and `within` (the rest). With `split_lo == split_hi`
+    /// this is a two-way partition with an empty `within`.
+    ///
+    /// Reports attained time bounds per part and the total number of records
+    /// walked. Bounds for the `before` part are reported only when
+    /// `track_before` is set: bounds tracking costs per-record work, and the
+    /// seal never uses that part's bounds, so its dominant ready-data case
+    /// must not pay for them.
+    fn extract_time_partitioned(
+        &mut self,
+        merged: Vec<Self::Chunk>,
+        split_lo: AntichainRef<'_, Self::Time>,
+        split_hi: AntichainRef<'_, Self::Time>,
+        track_before: bool,
+    ) -> TimePartitioned<Self::Chunk, Self::Time>;
+
+    /// Account size and allocation changes for a chunk. Returns
+    /// `(records, size, capacity, allocations)`, counting only resident
+    /// memory.
+    fn account(chunk: &Self::Chunk) -> (usize, usize, usize, usize);
+
+    /// A seal completed. Implementations drop per-seal scratch here, e.g.
+    /// recycled chunk buffers that should not stay resident across a quiet
+    /// stretch.
+    fn seal_done(&mut self) {}
+}
+
+/// Track the attained inclusive `(min, max)` over observed times.
+pub(crate) fn update_bounds<T: Ord + Clone>(bounds: &mut Option<(T, T)>, time: &T) {
+    match bounds {
+        None => *bounds = Some((time.clone(), time.clone())),
+        Some((lo, hi)) => {
+            if *time < *lo {
+                *lo = time.clone();
+            }
+            if *time > *hi {
+                *hi = time.clone();
+            }
+        }
+    }
+}
+
+/// The result of [`TemporalMerger::extract_time_partitioned`].
+pub struct TimePartitioned<C, T> {
+    /// Chunks with times not in advance of `split_lo`.
+    pub before: Vec<C>,
+    /// Attained `(min, max)` times in `before`; `None` iff empty.
+    pub before_bounds: Option<(T, T)>,
+    /// Chunks with times in advance of `split_lo` but not of `split_hi`.
+    pub within: Vec<C>,
+    /// Attained `(min, max)` times in `within`; `None` iff empty.
+    pub within_bounds: Option<(T, T)>,
+    /// Chunks with times in advance of `split_hi`.
+    pub beyond: Vec<C>,
+    /// Attained `(min, max)` times in `beyond`; `None` iff empty.
+    pub beyond_bounds: Option<(T, T)>,
+    /// Total records walked.
+    pub records: usize,
+}
+
+/// State shared between the batcher and its buckets: the records-touched
+/// counter and size accounting. Buckets need it because [`Bucket::split`] has
+/// no way to reach back to the batcher.
+struct BucketCtx {
+    /// Cumulative records touched by bucket-chain operations (routing, bucket
+    /// merges, splits, peel drains). Deliberately excludes the flat-chain
+    /// work that the plain batcher performs identically.
+    touched: Cell<u64>,
+    logger: Option<Logger>,
+    operator_id: usize,
+}
+
+impl BucketCtx {
+    fn touch(&self, records: usize) {
+        self.touched
+            .set(self.touched.get() + u64::cast_from(records));
+    }
+
+    /// Emit a [`BatcherEvent`] for the given per-chunk accounting tuples,
+    /// multiplied by `diff` (+1 for data entering the bucket chain or a new
+    /// chunk shape, -1 for data leaving or a consumed chunk shape).
+    fn account<I: IntoIterator<Item = (usize, usize, usize, usize)>>(&self, items: I, diff: isize) {
+        log_batcher_event(&self.logger, self.operator_id, items, diff);
+    }
+}
+
+/// Sum per-chunk `(records, size, capacity, allocations)` accounting tuples
+/// and log one [`BatcherEvent`] multiplied by `diff`. Without a logger this
+/// returns before consuming `items`, so callers may pass lazy iterators over
+/// work they would not otherwise perform.
+pub(crate) fn log_batcher_event<I: IntoIterator<Item = (usize, usize, usize, usize)>>(
+    logger: &Option<Logger>,
+    operator: usize,
+    items: I,
+    diff: isize,
+) {
+    let Some(logger) = logger else {
+        return;
+    };
+    let (mut records, mut size, mut capacity, mut allocations) = (0isize, 0isize, 0isize, 0isize);
+    for (records_, size_, capacity_, allocations_) in items {
+        records = records.saturating_add_unsigned(records_);
+        size = size.saturating_add_unsigned(size_);
+        capacity = capacity.saturating_add_unsigned(capacity_);
+        allocations = allocations.saturating_add_unsigned(allocations_);
+    }
+    logger.log(BatcherEvent {
+        operator,
+        records_diff: records.saturating_mul(diff),
+        size_diff: size.saturating_mul(diff),
+        capacity_diff: capacity.saturating_mul(diff),
+        allocations_diff: allocations.saturating_mul(diff),
+    })
+}
+
+/// Contents of a non-empty [`MergeBucket`].
+struct BucketContent<M: TemporalMerger> {
+    /// Chains of sorted, consolidated chunks, geometrically sized.
+    chains: Vec<Vec<M::Chunk>>,
+    /// Number of records across all chains.
+    records: usize,
+    /// Attained minimum time.
+    lo: M::Time,
+    /// Attained maximum time (inclusive).
+    hi: M::Time,
+}
+
+impl<M: TemporalMerger> BucketContent<M> {
+    /// Content holding `chain` with attained bounds `(lo, hi)`.
+    fn new(chain: Vec<M::Chunk>, lo: M::Time, hi: M::Time) -> Self {
+        let records = chain.iter().map(|c| M::chunk_len(c)).sum();
+        Self {
+            chains: vec![chain],
+            records,
+            lo,
+            hi,
+        }
+    }
+
+    fn recount(&mut self) {
+        self.records = self.chains.iter().flatten().map(|c| M::chunk_len(c)).sum();
+    }
+}
+
+/// A bucket of merge-batcher chunks for one time range of a [`BucketChain`].
+///
+/// `content` is `None` iff the bucket holds no records; time bounds exist
+/// whenever data does, so splits never lack the information for their
+/// short-circuit checks.
+pub struct MergeBucket<M: TemporalMerger> {
+    content: Option<BucketContent<M>>,
+    ctx: Rc<BucketCtx>,
+}
+
+impl<M: TemporalMerger> MergeBucket<M>
+where
+    M::Time: Ord + Clone,
+{
+    fn empty(ctx: Rc<BucketCtx>) -> Self {
+        Self { content: None, ctx }
+    }
+
+    /// Construct a bucket holding `chain` with attained bounds `(lo, hi)`.
+    /// Accounts the chunks as entering the bucket chain.
+    fn full(chain: Vec<M::Chunk>, lo: M::Time, hi: M::Time, ctx: Rc<BucketCtx>) -> Self {
+        ctx.account(chain.iter().map(M::account), 1);
+        Self {
+            content: Some(BucketContent::new(chain, lo, hi)),
+            ctx,
+        }
+    }
+
+    fn records(&self) -> usize {
+        self.content.as_ref().map_or(0, |c| c.records)
+    }
+
+    /// Insert `chain` (attained bounds `(lo, hi)`) and re-establish geometric
+    /// chain sizes. Accounts the chunks as entering the bucket chain and any
+    /// merges as chunk-shape changes.
+    fn insert_chain(&mut self, chain: Vec<M::Chunk>, lo: M::Time, hi: M::Time, merger: &mut M) {
+        if chain.is_empty() {
+            return;
+        }
+        self.ctx.account(chain.iter().map(M::account), 1);
+        match &mut self.content {
+            None => {
+                self.content = Some(BucketContent::new(chain, lo, hi));
+            }
+            Some(content) => {
+                if lo < content.lo {
+                    content.lo = lo;
+                }
+                if hi > content.hi {
+                    content.hi = hi;
+                }
+                content.chains.push(chain);
+                while content.chains.len() > 1
+                    && content.chains[content.chains.len() - 1].len()
+                        >= content.chains[content.chains.len() - 2].len() / 2
+                {
+                    let list1 = content.chains.pop().expect("checked above");
+                    let list2 = content.chains.pop().expect("checked above");
+                    let walked: usize = list1
+                        .iter()
+                        .chain(list2.iter())
+                        .map(|c| M::chunk_len(c))
+                        .sum();
+                    self.ctx.touch(walked);
+                    self.ctx
+                        .account(list1.iter().chain(list2.iter()).map(M::account), -1);
+                    let mut merged = Vec::with_capacity(list1.len() + list2.len());
+                    merger.merge(list1, list2, &mut merged);
+                    self.ctx.account(merged.iter().map(M::account), 1);
+                    content.chains.push(merged);
+                }
+                content.recount();
+                // The merges consolidate, so the bucket may now be empty. It
+                // must then drop its content: stale bounds would feed the
+                // frontier times for which no data exists, and with no
+                // records held anywhere the seal skips the peel that would
+                // otherwise clean them up. The arrange operator would hold a
+                // capability at such a phantom time below later seal uppers,
+                // and the trace import panics minting a capability from the
+                // next batch's hint.
+                if content.records == 0 {
+                    self.content = None;
+                }
+            }
+        }
+    }
+
+    /// Take the content, accounting the chunks as leaving the bucket chain.
+    fn take_content(mut self) -> Option<BucketContent<M>> {
+        let content = self.content.take()?;
+        self.ctx
+            .account(content.chains.iter().flatten().map(M::account), -1);
+        Some(content)
+    }
+}
+
+/// Pairwise-merge `chains` into a single sorted chain, counting the walked
+/// records into `ctx`.
+fn merge_into_one<M: TemporalMerger>(
+    mut chains: Vec<Vec<M::Chunk>>,
+    merger: &mut M,
+    ctx: &BucketCtx,
+) -> Vec<M::Chunk> {
+    while chains.len() > 1 {
+        let list1 = chains.pop().expect("len checked");
+        let list2 = chains.pop().expect("len checked");
+        let walked: usize = list1
+            .iter()
+            .chain(list2.iter())
+            .map(|c| M::chunk_len(c))
+            .sum();
+        ctx.touch(walked);
+        let mut merged = Vec::with_capacity(list1.len() + list2.len());
+        merger.merge(list1, list2, &mut merged);
+        chains.push(merged);
+    }
+    chains.pop().unwrap_or_default()
+}
+
+impl<M: TemporalMerger> Bucket for MergeBucket<M>
+where
+    M::Time: BucketTimestamp,
+{
+    type Timestamp = M::Time;
+
+    fn split(mut self, timestamp: &Self::Timestamp, fuel: &mut i64) -> (Self, Self) {
+        let Some(content) = self.content.take() else {
+            let empty = Self::empty(Rc::clone(&self.ctx));
+            return (empty, self);
+        };
+        // Short-circuit when the attained bounds prove one-sidedness. The
+        // surviving side keeps its content (and bounds) untouched.
+        if content.hi < *timestamp {
+            let empty = Self::empty(Rc::clone(&self.ctx));
+            self.content = Some(content);
+            return (self, empty);
+        }
+        if content.lo >= *timestamp {
+            let empty = Self::empty(Rc::clone(&self.ctx));
+            self.content = Some(content);
+            return (empty, self);
+        }
+        // The split genuinely cuts through the data: merge and re-extract,
+        // deriving exact bounds for both sides from the walk.
+        //
+        // NOTE: `Bucket::split` cannot reach the batcher's merger, so this
+        // works with a fresh default one. The split's chunks miss out on the
+        // batcher merger's recycled buffers, and any per-instance merger
+        // configuration (e.g. a test pager override) does not apply here.
+        let ctx = Rc::clone(&self.ctx);
+        ctx.account(content.chains.iter().flatten().map(M::account), -1);
+        let mut merger = M::default();
+        let merged = merge_into_one::<M>(content.chains, &mut merger, &ctx);
+        let at = Antichain::from_elem(timestamp.clone());
+        let parts = merger.extract_time_partitioned(merged, at.borrow(), at.borrow(), true);
+        *fuel = fuel.saturating_sub(i64::try_from(parts.records).unwrap_or(i64::MAX));
+        ctx.touch(parts.records);
+        ctx.account(
+            parts
+                .before
+                .iter()
+                .chain(parts.beyond.iter())
+                .map(M::account),
+            1,
+        );
+        let mk = |chain: Vec<M::Chunk>, bounds: Option<(M::Time, M::Time)>, ctx: Rc<BucketCtx>| {
+            match bounds {
+                Some((lo, hi)) => MergeBucket {
+                    content: Some(BucketContent::new(chain, lo, hi)),
+                    ctx,
+                },
+                None => MergeBucket::empty(ctx),
+            }
+        };
+        let bot = mk(parts.before, parts.before_bounds, Rc::clone(&ctx));
+        let top = mk(parts.beyond, parts.beyond_bounds, ctx);
+        (bot, top)
+    }
+}
+
+/// Statistics for observing the batcher's bucket-chain work. See
+/// [`TemporalBucketingMergeBatcher::temporal_stats`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TemporalBatcherStats {
+    /// Cumulative records touched by bucket-chain operations.
+    pub touched: u64,
+    /// Most records touched by any single seal.
+    pub high_water_touched: u64,
+    /// Records held in the bucket chain at the high-water seal, after routing
+    /// and before peeling.
+    pub high_water_held: u64,
+}
+
+/// A merge batcher that holds back far-future updates in a [`BucketChain`].
+/// See the module documentation for the design.
+pub struct TemporalBucketingMergeBatcher<M: TemporalMerger>
+where
+    M::Time: BucketTimestamp,
+{
+    /// Chains of sorted, consolidated chunks, geometrically sized; identical
+    /// to the plain `MergeBatcher`'s chains. All input lands here, and
+    /// near-future data returns here after each seal.
+    chains: Vec<Vec<M::Chunk>>,
+    /// Far-future data, deposited by seals, keyed by time range.
+    bucket_chain: BucketChain<MergeBucket<M>>,
+    merger: M,
+    /// Separates near-future from far-future relative to each seal's upper.
+    threshold: <M::Time as Timestamp>::Summary,
+    ctx: Rc<BucketCtx>,
+    /// `(touched, held)` of the seal with the most touched records.
+    high_water: (u64, u64),
+    /// We sealed up to here.
+    lower: Antichain<M::Time>,
+    /// Lower bound of held update times, recomputed at each seal. Never
+    /// below the seal's upper, which the arrange operator relies on for its
+    /// capability handling.
+    frontier: Antichain<M::Time>,
+}
+
+impl<M: TemporalMerger> TemporalBucketingMergeBatcher<M>
+where
+    M::Time: BucketTimestamp + TemporalThreshold,
+{
+    /// Override the near/far threshold. Intended for tests; production reads
+    /// [`TemporalThreshold`] at construction.
+    #[cfg(test)]
+    fn set_threshold(&mut self, threshold: <M::Time as Timestamp>::Summary) {
+        self.threshold = threshold;
+    }
+
+    /// The underlying merger. Intended for tests that need to configure
+    /// implementation-specific state (e.g. a pager override).
+    #[cfg(test)]
+    fn merger_mut(&mut self) -> &mut M {
+        &mut self.merger
+    }
+
+    /// Observation counters for the bucket-chain work performed so far.
+    pub fn temporal_stats(&self) -> TemporalBatcherStats {
+        TemporalBatcherStats {
+            touched: self.ctx.touched.get(),
+            high_water_touched: self.high_water.0,
+            high_water_held: self.high_water.1,
+        }
+    }
+
+    /// Records currently held in the bucket chain.
+    fn held_records(&self) -> usize {
+        self.bucket_chain.buckets().map(|b| b.records()).sum()
+    }
+
+    /// Verify that every bucket's stored bounds contain exactly its data and
+    /// respect its time range, and that record counts are consistent.
+    ///
+    /// Walks every held record. For tests only, never for production paths.
+    #[cfg(test)]
+    fn validate_bounds_invariant(&self) -> Result<(), String> {
+        for (range, bucket) in self.bucket_chain.ranges() {
+            let Some(content) = &bucket.content else {
+                continue;
+            };
+            if content.lo > content.hi {
+                return Err(format!(
+                    "bucket bounds inverted: lo {:?} > hi {:?}",
+                    content.lo, content.hi
+                ));
+            }
+            let mut records = 0;
+            for chunk in content.chains.iter().flatten() {
+                records += M::chunk_len(chunk);
+                if let Some((min, max)) = M::chunk_time_bounds(chunk) {
+                    if min < content.lo || max > content.hi {
+                        return Err(format!(
+                            "chunk times [{min:?}, {max:?}] outside bucket bounds [{:?}, {:?}]",
+                            content.lo, content.hi
+                        ));
+                    }
+                }
+            }
+            if records != content.records {
+                return Err(format!(
+                    "bucket record count {} != actual {records}",
+                    content.records
+                ));
+            }
+            if records == 0 {
+                return Err(format!(
+                    "bucket with content but no records, bounds [{:?}, {:?}]",
+                    content.lo, content.hi
+                ));
+            }
+            if content.lo < range.start {
+                return Err(format!(
+                    "bucket bounds lo {:?} below bucket range start {:?}",
+                    content.lo, range.start
+                ));
+            }
+            if let Some(end) = range.end() {
+                if content.hi >= *end {
+                    return Err(format!(
+                        "bucket bounds hi {:?} at or beyond bucket range end {end:?}",
+                        content.hi
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Route a sorted, consolidated chain of far-future data (attained bounds
+    /// `(lo, hi)`) into the bucket chain.
+    fn route_into_bucket_chain(&mut self, chain: Vec<M::Chunk>, lo: M::Time, hi: M::Time) {
+        let records: usize = chain.iter().map(|c| M::chunk_len(c)).sum();
+        self.ctx.touch(records);
+
+        // A fully-drained chain (all buckets peeled) is reseeded with one
+        // bucket spanning the whole domain, which adopts the chain wholesale.
+        if self.bucket_chain.is_empty() {
+            self.bucket_chain =
+                BucketChain::new(MergeBucket::full(chain, lo, hi, Rc::clone(&self.ctx)));
+            return;
+        }
+
+        // Walk bucket boundaries in time order, splitting off each bucket's
+        // portion. A chain that fits into a single bucket (the common case)
+        // exits on the first iteration without an extract.
+        let starts: Vec<M::Time> = self
+            .bucket_chain
+            .ranges()
+            .map(|(range, _)| range.start)
+            .collect();
+        let mut idx = match starts.partition_point(|s| *s <= lo).checked_sub(1) {
+            Some(idx) => idx,
+            None => {
+                // Data below the lowest bucket start. This violates the
+                // routing invariant (far data is in advance of the seal
+                // upper, and peels leave bucket starts at or beyond it), but
+                // inserting into the lowest bucket is safe: the data is
+                // released no later than that bucket, splits redistribute by
+                // value, and the attained bounds keep the frontier exact.
+                soft_panic_or_log!("temporal batcher: routed data below the lowest bucket start");
+                0
+            }
+        };
+        let mut chain = chain;
+        let mut lo = lo;
+        loop {
+            let end = starts.get(idx + 1);
+            let fits = match end {
+                None => true,
+                Some(end) => hi < *end,
+            };
+            if fits {
+                let start = starts[idx].clone();
+                let bucket = self
+                    .bucket_chain
+                    .find_mut(&start)
+                    .expect("bucket exists for a known start");
+                bucket.insert_chain(chain, lo, hi.clone(), &mut self.merger);
+                return;
+            }
+            let at = Antichain::from_elem(end.expect("checked above").clone());
+            let parts = self
+                .merger
+                .extract_time_partitioned(chain, at.borrow(), at.borrow(), true);
+            self.ctx.touch(parts.records);
+            if let Some((part_lo, part_hi)) = parts.before_bounds {
+                let start = starts[idx].clone();
+                let bucket = self
+                    .bucket_chain
+                    .find_mut(&start)
+                    .expect("bucket exists for a known start");
+                bucket.insert_chain(parts.before, part_lo, part_hi, &mut self.merger);
+            }
+            let Some((rest_lo, _)) = &parts.beyond_bounds else {
+                return;
+            };
+            lo = rest_lo.clone();
+            chain = parts.beyond;
+            idx += 1;
+            // Skip buckets the remaining data lies entirely beyond.
+            while idx + 1 < starts.len() && starts[idx + 1] <= lo {
+                idx += 1;
+            }
+        }
+    }
+
+    /// Merge two sorted chains via the merger. Counts the walked records.
+    fn merge_chains(&mut self, list1: Vec<M::Chunk>, list2: Vec<M::Chunk>) -> Vec<M::Chunk> {
+        if list1.is_empty() {
+            return list2;
+        }
+        if list2.is_empty() {
+            return list1;
+        }
+        let walked: usize = list1
+            .iter()
+            .chain(list2.iter())
+            .map(|c| M::chunk_len(c))
+            .sum();
+        self.ctx.touch(walked);
+        let mut merged = Vec::with_capacity(list1.len() + list2.len());
+        self.merger.merge(list1, list2, &mut merged);
+        merged
+    }
+
+    /// Insert a chain into the flat chains and maintain the geometric chain
+    /// property, mirroring the plain `MergeBatcher`.
+    fn insert_chain(&mut self, chain: Vec<M::Chunk>) {
+        if !chain.is_empty() {
+            self.chain_push(chain);
+            while self.chains.len() > 1
+                && (self.chains[self.chains.len() - 1].len()
+                    >= self.chains[self.chains.len() - 2].len() / 2)
+            {
+                let list1 = self.chain_pop().expect("len checked");
+                let list2 = self.chain_pop().expect("len checked");
+                let mut merged = Vec::with_capacity(list1.len() + list2.len());
+                self.merger.merge(list1, list2, &mut merged);
+                self.chain_push(merged);
+            }
+        }
+    }
+
+    fn chain_pop(&mut self) -> Option<Vec<M::Chunk>> {
+        let chain = self.chains.pop();
+        self.ctx.account(chain.iter().flatten().map(M::account), -1);
+        chain
+    }
+
+    fn chain_push(&mut self, chain: Vec<M::Chunk>) {
+        self.ctx.account(chain.iter().map(M::account), 1);
+        self.chains.push(chain);
+    }
+}
+
+impl<M: TemporalMerger> PushInto<M::Output> for TemporalBucketingMergeBatcher<M>
+where
+    M::Time: BucketTimestamp + TemporalThreshold,
+{
+    fn push_into(&mut self, input: M::Output) {
+        let chunk = self.merger.absorb(input);
+        if M::chunk_len(&chunk) > 0 {
+            self.insert_chain(vec![chunk]);
+        }
+    }
+}
+
+impl<M: TemporalMerger> Batcher for TemporalBucketingMergeBatcher<M>
+where
+    M::Time: BucketTimestamp + TemporalThreshold,
+{
+    type Time = M::Time;
+    type Output = M::Output;
+
+    fn new(logger: Option<Logger>, operator_id: usize) -> Self {
+        let ctx = Rc::new(BucketCtx {
+            touched: Cell::new(0),
+            logger,
+            operator_id,
+        });
+        Self {
+            chains: Vec::new(),
+            bucket_chain: BucketChain::new(MergeBucket::empty(Rc::clone(&ctx))),
+            merger: M::default(),
+            threshold: M::Time::temporal_threshold(),
+            ctx,
+            high_water: (0, 0),
+            lower: Antichain::from_elem(M::Time::minimum()),
+            frontier: Antichain::new(),
+        }
+    }
+
+    fn seal(
+        &mut self,
+        upper: Antichain<Self::Time>,
+    ) -> (Vec<Self::Output>, Description<Self::Time>) {
+        // Merge the flat chains into one and partition it by time. This is
+        // the same work the plain batcher performs at every seal.
+        while self.chains.len() > 1 {
+            let list1 = self.chain_pop().expect("len checked");
+            let list2 = self.chain_pop().expect("len checked");
+            let mut merged = Vec::with_capacity(list1.len() + list2.len());
+            self.merger.merge(list1, list2, &mut merged);
+            self.chain_push(merged);
+        }
+        let merged = self.chain_pop().unwrap_or_default();
+
+        // The far boundary is `upper + threshold`. Elements whose advance
+        // overflows drop out; if that empties the boundary, nothing
+        // classifies as far and all future data stays in the flat chains,
+        // which is the plain batcher's behavior.
+        let mut far_lower = Antichain::new();
+        for time in upper.elements() {
+            if let Some(advanced) = self.threshold.results_in(time) {
+                far_lower.insert(advanced);
+            }
+        }
+
+        // The `before` part is emitted, so its bounds are never needed; the
+        // `within` minimum feeds the frontier and the `beyond` bounds feed
+        // the bucket routing.
+        let parts =
+            self.merger
+                .extract_time_partitioned(merged, upper.borrow(), far_lower.borrow(), false);
+        let mut readied = parts.before;
+
+        // Near-future data returns to the flat chains, exactly like the
+        // plain batcher's kept updates.
+        if !parts.within.is_empty() {
+            self.chain_push(parts.within);
+        }
+
+        let seal_touched_start = self.ctx.touched.get();
+
+        if !parts.beyond.is_empty() {
+            match parts.beyond_bounds.clone() {
+                Some((lo, hi)) => self.route_into_bucket_chain(parts.beyond, lo, hi),
+                None => {
+                    // The extract reports bounds for every non-empty part.
+                    // Recover with another extract against the minimum
+                    // frontier: everything classifies as beyond and the walk
+                    // re-derives the attained bounds.
+                    soft_panic_or_log!("temporal batcher: non-empty extract part without bounds");
+                    let at = Antichain::from_elem(M::Time::minimum());
+                    let parts = self.merger.extract_time_partitioned(
+                        parts.beyond,
+                        at.borrow(),
+                        at.borrow(),
+                        false,
+                    );
+                    if let Some((lo, hi)) = parts.beyond_bounds {
+                        self.route_into_bucket_chain(parts.beyond, lo, hi);
+                    }
+                }
+            }
+        }
+
+        let held = self.held_records();
+        if held > 0 {
+            // Release matured buckets. `peel`'s contract guarantees peeled
+            // buckets lie entirely below `upper`, so their contents join the
+            // readied chain without a further extract.
+            let peeled = self.bucket_chain.peel(upper.borrow());
+            let mut peeled_chain: Vec<M::Chunk> = Vec::new();
+            for bucket in peeled {
+                let Some(content) = bucket.take_content() else {
+                    continue;
+                };
+                let one = merge_into_one::<M>(content.chains, &mut self.merger, &self.ctx);
+                // TODO: A merge tree would beat sequential merging when many
+                // data-bearing buckets mature at once (large frontier jumps).
+                peeled_chain = self.merge_chains(peeled_chain, one);
+            }
+            readied = self.merge_chains(readied, peeled_chain);
+
+            let mut fuel = RESTORE_FUEL;
+            self.bucket_chain.restore(&mut fuel);
+        }
+
+        // The frontier is the exact minimum of held times: the near data
+        // returned to the flat chains and the lowest non-empty bucket's
+        // attained minimum (buckets are range-ordered, and each bucket's data
+        // lies within its range, so the first non-empty bucket attains the
+        // bucket-chain minimum).
+        self.frontier.clear();
+        if let Some((lo, _)) = &parts.within_bounds {
+            self.frontier.insert(lo.clone());
+        }
+        if let Some(content) = self
+            .bucket_chain
+            .buckets()
+            .find_map(|bucket| bucket.content.as_ref())
+        {
+            self.frontier.insert(content.lo.clone());
+        }
+
+        // The arrange operator downgrades its capabilities to our frontier
+        // after each seal, so a frontier element below `upper` would let it
+        // hold a capability below the sealed trace upper, and the trace
+        // import panics minting a capability from that batch's hint.
+        if !PartialOrder::less_equal(&upper.borrow(), &self.frontier.borrow()) {
+            let buckets: Vec<_> = self
+                .bucket_chain
+                .ranges()
+                .map(|(range, bucket)| {
+                    let bounds = bucket
+                        .content
+                        .as_ref()
+                        .map(|c| (c.lo.clone(), c.hi.clone(), c.records));
+                    (range.start.clone(), range.end().cloned(), bounds)
+                })
+                .collect();
+            soft_panic_or_log!(
+                "temporal batcher: frontier regressed below seal upper: \
+                 upper {:?}, frontier {:?}, lower {:?}, within_bounds {:?}, \
+                 held {}, buckets (start, end, (lo, hi, records)) {:?}",
+                upper.elements(),
+                self.frontier.elements(),
+                self.lower.elements(),
+                parts.within_bounds,
+                held,
+                buckets,
+            );
+        }
+
+        let seal_touched = self.ctx.touched.get() - seal_touched_start;
+        if seal_touched > self.high_water.0 {
+            self.high_water = (seal_touched, u64::cast_from(held));
+        }
+        if seal_touched > 0 {
+            // Observability for the bucket-chain work: expected to stay
+            // within a small multiple of held records per seal (large only
+            // at hydration-shaped seals). Fast-path seals never log.
+            tracing::debug!(
+                operator_id = self.ctx.operator_id,
+                seal_touched,
+                held,
+                upper = ?upper.elements(),
+                "temporal batcher seal performed bucket-chain work",
+            );
+        }
+
+        self.merger.seal_done();
+
+        let description = Description::new(
+            self.lower.clone(),
+            upper.clone(),
+            Antichain::from_elem(M::Time::minimum()),
+        );
+        self.lower = upper;
+        let readied = readied
+            .into_iter()
+            .map(|chunk| self.merger.materialize(chunk))
+            .collect();
+        (readied, description)
+    }
+
+    fn frontier(&mut self) -> AntichainRef<'_, Self::Time> {
+        self.frontier.borrow()
+    }
+}
+
+impl<M: TemporalMerger> Drop for TemporalBucketingMergeBatcher<M>
+where
+    M::Time: BucketTimestamp,
+{
+    fn drop(&mut self) {
+        // Retract all accounted data: the flat chains and the bucket chain.
+        for chain in self.chains.drain(..) {
+            self.ctx.account(chain.iter().map(M::account), -1);
+        }
+        for bucket in self.bucket_chain.buckets_mut() {
+            if let Some(content) = bucket.content.take() {
+                self.ctx
+                    .account(content.chains.iter().flatten().map(M::account), -1);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use columnar::{Columnar, Index, Len};
+    use differential_dataflow::consolidation::consolidate_updates;
+    use proptest::prelude::*;
+    use timely::container::PushInto;
+
+    use crate::column_pager::{ColumnPager, PageDecision, PageEvent, PageHint, PagingPolicy};
+    use crate::columnar::Column;
+    use crate::columnar::merge_batcher::PagedColumnMerger;
+
+    use super::*;
+
+    type TestUpdate = (u64, u64, i64);
+    type PagedTestMerger = PagedColumnMerger<u64, u64, i64>;
+    type PagedTestBatcher = TemporalBucketingMergeBatcher<PagedTestMerger>;
+
+    /// Chunk conversions that let the generic drivers run over any merger.
+    trait TestChunks: TemporalMerger<Time = u64> {
+        fn chunk(updates: Vec<TestUpdate>) -> Self::Output;
+        fn unchunk(chunks: Vec<Self::Output>) -> Vec<TestUpdate>;
+    }
+
+    impl TestChunks for PagedTestMerger {
+        fn chunk(updates: Vec<TestUpdate>) -> Column<TestUpdate> {
+            let mut chunk = Column::default();
+            for update in updates {
+                chunk.push_into(update);
+            }
+            chunk
+        }
+
+        fn unchunk(chunks: Vec<Column<TestUpdate>>) -> Vec<TestUpdate> {
+            let mut out = Vec::new();
+            for chunk in chunks {
+                let view = chunk.borrow();
+                for i in 0..view.len() {
+                    let (data, time, diff) = view.get(i);
+                    out.push((
+                        u64::into_owned(data),
+                        u64::into_owned(time),
+                        i64::into_owned(diff),
+                    ));
+                }
+            }
+            out
+        }
+    }
+
+    /// Policy that pages every chunk out (swap-backed, uncompressed), so the
+    /// paged tests exercise offloaded chains rather than the resident
+    /// fast path.
+    struct PageAllPolicy;
+
+    impl PagingPolicy for PageAllPolicy {
+        fn decide(&self, _hint: PageHint) -> PageDecision {
+            PageDecision::Page {
+                backend: mz_ore::pager::Backend::Swap,
+                codec: None,
+            }
+        }
+        fn record(&self, _event: PageEvent) {}
+    }
+
+    fn paged_batcher(threshold: u64, page_all: bool) -> PagedTestBatcher {
+        let mut batcher = PagedTestBatcher::new(None, 0);
+        batcher.set_threshold(threshold);
+        let pager = if page_all {
+            ColumnPager::new(Arc::new(PageAllPolicy))
+        } else {
+            ColumnPager::disabled()
+        };
+        batcher.merger_mut().set_pager(pager);
+        batcher
+    }
+
+    /// Consolidate and push `updates` as a single chunk, mirroring the
+    /// chunker contract (sorted, consolidated input).
+    fn push<M: TestChunks>(
+        batcher: &mut TemporalBucketingMergeBatcher<M>,
+        mut updates: Vec<TestUpdate>,
+    ) {
+        consolidate_updates(&mut updates);
+        batcher.push_into(M::chunk(updates));
+    }
+
+    fn seal<M: TestChunks>(
+        batcher: &mut TemporalBucketingMergeBatcher<M>,
+        upper: Option<u64>,
+    ) -> Vec<TestUpdate> {
+        let upper = match upper {
+            Some(time) => Antichain::from_elem(time),
+            None => Antichain::new(),
+        };
+        let (chain, _description) = batcher.seal(upper);
+        M::unchunk(chain)
+    }
+
+    fn consolidated(mut updates: Vec<TestUpdate>) -> Vec<TestUpdate> {
+        consolidate_updates(&mut updates);
+        updates
+    }
+
+    /// Model-based test: the batcher must emit, at each seal, exactly the
+    /// not-yet-emitted updates below the upper, consolidated, and report the
+    /// exact minimum of what it retains.
+    fn run_model<M: TestChunks>(
+        mut b: TemporalBucketingMergeBatcher<M>,
+        ops: Vec<(Vec<(u8, u16)>, u16)>,
+    ) {
+        let mut pending: Vec<TestUpdate> = Vec::new();
+        let mut lower = 0_u64;
+        for (batch, advance) in ops {
+            let updates: Vec<TestUpdate> = batch
+                .into_iter()
+                .map(|(data, dt)| (u64::from(data), lower + u64::from(dt), 1))
+                .collect();
+            pending.extend(updates.iter().copied());
+            push(&mut b, updates);
+
+            let upper = lower + u64::from(advance);
+            let out = seal(&mut b, Some(upper));
+            b.validate_bounds_invariant().unwrap();
+
+            let expected: Vec<TestUpdate> = pending
+                .iter()
+                .copied()
+                .filter(|(_, t, _)| *t < upper)
+                .collect();
+            pending.retain(|(_, t, _)| *t >= upper);
+            assert_eq!(consolidated(out), consolidated(expected));
+
+            let min_pending = pending.iter().map(|(_, t, _)| *t).min();
+            let expected_frontier = match min_pending {
+                Some(t) => Antichain::from_elem(t),
+                None => Antichain::new(),
+            };
+            assert_eq!(b.frontier().to_owned(), expected_frontier);
+
+            lower = upper;
+        }
+        let out = seal(&mut b, None);
+        assert_eq!(consolidated(out), consolidated(pending));
+    }
+
+    /// Strategy for [`run_model`] ops: per step, a batch of
+    /// `(data, time_delta)` updates and a frontier advance.
+    fn model_ops() -> impl Strategy<Value = Vec<(Vec<(u8, u16)>, u16)>> {
+        prop::collection::vec(
+            (
+                prop::collection::vec((any::<u8>(), any::<u16>()), 0..20),
+                any::<u16>(),
+            ),
+            1..20,
+        )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(32))]
+        #[mz_ore::test]
+        #[cfg_attr(miri, ignore)] // slow
+        fn paged_batcher_matches_model(
+            threshold in proptest::sample::select(vec![0_u64, 1, 10, 1_000]),
+            page_all in any::<bool>(),
+            ops in model_ops(),
+        ) {
+            run_model(paged_batcher(threshold, page_all), ops);
+        }
+    }
+
+    /// Simulate the capability protocol between differential's arrange
+    /// operator and a downstream trace import, asserting the import can
+    /// always mint a delayed capability for the batches it receives.
+    ///
+    /// The arrange holds one capability (the minimum, since the time is
+    /// totally ordered), downgrades it to `batcher.frontier()` after each
+    /// real seal, and uses it as the batch hint. The import's capability set
+    /// tracks the trace upper. A batcher frontier below a sealed upper lets
+    /// the arrange hold a capability below the trace upper, and the next
+    /// batch's hint then panics the import.
+    ///
+    /// Each step mirrors one arrange invocation: optionally deliver one
+    /// message (capability at `frontier + cap_delta`, update times at
+    /// `capability + time_delta`, diffs `±1` so updates can cancel), then
+    /// advance the input frontier by `advance`.
+    fn run_arrange_protocol<M: TestChunks>(
+        mut b: TemporalBucketingMergeBatcher<M>,
+        steps: Vec<(u8, Vec<(u8, u8, bool)>, u8)>,
+    ) {
+        let mut frontier = 0_u64;
+        let mut cap: Option<u64> = None;
+        let mut writer_upper = 0_u64;
+        let mut import_cap = 0_u64;
+
+        for (cap_delta, updates, advance) in steps {
+            if !updates.is_empty() {
+                let msg_cap = frontier + u64::from(cap_delta);
+                let updates: Vec<TestUpdate> = updates
+                    .into_iter()
+                    .map(|(data, dt, sign)| {
+                        let diff = if sign { 1 } else { -1 };
+                        (u64::from(data), msg_cap + u64::from(dt), diff)
+                    })
+                    .collect();
+                push(&mut b, updates);
+                cap = Some(cap.map_or(msg_cap, |c| c.min(msg_cap)));
+            }
+
+            // The arrange seals only on strict progress.
+            if advance == 0 {
+                continue;
+            }
+            frontier += u64::from(advance);
+
+            if cap.is_some_and(|c| c < frontier) {
+                // Real seal: emit a batch with the capability as its hint.
+                let hint = cap.expect("checked above");
+                let (chain, description) = b.seal(Antichain::from_elem(frontier));
+                b.validate_bounds_invariant().unwrap();
+                assert_eq!(
+                    description.lower().as_ref(),
+                    &[writer_upper],
+                    "writer continuity"
+                );
+                writer_upper = frontier;
+                // The import processes Batch(chain, hint), then
+                // Frontier(upper). Empty batches skip the mint.
+                if !M::unchunk(chain).is_empty() {
+                    assert!(
+                        import_cap <= hint,
+                        "import cannot mint delayed capability: \
+                         hint {hint}, import capability {import_cap}",
+                    );
+                }
+                import_cap = frontier;
+                // Downgrade the arrange capability to the batcher frontier.
+                cap = match b.frontier().as_ref() {
+                    [] => None,
+                    [time] => {
+                        assert!(hint <= *time, "failed to find capability");
+                        Some(*time)
+                    }
+                    _ => unreachable!("total order"),
+                };
+            } else {
+                // All capabilities in advance of the frontier: the arrange
+                // seals the batcher, discards the output, and seals the
+                // writer, which announces the new upper to the import.
+                let _ = b.seal(Antichain::from_elem(frontier));
+                b.validate_bounds_invariant().unwrap();
+                if writer_upper != frontier {
+                    writer_upper = frontier;
+                    import_cap = frontier;
+                }
+            }
+        }
+    }
+
+    /// Strategy for [`run_arrange_protocol`] steps: per step, an optional
+    /// message (capability delta, updates) and a frontier advance.
+    fn protocol_steps() -> impl Strategy<Value = Vec<(u8, Vec<(u8, u8, bool)>, u8)>> {
+        prop::collection::vec(
+            (
+                0..4_u8,
+                prop::collection::vec((0..3_u8, 0..12_u8, any::<bool>()), 0..6),
+                0..8_u8,
+            ),
+            1..40,
+        )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+        #[mz_ore::test]
+        #[cfg_attr(miri, ignore)] // slow
+        fn paged_arrange_protocol_mints_capabilities(
+            threshold in proptest::sample::select(vec![0_u64, 1, 2, 4]),
+            page_all in any::<bool>(),
+            steps in protocol_steps(),
+        ) {
+            run_arrange_protocol(paged_batcher(threshold, page_all), steps);
+        }
+    }
+}

--- a/src/timely-util/src/merge_batcher.rs
+++ b/src/timely-util/src/merge_batcher.rs
@@ -963,10 +963,13 @@ mod tests {
     use crate::column_pager::{ColumnPager, PageDecision, PageEvent, PageHint, PagingPolicy};
     use crate::columnar::Column;
     use crate::columnar::merge_batcher::PagedColumnMerger;
+    use crate::columnation::{ColTemporalMerger, ColumnationStack};
 
     use super::*;
 
     type TestUpdate = (u64, u64, i64);
+    type TestMerger = ColTemporalMerger<u64, u64, i64>;
+    type TestBatcher = TemporalBucketingMergeBatcher<TestMerger>;
     type PagedTestMerger = PagedColumnMerger<u64, u64, i64>;
     type PagedTestBatcher = TemporalBucketingMergeBatcher<PagedTestMerger>;
 
@@ -974,6 +977,24 @@ mod tests {
     trait TestChunks: TemporalMerger<Time = u64> {
         fn chunk(updates: Vec<TestUpdate>) -> Self::Output;
         fn unchunk(chunks: Vec<Self::Output>) -> Vec<TestUpdate>;
+    }
+
+    impl TestChunks for TestMerger {
+        fn chunk(updates: Vec<TestUpdate>) -> ColumnationStack<TestUpdate> {
+            let mut chunk = ColumnationStack::default();
+            for update in updates {
+                chunk.push_into(update);
+            }
+            chunk
+        }
+
+        fn unchunk(chunks: Vec<ColumnationStack<TestUpdate>>) -> Vec<TestUpdate> {
+            let mut out = Vec::new();
+            for chunk in chunks {
+                out.extend_from_slice(&chunk[..]);
+            }
+            out
+        }
     }
 
     impl TestChunks for PagedTestMerger {
@@ -1000,6 +1021,12 @@ mod tests {
             }
             out
         }
+    }
+
+    fn batcher(threshold: u64) -> TestBatcher {
+        let mut batcher = TestBatcher::new(None, 0);
+        batcher.set_threshold(threshold);
+        batcher
     }
 
     /// Policy that pages every chunk out (swap-backed, uncompressed), so the
@@ -1056,6 +1083,132 @@ mod tests {
         updates
     }
 
+    #[mz_ore::test]
+    fn all_past_takes_fast_path() {
+        let mut b = batcher(2_000);
+        push(&mut b, vec![(1, 10, 1), (2, 20, 1), (1, 30, -1)]);
+        let out = seal(&mut b, Some(100));
+        assert_eq!(
+            consolidated(out),
+            consolidated(vec![(1, 10, 1), (2, 20, 1), (1, 30, -1)])
+        );
+        assert_eq!(b.temporal_stats(), TemporalBatcherStats::default());
+        assert!(b.frontier().is_empty());
+    }
+
+    #[mz_ore::test]
+    fn near_future_stays_flat() {
+        let mut b = batcher(2_000);
+        // Data one "tick" ahead of the upper: within the threshold.
+        push(&mut b, vec![(1, 150, 1), (2, 1_050, 1)]);
+        let out = seal(&mut b, Some(100));
+        assert_eq!(out, vec![]);
+        // Never entered the bucket chain.
+        assert_eq!(b.temporal_stats().touched, 0);
+        assert_eq!(b.frontier().to_owned(), Antichain::from_elem(150));
+        let out = seal(&mut b, Some(200));
+        assert_eq!(out, vec![(1, 150, 1)]);
+        assert_eq!(b.frontier().to_owned(), Antichain::from_elem(1_050));
+        let out = seal(&mut b, Some(2_000));
+        assert_eq!(out, vec![(2, 1_050, 1)]);
+        assert_eq!(b.temporal_stats().touched, 0);
+        assert!(b.frontier().is_empty());
+    }
+
+    #[mz_ore::test]
+    fn far_future_bucketed_and_released() {
+        let mut b = batcher(1_000);
+        push(&mut b, vec![(1, 50, 1), (2, 5_000, 1), (3, 100_000, 1)]);
+        let out = seal(&mut b, Some(100));
+        assert_eq!(out, vec![(1, 50, 1)]);
+        // Both future updates are beyond upper + threshold: bucketed.
+        assert!(b.temporal_stats().touched > 0);
+        assert_eq!(b.frontier().to_owned(), Antichain::from_elem(5_000));
+        b.validate_bounds_invariant().unwrap();
+
+        let out = seal(&mut b, Some(6_000));
+        assert_eq!(out, vec![(2, 5_000, 1)]);
+        assert_eq!(b.frontier().to_owned(), Antichain::from_elem(100_000));
+        b.validate_bounds_invariant().unwrap();
+
+        let out = seal(&mut b, Some(200_000));
+        assert_eq!(out, vec![(3, 100_000, 1)]);
+        assert!(b.frontier().is_empty());
+        b.validate_bounds_invariant().unwrap();
+    }
+
+    #[mz_ore::test]
+    fn retraction_consolidates_across_seals() {
+        let mut b = batcher(0);
+        push(&mut b, vec![(7, 10_000, 1)]);
+        let out = seal(&mut b, Some(100));
+        assert_eq!(out, vec![]);
+        push(&mut b, vec![(7, 10_000, -1)]);
+        let out = seal(&mut b, Some(200));
+        assert_eq!(out, vec![]);
+        b.validate_bounds_invariant().unwrap();
+        // The insert and its retraction met in the bucket chain; nothing
+        // remains to emit.
+        let out = seal(&mut b, None);
+        assert_eq!(consolidated(out), vec![]);
+    }
+
+    #[mz_ore::test]
+    fn final_seal_flushes_everything() {
+        let mut b = batcher(1_000);
+        push(&mut b, vec![(1, 50, 1), (2, 1_500, 1), (3, 1 << 40, 1)]);
+        let out = seal(&mut b, Some(100));
+        assert_eq!(out, vec![(1, 50, 1)]);
+        let out = seal(&mut b, None);
+        assert_eq!(consolidated(out), vec![(2, 1_500, 1), (3, 1 << 40, 1)]);
+        assert!(b.frontier().is_empty());
+        assert_eq!(b.held_records(), 0);
+    }
+
+    #[mz_ore::test]
+    fn hydration_touched_within_bound() {
+        // Snapshot below the upper plus a uniform 45-day tail above it,
+        // sealed once: the simulation-backed contract is that bucket work
+        // stays within a small multiple of the tail.
+        let now = 1_752_192_000_000_u64;
+        let window = 45 * 86_400_000_u64;
+        let tail = 10_000_u64;
+        let mut b = batcher(2_000);
+        let mut updates = Vec::new();
+        for i in 0..tail {
+            updates.push((i, now - 1_000 - (i % 1_000), 1));
+            updates.push((i, now + 1 + (i * (window / tail)), -1));
+        }
+        push(&mut b, updates);
+        let out = seal(&mut b, Some(now));
+        assert_eq!(out.len(), usize::try_from(tail).unwrap());
+        b.validate_bounds_invariant().unwrap();
+        let stats = b.temporal_stats();
+        assert!(
+            stats.touched <= 5 * tail,
+            "hydration touched {} > 5x tail {tail}",
+            stats.touched
+        );
+        // The single hydration seal did all the bucket work so far, so it is
+        // the high-water seal, with all far retractions held at its start.
+        // The i == 0 retraction lands within the threshold and stays in the
+        // flat chains.
+        assert_eq!(stats.high_water_touched, stats.touched);
+        assert_eq!(stats.high_water_held, tail - 1);
+        // Tick forward; steady-state work must stay negligible.
+        let before = b.temporal_stats().touched;
+        let mut released = 0;
+        for tick in 1..=60 {
+            released += seal(&mut b, Some(now + tick * 1_000)).len();
+            b.validate_bounds_invariant().unwrap();
+        }
+        let per_tick = (b.temporal_stats().touched - before) / 60;
+        assert!(
+            per_tick <= 4 * (u64::try_from(released).unwrap() / 60 + 1),
+            "steady-state per-tick touched {per_tick} too high"
+        );
+    }
+
     /// Model-based test: the batcher must emit, at each seal, exactly the
     /// not-yet-emitted updates below the upper, consolidated, and report the
     /// exact minimum of what it retains.
@@ -1108,6 +1261,18 @@ mod tests {
             ),
             1..20,
         )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+        #[mz_ore::test]
+        #[cfg_attr(miri, ignore)] // slow
+        fn batcher_matches_model(
+            threshold in proptest::sample::select(vec![0_u64, 1, 10, 1_000]),
+            ops in model_ops(),
+        ) {
+            run_model(batcher(threshold), ops);
+        }
     }
 
     proptest! {
@@ -1222,6 +1387,18 @@ mod tests {
             ),
             1..40,
         )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+        #[mz_ore::test]
+        #[cfg_attr(miri, ignore)] // slow
+        fn arrange_protocol_mints_capabilities(
+            threshold in proptest::sample::select(vec![0_u64, 1, 2, 4]),
+            steps in protocol_steps(),
+        ) {
+            run_arrange_protocol(batcher(threshold), steps);
+        }
     }
 
     proptest! {

--- a/src/timely-util/src/temporal.rs
+++ b/src/timely-util/src/temporal.rs
@@ -32,6 +32,12 @@ pub trait BucketTimestamp: Timestamp {
     fn advance_by_power_of_two(&self, exponent: u32) -> Option<Self>;
 }
 
+impl BucketTimestamp for u64 {
+    fn advance_by_power_of_two(&self, bits: u32) -> Option<Self> {
+        self.checked_add(1_u64.checked_shl(bits)?)
+    }
+}
+
 /// A type that can be split into two parts based on a timestamp.
 pub trait Bucket: Sized {
     /// The timestamp type associated with this storage.
@@ -47,6 +53,13 @@ pub struct BucketRange<T> {
     /// The lower bound (inclusive).
     pub start: T,
     end: Option<T>,
+}
+
+impl<T> BucketRange<T> {
+    /// The exclusive upper bound, or `None` when the bucket covers the rest of the domain.
+    pub fn end(&self) -> Option<&T> {
+        self.end.as_ref()
+    }
 }
 
 impl<T: PartialOrd> BucketRange<T> {
@@ -219,6 +232,20 @@ impl<S: Bucket> BucketChain<S> {
         self.content.values_mut().map(|(_, storage)| storage)
     }
 
+    /// An iterator over the buckets and their time ranges, in time order.
+    ///
+    /// The ranges are only valid until the next call to `peel` or `restore`.
+    #[inline]
+    pub fn ranges(&self) -> impl Iterator<Item = (BucketRange<S::Timestamp>, &S)> {
+        self.content.iter().map(|(time, (bits, storage))| {
+            let range = BucketRange {
+                start: time.clone(),
+                end: time.advance_by_power_of_two(*bits),
+            };
+            (range, storage)
+        })
+    }
+
     /// Split the bucket specified by `(bits, offset, storage)` and insert the new buckets.
     /// Updates `fuel`.
     ///
@@ -240,12 +267,6 @@ mod tests {
     impl BucketTimestamp for u8 {
         fn advance_by_power_of_two(&self, bits: u32) -> Option<Self> {
             self.checked_add(1_u8.checked_shl(bits)?)
-        }
-    }
-
-    impl BucketTimestamp for u64 {
-        fn advance_by_power_of_two(&self, bits: u32) -> Option<Self> {
-            self.checked_add(1_u64.checked_shl(bits)?)
         }
     }
 

--- a/test/sqllogictest/temporal_bucketing.slt
+++ b/test/sqllogictest/temporal_bucketing.slt
@@ -276,3 +276,142 @@ materialize.public.mv_except_distinct_buckets_at_reduce:
 Target cluster: quickstart
 
 EOF
+
+# -----------------------------------------------------------------------------
+# Batcher-mode temporal bucketing: with
+# `enable_compute_temporal_bucketing_batcher` on, bucketing happens inside
+# every arrangement merge batcher (and the standalone bucketing operator is
+# suppressed), regardless of the lowering's strategy annotations. The plans
+# above are unaffected; these are end-to-end correctness checks for temporal
+# filters under batcher mode. Timestamps are far in the past/future relative
+# to any plausible test-run time, so results are deterministic.
+# -----------------------------------------------------------------------------
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_compute_temporal_bucketing_batcher = true;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE batcher_events (k INT NOT NULL, event_time TIMESTAMP NOT NULL);
+
+statement ok
+INSERT INTO batcher_events VALUES
+  (1, TIMESTAMP '2000-01-01 00:00:00'),
+  (1, TIMESTAMP '2099-01-01 00:00:00'),
+  (2, TIMESTAMP '2099-01-01 00:00:00'),
+  (2, TIMESTAMP '2099-06-01 00:00:00'),
+  (3, TIMESTAMP '2000-06-01 00:00:00');
+
+# Reduce under a temporal filter: only live (far-future-expiring) rows count.
+statement ok
+CREATE MATERIALIZED VIEW batcher_counts AS
+SELECT k, count(*) AS c
+FROM batcher_events
+WHERE event_time + INTERVAL '45 day' > mz_now()
+GROUP BY k;
+
+query II rowsort
+SELECT k, c FROM batcher_counts;
+----
+1 1
+2 2
+
+# TopK under a temporal filter.
+statement ok
+CREATE MATERIALIZED VIEW batcher_topk AS
+SELECT k FROM batcher_events
+WHERE event_time + INTERVAL '45 day' > mz_now()
+ORDER BY k LIMIT 2;
+
+query I rowsort
+SELECT k FROM batcher_topk;
+----
+1
+2
+
+# Consolidating Union + Threshold (EXCEPT ALL) under temporal filters.
+query I rowsort
+(SELECT k FROM batcher_events WHERE event_time + INTERVAL '45 day' > mz_now())
+EXCEPT ALL
+(SELECT k FROM batcher_events WHERE event_time + INTERVAL '36500 day' > mz_now() AND k = 1);
+----
+2
+2
+
+# Indexed view (ArrangeBy) under a temporal filter.
+statement ok
+CREATE VIEW batcher_live AS
+SELECT k FROM batcher_events WHERE event_time + INTERVAL '45 day' > mz_now();
+
+statement ok
+CREATE DEFAULT INDEX ON batcher_live;
+
+query I rowsort
+SELECT k FROM batcher_live;
+----
+1
+2
+2
+
+statement ok
+DROP TABLE batcher_events CASCADE;
+
+# -----------------------------------------------------------------------------
+# Batcher mode composed with the column-paged batcher: the affected
+# arrangements use the temporal-bucketing batcher over paged chains.
+# -----------------------------------------------------------------------------
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_column_paged_batcher = true;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE paged_events (k INT NOT NULL, event_time TIMESTAMP NOT NULL);
+
+statement ok
+INSERT INTO paged_events VALUES
+  (1, TIMESTAMP '2000-01-01 00:00:00'),
+  (1, TIMESTAMP '2099-01-01 00:00:00'),
+  (2, TIMESTAMP '2099-01-01 00:00:00'),
+  (2, TIMESTAMP '2099-06-01 00:00:00'),
+  (3, TIMESTAMP '2000-06-01 00:00:00');
+
+statement ok
+CREATE VIEW paged_live AS
+SELECT k FROM paged_events WHERE event_time + INTERVAL '45 day' > mz_now();
+
+statement ok
+CREATE DEFAULT INDEX ON paged_live;
+
+query I rowsort
+SELECT k FROM paged_live;
+----
+1
+2
+2
+
+# A join between two temporally filtered inputs exercises the paged temporal
+# batcher in the join stages as well.
+query II rowsort
+SELECT a.k, b.k FROM paged_live a, paged_live b WHERE a.k = b.k;
+----
+1 1
+2 2
+2 2
+2 2
+2 2
+
+statement ok
+DROP TABLE paged_events CASCADE;
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET enable_column_paged_batcher;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET enable_compute_temporal_bucketing_batcher;
+----
+COMPLETE 0

--- a/test/sqllogictest/temporal_bucketing_legacy.slt
+++ b/test/sqllogictest/temporal_bucketing_legacy.slt
@@ -1,0 +1,165 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+# -----------------------------------------------------------------------------
+# Temporal-filter correctness with `enable_compute_temporal_bucketing_batcher`
+# OFF, covering the production configurations that exist while the flag rolls
+# out. CI otherwise runs with the flag on, which would leave these paths
+# unexercised.
+#
+# DELETE THIS FILE when batcher-mode temporal bucketing becomes unconditional
+# and the standalone temporal_bucket operator with its
+# `enable_compute_temporal_bucketing` flag is removed.
+#
+# Timestamps are far in the past/future relative to any plausible test-run
+# time, so results are deterministic.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Batcher flag off, operator flag on: the standalone bucketing operator
+# handles far-future updates where the lowering selected it.
+# -----------------------------------------------------------------------------
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_compute_temporal_bucketing_batcher = false;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_compute_temporal_bucketing = true;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE legacy_events (k INT NOT NULL, event_time TIMESTAMP NOT NULL);
+
+statement ok
+INSERT INTO legacy_events VALUES
+  (1, TIMESTAMP '2000-01-01 00:00:00'),
+  (1, TIMESTAMP '2099-01-01 00:00:00'),
+  (2, TIMESTAMP '2099-01-01 00:00:00'),
+  (2, TIMESTAMP '2099-06-01 00:00:00'),
+  (3, TIMESTAMP '2000-06-01 00:00:00');
+
+# Reduce under a temporal filter: only live (far-future-expiring) rows count.
+statement ok
+CREATE MATERIALIZED VIEW legacy_counts AS
+SELECT k, count(*) AS c
+FROM legacy_events
+WHERE event_time + INTERVAL '45 day' > mz_now()
+GROUP BY k;
+
+query II rowsort
+SELECT k, c FROM legacy_counts;
+----
+1 1
+2 2
+
+# TopK under a temporal filter.
+statement ok
+CREATE MATERIALIZED VIEW legacy_topk AS
+SELECT k FROM legacy_events
+WHERE event_time + INTERVAL '45 day' > mz_now()
+ORDER BY k LIMIT 2;
+
+query I rowsort
+SELECT k FROM legacy_topk;
+----
+1
+2
+
+# Consolidating Union + Threshold (EXCEPT ALL) under temporal filters.
+query I rowsort
+(SELECT k FROM legacy_events WHERE event_time + INTERVAL '45 day' > mz_now())
+EXCEPT ALL
+(SELECT k FROM legacy_events WHERE event_time + INTERVAL '36500 day' > mz_now() AND k = 1);
+----
+2
+2
+
+# Indexed view (ArrangeBy) under a temporal filter.
+statement ok
+CREATE VIEW legacy_live AS
+SELECT k FROM legacy_events WHERE event_time + INTERVAL '45 day' > mz_now();
+
+statement ok
+CREATE DEFAULT INDEX ON legacy_live;
+
+query I rowsort
+SELECT k FROM legacy_live;
+----
+1
+2
+2
+
+statement ok
+DROP TABLE legacy_events CASCADE;
+
+# -----------------------------------------------------------------------------
+# Both flags off: plain merge batchers hold the future updates. This is the
+# self-managed default configuration.
+# -----------------------------------------------------------------------------
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_compute_temporal_bucketing = false;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE plain_events (k INT NOT NULL, event_time TIMESTAMP NOT NULL);
+
+statement ok
+INSERT INTO plain_events VALUES
+  (1, TIMESTAMP '2000-01-01 00:00:00'),
+  (1, TIMESTAMP '2099-01-01 00:00:00'),
+  (2, TIMESTAMP '2099-01-01 00:00:00'),
+  (2, TIMESTAMP '2099-06-01 00:00:00'),
+  (3, TIMESTAMP '2000-06-01 00:00:00');
+
+statement ok
+CREATE MATERIALIZED VIEW plain_counts AS
+SELECT k, count(*) AS c
+FROM plain_events
+WHERE event_time + INTERVAL '45 day' > mz_now()
+GROUP BY k;
+
+query II rowsort
+SELECT k, c FROM plain_counts;
+----
+1 1
+2 2
+
+statement ok
+CREATE VIEW plain_live AS
+SELECT k FROM plain_events WHERE event_time + INTERVAL '45 day' > mz_now();
+
+statement ok
+CREATE DEFAULT INDEX ON plain_live;
+
+query I rowsort
+SELECT k FROM plain_live;
+----
+1
+2
+2
+
+statement ok
+DROP TABLE plain_events CASCADE;
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET enable_compute_temporal_bucketing;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET enable_compute_temporal_bucketing_batcher;
+----
+COMPLETE 0


### PR DESCRIPTION
https://linear.app/materializeinc/project/clean-up-temporal-bucketing-dc1c6f9fcd84/overview

Moves temporal bucketing from the standalone `temporal_bucket` operator
into the merge batcher itself: each batcher decides at every seal, based
on the data it actually holds, whether to park far-future updates in a
bucket chain. This localizes the bucketing complexity in the batcher
instead of smearing it across the lowering, covers every batcher site
uniformly, and also catches future updates no static analysis can see
(e.g. worker skew and input skew in multi-input operators in lagging dataflows).

Takes over and productionizes #36427.

The design doc in this PR
(`doc/developer/design/20260711_temporal_bucketing_batcher.md`) has the
motivation, the design, and the performance story. The PR is structured
for commit-by-commit review, and the commit messages carry the
per-commit details.

**Rollout**: everything is behind the new
`enable_compute_temporal_bucketing_batcher` flag, default off. Off means
bit-for-bit today's behavior. When on, it supersedes
`enable_compute_temporal_bucketing` (the operator is suppressed). The old
code, the operator and its lowering plumbing, is not deleted here. That
is a later cleanup PR, once the rollout completes.

**Engines**: the primary focus is the new `ColumnMergeBatcher` (the
paged engine), as discussed. The batcher is generic over its engine, and
a small adapter (~8% of the diff, will be deleted together with the old engine)
also covers the columnation batcher, for three reasons: the columnation
engine is currently the default everywhere, so the rollout can proceed
independently of the paged rollout. Paged builders exist only for the
row-row and val-row arrangement families, so uniform coverage of every
batcher site is only expressible on the columnation engine today. And CI
currently runs the columnation engine nearly exclusively, so the temporal
code paths would otherwise go largely unexercised.

**Changes from #36427**:

1. No vendoring: instead of a vendored copy of differential's
   `MergeBatcher`, the batcher is a standalone type generic over a
   self-contained `TemporalMerger` engine trait, reusing the
   record-walking loops we already own in-repo.
2. Two engine implementations: the paged `ColumnMergeBatcher` chains
   (primary, spillable far tail) and the columnation `ColInternalMerger`
   (rollout carrier).
3. A near/far threshold (θ, the operator's existing
   `compute_temporal_bucketing_summary`): data within θ of the frontier
   stays in the flat chains exactly like the plain batcher's kept
   updates. The draft bucketed all future data. This is what makes
   always-on safe for data that races a tick ahead of the frontier
   without any temporal filter.
4. Bucket bounds are non-optional (empty-or-bounded, no
   unknown-with-scan-fallback state): silent performance-degradation
   bugs become loud invariant violations. Bounds are conservative under
   consolidation, and a bucket whose contents cancel entirely drops its
   content (a real bug class the protocol proptest caught: a fully
   cancelled bucket retaining stale bounds panicked downstream trace
   imports).
5. A precise frontier contract with the arrange operator: the reported
   frontier never falls below a sealed upper (capability/hint protocol),
   with a cheap runtime guard and an arrange-protocol proptest (with
   cancelling updates) pinning it. The reported frontier is the attained
   minimum of held times rather than coarsened to bucket boundaries.
6. Uniform coverage: the draft wired only the RowRow arrange in
   `ensure_collections`; this PR covers every rendering batcher site on
   totally ordered timestamps (ArrangeBy ok+err, Reduce, TopK,
   Threshold, linear-join stages, consolidating Unions, LetRec, index
   exports) and suppresses the operator at all of its insertion sites.
7. Rollout machinery: new default-off dyncfg with precedence over the
   operator flag, both mechanisms coexisting, CI system-parameter
   registration (batcher mode on in minimal, variable in randomized),
   and a dedicated flag-off sqllogictest so the production
   configurations stay covered while CI runs batcher mode.
8. Observability: bucket contents wired into `BatcherEvent` accounting
   (the draft's logger was dead), plus a cumulative records-touched
   counter, a per-seal high-water mark, and a debug log line for seals
   that did bucket work.
9. Tests and benchmarks: unit tests, a model-based proptest, the
   arrange-protocol proptest, paged variants under an always-resident
   and a page-everything pager, and a criterion suite asserting parity
   with the plain batcher on no-future and raced-ahead workloads and
   the order-of-magnitude win on far-future ones.
10. Threshold plumbing: θ reaches batchers through a process-global
    installed from the worker config (live-tunable for new dataflows),
    read once per batcher.
11. `PagedColumn` records its record count in pageout metadata, so held
    records are accountable without materializing chunks.
12. Fast-path parity engineering: ready data pays exactly the plain
    extract's single comparison (classification tests the emitted part
    first), bounds tracking is skipped where the seal never uses it, and
    the near/far output builders allocate lazily. Criterion-gated at a
    0.98-0.99 temporal-to-plain runtime ratio.
13. The first-seal (hydration) cost is analyzed and bounded: the design
    doc ("The first seal" section) argues the halving cascade (about 2 F
    record-touches for interval-shaped tails) with simulations confirming
    2-4 F across data shapes, the seal budget defers restore work across
    subsequent seals so only the peel share runs synchronously, and a
    regression test asserts the touched-records counter stays within
    bounds for a hydration-shaped seal.
14. A design doc covering motivation, the mechanism and its contracts,
    the performance regimes with per-regime baselines, and the rollout
    plan.

**Validation**: full Nightly runs are green in batcher mode (CI runs
with the flag on everywhere via the minimal system parameters). A sweep
of all 90 feature-benchmark scenarios against the merge base measured
overall parity (median runtime ratio 1.0025), with the temporal-filter
scenarios at parity against today's operator mode.

Nightly runs:
- https://buildkite.com/materialize/nightly/builds/17161 (unrelated flakes; the miri stuff was also failing on main)
- https://buildkite.com/materialize/nightly/builds/17162 (unrelated flakes: the k8s stuff failed in setup, the two Parallel Benchmark fails are both Coordinator-side stuff, i.e., no dataflows involved.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
