### PR TITLE
persist: Use pipelining for consensus connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9996,6 +9996,7 @@ dependencies = [
  "mz-persist",
  "mz-persist-client",
  "mz-persist-types",
+ "mz-postgres-client",
  "mz-repr",
  "mz-timestamp-oracle",
  "mz-txn-wal",

--- a/ci/test/lint-main/checks/check-mzcompose-files.sh
+++ b/ci/test/lint-main/checks/check-mzcompose-files.sh
@@ -26,6 +26,7 @@ check_all_files_referenced_in_ci() {
         -not -wholename "./test/console/mzcompose.py" `# Only run manually` \
         -not -wholename "./test/cargo-fuzz/mzcompose.py" `# Enabled in release qualification later in the cargo-fuzz stack` \
         -not -wholename "./test/mzcompose_examples/mzcompose.py" `# Example only` \
+        -not -wholename "./test/persist-consensus-scaling/mzcompose.py" `# Benchmark, only run manually` \
         -not -wholename "./test/get-cloud-hostname/mzcompose.py" `# Utility, no test` \
         | sed -e "s|.*/\([^/]*\)/mzcompose.py|\1|")
     while read -r composition; do

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -21,6 +21,24 @@ metrics:
   help: times a connection was created
   source: src/postgres-client/src/metrics.rs
   visibility: internal
+- name: '*_postgres_connpool_shared_inflight_bucket'
+  help: in-flight operations on a shared connection at acquisition
+  labels:
+  - le
+  source: src/postgres-client/src/metrics.rs
+  visibility: internal
+- name: '*_postgres_connpool_shared_inflight_count'
+  help: in-flight operations on a shared connection at acquisition
+  source: src/postgres-client/src/metrics.rs
+  visibility: internal
+- name: '*_postgres_connpool_shared_inflight_sum'
+  help: in-flight operations on a shared connection at acquisition
+  source: src/postgres-client/src/metrics.rs
+  visibility: internal
+- name: '*_postgres_connpool_shared_size'
+  help: connections in the shared set for pipelined operations
+  source: src/postgres-client/src/metrics.rs
+  visibility: internal
 - name: '*_postgres_connpool_size'
   help: number of connections currently in pool
   source: src/postgres-client/src/metrics.rs

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -440,6 +440,11 @@ def get_variable_system_parameters(
             "50",
             ["0", "10", "25", "50", "100", "200"],
         ),
+        VariableSystemParameter(
+            "persist_pg_consensus_pipeline_depth",
+            "1024",
+            ["0", "1", "16", "1024"],
+        ),
         persist_pg_consensus_read_committed,
         VariableSystemParameter(
             "persist_state_update_lease_timeout", "1s", ["0s", "1s", "10s"]

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -435,6 +435,11 @@ def get_variable_system_parameters(
         VariableSystemParameter(
             "persist_blob_cache_scale_with_threads", "true", ["true", "false"]
         ),
+        VariableSystemParameter(
+            "persist_pg_consensus_pipeline_connections",
+            "50",
+            ["0", "10", "25", "50", "100", "200"],
+        ),
         persist_pg_consensus_read_committed,
         VariableSystemParameter(
             "persist_state_update_lease_timeout", "1s", ["0s", "1s", "10s"]

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1719,6 +1719,12 @@ class FlipFlagsAction(Action):
             "100",
             "200",
         ]
+        self.flags_with_values["persist_pg_consensus_pipeline_depth"] = [
+            "0",
+            "1",
+            "16",
+            "1024",
+        ]
         self.flags_with_values["persist_source_fetch_concurrency"] = [
             "1",
             "2",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1711,6 +1711,14 @@ class FlipFlagsAction(Action):
         self.flags_with_values["persist_optimize_ignored_data_fetch"] = (
             BOOLEAN_FLAG_VALUES
         )
+        self.flags_with_values["persist_pg_consensus_pipeline_connections"] = [
+            "0",
+            "10",
+            "25",
+            "50",
+            "100",
+            "200",
+        ]
         self.flags_with_values["persist_source_fetch_concurrency"] = [
             "1",
             "2",

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -33,6 +33,7 @@ mz-ore = { path = "../ore", features = ["bytes", "network", "panic", "tracing", 
 mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
+mz-postgres-client = { path = "../postgres-client" }
 mz-repr = { path = "../repr" }
 mz-timestamp-oracle = { path = "../timestamp-oracle" }
 mz-txn-wal = { path = "../txn-wal" }

--- a/src/persist-cli/src/consensus_bench.rs
+++ b/src/persist-cli/src/consensus_bench.rs
@@ -28,7 +28,9 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::url::SensitiveUrl;
 use mz_persist::cfg::ConsensusConfig;
 use mz_persist::location::{CaSResult, Consensus, SeqNo, VersionedData};
-use mz_persist::postgres::PG_CONSENSUS_READ_COMMITTED;
+use mz_persist::postgres::{
+    PG_CONSENSUS_PIPELINE_CONNECTIONS, PG_CONSENSUS_PIPELINE_DEPTH, PG_CONSENSUS_READ_COMMITTED,
+};
 use mz_persist_client::ShardId;
 use mz_postgres_client::PostgresClientKnobs;
 use mz_postgres_client::metrics::PostgresClientMetrics;
@@ -79,6 +81,11 @@ pub struct Args {
     /// uses the production default.
     #[clap(long)]
     pipeline_connections: Option<usize>,
+
+    /// Maximum in-flight ops per shared connection before new ops wait for a
+    /// slot. 0 disables the limit. Unset uses the production default.
+    #[clap(long)]
+    pipeline_depth: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -136,14 +143,14 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
     let mut updates = ConfigUpdates::default();
     updates.add(&PG_CONSENSUS_READ_COMMITTED, args.read_committed);
     if let Some(pipeline_connections) = args.pipeline_connections {
-        updates.add(
-            &mz_persist::postgres::PG_CONSENSUS_PIPELINE_CONNECTIONS,
-            pipeline_connections,
-        );
+        updates.add(&PG_CONSENSUS_PIPELINE_CONNECTIONS, pipeline_connections);
+    }
+    if let Some(pipeline_depth) = args.pipeline_depth {
+        updates.add(&PG_CONSENSUS_PIPELINE_DEPTH, pipeline_depth);
     }
     updates.apply(&configs);
-    let pipeline_connections =
-        mz_persist::postgres::PG_CONSENSUS_PIPELINE_CONNECTIONS.get(&configs);
+    let pipeline_connections = PG_CONSENSUS_PIPELINE_CONNECTIONS.get(&configs);
+    let pipeline_depth = PG_CONSENSUS_PIPELINE_DEPTH.get(&configs);
 
     let consensus = ConsensusConfig::try_from(
         &args.consensus_uri,
@@ -251,6 +258,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         "num_shards": args.num_shards,
         "pool_size": args.pool_size,
         "pipeline_connections": pipeline_connections,
+        "pipeline_depth": pipeline_depth,
         "read_committed": args.read_committed,
         "data_size": args.data_size,
         "runtime_s": runtime_s,

--- a/src/persist-cli/src/consensus_bench.rs
+++ b/src/persist-cli/src/consensus_bench.rs
@@ -1,0 +1,371 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Closed-loop benchmark for the persist [Consensus] implementation.
+//!
+//! Models the write-side load persist puts on the consensus backend: one
+//! logical shard is one sequential compare-and-set stream (persist never has
+//! more than one CaS in flight per shard), so the concurrency axis is the
+//! number of shards. Each shard commits diffs as fast as the backend allows
+//! and periodically truncates its prefix, mirroring what state maintenance
+//! and GC do in production.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail};
+use bytes::Bytes;
+use mz_dyncfg::{ConfigSet, ConfigUpdates};
+use mz_ore::cast::CastLossy;
+use mz_ore::metrics::MetricsRegistry;
+use mz_ore::url::SensitiveUrl;
+use mz_persist::cfg::ConsensusConfig;
+use mz_persist::location::{CaSResult, Consensus, SeqNo, VersionedData};
+use mz_persist::postgres::PG_CONSENSUS_READ_COMMITTED;
+use mz_persist_client::ShardId;
+use mz_postgres_client::PostgresClientKnobs;
+use mz_postgres_client::metrics::PostgresClientMetrics;
+use tokio::sync::Barrier;
+use tracing::info;
+
+/// Closed-loop benchmark of consensus compare-and-set across many shards.
+#[derive(Debug, clap::Parser)]
+pub struct Args {
+    /// Consensus URI, e.g. postgres://root@localhost:26257?options=--search_path=consensus
+    #[clap(long)]
+    consensus_uri: SensitiveUrl,
+
+    /// Number of shards. Each shard is an independent sequential CaS stream,
+    /// so this is also the number of concurrent in-flight consensus ops.
+    #[clap(long, default_value_t = 64)]
+    num_shards: usize,
+
+    /// Length of the measured window.
+    #[clap(long, value_parser = humantime::parse_duration, default_value = "30s")]
+    runtime: Duration,
+
+    /// Warmup before the measured window. Ops in this period run but are not
+    /// recorded, letting the connection pool reach steady state.
+    #[clap(long, value_parser = humantime::parse_duration, default_value = "5s")]
+    warmup: Duration,
+
+    /// Size of the data payload of each consensus entry, in bytes.
+    #[clap(long, default_value_t = 1024)]
+    data_size: usize,
+
+    /// After every this many commits a shard truncates all but the most
+    /// recent this many entries, keeping the table bounded like GC does.
+    #[clap(long, default_value_t = 32)]
+    truncate_every: u64,
+
+    /// Maximum size of the Postgres connection pool.
+    #[clap(long, default_value_t = 50)]
+    pool_size: usize,
+
+    /// Run consensus connections under READ COMMITTED isolation
+    /// (vanilla Postgres only).
+    #[clap(long)]
+    read_committed: bool,
+
+    /// Cap on shared connections that consensus ops run on (pipelining once
+    /// all are busy). 0 forces the regular exclusive-checkout pool. Unset
+    /// uses the production default.
+    #[clap(long)]
+    pipeline_connections: Option<usize>,
+}
+
+#[derive(Debug)]
+struct BenchKnobs {
+    pool_size: usize,
+}
+
+/// Production-shaped knobs (see the defaults in mz_persist_client::cfg), with
+/// only the pool size under the benchmark's control.
+impl PostgresClientKnobs for BenchKnobs {
+    fn connection_pool_max_size(&self) -> usize {
+        self.pool_size
+    }
+    fn connection_pool_max_wait(&self) -> Option<Duration> {
+        Some(Duration::from_secs(60))
+    }
+    fn connection_pool_ttl(&self) -> Duration {
+        Duration::from_secs(300)
+    }
+    fn connection_pool_ttl_stagger(&self) -> Duration {
+        Duration::from_secs(6)
+    }
+    fn connect_timeout(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+    fn tcp_user_timeout(&self) -> Duration {
+        Duration::from_secs(30)
+    }
+    fn keepalives_idle(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+    fn keepalives_interval(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+    fn keepalives_retries(&self) -> u32 {
+        5
+    }
+    fn statement_timeout(&self) -> Duration {
+        Duration::ZERO
+    }
+}
+
+#[derive(Default)]
+struct WorkerStats {
+    /// CaS latencies (micros), measured window only.
+    cas_latencies_us: Vec<u64>,
+    cas_committed: u64,
+    cas_mismatches: u64,
+    truncates: u64,
+    errors: u64,
+}
+
+pub async fn run(args: Args) -> Result<(), anyhow::Error> {
+    let configs = mz_persist::cfg::all_dyn_configs(ConfigSet::default());
+    let mut updates = ConfigUpdates::default();
+    updates.add(&PG_CONSENSUS_READ_COMMITTED, args.read_committed);
+    if let Some(pipeline_connections) = args.pipeline_connections {
+        updates.add(
+            &mz_persist::postgres::PG_CONSENSUS_PIPELINE_CONNECTIONS,
+            pipeline_connections,
+        );
+    }
+    updates.apply(&configs);
+    let pipeline_connections =
+        mz_persist::postgres::PG_CONSENSUS_PIPELINE_CONNECTIONS.get(&configs);
+
+    let consensus = ConsensusConfig::try_from(
+        &args.consensus_uri,
+        Box::new(BenchKnobs {
+            pool_size: args.pool_size,
+        }),
+        PostgresClientMetrics::new(&MetricsRegistry::new(), "mz_persist"),
+        Arc::new(configs),
+    )?
+    .open()
+    .await?;
+
+    let data = Bytes::from(vec![0xa5u8; args.data_size]);
+
+    info!(
+        "initializing {} shards (pool_size={}, read_committed={})",
+        args.num_shards, args.pool_size, args.read_committed
+    );
+
+    // Every worker (plus the coordinator) meets at the barrier after shard
+    // initialization so that the warmup starts with all streams live.
+    let barrier = Arc::new(Barrier::new(args.num_shards + 1));
+    let progress = Arc::new(AtomicU64::new(0));
+    let start_time = Arc::new(std::sync::Mutex::new(None::<(Instant, Instant)>));
+
+    let mut handles = Vec::with_capacity(args.num_shards);
+    for i in 0..args.num_shards {
+        let consensus = Arc::clone(&consensus);
+        let data = data.clone();
+        let barrier = Arc::clone(&barrier);
+        let progress = Arc::clone(&progress);
+        let start_time = Arc::clone(&start_time);
+        let truncate_every = args.truncate_every;
+        handles.push(mz_ore::task::spawn(
+            || format!("consensus_bench_worker_{i}"),
+            async move {
+                let key = ShardId::new().to_string();
+                init_shard(&*consensus, &key, &data).await?;
+                barrier.wait().await;
+                let (warmup_end, deadline) = *start_time
+                    .lock()
+                    .expect("lock poisoned")
+                    .as_ref()
+                    .expect("coordinator sets timestamps before releasing the barrier");
+                Ok::<_, anyhow::Error>(
+                    shard_worker(
+                        &*consensus,
+                        &key,
+                        &data,
+                        truncate_every,
+                        warmup_end,
+                        deadline,
+                        &progress,
+                    )
+                    .await,
+                )
+            },
+        ));
+    }
+
+    // Stamp the shared warmup/deadline right before releasing the workers, so
+    // slow shard initialization doesn't eat into the measured window.
+    let warmup_end = Instant::now() + args.warmup;
+    let deadline = warmup_end + args.runtime;
+    *start_time.lock().expect("lock poisoned") = Some((warmup_end, deadline));
+    barrier.wait().await;
+    info!(
+        "shards initialized, warming up for {:?} then measuring for {:?}",
+        args.warmup, args.runtime
+    );
+
+    // Progress reporter, exits on its own at the deadline.
+    {
+        let progress = Arc::clone(&progress);
+        mz_ore::task::spawn(|| "consensus_bench_progress", async move {
+            let mut last = 0u64;
+            let mut last_at = Instant::now();
+            while Instant::now() < deadline {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                let now = Instant::now();
+                let cur = progress.load(Ordering::Relaxed);
+                let rate = f64::cast_lossy(cur - last) / now.duration_since(last_at).as_secs_f64();
+                info!("committed={} rate={:.0}/s", cur, rate);
+                last = cur;
+                last_at = now;
+            }
+        });
+    }
+
+    let mut merged = WorkerStats::default();
+    for handle in handles {
+        let stats = handle.await?;
+        merged.cas_latencies_us.extend(stats.cas_latencies_us);
+        merged.cas_committed += stats.cas_committed;
+        merged.cas_mismatches += stats.cas_mismatches;
+        merged.truncates += stats.truncates;
+        merged.errors += stats.errors;
+    }
+
+    merged.cas_latencies_us.sort_unstable();
+    let lat = &merged.cas_latencies_us;
+    let runtime_s = args.runtime.as_secs_f64();
+    let ms = |us: u64| f64::cast_lossy(us) / 1000.0;
+    let result = serde_json::json!({
+        "num_shards": args.num_shards,
+        "pool_size": args.pool_size,
+        "pipeline_connections": pipeline_connections,
+        "read_committed": args.read_committed,
+        "data_size": args.data_size,
+        "runtime_s": runtime_s,
+        "cas_committed": merged.cas_committed,
+        "cas_per_s": f64::cast_lossy(merged.cas_committed) / runtime_s,
+        "cas_mismatches": merged.cas_mismatches,
+        "truncates": merged.truncates,
+        "errors": merged.errors,
+        "p50_ms": ms(percentile(lat, 0.50)),
+        "p95_ms": ms(percentile(lat, 0.95)),
+        "p99_ms": ms(percentile(lat, 0.99)),
+        "max_ms": ms(lat.last().copied().unwrap_or(0)),
+    });
+    println!("RESULT {result}");
+    Ok(())
+}
+
+async fn init_shard(
+    consensus: &dyn Consensus,
+    key: &str,
+    data: &Bytes,
+) -> Result<(), anyhow::Error> {
+    // Transient errors (e.g. pool contention while hundreds of shards
+    // initialize at once) get a few retries; a mismatch on a fresh random key
+    // is a bug.
+    for attempt in 0.. {
+        let new = VersionedData {
+            seqno: SeqNo::minimum(),
+            data: data.clone(),
+        };
+        match consensus.compare_and_set(key, new).await {
+            Ok(CaSResult::Committed) => return Ok(()),
+            Ok(CaSResult::ExpectationMismatch) => {
+                bail!("mismatch initializing fresh shard {key}")
+            }
+            Err(e) if attempt < 10 => {
+                tracing::warn!("init {key} attempt {attempt}: {e}");
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            Err(e) => return Err(anyhow!(e)),
+        }
+    }
+    unreachable!()
+}
+
+async fn shard_worker(
+    consensus: &dyn Consensus,
+    key: &str,
+    data: &Bytes,
+    truncate_every: u64,
+    warmup_end: Instant,
+    deadline: Instant,
+    progress: &AtomicU64,
+) -> WorkerStats {
+    let mut stats = WorkerStats::default();
+    let mut seqno = SeqNo::minimum();
+    while Instant::now() < deadline {
+        let next = seqno.next();
+        let start = Instant::now();
+        let res = consensus
+            .compare_and_set(
+                key,
+                VersionedData {
+                    seqno: next,
+                    data: data.clone(),
+                },
+            )
+            .await;
+        let elapsed = start.elapsed();
+        let measured = start >= warmup_end;
+        match res {
+            Ok(CaSResult::Committed) => {
+                seqno = next;
+                progress.fetch_add(1, Ordering::Relaxed);
+                if measured {
+                    stats.cas_committed += 1;
+                    stats
+                        .cas_latencies_us
+                        .push(u64::try_from(elapsed.as_micros()).unwrap_or(u64::MAX));
+                }
+                if seqno.0 % truncate_every == 0 && seqno.0 >= 2 * truncate_every {
+                    match consensus
+                        .truncate(key, SeqNo(seqno.0 - truncate_every))
+                        .await
+                    {
+                        Ok(_) => {
+                            if measured {
+                                stats.truncates += 1;
+                            }
+                        }
+                        Err(_) => stats.errors += 1,
+                    }
+                }
+            }
+            // Nobody else writes to this shard, so a mismatch means an earlier
+            // "indeterminate" error actually committed. Resync from head.
+            Ok(CaSResult::ExpectationMismatch) => {
+                stats.cas_mismatches += 1;
+                if let Ok(Some(head)) = consensus.head(key).await {
+                    seqno = head.seqno;
+                }
+            }
+            Err(_) => {
+                stats.errors += 1;
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+    }
+    stats
+}
+
+fn percentile(sorted: &[u64], q: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = usize::cast_lossy((f64::cast_lossy(sorted.len() - 1) * q).round());
+    sorted[idx]
+}

--- a/src/persist-cli/src/main.rs
+++ b/src/persist-cli/src/main.rs
@@ -21,6 +21,7 @@ use mz_ore::cli::{self, CliConfig};
 use mz_ore::error::ErrorExt;
 use mz_ore::metrics::MetricsRegistry;
 
+pub mod consensus_bench;
 pub mod maelstrom;
 pub mod open_loop;
 pub mod service;
@@ -37,6 +38,7 @@ struct Args {
 
 #[derive(Debug, clap::Subcommand)]
 enum Command {
+    ConsensusBench(crate::consensus_bench::Args),
     Maelstrom(crate::maelstrom::Args),
     MaelstromTxn(crate::maelstrom::Args),
     OpenLoop(crate::open_loop::Args),
@@ -68,6 +70,7 @@ fn main() {
         .expect("failed to init tracing");
 
     let res = match args.command {
+        Command::ConsensusBench(args) => runtime.block_on(crate::consensus_bench::run(args)),
         Command::Maelstrom(args) => runtime.block_on(crate::maelstrom::run::<
             crate::maelstrom::txn_list_append_single::TransactorService,
         >(args)),

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -36,6 +36,7 @@ pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&crate::postgres::PG_CONSENSUS_READ_COMMITTED)
         .add(&crate::postgres::PG_CONSENSUS_PIPELINE_CONNECTIONS)
+        .add(&crate::postgres::PG_CONSENSUS_PIPELINE_DEPTH)
 }
 
 /// Config for an implementation of [Blob].

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -33,7 +33,9 @@ use crate::s3::{S3Blob, S3BlobConfig};
 
 /// Adds the full set of all mz_persist `Config`s.
 pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
-    configs.add(&crate::postgres::PG_CONSENSUS_READ_COMMITTED)
+    configs
+        .add(&crate::postgres::PG_CONSENSUS_READ_COMMITTED)
+        .add(&crate::postgres::PG_CONSENSUS_PIPELINE_CONNECTIONS)
 }
 
 /// Config for an implementation of [Blob].

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -28,7 +28,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::url::SensitiveUrl;
 use mz_postgres_client::metrics::PostgresClientMetrics;
 use mz_postgres_client::{
-    Connection, IsolationLevel, PostgresClient, PostgresClientConfig, PostgresClientKnobs,
+    Client, Connection, IsolationLevel, PostgresClient, PostgresClientConfig, PostgresClientKnobs,
 };
 use postgres_protocol::escape::escape_identifier;
 use tokio_postgres::error::SqlState;
@@ -60,6 +60,29 @@ pub const PG_CONSENSUS_READ_COMMITTED: mz_dyncfg::Config<bool> = mz_dyncfg::Conf
     PostgreSQL backends. This flag must be off when targetting CockroachDB.",
 );
 
+/// Maximum number of shared connections that single-statement consensus operations run on.
+/// 0 disables sharing entirely (each operation checks out an exclusive pooled connection).
+///
+/// The shared set scales with demand: an operation prefers an idle shared connection (behaving
+/// exactly like an exclusive checkout), grows the set while all connections are busy and the set
+/// is below the cap, and only once the cap is reached pipelines onto the least-loaded connection
+/// instead of queueing. tokio-postgres pipelines concurrent requests issued on the same
+/// connection at the wire protocol level, so one connection can carry many in-flight operations.
+/// Each operation is its own implicit transaction, so interleaving them on a shared session is
+/// indistinguishable from running them on separate sessions. The multi-statement shard
+/// initialization path always uses an exclusive pooled connection, since an explicit transaction
+/// must not interleave.
+///
+/// The effective cap is clamped below the pool's max size, reserving capacity for the exclusive
+/// paths so they cannot be starved by the shared set.
+pub const PG_CONSENSUS_PIPELINE_CONNECTIONS: mz_dyncfg::Config<usize> = mz_dyncfg::Config::new(
+    "persist_pg_consensus_pipeline_connections",
+    50,
+    "Maximum number of shared connections that consensus operations run on, pipelining once all \
+    are busy, instead of checking out an exclusive pooled connection per operation. 0 disables \
+    sharing.",
+);
+
 const SCHEMA: &str = "
 CREATE TABLE IF NOT EXISTS consensus (
     shard text NOT NULL,
@@ -87,13 +110,13 @@ const CRDB_CONFIGURE_ZONE: &str = "ALTER TABLE consensus CONFIGURE ZONE USING gc
 
 /// NOTE: `mz-persist` intentionally does not depend on `mz-postgres-util`.
 /// These helpers are the only direct driver-call boundary in this module.
-async fn pg_batch_execute(client: &Connection, query: &str) -> Result<(), tokio_postgres::Error> {
+async fn pg_batch_execute(client: &Client, query: &str) -> Result<(), tokio_postgres::Error> {
     #[allow(clippy::disallowed_methods)]
     client.batch_execute(query).await
 }
 
 async fn pg_query_prepared(
-    client: &Connection,
+    client: &Client,
     statement: &Statement,
     params: &[&(dyn ToSql + Sync)],
 ) -> Result<Vec<Row>, tokio_postgres::Error> {
@@ -102,7 +125,7 @@ async fn pg_query_prepared(
 }
 
 async fn pg_query_opt_prepared(
-    client: &Connection,
+    client: &Client,
     statement: &Statement,
     params: &[&(dyn ToSql + Sync)],
 ) -> Result<Option<Row>, tokio_postgres::Error> {
@@ -111,7 +134,7 @@ async fn pg_query_opt_prepared(
 }
 
 async fn pg_execute_prepared(
-    client: &Connection,
+    client: &Client,
     statement: &Statement,
     params: &[&(dyn ToSql + Sync)],
 ) -> Result<u64, tokio_postgres::Error> {
@@ -266,7 +289,7 @@ impl PostgresConsensusConfig {
             }
         }
 
-        let dyncfg = ConfigSet::default().add(&PG_CONSENSUS_READ_COMMITTED);
+        let dyncfg = crate::cfg::all_dyn_configs(ConfigSet::default());
         let config = PostgresConsensusConfig::new(
             &url,
             Box::new(TestConsensusKnobs),
@@ -290,6 +313,91 @@ enum PostgresMode {
 pub struct PostgresConsensus {
     postgres_client: PostgresClient,
     mode: PostgresMode,
+    dyncfg: Arc<ConfigSet>,
+    knobs: Arc<dyn PostgresClientKnobs>,
+    pipeline: SharedConns,
+}
+
+/// A demand-scaled set of connections shared by concurrent single-statement operations, used
+/// when [PG_CONSENSUS_PIPELINE_CONNECTIONS] is non-zero.
+///
+/// Entries hold checked-out pool objects, so shared connections count against the pool's max
+/// size and inherit its TLS, isolation, and timeout setup. An entry an operation is using is kept
+/// alive by the operation's own Arc clone, which means `Arc::strong_count - 1` is exactly the
+/// number of in-flight operations on that connection and is used for least-loaded dispatch.
+/// Dead or expired entries are shed at acquisition time; dropping the last Arc returns the
+/// object to the pool, where the pool's own recycling applies. The operation that was in flight
+/// when a connection died surfaces an error to the caller, which retries at the persist layer.
+#[derive(Default)]
+struct SharedConns {
+    conns: std::sync::Mutex<Vec<SharedConn>>,
+}
+
+struct SharedConn {
+    conn: Arc<Connection>,
+    created_at: std::time::Instant,
+}
+
+enum SharedAcquire {
+    /// A connection with no other operation in flight, or the least-loaded one at cap.
+    Conn(Arc<Connection>),
+    /// All connections are busy and the set is below cap: the caller should check out a pool
+    /// connection and offer it via [SharedConns::insert].
+    Grow,
+}
+
+impl SharedConns {
+    fn acquire(&self, cap: usize, ttl: Duration) -> SharedAcquire {
+        let mut conns = self.conns.lock().expect("lock poisoned");
+        // Shed dead and expired entries. In-flight operations keep their entry alive through
+        // their own Arc; once the last clone drops, the object returns to the pool.
+        conns.retain(|c| !c.conn.is_closed() && c.created_at.elapsed() < ttl);
+        // Prefer the first idle connection, keeping low-index connections hot and letting the
+        // tail expire out after bursts.
+        if let Some(c) = conns.iter().find(|c| Arc::strong_count(&c.conn) == 1) {
+            return SharedAcquire::Conn(Arc::clone(&c.conn));
+        }
+        if conns.len() < cap {
+            return SharedAcquire::Grow;
+        }
+        let least_loaded = conns
+            .iter()
+            .min_by_key(|c| Arc::strong_count(&c.conn))
+            .expect("cap > 0 implies non-empty set");
+        SharedAcquire::Conn(Arc::clone(&least_loaded.conn))
+    }
+
+    /// Adds a connection to the shared set, unless a concurrent grower already filled it to
+    /// `cap`. Either way the caller keeps using the connection it passed in for its own
+    /// operation; an un-inserted surplus connection returns to the pool when the operation
+    /// drops it.
+    fn insert(&self, conn: &Arc<Connection>, cap: usize) {
+        let mut conns = self.conns.lock().expect("lock poisoned");
+        if conns.len() < cap {
+            conns.push(SharedConn {
+                conn: Arc::clone(conn),
+                created_at: std::time::Instant::now(),
+            });
+        }
+    }
+}
+
+/// A connection to run a single-statement consensus operation on: either an exclusively held
+/// pooled connection or a shared (possibly pipelined) one.
+enum OpConn {
+    Pooled(Connection),
+    Shared(Arc<Connection>),
+}
+
+impl std::ops::Deref for OpConn {
+    type Target = Client;
+
+    fn deref(&self) -> &Client {
+        match self {
+            OpConn::Pooled(conn) => conn,
+            OpConn::Shared(conn) => conn,
+        }
+    }
 }
 
 impl std::fmt::Debug for PostgresConsensus {
@@ -311,6 +419,7 @@ impl PostgresConsensus {
         );
 
         let dyncfg = Arc::clone(&config.dyncfg);
+        let knobs = Arc::clone(&config.knobs);
 
         // The resolver runs per connection, so a flag change takes effect as the pool cycles
         // connections. It unconditionally follows the flag: it does not know the backend. The
@@ -370,6 +479,9 @@ impl PostgresConsensus {
         Ok(PostgresConsensus {
             postgres_client,
             mode,
+            dyncfg: Arc::clone(&config.dyncfg),
+            knobs,
+            pipeline: SharedConns::default(),
         })
     }
 
@@ -430,6 +542,37 @@ impl PostgresConsensus {
         }
         Ok(conn)
     }
+
+    /// Returns the connection to run a single-statement operation on: a shared connection when
+    /// [PG_CONSENSUS_PIPELINE_CONNECTIONS] is non-zero, otherwise an exclusive pooled connection.
+    /// Multi-statement (explicit transaction) paths must use [Self::get_connection] instead, an
+    /// explicit transaction must not interleave with other operations on a shared session.
+    async fn op_connection(&self) -> Result<OpConn, PoolError> {
+        // Clamp below the pool's actual size so the exclusive paths (shard init, schema setup)
+        // always have at least one pool slot the shared set cannot occupy. This must use the
+        // pool's built size, not the `connection_pool_max_size` knob: the knob is a dyncfg that a
+        // system-parameter sync can raise after the pool was built (the pool only picks up a new
+        // size across a restart). Clamping against the raised knob would let the shared set try to
+        // occupy more slots than the pool has, seizing every connection and starving the exclusive
+        // paths.
+        let cap = PG_CONSENSUS_PIPELINE_CONNECTIONS.get(&self.dyncfg).min(
+            self.postgres_client
+                .connection_pool_max_size()
+                .saturating_sub(1),
+        );
+        if cap == 0 {
+            return Ok(OpConn::Pooled(self.get_connection().await?));
+        }
+        let ttl = self.knobs.connection_pool_ttl();
+        match self.pipeline.acquire(cap, ttl) {
+            SharedAcquire::Conn(conn) => Ok(OpConn::Shared(conn)),
+            SharedAcquire::Grow => {
+                let conn = Arc::new(self.get_connection().await?);
+                self.pipeline.insert(&conn, cap);
+                Ok(OpConn::Shared(conn))
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -440,7 +583,7 @@ impl Consensus for PostgresConsensus {
         Box::pin(try_stream! {
             // NB: it's important that we hang on to this client for the lifetime of the stream,
             // to avoid returning it to the pool prematurely.
-            let client = self.get_connection().await?;
+            let client = self.op_connection().await?;
             let statement = client.prepare_cached(q).await?;
             let params: &[String] = &[];
             let mut rows = Box::pin(client.query_raw(&statement, params).await?);
@@ -455,7 +598,7 @@ impl Consensus for PostgresConsensus {
         let q = "SELECT sequence_number, data FROM consensus
              WHERE shard = $1 ORDER BY sequence_number DESC LIMIT 1";
         let row = {
-            let client = self.get_connection().await?;
+            let client = self.op_connection().await?;
             let statement = client.prepare_cached(q).await?;
             pg_query_opt_prepared(&client, &statement, &[&key]).await?
         };
@@ -607,7 +750,7 @@ impl Consensus for PostgresConsensus {
                     PostgresMode::CockroachDB => CRDB_CAS_QUERY,
                     PostgresMode::Postgres => POSTGRES_CAS_QUERY,
                 };
-                let client = self.get_connection().await?;
+                let client = self.op_connection().await?;
                 let statement = client.prepare_cached(q).await?;
                 pg_execute_prepared(
                     &client,
@@ -728,7 +871,7 @@ impl Consensus for PostgresConsensus {
                         NOT EXISTS (
                             SELECT * FROM consensus WHERE shard = $1
                         )";
-                        let client = self.get_connection().await?;
+                        let client = self.op_connection().await?;
                         let statement = client.prepare_cached(CRDB_INIT_QUERY).await?;
                         pg_execute_prepared(
                             &client,
@@ -767,7 +910,7 @@ impl Consensus for PostgresConsensus {
             )));
         };
         let rows = {
-            let client = self.get_connection().await?;
+            let client = self.op_connection().await?;
             let statement = client.prepare_cached(q).await?;
             pg_query_prepared(&client, &statement, &[&key, &from, &limit]).await?
         };
@@ -799,7 +942,7 @@ impl Consensus for PostgresConsensus {
         ";
 
         let result = {
-            let client = self.get_connection().await?;
+            let client = self.op_connection().await?;
             let statement = client.prepare_cached(TRUNCATE_QUERY).await?;
             pg_execute_prepared(&client, &statement, &[&key, &seqno]).await?
         };
@@ -865,6 +1008,10 @@ mod tests {
         {
             let mut updates = ConfigUpdates::default();
             updates.add(&PG_CONSENSUS_READ_COMMITTED, true);
+            // The default-config run above already covers the shared-connection path (the flag
+            // defaults on). Pin this run to the exclusive-checkout pool for coverage of that
+            // path.
+            updates.add(&PG_CONSENSUS_PIPELINE_CONNECTIONS, 0);
             updates.apply(&read_committed_config.dyncfg);
         }
         PostgresConsensus::open(read_committed_config.clone())
@@ -872,6 +1019,24 @@ mod tests {
             .drop_and_recreate()
             .await?;
         consensus_impl_test(|| PostgresConsensus::open(read_committed_config.clone())).await?;
+
+        // Re-run the contract with READ COMMITTED plus operations on shared connections, which
+        // must be observably identical to exclusive pooled connections. (The test knobs cap the
+        // pool at 2, so the effective shared cap is 1 and every operation pipelines onto a
+        // single connection, the most extreme sharing.)
+        let pipelined_config =
+            PostgresConsensusConfig::new_for_test()?.expect("postgres url was set above");
+        {
+            let mut updates = ConfigUpdates::default();
+            updates.add(&PG_CONSENSUS_READ_COMMITTED, true);
+            updates.add(&PG_CONSENSUS_PIPELINE_CONNECTIONS, 2);
+            updates.apply(&pipelined_config.dyncfg);
+        }
+        PostgresConsensus::open(pipelined_config.clone())
+            .await?
+            .drop_and_recreate()
+            .await?;
+        consensus_impl_test(|| PostgresConsensus::open(pipelined_config.clone())).await?;
 
         // and now verify the implementation-specific `drop_and_recreate` works as intended
         let consensus = PostgresConsensus::open(config.clone()).await?;

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -11,8 +11,8 @@
 
 use std::fmt::Formatter;
 use std::str::FromStr;
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use async_stream::try_stream;
@@ -23,7 +23,7 @@ use deadpool_postgres::tokio_postgres::Config;
 use deadpool_postgres::tokio_postgres::types::{FromSql, IsNull, ToSql, Type, to_sql_checked};
 use futures_util::StreamExt;
 use mz_dyncfg::ConfigSet;
-use mz_ore::cast::CastFrom;
+use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::url::SensitiveUrl;
 use mz_postgres_client::metrics::PostgresClientMetrics;
@@ -75,12 +75,36 @@ pub const PG_CONSENSUS_READ_COMMITTED: mz_dyncfg::Config<bool> = mz_dyncfg::Conf
 ///
 /// The effective cap is clamped below the pool's max size, reserving capacity for the exclusive
 /// paths so they cannot be starved by the shared set.
+///
+/// The default applies to CockroachDB as well, deliberately: with the network round trips real
+/// deployments have, sharing raises throughput and lowers median latency there too (throughput
+/// up to 1.7x and p50 down 1.3-1.7x at 2ms RTT in the committed benchmark). The one measured
+/// regression is sub-millisecond RTT combined with thousands of concurrently writing shards,
+/// where deeply pipelined commit bursts serve worse than pool queueing. Setting the flag to 0
+/// restores the exclusive-checkout behavior and frees the shared connections.
 pub const PG_CONSENSUS_PIPELINE_CONNECTIONS: mz_dyncfg::Config<usize> = mz_dyncfg::Config::new(
     "persist_pg_consensus_pipeline_connections",
     50,
     "Maximum number of shared connections that consensus operations run on, pipelining once all \
     are busy, instead of checking out an exclusive pooled connection per operation. 0 disables \
     sharing.",
+);
+
+/// Maximum number of operations in flight on one shared connection before new operations wait
+/// for a slot instead of stacking deeper. 0 disables the limit.
+///
+/// Unbounded pipelines degrade at extreme concurrency: every queued operation waits behind the
+/// entire queue in front of it on its connection, and past roughly a thousand in-flight
+/// operations per connection both throughput and tail latency suffer. The default is high
+/// enough that the limit only engages once total in-flight operations exceed the cap times the
+/// shared set size (tens of thousands of concurrently writing shards at the default pool
+/// size), where the benchmark shows bounding depth recovers throughput that unbounded
+/// pipelines lose. The wait is signaled by operation completions, without polling.
+pub const PG_CONSENSUS_PIPELINE_DEPTH: mz_dyncfg::Config<usize> = mz_dyncfg::Config::new(
+    "persist_pg_consensus_pipeline_depth",
+    1024,
+    "Maximum operations in flight per shared consensus connection before new operations wait \
+    for a slot. 0 disables the limit.",
 );
 
 const SCHEMA: &str = "
@@ -316,6 +340,7 @@ pub struct PostgresConsensus {
     dyncfg: Arc<ConfigSet>,
     knobs: Arc<dyn PostgresClientKnobs>,
     pipeline: SharedConns,
+    metrics: PostgresClientMetrics,
 }
 
 /// A demand-scaled set of connections shared by concurrent single-statement operations, used
@@ -330,12 +355,15 @@ pub struct PostgresConsensus {
 /// when a connection died surfaces an error to the caller, which retries at the persist layer.
 #[derive(Default)]
 struct SharedConns {
-    conns: std::sync::Mutex<Vec<SharedConn>>,
+    conns: Mutex<Vec<SharedConn>>,
+    /// Signaled once per completed shared operation, waking one operation waiting out the
+    /// per-connection depth limit.
+    released: tokio::sync::Notify,
 }
 
 struct SharedConn {
     conn: Arc<Connection>,
-    created_at: std::time::Instant,
+    created_at: Instant,
 }
 
 enum SharedAcquire {
@@ -344,14 +372,21 @@ enum SharedAcquire {
     /// All connections are busy and the set is below cap: the caller should check out a pool
     /// connection and offer it via [SharedConns::insert].
     Grow,
+    /// The set is at cap and every connection is at the depth limit: the caller must wait for
+    /// [SharedConns::released] and retry.
+    Full,
 }
 
 impl SharedConns {
-    fn acquire(&self, cap: usize, ttl: Duration) -> SharedAcquire {
+    fn acquire(&self, cap: usize, depth: usize, ttl: Duration) -> SharedAcquire {
         let mut conns = self.conns.lock().expect("lock poisoned");
         // Shed dead and expired entries. In-flight operations keep their entry alive through
         // their own Arc; once the last clone drops, the object returns to the pool.
         conns.retain(|c| !c.conn.is_closed() && c.created_at.elapsed() < ttl);
+        // Shed entries past the cap, so a lowered cap converges immediately instead of the
+        // excess staying in least-loaded dispatch until the TTL expires it. In-flight
+        // operations on a shed entry finish undisturbed through their own Arc.
+        conns.truncate(cap);
         // Prefer the first idle connection, keeping low-index connections hot and letting the
         // tail expire out after bursts.
         if let Some(c) = conns.iter().find(|c| Arc::strong_count(&c.conn) == 1) {
@@ -364,6 +399,9 @@ impl SharedConns {
             .iter()
             .min_by_key(|c| Arc::strong_count(&c.conn))
             .expect("cap > 0 implies non-empty set");
+        if depth > 0 && Arc::strong_count(&least_loaded.conn) - 1 >= depth {
+            return SharedAcquire::Full;
+        }
         SharedAcquire::Conn(Arc::clone(&least_loaded.conn))
     }
 
@@ -376,26 +414,56 @@ impl SharedConns {
         if conns.len() < cap {
             conns.push(SharedConn {
                 conn: Arc::clone(conn),
-                created_at: std::time::Instant::now(),
+                created_at: Instant::now(),
             });
         }
+    }
+
+    /// Drops every entry, returning each connection to the pool once its in-flight operations
+    /// finish. Called when sharing is disabled, so the flag actually frees the pool capacity
+    /// the shared set was occupying.
+    ///
+    /// NOTE: an operation that read a non-zero cap may insert a connection after a concurrent
+    /// zero-cap operation cleared the set. Such a straggler lingers only until the next
+    /// zero-cap operation clears again, so this needs no synchronization.
+    fn clear(&self) {
+        self.conns.lock().expect("lock poisoned").clear();
+    }
+
+    fn len(&self) -> usize {
+        self.conns.lock().expect("lock poisoned").len()
     }
 }
 
 /// A connection to run a single-statement consensus operation on: either an exclusively held
 /// pooled connection or a shared (possibly pipelined) one.
-enum OpConn {
+enum OpConn<'a> {
     Pooled(Connection),
-    Shared(Arc<Connection>),
+    Shared(SharedLease<'a>),
 }
 
-impl std::ops::Deref for OpConn {
+/// A shared connection held for the duration of one operation. Dropping it signals
+/// [SharedConns::released], admitting one operation waiting out the depth limit.
+struct SharedLease<'a> {
+    conn: Arc<Connection>,
+    set: &'a SharedConns,
+}
+
+impl Drop for SharedLease<'_> {
+    fn drop(&mut self) {
+        // With no waiter this stores a single permit, which at worst causes one spurious
+        // wakeup and re-check later.
+        self.set.released.notify_one();
+    }
+}
+
+impl std::ops::Deref for OpConn<'_> {
     type Target = Client;
 
     fn deref(&self) -> &Client {
         match self {
             OpConn::Pooled(conn) => conn,
-            OpConn::Shared(conn) => conn,
+            OpConn::Shared(lease) => &lease.conn,
         }
     }
 }
@@ -426,6 +494,7 @@ impl PostgresConsensus {
         // backend-specific safety check lives in `get_connection`, which asserts that CockroachDB
         // connections are SERIALIZABLE. The connection carries the level it was created with, so
         // that assertion is exact rather than a guess about what the resolver returned.
+        let metrics = config.metrics.clone();
         let client_config = PostgresClientConfig::new(config.url, config.knobs, config.metrics)
             .with_isolation(Arc::new(move || {
                 if PG_CONSENSUS_READ_COMMITTED.get(&dyncfg) {
@@ -482,6 +551,7 @@ impl PostgresConsensus {
             dyncfg: Arc::clone(&config.dyncfg),
             knobs,
             pipeline: SharedConns::default(),
+            metrics,
         })
     }
 
@@ -547,7 +617,7 @@ impl PostgresConsensus {
     /// [PG_CONSENSUS_PIPELINE_CONNECTIONS] is non-zero, otherwise an exclusive pooled connection.
     /// Multi-statement (explicit transaction) paths must use [Self::get_connection] instead, an
     /// explicit transaction must not interleave with other operations on a shared session.
-    async fn op_connection(&self) -> Result<OpConn, PoolError> {
+    async fn op_connection(&self) -> Result<OpConn<'_>, PoolError> {
         // Clamp below the pool's actual size so the exclusive paths (shard init, schema setup)
         // always have at least one pool slot the shared set cannot occupy. This must use the
         // pool's built size, not the `connection_pool_max_size` knob: the knob is a dyncfg that a
@@ -561,17 +631,44 @@ impl PostgresConsensus {
                 .saturating_sub(1),
         );
         if cap == 0 {
+            // Sharing is disabled: drop the shared set, otherwise its entries would stay
+            // checked out of the pool until process restart and the flag would degrade the
+            // exclusive path to whatever slots the set left over, instead of restoring the
+            // pre-sharing behavior it exists to roll back to.
+            self.pipeline.clear();
+            self.metrics.connpool_shared_size.set(0);
             return Ok(OpConn::Pooled(self.get_connection().await?));
         }
+        let depth = PG_CONSENSUS_PIPELINE_DEPTH.get(&self.dyncfg);
         let ttl = self.knobs.connection_pool_ttl();
-        match self.pipeline.acquire(cap, ttl) {
-            SharedAcquire::Conn(conn) => Ok(OpConn::Shared(conn)),
-            SharedAcquire::Grow => {
-                let conn = Arc::new(self.get_connection().await?);
-                self.pipeline.insert(&conn, cap);
-                Ok(OpConn::Shared(conn))
+        let conn = loop {
+            // Creating the future before the acquire check makes the wait race-free: a
+            // completion between the check and the await stores a permit that the first poll
+            // consumes.
+            let released = self.pipeline.released.notified();
+            match self.pipeline.acquire(cap, depth, ttl) {
+                SharedAcquire::Conn(conn) => break conn,
+                SharedAcquire::Grow => {
+                    let conn = Arc::new(self.get_connection().await?);
+                    self.pipeline.insert(&conn, cap);
+                    break conn;
+                }
+                SharedAcquire::Full => released.await,
             }
-        }
+        };
+        // strong_count - 1 discounts the set's own entry, leaving the in-flight operations
+        // including this one. A surplus connection that lost the insert race has no set entry,
+        // so the max(1) keeps its (sole) operation counted.
+        self.metrics
+            .connpool_shared_inflight
+            .observe(f64::cast_lossy((Arc::strong_count(&conn) - 1).max(1)));
+        self.metrics
+            .connpool_shared_size
+            .set(u64::cast_from(self.pipeline.len()));
+        Ok(OpConn::Shared(SharedLease {
+            conn,
+            set: &self.pipeline,
+        }))
     }
 }
 
@@ -583,7 +680,12 @@ impl Consensus for PostgresConsensus {
         Box::pin(try_stream! {
             // NB: it's important that we hang on to this client for the lifetime of the stream,
             // to avoid returning it to the pool prematurely.
-            let client = self.op_connection().await?;
+            //
+            // This must be an exclusive connection, not a shared one: tokio-postgres delivers
+            // responses in request order and stops reading the socket while a consumer lags,
+            // so a lazily drained stream would head-of-line block every operation pipelined
+            // behind it. list_keys is rare (admin tooling) and not latency-sensitive.
+            let client = self.get_connection().await?;
             let statement = client.prepare_cached(q).await?;
             let params: &[String] = &[];
             let mut rows = Box::pin(client.query_raw(&statement, params).await?);
@@ -1037,6 +1139,56 @@ mod tests {
             .drop_and_recreate()
             .await?;
         consensus_impl_test(|| PostgresConsensus::open(pipelined_config.clone())).await?;
+
+        // Re-run the contract with the per-connection depth limit at its most extreme (cap 1,
+        // depth 1: every operation on the single shared connection makes concurrent ones wait),
+        // which must also be observably identical.
+        let depth_config =
+            PostgresConsensusConfig::new_for_test()?.expect("postgres url was set above");
+        {
+            let mut updates = ConfigUpdates::default();
+            updates.add(&PG_CONSENSUS_READ_COMMITTED, true);
+            updates.add(&PG_CONSENSUS_PIPELINE_CONNECTIONS, 2);
+            updates.add(&PG_CONSENSUS_PIPELINE_DEPTH, 1);
+            updates.apply(&depth_config.dyncfg);
+        }
+        PostgresConsensus::open(depth_config.clone())
+            .await?
+            .drop_and_recreate()
+            .await?;
+        consensus_impl_test(|| PostgresConsensus::open(depth_config.clone())).await?;
+
+        // The flag is a kill switch: flipping it to 0 at runtime must drain the shared set,
+        // returning its connections to the pool, rather than stranding them checked out until
+        // the process restarts.
+        {
+            let consensus = PostgresConsensus::open(pipelined_config.clone()).await?;
+            let key = Uuid::new_v4().to_string();
+            // A single-statement operation populates the shared set.
+            assert_eq!(consensus.head(&key).await, Ok(None));
+            assert_eq!(
+                consensus
+                    .pipeline
+                    .conns
+                    .lock()
+                    .expect("lock poisoned")
+                    .len(),
+                1
+            );
+            let mut updates = ConfigUpdates::default();
+            updates.add(&PG_CONSENSUS_PIPELINE_CONNECTIONS, 0);
+            updates.apply(&pipelined_config.dyncfg);
+            assert_eq!(consensus.head(&key).await, Ok(None));
+            assert_eq!(
+                consensus
+                    .pipeline
+                    .conns
+                    .lock()
+                    .expect("lock poisoned")
+                    .len(),
+                0
+            );
+        }
 
         // and now verify the implementation-specific `drop_and_recreate` works as intended
         let consensus = PostgresConsensus::open(config.clone()).await?;

--- a/src/postgres-client/src/lib.rs
+++ b/src/postgres-client/src/lib.rs
@@ -338,6 +338,17 @@ impl PostgresClient {
         // Don't bother reporting the maximum size of the pool... we know that from config.
     }
 
+    /// The connection pool's maximum size, as the pool was actually built.
+    ///
+    /// This reflects the pool that exists, not [`PostgresClientKnobs::connection_pool_max_size`],
+    /// which reads a dyncfg that can be updated after the pool is constructed (the pool only
+    /// honors a new value across a restart). Callers that reserve pool capacity, e.g. to keep
+    /// exclusive checkouts from being starved by a shared set, must clamp against this. Clamping
+    /// against the knob instead can over-subscribe a pool that was built smaller.
+    pub fn connection_pool_max_size(&self) -> usize {
+        self.pool.status().max_size
+    }
+
     /// Gets connection from the pool or waits for one to become available.
     pub async fn get_connection(&self) -> Result<Connection, PoolError> {
         let start = Instant::now();

--- a/src/postgres-client/src/metrics.rs
+++ b/src/postgres-client/src/metrics.rs
@@ -23,6 +23,13 @@ pub struct PostgresClientMetrics {
     pub(crate) connpool_connections_created: Counter,
     pub(crate) connpool_connection_errors: Counter,
     pub(crate) connpool_ttl_reconnections: Counter,
+    /// Connections in a caller-managed shared set. These count against the pool's max size but
+    /// look permanently checked out to the connpool gauges, so this gauge is needed to read
+    /// those correctly.
+    pub connpool_shared_size: UIntGauge,
+    /// In-flight operations on a shared connection at acquisition, including the acquiring
+    /// operation itself. Values above 1 mean operations are pipelining.
+    pub connpool_shared_inflight: prometheus::Histogram,
 }
 
 impl PostgresClientMetrics {
@@ -56,6 +63,15 @@ impl PostgresClientMetrics {
             connpool_ttl_reconnections: registry.register(metric!(
                 name: format!("{}_postgres_connpool_ttl_reconnections", prefix),
                 help: "times a connection was recycled due to ttl",
+            )),
+            connpool_shared_size: registry.register(metric!(
+                name: format!("{}_postgres_connpool_shared_size", prefix),
+                help: "connections in the shared set for pipelined operations",
+            )),
+            connpool_shared_inflight: registry.register(metric!(
+                name: format!("{}_postgres_connpool_shared_inflight", prefix),
+                help: "in-flight operations on a shared connection at acquisition",
+                buckets: prometheus::exponential_buckets(1.0, 2.0, 11).expect("valid buckets"),
             )),
         }
     }

--- a/test/persist-consensus-scaling/mzcompose.py
+++ b/test/persist-consensus-scaling/mzcompose.py
@@ -27,8 +27,6 @@ import json
 import threading
 import time
 
-import requests
-
 from materialize.mzcompose.composition import (
     Composition,
     Service,
@@ -128,7 +126,12 @@ class ConnectionSampler(threading.Thread):
                 "--format=tsv",
                 "--set=show_times=false",
                 "-e",
-                "SELECT count(*) FROM crdb_internal.cluster_sessions",
+                # Internal sessions and the sampler's own shell set an
+                # application_name starting with '$'; the benchmark's
+                # connections leave it unset. Without this filter the counts
+                # would include the sampler itself.
+                "SELECT count(*) FROM crdb_internal.cluster_sessions"
+                " WHERE application_name NOT LIKE '$%'",
                 capture=True,
             ).stdout.splitlines()[-1]
         return int(out)
@@ -182,29 +185,30 @@ def reset_consensus_table(c: Composition, backend: str) -> None:
 
 
 def setup_proxy(c: Composition, upstream: str, rtt_ms: int) -> None:
-    url = f"http://localhost:{c.port('toxiproxy', 8474)}"
+    # Drive the admin API through toxiproxy-cli inside the container rather
+    # than the host-mapped port, which keeps working when host-to-container
+    # forwarding is flaky on long-lived hosts.
+    def cli(*args: str, check: bool = True) -> None:
+        c.exec("toxiproxy", "/toxiproxy-cli", *args, check=check)
+
     # Idempotent across reruns against a still-running toxiproxy.
-    requests.delete(f"{url}/proxies/postgres")
-    r = requests.post(
-        f"{url}/proxies",
-        json={
-            "name": "postgres",
-            "listen": f"0.0.0.0:{PROXY_PORT}",
-            "upstream": upstream,
-        },
-    )
-    r.raise_for_status()
+    cli("delete", "postgres", check=False)
+    cli("create", "-l", f"0.0.0.0:{PROXY_PORT}", "-u", upstream, "postgres")
     if rtt_ms > 0:
-        r = requests.post(
-            f"{url}/proxies/postgres/toxics",
-            json={
-                "name": "rtt",
-                "type": "latency",
-                "stream": "downstream",
-                "attributes": {"latency": rtt_ms, "jitter": 0},
-            },
+        cli(
+            "toxic",
+            "add",
+            "-n",
+            "rtt",
+            "-t",
+            "latency",
+            "-a",
+            f"latency={rtt_ms}",
+            "-a",
+            "jitter=0",
+            "--downstream",
+            "postgres",
         )
-        r.raise_for_status()
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -212,7 +216,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--shards",
         nargs="+",
         type=int,
-        default=[8, 32, 128, 512],
+        default=[8, 32, 128, 512, 2048, 8192, 32768],
         help="shard counts to sweep",
     )
     parser.add_argument("--pool-size", type=int, default=50)
@@ -239,17 +243,36 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         " uses the production default)",
     )
     parser.add_argument(
+        "--pipeline-depth",
+        type=int,
+        default=None,
+        help="maximum in-flight ops per shared connection before new ops"
+        " wait for a slot (0 disables the limit, unset uses the production"
+        " default)",
+    )
+    parser.add_argument(
         "--backend",
         choices=["postgres", "cockroach"],
         default="postgres",
     )
     parser.add_argument("--fsync", choices=["on", "off"], default="on")
+    parser.add_argument(
+        "--crdb-in-memory",
+        action="store_true",
+        help="run CockroachDB with an in-memory store, removing the raft"
+        " disk-sync cost from commits (the CRDB analogue of --fsync off)",
+    )
     args = parser.parse_args()
 
     metadata_service = (
         "postgres-metadata" if args.backend == "postgres" else "cockroach"
     )
-    with c.override(postgres_service(args.fsync)):
+    crdb_override = (
+        [Cockroach(setup_materialize=True, in_memory=True)]
+        if args.crdb_in_memory
+        else []
+    )
+    with c.override(postgres_service(args.fsync), *crdb_override):
         results = run_benchmarks(c, args, metadata_service)
 
     print()
@@ -269,7 +292,15 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
 def run_benchmarks(c: Composition, args, metadata_service: str) -> list[dict]:
     c.up(metadata_service, "toxiproxy", Service("persistcli", idle=True))
-    setup_proxy(c, f"{metadata_service}:26257", args.rtt_ms)
+    # The latency toxic delays each response chunk serially per stream, which
+    # penalizes pipelined connections in a way a real network does not. Runs
+    # with no added RTT therefore connect directly instead of through an
+    # unproxied toxiproxy, keeping them artifact-free.
+    if args.rtt_ms > 0:
+        setup_proxy(c, f"{metadata_service}:26257", args.rtt_ms)
+        consensus_addr = f"toxiproxy:{PROXY_PORT}"
+    else:
+        consensus_addr = f"{metadata_service}:26257"
 
     results = []
     for num_shards in args.shards:
@@ -279,7 +310,7 @@ def run_benchmarks(c: Composition, args, metadata_service: str) -> list[dict]:
         cmd = [
             "persistcli",
             "consensus-bench",
-            f"--consensus-uri=postgres://root@toxiproxy:{PROXY_PORT}"
+            f"--consensus-uri=postgres://root@{consensus_addr}"
             "?options=--search_path=consensus",
             f"--num-shards={num_shards}",
             f"--runtime={args.runtime}",
@@ -289,6 +320,8 @@ def run_benchmarks(c: Composition, args, metadata_service: str) -> list[dict]:
         ]
         if args.pipeline_connections is not None:
             cmd.append(f"--pipeline-connections={args.pipeline_connections}")
+        if args.pipeline_depth is not None:
+            cmd.append(f"--pipeline-depth={args.pipeline_depth}")
         # The READ COMMITTED query family is Postgres-only. CockroachDB always
         # runs the SERIALIZABLE CRDB_* queries.
         if not args.serializable and args.backend == "postgres":

--- a/test/persist-consensus-scaling/mzcompose.py
+++ b/test/persist-consensus-scaling/mzcompose.py
@@ -1,0 +1,309 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""
+Experiment: persist consensus throughput against vanilla Postgres as the
+number of shards scales.
+
+Each shard is one sequential compare-and-set stream (persist never has more
+than one CaS in flight per shard), so the shard count is the concurrency the
+consensus backend sees. Traffic runs through toxiproxy with a configurable
+added latency, standing in for the network RTT between Materialize and its
+metadata Postgres in a real deployment. Postgres runs with real fsync (no
+libeatmydata) so commits pay their true cost.
+
+Run manually, e.g.:
+
+    bin/mzcompose --find persist-consensus-scaling run default --shards 8 32 128 512
+"""
+
+import json
+import threading
+import time
+
+import requests
+
+from materialize.mzcompose.composition import (
+    Composition,
+    Service,
+    WorkflowArgumentParser,
+)
+from materialize.mzcompose.services.cockroach import Cockroach
+from materialize.mzcompose.services.persistcli import Persistcli
+from materialize.mzcompose.services.postgres import Postgres
+from materialize.mzcompose.services.toxiproxy import Toxiproxy
+
+PROXY_PORT = 26258
+
+
+def postgres_service(fsync: str = "on") -> Postgres:
+    return Postgres(
+        name="postgres-metadata",
+        setup_materialize=True,
+        ports=["26257"],
+        # The stock service preloads libeatmydata (fsync disabled), which
+        # would hide the commit-latency component this experiment measures.
+        environment=[
+            "POSTGRESDB=postgres",
+            "POSTGRES_PASSWORD=postgres",
+        ],
+        # Allow SERIALIZABLE runs at high concurrency without exhausting the
+        # SSI predicate-lock pool (mirrors PostgresMetadata).
+        extra_command=[
+            "-c",
+            "max_pred_locks_per_transaction=1024",
+            "-c",
+            "max_pred_locks_per_relation=10000",
+            "-c",
+            "max_pred_locks_per_page=512",
+            # The image's setup-postgres.sh bakes fsync=off into
+            # postgresql.conf. Command-line flags take precedence. Real WAL
+            # flushes are the one commit cost pipelining cannot hide, so runs
+            # default to paying them. fsync=off approximates the fast-flush
+            # regime (NVMe) on hosts with slow storage.
+            "-c",
+            f"fsync={fsync}",
+            # Keep checkpoints out of the short measurement windows. A run
+            # that randomly contains a checkpoint's fsync burst measures the
+            # checkpoint, not the workload, and which run eats it is purely
+            # an ordering artifact.
+            "-c",
+            "max_wal_size=8GB",
+            "-c",
+            "checkpoint_timeout=30min",
+            "-c",
+            "log_checkpoints=on",
+        ],
+    )
+
+
+SERVICES = [
+    postgres_service(),
+    Cockroach(setup_materialize=True),
+    Toxiproxy(),
+    Persistcli(),
+]
+
+
+class ConnectionSampler(threading.Thread):
+    """Samples the number of client connections the metadata store sees for
+    the consensus user.
+
+    Reports both the overall maximum (which includes the shard-initialization
+    burst, a path that always uses exclusive pooled connections) and the
+    steady-state maximum over the trailing samples, which reflects the
+    benchmark's measured window."""
+
+    def __init__(self, c: Composition, backend: str):
+        super().__init__(daemon=True)
+        self.c = c
+        self.backend = backend
+        self.samples: list[int] = []
+        self._stop = threading.Event()
+
+    def _sample(self) -> int:
+        if self.backend == "postgres":
+            out = self.c.exec(
+                "postgres-metadata",
+                "psql",
+                "-U",
+                "postgres",
+                "-tAc",
+                "SELECT count(*) FROM pg_stat_activity"
+                " WHERE backend_type = 'client backend' AND usename = 'root'",
+                capture=True,
+            ).stdout.strip()
+        else:
+            out = self.c.exec(
+                "cockroach",
+                "cockroach",
+                "sql",
+                "--insecure",
+                "--format=tsv",
+                "--set=show_times=false",
+                "-e",
+                "SELECT count(*) FROM crdb_internal.cluster_sessions",
+                capture=True,
+            ).stdout.splitlines()[-1]
+        return int(out)
+
+    def run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self.samples.append(self._sample())
+            except Exception:
+                pass
+            time.sleep(1)
+
+    @property
+    def max_connections(self) -> int:
+        return max(self.samples, default=0)
+
+    @property
+    def steady_connections(self) -> int:
+        # The tail half of the samples excludes initialization and warmup.
+        tail = self.samples[len(self.samples) // 2 :]
+        return max(tail, default=0)
+
+    def stop(self) -> None:
+        self._stop.set()
+        self.join()
+
+
+def reset_consensus_table(c: Composition, backend: str) -> None:
+    """Drop the consensus table (if it exists yet) so runs don't inherit
+    bloat or rows from earlier runs. The benchmark's open() recreates it."""
+    if backend == "postgres":
+        c.exec(
+            "postgres-metadata",
+            "psql",
+            "-U",
+            "postgres",
+            "-d",
+            "root",
+            "-c",
+            "DROP TABLE IF EXISTS consensus.consensus",
+        )
+    else:
+        c.exec(
+            "cockroach",
+            "cockroach",
+            "sql",
+            "--insecure",
+            "-e",
+            "DROP TABLE IF EXISTS consensus.consensus",
+        )
+
+
+def setup_proxy(c: Composition, upstream: str, rtt_ms: int) -> None:
+    url = f"http://localhost:{c.port('toxiproxy', 8474)}"
+    # Idempotent across reruns against a still-running toxiproxy.
+    requests.delete(f"{url}/proxies/postgres")
+    r = requests.post(
+        f"{url}/proxies",
+        json={
+            "name": "postgres",
+            "listen": f"0.0.0.0:{PROXY_PORT}",
+            "upstream": upstream,
+        },
+    )
+    r.raise_for_status()
+    if rtt_ms > 0:
+        r = requests.post(
+            f"{url}/proxies/postgres/toxics",
+            json={
+                "name": "rtt",
+                "type": "latency",
+                "stream": "downstream",
+                "attributes": {"latency": rtt_ms, "jitter": 0},
+            },
+        )
+        r.raise_for_status()
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    parser.add_argument(
+        "--shards",
+        nargs="+",
+        type=int,
+        default=[8, 32, 128, 512],
+        help="shard counts to sweep",
+    )
+    parser.add_argument("--pool-size", type=int, default=50)
+    parser.add_argument("--runtime", default="30s")
+    parser.add_argument("--warmup", default="5s")
+    parser.add_argument("--data-size", type=int, default=1024)
+    parser.add_argument(
+        "--rtt-ms",
+        type=int,
+        default=2,
+        help="added response latency via toxiproxy, simulating network RTT",
+    )
+    parser.add_argument(
+        "--serializable",
+        action="store_true",
+        help="run under SERIALIZABLE instead of READ COMMITTED",
+    )
+    parser.add_argument(
+        "--pipeline-connections",
+        type=int,
+        default=None,
+        help="cap on shared connections consensus ops run on, pipelining"
+        " once all are busy (0 forces the exclusive-checkout pool, unset"
+        " uses the production default)",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["postgres", "cockroach"],
+        default="postgres",
+    )
+    parser.add_argument("--fsync", choices=["on", "off"], default="on")
+    args = parser.parse_args()
+
+    metadata_service = (
+        "postgres-metadata" if args.backend == "postgres" else "cockroach"
+    )
+    with c.override(postgres_service(args.fsync)):
+        results = run_benchmarks(c, args, metadata_service)
+
+    print()
+    header = (
+        f"{'shards':>7} {'pipeline':>9} {'cas/s':>9} {'p50 ms':>8} {'p95 ms':>8}"
+        f" {'p99 ms':>8} {'max ms':>9} {'errors':>7} {'conns':>6} {'steady':>7}"
+    )
+    print(header)
+    for r in results:
+        print(
+            f"{r['num_shards']:>7} {r['pipeline_connections']:>9} {r['cas_per_s']:>9.0f}"
+            f" {r['p50_ms']:>8.2f} {r['p95_ms']:>8.2f} {r['p99_ms']:>8.2f}"
+            f" {r['max_ms']:>9.2f} {r['errors']:>7} {r['max_pg_connections']:>6}"
+            f" {r['steady_pg_connections']:>7}"
+        )
+
+
+def run_benchmarks(c: Composition, args, metadata_service: str) -> list[dict]:
+    c.up(metadata_service, "toxiproxy", Service("persistcli", idle=True))
+    setup_proxy(c, f"{metadata_service}:26257", args.rtt_ms)
+
+    results = []
+    for num_shards in args.shards:
+        reset_consensus_table(c, args.backend)
+        sampler = ConnectionSampler(c, args.backend)
+        sampler.start()
+        cmd = [
+            "persistcli",
+            "consensus-bench",
+            f"--consensus-uri=postgres://root@toxiproxy:{PROXY_PORT}"
+            "?options=--search_path=consensus",
+            f"--num-shards={num_shards}",
+            f"--runtime={args.runtime}",
+            f"--warmup={args.warmup}",
+            f"--data-size={args.data_size}",
+            f"--pool-size={args.pool_size}",
+        ]
+        if args.pipeline_connections is not None:
+            cmd.append(f"--pipeline-connections={args.pipeline_connections}")
+        # The READ COMMITTED query family is Postgres-only. CockroachDB always
+        # runs the SERIALIZABLE CRDB_* queries.
+        if not args.serializable and args.backend == "postgres":
+            cmd.append("--read-committed")
+        print(f"--- running {num_shards} shards")
+        out = c.exec("persistcli", *cmd, capture=True).stdout
+        sampler.stop()
+        result = None
+        for line in out.splitlines():
+            if line.startswith("RESULT "):
+                result = json.loads(line[len("RESULT ") :])
+        assert result is not None, f"no RESULT line in output:\n{out}"
+        result["max_pg_connections"] = sampler.max_connections
+        result["steady_pg_connections"] = sampler.steady_connections
+        print(f"--- {num_shards} shards: {result}")
+        results.append(result)
+
+    return results


### PR DESCRIPTION
### Motivation

Every persist consensus operation used to check out an exclusive connection from the pool for
its full duration, so the pool size (default 50) capped the number of in-flight consensus
operations. Since each shard is one sequential compare-and-set stream, environments with many
active shards saturate the pool: throughput pins at `pool_size / (RTT + commit_time)` and
operation latency grows linearly with the number of shards, no matter how much headroom the
metadata store has.

### Description

Single-statement consensus operations (CaS, head, scan, truncate) now run on a demand-scaled
set of shared connections, pipelining at the wire protocol level once all of them are busy.
Each operation is its own implicit transaction, so interleaving them on a shared session is
observably identical to running them on separate sessions. Multi-statement paths (shard
initialization) and the streaming `list_keys` keep using exclusive connections.

Dispatch prefers an idle shared connection, grows the set while all are busy (up to the cap),
then pipelines onto the least-loaded connection. Two new dyncfgs control this:

* `persist_pg_consensus_pipeline_connections` (default 50): cap on the shared set, clamped
  below the pool's built size so exclusive paths cannot be starved. **0 is the kill switch**:
  it restores the exclusive-checkout behavior at runtime and drains the shared set, returning
  its connections to the pool.
* `persist_pg_consensus_pipeline_depth` (default 1024): maximum in-flight operations per shared
  connection before new operations wait for a completion. This only engages beyond ~50k
  concurrently writing shards (with the default pool), where unbounded pipelines degrade; see
  the last rows of the tables.

The default deliberately applies to CockroachDB as well: with the round-trip times real
deployments see, sharing raises throughput and lowers median latency there too. The one known
regression regime is sub-millisecond RTT combined with thousands of concurrently writing
shards, where deeply pipelined commit bursts serve worse than pool queueing (measured -10% at
512 shards and -53% at 8192 shards against a local CockroachDB at ~0 RTT).

New metrics `<prefix>_postgres_connpool_shared_size` and
`<prefix>_postgres_connpool_shared_inflight` make the shared set observable; note that shared
connections look permanently checked out to the existing connpool gauges.

### Benchmark

`persistcli consensus-bench` (committed) models the write side: one shard = one sequential CaS
stream, so shard count is the offered concurrency. Driven by
`test/persist-consensus-scaling/mzcompose.py` with 2ms RTT via toxiproxy, pool 50, 1 KiB
payloads, on a 48-core c8g.12xlarge. "main" is `--pipeline-connections 0`, "PR" the default.
Rows at 32,768+ shards use longer warmups and windows (median latency reaches seconds there).

Postgres with fsync off:
```
┌─────────┬─────────────┬─────────────┬───────────┬────────────┬────────────┬─────────────┐
│ shards  │ main: CaS/s │  main: p50  │ PR: CaS/s │  PR: p50   │ throughput │   latency   │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼─────────────┤
│       8 │       3,335 │      2.3 ms │     3,334 │     2.3 ms │    1.0×    │      —      │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼─────────────┤
│     128 │      11,819 │      8.3 ms │    20,883 │     2.6 ms │    1.8×    │  3.1× lower │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼─────────────┤
│     512 │      15,484 │     29.5 ms │    19,808 │     2.8 ms │    1.3×    │ 10.6× lower │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼─────────────┤
│   2,048 │      16,900 │    117.2 ms │    40,573 │    39.9 ms │    2.4×    │  2.9× lower │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼─────────────┤
│   8,192 │      16,973 │    470.7 ms │    86,318 │    75.7 ms │    5.1×    │  6.2× lower │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼─────────────┤
│  32,768 │      17,344 │  1,888.0 ms │    90,229 │   240.7 ms │    5.2×    │  7.8× lower │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼─────────────┤
│ 131,072 │      17,289 │  7,563.2 ms │    46,206 │ 1,040.5 ms │    2.7×    │  7.3× lower │
└─────────┴─────────────┴─────────────┴───────────┴────────────┴────────────┴─────────────┘
```

CockroachDB with an in-memory store:
```
┌─────────┬─────────────┬─────────────┬───────────┬────────────┬────────────┬────────────┐
│ shards  │ main: CaS/s │  main: p50  │ PR: CaS/s │  PR: p50   │ throughput │  latency   │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼────────────┤
│       8 │       2,492 │      3.0 ms │     2,497 │     3.0 ms │    1.0×    │     —      │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼────────────┤
│     128 │      15,023 │      7.9 ms │    34,545 │     3.3 ms │    2.3×    │ 2.4× lower │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼────────────┤
│     512 │      14,882 │     33.2 ms │    38,804 │    12.1 ms │    2.6×    │ 2.7× lower │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼────────────┤
│   2,048 │      14,949 │    132.6 ms │    36,815 │    47.9 ms │    2.5×    │ 2.8× lower │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼────────────┤
│   8,192 │      15,158 │    517.5 ms │    43,316 │   168.8 ms │    2.9×    │ 3.1× lower │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼────────────┤
│  32,768 │      15,770 │  2,076.6 ms │    18,867 │   767.0 ms │    1.2×    │ 2.7× lower │
├─────────┼─────────────┼─────────────┼───────────┼────────────┼────────────┼────────────┤
│ 131,072 │      15,596 │  8,411.1 ms │    42,518 │ 1,202.7 ms │    2.7×    │ 7.0× lower │
└─────────┴─────────────┴─────────────┴───────────┴────────────┴────────────┴────────────┘
```

main pins at the connection-pool bound (~15-17k CaS/s) across the entire sweep with latency
growing linearly in shard count. The CockroachDB 32,768 row is reproducible across runs and
independent of the depth limit, so it appears to be a server-side effect (range count vs.
concurrency), not a dispatch artifact. The 131,072 rows run with the depth limit engaged;
without it Postgres drops to ~35k CaS/s with a 16s p95 at that scale.

### Verification

* The `postgres_consensus` contract test runs the `Consensus` implementation through five
  passes: default, READ COMMITTED exclusive, cap-1 sharing (every operation pipelined onto a
  single connection), depth-1 sharing (every concurrent operation waits), and a kill-switch
  check asserting the shared set drains when the flag flips to 0 at runtime.
* The benchmark and workflow above are committed (`test/persist-consensus-scaling`, manual-only)
  so the numbers are reproducible.
* Nightly parallel-workload flips `persist_pg_consensus_pipeline_connections` across
  0/10/25/50/100/200 via `FlipFlagsAction`, exercising runtime reconfiguration including the
  kill switch under concurrent load.
