### PR TITLE
compute: coalesce MV sink batches across workers

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -231,6 +231,11 @@ def get_variable_system_parameters(
             ["true", "false"],
         ),
         VariableSystemParameter(
+            "enable_compute_sync_mv_sink_shared_batches",
+            "true",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
             "enable_password_auth",
             "true",
             ["true", "false"],

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -306,6 +306,11 @@ def get_variable_system_parameters(
             ["true", "false"],
         ),
         VariableSystemParameter(
+            "enable_compute_sync_mv_sink_shared_batches",
+            "true",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
             "enable_password_auth",
             "true",
             ["true", "false"],

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1553,6 +1553,9 @@ class FlipFlagsAction(Action):
             BOOLEAN_FLAG_VALUES
         )
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_compute_sync_mv_sink_shared_batches"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_public_metrics_endpoint"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_scoped_system_parameters"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2882,6 +2882,9 @@ class FlipFlagsAction(Action):
             BOOLEAN_FLAG_VALUES
         )
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_compute_sync_mv_sink_shared_batches"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_public_metrics_endpoint"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [
             "0",

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -133,6 +133,15 @@ pub const ENABLE_SYNC_MV_SINK: Config<bool> = Config::new(
     "Use sync Timely operators with Tokio tasks for the MV sink.",
 );
 
+/// Coalesce the parts written by the workers in one process into a single shared batch per batch
+/// interval, instead of each worker writing its own batch.
+pub const ENABLE_SYNC_MV_SINK_SHARED_BATCHES: Config<bool> = Config::new(
+    "enable_compute_sync_mv_sink_shared_batches",
+    false,
+    "Coalesce the parts written by the workers in one process into a single shared batch per \
+     batch interval in the MV sink.",
+);
+
 /// Whether rendering should use the new MV sink correction buffer implementation.
 pub const ENABLE_CORRECTION_V2: Config<bool> = Config::new(
     "enable_compute_correction_v2",
@@ -492,6 +501,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_HALF_JOIN2)
         .add(&ENABLE_MZ_JOIN_CORE)
         .add(&ENABLE_SYNC_MV_SINK)
+        .add(&ENABLE_SYNC_MV_SINK_SHARED_BATCHES)
         .add(&ENABLE_CORRECTION_V2)
         .add(&CORRECTION_V2_CHAIN_PROPORTIONALITY)
         .add(&CORRECTION_V2_CHUNK_SIZE)

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -262,6 +262,16 @@ pub const ENABLE_SYNC_MV_SINK: Config<bool> = Config::new(
     ParameterScope::Environment,
 );
 
+/// Coalesce the parts written by the workers in one process into a single shared batch per batch
+/// interval, instead of each worker writing its own batch.
+pub const ENABLE_SYNC_MV_SINK_SHARED_BATCHES: Config<bool> = Config::new(
+    "enable_compute_sync_mv_sink_shared_batches",
+    false,
+    "Coalesce the parts written by the workers in one process into a single shared batch per \
+     batch interval in the MV sink.",
+    ParameterScope::Environment,
+);
+
 /// Whether rendering should use the new MV sink correction buffer implementation.
 pub const ENABLE_CORRECTION_V2: Config<bool> = Config::new(
     "enable_compute_correction_v2",
@@ -688,6 +698,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_ERROR_DISTINCT)
         .add(&ENABLE_MZ_JOIN_CORE)
         .add(&ENABLE_SYNC_MV_SINK)
+        .add(&ENABLE_SYNC_MV_SINK_SHARED_BATCHES)
         .add(&ENABLE_CORRECTION_V2)
         .add(&CORRECTION_V2_CHAIN_PROPORTIONALITY)
         .add(&CORRECTION_V2_CHUNK_SIZE)

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -52,6 +52,7 @@ use mz_persist_types::PersistLocation;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena, Timestamp};
+use mz_storage_operators::persist::SharedBatches;
 use mz_storage_operators::stats::StatsCursor;
 use mz_storage_types::StorageDiff;
 use mz_storage_types::controller::CollectionMetadata;
@@ -114,6 +115,9 @@ pub struct ComputeState {
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers.
     pub persist_clients: Arc<PersistClientCache>,
+    // A process-global cache of shared persist batch writers. This allows
+    // coalescing writes across local workers without explicit exchanges.
+    pub persist_batches: SharedBatches,
     /// Context necessary for rendering txn-wal operators.
     pub txns_ctx: TxnsContext,
     /// History of commands received by this workers and all its peers.
@@ -178,6 +182,7 @@ impl ComputeState {
     /// Construct a new `ComputeState`.
     pub fn new(
         persist_clients: Arc<PersistClientCache>,
+        persist_batches: SharedBatches,
         txns_ctx: TxnsContext,
         metrics: WorkerMetrics,
         tracing_handle: Arc<TracingHandle>,
@@ -198,6 +203,7 @@ impl ComputeState {
             peek_stash_persist_location: None,
             compute_logger: None,
             persist_clients,
+            persist_batches,
             txns_ctx,
             command_history,
             max_result_size: u64::MAX,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -51,6 +51,7 @@ use mz_persist_types::PersistLocation;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena, Timestamp};
+use mz_storage_operators::persist::SharedBatches;
 use mz_storage_operators::stats::StatsCursor;
 use mz_storage_types::StorageDiff;
 use mz_storage_types::controller::CollectionMetadata;
@@ -113,6 +114,9 @@ pub struct ComputeState {
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers.
     pub persist_clients: Arc<PersistClientCache>,
+    // A process-global cache of shared persist batch writers. This allows
+    // coalescing writes across local workers without explicit exchanges.
+    pub persist_batches: SharedBatches,
     /// Context necessary for rendering txn-wal operators.
     pub txns_ctx: TxnsContext,
     /// History of commands received by this workers and all its peers.
@@ -177,6 +181,7 @@ impl ComputeState {
     /// Construct a new `ComputeState`.
     pub fn new(
         persist_clients: Arc<PersistClientCache>,
+        persist_batches: SharedBatches,
         txns_ctx: TxnsContext,
         metrics: WorkerMetrics,
         tracing_handle: Arc<TracingHandle>,
@@ -197,6 +202,7 @@ impl ComputeState {
             peek_stash_persist_location: None,
             compute_logger: None,
             persist_clients,
+            persist_batches,
             txns_ctx,
             command_history,
             max_result_size: u64::MAX,

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -155,14 +155,12 @@ impl StashingPeek {
         //
         // TODO: We _could_ work around the above by teaching the bare columnar
         // Row encoder about zero-column rows.
-        let mut batch_builder = client
-            .batch_builder::<SourceData, (), Timestamp, i64>(
-                shard_id,
-                write_schemas,
-                lower,
-                Some(batch_max_runs),
-            )
-            .await;
+        let mut batch_builder = client.batch_builder::<SourceData, (), Timestamp, i64>(
+            shard_id,
+            write_schemas,
+            lower,
+            Some(batch_max_runs),
+        );
 
         let mut num_rows: u64 = 0;
 

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -155,14 +155,13 @@ impl StashingPeek {
         //
         // TODO: We _could_ work around the above by teaching the bare columnar
         // Row encoder about zero-column rows.
-        let mut batch_builder = client
-            .batch_builder::<SourceData, (), Timestamp, i64>(
-                shard_id,
-                write_schemas,
-                lower,
-                Some(batch_max_runs),
-            )
-            .await;
+        let mut batch_builder = client.batch_builder::<SourceData, (), Timestamp, i64>(
+            shard_id,
+            "peek_stash",
+            write_schemas,
+            lower,
+            Some(batch_max_runs),
+        );
 
         let mut num_rows: u64 = 0;
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -29,6 +29,7 @@ use mz_ore::halt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::tracing::TracingHandle;
 use mz_persist_client::cache::PersistClientCache;
+use mz_storage_operators::persist::SharedBatches;
 use mz_storage_types::connections::ConnectionContext;
 use mz_timely_util::capture::EventLink;
 use mz_txn_wal::operator::TxnsContext;
@@ -65,6 +66,8 @@ pub(crate) type StorageTimelyLogReader =
 struct Config {
     /// `persist` client cache.
     pub persist_clients: Arc<PersistClientCache>,
+    /// Shared persist batch state.
+    pub persist_batches: SharedBatches,
     /// Context necessary for rendering txn-wal operators.
     pub txns_ctx: TxnsContext,
     /// A process-global handle to tracing configuration.
@@ -107,6 +110,7 @@ pub async fn serve(
     );
 
     let config = Config {
+        persist_batches: SharedBatches::new(),
         persist_clients,
         txns_ctx,
         tracing_handle,
@@ -239,6 +243,7 @@ struct Worker<'w> {
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers
     persist_clients: Arc<PersistClientCache>,
+    persist_batches: SharedBatches,
     /// Context necessary for rendering txn-wal operators.
     txns_ctx: TxnsContext,
     /// A process-global handle to tracing configuration.
@@ -295,6 +300,7 @@ impl ClusterSpec for Config {
             metrics,
             context: self.context.clone(),
             persist_clients: Arc::clone(&self.persist_clients),
+            persist_batches: self.persist_batches.clone(),
             txns_ctx: self.txns_ctx.clone(),
             compute_state: None,
             tracing_handle: Arc::clone(&self.tracing_handle),
@@ -432,6 +438,7 @@ impl<'w> Worker<'w> {
         if matches!(&cmd, ComputeCommand::CreateInstance(_)) {
             self.compute_state = Some(ComputeState::new(
                 Arc::clone(&self.persist_clients),
+                self.persist_batches.clone(),
                 self.txns_ctx.clone(),
                 self.metrics.clone(),
                 Arc::clone(&self.tracing_handle),

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -29,6 +29,7 @@ use mz_ore::halt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::tracing::TracingHandle;
 use mz_persist_client::cache::PersistClientCache;
+use mz_storage_operators::persist::SharedBatches;
 use mz_storage_types::connections::ConnectionContext;
 use mz_timely_util::capture::EventLink;
 use mz_txn_wal::operator::TxnsContext;
@@ -129,6 +130,8 @@ pub(crate) type StorageTimelyLogReader =
 struct Config {
     /// `persist` client cache.
     pub persist_clients: Arc<PersistClientCache>,
+    /// Shared persist batch state.
+    pub persist_batches: SharedBatches,
     /// Context necessary for rendering txn-wal operators.
     pub txns_ctx: TxnsContext,
     /// A process-global handle to tracing configuration.
@@ -173,6 +176,7 @@ pub async fn serve(
     mz_timely_util::pool_config::metrics::register(metrics_registry);
 
     let config = Config {
+        persist_batches: SharedBatches::new(),
         persist_clients,
         txns_ctx,
         tracing_handle,
@@ -305,6 +309,7 @@ struct Worker<'w> {
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers
     persist_clients: Arc<PersistClientCache>,
+    persist_batches: SharedBatches,
     /// Context necessary for rendering txn-wal operators.
     txns_ctx: TxnsContext,
     /// A process-global handle to tracing configuration.
@@ -361,6 +366,7 @@ impl ClusterSpec for Config {
             metrics,
             context: self.context.clone(),
             persist_clients: Arc::clone(&self.persist_clients),
+            persist_batches: self.persist_batches.clone(),
             txns_ctx: self.txns_ctx.clone(),
             compute_state: None,
             tracing_handle: Arc::clone(&self.tracing_handle),
@@ -498,6 +504,7 @@ impl<'w> Worker<'w> {
         if matches!(&cmd, ComputeCommand::CreateInstance(_)) {
             self.compute_state = Some(ComputeState::new(
                 Arc::clone(&self.persist_clients),
+                self.persist_batches.clone(),
                 self.txns_ctx.clone(),
                 self.metrics.clone(),
                 Arc::clone(&self.tracing_handle),

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -765,6 +765,8 @@ mod mint {
 /// Implementation of the `write` operator.
 mod write {
     use super::*;
+    use mz_persist_client::Schemas;
+    use mz_persist_types::ShardId;
 
     /// Render the `write` operator.
     ///
@@ -832,13 +834,21 @@ mod write {
             // need to hold onto the initial capabilities.
             drop(capabilities);
 
-            let writer = persist_api.open_writer().await;
+            let shard_id = persist_api.collection.data_shard;
+            let persist_client = persist_api.open_client().await;
+            let schemas = Schemas {
+                id: None,
+                key: Arc::new(persist_api.collection.relation_desc.clone()),
+                val: Arc::new(UnitSchema),
+            };
             let sink_metrics = persist_api.open_metrics().await;
             let read_only = *read_only_rx.borrow_and_update();
             let mut state = State::new(
                 sink_id,
                 worker_id,
-                writer,
+                shard_id,
+                schemas,
+                persist_client,
                 sink_metrics,
                 channel_logging,
                 as_of,
@@ -942,7 +952,9 @@ mod write {
     struct State {
         sink_id: GlobalId,
         worker_id: usize,
-        persist_writer: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        shard_id: ShardId,
+        schemas: Schemas<SourceData, ()>,
+        persist_client: PersistClient,
         /// Contains `desired - persist`, reflecting the updates we would like to commit to
         /// `persist` in order to "correct" it to track `desired`. This collection is only modified
         /// by updates received from either the `desired` or `persist` inputs.
@@ -978,7 +990,9 @@ mod write {
         fn new(
             sink_id: GlobalId,
             worker_id: usize,
-            persist_writer: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+            shard_id: ShardId,
+            schemas: Schemas<SourceData, ()>,
+            persist_client: PersistClient,
             metrics: SinkMetrics,
             logging: Option<ChannelLogging>,
             as_of: Antichain<Timestamp>,
@@ -994,7 +1008,9 @@ mod write {
             let mut state = Self {
                 sink_id,
                 worker_id,
-                persist_writer,
+                persist_client,
+                shard_id,
+                schemas,
                 corrections: OkErr::new(
                     Correction::new(
                         metrics.clone(),
@@ -1171,12 +1187,23 @@ mod write {
                 return None;
             }
 
-            let batch = self
-                .persist_writer
-                .batch(updates, desc.lower.clone(), desc.upper.clone())
+            let mut builder = self
+                .persist_client
+                .batch_builder(
+                    self.shard_id,
+                    self.schemas.clone(),
+                    desc.lower.clone(),
+                    None,
+                )
+                .await;
+            for ((k, v), t, d) in updates {
+                builder.add(&k, &v, &t, &d).await.expect("valid timestamp");
+            }
+            let batch = builder
+                .finish(desc.upper.clone())
                 .await
-                .expect("valid usage")
-                .into_transmittable_batch();
+                .expect("valid timestamp");
+            let batch = batch.into_transmittable_batch();
 
             self.trace("wrote a batch");
             Some((desc, batch, cap))

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -134,6 +134,7 @@ use mz_persist_client::write::WriteHandle;
 use mz_persist_client::{Diagnostics, PersistClient};
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
+use mz_storage_operators::persist::{SharedBatchId, SharedBatches};
 use mz_storage_types::StorageDiff;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::sources::SourceData;
@@ -267,6 +268,7 @@ where
 
     let persist_api = PersistApi {
         persist_clients: Arc::clone(&compute_state.persist_clients),
+        persist_batches: compute_state.persist_batches.clone(),
         collection: target.clone(),
         shard_name: sink_id.to_string(),
         purpose: format!("MV sink {sink_id}"),
@@ -351,6 +353,7 @@ pub(super) fn advance(
 #[derive(Clone)]
 pub(super) struct PersistApi {
     pub(super) persist_clients: Arc<PersistClientCache>,
+    pub(super) persist_batches: SharedBatches,
     pub(super) collection: CollectionMetadata,
     pub(super) shard_name: String,
     pub(super) purpose: String,
@@ -442,6 +445,7 @@ pub(super) struct BatchDescription {
     pub(super) lower: Antichain<Timestamp>,
     pub(super) upper: Antichain<Timestamp>,
     pub(super) append_worker: usize,
+    pub(super) shared_id: SharedBatchId,
 }
 
 impl BatchDescription {
@@ -455,6 +459,7 @@ impl BatchDescription {
             lower,
             upper,
             append_worker,
+            shared_id: SharedBatchId::new(),
         }
     }
 }
@@ -766,7 +771,10 @@ mod mint {
 mod write {
     use super::*;
     use mz_persist_client::Schemas;
+
     use mz_persist_types::ShardId;
+    use mz_persist_types::part::PartBuilder;
+    use mz_storage_operators::persist::SharedBatchBuilder;
 
     /// Render the `write` operator.
     ///
@@ -849,6 +857,7 @@ mod write {
                 shard_id,
                 schemas,
                 persist_client,
+                persist_api.persist_batches.clone(),
                 sink_metrics,
                 channel_logging,
                 as_of,
@@ -920,7 +929,7 @@ mod write {
                         match event {
                             Event::Data(cap, data) => {
                                 for desc in data {
-                                    state.absorb_batch_description(desc, cap.clone());
+                                    state.absorb_batch_description(desc, cap.clone()).await;
                                 }
                                 state.maybe_write_batch().await
                             }
@@ -955,6 +964,7 @@ mod write {
         shard_id: ShardId,
         schemas: Schemas<SourceData, ()>,
         persist_client: PersistClient,
+        shared_writers: SharedBatches,
         /// Contains `desired - persist`, reflecting the updates we would like to commit to
         /// `persist` in order to "correct" it to track `desired`. This collection is only modified
         /// by updates received from either the `desired` or `persist` inputs.
@@ -970,8 +980,8 @@ mod write {
         /// description might still be valid even if its `lower` is before the persist frontiers we
         /// observe.
         persist_frontiers: OkErr<Antichain<Timestamp>, Antichain<Timestamp>>,
-        /// The current valid batch description and associated output capability, if any.
-        batch_description: Option<(BatchDescription, Capability<Timestamp>)>,
+        /// The current valid batch description and associated state, if any.
+        batch_description: Option<(BatchDescription, Capability<Timestamp>, SharedBatchBuilder)>,
         /// A request to force a consolidation of `corrections` once both `desired_frontiers` and
         /// `persist_frontiers` become greater than the given frontier.
         ///
@@ -993,6 +1003,7 @@ mod write {
             shard_id: ShardId,
             schemas: Schemas<SourceData, ()>,
             persist_client: PersistClient,
+            shared_writers: SharedBatches,
             metrics: SinkMetrics,
             logging: Option<ChannelLogging>,
             as_of: Antichain<Timestamp>,
@@ -1009,6 +1020,7 @@ mod write {
                 sink_id,
                 worker_id,
                 persist_client,
+                shared_writers,
                 shard_id,
                 schemas,
                 corrections: OkErr::new(
@@ -1049,7 +1061,7 @@ mod write {
                 worker = %self.worker_id,
                 desired_frontier = ?self.desired_frontiers.frontier().elements(),
                 persist_frontier = ?self.persist_frontiers.frontier().elements(),
-                batch_description = ?self.batch_description.as_ref().map(|(d, _)| d),
+                batch_description = ?self.batch_description.as_ref().map(|(d, _, _)| d),
                 message,
             );
         }
@@ -1136,7 +1148,11 @@ mod write {
             self.read_only = read_only;
         }
 
-        fn absorb_batch_description(&mut self, desc: BatchDescription, cap: Capability<Timestamp>) {
+        async fn absorb_batch_description(
+            &mut self,
+            desc: BatchDescription,
+            cap: Capability<Timestamp>,
+        ) {
             // The incoming batch description is outdated if we already have a batch description
             // with a greater `lower`.
             //
@@ -1144,21 +1160,35 @@ mod write {
             // `lower` with the `persist_frontier`. The persist frontier observed by the `write`
             // operator is initialized with the shard's read frontier, so it can be greater than
             // the shard's write frontier.
-            if let Some((prev, _)) = &self.batch_description {
+            if let Some((prev, _, _)) = &self.batch_description {
                 if PartialOrder::less_than(&desc.lower, &prev.lower) {
                     self.trace(format!("skipping outdated batch description: {desc:?}"));
                     return;
                 }
             }
 
-            self.batch_description = Some((desc, cap));
+            // To avoid leaking batches, wait for any pending write to finish and then drop the batch.
+            if let Some((_, _, batch)) = self.batch_description.take() {
+                if let Some(batch) = batch.finish().await {
+                    batch.delete().await;
+                }
+            }
+            let shared_writer = self.shared_writers.builder(
+                desc.shared_id,
+                self.persist_client.clone(),
+                self.shard_id,
+                self.schemas.clone(),
+                desc.lower.clone(),
+                desc.upper.clone(),
+            );
+            self.batch_description = Some((desc, cap, shared_writer));
             self.trace("set batch description");
         }
 
         async fn maybe_write_batch(
             &mut self,
         ) -> Option<(BatchDescription, ProtoBatch, Capability<Timestamp>)> {
-            let (desc, _cap) = self.batch_description.as_ref()?;
+            let (desc, _cap, _batch) = self.batch_description.as_ref()?;
 
             // We can write a new batch if we have seen all `persist` updates before `lower` and
             // all `desired` updates up to `upper`.
@@ -1170,7 +1200,7 @@ mod write {
                 return None;
             }
 
-            let (desc, cap) = self.batch_description.take()?;
+            let (desc, cap, batch) = self.batch_description.take()?;
 
             let ok_updates = self.corrections.ok.updates_before(&desc.upper);
             let err_updates = self.corrections.err.updates_before(&desc.upper);
@@ -1178,35 +1208,24 @@ mod write {
             let oks = ok_updates.map(|(d, t, r)| ((SourceData(Ok(d)), ()), t, r.into_inner()));
             let errs = err_updates
                 .map(|(d, t, r)| ((SourceData(Err(d.deserialize())), ()), t, r.into_inner()));
-            let mut updates = oks.chain(errs).peekable();
+            let updates = oks.chain(errs);
 
-            // Don't write empty batches.
-            if updates.peek().is_none() {
-                drop(updates);
-                self.trace("skipping empty batch");
-                return None;
-            }
-
-            let mut builder = self
-                .persist_client
-                .batch_builder(
-                    self.shard_id,
-                    self.schemas.clone(),
-                    desc.lower.clone(),
-                    None,
-                )
-                .await;
+            let mut builder = PartBuilder::new(&*self.schemas.key, &*self.schemas.val);
             for ((k, v), t, d) in updates {
-                builder.add(&k, &v, &t, &d).await.expect("valid timestamp");
+                builder.push(&k, &v, t, d);
+                if builder.len() >= 1000 {
+                    let part = builder.finish_and_replace(&*self.schemas.key, &*self.schemas.val);
+                    batch.push(part).await;
+                }
             }
-            let batch = builder
-                .finish(desc.upper.clone())
-                .await
-                .expect("valid timestamp");
-            let batch = batch.into_transmittable_batch();
+            let part = builder.finish();
+            batch.push(part).await;
+            // We must finish this batch even if we didn't write any data, since we may end up
+            // being assigned the shared batch.
+            let batch = batch.finish().await?;
 
             self.trace("wrote a batch");
-            Some((desc, batch, cap))
+            Some((desc, batch.into_transmittable_batch(), cap))
         }
     }
 }

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -134,6 +134,7 @@ use mz_persist_client::write::WriteHandle;
 use mz_persist_client::{Diagnostics, PersistClient};
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
+use mz_storage_operators::persist::{SharedBatchId, SharedBatches};
 use mz_storage_types::StorageDiff;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::sources::SourceData;
@@ -267,6 +268,7 @@ where
 
     let persist_api = PersistApi {
         persist_clients: Arc::clone(&compute_state.persist_clients),
+        persist_batches: compute_state.persist_batches.clone(),
         collection: target.clone(),
         shard_name: sink_id.to_string(),
         purpose: format!("MV sink {sink_id}"),
@@ -351,6 +353,7 @@ pub(super) fn advance(
 #[derive(Clone)]
 pub(super) struct PersistApi {
     pub(super) persist_clients: Arc<PersistClientCache>,
+    pub(super) persist_batches: SharedBatches,
     pub(super) collection: CollectionMetadata,
     pub(super) shard_name: String,
     pub(super) purpose: String,
@@ -442,6 +445,8 @@ pub(super) struct BatchDescription {
     pub(super) lower: Antichain<Timestamp>,
     pub(super) upper: Antichain<Timestamp>,
     pub(super) append_worker: usize,
+    /// Identifies the shared batch all workers building this description contribute to.
+    pub(super) shared_id: SharedBatchId,
 }
 
 impl BatchDescription {
@@ -455,6 +460,7 @@ impl BatchDescription {
             lower,
             upper,
             append_worker,
+            shared_id: SharedBatchId::new(),
         }
     }
 }

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -52,12 +52,19 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use differential_dataflow::{Hashable, VecCollection};
-use mz_compute_types::dyncfgs::MV_SINK_ADVANCE_PERSIST_FRONTIERS;
+use mz_compute_types::dyncfgs::{
+    ENABLE_SYNC_MV_SINK_SHARED_BATCHES, MV_SINK_ADVANCE_PERSIST_FRONTIERS,
+};
 use mz_dyncfg::ConfigSet;
 use mz_ore::cast::CastFrom;
 use mz_persist_client::batch::{Batch, ProtoBatch};
 use mz_persist_client::write::WriteHandle;
+use mz_persist_client::{PersistClient, Schemas};
+use mz_persist_types::ShardId;
+use mz_persist_types::codec_impls::UnitSchema;
+use mz_persist_types::part::PartBuilder;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
+use mz_storage_operators::persist::SharedBatches;
 use mz_storage_types::StorageDiff;
 use mz_storage_types::sources::SourceData;
 use timely::PartialOrder;
@@ -102,6 +109,7 @@ pub(super) fn persist_sink<'s>(
 
     let persist_api = PersistApi {
         persist_clients: Arc::clone(&compute_state.persist_clients),
+        persist_batches: compute_state.persist_batches.clone(),
         collection: target.clone(),
         shard_name: sink_id.to_string(),
         purpose: format!("MV sink {sink_id}"),
@@ -652,6 +660,10 @@ mod write {
         let advance_persist_frontiers_at_startup =
             MV_SINK_ADVANCE_PERSIST_FRONTIERS.get(&worker_config);
 
+        // Read the shared-batch flag on the Timely thread. `worker_config` is an `Rc<ConfigSet>`
+        // and thus not `Send`, so the value must be captured before it moves into the Tokio task.
+        let shared_batches_enabled = ENABLE_SYNC_MV_SINK_SHARED_BATCHES.get(&worker_config);
+
         // Mirror the persist-frontier initialization performed by `State::new` below. With the
         // flag enabled, `State` advances its Timely-side `persist_frontiers` to `as_of`, opening
         // the `maybe_start_batch` write gate (`desc.lower <= persist_frontiers.frontier()`)
@@ -676,16 +688,17 @@ mod write {
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<WriteCommand>();
         let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<WriteResponse>();
 
-        // Spawn Tokio task that owns the WriteHandle and corrections buffer.
+        // Spawn Tokio task that owns the batch-writing context and corrections buffer.
         let (activator, activation_ack) = ArcActivator::new(scope, &info);
         let write_task_handle = {
             mz_ore::task::spawn(
                 || operator_name(sink_id, "write::batch_writer"),
                 async move {
-                    let mut writer = persist_api.open_writer().await;
+                    let mut batch_writer =
+                        BatchWriter::new(&persist_api, shared_batches_enabled).await;
 
                     while let Some(cmd) = cmd_rx.recv().await {
-                        apply_command(&mut corrections, &mut writer, cmd, &resp_tx).await;
+                        apply_command(&mut corrections, &mut batch_writer, cmd, &resp_tx).await;
                         // Activate the operator to drain logging events and process batch responses.
                         // ArcActivator suppresses redundant activations, so this is cheap.
                         activator.activate();
@@ -831,6 +844,38 @@ mod write {
         batches_output_stream
     }
 
+    /// The batch-writing context owned by the Tokio write task.
+    ///
+    /// Batches are built through the process-global [`SharedBatches`], so that the workers running
+    /// in one process coalesce their parts for a given batch interval into a single, larger batch
+    /// instead of each writing its own small batch. The `writer` is retained only to clean up a
+    /// finished batch when the response channel has already gone away.
+    struct BatchWriter {
+        persist_client: PersistClient,
+        shard_id: ShardId,
+        schemas: Schemas<SourceData, ()>,
+        shared_batches: SharedBatches,
+        shared_batches_enabled: bool,
+        writer: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+    }
+
+    impl BatchWriter {
+        async fn new(persist_api: &PersistApi, shared_batches_enabled: bool) -> Self {
+            Self {
+                persist_client: persist_api.open_client().await,
+                shard_id: persist_api.collection.data_shard,
+                schemas: Schemas {
+                    id: None,
+                    key: Arc::new(persist_api.collection.relation_desc.clone()),
+                    val: Arc::new(UnitSchema),
+                },
+                shared_batches: persist_api.persist_batches.clone(),
+                shared_batches_enabled,
+                writer: persist_api.open_writer().await,
+            }
+        }
+    }
+
     /// Apply a single command to the task state.
     ///
     /// `desired` updates enter `corrections` as positive contributions and `persist` updates as
@@ -838,7 +883,7 @@ mod write {
     /// need to be written to bring the shard in line with `desired`.
     async fn apply_command(
         corrections: &mut OkErr<Correction<Row>, Correction<DataflowErrorSer>>,
-        writer: &mut WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        batch_writer: &mut BatchWriter,
         cmd: WriteCommand,
         resp_tx: &mpsc::UnboundedSender<WriteResponse>,
     ) {
@@ -881,28 +926,72 @@ mod write {
                     .err
                     .updates_before(&desc.upper)
                     .map(|(d, t, r)| ((SourceData(Err(d.deserialize())), ()), t, r.into_inner()));
-                let mut updates = oks.chain(errs).peekable();
 
-                if updates.peek().is_none() {
-                    // No corrections to write.
-                    let _ = resp_tx.send(WriteResponse { batch: None });
-                    return;
-                }
+                let proto_batch = if batch_writer.shared_batches_enabled {
+                    write_shared_batch(batch_writer, &desc, oks.chain(errs)).await
+                } else {
+                    // Per-worker path: each worker writes its own batch for the interval.
+                    let mut updates = oks.chain(errs).peekable();
+                    if updates.peek().is_none() {
+                        None
+                    } else {
+                        let batch = batch_writer
+                            .writer
+                            .batch(updates, desc.lower.clone(), desc.upper.clone())
+                            .await
+                            .expect("valid usage");
+                        Some(batch.into_transmittable_batch())
+                    }
+                };
 
-                let batch = writer
-                    .batch(updates, desc.lower, desc.upper)
-                    .await
-                    .expect("valid usage");
-                let proto_batch = batch.into_transmittable_batch();
-                if let Err(err) = resp_tx.send(WriteResponse {
-                    batch: Some(proto_batch),
-                }) {
-                    let batch =
-                        writer.batch_from_transmittable_batch(err.0.batch.expect("just sent"));
-                    batch.delete().await;
+                if let Err(err) = resp_tx.send(WriteResponse { batch: proto_batch }) {
+                    if let Some(proto_batch) = err.0.batch {
+                        let batch = batch_writer
+                            .writer
+                            .batch_from_transmittable_batch(proto_batch);
+                        batch.delete().await;
+                    }
                 }
             }
         }
+    }
+
+    /// Build the batch for `desc` through the process-global [`SharedBatches`], coalescing this
+    /// worker's parts with those of the other workers in the process that build the same interval.
+    ///
+    /// All workers building an interval share `desc.shared_id` (the `mint` operator broadcasts one
+    /// description), so their parts land in a single shared batch. Only the last worker to `finish`
+    /// receives that batch; the rest get `None`, which maps to the empty-batch response the write
+    /// operator already handles. Every worker must `finish` even when it pushed nothing, since any
+    /// one of them may be the last holder and thus responsible for delivering all workers' data.
+    async fn write_shared_batch(
+        batch_writer: &BatchWriter,
+        desc: &BatchDescription,
+        updates: impl Iterator<Item = ((SourceData, ()), Timestamp, StorageDiff)>,
+    ) -> Option<ProtoBatch> {
+        let schemas = &batch_writer.schemas;
+        let shared = batch_writer.shared_batches.builder(
+            desc.shared_id,
+            batch_writer.persist_client.clone(),
+            batch_writer.shard_id,
+            schemas.clone(),
+            desc.lower.clone(),
+            desc.upper.clone(),
+        );
+
+        let mut builder = PartBuilder::new(&*schemas.key, &*schemas.val);
+        for ((k, v), t, d) in updates {
+            builder.push(&k, &v, t, d);
+            if builder.len() >= 1000 {
+                let part = builder.finish_and_replace(&*schemas.key, &*schemas.val);
+                shared.push(part).await;
+            }
+        }
+        let part = builder.finish();
+        shared.push(part).await;
+
+        let batch = shared.finish().await;
+        batch.map(|batch| batch.into_transmittable_batch())
     }
 
     /// State maintained by the `write` operator on the Timely thread.

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -52,12 +52,19 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use differential_dataflow::{Hashable, VecCollection};
-use mz_compute_types::dyncfgs::MV_SINK_ADVANCE_PERSIST_FRONTIERS;
+use mz_compute_types::dyncfgs::{
+    ENABLE_SYNC_MV_SINK_SHARED_BATCHES, MV_SINK_ADVANCE_PERSIST_FRONTIERS,
+};
 use mz_dyncfg::ConfigSet;
 use mz_ore::cast::CastFrom;
 use mz_persist_client::batch::{Batch, ProtoBatch};
 use mz_persist_client::write::WriteHandle;
+use mz_persist_client::{PersistClient, Schemas};
+use mz_persist_types::ShardId;
+use mz_persist_types::codec_impls::UnitSchema;
+use mz_persist_types::part::PartBuilder;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
+use mz_storage_operators::persist::SharedBatches;
 use mz_storage_types::StorageDiff;
 use mz_storage_types::sources::SourceData;
 use timely::PartialOrder;
@@ -102,6 +109,7 @@ pub(super) fn persist_sink<'s>(
 
     let persist_api = PersistApi {
         persist_clients: Arc::clone(&compute_state.persist_clients),
+        persist_batches: compute_state.persist_batches.clone(),
         collection: target.clone(),
         shard_name: sink_id.to_string(),
         purpose: format!("MV sink {sink_id}"),
@@ -655,6 +663,10 @@ mod write {
         let advance_persist_frontiers_at_startup =
             MV_SINK_ADVANCE_PERSIST_FRONTIERS.get(&worker_config);
 
+        // Read the shared-batch flag on the Timely thread. `worker_config` is an `Rc<ConfigSet>`
+        // and thus not `Send`, so the value must be captured before it moves into the Tokio task.
+        let shared_batches_enabled = ENABLE_SYNC_MV_SINK_SHARED_BATCHES.get(&worker_config);
+
         // Mirror the persist-frontier initialization performed by `State::new` below. With the
         // flag enabled, `State` advances its Timely-side `persist_frontiers` to `as_of`, opening
         // the `maybe_start_batch` write gate (`desc.lower <= persist_frontiers.frontier()`)
@@ -679,17 +691,17 @@ mod write {
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<WriteCommand>();
         let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<WriteResponse>();
 
-        // Spawn Tokio task that owns the WriteHandle and corrections buffer.
+        // Spawn Tokio task that owns the batch-writing context and corrections buffer.
         let (activator, activation_ack) = ArcActivator::new(scope, &info);
         let write_task_handle = {
             mz_ore::task::spawn(
                 || operator_name(sink_id, "write::batch_writer"),
                 async move {
-                    let writer = persist_api.open_writer().await;
+                    let batch_writer = BatchWriter::new(&persist_api, shared_batches_enabled).await;
 
                     while let Some(cmd) = cmd_rx.recv().await {
                         corrections =
-                            apply_command(sink_id, corrections, &writer, cmd, &resp_tx).await;
+                            apply_command(sink_id, corrections, &batch_writer, cmd, &resp_tx).await;
                         // Activate the operator to drain logging events and process batch responses.
                         // ArcActivator suppresses redundant activations, so this is cheap.
                         activator.activate();
@@ -841,6 +853,52 @@ mod write {
     /// batch builder. Together with [`READ_BACK_CHUNK`] this bounds the handoff to a few thousand
     /// buffered updates.
     const READ_BACK_CHUNKS_IN_FLIGHT: usize = 4;
+    /// How many updates a worker accumulates before handing a part to the shared batch.
+    ///
+    /// The shared batch concatenates the parts it receives until they reach persist's blob target
+    /// size, so this only sets the granularity at which a worker's updates become visible to that
+    /// coalescing, not the size of the parts persist writes. Keeping it near [`READ_BACK_CHUNK`]
+    /// costs one part per read-back chunk.
+    const SHARED_PART_LEN: usize = 1024;
+
+    /// The batch-writing context owned by the Tokio write task.
+    ///
+    /// Batches are built through the process-global [`SharedBatches`], so that the workers running
+    /// in one process coalesce their parts for a given batch interval into a single, larger batch
+    /// instead of each writing its own small batch. The `writer` is retained only to clean up a
+    /// finished batch when the response channel has already gone away.
+    struct BatchWriter {
+        persist_client: PersistClient,
+        shard_id: ShardId,
+        shard_name: String,
+        schemas: Schemas<SourceData, ()>,
+        shared_batches: SharedBatches,
+        shared_batches_enabled: bool,
+        writer: WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+    }
+
+    impl BatchWriter {
+        async fn new(persist_api: &PersistApi, shared_batches_enabled: bool) -> Self {
+            let writer = persist_api.open_writer().await;
+            Self {
+                persist_client: persist_api.open_client().await,
+                shard_id: persist_api.collection.data_shard,
+                shard_name: persist_api.shard_name.clone(),
+                // Parts carry the id of the schema they were written under, and a part written
+                // under none cannot be decoded through the shard's schema registry. The handle
+                // resolves the registered id for this sink's schema, so take it from there rather
+                // than assembling an unregistered `Schemas`.
+                schemas: Schemas {
+                    id: writer.schema_id(),
+                    key: Arc::new(persist_api.collection.relation_desc.clone()),
+                    val: Arc::new(UnitSchema),
+                },
+                shared_batches: persist_api.persist_batches.clone(),
+                shared_batches_enabled,
+                writer,
+            }
+        }
+    }
 
     /// Apply a single command to the task state, returning the correction buffers.
     ///
@@ -857,7 +915,7 @@ mod write {
     async fn apply_command(
         sink_id: GlobalId,
         mut corrections: Corrections,
-        writer: &WriteHandle<SourceData, (), Timestamp, StorageDiff>,
+        batch_writer: &BatchWriter,
         cmd: WriteCommand,
         resp_tx: &mpsc::UnboundedSender<WriteResponse>,
     ) -> Corrections {
@@ -914,30 +972,39 @@ mod write {
                         },
                     );
 
-                // Create the builder lazily: an idle sink's descriptions find no corrections.
-                let mut builder = None;
-                while let Some(chunk) = updates_rx.recv().await {
-                    let builder = builder.get_or_insert_with(|| writer.builder(desc.lower.clone()));
-                    for ((k, v), t, d) in &chunk {
-                        builder.add(k, v, t, d).await.expect("valid usage");
+                let proto_batch = if batch_writer.shared_batches_enabled {
+                    write_shared_batch(batch_writer, &desc, &mut updates_rx).await
+                } else {
+                    // Per-worker path: each worker writes its own batch for the interval. Create
+                    // the builder lazily: an idle sink's descriptions find no corrections.
+                    let mut builder = None;
+                    while let Some(chunk) = updates_rx.recv().await {
+                        let builder = builder
+                            .get_or_insert_with(|| batch_writer.writer.builder(desc.lower.clone()));
+                        for ((k, v), t, d) in &chunk {
+                            builder.add(k, v, t, d).await.expect("valid usage");
+                        }
                     }
-                }
+                    match builder {
+                        Some(builder) => {
+                            let batch = builder
+                                .finish(desc.upper.clone())
+                                .await
+                                .expect("valid usage");
+                            Some(batch.into_transmittable_batch())
+                        }
+                        None => None,
+                    }
+                };
                 let corrections = read_back.await;
 
-                let Some(builder) = builder else {
-                    // No corrections to write.
-                    let _ = resp_tx.send(WriteResponse { batch: None });
-                    return corrections;
-                };
-
-                let batch = builder.finish(desc.upper).await.expect("valid usage");
-                let proto_batch = batch.into_transmittable_batch();
-                if let Err(err) = resp_tx.send(WriteResponse {
-                    batch: Some(proto_batch),
-                }) {
-                    let batch =
-                        writer.batch_from_transmittable_batch(err.0.batch.expect("just sent"));
-                    batch.delete().await;
+                if let Err(err) = resp_tx.send(WriteResponse { batch: proto_batch }) {
+                    if let Some(proto_batch) = err.0.batch {
+                        let batch = batch_writer
+                            .writer
+                            .batch_from_transmittable_batch(proto_batch);
+                        batch.delete().await;
+                    }
                 }
 
                 corrections
@@ -996,6 +1063,47 @@ mod write {
             },
         )
         .await
+    }
+
+    /// Build the batch for `desc` through the process-global [`SharedBatches`], coalescing this
+    /// worker's parts with those of the other workers in the process that build the same interval.
+    ///
+    /// All workers building an interval share `desc.shared_id` (the `mint` operator broadcasts one
+    /// description), so their parts land in a single shared batch. Only the last worker to `finish`
+    /// receives that batch; the rest get `None`, which maps to the empty-batch response the write
+    /// operator already handles. Every worker must `finish` even when it pushed nothing, since any
+    /// one of them may be the last holder and thus responsible for delivering all workers' data.
+    async fn write_shared_batch(
+        batch_writer: &BatchWriter,
+        desc: &BatchDescription,
+        updates_rx: &mut mpsc::Receiver<Vec<((SourceData, ()), Timestamp, StorageDiff)>>,
+    ) -> Option<ProtoBatch> {
+        let schemas = &batch_writer.schemas;
+        let shared = batch_writer.shared_batches.builder(
+            desc.shared_id,
+            batch_writer.persist_client.clone(),
+            batch_writer.shard_id,
+            batch_writer.shard_name.clone(),
+            schemas.clone(),
+            desc.lower.clone(),
+            desc.upper.clone(),
+        );
+
+        let mut builder = PartBuilder::new(&*schemas.key, &*schemas.val);
+        while let Some(chunk) = updates_rx.recv().await {
+            for ((k, v), t, d) in &chunk {
+                builder.push(k, v, *t, *d);
+                if builder.len() >= SHARED_PART_LEN {
+                    let part = builder.finish_and_replace(&*schemas.key, &*schemas.val);
+                    shared.push(part).await;
+                }
+            }
+        }
+        let part = builder.finish();
+        shared.push(part).await;
+
+        let batch = shared.finish().await;
+        batch.map(|batch| batch.into_transmittable_batch())
     }
 
     /// State maintained by the `write` operator on the Timely thread.

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -30,7 +30,7 @@ use mz_ore::instrument;
 use mz_persist::indexed::encoding::{BatchColumnarFormat, BlobTraceBatchPart, BlobTraceUpdates};
 use mz_persist::location::Blob;
 use mz_persist_types::arrow::{ArrayBound, ArrayOrd};
-use mz_persist_types::columnar::{ColumnDecoder, Schema};
+use mz_persist_types::columnar::{ColumnDecoder, Schema, data_type};
 use mz_persist_types::parquet::{CompressionFormat, EncodingConfig};
 use mz_persist_types::part::{Part, PartBuilder};
 use mz_persist_types::schema::SchemaId;
@@ -526,7 +526,8 @@ where
     inline_desc: Description<T>,
     inclusive_upper: Antichain<Reverse<T>>,
 
-    records_builder: PartBuilder<K, K::Schema, V, V::Schema>,
+    part_builder: PartBuilder<K, K::Schema, V, V::Schema>,
+    finished_parts: Vec<Part>,
     pub(crate) builder: BatchBuilderInternal<K, V, T, D>,
 }
 
@@ -548,8 +549,41 @@ where
         Self {
             inline_desc,
             inclusive_upper: Antichain::new(),
-            records_builder,
+            part_builder: records_builder,
+            finished_parts: vec![],
             builder,
+        }
+    }
+
+    fn in_progress_goodbytes(&self) -> usize {
+        self.part_builder.goodbytes()
+            + self
+                .finished_parts
+                .iter()
+                .map(|p| p.goodbytes())
+                .sum::<usize>()
+    }
+
+    fn finish_part_builder(&mut self) {
+        if self.part_builder.len() > 0 {
+            let part = self.part_builder.finish_and_replace(
+                &*self.builder.write_schemas.key,
+                &*self.builder.write_schemas.val,
+            );
+            self.finished_parts.push(part);
+        }
+    }
+
+    async fn flush_parts(&mut self) -> bool {
+        self.finish_part_builder();
+        if let Some(part) = Part::concat(&self.finished_parts).expect("type aligned") {
+            self.builder
+                .flush_part(self.inline_desc.clone(), part)
+                .await;
+            self.finished_parts.clear();
+            true
+        } else {
+            false
         }
     }
 
@@ -583,10 +617,7 @@ where
             }
         }
 
-        let updates = self.records_builder.finish();
-        self.builder
-            .flush_part(self.inline_desc.clone(), updates)
-            .await;
+        self.flush_parts().await;
 
         self.builder
             .finish(Description::new(
@@ -595,6 +626,51 @@ where
                 self.inline_desc.since().clone(),
             ))
             .await
+    }
+
+    /// Adds the given update to the batch.
+    ///
+    /// The update timestamp must be greater or equal to `lower` that was given
+    /// when creating this [BatchBuilder].
+    pub async fn add_part(&mut self, part: Part) -> Result<Added, InvalidUsage<T>> {
+        for time in part.time.values() {
+            let ts = T::decode(time.to_le_bytes());
+            if !self.inline_desc.lower().less_equal(&ts) {
+                return Err(InvalidUsage::UpdateNotBeyondLower {
+                    ts,
+                    lower: self.inline_desc.lower().clone(),
+                });
+            }
+            self.inclusive_upper.insert(Reverse(ts));
+        }
+
+        assert_eq!(
+            data_type::<K>(&self.builder.write_schemas.key).expect("valid type"),
+            *part.key.data_type(),
+        );
+        assert_eq!(
+            data_type::<V>(&self.builder.write_schemas.val).expect("valid type"),
+            *part.val.data_type()
+        );
+
+        self.finish_part_builder();
+
+        let mut flushed = false;
+        if self.in_progress_goodbytes() + part.goodbytes() > self.builder.parts.cfg.blob_target_size
+        {
+            flushed |= self.flush_parts().await;
+        }
+        self.finished_parts.push(part);
+        if self.in_progress_goodbytes() > self.builder.parts.cfg.blob_target_size {
+            flushed |= self.flush_parts().await;
+        }
+
+        let added = if flushed {
+            Added::RecordAndParts
+        } else {
+            Added::Record
+        };
+        Ok(added)
     }
 
     /// Adds the given update to the batch.
@@ -616,24 +692,13 @@ where
         }
         self.inclusive_upper.insert(Reverse(ts.clone()));
 
-        let added = {
-            self.records_builder
-                .push(key, val, ts.clone(), diff.clone());
-            if self.records_builder.goodbytes() >= self.builder.parts.cfg.blob_target_size {
-                let part = self.records_builder.finish_and_replace(
-                    self.builder.write_schemas.key.as_ref(),
-                    self.builder.write_schemas.val.as_ref(),
-                );
-                Some(part)
-            } else {
-                None
-            }
-        };
+        let mut flushed = false;
+        self.part_builder.push(key, val, ts.clone(), diff.clone());
+        if self.in_progress_goodbytes() >= self.builder.parts.cfg.blob_target_size {
+            flushed |= self.flush_parts().await;
+        }
 
-        let added = if let Some(full_batch) = added {
-            self.builder
-                .flush_part(self.inline_desc.clone(), full_batch)
-                .await;
+        let added = if flushed {
             Added::RecordAndParts
         } else {
             Added::Record
@@ -754,9 +819,8 @@ where
         Ok(batch)
     }
 
-    /// Flushes the current part to Blob storage, first consolidating and then
-    /// columnar encoding the updates. It is the caller's responsibility to
-    /// chunk `current_part` to be no greater than
+    /// Flushes the current part to Blob storage, first columnar encoding the updates.
+    /// It is the caller's responsibility to chunk `current_part` to be no greater than
     /// [BatchBuilderConfig::blob_target_size], and must absolutely be less than
     /// [mz_persist::indexed::columnar::KEY_VAL_DATA_MAX_LEN]
     pub async fn flush_part(&mut self, part_desc: Description<T>, columnar: Part) {

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -30,7 +30,7 @@ use mz_ore::instrument;
 use mz_persist::indexed::encoding::{BatchColumnarFormat, BlobTraceBatchPart, BlobTraceUpdates};
 use mz_persist::location::Blob;
 use mz_persist_types::arrow::{ArrayBound, ArrayOrd};
-use mz_persist_types::columnar::{ColumnDecoder, Schema};
+use mz_persist_types::columnar::{ColumnDecoder, Schema, data_type};
 use mz_persist_types::parquet::{CompressionFormat, EncodingConfig};
 use mz_persist_types::part::{Part, PartBuilder};
 use mz_persist_types::schema::SchemaId;
@@ -535,7 +535,15 @@ where
     inline_desc: Description<T>,
     inclusive_upper: Antichain<Reverse<T>>,
 
-    records_builder: PartBuilder<K, K::Schema, V, V::Schema>,
+    part_builder: PartBuilder<K, K::Schema, V, V::Schema>,
+    finished_parts: Vec<Part>,
+    /// The accumulated size of `finished_parts`.
+    ///
+    /// Tracked incrementally because `Part::goodbytes` rebuilds an `ArrayOrd` per key and value
+    /// column on every call, and parts accumulate until they reach the blob target size. Summing
+    /// the vector on each `add`/`add_part` would make a flush window quadratic in the number of
+    /// parts it holds.
+    finished_parts_goodbytes: usize,
     pub(crate) builder: BatchBuilderInternal<K, V, T, D>,
 }
 
@@ -557,8 +565,43 @@ where
         Self {
             inline_desc,
             inclusive_upper: Antichain::new(),
-            records_builder,
+            part_builder: records_builder,
+            finished_parts: vec![],
+            finished_parts_goodbytes: 0,
             builder,
+        }
+    }
+
+    fn in_progress_goodbytes(&self) -> usize {
+        self.part_builder.goodbytes() + self.finished_parts_goodbytes
+    }
+
+    fn push_finished_part(&mut self, part: Part) {
+        self.finished_parts_goodbytes += part.goodbytes();
+        self.finished_parts.push(part);
+    }
+
+    fn finish_part_builder(&mut self) {
+        if self.part_builder.len() > 0 {
+            let part = self.part_builder.finish_and_replace(
+                &*self.builder.write_schemas.key,
+                &*self.builder.write_schemas.val,
+            );
+            self.push_finished_part(part);
+        }
+    }
+
+    async fn flush_parts(&mut self) -> bool {
+        self.finish_part_builder();
+        if let Some(part) = Part::concat(&self.finished_parts).expect("type aligned") {
+            self.builder
+                .flush_part(self.inline_desc.clone(), part)
+                .await;
+            self.finished_parts.clear();
+            self.finished_parts_goodbytes = 0;
+            true
+        } else {
+            false
         }
     }
 
@@ -592,10 +635,7 @@ where
             }
         }
 
-        let updates = self.records_builder.finish();
-        self.builder
-            .flush_part(self.inline_desc.clone(), updates)
-            .await;
+        self.flush_parts().await;
 
         self.builder
             .finish(Description::new(
@@ -604,6 +644,56 @@ where
                 self.inline_desc.since().clone(),
             ))
             .await
+    }
+
+    /// Adds the given part to the batch, encoded with this builder's write schemas.
+    ///
+    /// Every update timestamp in the part must be greater or equal to `lower` that was given when
+    /// creating this [BatchBuilder].
+    ///
+    /// Parts accumulate until they reach the configured blob target size and are then concatenated
+    /// into one flushed part, so an individual `part` must stay well below persist's
+    /// `KEY_VAL_DATA_MAX_LEN`: a single oversized part is flushed on its own, but nothing splits
+    /// it.
+    pub async fn add_part(&mut self, part: Part) -> Result<Added, InvalidUsage<T>> {
+        for time in part.time.values() {
+            let ts = T::decode(time.to_le_bytes());
+            if !self.inline_desc.lower().less_equal(&ts) {
+                return Err(InvalidUsage::UpdateNotBeyondLower {
+                    ts,
+                    lower: self.inline_desc.lower().clone(),
+                });
+            }
+            self.inclusive_upper.insert(Reverse(ts));
+        }
+
+        assert_eq!(
+            data_type::<K>(&self.builder.write_schemas.key).expect("valid type"),
+            *part.key.data_type(),
+        );
+        assert_eq!(
+            data_type::<V>(&self.builder.write_schemas.val).expect("valid type"),
+            *part.val.data_type()
+        );
+
+        self.finish_part_builder();
+
+        let mut flushed = false;
+        if self.in_progress_goodbytes() + part.goodbytes() > self.builder.parts.cfg.blob_target_size
+        {
+            flushed |= self.flush_parts().await;
+        }
+        self.push_finished_part(part);
+        if self.in_progress_goodbytes() > self.builder.parts.cfg.blob_target_size {
+            flushed |= self.flush_parts().await;
+        }
+
+        let added = if flushed {
+            Added::RecordAndParts
+        } else {
+            Added::Record
+        };
+        Ok(added)
     }
 
     /// Adds the given update to the batch.
@@ -625,24 +715,13 @@ where
         }
         self.inclusive_upper.insert(Reverse(ts.clone()));
 
-        let added = {
-            self.records_builder
-                .push(key, val, ts.clone(), diff.clone());
-            if self.records_builder.goodbytes() >= self.builder.parts.cfg.blob_target_size {
-                let part = self.records_builder.finish_and_replace(
-                    self.builder.write_schemas.key.as_ref(),
-                    self.builder.write_schemas.val.as_ref(),
-                );
-                Some(part)
-            } else {
-                None
-            }
-        };
+        let mut flushed = false;
+        self.part_builder.push(key, val, ts.clone(), diff.clone());
+        if self.in_progress_goodbytes() >= self.builder.parts.cfg.blob_target_size {
+            flushed |= self.flush_parts().await;
+        }
 
-        let added = if let Some(full_batch) = added {
-            self.builder
-                .flush_part(self.inline_desc.clone(), full_batch)
-                .await;
+        let added = if flushed {
             Added::RecordAndParts
         } else {
             Added::Record
@@ -763,9 +842,8 @@ where
         Ok(batch)
     }
 
-    /// Flushes the current part to Blob storage, first consolidating and then
-    /// columnar encoding the updates. It is the caller's responsibility to
-    /// chunk `current_part` to be no greater than
+    /// Flushes the current part to Blob storage, first columnar encoding the updates.
+    /// It is the caller's responsibility to chunk `current_part` to be no greater than
     /// [BatchBuilderConfig::blob_target_size], and must absolutely be less than
     /// [mz_persist::indexed::columnar::KEY_VAL_DATA_MAX_LEN]
     pub async fn flush_part(&mut self, part_desc: Description<T>, columnar: Part) {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -552,7 +552,7 @@ impl PersistClient {
     /// enough that we can reasonably chunk them up: O(KB) is definitely fine,
     /// O(MB) come talk to us.
     #[instrument(level = "debug", fields(shard = %shard_id))]
-    pub async fn batch_builder<K, V, T, D>(
+    pub fn batch_builder<K, V, T, D>(
         &self,
         shard_id: ShardId,
         write_schemas: Schemas<K, V>,

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -551,9 +551,10 @@ impl PersistClient {
     /// enough that we can reasonably chunk them up: O(KB) is definitely fine,
     /// O(MB) come talk to us.
     #[instrument(level = "debug", fields(shard = %shard_id))]
-    pub async fn batch_builder<K, V, T, D>(
+    pub fn batch_builder<K, V, T, D>(
         &self,
         shard_id: ShardId,
+        shard_name: &str,
         write_schemas: Schemas<K, V>,
         lower: Antichain<T>,
         max_runs: Option<usize>,
@@ -570,7 +571,7 @@ impl PersistClient {
             &self.cfg,
             compact_cfg,
             Arc::clone(&self.metrics),
-            self.metrics.shards.shard(&shard_id, "peek_stash"),
+            self.metrics.shards.shard(&shard_id, shard_name),
             &self.metrics.user,
             Arc::clone(&self.isolated_runtime),
             Arc::clone(&self.blob),

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -187,6 +187,11 @@ impl<K, KS: Schema<K>, V, VS: Schema<V>> PartBuilder<K, KS, V, VS> {
         }
     }
 
+    /// The number of elements pushed into the builder.
+    pub fn len(&self) -> usize {
+        self.time.len()
+    }
+
     /// Estimate the size of the part this builder will build.
     pub fn goodbytes(&self) -> usize {
         self.key.goodbytes() + self.val.goodbytes() + self.time.goodbytes() + self.diff.goodbytes()

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -51,6 +51,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-util = { workspace = true, features = ["io"] }
 tracing.workspace = true
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 bytesize.workspace = true

--- a/src/storage-operators/src/lib.rs
+++ b/src/storage-operators/src/lib.rs
@@ -14,3 +14,5 @@ pub mod oneshot_source;
 pub mod persist_source;
 pub mod s3_oneshot_sink;
 pub mod stats;
+
+pub mod persist;

--- a/src/storage-operators/src/persist.rs
+++ b/src/storage-operators/src/persist.rs
@@ -1,0 +1,258 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_ore::task::JoinHandle;
+use mz_persist_client::batch::Batch;
+use mz_persist_client::{PersistClient, Schemas};
+use mz_persist_types::ShardId;
+use mz_persist_types::part::Part;
+use mz_repr::Timestamp;
+use mz_storage_types::StorageDiff;
+use mz_storage_types::sources::SourceData;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::sync::{Arc, Weak};
+use timely::progress::Antichain;
+use uuid::Uuid;
+
+/// A unique identifier for a [SharedBatchBuilder].
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    Serialize,
+    Deserialize,
+    Ord,
+    PartialOrd,
+    Eq,
+    PartialEq,
+    Hash
+)]
+#[serde(transparent)]
+pub struct SharedBatchId(Uuid);
+
+impl SharedBatchId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+/// A struct from which to obtain a [SharedBatchBuilder].
+#[derive(Debug, Clone)]
+pub struct SharedBatches {
+    data: Arc<std::sync::Mutex<(usize, BTreeMap<SharedBatchId, Weak<BatchState>>)>>,
+}
+
+fn upgrade_or_init<T>(weak: &mut Weak<T>, init: impl FnOnce() -> T) -> Arc<T> {
+    if let Some(owned) = weak.upgrade() {
+        owned
+    } else {
+        let owned = Arc::new(init());
+        *weak = Arc::downgrade(&owned);
+        owned
+    }
+}
+
+impl SharedBatches {
+    pub fn new() -> Self {
+        Self {
+            data: Arc::default(),
+        }
+    }
+
+    /// Get a builder for the specified batch. If there is an existing, live builder for the same
+    /// batch id managed by [Self], any parts added to this builder will be included in the same,
+    /// shared batch; if not, a new batch will be created.
+    ///
+    /// This is designed so that, in a multi-worker dataflow, workers that are building the same batch
+    /// at the same time can write fewer, larger parts instead of many small ones. It does not guarantee
+    /// that there will be _precisely_ one batch across all workers, however.
+    pub fn builder(
+        &self,
+        shared_batch_id: SharedBatchId,
+        client: PersistClient,
+        shard_id: ShardId,
+        schemas: Schemas<SourceData, ()>,
+        lower: Antichain<Timestamp>,
+        upper: Antichain<Timestamp>,
+    ) -> SharedBatchBuilder {
+        let mut guard = self.data.lock().unwrap();
+        let (last_retained_len, state_map) = &mut *guard;
+        // We clean out entries from the map where all shared batch handles have been dropped.
+        // Amortize by only scanning the map once it's doubled in size.
+        if state_map.len() > *last_retained_len * 2 {
+            state_map.retain(|_, weak| weak.upgrade().is_some());
+            *last_retained_len = state_map.len();
+        }
+        let weak = state_map.entry(shared_batch_id).or_default();
+        let state = upgrade_or_init(weak, || {
+            let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+            let task_id = format!("shared-batch-{shared_batch_id:?}-{shard_id}",);
+            BatchState {
+                tx,
+                handle: mz_ore::task::spawn(|| task_id, async move {
+                    let mut builder = None;
+                    while let Some(cmd) = rx.recv().await {
+                        match cmd {
+                            BatchCommand::Push(part) => {
+                                let builder = builder.get_or_insert_with(|| {
+                                    client.batch_builder(
+                                        shard_id,
+                                        schemas.clone(),
+                                        lower.clone(),
+                                        None,
+                                    )
+                                });
+                                builder.add_part(part).await.expect("valid timestamps");
+                            }
+                        }
+                    }
+                    if let Some(builder) = builder {
+                        Some(builder.finish(upper).await.expect("valid upper bound"))
+                    } else {
+                        None
+                    }
+                }),
+            }
+        });
+
+        SharedBatchBuilder {
+            batch_id: shared_batch_id,
+            shard_id,
+            state,
+        }
+    }
+}
+
+enum BatchCommand {
+    Push(Part),
+}
+
+#[derive(Debug)]
+struct BatchState {
+    tx: tokio::sync::mpsc::Sender<BatchCommand>,
+    handle: JoinHandle<Option<Batch<SourceData, (), Timestamp, StorageDiff>>>,
+}
+
+/// A handle for a shared batch builder. Everyone with a handle for the same builder can
+/// [Self::push] to that builder, but the last handle to call [Self::finish] will receive a batch
+/// containing all the data.
+///
+/// Note that it's quite important to call [Self::finish], even if you haven't pushed anything
+/// into the batch, in case you're holding the last builder for a shared batch.
+pub struct SharedBatchBuilder {
+    batch_id: SharedBatchId,
+    shard_id: ShardId,
+    state: Arc<BatchState>,
+}
+
+impl Debug for SharedBatchBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedBatchBuilder")
+            .field("batch_id", &self.batch_id)
+            .field("shard_id", &self.shard_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SharedBatchBuilder {
+    /// Include the provided part in the batch. If there are a large number of updates that have
+    /// not been flushed to S3, this call may wait.
+    pub async fn push(&self, part: Part) {
+        if part.len() == 0 {
+            return;
+        }
+        self.state
+            .tx
+            .send(BatchCommand::Push(part))
+            .await
+            .expect("task failed");
+    }
+
+    /// Fetch the results of the batch builder from the shared state, if any.
+    ///
+    /// Only the last builder to call this method will obtain the resulting batch, and that batch
+    /// will include all data written by all workers.
+    /// This means that, for any batch interval that we actually want to append, all workers
+    /// must call finish even if they did not push any batches themselves.
+    pub async fn finish(self) -> Option<Batch<SourceData, (), Timestamp, StorageDiff>> {
+        let state = Arc::into_inner(self.state)?;
+        drop(state.tx); // The task only finishes the batch once the channel is closed.
+        state.handle.await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mz_persist_types::codec_impls::UnitSchema;
+    use mz_persist_types::part::PartBuilder;
+    use mz_repr::{Datum, RelationDesc, Row, SqlScalarType};
+
+    #[mz_ore::test(tokio::test)]
+    async fn test_shared_batch() {
+        let client = PersistClient::new_for_tests().await;
+        let shared = SharedBatches::new();
+        let batch_id = SharedBatchId::new();
+        let shard_id = ShardId::new();
+        let schemas = Schemas {
+            id: None,
+            key: Arc::new(
+                RelationDesc::builder()
+                    .with_column("test", SqlScalarType::Bool.nullable(true))
+                    .finish(),
+            ),
+            val: Arc::new(UnitSchema),
+        };
+        let lower = Antichain::from_elem(0.into());
+        let upper = Antichain::from_elem(1.into());
+        let first = shared.builder(
+            batch_id,
+            client.clone(),
+            shard_id,
+            schemas.clone(),
+            lower.clone(),
+            upper.clone(),
+        );
+        let second = shared.builder(
+            batch_id,
+            client,
+            shard_id,
+            schemas.clone(),
+            lower.clone(),
+            upper.clone(),
+        );
+        let mut builder = PartBuilder::new(&*schemas.key, &*schemas.val);
+        builder.push(
+            &SourceData(Ok(Row::pack_slice(&[Datum::True]))),
+            &(),
+            Timestamp::new(0),
+            1i64,
+        );
+        let part = builder.finish();
+        first.push(part.clone()).await;
+        second.push(part.clone()).await;
+        assert!(
+            second.finish().await.is_none(),
+            "first batch to finish should be empty"
+        );
+        let batch = first.finish().await.unwrap();
+        assert_eq!(
+            batch.shard_id(),
+            shard_id,
+            "batch should be for the expected shard"
+        );
+        assert_eq!(
+            batch.into_hollow_batch().len,
+            2,
+            "batch should include updates from both pushes"
+        )
+    }
+}

--- a/src/storage-operators/src/persist.rs
+++ b/src/storage-operators/src/persist.rs
@@ -1,0 +1,305 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_ore::task::JoinHandle;
+use mz_persist_client::batch::Batch;
+use mz_persist_client::{PersistClient, Schemas};
+use mz_persist_types::ShardId;
+use mz_persist_types::part::Part;
+use mz_repr::Timestamp;
+use mz_storage_types::StorageDiff;
+use mz_storage_types::sources::SourceData;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::sync::{Arc, Weak};
+use timely::progress::Antichain;
+use uuid::Uuid;
+
+/// A unique identifier for a [SharedBatchBuilder].
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    Serialize,
+    Deserialize,
+    Ord,
+    PartialOrd,
+    Eq,
+    PartialEq,
+    Hash
+)]
+#[serde(transparent)]
+pub struct SharedBatchId(Uuid);
+
+impl SharedBatchId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+/// A struct from which to obtain a [SharedBatchBuilder].
+#[derive(Debug, Clone)]
+pub struct SharedBatches {
+    data: Arc<std::sync::Mutex<(usize, BTreeMap<SharedBatchId, Weak<BatchState>>)>>,
+}
+
+fn upgrade_or_init<T>(weak: &mut Weak<T>, init: impl FnOnce() -> T) -> Arc<T> {
+    if let Some(owned) = weak.upgrade() {
+        owned
+    } else {
+        let owned = Arc::new(init());
+        *weak = Arc::downgrade(&owned);
+        owned
+    }
+}
+
+impl SharedBatches {
+    pub fn new() -> Self {
+        Self {
+            data: Arc::default(),
+        }
+    }
+
+    /// Get a builder for the specified batch. If there is an existing, live builder for the same
+    /// batch id managed by [Self], any parts added to this builder will be included in the same,
+    /// shared batch; if not, a new batch will be created.
+    ///
+    /// This is designed so that, in a multi-worker dataflow, workers that are building the same batch
+    /// at the same time can write fewer, larger parts instead of many small ones. It does not guarantee
+    /// that there will be _precisely_ one batch across all workers, however.
+    ///
+    /// The batch's description is fixed by whichever caller creates it, so every caller sharing a
+    /// `shared_batch_id` must pass the same `shard_id`, `lower`, and `upper`. Callers derive them
+    /// from a single broadcast description, and the assertions below hold them to it: a caller
+    /// whose description disagreed would otherwise have its updates silently written under someone
+    /// else's bounds.
+    pub fn builder(
+        &self,
+        shared_batch_id: SharedBatchId,
+        client: PersistClient,
+        shard_id: ShardId,
+        shard_name: String,
+        schemas: Schemas<SourceData, ()>,
+        lower: Antichain<Timestamp>,
+        upper: Antichain<Timestamp>,
+    ) -> SharedBatchBuilder {
+        let mut guard = self.data.lock().unwrap();
+        let (last_retained_len, state_map) = &mut *guard;
+        // We clean out entries from the map where all shared batch handles have been dropped.
+        // Amortize by only scanning the map once it's doubled in size.
+        if state_map.len() > *last_retained_len * 2 {
+            // Probe the count rather than `upgrade()`: the temporary strong reference an upgrade
+            // creates can make a concurrent `SharedBatchBuilder::finish` see a strong count above
+            // one and hand the batch to nobody, which seals the interval with no data. A stale
+            // count is harmless in both directions, since zero cannot become live again and a
+            // stale non-zero only keeps a dead entry until the next sweep.
+            state_map.retain(|_, weak| weak.strong_count() > 0);
+            *last_retained_len = state_map.len();
+        }
+        let weak = state_map.entry(shared_batch_id).or_default();
+        let desc = BatchDesc {
+            shard_id,
+            lower: lower.clone(),
+            upper: upper.clone(),
+        };
+        let state = upgrade_or_init(weak, || {
+            let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+            let task_id = format!("shared-batch-{shared_batch_id:?}-{shard_id}",);
+            BatchState {
+                desc: desc.clone(),
+                tx,
+                handle: mz_ore::task::spawn(|| task_id, async move {
+                    let mut builder = None;
+                    while let Some(cmd) = rx.recv().await {
+                        match cmd {
+                            BatchCommand::Push(part) => {
+                                let builder = builder.get_or_insert_with(|| {
+                                    client.batch_builder(
+                                        shard_id,
+                                        &shard_name,
+                                        schemas.clone(),
+                                        lower.clone(),
+                                        None,
+                                    )
+                                });
+                                builder.add_part(part).await.expect("valid timestamps");
+                            }
+                        }
+                    }
+                    if let Some(builder) = builder {
+                        Some(builder.finish(upper).await.expect("valid upper bound"))
+                    } else {
+                        None
+                    }
+                }),
+            }
+        });
+
+        assert_eq!(
+            state.desc, desc,
+            "shared batch {shared_batch_id:?} requested with conflicting descriptions",
+        );
+
+        SharedBatchBuilder {
+            batch_id: shared_batch_id,
+            shard_id,
+            state,
+        }
+    }
+}
+
+/// The bounds a shared batch is built under, fixed by the caller that creates it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BatchDesc {
+    shard_id: ShardId,
+    lower: Antichain<Timestamp>,
+    upper: Antichain<Timestamp>,
+}
+
+enum BatchCommand {
+    Push(Part),
+}
+
+#[derive(Debug)]
+struct BatchState {
+    desc: BatchDesc,
+    tx: tokio::sync::mpsc::Sender<BatchCommand>,
+    handle: JoinHandle<Option<Batch<SourceData, (), Timestamp, StorageDiff>>>,
+}
+
+/// A handle for a shared batch builder. Everyone with a handle for the same builder can
+/// [Self::push] to that builder, but the last handle to call [Self::finish] will receive a batch
+/// containing all the data.
+///
+/// Note that it's quite important to call [Self::finish], even if you haven't pushed anything
+/// into the batch, in case you're holding the last builder for a shared batch.
+///
+/// Dropping the last handle instead still completes the batch, but hands it to nobody, so its
+/// parts stay in blob until persist's leaked-blob cleanup collects them. That is the teardown
+/// path, not a path any caller should take deliberately.
+pub struct SharedBatchBuilder {
+    batch_id: SharedBatchId,
+    shard_id: ShardId,
+    state: Arc<BatchState>,
+}
+
+impl Debug for SharedBatchBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedBatchBuilder")
+            .field("batch_id", &self.batch_id)
+            .field("shard_id", &self.shard_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SharedBatchBuilder {
+    /// Include the provided part in the batch. If there are a large number of updates that have
+    /// not been flushed to S3, this call may wait.
+    pub async fn push(&self, part: Part) {
+        if part.len() == 0 {
+            return;
+        }
+        self.state
+            .tx
+            .send(BatchCommand::Push(part))
+            .await
+            .expect("task failed");
+    }
+
+    /// Fetch the results of the batch builder from the shared state, if any.
+    ///
+    /// Only the last builder to call this method will obtain the resulting batch, and that batch
+    /// will include all data written by all workers.
+    /// This means that, for any batch interval that we actually want to append, all workers
+    /// must call finish even if they did not push any batches themselves.
+    pub async fn finish(self) -> Option<Batch<SourceData, (), Timestamp, StorageDiff>> {
+        let state = Arc::into_inner(self.state)?;
+        drop(state.tx); // The task only finishes the batch once the channel is closed.
+        state.handle.await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mz_persist_types::codec_impls::UnitSchema;
+    use mz_persist_types::part::PartBuilder;
+    use mz_repr::{Datum, RelationDesc, Row, SqlScalarType};
+
+    fn bool_schemas() -> Schemas<SourceData, ()> {
+        Schemas {
+            id: None,
+            key: Arc::new(
+                RelationDesc::builder()
+                    .with_column("test", SqlScalarType::Bool.nullable(true))
+                    .finish(),
+            ),
+            val: Arc::new(UnitSchema),
+        }
+    }
+
+    fn bool_part(schemas: &Schemas<SourceData, ()>) -> Part {
+        let mut builder = PartBuilder::new(&*schemas.key, &*schemas.val);
+        builder.push(
+            &SourceData(Ok(Row::pack_slice(&[Datum::True]))),
+            &(),
+            Timestamp::new(0),
+            1i64,
+        );
+        builder.finish()
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn test_shared_batch() {
+        let client = PersistClient::new_for_tests().await;
+        let shared = SharedBatches::new();
+        let batch_id = SharedBatchId::new();
+        let shard_id = ShardId::new();
+        let schemas = bool_schemas();
+        let lower = Antichain::from_elem(0.into());
+        let upper = Antichain::from_elem(1.into());
+        let first = shared.builder(
+            batch_id,
+            client.clone(),
+            shard_id,
+            "test".to_string(),
+            schemas.clone(),
+            lower.clone(),
+            upper.clone(),
+        );
+        let second = shared.builder(
+            batch_id,
+            client,
+            shard_id,
+            "test".to_string(),
+            schemas.clone(),
+            lower.clone(),
+            upper.clone(),
+        );
+        let part = bool_part(&schemas);
+        first.push(part.clone()).await;
+        second.push(part.clone()).await;
+        assert!(
+            second.finish().await.is_none(),
+            "a handle that is not the last to finish receives no batch"
+        );
+        let batch = first.finish().await.unwrap();
+        assert_eq!(
+            batch.shard_id(),
+            shard_id,
+            "batch should be for the expected shard"
+        );
+        assert_eq!(
+            batch.into_hollow_batch().len,
+            2,
+            "batch should include updates from both pushes"
+        )
+    }
+}

--- a/test/testdrive/mv-sink-shared-batches.td
+++ b/test/testdrive/mv-sink-shared-batches.td
@@ -1,0 +1,81 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Coalesced ("shared") batch writing in the MV sink must produce results that
+# are identical to the per-worker path. Exercise it across multiple workers in
+# a single process, with churn (retractions and inserts), and assert that the
+# materialized view always equals the equivalent one-shot aggregation.
+
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET enable_compute_sync_mv_sink_shared_batches = true
+
+# Multiple workers in one process, so the sink coalesces their parts.
+> CREATE CLUSTER shared_batches SIZE 'scale=1,workers=4'
+
+> SET cluster = shared_batches
+
+> CREATE TABLE t (k bigint, v bigint)
+
+> INSERT INTO t SELECT x, x * 10 FROM generate_series(1, 20000) x
+
+> CREATE MATERIALIZED VIEW mv AS
+  SELECT k % 256 AS bucket, count(*) AS cnt, sum(v) AS s
+  FROM t
+  GROUP BY k % 256
+
+> SELECT count(*) FROM mv
+256
+
+# The view must equal the one-shot aggregation. Both directions of the
+# difference must be empty.
+> (SELECT k % 256, count(*), sum(v) FROM t GROUP BY k % 256)
+  EXCEPT ALL
+  (SELECT bucket, cnt, s FROM mv)
+
+> (SELECT bucket, cnt, s FROM mv)
+  EXCEPT ALL
+  (SELECT k % 256, count(*), sum(v) FROM t GROUP BY k % 256)
+
+# Churn: retract half the rows and insert new keys. This spreads updates across
+# all four workers within a single batch interval, which is what the shared
+# batch coalesces.
+> DELETE FROM t WHERE k % 2 = 0
+
+> INSERT INTO t SELECT x, x * 10 FROM generate_series(20001, 35000) x
+
+> (SELECT k % 256, count(*), sum(v) FROM t GROUP BY k % 256)
+  EXCEPT ALL
+  (SELECT bucket, cnt, s FROM mv)
+
+> (SELECT bucket, cnt, s FROM mv)
+  EXCEPT ALL
+  (SELECT k % 256, count(*), sum(v) FROM t GROUP BY k % 256)
+
+# Odd k in 1..20000 (10000 rows) plus 20001..35000 (15000 rows).
+> SELECT sum(cnt) FROM mv
+25000
+
+# A write with no net change must not corrupt the view. Workers that end up
+# with no data for the interval must still finish their shared batch, since any
+# one of them may be the last holder responsible for delivering the batch.
+> DELETE FROM t WHERE false
+
+> (SELECT bucket, cnt, s FROM mv)
+  EXCEPT ALL
+  (SELECT k % 256, count(*), sum(v) FROM t GROUP BY k % 256)
+
+> DROP MATERIALIZED VIEW mv
+> DROP TABLE t
+> SET cluster = quickstart
+> DROP CLUSTER shared_batches
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM RESET enable_compute_sync_mv_sink_shared_batches


### PR DESCRIPTION
Continues #35411 (draft by @bkirwi), rebased onto `main`.

With many workers each MV sink worker writes its own small batch per interval, so the sink emits many small parts and a large consensus state diff. This coalesces the parts the workers in one process write for a batch interval into a single, larger shared batch.

`SharedBatches` hands out a `SharedBatchBuilder` per batch id; handles for the same id feed one process-global builder task, and the last handle to finish receives the batch. The sync (v2) sink is wired to it, best-effort and default off (`enable_compute_sync_mv_sink_shared_batches`). On an 8-worker replica this cut persist blob PUTs ~67% and consensus state-diff bytes ~54%, at unchanged consensus command count.

Best-effort means a worker only merges its part into the shared batch when its write overlaps the others still building in the same interval, so parts per append land around 1.4 rather than the ideal 1.0. The barrier that closes that gap to exactly 1.0 is split into the follow-up #37617.

The v1 sink is untouched apart from carrying a shared batch id on `BatchDescription`. @bkirwi's draft also rewired v1 onto the shared builder, but that path is the default sink and the rewiring is not flag-gated, so it is left out here.

Original authorship by @bkirwi is preserved in the first commit.
