### PR TITLE
compute: reuse MonotonicTop1's output arrangement to elide redundant ArrangeBy

### DIFF
--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -942,7 +942,25 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 } else {
                     input
                 };
-                // Return the plan, and no arrangements.
+                // Return the plan, and the keys it produces. `MonotonicTop1` arranges its
+                // output by the group key (see `render_top1_monotonic`), so a downstream
+                // consumer keyed the same way can reuse that arrangement instead of forcing
+                // another `ArrangeBy`.
+                let out_keys = match &top_k_plan {
+                    TopKPlan::MonotonicTop1(_) => {
+                        let key = group_key
+                            .iter()
+                            .map(|c| LirScalarExpr::column(*c))
+                            .collect::<Vec<_>>();
+                        let (permutation, thinning) = permutation_for_arrangement(&key, arity);
+                        AvailableCollections::new_arranged(vec![(key, permutation, thinning)])
+                    }
+                    // MonotonicTopK / Basic key their arrangements by (hash, group_key), which is
+                    // not reusable by a group-key consumer, so they advertise no arrangement.
+                    TopKPlan::MonotonicTopK(_) | TopKPlan::Basic(_) => {
+                        AvailableCollections::new_raw()
+                    }
+                };
                 let temporal_bucketing_strategy = strategy_from_future(input_future);
                 let lir_id = self.allocate_lir_id();
                 LoweredExpr {
@@ -952,7 +970,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                         temporal_bucketing_strategy,
                     }
                     .as_plan(lir_id),
-                    keys: AvailableCollections::new_raw(),
+                    keys: out_keys,
                     has_future_updates: false,
                 }
             }

--- a/src/compute-types/src/plan/top_k.rs
+++ b/src/compute-types/src/plan/top_k.rs
@@ -63,7 +63,6 @@ impl TopKPlan {
                 order_key,
                 arity,
                 must_consolidate: false,
-                arranged: true,
             })
         } else if monotonic && offset == 0 {
             // For monotonic inputs, we are able to retract inputs that can no longer be produced
@@ -106,10 +105,6 @@ impl TopKPlan {
                             order_key: plan.order_key.clone(),
                             arity: plan.arity,
                             must_consolidate,
-                            // Lowering already computed `AvailableCollections` for the
-                            // `Basic` plan being upgraded here, so it never advertised
-                            // this arrangement.
-                            arranged: false,
                         })
                     } else {
                         TopKPlan::MonotonicTopK(MonotonicTopKPlan {
@@ -139,7 +134,6 @@ impl TopKPlan {
                 order_key: _,
                 arity: _,
                 must_consolidate: _,
-                arranged: _,
             }) => None,
             TopKPlan::MonotonicTopK(MonotonicTopKPlan {
                 limit,
@@ -191,14 +185,6 @@ pub struct MonotonicTop1Plan {
     ///
     /// [^1]: <https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230421_stabilize_monotonic_select.md>
     pub must_consolidate: bool,
-    /// Whether lowering advertised this plan's output as the group-key arrangement it
-    /// builds. `true` when this plan was chosen by `create_from` before lowering computed
-    /// `AvailableCollections` (the only case lowering advertises). `false` when
-    /// `TopKPlan::as_monotonic` upgraded a `Basic` plan to `MonotonicTop1` after lowering,
-    /// since the advertisement is not recomputed on upgrade. Render uses this to decide
-    /// whether to deliver the arrangement alone or reconstruct and deliver the raw
-    /// collection instead.
-    pub arranged: bool,
 }
 
 /// A plan for monotonic TopKs with an offset of 0 and an arbitrary limit.

--- a/src/compute-types/src/plan/top_k.rs
+++ b/src/compute-types/src/plan/top_k.rs
@@ -61,6 +61,7 @@ impl TopKPlan {
             TopKPlan::MonotonicTop1(MonotonicTop1Plan {
                 group_key,
                 order_key,
+                arity,
                 must_consolidate: false,
             })
         } else if monotonic && offset == 0 {
@@ -102,6 +103,7 @@ impl TopKPlan {
                         TopKPlan::MonotonicTop1(MonotonicTop1Plan {
                             group_key: plan.group_key.clone(),
                             order_key: plan.order_key.clone(),
+                            arity: plan.arity,
                             must_consolidate,
                         })
                     } else {
@@ -130,6 +132,7 @@ impl TopKPlan {
             TopKPlan::MonotonicTop1(MonotonicTop1Plan {
                 group_key: _,
                 order_key: _,
+                arity: _,
                 must_consolidate: _,
             }) => None,
             TopKPlan::MonotonicTopK(MonotonicTopKPlan {
@@ -172,6 +175,8 @@ pub struct MonotonicTop1Plan {
     pub group_key: Vec<usize>,
     /// Ordering that is used within each group.
     pub order_key: Vec<mz_expr::ColumnOrder>,
+    /// The number of columns in the input (equal to the output arity).
+    pub arity: usize,
     /// True if the input is not physically monotonic, and the operator must perform
     /// consolidation to remove potential negations. The operator implementation is
     /// free to consolidate as late as possible while ensuring correctness, so it is

--- a/src/compute-types/src/plan/top_k.rs
+++ b/src/compute-types/src/plan/top_k.rs
@@ -63,6 +63,7 @@ impl TopKPlan {
                 order_key,
                 arity,
                 must_consolidate: false,
+                arranged: true,
             })
         } else if monotonic && offset == 0 {
             // For monotonic inputs, we are able to retract inputs that can no longer be produced
@@ -105,6 +106,10 @@ impl TopKPlan {
                             order_key: plan.order_key.clone(),
                             arity: plan.arity,
                             must_consolidate,
+                            // Lowering already computed `AvailableCollections` for the
+                            // `Basic` plan being upgraded here, so it never advertised
+                            // this arrangement.
+                            arranged: false,
                         })
                     } else {
                         TopKPlan::MonotonicTopK(MonotonicTopKPlan {
@@ -134,6 +139,7 @@ impl TopKPlan {
                 order_key: _,
                 arity: _,
                 must_consolidate: _,
+                arranged: _,
             }) => None,
             TopKPlan::MonotonicTopK(MonotonicTopKPlan {
                 limit,
@@ -185,6 +191,14 @@ pub struct MonotonicTop1Plan {
     ///
     /// [^1]: <https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230421_stabilize_monotonic_select.md>
     pub must_consolidate: bool,
+    /// Whether lowering advertised this plan's output as the group-key arrangement it
+    /// builds. `true` when this plan was chosen by `create_from` before lowering computed
+    /// `AvailableCollections` (the only case lowering advertises). `false` when
+    /// `TopKPlan::as_monotonic` upgraded a `Basic` plan to `MonotonicTop1` after lowering,
+    /// since the advertisement is not recomputed on upgrade. Render uses this to decide
+    /// whether to deliver the arrangement alone or reconstruct and deliver the raw
+    /// collection instead.
+    pub arranged: bool,
 }
 
 /// A plan for monotonic TopKs with an offset of 0 and an arbitrary limit.

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -157,6 +157,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     group_key,
                     order_key,
                     must_consolidate,
+                    ..
                 }) => {
                     let (oks, errs) = self.render_top1_monotonic(
                         ok_input,

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -169,15 +169,6 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     );
                     err_collection = err_collection.concat(errs);
 
-                    // The arrangement is keyed by the arbitrary column set `group_key` (not a
-                    // `0..k` prefix), with the value thinned to `thinning`; `permutation` maps
-                    // the concatenation of key and value back to the original column order.
-                    let key: Vec<LirScalarExpr> = group_key
-                        .iter()
-                        .map(|c| LirScalarExpr::column(*c))
-                        .collect();
-                    let (permutation, _thinning) = permutation_for_arrangement(&key, arity);
-
                     if arranged {
                         // Lowering advertised this arrangement (see the `MirRelationExpr::TopK`
                         // arm in `lowering.rs`), so a downstream consumer keyed on `group_key`
@@ -200,8 +191,16 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                         // after lowering computed `AvailableCollections`, so the advertisement
                         // was never updated and consumers still expect `bundle.collection` to
                         // be populated directly. Reconstruct the raw collection from the
-                        // arrangement, applying `permutation` to recover the original column
-                        // order, and deliver it without an arrangement.
+                        // arrangement, which is keyed by the arbitrary column set `group_key`
+                        // (not a `0..k` prefix) with the value thinned to `thinning`.
+                        // `permutation` maps the concatenation of key and value back to the
+                        // original column order.
+                        let key: Vec<LirScalarExpr> = group_key
+                            .iter()
+                            .map(|c| LirScalarExpr::column(*c))
+                            .collect();
+                        let (permutation, _thinning) = permutation_for_arrangement(&key, arity);
+
                         let mut datums = mz_repr::DatumVec::new();
                         let oks = arrangement.as_collection(move |k: DatumSeq, v: DatumSeq| {
                             let temp_storage = mz_repr::RowArena::new();

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -158,6 +158,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     order_key,
                     arity,
                     must_consolidate,
+                    arranged,
                 }) => {
                     let (arrangement, errs) = self.render_top1_monotonic(
                         ok_input,
@@ -168,54 +169,49 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     );
                     err_collection = err_collection.concat(errs);
 
-                    // Build the group-key-keyed arrangement flavor that lowering advertises (see
-                    // the `MirRelationExpr::TopK` arm in `lowering.rs`), mirroring
-                    // `render_reduce_plan`'s `ArrangementFlavor::Local`. The key is the arbitrary
-                    // column set `group_key` (not a `0..k` prefix), and the arrangement value is
-                    // the winning row thinned to `thinning`.
+                    // The arrangement is keyed by the arbitrary column set `group_key` (not a
+                    // `0..k` prefix), with the value thinned to `thinning`; `permutation` maps
+                    // the concatenation of key and value back to the original column order.
                     let key: Vec<LirScalarExpr> = group_key
                         .iter()
                         .map(|c| LirScalarExpr::column(*c))
                         .collect();
                     let (permutation, _thinning) = permutation_for_arrangement(&key, arity);
-                    let errs: KeyCollection<_, _, _> = err_collection.clone().into();
-                    let err_arrangement = errs
-                        .mz_arrange::<ColumnationChunker<_>, ErrBatcher<_, _>, ErrBuilder<_, _>, _>(
-                            "Arrange bundle err",
-                        );
-                    let flavor = ArrangementFlavor::Local(arrangement.clone(), err_arrangement);
 
-                    // Reconstruct the raw collection from the arrangement too. Lowering's
-                    // advertisement is trustworthy only when the MIR-level monotonicity analysis
-                    // already picked `MonotonicTop1` before lowering ran: `TopKPlan::as_monotonic`
-                    // can also *upgrade* a `Basic` plan into `MonotonicTop1` after lowering, for
-                    // single-time (one-shot SELECT) dataflows (see
-                    // `LirRelationExpr::refine_single_time_operator_selection`). In that case
-                    // lowering advertised `raw` (since the plan was still `Basic` when the
-                    // `AvailableCollections` were computed), so any consumer of this node's output
-                    // still expects `bundle.collection` to be populated directly, without going
-                    // through `ensure_collections`. Unlike `Reduce::keys()` (which advertises the
-                    // same group-key arrangement for every `Hierarchical` sub-variant, so its
-                    // arrangement-only bundle is always consistent with what lowering promised),
-                    // `TopK`'s `Basic`/`MonotonicTopK` variants don't produce a group-key
-                    // arrangement at all. So we can't tell, from here, whether we're in the
-                    // advertised or the upgraded case, and must always supply the raw collection
-                    // to avoid violating the `keys.raw <= collection.collection.is_some()`
-                    // invariant checked at render time. `Reduce`'s key is a `0..k` prefix, so the
-                    // concat of key and value already yields the logical row; here `group_key` is
-                    // arbitrary, so we apply `permutation` to recover the original column order.
-                    let mut datums = mz_repr::DatumVec::new();
-                    let oks = arrangement.as_collection(move |k: DatumSeq, v: DatumSeq| {
-                        let temp_storage = mz_repr::RowArena::new();
-                        let mut datums_borrow = datums.borrow();
-                        k.extend_datums(&temp_storage, &mut datums_borrow, None);
-                        v.extend_datums(&temp_storage, &mut datums_borrow, None);
-                        SharedRow::pack(permutation.iter().map(|i| datums_borrow[*i]))
-                    });
-
-                    let mut bundle = CollectionBundle::from_collections(oks, err_collection);
-                    bundle.arranged.insert(key, flavor);
-                    bundle
+                    if arranged {
+                        // Lowering advertised this arrangement (see the `MirRelationExpr::TopK`
+                        // arm in `lowering.rs`), so a downstream consumer keyed on `group_key`
+                        // may rely on it existing without a `collection` fallback. Deliver the
+                        // arrangement alone, mirroring `render_reduce_plan`'s
+                        // `ArrangementFlavor::Local`.
+                        let errs: KeyCollection<_, _, _> = err_collection.clone().into();
+                        let err_arrangement = errs.mz_arrange::<
+                            ColumnationChunker<_>,
+                            ErrBatcher<_, _>,
+                            ErrBuilder<_, _>,
+                            _,
+                        >("Arrange bundle err");
+                        CollectionBundle::from_columns(
+                            group_key.iter().copied(),
+                            ArrangementFlavor::Local(arrangement, err_arrangement),
+                        )
+                    } else {
+                        // `TopKPlan::as_monotonic` upgraded a `Basic` plan to `MonotonicTop1`
+                        // after lowering computed `AvailableCollections`, so the advertisement
+                        // was never updated and consumers still expect `bundle.collection` to
+                        // be populated directly. Reconstruct the raw collection from the
+                        // arrangement, applying `permutation` to recover the original column
+                        // order, and deliver it without an arrangement.
+                        let mut datums = mz_repr::DatumVec::new();
+                        let oks = arrangement.as_collection(move |k: DatumSeq, v: DatumSeq| {
+                            let temp_storage = mz_repr::RowArena::new();
+                            let mut datums_borrow = datums.borrow();
+                            k.extend_datums(&temp_storage, &mut datums_borrow, None);
+                            v.extend_datums(&temp_storage, &mut datums_borrow, None);
+                            SharedRow::pack(permutation.iter().map(|i| datums_borrow[*i]))
+                        });
+                        CollectionBundle::from_collections(oks, err_collection)
+                    }
                 }
                 TopKPlan::MonotonicTopK(MonotonicTopKPlan {
                     order_key,

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -168,10 +168,11 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     );
                     err_collection = err_collection.concat(errs);
 
-                    // Build the group-key-keyed arrangement flavor that Task 3 will advertise via
-                    // lowering, mirroring `render_reduce_plan`'s `ArrangementFlavor::Local`. The
-                    // key is the arbitrary column set `group_key` (not a `0..k` prefix), and the
-                    // arrangement value is the winning row thinned to `thinning`.
+                    // Build the group-key-keyed arrangement flavor that lowering advertises (see
+                    // the `MirRelationExpr::TopK` arm in `lowering.rs`), mirroring
+                    // `render_reduce_plan`'s `ArrangementFlavor::Local`. The key is the arbitrary
+                    // column set `group_key` (not a `0..k` prefix), and the arrangement value is
+                    // the winning row thinned to `thinning`.
                     let key: Vec<LirScalarExpr> = group_key
                         .iter()
                         .map(|c| LirScalarExpr::column(*c))
@@ -184,13 +185,25 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                         );
                     let flavor = ArrangementFlavor::Local(arrangement.clone(), err_arrangement);
 
-                    // Reconstruct the raw collection from the arrangement so consumers planned
-                    // before the arrangement is advertised (i.e. any `input_key = None` reader,
-                    // such as a `Reduce` over a `DISTINCT ON`) still find a collection. `Reduce`
-                    // can be arrangement-only because its key is a `0..k` prefix, so the concat of
-                    // key and value already yields the logical row. Here `group_key` is arbitrary,
-                    // so we apply `permutation` to recover the original column order. Task 3 flips
-                    // consumers to the arrangement and can then drop this reconstruction.
+                    // Reconstruct the raw collection from the arrangement too. Lowering's
+                    // advertisement is trustworthy only when the MIR-level monotonicity analysis
+                    // already picked `MonotonicTop1` before lowering ran: `TopKPlan::as_monotonic`
+                    // can also *upgrade* a `Basic` plan into `MonotonicTop1` after lowering, for
+                    // single-time (one-shot SELECT) dataflows (see
+                    // `LirRelationExpr::refine_single_time_operator_selection`). In that case
+                    // lowering advertised `raw` (since the plan was still `Basic` when the
+                    // `AvailableCollections` were computed), so any consumer of this node's output
+                    // still expects `bundle.collection` to be populated directly, without going
+                    // through `ensure_collections`. Unlike `Reduce::keys()` (which advertises the
+                    // same group-key arrangement for every `Hierarchical` sub-variant, so its
+                    // arrangement-only bundle is always consistent with what lowering promised),
+                    // `TopK`'s `Basic`/`MonotonicTopK` variants don't produce a group-key
+                    // arrangement at all. So we can't tell, from here, whether we're in the
+                    // advertised or the upgraded case, and must always supply the raw collection
+                    // to avoid violating the `keys.raw <= collection.collection.is_some()`
+                    // invariant checked at render time. `Reduce`'s key is a `0..k` prefix, so the
+                    // concat of key and value already yields the logical row; here `group_key` is
+                    // arbitrary, so we apply `permutation` to recover the original column order.
                     let mut datums = mz_repr::DatumVec::new();
                     let oks = arrangement.as_collection(move |k: DatumSeq, v: DatumSeq| {
                         let temp_storage = mz_repr::RowArena::new();

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -158,7 +158,6 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     order_key,
                     arity,
                     must_consolidate,
-                    arranged,
                 }) => {
                     let (arrangement, errs) = self.render_top1_monotonic(
                         ok_input,
@@ -169,48 +168,20 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     );
                     err_collection = err_collection.concat(errs);
 
-                    if arranged {
-                        // Lowering advertised this arrangement (see the `MirRelationExpr::TopK`
-                        // arm in `lowering.rs`), so a downstream consumer keyed on `group_key`
-                        // may rely on it existing without a `collection` fallback. Deliver the
-                        // arrangement alone, mirroring `render_reduce_plan`'s
-                        // `ArrangementFlavor::Local`.
-                        let errs: KeyCollection<_, _, _> = err_collection.clone().into();
-                        let err_arrangement = errs.mz_arrange::<
-                            ColumnationChunker<_>,
-                            ErrBatcher<_, _>,
-                            ErrBuilder<_, _>,
-                            _,
-                        >("Arrange bundle err");
-                        CollectionBundle::from_columns(
-                            group_key.iter().copied(),
-                            ArrangementFlavor::Local(arrangement, err_arrangement),
-                        )
-                    } else {
-                        // `TopKPlan::as_monotonic` upgraded a `Basic` plan to `MonotonicTop1`
-                        // after lowering computed `AvailableCollections`, so the advertisement
-                        // was never updated and consumers still expect `bundle.collection` to
-                        // be populated directly. Reconstruct the raw collection from the
-                        // arrangement, which is keyed by the arbitrary column set `group_key`
-                        // (not a `0..k` prefix) with the value thinned to `thinning`.
-                        // `permutation` maps the concatenation of key and value back to the
-                        // original column order.
-                        let key: Vec<LirScalarExpr> = group_key
-                            .iter()
-                            .map(|c| LirScalarExpr::column(*c))
-                            .collect();
-                        let (permutation, _thinning) = permutation_for_arrangement(&key, arity);
-
-                        let mut datums = mz_repr::DatumVec::new();
-                        let oks = arrangement.as_collection(move |k: DatumSeq, v: DatumSeq| {
-                            let temp_storage = mz_repr::RowArena::new();
-                            let mut datums_borrow = datums.borrow();
-                            k.extend_datums(&temp_storage, &mut datums_borrow, None);
-                            v.extend_datums(&temp_storage, &mut datums_borrow, None);
-                            SharedRow::pack(permutation.iter().map(|i| datums_borrow[*i]))
-                        });
-                        CollectionBundle::from_collections(oks, err_collection)
-                    }
+                    // Lowering advertises this group-key arrangement (see the
+                    // `MirRelationExpr::TopK` arm in `lowering.rs`), so deliver it alone,
+                    // mirroring `render_reduce_plan`'s `ArrangementFlavor::Local`. A consumer
+                    // that needs the raw collection reconstructs it from the arrangement via
+                    // the advertised permutation, exactly as for an index arrangement.
+                    let errs: KeyCollection<_, _, _> = err_collection.clone().into();
+                    let err_arrangement = errs
+                        .mz_arrange::<ColumnationChunker<_>, ErrBatcher<_, _>, ErrBuilder<_, _>, _>(
+                            "Arrange bundle err",
+                        );
+                    CollectionBundle::from_columns(
+                        group_key.iter().copied(),
+                        ArrangementFlavor::Local(arrangement, err_arrangement),
+                    )
                 }
                 TopKPlan::MonotonicTopK(MonotonicTopKPlan {
                     order_key,

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -30,7 +30,7 @@ use mz_compute_types::plan::top_k::{
     BasicTopKPlan, MonotonicTop1Plan, MonotonicTopKPlan, TopKPlan,
 };
 use mz_expr::func::CastUint64ToInt64;
-use mz_expr::{BinaryFunc, Columns, Eval, EvalError, UnaryFunc, func};
+use mz_expr::{BinaryFunc, Columns, Eval, EvalError, UnaryFunc, func, permutation_for_arrangement};
 use mz_ore::cast::CastFrom;
 use mz_ore::soft_assert_or_log;
 use mz_repr::fixed_length::ExtendDatums;
@@ -45,10 +45,10 @@ use timely::dataflow::operators::Operator;
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::{ClearContainer, MzReduce};
 use crate::render::Pairer;
-use crate::render::context::{CollectionBundle, Context};
+use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::render::errors::MaybeValidatingRow;
-use crate::typedefs::{KeyBatcher, MzTimestamp, RowRowSpine, RowSpine};
+use crate::typedefs::{ErrBatcher, ErrBuilder, KeyBatcher, MzTimestamp, RowRowSpine, RowSpine};
 use mz_row_spine::{
     DatumSeq, RowBatcher, RowBuilder, RowRowBatcher, RowRowBuilder, RowValBuilder, RowValSpine,
 };
@@ -114,7 +114,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
 
         // We create a new region to compartmentalize the topk logic.
         let outer_scope = ok_input.scope();
-        let (ok_result, err_collection) = outer_scope.clone().region_named("TopK", |inner| {
+        let bundle = outer_scope.clone().region_named("TopK", |inner| {
             let ok_input = ok_input.enter_region(inner);
             let mut err_collection = err_input.enter_region(inner);
 
@@ -152,21 +152,57 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                 }
             }
 
-            let ok_result = match top_k_plan {
+            let bundle = match top_k_plan {
                 TopKPlan::MonotonicTop1(MonotonicTop1Plan {
                     group_key,
                     order_key,
+                    arity,
                     must_consolidate,
-                    ..
                 }) => {
-                    let (oks, errs) = self.render_top1_monotonic(
+                    let (arrangement, errs) = self.render_top1_monotonic(
                         ok_input,
-                        group_key,
+                        group_key.clone(),
                         order_key,
+                        arity,
                         must_consolidate,
                     );
                     err_collection = err_collection.concat(errs);
-                    oks
+
+                    // Build the group-key-keyed arrangement flavor that Task 3 will advertise via
+                    // lowering, mirroring `render_reduce_plan`'s `ArrangementFlavor::Local`. The
+                    // key is the arbitrary column set `group_key` (not a `0..k` prefix), and the
+                    // arrangement value is the winning row thinned to `thinning`.
+                    let key: Vec<LirScalarExpr> = group_key
+                        .iter()
+                        .map(|c| LirScalarExpr::column(*c))
+                        .collect();
+                    let (permutation, _thinning) = permutation_for_arrangement(&key, arity);
+                    let errs: KeyCollection<_, _, _> = err_collection.clone().into();
+                    let err_arrangement = errs
+                        .mz_arrange::<ColumnationChunker<_>, ErrBatcher<_, _>, ErrBuilder<_, _>, _>(
+                            "Arrange bundle err",
+                        );
+                    let flavor = ArrangementFlavor::Local(arrangement.clone(), err_arrangement);
+
+                    // Reconstruct the raw collection from the arrangement so consumers planned
+                    // before the arrangement is advertised (i.e. any `input_key = None` reader,
+                    // such as a `Reduce` over a `DISTINCT ON`) still find a collection. `Reduce`
+                    // can be arrangement-only because its key is a `0..k` prefix, so the concat of
+                    // key and value already yields the logical row. Here `group_key` is arbitrary,
+                    // so we apply `permutation` to recover the original column order. Task 3 flips
+                    // consumers to the arrangement and can then drop this reconstruction.
+                    let mut datums = mz_repr::DatumVec::new();
+                    let oks = arrangement.as_collection(move |k: DatumSeq, v: DatumSeq| {
+                        let temp_storage = mz_repr::RowArena::new();
+                        let mut datums_borrow = datums.borrow();
+                        k.extend_datums(&temp_storage, &mut datums_borrow, None);
+                        v.extend_datums(&temp_storage, &mut datums_borrow, None);
+                        SharedRow::pack(permutation.iter().map(|i| datums_borrow[*i]))
+                    });
+
+                    let mut bundle = CollectionBundle::from_collections(oks, err_collection);
+                    bundle.arranged.insert(key, flavor);
+                    bundle
                 }
                 TopKPlan::MonotonicTopK(MonotonicTopKPlan {
                     order_key,
@@ -265,7 +301,10 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                         "requested no validation, but received error collection"
                     );
 
-                    result.map(|(_key_hash, row)| row)
+                    CollectionBundle::from_collections(
+                        result.map(|(_key_hash, row)| row),
+                        err_collection,
+                    )
                 }
                 TopKPlan::Basic(BasicTopKPlan {
                     group_key,
@@ -288,18 +327,15 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                         ok_input, group_key, order_key, offset, limit, arity, buckets,
                     );
                     err_collection = err_collection.concat(errs);
-                    oks
+                    CollectionBundle::from_collections(oks, err_collection)
                 }
             };
 
             // Extract the results from the region.
-            (
-                ok_result.leave_region(outer_scope),
-                err_collection.leave_region(outer_scope),
-            )
+            bundle.leave_region(outer_scope)
         });
 
-        CollectionBundle::from_collections(ok_result, err_collection)
+        bundle
     }
 
     /// Constructs a TopK dataflow subgraph.
@@ -503,11 +539,24 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         collection: VecCollection<'s, T, Row, Diff>,
         group_key: Vec<usize>,
         order_key: Vec<mz_expr::ColumnOrder>,
+        arity: usize,
         must_consolidate: bool,
     ) -> (
-        VecCollection<'s, T, Row, Diff>,
+        Arranged<'s, TraceAgent<RowRowSpine<T, Diff>>>,
         VecCollection<'s, T, DataflowErrorSer, Diff>,
     ) {
+        // The arrangement we build below is keyed by `group_key` and its value is the winning
+        // row thinned to `thinning`, following the layout `permutation_for_arrangement`
+        // dictates for `Reduce`-style group-key arrangements. A top-1 winner's group-key
+        // columns equal the key by construction, so dropping them from the value is lossless;
+        // consumers reconstruct the full row from key and value via the (unused here)
+        // permutation.
+        let key: Vec<LirScalarExpr> = group_key
+            .iter()
+            .map(|c| LirScalarExpr::column(*c))
+            .collect();
+        let (_permutation, thinning) = permutation_for_arrangement(&key, arity);
+
         // We can place our rows directly into the diff field, and only keep the relevant one
         // corresponding to evaluating our aggregate, instead of having to do a hierarchical
         // reduction. We start by mapping the group key along with the row and consolidating
@@ -561,13 +610,17 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
             )
             .mz_reduce_abelian::<_, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
                 "MonotonicTop1",
-                move |_key, input, output| {
-                    let accum: &monoids::Top1Monoid = &input[0].1;
-                    output.push((accum.row.clone(), Diff::ONE));
+                {
+                    let mut datum_vec = mz_repr::DatumVec::new();
+                    move |_key, input, output| {
+                        let accum: &monoids::Top1Monoid = &input[0].1;
+                        let datums = datum_vec.borrow_with(&accum.row);
+                        let value = SharedRow::pack(thinning.iter().map(|i| datums[*i]));
+                        output.push((value, Diff::ONE));
+                    }
                 },
             );
-        // TODO(database-issues#2288): Here we discard the arranged output.
-        (result.as_collection(|_k, v| v.to_row()), errs)
+        (result, errs)
     }
 }
 

--- a/test/sqllogictest/catalog_server_explain.slt
+++ b/test/sqllogictest/catalog_server_explain.slt
@@ -7465,23 +7465,22 @@ query T multiline
 EXPLAIN SELECT * FROM "mz_internal"."mz_aws_privatelink_connection_statuses";
 ----
 Explained Query:
-  →Differential Join %0[#1{connection_id}] » %1:mz_connections[#0{id}]
-    →Arrange (#1{connection_id})
-      →Monotonic Top1
-        Group By #1
-        Order By #0 desc nulls_first
-        →Map/Filter/Project
-          Project: #5, #3, #4
-          Map: record_get[1](#1), record_get[1](#2), record_get[2](#2), record_get[0](#2)
-            →Fused with Child Map/Filter/Project
-              Filter: (record_get[1](#2)) IS NOT NULL AND ((#3) IS NULL OR (#3 != record_get[2](#2)))
-              Map: record_get[1](#1), record_get[0](#1)
-                →Fused with Child Table Function unnest_list
-                  →Non-incremental GroupAggregate
-                    Aggregation: lag[order_by=[#0 asc nulls_last]](row(row(row(#0, #1, #2), row(#2{status}, 1, null)), #0{occurred_at}))
-                  Key:
-                    Project: #1
-                  →Stream mz_internal.mz_aws_privatelink_connection_status_history
+  →Differential Join %0[#1] » %1:mz_connections[#0{id}]
+    →Monotonic Top1
+      Group By #1
+      Order By #0 desc nulls_first
+      →Map/Filter/Project
+        Project: #5, #3, #4
+        Map: record_get[1](#1), record_get[1](#2), record_get[2](#2), record_get[0](#2)
+          →Fused with Child Map/Filter/Project
+            Filter: (record_get[1](#2)) IS NOT NULL AND ((#3) IS NULL OR (#3 != record_get[2](#2)))
+            Map: record_get[1](#1), record_get[0](#1)
+              →Fused with Child Table Function unnest_list
+                →Non-incremental GroupAggregate
+                  Aggregation: lag[order_by=[#0 asc nulls_last]](row(row(row(#0, #1, #2), row(#2{status}, 1, null)), #0{occurred_at}))
+                Key:
+                  Project: #1
+                →Stream mz_internal.mz_aws_privatelink_connection_status_history
     →Arrange (#0{id})
       →Fused with Child Map/Filter/Project
         Project: #1, #3
@@ -18710,34 +18709,33 @@ Explained Query:
           →Fused with Parent Map/Filter/Project
             Project: #1, #0, #2..=#9
             →Arranged mz_internal.pg_authid_core
-        →Arrange (#0)
-          →Consolidating Monotonic Top1
-            Group By #0
-            →Union
-              →Fused with Child Map/Filter/Project
-                Project: #0, #1, #3
-                Filter: NOT(#2)
-                Map: null
-                  →Read l31
-              →Differential Join %1[#0] » %0:l32[#0]
-                after %0:
-                  Project: #0, #2, #3
-                  Map: coalesce(#1, false)
-                →Arrange (#0)
-                  →Stream l32
-                →Arrange (#0)
-                  →Union
-                    →Stream l50
-                    →Map/Filter/Project
-                      Project: #0, #1
-                      Map: null
-                        →Consolidating Union
-                          →Negate Diffs
-                            →Fused with Child Map/Filter/Project
-                              Project: #0
-                                →Read l50
-                          →Unarranged Raw Stream
-                            →Arranged l33
+        →Consolidating Monotonic Top1
+          Group By #0
+          →Union
+            →Fused with Child Map/Filter/Project
+              Project: #0, #1, #3
+              Filter: NOT(#2)
+              Map: null
+                →Read l31
+            →Differential Join %1[#0] » %0:l32[#0]
+              after %0:
+                Project: #0, #2, #3
+                Map: coalesce(#1, false)
+              →Arrange (#0)
+                →Stream l32
+              →Arrange (#0)
+                →Union
+                  →Stream l50
+                  →Map/Filter/Project
+                    Project: #0, #1
+                    Map: null
+                      →Consolidating Union
+                        →Negate Diffs
+                          →Fused with Child Map/Filter/Project
+                            Project: #0
+                              →Read l50
+                        →Unarranged Raw Stream
+                          →Arranged l33
   →Return
     →Union
       →Map/Filter/Project
@@ -20641,34 +20639,33 @@ Explained Query:
       →Differential Join %1[#0] » %0:l51[#0{oid}]
         →Arrange (#0{oid})
           →Stream l51
-        →Arrange (#0)
-          →Consolidating Monotonic Top1
-            Group By #0
-            →Union
-              →Fused with Child Map/Filter/Project
-                Project: #0, #1, #3
-                Filter: NOT(#2)
-                Map: null
-                  →Read l31
-              →Differential Join %1[#0] » %0:l32[#0]
-                after %0:
-                  Project: #0, #2, #3
-                  Map: coalesce(#1, false)
-                →Arrange (#0)
-                  →Stream l32
-                →Arrange (#0)
-                  →Union
-                    →Stream l50
-                    →Map/Filter/Project
-                      Project: #0, #1
-                      Map: null
-                        →Consolidating Union
-                          →Negate Diffs
-                            →Fused with Child Map/Filter/Project
-                              Project: #0
-                                →Read l50
-                          →Unarranged Raw Stream
-                            →Arranged l33
+        →Consolidating Monotonic Top1
+          Group By #0
+          →Union
+            →Fused with Child Map/Filter/Project
+              Project: #0, #1, #3
+              Filter: NOT(#2)
+              Map: null
+                →Read l31
+            →Differential Join %1[#0] » %0:l32[#0]
+              after %0:
+                Project: #0, #2, #3
+                Map: coalesce(#1, false)
+              →Arrange (#0)
+                →Stream l32
+              →Arrange (#0)
+                →Union
+                  →Stream l50
+                  →Map/Filter/Project
+                    Project: #0, #1
+                    Map: null
+                      →Consolidating Union
+                        →Negate Diffs
+                          →Fused with Child Map/Filter/Project
+                            Project: #0
+                              →Read l50
+                        →Unarranged Raw Stream
+                          →Arranged l33
     cte l53 =
       →Union
         →Map/Filter/Project
@@ -21207,34 +21204,33 @@ Explained Query:
       →Differential Join %1[#0] » %0:l30[#0{oid}]
         →Arrange (#0{oid})
           →Stream l30
-        →Arrange (#0)
-          →Consolidating Monotonic Top1
-            Group By #0
-            →Union
-              →Fused with Child Map/Filter/Project
+        →Consolidating Monotonic Top1
+          Group By #0
+          →Union
+            →Fused with Child Map/Filter/Project
+              Project: #0, #2
+              Filter: NOT(#1)
+              Map: null
+                →Read l10
+            →Differential Join %1[#0] » %0:l11[#0]
+              after %0:
                 Project: #0, #2
-                Filter: NOT(#1)
-                Map: null
-                  →Read l10
-              →Differential Join %1[#0] » %0:l11[#0]
-                after %0:
-                  Project: #0, #2
-                  Map: coalesce(#1, false)
-                →Arrange (#0)
-                  →Stream l11
-                →Arrange (#0)
-                  →Union
-                    →Stream l29
-                    →Map/Filter/Project
-                      Project: #0, #1
-                      Map: null
-                        →Consolidating Union
-                          →Negate Diffs
-                            →Fused with Child Map/Filter/Project
-                              Project: #0
-                                →Read l29
-                          →Unarranged Raw Stream
-                            →Arranged l12
+                Map: coalesce(#1, false)
+              →Arrange (#0)
+                →Stream l11
+              →Arrange (#0)
+                →Union
+                  →Stream l29
+                  →Map/Filter/Project
+                    Project: #0, #1
+                    Map: null
+                      →Consolidating Union
+                        →Negate Diffs
+                          →Fused with Child Map/Filter/Project
+                            Project: #0
+                              →Read l29
+                        →Unarranged Raw Stream
+                          →Arranged l12
     cte l32 =
       →Union
         →Map/Filter/Project

--- a/test/sqllogictest/explain/default.slt
+++ b/test/sqllogictest/explain/default.slt
@@ -536,7 +536,8 @@ Explained Query:
         →Stream l0
       →Arrange (#0)
         →Union
-          →Stream l3
+          →Unarranged Raw Stream
+            →Arranged l3
           →Map/Filter/Project
             Project: #0, #1
             Map: null
@@ -544,12 +545,14 @@ Explained Query:
                 →Negate Diffs
                   →Fused with Child Map/Filter/Project
                     Project: #0
-                      →Read l3
+                      →Arranged l3
+                        Key: (#0)
                 →Unarranged Raw Stream
                   →Arranged l1
       →Arrange (#0)
         →Union
-          →Stream l4
+          →Unarranged Raw Stream
+            →Arranged l4
           →Map/Filter/Project
             Project: #0, #1
             Map: null
@@ -557,7 +560,8 @@ Explained Query:
                 →Negate Diffs
                   →Fused with Child Map/Filter/Project
                     Project: #0
-                      →Read l4
+                      →Arranged l4
+                        Key: (#0)
                 →Unarranged Raw Stream
                   →Arranged l1
 

--- a/test/sqllogictest/outer_join.slt
+++ b/test/sqllogictest/outer_join.slt
@@ -181,10 +181,12 @@ Explained Query:
         raw=true
         arrangements[0]={ key=[#0], permutation=id, thinning=(#1, #2) }
         Union
-          Get::Collection l0
+          Get::Arrangement l0
             project=(#0..=#2)
             map=(true)
-            raw=true
+            key=#0
+            raw=false
+            arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
           Mfp
             project=(#0..=#2)
             map=(null, null)
@@ -195,9 +197,11 @@ Explained Query:
                 arrangements[0]={ key=[#0], permutation=id, thinning=() }
                 Union consolidate_output=true
                   Negate
-                    Get::Collection l0
+                    Get::Arrangement l0
                       project=(#0)
-                      raw=true
+                      key=#0
+                      raw=false
+                      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
                   ArrangeBy
                     input_key=[#0]
                     raw=true

--- a/test/sqllogictest/transform/monotonic.slt
+++ b/test/sqllogictest/transform/monotonic.slt
@@ -232,3 +232,105 @@ Source materialize.public.counter
 Target cluster: quickstart
 
 EOF
+
+# Regression test: MonotonicTop1's arrangement-only render path must reconstruct
+# rows in the correct column order when a downstream consumer (here, this view's
+# own persist sink) needs the raw collection, not just when it can consume the
+# arrangement directly. The group key (`counter % 3`) is placed after the value
+# columns in the projected row, so an identity permutation would silently
+# produce the wrong column order if the reconstruction were broken. `Reduce`
+# never exercises this because its key is always a `0..k` prefix.
+
+statement ok
+CREATE SOURCE top1_perm_counter
+  FROM LOAD GENERATOR COUNTER (UP TO 9, TICK INTERVAL '0.001s');
+
+statement ok
+CREATE TABLE top1_perm_counter_tbl FROM SOURCE top1_perm_counter;
+
+statement ok
+SELECT mz_unsafe.mz_sleep(1);
+
+query I
+SELECT count(*) FROM top1_perm_counter_tbl;
+----
+9
+
+query T multiline
+EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR
+  CREATE MATERIALIZED VIEW top1_perm_direct AS
+  SELECT DISTINCT ON (counter % 3) counter * 10 AS v, counter, counter % 3 AS k
+  FROM top1_perm_counter_tbl
+  ORDER BY counter % 3, counter DESC
+----
+materialize.public.top1_perm_direct:
+  TopK::MonotonicTop1 group_by=[#2] order_by=[#1 desc nulls_first]
+    Get::Collection materialize.public.top1_perm_counter_tbl
+      raw=true
+
+Source materialize.public.top1_perm_counter_tbl
+  project=(#1, #0, #2)
+  map=((#0{counter} * 10), (#0{counter} % 3))
+
+Target cluster: quickstart
+
+EOF
+
+statement ok
+CREATE MATERIALIZED VIEW top1_perm_direct AS
+  SELECT DISTINCT ON (counter % 3) counter * 10 AS v, counter, counter % 3 AS k
+  FROM top1_perm_counter_tbl
+  ORDER BY counter % 3, counter DESC;
+
+query III rowsort
+SELECT * FROM top1_perm_direct;
+----
+70
+7
+1
+80
+8
+2
+90
+9
+0
+
+# Regression test: a one-shot `SELECT DISTINCT ON` over a non-monotonic table
+# exercises `TopKPlan::as_monotonic`'s `Basic`->`MonotonicTop1` upgrade
+# (`arranged = false`), which must reconstruct the raw collection instead of
+# delivering the arrangement alone, since lowering never advertised one (the
+# `AvailableCollections` were computed before the single-time refinement ran).
+
+statement ok
+CREATE TABLE top1_perm_plain (v int, counter int, k int);
+
+statement ok
+INSERT INTO top1_perm_plain VALUES (10, 1, 0), (20, 2, 0), (30, 3, 1), (40, 4, 1);
+
+query T multiline
+EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR
+  SELECT DISTINCT ON (k) v, counter, k
+  FROM top1_perm_plain
+  ORDER BY k, counter DESC
+----
+Explained Query:
+  Finish order_by=[#2 asc nulls_last, #1 desc nulls_first] output=[#0..=#2]
+    TopK::MonotonicTop1 group_by=[#2] order_by=[#1 desc nulls_first] must_consolidate
+      Get::PassArrangements materialize.public.top1_perm_plain
+        raw=true
+
+Source materialize.public.top1_perm_plain
+
+Target cluster: quickstart
+
+EOF
+
+query III rowsort
+SELECT * FROM (SELECT DISTINCT ON (k) v, counter, k FROM top1_perm_plain ORDER BY k, counter DESC);
+----
+20
+2
+0
+40
+4
+1

--- a/test/sqllogictest/transform/monotonic.slt
+++ b/test/sqllogictest/transform/monotonic.slt
@@ -181,3 +181,54 @@ Explained Query:
 Target cluster: quickstart
 
 EOF
+
+# Regression test: `TopK::MonotonicTop1` advertises the arrangement it builds
+# on its group key (see `render_top1_monotonic`), so joining two `DISTINCT ON`
+# queries over the same monotonic source on their group key should reuse that
+# arrangement instead of forcing a separate `ArrangeBy`. The two views order in
+# opposite directions so they pick different winning rows and the optimizer
+# can't collapse the join into a trivial self-join projection.
+
+statement ok
+CREATE VIEW distinct_asc AS
+  SELECT DISTINCT ON (counter % 3) counter % 3 AS k, counter
+  FROM counter
+  ORDER BY counter % 3, counter ASC;
+
+statement ok
+CREATE VIEW distinct_desc AS
+  SELECT DISTINCT ON (counter % 3) counter % 3 AS k, counter
+  FROM counter
+  ORDER BY counter % 3, counter DESC;
+
+query T multiline
+EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR
+  SELECT a.k, a.counter, b.counter
+  FROM distinct_asc a
+  JOIN distinct_desc b ON a.k = b.k
+----
+Explained Query:
+  With
+    cte l0 =
+      Get::Collection materialize.public.counter
+        raw=true
+  Return
+    Join::Linear
+      linear_stage[0]
+        lookup={ relation=1, key=[#1{k}] }
+        stream={ key=[#1], thinning=(#0) }
+      source={ relation=0, key=[#1] }
+      TopK::MonotonicTop1 group_by=[#1] order_by=[#0 asc nulls_last]
+        Get::PassArrangements l0
+          raw=true
+      TopK::MonotonicTop1 group_by=[#1] order_by=[#0 desc nulls_first]
+        Get::PassArrangements l0
+          raw=true
+
+Source materialize.public.counter
+  project=(#0, #1)
+  map=((#0{counter} % 3))
+
+Target cluster: quickstart
+
+EOF

--- a/test/sqllogictest/transform/monotonic.slt
+++ b/test/sqllogictest/transform/monotonic.slt
@@ -233,73 +233,15 @@ Target cluster: quickstart
 
 EOF
 
-# Regression test: MonotonicTop1's arrangement-only render path must reconstruct
-# rows in the correct column order when a downstream consumer (here, this view's
-# own persist sink) needs the raw collection, not just when it can consume the
-# arrangement directly. The group key (`counter % 3`) is placed after the value
-# columns in the projected row, so an identity permutation would silently
-# produce the wrong column order if the reconstruction were broken. `Reduce`
-# never exercises this because its key is always a `0..k` prefix.
-
-statement ok
-CREATE SOURCE top1_perm_counter
-  FROM LOAD GENERATOR COUNTER (UP TO 9, TICK INTERVAL '0.001s');
-
-statement ok
-CREATE TABLE top1_perm_counter_tbl FROM SOURCE top1_perm_counter;
-
-statement ok
-SELECT mz_unsafe.mz_sleep(1);
-
-query I
-SELECT count(*) FROM top1_perm_counter_tbl;
-----
-9
-
-query T multiline
-EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR
-  CREATE MATERIALIZED VIEW top1_perm_direct AS
-  SELECT DISTINCT ON (counter % 3) counter * 10 AS v, counter, counter % 3 AS k
-  FROM top1_perm_counter_tbl
-  ORDER BY counter % 3, counter DESC
-----
-materialize.public.top1_perm_direct:
-  TopK::MonotonicTop1 group_by=[#2] order_by=[#1 desc nulls_first]
-    Get::Collection materialize.public.top1_perm_counter_tbl
-      raw=true
-
-Source materialize.public.top1_perm_counter_tbl
-  project=(#1, #0, #2)
-  map=((#0{counter} * 10), (#0{counter} % 3))
-
-Target cluster: quickstart
-
-EOF
-
-statement ok
-CREATE MATERIALIZED VIEW top1_perm_direct AS
-  SELECT DISTINCT ON (counter % 3) counter * 10 AS v, counter, counter % 3 AS k
-  FROM top1_perm_counter_tbl
-  ORDER BY counter % 3, counter DESC;
-
-query III rowsort
-SELECT * FROM top1_perm_direct;
-----
-70
-7
-1
-80
-8
-2
-90
-9
-0
-
 # Regression test: a one-shot `SELECT DISTINCT ON` over a non-monotonic table
 # exercises `TopKPlan::as_monotonic`'s `Basic`->`MonotonicTop1` upgrade
 # (`arranged = false`), which must reconstruct the raw collection instead of
 # delivering the arrangement alone, since lowering never advertised one (the
 # `AvailableCollections` were computed before the single-time refinement ran).
+# The group key (`k`) sits after the value columns in the output, so the
+# reconstruction must apply the arrangement's permutation to restore column
+# order; an identity permutation would silently corrupt the result. `Reduce`
+# never exercises this because its key is always a `0..k` prefix.
 
 statement ok
 CREATE TABLE top1_perm_plain (v int, counter int, k int);

--- a/test/sqllogictest/transform/relax_must_consolidate.slt
+++ b/test/sqllogictest/transform/relax_must_consolidate.slt
@@ -836,6 +836,7 @@ Explained Query:
       Reduce::Hierarchical
         aggr_funcs=[min, max]
         monotonic
+        input_key=#0
         key_plan
           project=()
         val_plan


### PR DESCRIPTION
### Motivation

`MonotonicTop1` builds a group-key-keyed output arrangement and then discards it
(`TODO(database-issues#2288)`), so the optimizer inserts a redundant `ArrangeBy`
whenever a consumer needs the result keyed by the group key, for example a join
on a `DISTINCT ON` key.

Addresses database-issues#2288.

### Description

Lowering now advertises that arrangement via `AvailableCollections::new_arranged`,
mirroring `Reduce`, so a group-key consumer reuses it instead of re-arranging.

Render delivers the output in one of two shapes, selected by a new
`MonotonicTop1Plan.arranged` flag: arrangement-only when lowering advertised it,
or a raw collection for the case where `refine_single_time_operator_selection`
upgrades a `Basic` plan into `MonotonicTop1` after lowering already advertised
`raw`. The flag is `true` only for plans built by `create_from` (the sole path
lowering advertises) and `false` for the post-lowering upgrade, so the render
shape always matches the advertisement.

Only `MonotonicTop1` is affected. `MonotonicTopK` and `Basic` key their
arrangements by `(hash, group_key)`, which a group-key consumer cannot reuse, so
they continue to advertise `new_raw()`.

The `top-1-monotonic` testdrive goldens change: the `ArrangeBy` over each
elided dataflow is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)