### PR TITLE
compute: fix lost updates in mz_join_core after advance_upper

### DIFF
--- a/src/compute/src/render/join/mz_join_core.rs
+++ b/src/compute/src/render/join/mz_join_core.rs
@@ -164,6 +164,19 @@ where
                 &acknowledged2.borrow()
             ));
 
+            // Batches wholly at or before these frontiers were joined by the start-up loading
+            // above, and arriving input batches are ignored up to them. Beyond them, every
+            // non-empty arriving batch must be joined, even once `acknowledged` has advanced past
+            // it. `advance_upper` consults the shared trace, whose merges may have consolidated an
+            // in-flight batch's updates away once logical compaction equates an add/remove pair's
+            // times. The trace's emptiness there is valid only for readers at or beyond the
+            // compaction frontier, while our consumers may read finer times, so the raw batch still
+            // owes them its updates. Testing against these fixed boundaries rather than the mutable
+            // `acknowledged` frontiers keeps such batches from being dropped. See
+            // TimelyDataflow/differential-dataflow#801.
+            let preload_upper1 = acknowledged1.clone();
+            let preload_upper2 = acknowledged2.clone();
+
             // Load up deferred work using trace2 cursors and batches captured just above.
             for (batch2_cursor, batch2) in batch2_cursors.into_iter() {
                 trace!(
@@ -221,8 +234,11 @@ where
                         .expect("we only drop a trace in response to the other input emptying");
                     let capability = capability.retain(0);
                     for batch1 in data.drain(..) {
-                        // Ignore any pre-loaded data.
-                        if PartialOrder::less_equal(&acknowledged1, batch1.lower()) {
+                        // Ignore any pre-loaded data, which was joined at start-up. This tests the
+                        // fixed preload boundary, not `acknowledged1`, which `advance_upper` can
+                        // move past an in-flight batch whose updates trace merges consolidated away.
+                        // Such a batch must still be joined.
+                        if !PartialOrder::less_equal(batch1.upper(), &preload_upper1) {
                             trace!(
                                 operator_id,
                                 input = 1,
@@ -256,9 +272,17 @@ where
 
                             // To update `acknowledged1` we might presume that `batch1.lower` should equal it, but we
                             // may have skipped over empty batches. Still, the batches are in-order, and we should be
-                            // able to just assume the most recent `batch1.upper`
-                            debug_assert!(PartialOrder::less_equal(&acknowledged1, batch1.upper()));
-                            acknowledged1.clone_from(batch1.upper());
+                            // able to just assume the most recent `batch1.upper`, unless `advance_upper` already moved
+                            // `acknowledged1` past this batch, in which case we keep the further frontier.
+                            if PartialOrder::less_equal(&acknowledged1, batch1.lower()) {
+                                mz_ore::soft_assert_or_log!(
+                                    PartialOrder::less_equal(&acknowledged1, batch1.upper()),
+                                    "acknowledged1 {:?} regressed past batch1 upper {:?}",
+                                    acknowledged1.elements(),
+                                    batch1.upper().elements(),
+                                );
+                                acknowledged1.clone_from(batch1.upper());
+                            }
 
                             trace!(
                                 operator_id,
@@ -277,8 +301,11 @@ where
                         .expect("we only drop a trace in response to the other input emptying");
                     let capability = capability.retain(0);
                     for batch2 in data.drain(..) {
-                        // Ignore any pre-loaded data.
-                        if PartialOrder::less_equal(&acknowledged2, batch2.lower()) {
+                        // Ignore any pre-loaded data, which was joined at start-up. This tests the
+                        // fixed preload boundary, not `acknowledged2`, which `advance_upper` can
+                        // move past an in-flight batch whose updates trace merges consolidated away.
+                        // Such a batch must still be joined.
+                        if !PartialOrder::less_equal(batch2.upper(), &preload_upper2) {
                             trace!(
                                 operator_id,
                                 input = 2,
@@ -312,9 +339,17 @@ where
 
                             // To update `acknowledged2` we might presume that `batch2.lower` should equal it, but we
                             // may have skipped over empty batches. Still, the batches are in-order, and we should be
-                            // able to just assume the most recent `batch2.upper`
-                            debug_assert!(PartialOrder::less_equal(&acknowledged2, batch2.upper()));
-                            acknowledged2.clone_from(batch2.upper());
+                            // able to just assume the most recent `batch2.upper`, unless `advance_upper` already moved
+                            // `acknowledged2` past this batch, in which case we keep the further frontier.
+                            if PartialOrder::less_equal(&acknowledged2, batch2.lower()) {
+                                mz_ore::soft_assert_or_log!(
+                                    PartialOrder::less_equal(&acknowledged2, batch2.upper()),
+                                    "acknowledged2 {:?} regressed past batch2 upper {:?}",
+                                    acknowledged2.elements(),
+                                    batch2.upper().elements(),
+                                );
+                                acknowledged2.clone_from(batch2.upper());
+                            }
 
                             trace!(
                                 operator_id,


### PR DESCRIPTION
Our `mz_join_core` is a fork of differential's `JoinCore::join_core` and inherited a correctness bug fixed upstream in TimelyDataflow/differential-dataflow#802 (issue #801).

The operator skipped incoming batches by testing `batch.lower()` against the mutable `acknowledged` frontier. `advance_upper` can advance `acknowledged` past an in-flight batch when trace merges consolidate the batch's updates away, e.g. an add/remove pair collapsing once logical compaction equates their times. The trace is legitimately empty there only for readers at or beyond the compaction frontier, while our consumers may read finer times where the batch's updates are still real. Testing against `acknowledged` therefore dropped such batches and silently lost updates.

The fix captures fixed `preload_upper` frontiers at start-up and gates the skip on them, and advances `acknowledged` only when a batch sits at or beyond it. This is a one-to-one port of the upstream change.

No regression test: deterministically reproducing the race requires trace merges to consolidate an add/remove pair while a batch is in flight and `advance_upper` to then jump ahead, which is timing-dependent and not reliable in testdrive/sqllogictest. Upstream #802 added no direct join test either. Correctness rests on mirroring the upstream reasoning.

Note: the alternate `DifferentialDataflow` join implementation calls upstream `join_core` from crates.io `differential-dataflow` 0.24.0, which still carries the bug and will be fixed by a future dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)