### PR TITLE
SS-337: Enable Azure SQL tests in nightly

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -609,8 +609,6 @@ steps:
           run: azure
     agents:
       queue: hetzner-x86-64-4cpu-8gb
-    # Requires AZURE_SQL_* credentials in the CI secrets `env` file.
-    skip: "Pending Azure SQL Database credentials in the CI secrets bucket"
 
   - id: http-auth
     label: HTTP auth

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -596,7 +596,7 @@ steps:
   - id: sql-server-cdc-azure
     topics: [sql-server]
     label: "SQL Server (Azure SQL Database)"
-    depends_on: build-x86_64
+    depends_on: build-aarch64
     timeout_in_minutes: 30
     inputs: [test/sql-server-cdc]
     # Runs against a single shared Azure SQL Database, so only one build may
@@ -608,7 +608,7 @@ steps:
           composition: sql-server-cdc
           run: azure
     agents:
-      queue: hetzner-x86-64-4cpu-8gb
+      queue: linux-aarch64-small
 
   - id: http-auth
     label: HTTP auth


### PR DESCRIPTION
Enabling Azure SQL tests in nightly now that i2 deploys Azure SQL and sets environment variables in buildkite.


The first test failed (this was the first time anything tried to access the DB), but a retry succeeded.  The auto pause delay is 1 hour, so I tried rerunning the test after ~2 hours, and it passed successfully.  If there are issues, we can bump the auto pause delay to 1-2 days or look at provisioned DBs.