### PR TITLE
SS-199 storage-controller: configure Instance at construction time

### DIFF
--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -32,6 +32,7 @@ use mz_storage_client::client::{
     RunIngestionCommand, RunSinkCommand, Status, StatusUpdate, StorageCommand, StorageResponse,
 };
 use mz_storage_client::metrics::{InstanceMetrics, ReplicaMetrics};
+use mz_storage_types::parameters::StorageParameters;
 use mz_storage_types::sinks::StorageSinkDesc;
 use mz_storage_types::sources::{IngestionDescription, SourceConnection};
 use timely::progress::Antichain;
@@ -73,6 +74,12 @@ pub(crate) struct Instance {
     /// list of running exports is quite a bit more convenient for the
     /// controller.
     active_exports: BTreeMap<GlobalId, ActiveExport>,
+    /// The instance's current storage configuration.
+    ///
+    /// Seeded at construction and merged on every runtime update via
+    /// [`Instance::update_configuration`]. New replicas receive it by replaying
+    /// the reduced command history, so this field is not read locally today.
+    config: StorageParameters,
     /// The command history, used to replay past commands when introducing new replicas or
     /// reconnecting to existing replicas.
     history: CommandHistory,
@@ -101,8 +108,13 @@ struct ActiveExport {
 }
 
 impl Instance {
-    /// Creates a new [`Instance`].
+    /// Creates a new [`Instance`] configured with `config`.
+    ///
+    /// The configuration is seeded into the command history as an
+    /// `UpdateConfiguration`, so replicas added later replay it without the
+    /// caller having to send the command separately.
     pub fn new(
+        config: StorageParameters,
         workload_class: Option<String>,
         metrics: InstanceMetrics,
         now: NowFn,
@@ -116,6 +128,7 @@ impl Instance {
             active_ingestions: Default::default(),
             ingestion_exports: Default::default(),
             active_exports: BTreeMap::new(),
+            config,
             history,
             metrics,
             now,
@@ -127,8 +140,18 @@ impl Instance {
             // `ReplicaTask::specialize_command`.
             nonce: Default::default(),
         });
+        instance.send(StorageCommand::UpdateConfiguration(Box::new(
+            instance.config.clone(),
+        )));
 
         instance
+    }
+
+    /// Merges `params` into the instance's configuration and forwards the update
+    /// to all replicas.
+    pub fn update_configuration(&mut self, params: StorageParameters) {
+        self.config.update(params.clone());
+        self.send(StorageCommand::UpdateConfiguration(Box::new(params)));
     }
 
     /// Returns the IDs of all replicas connected to this storage instance.
@@ -959,5 +982,72 @@ impl ReplicaTask {
         if let StorageCommand::Hello { nonce } = command {
             *nonce = Uuid::new_v4();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_cluster_client::metrics::ControllerMetrics;
+    use mz_ore::metrics::MetricsRegistry;
+    use mz_ore::now::SYSTEM_TIME;
+    use mz_storage_client::metrics::StorageControllerMetrics;
+    use mz_storage_types::instances::StorageInstanceId;
+
+    use super::*;
+
+    fn instance(config: StorageParameters) -> Instance {
+        let registry = MetricsRegistry::new();
+        let controller_metrics = ControllerMetrics::new(&registry);
+        let metrics = StorageControllerMetrics::new(&registry, controller_metrics)
+            .for_instance(StorageInstanceId::system(0).expect("0 is a valid ID"));
+        let (response_tx, _response_rx) = mpsc::unbounded_channel();
+        Instance::new(config, None, metrics, SYSTEM_TIME.clone(), response_tx)
+    }
+
+    /// Flips one field off its default so the parameters are not `all_unset`,
+    /// which lets the seeded `UpdateConfiguration` survive history reduction.
+    fn non_default_params() -> StorageParameters {
+        let mut params = StorageParameters::default();
+        params.finalize_shards = !params.finalize_shards;
+        params
+    }
+
+    /// The config handed to the constructor is stored and seeded into the
+    /// command history, so a freshly-added replica replays it.
+    #[mz_ore::test]
+    fn new_seeds_configuration() {
+        let params = non_default_params();
+        let mut instance = instance(params.clone());
+
+        assert_eq!(instance.config, params);
+
+        // After reduction the history carries exactly the seeded configuration.
+        instance.history.reduce();
+        let configs: Vec<_> = instance
+            .history
+            .iter()
+            .filter_map(|command| match command {
+                StorageCommand::UpdateConfiguration(params) => Some((**params).clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(configs, vec![params]);
+    }
+
+    /// A runtime update merges into the stored config via
+    /// [`StorageParameters::update`] rather than replacing it wholesale.
+    #[mz_ore::test]
+    fn update_configuration_merges_into_stored_config() {
+        let base = non_default_params();
+        let mut instance = instance(base.clone());
+
+        let mut update = StorageParameters::default();
+        update.keep_n_source_status_history_entries = 42;
+
+        let mut expected = base;
+        expected.update(update.clone());
+
+        instance.update_configuration(update);
+        assert_eq!(instance.config, expected);
     }
 }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -292,8 +292,7 @@ impl StorageController for Controller {
         self.persist.cfg().apply_from(&config_params.dyncfg_updates);
 
         for instance in self.instances.values_mut() {
-            let params = Box::new(config_params.clone());
-            instance.send(StorageCommand::UpdateConfiguration(params));
+            instance.update_configuration(config_params.clone());
         }
         self.config.update(config_params);
         self.statistics_interval_sender
@@ -510,6 +509,7 @@ impl StorageController for Controller {
     fn create_instance(&mut self, id: StorageInstanceId, workload_class: Option<String>) {
         let metrics = self.metrics.for_instance(id);
         let mut instance = Instance::new(
+            self.config.parameters.clone(),
             workload_class,
             metrics,
             self.now.clone(),
@@ -521,9 +521,6 @@ impl StorageController for Controller {
         if !self.read_only {
             instance.send(StorageCommand::AllowWrites);
         }
-
-        let params = Box::new(self.config.parameters.clone());
-        instance.send(StorageCommand::UpdateConfiguration(params));
 
         let old_instance = self.instances.insert(id, instance);
         assert_none!(old_instance, "storage instance {id} already exists");


### PR DESCRIPTION
## Motivation

The storage-controller `Instance` was built config-less and then immediately configured by a follow-up `StorageCommand::UpdateConfiguration` command in `Controller::create_instance`. This "construct, then configure" dance was awkward: the configuration is already available synchronously on the controller (`self.config.parameters`), so the caller had to remember to push it in as a separate step, and the `Instance` held no notion of its own configuration.

The compute controller already avoids this by folding create-time config into instance construction.

## Description

- `Instance::new` now takes a `StorageParameters` as its first argument and stores it as a field. It seeds the initial `UpdateConfiguration` into the command history itself, so replicas added later still replay it without the caller sending the command by hand.
- Adds an `Instance::update_configuration` method, mirroring the compute controller, that merges an update into the stored config (via `StorageParameters::update`) and forwards it to replicas. `Controller::update_parameters` now calls this so the stored field stays in sync on runtime parameter changes.
- `create_instance` passes the config into the constructor and drops the separate post-construction send.
- `StorageCommand::UpdateConfiguration` is retained, since it remains a genuine runtime command (parameters can change after instance creation).

This is behavior-preserving for replicas: the command history is canonicalized by `CommandHistory::reduce` before any replica replay (in `Instance::add_replica`), so relocating the config send into the constructor changes nothing a replica observes.

## Tests

Adds two unit tests in `instance.rs`:
- `new_seeds_configuration` — construction stores the config and the reduced history carries exactly the seeded `UpdateConfiguration`.
- `update_configuration_merges_into_stored_config` — a runtime update merges into the stored config rather than replacing it wholesale.

Internal refactor with no user-visible behavior change, so no release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)