### PR TITLE
SQL Server: update source versioning syntax

### DIFF
--- a/doc/user/content/headless/sql-server-considerations.md
+++ b/doc/user/content/headless/sql-server-considerations.md
@@ -32,14 +32,24 @@ guide](/ingest-data/sql-server/source-versioning/).
 
 #### Incompatible schema changes
 
-All other schema changes to upstream tables will set the corresponding subsource
-into an error state, which prevents you from reading from the source.
+All other schema changes to upstream tables will set the corresponding
+Materialize table (new syntax) or subsource (legacy syntax) into an error state,
+which prevents you from reading from the source.
 
-To handle incompatible [schema changes](#schema-changes), use [`DROP SOURCE`](/sql/alter-source/#context)
-and [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/) to first drop the
-affected subsource, and then add the table back to the source. When you add the
-subsource, it will have the updated schema from the corresponding upstream
-table.
+To handle incompatible [schema changes](#schema-changes), the recovery steps
+depend on the syntax used to create the source:
+
+- With the new [`CREATE SOURCE`](/sql/create-source/sql-server-v2/) and [`CREATE
+  TABLE FROM SOURCE`](/sql/create-table/) syntax, drop the affected table with
+  [`DROP TABLE`](/sql/drop-table/), and then [`CREATE TABLE FROM
+  SOURCE`](/sql/create-table/) to recreate the table with the updated schema
+  from the corresponding upstream table.
+
+- With the legacy [`CREATE SOURCE ... FOR ...`](/sql/create-source/sql-server/)
+  syntax, use [`DROP SOURCE`](/sql/alter-source/#context) to drop the affected
+  subsource, and then [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/) to add
+  the table back to the source. When you add the subsource, it will have the
+  updated schema from the corresponding upstream table.
 
 
 ### Supported types

--- a/doc/user/content/ingest-data/sql-server/azure-db.md
+++ b/doc/user/content/ingest-data/sql-server/azure-db.md
@@ -329,12 +329,7 @@ are receiving write queries, snapshotting may take up to an additional 5 minutes
 to complete. For details, see [snapshot latency for inactive databases](#snapshot-latency-for-inactive-databases)
 {{</ note >}}
 
-{{% include-example file="examples/ingest_data/sql_server/create_source_cloud" example="create-source" %}}
-
-{{% include-example file="examples/ingest_data/sql_server/create_source_cloud" example="create-source-options" %}}
-
-{{% include-example file="examples/ingest_data/sql_server/create_source_cloud"
-example="schema-changes" %}}
+{{% include-example file="examples/ingest_data/sql_server/create_source_cloud" example="ingest-data-step" %}}
 
 ### 4. Right-size the cluster
 

--- a/doc/user/content/ingest-data/sql-server/self-hosted.md
+++ b/doc/user/content/ingest-data/sql-server/self-hosted.md
@@ -253,12 +253,7 @@ are receiving write queries, snapshotting may take up to an additional 5 minutes
 to complete. For details, see [snapshot latency for inactive databases](#snapshot-latency-for-inactive-databases)
 {{</ note >}}
 
-{{% include-example file="examples/ingest_data/sql_server/create_source_cloud" example="create-source" %}}
-
-{{% include-example file="examples/ingest_data/sql_server/create_source_cloud" example="create-source-options" %}}
-
-{{% include-example file="examples/ingest_data/sql_server/create_source_cloud"
-example="schema-changes" %}}
+{{% include-example file="examples/ingest_data/sql_server/create_source_cloud" example="ingest-data-step" %}}
 
 ### 4. Right-size the cluster
 

--- a/doc/user/data/examples/ingest_data/sql_server/create_source_cloud.yml
+++ b/doc/user/data/examples/ingest_data/sql_server/create_source_cloud.yml
@@ -1,6 +1,7 @@
-- name: "create-source"
+- name: "create-source-legacy"
   description: |
-    Use the [`CREATE SOURCE`](/sql/create-source/) command to connect
+    Once you have created the connection, you can use the connection in the
+    [`CREATE SOURCE`](/sql/create-source/sql-server/) command to connect
     Materialize to your SQL Server instance and start ingesting data:
   test_setup: |
     $ sql-server-connect name=sql-server
@@ -20,9 +21,13 @@
     EXEC sys.sp_cdc_enable_db;
     ALTER DATABASE test SET ALLOW_SNAPSHOT_ISOLATION ON;
 
-    CREATE TABLE dummy (t datetime);
-    INSERT INTO dummy VALUES (CURRENT_TIMESTAMP);
-    EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'dummy', @role_name = 'SA', @supports_net_changes = 0;
+    CREATE TABLE table1 (a int);
+    INSERT INTO table1 VALUES (1);
+    EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table1', @role_name = 'SA', @supports_net_changes = 0;
+
+    CREATE TABLE table2 (a int);
+    INSERT INTO table2 VALUES (1);
+    EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'table2', @role_name = 'SA', @supports_net_changes = 0;
 
     > CREATE SECRET IF NOT EXISTS sqlserver_pass AS 'RPSsql12345'
 
@@ -37,18 +42,68 @@
     CREATE SOURCE mz_source
       FROM SQL SERVER CONNECTION sqlserver_connection
       FOR ALL TABLES;
-
-- name: "create-source-options"
-  description: |
+  results: |
     - By default, the source will be created in the active cluster; to use a
       different cluster, use the `IN CLUSTER` clause.
     - To ingest data from specific tables use the `FOR TABLES
-      (<table1>, <table2>)` options instead of `FOR ALL TABLES`.
+      (<table1>, <table2>)` option instead of `FOR ALL TABLES`.
     - To handle unsupported data types, use the `TEXT COLUMNS` or `EXCLUDE
       COLUMNS` options. Check out the [reference
       documentation](#supported-types) for guidance.
+  testable_results: false
+
+- name: "create-source"
+  description: |
+    Once you have created the connection, you can:
+    - use the connection in the [`CREATE
+    SOURCE`](/sql/create-source/sql-server-v2/) command to connect Materialize
+    to your SQL Server instance and
+    - use the source in the [`CREATE TABLE FROM SOURCE`](/sql/create-table/) in a
+    [DDL transaction block](/sql/begin/#ddl-only-transactions) to create the
+    tables in Materialize and start ingesting data:
+
+  test_setup: |
+    > DROP SOURCE mz_source CASCADE
+  code: |
+      -- Step 1: Create the source
+      CREATE SOURCE mz_source
+        FROM SQL SERVER CONNECTION sqlserver_connection;
+
+      -- Step 2: Create tables from the source
+      BEGIN;
+      CREATE TABLE table1 FROM SOURCE mz_source (REFERENCE dbo.table1);
+      CREATE TABLE table2 FROM SOURCE mz_source (REFERENCE dbo.table2);
+      COMMIT;
+  results: |
+    - By default, the source will be created in the active cluster; to use a
+      different cluster, use the `IN CLUSTER` clause.
+    - After creating the source, you can query
+      `mz_internal.mz_source_references` to see the available tables in the
+      upstream database.
+    - Create individual tables using [`CREATE TABLE <table_name> FROM SOURCE
+      <source_name> (REFERENCE <upstream_table>)`](/sql/create-table/).
+    - To handle unsupported data types, use `WITH (TEXT COLUMNS = [<column>])` or
+      `WITH (EXCLUDE COLUMNS = [<column>])` in the [`CREATE
+      TABLE`](/sql/create-table/) statement.
+  testable_results: false
 
 - name: "schema-changes"
   description: |
     After source creation, refer to [schema changes
     considerations](#schema-changes) for information on handling upstream schema changes.
+
+- name: "ingest-data-step"
+  description: |
+    {{< tabs level=4 >}}
+    {{< tab "New Syntax" >}}
+
+    {{% include-example file="examples/ingest_data/sql_server/create_source_cloud" example="create-source" %}}
+    {{% include-example file="examples/ingest_data/sql_server/create_source_cloud" example="schema-changes" %}}
+    {{< /tab >}}
+
+    {{< tab "Legacy Syntax" >}}
+
+    {{% include-example file="examples/ingest_data/sql_server/create_source_cloud" example="create-source-legacy" %}}
+    {{% include-example file="examples/ingest_data/sql_server/create_source_cloud" example="schema-changes" %}}
+    {{< /tab >}}
+    {{< /tabs >}}


### PR DESCRIPTION
This expands the user documentation for SQL Server (self-hosted and Azure SQL) to include new and legacy SOURCE syntax..

This is follow up from adding Azure SQL documentation.