### PR TITLE
timely-util: co_reduce2, a two-input reduce over co-arranged inputs (CLU-168)

### DIFF
--- a/doc/developer/design/20260714_co_reduce_operator.md
+++ b/doc/developer/design/20260714_co_reduce_operator.md
@@ -1,0 +1,286 @@
+# Design: `co_reduce2`, a two-input reduce over co-arranged inputs
+
+## Goal
+
+Generalize the fused `SetDifference` operator (`src/compute/src/render/set_difference.rs`,
+CLU-168) into `co_reduce2`: a reduce over two co-arranged inputs, with distinct trace
+types, with the per-key computation supplied as a closure.
+Naiad calls this shape `CoGroupBy`.
+`SetDifference` is a two-input caller whose closure computes the thresholded net.
+
+A variadic reduce over N homogeneous inputs was the original target for this design.
+That scope was descoped to the two-input, heterogeneous-trace `co_reduce2` that shipped.
+See "Future work: variadic-N `co_reduce`" at the end for the deferred generalization.
+
+## Where it lives
+
+`mz-timely-util` (`src/timely-util/`).
+The crate already depends on `timely` and `differential-dataflow`, carries no
+`mz-repr` dependency, and hosts exactly this class of generic timely+dd machinery
+(`operator.rs` extension traits, the columnar merge-batchers, `antichain.rs`,
+`order.rs`, `pact.rs`).
+Authoring `co_reduce2` there keeps it Row-agnostic and on par with differential's own
+`reduce`.
+Materialize's `RowRowSpine` satisfies the trait bounds without the crate learning
+about `Row`.
+
+The alternatives are worse for this purpose.
+Timely alone has no arrangement or trace concept, so it is the wrong layer.
+`differential-dataflow` proper or `differential-dogs3` would work but add an external
+release cycle.
+Lift to one of those later only if a non-Materialize consumer appears.
+
+## What was generic vs Materialize-specific
+
+The original fused operator mixed a generic reduce-core with Row/compute wiring.
+The extraction split along that seam.
+
+| Piece | Home |
+| --- | --- |
+| Two-input consumption, per-input frontier tracking, `upper_limit = meet`, read-at-own-frontier, output `TraceAgent`, per-capability builders, `seal`, input/output compaction, `pending`/`CapabilitySet` interesting-times, fueling | `mz-timely-util` (`co_reduce.rs`) |
+| `KeyWork`, `own_current_key`, `seek_owned_key`, `stage_times`, `read_key_values` | `mz-timely-util`, generic over `Cursor` |
+| `compute_key`/`emit_deltas` per-key synthetic-time closure evaluation | `mz-timely-util`. The arithmetic (base plus diff, subtract minus diff, threshold) is the caller's closure |
+| `RowRowSpine`/`RowRowAgent`/`RowRowBuilder`, `Row`, `Diff`, error handling, `MzArrange`, `log_arrangement_size`, `differential/default_exert_logic` lookup | compute |
+| `Context`, `CollectionBundle`, `ArrangementFlavor`, the `Local`/`Trace` arm demux, `arm_arrangement` | compute |
+
+## Signature
+
+The shipped signature (`src/timely-util/src/co_reduce.rs`):
+
+```rust
+pub fn co_reduce2<'scope, T, Tr1, Tr2, K, V, V2, R2, Bu, Out, L>(
+    input0: Arranged<'scope, Tr1>,
+    input1: Arranged<'scope, Tr2>,
+    name: &str,
+    fuel: usize,
+    logic: L,
+) -> Arranged<'scope, TraceAgent<Out>>
+where
+    T: Timestamp + Lattice + Ord,
+    Tr1: TraceReader<Time = T> + Clone + 'static,
+    // `Tr2` shares the key GAT with `Tr1` so their keys compare, and its diff is pinned
+    // to `Tr1::Diff` so both inputs feed the closure as the one input diff type `D`.
+    Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = T, Diff = Tr1::Diff> + Clone + 'static,
+    Tr1::Diff: Semigroup + Clone + 'static,
+    Tr1::KeyContainer: BatchContainer<Owned = K>,
+    Tr1::ValContainer: BatchContainer<Owned = V>,
+    Tr2::KeyContainer: BatchContainer<Owned = K>,
+    Tr2::ValContainer: BatchContainer<Owned = V>,
+    K: Ord + Clone + 'static,
+    V: Ord + Clone + 'static,
+    V2: Ord + Clone + 'static,
+    R2: Abelian + Clone + 'static,
+    Out: for<'a> Trace<Key<'a> = Tr1::Key<'a>, ValOwn = V2, Time = T, Diff = R2> + 'static,
+    Out::KeyContainer: BatchContainer<Owned = K>,
+    Out::ValContainer: BatchContainer<Owned = V2>,
+    Bu: Builder<Time = T, Output = Out::Batch> + 'static,
+    Bu::Input: Default + PushInto<((K, V2), T, R2)>,
+    L: FnMut(&K, &[&[(V, Tr1::Diff)]], &mut Vec<(V2, R2)>) + 'static,
+```
+
+For each key present in either input, at every interesting time `t`, `logic` runs with
+the two consolidated `(value, diff)` multisets of updates with time `<= t`: `input0`'s
+slice first, `input1`'s second.
+`logic` writes the desired output `(value, diff)` multiset at `t`.
+The operator diffs desired against prior output per value and emits the minimal
+updates into one output arrangement.
+An output time finalizes only once it is complete in both inputs, i.e.
+`<=`-covered by the meet of the two input frontiers.
+
+`Tr1` and `Tr2` may be distinct trace types.
+They unify only on the key GAT (so their keys compare), the owned key `K` and value
+`V` (so the closure sees homogeneous `(V, D)` slices), and the diff `D` (pinned to
+`Tr1::Diff`).
+This lets a caller pass two different arrangement flavors directly, for example a
+local arrangement and an entered trace, taking each by monomorphization instead of
+forcing both onto one trace type.
+
+There is no `G: Scope` type parameter.
+The scope is read off `input0.stream.scope()` inside the function body.
+
+## The two forked pieces, generalized
+
+1. **Value-collapse to value-aware.**
+   The pre-extraction `set_difference` fused operator emitted a single empty value
+   and collapsed each input to a per-time running count, so its per-key computation
+   never grouped by value.
+   `co_reduce2` retains values: per key, per input, a `Vec<(V, T, D)>`.
+   At each interesting time it consolidates each input's `(V, D)` as-of that time
+   (sum diffs of entries with `ti <= t`, group by `V`, drop zeros) and hands the
+   closure `&[&[(V, D)]]`.
+   This re-derives, for two inputs, what differential's private `ValueHistory` does
+   for one.
+   The collapsed single-empty-value operator is the special case of it.
+
+2. **Baked-in arithmetic to closure.**
+   The old `net = sum(base) - sum(subtract)` and threshold are now the closure body
+   (`set_difference_threshold` in `set_difference.rs`).
+   The operator keeps ownership of the interesting-times worklist, synthetic
+   join-closure, capability assignment, and desired-vs-current diffing.
+
+## Negation in the closure
+
+Negation is not an operator feature.
+The operator reads both inputs plainly (no sign flip) and passes each input's
+`(V, D)` slice separately.
+`SetDifference`'s closure, with `input0 = base` and `input1 = subtract`:
+
+```rust
+fn set_difference_threshold(_key: &Row, inputs: &[&[(Row, Diff)]], out: &mut Vec<(Row, Diff)>) {
+    let sum = |s: &[(Row, Diff)]| s.iter().map(|(_v, d)| *d).sum::<Diff>();
+    let net = sum(inputs[0]) - sum(inputs[1]);
+    if net.is_positive() {
+        out.push((Row::default(), net));
+    }
+}
+```
+
+The operator does not know which input is the minuend.
+This is simpler than the pre-extraction code, which flipped the subtract diffs while
+reading them.
+Value/collision closures (PIVOT's collision-resolve, replace) would compose with this
+one: one closure over structure, one over arithmetic.
+
+## Fueling
+
+The pre-extraction operator processed every dirty key in one activation: an
+O(dirty-set-size)-per-round cost with no bound on the work done in a single
+activation.
+`co_reduce2` bounds that with a `fuel: usize` parameter and an
+accumulate-then-ship-on-drain scheme.
+
+A round finalizes the interval `[processed, upper_limit)` over the dirty-key set
+staged in `pending`.
+Each activation processes at most `fuel` keys from that set (`Round::remaining`, a
+`BTreeMap` drained in ascending key order).
+Per-key output accumulates into per-capability `Builder`s (`Round::builders`) rather
+than being shipped immediately.
+Only once `remaining` is fully drained does the operator build, ship, and seal the
+round's batches.
+While it is not drained, the operator re-activates itself (`reactivate.activate()`)
+and resumes the same round on the next activation, holding the round's output
+capabilities so the output frontier stays at the round's lower limit, and deferring
+input/output compaction.
+
+This guarantees downstream never observes a partially emitted round as complete: a
+round is atomic from the outside regardless of how many activations it takes
+internally.
+Bounding keys per activation caps CPU per activation without changing output
+correctness or frontier semantics.
+`SetDifference` wires this to a fixed constant, `SET_DIFFERENCE_FUEL`
+(`set_difference.rs`).
+See the `TODO` on that constant for the plan to make it configurable.
+
+## Migration (as it played out)
+
+1. Landed `co_reduce2` in `mz-timely-util` with unit tests (`co_reduce.rs`) covering
+   incremental correctness (retraction, reappearance, net-zero, multiplicity,
+   multi-value-per-key) and fueled/unfueled equivalence.
+2. Reimplemented the fused set-difference operator as a `co_reduce2` call with the
+   threshold closure.
+   The compute-side `render_set_difference` (bundle demux, error arrange,
+   `arm_arrangement`, output `CollectionBundle`) stayed unchanged.
+   Only its inner operator call changed.
+   `outer_join.slt` stayed byte-identical.
+3. Added the fueling seam (`fuel: usize` plus the `Round` accumulate-then-drain
+   scheme) in the same operator, ahead of any large-dirty-set caller needing it.
+4. Future callers, still open: PIVOT (triple-store to wide row, collapses a wide
+   delta join into one reduce), some `DISTINCT` forms, same-key variadic joins
+   without inter-stage re-arrangement.
+   These motivate the variadic-N generalization below.
+
+## Resolved against differential-dataflow 0.24 source
+
+### Output builder / trace generality (resolved)
+
+The `Arranged`-based `reduce_trace` (`reduce.rs:34`) was the template, not the
+`Collection`-based `reduce_core` (which hardcodes `Bu::Input = Vec<..>` and is
+incompatible with `RowRowBuilder`, whose `Input` is a `TimelyStack` columnation
+stack).
+Its output bounds:
+
+```rust
+Out: for<'a> Trace<Key<'a> = Tr::Key<'a>, ValOwn = V2, Time = Tr::Time, Diff = R2> + 'static,
+Bu:  Builder<Time = Tr::Time, Output = Out::Batch, Input: Default>,
+```
+
+No output `Batcher` parameter exists on the reduce path.
+Reduce builds batches directly with a `Builder`.
+The `Batcher` bounds in the arrange operators are unrelated.
+`Batch: Batch` rides in free on the `Trace` supertrait.
+Every output call the shipped operator makes (`Trace::new`, `TraceAgent::new`,
+`Builder::new/push/done`, `TraceWriter::insert/seal/exert`, the `TraceReader`
+compaction/`cursor_through` calls) is generic surface, nothing inherent to
+`RowRowSpine`.
+So `Out = RowRowSpine<T, Diff>`, `Bu = RowRowBuilder<T, Diff>` reproduces the fused
+operator's return type `Arranged<TraceAgent<RowRowSpine<T, Diff>>> = Arranged<RowRowAgent>`,
+matching `co_reduce2`'s actual output bounds shown above.
+
+### Interesting-time synthesis (resolved: always synthesize)
+
+Differential has no linearity fast-path.
+`HistoryReplayer::compute` (`reduce.rs:558-575`) synthesizes the join-closure
+unconditionally for every in-region time, joining it with all batch and current
+times, regardless of the user logic (`L` is opaque).
+The only gate is the `interesting` flag (`reduce.rs:444-486`), which decides whether
+`logic` is *called* at a time, driven by presence of updates, not by any property of
+`L`.
+`co_reduce2`'s `compute_key` partner-join is a faithful fork of this.
+
+For a totally ordered timestamp, synthesis is already a no-op (a join of comparable
+times is one of them, already interesting: the `synth == t` guard in `compute_key`).
+It only bites for multi-dimensional lattice times (product/nested timestamps in
+iterative scopes).
+
+Decision: `co_reduce2` **always synthesizes**, matching differential.
+Simplest, unconditionally correct, free for single-dimensional time.
+A `linear` opt-out to skip synthesis is a legitimate future optimization but must be
+an explicit, off-by-default caller opt-in, never inferred.
+Skipping synthesis under a non-linear closure yields silent wrong results: the
+output multiplicity at an un-evaluated join time is stale and nothing downstream
+flags it.
+It only earns its keep on multi-dimensional lattice timestamps under a provably
+linear closure.
+
+## Builder-input filling (decided: inlined push)
+
+`co_reduce2` fills the output builder itself, via
+`Bu::Input: Default + PushInto<((K, V2), T, R2)>`.
+The public signature stays `logic`-only (one closure), matching the pre-extraction
+fused operator.
+This bakes the `((key, val), time, diff)` input layout into `co_reduce2`, which
+covers every foreseeable Materialize caller (all use `RowRowBuilder`, exactly this
+layout).
+
+The push-closure form `reduce_trace` exposes (a second parameter
+`P: FnMut(&mut Bu::Input, K, &mut Vec<(V2, Tr::Time, R2)>)`, requiring only
+`Bu::Input: Default`) is more general but adds a second closure to the public
+signature.
+No Materialize caller needs it.
+If a builder whose input is not `((key, val), t, r)` ever appears, add `P` then.
+
+## Future work: variadic-N `co_reduce`
+
+The original goal for this design was a variadic `co_reduce` over N homogeneous
+arranged inputs sharing one trace type `Tr`, in the shape of Naiad's `CoGroupBy`.
+That generalization did not ship.
+`co_reduce2` covers `SetDifference`'s two heterogeneous-trace inputs, which was
+enough for CLU-168, and remains the only caller.
+The N-input generalization is deferred, not abandoned.
+PIVOT and same-key variadic joins (see Migration step 4) are the motivating future
+callers.
+
+Sketch of the extension, unchanged from the original design:
+
+* Replace `binary_frontier` with a hand-built `timely::OperatorBuilder` that calls
+  `new_input` in a loop over a `Vec<Arranged<G, Tr>>`.
+* The per-input frontiers become one `Vec<Antichain<T>>`.
+  `upper_limit` is the meet across all of them, not just two.
+* `stage_times` runs per input, as it already does for two.
+* The self-difference safety argument (acquire each cursor sequentially,
+  `cursor_through` returns owned storage, no two trace borrows held at once) extends
+  unchanged to N sequential acquisitions.
+* Homogeneity (all inputs share one `Tr`) is the one place this shape is less
+  general than `co_reduce2`, which takes two distinct trace types.
+  Heterogeneous-N would need boxed or erased cursors and is not needed by any known
+  caller.

--- a/src/timely-util/src/co_reduce.rs
+++ b/src/timely-util/src/co_reduce.rs
@@ -1,0 +1,497 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A reduce over two co-arranged inputs.
+//!
+//! [`co_reduce2`] takes two arrangements that agree on key type but may carry distinct
+//! trace types, and a per-key `logic` closure, and produces a single output arrangement.
+//! It generalizes a fused two-input set-difference operator along two axes: a caller
+//! closure instead of baked-in arithmetic, and value-aware output accounting instead of
+//! a single collapsed empty value. The two inputs feed the closure as homogeneous
+//! `(value, diff)` multisets, so they share the input value type `V` and diff type `D`,
+//! while their trace types stay independent. Callers pass two arrangement flavors
+//! (for example a local agent versus an entered trace) directly, and the operator
+//! is monomorphized per pair.
+//!
+//! The operator is split into a driver ([`co_reduce2_with_tactic`]) that owns frontiers,
+//! capabilities, and trace maintenance, and a [`CoReduceTactic`] that owns per-key
+//! computation. [`co_reduce2`] runs the conventional [`CursorTactic`].
+//!
+//! The operator finalizes an output time only once it is complete in both inputs (the
+//! meet of the two per-input frontiers). It reads each input at its OWN frontier, not at
+//! the meet: `cursor_through(meet)` would panic with "upper straddles batch" whenever
+//! the meet fell inside a batch of an input whose frontier ran ahead. Reading each
+//! input at its own frontier is straddle-free, and reading data beyond the meet is
+//! harmless because it cannot affect the output at any time below the meet.
+//!
+//! Interesting times: because `logic` may be non-linear (its output can change at a
+//! join of input times where no input has a literal update), the operator seeds
+//! interesting times from batch and pending times and repeatedly joins each processed
+//! time with every input time to reach the full join-closure. For a totally ordered
+//! timestamp this synthesis is a no-op.
+//!
+//! Fuel: a round finalizes the interval `[processed, upper_limit)` over the dirty-key set
+//! staged in `pending`. That set can be arbitrarily large, so the operator bounds the
+//! number of keys it processes per activation by `fuel` and yields the timely worker
+//! rather than draining the whole set in one shot. A round in progress is finalized
+//! atomically: the tactic accumulates processed keys' updates into per-held-time
+//! builders and only builds, ships, and seals the round's batches once its dirty set
+//! fully drains. Until then it holds the round's output capabilities (so the output
+//! frontier stays at `processed`), leaves `processed` unadvanced, defers compaction, and
+//! re-activates itself. This guarantees downstream never observes a partially emitted
+//! round as complete. Bounding keys per activation caps CPU per activation without
+//! changing output correctness or frontier semantics.
+
+use std::rc::Rc;
+
+use differential_dataflow::difference::{Abelian, Semigroup};
+use differential_dataflow::lattice::{Lattice, antichain_join_into};
+use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
+use differential_dataflow::trace::implementations::BatchContainer;
+use differential_dataflow::trace::{
+    BatchCursor, BatchDiff, BatchReader, Builder, Cursor, ExertionLogic, Navigable, Trace,
+    TraceReader,
+};
+use timely::container::PushInto;
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::{CapabilitySet, Operator};
+use timely::progress::{Antichain, Timestamp};
+
+mod cursor;
+mod reference;
+
+#[cfg(test)]
+mod tests;
+
+pub use cursor::CursorTactic;
+#[doc(hidden)]
+pub use reference::co_reduce2_reference;
+
+/// A per-round engine for a two-input key-wise reduction.
+///
+/// The interface trades only in structural information: batch handles, frontiers, and
+/// time-tagged output batches. Key and value opinions live inside implementations,
+/// which state them as bounds on the batches' cursors.
+///
+/// # Contract
+///
+/// The driver ([`co_reduce2_with_tactic`]) relies on the following.
+///
+/// * **Ordered, tiling output.** `finish`'s `(time, batch)` pairs are in ascending order
+///   and their descriptions tile `[lower, upper)`: the first batch's lower is `lower`,
+///   each batch's upper is the next batch's lower, and the last batch's upper is `upper`.
+///   Zero-width sub-intervals are skipped.
+/// * **Shipped at a held time.** Each returned `time` is an element of the `held`
+///   antichain passed to `begin`. The driver mints a capability at it.
+/// * **Progress.** A `step` call with `fuel >= 1` must process at least one key or
+///   return true, else the driver's reactivation loop livelocks with capabilities held.
+/// * **Frontier bounds withheld work, and collapses to empty when there is none.**
+///   `finish`'s returned frontier must be at-or-below every time the tactic withholds
+///   for later rounds, and MUST be the empty antichain when nothing is withheld, else
+///   capabilities are held forever and recursive scopes deadlock.
+///
+/// A tactic that evaluates a caller `logic` at interesting times may see fully cancelled
+/// input accumulations. Such a `logic` must produce the empty output there, per the
+/// contract on [`co_reduce2`].
+pub trait CoReduceTactic<B0, B1, BOut>
+where
+    B0: BatchReader,
+    B1: BatchReader<Time = B0::Time>,
+    BOut: BatchReader<Time = B0::Time>,
+{
+    /// Freeze a round over `[lower, upper)`.
+    ///
+    /// `history0`/`history1`: ALL batches of that input through its own (batch-aligned)
+    /// read frontier, for cursor-building over full per-key histories. `new0`/`new1`:
+    /// the batches that arrived since the last round, a subset of the corresponding
+    /// history's content, used solely to stage `(key, time)` pairs into the tactic's
+    /// internal pending set. The views overlap by design. `output`: prior output batches
+    /// through `lower`. `held`: the times the driver holds capabilities for.
+    #[allow(clippy::too_many_arguments)]
+    fn begin(
+        &mut self,
+        history0: Vec<B0>,
+        new0: Vec<B0>,
+        history1: Vec<B1>,
+        new1: Vec<B1>,
+        output: Vec<BOut>,
+        lower: &Antichain<B0::Time>,
+        upper: &Antichain<B0::Time>,
+        held: &Antichain<B0::Time>,
+    );
+
+    /// Process up to `fuel` dirty keys of the in-flight round. Returns true when the
+    /// round's dirty set has drained.
+    fn step(&mut self, fuel: usize) -> bool;
+
+    /// Finalize the round: the round's output batches, each tagged with the held time
+    /// to ship it at, plus the frontier of times the tactic withholds.
+    fn finish(&mut self) -> (Vec<(B0::Time, BOut)>, Antichain<B0::Time>);
+}
+
+/// Drives a two-input key-wise reduction using a supplied [`CoReduceTactic`].
+///
+/// The driver does the dataflow plumbing: per-input received frontiers, the meet that
+/// finalizes output times, capabilities, the fuel loop, output trace maintenance, and
+/// compaction. It requires only `TraceReader` of its inputs and `Trace` of its output,
+/// never `Navigable`. Building cursors over the batches it hands to `begin` is the
+/// tactic's concern.
+///
+/// An output time is finalized only once it is complete in both inputs, at the meet of
+/// the two per-input frontiers. Each input is read at its OWN frontier, not at the
+/// meet: a cut at the meet can straddle a batch of an input whose frontier ran ahead.
+/// Reading data beyond the meet is harmless because it cannot affect the output at any
+/// time below the meet.
+///
+/// `fuel` bounds the keys the tactic processes per activation. The driver clamps it to
+/// at least one and forwards it to every `step` call.
+pub fn co_reduce2_with_tactic<'scope, T, Tr0, Tr1, Out, TAC>(
+    input0: Arranged<'scope, Tr0>,
+    input1: Arranged<'scope, Tr1>,
+    name: &str,
+    fuel: usize,
+    tactic: TAC,
+) -> Arranged<'scope, TraceAgent<Out>>
+where
+    T: Timestamp + Lattice + Ord,
+    Tr0: TraceReader<Time = T> + Clone + 'static,
+    Tr1: TraceReader<Time = T> + Clone + 'static,
+    Out: Trace<Time = T> + 'static,
+    TAC: CoReduceTactic<Tr0::Batch, Tr1::Batch, Out::Batch> + 'static,
+{
+    let scope = input0.stream.scope();
+
+    // A round must make progress, so the tactic sees at least one key of budget.
+    let fuel = fuel.max(1);
+
+    // Clones of both input traces, held for the operator's lifetime: each round reads
+    // both inputs through their own frontiers.
+    let mut input0_trace = input0.trace.clone();
+    let mut input1_trace = input1.trace.clone();
+
+    let mut result_trace = None;
+    let stream = {
+        let result_trace = &mut result_trace;
+        input0.stream.binary_frontier(
+            input1.stream,
+            Pipeline,
+            Pipeline,
+            name,
+            move |_capability, operator_info| {
+                let mut tactic = tactic;
+                let logger = scope
+                    .worker()
+                    .logger_for::<differential_dataflow::logging::DifferentialEventBuilder>(
+                        "differential/arrange",
+                    )
+                    .map(Into::into);
+
+                let activator = Some(scope.activator_for(Rc::clone(&operator_info.address)));
+                // Separate activator the operator uses to re-schedule itself while a
+                // round defers work under fuel.
+                let reactivate = scope.activator_for(Rc::clone(&operator_info.address));
+                let mut empty = Out::new(operator_info.clone(), logger.clone(), activator);
+                if let Some(exert_logic) = scope
+                    .worker()
+                    .config()
+                    .get::<ExertionLogic>("differential/default_exert_logic")
+                    .cloned()
+                {
+                    empty.set_exert_logic(exert_logic);
+                }
+                let (mut output_reader, mut output_writer) =
+                    TraceAgent::new(empty, operator_info, logger);
+                *result_trace = Some(output_reader.clone());
+
+                // Persistent per-input received frontiers. Each advances monotonically
+                // and combines batch uppers, `advance_upper`, and the input frontier.
+                let mut upper_input0 = Antichain::from_elem(T::minimum());
+                let mut upper_input1 = Antichain::from_elem(T::minimum());
+                // The last processed frontier. Next round's lower limit.
+                let mut processed = Antichain::from_elem(T::minimum());
+
+                let mut capabilities = CapabilitySet::<T>::new();
+
+                // Batches drained but not yet handed to a round. A batch on one input
+                // need not advance the meet, so its handles wait here, possibly across
+                // activations, until the next round starts. `queued_times` tracks the
+                // capability times covering them: the round-end downgrade folds these
+                // in, since the tactic knows nothing of queued batches and its returned
+                // frontier alone would release the capabilities their output needs.
+                let mut queued0: Vec<Tr0::Batch> = Vec::new();
+                let mut queued1: Vec<Tr1::Batch> = Vec::new();
+                let mut queued_times: Antichain<T> = Antichain::new();
+
+                // Metadata of the in-flight round, if any. The tactic holds the round's
+                // working state. The driver keeps only what sealing and compaction need.
+                // While a round is in flight the driver never downgrades capabilities,
+                // which pins the output frontier at the round's lower limit.
+                let mut round: Option<(Antichain<T>, Antichain<T>, Antichain<T>, Antichain<T>)> =
+                    None;
+
+                move |(input1_handle, frontier1), (input2_handle, frontier2), output| {
+                    // Drain both inputs: capture capabilities, record batch uppers, and
+                    // queue the handles for the next round.
+                    input1_handle.for_each(|cap, data: &mut Vec<Tr0::Batch>| {
+                        queued_times.insert(cap.time().clone());
+                        capabilities.insert(cap.retain(0));
+                        for batch in data.drain(..) {
+                            upper_input0.clone_from(batch.upper());
+                            queued0.push(batch);
+                        }
+                    });
+                    input2_handle.for_each(|cap, data: &mut Vec<Tr1::Batch>| {
+                        queued_times.insert(cap.time().clone());
+                        capabilities.insert(cap.retain(0));
+                        for batch in data.drain(..) {
+                            upper_input1.clone_from(batch.upper());
+                            queued1.push(batch);
+                        }
+                    });
+
+                    // Advance each received frontier through empty regions the trace
+                    // knows about, then incorporate the input frontier guarantee. Each
+                    // `upper_*` stays batch-aligned to its input, which makes
+                    // `batches_through(upper_*)` a clean cut.
+                    input0_trace.advance_upper(&mut upper_input0);
+                    input1_trace.advance_upper(&mut upper_input1);
+                    {
+                        let mut joined = Antichain::new();
+                        antichain_join_into(
+                            &upper_input0.borrow()[..],
+                            &frontier1.frontier()[..],
+                            &mut joined,
+                        );
+                        upper_input0 = joined;
+                    }
+                    {
+                        let mut joined = Antichain::new();
+                        antichain_join_into(
+                            &upper_input1.borrow()[..],
+                            &frontier2.frontier()[..],
+                            &mut joined,
+                        );
+                        upper_input1 = joined;
+                    }
+
+                    // Start a round if none is in flight. A round in flight freezes its
+                    // finalization target and is driven to completion before any newer
+                    // interval is considered.
+                    if round.is_none() {
+                        let upper_limit = upper_input0.meet(&upper_input1);
+                        if upper_limit != processed {
+                            if capabilities
+                                .iter()
+                                .any(|c| !upper_limit.less_equal(c.time()))
+                            {
+                                let history0 = input0_trace
+                                    .batches_through(upper_input0.borrow())
+                                    .expect("failed to acquire input0 batches");
+                                let history1 = input1_trace
+                                    .batches_through(upper_input1.borrow())
+                                    .expect("failed to acquire input1 batches");
+                                let output_batches = output_reader
+                                    .batches_through(processed.borrow())
+                                    .expect("failed to acquire output batches");
+                                let held: Antichain<T> =
+                                    capabilities.iter().map(|c| c.time().clone()).collect();
+                                tactic.begin(
+                                    history0,
+                                    std::mem::take(&mut queued0),
+                                    history1,
+                                    std::mem::take(&mut queued1),
+                                    output_batches,
+                                    &processed,
+                                    &upper_limit,
+                                    &held,
+                                );
+                                queued_times = Antichain::new();
+                                round = Some((
+                                    processed.clone(),
+                                    upper_limit,
+                                    upper_input0.clone(),
+                                    upper_input1.clone(),
+                                ));
+                            } else {
+                                // Empty region: nothing to output, but progress must
+                                // still be reflected. Queued batches are not consumed,
+                                // as their capability times are at or beyond the meet.
+                                output_writer.seal(upper_limit.clone());
+                                input0_trace.set_logical_compaction(upper_limit.borrow());
+                                input0_trace.set_physical_compaction(upper_input0.borrow());
+                                input1_trace.set_logical_compaction(upper_limit.borrow());
+                                input1_trace.set_physical_compaction(upper_input1.borrow());
+                                output_reader.set_logical_compaction(upper_limit.borrow());
+                                output_reader.set_physical_compaction(upper_limit.borrow());
+                                processed = upper_limit;
+                            }
+                        }
+                    }
+
+                    // Drive the in-flight round.
+                    if let Some((lower, upper, read0, read1)) = round.take() {
+                        if tactic.step(fuel) {
+                            let (produced, tactic_frontier) = tactic.finish();
+
+                            // Contract checks (see CoReduceTactic). Cheap, debug-only.
+                            debug_assert!(
+                                produced
+                                    .iter()
+                                    .all(|(time, _)| capabilities
+                                        .iter()
+                                        .any(|c| c.time().less_equal(time))),
+                                "CoReduceTactic::finish shipped a batch at an uncovered time",
+                            );
+                            debug_assert!(
+                                {
+                                    let mut edge = lower.clone();
+                                    let abutting = produced.iter().all(|(_, batch)| {
+                                        let matches = batch.description().lower() == &edge;
+                                        edge = batch.description().upper().clone();
+                                        matches
+                                    });
+                                    abutting && (produced.is_empty() || edge == upper)
+                                },
+                                "CoReduceTactic::finish output must be ordered and tile [lower, upper)",
+                            );
+
+                            for (time, batch) in produced {
+                                let cap = capabilities.delayed(&time);
+                                output.session(&cap).give(batch.clone());
+                                output_writer.insert(batch, Some(time));
+                            }
+
+                            // Downgrade to the tactic's withheld frontier joined with
+                            // the times covering still-queued batches.
+                            let mut target = tactic_frontier;
+                            for time in queued_times.elements() {
+                                target.insert(time.clone());
+                            }
+                            capabilities.downgrade(target.iter());
+
+                            // Reflect observed progress. The output is sealed and
+                            // compacted to the meet. Each input trace is compacted
+                            // physically to the round's read frontier and logically to
+                            // the meet.
+                            output_writer.seal(upper.clone());
+                            input0_trace.set_logical_compaction(upper.borrow());
+                            input0_trace.set_physical_compaction(read0.borrow());
+                            input1_trace.set_logical_compaction(upper.borrow());
+                            input1_trace.set_physical_compaction(read1.borrow());
+                            output_reader.set_logical_compaction(upper.borrow());
+                            output_reader.set_physical_compaction(upper.borrow());
+                            processed = upper;
+
+                            // If newer input advanced the received frontiers during the
+                            // round, a further interval is now retirable.
+                            if upper_input0.meet(&upper_input1) != processed {
+                                reactivate.activate();
+                            }
+                        } else {
+                            // Fuel exhausted with work left. Keep the round and resume
+                            // it on the next activation. Do NOT seal or advance
+                            // `processed`: unprocessed keys still owe output below the
+                            // round's upper.
+                            round = Some((lower, upper, read0, read1));
+                            reactivate.activate();
+                        }
+                    }
+
+                    output_writer.exert();
+                }
+            },
+        )
+    };
+
+    Arranged {
+        stream,
+        trace: result_trace.unwrap(),
+    }
+}
+
+/// A reduce over two co-arranged inputs.
+///
+/// For each key present in either input, at every interesting time `t`, `logic` is called
+/// with the two consolidated `(value, diff)` multisets of the inputs' updates with time
+/// `<= t`: slice `[0]` is `input0`, slice `[1]` is `input1`. `logic` writes the desired
+/// output `(value, diff)` multiset at `t` into its `out` argument. The operator diffs
+/// desired against prior output per value and emits the minimal updates into one output
+/// arrangement. An output time is finalized only once it is complete in both inputs, i.e.
+/// `<=`-covered by the meet of the two input frontiers.
+///
+/// The two inputs may carry distinct trace types (`Tr1`, `Tr2`), so callers can pass two
+/// different arrangement flavors directly without unifying them. They must agree on key
+/// GAT, owned key `K`, owned value `V`, and diff `D` (`Tr1::Diff`), since the closure sees
+/// both as homogeneous `(V, D)` slices.
+///
+/// `fuel` bounds the number of dirty keys processed per activation. When a round's dirty
+/// set exceeds `fuel`, the operator processes `fuel` keys, re-activates itself, and
+/// resumes the same round on the next activation, yielding the timely worker in between.
+/// Fueling does not change output correctness or frontier semantics: a round's output is
+/// sealed only once its dirty set fully drains.
+///
+/// `logic` must produce the empty output multiset when both input accumulations are
+/// empty. The operator evaluates `logic` at times where all diffs have cancelled, and a
+/// nonempty result there is unsound.
+pub fn co_reduce2<'scope, T, Tr1, Tr2, K, V, V2, R2, Bu, Out, L>(
+    input0: Arranged<'scope, Tr1>,
+    input1: Arranged<'scope, Tr2>,
+    name: &str,
+    fuel: usize,
+    logic: L,
+) -> Arranged<'scope, TraceAgent<Out>>
+where
+    T: Timestamp + Lattice + Ord,
+    // The inputs are read only through their batch cursors, so all key, value, and diff
+    // opinions are stated on `BatchCursor<Tr>` rather than on the trace itself, which in this
+    // differential version carries only a time opinion. Both batches must be `Navigable` so the
+    // operator can build cursors over them.
+    Tr1: TraceReader<Time = T> + Clone + 'static,
+    Tr1::Batch: Navigable,
+    Tr2: TraceReader<Time = T> + Clone + 'static,
+    Tr2::Batch: Navigable,
+    BatchCursor<Tr1>: Cursor<Time = T>,
+    <BatchCursor<Tr1> as Cursor>::Diff: Semigroup + Clone + 'static,
+    <BatchCursor<Tr1> as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <BatchCursor<Tr1> as Cursor>::ValContainer: BatchContainer<Owned = V>,
+    // `Tr2`'s diff is pinned to `Tr1`'s so both inputs feed the closure as the one input diff
+    // type, and its key and value containers carry the same owned types.
+    BatchCursor<Tr2>: Cursor<Time = T, Diff = BatchDiff<Tr1>>,
+    <BatchCursor<Tr2> as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <BatchCursor<Tr2> as Cursor>::ValContainer: BatchContainer<Owned = V>,
+    K: Ord + Clone + 'static,
+    V: Ord + Clone + 'static,
+    V2: Ord + Clone + 'static,
+    R2: Abelian + Clone + 'static,
+    Out: Trace<Time = T> + 'static,
+    Out::Batch: Navigable,
+    BatchCursor<Out>: Cursor<Time = T, Diff = R2, ValOwn = V2>,
+    <BatchCursor<Out> as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <BatchCursor<Out> as Cursor>::ValContainer: BatchContainer<Owned = V2>,
+    // `Bu::Input` is only required to be default-constructible and to accept output tuples.
+    // This admits builders whose input is not a `Vec` (for example a columnar stack), which
+    // a `Vec`-typed bound would reject.
+    Bu: Builder<Time = T, Output = Out::Batch> + 'static,
+    Bu::Input: Default + PushInto<((K, V2), T, R2)>,
+    L: FnMut(&K, &[&[(V, BatchDiff<Tr1>)]], &mut Vec<(V2, R2)>) + 'static,
+{
+    co_reduce2_with_tactic(
+        input0,
+        input1,
+        name,
+        fuel,
+        cursor::CursorTactic::<Tr1::Batch, Tr2::Batch, Out::Batch, K, V, V2, R2, Bu, L>::new(logic),
+    )
+}

--- a/src/timely-util/src/co_reduce/cursor.rs
+++ b/src/timely-util/src/co_reduce/cursor.rs
@@ -1,0 +1,560 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cursor-based helpers for reading co-arranged batches and computing per-key output deltas.
+
+use std::cmp::{Ordering, Reverse};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
+use std::marker::PhantomData;
+
+use differential_dataflow::consolidation::consolidate;
+use differential_dataflow::difference::{Abelian, Semigroup};
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::trace::cursor::cursor_list;
+use differential_dataflow::trace::implementations::BatchContainer;
+use differential_dataflow::trace::{BatchReader, Builder, Cursor, Description, Navigable};
+use timely::PartialOrder;
+use timely::container::PushInto;
+use timely::progress::{Antichain, Timestamp};
+
+use super::CoReduceTactic;
+
+/// Owns the cursor's current key.
+pub(super) fn own_current_key<C, K>(cursor: &C, storage: &C::Storage) -> K
+where
+    C: Cursor,
+    C::KeyContainer: BatchContainer<Owned = K>,
+{
+    <C::KeyContainer as BatchContainer>::into_owned(cursor.get_key(storage).expect("key exists"))
+}
+
+/// Advances the cursor forward to `target`, returning whether it is present.
+///
+/// Keys are visited in ascending order across a round, so advancing each source cursor
+/// forward to successive targets is monotone. On a match the cursor is left positioned
+/// at the key with values at their start. On a miss it stops at the first key greater
+/// than `target`.
+pub(super) fn seek_owned_key<C, K>(cursor: &mut C, storage: &C::Storage, target: &K) -> bool
+where
+    C: Cursor,
+    C::KeyContainer: BatchContainer<Owned = K>,
+    K: Ord,
+{
+    while cursor.key_valid(storage) {
+        match own_current_key::<C, K>(cursor, storage).cmp(target) {
+            Ordering::Less => cursor.step_key(storage),
+            Ordering::Equal => return true,
+            Ordering::Greater => return false,
+        }
+    }
+    false
+}
+
+/// Records every update time of every key in the cursor into `pending`.
+///
+/// Staged times survive rounds in which the combined frontier does not advance, so a
+/// batch that arrives while another input lags is not lost. Diffs and values are not
+/// staged: the per-key history is re-read from the input traces at process time.
+pub(super) fn stage_times<C, K>(
+    cursor: &mut C,
+    storage: &C::Storage,
+    pending: &mut BTreeMap<K, Vec<C::Time>>,
+) where
+    C: Cursor,
+    C::KeyContainer: BatchContainer<Owned = K>,
+    K: Ord + Clone,
+    C::Time: Clone,
+{
+    while cursor.key_valid(storage) {
+        let key = own_current_key::<C, K>(cursor, storage);
+        let times = pending.entry(key).or_default();
+        while cursor.val_valid(storage) {
+            cursor.map_times(storage, |t, _d| times.push(C::owned_time(t)));
+            cursor.step_val(storage);
+        }
+        cursor.step_key(storage);
+    }
+}
+
+/// Reads all `(value, time, diff)` updates of the cursor's current key, owning values.
+///
+/// The cursor must be positioned at the key. The value cursor is advanced to its end.
+/// Unlike a threshold reduce, values are retained: the closure sees per-input value
+/// multisets, so it can key output on input values.
+pub(super) fn read_key_values<C, V>(
+    cursor: &mut C,
+    storage: &C::Storage,
+    out: &mut Vec<(V, C::Time, C::Diff)>,
+) where
+    C: Cursor,
+    C::ValContainer: BatchContainer<Owned = V>,
+    V: Clone,
+    C::Time: Clone,
+    C::Diff: Clone,
+{
+    while cursor.val_valid(storage) {
+        let val: V = <C::ValContainer as BatchContainer>::into_owned(cursor.val(storage));
+        cursor.map_times(storage, |t, d| {
+            out.push((val.clone(), C::owned_time(t), C::owned_diff(d)));
+        });
+        cursor.step_val(storage);
+    }
+}
+
+/// Per-key state assembled during a round.
+pub(super) struct KeyWork<T, V, D, V2, R2> {
+    /// Per input: full `(value, time, diff)` history read from that input's trace.
+    pub(super) inputs: Vec<Vec<(V, T, D)>>,
+    /// Prior output `(value, time, diff)` read from the output trace.
+    pub(super) prior: Vec<(V2, T, R2)>,
+    /// In-region interesting seed times (batch and pending times below the round upper).
+    pub(super) seeds: Vec<T>,
+}
+
+/// Evaluates one key over the round's interesting times.
+///
+/// At each interesting time `t`, consolidates each input's `(value, diff)` accumulated
+/// up to `t`, calls `logic` to get the desired output multiset at `t`, and emits the
+/// per-value delta against the current output (prior plus already-produced). Synthesizes
+/// join-closure times so a non-linear closure is evaluated wherever its output can
+/// change. Times at or beyond `upper_limit` are deferred into `new_interesting`.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn compute_key<T, K, V, D, V2, R2, L>(
+    key: &K,
+    kw: &KeyWork<T, V, D, V2, R2>,
+    upper_limit: &Antichain<T>,
+    logic: &mut L,
+    held_times: &[T],
+    updates: &mut [Vec<(V2, T, R2)>],
+    new_interesting: &mut Vec<T>,
+) where
+    T: Lattice + Ord + Clone,
+    V: Ord + Clone,
+    D: Semigroup + Clone,
+    V2: Ord + Clone,
+    R2: Abelian + Clone,
+    L: FnMut(&K, &[&[(V, D)]], &mut Vec<(V2, R2)>),
+{
+    // Partners for synthetic-time joins: every input time and prior-output time. Both
+    // lie in the join-closure of input times, so including prior is redundant but harmless.
+    let mut partners: Vec<T> = Vec::new();
+    for hist in &kw.inputs {
+        partners.extend(hist.iter().map(|(_v, t, _d)| t.clone()));
+    }
+    partners.extend(kw.prior.iter().map(|(_v, t, _d)| t.clone()));
+    partners.extend(kw.seeds.iter().cloned());
+    partners.sort();
+    partners.dedup();
+
+    let mut queued: BTreeSet<T> = BTreeSet::new();
+    let mut worklist: BinaryHeap<Reverse<T>> = BinaryHeap::new();
+    for t in &kw.seeds {
+        if upper_limit.less_equal(t) {
+            new_interesting.push(t.clone());
+        } else if queued.insert(t.clone()) {
+            worklist.push(Reverse(t.clone()));
+        }
+    }
+
+    // Output produced this round for this key, diffed against.
+    let mut produced: Vec<(V2, T, R2)> = Vec::new();
+    // Reusable buffers.
+    let mut asof: Vec<Vec<(V, D)>> = (0..kw.inputs.len()).map(|_| Vec::new()).collect();
+    let mut desired: Vec<(V2, R2)> = Vec::new();
+
+    while let Some(Reverse(t)) = worklist.pop() {
+        // Per-input consolidated (value, diff) as of `t`.
+        for (i, hist) in kw.inputs.iter().enumerate() {
+            asof[i].clear();
+            for (v, ti, d) in hist {
+                if PartialOrder::less_equal(ti, &t) {
+                    asof[i].push((v.clone(), d.clone()));
+                }
+            }
+            consolidate(&mut asof[i]);
+        }
+        let slices: Vec<&[(V, D)]> = asof.iter().map(|v| v.as_slice()).collect();
+
+        desired.clear();
+        logic(key, &slices, &mut desired);
+        consolidate(&mut desired);
+
+        // Current output as of `t`, per value: prior + produced with time <= t.
+        let mut current: Vec<(V2, R2)> = Vec::new();
+        for (v, ti, d) in kw.prior.iter().chain(produced.iter()) {
+            if PartialOrder::less_equal(ti, &t) {
+                current.push((v.clone(), d.clone()));
+            }
+        }
+        consolidate(&mut current);
+
+        // Emit per-value delta = desired - current. Both are consolidated and sorted by
+        // value, so merge-walk them.
+        emit_deltas(&desired, &current, &t, held_times, updates, &mut produced);
+
+        // Synthesize joins of `t` with every partner not already <= t.
+        for tp in &partners {
+            if PartialOrder::less_equal(tp, &t) {
+                continue;
+            }
+            let synth = t.join(tp);
+            if synth == t {
+                continue;
+            }
+            if upper_limit.less_equal(&synth) {
+                new_interesting.push(synth);
+            } else if queued.insert(synth.clone()) {
+                worklist.push(Reverse(synth));
+            }
+        }
+    }
+}
+
+/// Merge-walks `desired` and `current` (both consolidated, sorted by value) and pushes
+/// `desired - current` per value into `produced` and the covering held time's updates.
+pub(super) fn emit_deltas<T, V2, R2>(
+    desired: &[(V2, R2)],
+    current: &[(V2, R2)],
+    t: &T,
+    held_times: &[T],
+    updates: &mut [Vec<(V2, T, R2)>],
+    produced: &mut Vec<(V2, T, R2)>,
+) where
+    T: Lattice + Ord + Clone,
+    V2: Ord + Clone,
+    R2: Abelian + Clone,
+{
+    let mut di = 0;
+    let mut ci = 0;
+    let mut push = |v: &V2, delta: R2, produced: &mut Vec<(V2, T, R2)>| {
+        if delta.is_zero() {
+            return;
+        }
+        produced.push((v.clone(), t.clone(), delta.clone()));
+        // Latest held time covering `t`. One must exist: `t` is reachable from a batch
+        // or a pending time, both of which retain a capability at or below their time.
+        let idx = held_times
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, ct)| PartialOrder::less_equal(*ct, t))
+            .map(|(i, _)| i)
+            .expect("a held time covers every produced time");
+        updates[idx].push((v.clone(), t.clone(), delta));
+    };
+    while di < desired.len() && ci < current.len() {
+        match desired[di].0.cmp(&current[ci].0) {
+            Ordering::Less => {
+                push(&desired[di].0, desired[di].1.clone(), produced);
+                di += 1;
+            }
+            Ordering::Greater => {
+                let mut neg = current[ci].1.clone();
+                neg.negate();
+                push(&current[ci].0, neg, produced);
+                ci += 1;
+            }
+            Ordering::Equal => {
+                let mut delta = desired[di].1.clone();
+                let mut neg = current[ci].1.clone();
+                neg.negate();
+                delta.plus_equals(&neg);
+                push(&desired[di].0, delta, produced);
+                di += 1;
+                ci += 1;
+            }
+        }
+    }
+    while di < desired.len() {
+        push(&desired[di].0, desired[di].1.clone(), produced);
+        di += 1;
+    }
+    while ci < current.len() {
+        let mut neg = current[ci].1.clone();
+        neg.negate();
+        push(&current[ci].0, neg, produced);
+        ci += 1;
+    }
+}
+
+/// Builds one output batch per held time, folding later held times into each batch's
+/// upper so the descriptions tile `[lower, upper)` in ascending order. Zero-width
+/// batches are skipped. Shared by the cursor and reference tactics so both satisfy the
+/// driver's tiling contract by construction.
+pub(super) fn build_tiled_batches<T, Bu>(
+    held_times: &[T],
+    builders: Vec<Bu>,
+    lower: &Antichain<T>,
+    upper: &Antichain<T>,
+) -> Vec<(T, Bu::Output)>
+where
+    T: Timestamp + Lattice,
+    Bu: Builder<Time = T>,
+{
+    let mut produced = Vec::new();
+    let mut output_lower = lower.clone();
+    for (index, builder) in builders.into_iter().enumerate() {
+        let mut output_upper = upper.clone();
+        for time in &held_times[index + 1..] {
+            output_upper.insert(time.clone());
+        }
+        if output_upper != output_lower {
+            let description = Description::new(
+                output_lower.clone(),
+                output_upper.clone(),
+                Antichain::from_elem(T::minimum()),
+            );
+            produced.push((held_times[index].clone(), builder.done(description)));
+            output_lower = output_upper;
+        }
+    }
+    produced
+}
+
+/// State of an in-flight round.
+///
+/// `builders` and `updates` are allocated once in `begin`, sized from `held`, and
+/// mutated by successive `step` calls. They must persist across calls: a fuel-limited
+/// round spans many activations, and rebuilding them would discard prior activations'
+/// rows.
+struct RoundState<B0, B1, BOut, K, V2, R2, Bu>
+where
+    B0: BatchReader,
+{
+    history0: Vec<B0>,
+    history1: Vec<B1>,
+    output: Vec<BOut>,
+    lower: Antichain<B0::Time>,
+    upper: Antichain<B0::Time>,
+    held_times: Vec<B0::Time>,
+    builders: Vec<Bu>,
+    updates: Vec<Vec<(V2, B0::Time, R2)>>,
+    /// Dirty keys not yet processed this round, ascending. Values are in-region seeds.
+    remaining: BTreeMap<K, Vec<B0::Time>>,
+    /// Beyond-upper synthetic times discovered this round, folded into pending at finish.
+    deferred: BTreeMap<K, Vec<B0::Time>>,
+}
+
+/// The conventional cursor-based [`CoReduceTactic`]: incremental per-key evaluation
+/// over the interesting-time join-closure, reading full histories through batch
+/// cursors.
+pub struct CursorTactic<B0, B1, BOut, K, V, V2, R2, Bu, L>
+where
+    B0: BatchReader,
+{
+    logic: L,
+    /// Staged interesting times by key, surviving across rounds. Holds both times not
+    /// yet retired (one input's frontier lags) and beyond-upper synthetic times.
+    pending: BTreeMap<K, Vec<B0::Time>>,
+    round: Option<RoundState<B0, B1, BOut, K, V2, R2, Bu>>,
+    _marker: PhantomData<(V, V2, R2)>,
+}
+
+impl<B0, B1, BOut, K, V, V2, R2, Bu, L> CursorTactic<B0, B1, BOut, K, V, V2, R2, Bu, L>
+where
+    B0: BatchReader,
+    K: Ord,
+{
+    pub fn new(logic: L) -> Self {
+        Self {
+            logic,
+            pending: BTreeMap::new(),
+            round: None,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<B0, B1, BOut, K, V, V2, R2, Bu, L> CoReduceTactic<B0, B1, BOut>
+    for CursorTactic<B0, B1, BOut, K, V, V2, R2, Bu, L>
+where
+    B0: BatchReader + Navigable + Clone,
+    B1: BatchReader<Time = B0::Time> + Navigable + Clone,
+    BOut: BatchReader<Time = B0::Time> + Navigable + Clone,
+    B0::Time: Timestamp + Lattice + Ord,
+    B0::Cursor: Cursor<Time = B0::Time>,
+    <B0::Cursor as Cursor>::Diff: Semigroup + Clone + 'static,
+    <B0::Cursor as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <B0::Cursor as Cursor>::ValContainer: BatchContainer<Owned = V>,
+    B1::Cursor: Cursor<Time = B0::Time, Diff = <B0::Cursor as Cursor>::Diff>,
+    <B1::Cursor as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <B1::Cursor as Cursor>::ValContainer: BatchContainer<Owned = V>,
+    BOut::Cursor: Cursor<Time = B0::Time, Diff = R2, ValOwn = V2>,
+    <BOut::Cursor as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <BOut::Cursor as Cursor>::ValContainer: BatchContainer<Owned = V2>,
+    K: Ord + Clone + 'static,
+    V: Ord + Clone + 'static,
+    V2: Ord + Clone + 'static,
+    R2: Abelian + Clone + 'static,
+    Bu: Builder<Time = B0::Time, Output = BOut> + 'static,
+    Bu::Input: Default + PushInto<((K, V2), B0::Time, R2)>,
+    L: FnMut(&K, &[&[(V, <B0::Cursor as Cursor>::Diff)]], &mut Vec<(V2, R2)>) + 'static,
+{
+    fn begin(
+        &mut self,
+        history0: Vec<B0>,
+        new0: Vec<B0>,
+        history1: Vec<B1>,
+        new1: Vec<B1>,
+        output: Vec<BOut>,
+        lower: &Antichain<B0::Time>,
+        upper: &Antichain<B0::Time>,
+        held: &Antichain<B0::Time>,
+    ) {
+        assert!(self.round.is_none(), "begin called with a round in flight");
+        for batch in &new0 {
+            let mut cursor = batch.cursor();
+            stage_times(&mut cursor, batch, &mut self.pending);
+        }
+        for batch in &new1 {
+            let mut cursor = batch.cursor();
+            stage_times(&mut cursor, batch, &mut self.pending);
+        }
+        // Partition the staged dirty set into this round's in-region seeds (processed
+        // under fuel) and beyond-upper times kept staged for a later round.
+        let mut remaining: BTreeMap<K, Vec<B0::Time>> = BTreeMap::new();
+        let mut kept: BTreeMap<K, Vec<B0::Time>> = BTreeMap::new();
+        for (key, times) in std::mem::take(&mut self.pending) {
+            let mut seeds = Vec::new();
+            let mut carried = Vec::new();
+            for t in times {
+                if upper.less_equal(&t) {
+                    carried.push(t);
+                } else {
+                    seeds.push(t);
+                }
+            }
+            if !seeds.is_empty() {
+                remaining.insert(key.clone(), seeds);
+            }
+            if !carried.is_empty() {
+                kept.insert(key, carried);
+            }
+        }
+        self.pending = kept;
+        let held_times: Vec<B0::Time> = held.elements().to_vec();
+        let builders: Vec<Bu> = (0..held_times.len()).map(|_| Bu::new()).collect();
+        let updates: Vec<Vec<(V2, B0::Time, R2)>> =
+            (0..held_times.len()).map(|_| Vec::new()).collect();
+        self.round = Some(RoundState {
+            history0,
+            history1,
+            output,
+            lower: lower.clone(),
+            upper: upper.clone(),
+            held_times,
+            builders,
+            updates,
+            remaining,
+            deferred: BTreeMap::new(),
+        });
+    }
+
+    fn step(&mut self, fuel: usize) -> bool {
+        let Some(r) = self.round.as_mut() else {
+            return true;
+        };
+        if r.remaining.is_empty() {
+            return true;
+        }
+        // Build cursors over the frozen batch vectors. Batch handles are Rc-backed, so
+        // the clones are cheap. Rebuilding per step re-seeks from scratch, which makes
+        // total seek work across a fuel-split round O(N^2 / fuel) in the round's
+        // dirty-key count N. Dormant while production callers drain a round's whole
+        // dirty set in one activation. If a smaller budget ever makes this bite,
+        // persist the cursors in RoundState instead.
+        let (mut input0_src, input0_stor) = cursor_list(r.history0.clone());
+        let (mut input1_src, input1_stor) = cursor_list(r.history1.clone());
+        let (mut out_cur, out_stor) = cursor_list(r.output.clone());
+
+        let mut processed_keys = 0usize;
+        while processed_keys < fuel {
+            let Some((key, seeds)) = r.remaining.pop_first() else {
+                break;
+            };
+            processed_keys += 1;
+
+            let mut kw = KeyWork {
+                inputs: vec![Vec::new(); 2],
+                prior: Vec::new(),
+                seeds,
+            };
+            if seek_owned_key(&mut input0_src, &input0_stor, &key) {
+                read_key_values(&mut input0_src, &input0_stor, &mut kw.inputs[0]);
+            }
+            if seek_owned_key(&mut input1_src, &input1_stor, &key) {
+                read_key_values(&mut input1_src, &input1_stor, &mut kw.inputs[1]);
+            }
+            if seek_owned_key(&mut out_cur, &out_stor, &key) {
+                read_key_values(&mut out_cur, &out_stor, &mut kw.prior);
+            }
+
+            let mut new_interesting = Vec::new();
+            compute_key(
+                &key,
+                &kw,
+                &r.upper,
+                &mut self.logic,
+                &r.held_times,
+                &mut r.updates,
+                &mut new_interesting,
+            );
+
+            // Push this key's updates into each held time's builder, preserving
+            // ascending key order across the builder. The builder assumes value-sorted
+            // input per key, but the updates arrive time-ordered. A stable sort by
+            // value reorders them into (value, time) order.
+            for i in 0..r.held_times.len() {
+                if r.updates[i].is_empty() {
+                    continue;
+                }
+                r.updates[i].sort_by(|a, b| a.0.cmp(&b.0));
+                let mut buffer = <Bu::Input>::default();
+                for (v2, time, r2) in r.updates[i].drain(..) {
+                    buffer.push_into(((key.clone(), v2), time, r2));
+                }
+                r.builders[i].push(&mut buffer);
+            }
+
+            if !new_interesting.is_empty() {
+                new_interesting.sort();
+                new_interesting.dedup();
+                r.deferred.entry(key).or_default().extend(new_interesting);
+            }
+        }
+        r.remaining.is_empty()
+    }
+
+    fn finish(&mut self) -> (Vec<(B0::Time, BOut)>, Antichain<B0::Time>) {
+        let r = self.round.take().expect("finish called without a round");
+        assert!(r.remaining.is_empty(), "finish called with keys remaining");
+        let produced = build_tiled_batches(&r.held_times, r.builders, &r.lower, &r.upper);
+        // Fold the round's deferred times back into pending, which still holds the
+        // carried beyond-upper times from begin.
+        for (key, mut times) in r.deferred {
+            let entry = self.pending.entry(key).or_default();
+            entry.append(&mut times);
+            entry.sort();
+            entry.dedup();
+        }
+        let mut frontier = Antichain::new();
+        for times in self.pending.values() {
+            for t in times {
+                frontier.insert(t.clone());
+            }
+        }
+        (produced, frontier)
+    }
+}

--- a/src/timely-util/src/co_reduce/reference.rs
+++ b/src/timely-util/src/co_reduce/reference.rs
@@ -1,0 +1,408 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A model-derived reference tactic: from-scratch evaluation per key per interesting time. A testing oracle, not a production engine.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::marker::PhantomData;
+
+use differential_dataflow::consolidation::consolidate;
+use differential_dataflow::difference::{Abelian, Semigroup};
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
+use differential_dataflow::trace::cursor::cursor_list;
+use differential_dataflow::trace::implementations::BatchContainer;
+use differential_dataflow::trace::{
+    BatchCursor, BatchDiff, BatchReader, Builder, Cursor, Navigable, Trace, TraceReader,
+};
+use timely::PartialOrder;
+use timely::container::PushInto;
+use timely::progress::{Antichain, Timestamp};
+
+use super::CoReduceTactic;
+use super::cursor::{build_tiled_batches, read_key_values, seek_owned_key, stage_times};
+
+/// State of an in-flight round.
+///
+/// Mirrors the cursor tactic's round state. `builders` and `updates` are allocated once
+/// in `begin`, sized from `held`, and mutated by `step`.
+struct RoundState<B0, B1, BOut, K, V2, R2, Bu>
+where
+    B0: BatchReader,
+{
+    history0: Vec<B0>,
+    history1: Vec<B1>,
+    output: Vec<BOut>,
+    lower: Antichain<B0::Time>,
+    upper: Antichain<B0::Time>,
+    held_times: Vec<B0::Time>,
+    builders: Vec<Bu>,
+    updates: Vec<Vec<(V2, B0::Time, R2)>>,
+    /// Dirty keys not yet processed this round, ascending. Values are in-region seeds.
+    remaining: BTreeMap<K, Vec<B0::Time>>,
+    /// Beyond-upper closure times discovered this round, folded into pending at finish.
+    deferred: BTreeMap<K, Vec<B0::Time>>,
+}
+
+/// A model-derived [`CoReduceTactic`]: for each key it recomputes output from scratch
+/// over the join-closure of the interesting times, diffing the desired output at each
+/// time against prior plus already-produced output. Correct by construction and slow by
+/// construction, so it is a differential-testing oracle for [`CursorTactic`], not a
+/// production engine.
+///
+/// [`CursorTactic`]: super::CursorTactic
+pub struct ReferenceTactic<B0, B1, BOut, K, V, V2, R2, Bu, L>
+where
+    B0: BatchReader,
+{
+    logic: L,
+    /// Staged interesting times by key, surviving across rounds. Holds both times not
+    /// yet retired (one input's frontier lags) and beyond-upper closure times.
+    pending: BTreeMap<K, Vec<B0::Time>>,
+    round: Option<RoundState<B0, B1, BOut, K, V2, R2, Bu>>,
+    _marker: PhantomData<(V, V2, R2)>,
+}
+
+impl<B0, B1, BOut, K, V, V2, R2, Bu, L> ReferenceTactic<B0, B1, BOut, K, V, V2, R2, Bu, L>
+where
+    B0: BatchReader,
+    K: Ord,
+{
+    pub fn new(logic: L) -> Self {
+        Self {
+            logic,
+            pending: BTreeMap::new(),
+            round: None,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<B0, B1, BOut, K, V, V2, R2, Bu, L> CoReduceTactic<B0, B1, BOut>
+    for ReferenceTactic<B0, B1, BOut, K, V, V2, R2, Bu, L>
+where
+    B0: BatchReader + Navigable + Clone,
+    B1: BatchReader<Time = B0::Time> + Navigable + Clone,
+    BOut: BatchReader<Time = B0::Time> + Navigable + Clone,
+    B0::Time: Timestamp + Lattice + Ord,
+    B0::Cursor: Cursor<Time = B0::Time>,
+    <B0::Cursor as Cursor>::Diff: Semigroup + Clone + 'static,
+    <B0::Cursor as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <B0::Cursor as Cursor>::ValContainer: BatchContainer<Owned = V>,
+    B1::Cursor: Cursor<Time = B0::Time, Diff = <B0::Cursor as Cursor>::Diff>,
+    <B1::Cursor as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <B1::Cursor as Cursor>::ValContainer: BatchContainer<Owned = V>,
+    BOut::Cursor: Cursor<Time = B0::Time, Diff = R2, ValOwn = V2>,
+    <BOut::Cursor as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <BOut::Cursor as Cursor>::ValContainer: BatchContainer<Owned = V2>,
+    K: Ord + Clone + 'static,
+    V: Ord + Clone + 'static,
+    V2: Ord + Clone + 'static,
+    R2: Abelian + Clone + 'static,
+    Bu: Builder<Time = B0::Time, Output = BOut> + 'static,
+    Bu::Input: Default + PushInto<((K, V2), B0::Time, R2)>,
+    L: FnMut(&K, &[&[(V, <B0::Cursor as Cursor>::Diff)]], &mut Vec<(V2, R2)>) + 'static,
+{
+    fn begin(
+        &mut self,
+        history0: Vec<B0>,
+        new0: Vec<B0>,
+        history1: Vec<B1>,
+        new1: Vec<B1>,
+        output: Vec<BOut>,
+        lower: &Antichain<B0::Time>,
+        upper: &Antichain<B0::Time>,
+        held: &Antichain<B0::Time>,
+    ) {
+        assert!(self.round.is_none(), "begin called with a round in flight");
+        for batch in &new0 {
+            let mut cursor = batch.cursor();
+            stage_times(&mut cursor, batch, &mut self.pending);
+        }
+        for batch in &new1 {
+            let mut cursor = batch.cursor();
+            stage_times(&mut cursor, batch, &mut self.pending);
+        }
+        // Partition the staged dirty set into this round's in-region seeds (processed
+        // under fuel) and beyond-upper times kept staged for a later round.
+        let mut remaining: BTreeMap<K, Vec<B0::Time>> = BTreeMap::new();
+        let mut kept: BTreeMap<K, Vec<B0::Time>> = BTreeMap::new();
+        for (key, times) in std::mem::take(&mut self.pending) {
+            let mut seeds = Vec::new();
+            let mut carried = Vec::new();
+            for t in times {
+                if upper.less_equal(&t) {
+                    carried.push(t);
+                } else {
+                    seeds.push(t);
+                }
+            }
+            if !seeds.is_empty() {
+                remaining.insert(key.clone(), seeds);
+            }
+            if !carried.is_empty() {
+                kept.insert(key, carried);
+            }
+        }
+        self.pending = kept;
+        let held_times: Vec<B0::Time> = held.elements().to_vec();
+        let builders: Vec<Bu> = (0..held_times.len()).map(|_| Bu::new()).collect();
+        let updates: Vec<Vec<(V2, B0::Time, R2)>> =
+            (0..held_times.len()).map(|_| Vec::new()).collect();
+        self.round = Some(RoundState {
+            history0,
+            history1,
+            output,
+            lower: lower.clone(),
+            upper: upper.clone(),
+            held_times,
+            builders,
+            updates,
+            remaining,
+            deferred: BTreeMap::new(),
+        });
+    }
+
+    fn step(&mut self, _fuel: usize) -> bool {
+        let Some(r) = self.round.as_mut() else {
+            return true;
+        };
+        let (mut input0_src, input0_stor) = cursor_list(r.history0.clone());
+        let (mut input1_src, input1_stor) = cursor_list(r.history1.clone());
+        let (mut out_cur, out_stor) = cursor_list(r.output.clone());
+
+        while let Some((key, seeds)) = r.remaining.pop_first() {
+            let mut hist0: Vec<(V, B0::Time, <B0::Cursor as Cursor>::Diff)> = Vec::new();
+            let mut hist1: Vec<(V, B0::Time, <B0::Cursor as Cursor>::Diff)> = Vec::new();
+            let mut prior: Vec<(V2, B0::Time, R2)> = Vec::new();
+            if seek_owned_key(&mut input0_src, &input0_stor, &key) {
+                read_key_values(&mut input0_src, &input0_stor, &mut hist0);
+            }
+            if seek_owned_key(&mut input1_src, &input1_stor, &key) {
+                read_key_values(&mut input1_src, &input1_stor, &mut hist1);
+            }
+            if seek_owned_key(&mut out_cur, &out_stor, &key) {
+                read_key_values(&mut out_cur, &out_stor, &mut prior);
+            }
+
+            // The time universe: seeds, both input histories, prior output. Closed under
+            // join by naive fixpoint. The closure of a finite set under an idempotent,
+            // commutative, associative join is finite, so this terminates.
+            let mut times: Vec<B0::Time> = seeds;
+            times.extend(hist0.iter().map(|(_, t, _)| t.clone()));
+            times.extend(hist1.iter().map(|(_, t, _)| t.clone()));
+            times.extend(prior.iter().map(|(_, t, _)| t.clone()));
+            times.sort();
+            times.dedup();
+            loop {
+                let mut grown = Vec::new();
+                for i in 0..times.len() {
+                    for j in (i + 1)..times.len() {
+                        let joined = times[i].join(&times[j]);
+                        if times.binary_search(&joined).is_err() {
+                            grown.push(joined);
+                        }
+                    }
+                }
+                if grown.is_empty() {
+                    break;
+                }
+                times.extend(grown);
+                times.sort();
+                times.dedup();
+            }
+
+            // Beyond-upper times are withheld for a later round.
+            let mut deferred = Vec::new();
+            times.retain(|t| {
+                if r.upper.less_equal(t) {
+                    deferred.push(t.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+            if !deferred.is_empty() {
+                deferred.sort();
+                deferred.dedup();
+                r.deferred.entry(key.clone()).or_default().extend(deferred);
+            }
+
+            // Evaluate ascending by Ord. Correctness requires Ord to be a linear
+            // extension of the partial order, so that every t' < t is evaluated before t
+            // and `produced` is complete when t reads it.
+            let mut produced: Vec<(V2, B0::Time, R2)> = Vec::new();
+            for t in &times {
+                let mut acc0: Vec<(V, <B0::Cursor as Cursor>::Diff)> = hist0
+                    .iter()
+                    .filter(|(_, ti, _)| PartialOrder::less_equal(ti, t))
+                    .map(|(v, _, d)| (v.clone(), d.clone()))
+                    .collect();
+                consolidate(&mut acc0);
+                let mut acc1: Vec<(V, <B0::Cursor as Cursor>::Diff)> = hist1
+                    .iter()
+                    .filter(|(_, ti, _)| PartialOrder::less_equal(ti, t))
+                    .map(|(v, _, d)| (v.clone(), d.clone()))
+                    .collect();
+                consolidate(&mut acc1);
+
+                let mut desired_list: Vec<(V2, R2)> = Vec::new();
+                (self.logic)(&key, &[&acc0, &acc1], &mut desired_list);
+                consolidate(&mut desired_list);
+                let desired: BTreeMap<V2, R2> = desired_list.into_iter().collect();
+
+                // Current output as of `t`: prior plus this-round produced, values with
+                // time <= t. `consolidate` combines per value and drops zeros.
+                let mut current_list: Vec<(V2, R2)> = prior
+                    .iter()
+                    .chain(produced.iter())
+                    .filter(|(_, ti, _)| PartialOrder::less_equal(ti, t))
+                    .map(|(v, _, d)| (v.clone(), d.clone()))
+                    .collect();
+                consolidate(&mut current_list);
+                let current: BTreeMap<V2, R2> = current_list.into_iter().collect();
+
+                // Delta per value over the union of both maps. The (present, absent)
+                // cases avoid an additive-zero constructor, which R2: Abelian lacks: the
+                // desired-only delta is `desired[v]`, the current-only delta is
+                // `-current[v]`, computed directly.
+                let values: BTreeSet<V2> = desired.keys().chain(current.keys()).cloned().collect();
+                for v in values {
+                    let delta = match (desired.get(&v), current.get(&v)) {
+                        (Some(d), Some(c)) => {
+                            let mut delta = d.clone();
+                            let mut neg = c.clone();
+                            neg.negate();
+                            delta.plus_equals(&neg);
+                            delta
+                        }
+                        (Some(d), None) => d.clone(),
+                        (None, Some(c)) => {
+                            let mut neg = c.clone();
+                            neg.negate();
+                            neg
+                        }
+                        (None, None) => unreachable!("value came from the union of both maps"),
+                    };
+                    if delta.is_zero() {
+                        continue;
+                    }
+                    // Assign the delta to the latest held time covering t, as the driver
+                    // mints capabilities only at held times.
+                    let idx = r
+                        .held_times
+                        .iter()
+                        .enumerate()
+                        .rev()
+                        .find(|(_, ht)| PartialOrder::less_equal(*ht, t))
+                        .map(|(i, _)| i)
+                        .expect("a held time covers every produced time");
+                    produced.push((v.clone(), t.clone(), delta.clone()));
+                    r.updates[idx].push((v, t.clone(), delta));
+                }
+            }
+
+            // Push into builders, value-sorted, same as the cursor tactic.
+            for i in 0..r.held_times.len() {
+                if r.updates[i].is_empty() {
+                    continue;
+                }
+                r.updates[i].sort_by(|a, b| a.0.cmp(&b.0));
+                let mut buffer = <Bu::Input>::default();
+                for (v2, time, r2) in r.updates[i].drain(..) {
+                    buffer.push_into(((key.clone(), v2), time, r2));
+                }
+                r.builders[i].push(&mut buffer);
+            }
+        }
+        true
+    }
+
+    fn finish(&mut self) -> (Vec<(B0::Time, BOut)>, Antichain<B0::Time>) {
+        let r = self.round.take().expect("finish called without a round");
+        assert!(r.remaining.is_empty(), "finish called with keys remaining");
+        let produced = build_tiled_batches(&r.held_times, r.builders, &r.lower, &r.upper);
+        // Fold the round's deferred times back into pending, which still holds the
+        // carried beyond-upper times from begin.
+        for (key, mut times) in r.deferred {
+            let entry = self.pending.entry(key).or_default();
+            entry.append(&mut times);
+            entry.sort();
+            entry.dedup();
+        }
+        let mut frontier = Antichain::new();
+        for times in self.pending.values() {
+            for t in times {
+                frontier.insert(t.clone());
+            }
+        }
+        (produced, frontier)
+    }
+}
+
+/// Runs the two-input reduction with the model-derived [`ReferenceTactic`], the analogue
+/// of [`super::co_reduce2`]. Same result contract, intended for differential testing of
+/// the two tactics against each other. A testing oracle, not a stable entry point to
+/// build on.
+pub fn co_reduce2_reference<'scope, T, Tr1, Tr2, K, V, V2, R2, Bu, Out, L>(
+    input0: Arranged<'scope, Tr1>,
+    input1: Arranged<'scope, Tr2>,
+    name: &str,
+    fuel: usize,
+    logic: L,
+) -> Arranged<'scope, TraceAgent<Out>>
+where
+    T: Timestamp + Lattice + Ord,
+    // The inputs are read only through their batch cursors, so all key, value, and diff
+    // opinions are stated on `BatchCursor<Tr>` rather than on the trace itself, which in this
+    // differential version carries only a time opinion. Both batches must be `Navigable` so the
+    // operator can build cursors over them.
+    Tr1: TraceReader<Time = T> + Clone + 'static,
+    Tr1::Batch: Navigable,
+    Tr2: TraceReader<Time = T> + Clone + 'static,
+    Tr2::Batch: Navigable,
+    BatchCursor<Tr1>: Cursor<Time = T>,
+    <BatchCursor<Tr1> as Cursor>::Diff: Semigroup + Clone + 'static,
+    <BatchCursor<Tr1> as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <BatchCursor<Tr1> as Cursor>::ValContainer: BatchContainer<Owned = V>,
+    // `Tr2`'s diff is pinned to `Tr1`'s so both inputs feed the closure as the one input diff
+    // type, and its key and value containers carry the same owned types.
+    BatchCursor<Tr2>: Cursor<Time = T, Diff = BatchDiff<Tr1>>,
+    <BatchCursor<Tr2> as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <BatchCursor<Tr2> as Cursor>::ValContainer: BatchContainer<Owned = V>,
+    K: Ord + Clone + 'static,
+    V: Ord + Clone + 'static,
+    V2: Ord + Clone + 'static,
+    R2: Abelian + Clone + 'static,
+    Out: Trace<Time = T> + 'static,
+    Out::Batch: Navigable,
+    BatchCursor<Out>: Cursor<Time = T, Diff = R2, ValOwn = V2>,
+    <BatchCursor<Out> as Cursor>::KeyContainer: BatchContainer<Owned = K>,
+    <BatchCursor<Out> as Cursor>::ValContainer: BatchContainer<Owned = V2>,
+    // `Bu::Input` is only required to be default-constructible and to accept output tuples.
+    // This admits builders whose input is not a `Vec` (for example a columnar stack), which
+    // a `Vec`-typed bound would reject.
+    Bu: Builder<Time = T, Output = Out::Batch> + 'static,
+    Bu::Input: Default + PushInto<((K, V2), T, R2)>,
+    L: FnMut(&K, &[&[(V, BatchDiff<Tr1>)]], &mut Vec<(V2, R2)>) + 'static,
+{
+    super::co_reduce2_with_tactic(
+        input0,
+        input1,
+        name,
+        fuel,
+        ReferenceTactic::<Tr1::Batch, Tr2::Batch, Out::Batch, K, V, V2, R2, Bu, L>::new(logic),
+    )
+}

--- a/src/timely-util/src/co_reduce/tests.rs
+++ b/src/timely-util/src/co_reduce/tests.rs
@@ -1,0 +1,1235 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The tests drive the operator with differential's stock `arrange_by_key`, which the
+// repo lint discourages in favor of the compute-crate `MzArrange` wrapper. This crate
+// has no such wrapper, and the stock arrangement is exactly what these unit tests need.
+#![allow(clippy::disallowed_methods)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
+
+use super::cursor::{own_current_key, read_key_values};
+use super::*;
+use differential_dataflow::AsCollection;
+use differential_dataflow::input::Input;
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::operators::iterate::Variable;
+use differential_dataflow::trace::implementations::ord_neu::{OrdValSpine, RcOrdValBuilder};
+use proptest::prelude::*;
+use proptest::strategy::Union;
+use timely::dataflow::operators::capture::Extract;
+use timely::dataflow::operators::vec::UnorderedInput;
+use timely::dataflow::operators::{Capture, Inspect, Probe, ToStream};
+use timely::order::{PartialOrder, Product};
+
+type Spine = OrdValSpine<u64, u64, u64, isize>;
+type Builder_ = RcOrdValBuilder<u64, u64, u64, isize>;
+
+/// Net-of-two closure: input 0 positive, input 1 negated, keep positive residual on
+/// the empty output value `0u64`.
+fn net_positive(_k: &u64, inputs: &[&[(u64, isize)]], out: &mut Vec<(u64, isize)>) {
+    let sum = |s: &[(u64, isize)]| s.iter().map(|(_v, d)| *d).sum::<isize>();
+    let net = sum(inputs[0]) - sum(inputs[1]);
+    if net > 0 {
+        out.push((0u64, net));
+    }
+}
+
+#[mz_ore::test]
+fn co_reduce_sum_two_inputs_static() {
+    let captured = timely::execute_directly(move |worker| {
+        let (mut in0, mut in1, cap) = worker.dataflow(|scope| {
+            let (h0, c0) = scope.new_collection::<u64, isize>();
+            let (h1, c1) = scope.new_collection::<u64, isize>();
+            let a0 = c0.map(|k| (k, k)).arrange_by_key();
+            let a1 = c1.map(|k| (k, k)).arrange_by_key();
+            let out = co_reduce2::<
+                u64,
+                TraceAgent<Spine>,
+                TraceAgent<Spine>,
+                u64,
+                u64,
+                u64,
+                isize,
+                Builder_,
+                Spine,
+                _,
+            >(a0, a1, "test", usize::MAX, net_positive);
+            let cap = out.as_collection(|k, _v| *k).inner.capture();
+            (h0, h1, cap)
+        });
+        // input 0: keys 1,2,3 each once; input 1: key 2 once, key 3 twice.
+        // net: 1 -> +1 (keep), 2 -> 0 (drop), 3 -> -1 (drop). Output: {1}.
+        in0.insert(1);
+        in0.insert(2);
+        in0.insert(3);
+        in1.insert(2);
+        in1.insert(3);
+        in1.insert(3);
+        in0.close();
+        in1.close();
+        cap
+    });
+    let mut rows: Vec<(u64, u64, isize)> = captured
+        .extract()
+        .into_iter()
+        .flat_map(|(_t, data)| data)
+        .map(|(k, _t, r)| (k, 0u64, r))
+        .collect();
+    rows.sort();
+    assert_eq!(rows, vec![(1u64, 0u64, 1isize)]);
+}
+
+#[mz_ore::test]
+fn co_reduce_reference_smoke() {
+    let captured = timely::execute_directly(move |worker| {
+        let (mut in0, mut in1, cap) = worker.dataflow(|scope| {
+            let (h0, c0) = scope.new_collection::<u64, isize>();
+            let (h1, c1) = scope.new_collection::<u64, isize>();
+            let a0 = c0.map(|k| (k, k)).arrange_by_key();
+            let a1 = c1.map(|k| (k, k)).arrange_by_key();
+            let out = super::co_reduce2_reference::<
+                u64,
+                TraceAgent<Spine>,
+                TraceAgent<Spine>,
+                u64,
+                u64,
+                u64,
+                isize,
+                Builder_,
+                Spine,
+                _,
+            >(a0, a1, "test", usize::MAX, net_positive);
+            let cap = out.as_collection(|k, _v| *k).inner.capture();
+            (h0, h1, cap)
+        });
+        // input 0: keys 1,2,3 each once; input 1: key 2 once, key 3 twice.
+        // net: 1 -> +1 (keep), 2 -> 0 (drop), 3 -> -1 (drop). Output: {1}.
+        in0.insert(1);
+        in0.insert(2);
+        in0.insert(3);
+        in1.insert(2);
+        in1.insert(3);
+        in1.insert(3);
+        in0.close();
+        in1.close();
+        cap
+    });
+    let mut rows: Vec<(u64, u64, isize)> = captured
+        .extract()
+        .into_iter()
+        .flat_map(|(_t, data)| data)
+        .map(|(k, _t, r)| (k, 0u64, r))
+        .collect();
+    rows.sort();
+    assert_eq!(rows, vec![(1u64, 0u64, 1isize)]);
+}
+
+#[mz_ore::test]
+fn co_reduce_incremental() {
+    let captured = timely::execute_directly(move |worker| {
+        let (mut in0, mut in1, probe, cap) = worker.dataflow(|scope| {
+            let (h0, c0) = scope.new_collection::<u64, isize>();
+            let (h1, c1) = scope.new_collection::<u64, isize>();
+            let a0 = c0.map(|k| (k, k)).arrange_by_key();
+            let a1 = c1.map(|k| (k, k)).arrange_by_key();
+            let out = co_reduce2::<
+                u64,
+                TraceAgent<Spine>,
+                TraceAgent<Spine>,
+                u64,
+                u64,
+                u64,
+                isize,
+                Builder_,
+                Spine,
+                _,
+            >(a0, a1, "test", usize::MAX, net_positive);
+            let coll = out.as_collection(|k, _v| *k);
+            let (probe, probed) = coll.inner.probe();
+            let cap = probed.capture();
+            (h0, h1, probe, cap)
+        });
+
+        // Round 1 (time 0): in0={1,1}, in1={1}. net(1) = 2 - 1 = +1 -> output +1.
+        in0.insert(1);
+        in0.insert(1);
+        in1.insert(1);
+        in0.advance_to(1);
+        in1.advance_to(1);
+        in0.flush();
+        in1.flush();
+        worker.step_while(|| probe.less_than(in0.time()));
+
+        // Round 2 (time 1): retract one in0 1. net(1) = 1 - 1 = 0 -> retract -> -1.
+        in0.remove(1);
+        in0.advance_to(2);
+        in1.advance_to(2);
+        in0.flush();
+        in1.flush();
+        worker.step_while(|| probe.less_than(in0.time()));
+
+        // Round 3 (time 2): insert in0 1 once. net(1) = 2 - 1 = +1 -> output +1.
+        in0.insert(1);
+        in0.advance_to(3);
+        in1.advance_to(3);
+        in0.flush();
+        in1.flush();
+        worker.step_while(|| probe.less_than(in0.time()));
+
+        in0.close();
+        in1.close();
+        cap
+    });
+
+    let stream: Vec<(u64, u64, isize)> = captured
+        .extract()
+        .into_iter()
+        .flat_map(|(t, data)| data.into_iter().map(move |(k, _t, r)| (k, t, r)))
+        .collect();
+
+    // The round-2 retraction must appear in the change stream.
+    assert!(
+        stream.iter().any(|(k, _t, r)| *k == 1 && *r == -1),
+        "expected a retraction of key 1 in the change stream, got {stream:?}"
+    );
+
+    // Consolidating over time leaves the net multiplicity +1 for key 1.
+    let mut consolidated: BTreeMap<u64, isize> = BTreeMap::new();
+    for (k, _t, r) in &stream {
+        *consolidated.entry(*k).or_default() += *r;
+    }
+    consolidated.retain(|_k, r| *r != 0);
+    assert_eq!(
+        consolidated.into_iter().collect::<Vec<_>>(),
+        vec![(1u64, 1isize)]
+    );
+}
+
+/// Value-aware closure: output the maximum present value across all inputs, with diff
+/// `+1`. A collapsed empty-value operator could not express this.
+fn max_present(_k: &u64, inputs: &[&[(u64, isize)]], out: &mut Vec<(u64, isize)>) {
+    let mut best: Option<u64> = None;
+    for slice in inputs {
+        for (v, d) in *slice {
+            if *d > 0 {
+                best = Some(best.map_or(*v, |b| b.max(*v)));
+            }
+        }
+    }
+    if let Some(v) = best {
+        out.push((v, 1));
+    }
+}
+
+#[mz_ore::test]
+fn co_reduce_value_aware() {
+    let captured = timely::execute_directly(move |worker| {
+        let (mut in0, mut in1, cap) = worker.dataflow(|scope| {
+            let (h0, c0) = scope.new_collection::<(u64, u64), isize>();
+            let (h1, c1) = scope.new_collection::<(u64, u64), isize>();
+            let a0 = c0.arrange_by_key();
+            let a1 = c1.arrange_by_key();
+            let out = co_reduce2::<
+                u64,
+                TraceAgent<Spine>,
+                TraceAgent<Spine>,
+                u64,
+                u64,
+                u64,
+                isize,
+                Builder_,
+                Spine,
+                _,
+            >(a0, a1, "test", usize::MAX, max_present);
+            // Retain the output value: the closure keys output on input values.
+            let cap = out.as_collection(|k, v| (*k, *v)).inner.capture();
+            (h0, h1, cap)
+        });
+        // key 1: in0 value 10, in1 value 20, both +1. max = 20 -> ((1, 20), +1).
+        in0.insert((1, 10));
+        in1.insert((1, 20));
+        in0.close();
+        in1.close();
+        cap
+    });
+    let mut rows: Vec<((u64, u64), isize)> = captured
+        .extract()
+        .into_iter()
+        .flat_map(|(_t, data)| data)
+        .map(|(kv, _t, r)| (kv, r))
+        .collect();
+    rows.sort();
+    assert_eq!(rows, vec![((1u64, 20u64), 1isize)]);
+}
+
+/// Echoes every input `(value, diff)` unchanged, so one key emits every distinct
+/// input value as its own output value.
+fn echo_values(_k: &u64, inputs: &[&[(u64, isize)]], out: &mut Vec<(u64, isize)>) {
+    for slice in inputs {
+        for (v, d) in *slice {
+            out.push((*v, *d));
+        }
+    }
+}
+
+#[mz_ore::test]
+fn co_reduce_multi_value_per_key() {
+    // Read the output arrangement back through its batch stream. A linear scan of a
+    // batch (or `as_collection` + external consolidation) always recovers the correct
+    // multiset even from a value-unsorted batch, because updates are only ever combined
+    // when values compare equal, never dropped. So the corruption is invisible to a
+    // summed readback. It is visible only in the batch's stored value order, which
+    // downstream value seeks (binary search) and spine merges rely on being ascending.
+    //
+    // Batches are `Rc`-backed (neither `Send` nor `Ord`), so they cannot leave the
+    // worker via `capture`/`extract`. Instead an `inspect_batch` walks each batch's
+    // cursor in place and records, per key, its `(value, time, diff)` updates in stored
+    // order into a shared buffer.
+    type Recorded = Vec<(u64, Vec<(u64, u64, isize)>)>;
+    let recorded: Arc<Mutex<Recorded>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&recorded);
+    timely::execute_directly(move |worker| {
+        worker.dataflow::<u64, _, _>(|scope| {
+            // Key 1 gains a new distinct value at each of three times, in non-ascending
+            // value order. Feeding all updates as one stream message makes
+            // `arrange_by_key` form a single batch spanning times 0, 1, 2 under one
+            // capability, so all three times retire in one round under that capability.
+            // `emit_deltas` appends them to the same per-key buffer time-major
+            // (30@t0, 10@t1, 20@t2), i.e. value-unsorted. Without the value sort the
+            // builder writes the vals in that order, violating the batch invariant.
+            let a0 = vec![
+                ((1u64, 30u64), 0, 1isize),
+                ((1u64, 10u64), 1, 1isize),
+                ((1u64, 20u64), 2, 1isize),
+            ]
+            .to_stream(scope)
+            .as_collection()
+            .arrange_by_key();
+            // `co_reduce2` is two-input. The second arm carries no updates, so
+            // `echo_values` echoes only `a0` and the stored-order guard still holds.
+            let a1 = Vec::<((u64, u64), u64, isize)>::new()
+                .to_stream(scope)
+                .as_collection()
+                .arrange_by_key();
+            let out = co_reduce2::<
+                u64,
+                TraceAgent<Spine>,
+                TraceAgent<Spine>,
+                u64,
+                u64,
+                u64,
+                isize,
+                Builder_,
+                Spine,
+                _,
+            >(a0, a1, "test", usize::MAX, echo_values);
+            out.stream.inspect_batch(move |_t, batches| {
+                let mut recorded = sink.lock().expect("lock poisoned");
+                for batch in batches {
+                    let mut cursor = batch.cursor();
+                    while cursor.key_valid(batch) {
+                        let key = own_current_key::<_, u64>(&cursor, batch);
+                        let mut updates: Vec<(u64, u64, isize)> = Vec::new();
+                        read_key_values(&mut cursor, batch, &mut updates);
+                        recorded.push((key, updates));
+                        cursor.step_key(batch);
+                    }
+                }
+            });
+        });
+    });
+
+    let recorded = Arc::try_unwrap(recorded)
+        .expect("no outstanding references")
+        .into_inner()
+        .expect("lock poisoned");
+
+    // The batch invariant: within a batch each key's stored values are strictly
+    // ascending. The pre-fix code stores them time-major (30, 10, 20), failing this.
+    for (key, updates) in &recorded {
+        let mut vals_order: Vec<u64> = Vec::new();
+        for (v, _t, _d) in updates {
+            if vals_order.last() != Some(v) {
+                vals_order.push(*v);
+            }
+        }
+        let mut sorted = vals_order.clone();
+        sorted.sort();
+        assert_eq!(
+            vals_order, sorted,
+            "key {key} stored values are not ascending: {vals_order:?}"
+        );
+    }
+
+    // The multiset is correct regardless (see the note above), asserted for completeness.
+    let mut multiset: BTreeMap<(u64, u64), isize> = BTreeMap::new();
+    for (key, updates) in &recorded {
+        for (v, _t, d) in updates {
+            *multiset.entry((*key, *v)).or_default() += d;
+        }
+    }
+    multiset.retain(|_kv, r| *r != 0);
+    assert_eq!(
+        multiset.into_iter().collect::<Vec<_>>(),
+        vec![((1, 10), 1), ((1, 20), 1), ((1, 30), 1)]
+    );
+}
+
+/// Builds a one-round dataflow with `keys` keys, all present once in input 0 only (net
+/// `+1` each), drives the single worker to completion counting worker steps, and returns
+/// the consolidated output multiset and the step count.
+///
+/// The step count is the yielding witness. `co_reduce2` is the only operator that
+/// re-activates itself here (via its fuel path), so extra steps under a small fuel
+/// isolate its yielding. We count worker steps rather than the operator's own closure
+/// invocations because the closure is internal to `co_reduce2` and cannot be hooked
+/// without changing its signature.
+fn run_fueled_round(fuel: usize, keys: u64) -> (Vec<(u64, isize)>, usize) {
+    let (captured, steps) = timely::execute_directly(move |worker| {
+        let (mut in0, in1, cap) = worker.dataflow(|scope| {
+            let (h0, c0) = scope.new_collection::<u64, isize>();
+            let (h1, c1) = scope.new_collection::<u64, isize>();
+            let a0 = c0.map(|k| (k, k)).arrange_by_key();
+            let a1 = c1.map(|k| (k, k)).arrange_by_key();
+            let out = co_reduce2::<
+                u64,
+                TraceAgent<Spine>,
+                TraceAgent<Spine>,
+                u64,
+                u64,
+                u64,
+                isize,
+                Builder_,
+                Spine,
+                _,
+            >(a0, a1, "test", fuel, net_positive);
+            let cap = out.as_collection(|k, _v| *k).inner.capture();
+            (h0, h1, cap)
+        });
+
+        for k in 0..keys {
+            in0.insert(k);
+        }
+        in0.close();
+        in1.close();
+
+        // Drive to completion, counting steps. Each `co_reduce2` self-reactivation
+        // under fuel adds a step.
+        let mut steps = 0usize;
+        while worker.step() {
+            steps += 1;
+        }
+        (cap, steps)
+    });
+
+    let mut consolidated: BTreeMap<u64, isize> = BTreeMap::new();
+    for (_t, data) in captured.extract() {
+        for (k, _t, r) in data {
+            *consolidated.entry(k).or_default() += r;
+        }
+    }
+    consolidated.retain(|_k, r| *r != 0);
+    (consolidated.into_iter().collect(), steps)
+}
+
+#[mz_ore::test]
+fn co_reduce_fuels() {
+    // Stage a dirty set far larger than the fuel budget in one round. Assert both that
+    // the final output is correct and complete and that the operator yielded (took more
+    // steps than the same round drained in one shot). The complete-output assertion
+    // guards the invariant that a round is never sealed while any dirty key still owes
+    // output: a premature seal would drop the deferred keys' `+1`s from the result.
+    const KEYS: u64 = 8_000;
+    const SMALL_FUEL: usize = 100;
+
+    let expected: Vec<(u64, isize)> = (0..KEYS).map(|k| (k, 1isize)).collect();
+
+    // Small fuel: many activations. Large fuel: the whole round drains in one activation.
+    let (out_small, steps_small) = run_fueled_round(SMALL_FUEL, KEYS);
+    let (out_large, steps_large) = run_fueled_round(usize::MAX, KEYS);
+
+    // (1) Output is correct and complete under both budgets: fueling shed no work.
+    assert_eq!(out_small, expected, "small-fuel output incomplete or wrong");
+    assert_eq!(out_large, expected, "large-fuel output incomplete or wrong");
+
+    // (2) The small-fuel run took strictly more worker steps, proving `co_reduce2`
+    // re-activated itself to yield rather than draining the whole dirty set in one shot.
+    assert!(
+        steps_small > steps_large,
+        "expected fueling to add worker steps: small={steps_small}, large={steps_large}"
+    );
+    assert!(
+        steps_small > 1,
+        "expected the fueled operator to take more than one activation, took {steps_small}"
+    );
+}
+
+#[mz_ore::test]
+fn co_reduce_fuels_retraction() {
+    // `co_reduce_fuels` only covers insertion under small fuel. Retraction is the case
+    // that actually stresses the fuel/seal interaction: a round must not seal while any
+    // fuel-deferred key still owes a retraction, or the stale `+1` from a prior round
+    // would survive in the output. Stage a dirty set (KEYS/2) far larger than the fuel
+    // budget for the retracting round, so it spans many activations before it seals.
+    const KEYS: u64 = 8_000;
+    const SMALL_FUEL: usize = 100;
+
+    let stream: Vec<(u64, u64, isize)> = {
+        let captured = timely::execute_directly(move |worker| {
+            let (mut in0, mut in1, probe, cap) = worker.dataflow(|scope| {
+                let (h0, c0) = scope.new_collection::<u64, isize>();
+                let (h1, c1) = scope.new_collection::<u64, isize>();
+                let a0 = c0.map(|k| (k, k)).arrange_by_key();
+                let a1 = c1.map(|k| (k, k)).arrange_by_key();
+                let out = co_reduce2::<
+                    u64,
+                    TraceAgent<Spine>,
+                    TraceAgent<Spine>,
+                    u64,
+                    u64,
+                    u64,
+                    isize,
+                    Builder_,
+                    Spine,
+                    _,
+                >(a0, a1, "test", SMALL_FUEL, net_positive);
+                let coll = out.as_collection(|k, _v| *k);
+                let (probe, probed) = coll.inner.probe();
+                let cap = probed.capture();
+                (h0, h1, probe, cap)
+            });
+
+            // Round 1 (time 0): every key present once in input 0 only. net(k) = 1 for
+            // all KEYS keys -> output +1 each.
+            for k in 0..KEYS {
+                in0.insert(k);
+            }
+            in0.advance_to(1);
+            in1.advance_to(1);
+            in0.flush();
+            in1.flush();
+            worker.step_while(|| probe.less_than(in0.time()));
+
+            // Round 2 (time 1): retract the first half of the keys by matching them on
+            // input 1, netting those keys to 0 -> output -1 each. The other half is
+            // untouched and stays at +1.
+            for k in 0..KEYS / 2 {
+                in1.insert(k);
+            }
+            in0.advance_to(2);
+            in1.advance_to(2);
+            in0.flush();
+            in1.flush();
+            worker.step_while(|| probe.less_than(in0.time()));
+
+            in0.close();
+            in1.close();
+            cap
+        });
+
+        captured
+            .extract()
+            .into_iter()
+            .flat_map(|(t, data)| data.into_iter().map(move |(k, _t, r)| (k, t, r)))
+            .collect()
+    };
+
+    // Every retracted key must appear as a negative diff in the change stream, not merely
+    // be absent from the final consolidated output: fuel must retract explicitly, not
+    // just fail to re-emit.
+    let mut retracted: BTreeSet<u64> = BTreeSet::new();
+    for (k, _t, r) in &stream {
+        if *k < KEYS / 2 && *r < 0 {
+            retracted.insert(*k);
+        }
+    }
+    assert_eq!(
+        retracted.len(),
+        usize::try_from(KEYS / 2).expect("KEYS/2 fits in usize"),
+        "expected every retracted key to appear as a negative diff in the change stream"
+    );
+
+    // Consolidating over time leaves exactly the surviving keys, each once.
+    let mut consolidated: BTreeMap<u64, isize> = BTreeMap::new();
+    for (k, _t, r) in &stream {
+        *consolidated.entry(*k).or_default() += r;
+    }
+    consolidated.retain(|_k, r| *r != 0);
+    let expected: Vec<(u64, isize)> = (KEYS / 2..KEYS).map(|k| (k, 1isize)).collect();
+    assert_eq!(
+        consolidated.into_iter().collect::<Vec<_>>(),
+        expected,
+        "final output must be exactly the surviving keys"
+    );
+}
+
+// ===================== Partially ordered timestamp: harness and fixed cases =====================
+//
+// `Pair` is a partially ordered timestamp: two updates at incomparable times can have a join that
+// neither input mentions, and a non-linear `logic` can produce a real delta only visible at that
+// synthetic join time. `run_pair` below drives `co_reduce2` (or the reference tactic) at `Pair`
+// times so Tasks 5-6 can fuzz the two tactics against each other and against a from-scratch model.
+
+/// A partially ordered test timestamp. Product's derived Ord is lexicographic, a
+/// linear extension of its componentwise PartialOrder, as the tactics' evaluation
+/// order requires.
+type Pair = Product<u64, u64>;
+type PairSpine = OrdValSpine<u64, u64, Pair, isize>;
+type PairBuilder = RcOrdValBuilder<u64, u64, Pair, isize>;
+type Logic = fn(&u64, &[&[(u64, isize)]], &mut Vec<(u64, isize)>);
+
+/// Runs both inputs through `co_reduce2` (or the reference tactic, if `reference`) at `Pair`
+/// timestamps and returns the raw captured change stream.
+fn run_pair(
+    updates0: &[((u64, u64), Pair, isize)],
+    updates1: &[((u64, u64), Pair, isize)],
+    fuel: usize,
+    logic: Logic,
+    reference: bool,
+) -> Vec<((u64, u64), Pair, isize)> {
+    let updates0 = updates0.to_vec();
+    let updates1 = updates1.to_vec();
+    let captured = timely::execute_directly(move |worker| {
+        // `Pair` refines `u64` (its own outer coordinate), not `()`, so it cannot be the root
+        // dataflow's timestamp directly: `worker.dataflow` requires `Refines<()>`. Host the
+        // computation in a `Pair`-timestamped child scope of a `u64`-timestamped root instead.
+        // The root does nothing but satisfy that bound.
+        let (mut input0, cap0, mut input1, cap1, cap) = worker.dataflow::<u64, _, _>(|root| {
+            root.scoped::<Pair, _, _>("co_reduce_pair_test", |scope| {
+                let ((input0, cap0), stream0) =
+                    scope.new_unordered_input::<((u64, u64), Pair, isize)>();
+                let ((input1, cap1), stream1) =
+                    scope.new_unordered_input::<((u64, u64), Pair, isize)>();
+                let a0 = stream0.as_collection().arrange_by_key();
+                let a1 = stream1.as_collection().arrange_by_key();
+                let out = if reference {
+                    co_reduce2_reference::<
+                        Pair,
+                        TraceAgent<PairSpine>,
+                        TraceAgent<PairSpine>,
+                        u64,
+                        u64,
+                        u64,
+                        isize,
+                        PairBuilder,
+                        PairSpine,
+                        _,
+                    >(a0, a1, "test", fuel, logic)
+                } else {
+                    co_reduce2::<
+                        Pair,
+                        TraceAgent<PairSpine>,
+                        TraceAgent<PairSpine>,
+                        u64,
+                        u64,
+                        u64,
+                        isize,
+                        PairBuilder,
+                        PairSpine,
+                        _,
+                    >(a0, a1, "test", fuel, logic)
+                };
+                let cap = out.as_collection(|k, v| (*k, *v)).inner.capture();
+                (input0, cap0, input1, cap1, cap)
+            })
+        });
+        for u in updates0 {
+            input0
+                .activate()
+                .session(&cap0.delayed(&u.1))
+                .give(u.clone());
+        }
+        for u in updates1 {
+            input1
+                .activate()
+                .session(&cap1.delayed(&u.1))
+                .give(u.clone());
+        }
+        drop(cap0);
+        drop(cap1);
+        while worker.step() {}
+        cap
+    });
+    captured
+        .extract()
+        .into_iter()
+        .flat_map(|(_t, data)| data)
+        .collect()
+}
+
+/// Consolidates a change stream: sums diffs per `((key, value), time)`, drops zeros.
+fn consolidate_updates(
+    mut stream: Vec<((u64, u64), Pair, isize)>,
+) -> Vec<((u64, u64), Pair, isize)> {
+    stream.sort_by(|a, b| (a.0, a.1).cmp(&(b.0, b.1)));
+    let mut out: Vec<((u64, u64), Pair, isize)> = Vec::new();
+    for (kv, t, d) in stream {
+        match out.last_mut() {
+            Some((lkv, lt, ld)) if *lkv == kv && *lt == t => *ld += d,
+            _ => out.push((kv, t, d)),
+        }
+    }
+    out.retain(|(_, _, d)| *d != 0);
+    out
+}
+
+/// The canonical partial-order case: two updates at incomparable times, fed through a linear
+/// `logic` (`net_positive`). Their join `(1, 1)` is a time neither input mentions. Since
+/// `net_positive` is linear, the output at the join equals the sum of the outputs at the two
+/// updates' own times, so no extra delta is owed there. The exact stream is just the two
+/// per-update emissions, each at its own time.
+#[mz_ore::test]
+fn co_reduce_pair_synthetic_time() {
+    let updates0 = vec![
+        ((1u64, 10u64), Pair::new(0, 1), 1isize),
+        ((1u64, 11u64), Pair::new(1, 0), 1isize),
+    ];
+    let updates1 = vec![];
+    let cursor = consolidate_updates(run_pair(
+        &updates0,
+        &updates1,
+        usize::MAX,
+        net_positive,
+        false,
+    ));
+    let reference = consolidate_updates(run_pair(
+        &updates0,
+        &updates1,
+        usize::MAX,
+        net_positive,
+        true,
+    ));
+    assert_eq!(cursor, reference);
+    let expected = vec![
+        ((1u64, 0u64), Pair::new(0, 1), 1isize),
+        ((1u64, 0u64), Pair::new(1, 0), 1isize),
+    ];
+    assert_eq!(cursor, expected);
+}
+
+/// A genuinely non-linear logic (thresholded net): below threshold 2 the output is empty, at or
+/// above it the output is a single row. Net at each of the two incomparable times is 1 (below
+/// threshold, empty), but net at their join is 2 (at threshold), so the join carries a REAL delta
+/// that neither input time can produce on its own.
+fn net_at_least_two(_k: &u64, inputs: &[&[(u64, isize)]], out: &mut Vec<(u64, isize)>) {
+    let sum = |s: &[(u64, isize)]| s.iter().map(|(_v, d)| *d).sum::<isize>();
+    let net = sum(inputs[0]) - sum(inputs[1]);
+    if net >= 2 {
+        out.push((0u64, 1));
+    }
+}
+
+#[mz_ore::test]
+fn co_reduce_pair_nonlinear_synthetic_delta() {
+    let updates0 = vec![
+        ((1u64, 10u64), Pair::new(0, 1), 1isize),
+        ((1u64, 11u64), Pair::new(1, 0), 1isize),
+    ];
+    let updates1 = vec![];
+    let cursor = consolidate_updates(run_pair(
+        &updates0,
+        &updates1,
+        usize::MAX,
+        net_at_least_two,
+        false,
+    ));
+    let reference = consolidate_updates(run_pair(
+        &updates0,
+        &updates1,
+        usize::MAX,
+        net_at_least_two,
+        true,
+    ));
+    assert_eq!(cursor, reference);
+    // Output appears exactly at the synthetic join (1,1), a time in neither input.
+    let expected = vec![((1u64, 0u64), Pair::new(1, 1), 1isize)];
+    assert_eq!(cursor, expected);
+}
+
+// ===================== Property A: differential fuzzing of the two tactics =====================
+
+/// Small domains force key collisions, diff cancellations, and incomparable times.
+fn arb_updates() -> impl Strategy<Value = Vec<((u64, u64), Pair, isize)>> {
+    proptest::collection::vec(
+        (
+            (0..6u64, 0..4u64),
+            (0..4u64, 0..4u64).prop_map(|(a, b)| Pair::new(a, b)),
+            Union::new(vec![Just(1isize), Just(-1isize)]),
+        )
+            .prop_map(|(kv, t, d)| (kv, t, d)),
+        0..30,
+    )
+}
+
+fn arb_fuel() -> impl Strategy<Value = usize> {
+    Union::new(vec![Just(1usize), Just(7usize), Just(usize::MAX)])
+}
+
+// `Logic` is a named fn-pointer type. Each of these functions is otherwise a distinct
+// zero-sized fn-item type, so the cast is required to unify them into one `Union`, not
+// a numeric conversion.
+#[allow(clippy::as_conversions)]
+fn arb_logic() -> impl Strategy<Value = Logic> {
+    Union::new(vec![
+        Just(net_positive as Logic),
+        Just(max_present as Logic),
+        Just(echo_values as Logic),
+    ])
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 48, ..ProptestConfig::default() })]
+
+    /// Property A: the cursor tactic and the reference tactic produce identical
+    /// consolidated change streams on identical inputs, across fuel budgets.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)]
+    fn co_reduce_differential(
+        updates0 in arb_updates(),
+        updates1 in arb_updates(),
+        fuel in arb_fuel(),
+        logic in arb_logic(),
+    ) {
+        let cursor = consolidate_updates(run_pair(&updates0, &updates1, fuel, logic, false));
+        let reference = consolidate_updates(run_pair(&updates0, &updates1, usize::MAX, logic, true));
+        prop_assert_eq!(cursor, reference);
+    }
+}
+
+// ===================== Property B: from-scratch oracle model =====================
+//
+// Property A only checks the two tactics against each other, so a bug that both share
+// (e.g. in a helper both call, or a shared misreading of the operator contract) is
+// invisible to it. `oracle_check` below is an independent model with no code path in
+// common with either tactic: it accumulates each input's raw updates directly and calls
+// `logic` itself, rather than reading anything the operator produced internally.
+
+/// Brute-force model check: at every time in the join-closure of all input AND output
+/// times, the output accumulated up to that time must equal `logic` applied to the
+/// inputs accumulated up to that time, per key. Including output times catches
+/// emissions at times outside the input closure.
+fn oracle_check(
+    updates0: &[((u64, u64), Pair, isize)],
+    updates1: &[((u64, u64), Pair, isize)],
+    output: &[((u64, u64), Pair, isize)],
+    logic: Logic,
+) -> Result<(), String> {
+    let mut times: Vec<Pair> = updates0
+        .iter()
+        .chain(updates1.iter())
+        .chain(output.iter())
+        .map(|(_, t, _)| *t)
+        .collect();
+    times.sort();
+    times.dedup();
+    // Join-closure fixpoint: a non-linear `logic` can produce a real delta at a
+    // synthetic join time that neither input nor output mentions on its own, so the
+    // closure must be completed before checking, not just seeded from observed times.
+    loop {
+        let mut grown = Vec::new();
+        for i in 0..times.len() {
+            for j in (i + 1)..times.len() {
+                let joined = times[i].join(&times[j]);
+                if times.binary_search(&joined).is_err() {
+                    grown.push(joined);
+                }
+            }
+        }
+        if grown.is_empty() {
+            break;
+        }
+        times.extend(grown);
+        times.sort();
+        times.dedup();
+    }
+
+    let mut keys: Vec<u64> = updates0
+        .iter()
+        .chain(updates1.iter())
+        .chain(output.iter())
+        .map(|((k, _), _, _)| *k)
+        .collect();
+    keys.sort();
+    keys.dedup();
+
+    for q in &times {
+        for k in &keys {
+            let acc = |updates: &[((u64, u64), Pair, isize)]| {
+                let mut a: Vec<(u64, isize)> = updates
+                    .iter()
+                    .filter(|((k2, _), t, _)| k2 == k && PartialOrder::less_equal(t, q))
+                    .map(|((_, v), _, d)| (*v, *d))
+                    .collect();
+                differential_dataflow::consolidation::consolidate(&mut a);
+                a
+            };
+            let acc0 = acc(updates0);
+            let acc1 = acc(updates1);
+            // The logic contract requires logic(empty, empty) == empty, so evaluating
+            // on empty accumulations is well-defined.
+            let mut desired: Vec<(u64, isize)> = Vec::new();
+            logic(k, &[&acc0, &acc1], &mut desired);
+            differential_dataflow::consolidation::consolidate(&mut desired);
+            let actual = acc(output);
+            if desired != actual {
+                return Err(format!(
+                    "key {k} at {q:?}: desired {desired:?}, actual {actual:?}"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 48, ..ProptestConfig::default() })]
+
+    /// Property B: the cursor tactic's output matches the from-scratch model at every
+    /// closure time, fuzzed across fuel budgets.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)]
+    fn co_reduce_oracle_cursor(
+        updates0 in arb_updates(),
+        updates1 in arb_updates(),
+        fuel in arb_fuel(),
+        logic in arb_logic(),
+    ) {
+        let output = run_pair(&updates0, &updates1, fuel, logic, false);
+        if let Err(e) = oracle_check(&updates0, &updates1, &output, logic) {
+            return Err(TestCaseError::fail(e));
+        }
+    }
+
+    /// Property B: the reference tactic's output matches the from-scratch model at every
+    /// closure time.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)]
+    fn co_reduce_oracle_reference(
+        updates0 in arb_updates(),
+        updates1 in arb_updates(),
+        logic in arb_logic(),
+    ) {
+        let output = run_pair(&updates0, &updates1, usize::MAX, logic, true);
+        if let Err(e) = oracle_check(&updates0, &updates1, &output, logic) {
+            return Err(TestCaseError::fail(e));
+        }
+    }
+}
+
+// ===================== Nested recursion: SCC-style iterative fixpoint =====================
+//
+// Differential's flagship nested-recursion example (`algorithms::graphs::scc`) runs a
+// reduce inside an iterative `Product`-timestamped scope whose feedback edge advances the
+// iteration coordinate. Every test above feeds `co_reduce2` direct updates and never
+// places it in such a feedback loop, so its frontier and capability handling under an
+// advancing iteration coordinate went untested. These tests close that gap. They mirror
+// the recursive set difference the SQL layer already exercises: `live = candidates EXCEPT
+// dead` and `dead = dead UNION even(live)`, with `co_reduce2` as the loop-body reduce.
+//
+// The `dead` set is monotone. It only ever gains nodes, because its own recursion carries
+// its prior contents forward. That is what makes the fixpoint converge: once an even node
+// enters `dead` it stays, so `live` loses every even candidate permanently and the
+// fixpoint is exactly the odd candidates.
+
+/// Union/threshold logic: a key is present in the output (value `0`, diff `+1`) iff its net
+/// multiplicity summed across both inputs is positive. Used as a two-input `distinct`, so
+/// the monotone `dead` union does not accumulate multiplicity across iterations. `logic`
+/// must map fully cancelled input to empty output, which this does (net `0` emits nothing).
+fn either_present(_k: &u64, inputs: &[&[(u64, isize)]], out: &mut Vec<(u64, isize)>) {
+    let sum = |s: &[(u64, isize)]| s.iter().map(|(_v, d)| *d).sum::<isize>();
+    if sum(inputs[0]) + sum(inputs[1]) > 0 {
+        out.push((0u64, 1));
+    }
+}
+
+/// Runs the two `Pair`-time arrangements through `co_reduce2` (cursor tactic) or
+/// `co_reduce2_reference` (reference tactic), so a recursive dataflow can be driven through
+/// either tactic from one call site. Both tactics carry the same driver, so the feedback
+/// loop stresses the same frontier and capability logic regardless of the branch.
+macro_rules! recur_reduce {
+    ($reference:expr, $a0:expr, $a1:expr, $name:expr, $fuel:expr, $logic:expr) => {
+        if $reference {
+            co_reduce2_reference::<
+                Pair,
+                TraceAgent<PairSpine>,
+                TraceAgent<PairSpine>,
+                u64,
+                u64,
+                u64,
+                isize,
+                PairBuilder,
+                PairSpine,
+                _,
+            >($a0, $a1, $name, $fuel, $logic)
+        } else {
+            co_reduce2::<
+                Pair,
+                TraceAgent<PairSpine>,
+                TraceAgent<PairSpine>,
+                u64,
+                u64,
+                u64,
+                isize,
+                PairBuilder,
+                PairSpine,
+                _,
+            >($a0, $a1, $name, $fuel, $logic)
+        }
+    };
+}
+
+/// Drives the recursive `live = candidates EXCEPT dead` / `dead = dead UNION even(live)`
+/// fixpoint through `co_reduce2` (or the reference tactic, if `reference`) in a single
+/// iterative `Pair`-timestamped scope. `sets[i]` is the candidate set at outer time `i`;
+/// consecutive sets are diffed into inserts and removals. A small `fuel` forces the
+/// loop-body reduce to yield mid-round inside the feedback loop, exercising the contract
+/// that a fuel-withholding round still collapses its frontier to empty so the recursive
+/// scope does not deadlock. Returns the raw captured change stream as
+/// `(node, outer_time, diff)`.
+fn run_recursive(sets: &[Vec<u64>], fuel: usize, reference: bool) -> Vec<(u64, u64, isize)> {
+    let sets: Vec<Vec<u64>> = sets.to_vec();
+    let captured = timely::execute_directly(move |worker| {
+        let (mut input, probe, cap) = worker.dataflow::<u64, _, _>(|root| {
+            let (input, cand) = root.new_collection::<u64, isize>();
+            let live = root.iterative::<u64, _, _>(|inner| {
+                let cand = cand.enter(inner);
+                // Advance the iteration coordinate by one per feedback pass.
+                let (dead_var, dead) = Variable::new(inner, Product::new(Default::default(), 1));
+                // live = candidates EXCEPT dead.
+                let live = {
+                    let ca = cand.map(|k| (k, 0u64)).arrange_by_key();
+                    let da = dead.clone().map(|k| (k, 0u64)).arrange_by_key();
+                    recur_reduce!(reference, ca, da, "recursive-live", fuel, net_positive)
+                        .as_collection(|k, _v| *k)
+                };
+                // dead_next = distinct(dead UNION even(live)). Deduping the union keeps
+                // `dead` at multiplicity one so the loop reaches a fixpoint.
+                let dead_next = {
+                    let da = dead.map(|k| (k, 0u64)).arrange_by_key();
+                    let ea = live
+                        .clone()
+                        .filter(|k| k % 2 == 0)
+                        .map(|k| (k, 0u64))
+                        .arrange_by_key();
+                    recur_reduce!(reference, da, ea, "recursive-dead", fuel, either_present)
+                        .as_collection(|k, _v| *k)
+                };
+                dead_var.set(dead_next);
+                live.leave(root)
+            });
+            let (probe, probed) = live.inner.probe();
+            let cap = probed.capture();
+            (input, probe, cap)
+        });
+
+        let mut current: BTreeSet<u64> = BTreeSet::new();
+        for (round, set) in sets.into_iter().enumerate() {
+            let target: BTreeSet<u64> = set.into_iter().collect();
+            for &k in target.difference(&current) {
+                input.insert(k);
+            }
+            for &k in current.difference(&target) {
+                input.remove(k);
+            }
+            current = target;
+            let next = u64::try_from(round + 1).expect("round count fits in u64");
+            input.advance_to(next);
+            input.flush();
+            worker.step_while(|| probe.less_than(input.time()));
+        }
+        input.close();
+        cap
+    });
+
+    captured
+        .extract()
+        .into_iter()
+        .flat_map(|(t, data)| data.into_iter().map(move |(k, _t, r)| (k, t, r)))
+        .collect()
+}
+
+/// Consolidates a `(node, time, diff)` change stream to the final per-node multiset,
+/// summing over all times and dropping zeros.
+fn final_multiset(stream: &[(u64, u64, isize)]) -> Vec<(u64, isize)> {
+    let mut acc: BTreeMap<u64, isize> = BTreeMap::new();
+    for (k, _t, r) in stream {
+        *acc.entry(*k).or_default() += *r;
+    }
+    acc.retain(|_k, r| *r != 0);
+    acc.into_iter().collect()
+}
+
+#[mz_ore::test]
+fn co_reduce_recursive_set_difference() {
+    // Candidates 0..=5. The fixpoint is the odd candidates: every even one is trapped in
+    // `dead` after the first pass and stays there.
+    let candidates = vec![vec![0u64, 1, 2, 3, 4, 5]];
+    let expected = vec![(1u64, 1isize), (3, 1), (5, 1)];
+
+    // Both tactics, and both a one-shot and a fuel-yielding loop body, agree on the
+    // analytic fixpoint. A fuel of 1 forces the reduce to yield inside the feedback loop.
+    for reference in [false, true] {
+        for fuel in [1usize, usize::MAX] {
+            assert_eq!(
+                final_multiset(&run_recursive(&candidates, fuel, reference)),
+                expected,
+                "fixpoint wrong (reference={reference}, fuel={fuel})"
+            );
+        }
+    }
+}
+
+#[mz_ore::test]
+fn co_reduce_recursive_incremental() {
+    // Round 0: candidates 0..=5 -> fixpoint {1, 3, 5}. Round 1: drop 5 (an odd survivor)
+    // and add 6 (an even node that `dead` immediately traps) -> fixpoint {1, 3}. The
+    // recursive reduce must re-run incrementally across the outer round and retract 5. A
+    // round's changes land at its own outer time, so round 1's diffs appear at time 1.
+    let sets = vec![vec![0u64, 1, 2, 3, 4, 5], vec![0u64, 1, 2, 3, 4, 6]];
+
+    for reference in [false, true] {
+        let stream = run_recursive(&sets, usize::MAX, reference);
+
+        // The dropped survivor 5 must appear as an explicit retraction at round 1 (time 1),
+        // not merely be absent from the final state.
+        assert!(
+            stream.iter().any(|(k, t, r)| *k == 5 && *t == 1 && *r < 0),
+            "expected an explicit retraction of node 5 at round 1 (reference={reference}), \
+             got {stream:?}"
+        );
+
+        // The final state after both rounds is {1, 3}.
+        assert_eq!(
+            final_multiset(&stream),
+            vec![(1u64, 1isize), (3, 1)],
+            "final incremental state wrong (reference={reference})"
+        );
+    }
+}
+
+// A doubly nested iterative scope, mirroring SCC's outer-loop-over-inner-fixpoint shape.
+// The inner scope runs the `live`/`dead` set-difference fixpoint at the depth-two timestamp
+// `Product<Pair, u64>`. The outer scope accumulates the inner result into a monotone `acc`
+// variable at `Pair`. `co_reduce2` therefore runs under two live feedback edges at once,
+// the deepest nesting these tests reach.
+type Nested = Product<Pair, u64>;
+type NestedSpine = OrdValSpine<u64, u64, Nested, isize>;
+type NestedBuilder = RcOrdValBuilder<u64, u64, Nested, isize>;
+
+#[mz_ore::test]
+fn co_reduce_recursive_nested_scopes() {
+    let candidates = vec![0u64, 1, 2, 3, 4, 5];
+    let captured = timely::execute_directly(move |worker| {
+        let (mut input, cap) = worker.dataflow::<u64, _, _>(|root| {
+            let (input, cand) = root.new_collection::<u64, isize>();
+            let acc = root.iterative::<u64, _, _>(|mid| {
+                let cand_mid = cand.enter(mid);
+                let (acc_var, acc) = Variable::new(mid, Product::new(Default::default(), 1));
+
+                // Inner fixpoint at Product<Pair, u64>: live = candidates EXCEPT dead.
+                let live = mid.iterative::<u64, _, _>(|inner| {
+                    let cand_in = cand_mid.enter(inner);
+                    let (dead_var, dead) =
+                        Variable::new(inner, Product::new(Default::default(), 1));
+                    let live = {
+                        let ca = cand_in.map(|k| (k, 0u64)).arrange_by_key();
+                        let da = dead.clone().map(|k| (k, 0u64)).arrange_by_key();
+                        co_reduce2::<
+                            Nested,
+                            TraceAgent<NestedSpine>,
+                            TraceAgent<NestedSpine>,
+                            u64,
+                            u64,
+                            u64,
+                            isize,
+                            NestedBuilder,
+                            NestedSpine,
+                            _,
+                        >(ca, da, "nested-live", usize::MAX, net_positive)
+                        .as_collection(|k, _v| *k)
+                    };
+                    let dead_next = {
+                        let da = dead.map(|k| (k, 0u64)).arrange_by_key();
+                        let ea = live
+                            .clone()
+                            .filter(|k| k % 2 == 0)
+                            .map(|k| (k, 0u64))
+                            .arrange_by_key();
+                        co_reduce2::<
+                            Nested,
+                            TraceAgent<NestedSpine>,
+                            TraceAgent<NestedSpine>,
+                            u64,
+                            u64,
+                            u64,
+                            isize,
+                            NestedBuilder,
+                            NestedSpine,
+                            _,
+                        >(da, ea, "nested-dead", usize::MAX, either_present)
+                        .as_collection(|k, _v| *k)
+                    };
+                    dead_var.set(dead_next);
+                    live.leave(mid)
+                });
+
+                // Outer fixpoint at Pair: acc = distinct(acc UNION live). `live` is constant
+                // across outer passes, so acc converges once it has absorbed it.
+                let acc_next = {
+                    let aa = acc.clone().map(|k| (k, 0u64)).arrange_by_key();
+                    let la = live.map(|k| (k, 0u64)).arrange_by_key();
+                    co_reduce2::<
+                        Pair,
+                        TraceAgent<PairSpine>,
+                        TraceAgent<PairSpine>,
+                        u64,
+                        u64,
+                        u64,
+                        isize,
+                        PairBuilder,
+                        PairSpine,
+                        _,
+                    >(aa, la, "outer-acc", usize::MAX, either_present)
+                    .as_collection(|k, _v| *k)
+                };
+                acc_var.set(acc_next);
+                acc.leave(root)
+            });
+            let cap = acc.inner.capture();
+            (input, cap)
+        });
+
+        for k in candidates {
+            input.insert(k);
+        }
+        input.close();
+        cap
+    });
+
+    let stream: Vec<(u64, u64, isize)> = captured
+        .extract()
+        .into_iter()
+        .flat_map(|(t, data)| data.into_iter().map(move |(k, _t, r)| (k, t, r)))
+        .collect();
+
+    // The doubly nested fixpoint is the same odd survivors, accumulated at the root.
+    assert_eq!(
+        final_multiset(&stream),
+        vec![(1u64, 1isize), (3, 1), (5, 1)],
+        "doubly nested fixpoint wrong"
+    );
+}

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -19,6 +19,7 @@ pub mod activator;
 pub mod antichain;
 pub mod builder_async;
 pub mod capture;
+pub mod co_reduce;
 pub mod column_pager;
 pub mod columnar;
 pub mod columnation;


### PR DESCRIPTION
Split of #37595. First of two: the operator, standalone. The SetDifference feature that consumes it is the follow-up.

`co_reduce2` reduces two co-arranged inputs per key through a caller closure and produces one output arrangement. The two inputs may carry distinct trace types, unified only on the key GAT, owned key/value, and diff, so arrangement flavors are handled by monomorphization rather than a hand-written operator. It is Row-agnostic and value-aware, living beside differential's own `reduce`.

The operator splits into a driver (`co_reduce2_with_tactic`) owning frontiers, capabilities, fuel, and trace maintenance, and a `CoReduceTactic` owning per-key computation. The conventional `CursorTactic` is the incremental engine; a reference tactic is an in-tree oracle. A `fuel` budget bounds keys processed per activation and reschedules; the output frontier is held until a round's dirty set fully drains, so an incomplete round is never finalized.

Tests cover fixed cases, fuel yielding, partially-ordered (`Product`) times, differential fuzzing of the two tactics against each other, a from-scratch oracle model, and SCC-style nested-recursion fixpoints.

Design: `doc/developer/design/20260714_co_reduce_operator.md`. A variadic-N `co_reduce` remains deferred future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)