### PR TITLE
storage-controller: keep export descriptions in sync on ALTER SINK and skip no-op connection alters

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1665,6 +1665,14 @@ impl StorageController for Controller {
 
                 (export_description, as_of)
             };
+            // If the connection hasn't changed, there's no sense in restarting
+            // the sink dataflow. Catalog changes that don't affect the
+            // connection's runtime config, like GRANT and REVOKE, also arrive
+            // here.
+            if new_export_description.sink.connection == connection {
+                continue;
+            }
+
             let current_sink = new_export_description.sink.clone();
 
             new_export_description.sink.connection = connection;

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1594,10 +1594,10 @@ impl StorageController for Controller {
             id,
             description: StorageSinkDesc {
                 from: from_id,
-                from_desc: new_description.sink.from_desc,
-                connection: new_description.sink.connection,
+                from_desc: new_description.sink.from_desc.clone(),
+                connection: new_description.sink.connection.clone(),
                 envelope: new_description.sink.envelope,
-                as_of: new_description.sink.as_of,
+                as_of: new_description.sink.as_of.clone(),
                 version: new_description.sink.version,
                 from_storage_metadata,
                 with_snapshot,
@@ -1616,6 +1616,23 @@ impl StorageController for Controller {
             })?;
 
         instance.send(StorageCommand::RunSink(Box::new(cmd)));
+
+        // Store the new description as the export's current definition, so
+        // that later operations work off the sink we just told the cluster to
+        // run. In particular, alter_export_connections diffs an updated
+        // connection against this description with alter_compatible. Leaving
+        // the old description in place makes any later connection alter fail
+        // against a sink definition the catalog has already moved past, which
+        // panics the coordinator.
+        let state = self
+            .collections
+            .get_mut(&id)
+            .expect("export known to exist");
+        let DataSource::Sink { desc } = &mut state.data_source else {
+            panic!("export known to exist")
+        };
+        *desc = new_description;
+
         Ok(())
     }
 

--- a/test/testdrive/alter-sink.td
+++ b/test/testdrive/alter-sink.td
@@ -125,6 +125,20 @@ $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
 $ kafka-verify-data format=json sink=materialize.public.sink key=false
 {"before": null, "after": {"created_post_name": "hundred", "created_post_value": 99}}
 
+# Regression test for SQL-517. A catalog change to a connection, for example
+# a GRANT, re-alters all dependent sinks in the storage controller. This used
+# to panic the coordinator after ALTER SINK ... SET FROM, because the
+# controller kept the sink's pre-ALTER description and considered the newly
+# computed connection incompatible with it.
+> CREATE ROLE conn_grant_role;
+
+> GRANT USAGE ON CONNECTION kafka_conn TO conn_grant_role;
+
+> INSERT INTO created_post_alter VALUES ('after-grant', 1);
+
+$ kafka-verify-data format=json sink=materialize.public.sink key=false
+{"before": null, "after": {"created_post_name": "after-grant", "created_post_value": 1}}
+
 # COMMIT INTERVAL only applies to Iceberg sinks.
 ! ALTER SINK sink SET (COMMIT INTERVAL = '1s');
 contains: COMMIT INTERVAL option is not supported with KAFKA sinks


### PR DESCRIPTION
Fixes [SQL-517](https://linear.app/materializeinc/issue/SQL-517)

### Motivation

`GRANT`, `REVOKE`, `ALTER ... OWNER`, or `ALTER CONNECTION` on a connection
panicked the coordinator with

```
altering export connections after txn must succeed: InvalidAlter(AlterError { id: User(...) })
```

whenever a dependent sink had previously been changed with
`ALTER SINK ... SET FROM`. Seen in the Nightly Parallel Workload jobs
"rename + naughty identifiers" and "DDL Only".

Root cause: `StorageController::alter_export` (the `ALTER SINK` path) sends the
new sink definition to the cluster and updates the `ExportState`, but never
wrote the new `ExportDescription` into the collection's `DataSource::Sink`. The
controller's stored export description therefore kept the sink definition from
sink creation forever. This update was lost when the description moved from
`ExportState` into `CollectionState` in 273b3e42cf ("Make sinks a variant of
collections").

Any catalog change to a connection item (including privilege and owner changes)
emits a `Connection(Altered)` implication, which recomputes the connection of
every dependent sink from the catalog and calls `alter_export_connections`.
That method diffs the new connection against the stale stored description with
`alter_compatible`, which requires fields like `value_desc` and
`relation_key_indices` to match. After an `ALTER SINK ... SET FROM` had changed
those, the check failed with `InvalidAlter`, and the coordinator treats that as
a violated invariant and panics.

### Description

Two commits:

* **Keep the stored export description current on `ALTER SINK`** (the bug fix):
  `alter_export` now stores the new `ExportDescription` in the collection state
  after sending the `RunSink` command, mirroring `alter_export_connections`.
  With the controller's description tracking the catalog, later connection
  alters diff against the sink that is actually running. This also makes
  `run_export` rerun the current sink definition instead of the stale one.

* **Skip no-op sink connection alters** (separable optimization): catalog
  changes that don't affect a connection's runtime config, like `GRANT` and
  `REVOKE`, also arrive at `alter_export_connections`. Previously they
  restarted every dependent sink dataflow for no reason. Skip updates where
  the connection is unchanged, mirroring `alter_ingestion_connections`. This
  does not mask the bug above: with a stale description the recomputed
  connection differs, so the compatibility check still runs.

User-facing changes:

* `GRANT`/`REVOKE`/`ALTER` on a connection no longer panics the coordinator
  when a dependent sink had been altered with `ALTER SINK ... SET FROM`.
* Privilege- and owner-only changes to a connection no longer needlessly
  restart dependent sink dataflows.

### Verification

* New regression test in `test/testdrive/alter-sink.td`: `GRANT` on the sink's
  connection after `ALTER SINK ... SET FROM`, then verify data still flows.
  Before the fix, a minimal repro (CREATE SINK, ALTER SINK SET FROM, GRANT ON
  CONNECTION) deterministically reproduced the exact panic and backtrace from
  the Nightly failures. After the fix it passes.
* `alter-sink.td`, `connection-alter.td`, and `kafka-sink-statistics.td` (which
  breaks and restores a sink's connection via real `ALTER CONNECTION`,
  exercising the non-skipped path) all pass with both commits.
* `bin/cargo-test -p mz-storage-controller` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
