### PR TITLE
pgwire: report ParameterStatus for DISCARD ALL

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -640,7 +640,10 @@ pub enum ExecuteResponse {
     /// The temporary objects associated with the session have been discarded.
     DiscardedTemp,
     /// All state associated with the session has been discarded.
-    DiscardedAll,
+    DiscardedAll {
+        /// Session parameters that changed because the session was reset.
+        params: BTreeMap<&'static str, String>,
+    },
     /// The requested object was dropped.
     DroppedObject(ObjectType),
     /// The requested objects were dropped.
@@ -802,7 +805,7 @@ impl TryInto<ExecuteResponse> for ExecuteResponseKind {
             ExecuteResponseKind::DeclaredCursor => Ok(ExecuteResponse::DeclaredCursor),
             ExecuteResponseKind::Deleted => Err(()),
             ExecuteResponseKind::DiscardedTemp => Ok(ExecuteResponse::DiscardedTemp),
-            ExecuteResponseKind::DiscardedAll => Ok(ExecuteResponse::DiscardedAll),
+            ExecuteResponseKind::DiscardedAll => Err(()),
             ExecuteResponseKind::DroppedObject => Err(()),
             ExecuteResponseKind::DroppedOwned => Ok(ExecuteResponse::DroppedOwned),
             ExecuteResponseKind::EmptyQuery => Ok(ExecuteResponse::EmptyQuery),
@@ -864,7 +867,7 @@ impl ExecuteResponse {
             DeclaredCursor => Some("DECLARE CURSOR".into()),
             Deleted(n) => Some(format!("DELETE {}", n)),
             DiscardedTemp => Some("DISCARD TEMP".into()),
-            DiscardedAll => Some("DISCARD ALL".into()),
+            DiscardedAll { .. } => Some("DISCARD ALL".into()),
             DroppedObject(o) => Some(format!("DROP {o}")),
             DroppedOwned => Some("DROP OWNED".into()),
             EmptyQuery => None,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -554,8 +554,8 @@ impl Coordinator {
                         let (_, retire_notify) = self.clear_transaction(ctx.session_mut()).await;
                         ctx.delay_response_until(retire_notify);
                         self.drop_temp_items(ctx.session().conn_id()).await;
-                        ctx.session_mut().reset();
-                        Ok(ExecuteResponse::DiscardedAll)
+                        let params = ctx.session_mut().reset();
+                        Ok(ExecuteResponse::DiscardedAll { params })
                     } else {
                         Err(AdapterError::OperationProhibitsTransaction(
                             "DISCARD ALL".into(),

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -820,12 +820,14 @@ impl Session {
         coord_bail!("unable to create a new portal");
     }
 
-    /// Resets the session to its initial state. Returns sinks that need to be
-    /// dropped.
-    pub fn reset(&mut self) {
+    /// Resets the session to its initial state.
+    ///
+    /// Returns the session parameters whose value changed as a result, with
+    /// their new values, so that callers can report the changes to the client.
+    pub fn reset(&mut self) -> BTreeMap<&'static str, String> {
         let _ = self.clear_transaction();
         self.prepared_statements.clear();
-        self.vars.reset_all();
+        self.vars.reset_all()
     }
 
     /// Returns the [application_name] that created this session.

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -243,7 +243,7 @@ impl From<&ExecuteResponse> for StatementEndedExecutionReason {
             | ExecuteResponse::DeclaredCursor
             | ExecuteResponse::Deleted(_)
             | ExecuteResponse::DiscardedTemp
-            | ExecuteResponse::DiscardedAll
+            | ExecuteResponse::DiscardedAll { .. }
             | ExecuteResponse::DroppedObject(_)
             | ExecuteResponse::DroppedOwned
             | ExecuteResponse::EmptyQuery

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1539,7 +1539,6 @@ async fn execute_stmt<S: ResultSender>(
         | ExecuteResponse::Comment
         | ExecuteResponse::Deleted(_)
         | ExecuteResponse::DiscardedTemp
-        | ExecuteResponse::DiscardedAll
         | ExecuteResponse::DroppedObject(_)
         | ExecuteResponse::DroppedOwned
         | ExecuteResponse::EmptyQuery
@@ -1566,7 +1565,8 @@ async fn execute_stmt<S: ResultSender>(
         )
         .into(),
         ExecuteResponse::TransactionCommitted { params }
-        | ExecuteResponse::TransactionRolledBack { params } => {
+        | ExecuteResponse::TransactionRolledBack { params }
+        | ExecuteResponse::DiscardedAll { params } => {
             let notify_set: mz_ore::collections::HashSet<_> = client
                 .session()
                 .vars()

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -901,6 +901,11 @@ fn test_pgtest_mz_desc() {
 }
 
 #[mz_ore::test]
+fn test_pgtest_mz_discard() {
+    pg_test_inner(Path::new("../../test/pgtest-mz/discard.pt"), true);
+}
+
+#[mz_ore::test]
 fn test_pgtest_mz_notice() {
     pg_test_inner(Path::new("../../test/pgtest-mz/notice.pt"), true);
 }

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -151,6 +151,10 @@ impl PgConn {
         err_field_typs: Vec<char>,
         ignore: BTreeSet<String>,
     ) -> anyhow::Result<Vec<String>> {
+        // ParameterStatus messages are skipped unless the test explicitly
+        // expects them, because the server may send them at surprising times
+        // (e.g. during connection startup).
+        let expect_parameter_status = until.iter().any(|m| m.starts_with("ParameterStatus"));
         let mut msgs = Vec::with_capacity(until.len());
         for expect in until {
             loop {
@@ -296,7 +300,18 @@ impl PgConn {
                             parameters: body.parameters().collect().unwrap(),
                         })?,
                     ),
-                    Message::ParameterStatus(_) => continue,
+                    Message::ParameterStatus(body) => {
+                        if !expect_parameter_status {
+                            continue;
+                        }
+                        (
+                            "ParameterStatus",
+                            serde_json::to_string(&ParameterStatus {
+                                name: body.name()?.to_string(),
+                                value: body.value()?.to_string(),
+                            })?,
+                        )
+                    }
                     Message::NoData => ("NoData", "".to_string()),
                     Message::EmptyQueryResponse => ("EmptyQueryResponse", "".to_string()),
                     _ => ("UNKNOWN", format!("'{}'", ch)),
@@ -451,6 +466,12 @@ pub struct CopyOut {
 #[derive(Serialize)]
 pub struct ParameterDescription {
     parameters: Vec<u32>,
+}
+
+#[derive(Serialize)]
+pub struct ParameterStatus {
+    pub name: String,
+    pub value: String,
 }
 
 #[derive(Serialize)]

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -2365,7 +2365,8 @@ where
                     .await
             }
             ExecuteResponse::TransactionCommitted { params }
-            | ExecuteResponse::TransactionRolledBack { params } => {
+            | ExecuteResponse::TransactionRolledBack { params }
+            | ExecuteResponse::DiscardedAll { params } => {
                 let notify_set: mz_ore::collections::HashSet<String> = self
                     .adapter_client
                     .session()
@@ -2409,7 +2410,6 @@ where
             | ExecuteResponse::Comment
             | ExecuteResponse::Deallocate { .. }
             | ExecuteResponse::Deleted(..)
-            | ExecuteResponse::DiscardedAll
             | ExecuteResponse::DiscardedTemp
             | ExecuteResponse::DroppedObject(_)
             | ExecuteResponse::DroppedOwned

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -521,11 +521,22 @@ impl SessionVars {
     }
 
     /// Resets all variables to their default value.
-    pub fn reset_all(&mut self) {
+    ///
+    /// Returns the parameters whose value changed as a result, with their new
+    /// values, so that callers can report the changes to the client.
+    pub fn reset_all(&mut self) -> BTreeMap<&'static str, String> {
+        let mut changed = BTreeMap::new();
         let names: Vec<_> = self.vars.keys().copied().collect();
         for name in names {
-            self.vars[name].reset(false);
+            let var = &mut self.vars[name];
+            let before = var.value();
+            var.reset(false);
+            let after = var.value();
+            if before != after {
+                changed.insert(var.name(), after);
+            }
         }
+        changed
     }
 
     /// Returns a [`Var`] representing the configuration parameter with the

--- a/test/pgtest-mz/discard.pt
+++ b/test/pgtest-mz/discard.pt
@@ -1,0 +1,70 @@
+# DISCARD ALL resets session variables and must send a ParameterStatus
+# message for every parameter in the notify set whose value changed, just
+# like RESET does. Connection poolers (e.g. pgbouncer with
+# server_reset_query) rely on this to keep their tracked parameters in sync.
+#
+# Note that Materialize sends ParameterStatus before CommandComplete, while
+# PostgreSQL sends it after, which is why this test lives in pgtest-mz.
+
+send
+Query {"query": "SET application_name = 'foo'"}
+----
+
+until
+ParameterStatus
+CommandComplete
+ReadyForQuery
+----
+ParameterStatus {"name":"application_name","value":"foo"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "DISCARD ALL"}
+----
+
+until
+ParameterStatus
+CommandComplete
+ReadyForQuery
+----
+ParameterStatus {"name":"application_name","value":""}
+CommandComplete {"tag":"DISCARD ALL"}
+ReadyForQuery {"status":"I"}
+
+# Multiple changed parameters are all reported, in one batch.
+
+send
+Query {"query": "SET application_name = 'bar'"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "SET timezone = 'GMT'"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "DISCARD ALL"}
+----
+
+until
+ParameterStatus
+ParameterStatus
+CommandComplete
+ReadyForQuery
+----
+ParameterStatus {"name":"TimeZone","value":"UTC"}
+ParameterStatus {"name":"application_name","value":""}
+CommandComplete {"tag":"DISCARD ALL"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Fixes [SQL-485](https://linear.app/materializeinc/issue/SQL-485)

### Motivation

`DISCARD ALL` resets all session variables but did not send `ParameterStatus` messages for the reportable (GUC_REPORT) parameters it changed, unlike `RESET <var>`. Connection poolers that track reported parameters silently desync from the server. For example, with pgbouncer and `server_reset_query_always=1`, every client's `application_name` silently became `''` on Materialize while PostgreSQL preserves the pooler-tracked value. PostgreSQL reports every changed GUC_REPORT parameter after `DISCARD ALL` (verified against Postgres 18 on the raw wire).

### Description

`DISCARD ALL` now sends a `ParameterStatus` message for every parameter in the notify set whose value changed as a result of the session reset, matching PostgreSQL's wire behavior.

This reuses the existing reporting mechanism instead of hand-emitting messages: `SessionVars::reset_all` and `Session::reset` now return the parameters whose value changed, `ExecuteResponse::DiscardedAll` carries them, and the pgwire endpoint handles them in the same match arm as `TransactionCommitted`/`TransactionRolledBack`, which already report changed parameters. The websocket SQL endpoint gets the same treatment, so `DISCARD ALL` over ws now includes the changed parameters in its result, consistent with how that endpoint reports `SET` and transaction ends.

One benign divergence from PostgreSQL: Materialize sends `ParameterStatus` before `CommandComplete`, PostgreSQL after. The protocol does not specify an order, and this matches Materialize's existing `SET`/`RESET` behavior.

The pgtest framework previously discarded all `ParameterStatus` messages. It now renders them when (and only when) a test's `until` block explicitly expects `ParameterStatus`, so existing tests are unaffected.

### Verification

* New regression test `test/pgtest-mz/discard.pt` asserts on the raw wire that `SET application_name` followed by `DISCARD ALL` produces `ParameterStatus {"name":"application_name","value":""}`, including a case with two changed parameters (`TimeZone` and `application_name`) reported in one batch.
* Verified PostgreSQL 18's behavior with a raw-pgwire probe: `DISCARD ALL` (and `RESET ALL`) emit `ParameterStatus` for each changed GUC_REPORT parameter, restoring startup-packet values. Materialize already treats startup parameters as session defaults (`test_startup_params_survive_reset`), so the reported values match.
* Existing coverage: full pgtest suite, `test/sqllogictest/discard.slt`, and the mz-sql/mz-pgwire unit tests all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
