### PR TITLE
docs: rework resize-node-pools for new Terraform modules and CRD v1

### DIFF
--- a/doc/user/content/headless/self-managed-deployments/force-rollout-terraform.md
+++ b/doc/user/content/headless/self-managed-deployments/force-rollout-terraform.md
@@ -1,0 +1,39 @@
+---
+headless: true
+---
+The Materialize spec itself is unchanged (the node move happens at the
+Kubernetes cluster level and not in the Materialize CR), so you need to force
+the rollout.
+
+{{< tabs >}}
+{{< tab "Materialize CRD v1" >}}
+
+The `v1` version of the Materialize CRD is the default starting in v4.0.0 of
+the Terraform modules. Set the `force_rollout` input of the
+`materialize-instance` module to a new UUID:
+
+```hcl
+module "materialize_instance" {
+  # ...
+  rollout_strategy = "WaitUntilReady"  # default
+  force_rollout    = "00000000-0000-0000-0000-000000000002"  # any new UUID
+}
+```
+
+{{< /tab >}}
+{{< tab "Materialize CRD v1alpha1" >}}
+
+If you have reverted to the `v1alpha1` version of the Materialize CRD, also
+set `request_rollout` to the same UUID:
+
+```hcl
+module "materialize_instance" {
+  # ...
+  rollout_strategy = "WaitUntilReady"  # default
+  request_rollout  = "00000000-0000-0000-0000-000000000002"  # any new UUID
+  force_rollout    = "00000000-0000-0000-0000-000000000002"  # same UUID
+}
+```
+
+{{< /tab >}}
+{{< /tabs >}}

--- a/doc/user/content/headless/self-managed-deployments/force-rollout-terraform.md
+++ b/doc/user/content/headless/self-managed-deployments/force-rollout-terraform.md
@@ -23,8 +23,9 @@ module "materialize_instance" {
 {{< /tab >}}
 {{< tab "Materialize CRD v1alpha1" >}}
 
-If you have reverted to the `v1alpha1` version of the Materialize CRD, also
-set `request_rollout` to the same UUID:
+If you have reverted to the `v1alpha1` version of the Materialize CRD, set
+both the `request_rollout` and `force_rollout` inputs of the
+`materialize-instance` module to the same new UUID:
 
 ```hcl
 module "materialize_instance" {

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
@@ -69,6 +69,16 @@ Certificate Authority (CA) rather than self-signed certificates.
 {{< include-md file="shared-content/self-managed/general-rules-for-upgrades.md"
 >}}
 
+## Karpenter node expiry
+
+The examples in the [Terraform
+modules](https://github.com/MaterializeInc/materialize-terraform-self-managed)
+set `expire_after` to `Never` on the Materialize nodepool. We recommend
+keeping that value. Node expiry is not a voluntary disruption: with any other
+value, Karpenter removes nodes that reach their lifetime even if they run pods
+annotated with `karpenter.sh/do-not-disrupt`, which causes downtime unless you
+gracefully roll the nodes first.
+
 ## Node pool resizing
 
 {{% include-headless "/headless/self-managed-deployments/resize-node-pool" %}}

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
@@ -71,24 +71,28 @@ Certificate Authority (CA) rather than self-signed certificates.
 
 ## Karpenter node expiry
 
-The examples in the [Terraform
+We recommend setting `expire_after` to `Never` on the Materialize nodepool
+since node expiry is not a voluntary disruption. With any other value,
+Karpenter removes nodes that reach their configured lifetime even if they run
+pods annotated with `karpenter.sh/do-not-disrupt`. This can cause downtime
+unless you gracefully roll the nodes first. The [Materialize Terraform
 modules](https://github.com/MaterializeInc/materialize-terraform-self-managed)
-set `expire_after` to `Never` on the Materialize nodepool. We recommend
-keeping that value, since node expiry is not a voluntary disruption. With any
-other value, Karpenter removes nodes that reach their lifetime even if they
-run pods annotated with `karpenter.sh/do-not-disrupt`. This can cause
-downtime unless you gracefully roll the nodes first.
+default `expire_after` to `Never`.
 
 ## Karpenter termination grace period
 
-Prior to v6.0.0 of the Terraform modules, the Materialize nodepool set
-`termination_grace_period` to `300s`. This caused nodes to be terminated five
-minutes after any change to the nodepool configuration, ignoring the
-`karpenter.sh/do-not-disrupt` annotation on pods. In v6.0.0 and later the
-value is unset by default. We recommend keeping it unset on nodepools for
-Materialize workloads. If you are running an older version of the modules,
-upgrade following the [upgrade
+We recommend leaving `termination_grace_period` unset on nodepools that run
+Materialize workloads. When this value is set, Karpenter terminates nodes after
+the configured grace period following any change to the nodepool
+configuration, even if they run pods annotated with
+`karpenter.sh/do-not-disrupt`.
+
+Before v6.0.0, the modules set `termination_grace_period` to `300s`. If you are
+using a version earlier than v6.0.0, upgrade to v6.0.0 using the [v6.0.0
+upgrade
 notes](https://github.com/MaterializeInc/materialize-terraform-self-managed/blob/v6.0.0/README.md#v600).
+Starting in v6.0.0, the Materialize Terraform modules leave
+`termination_grace_period` unset by default.
 
 ## Node pool resizing
 

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
@@ -74,10 +74,21 @@ Certificate Authority (CA) rather than self-signed certificates.
 The examples in the [Terraform
 modules](https://github.com/MaterializeInc/materialize-terraform-self-managed)
 set `expire_after` to `Never` on the Materialize nodepool. We recommend
-keeping that value. Node expiry is not a voluntary disruption: with any other
-value, Karpenter removes nodes that reach their lifetime even if they run pods
-annotated with `karpenter.sh/do-not-disrupt`, which causes downtime unless you
-gracefully roll the nodes first.
+keeping that value, since node expiry is not a voluntary disruption. With any
+other value, Karpenter removes nodes that reach their lifetime even if they
+run pods annotated with `karpenter.sh/do-not-disrupt`. This can cause
+downtime unless you gracefully roll the nodes first.
+
+## Karpenter termination grace period
+
+Prior to v6.0.0 of the Terraform modules, the Materialize nodepool set
+`termination_grace_period` to `300s`. This caused nodes to be terminated five
+minutes after any change to the nodepool configuration, ignoring the
+`karpenter.sh/do-not-disrupt` annotation on pods. In v6.0.0 and later the
+value is unset by default. We recommend keeping it unset on nodepools for
+Materialize workloads. If you are running an older version of the modules,
+upgrade following the [upgrade
+notes](https://github.com/MaterializeInc/materialize-terraform-self-managed/blob/v6.0.0/README.md#v600).
 
 ## Node pool resizing
 

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/resize-node-pools.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/resize-node-pools.md
@@ -9,109 +9,285 @@ aliases:
   - /self-managed-deployments/upgrading/resize-node-pools/
 ---
 
-When you need a larger (or smaller) VM type for a node pool that Materialize
-runs on, the change cannot be applied in place. The underlying cloud APIs do
-not support an in-place "change VM type" operation on an existing managed node
-pool, so the Terraform providers mark the VM type field `ForceNew` on all three
-clouds:
+When you need a larger (or smaller) VM type for the nodes that Materialize
+runs on, how to proceed depends on how the nodes are managed:
 
-- GKE: `google_container_node_pool.node_config.machine_type`
-- AKS: `azurerm_kubernetes_cluster_node_pool.vm_size`
-- EKS: `aws_eks_node_group.instance_types`
+- **Static node pools** (the GCP and Azure modules, and AWS node groups when
+  not using Karpenter) cannot change VM type in place. The underlying cloud
+  APIs do not support it, so the Terraform providers mark the VM type field
+  `ForceNew` (GKE: `machine_type`, AKS: `vm_size`, EKS node groups:
+  `instance_types`), and changing it plans a `destroy + create`. The destroy
+  fails if the pool still has Materialize pods on it, because nothing in the
+  Terraform graph migrates the workloads to a replacement pool first. The
+  supported pattern is to **add a second pool, taint the old pool so no new
+  pods schedule on it, trigger a Materialize rollout so the new generation of
+  pods lands on the new pool, then drop the old pool**.
 
-Changing the value makes Terraform plan a `destroy + create`. The destroy step
-fails if the pool still has Materialize pods running on it, because nothing in
-the Terraform graph migrates the workloads to a replacement pool first.
-
-The supported pattern is to **add a second pool, trigger a Materialize rollout
-so the new generation of pods lands on it, then drop the old pool**.
-
-{{< note >}}
-This guide applies to deployments that use static node groups (the default for
-the GCP and Azure modules, and for the AWS modules when Karpenter is disabled).
-If you're using [Karpenter](https://karpenter.sh/) for dynamic node provisioning,
-resizing is just a `NodePool` template change because Karpenter sizes nodes per
-pod rather than per pool.
-{{</ note >}}
+- **Karpenter-managed nodes** (the default for Materialize nodes in the AWS
+  modules) size nodes per pod rather than per pool. Changing the VM type is a
+  template change on the Karpenter `NodePool`, followed by a Materialize
+  rollout to move the pods onto new-spec nodes.
 
 ## Steps
 
+{{< tabs >}}
+{{< tab "Terraform" >}}
+
+These steps apply to the [Materialize Terraform
+modules](https://github.com/MaterializeInc/materialize-terraform-self-managed).
+
+{{< tabs >}}
+{{< tab "GCP" >}}
+
 ### 1. Declare a second node pool with the new VM type
 
-Add a second node pool alongside the existing one. Give it the same labels and
-taints as the existing pool so Materialize pods are eligible to schedule on it,
-but a distinct name and the new VM type.
+Add a new nodepool module instance alongside the existing one, keeping the old
+pool unchanged. Copy the existing configuration, then change:
 
-The exact shape depends on which module or resource you're using. For example,
-with `terraform-google-modules/kubernetes-engine` on GCP:
+- The `prefix`, so the pool gets a distinct name.
+- The `machine_type`.
+- For a swap-enabled pool, a distinct `disk_setup_name` (e.g.
+  `disk-setup-xl`). It names the disk-setup namespace and daemonset, which
+  otherwise collide with the old pool's.
+- The `local_ssd_count`, if the new machine type bundles a different number of
+  local SSDs (`c4a-highmem-16-lssd` has 4, for example).
 
-```hcl
-module "gke" {
-  # ...
-  node_pools = [
-    {
-      name         = "materialize"
-      machine_type = "c4a-highmem-8-lssd"
-      # ...
-    },
-    {
-      name         = "materialize-xl"
-      machine_type = "c4a-highmem-16-lssd"
-      # ... same labels and taints as above ...
-    },
-  ]
-}
-```
-
-Or, if you're using a single-pool module wrapper, instantiate it twice:
+Keep the same labels and taints as the existing pool so Materialize pods are
+eligible to schedule on it. For example:
 
 ```hcl
 module "materialize_nodepool" {
-  # ... existing pool config ...
+  # ... existing pool config, unchanged ...
   machine_type = "c4a-highmem-8-lssd"
 }
 
 module "materialize_nodepool_xl" {
-  # ... copy the existing config, change name and machine_type. For -lssd
-  # machine types, also update local_ssd_count to the variant's bundled
-  # disk count (c4a-highmem-16-lssd bundles 4) ...
-  machine_type = "c4a-highmem-16-lssd"
+  # ... copy of the existing config, with a new prefix ...
+  machine_type    = "c4a-highmem-16-lssd"
+  local_ssd_count = 4
+  disk_setup_name = "disk-setup-xl"
 }
 ```
 
-The Azure and AWS equivalents change `vm_size` (Azure) or `instance_types` (AWS)
-instead of `machine_type`.
-
-Apply. Both pools now exist. Materialize pods have not yet been scheduled on
-the new pool.
-
-### 2. Cordon the old pool so new pods schedule on the new one
+Run `terraform init` to pick up the new module instance, then apply:
 
 ```bash
-# Cordon every node in the old pool so the scheduler stops placing new pods there
-for node in $(kubectl get nodes -l <your-old-pool-label> -o name); do
-  kubectl cordon "$node"
-done
+terraform init
+terraform apply
 ```
 
-DaemonSets and existing pods stay in place; only new pods are kept off the
-cordoned nodes.
+Both pools now exist. Materialize pods have not yet been scheduled on the new
+pool.
 
-### 3. Roll out the Materialize instance to land new pods on the new pool
+### 2. Taint the old pool so no new pods schedule on it
 
-Use the Materialize CR's rollout machinery to have the operator create a new
-generation of `environmentd` and `clusterd` pods. With the old pool cordoned,
-the new generation schedules onto the new pool's nodes.
-
-If you're using the `materialize-instance` Terraform module, bump both
-`force_rollout` and `request_rollout` inputs to a new UUID and apply:
+Add a decommission taint to the old pool's `node_taints`:
 
 ```hcl
-module "materialize_instance" {
+node_taints = [
+  # ... existing taints ...
+  {
+    key    = "materialize.cloud/decommissioned"
+    value  = "true"
+    effect = "NO_SCHEDULE"
+  }
+]
+```
+
+Taints update in place (no pool replacement) on the provider versions the
+modules require. Running pods are not evicted, but no new pods schedule to the
+old pool, and the cluster autoscaler will not scale it up for pending pods,
+since they don't tolerate the taint. Use a taint key the Materialize pods
+don't tolerate (not `materialize.cloud/workload` or `kubernetes.io/arch`).
+
+Apply:
+
+```bash
+terraform apply
+```
+
+### 3. Roll out the Materialize instance
+
+With the old pool tainted, a forced rollout lands the new generation of pods
+on the new pool.
+
+{{% include-headless "/headless/self-managed-deployments/force-rollout-terraform" %}}
+
+Apply:
+
+```bash
+terraform apply
+```
+
+See [Rollout behavior](#rollout-behavior) for what to expect during the
+rollout. Verify the new `environmentd` and `clusterd` pods are only scheduled
+onto the new pool.
+
+### 4. Remove the old pool
+
+Once the rollout has completed, the old pool's nodes have no Materialize
+workloads on them. Remove the old nodepool module instance from your Terraform
+configuration and apply:
+
+```bash
+terraform apply
+```
+
+The destroy step now succeeds because the pool has no running workloads.
+
+### 5. Optional: rename the new pool back
+
+If you want the pool to keep the original name (for example because other
+Terraform or kubectl tooling references it), repeat these steps with a third
+pool that carries the original name. Otherwise, accept the new name and update
+any references.
+
+{{< /tab >}}
+{{< tab "Azure" >}}
+
+### 1. Declare a second node pool with the new VM type
+
+Add a new nodepool module instance alongside the existing one, keeping the old
+pool unchanged. Copy the existing configuration, then change:
+
+- The `prefix`, so the pool gets a distinct name. The AKS node pool name is
+  the prefix with dashes removed, truncated to 12 characters, so the new
+  prefix must differ from the old one within those characters. A suffix
+  appended to a long prefix is silently truncated away and the apply fails
+  because the pool name already exists.
+- The `vm_size`.
+- For a swap-enabled pool, a distinct `disk_setup_name` (e.g.
+  `disk-setup-xl`). It names the disk-setup namespace and daemonset, which
+  otherwise collide with the old pool's.
+
+Keep the same labels and taints as the existing pool so Materialize pods are
+eligible to schedule on it. For example:
+
+```hcl
+module "materialize_nodepool" {
+  # ... existing pool config, unchanged ...
+  prefix  = "mzpool"
+  vm_size = "Standard_E4pds_v6"
+}
+
+module "materialize_nodepool_xl" {
+  # ... copy of the existing config ...
+  prefix          = "mzpoolxl"
+  vm_size         = "Standard_E8pds_v6"
+  disk_setup_name = "disk-setup-xl"
+}
+```
+
+Run `terraform init` to pick up the new module instance, then apply:
+
+```bash
+terraform init
+terraform apply
+```
+
+Both pools now exist. Materialize pods have not yet been scheduled on the new
+pool.
+
+### 2. Taint the old pool so no new pods schedule on it
+
+Add a decommission taint to the old pool's `node_taints`:
+
+```hcl
+node_taints = [
+  # ... existing taints ...
+  {
+    key    = "materialize.cloud/decommissioned"
+    value  = "true"
+    effect = "NO_SCHEDULE"
+  }
+]
+```
+
+Taints update in place (no pool replacement) on the provider versions the
+modules require. Running pods are not evicted, but no new pods schedule to the
+old pool, and the cluster autoscaler will not scale it up for pending pods,
+since they don't tolerate the taint. Use a taint key the Materialize pods
+don't tolerate (not `materialize.cloud/workload` or `kubernetes.io/arch`).
+
+Apply:
+
+```bash
+terraform apply
+```
+
+### 3. Roll out the Materialize instance
+
+With the old pool tainted, a forced rollout lands the new generation of pods
+on the new pool.
+
+{{% include-headless "/headless/self-managed-deployments/force-rollout-terraform" %}}
+
+Apply:
+
+```bash
+terraform apply
+```
+
+See [Rollout behavior](#rollout-behavior) for what to expect during the
+rollout. Verify the new `environmentd` and `clusterd` pods are only scheduled
+onto the new pool.
+
+### 4. Remove the old pool
+
+Once the rollout has completed, the old pool's nodes have no Materialize
+workloads on them. Remove the old nodepool module instance from your Terraform
+configuration and apply:
+
+```bash
+terraform apply
+```
+
+The destroy step now succeeds because the pool has no running workloads.
+
+### 5. Optional: rename the new pool back
+
+If you want the pool to keep the original name (for example because other
+Terraform or kubectl tooling references it), repeat these steps with a third
+pool that carries the original name. Otherwise, accept the new name and update
+any references.
+
+{{< /tab >}}
+{{< tab "AWS" >}}
+
+{{< warning >}}
+Prior to v6.0.0 of the Terraform modules, the nodepools had `termination_grace_period`
+set to `300s`. This caused nodes to be terminated five minutes after any change to the
+nodepool configuration, ignoring the `karpenter.sh/do-not-disrupt` annotation on pods.
+
+If you are running an older version of the Terraform modules, to avoid downtime,
+we recommend upgrading to at least v6.0.0, following the steps in the
+[upgrade notes](https://github.com/MaterializeInc/materialize-terraform-self-managed/blob/v6.0.0/README.md#v600).
+
+On later versions, the `termination_grace_period` is unset by default.
+We recommend keeping it unset on nodepools for Materialize workloads.
+{{</ warning >}}
+
+The AWS modules provision Materialize nodes with Karpenter, so there is no
+second pool to create. Karpenter provisions new-spec nodes on demand.
+
+If you have disabled Karpenter and run Materialize on a static EKS node
+group, follow the blue-green pattern from the GCP and Azure tabs instead,
+changing `instance_types` on a second node group module instance.
+
+### 1. Update the instance types
+
+Change `instance_types` on the Materialize `karpenter-ec2nodeclass` and
+`karpenter-nodepool` module instances and apply:
+
+```hcl
+module "ec2nodeclass_materialize" {
   # ...
-  rollout_strategy = "WaitUntilReady"  # default
-  request_rollout  = "00000000-0000-0000-0000-000000000002"  # any new UUID
-  force_rollout    = "00000000-0000-0000-0000-000000000002"  # any new UUID
+  instance_types = ["r7gd.4xlarge"]
+}
+
+module "nodepool_materialize" {
+  # ...
+  instance_types = ["r7gd.4xlarge"]
 }
 ```
 
@@ -119,27 +295,153 @@ module "materialize_instance" {
 terraform apply
 ```
 
-If you're managing the Materialize CR directly, the equivalent kubectl
-command is:
+Karpenter marks the existing nodes as drifted but does not drain them: the
+`environmentd` and `clusterd` pods carry the `karpenter.sh/do-not-disrupt`
+annotation, which blocks voluntary disruption while they run. This relies on
+the nodepool's `expire_after` being `Never`, see [Karpenter node
+expiry](/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines/#karpenter-node-expiry).
+
+### 2. Cordon the drifted nodes
+
+Cordon the existing Materialize nodes so the rollout's new pods cannot
+schedule onto them and instead trigger Karpenter to provision nodes with the
+new instance types:
+
+```bash
+# The nodepool name is the `name` input of the karpenter-nodepool module
+# ("materialize" in the examples).
+for node in $(kubectl get nodes -l karpenter.sh/nodepool=materialize -o name); do
+  kubectl cordon "$node"
+done
+```
+
+Nodes that Karpenter provisions after this point are not cordoned.
+
+### 3. Roll out the Materialize instance
+
+{{% include-headless "/headless/self-managed-deployments/force-rollout-terraform" %}}
+
+Apply:
+
+```bash
+terraform apply
+```
+
+Karpenter provisions new-spec nodes for the pending pods of the new
+generation. See [Rollout behavior](#rollout-behavior) for what to expect
+during the rollout. Verify the new `environmentd` and `clusterd` pods are
+only scheduled onto the new nodes.
+
+### 4. Verify the old nodes are removed
+
+Once the rollout has completed and the old generation's pods are gone, the
+cordoned nodes are empty and Karpenter consolidates them away (the modules
+configure `consolidationPolicy: WhenEmpty`). Confirm they disappear:
+
+```bash
+kubectl get nodes -l karpenter.sh/nodepool=materialize
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+{{< /tab >}}
+{{< tab "Legacy Terraform" >}}
+
+The legacy Terraform modules
+([terraform-aws-materialize](https://github.com/MaterializeInc/terraform-aws-materialize),
+[terraform-google-materialize](https://github.com/MaterializeInc/terraform-google-materialize),
+and
+[terraform-azurerm-materialize](https://github.com/MaterializeInc/terraform-azurerm-materialize))
+are no longer supported. Migrate to the [new Terraform
+modules](https://github.com/MaterializeInc/materialize-terraform-self-managed)
+first, then follow the steps in the **Terraform** tab.
+
+{{< /tab >}}
+{{< tab "Manual" >}}
+
+If you manage your infrastructure without the Materialize Terraform modules:
+
+### 1. Create a second node pool with the new VM type
+
+Using your cloud provider's tooling, create a second node pool with the same
+labels and taints as the existing pool (so Materialize pods are eligible to
+schedule on it), a distinct name, and the new VM type.
+
+If your nodes are managed by Karpenter, skip this step and instead update the
+instance requirements on the Karpenter `NodePool`. Karpenter provisions
+new-spec nodes on demand once the old nodes are cordoned.
+
+### 2. Keep new pods off the old nodes
+
+For a static pool, add a decommission taint, such as
+`materialize.cloud/decommissioned=true:NoSchedule`, to the old pool. Apply the
+taint at the node pool level through your cloud provider rather than with
+`kubectl taint`: node-level taints do not carry over to nodes the cluster
+autoscaler adds to the pool later. Running pods are not evicted, but no new
+pods schedule to the old pool, and the cluster autoscaler will not scale it
+up for pending pods, since they don't tolerate the taint. Use a taint key the
+Materialize pods don't tolerate (not `materialize.cloud/workload` or
+`kubernetes.io/arch`).
+
+For Karpenter-managed nodes, cordon the old nodes instead. Nodes that
+Karpenter provisions afterwards are not cordoned.
+
+### 3. Roll out the Materialize instance to land new pods on the new nodes
+
+Use the Materialize CR's rollout machinery to have the operator create a new
+generation of `environmentd` and `clusterd` pods. Because the Materialize
+spec itself is unchanged (the node move happens at the Kubernetes cluster
+level and not in the Materialize CR), you need to force the rollout.
+
+{{< tabs >}}
+{{< tab "Materialize CRD v1" >}}
+
+Set `forceRollout` to a new UUID:
 
 ```bash
 kubectl patch materialize <instance-name> \
   -n <materialize-instance-namespace> \
   --type='merge' \
-  -p "{\"spec\": {\"requestRollout\": \"$(uuidgen)\", \"forceRollout\": \"$(uuidgen)\"}}"
+  -p "{\"spec\": {\"forceRollout\": \"$(uuidgen)\"}}"
 ```
 
-Both paths set `requestRollout` and `forceRollout` to new UUIDs, which is what
-the operator watches for. Because the Materialize spec itself is unchanged (the
-node pool move happens at the Kubernetes cluster level and not in the
-Materialize CR), you need to update `forceRollout` (in addition to
-`requestRollout`).
+{{< /tab >}}
+{{< tab "Materialize CRD v1alpha1" >}}
 
-The default `rolloutStrategy` is `WaitUntilReady`, which creates the new
-generation alongside the old, waits for it to catch up, then promotes it and
-tears down the old generation. This briefly doubles the resource footprint
-during the rollout (so make sure the new pool has the capacity) but is
-otherwise zero-downtime. For other rollout strategies (manual promotion,
+Set both `requestRollout` and `forceRollout` to the same new UUID:
+
+```bash
+UUID="$(uuidgen)"
+kubectl patch materialize <instance-name> \
+  -n <materialize-instance-namespace> \
+  --type='merge' \
+  -p "{\"spec\": {\"requestRollout\": \"$UUID\", \"forceRollout\": \"$UUID\"}}"
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+See [Rollout behavior](#rollout-behavior) for what to expect. Verify the new
+`environmentd` and `clusterd` pods are only scheduled onto the new nodes.
+
+### 4. Remove the old pool
+
+Once the rollout has completed, the old nodes have no Materialize workloads
+on them. Delete the old node pool using your cloud provider's tooling. For
+Karpenter-managed nodes, empty drifted nodes are consolidated away
+automatically.
+
+{{< /tab >}}
+{{< /tabs >}}
+
+## Rollout behavior
+
+The default rollout strategy, `WaitUntilReady`, creates the new generation
+alongside the old, waits for it to catch up, then promotes it and tears down
+the old generation. This briefly doubles the resource footprint during the
+rollout (so make sure the new nodes have the capacity) but otherwise incurs
+minimal downtime. For other rollout strategies (manual promotion,
 immediate-with-downtime), see
 [Rollout Configuration](/self-managed-deployments/upgrading/#rollout-configuration).
 
@@ -150,31 +452,17 @@ kubectl get materialize <instance-name> -n <materialize-instance-namespace> -w
 kubectl get pods -n <materialize-instance-namespace> -o wide
 ```
 
-You should see the new generation pods come up on the new pool's nodes, the
+You should see the new generation pods come up on the new nodes, the
 `UpToDate` condition flip to `True`, and the old generation pods get
 terminated.
 
-### 4. Remove the old pool
-
-Once the rollout has completed, the old pool's nodes have no Materialize
-workloads on them. Remove the original node pool entry (or module call) from
-your Terraform configuration and apply.
-
-The destroy step now succeeds because the pool has no running workloads.
-
-### 5. Optional: rename the new pool back
-
-If you want the pool to keep the original name (for example because other
-Terraform or kubectl tooling references it), repeat the same pattern in
-reverse: add a third pool with the original name, roll out onto it, then drop
-the renamed pool. Otherwise, accept the new name and update any references.
-
 ## Why not change the VM type in place
 
-It's tempting to update the existing pool's `machine_type` / `vm_size` /
-`instance_types` and re-apply. The Terraform plan correctly shows `destroy +
-create`, but the apply gets stuck on the destroy because the pool still has
-running pods that nothing has moved off. You end up with an error like:
+For static node pools, it's tempting to update the existing pool's
+`machine_type` / `vm_size` / `instance_types` and re-apply. The Terraform
+plan correctly shows `destroy + create`, but the apply gets stuck on the
+destroy because the pool still has running pods that nothing has moved off.
+You end up with an error like:
 
 ```
 cannot update node types in pool

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/resize-node-pools.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/resize-node-pools.md
@@ -28,6 +28,15 @@ runs on, how to proceed depends on how the nodes are managed:
   template change on the Karpenter `NodePool`, followed by a Materialize
   rollout to move the pods onto new-spec nodes.
 
+{{< note >}}
+
+The default rollout strategy (`WaitUntilReady`) used in the outlined steps
+temporarily runs the old and new generations of Materialize simultaneously. Make
+sure the new node pool has enough capacity to accommodate both generations
+during the rollout.
+
+{{< /note >}}
+
 ## Steps
 
 {{< tabs level=3 >}}

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/resize-node-pools.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/resize-node-pools.md
@@ -30,16 +30,16 @@ runs on, how to proceed depends on how the nodes are managed:
 
 ## Steps
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Terraform" >}}
 
 These steps apply to the [Materialize Terraform
 modules](https://github.com/MaterializeInc/materialize-terraform-self-managed).
 
-{{< tabs >}}
+{{< tabs level=4 >}}
 {{< tab "GCP" >}}
 
-### 1. Declare a second node pool with the new VM type
+##### 1. Declare a second node pool with the new VM type
 
 Add a new nodepool module instance alongside the existing one, keeping the old
 pool unchanged. Copy the existing configuration, then change:
@@ -79,7 +79,7 @@ terraform apply
 Both pools now exist. Materialize pods have not yet been scheduled on the new
 pool.
 
-### 2. Taint the old pool so no new pods schedule on it
+##### 2. Taint the old pool so no new pods schedule on it
 
 Add a decommission taint to the old pool's `node_taints`:
 
@@ -106,7 +106,7 @@ Apply:
 terraform apply
 ```
 
-### 3. Roll out the Materialize instance
+##### 3. Roll out the Materialize instance
 
 With the old pool tainted, a forced rollout lands the new generation of pods
 on the new pool.
@@ -123,7 +123,7 @@ See [Rollout behavior](#rollout-behavior) for what to expect during the
 rollout. Verify the new `environmentd` and `clusterd` pods are only scheduled
 onto the new pool.
 
-### 4. Remove the old pool
+##### 4. Remove the old pool
 
 Once the rollout has completed, the old pool's nodes have no Materialize
 workloads on them. Remove the old nodepool module instance from your Terraform
@@ -135,7 +135,7 @@ terraform apply
 
 The destroy step now succeeds because the pool has no running workloads.
 
-### 5. Optional: rename the new pool back
+##### 5. Optional: rename the new pool back
 
 If you want the pool to keep the original name (for example because other
 Terraform or kubectl tooling references it), repeat these steps with a third
@@ -145,7 +145,7 @@ any references.
 {{< /tab >}}
 {{< tab "Azure" >}}
 
-### 1. Declare a second node pool with the new VM type
+##### 1. Declare a second node pool with the new VM type
 
 Add a new nodepool module instance alongside the existing one, keeping the old
 pool unchanged. Copy the existing configuration, then change:
@@ -188,7 +188,7 @@ terraform apply
 Both pools now exist. Materialize pods have not yet been scheduled on the new
 pool.
 
-### 2. Taint the old pool so no new pods schedule on it
+##### 2. Taint the old pool so no new pods schedule on it
 
 Add a decommission taint to the old pool's `node_taints`:
 
@@ -215,7 +215,7 @@ Apply:
 terraform apply
 ```
 
-### 3. Roll out the Materialize instance
+##### 3. Roll out the Materialize instance
 
 With the old pool tainted, a forced rollout lands the new generation of pods
 on the new pool.
@@ -232,7 +232,7 @@ See [Rollout behavior](#rollout-behavior) for what to expect during the
 rollout. Verify the new `environmentd` and `clusterd` pods are only scheduled
 onto the new pool.
 
-### 4. Remove the old pool
+##### 4. Remove the old pool
 
 Once the rollout has completed, the old pool's nodes have no Materialize
 workloads on them. Remove the old nodepool module instance from your Terraform
@@ -244,7 +244,7 @@ terraform apply
 
 The destroy step now succeeds because the pool has no running workloads.
 
-### 5. Optional: rename the new pool back
+##### 5. Optional: rename the new pool back
 
 If you want the pool to keep the original name (for example because other
 Terraform or kubectl tooling references it), repeat these steps with a third
@@ -274,7 +274,7 @@ If you have disabled Karpenter and run Materialize on a static EKS node
 group, follow the blue-green pattern from the GCP and Azure tabs instead,
 changing `instance_types` on a second node group module instance.
 
-### 1. Update the instance types
+##### 1. Update the instance types
 
 Change `instance_types` on the Materialize `karpenter-ec2nodeclass` and
 `karpenter-nodepool` module instances and apply:
@@ -301,7 +301,7 @@ annotation, which blocks voluntary disruption while they run. This relies on
 the nodepool's `expire_after` being `Never`, see [Karpenter node
 expiry](/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines/#karpenter-node-expiry).
 
-### 2. Cordon the drifted nodes
+##### 2. Cordon the drifted nodes
 
 Cordon the existing Materialize nodes so the rollout's new pods cannot
 schedule onto them and instead trigger Karpenter to provision nodes with the
@@ -317,7 +317,7 @@ done
 
 Nodes that Karpenter provisions after this point are not cordoned.
 
-### 3. Roll out the Materialize instance
+##### 3. Roll out the Materialize instance
 
 {{% include-headless "/headless/self-managed-deployments/force-rollout-terraform" %}}
 
@@ -332,7 +332,7 @@ generation. See [Rollout behavior](#rollout-behavior) for what to expect
 during the rollout. Verify the new `environmentd` and `clusterd` pods are
 only scheduled onto the new nodes.
 
-### 4. Verify the old nodes are removed
+##### 4. Verify the old nodes are removed
 
 Once the rollout has completed and the old generation's pods are gone, the
 cordoned nodes are empty and Karpenter consolidates them away (the modules
@@ -362,7 +362,7 @@ first, then follow the steps in the **Terraform** tab.
 
 If you manage your infrastructure without the Materialize Terraform modules:
 
-### 1. Create a second node pool with the new VM type
+##### 1. Create a second node pool with the new VM type
 
 Using your cloud provider's tooling, create a second node pool with the same
 labels and taints as the existing pool (so Materialize pods are eligible to
@@ -372,7 +372,7 @@ If your nodes are managed by Karpenter, skip this step and instead update the
 instance requirements on the Karpenter `NodePool`. Karpenter provisions
 new-spec nodes on demand once the old nodes are cordoned.
 
-### 2. Keep new pods off the old nodes
+##### 2. Keep new pods off the old nodes
 
 For a static pool, add a decommission taint, such as
 `materialize.cloud/decommissioned=true:NoSchedule`, to the old pool. Apply the
@@ -387,7 +387,7 @@ Materialize pods don't tolerate (not `materialize.cloud/workload` or
 For Karpenter-managed nodes, cordon the old nodes instead. Nodes that
 Karpenter provisions afterwards are not cordoned.
 
-### 3. Roll out the Materialize instance to land new pods on the new nodes
+##### 3. Roll out the Materialize instance to land new pods on the new nodes
 
 Use the Materialize CR's rollout machinery to have the operator create a new
 generation of `environmentd` and `clusterd` pods. Because the Materialize
@@ -425,7 +425,7 @@ kubectl patch materialize <instance-name> \
 See [Rollout behavior](#rollout-behavior) for what to expect. Verify the new
 `environmentd` and `clusterd` pods are only scheduled onto the new nodes.
 
-### 4. Remove the old pool
+##### 4. Remove the old pool
 
 Once the rollout has completed, the old nodes have no Materialize workloads
 on them. Delete the old node pool using your cloud provider's tooling. For


### PR DESCRIPTION
Stacked on #37683 (contains its commit, review only the last one until it merges).

### Motivation

The resize steps predate the blue-green migration procedure written for the new Terraform modules in MaterializeInc/materialize-terraform-self-managed#282 and were subtly incomplete (kubectl cordon instead of a pool-level taint, no disk_setup_name / local_ssd_count handling, no CRD v1 rollout path, no AWS/Karpenter path).

### Changes

- Tabs for deployment methods (Terraform, Legacy Terraform, Manual) and, within Terraform, per-cloud tabs (GCP, Azure, AWS).
- GCP/Azure: blue-green pool swap with a pool-level decommission taint instead of `kubectl cordon`. Covers distinct `prefix` and `disk_setup_name`, `local_ssd_count` for `-lssd` machine types, and the AKS 12-character pool-name truncation pitfall.
- AWS: Karpenter flow, since the AWS modules provision Materialize nodes with Karpenter. Update `instance_types`, cordon the drifted nodes (the operator's `karpenter.sh/do-not-disrupt` annotations on environmentd/clusterd keep Karpenter from draining them), force a rollout, and let `WhenEmpty` consolidation remove the old nodes.
- Nested tabs for Materialize CRD `v1` vs `v1alpha1` rollouts: `v1` (default since v4.0.0 of the Terraform modules) only uses `force_rollout`, `v1alpha1` also needs `request_rollout`.
- Legacy modules marked unsupported with a pointer to migrate to the new modules first. Dropped the multi-`node_pools` `module "gke"` example, which was for the legacy modules.
- Rollout behavior/monitoring shared in one section. `WaitUntilReady` described as minimal downtime rather than zero-downtime.

Steps manually verified using in self-managed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
