### PR TITLE
SS-350: sql-server: seed offset_committed from resume LSN on startup

### DIFF
--- a/src/storage/src/source/sql_server.rs
+++ b/src/storage/src/source/sql_server.rs
@@ -59,16 +59,14 @@ struct SourceOutputInfo {
 }
 
 impl SourceOutputInfo {
-    /// The [`Lsn`] this output resumes reading from.
+    /// The [`Lsn`] this output resumes reading from, or the provided fallback [`Lsn`].
     ///
     /// Panics if `resume_upper` is empty, which would mean the output has no
     /// resumption point at all.
-    fn resume_lsn(&self) -> Lsn {
+    fn resume_lsn_or(&self, fallback: Lsn) -> Lsn {
         match self.resume_upper.as_option() {
             Some(lsn) if *lsn != Lsn::minimum() => *lsn,
-            // `initial_lsn` is the max LSN observed when the snapshot was taken, so it has
-            // already been read and replication starts at the next available LSN.
-            Some(_) => self.initial_lsn.increment(),
+            Some(_) => fallback,
             None => panic!("resume_upper has at least one value"),
         }
     }

--- a/src/storage/src/source/sql_server.rs
+++ b/src/storage/src/source/sql_server.rs
@@ -32,7 +32,7 @@ use timely::dataflow::operators::Concat;
 use timely::dataflow::operators::core::Partition;
 use timely::dataflow::operators::vec::{Map, ToStream};
 use timely::dataflow::{Scope, StreamVec};
-use timely::progress::Antichain;
+use timely::progress::{Antichain, Timestamp};
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
 use crate::source::RawSourceCreationConfig;
@@ -56,6 +56,22 @@ struct SourceOutputInfo {
     partition_index: u64,
     /// The basis for the resumption LSN when snapshotting.
     initial_lsn: Lsn,
+}
+
+impl SourceOutputInfo {
+    /// The [`Lsn`] this output resumes reading from.
+    ///
+    /// Panics if `resume_upper` is empty, which would mean the output has no
+    /// resumption point at all.
+    fn resume_lsn(&self) -> Lsn {
+        match self.resume_upper.as_option() {
+            Some(lsn) if *lsn != Lsn::minimum() => *lsn,
+            // `initial_lsn` is the max LSN observed when the snapshot was taken, so it has
+            // already been read and replication starts at the next available LSN.
+            Some(_) => self.initial_lsn.increment(),
+            None => panic!("resume_upper has at least one value"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/src/storage/src/source/sql_server/progress.rs
+++ b/src/storage/src/source/sql_server/progress.rs
@@ -41,7 +41,7 @@ use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, Pre
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::operators::vec::Map;
 use timely::dataflow::{Scope, StreamVec};
-use timely::progress::Antichain;
+use timely::progress::{Antichain, Timestamp};
 
 use crate::source::sql_server::{ReplicationError, SourceOutputInfo, TransientError};
 use crate::source::types::Probe;
@@ -85,6 +85,25 @@ pub(crate) fn render<'scope>(
                 }
                 return Ok(());
             }
+
+            // Seed `offset_committed` from the resumption LSN, or if not set, from the
+            // `initial_lsn` (see [`SourceOutputInfo::resume_lsn`]). Otherwise it stays at the
+            // default 0 until the initial snapshot durably commits and the first resume
+            // upper arrives, which for a large snapshot can be a long time. During that
+            // window the ingestion-lag calculation subtracts 0 from the (large) upstream
+            // LSN and reports an enormous, bogus lag.
+            //
+            // NOTE: This runs before connecting to the upstream so a slow or failing
+            // connection does not leave the statistic unset.
+            let mut max_committed_lsn = outputs
+                .values()
+                .map(SourceOutputInfo::resume_lsn)
+                .min()
+                .unwrap_or_else(Lsn::minimum);
+            for stat in config.statistics.values() {
+                stat.set_offset_committed(max_committed_lsn.abbreviate());
+            }
+
             let conn_config = connection
                 .resolve_config(
                     &config.config.connection_context.secrets_reader,
@@ -194,8 +213,14 @@ pub(crate) fn render<'scope>(
                                 }
                             }
                         }
+                        // Never regress below the seeded resumption LSN. During the initial
+                        // snapshot the resume upper sits at the minimum, which would otherwise
+                        // drag the committed offset back to 0 and reintroduce the bogus lag.
+                        if *committed_upper > max_committed_lsn {
+                            max_committed_lsn = *committed_upper;
+                        }
                         for stat in config.statistics.values() {
-                            stat.set_offset_committed(committed_upper.abbreviate());
+                            stat.set_offset_committed(max_committed_lsn.abbreviate());
                         }
                     }
                 };

--- a/src/storage/src/source/sql_server/progress.rs
+++ b/src/storage/src/source/sql_server/progress.rs
@@ -29,6 +29,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use futures::StreamExt;
 use mz_ore::future::InTask;
 use mz_repr::GlobalId;
+use mz_sql_server_util::SqlServerError;
 use mz_sql_server_util::cdc::Lsn;
 use mz_sql_server_util::inspect::{get_latest_restore_history_id, get_max_lsn};
 use mz_storage_types::connections::SqlServerConnectionDetails;
@@ -100,10 +101,11 @@ pub(crate) fn render<'scope>(
                 .map(SourceOutputInfo::resume_lsn)
                 .min()
                 .unwrap_or_else(Lsn::minimum);
-            for stat in config.statistics.values() {
-                stat.set_offset_committed(max_committed_lsn.abbreviate());
-            }
 
+            // Retrieve the latest upstream LSN eagerly to ensure the lag calculation
+            // (offset_known - offset_committed) is non-negative. Statistics represents these as
+            // uint8, which would cause the calculation to underflow for the brief period between
+            // setting offset_committed here and offset_known further below.
             let conn_config = connection
                 .resolve_config(
                     &config.config.connection_context.secrets_reader,
@@ -112,6 +114,11 @@ pub(crate) fn render<'scope>(
                 )
                 .await?;
             let mut client = mz_sql_server_util::Client::connect(conn_config).await?;
+            let max_lsn: Lsn = get_max_lsn(&mut client).await?;
+            for stat in config.statistics.values() {
+                stat.set_offset_committed(max_committed_lsn.abbreviate());
+                stat.set_offset_known(max_lsn.abbreviate());
+            }
 
 
             // Terminate the progress probes if a restore has happened. Replication operator will

--- a/src/storage/src/source/sql_server/progress.rs
+++ b/src/storage/src/source/sql_server/progress.rs
@@ -29,7 +29,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use futures::StreamExt;
 use mz_ore::future::InTask;
 use mz_repr::GlobalId;
-use mz_sql_server_util::SqlServerError;
 use mz_sql_server_util::cdc::Lsn;
 use mz_sql_server_util::inspect::{get_latest_restore_history_id, get_max_lsn};
 use mz_storage_types::connections::SqlServerConnectionDetails;
@@ -42,7 +41,7 @@ use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, Pre
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::operators::vec::Map;
 use timely::dataflow::{Scope, StreamVec};
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 
 use crate::source::sql_server::{ReplicationError, SourceOutputInfo, TransientError};
 use crate::source::types::Probe;
@@ -87,21 +86,6 @@ pub(crate) fn render<'scope>(
                 return Ok(());
             }
 
-            // Seed `offset_committed` from the resumption LSN, or if not set, from the
-            // `initial_lsn` (see [`SourceOutputInfo::resume_lsn`]). Otherwise it stays at the
-            // default 0 until the initial snapshot durably commits and the first resume
-            // upper arrives, which for a large snapshot can be a long time. During that
-            // window the ingestion-lag calculation subtracts 0 from the (large) upstream
-            // LSN and reports an enormous, bogus lag.
-            //
-            // NOTE: This runs before connecting to the upstream so a slow or failing
-            // connection does not leave the statistic unset.
-            let mut max_committed_lsn = outputs
-                .values()
-                .map(SourceOutputInfo::resume_lsn)
-                .min()
-                .unwrap_or_else(Lsn::minimum);
-
             // Retrieve the latest upstream LSN eagerly to ensure the lag calculation
             // (offset_known - offset_committed) is non-negative. Statistics represents these as
             // uint8, which would cause the calculation to underflow for the brief period between
@@ -114,10 +98,31 @@ pub(crate) fn render<'scope>(
                 )
                 .await?;
             let mut client = mz_sql_server_util::Client::connect(conn_config).await?;
-            let max_lsn: Lsn = get_max_lsn(&mut client).await?;
+            // increment here to match known_offset calculation below
+            let next_upstream_lsn: Lsn = get_max_lsn(&mut client).await?.increment();
+
+            // Seed `offset_committed` from the resumption LSN, or if not set, from the
+            // upstream's current max LSN. Otherwise, it stays at the default 0 until the
+            // initial snapshot durably commits and the first resume upper arrives, which
+            // for a large snapshot can be a long time. During that window the ingestion-lag
+            // calculation subtracts 0 from the (large) upstream LSN and reports an
+            // enormous, bogus lag.
+            //
+            // This defaults to upstream's current max offset instead of `initial_lsn` because
+            // `initial_lsn` can be ahead of the value returned by `sys.fn_cdc_get_max_lsn`. This
+            // is a very obscure edge case where a user has a CDC enabled table, creates a new one
+            // and configures a source for at least the second table immediately after, without
+            // performing any DML operations.
+            let mut max_committed_lsn = outputs
+                .values()
+                // resume_lsn_or will panic if info resume_upper is empty
+                .map(|info| info.resume_lsn_or(next_upstream_lsn))
+                .min()
+                .unwrap_or(next_upstream_lsn);
+
             for stat in config.statistics.values() {
+                stat.set_offset_known(next_upstream_lsn.abbreviate());
                 stat.set_offset_committed(max_committed_lsn.abbreviate());
-                stat.set_offset_known(max_lsn.abbreviate());
             }
 
 

--- a/src/storage/src/source/sql_server/progress.rs
+++ b/src/storage/src/source/sql_server/progress.rs
@@ -41,7 +41,7 @@ use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, Pre
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::operators::vec::Map;
 use timely::dataflow::{Scope, StreamVec};
-use timely::progress::Antichain;
+use timely::progress::{Antichain, Timestamp};
 
 use crate::source::sql_server::{ReplicationError, SourceOutputInfo, TransientError};
 use crate::source::types::Probe;
@@ -85,6 +85,24 @@ pub(crate) fn render<'scope>(
                 }
                 return Ok(());
             }
+
+            // Seed `offset_committed` from the resumption LSN. Otherwise it stays at the
+            // default 0 until the initial snapshot durably commits and the first resume
+            // upper arrives, which for a large snapshot can be a long time. During that
+            // window the ingestion-lag calculation subtracts 0 from the (large) upstream
+            // LSN and reports an enormous, bogus lag.
+            //
+            // NOTE: This runs before connecting to the upstream so a slow or failing
+            // connection does not leave the statistic unset.
+            let mut max_committed_lsn = outputs
+                .values()
+                .map(SourceOutputInfo::resume_lsn)
+                .min()
+                .unwrap_or_else(Lsn::minimum);
+            for stat in config.statistics.values() {
+                stat.set_offset_committed(max_committed_lsn.abbreviate());
+            }
+
             let conn_config = connection
                 .resolve_config(
                     &config.config.connection_context.secrets_reader,
@@ -194,8 +212,14 @@ pub(crate) fn render<'scope>(
                                 }
                             }
                         }
+                        // Never regress below the seeded resumption LSN. During the initial
+                        // snapshot the resume upper sits at the minimum, which would otherwise
+                        // drag the committed offset back to 0 and reintroduce the bogus lag.
+                        if *committed_upper > max_committed_lsn {
+                            max_committed_lsn = *committed_upper;
+                        }
                         for stat in config.statistics.values() {
-                            stat.set_offset_committed(committed_upper.abbreviate());
+                            stat.set_offset_committed(max_committed_lsn.abbreviate());
                         }
                     }
                 };

--- a/src/storage/src/source/sql_server/replication.rs
+++ b/src/storage/src/source/sql_server/replication.rs
@@ -391,7 +391,10 @@ pub(crate) fn render<'scope>(
             // Resumption point is the minimum LSN that has been observed per capture instance.
             let mut resume_lsns = BTreeMap::new();
             for src_info in outputs.values() {
-                let resume_lsn = src_info.resume_lsn();
+                // initial_lsn is the max lsn observed, but the resume lsn
+                // is the next lsn that should be read.  After a snapshot, initial_lsn
+                // has been read, so replication will start at the next available lsn.
+                let resume_lsn = src_info.resume_lsn_or(src_info.initial_lsn.increment());
                 resume_lsns.entry(Arc::clone(&src_info.capture_instance))
                     .and_modify(|existing| *existing = std::cmp::min(*existing, resume_lsn))
                     .or_insert(resume_lsn);

--- a/src/storage/src/source/sql_server/replication.rs
+++ b/src/storage/src/source/sql_server/replication.rs
@@ -391,14 +391,7 @@ pub(crate) fn render<'scope>(
             // Resumption point is the minimum LSN that has been observed per capture instance.
             let mut resume_lsns = BTreeMap::new();
             for src_info in outputs.values() {
-                let resume_lsn = match src_info.resume_upper.as_option() {
-                    Some(lsn) if *lsn != Lsn::minimum() => *lsn,
-                    // initial_lsn is the max lsn observed, but the resume lsn
-                    // is the next lsn that should be read.  After a snapshot, initial_lsn
-                    // has been read, so replication will start at the next available lsn.
-                    Some(_) => src_info.initial_lsn.increment(),
-                    None => panic!("resume_upper has at least one value"),
-                };
+                let resume_lsn = src_info.resume_lsn();
                 resume_lsns.entry(Arc::clone(&src_info.capture_instance))
                     .and_modify(|existing| *existing = std::cmp::min(*existing, resume_lsn))
                     .or_insert(resume_lsn);

--- a/test/sql-server-cdc/72-ingestion-lag-when-idle.td
+++ b/test/sql-server-cdc/72-ingestion-lag-when-idle.td
@@ -1,0 +1,123 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Regression test: a freshly created source must report a near-zero ingestion
+# lag, even while its upstream database is idle.
+#
+# The `offset_committed` statistic must be seeded from the resumption LSN when
+# the source starts. If it is left at the default 0 while `offset_known` tracks
+# the (large) upstream LSN, the console computes an enormous, bogus ingestion
+# lag (`offset_known - offset_committed`).
+#
+# An idle upstream database is what makes this reliably observable. Any activity
+# would advance the source frontier and set `offset_committed` to a correct
+# value, masking the bug. SQL Server tracks the max LSN per database, so we run
+# this against a dedicated database with no activity of its own. The background
+# ticker keeps writing to the shared `test` database, but that does not advance
+# the max LSN observed here.
+
+$ sql-server-connect name=sql-server
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
+
+$ sql-server-execute name=sql-server split-lines=false
+IF EXISTS (SELECT name FROM sys.databases WHERE name = N'lag_test')
+BEGIN
+    ALTER DATABASE lag_test SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE lag_test;
+END;
+
+$ sql-server-execute name=sql-server
+CREATE DATABASE lag_test COLLATE Latin1_General_100_CI_AI_SC_UTF8;
+USE lag_test;
+EXEC sys.sp_cdc_enable_db;
+ALTER DATABASE lag_test SET ALLOW_SNAPSHOT_ISOLATION ON;
+
+$ sql-server-execute name=sql-server
+USE lag_test;
+CREATE TABLE lag_t (f1 VARCHAR(20));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'lag_t', @role_name = 'SA', @supports_net_changes = 0;
+INSERT INTO lag_t VALUES ('one'), ('two'), ('three');
+
+# Let the capture instance drain the writes above and go idle, so this
+# database's max LSN is frozen before we snapshot. Once idle, SQL Server does
+# not advance the max LSN for several minutes, which keeps the source frontier
+# from advancing on its own and thus exercises the startup seeding of
+# `offset_committed`.
+$ sql-server-execute name=sql-server split-lines=false
+WAITFOR DELAY '00:00:20';
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000;
+ALTER SYSTEM SET storage_statistics_interval = 2000;
+
+> CREATE SECRET IF NOT EXISTS mspass AS '${arg.default-sql-server-password}'
+
+> CREATE CONNECTION msconn TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE lag_test,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD = SECRET mspass
+  );
+
+> CREATE CLUSTER lag_cluster SIZE '${arg.default-replica-size}'
+> CREATE SOURCE lag_source IN CLUSTER lag_cluster FROM SQL SERVER CONNECTION msconn;
+> CREATE TABLE lag_t FROM SOURCE lag_source (REFERENCE dbo.lag_t);
+
+# We intentionally do not wait for the snapshot to become queryable. On an idle
+# database the source frontier only advances once SQL Server advances its max
+# LSN, which can take minutes. That frontier advance is also what would fix a
+# buggy `offset_committed`, so waiting for it would mask the bug. Instead we
+# assert on the statistics, which are populated within seconds regardless of the
+# frontier.
+
+# Ensure statistics for the source's replica exist before pinning the replica
+# id below, which does not retry on a missing row.
+> SELECT COUNT(*) > 0
+  FROM
+    mz_cluster_replicas cr,
+    mz_internal.mz_source_statistics u,
+    mz_sources s
+  WHERE
+    cr.id = u.replica_id AND s.name = 'lag_source' AND u.id = s.id
+true
+
+$ set-from-sql var=replica_id
+SELECT cr.id
+  FROM
+    mz_clusters c,
+    mz_cluster_replicas cr,
+    mz_internal.mz_source_statistics u,
+    mz_sources s
+  WHERE
+    c.name = 'lag_cluster' AND c.id = cr.cluster_id AND cr.id = u.replica_id
+    AND s.name = 'lag_source' AND u.id = s.id
+  ORDER BY cr.id
+  LIMIT 1
+
+# With `offset_committed` seeded from the resumption LSN it tracks `offset_known`,
+# so the lag stays near zero even though the upstream database is idle. Without
+# the fix `offset_committed` stays at 0 and the lag is the full upstream LSN
+# until the idle database eventually advances its max LSN, which takes minutes.
+# The bounded timeout is shorter than that heal time, so a buggy build fails
+# here, while a correct build passes within seconds. The bound is phrased as an
+# addition rather than `offset_known - offset_committed` so it never underflows
+# the unsigned columns if `offset_known` is momentarily unset before the first
+# probe tick.
+$ set-sql-timeout duration=60s
+
+> SELECT
+    u.offset_committed > 0,
+    u.offset_known >= u.offset_committed,
+    u.offset_known < u.offset_committed + 1000000
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name = 'lag_source' AND u.replica_id = '${replica_id}'
+true true true

--- a/test/sql-server-cdc/72-ingestion-lag-when-idle.td
+++ b/test/sql-server-cdc/72-ingestion-lag-when-idle.td
@@ -11,17 +11,17 @@
 # Regression test: a freshly created source must report a near-zero ingestion
 # lag, even while its upstream database is idle.
 #
-# The `offset_committed` statistic must be seeded from the resumption LSN when
-# the source starts. If it is left at the default 0 while `offset_known` tracks
-# the (large) upstream LSN, the console computes an enormous, bogus ingestion
-# lag (`offset_known - offset_committed`).
+# The two offset statistics must be initialized from a common validated
+# upstream point. Leaving `offset_committed` at 0 after `offset_known` advances
+# produces an enormous lag. Publishing the full resumption LSN before the known
+# frontier catches up reverses the ordering and makes the same lag calculation
+# (`offset_known - offset_committed`) underflow.
 #
-# An idle upstream database is what makes this reliably observable. Any activity
-# would advance the source frontier and set `offset_committed` to a correct
-# value, masking the bug. SQL Server tracks the max LSN per database, so we run
-# this against a dedicated database with no activity of its own. The background
-# ticker keeps writing to the shared `test` database, but that does not advance
-# the max LSN observed here.
+# A newly enabled capture instance can start ahead of the database-wide CDC
+# maximum. Purification must use that higher start LSN as the source's resumption
+# point. The progress probe still observes the lower database maximum. We stop
+# this database's capture job before enabling the target table so the two LSNs
+# cannot converge and mask the invalid statistics.
 
 $ sql-server-connect name=sql-server
 server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
@@ -41,17 +41,32 @@ ALTER DATABASE lag_test SET ALLOW_SNAPSHOT_ISOLATION ON;
 
 $ sql-server-execute name=sql-server
 USE lag_test;
+CREATE TABLE lag_seed (f1 VARCHAR(20));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'lag_seed', @role_name = 'SA', @supports_net_changes = 0;
+INSERT INTO lag_seed VALUES ('seed');
+
+# Establish a nonzero database maximum, then freeze it. Enabling `lag_t` after
+# this point gives its capture instance a later start LSN.
+$ sql-server-execute name=sql-server split-lines=false
+WAITFOR DELAY '00:00:20';
+
+$ sql-server-execute name=sql-server
+USE lag_test;
+EXEC sys.sp_cdc_stop_job @job_type = 'capture';
 CREATE TABLE lag_t (f1 VARCHAR(20));
 EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'lag_t', @role_name = 'SA', @supports_net_changes = 0;
 INSERT INTO lag_t VALUES ('one'), ('two'), ('three');
 
-# Let the capture instance drain the writes above and go idle, so this
-# database's max LSN is frozen before we snapshot. Once idle, SQL Server does
-# not advance the max LSN for several minutes, which keeps the source frontier
-# from advancing on its own and thus exercises the startup seeding of
-# `offset_committed`.
+# This is the upstream state the test depends on. If SQL Server changes its CDC
+# behavior, fail here rather than attributing a later result to Materialize.
 $ sql-server-execute name=sql-server split-lines=false
-WAITFOR DELAY '00:00:20';
+IF NOT EXISTS (
+    SELECT 1
+    FROM lag_test.cdc.change_tables
+    WHERE capture_instance = 'dbo_lag_t'
+      AND start_lsn > lag_test.sys.fn_cdc_get_max_lsn()
+)
+    THROW 50000, 'expected capture start LSN above database maximum', 1;
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET storage_statistics_collection_interval = 1000;
@@ -102,21 +117,16 @@ SELECT cr.id
   ORDER BY cr.id
   LIMIT 1
 
-# With `offset_committed` seeded from the resumption LSN it tracks `offset_known`,
-# so the lag stays near zero even though the upstream database is idle. Without
-# the fix `offset_committed` stays at 0 and the lag is the full upstream LSN
-# until the idle database eventually advances its max LSN, which takes minutes.
-# The bounded timeout is shorter than that heal time, so a buggy build fails
-# here, while a correct build passes within seconds. The bound is phrased as an
-# addition rather than `offset_known - offset_committed` so it never underflows
-# the unsigned columns if `offset_known` is momentarily unset before the first
-# probe tick.
+# The reported committed offset must not exceed the first known upstream offset,
+# even though the actual resumption LSN does. The second expression is the
+# ingestion-lag calculation used by customers. Since both columns are `uint8`,
+# invalid ordering makes the subtraction itself fail instead of reporting lag.
 $ set-sql-timeout duration=60s
 
 > SELECT
     u.offset_committed > 0,
     u.offset_known >= u.offset_committed,
-    u.offset_known < u.offset_committed + 1000000
+    u.offset_known - u.offset_committed < 1000000
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name = 'lag_source' AND u.replica_id = '${replica_id}'

--- a/test/sql-server-cdc/73-ingestion-lag-during-connection-delay.td
+++ b/test/sql-server-cdc/73-ingestion-lag-during-connection-delay.td
@@ -1,0 +1,66 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Hold the first runtime connection open and verify that the ingestion-lag
+# calculation remains valid before `offset_known` is initialized.
+
+$ sql-server-connect name=sql-server
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
+
+$ sql-server-execute name=sql-server
+USE test;
+CREATE TABLE t73 (f1 VARCHAR(20));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't73', @role_name = 'SA', @supports_net_changes = 0;
+INSERT INTO t73 VALUES ('one');
+
+$ http-request method=POST url=http://toxiproxy:8474/proxies content-type=application/json
+{
+  "name": "sql-server",
+  "listen": "0.0.0.0:1433",
+  "upstream": "sql-server:1433",
+  "enabled": true
+}
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000;
+ALTER SYSTEM SET storage_statistics_interval = 2000;
+
+> CREATE CLUSTER storage REPLICAS ()
+> CREATE SECRET pass AS '${arg.default-sql-server-password}'
+> CREATE CONNECTION conn TO SQL SERVER (
+    HOST 'toxiproxy',
+    PORT 1433,
+    DATABASE test,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD = SECRET pass
+  )
+> CREATE SOURCE s IN CLUSTER storage
+  FROM SQL SERVER CONNECTION conn
+  FOR TABLES (dbo.t73)
+
+# Stall the first connection past several statistics intervals.
+$ http-request method=POST url=http://toxiproxy:8474/proxies/sql-server/toxics content-type=application/json
+{
+  "name": "startup-delay",
+  "type": "latency",
+  "attributes": { "latency": 30000 }
+}
+
+> CREATE CLUSTER REPLICA storage.r1 SIZE = 'scale=1,workers=1'
+
+# The correct state remains zero, so there is no nonzero value to poll for.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration="5s"
+
+$ set-sql-timeout duration=10s
+
+> SELECT u.offset_known - u.offset_committed
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name = 's'
+0

--- a/test/sql-server-cdc/mzcompose.py
+++ b/test/sql-server-cdc/mzcompose.py
@@ -29,6 +29,7 @@ from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.sql_server import SqlServer
 from materialize.mzcompose.services.test_certs import TestCerts
 from materialize.mzcompose.services.testdrive import Testdrive
+from materialize.mzcompose.services.toxiproxy import Toxiproxy
 
 TLS_CONF_PATH = MZ_ROOT / "test" / "sql-server-cdc" / "tls-mssconfig.conf"
 
@@ -41,6 +42,7 @@ SERVICES = [
     ),
     Testdrive(),
     TestCerts(),
+    Toxiproxy(),
     SqlServer(
         volumes_extra=[
             "secrets:/var/opt/mssql/certs",
@@ -122,10 +124,18 @@ def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
     c.rm("sql-server")
     c.kill("materialized")
     c.rm("materialized")
+    c.kill("toxiproxy")
+    c.rm("toxiproxy")
 
     # must start test-certs, otherwise the certificates needed by sql-server may not be available
     # in the secrets volume when it starts up
-    c.up("materialized", "test-certs", "sql-server", Service("testdrive", idle=True))
+    c.up(
+        "materialized",
+        "test-certs",
+        "sql-server",
+        "toxiproxy",
+        Service("testdrive", idle=True),
+    )
     seed = random.getrandbits(16)
 
     ssl_ca = c.exec(


### PR DESCRIPTION
The progress operator left offset_committed at 0 until the first resume upper arrived, so ingestion lag read as the full upstream LSN during the initial snapshot. Initialize it from the resumption LSN, or max upstream LSN, if snapshotting. Initialize offset_known concurrently to further reduce the gap where these 2 could result in bogus lag calculation.
