### PR TITLE
docs: data-driven system-catalog reference, phase 1 (mz_active_peeks)

### DIFF
--- a/ci/test/lint-docs-catalog.py
+++ b/ci/test/lint-docs-catalog.py
@@ -10,9 +10,12 @@
 # by the Apache License, Version 2.0.
 
 import fileinput
+import os
 import re
 import sys
 from enum import Enum
+
+import yaml
 
 
 class ParserState(Enum):
@@ -73,6 +76,94 @@ CREATE INDEX objects_idx ON objects(schema, object)
 """
 
 
+# Cache of loaded data files keyed by schema name.
+_DATA_CACHE: dict[str, dict] = {}
+
+
+def load_relation(schema: str, object_name: str) -> dict:
+    """Return the data entry for `schema.object_name` from doc/user/data/<schema>.yml.
+
+    Raises if the file or the relation is missing, so a stale FROM_YAML marker
+    fails loudly rather than silently documenting nothing.
+    """
+    if schema not in _DATA_CACHE:
+        path = os.path.join("doc", "user", "data", f"{schema}.yml")
+        with open(path, encoding="utf-8") as f:
+            _DATA_CACHE[schema] = yaml.safe_load(f)
+    for relation in _DATA_CACHE[schema].get("relations", []):
+        if relation["name"] == object_name:
+            return relation
+    raise ValueError(f"no data entry for {schema}.{object_name} in {schema}.yml")
+
+
+def format_meaning(text: str) -> str:
+    """Strip doc links to their text and escape spaces, matching the catalog
+    comment form the generated sqllogictest compares against."""
+    text = DOC_LINK_TYPE1_RE.sub(r"\1", text)
+    text = DOC_LINK_TYPE2_RE.sub(r"\1", text)
+    return text.replace(" ", "␠")
+
+
+def normalize_type(type_name: str) -> str:
+    """Match the inline path's type normalization for list/array types."""
+    if type_name == "mz_aclitem array":
+        return "mz_aclitem[]"
+    if type_name == "text array":
+        return "text[]"
+    if "list" in type_name:
+        return "list"
+    if "array" in type_name:
+        return "array"
+    return type_name.replace(" ", "␠")
+
+
+def emit_from_yaml(schema: str, object_name: str, objects: list, schemas: set) -> None:
+    """Emit sqllogictest checks for a FROM_YAML relation and its variants, and
+    record every emitted relation name for the completeness query."""
+    relation = load_relation(schema, object_name)
+    schemas.add(f"'{schema}'")
+
+    # Base table: full check with comments, position-ordered (identical to the
+    # inline-table output it replaces).
+    objects.append(object_name)
+    print("query TTT")
+    print(
+        f"SELECT name, type, comment FROM objects WHERE schema = '{schema}' AND object = '{object_name}' ORDER BY position"
+    )
+    print("----")
+    for column in relation["columns"]:
+        print(
+            "  ".join(
+                [
+                    column["name"],
+                    normalize_type(column["type"]),
+                    format_meaning(column["meaning"]),
+                ]
+            )
+        )
+    print()
+
+    for variant in relation.get("variants", []):
+        objects.append(variant["name"])
+        if variant.get("kind") == "raw":
+            # Existence only: no column table to check, the relation is recorded
+            # above so the completeness query still covers it.
+            continue
+        # per_worker (and any future non-raw variant): base columns plus the
+        # variant's extra columns, checked columns-and-types only. Ordered by
+        # name because the catalog column position of worker_id is not fixed.
+        columns = list(relation["columns"]) + list(variant.get("columns", []))
+        columns.sort(key=lambda c: c["name"])
+        print("query TT")
+        print(
+            f"SELECT name, type FROM objects WHERE schema = '{schema}' AND object = '{variant['name']}' ORDER BY name"
+        )
+        print("----")
+        for column in columns:
+            print("  ".join([column["name"], normalize_type(column["type"])]))
+        print()
+
+
 def main() -> None:
     print(HEADER)
 
@@ -92,9 +183,12 @@ def main() -> None:
             match = RELATION_MARKER_RE.search(line)
             if match:
                 modifiers = match.group(3)
-                include_comments = "NO_COMMENTS" not in modifiers
                 schema = match.group(1)
                 object_name = match.group(2)
+                if "FROM_YAML" in modifiers:
+                    emit_from_yaml(schema, object_name, objects, schemas)
+                    continue
+                include_comments = "NO_COMMENTS" not in modifiers
                 if include_comments:
                     print("query TTT")
                     print(
@@ -135,9 +229,7 @@ def main() -> None:
                     type_name = "array"
                 type_name = type_name.replace(" ", "␠")
                 if include_comments:
-                    documentation = DOC_LINK_TYPE1_RE.sub(r"\1", fields[2])
-                    documentation = DOC_LINK_TYPE2_RE.sub(r"\1", documentation)
-                    documentation = documentation.replace(" ", "␠")
+                    documentation = format_meaning(fields[2])
                     print("  ".join([field, type_name, documentation]))
                 else:
                     print("  ".join([field, type_name]))

--- a/doc/user/content/reference/system-catalog/mz_introspection.md
+++ b/doc/user/content/reference/system-catalog/mz_introspection.md
@@ -32,17 +32,8 @@ Per-worker relations expose the same data as their global counterparts, but have
 
 ## `mz_active_peeks`
 
-The `mz_active_peeks` view describes all read queries ("peeks") that are pending in the [dataflow] layer.
-
-<!-- RELATION_SPEC mz_introspection.mz_active_peeks -->
-| Field       | Type             | Meaning                                                                                                                                                                                                                                                                                                               |
-|-------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`        | [`uuid`]         | The ID of the peek request.                                                                                                                                                                                                                                                                                           |
-| `object_id` | [`text`]         | The ID of the collection the peek is targeting. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables). |
-| `type`      | [`text`]         | The type of the corresponding peek: `index` if targeting an index or temporary dataflow; `persist` for a source, materialized view, or table.                                                                                                                                                                         |
-| `time`      | [`mz_timestamp`] | The timestamp the peek has requested.                                                                                                                                                                                                                                                                                 |
-
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_active_peeks_per_worker -->
+<!-- RELATION_SPEC mz_introspection.mz_active_peeks FROM_YAML -->
+{{< catalog-relation schema="mz_introspection" name="mz_active_peeks" >}}
 
 ## `mz_arrangement_sharing`
 

--- a/doc/user/data/catalog_types.yml
+++ b/doc/user/data/catalog_types.yml
@@ -1,0 +1,10 @@
+# doc/user/data/catalog_types.yml
+#
+# Maps a catalog column type name to its documentation URL. The catalog-relation
+# shortcode uses this to render type links, because shortcode-rendered cells go
+# through RenderString and cannot see the page-level reference-link definitions.
+# Extend this map as new relations are migrated to data entries.
+uuid: /sql/types/uuid
+text: /sql/types/text
+mz_timestamp: /sql/types/mz_timestamp
+uint8: /sql/types/uint8

--- a/doc/user/data/mz_introspection.yml
+++ b/doc/user/data/mz_introspection.yml
@@ -1,0 +1,33 @@
+# doc/user/data/mz_introspection.yml
+#
+# Column documentation for relations in the mz_introspection schema, rendered by
+# the catalog-relation shortcode and checked against the catalog by
+# ci/test/lint-docs-catalog.py. Each relation lists its base columns and any
+# per_worker or raw variants. Column `meaning` must match the catalog
+# column_comments verbatim. Use inline markdown links, not reference-style links.
+relations:
+  - name: mz_active_peeks
+    description: |
+      The `mz_active_peeks` view describes all read queries ("peeks") that are pending in the [dataflow](/get-started/arrangements/#dataflows) layer.
+    columns:
+      - name: id
+        type: uuid
+        meaning: The ID of the peek request.
+      - name: object_id
+        type: text
+        meaning: "The ID of the collection the peek is targeting. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables)."
+      - name: type
+        type: text
+        meaning: "The type of the corresponding peek: `index` if targeting an index or temporary dataflow; `persist` for a source, materialized view, or table."
+      - name: time
+        type: mz_timestamp
+        meaning: The timestamp the peek has requested.
+    variants:
+      - name: mz_active_peeks_per_worker
+        kind: per_worker
+        description: |
+          The same data as `mz_active_peeks`, but split by Timely Dataflow worker.
+        columns:
+          - name: worker_id
+            type: uint8
+            meaning: The ID of the Timely Dataflow worker.

--- a/doc/user/layouts/shortcodes/catalog-relation.html
+++ b/doc/user/layouts/shortcodes/catalog-relation.html
@@ -35,7 +35,7 @@
 {{- range .columns }}
 <tr>
 <td><code>{{ .name }}</code></td>
-<td>{{- $u := index $.types .type -}}{{- if $u -}}<a href="{{ $u }}"><code>{{ .type }}</code></a>{{- else -}}<code>{{ .type }}</code>{{- end -}}</td>
+<td>{{- $u := index $.types .type -}}{{- if $u -}}{{ printf "[`%s`](%s)" .type $u | $.Page.RenderString }}{{- else -}}{{ printf "`%s`" .type | $.Page.RenderString }}{{- end -}}</td>
 <td>{{ .meaning | $.Page.RenderString }}</td>
 </tr>
 {{- end }}

--- a/doc/user/layouts/shortcodes/catalog-relation.html
+++ b/doc/user/layouts/shortcodes/catalog-relation.html
@@ -1,0 +1,44 @@
+{{/* catalog-relation: render a system-catalog relation from a data entry.
+
+     Params:
+       schema - data file basename under doc/user/data (e.g. "mz_introspection")
+       name   - relation name (e.g. "mz_active_peeks")
+
+     Looks up the relation in .Site.Data.<schema>.relations and renders its
+     description, base column table, and each variant. per_worker variants show
+     the base columns plus their own extra columns; raw variants show only a
+     warning. Type links come from .Site.Data.catalog_types. */}}
+{{- $schema := .Get "schema" -}}
+{{- $name := .Get "name" -}}
+{{- $types := .Site.Data.catalog_types -}}
+{{- $data := index .Site.Data $schema -}}
+{{- $rel := false -}}
+{{- range $data.relations -}}
+  {{- if eq .name $name -}}{{- $rel = . -}}{{- end -}}
+{{- end -}}
+{{- with $rel -}}
+{{ .description | $.Page.RenderString }}
+{{ template "catalog-relation-table" (dict "columns" .columns "types" $types "Page" $.Page) }}
+{{- range .variants -}}
+<h4><code>{{ .name }}</code></h4>
+{{ .description | $.Page.RenderString }}
+{{- if ne .kind "raw" -}}
+{{ template "catalog-relation-table" (dict "columns" (append (index $rel "columns") .columns) "types" $types "Page" $.Page) }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "catalog-relation-table" -}}
+<table>
+<thead><tr><th>Field</th><th>Type</th><th>Meaning</th></tr></thead>
+<tbody>
+{{- range .columns }}
+<tr>
+<td><code>{{ .name }}</code></td>
+<td>{{- $u := index $.types .type -}}{{- if $u -}}<a href="{{ $u }}"><code>{{ .type }}</code></a>{{- else -}}<code>{{ .type }}</code>{{- end -}}</td>
+<td>{{ .meaning | $.Page.RenderString }}</td>
+</tr>
+{{- end }}
+</tbody>
+</table>
+{{- end -}}

--- a/test/sqllogictest/autogenerated/mz_introspection.slt
+++ b/test/sqllogictest/autogenerated/mz_introspection.slt
@@ -43,6 +43,15 @@ object_id  text  The␠ID␠of␠the␠collection␠the␠peek␠is␠targeting.
 type  text  The␠type␠of␠the␠corresponding␠peek:␠`index`␠if␠targeting␠an␠index␠or␠temporary␠dataflow;␠`persist`␠for␠a␠source,␠materialized␠view,␠or␠table.
 time  mz_timestamp  The␠timestamp␠the␠peek␠has␠requested.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_active_peeks_per_worker' ORDER BY name
+----
+id  uuid
+object_id  text
+time  mz_timestamp
+type  text
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_arrangement_sharing' ORDER BY position
 ----


### PR DESCRIPTION
### Motivation

The system-catalog reference pages carry many `RELATION_SPEC_UNDOCUMENTED` markers.
Documenting them by hand means writing near-duplicate tables for every `_per_worker` and `_raw` sibling.
This starts moving the column tables into `doc/user/data`, so a relation is defined once and its variants render from that single definition.

### Description

Phase 1 vertical slice on the `mz_active_peeks` family, proving the pipeline end to end.
Adds a `catalog-relation` Hugo shortcode, a per-schema YAML data entry (`doc/user/data/mz_introspection.yml`) whose entries carry base columns plus a `variants` list, and a `FROM_YAML` marker mode in `ci/test/lint-docs-catalog.py` that emits the same catalog checks from the data instead of an inline table.
The base-table check stays byte-identical to the old inline output; variant checks are name-sorted columns-and-types only (the per-worker `worker_id` column is not always last).
Type links render through the markdown link hook so they pick up the baseURL prefix.

Phase 2 (migrating the remaining `mz_introspection` relations) is stacked on this branch.

### Verification

`ci/test/lint-docs-catalog.sh` reports no diff, the regenerated `test/sqllogictest/autogenerated/mz_introspection.slt` passes, and `hugo` + `htmltest` are clean.