### PR TITLE
SS-336: testdrive: read and decode messages using GSR

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -877,6 +877,9 @@ impl Run for PosCommand {
                     "file-append" => file::run_append(builtin, state).await,
                     "file-delete" => file::run_delete(builtin, state).await,
                     "glue-create-schema" => glue::run_create_schema(builtin, state).await,
+                    "glue-verify-compatibility" => {
+                        glue::run_verify_compatibility(builtin, state).await
+                    }
                     "http-request" => http::run_request(builtin, state).await,
                     "kafka-add-partitions" => kafka::run_add_partitions(builtin, state).await,
                     "kafka-create-topic" => kafka::run_create_topic(builtin, state).await,

--- a/src/testdrive/src/action/glue.rs
+++ b/src/testdrive/src/action/glue.rs
@@ -65,23 +65,11 @@ pub async fn run_create_schema(
         "protobuf" => DataFormat::Protobuf,
         other => bail!("unknown data-format: {}", other),
     };
-    let compatibility = match cmd
-        .args
-        .opt_string("compatibility")
-        .unwrap_or_else(|| "backward".into())
-        .to_lowercase()
-        .as_str()
-    {
-        "backward" => Compatibility::Backward,
-        "backward_all" => Compatibility::BackwardAll,
-        "forward" => Compatibility::Forward,
-        "forward_all" => Compatibility::ForwardAll,
-        "full" => Compatibility::Full,
-        "full_all" => Compatibility::FullAll,
-        "none" => Compatibility::None,
-        "disabled" => Compatibility::Disabled,
-        other => bail!("unknown compatibility: {}", other),
-    };
+    let compatibility = parse_compatibility(
+        &cmd.args
+            .opt_string("compatibility")
+            .unwrap_or_else(|| "backward".into()),
+    )?;
     cmd.args.done()?;
 
     // The schema definition comes from the `schema=` argument (typically a
@@ -143,4 +131,64 @@ pub async fn run_create_schema(
         state.cmd_vars.insert(var, version_id);
     }
     Ok(ControlFlow::Continue)
+}
+
+/// Verify that a schema in AWS Glue Schema Registry has the expected
+/// compatibility policy, looked up by name.
+///
+/// A sink applies a compatibility policy only when it first creates a schema,
+/// and never overwrites it afterward. Record decoding cannot observe that
+/// policy, so this reads it back to assert the create path applied the intended
+/// value.
+///
+/// Arguments:
+///   * `name` (required): the schema name.
+///   * `compatibility` (required): the expected compatibility, e.g. `backward`
+///     or `full`. Matched case-insensitively.
+///   * `registry` (optional): registry name. Omit to target Glue's implicit
+///     default registry.
+pub async fn run_verify_compatibility(
+    mut cmd: BuiltinCommand,
+    state: &State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let name = cmd.args.string("name")?;
+    let registry = cmd.args.opt_string("registry");
+    let expected = parse_compatibility(&cmd.args.string("compatibility")?)?;
+    cmd.args.done()?;
+
+    let glue = aws_sdk_glue::Client::new(&state.aws_config);
+    let mut schema_id = SchemaId::builder().schema_name(&name);
+    if let Some(registry) = &registry {
+        schema_id = schema_id.registry_name(registry);
+    }
+    let resp = glue
+        .get_schema()
+        .schema_id(schema_id.build())
+        .send()
+        .await
+        .context("fetching Glue schema")?;
+
+    let actual = resp
+        .compatibility()
+        .ok_or_else(|| anyhow!("Glue schema {name:?} has no compatibility set"))?;
+    if *actual != expected {
+        bail!("Glue schema {name:?} has compatibility {actual:?}, expected {expected:?}");
+    }
+    Ok(ControlFlow::Continue)
+}
+
+/// Parse a Glue compatibility policy from its testdrive spelling, matched
+/// case-insensitively.
+fn parse_compatibility(s: &str) -> Result<Compatibility, anyhow::Error> {
+    Ok(match s.to_lowercase().as_str() {
+        "backward" => Compatibility::Backward,
+        "backward_all" => Compatibility::BackwardAll,
+        "forward" => Compatibility::Forward,
+        "forward_all" => Compatibility::ForwardAll,
+        "full" => Compatibility::Full,
+        "full_all" => Compatibility::FullAll,
+        "none" => Compatibility::None,
+        "disabled" => Compatibility::Disabled,
+        other => bail!("unknown compatibility: {}", other),
+    })
 }

--- a/src/testdrive/src/action/kafka/verify_data.rs
+++ b/src/testdrive/src/action/kafka/verify_data.rs
@@ -11,7 +11,7 @@ use std::fmt::Debug;
 use std::time::Duration;
 use std::{cmp, str};
 
-use anyhow::{Context, bail, ensure};
+use anyhow::{Context, anyhow, bail, ensure};
 use mz_postgres_util::{Sql, query_one, sql};
 use rdkafka::consumer::{Consumer, StreamConsumer};
 use rdkafka::error::KafkaError;
@@ -147,6 +147,9 @@ pub async fn run_verify_data(
     }
     let partial_search = cmd.args.opt_parse("partial-search")?;
     let debug_print_only = cmd.args.opt_bool("debug-print-only")?.unwrap_or(false);
+    // When set, decode Avro from AWS Glue framing (18-byte header) and resolve the
+    // writer schema from Glue rather than Confluent Schema Registry.
+    let glue = cmd.args.opt_bool("glue")?.unwrap_or(false);
     cmd.args.done()?;
 
     let topic: String = match &source {
@@ -241,38 +244,48 @@ pub async fn run_verify_data(
         }
     }
 
-    let key_schema = if let Format::Avro = format.key {
-        let schema = state
-            .ccsr_client
-            .get_schema_by_subject(&format!("{}-key", topic))
-            .await
-            .ok()
-            .map(|key_schema| {
-                avro::parse_schema(&key_schema.raw, &[]).context("parsing avro schema")
-            })
-            .transpose()?;
-        // for avro, we can determine if a key is required based on the presence of the key schema
-        // rather than requiring the user to specify the key=true flag
-        if schema.is_some() {
-            format.requires_key = true;
-        }
-        schema
+    let (key_schema, value_schema) = if glue {
+        // A Glue sink frames each record with an 18-byte header carrying the
+        // schema-version UUID. Resolve the writer schema for each side from Glue
+        // using the UUID on the first record of that side. All records in a
+        // verify batch share the sink's schema, so one lookup per side suffices.
+        resolve_glue_schemas(state, &actual_bytes, &mut format).await?
     } else {
-        None
-    };
-    let value_schema = if let Format::Avro = format.value {
-        let val_schema = state
-            .ccsr_client
-            .get_schema_by_subject(&format!("{}-value", topic))
-            .await
-            .context("fetching schema")?
-            .raw;
-        Some(avro::parse_schema(&val_schema, &[]).context("parsing avro schema")?)
-    } else {
-        None
+        let key_schema = if let Format::Avro = format.key {
+            let schema = state
+                .ccsr_client
+                .get_schema_by_subject(&format!("{}-key", topic))
+                .await
+                .ok()
+                .map(|key_schema| {
+                    avro::parse_schema(&key_schema.raw, &[]).context("parsing avro schema")
+                })
+                .transpose()?;
+            // for avro, we can determine if a key is required based on the presence of the key schema
+            // rather than requiring the user to specify the key=true flag
+            if schema.is_some() {
+                format.requires_key = true;
+            }
+            schema
+        } else {
+            None
+        };
+        let value_schema = if let Format::Avro = format.value {
+            let val_schema = state
+                .ccsr_client
+                .get_schema_by_subject(&format!("{}-value", topic))
+                .await
+                .context("fetching schema")?
+                .raw;
+            Some(avro::parse_schema(&val_schema, &[]).context("parsing avro schema")?)
+        } else {
+            None
+        };
+        (key_schema, value_schema)
     };
 
-    let mut actual_messages = decode_messages(actual_bytes, &key_schema, &value_schema, &format)?;
+    let mut actual_messages =
+        decode_messages(actual_bytes, &key_schema, &value_schema, &format, glue)?;
 
     if sort_messages {
         actual_messages.sort_by_key(|r| format!("{:?}", r));
@@ -308,6 +321,59 @@ pub async fn run_verify_data(
     Ok(ControlFlow::Continue)
 }
 
+/// Resolve the writer schema for each record side from AWS Glue.
+///
+/// Reads the schema-version UUID from the Glue header of the first record on each
+/// side and fetches that version's definition from Glue. Returns
+/// `(key_schema, value_schema)`, mirroring the Confluent resolution path, and
+/// sets `format.requires_key` when a key schema is present. All records in a
+/// verify batch share the sink's schema, so one lookup per side is enough.
+async fn resolve_glue_schemas(
+    state: &State,
+    records: &[Record<Vec<u8>>],
+    format: &mut RecordFormat,
+) -> Result<(Option<mz_avro::Schema>, Option<mz_avro::Schema>), anyhow::Error> {
+    let client = aws_sdk_glue::Client::new(&state.aws_config);
+
+    async fn schema_for(
+        client: &aws_sdk_glue::Client,
+        payload: Option<&Vec<u8>>,
+    ) -> Result<Option<mz_avro::Schema>, anyhow::Error> {
+        let Some(payload) = payload else {
+            return Ok(None);
+        };
+        let (schema_version_id, _) = mz_interchange::glue::extract_avro_header(payload)?;
+        let resp = client
+            .get_schema_version()
+            .schema_version_id(schema_version_id.to_string())
+            .send()
+            .await
+            .with_context(|| format!("fetching Glue schema version {schema_version_id}"))?;
+        let definition = resp
+            .schema_definition()
+            .ok_or_else(|| anyhow!("Glue schema version {schema_version_id} has no definition"))?;
+        Ok(Some(
+            avro::parse_schema(definition, &[]).context("parsing Glue avro schema")?,
+        ))
+    }
+
+    let value_schema = if let Format::Avro = format.value {
+        schema_for(&client, records.iter().find_map(|r| r.value.as_ref())).await?
+    } else {
+        None
+    };
+    let key_schema = if let Format::Avro = format.key {
+        let schema = schema_for(&client, records.iter().find_map(|r| r.key.as_ref())).await?;
+        if schema.is_some() {
+            format.requires_key = true;
+        }
+        schema
+    } else {
+        None
+    };
+    Ok((key_schema, value_schema))
+}
+
 /// Expect and split out `n` whitespace-delimited headers before the main contents of the 'expect' row.
 fn split_headers(input: &str, n_headers: usize) -> anyhow::Result<(Vec<String>, &str)> {
     let whitespace = Regex::new("\\s+").expect("building known-valid regex");
@@ -333,11 +399,26 @@ fn split_headers(input: &str, n_headers: usize) -> anyhow::Result<(Vec<String>, 
     Ok((headers, rest))
 }
 
+/// Decode Avro `bytes` with `schema`, stripping Glue framing when `glue` is set
+/// and Confluent framing otherwise.
+fn decode_avro(
+    schema: &mz_avro::Schema,
+    bytes: &[u8],
+    glue: bool,
+) -> Result<avro::Value, anyhow::Error> {
+    if glue {
+        avro::from_glue_bytes(schema, bytes)
+    } else {
+        avro::from_confluent_bytes(schema, bytes)
+    }
+}
+
 fn decode_messages(
     actual_bytes: Vec<Record<Vec<u8>>>,
     key_schema: &Option<mz_avro::Schema>,
     value_schema: &Option<mz_avro::Schema>,
     format: &RecordFormat,
+    glue: bool,
 ) -> Result<Vec<Record<DecodedValue>>, anyhow::Error> {
     let mut actual_messages = vec![];
 
@@ -345,9 +426,11 @@ fn decode_messages(
         let Record { key, value, .. } = record;
         let key = if format.requires_key {
             match (key, format.key) {
-                (Some(bytes), Format::Avro) => Some(DecodedValue::Avro(DebugValue(
-                    avro::from_confluent_bytes(key_schema.as_ref().unwrap(), &bytes)?,
-                ))),
+                (Some(bytes), Format::Avro) => Some(DecodedValue::Avro(DebugValue(decode_avro(
+                    key_schema.as_ref().unwrap(),
+                    &bytes,
+                    glue,
+                )?))),
                 (Some(bytes), Format::Json) => Some(DecodedValue::Json(
                     serde_json::from_slice(&bytes).context("decoding json")?,
                 )),
@@ -361,9 +444,11 @@ fn decode_messages(
         };
 
         let value = match (value, format.value) {
-            (Some(bytes), Format::Avro) => Some(DecodedValue::Avro(DebugValue(
-                avro::from_confluent_bytes(value_schema.as_ref().unwrap(), &bytes)?,
-            ))),
+            (Some(bytes), Format::Avro) => Some(DecodedValue::Avro(DebugValue(decode_avro(
+                value_schema.as_ref().unwrap(),
+                &bytes,
+                glue,
+            )?))),
             (Some(bytes), Format::Json) => Some(DecodedValue::Json(
                 serde_json::from_slice(&bytes).context("decoding json")?,
             )),

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -256,6 +256,16 @@ pub fn from_confluent_bytes(schema: &Schema, mut bytes: &[u8]) -> Result<Value, 
     Ok(datum)
 }
 
+/// Strip the AWS Glue wire-format header and decode the Avro payload with
+/// `schema`. The 16-byte schema-version UUID in the header identifies the writer
+/// schema; callers that need it should extract it separately via
+/// [`mz_interchange::glue::extract_avro_header`].
+pub fn from_glue_bytes(schema: &Schema, bytes: &[u8]) -> Result<Value, anyhow::Error> {
+    let (_schema_version_id, mut payload) = mz_interchange::glue::extract_avro_header(bytes)?;
+    let datum = from_avro_datum(schema, &mut payload).context("decoding avro datum")?;
+    Ok(datum)
+}
+
 /// A struct to enhance the debug output of various Avro types.
 ///
 /// Testdrive scripts, for example, specify timestamps in micros, but debug


### PR DESCRIPTION
Adds testdrive support for verifying Kafka sink output encoded via AWS Glue Schema Registry (GSR), enabling end-to-end coverage of CREATE SINK ... FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY.

Changes

- `kafka-verify-data glue=true` : flag that decodes Avro with Glue's framing.
- `glue-verify-compatibility` : command that reads a schema's compatibility policy back from Glue and asserts it matches the expected value. This is the only way to prove a sink applied the intended COMPATIBILITY LEVEL when it created the schema.
- `avro::from_glue_bytes` : Glue analogue of from_confluent_bytes. Strips the Glue header and decodes the payload.
- `glue.rs` refactor : extracts the duplicated compatibility-string parsing into a shared parse_compatibility helper.


E2E tests: https://github.com/MaterializeInc/materialize/pull/37496