### PR TITLE
catalog: tolerate and strip stale builtin version pins on upgrade

### DIFF
--- a/misc/python/materialize/checks/all_checks/builtin_version_pin.py
+++ b/misc/python/materialize/checks/all_checks/builtin_version_pin.py
@@ -1,0 +1,141 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.mz_version import MzVersion
+
+# Builtin tables in stable, user-referenceable schemas (all in mz_catalog),
+# each mapped to the version that converted it from a table to a materialized
+# view, or None while it is still a table.
+#
+# An old binary with enable_alter_table_add_column on pins a view over a
+# builtin table at VERSION 0. Once a later binary has converted that builtin
+# to a view, VERSION 0 no longer validates and catalog open panics, unless the
+# binary carries the tolerance fix. The check confirms the pin survives an
+# upgrade instead of wedging the catalog.
+#
+# A builtin is skipped for a given upgrade only inside the window where the
+# writer is a table-era binary but the first reader of the converted view is a
+# released binary that predates the fix. See _active_builtins. Outside that
+# window the entry runs again on its own, so record a conversion here rather
+# than deleting the builtin.
+#
+# When you convert a builtin to a view, set its version here. mz_internal
+# builtin tables are excluded: users cannot create views with unstable
+# dependencies, so conversions there cannot poison customer catalogs.
+# mz_role_auth is excluded because only mz_system can read it.
+_STABLE_BUILTINS: dict[str, MzVersion | None] = {
+    "mz_array_types": None,
+    "mz_audit_events": MzVersion.parse_mz("v26.33.0"),
+    "mz_aws_privatelink_connections": None,
+    "mz_base_types": None,
+    "mz_cluster_replica_sizes": None,
+    "mz_cluster_replicas": MzVersion.parse_mz("v26.30.0"),
+    "mz_clusters": MzVersion.parse_mz("v26.30.0"),
+    "mz_columns": None,
+    "mz_default_privileges": MzVersion.parse_mz("v26.30.0"),
+    "mz_egress_ips": None,
+    "mz_functions": None,
+    "mz_iceberg_sinks": None,
+    "mz_index_columns": None,
+    "mz_kafka_connections": None,
+    "mz_kafka_sinks": None,
+    "mz_kafka_sources": None,
+    "mz_list_types": None,
+    "mz_map_types": None,
+    "mz_operators": None,
+    "mz_pseudo_types": None,
+    "mz_sinks": None,
+    "mz_ssh_tunnel_connections": None,
+    "mz_system_privileges": MzVersion.parse_mz("v26.30.0"),
+    "mz_tables": None,
+    "mz_types": None,
+    "mz_views": None,
+}
+
+
+def _pin_views(suffix_tables: list[str], prefix: str) -> str:
+    create = "\n".join(
+        f"> CREATE VIEW {prefix}{t} AS SELECT count(*) AS c FROM mz_catalog.{t};"
+        for t in suffix_tables
+    )
+    rename = "\n".join(
+        f"> ALTER VIEW {prefix}{t} RENAME TO {prefix}{t}_r;" for t in suffix_tables
+    )
+    return f"{create}\n{rename}"
+
+
+class BuiltinItemVersionPin(Check):
+    """Views over builtin tables must keep working when a later version
+    converts the builtin to another item type (e.g. mz_clusters became a
+    materialized view in v26.30).
+
+    With enable_alter_table_add_column on, re-parsing a persisted view pins
+    referenced builtin tables at VERSION 0 in the in-memory create_sql
+    (resolve_item_name_id pins any versioned item, not just user tables).
+    A rename then persists the pinned reference. A later version where the
+    builtin is no longer a table rejects VERSION 0 with InvalidVersion and
+    environmentd panics during catalog open, wedging the upgrade.
+    """
+
+    def _can_run(self, e: Executor) -> bool:
+        # mz_iceberg_sinks is the newest builtin referenced below.
+        return self.base_version >= MzVersion.parse_mz("v26.25.0")
+
+    def _active_builtins(self) -> list[str]:
+        """Builtins safe to pin for this upgrade.
+
+        The writer of the VERSION 0 pin is base_version, which pins only while
+        the builtin is still a table (base_version < converted). A reader
+        crashes on the pin only if it has converted the builtin to a view and
+        lacks the tolerance fix, which is true of every released binary up to
+        the last released version. So a builtin is unsafe only when its
+        conversion shipped in a release the upgrade passes through, that is
+        base_version < converted <= last released version. The current binary
+        under test carries the fix, so a conversion newer than the last release
+        is safe and is exactly the case worth exercising.
+        """
+        # Imported lazily: the module resolves published versions over the
+        # network, and the check registry imports this file at startup.
+        from materialize.checks.scenarios_upgrade import get_last_version
+
+        last_released = get_last_version()
+        return [
+            name
+            for name, converted in _STABLE_BUILTINS.items()
+            if converted is None or not (self.base_version < converted <= last_released)
+        ]
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(dedent("""
+                $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                ALTER SYSTEM SET enable_alter_table_add_column = true;
+
+                """) + _pin_views(self._active_builtins(), "builtin_pin_"))
+
+    def manipulate(self) -> list[Testdrive]:
+        # Re-run the poisoning on the intermediate versions of multi-version
+        # upgrade scenarios. In 0dt scenarios this also exercises applying a
+        # poisoned catalog update while the next generation follows the
+        # catalog in read-only mode.
+        return [
+            Testdrive(_pin_views(self._active_builtins(), f"builtin_pin_m{i}_"))
+            for i in [1, 2]
+        ]
+
+    def validate(self) -> Testdrive:
+        selects = "\n".join(
+            f"> SELECT c >= 0 FROM {prefix}{t}_r;\ntrue"
+            for prefix in ["builtin_pin_", "builtin_pin_m1_", "builtin_pin_m2_"]
+            for t in self._active_builtins()
+        )
+        return Testdrive(selects)

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -156,6 +156,7 @@ pub(crate) async fn migrate(
         ast_rewrite_add_missing_index_ids(tx, stmt)?;
         ast_rewrite_kafka_metadata_refresh_intervals(stmt)?;
         ast_rewrite_small_commit_intervals(stmt)?;
+        ast_rewrite_strip_builtin_version_pins(stmt)?;
         Ok(())
     })?;
 
@@ -1043,6 +1044,44 @@ fn ast_rewrite_add_missing_index_ids(
     Ok(())
 }
 
+/// Strips the `VERSION` qualifier from by-id references to non-user (builtin)
+/// items.
+///
+/// A version pin on a builtin is meaningless, since builtins are not
+/// user-versioned. Older binaries could still persist such a pin, and once the
+/// builtin is converted to an item type without versions (e.g. a materialized
+/// view) reparsing the pin fails with `InvalidVersion` and panics during
+/// catalog open, wedging the upgrade. Stripping it makes the reference resolve
+/// to the latest version.
+///
+/// The read-side resolver tolerates these pins too, so this is durable cleanup
+/// rather than a correctness requirement. Safe to run every boot: stripping an
+/// absent version is a no-op.
+fn ast_rewrite_strip_builtin_version_pins(stmt: &mut Statement<Raw>) -> Result<(), anyhow::Error> {
+    use mz_sql::ast::RawItemName;
+    use mz_sql::ast::visit_mut::{VisitMut, VisitMutNode};
+
+    struct StripBuiltinVersionPins;
+
+    impl<'ast> VisitMut<'ast, Raw> for StripBuiltinVersionPins {
+        fn visit_item_name_mut(&mut self, item_name: &mut RawItemName) {
+            if let RawItemName::Id(id, _, version) = item_name {
+                if version.is_some() {
+                    if let Ok(parsed) = id.parse::<CatalogItemId>() {
+                        if !parsed.is_user() {
+                            *version = None;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let mut visitor = StripBuiltinVersionPins;
+    stmt.visit_mut(&mut visitor);
+    Ok(())
+}
+
 fn ast_rewrite_kafka_metadata_refresh_intervals(
     stmt: &mut Statement<Raw>,
 ) -> Result<(), anyhow::Error> {
@@ -1143,4 +1182,54 @@ fn rewrite_interval_option_floor_1s(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strip(sql: &str) -> String {
+        let mut stmt = mz_sql::parse::parse(sql)
+            .expect("test sql parses")
+            .into_element()
+            .ast;
+        ast_rewrite_strip_builtin_version_pins(&mut stmt).expect("rewrite succeeds");
+        stmt.to_ast_string_stable()
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` (SQL parser stack growth)
+    fn strips_version_from_builtin_reference() {
+        // A system (builtin) id must lose its version pin: builtins are never
+        // user-versioned, so a persisted `VERSION 0` is a stale artifact that
+        // wedges catalog open once the builtin is converted to a non-table.
+        let out = strip(
+            r#"CREATE VIEW "materialize"."public"."v" AS SELECT 1 FROM [s518 AS "mz_catalog"."mz_audit_events" VERSION 0]"#,
+        );
+        assert!(!out.contains("VERSION"), "version not stripped: {out}");
+        // The reference itself is preserved, only the version is dropped.
+        assert!(out.contains("s518"), "reference dropped: {out}");
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` (SQL parser stack growth)
+    fn preserves_version_on_user_reference() {
+        // A user table legitimately carries versions (`ALTER TABLE ... ADD
+        // COLUMN`), so the pin must survive.
+        let out = strip(
+            r#"CREATE VIEW "materialize"."public"."v" AS SELECT 1 FROM [u5 AS "materialize"."public"."t" VERSION 1]"#,
+        );
+        assert!(out.contains("VERSION"), "user version stripped: {out}");
+        assert!(out.contains("u5"), "reference dropped: {out}");
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` (SQL parser stack growth)
+    fn leaves_unpinned_builtin_reference_untouched() {
+        let out = strip(
+            r#"CREATE VIEW "materialize"."public"."v" AS SELECT 1 FROM [s518 AS "mz_catalog"."mz_audit_events"]"#,
+        );
+        assert!(!out.contains("VERSION"), "unexpected version: {out}");
+        assert!(out.contains("s518"), "reference dropped: {out}");
+    }
 }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1602,8 +1602,13 @@ impl<'a> NameResolver<'a> {
             // If there isn't a version specified, and this item supports versioning, track the
             // latest.
             None => match item.latest_version() {
-                // Only track the version of the referenced object, if the feature is enabled.
-                Some(v) if alter_table_enabled => RelationVersionSelector::Specific(v),
+                // Only pin a version for user items, and only with the feature on. Mirrors the
+                // by-name path in `fold_item_name`. Builtins are not user-versioned, so pinning
+                // one strands the reference if the builtin is ever converted to an item type
+                // without versions.
+                Some(v) if id.is_user() && alter_table_enabled => {
+                    RelationVersionSelector::Specific(v)
+                }
                 _ => RelationVersionSelector::Latest,
             },
             // Note: Return the specific version if one is specified, even if the feature is off.
@@ -1613,6 +1618,12 @@ impl<'a> NameResolver<'a> {
                     Some(latest) if latest >= specified_version => {
                         RelationVersionSelector::Specific(specified_version)
                     }
+                    // A version pin on a builtin is meaningless, since builtins are not
+                    // user-versioned. Such a pin can still sit in a persisted catalog, and if the
+                    // builtin has been converted to an item type without versions it no longer
+                    // validates. Resolve to latest instead of failing catalog open. User items
+                    // keep the strict check so real out-of-range versions still error.
+                    _ if !id.is_user() => RelationVersionSelector::Latest,
                     _ => {
                         if self.status.is_ok() {
                             self.status = Err(PlanError::InvalidVersion {


### PR DESCRIPTION
Problem:
Zero-downtime upgrades panic during catalog open with `InvalidVersion { name, version: "0" }` when a persisted user object holds a version-pinned reference to a builtin that a later release converted from a table to a materialized view (e.g. mz_clusters, mz_audit_events).

Builtins are not user-versioned. The by-id name resolver (`resolve_item_name_id`) lacked the `is_user()` gate that the by-name path has, so with `enable_alter_table_add_column` on it pinned any versioned item, including builtin tables, at VERSION 0.

Once the builtin is no longer a table its `latest_version()` is None, the persisted pin no longer validates, and reparsing it in `apply_item_update` panics the upgrade.

The enable_alter_table_add_column flag defaults off, so only environments that enabled it are affected, but the gap exists.

Solution:
Two paths: fix the read side and add a migration to strip the identifiers.

Read side: resolve a stale version pin on a non-user item to the latest version instead of returning `InvalidVersion`. Also add the `is_user()` gate to the by-id `None` arm so builtin references are never pinned.

Migration: `ast_rewrite_strip_builtin_version_pins` strips the VERSION qualifier from by-id references to non-user items. Durable cleanup for catalogs that already carry pins, and safe to run every boot.

Testing:
- Unit tests for the migration: builtin pin stripped, user pin preserved, unpinned reference untouched.
- Platform-check `BuiltinItemVersionPin` reproduces the panic and validates the fix across a multi-version upgrade (via Dennis)

