### PR TITLE
docs: update GCP instance type recommendations to C4A/C4/N4

### DIFF
--- a/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
@@ -19,7 +19,7 @@ As a general guideline, we recommend:
 
 - ARM-based CPU
 - A 1:8 ratio of vCPU to GiB memory.
-- A 8:1 ratio of GiB local instance storage to GiB memory when using swap.
+- At least a 2:1 ratio of GiB local instance storage to GiB memory when using swap.
 
 {{% self-managed/aws-recommended-instances %}}
 

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/azure-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/azure-deployment-guidelines.md
@@ -17,7 +17,7 @@ As a general guideline, we recommend:
 
 - ARM-based CPU.
 - A 1:8 ratio of vCPU to GiB memory.
-- An 8:1 ratio of GiB local instance storage to GiB memory when using swap.
+- At least a 2:1 ratio of GiB local instance storage to GiB memory when using swap.
 
 ### Recommended Azure VM Types with Local NVMe Disks
 

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/gcp-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/gcp-deployment-guidelines.md
@@ -17,17 +17,21 @@ As a general guideline, we recommend:
 
 - ARM-based CPU.
 - A 1:8 ratio of vCPU to GiB memory.
-- An 8:1 ratio of GiB local instance storage to GiB memory when using swap.
+- At least a 2:1 ratio of GiB local instance storage to GiB memory when using swap.
 
-When operating on GCP in production, we recommend the following machine types
-that support local SSD attachment:
+When operating on GCP in production, we recommend the Arm-based [C4A
+high-memory series]. Both C4A and C4 offer local SSDs only on their `-lssd`
+machine variants, which bundle a fixed number of Titanium SSD disks.
 
 | Series | Examples   |
 | ------ | ---------- |
-| [N2 high-memory series] | `n2-highmem-16` or `n2-highmem-32` with local NVMe SSDs |
-| [N2D  high-memory series] | `n2d-highmem-16` or `n2d-highmem-32` with local NVMe SSDs |
+| [C4A high-memory series] (recommended) | `c4a-highmem-16-lssd` or `c4a-highmem-32-lssd` |
+| [C4 high-memory series] | `c4-highmem-16-lssd` or `c4-highmem-32-lssd` |
 
-To maintain the recommended 8:1 disk-to-RAM ratio for your machine type, see
+C4A is not available in every region. Where it is unavailable, use the
+x86-based [C4 high-memory series] instead.
+
+To maintain the recommended disk-to-RAM ratio for your machine type, see
 [Number of local SSDs](#number-of-local-ssds) to determine the number of local
 SSDs to use.
 
@@ -35,34 +39,33 @@ See also [Locally attached NVMe storage](#locally-attached-nvme-storage).
 
 ## Number of local SSDs
 
-Each local NVMe SSD in GCP provides 375GB of storage. Use the appropriate number
+Each local SSD in GCP provides 375GB of storage. Use the appropriate number
 of local SSDs to ensure your total disk space is at least twice the amount of RAM in your
 machine type for optimal Materialize performance.
 
-{{< note >}}
+C4A and C4 bundle a fixed number of Titanium SSD disks in each `-lssd`
+machine variant. The count is not configurable, but every high-memory `-lssd`
+variant satisfies the 2:1 disk-to-RAM ratio:
 
-Your machine type may only supports predefined number of local SSDs. For instance, `n2d-highmem-32` allows only the following number of local
-SSDs: `4`,`8`,`16`, or `24`. To determine the valid number of Local SSDs to attach for your machine type, see the [GCP
+| Machine Type          | RAM     | Bundled Local SSDs | Total SSD Storage |
+|-----------------------|---------|--------------------|-------------------|
+| `c4a-highmem-8-lssd`  | `64GB`  | 2                  | `750GB`           |
+| `c4a-highmem-16-lssd` | `128GB` | 4                  | `1500GB`          |
+| `c4a-highmem-32-lssd` | `256GB` | 6                  | `2250GB`          |
+| `c4a-highmem-64-lssd` | `512GB` | 14                 | `5250GB`          |
+| `c4-highmem-8-lssd`   | `62GB`  | 1                  | `375GB`           |
+| `c4-highmem-16-lssd`  | `124GB` | 2                  | `750GB`           |
+| `c4-highmem-32-lssd`  | `248GB` | 5                  | `1875GB`          |
+| `c4-highmem-48-lssd`  | `372GB` | 8                  | `3000GB`          |
+
+For other machine series, the local SSD count is configurable but may only
+support predefined values. To determine the valid number of local SSDs to
+attach for your machine type, see the [GCP
 documentation](https://cloud.google.com/compute/docs/disks/local-ssd#lssd_disk_options).
 
-{{</ note >}}
+[C4A high-memory series]: https://cloud.google.com/compute/docs/general-purpose-machines#c4a_series
 
-For example, the following table provides a minimum local SSD count to ensure
-the 2:1 disk-to-RAM ratio. Your actual
-count will depend on the [your machine
-type](https://cloud.google.com/compute/docs/disks/local-ssd#lssd_disk_options).
-
-| Machine Type    | RAM     | Required Disk | Minimum Local SSD Count | Total SSD Storage |
-|-----------------|---------|---------------|-----------------------------|-------------------|
-| `n2-highmem-8`  | `64GB`  | `128GB`       | 1                           | `375GB`           |
-| `n2-highmem-16` | `128GB` | `256GB`       | 1                           | `375GB`           |
-| `n2-highmem-32` | `256GB` | `512GB`       | 2                           | `750GB`           |
-| `n2-highmem-64` | `512GB` | `1024GB`      | 3                           | `1125GB`          |
-| `n2-highmem-80` | `640GB` | `1280GB`      | 4                           | `1500GB`          |
-
-[N2 high-memory series]: https://cloud.google.com/compute/docs/general-purpose-machines#n2-high-mem
-
-[N2D high-memory series]: https://cloud.google.com/compute/docs/general-purpose-machines#n2d_machine_types
+[C4 high-memory series]: https://cloud.google.com/compute/docs/general-purpose-machines#c4_series
 
 
 ## Locally-attached NVMe storage

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/resize-node-pools.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/resize-node-pools.md
@@ -51,12 +51,12 @@ module "gke" {
   node_pools = [
     {
       name         = "materialize"
-      machine_type = "n2-highmem-8"
+      machine_type = "c4a-highmem-8-lssd"
       # ...
     },
     {
       name         = "materialize-xl"
-      machine_type = "n2-highmem-16"
+      machine_type = "c4a-highmem-16-lssd"
       # ... same labels and taints as above ...
     },
   ]
@@ -68,12 +68,14 @@ Or, if you're using a single-pool module wrapper, instantiate it twice:
 ```hcl
 module "materialize_nodepool" {
   # ... existing pool config ...
-  machine_type = "n2-highmem-8"
+  machine_type = "c4a-highmem-8-lssd"
 }
 
 module "materialize_nodepool_xl" {
-  # ... copy the existing config, change name and machine_type ...
-  machine_type = "n2-highmem-16"
+  # ... copy the existing config, change name and machine_type. For -lssd
+  # machine types, also update local_ssd_count to the variant's bundled
+  # disk count (c4a-highmem-16-lssd bundles 4) ...
+  machine_type = "c4a-highmem-16-lssd"
 }
 ```
 

--- a/doc/user/content/self-managed-deployments/installation/install-on-gcp.md
+++ b/doc/user/content/self-managed-deployments/installation/install-on-gcp.md
@@ -45,8 +45,8 @@ This example provisions the following infrastructure:
 | Resource | Description |
 |----------|-------------|
 | GKE Cluster | Regional cluster with Workload Identity enabled |
-| Generic Node Pool | e2-standard-8 machines, autoscaling 2-5 nodes, 50GB disk, for general workloads |
-| Materialize Node Pool | n2-highmem-8 machines, autoscaling 2-5 nodes, 100GB disk, 1 local SSD, swap enabled, dedicated taints for Materialize workloads |
+| Generic Node Pool | c4-standard-8 machines, autoscaling 2-5 nodes, 50GB disk, for general workloads |
+| Materialize Node Pool | c4a-highmem-8-lssd machines (Arm-based), autoscaling 2-5 nodes, 100GB disk, 2 bundled local SSDs, swap enabled, dedicated taints for Materialize workloads |
 | Service Account | GKE service account with workload identity binding |
 
 ### Database
@@ -54,7 +54,7 @@ This example provisions the following infrastructure:
 | Resource | Description |
 |----------|-------------|
 | Cloud SQL PostgreSQL | Private IP only (no public IP) |
-| Tier | db-custom-2-4096 (2 vCPUs, 4GB memory) |
+| Tier | db-custom-N4-2-4096 (N4 series, 2 vCPUs, 4GB memory) |
 | Database | `materialize` database with UTF8 charset |
 | User | `materialize` user with auto-generated password |
 | Network | Connected via VPC peering for private access |


### PR DESCRIPTION
### Motivation

MaterializeInc/materialize-terraform-self-managed#282 switched the GCP terraform example defaults to newer machine series (C4A/C4/N4) due to capacity issues with the older types. This updates the docs to match.

### Changes

- **GCP deployment guidelines**: recommend the Arm-based C4A high-memory `-lssd` series for Materialize node pools, with the x86-based C4 high-memory `-lssd` series as fallback where C4A is unavailable. Drop the N2/N2D recommendations. Document the fixed bundled Titanium SSD counts of the `-lssd` variants (verified against GCP docs, all high-memory variants satisfy the 2:1 disk-to-RAM minimum).
- **install-on-gcp**: update the infrastructure tables to the new simple example defaults (`c4-standard-8`, `c4a-highmem-8-lssd` with 2 bundled local SSDs, `db-custom-N4-2-4096`).
- **resize-node-pools**: update example machine types, and note that resizing across `-lssd` variants also means updating `local_ssd_count`.
- **AWS/Azure/GCP guidelines**: fix the stated storage-to-memory ratio (8:1 -> at least 2:1) to match the sizing tables.

Docs-only change, no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Notes for the reviewer
I think the steps in resize-node-pools.md are subtly incomplete and don't match the steps I wrote in the terraform README.md. Fixing that is a larger and more complicated change, so in the interest of keeping these changes reviewable and going out sooner, I'm leaving that out of scope for this PR.