### PR TITLE
compute: select monotonic operators during lowering

### DIFF
--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -594,8 +594,6 @@ impl LirRelationExpr {
         // available.
 
         if dataflow.is_single_time() {
-            Self::refine_single_time_operator_selection(&mut dataflow);
-
             // The relaxation of the `must_consolidate` flag performs an LIR-based
             // analysis and transform under checked recursion. By a similar argument
             // made in `from_mir`, we do not expect the recursion limit to be hit.
@@ -763,55 +761,6 @@ impl LirRelationExpr {
                         }
                     }
                     todo.extend(expression.node.children_mut());
-                }
-            }
-        }
-        mz_repr::explain::trace_plan(dataflow);
-    }
-
-    /// Refines the plans of objects to be built as part of `dataflow` to take advantage
-    /// of monotonic operators if the dataflow refers to a single-time, i.e., is for a
-    /// one-shot SELECT query.
-    #[mz_ore::instrument(
-        target = "optimizer",
-        level = "debug",
-        fields(path.segment = "refine_single_time_operator_selection")
-    )]
-    fn refine_single_time_operator_selection(dataflow: &mut DataflowDescription<Self>) {
-        // We should only reach here if we have a one-shot SELECT query, i.e.,
-        // a single-time dataflow.
-        assert!(dataflow.is_single_time());
-
-        // Upgrade single-time plans to monotonic.
-        for build_desc in dataflow.objects_to_build.iter_mut() {
-            let mut todo = vec![&mut build_desc.plan];
-            while let Some(expression) = todo.pop() {
-                let node = &mut expression.node;
-                match node {
-                    LirRelationNode::Reduce { plan, .. } => {
-                        // Upgrade non-monotonic hierarchical plans to monotonic with mandatory consolidation.
-                        match plan {
-                            ReducePlan::Hierarchical(hierarchical) => {
-                                hierarchical.as_monotonic(true);
-                            }
-                            _ => {
-                                // Nothing to do for other plans, and doing nothing is safe for future variants.
-                            }
-                        }
-                        todo.extend(node.children_mut());
-                    }
-                    LirRelationNode::TopK { top_k_plan, .. } => {
-                        top_k_plan.as_monotonic(true);
-                        todo.extend(node.children_mut());
-                    }
-                    LirRelationNode::LetRec { body, .. } => {
-                        // Only the non-recursive `body` is restricted to a single time.
-                        todo.push(body);
-                    }
-                    _ => {
-                        // Nothing to do for other expressions, and doing nothing is safe for future expressions.
-                        todo.extend(node.children_mut());
-                    }
                 }
             }
         }

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -71,6 +71,19 @@ pub(super) struct Context {
     enable_reduce_mfp_fusion: bool,
     /// Metrics recorded during lowering, if any are being collected.
     metrics: Option<LoweringMetrics>,
+    /// Whether the current expression is subject to single-time (one-shot
+    /// `SELECT`) monotonic operator selection.
+    ///
+    /// Lowering locks in which arrangements a node makes available, and that set
+    /// changes with the chosen operator variant (e.g. a monotonic `TopK`/`Reduce`
+    /// arranges differently than its non-monotonic form). So the variant must be
+    /// picked here, during lowering, rather than by a later rewrite that would
+    /// leave the already-computed `AvailableCollections` describing the wrong shape.
+    ///
+    /// Initialized from the dataflow's `is_single_time()` and forced to `false`
+    /// while lowering the recursive bindings of a `LetRec`, whose values are not
+    /// restricted to a single time.
+    single_time: bool,
 }
 
 impl Context {
@@ -89,6 +102,8 @@ impl Context {
             },
             enable_reduce_mfp_fusion: features.enable_reduce_mfp_fusion,
             metrics: metrics.cloned(),
+            // Set from the dataflow in `lower` before any expression is lowered.
+            single_time: false,
         }
     }
 
@@ -136,6 +151,11 @@ impl Context {
                 .entry(Id::Global(*id))
                 .or_insert_with(AvailableCollections::new_raw);
         }
+
+        // One-shot `SELECT` dataflows run at a single time, which lets us select
+        // monotonic operator variants during lowering (see the `TopK` and `Reduce`
+        // arms), so that `AvailableCollections` reflect the final operator variant.
+        self.single_time = desc.is_single_time();
 
         // Build each object in order, registering the arrangements it forms.
         let mut objects_to_build = Vec::with_capacity(desc.objects_to_build.len());
@@ -393,6 +413,11 @@ impl Context {
                 // as we cannot circulate an arrangement through a `Variable` yet.
                 let mut lir_values = Vec::with_capacity(values.len());
                 let mut any_v_future = false;
+                // The recursive bindings of a `LetRec` are not restricted to a single
+                // time, so single-time monotonic selection must not apply to them. Only
+                // the `body`, lowered below, inherits the enclosing scope's flag.
+                let outer_single_time = self.single_time;
+                self.single_time = false;
                 for (id, value) in ids.iter().zip_eq(values) {
                     let LoweredExpr {
                         plan: mut lir_value,
@@ -478,6 +503,7 @@ impl Context {
                 }
                 // Plan the body using initial and `value` arrangements,
                 // and then remove reference to the value arrangements.
+                self.single_time = outer_single_time;
                 let LoweredExpr {
                     plan: body,
                     keys: b_keys,
@@ -883,7 +909,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     has_future_updates: input_future,
                 } = self.lower_mir_expr(input)?;
 
-                let top_k_plan = TopKPlan::create_from(
+                let mut top_k_plan = TopKPlan::create_from(
                     group_key.clone(),
                     order_key.clone(),
                     *offset,
@@ -894,6 +920,13 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     *monotonic,
                     *expected_group_size,
                 );
+
+                // For single-time dataflows, upgrade to the monotonic variant with
+                // mandatory consolidation. `refine_single_time_consolidation` later
+                // relaxes `must_consolidate` where the input is physically monotonic.
+                if self.single_time {
+                    top_k_plan.as_monotonic(true);
+                }
 
                 // We don't have an MFP here -- install an operator to permute the
                 // input, if necessary.
@@ -1286,12 +1319,26 @@ This is not expected to cause incorrect results, but could indicate a performanc
             aggregates,
             permutation_and_new_arity,
         );
-        let reduce_plan = ReducePlan::create_from(
+        let mut reduce_plan = ReducePlan::create_from(
             aggregates.clone(),
             *monotonic,
             *expected_group_size,
             fused_unnest_list,
         );
+
+        // For single-time dataflows, upgrade a hierarchical reduce to its monotonic
+        // variant with mandatory consolidation. `refine_single_time_consolidation`
+        // later relaxes `must_consolidate` where the input is physically monotonic.
+        // Selecting the variant before computing `keys` below keeps the advertised
+        // `AvailableCollections` consistent with the final plan. `Reduce::keys()` is
+        // the same for every hierarchical sub-variant, so the advertisement is in fact
+        // identical either way.
+        if self.single_time {
+            if let ReducePlan::Hierarchical(hierarchical) = &mut reduce_plan {
+                hierarchical.as_monotonic(true);
+            }
+        }
+
         // Return the plan, and the keys it produces.
         let mfp_after;
         let output_arity;


### PR DESCRIPTION
Absorbs single-time (one-shot `SELECT`) monotonic operator selection into lowering, replacing the post-lowering `refine_single_time_operator_selection` pass that mutated LIR nodes in place after `AvailableCollections` were already computed.

`lower` reads `is_single_time()` and records it on the lowering `Context`; the `TopK` and `Reduce` arms pick the monotonic variant at construction, so lowering computes `AvailableCollections` for the final variant. The flag is forced off around `LetRec` recursive bindings, matching the old pass.

Behavior-preserving: `ReducePlan::keys()` and `extract_mfp_after` are variant-independent and `TopK` advertises no arrangement, so advertised collections are unchanged. `refine_single_time_consolidation` still relaxes `must_consolidate` afterward.

Fixes CLU-166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)