### PR TITLE
adapter: fail cleanly when a staged CREATE races with DROP ... CASCADE

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -2845,6 +2845,18 @@ steps:
                composition: race-condition
                run: rotate-keys-race
 
+       - id: race-condition-create-secret-db-drop
+         topics: [iceberg, kafka, mysql, postgres, sql-server]
+         label: "CREATE SECRET vs DROP DATABASE race"
+         depends_on: build-x86_64
+         timeout_in_minutes: 15
+         agents:
+           queue: hetzner-x86-64-4cpu-8gb
+         plugins:
+           - ./ci/plugins/mzcompose:
+               composition: race-condition
+               run: create-secret-db-drop-race
+
   - id: mz-deploy
     topics: [kafka, postgres]
     label: "mz-deploy"

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1627,6 +1627,10 @@ impl CatalogState {
             .flatten()
     }
 
+    pub(super) fn try_get_database(&self, database_id: &DatabaseId) -> Option<&Database> {
+        self.database_by_id.get(database_id)
+    }
+
     pub(super) fn get_database(&self, database_id: &DatabaseId) -> &Database {
         &self.database_by_id[database_id]
     }

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -1620,6 +1620,42 @@ impl Catalog {
                 item,
                 owner_id,
             } => {
+                // Concurrent DDL may commit between planning and this
+                // transaction, because staged statements (e.g. CREATE SECRET,
+                // CONNECTION, SOURCE) do off-thread work in between. A
+                // concurrent DROP ... CASCADE can therefore have removed the
+                // item's target database or schema, and nothing downstream
+                // revalidates them: `insert_user_item` would durably write the
+                // item under a dangling schema id and `resolve_full_name`
+                // below panics on the missing entry. Reject the op with a
+                // clean error instead.
+                if name.qualifiers.schema_spec != SchemaSpecifier::Temporary {
+                    if let ResolvedDatabaseSpecifier::Id(database_id) =
+                        &name.qualifiers.database_spec
+                    {
+                        if state.try_get_database(database_id).is_none() {
+                            return Err(AdapterError::ConcurrentDependencyDrop {
+                                dependency_kind: "database",
+                                dependency_id: database_id.to_string(),
+                            });
+                        }
+                    }
+                    let conn_id = session.map_or(&SYSTEM_CONN_ID, |session| session.conn_id());
+                    if state
+                        .try_get_schema(
+                            &name.qualifiers.database_spec,
+                            &name.qualifiers.schema_spec,
+                            conn_id,
+                        )
+                        .is_none()
+                    {
+                        return Err(AdapterError::ConcurrentDependencyDrop {
+                            dependency_kind: "schema",
+                            dependency_id: name.qualifiers.schema_spec.to_string(),
+                        });
+                    }
+                }
+
                 state.check_unstable_dependencies(&item)?;
 
                 match &item {
@@ -4058,6 +4094,86 @@ mod tests {
             let all_t2 = state_all_at_once.try_get_entry(&id_t2).expect("all t2");
             assert_eq!(inc_t2.name(), all_t2.name());
             assert_eq!(inc_t2.owner_id, all_t2.owner_id);
+
+            catalog.expire().await;
+        })
+        .await
+    }
+
+    /// Regression test for SQL-518: an `Op::CreateItem` whose target database
+    /// or schema no longer exists must fail with a clean error instead of
+    /// panicking during name resolution. This happens when a staged CREATE
+    /// (e.g. CREATE SECRET) finishes after a concurrent DROP ... CASCADE
+    /// removed the target.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method`
+    async fn test_create_item_into_dropped_database_or_schema() {
+        use mz_catalog::memory::objects::Secret;
+        use mz_ore::assert_contains;
+        use mz_sql::names::{DatabaseId, SchemaId, SchemaSpecifier};
+
+        Catalog::with_debug(|mut catalog| async move {
+            let database = catalog
+                .resolve_database(DEFAULT_DATABASE_NAME)
+                .expect("default database");
+            let database_spec = ResolvedDatabaseSpecifier::Id(database.id());
+
+            let (id, global_id) = catalog
+                .allocate_user_id_for_test()
+                .await
+                .expect("allocate id");
+
+            let make_secret_op = |database_spec, schema_spec| Op::CreateItem {
+                id,
+                name: QualifiedItemName {
+                    qualifiers: ItemQualifiers {
+                        database_spec,
+                        schema_spec,
+                    },
+                    item: "sec".to_string(),
+                },
+                item: CatalogItem::Secret(Secret {
+                    create_sql: "CREATE SECRET sec AS 'x'".to_string(),
+                    global_id,
+                }),
+                owner_id: MZ_SYSTEM_ROLE_ID,
+            };
+
+            // Ids that have never been allocated stand in for a database and
+            // schema dropped between staging and the finishing transaction.
+            let oracle_write_ts = catalog.current_upper().await;
+            let err = catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![make_secret_op(
+                        ResolvedDatabaseSpecifier::Id(DatabaseId::User(u64::MAX)),
+                        SchemaSpecifier::Id(SchemaId::User(u64::MAX)),
+                    )],
+                )
+                .await
+                .map(|_| ())
+                .expect_err("create into missing database must fail");
+            assert_contains!(err.to_string(), "database");
+            assert_contains!(err.to_string(), "was dropped");
+
+            let oracle_write_ts = catalog.current_upper().await;
+            let err = catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![make_secret_op(
+                        database_spec,
+                        SchemaSpecifier::Id(SchemaId::User(u64::MAX)),
+                    )],
+                )
+                .await
+                .map(|_| ())
+                .expect_err("create into missing schema must fail");
+            assert_contains!(err.to_string(), "schema");
+            assert_contains!(err.to_string(), "was dropped");
 
             catalog.expire().await;
         })

--- a/src/adapter/src/coord/sequencer/inner/secret.rs
+++ b/src/adapter/src/coord/sequencer/inner/secret.rs
@@ -127,6 +127,14 @@ impl Coordinator {
             || "create secret ensure",
             async move {
                 secrets_controller.ensure(item_id, &payload).await?;
+
+                // Pause between the secret-store write and the finishing
+                // catalog transaction so a concurrent DROP DATABASE/SCHEMA
+                // ... CASCADE can commit. Runs in the off-thread ensure task,
+                // not the coordinator main loop, so the pause won't freeze
+                // the coordinator (which would block that DROP).
+                fail::fail_point!("create_secret_between_ensure_and_finish");
+
                 let stage = SecretStage::CreateFinish(CreateSecretFinish {
                     validity,
                     item_id,

--- a/test/race-condition/mzcompose.py
+++ b/test/race-condition/mzcompose.py
@@ -1521,3 +1521,91 @@ def workflow_rotate_keys_race(c: Composition, parser: WorkflowArgumentParser) ->
         )
 
     print(f"OK: ROTATE aborted with OCC conflict, SET preserved: {err_str}")
+
+
+# Pauses CREATE SECRET in its off-thread ensure task, between the secret-store
+# write and the finishing catalog transaction. Defined in
+# src/adapter/src/coord/sequencer/inner/secret.rs.
+CREATE_SECRET_FAILPOINT = "create_secret_between_ensure_and_finish"
+
+# Substring of the Display impl of `AdapterError::ConcurrentDependencyDrop` in
+# src/adapter/src/error.rs; what we look for in the CREATE SECRET error to
+# confirm the concurrent drop was detected cleanly.
+CONCURRENT_DROP_MESSAGE = "was dropped"
+
+
+def workflow_create_secret_db_drop_race(
+    c: Composition, parser: WorkflowArgumentParser
+) -> None:
+    """Regression test for SQL-518: the coordinator panics with
+    `OrdMap::index: invalid key` when a staged CREATE SECRET finishes after its
+    target database was dropped.
+
+    CREATE SECRET is staged: the ensure stage writes the secret to the secret
+    store in an off-thread task, then the finish stage transacts the catalog
+    back on the coordinator loop. A DROP DATABASE ... CASCADE that commits
+    inside that window removes the secret's target database and schema, and
+    the finishing `Op::CreateItem` used to panic resolving the new item's full
+    name against the missing database. With the fix, `transact_op` revalidates
+    the target database and schema and returns
+    `AdapterError::ConcurrentDependencyDrop` instead.
+
+    We force the interleaving deterministically with the
+    `create_secret_between_ensure_and_finish` failpoint.
+    """
+    parser.parse_args()
+
+    c.up("materialized")
+
+    c.sql("CREATE DATABASE secret_race_db")
+
+    # `SET failpoints` writes to the process-global registry, so the pause
+    # applies to any session that later hits the named failpoint.
+    c.sql(f"SET failpoints = '{CREATE_SECRET_FAILPOINT}=pause'")
+
+    create_err: Exception | None = None
+
+    def create_secret() -> None:
+        nonlocal create_err
+        try:
+            with c.sql_cursor(reuse_connection=False) as cur:
+                cur.execute(b"CREATE SECRET secret_race_db.public.sec1 AS 'val'")
+        except Exception as e:
+            create_err = e
+
+    t_create = PropagatingThread(target=create_secret, name="create_secret")
+    t_create.start()
+
+    # Give CREATE SECRET time to evaluate the secret, write it to the secret
+    # store, and park at the failpoint.
+    time.sleep(1)
+
+    # CREATE SECRET is now blocked between ensure and finish. Drop its target
+    # database. CASCADE is required because the database is not empty (it
+    # contains the public schema).
+    c.sql("DROP DATABASE secret_race_db CASCADE")
+
+    # Release CREATE SECRET. It will resume into the finishing catalog
+    # transaction, whose `Op::CreateItem` must now detect the missing
+    # database instead of panicking.
+    c.sql(f"SET failpoints = '{CREATE_SECRET_FAILPOINT}=off'")
+
+    t_create.join()
+
+    if create_err is None:
+        raise Exception(
+            "CREATE SECRET unexpectedly succeeded despite its target database "
+            "being dropped inside the staging window."
+        )
+
+    err_str = str(create_err)
+    if CONCURRENT_DROP_MESSAGE not in err_str:
+        raise Exception(
+            "CREATE SECRET failed but not with the expected concurrent-drop "
+            f"error (did the coordinator panic?): {create_err}"
+        )
+
+    # The coordinator must have survived.
+    c.sql_query("SELECT 1")
+
+    print(f"OK: CREATE SECRET aborted cleanly on the dropped database: {err_str}")


### PR DESCRIPTION
Fixes [SQL-518](https://linear.app/materializeinc/issue/SQL-518)

### Motivation

Nightly Parallel Workload hit a coordinator panic (`OrdMap::index: invalid key` in `CatalogState::get_database`, reached via `resolve_full_name` in `Catalog::transact_op`). CREATE SECRET is staged: its ensure stage writes the secret to the secret store in an off-thread task, and only the finish stage transacts the catalog. CREATE SECRET is exempt from DDL serialization, so a concurrent `DROP DATABASE ... CASCADE` can commit inside that window. The finishing `Op::CreateItem` then names a schema in the dropped database and the coordinator panics resolving the new item's full name. The CREATE SECRET `PlanValidity` tracks no dependencies, so nothing catches the drop before the transaction. The same window exists for `DROP SCHEMA ... CASCADE` (via the schema lookup one step later) and for every other statement that reaches `Op::CreateItem` without holding the DDL lock: CREATE CONNECTION (off-thread validation) and CREATE SOURCE / SINK / TABLE FROM SOURCE (off-thread purification).

### Description

User-facing change: a staged CREATE statement (CREATE SECRET, CREATE CONNECTION, CREATE SOURCE, CREATE SINK, CREATE TABLE ... FROM SOURCE) that races with a concurrent `DROP DATABASE ... CASCADE` or `DROP SCHEMA ... CASCADE` of its target now returns a clean `database 'uN' was dropped` / `schema 'uN' was dropped` error instead of crashing `environmentd`.

The fix is at the `transact_op` level rather than in `PlanValidity`, so one check covers the whole statement class. `Op::CreateItem` now revalidates that the item's target database and schema still exist and returns `AdapterError::ConcurrentDependencyDrop` otherwise, consistent with the error `PlanValidity` raises for concurrently dropped dependencies. The check must sit before `insert_user_item`: the durable catalog performs no referential validation, so without it a fallible name lookup would durably commit an item under a dangling schema id (previously only the panic prevented that).

Also adds a `create_secret_between_ensure_and_finish` failpoint (mirroring the existing rotate-keys one) and a deterministic regression workflow `create-secret-db-drop-race` in `test/race-condition`, wired into Nightly as a new step `race-condition-create-secret-db-drop`.

### Verification

* Pre-fix, the new race-condition workflow reproduces the exact CI panic (same message and stack); post-fix it passes: CREATE SECRET fails with `database 'u2' was dropped`, the coordinator survives, and the sanity restart finds no panics.
* New unit test `test_create_item_into_dropped_database_or_schema` exercises the `transact_op` check directly for both the missing-database and missing-schema cases.
* `catalog::transact` and `coord::validity` unit test suites, plus `test/sqllogictest/secret.slt` and `schemas.slt`, pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
