### PR TITLE
adapter: bound read-then-write dependency validation

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -717,6 +717,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "cluster_controller_tick_interval",
     "enable_background_alter_cluster",
     "default_cluster_reconfiguration_timeout",
+    "read_then_write_max_dependencies",
 ]
 
 

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1940,6 +1940,10 @@ class FlipFlagsAction(Action):
             "cluster_controller_tick_interval",
             "enable_background_alter_cluster",
             "default_cluster_reconfiguration_timeout",
+            # A safety bound on read-then-write dependency validation. Flipping
+            # it low would make ordinary DELETE/UPDATE/INSERT ... SELECT fail,
+            # which the workload does not expect.
+            "read_then_write_max_dependencies",
         ]
 
     def run(self, exe: Executor) -> bool:

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -127,6 +127,18 @@ pub const ENABLE_PASSWORD_AUTH: Config<bool> = Config::new(
     "Enable password authentication.",
 );
 
+/// Upper bound on the number of transitive dependencies validated for a
+/// read-then-write statement (e.g. `DELETE ... WHERE ... IN (SELECT ...)`).
+/// Validation walks the read set's dependency graph, which is user controlled
+/// and can be arbitrarily large. The bound rejects pathological graphs with a
+/// clean error instead of consuming unbounded time and memory.
+pub const READ_THEN_WRITE_MAX_DEPENDENCIES: Config<usize> = Config::new(
+    "read_then_write_max_dependencies",
+    100_000,
+    "Maximum number of transitive dependencies validated for a read-then-write \
+     statement before it is rejected.",
+);
+
 /// OIDC issuer URL.
 pub const OIDC_ISSUER: Config<Option<&'static str>> =
     Config::new("oidc_issuer", None, "OIDC issuer URL.");
@@ -396,6 +408,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION)
         .add(&ENABLE_EXPRESSION_CACHE)
         .add(&ENABLE_PASSWORD_AUTH)
+        .add(&READ_THEN_WRITE_MAX_DEPENDENCIES)
         .add(&OIDC_ISSUER)
         .add(&OIDC_AUDIENCE)
         .add(&OIDC_AUTHENTICATION_CLAIM)

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -2950,4 +2950,117 @@ mod tests {
         })
         .await
     }
+
+    /// Read-then-write dependency validation walks the transitive `uses()` of
+    /// the read set. A deep chain of stacked views (user controlled, arbitrarily
+    /// deep) must be validated without overflowing the coordinator thread's
+    /// stack, so the traversal must not recurse.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method`
+    async fn validate_read_then_write_deep_chain_no_stack_overflow() {
+        use crate::coord::read_then_write::validate_read_then_write_dependencies;
+
+        Catalog::with_debug(|mut catalog| async move {
+            // Deep enough that the previous recursive implementation overflowed
+            // the stack.
+            const DEPTH: usize = 100_000;
+            const BASE: u64 = 1 << 40;
+            insert_synthetic_view_chain(&mut catalog, BASE, DEPTH);
+
+            // A generous bound so this test isolates the no-overflow property
+            // rather than the dependency limit.
+            validate_read_then_write_dependencies(
+                &catalog,
+                [CatalogItemId::User(BASE)],
+                usize::MAX,
+            )
+            .expect("deep chain of user views is valid for read-then-write");
+
+            catalog.expire().await;
+        })
+        .await
+    }
+
+    /// Read-then-write dependency validation is bounded: a read set with more
+    /// transitive dependencies than the limit is rejected with a clean error
+    /// rather than walking an unbounded graph.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method`
+    async fn validate_read_then_write_dependency_limit() {
+        use crate::coord::read_then_write::validate_read_then_write_dependencies;
+        use crate::error::AdapterError;
+
+        Catalog::with_debug(|mut catalog| async move {
+            const DEPTH: usize = 100;
+            const BASE: u64 = 1 << 40;
+            insert_synthetic_view_chain(&mut catalog, BASE, DEPTH);
+
+            // The chain has DEPTH + 1 distinct objects (root plus DEPTH links).
+            const OBJECTS: usize = DEPTH + 1;
+
+            // Exactly at the limit is allowed.
+            validate_read_then_write_dependencies(&catalog, [CatalogItemId::User(BASE)], OBJECTS)
+                .expect("chain at the limit is valid");
+
+            // One below the limit is rejected with a clean error.
+            let err = validate_read_then_write_dependencies(
+                &catalog,
+                [CatalogItemId::User(BASE)],
+                OBJECTS - 1,
+            )
+            .expect_err("chain over the limit is rejected");
+            assert!(matches!(
+                err,
+                AdapterError::ReadThenWriteDependencyLimitExceeded {
+                    max_rw_dependencies
+                } if max_rw_dependencies == OBJECTS - 1
+            ));
+
+            catalog.expire().await;
+        })
+        .await
+    }
+
+    /// Inserts a synthetic chain of `depth + 1` user views into `catalog` where
+    /// view `base + i` reads from `base + i + 1`. Ids start well above any id
+    /// the debug catalog assigns so they do not collide with real entries.
+    ///
+    /// Clones a builtin view as a template rather than constructing a `View` by
+    /// hand. Read-then-write validation only reads the item type, `uses()`, and
+    /// the optimized expression's temporal-ness, all of which a builtin view
+    /// satisfies (user id + non-temporal).
+    fn insert_synthetic_view_chain(catalog: &mut Catalog, base: u64, depth: usize) {
+        use mz_ore::cast::CastFrom;
+        use mz_sql::names::{DependencyIds, ResolvedIds};
+
+        let template = catalog
+            .state
+            .entry_by_id
+            .values()
+            .find(|entry| matches!(entry.item(), CatalogItem::View(_)))
+            .expect("debug catalog has builtin views")
+            .clone();
+
+        // `uses()` for a view unions `resolved_ids` and `dependencies`, so clear
+        // both and point only at the next link.
+        for i in 0..=depth {
+            let id = CatalogItemId::User(base + u64::cast_from(i));
+            let mut entry = template.clone();
+            entry.id = id;
+            entry.referenced_by = Vec::new();
+            entry.used_by = Vec::new();
+            let mut resolved_ids = ResolvedIds::empty();
+            if i < depth {
+                resolved_ids.add_item(CatalogItemId::User(base + u64::cast_from(i + 1)));
+            }
+            match &mut entry.item {
+                CatalogItem::View(view) => {
+                    view.resolved_ids = resolved_ids;
+                    view.dependencies = DependencyIds(BTreeSet::new());
+                }
+                _ => unreachable!("template is a view"),
+            }
+            catalog.state.entry_by_id.insert(id, entry);
+        }
+    }
 }

--- a/src/adapter/src/coord/read_then_write.rs
+++ b/src/adapter/src/coord/read_then_write.rs
@@ -9,6 +9,8 @@
 
 //! Coordinator-side support machinery for (frontend) read-then write.
 
+use std::collections::BTreeSet;
+
 use mz_catalog::memory::objects::CatalogItem;
 use mz_repr::CatalogItemId;
 use mz_sql::catalog::CatalogItemType;
@@ -16,93 +18,133 @@ use mz_sql::catalog::CatalogItemType;
 use crate::catalog::Catalog;
 use crate::error::AdapterError;
 
+/// Adds `id` to the worklist the first time it is seen, enforcing the
+/// dependency bound.
+///
+/// Deduping at enqueue time keeps `seen` and `stack` proportional to the number
+/// of distinct objects, not the number of dependency edges. A diamond-shaped
+/// graph is validated once per object.
+fn enqueue(
+    seen: &mut BTreeSet<CatalogItemId>,
+    stack: &mut Vec<CatalogItemId>,
+    id: CatalogItemId,
+    max_rw_dependencies: usize,
+) -> Result<(), AdapterError> {
+    if seen.insert(id) {
+        if seen.len() > max_rw_dependencies {
+            return Err(AdapterError::ReadThenWriteDependencyLimitExceeded {
+                max_rw_dependencies,
+            });
+        }
+        stack.push(id);
+    }
+    Ok(())
+}
+
 /// Validates that all dependencies are valid for read-then-write operations.
 ///
-/// Ensures all objects the selection depends on are valid for `ReadThenWrite` operations:
+/// Ensures all objects the selection transitively depends on (seeded by `ids`) are valid for
+/// `ReadThenWrite` operations:
 ///
 /// - They do not refer to any objects whose notion of time moves differently than that of
 ///   user tables. This limitation is meant to ensure no writes occur between this read and the
 ///   subsequent write.
 /// - They do not use mz_now(), whose time produced during read will differ from the write
 ///   timestamp.
+///
+/// The first invalid or temporal dependency encountered short-circuits with the corresponding
+/// error. Traversal is bounded at `max_rw_dependencies` distinct objects, returning
+/// [`AdapterError::ReadThenWriteDependencyLimitExceeded`] if exceeded.
 pub(crate) fn validate_read_then_write_dependencies(
     catalog: &Catalog,
-    id: &CatalogItemId,
+    ids: impl IntoIterator<Item = CatalogItemId>,
+    max_rw_dependencies: usize,
 ) -> Result<(), AdapterError> {
     use CatalogItemType::*;
     use mz_catalog::memory::objects;
-    let mut ids_to_check = Vec::new();
-    let valid = match catalog.try_get_entry(id) {
-        Some(entry) => {
-            if let CatalogItem::View(objects::View {
-                locally_optimized_expr: optimized_expr,
-                ..
-            })
-            | CatalogItem::MaterializedView(objects::MaterializedView {
-                locally_optimized_expr: optimized_expr,
-                ..
-            }) = entry.item()
-            {
-                if optimized_expr.contains_temporal() {
-                    return Err(AdapterError::Unsupported(
-                        "calls to mz_now in write statements",
-                    ));
-                }
-            }
-            match entry.item().typ() {
-                typ @ (Func | View | MaterializedView) => {
-                    ids_to_check.extend(entry.uses());
-                    let valid_id = id.is_user() || matches!(typ, Func);
-                    valid_id
-                }
-                Source | Secret | Connection => false,
-                // Cannot select from sinks or indexes.
-                Sink | Index => unreachable!(),
-                Table => {
-                    if !id.is_user() {
-                        // We can't read from non-user tables
-                        false
-                    } else {
-                        // We can't read from tables that are source-exports
-                        entry.source_export_details().is_none()
+
+    // Iterative worklist rather than recursion. Dependency chains are user
+    // controlled and can be arbitrarily deep (e.g. a long chain of stacked
+    // views), so recursing risks a stack overflow on the coordinator thread.
+    let mut seen = BTreeSet::new();
+    let mut stack = Vec::new();
+    for id in ids {
+        enqueue(&mut seen, &mut stack, id, max_rw_dependencies)?;
+    }
+    while let Some(id) = stack.pop() {
+        let mut ids_to_check = Vec::new();
+        let valid = match catalog.try_get_entry(&id) {
+            Some(entry) => {
+                if let CatalogItem::View(objects::View {
+                    locally_optimized_expr: optimized_expr,
+                    ..
+                })
+                | CatalogItem::MaterializedView(objects::MaterializedView {
+                    locally_optimized_expr: optimized_expr,
+                    ..
+                }) = entry.item()
+                {
+                    if optimized_expr.contains_temporal() {
+                        return Err(AdapterError::Unsupported(
+                            "calls to mz_now in write statements",
+                        ));
                     }
                 }
-                Type => true,
-            }
-        }
-        None => false,
-    };
-    if !valid {
-        let (object_name, object_type) = match catalog.try_get_entry(id) {
-            Some(entry) => {
-                let object_name = catalog.resolve_full_name(entry.name(), None).to_string();
-                let object_type = match entry.item().typ() {
-                    // We only need the disallowed types here; the allowed types are handled above.
-                    Source => "source",
-                    Secret => "secret",
-                    Connection => "connection",
+                match entry.item().typ() {
+                    typ @ (Func | View | MaterializedView) => {
+                        ids_to_check.extend(entry.uses());
+                        let valid_id = id.is_user() || matches!(typ, Func);
+                        valid_id
+                    }
+                    Source | Secret | Connection => false,
+                    // Cannot select from sinks or indexes.
+                    Sink | Index => unreachable!(),
                     Table => {
                         if !id.is_user() {
-                            "system table"
+                            // We can't read from non-user tables
+                            false
                         } else {
-                            "source-export table"
+                            // We can't read from tables that are source-exports
+                            entry.source_export_details().is_none()
                         }
                     }
-                    View => "system view",
-                    MaterializedView => "system materialized view",
-                    _ => "invalid dependency",
-                };
-                (object_name, object_type.to_string())
+                    Type => true,
+                }
             }
-            None => (id.to_string(), "unknown".to_string()),
+            None => false,
         };
-        return Err(AdapterError::InvalidTableMutationSelection {
-            object_name,
-            object_type,
-        });
-    }
-    for id in ids_to_check {
-        validate_read_then_write_dependencies(catalog, &id)?;
+        if !valid {
+            let (object_name, object_type) = match catalog.try_get_entry(&id) {
+                Some(entry) => {
+                    let object_name = catalog.resolve_full_name(entry.name(), None).to_string();
+                    let object_type = match entry.item().typ() {
+                        // We only need the disallowed types here; the allowed types are handled above.
+                        Source => "source",
+                        Secret => "secret",
+                        Connection => "connection",
+                        Table => {
+                            if !id.is_user() {
+                                "system table"
+                            } else {
+                                "source-export table"
+                            }
+                        }
+                        View => "system view",
+                        MaterializedView => "system materialized view",
+                        _ => "invalid dependency",
+                    };
+                    (object_name, object_type.to_string())
+                }
+                None => (id.to_string(), "unknown".to_string()),
+            };
+            return Err(AdapterError::InvalidTableMutationSelection {
+                object_name,
+                object_type,
+            });
+        }
+        for dep in ids_to_check {
+            enqueue(&mut seen, &mut stack, dep, max_rw_dependencies)?;
+        }
     }
     Ok(())
 }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -20,7 +20,7 @@ use futures::{Future, StreamExt, future};
 use itertools::Itertools;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
-use mz_adapter_types::dyncfgs::ENABLE_PASSWORD_AUTH;
+use mz_adapter_types::dyncfgs::{ENABLE_PASSWORD_AUTH, READ_THEN_WRITE_MAX_DEPENDENCIES};
 use mz_catalog::memory::error::ErrorKind;
 use mz_catalog::memory::objects::{
     CatalogItem, Connection, DataSourceDesc, Sink, Source, Table, TableDataSource, Type,
@@ -2803,12 +2803,19 @@ impl Coordinator {
         }
 
         // Ensure all objects `selection` depends on are valid for `ReadThenWrite` operations.
-        for gid in selection.depends_on() {
-            let item_id = self.catalog().resolve_item_id(&gid);
-            if let Err(err) = validate_read_then_write_dependencies(self.catalog(), &item_id) {
-                ctx.retire(Err(err));
-                return;
-            }
+        let dependency_ids = selection
+            .depends_on()
+            .into_iter()
+            .map(|gid| self.catalog().resolve_item_id(&gid));
+        let max_rw_dependencies =
+            READ_THEN_WRITE_MAX_DEPENDENCIES.get(self.catalog().system_config().dyncfgs());
+        if let Err(err) = validate_read_then_write_dependencies(
+            self.catalog(),
+            dependency_ids,
+            max_rw_dependencies,
+        ) {
+            ctx.retire(Err(err));
+            return;
         }
 
         let (peek_tx, peek_rx) = oneshot::channel();

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -110,6 +110,12 @@ pub enum AdapterError {
         /// Human-readable type of the object (e.g. "source", "source-export table").
         object_type: String,
     },
+    /// A read-then-write statement's read set has more transitive dependencies
+    /// than validation is willing to walk.
+    ReadThenWriteDependencyLimitExceeded {
+        /// The configured maximum number of dependencies.
+        max_rw_dependencies: usize,
+    },
     /// Expression violated a column's constraint
     ConstraintViolation(NotNullViolation),
     /// An error occurred while decoding COPY data.
@@ -540,6 +546,13 @@ impl AdapterError {
                      dependencies must not include sources or source-export tables",
                 object_name.quoted()
             )),
+            AdapterError::ReadThenWriteDependencyLimitExceeded {
+                max_rw_dependencies,
+            } => Some(format!(
+                "The read set transitively depends on more than {max_rw_dependencies} \
+                     objects. Reduce the number of dependencies, or raise the \
+                     read_then_write_max_dependencies system parameter."
+            )),
             AdapterError::SafeModeViolation(_) => Some(
                 "The Materialize server you are connected to is running in \
                  safe mode, which limits the features that are available."
@@ -839,6 +852,9 @@ impl AdapterError {
             AdapterError::SourceOrSinkSizeRequired { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::InvalidTableMutationSelection { .. } => {
                 SqlState::INVALID_TRANSACTION_STATE
+            }
+            AdapterError::ReadThenWriteDependencyLimitExceeded { .. } => {
+                SqlState::PROGRAM_LIMIT_EXCEEDED
             }
             AdapterError::ConstraintViolation(NotNullViolation(_)) => SqlState::NOT_NULL_VIOLATION,
             AdapterError::CopyFormatError(_) => SqlState::BAD_COPY_FILE_FORMAT,
@@ -1184,6 +1200,14 @@ impl fmt::Display for AdapterError {
                 write!(
                     f,
                     "invalid selection: operation may only (transitively) refer to non-source, non-system tables"
+                )
+            }
+            AdapterError::ReadThenWriteDependencyLimitExceeded {
+                max_rw_dependencies,
+            } => {
+                write!(
+                    f,
+                    "selection has too many transitive dependencies to validate (limit {max_rw_dependencies})"
                 )
             }
             AdapterError::ReplaceMaterializedViewSealed { name } => {

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1069,6 +1069,32 @@ class ViewsMaterializedNested(Generator):
         print(f"{cls.COUNT}")
 
 
+class ReadThenWriteNestedViews(Generator):
+    # A read-then-write (DELETE ... WHERE ... IN (SELECT ... FROM deep_view))
+    # validates the transitive dependencies of its read set. That validation
+    # must not recurse over the view chain (SQL-426: it used to, overflowing the
+    # coordinator stack). This is a smoke test of the read-then-write path over
+    # a nested-view read set. The inner SELECT is a one-shot peek that inlines
+    # the chain, so COUNT is capped like ViewsNested. The deep-chain validation
+    # itself is covered by a Rust unit test.
+    COUNT = min(Generator.COUNT, 10)
+
+    @classmethod
+    def body(cls) -> None:
+        print("$ postgres-execute connection=mz_system")
+        print(f"ALTER SYSTEM SET max_objects_per_schema = {cls.COUNT * 10};")
+        print("> CREATE TABLE t (a INTEGER);")
+        print("> INSERT INTO t VALUES (1);")
+        print("> CREATE VIEW c0 AS SELECT a FROM t;")
+
+        for i in cls.all():
+            print(f"> CREATE VIEW c{i} AS SELECT a FROM c{i-1};")
+
+        print(f"> DELETE FROM t WHERE a IN (SELECT a FROM c{cls.COUNT});")
+        cls.store_explain_and_run("SELECT count(*) FROM t;")
+        print("0")
+
+
 class CTEs(Generator):
     COUNT = min(
         Generator.COUNT, 10


### PR DESCRIPTION
Problem:
validate_read_then_write_dependencies recursed over the transitive uses() of a read-then-write's read set, one coordinator-thread frame per object. A statement whose selection reads from a deep chain of stacked views overflowed the coordinator stack

Solution:
Replace the recursion with an iterative worklist. Dedup at enqueue time so each object is validated once and the worklist stays proportional to the number of distinct objects, not the number of dependency edges. Cap the traversal at read_then_write_max_dependencies (a dyncfg, default 100k) and reject larger graphs with a clean error instead of walking an unbounded graph.

Tests:
- a unit test validating a 100k-deep chain (the old recursive code overflowed the stack on it)
- a unit test for the dependency bound
- a small read-then-write limits smoke test.

Fixes SQL-426
