### PR TITLE
cluster-controller: reject a drop for a replica that has vanished

### DIFF
--- a/src/adapter/src/coord/cluster_controller.rs
+++ b/src/adapter/src/coord/cluster_controller.rs
@@ -582,6 +582,19 @@ impl Coordinator {
                     replica_id,
                     ..
                 } => {
+                    // The replica may have vanished since the decisions were
+                    // derived (a user DDL landed between the tick's read and
+                    // this apply). The in-transaction witness check would
+                    // reject such a stale batch, but resource-limit validation
+                    // runs before the transaction and panics on a missing
+                    // replica, so reject the batch here instead.
+                    if self
+                        .catalog()
+                        .try_get_cluster_replica(cluster_id, replica_id)
+                        .is_none()
+                    {
+                        return None;
+                    }
                     drops.push(DropObjectInfo::ClusterReplica((
                         cluster_id,
                         replica_id,


### PR DESCRIPTION
A `DropReplica` decision can outlive its replica: a user DDL that removes the replica (e.g. a `DROP CLUSTER`) can land between the controller tick's catalog read and the apply. The in-transaction compare-and-append witness would reject such a stale batch, but resource-limit validation runs before the transaction and panics on the missing replica:

```
thread 'coordinator' panicked at src/adapter/src/catalog/state.rs:
unknown cluster replica: u12.u25
```

so the witness never gets the chance. Reject the batch when building the ops instead, mirroring the existing vanished-cluster handling. The controller re-derives its decisions from fresh state on the next tick.

Surfaced by nightly (SLT with 2 replicas, where the harness's cluster resets race the controller's convergence drops). Main is not exposed in practice since `enable_cluster_controller` defaults off, but any flags-on run can hit it.

### Motivation

Fixes a coordinator panic in the cluster controller's apply path.

### Tips for reviewer

The fix is the single guard in `build_mutation_ops`. Extracted from the in-flight controller stack (#36738) so it can land independently.