### PR TITLE
adapter: decide cluster restriction by schema identity, not name

### DIFF
--- a/src/adapter/src/coord/catalog_serving.rs
+++ b/src/adapter/src/coord/catalog_serving.rs
@@ -20,7 +20,6 @@
 
 use mz_expr::CollectionPlan;
 use mz_repr::GlobalId;
-use mz_repr::namespaces::is_system_schema;
 use mz_sql::catalog::SessionCatalog;
 use mz_sql::plan::{
     ExplainPlanPlan, ExplainTimestampPlan, Explainee, ExplaineeStatement, Plan, SubscribeFrom,
@@ -255,12 +254,17 @@ pub fn check_cluster_restrictions(
     };
 
     // Collect any items that are not allowed to be run on the catalog server cluster.
+    //
+    // Note: We decide whether an item is a system item by the identity of its
+    // schema, not the schema's name. A user-created schema can shadow a system
+    // schema name (`information_schema`) and must not bypass the restriction.
     let unallowed_dependents: SmallVec<[String; 2]> = depends_on
         .filter_map(|id| {
             let item = catalog.get_item_by_global_id(&id);
-            let full_name = catalog.resolve_full_name(item.name());
+            let schema_spec = item.name().qualifiers.schema_spec;
 
-            if !is_system_schema(&full_name.schema) {
+            if !catalog.is_system_schema_specifier(schema_spec) {
+                let full_name = catalog.resolve_full_name(item.name());
                 Some(full_name.to_string())
             } else {
                 None

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -526,11 +526,24 @@ SET CLUSTER TO foo;
 statement ok
 CREATE TABLE bar ( key text, val bigint );
 
+# The system check must decide by the schema's identity, not its bare name. A
+# user-created `information_schema` (the one system schema name not blocked by
+# the `mz_`/`pg_` prefix rule) must not bypass the restriction, so a user table
+# in it is rejected exactly like `materialize.public.bar` below.
+statement ok
+CREATE SCHEMA information_schema;
+
+statement ok
+CREATE TABLE materialize.information_schema.spoof ( key text );
+
 statement ok
 SET CLUSTER TO mz_catalog_server;
 
 statement error querying the following items "materialize\.public\.bar" is not allowed from the "mz_catalog_server" cluster
 SELECT key FROM bar;
+
+statement error querying the following items "materialize\.information_schema\.spoof" is not allowed from the "mz_catalog_server" cluster
+SELECT key FROM materialize.information_schema.spoof;
 
 # INSERT ... SELECT with a non-constant body is internally a read-then-write
 # whose SELECT half peeks on the active cluster, so reading a user object this


### PR DESCRIPTION
Fixes SQL-434

### Motivation

The `mz_catalog_server` cluster is reserved for system catalog queries, so user objects must not be queryable from it. `check_cluster_restrictions` decided whether an item is a system item by matching its bare schema name against the system schema names. A user-created schema named `information_schema`, the one system schema name not blocked by the `mz_`/`pg_` prefix reservation, therefore let user objects slip past the restriction and run on `mz_catalog_server`.

### Description

Decide by the schema's identity instead of its name: check the item's `SchemaSpecifier` with `SessionCatalog::is_system_schema_specifier`, which resolves against the ambient system schemas' IDs. A name-colliding user schema has a user schema ID and is now correctly rejected. This matches how `auto_run_on_catalog_server` in the same module already makes the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
