### PR TITLE
adapter: make statement arrival logging check local

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -13,6 +13,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::future::Future;
 use std::pin::{self, Pin};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::bail;
@@ -80,6 +81,23 @@ pub struct Handle {
     pub(crate) _thread: JoinOnDropHandle<()>,
 }
 
+/// A shared, cheaply readable switch for statement-arrival logging.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct StatementArrivalLogging {
+    enabled: Arc<AtomicBool>,
+}
+
+impl StatementArrivalLogging {
+    pub(crate) fn enabled(&self) -> bool {
+        // The flag does not guard any other data, so ordering beyond atomicity is unnecessary.
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Relaxed);
+    }
+}
+
 impl Handle {
     /// Returns the session ID associated with this coordinator.
     ///
@@ -112,6 +130,7 @@ pub struct Client {
     metrics: Metrics,
     environment_id: EnvironmentId,
     segment_client: Option<mz_segment::Client>,
+    statement_arrival_logging: StatementArrivalLogging,
 }
 
 impl Client {
@@ -122,6 +141,7 @@ impl Client {
         now: NowFn,
         environment_id: EnvironmentId,
         segment_client: Option<mz_segment::Client>,
+        statement_arrival_logging: StatementArrivalLogging,
     ) -> Client {
         // Connection ids are 32 bits and have 3 parts.
         // 1. MSB bit is always 0 because these are interpreted as an i32, and it is possible some
@@ -139,6 +159,7 @@ impl Client {
             metrics,
             environment_id,
             segment_client,
+            statement_arrival_logging,
         }
     }
 
@@ -1123,9 +1144,8 @@ impl SessionClient {
     }
 
     /// Reports whether `enable_statement_arrival_logging` is on.
-    pub async fn statement_arrival_logging_enabled(&mut self) -> bool {
-        let catalog = self.catalog_snapshot("statement_arrival_logging").await;
-        catalog.system_config().enable_statement_arrival_logging()
+    pub fn statement_arrival_logging_enabled(&self) -> bool {
+        self.inner().statement_arrival_logging.enabled()
     }
 
     /// Dumps the catalog to a JSON string.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -182,7 +182,7 @@ use uuid::Uuid;
 
 use crate::active_compute_sink::{ActiveComputeSink, ActiveCopyFrom};
 use crate::catalog::{BuiltinTableUpdate, Catalog, OpenCatalogResult};
-use crate::client::{Client, Handle};
+use crate::client::{Client, Handle, StatementArrivalLogging};
 use crate::command::{Command, ExecuteResponse};
 use crate::config::{
     ClusterEvalContext, ReplicaEvalContext, ScopedParameters, ScopedParametersScope,
@@ -4602,6 +4602,18 @@ impl fmt::Debug for LastMessage {
     }
 }
 
+fn register_statement_arrival_logging(system_vars: &mut SystemVars) -> StatementArrivalLogging {
+    let statement_arrival_logging = StatementArrivalLogging::default();
+    let callback_handle = statement_arrival_logging.clone();
+    system_vars.register_callback(
+        &mz_sql::session::vars::ENABLE_STATEMENT_ARRIVAL_LOGGING,
+        Arc::new(move |system_vars| {
+            callback_handle.set_enabled(system_vars.enable_statement_arrival_logging());
+        }),
+    );
+    statement_arrival_logging
+}
+
 impl Drop for LastMessage {
     fn drop(&mut self) {
         // Only print the last message if we're currently panicking, otherwise we'd spam our logs.
@@ -4956,6 +4968,8 @@ pub fn serve(
             &mz_sql::session::vars::SUPERUSER_RESERVED_CONNECTIONS,
             connection_limit_callback,
         );
+        let statement_arrival_logging =
+            register_statement_arrival_logging(catalog.system_config_mut());
 
         let (group_commit_tx, group_commit_rx) = appends::notifier();
 
@@ -5114,6 +5128,7 @@ pub fn serve(
                     now,
                     environment_id,
                     segment_client_clone,
+                    statement_arrival_logging,
                 );
                 Ok((handle, client))
             }
@@ -5121,6 +5136,32 @@ pub fn serve(
         }
     }
     .boxed()
+}
+
+#[cfg(test)]
+mod statement_arrival_logging_tests {
+    use mz_sql::session::vars::{ENABLE_STATEMENT_ARRIVAL_LOGGING, VarInput};
+
+    use super::*;
+
+    #[mz_ore::test]
+    fn follows_system_var() {
+        let mut system_vars = SystemVars::new();
+        let statement_arrival_logging = register_statement_arrival_logging(&mut system_vars);
+
+        assert!(!statement_arrival_logging.enabled());
+        system_vars
+            .set(
+                ENABLE_STATEMENT_ARRIVAL_LOGGING.name(),
+                VarInput::Flat("on"),
+            )
+            .expect("set system variable");
+        assert!(statement_arrival_logging.enabled());
+        system_vars
+            .reset(ENABLE_STATEMENT_ARRIVAL_LOGGING.name())
+            .expect("reset system variable");
+        assert!(!statement_arrival_logging.enabled());
+    }
 }
 
 // Determines and returns the highest timestamp for each timeline, for all known

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1245,7 +1245,7 @@ pub(in crate::http) async fn execute_request<S: ResultSender>(
 ) -> Result<(), Error> {
     let client = &mut client.client;
 
-    if client.statement_arrival_logging_enabled().await {
+    if client.statement_arrival_logging_enabled() {
         let session = client.session();
         let conn_id = session.conn_id();
         let session_uuid = session.uuid();

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -948,7 +948,7 @@ where
         let message_name = message.as_ref().map(|m| m.name()).unwrap_or_default();
 
         if let Some(message) = &message {
-            self.maybe_log_message_arrival(message).await;
+            self.maybe_log_message_arrival(message);
         }
 
         let start = message.as_ref().map(|_| Instant::now());
@@ -1205,12 +1205,8 @@ where
     /// is logged as its length only, and only when it arrives as a stray
     /// message in the ready state: messages consumed by the COPY subprotocol
     /// or the post-error drain loop don't pass through here at all.
-    async fn maybe_log_message_arrival(&mut self, message: &FrontendMessage) {
-        if !self
-            .adapter_client
-            .statement_arrival_logging_enabled()
-            .await
-        {
+    fn maybe_log_message_arrival(&mut self, message: &FrontendMessage) {
+        if !self.adapter_client.statement_arrival_logging_enabled() {
             return;
         }
         let session = self.adapter_client.session();


### PR DESCRIPTION
Keep the switch synchronized with the system variable through a callback. This avoids an async catalog snapshot for every pgwire message and HTTP request when emergency logging is disabled.

Follow-up to https://github.com/MaterializeInc/materialize/pull/37567

This seems to have caused a perf. regression, seen in https://buildkite.com/materialize/nightly/builds/17267:
```
QUERY                                    | STAT    |     THIS     |    OTHER     |  CHANGE   | THRESHOLD | REGRESSION?
----------------------------------------------------------------------------------------------------------------------
SELECT 1 (standalone)                    | avg     |        13.61 |        11.26 |    20.84% |       20% |   !!YES!!
SELECT 1 (standalone)                    | max     |        54.85 |        74.97 |   -26.84% |           |
SELECT 1 (standalone)                    | min     |         5.23 |         3.54 |    47.71% |           |
SELECT 1 (standalone)                    | p50     |        13.40 |        10.94 |    22.43% |       20% |   !!YES!!
SELECT 1 (standalone)                    | p95     |        18.72 |        16.39 |    14.20% |       30% |      no
SELECT 1 (standalone)                    | p99     |        22.44 |        19.86 |    12.99% |           |
SELECT 1 (standalone)                    | qps     |       734.60 |       887.70 |   -17.25% |       20% |   !!YES!!
```

Performance nightly run: https://buildkite.com/materialize/nightly/builds/17310