### PR TITLE
pgtest: Fix expected error type & ci: less SQLsmith load to prevent OoMs

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1824,7 +1824,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: sqlsmith
-              args: [--max-joins=2, --runtime=1500]
+              args: [--max-joins=1, --runtime=1500]
 
       - id: sqlsmith-explain
         label: "SQLsmith explain"

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -255,7 +255,7 @@ steps:
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
-            args: [--max-joins=2, --runtime=6000]
+            args: [--max-joins=1, --runtime=6000]
 
     - id: sqlsmith-explain-long
       label: "Longer SQLsmith explain"

--- a/test/pgtest-mz/stray-copy.pt
+++ b/test/pgtest-mz/stray-copy.pt
@@ -28,7 +28,7 @@ until
 ReadyForQuery
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"FORMAT BINARY not yet supported"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"FORMAT BINARY not yet supported"}]}
 ReadyForQuery {"status":"I"}
 RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["1"]}
@@ -51,7 +51,7 @@ until
 ReadyForQuery
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"FORMAT BINARY not yet supported"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"FORMAT BINARY not yet supported"}]}
 ReadyForQuery {"status":"I"}
 ParseComplete
 BindComplete

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -114,7 +114,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         # non-trivial arrangement sizes occur, indexes so index-based plans
         # (lookup/delta joins) occur, and arrays/lists/maps/ranges so
         # functions over those types have interesting inputs. NOTE: t5 is
-        # deliberately capped at 1000 rows, larger sizes make random
+        # deliberately capped at 100 rows. Larger sizes make random
         # multi-way joins OOM the memory-capped clusterd regularly.
         c.sql(
             """
@@ -186,7 +186,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             INSERT INTO t3 VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
             CREATE TABLE t4 (a int4, b text);
             CREATE TABLE t5 (a int4, b int8, c text);
-            INSERT INTO t5 SELECT a, a::int8 * 37, 'val_' || a FROM generate_series(1, 1000) g(a);
+            INSERT INTO t5 SELECT a, a::int8 * 37, 'val_' || a FROM generate_series(1, 100) g(a);
             CREATE INDEX t5_idx_a ON t5 (a);
             """,
             service=mz_server,


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/128284
Merge skew between https://github.com/MaterializeInc/materialize/pull/37436 and https://github.com/MaterializeInc/materialize/pull/37479
The sqlsmith one is fallout from https://github.com/MaterializeInc/materialize/pull/37562, which of course was green there and then immediately went OoM twice on main!