### PR TITLE
adapter: fix panic in EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -1008,8 +1008,16 @@ impl Coordinator {
         // We don't have any way to "duplicate" the read hold of the actual collection, which we
         // obtain below... but the current implementation of read holds guarantees that the storage
         // holds we obtain here will not be any greater than the hold we actually want.
-        let read_holds =
-            Some(self.acquire_read_holds(&dataflow_import_id_bundle(&plan, mview.cluster_id)));
+        //
+        // We hold only the plan's storage imports, whose persist part stats the pushdown
+        // explanation reads. We must not acquire holds on the plan's compute imports: an index
+        // that the materialized view was planned against can be dropped while the view keeps
+        // running, and a dropped index no longer has a compute collection to hold.
+        let id_bundle = CollectionIdBundle {
+            storage_ids: plan.source_imports.keys().copied().collect(),
+            compute_ids: BTreeMap::new(),
+        };
+        let read_holds = Some(self.acquire_read_holds(&id_bundle));
 
         let frontiers = self
             .controller

--- a/test/sqllogictest/explain/pushdown.slt
+++ b/test/sqllogictest/explain/pushdown.slt
@@ -136,6 +136,27 @@ EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW big_numbers
 ----
 materialize.public.numbers  1313  0  1  0
 
+# Regression test for a panic (SQL-519): EXPLAIN FILTER PUSHDOWN FOR
+# MATERIALIZED VIEW panicked with "missing compute collection" when the view's
+# plan imported an index that was dropped after the view was created. The
+# dropped index no longer has a compute collection, but the view's dataflow
+# keeps running and reading from it.
+
+statement ok
+CREATE INDEX numbers_value_idx ON numbers (value);
+
+statement ok
+CREATE MATERIALIZED VIEW indexed_numbers AS SELECT * FROM numbers WHERE value > 10000;
+
+statement ok
+DROP INDEX numbers_value_idx;
+
+# The view's plan reads entirely from the (dropped) index, so there are no
+# storage imports to report stats for.
+query TIIII
+EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW indexed_numbers
+----
+
 # EXPLAIN FILTER PUSHDOWN should work even if there are no replicas.
 statement ok
 CREATE CLUSTER no_replicas (SIZE 'scale=1,workers=1', REPLICATION FACTOR 0);


### PR DESCRIPTION
Fixes SQL-519

### Motivation

`EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW` panicked with `missing compute collection: CollectionMissing(...)` and crashed environmentd when the view's cached physical plan imported an index that was later dropped. This was seen in CI in the Parallel Workload (0dt deploy) job.

This was not a race. Dropping an index that a materialized view was planned against is allowed (the view's dataflow keeps running), but the compute controller removes the index's collection immediately on drop. The view's cached physical plan still imports the dropped index, so once the index was dropped, every `EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW` on that view deterministically panicked while acquiring read holds on the plan's imports, until the next restart.

### Description

`explain_pushdown_materialized_view` now acquires read holds only on the plan's storage imports instead of the full import bundle. The pushdown explanation only reads persist part stats of the plan's storage imports, so compute holds served no purpose. Storage imports are catalog dependencies of the view and cannot be dropped while it exists, so acquiring holds on them cannot hit a missing collection on the coordinator task.

User-facing change: `EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW` no longer crashes environmentd after an index imported by the view's cached plan was dropped. The statement now succeeds and reports stats for the plan's storage imports (possibly zero rows if the plan reads entirely from the dropped index).

The `EXPLAIN FILTER PUSHDOWN FOR SELECT` path is unaffected: it goes through the staged peek sequencing, which re-checks plan validity and selects indexes from the current catalog synchronously on the coordinator task.

### Verification

- Deterministic repro before the fix (create table, create index, create materialized view using the index, drop index, `EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW`) crashes environmentd with the exact CI panic. After the fix the statement returns cleanly, both for an index-only plan and for a plan with mixed storage and index imports.
- Added a regression test to `test/sqllogictest/explain/pushdown.slt` that panics environmentd without the fix and passes with it.
- Ran `test/sqllogictest/explain/pushdown.slt`, `materialized_views.slt`, `statement_timeout.slt`, and `explain/broken_statements.slt`, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
