### PR TITLE
sql-parser: support OPERATOR(pg_catalog.=) and prefix OPERATOR(...)

### DIFF
--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -356,12 +356,7 @@ impl<T: AstInfo> AstDisplay for Expr<T> {
                 } else {
                     f.write_str(op);
                     f.write_str(" ");
-                    // A prefix operator binds tighter than `COLLATE` and the
-                    // binary operators but looser than the postfix `::`/`[…]`
-                    // forms, and `- <number>` lexes as a negative literal, so a
-                    // low-precedence or numeric-leftmost operand must be
-                    // parenthesized to keep the prefix operator's scope.
-                    if prefix_operand_needs_parens(expr1.as_ref()) {
+                    if prefix_operand_needs_parens(op, expr1.as_ref()) {
                         f.write_str("(");
                         f.write_node(&expr1);
                         f.write_str(")");
@@ -867,8 +862,28 @@ fn prints_self_delimiting<T: AstInfo>(expr: &Expr<T>) -> bool {
     }
 }
 
-/// Whether the operand of a prefix operator (`-`/`+`/`~`) must be parenthesized
-/// to round-trip. A prefix op binds *tighter* than `COLLATE`/`AT TIME ZONE` and
+/// Whether the operand of a prefix operator (an `Op` with no second operand)
+/// must be parenthesized so the printed expression reparses with the same
+/// structure. Shared by the `AstDisplay` impl and `mz-sql-pretty`, which must
+/// agree on when parens are required.
+///
+/// A bare `-`/`+` binds at `PrefixPlusMinus`, tighter than every infix
+/// operator, so any operand with an exposed operator spine needs parens, plus
+/// the `- <number>` fold and postfix hazards that
+/// `bare_prefix_operand_needs_parens` handles. An `Other`-level prefix (`~`
+/// or a namespaced `OPERATOR(...)`) instead reparses its operand at `Other`,
+/// so the operand re-associates exactly when its left spine exposes that level
+/// or looser, the same rule as a binary operator's right operand.
+pub fn prefix_operand_needs_parens<T: AstInfo>(op: &Op, operand: &Expr<T>) -> bool {
+    if unary_prec(op) == prec::PREFIX {
+        bare_prefix_operand_needs_parens(operand)
+    } else {
+        left_edge(operand) <= prec::OTHER
+    }
+}
+
+/// Whether the operand of a bare prefix `-`/`+` must be parenthesized
+/// to round-trip. Such a prefix op binds *tighter* than `COLLATE`/`AT TIME ZONE` and
 /// the binary/comparison operators, but *looser* than the postfix `::`/`[…]`
 /// forms — and `- <number>` additionally lexes as a negative literal. So peel
 /// the tight postfixes (`::`/`[…]`); if the chain bottoms out at a numeric
@@ -876,7 +891,7 @@ fn prints_self_delimiting<T: AstInfo>(expr: &Expr<T>) -> bool {
 /// than a self-delimiting non-`COLLATE` primary (a `COLLATE`, a binary op, …) the
 /// prefix op would re-associate — both need parens. (`a + b COLLATE c` reparses
 /// as `a + (b COLLATE c)`; `- x COLLATE c` as `(- x) COLLATE c`.)
-fn prefix_operand_needs_parens<T: AstInfo>(operand: &Expr<T>) -> bool {
+fn bare_prefix_operand_needs_parens<T: AstInfo>(operand: &Expr<T>) -> bool {
     let mut e = operand;
     let mut saw_postfix = false;
     loop {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1556,7 +1556,10 @@ impl<'a> Parser<'a> {
                 Some(Token::Keyword(kw)) => namespace.push(kw.into()),
                 Some(Token::Ident(id)) => namespace.push(self.new_identifier(id)?),
                 Some(Token::Op(op)) => break op,
+                // The lexer emits `*` and `=` as dedicated tokens rather than
+                // `Token::Op`, but both are valid operator names here.
                 Some(Token::Star) => break "*".to_string(),
+                Some(Token::Eq) => break "=".to_string(),
                 tok => self.expected(self.peek_prev_pos(), "operator", tok)?,
             }
             self.expect_token(&Token::Dot)?;

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -695,6 +695,20 @@ impl<'a> Parser<'a> {
             (Token::Keyword(NOT), _) => Ok(Expr::Not {
                 expr: Box::new(self.parse_subexpr(Precedence::PrefixNot)?),
             }),
+            (Token::Keyword(OPERATOR), Some(Token::LParen)) => {
+                self.expect_token(&Token::LParen)?;
+                let op = self.parse_operator()?;
+                self.expect_token(&Token::RParen)?;
+                // Like PostgreSQL, the operand of a prefix `OPERATOR(...)`
+                // parses at the precedence of "any other operator", not at
+                // the tighter precedence of bare unary `+` and `-`, so
+                // `OPERATOR(pg_catalog.-) 1 + 2` means `- (1 + 2)`.
+                Ok(Expr::Op {
+                    op,
+                    expr1: Box::new(self.parse_subexpr(Precedence::Other)?),
+                    expr2: None,
+                })
+            }
             (Token::Keyword(ROW), Some(Token::LParen)) => self.parse_row_expr(),
             (Token::Keyword(TRIM), Some(Token::LParen)) => self.parse_trim_expr(),
             (Token::Keyword(POSITION), Some(Token::LParen)) => self.parse_position_expr(),

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -699,6 +699,66 @@ parse-scalar roundtrip
 1 OPERATOR(pg_catalog.=) 2
 
 parse-scalar
+OPERATOR(pg_catalog.-) 1
+----
+Op { op: Op { namespace: Some([Ident("pg_catalog")]), op: "-" }, expr1: Value(Number("1")), expr2: None }
+
+parse-scalar roundtrip
+OPERATOR(pg_catalog.-) 1
+----
+OPERATOR(pg_catalog.-) 1
+
+parse-scalar roundtrip
+OPERATOR(-) 1
+----
+OPERATOR(-) 1
+
+parse-scalar
+OPERATOR(pg_catalog.-) 1 + 2
+----
+Op { op: Op { namespace: Some([Ident("pg_catalog")]), op: "-" }, expr1: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }, expr2: None }
+
+parse-scalar roundtrip
+OPERATOR(pg_catalog.-) (1 + 2)
+----
+OPERATOR(pg_catalog.-) (1 + 2)
+
+parse-scalar roundtrip
+OPERATOR(pg_catalog.-) 1 + 2
+----
+OPERATOR(pg_catalog.-) 1 + 2
+
+parse-scalar roundtrip
+2 * OPERATOR(pg_catalog.-) 3 + 4
+----
+2 * OPERATOR(pg_catalog.-) 3 + 4
+
+parse-scalar roundtrip
+~ 1 + 2
+----
+~ 1 + 2
+
+parse-scalar
+OPERATOR(pg_catalog.-) 1 < 2
+----
+Op { op: Op { namespace: None, op: "<" }, expr1: Op { op: Op { namespace: Some([Ident("pg_catalog")]), op: "-" }, expr1: Value(Number("1")), expr2: None }, expr2: Some(Value(Number("2"))) }
+
+parse-scalar roundtrip
+OPERATOR(pg_catalog.-) 1 < 2
+----
+OPERATOR(pg_catalog.-) 1 < 2
+
+parse-scalar
+2 * OPERATOR(pg_catalog.-) 3
+----
+Op { op: Op { namespace: None, op: "*" }, expr1: Value(Number("2")), expr2: Some(Op { op: Op { namespace: Some([Ident("pg_catalog")]), op: "-" }, expr1: Value(Number("3")), expr2: None }) }
+
+parse-scalar
+OPERATOR(-) OPERATOR(-) 1
+----
+Op { op: Op { namespace: Some([]), op: "-" }, expr1: Op { op: Op { namespace: Some([]), op: "-" }, expr1: Value(Number("1")), expr2: None }, expr2: None }
+
+parse-scalar
 1 < ANY (SELECT 2)
 ----
 AnySubquery { left: Value(Number("1")), op: Op { namespace: None, op: "<" }, right: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -679,6 +679,26 @@ parse-scalar
 Op { op: Op { namespace: Some([Ident("pg_catalog")]), op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }
 
 parse-scalar
+1 OPERATOR(=) 2
+----
+Op { op: Op { namespace: Some([]), op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }
+
+parse-scalar roundtrip
+1 OPERATOR(=) 2
+----
+1 OPERATOR(=) 2
+
+parse-scalar
+1 OPERATOR(pg_catalog.=) 2
+----
+Op { op: Op { namespace: Some([Ident("pg_catalog")]), op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }
+
+parse-scalar roundtrip
+1 OPERATOR(pg_catalog.=) 2
+----
+1 OPERATOR(pg_catalog.=) 2
+
+parse-scalar
 1 < ANY (SELECT 2)
 ----
 AnySubquery { left: Value(Number("1")), op: Op { namespace: None, op: "<" }, right: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None } }

--- a/src/sql-pretty/src/doc.rs
+++ b/src/sql-pretty/src/doc.rs
@@ -1217,49 +1217,7 @@ impl Pretty {
                         self.doc_expr(expr2).nest(TAB),
                     ])
                 } else {
-                    // See the AstDisplay `Expr::Op` comment (`prefix_operand_needs_parens`):
-                    // a prefix op binds tighter than `COLLATE`/the binary ops but
-                    // looser than the postfix `::`/`[…]`, and `- <number>` folds, so
-                    // peel the tight postfixes and parenthesize when the chain
-                    // bottoms out at a numeric literal or a non-self-delimiting /
-                    // `COLLATE` operand.
-                    let needs_parens = {
-                        let mut e = expr1.as_ref();
-                        let mut saw_postfix = false;
-                        loop {
-                            match e {
-                                Expr::Cast { expr, .. } | Expr::Subscript { expr, .. } => {
-                                    saw_postfix = true;
-                                    e = expr.as_ref();
-                                }
-                                Expr::Value(Value::Number(_)) => break saw_postfix,
-                                // Another prefix operator stacks directly (no
-                                // re-association, no `- <number>` fold) — safe,
-                                // and avoids exploding deep unary chains.
-                                Expr::Op { expr2: None, .. } | Expr::Not { .. } => break false,
-                                Expr::Value(_)
-                                | Expr::Identifier(_)
-                                | Expr::QualifiedWildcard(_)
-                                | Expr::Parameter(_)
-                                | Expr::Function(_)
-                                | Expr::HomogenizingFunction { .. }
-                                | Expr::NullIf { .. }
-                                | Expr::Subquery(_)
-                                | Expr::Exists(_)
-                                | Expr::Nested(_)
-                                | Expr::Array(_)
-                                | Expr::ArraySubquery(_)
-                                | Expr::List(_)
-                                | Expr::ListSubquery(_)
-                                | Expr::Map(_)
-                                | Expr::MapSubquery(_)
-                                | Expr::Case { .. }
-                                | Expr::Row { .. } => break false,
-                                _ => break true,
-                            }
-                        }
-                    };
-                    let operand = if needs_parens {
+                    let operand = if prefix_operand_needs_parens(op, expr1.as_ref()) {
                         bracket("(", self.doc_expr(expr1), ")")
                     } else {
                         self.doc_expr(expr1)

--- a/test/sqllogictest/operator.slt
+++ b/test/sqllogictest/operator.slt
@@ -54,6 +54,26 @@ select 2 OPERATOR(pg_catalog./) 2
 ----
 1
 
+query I
+select 1 where 1 OPERATOR(=) 1;
+----
+1
+
+query I
+select 1 where 1 OPERATOR(pg_catalog.=) 1;
+----
+1
+
+query I
+select 1 where 2 OPERATOR(pg_catalog.<>) 3;
+----
+1
+
+query I
+select 1 where 1 OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2]);
+----
+1
+
 query error operator does not exist: mz_catalog.*
 select 2 OPERATOR(mz_catalog.*) 2;
 
@@ -152,6 +172,15 @@ SHOW CREATE VIEW PG_MULTIPLIER
 ----
 materialize.public.pg_multiplier
 CREATE VIEW materialize.public.pg_multiplier AS SELECT 2 OPERATOR(pg_catalog.*) 2;
+
+statement ok
+CREATE VIEW PG_EQUALER AS SELECT 1 WHERE 1 OPERATOR(pg_catalog.=) 1;
+
+query TT
+SHOW CREATE VIEW PG_EQUALER
+----
+materialize.public.pg_equaler
+CREATE VIEW materialize.public.pg_equaler AS SELECT 1 WHERE 1 OPERATOR(pg_catalog.=) 1;
 
 query error Expected operator, found number "5."
 CREATE VIEW INVALID_FIVE AS select 2 OPERATOR(5.*) 2;

--- a/test/sqllogictest/operator.slt
+++ b/test/sqllogictest/operator.slt
@@ -74,6 +74,53 @@ select 1 where 1 OPERATOR(pg_catalog.=) ANY (ARRAY[1, 2]);
 ----
 1
 
+# Prefix (unary) OPERATOR().
+
+query I
+select OPERATOR(pg_catalog.-) 1;
+----
+-1
+
+query I
+select OPERATOR(-) 1;
+----
+-1
+
+query I
+select OPERATOR(pg_catalog.+) 5;
+----
+5
+
+query I
+select OPERATOR(pg_catalog.~) 1;
+----
+-2
+
+# The operand of a prefix OPERATOR() parses at the precedence of "any other
+# operator", like in PostgreSQL, so it absorbs binary + and *.
+query I
+select OPERATOR(pg_catalog.-) 1 + 2;
+----
+-3
+
+query I
+select 2 * OPERATOR(pg_catalog.-) 3 + 4;
+----
+-14
+
+query I
+select 1 where OPERATOR(pg_catalog.-) 1 < 2;
+----
+1
+
+query I
+select OPERATOR(-) OPERATOR(-) 1;
+----
+1
+
+query error operator does not exist: = integer
+select OPERATOR(pg_catalog.=) 1;
+
 query error operator does not exist: mz_catalog.*
 select 2 OPERATOR(mz_catalog.*) 2;
 
@@ -181,6 +228,15 @@ SHOW CREATE VIEW PG_EQUALER
 ----
 materialize.public.pg_equaler
 CREATE VIEW materialize.public.pg_equaler AS SELECT 1 WHERE 1 OPERATOR(pg_catalog.=) 1;
+
+statement ok
+CREATE VIEW PG_NEGATER AS SELECT OPERATOR(pg_catalog.-) 1 + 2;
+
+query TT
+SHOW CREATE VIEW PG_NEGATER
+----
+materialize.public.pg_negater
+CREATE VIEW materialize.public.pg_negater AS SELECT OPERATOR(pg_catalog.-) 1 + 2;
 
 query error Expected operator, found number "5."
 CREATE VIEW INVALID_FIVE AS select 2 OPERATOR(5.*) 2;


### PR DESCRIPTION
Fixes [SQL-486](https://linear.app/materializeinc/issue/SQL-486).

### Motivation

`expr OPERATOR(pg_catalog.=) expr` failed to parse with `Expected operator, found equals sign`, while every other operator worked inside `OPERATOR(...)`. psqlODBC generates this construct routinely, so the gap breaks real ODBC clients. PostgreSQL additionally accepts the prefix form, e.g. `SELECT OPERATOR(pg_catalog.-) 1`, which Materialize rejected entirely.

### Description

Two commits:

1. **Accept `=` inside `OPERATOR(...)`.** The lexer emits `=` (and `*`) as dedicated tokens rather than general operator tokens, and the `OPERATOR(...)` name parser only handled the general token and `*`. Map `=` back to its operator name, mirroring the existing `*` special case.

2. **Support the prefix (unary) `OPERATOR(...)` form.** Matching PostgreSQL, the operand parses at the precedence of "any other operator", looser than bare unary `+`/`-`, so `OPERATOR(pg_catalog.-) 1 + 2` means `- (1 + 2)`. Precedence behavior was verified against PostgreSQL 18, including compositions like `2 * OPERATOR(pg_catalog.-) 3 + 4`. Operator resolution reuses the infix path, so non-unary operators fail with `operator does not exist`, like PostgreSQL. The `OPERATOR(` construct is only claimed in expression position when followed by `(`, so `operator` remains usable as an identifier.

   The second commit also makes the AST printer's parenthesization of prefix operands precedence-aware. The printer used to over-parenthesize operands of `Other`-level prefix operators (`~` and namespaced `OPERATOR(...)`), which broke print/reparse fidelity for the new syntax. The rule now lives in one helper shared by `AstDisplay` and `mz-sql-pretty`, which previously duplicated the logic.

User-facing behavior change: `OPERATOR(pg_catalog.=)` (and unqualified `OPERATOR(=)`) now parses, and the prefix operator call syntax `OPERATOR(pg_catalog.-) expr` is now supported, improving PostgreSQL compatibility, in particular for psqlODBC.

### Verification

New parser datadriven tests in `src/sql-parser/tests/testdata/scalar` (ASTs, round-trips, and precedence pins) and new sqllogictest coverage in `test/sqllogictest/operator.slt` (results, precedence, error cases, and `SHOW CREATE VIEW` round-trips through the catalog). The existing `mz-sql-pretty` fidelity test now exercises the shared parenthesization rule across all parser testdata. Edge-case behavior (precedence, invalid prefix operators, `operator` as an identifier) was compared against a live PostgreSQL 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
