### PR TITLE
docs: data-driven system-catalog reference, phase 1 (mz_active_peeks)

### DIFF
--- a/ci/test/lint-docs-catalog.py
+++ b/ci/test/lint-docs-catalog.py
@@ -10,9 +10,12 @@
 # by the Apache License, Version 2.0.
 
 import fileinput
+import os
 import re
 import sys
 from enum import Enum
+
+import yaml
 
 
 class ParserState(Enum):
@@ -73,6 +76,94 @@ CREATE INDEX objects_idx ON objects(schema, object)
 """
 
 
+# Cache of loaded data files keyed by schema name.
+_DATA_CACHE: dict[str, dict] = {}
+
+
+def load_relation(schema: str, object_name: str) -> dict:
+    """Return the data entry for `schema.object_name` from doc/user/data/<schema>.yml.
+
+    Raises if the file or the relation is missing, so a stale FROM_YAML marker
+    fails loudly rather than silently documenting nothing.
+    """
+    if schema not in _DATA_CACHE:
+        path = os.path.join("doc", "user", "data", f"{schema}.yml")
+        with open(path, encoding="utf-8") as f:
+            _DATA_CACHE[schema] = yaml.safe_load(f)
+    for relation in _DATA_CACHE[schema].get("relations", []):
+        if relation["name"] == object_name:
+            return relation
+    raise ValueError(f"no data entry for {schema}.{object_name} in {schema}.yml")
+
+
+def format_meaning(text: str) -> str:
+    """Strip doc links to their text and escape spaces, matching the catalog
+    comment form the generated sqllogictest compares against."""
+    text = DOC_LINK_TYPE1_RE.sub(r"\1", text)
+    text = DOC_LINK_TYPE2_RE.sub(r"\1", text)
+    return text.replace(" ", "␠")
+
+
+def normalize_type(type_name: str) -> str:
+    """Match the inline path's type normalization for list/array types."""
+    if type_name == "mz_aclitem array":
+        return "mz_aclitem[]"
+    if type_name == "text array":
+        return "text[]"
+    if "list" in type_name:
+        return "list"
+    if "array" in type_name:
+        return "array"
+    return type_name.replace(" ", "␠")
+
+
+def emit_from_yaml(schema: str, object_name: str, objects: list, schemas: set) -> None:
+    """Emit sqllogictest checks for a FROM_YAML relation and its variants, and
+    record every emitted relation name for the completeness query."""
+    relation = load_relation(schema, object_name)
+    schemas.add(f"'{schema}'")
+
+    # Base table: full check with comments, position-ordered (identical to the
+    # inline-table output it replaces).
+    objects.append(object_name)
+    print("query TTT")
+    print(
+        f"SELECT name, type, comment FROM objects WHERE schema = '{schema}' AND object = '{object_name}' ORDER BY position"
+    )
+    print("----")
+    for column in relation["columns"]:
+        print(
+            "  ".join(
+                [
+                    column["name"],
+                    normalize_type(column["type"]),
+                    format_meaning(column["meaning"]),
+                ]
+            )
+        )
+    print()
+
+    for variant in relation.get("variants", []):
+        objects.append(variant["name"])
+        if variant.get("kind") == "raw":
+            # Existence only: no column table to check, the relation is recorded
+            # above so the completeness query still covers it.
+            continue
+        # per_worker (and any future non-raw variant): base columns plus the
+        # variant's extra columns, checked columns-and-types only. Ordered by
+        # name because the catalog column position of worker_id is not fixed.
+        columns = list(relation["columns"]) + list(variant.get("columns", []))
+        columns.sort(key=lambda c: c["name"])
+        print("query TT")
+        print(
+            f"SELECT name, type FROM objects WHERE schema = '{schema}' AND object = '{variant['name']}' ORDER BY name"
+        )
+        print("----")
+        for column in columns:
+            print("  ".join([column["name"], normalize_type(column["type"])]))
+        print()
+
+
 def main() -> None:
     print(HEADER)
 
@@ -92,9 +183,12 @@ def main() -> None:
             match = RELATION_MARKER_RE.search(line)
             if match:
                 modifiers = match.group(3)
-                include_comments = "NO_COMMENTS" not in modifiers
                 schema = match.group(1)
                 object_name = match.group(2)
+                if "FROM_YAML" in modifiers:
+                    emit_from_yaml(schema, object_name, objects, schemas)
+                    continue
+                include_comments = "NO_COMMENTS" not in modifiers
                 if include_comments:
                     print("query TTT")
                     print(
@@ -135,9 +229,7 @@ def main() -> None:
                     type_name = "array"
                 type_name = type_name.replace(" ", "␠")
                 if include_comments:
-                    documentation = DOC_LINK_TYPE1_RE.sub(r"\1", fields[2])
-                    documentation = DOC_LINK_TYPE2_RE.sub(r"\1", documentation)
-                    documentation = documentation.replace(" ", "␠")
+                    documentation = format_meaning(fields[2])
                     print("  ".join([field, type_name, documentation]))
                 else:
                     print("  ".join([field, type_name]))

--- a/ci/test/migrate-docs-catalog.py
+++ b/ci/test/migrate-docs-catalog.py
@@ -196,3 +196,45 @@ def migrate(md_text: str) -> tuple[list[dict], str, dict[str, str]]:
         rewritten_md += "\n"
 
     return entries, rewritten_md, types_seen
+
+
+if __name__ == "__main__":
+    import sys
+
+    md_path = sys.argv[
+        1
+    ]  # e.g. doc/user/content/reference/system-catalog/mz_introspection.md
+    md_text = open(md_path, encoding="utf-8").read()
+    entries, rewritten, types = migrate(md_text)
+
+    # Schema is the data file basename (matches the markers' schema).
+    import os
+
+    schema_name = os.path.splitext(os.path.basename(md_path))[0]
+    data_path = os.path.join("doc", "user", "data", f"{schema_name}.yml")
+
+    import yaml
+
+    existing = {}
+    if os.path.exists(data_path):
+        existing = yaml.safe_load(open(data_path, encoding="utf-8")) or {}
+    relations = existing.get("relations", [])
+    have = {r["name"] for r in relations}
+    for e in entries:
+        if e["name"] not in have:
+            relations.append(e)
+    existing["relations"] = relations
+
+    types_path = os.path.join("doc", "user", "data", "catalog_types.yml")
+    types_map = {}
+    if os.path.exists(types_path):
+        types_map = yaml.safe_load(open(types_path, encoding="utf-8")) or {}
+    for k, v in types.items():
+        types_map.setdefault(k, v)
+
+    open(md_path, "w", encoding="utf-8").write(rewritten)
+    with open(data_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(existing, f, sort_keys=False, allow_unicode=True, width=10_000)
+    with open(types_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(types_map, f, sort_keys=False, allow_unicode=True, width=10_000)
+    print(f"migrated {len(entries)} relations into {data_path}")

--- a/ci/test/migrate-docs-catalog.py
+++ b/ci/test/migrate-docs-catalog.py
@@ -24,7 +24,7 @@ TWO_PART_LINK_RE = re.compile(r"\[([^\]]+)\]\[([^\]]+)\]")
 # immediately followed by `(` (inline link) or `[` (two-part link).
 SHORTCUT_LINK_RE = re.compile(r"\[([^\]]+)\](?!\(|\[)")
 
-HEADING_RE = re.compile(r"^## `")
+HEADING_RE = re.compile(r"^#{2,6} `")
 HEADER_SEPARATOR_RE = re.compile(r"\|?(\s*-+\s*)(\|\s*-+\s*){2}\|?")
 # Field names are enclosed in backticks.
 FIELD_NAME_RE = re.compile(r"`(.*)`")
@@ -94,11 +94,11 @@ def _parse_table(
             break
         fields = [f.strip() for f in stripped[1:].split("|")]
         if len(fields) < 3:
-            break
+            raise ValueError(f"unexpected field format: {stripped}")
         field_match = FIELD_NAME_RE.search(fields[0])
         type_match = FIELD_TYPE_RE.search(fields[1])
         if not field_match or not type_match:
-            break
+            raise ValueError(f"unexpected field format: {stripped}")
         columns.append(
             {
                 "name": field_match.group(1),
@@ -152,7 +152,11 @@ def migrate(md_text: str) -> tuple[list[dict], str, dict[str, str]]:
             idx += 1
             continue
 
-        description_start = (heading_idx + 1) if heading_idx is not None else idx
+        if heading_idx is None:
+            raise ValueError(
+                f"no heading found before RELATION_SPEC marker for {schema}.{object_name}"
+            )
+        description_start = heading_idx + 1
         description_lines = lines[description_start:idx]
         while description_lines and description_lines[0].strip() == "":
             description_lines.pop(0)

--- a/ci/test/migrate-docs-catalog.py
+++ b/ci/test/migrate-docs-catalog.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Converts inline system-catalog reference tables in the docs into YAML data
+entries plus a `catalog-relation` shortcode, the inverse of the table parser
+in `lint-docs-catalog.py`.
+"""
+
+import re
+
+# Matches Markdown reference-style link definitions, e.g. `[`uint8`]: /sql/types/uint8`.
+REFERENCE_DEF_RE = re.compile(r"^\[(?P<label>[^\]]+)\]:\s*(?P<url>\S+)\s*$")
+# Reference-style two-part links, e.g. `[text][label]`.
+TWO_PART_LINK_RE = re.compile(r"\[([^\]]+)\]\[([^\]]+)\]")
+# Reference-style shortcut links, e.g. `[text]`, as long as they are not
+# immediately followed by `(` (inline link) or `[` (two-part link).
+SHORTCUT_LINK_RE = re.compile(r"\[([^\]]+)\](?!\(|\[)")
+
+HEADING_RE = re.compile(r"^## `")
+HEADER_SEPARATOR_RE = re.compile(r"\|?(\s*-+\s*)(\|\s*-+\s*){2}\|?")
+# Field names are enclosed in backticks.
+FIELD_NAME_RE = re.compile(r"`(.*)`")
+# Field types are enclosed in backticks and optionally in square brackets.
+FIELD_TYPE_RE = re.compile(r"\[?`(.*)`\]?")
+RELATION_MARKER_RE = re.compile(r"<!-- RELATION_SPEC (\w+)\.(\w+)([^>]*)-->")
+
+
+def parse_reference_defs(lines: list[str]) -> dict[str, str]:
+    """Parse Markdown reference-style link definitions (`[label]: url`) into a
+    map from label (verbatim, backticks included) to URL."""
+    refs = {}
+    for line in lines:
+        m = REFERENCE_DEF_RE.match(line)
+        if m:
+            refs[m.group("label")] = m.group("url")
+    return refs
+
+
+def inline_links(text: str, refs: dict[str, str]) -> str:
+    """Convert reference-style links (`[text][label]` and shortcut `[text]`)
+    into inline links (`[text](url)`) using `refs`. Existing inline links and
+    unknown labels are left untouched."""
+
+    def two_part_sub(m: re.Match) -> str:
+        link_text, label = m.group(1), m.group(2)
+        if label in refs:
+            return f"[{link_text}]({refs[label]})"
+        return m.group(0)
+
+    text = TWO_PART_LINK_RE.sub(two_part_sub, text)
+
+    def shortcut_sub(m: re.Match) -> str:
+        link_text = m.group(1)
+        if link_text in refs:
+            return f"[{link_text}]({refs[link_text]})"
+        return m.group(0)
+
+    # The negative lookahead in SHORTCUT_LINK_RE ensures already-inline links
+    # (produced above or already present in the source) are never rewritten.
+    text = SHORTCUT_LINK_RE.sub(shortcut_sub, text)
+    return text
+
+
+def _parse_table(
+    lines: list[str], start: int, refs: dict[str, str]
+) -> tuple[list[dict], int]:
+    """Parse a Markdown table starting at or after `lines[start]`. Returns the
+    parsed columns and the index of the last consumed line.
+
+    Mirrors lint-docs-catalog.py's state machine: the header title row is
+    skipped (not parsed), only the separator row is used to locate where body
+    rows begin.
+    """
+    idx = start
+    if idx < len(lines) and lines[idx].strip() == "":
+        idx += 1  # allow one optional blank line before the table
+    while idx < len(lines) and not HEADER_SEPARATOR_RE.match(lines[idx]):
+        idx += 1  # skip the header title row (and anything else) until the separator
+    idx += 1  # move past the separator row, onto the first body row
+
+    columns = []
+    last_row_idx = idx - 1
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+        if not stripped.startswith("|"):
+            break
+        fields = [f.strip() for f in stripped[1:].split("|")]
+        if len(fields) < 3:
+            break
+        field_match = FIELD_NAME_RE.search(fields[0])
+        type_match = FIELD_TYPE_RE.search(fields[1])
+        if not field_match or not type_match:
+            break
+        columns.append(
+            {
+                "name": field_match.group(1),
+                "type": type_match.group(1),
+                "meaning": inline_links(fields[2], refs),
+            }
+        )
+        last_row_idx = idx
+        idx += 1
+
+    return columns, last_row_idx
+
+
+def migrate(md_text: str) -> tuple[list[dict], str, dict[str, str]]:
+    """Extract migratable relation tables from `md_text` into YAML-ready data
+    entries, and rewrite those tables into `catalog-relation` shortcodes.
+
+    A relation is migratable when it has a `RELATION_SPEC schema.object`
+    marker whose modifiers do not include `FROM_YAML` (already migrated) or
+    `NO_COMMENTS` (no comment table to migrate). `RELATION_SPEC_UNDOCUMENTED`
+    markers never match and are left untouched.
+
+    Returns `(relation_entries, rewritten_md, types_seen)`, where
+    `types_seen` maps each plain column type name encountered to its
+    reference-definition URL, if one exists.
+    """
+    lines = md_text.splitlines()
+    refs = parse_reference_defs(lines)
+
+    heading_idx = None
+    entries = []
+    types_seen: dict[str, str] = {}
+    # (replace_start, replace_end_inclusive, schema, object) spans to rewrite,
+    # applied back-to-front so earlier indices stay valid.
+    rewrite_spans = []
+
+    idx = 0
+    while idx < len(lines):
+        if HEADING_RE.match(lines[idx]):
+            heading_idx = idx
+            idx += 1
+            continue
+
+        marker = RELATION_MARKER_RE.search(lines[idx])
+        if not marker:
+            idx += 1
+            continue
+
+        schema, object_name, mods = marker.group(1), marker.group(2), marker.group(3)
+        if "FROM_YAML" in mods or "NO_COMMENTS" in mods:
+            idx += 1
+            continue
+
+        description_start = (heading_idx + 1) if heading_idx is not None else idx
+        description_lines = lines[description_start:idx]
+        while description_lines and description_lines[0].strip() == "":
+            description_lines.pop(0)
+        while description_lines and description_lines[-1].strip() == "":
+            description_lines.pop()
+        description = inline_links("\n".join(description_lines), refs)
+
+        columns, last_table_row_idx = _parse_table(lines, idx + 1, refs)
+        for column in columns:
+            type_name = column["type"]
+            ref_url = refs.get("`" + type_name + "`")
+            if ref_url is not None:
+                types_seen[type_name] = ref_url
+
+        entries.append(
+            {"name": object_name, "description": description, "columns": columns}
+        )
+        rewrite_spans.append(
+            (description_start, last_table_row_idx, schema, object_name)
+        )
+
+        idx = last_table_row_idx + 1
+
+    rewritten_lines = list(lines)
+    for description_start, last_table_row_idx, schema, object_name in reversed(
+        rewrite_spans
+    ):
+        replacement = [
+            "",
+            f"<!-- RELATION_SPEC {schema}.{object_name} FROM_YAML -->",
+            f'{{{{< catalog-relation schema="{schema}" name="{object_name}" >}}}}',
+        ]
+        rewritten_lines[description_start : last_table_row_idx + 1] = replacement
+
+    rewritten_md = "\n".join(rewritten_lines)
+    if md_text.endswith("\n"):
+        rewritten_md += "\n"
+
+    return entries, rewritten_md, types_seen

--- a/ci/test/migrate-docs-catalog.py
+++ b/ci/test/migrate-docs-catalog.py
@@ -44,10 +44,22 @@ def parse_reference_defs(lines: list[str]) -> dict[str, str]:
     return refs
 
 
-def inline_links(text: str, refs: dict[str, str]) -> str:
-    """Convert reference-style links (`[text][label]` and shortcut `[text]`)
-    into inline links (`[text](url)`) using `refs`. Existing inline links and
-    unknown labels are left untouched."""
+def inline_links(
+    text: str, refs: dict[str, str], resolve_shortcuts: bool = True
+) -> str:
+    """Convert reference-style links (`[text][label]` and, when
+    `resolve_shortcuts`, shortcut `[text]`) into inline links (`[text](url)`)
+    using `refs`. Existing inline links and unknown labels are left
+    untouched.
+
+    `resolve_shortcuts` is False for column `meaning` text (see
+    `_parse_table`): `lint-docs-catalog.py`'s comment-text stripping treats a
+    resolved shortcut the same as any other inline link and drops it down to
+    bare text, but it leaves an *unresolved* shortcut's brackets in place, and
+    that bracketed form is what the live SQL comment literally contains. Two-
+    part links do not have this problem: the stripper matches `[text][label]`
+    syntactically, independent of resolution, so resolving them here is safe.
+    """
 
     def two_part_sub(m: re.Match) -> str:
         link_text, label = m.group(1), m.group(2)
@@ -56,6 +68,9 @@ def inline_links(text: str, refs: dict[str, str]) -> str:
         return m.group(0)
 
     text = TWO_PART_LINK_RE.sub(two_part_sub, text)
+
+    if not resolve_shortcuts:
+        return text
 
     def shortcut_sub(m: re.Match) -> str:
         link_text = m.group(1)
@@ -103,7 +118,7 @@ def _parse_table(
             {
                 "name": field_match.group(1),
                 "type": type_match.group(1),
-                "meaning": inline_links(fields[2], refs),
+                "meaning": inline_links(fields[2], refs, resolve_shortcuts=False),
             }
         )
         last_row_idx = idx

--- a/ci/test/test_migrate_docs_catalog.py
+++ b/ci/test/test_migrate_docs_catalog.py
@@ -56,7 +56,16 @@ def test_migrate_extracts_documented_relation():
             "type": "uint8",
             "meaning": "The ID. Corresponds to [`mz_bar.id`](#mz_bar).",
         },
-        {"name": "name", "type": "text", "meaning": "The name."},
+        {
+            "name": "name",
+            "type": "text",
+            # The bare shortcut ref stays unresolved in column "meaning": once
+            # resolved it would be an inline link, and lint-docs-catalog.py's
+            # comment-text stripping only strips already-resolved links,
+            # discarding the brackets a raw shortcut keeps. See
+            # `inline_links`'s `resolve_shortcuts` docstring.
+            "meaning": "The name of the [dataflow].",
+        },
     ]
     assert types == {"uint8": "/sql/types/uint8", "text": "/sql/types/text"}
 

--- a/ci/test/test_migrate_docs_catalog.py
+++ b/ci/test/test_migrate_docs_catalog.py
@@ -1,0 +1,78 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import pathlib
+
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "migrate_docs_catalog",
+    pathlib.Path(__file__).parent / "migrate-docs-catalog.py",
+)
+migrate_docs_catalog = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(migrate_docs_catalog)
+
+FIXTURE = (pathlib.Path(__file__).parent / "testdata" / "sample_catalog.md").read_text()
+
+
+def test_reference_defs_parsed():
+    refs = migrate_docs_catalog.parse_reference_defs(FIXTURE.splitlines())
+    assert refs["`uint8`"] == "/sql/types/uint8"
+    assert refs["dataflow"] == "/get-started/arrangements/#dataflows"
+
+
+def test_inline_links_converts_reference_style():
+    refs = {"dataflow": "/get-started/arrangements/#dataflows"}
+    assert (
+        migrate_docs_catalog.inline_links("in the [dataflow] layer", refs)
+        == "in the [dataflow](/get-started/arrangements/#dataflows) layer"
+    )
+
+
+def test_inline_links_leaves_inline_untouched():
+    refs = {}
+    text = "see [x](/y) here"
+    assert migrate_docs_catalog.inline_links(text, refs) == text
+
+
+def test_migrate_extracts_documented_relation():
+    entries, _, types = migrate_docs_catalog.migrate(FIXTURE)
+    names = [e["name"] for e in entries]
+    assert names == ["mz_foo"]  # mz_baz is NO_COMMENTS, skipped
+    foo = entries[0]
+    assert "It has more detail." in foo["description"]
+    assert "[dataflow](/get-started/arrangements/#dataflows)" in foo["description"]
+    assert foo["columns"] == [
+        {
+            "name": "id",
+            "type": "uint8",
+            "meaning": "The ID. Corresponds to [`mz_bar.id`](#mz_bar).",
+        },
+        {"name": "name", "type": "text", "meaning": "The name."},
+    ]
+    assert types == {"uint8": "/sql/types/uint8", "text": "/sql/types/text"}
+
+
+def test_migrate_rewrites_markdown_section():
+    _, rewritten, _ = migrate_docs_catalog.migrate(FIXTURE)
+    assert "<!-- RELATION_SPEC test_schema.mz_foo FROM_YAML -->" in rewritten
+    assert '{{< catalog-relation schema="test_schema" name="mz_foo" >}}' in rewritten
+    # Old table gone.
+    assert "| `id`" not in rewritten
+    # Heading kept.
+    assert "## `mz_foo`" in rewritten
+    # UNDOCUMENTED sibling untouched.
+    assert (
+        "<!-- RELATION_SPEC_UNDOCUMENTED test_schema.mz_foo_per_worker -->" in rewritten
+    )
+    # NO_COMMENTS relation untouched (still an inline table).
+    assert "<!-- RELATION_SPEC test_schema.mz_baz NO_COMMENTS -->" in rewritten
+    assert "| `x`" in rewritten
+    # Trailing prose after the mz_baz table preserved.
+    assert "See [more](/somewhere) for details." in rewritten

--- a/ci/test/test_migrate_docs_catalog.py
+++ b/ci/test/test_migrate_docs_catalog.py
@@ -11,6 +11,8 @@ import pathlib
 
 import importlib.util
 
+import pytest
+
 _spec = importlib.util.spec_from_file_location(
     "migrate_docs_catalog",
     pathlib.Path(__file__).parent / "migrate-docs-catalog.py",
@@ -76,3 +78,43 @@ def test_migrate_rewrites_markdown_section():
     assert "| `x`" in rewritten
     # Trailing prose after the mz_baz table preserved.
     assert "See [more](/somewhere) for details." in rewritten
+
+
+def test_migrate_accepts_non_h2_heading_level():
+    # mz_catalog.md uses `###` for relation headings; the converter must not
+    # be hardcoded to `##`.
+    md = """### `mz_qux`
+
+The `mz_qux` view is documented under a level-3 heading.
+
+<!-- RELATION_SPEC test_schema.mz_qux -->
+| Field | Type      | Meaning |
+|-------|-----------|---------|
+| `id`  | [`uint8`] | The ID. |
+
+[`uint8`]: /sql/types/uint8
+"""
+    entries, _, _ = migrate_docs_catalog.migrate(md)
+    assert len(entries) == 1
+    assert entries[0]["name"] == "mz_qux"
+    assert "documented under a level-3 heading" in entries[0]["description"]
+
+
+def test_migrate_raises_when_marker_has_no_preceding_heading():
+    md = """<!-- RELATION_SPEC test_schema.mz_qux -->
+| Field | Type      | Meaning |
+|-------|-----------|---------|
+| `id`  | [`uint8`] | The ID. |
+"""
+    with pytest.raises(ValueError, match="test_schema.mz_qux"):
+        migrate_docs_catalog.migrate(md)
+
+
+def test_parse_table_raises_on_malformed_row():
+    lines = [
+        "| Field | Type | Meaning |",
+        "|-------|------|---------|",
+        "| no_backticks_here | text | broken row |",
+    ]
+    with pytest.raises(ValueError, match="unexpected field format"):
+        migrate_docs_catalog._parse_table(lines, 0, {})

--- a/ci/test/testdata/sample_catalog.md
+++ b/ci/test/testdata/sample_catalog.md
@@ -8,7 +8,7 @@ It has more detail.
 | Field  | Type       | Meaning                                       |
 |--------|------------|-----------------------------------------------|
 | `id`   | [`uint8`]  | The ID. Corresponds to [`mz_bar.id`](#mz_bar). |
-| `name` | [`text`]   | The name.                                     |
+| `name` | [`text`]   | The name of the [dataflow].                   |
 
 <!-- RELATION_SPEC_UNDOCUMENTED test_schema.mz_foo_per_worker -->
 

--- a/ci/test/testdata/sample_catalog.md
+++ b/ci/test/testdata/sample_catalog.md
@@ -1,0 +1,28 @@
+## `mz_foo`
+
+The `mz_foo` view describes foos in the [dataflow] layer.
+
+It has more detail.
+
+<!-- RELATION_SPEC test_schema.mz_foo -->
+| Field  | Type       | Meaning                                       |
+|--------|------------|-----------------------------------------------|
+| `id`   | [`uint8`]  | The ID. Corresponds to [`mz_bar.id`](#mz_bar). |
+| `name` | [`text`]   | The name.                                     |
+
+<!-- RELATION_SPEC_UNDOCUMENTED test_schema.mz_foo_per_worker -->
+
+## `mz_baz`
+
+The `mz_baz` source is special.
+
+<!-- RELATION_SPEC test_schema.mz_baz NO_COMMENTS -->
+| Field | Type      | Meaning |
+|-------|-----------|---------|
+| `x`   | [`text`]  | ex      |
+
+See [more](/somewhere) for details.
+
+[`uint8`]: /sql/types/uint8
+[`text`]: /sql/types/text
+[dataflow]: /get-started/arrangements/#dataflows

--- a/doc/user/content/reference/system-catalog/mz_introspection.md
+++ b/doc/user/content/reference/system-catalog/mz_introspection.md
@@ -32,17 +32,8 @@ Per-worker relations expose the same data as their global counterparts, but have
 
 ## `mz_active_peeks`
 
-The `mz_active_peeks` view describes all read queries ("peeks") that are pending in the [dataflow] layer.
-
-<!-- RELATION_SPEC mz_introspection.mz_active_peeks -->
-| Field       | Type             | Meaning                                                                                                                                                                                                                                                                                                               |
-|-------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`        | [`uuid`]         | The ID of the peek request.                                                                                                                                                                                                                                                                                           |
-| `object_id` | [`text`]         | The ID of the collection the peek is targeting. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables). |
-| `type`      | [`text`]         | The type of the corresponding peek: `index` if targeting an index or temporary dataflow; `persist` for a source, materialized view, or table.                                                                                                                                                                         |
-| `time`      | [`mz_timestamp`] | The timestamp the peek has requested.                                                                                                                                                                                                                                                                                 |
-
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_active_peeks_per_worker -->
+<!-- RELATION_SPEC mz_introspection.mz_active_peeks FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_active_peeks" >}}
 
 ## `mz_arrangement_sharing`
 

--- a/doc/user/content/reference/system-catalog/mz_introspection.md
+++ b/doc/user/content/reference/system-catalog/mz_introspection.md
@@ -37,33 +37,16 @@ Per-worker relations expose the same data as their global counterparts, but have
 
 ## `mz_arrangement_sharing`
 
-The `mz_arrangement_sharing` view describes how many times each [arrangement] in the system is used.
-
-<!-- RELATION_SPEC mz_introspection.mz_arrangement_sharing -->
-| Field          | Type       | Meaning                                                                                                                   |
-| -------------- |------------| --------                                                                                                                  |
-| `operator_id`  | [`uint8`]  | The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
-| `count`        | [`bigint`] | The number of operators that share the arrangement.                                                                       |
+<!-- RELATION_SPEC mz_introspection.mz_arrangement_sharing FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_arrangement_sharing" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_sharing_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_sharing_raw -->
 
 ## `mz_arrangement_sizes`
 
-The `mz_arrangement_sizes` view describes the size of each [arrangement] in the system.
-
-The size, capacity, and allocations are an approximation, which may underestimate the actual size in memory.
-Specifically, reductions can use more memory than we show here.
-
-<!-- RELATION_SPEC mz_introspection.mz_arrangement_sizes -->
-| Field         | Type       | Meaning                                                                                                                   |
-|---------------|------------| --------                                                                                                                  |
-| `operator_id` | [`uint8`]  | The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
-| `records`     | [`bigint`] | The number of records in the arrangement.                                                                                 |
-| `batches`     | [`bigint`] | The number of batches in the arrangement.                                                                                 |
-| `size`        | [`bigint`] | The utilized size in bytes of the arrangement.                                                                            |
-| `capacity`    | [`bigint`] | The capacity in bytes of the arrangement. Can be larger than the size.                                                    |
-| `allocations` | [`bigint`] | The number of separate memory allocations backing the arrangement.                                                        |
+<!-- RELATION_SPEC mz_introspection.mz_arrangement_sizes FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_arrangement_sizes" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_sizes_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_records_raw -->
@@ -78,68 +61,37 @@ Specifically, reductions can use more memory than we show here.
 
 ## `mz_compute_error_counts`
 
-The `mz_compute_error_counts` view describes the counts of errors in objects exported by [dataflows][dataflow] in the system.
-
-Dataflow exports that don't have any errors are not included in this view.
-
-<!-- RELATION_SPEC mz_introspection.mz_compute_error_counts -->
-| Field        | Type        | Meaning                                                                                              |
-| ------------ |-------------| --------                                                                                             |
-| `export_id`  | [`text`]    | The ID of the dataflow export. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports). |
-| `count`      | [`numeric`] | The count of errors present in this dataflow export.                                                 |
+<!-- RELATION_SPEC mz_introspection.mz_compute_error_counts FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_compute_error_counts" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_error_counts_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_error_counts_raw -->
 
 ## `mz_compute_exports`
 
-The `mz_compute_exports` view describes the objects exported by [dataflows][dataflow] in the system.
-
-<!-- RELATION_SPEC mz_introspection.mz_compute_exports -->
-| Field          | Type      | Meaning                                                                                                                                                                                                                                                                                        |
-| -------------- |-----------| --------                                                                                                                                                                                                                                                                                       |
-| `export_id`    | [`text`]  | The ID of the index, materialized view, or subscription exported by the dataflow. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), or [`mz_internal.mz_subscriptions.id`](../mz_internal#mz_subscriptions). |
-| `dataflow_id`  | [`uint8`] | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).                                                                                                                                                                                                               |
+<!-- RELATION_SPEC mz_introspection.mz_compute_exports FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_compute_exports" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_exports_per_worker -->
 
 ## `mz_compute_frontiers`
 
-The `mz_compute_frontiers` view describes the frontier of each [dataflow] export in the system.
-The frontier describes the earliest timestamp at which the output of the dataflow may change; data prior to that timestamp is sealed.
-
-<!-- RELATION_SPEC mz_introspection.mz_compute_frontiers -->
-| Field        | Type               | Meaning                                                                                              |
-| ------------ | ------------------ | --------                                                                                             |
-| `export_id`  | [`text`]           | The ID of the dataflow export. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports). |
-| `time`       | [`mz_timestamp`]   | The next timestamp at which the dataflow output may change.                                          |
+<!-- RELATION_SPEC mz_introspection.mz_compute_frontiers FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_compute_frontiers" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_frontiers_per_worker -->
 
 ## `mz_compute_import_frontiers`
 
-The `mz_compute_import_frontiers` view describes the frontiers of each [dataflow] import in the system.
-The frontier describes the earliest timestamp at which the input into the dataflow may change; data prior to that timestamp is sealed.
-
-<!-- RELATION_SPEC mz_introspection.mz_compute_import_frontiers -->
-| Field        | Type               | Meaning                                                                                                                                                                                                                |
-| ------------ | ------------------ | --------                                                                                                                                                                                                               |
-| `export_id`  | [`text`]           | The ID of the dataflow export. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports).                                                                                                                   |
-| `import_id`  | [`text`]           | The ID of the dataflow import. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources) or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables) or [`mz_compute_exports.export_id`](#mz_compute_exports). |
-| `time`       | [`mz_timestamp`]   | The next timestamp at which the dataflow input may change.                                                                                                                                                             |
+<!-- RELATION_SPEC mz_introspection.mz_compute_import_frontiers FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_compute_import_frontiers" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_import_frontiers_per_worker -->
 
 ## `mz_compute_operator_durations_histogram`
 
-The `mz_compute_operator_durations_histogram` view describes a histogram of the duration in nanoseconds of each invocation for each [dataflow] operator.
-
-<!-- RELATION_SPEC mz_introspection.mz_compute_operator_durations_histogram -->
-| Field          | Type        | Meaning                                                                                      |
-| -------------- |-------------| --------                                                                                     |
-| `id`           | [`uint8`]   | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
-| `duration_ns`  | [`uint8`]   | The upper bound of the duration bucket in nanoseconds.                                       |
-| `count`        | [`numeric`] | The (noncumulative) count of invocations in the bucket.                                      |
+<!-- RELATION_SPEC mz_introspection.mz_compute_operator_durations_histogram FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_compute_operator_durations_histogram" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_operator_durations_histogram_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_operator_durations_histogram_raw -->
@@ -163,196 +115,88 @@ Summaries are flattened into separate quantile, sum, and count rows.
 
 ## `mz_dataflows`
 
-The `mz_dataflows` view describes the [dataflows][dataflow] in the system.
-
-<!-- RELATION_SPEC mz_introspection.mz_dataflows -->
-| Field       | Type      | Meaning                                |
-| ----------- |-----------| --------                               |
-| `id`        | [`uint8`] | The ID of the dataflow.                |
-| `name`      | [`text`]  | The internal name of the dataflow.     |
+<!-- RELATION_SPEC mz_introspection.mz_dataflows FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_dataflows" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflows_per_worker -->
 
 ## `mz_dataflow_addresses`
 
-The `mz_dataflow_addresses` view describes how the [dataflow] channels and operators in the system are nested into scopes.
-
-<!-- RELATION_SPEC mz_introspection.mz_dataflow_addresses -->
-| Field        | Type            | Meaning                                                                                                                                                       |
-| ------------ |-----------------| --------                                                                                                                                                      |
-| `id`         | [`uint8`]       | The ID of the channel or operator. Corresponds to [`mz_dataflow_channels.id`](#mz_dataflow_channels) or [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
-| `address`    | [`bigint list`] | A list of scope-local indexes indicating the path from the root to this channel or operator.                                                                  |
+<!-- RELATION_SPEC mz_introspection.mz_dataflow_addresses FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_dataflow_addresses" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_addresses_per_worker -->
 
 ## `mz_dataflow_arrangement_sizes`
 
-The `mz_dataflow_arrangement_sizes` view describes the size of arrangements per
-operators under each dataflow.
-
-<!-- RELATION_SPEC mz_introspection.mz_dataflow_arrangement_sizes -->
-| Field         | Type       | Meaning                                                                      |
-|---------------|------------|------------------------------------------------------------------------------|
-| `id`          | [`uint8`]  | The ID of the [dataflow]. Corresponds to [`mz_dataflows.id`](#mz_dataflows). |
-| `name`        | [`text`]   | The name of the [dataflow].                                                  |
-| `records`     | [`bigint`] | The number of records in all arrangements in the dataflow.                   |
-| `batches`     | [`bigint`] | The number of batches in all arrangements in the dataflow.                   |
-| `size`        | [`bigint`] | The utilized size in bytes of the arrangements.                              |
-| `capacity`    | [`bigint`] | The capacity in bytes of the arrangements. Can be larger than the size.      |
-| `allocations` | [`bigint`] | The number of separate memory allocations backing the arrangements.          |
+<!-- RELATION_SPEC mz_introspection.mz_dataflow_arrangement_sizes FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_dataflow_arrangement_sizes" >}}
 
 ## `mz_dataflow_channels`
 
-The `mz_dataflow_channels` view describes the communication channels between [dataflow] operators.
-A communication channel connects one of the outputs of a source operator to one of the inputs of a target operator.
-
-<!-- RELATION_SPEC mz_introspection.mz_dataflow_channels -->
-| Field            | Type      | Meaning                                                                                                                 |
-| ---------------- |-----------| --------                                                                                                                |
-| `id`             | [`uint8`] | The ID of the channel.                                                                                                  |
-| `from_index`     | [`uint8`] | The scope-local index of the source operator. Corresponds to [`mz_dataflow_addresses.address`](#mz_dataflow_addresses). |
-| `from_port`      | [`uint8`] | The source operator's output port.                                                                                      |
-| `to_index`       | [`uint8`] | The scope-local index of the target operator. Corresponds to [`mz_dataflow_addresses.address`](#mz_dataflow_addresses). |
-| `to_port`        | [`uint8`] | The target operator's input port.                                                                                       |
-| `type`           | [`text`]  | The container type of the channel.                                                                                      |
+<!-- RELATION_SPEC mz_introspection.mz_dataflow_channels FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_dataflow_channels" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_channels_per_worker -->
 
 ## `mz_dataflow_channel_operators`
 
-The `mz_dataflow_channel_operators` view associates [dataflow] channels with the operators that are their endpoints.
-
-<!-- RELATION_SPEC mz_introspection.mz_dataflow_channel_operators -->
-| Field                   | Type           | Meaning                                                                                                             |
-|-------------------------|----------------|---------------------------------------------------------------------------------------------------------------------|
-| `id`                    | [`uint8`]      | The ID of the channel. Corresponds to [`mz_dataflow_channels.id`](#mz_dataflow_channels).                           |
-| `from_operator_id`      | [`uint8`]      | The ID of the source of the channel. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).           |
-| `from_operator_address` | [`uint8 list`] | The address of the source of the channel. Corresponds to [`mz_dataflow_addresses.address`](#mz_dataflow_addresses). |
-| `to_operator_id`        | [`uint8`]      | The ID of the target of the channel. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).           |
-| `to_operator_address`   | [`uint8 list`] | The address of the target of the channel. Corresponds to [`mz_dataflow_addresses.address`](#mz_dataflow_addresses). |
-| `type`                  | [`text`]  | The container type of the channel.                                                                                       |
+<!-- RELATION_SPEC mz_introspection.mz_dataflow_channel_operators FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_dataflow_channel_operators" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_channel_operators_per_worker -->
 
 ## `mz_dataflow_global_ids`
 
-The `mz_dataflow_global_ids` view associates [dataflow] ids with global ids (ids of the form `u8` or `t5`).
-
-<!-- RELATION_SPEC mz_introspection.mz_dataflow_global_ids -->
-
-| Field        | Type      | Meaning                                    |
-|------------- | -------   | --------                                   |
-| `id`         | [`uint8`] | The dataflow ID.                           |
-| `global_id`  | [`text`]  | A global ID associated with that dataflow. |
+<!-- RELATION_SPEC mz_introspection.mz_dataflow_global_ids FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_dataflow_global_ids" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_dataflow_global_ids_per_worker -->
 
 ## `mz_dataflow_operators`
 
-The `mz_dataflow_operators` view describes the [dataflow] operators in the system.
-
-<!-- RELATION_SPEC mz_introspection.mz_dataflow_operators -->
-| Field        | Type      | Meaning                            |
-| ------------ |-----------| --------                           |
-| `id`         | [`uint8`] | The ID of the operator.            |
-| `name`       | [`text`]  | The internal name of the operator. |
+<!-- RELATION_SPEC mz_introspection.mz_dataflow_operators FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_dataflow_operators" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_operators_per_worker -->
 
 ## `mz_dataflow_operator_dataflows`
 
-The `mz_dataflow_operator_dataflows` view describes the [dataflow] to which each operator belongs.
-
-<!-- RELATION_SPEC mz_introspection.mz_dataflow_operator_dataflows -->
-| Field            | Type      | Meaning                                                                                         |
-| ---------------- |-----------| --------                                                                                        |
-| `id`             | [`uint8`] | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).    |
-| `name`           | [`text`]  | The internal name of the operator.                                                              |
-| `dataflow_id`    | [`uint8`] | The ID of the dataflow hosting the operator. Corresponds to [`mz_dataflows.id`](#mz_dataflows). |
-| `dataflow_name`  | [`text`]  | The internal name of the dataflow hosting the operator.                                         |
+<!-- RELATION_SPEC mz_introspection.mz_dataflow_operator_dataflows FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_dataflow_operator_dataflows" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_operator_dataflows_per_worker -->
 
 ## `mz_dataflow_operator_parents`
 
-The `mz_dataflow_operator_parents` view describes how [dataflow] operators are nested into scopes, by relating operators to their parent operators.
-
-<!-- RELATION_SPEC mz_introspection.mz_dataflow_operator_parents -->
-| Field        | Type      | Meaning                                                                                                        |
-| ------------ |-----------| --------                                                                                                       |
-| `id`         | [`uint8`] | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).                   |
-| `parent_id`  | [`uint8`] | The ID of the operator's parent operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
+<!-- RELATION_SPEC mz_introspection.mz_dataflow_operator_parents FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_dataflow_operator_parents" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_operator_parents_per_worker -->
 
 ## `mz_expected_group_size_advice`
 
-The `mz_expected_group_size_advice` view provides advice on opportunities to set [query hints].
-Query hints are applicable to dataflows maintaining [`MIN`], [`MAX`], or [Top K] query patterns.
-The maintainance of these query patterns is implemented inside an operator scope, called a region,
-through a hierarchical scheme for either aggregation or Top K computations.
-
-<!-- RELATION_SPEC mz_introspection.mz_expected_group_size_advice -->
-| Field           | Type                 | Meaning                                                                                                   |
-|-----------------|----------------------|-----------------------------------------------------------------------------------------------------------|
-| `dataflow_id`   | [`uint8`]            | The ID of the [dataflow]. Corresponds to [`mz_dataflows.id`](#mz_dataflows).                              |
-| `dataflow_name` | [`text`]             | The internal name of the dataflow hosting the min/max aggregation or Top K.                               |
-| `region_id`     | [`uint8`]            | The ID of the root operator scope. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).   |
-| `region_name`   | [`text`]             | The internal name of the root operator scope for the min/max aggregation or Top K.                        |
-| `levels`        | [`bigint`]           | The number of levels in the hierarchical scheme implemented by the region.                                |
-| `to_cut`        | [`bigint`]           | The number of levels that can be eliminated (cut) from the region's hierarchy.                            |
-| `savings`       | [`numeric`]          | A conservative estimate of the amount of memory in bytes to be saved by applying the hint.                |
-| `hint`          | [`double precision`] | The hint value that will eliminate `to_cut` levels from the region's hierarchy.                           |
+<!-- RELATION_SPEC mz_introspection.mz_expected_group_size_advice FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_expected_group_size_advice" >}}
 
 ## `mz_mappable_objects`
 
-The `mz_mappable_objects` identifies indexes (and their underlying views) and materialized views which can be debugged using the [`mz_lir_mapping`](#mz_lir_mapping) view.
-
-<!-- RELATION_SPEC mz_introspection.mz_mappable_objects -->
-| Field        | Type      | Meaning
-| ------------ | --------  | -----------
-| `name`       | [`text`]  | The name of the object. This name is unquoted, and you might need to call `quote_ident` if you want to reference the name shown here.
-| `global_id`  | [`text`]  | The global ID of the object.
+<!-- RELATION_SPEC mz_introspection.mz_mappable_objects FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_mappable_objects" >}}
 
 See [Which part of my query runs slowly or uses a lot of memory?](/transform-data/troubleshooting/#which-part-of-my-query-runs-slowly-or-uses-a-lot-of-memory) for examples of debugging with `mz_mappable_objects` and `mz_lir_mapping`.
 
 ## `mz_lir_mapping`
 
-The `mz_lir_mapping` view describes the low-level internal representation (LIR) plan that corresponds to global ids of indexes (and their underlying views) and materialized views.
-You can find a list of all debuggable objects in [`mz_mappable_objects`](#mz_mappable_objects).
-LIR is a higher-level representation than dataflows; this view is used for profiling and debugging indices and materialized views.
-Note that LIR is not a stable interface and may change at any time.
-In particular, you should not attempt to parse `operator` descriptions.
-LIR nodes are implemented by zero or more dataflow operators with sequential ids.
-We use the range `[operator_id_start, operator_id_end)` to record this information.
-If an LIR node was implemented without any dataflow operators, `operator_id_start` will be equal to `operator_id_end`.
-
-<!-- RELATION_SPEC mz_introspection.mz_lir_mapping -->
-| Field               | Type      | Meaning
-| ---------           | --------  | -----------
-| `global_id`         | [`text`]  | The global ID.
-| `lir_id`            | [`uint8`] | The LIR node ID.
-| `operator`          | [`text`]  | The LIR operator, in the format `OperatorName INPUTS [OPTIONS]`.
-| `parent_lir_id`     | [`uint8`] | The parent of this LIR node. May be `NULL`.
-| `nesting`           | [`uint2`] | The nesting level of this LIR node.
-| `operator_id_start` | [`uint8`] | The first dataflow operator ID implementing this LIR operator (inclusive).
-| `operator_id_end`   | [`uint8`] | The first dataflow operator ID _after_ this LIR operator (exclusive).
+<!-- RELATION_SPEC mz_introspection.mz_lir_mapping FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_lir_mapping" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_lir_mapping_per_worker -->
 
 ## `mz_message_counts`
 
-The `mz_message_counts` view describes the messages and message batches sent and received over the [dataflow] channels in the system.
-It distinguishes between individual records (`sent`, `received`) and batches of records (`batch_sent`, `batch_sent`).
-
-<!-- RELATION_SPEC mz_introspection.mz_message_counts -->
-| Field              | Type        | Meaning                                                                                   |
-| ------------------ |-------------| --------                                                                                  |
-| `channel_id`       | [`uint8`]   | The ID of the channel. Corresponds to [`mz_dataflow_channels.id`](#mz_dataflow_channels). |
-| `sent`             | [`numeric`] | The number of messages sent.                                                              |
-| `received`         | [`numeric`] | The number of messages received.                                                          |
-| `batch_sent`       | [`numeric`] | The number of batches sent.                                                               |
-| `batch_received`   | [`numeric`] | The number of batches received.                                                           |
+<!-- RELATION_SPEC mz_introspection.mz_message_counts FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_message_counts" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_message_counts_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_message_batch_counts_received_raw -->
@@ -362,76 +206,38 @@ It distinguishes between individual records (`sent`, `received`) and batches of 
 
 ## `mz_peek_durations_histogram`
 
-The `mz_peek_durations_histogram` view describes a histogram of the duration in nanoseconds of read queries ("peeks") in the [dataflow] layer.
-
-<!-- RELATION_SPEC mz_introspection.mz_peek_durations_histogram -->
-| Field         | Type        | Meaning                                            |
-|---------------|-------------|----------------------------------------------------|
-| `type`        | [`text`]    | The peek variant: `index` or `persist`.            |
-| `duration_ns` | [`uint8`]   | The upper bound of the bucket in nanoseconds.      |
-| `count`       | [`numeric`] | The (noncumulative) count of peeks in this bucket. |
+<!-- RELATION_SPEC mz_introspection.mz_peek_durations_histogram FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_peek_durations_histogram" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_peek_durations_histogram_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_peek_durations_histogram_raw -->
 
 ## `mz_records_per_dataflow`
 
-The `mz_records_per_dataflow` view describes the number of records in each [dataflow].
-
-<!-- RELATION_SPEC mz_introspection.mz_records_per_dataflow -->
-| Field         | Type       | Meaning                                                                    |
-| ------------  |------------| --------                                                                   |
-| `id`          | [`uint8`]  | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows). |
-| `name`        | [`text`]   | The internal name of the dataflow.                                         |
-| `records`     | [`bigint`] | The number of records in the dataflow.                                     |
-| `batches`     | [`bigint`] | The number of batches in the dataflow.                                     |
-| `size`        | [`bigint`] | The utilized size in bytes of the arrangements.                            |
-| `capacity`    | [`bigint`] | The capacity in bytes of the arrangements. Can be larger than the size.    |
-| `allocations` | [`bigint`] | The number of separate memory allocations backing the arrangements.        |
+<!-- RELATION_SPEC mz_introspection.mz_records_per_dataflow FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_records_per_dataflow" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_records_per_dataflow_per_worker -->
 
 ## `mz_records_per_dataflow_operator`
 
-The `mz_records_per_dataflow_operator` view describes the number of records in each [dataflow] operator in the system.
-
-<!-- RELATION_SPEC mz_introspection.mz_records_per_dataflow_operator -->
-| Field          | Type       | Meaning                                                                                      |
-| -------------- |------------| --------                                                                                     |
-| `id`           | [`uint8`]  | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
-| `name`         | [`text`]   | The internal name of the operator.                                                           |
-| `dataflow_id`  | [`uint8`]  | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).                   |
-| `records`      | [`bigint`] | The number of records in the operator.                                                       |
-| `batches`      | [`bigint`] | The number of batches in the dataflow.                                                       |
-| `size`         | [`bigint`] | The utilized size in bytes of the arrangement.                                               |
-| `capacity`     | [`bigint`] | The capacity in bytes of the arrangement. Can be larger than the size.                       |
-| `allocations`  | [`bigint`] | The number of separate memory allocations backing the arrangement.                           |
+<!-- RELATION_SPEC mz_introspection.mz_records_per_dataflow_operator FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_records_per_dataflow_operator" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_records_per_dataflow_operator_per_worker -->
 
 ## `mz_scheduling_elapsed`
 
-The `mz_scheduling_elapsed` view describes the total amount of time spent in each [dataflow] operator.
-
-<!-- RELATION_SPEC mz_introspection.mz_scheduling_elapsed -->
-| Field         | Type        | Meaning                                                                                      |
-| ------------- |-------------| --------                                                                                     |
-| `id`          | [`uint8`]   | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
-| `elapsed_ns`  | [`numeric`] | The total elapsed time spent in the operator in nanoseconds.                                 |
+<!-- RELATION_SPEC mz_introspection.mz_scheduling_elapsed FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_scheduling_elapsed" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_scheduling_elapsed_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_scheduling_elapsed_raw -->
 
 ## `mz_scheduling_parks_histogram`
 
-The `mz_scheduling_parks_histogram` view describes a histogram of [dataflow] worker park events. A park event occurs when a worker has no outstanding work.
-
-<!-- RELATION_SPEC mz_introspection.mz_scheduling_parks_histogram -->
-| Field           | Type        | Meaning                                                  |
-| --------------- |-------------| -------                                                  |
-| `slept_for_ns`  | [`uint8`]   | The actual length of the park event in nanoseconds.      |
-| `requested_ns`  | [`uint8`]   | The requested length of the park event in nanoseconds.   |
-| `count`         | [`numeric`] | The (noncumulative) count of park events in this bucket. |
+<!-- RELATION_SPEC mz_introspection.mz_scheduling_parks_histogram FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_scheduling_parks_histogram" >}}
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_scheduling_parks_histogram_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_scheduling_parks_histogram_raw -->

--- a/doc/user/data/catalog_types.yml
+++ b/doc/user/data/catalog_types.yml
@@ -1,10 +1,10 @@
-# doc/user/data/catalog_types.yml
-#
-# Maps a catalog column type name to its documentation URL. The catalog-relation
-# shortcode uses this to render type links, because shortcode-rendered cells go
-# through RenderString and cannot see the page-level reference-link definitions.
-# Extend this map as new relations are migrated to data entries.
 uuid: /sql/types/uuid
 text: /sql/types/text
 mz_timestamp: /sql/types/mz_timestamp
 uint8: /sql/types/uint8
+bigint: /sql/types/bigint
+numeric: /sql/types/numeric
+bigint list: /sql/types/list
+uint8 list: /sql/types/list
+double precision: /sql/types/double-precision
+uint2: /sql/types/uint2

--- a/doc/user/data/catalog_types.yml
+++ b/doc/user/data/catalog_types.yml
@@ -1,0 +1,10 @@
+# doc/user/data/catalog_types.yml
+#
+# Maps a catalog column type name to its documentation URL. The catalog-relation
+# shortcode uses this to render type links, because shortcode-rendered cells go
+# through RenderString and cannot see the page-level reference-link definitions.
+# Extend this map as new relations are migrated to data entries.
+uuid: /sql/types/uuid
+text: /sql/types/text
+mz_timestamp: /sql/types/mz_timestamp
+uint8: /sql/types/uint8

--- a/doc/user/data/mz_introspection.yml
+++ b/doc/user/data/mz_introspection.yml
@@ -1,33 +1,435 @@
-# doc/user/data/mz_introspection.yml
-#
-# Column documentation for relations in the mz_introspection schema, rendered by
-# the catalog-relation shortcode and checked against the catalog by
-# ci/test/lint-docs-catalog.py. Each relation lists its base columns and any
-# per_worker or raw variants. Column `meaning` must match the catalog
-# column_comments verbatim. Use inline markdown links, not reference-style links.
 relations:
-  - name: mz_active_peeks
-    description: |
-      The `mz_active_peeks` view describes all read queries ("peeks") that are pending in the [dataflow](/get-started/arrangements/#dataflows) layer.
+- name: mz_active_peeks
+  description: 'The `mz_active_peeks` view describes all read queries ("peeks") that are pending in the [dataflow](/get-started/arrangements/#dataflows) layer.
+
+    '
+  columns:
+  - name: id
+    type: uuid
+    meaning: The ID of the peek request.
+  - name: object_id
+    type: text
+    meaning: The ID of the collection the peek is targeting. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables).
+  - name: type
+    type: text
+    meaning: 'The type of the corresponding peek: `index` if targeting an index or temporary dataflow; `persist` for a source, materialized view, or table.'
+  - name: time
+    type: mz_timestamp
+    meaning: The timestamp the peek has requested.
+  variants:
+  - name: mz_active_peeks_per_worker
+    kind: per_worker
+    description: 'The same data as `mz_active_peeks`, but split by Timely Dataflow worker.
+
+      '
     columns:
-      - name: id
-        type: uuid
-        meaning: The ID of the peek request.
-      - name: object_id
-        type: text
-        meaning: "The ID of the collection the peek is targeting. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables)."
-      - name: type
-        type: text
-        meaning: "The type of the corresponding peek: `index` if targeting an index or temporary dataflow; `persist` for a source, materialized view, or table."
-      - name: time
-        type: mz_timestamp
-        meaning: The timestamp the peek has requested.
-    variants:
-      - name: mz_active_peeks_per_worker
-        kind: per_worker
-        description: |
-          The same data as `mz_active_peeks`, but split by Timely Dataflow worker.
-        columns:
-          - name: worker_id
-            type: uint8
-            meaning: The ID of the Timely Dataflow worker.
+    - name: worker_id
+      type: uint8
+      meaning: The ID of the Timely Dataflow worker.
+- name: mz_arrangement_sharing
+  description: The `mz_arrangement_sharing` view describes how many times each [arrangement](/get-started/arrangements/#arrangements) in the system is used.
+  columns:
+  - name: operator_id
+    type: uint8
+    meaning: The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  - name: count
+    type: bigint
+    meaning: The number of operators that share the arrangement.
+- name: mz_arrangement_sizes
+  description: 'The `mz_arrangement_sizes` view describes the size of each [arrangement](/get-started/arrangements/#arrangements) in the system.
+
+
+    The size, capacity, and allocations are an approximation, which may underestimate the actual size in memory.
+
+    Specifically, reductions can use more memory than we show here.'
+  columns:
+  - name: operator_id
+    type: uint8
+    meaning: The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  - name: records
+    type: bigint
+    meaning: The number of records in the arrangement.
+  - name: batches
+    type: bigint
+    meaning: The number of batches in the arrangement.
+  - name: size
+    type: bigint
+    meaning: The utilized size in bytes of the arrangement.
+  - name: capacity
+    type: bigint
+    meaning: The capacity in bytes of the arrangement. Can be larger than the size.
+  - name: allocations
+    type: bigint
+    meaning: The number of separate memory allocations backing the arrangement.
+- name: mz_compute_error_counts
+  description: 'The `mz_compute_error_counts` view describes the counts of errors in objects exported by [dataflows](/get-started/arrangements/#dataflows) in the system.
+
+
+    Dataflow exports that don''t have any errors are not included in this view.'
+  columns:
+  - name: export_id
+    type: text
+    meaning: The ID of the dataflow export. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports).
+  - name: count
+    type: numeric
+    meaning: The count of errors present in this dataflow export.
+- name: mz_compute_exports
+  description: The `mz_compute_exports` view describes the objects exported by [dataflows](/get-started/arrangements/#dataflows) in the system.
+  columns:
+  - name: export_id
+    type: text
+    meaning: The ID of the index, materialized view, or subscription exported by the dataflow. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), or [`mz_internal.mz_subscriptions.id`](../mz_internal#mz_subscriptions).
+  - name: dataflow_id
+    type: uint8
+    meaning: The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
+- name: mz_compute_frontiers
+  description: 'The `mz_compute_frontiers` view describes the frontier of each [dataflow](/get-started/arrangements/#dataflows) export in the system.
+
+    The frontier describes the earliest timestamp at which the output of the dataflow may change; data prior to that timestamp is sealed.'
+  columns:
+  - name: export_id
+    type: text
+    meaning: The ID of the dataflow export. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports).
+  - name: time
+    type: mz_timestamp
+    meaning: The next timestamp at which the dataflow output may change.
+- name: mz_compute_import_frontiers
+  description: 'The `mz_compute_import_frontiers` view describes the frontiers of each [dataflow](/get-started/arrangements/#dataflows) import in the system.
+
+    The frontier describes the earliest timestamp at which the input into the dataflow may change; data prior to that timestamp is sealed.'
+  columns:
+  - name: export_id
+    type: text
+    meaning: The ID of the dataflow export. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports).
+  - name: import_id
+    type: text
+    meaning: The ID of the dataflow import. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources) or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables) or [`mz_compute_exports.export_id`](#mz_compute_exports).
+  - name: time
+    type: mz_timestamp
+    meaning: The next timestamp at which the dataflow input may change.
+- name: mz_compute_operator_durations_histogram
+  description: The `mz_compute_operator_durations_histogram` view describes a histogram of the duration in nanoseconds of each invocation for each [dataflow](/get-started/arrangements/#dataflows) operator.
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  - name: duration_ns
+    type: uint8
+    meaning: The upper bound of the duration bucket in nanoseconds.
+  - name: count
+    type: numeric
+    meaning: The (noncumulative) count of invocations in the bucket.
+- name: mz_dataflows
+  description: The `mz_dataflows` view describes the [dataflows](/get-started/arrangements/#dataflows) in the system.
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the dataflow.
+  - name: name
+    type: text
+    meaning: The internal name of the dataflow.
+- name: mz_dataflow_addresses
+  description: The `mz_dataflow_addresses` view describes how the [dataflow](/get-started/arrangements/#dataflows) channels and operators in the system are nested into scopes.
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the channel or operator. Corresponds to [`mz_dataflow_channels.id`](#mz_dataflow_channels) or [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  - name: address
+    type: bigint list
+    meaning: A list of scope-local indexes indicating the path from the root to this channel or operator.
+- name: mz_dataflow_arrangement_sizes
+  description: 'The `mz_dataflow_arrangement_sizes` view describes the size of arrangements per
+
+    operators under each dataflow.'
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the [dataflow]. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
+  - name: name
+    type: text
+    meaning: The name of the [dataflow].
+  - name: records
+    type: bigint
+    meaning: The number of records in all arrangements in the dataflow.
+  - name: batches
+    type: bigint
+    meaning: The number of batches in all arrangements in the dataflow.
+  - name: size
+    type: bigint
+    meaning: The utilized size in bytes of the arrangements.
+  - name: capacity
+    type: bigint
+    meaning: The capacity in bytes of the arrangements. Can be larger than the size.
+  - name: allocations
+    type: bigint
+    meaning: The number of separate memory allocations backing the arrangements.
+- name: mz_dataflow_channels
+  description: 'The `mz_dataflow_channels` view describes the communication channels between [dataflow](/get-started/arrangements/#dataflows) operators.
+
+    A communication channel connects one of the outputs of a source operator to one of the inputs of a target operator.'
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the channel.
+  - name: from_index
+    type: uint8
+    meaning: The scope-local index of the source operator. Corresponds to [`mz_dataflow_addresses.address`](#mz_dataflow_addresses).
+  - name: from_port
+    type: uint8
+    meaning: The source operator's output port.
+  - name: to_index
+    type: uint8
+    meaning: The scope-local index of the target operator. Corresponds to [`mz_dataflow_addresses.address`](#mz_dataflow_addresses).
+  - name: to_port
+    type: uint8
+    meaning: The target operator's input port.
+  - name: type
+    type: text
+    meaning: The container type of the channel.
+- name: mz_dataflow_channel_operators
+  description: The `mz_dataflow_channel_operators` view associates [dataflow](/get-started/arrangements/#dataflows) channels with the operators that are their endpoints.
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the channel. Corresponds to [`mz_dataflow_channels.id`](#mz_dataflow_channels).
+  - name: from_operator_id
+    type: uint8
+    meaning: The ID of the source of the channel. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  - name: from_operator_address
+    type: uint8 list
+    meaning: The address of the source of the channel. Corresponds to [`mz_dataflow_addresses.address`](#mz_dataflow_addresses).
+  - name: to_operator_id
+    type: uint8
+    meaning: The ID of the target of the channel. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  - name: to_operator_address
+    type: uint8 list
+    meaning: The address of the target of the channel. Corresponds to [`mz_dataflow_addresses.address`](#mz_dataflow_addresses).
+  - name: type
+    type: text
+    meaning: The container type of the channel.
+- name: mz_dataflow_global_ids
+  description: The `mz_dataflow_global_ids` view associates [dataflow](/get-started/arrangements/#dataflows) ids with global ids (ids of the form `u8` or `t5`).
+  columns:
+  - name: id
+    type: uint8
+    meaning: The dataflow ID.
+  - name: global_id
+    type: text
+    meaning: A global ID associated with that dataflow.
+- name: mz_dataflow_operators
+  description: The `mz_dataflow_operators` view describes the [dataflow](/get-started/arrangements/#dataflows) operators in the system.
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the operator.
+  - name: name
+    type: text
+    meaning: The internal name of the operator.
+- name: mz_dataflow_operator_dataflows
+  description: The `mz_dataflow_operator_dataflows` view describes the [dataflow](/get-started/arrangements/#dataflows) to which each operator belongs.
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  - name: name
+    type: text
+    meaning: The internal name of the operator.
+  - name: dataflow_id
+    type: uint8
+    meaning: The ID of the dataflow hosting the operator. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
+  - name: dataflow_name
+    type: text
+    meaning: The internal name of the dataflow hosting the operator.
+- name: mz_dataflow_operator_parents
+  description: The `mz_dataflow_operator_parents` view describes how [dataflow](/get-started/arrangements/#dataflows) operators are nested into scopes, by relating operators to their parent operators.
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  - name: parent_id
+    type: uint8
+    meaning: The ID of the operator's parent operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+- name: mz_expected_group_size_advice
+  description: 'The `mz_expected_group_size_advice` view provides advice on opportunities to set [query hints](/sql/select/#query-hints).
+
+    Query hints are applicable to dataflows maintaining [`MIN`](/sql/functions/#min), [`MAX`](/sql/functions/#max), or [Top K](/transform-data/patterns/top-k) query patterns.
+
+    The maintainance of these query patterns is implemented inside an operator scope, called a region,
+
+    through a hierarchical scheme for either aggregation or Top K computations.'
+  columns:
+  - name: dataflow_id
+    type: uint8
+    meaning: The ID of the [dataflow]. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
+  - name: dataflow_name
+    type: text
+    meaning: The internal name of the dataflow hosting the min/max aggregation or Top K.
+  - name: region_id
+    type: uint8
+    meaning: The ID of the root operator scope. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  - name: region_name
+    type: text
+    meaning: The internal name of the root operator scope for the min/max aggregation or Top K.
+  - name: levels
+    type: bigint
+    meaning: The number of levels in the hierarchical scheme implemented by the region.
+  - name: to_cut
+    type: bigint
+    meaning: The number of levels that can be eliminated (cut) from the region's hierarchy.
+  - name: savings
+    type: numeric
+    meaning: A conservative estimate of the amount of memory in bytes to be saved by applying the hint.
+  - name: hint
+    type: double precision
+    meaning: The hint value that will eliminate `to_cut` levels from the region's hierarchy.
+- name: mz_mappable_objects
+  description: The `mz_mappable_objects` identifies indexes (and their underlying views) and materialized views which can be debugged using the [`mz_lir_mapping`](#mz_lir_mapping) view.
+  columns:
+  - name: name
+    type: text
+    meaning: The name of the object. This name is unquoted, and you might need to call `quote_ident` if you want to reference the name shown here.
+  - name: global_id
+    type: text
+    meaning: The global ID of the object.
+- name: mz_lir_mapping
+  description: 'The `mz_lir_mapping` view describes the low-level internal representation (LIR) plan that corresponds to global ids of indexes (and their underlying views) and materialized views.
+
+    You can find a list of all debuggable objects in [`mz_mappable_objects`](#mz_mappable_objects).
+
+    LIR is a higher-level representation than dataflows; this view is used for profiling and debugging indices and materialized views.
+
+    Note that LIR is not a stable interface and may change at any time.
+
+    In particular, you should not attempt to parse `operator` descriptions.
+
+    LIR nodes are implemented by zero or more dataflow operators with sequential ids.
+
+    We use the range `[operator_id_start, operator_id_end)` to record this information.
+
+    If an LIR node was implemented without any dataflow operators, `operator_id_start` will be equal to `operator_id_end`.'
+  columns:
+  - name: global_id
+    type: text
+    meaning: The global ID.
+  - name: lir_id
+    type: uint8
+    meaning: The LIR node ID.
+  - name: operator
+    type: text
+    meaning: The LIR operator, in the format `OperatorName INPUTS [OPTIONS]`.
+  - name: parent_lir_id
+    type: uint8
+    meaning: The parent of this LIR node. May be `NULL`.
+  - name: nesting
+    type: uint2
+    meaning: The nesting level of this LIR node.
+  - name: operator_id_start
+    type: uint8
+    meaning: The first dataflow operator ID implementing this LIR operator (inclusive).
+  - name: operator_id_end
+    type: uint8
+    meaning: The first dataflow operator ID _after_ this LIR operator (exclusive).
+- name: mz_message_counts
+  description: 'The `mz_message_counts` view describes the messages and message batches sent and received over the [dataflow](/get-started/arrangements/#dataflows) channels in the system.
+
+    It distinguishes between individual records (`sent`, `received`) and batches of records (`batch_sent`, `batch_sent`).'
+  columns:
+  - name: channel_id
+    type: uint8
+    meaning: The ID of the channel. Corresponds to [`mz_dataflow_channels.id`](#mz_dataflow_channels).
+  - name: sent
+    type: numeric
+    meaning: The number of messages sent.
+  - name: received
+    type: numeric
+    meaning: The number of messages received.
+  - name: batch_sent
+    type: numeric
+    meaning: The number of batches sent.
+  - name: batch_received
+    type: numeric
+    meaning: The number of batches received.
+- name: mz_peek_durations_histogram
+  description: The `mz_peek_durations_histogram` view describes a histogram of the duration in nanoseconds of read queries ("peeks") in the [dataflow](/get-started/arrangements/#dataflows) layer.
+  columns:
+  - name: type
+    type: text
+    meaning: 'The peek variant: `index` or `persist`.'
+  - name: duration_ns
+    type: uint8
+    meaning: The upper bound of the bucket in nanoseconds.
+  - name: count
+    type: numeric
+    meaning: The (noncumulative) count of peeks in this bucket.
+- name: mz_records_per_dataflow
+  description: The `mz_records_per_dataflow` view describes the number of records in each [dataflow](/get-started/arrangements/#dataflows).
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
+  - name: name
+    type: text
+    meaning: The internal name of the dataflow.
+  - name: records
+    type: bigint
+    meaning: The number of records in the dataflow.
+  - name: batches
+    type: bigint
+    meaning: The number of batches in the dataflow.
+  - name: size
+    type: bigint
+    meaning: The utilized size in bytes of the arrangements.
+  - name: capacity
+    type: bigint
+    meaning: The capacity in bytes of the arrangements. Can be larger than the size.
+  - name: allocations
+    type: bigint
+    meaning: The number of separate memory allocations backing the arrangements.
+- name: mz_records_per_dataflow_operator
+  description: The `mz_records_per_dataflow_operator` view describes the number of records in each [dataflow](/get-started/arrangements/#dataflows) operator in the system.
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  - name: name
+    type: text
+    meaning: The internal name of the operator.
+  - name: dataflow_id
+    type: uint8
+    meaning: The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
+  - name: records
+    type: bigint
+    meaning: The number of records in the operator.
+  - name: batches
+    type: bigint
+    meaning: The number of batches in the dataflow.
+  - name: size
+    type: bigint
+    meaning: The utilized size in bytes of the arrangement.
+  - name: capacity
+    type: bigint
+    meaning: The capacity in bytes of the arrangement. Can be larger than the size.
+  - name: allocations
+    type: bigint
+    meaning: The number of separate memory allocations backing the arrangement.
+- name: mz_scheduling_elapsed
+  description: The `mz_scheduling_elapsed` view describes the total amount of time spent in each [dataflow](/get-started/arrangements/#dataflows) operator.
+  columns:
+  - name: id
+    type: uint8
+    meaning: The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  - name: elapsed_ns
+    type: numeric
+    meaning: The total elapsed time spent in the operator in nanoseconds.
+- name: mz_scheduling_parks_histogram
+  description: The `mz_scheduling_parks_histogram` view describes a histogram of [dataflow](/get-started/arrangements/#dataflows) worker park events. A park event occurs when a worker has no outstanding work.
+  columns:
+  - name: slept_for_ns
+    type: uint8
+    meaning: The actual length of the park event in nanoseconds.
+  - name: requested_ns
+    type: uint8
+    meaning: The requested length of the park event in nanoseconds.
+  - name: count
+    type: numeric
+    meaning: The (noncumulative) count of park events in this bucket.

--- a/doc/user/data/mz_introspection.yml
+++ b/doc/user/data/mz_introspection.yml
@@ -1,0 +1,33 @@
+# doc/user/data/mz_introspection.yml
+#
+# Column documentation for relations in the mz_introspection schema, rendered by
+# the catalog-relation shortcode and checked against the catalog by
+# ci/test/lint-docs-catalog.py. Each relation lists its base columns and any
+# per_worker or raw variants. Column `meaning` must match the catalog
+# column_comments verbatim. Use inline markdown links, not reference-style links.
+relations:
+  - name: mz_active_peeks
+    description: |
+      The `mz_active_peeks` view describes all read queries ("peeks") that are pending in the [dataflow](/get-started/arrangements/#dataflows) layer.
+    columns:
+      - name: id
+        type: uuid
+        meaning: The ID of the peek request.
+      - name: object_id
+        type: text
+        meaning: "The ID of the collection the peek is targeting. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables)."
+      - name: type
+        type: text
+        meaning: "The type of the corresponding peek: `index` if targeting an index or temporary dataflow; `persist` for a source, materialized view, or table."
+      - name: time
+        type: mz_timestamp
+        meaning: The timestamp the peek has requested.
+    variants:
+      - name: mz_active_peeks_per_worker
+        kind: per_worker
+        description: |
+          The same data as `mz_active_peeks`, but split by Timely Dataflow worker.
+        columns:
+          - name: worker_id
+            type: uint8
+            meaning: The ID of the Timely Dataflow worker.

--- a/doc/user/layouts/shortcodes/catalog-relation.html
+++ b/doc/user/layouts/shortcodes/catalog-relation.html
@@ -35,7 +35,7 @@
 {{- range .columns }}
 <tr>
 <td><code>{{ .name }}</code></td>
-<td>{{- $u := index $.types .type -}}{{- if $u -}}<a href="{{ $u }}"><code>{{ .type }}</code></a>{{- else -}}<code>{{ .type }}</code>{{- end -}}</td>
+<td>{{- $u := index $.types .type -}}{{- if $u -}}{{ printf "[`%s`](%s)" .type $u | $.Page.RenderString }}{{- else -}}{{ printf "`%s`" .type | $.Page.RenderString }}{{- end -}}</td>
 <td>{{ .meaning | $.Page.RenderString }}</td>
 </tr>
 {{- end }}

--- a/doc/user/layouts/shortcodes/catalog-relation.html
+++ b/doc/user/layouts/shortcodes/catalog-relation.html
@@ -1,0 +1,44 @@
+{{/* catalog-relation: render a system-catalog relation from a data entry.
+
+     Params:
+       schema - data file basename under doc/user/data (e.g. "mz_introspection")
+       name   - relation name (e.g. "mz_active_peeks")
+
+     Looks up the relation in .Site.Data.<schema>.relations and renders its
+     description, base column table, and each variant. per_worker variants show
+     the base columns plus their own extra columns; raw variants show only a
+     warning. Type links come from .Site.Data.catalog_types. */}}
+{{- $schema := .Get "schema" -}}
+{{- $name := .Get "name" -}}
+{{- $types := .Site.Data.catalog_types -}}
+{{- $data := index .Site.Data $schema -}}
+{{- $rel := false -}}
+{{- range $data.relations -}}
+  {{- if eq .name $name -}}{{- $rel = . -}}{{- end -}}
+{{- end -}}
+{{- with $rel -}}
+{{ .description | $.Page.RenderString }}
+{{ template "catalog-relation-table" (dict "columns" .columns "types" $types "Page" $.Page) }}
+{{- range .variants -}}
+<h4><code>{{ .name }}</code></h4>
+{{ .description | $.Page.RenderString }}
+{{- if ne .kind "raw" -}}
+{{ template "catalog-relation-table" (dict "columns" (append (index $rel "columns") .columns) "types" $types "Page" $.Page) }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "catalog-relation-table" -}}
+<table>
+<thead><tr><th>Field</th><th>Type</th><th>Meaning</th></tr></thead>
+<tbody>
+{{- range .columns }}
+<tr>
+<td><code>{{ .name }}</code></td>
+<td>{{- $u := index $.types .type -}}{{- if $u -}}<a href="{{ $u }}"><code>{{ .type }}</code></a>{{- else -}}<code>{{ .type }}</code>{{- end -}}</td>
+<td>{{ .meaning | $.Page.RenderString }}</td>
+</tr>
+{{- end }}
+</tbody>
+</table>
+{{- end -}}

--- a/test/sqllogictest/autogenerated/mz_introspection.slt
+++ b/test/sqllogictest/autogenerated/mz_introspection.slt
@@ -43,6 +43,15 @@ object_id  text  The␠ID␠of␠the␠collection␠the␠peek␠is␠targeting.
 type  text  The␠type␠of␠the␠corresponding␠peek:␠`index`␠if␠targeting␠an␠index␠or␠temporary␠dataflow;␠`persist`␠for␠a␠source,␠materialized␠view,␠or␠table.
 time  mz_timestamp  The␠timestamp␠the␠peek␠has␠requested.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_active_peeks_per_worker' ORDER BY name
+----
+id  uuid
+object_id  text
+time  mz_timestamp
+type  text
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_arrangement_sharing' ORDER BY position
 ----


### PR DESCRIPTION
Superseded: split into a phase-1 PR (`catalog-docs-data-phase1`) and a stacked phase-2 PR (`catalog-docs-data-phase2`).