### PR TITLE
adapter: choose table append completion by group size

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -158,7 +158,9 @@ use mz_sql::session::vars::{MAX_CREDIT_CONSUMPTION_RATE, SystemVars, Var};
 use mz_sql_parser::ast::ExplainStage;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_storage_client::client::TableData;
-use mz_storage_client::controller::{CollectionDescription, DataSource, ExportDescription};
+use mz_storage_client::controller::{
+    AppendTableResponse, CollectionDescription, DataSource, ExportDescription,
+};
 use mz_storage_types::connections::Connection as StorageConnection;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::connections::inline::{IntoInlineConnection, ReferencedConnection};
@@ -2809,7 +2811,12 @@ impl Coordinator {
                 let fut = self
                     .controller
                     .storage
-                    .append_table(min_timestamp, boot_ts.step_forward(), all_appends)
+                    .append_table(
+                        min_timestamp,
+                        boot_ts.step_forward(),
+                        all_appends,
+                        AppendTableResponse::Applied,
+                    )
                     .expect("cannot fail to append");
                 async {
                     fut.await
@@ -2995,7 +3002,12 @@ impl Coordinator {
         let table_fence_rx = self
             .controller
             .storage
-            .append_table(write_ts.clone(), advance_to, appends)
+            .append_table(
+                write_ts.clone(),
+                advance_to,
+                appends,
+                AppendTableResponse::Applied,
+            )
             .expect("invalid updates");
 
         self.apply_local_write(write_ts).await;

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -29,6 +29,7 @@ use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{ExplainPlanPlan, ExplainTimestampPlan, Explainee, ExplaineeStatement, Plan};
 use mz_sql::session::metadata::SessionMetadata;
 use mz_storage_client::client::TableData;
+use mz_storage_client::controller::AppendTableResponse;
 use mz_timestamp_oracle::WriteTimestamp;
 use smallvec::SmallVec;
 use tokio::sync::{Notify, OwnedMutexGuard, OwnedSemaphorePermit, Semaphore, oneshot};
@@ -39,6 +40,24 @@ use crate::coord::{Coordinator, Message, PendingTxn, PlanValidity};
 use crate::session::{GroupCommitWriteLocks, Session, WriteLocks};
 use crate::util::{CompletedClientTransmitter, ResultExt};
 use crate::{AdapterError, ExecuteContext};
+
+// Small groups cannot keep the next group commit supplied while every client
+// waits for physical apply. Scalability tests show this starvation through four
+// writers. For larger groups, waiting avoids reads piling up behind apply.
+const MAX_COMMITTED_RESPONSE_USER_WRITES: usize = 4;
+
+fn append_table_response(
+    updated_collection_count: usize,
+    user_write_count: usize,
+) -> AppendTableResponse {
+    if updated_collection_count > 1
+        || (1..=MAX_COMMITTED_RESPONSE_USER_WRITES).contains(&user_write_count)
+    {
+        AppendTableResponse::Committed
+    } else {
+        AppendTableResponse::Applied
+    }
+}
 
 /// Tables that we emit updates for when starting a new session.
 pub(crate) static REQUIRED_BUILTIN_TABLES: &[&LazyLock<BuiltinTable>] = &[&MZ_SESSIONS];
@@ -556,6 +575,11 @@ impl Coordinator {
                 }
             })
             .collect();
+        let updated_collection_count = appends
+            .iter()
+            .filter(|(_, updates)| !updates.iter().all(TableData::is_empty))
+            .count();
+        let append_response = append_table_response(updated_collection_count, responses.len());
         if !modified_tables.is_empty() {
             info!(
                 "Appending to tables, {modified_tables:?}, at {timestamp}, advancing to {advance_to}"
@@ -573,7 +597,7 @@ impl Coordinator {
         let append_fut = self
             .controller
             .storage
-            .append_table(timestamp, advance_to, appends)
+            .append_table(timestamp, advance_to, appends, append_response)
             .expect("invalid updates")
             .wall_time()
             .observe(histogram);
@@ -717,6 +741,22 @@ impl Coordinator {
         let write_lock_handle = Arc::clone(write_lock_handle);
 
         write_lock_handle.try_lock_owned().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_storage_client::controller::AppendTableResponse;
+
+    use super::append_table_response;
+
+    #[mz_ore::test]
+    fn test_append_table_response() {
+        assert_eq!(append_table_response(0, 0), AppendTableResponse::Applied);
+        assert_eq!(append_table_response(1, 1), AppendTableResponse::Committed);
+        assert_eq!(append_table_response(1, 4), AppendTableResponse::Committed);
+        assert_eq!(append_table_response(1, 5), AppendTableResponse::Applied);
+        assert_eq!(append_table_response(2, 5), AppendTableResponse::Committed);
     }
 }
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -289,6 +289,15 @@ pub enum StorageWriteOp {
     Delete { filter: RowPredicate },
 }
 
+/// Controls when an append-table response is delivered to its caller.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AppendTableResponse {
+    /// Respond once the transaction is durably committed to the txn WAL.
+    Committed,
+    /// Respond once the transaction is physically applied to its data shards.
+    Applied,
+}
+
 impl StorageWriteOp {
     /// Returns whether this operation appends an empty set of updates.
     pub fn is_empty_append(&self) -> bool {
@@ -601,7 +610,8 @@ pub trait StorageController: Debug {
 
     /// Append `updates` into the local input named `id` and advance its upper to `upper`.
     ///
-    /// The method returns a oneshot that can be awaited to indicate completion of the write.
+    /// The method returns a oneshot that can be awaited to indicate the completion selected by
+    /// `response`.
     /// The method may return an error, indicating an immediately visible error, and also the
     /// oneshot may return an error if one is encountered during the write.
     ///
@@ -612,6 +622,7 @@ pub trait StorageController: Debug {
         write_ts: Timestamp,
         advance_to: Timestamp,
         commands: Vec<(GlobalId, Vec<TableData>)>,
+        response: AppendTableResponse,
     ) -> Result<tokio::sync::oneshot::Receiver<Result<(), StorageError>>, StorageError>;
 
     /// Returns a [`MonotonicAppender`] which is a channel that can be used to monotonically

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -56,8 +56,8 @@ use mz_storage_client::client::{
     StatusUpdate, StorageCommand, StorageResponse, TableData,
 };
 use mz_storage_client::controller::{
-    BoxFuture, CollectionDescription, DataSource, ExportDescription, ExportState,
-    IntrospectionType, MonotonicAppender, PersistEpoch, Response, StorageController,
+    AppendTableResponse, BoxFuture, CollectionDescription, DataSource, ExportDescription,
+    ExportState, IntrospectionType, MonotonicAppender, PersistEpoch, Response, StorageController,
     StorageMetadata, StorageTxn, StorageWriteOp, WallclockLag, WallclockLagHistogramPeriod,
 };
 use mz_storage_client::healthcheck::{
@@ -2086,6 +2086,7 @@ impl StorageController for Controller {
         write_ts: Timestamp,
         advance_to: Timestamp,
         commands: Vec<(GlobalId, Vec<TableData>)>,
+        response: AppendTableResponse,
     ) -> Result<tokio::sync::oneshot::Receiver<Result<(), StorageError>>, StorageError> {
         if self.read_only {
             // While in read only mode, ONLY collections that have been migrated
@@ -2109,7 +2110,7 @@ impl StorageController for Controller {
 
         Ok(self
             .persist_table_worker
-            .append(write_ts, advance_to, commands))
+            .append(write_ts, advance_to, commands, response))
     }
 
     fn monotonic_appender(&self, id: GlobalId) -> Result<MonotonicAppender, StorageError> {

--- a/src/storage-controller/src/persist_handles.rs
+++ b/src/storage-controller/src/persist_handles.rs
@@ -25,6 +25,7 @@ use mz_persist_client::ShardId;
 use mz_persist_client::write::WriteHandle;
 use mz_repr::{GlobalId, Timestamp};
 use mz_storage_client::client::{TableData, Update};
+use mz_storage_client::controller::AppendTableResponse;
 use mz_storage_types::StorageDiff;
 use mz_storage_types::controller::{InvalidUpper, TxnsCodecRow};
 use mz_storage_types::sources::SourceData;
@@ -79,6 +80,7 @@ enum PersistTableWriteCmd {
         write_ts: Timestamp,
         advance_to: Timestamp,
         updates: Vec<(GlobalId, Vec<TableData>)>,
+        response: AppendTableResponse,
         tx: tokio::sync::oneshot::Sender<Result<(), StorageError>>,
     },
     Shutdown,
@@ -246,6 +248,7 @@ impl PersistTableWriteWorker {
         write_ts: Timestamp,
         advance_to: Timestamp,
         updates: Vec<(GlobalId, Vec<TableData>)>,
+        response: AppendTableResponse,
     ) -> tokio::sync::oneshot::Receiver<Result<(), StorageError>> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         // Always send the append command to the txn-wal layer, even for empty
@@ -256,6 +259,7 @@ impl PersistTableWriteWorker {
             write_ts,
             advance_to,
             updates,
+            response,
             tx,
         });
         rx
@@ -332,9 +336,10 @@ impl TxnsTableWorker {
                     write_ts,
                     advance_to,
                     updates,
+                    response,
                     tx,
                 } => {
-                    self.append(write_ts, advance_to, updates, tx)
+                    self.append(write_ts, advance_to, updates, response, tx)
                         .instrument(span)
                         .await
                 }
@@ -420,6 +425,7 @@ impl TxnsTableWorker {
         write_ts: Timestamp,
         advance_to: Timestamp,
         updates: Vec<(GlobalId, Vec<TableData>)>,
+        response: AppendTableResponse,
         tx: tokio::sync::oneshot::Sender<Result<(), StorageError>>,
     ) {
         debug!(
@@ -486,25 +492,38 @@ impl TxnsTableWorker {
         match txn_res {
             Ok(apply) => {
                 // The commit to the txns shard already made the write durable
-                // and linearized, so unblock the caller before applying. The
-                // apply is idempotent and reads of the affected data shards
-                // block until it has happened, so deferring it shifts latency
-                // from every write onto reads of the just-written shards. If
-                // we crash before applying, the next append's apply covers it,
-                // because applying is `apply_le`: it applies all unapplied
-                // txns up to its timestamp, and group commit appends at least
-                // once per timestamp interval.
+                // and linearized. Applying is idempotent, and reads of the
+                // affected data shards block until it completes. It is
+                // therefore safe to respond before applying. If we crash
+                // before applying, the next append's `apply_le` covers all
+                // unapplied transactions up to its timestamp. Group commit
+                // appends at least once per timestamp interval.
                 //
-                // It is not an error for the other end to hang up.
-                let _ = tx.send(Ok(()));
+                let response_before_apply = matches!(response, AppendTableResponse::Committed);
+                let response_tx = if response_before_apply {
+                    // It is not an error for the other end to hang up.
+                    let _ = tx.send(Ok(()));
+                    None
+                } else {
+                    Some(tx)
+                };
 
                 debug!("applying {:?}", apply);
-                let tidy = apply
-                    .apply(&mut self.txns)
-                    .wall_time()
-                    .observe(self.apply_seconds.clone())
-                    .await;
+                let tidy = if response_before_apply {
+                    apply
+                        .apply(&mut self.txns)
+                        .wall_time()
+                        .observe(self.apply_seconds.clone())
+                        .await
+                } else {
+                    apply.apply(&mut self.txns).await
+                };
                 self.tidy.merge(tidy);
+
+                if let Some(tx) = response_tx {
+                    // It is not an error for the other end to hang up.
+                    let _ = tx.send(Ok(()));
+                }
 
                 // We don't serve any reads out of this TxnsHandle, so go ahead
                 // and compact as aggressively as we can (i.e. to the time we

--- a/src/storage-controller/src/persist_handles/read_only_table_worker.rs
+++ b/src/storage-controller/src/persist_handles/read_only_table_worker.rs
@@ -173,6 +173,7 @@ async fn handle_commands(
                 write_ts,
                 advance_to,
                 updates,
+                response: _,
                 tx,
             } => {
                 let mut ids = BTreeSet::new();

--- a/test/pgtest-mz/stray-copy.pt
+++ b/test/pgtest-mz/stray-copy.pt
@@ -28,7 +28,7 @@ until
 ReadyForQuery
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"FORMAT BINARY not yet supported"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"FORMAT BINARY not yet supported"}]}
 ReadyForQuery {"status":"I"}
 RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["1"]}
@@ -51,7 +51,7 @@ until
 ReadyForQuery
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"FORMAT BINARY not yet supported"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"FORMAT BINARY not yet supported"}]}
 ReadyForQuery {"status":"I"}
 ParseComplete
 BindComplete


### PR DESCRIPTION
## Motivation

Responding once a txn-wal commit is durable reduces table write latency, but allowing large single-table groups to continue before physical apply makes immediate reads pile up behind apply. The first version of this PR always waited for single-shard apply. That recovered the mixed read and write workload, but nightly testing exposed two new regressions:

- InsertWorkload at concurrency 2 fell from 416.9 to 211.9 TPS, a 49.2% regression.
- ManySmallInserts increased from 1.130s to 1.295s, a 14.5% regression.

## Description

Make append response timing an explicit StorageController contract and let group commit choose the completion point. Multi-table writes and groups of up to four user writes respond once the txn-wal commit is durable. Larger single-table groups respond after physical apply. Bootstrap appends continue to wait for physical apply.

Also update the stray COPY pgtest expectation. Unsupported COPY FORMAT BINARY now correctly uses SQLSTATE 0A000 for feature not supported.

## Verification

The response policy has a unit test, and the pgtest fixture covers both simple and extended query protocol paths.

Targeted optimized benchmarks against commit 75cdbb9e3f showed:

- InsertWorkload at concurrency 2: 966 versus 848 TPS, 13.9% faster.
- InsertWorkload at concurrency 4: 1591 versus 1549 TPS, 2.8% faster.
- InsertWorkload at concurrency 16: 3326 versus 3259 TPS, 2.0% faster.
- InsertAndSelectLimitWorkload at concurrency 16: 2638 versus 2448 TPS, 7.7% faster.
- ManySmallInserts: 0.356s versus 0.358s, 0.6% faster.

Follow-up to https://github.com/MaterializeInc/materialize/pull/37443.

Nightly benchmark: https://buildkite.com/materialize/nightly/builds/17312