### PR TITLE
transform: guard recursive MIR transforms against stack overflow

### DIFF
--- a/src/transform/src/canonicalize_mfp.rs
+++ b/src/transform/src/canonicalize_mfp.rs
@@ -29,13 +29,30 @@
 //! expressions re-use complex subexpressions.
 
 use mz_expr::visit::VisitChildren;
-use mz_expr::{MapFilterProject, MirRelationExpr};
+use mz_expr::{MapFilterProject, MirRelationExpr, RECURSION_LIMIT};
+use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 
 use crate::TransformCtx;
 
 /// Canonicalizes MFPs and performs common sub-expression elimination.
 #[derive(Debug)]
-pub struct CanonicalizeMfp;
+pub struct CanonicalizeMfp {
+    recursion_guard: RecursionGuard,
+}
+
+impl Default for CanonicalizeMfp {
+    fn default() -> CanonicalizeMfp {
+        CanonicalizeMfp {
+            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
+        }
+    }
+}
+
+impl CheckedRecursion for CanonicalizeMfp {
+    fn recursion_guard(&self) -> &RecursionGuard {
+        &self.recursion_guard
+    }
+}
 
 impl crate::Transform for CanonicalizeMfp {
     fn name(&self) -> &'static str {
@@ -61,19 +78,21 @@ impl crate::Transform for CanonicalizeMfp {
 impl CanonicalizeMfp {
     /// Extract and optimize MFPs.
     pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
-        let mut mfp = MapFilterProject::extract_non_errors_from_expr_mut(relation);
-        // Optimize MFP, e.g., perform CSE Push MFPs through `Negate` operators,
-        // if encountered. This is a first steps toward a `CanonicalizeLinear`,
-        // which puts linear operators in a canonical representation.
-        mfp.optimize();
-        if let MirRelationExpr::Negate { input } = relation {
-            Self::rebuild_mfp(mfp, &mut **input);
-            relation.try_visit_mut_children(|e| self.action(e))?;
-        } else {
-            relation.try_visit_mut_children(|e| self.action(e))?;
-            Self::rebuild_mfp(mfp, relation);
-        }
-        Ok(())
+        self.checked_recur(|_| {
+            let mut mfp = MapFilterProject::extract_non_errors_from_expr_mut(relation);
+            // Optimize MFP, e.g., perform CSE Push MFPs through `Negate` operators,
+            // if encountered. This is a first steps toward a `CanonicalizeLinear`,
+            // which puts linear operators in a canonical representation.
+            mfp.optimize();
+            if let MirRelationExpr::Negate { input } = relation {
+                Self::rebuild_mfp(mfp, &mut **input);
+                relation.try_visit_mut_children(|e| self.action(e))?;
+            } else {
+                relation.try_visit_mut_children(|e| self.action(e))?;
+                Self::rebuild_mfp(mfp, relation);
+            }
+            Ok(())
+        })
     }
 
     /// Canonicalize the MapFilterProject to Map-Filter-Project, in that order.
@@ -92,5 +111,35 @@ impl CanonicalizeMfp {
                 *relation = relation.take_dangerous().project(project);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_repr::ReprRelationType;
+
+    use super::*;
+
+    /// Dismantle a deep expression iteratively, as dropping it recursively
+    /// could overflow the stack.
+    fn dismantle(expr: MirRelationExpr) {
+        let mut todo = vec![expr];
+        while let Some(mut e) = todo.pop() {
+            todo.extend(e.children_mut().map(|c| c.take_dangerous()));
+        }
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    fn action_errors_on_deep_plan() {
+        let mut expr = MirRelationExpr::constant(vec![], ReprRelationType::new(vec![]));
+        for _ in 0..RECURSION_LIMIT + 100 {
+            // Constructed directly, as the `negate` builder cancels double negation.
+            expr = MirRelationExpr::Negate {
+                input: Box::new(expr),
+            };
+        }
+        assert!(CanonicalizeMfp::default().action(&mut expr).is_err());
+        dismantle(expr);
     }
 }

--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -31,7 +31,8 @@
 use std::collections::BTreeMap;
 
 use itertools::Itertools;
-use mz_expr::{Eval, Id, MirRelationExpr, MirScalarExpr};
+use mz_expr::{Eval, Id, MirRelationExpr, MirScalarExpr, RECURSION_LIMIT};
+use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
 use mz_repr::{Datum, ReprScalarType};
 use tracing::debug;
 
@@ -46,8 +47,24 @@ use crate::analysis::{Arity, DerivedView, ReprRelationType};
 use crate::{TransformCtx, TransformError};
 
 /// Pulls up and pushes down predicate information represented as equivalences
-#[derive(Debug, Default)]
-pub struct EquivalencePropagation;
+#[derive(Debug)]
+pub struct EquivalencePropagation {
+    recursion_guard: RecursionGuard,
+}
+
+impl Default for EquivalencePropagation {
+    fn default() -> EquivalencePropagation {
+        EquivalencePropagation {
+            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
+        }
+    }
+}
+
+impl CheckedRecursion for EquivalencePropagation {
+    fn recursion_guard(&self) -> &RecursionGuard {
+        &self.recursion_guard
+    }
+}
 
 impl crate::Transform for EquivalencePropagation {
     fn name(&self) -> &'static str {
@@ -64,6 +81,18 @@ impl crate::Transform for EquivalencePropagation {
         relation: &mut MirRelationExpr,
         ctx: &mut TransformCtx,
     ) -> Result<(), TransformError> {
+        // Check the plan depth up front, iteratively. This method clones and compares
+        // `relation` with recursive `Clone` and `PartialEq` implementations, which would
+        // overflow the stack on a too-deep plan before the recursion guard in `apply`
+        // could trigger.
+        let mut todo = vec![(&*relation, 1usize)];
+        while let Some((expr, depth)) = todo.pop() {
+            if depth > RECURSION_LIMIT {
+                return Err(RecursionLimitError::new(RECURSION_LIMIT).into());
+            }
+            todo.extend(expr.children().map(|child| (child, depth + 1)));
+        }
+
         // Perform bottom-up equivalence class analysis.
         use crate::analysis::DerivedBuilder;
         let mut builder = DerivedBuilder::new(ctx.features);
@@ -81,7 +110,7 @@ impl crate::Transform for EquivalencePropagation {
             EquivalenceClasses::default(),
             &mut get_equivalences,
             ctx,
-        );
+        )?;
 
         // Trace the plan as the result of `equivalence_propagation` before potentially applying
         // `ColumnKnowledge`. (If `ColumnKnowledge` runs, it will trace its own result.)
@@ -121,6 +150,8 @@ impl EquivalencePropagation {
     /// After the call, `get_equivalences` will be populated with certainly equivalences that will be certainly
     /// enforced for all uses of each identifier. The information can be harvested and propagated to the definitions
     /// of those identifiers.
+    ///
+    /// Returns an error if the depth of `expr` exceeds the recursion limit.
     pub fn apply(
         &self,
         expr: &mut MirRelationExpr,
@@ -128,589 +159,595 @@ impl EquivalencePropagation {
         mut outer_equivalences: EquivalenceClasses,
         get_equivalences: &mut BTreeMap<Id, EquivalenceClasses>,
         ctx: &mut TransformCtx,
-    ) {
+    ) -> Result<(), TransformError> {
         // TODO: The top-down traversal can be coded as a worklist, with arguments tupled and enqueued.
         // This has the potential to do a lot more cloning (of `outer_equivalences`), and some care is needed
         // for `get_equivalences` which would be scoped to the whole method rather than tupled and enqueued.
 
-        let repr_expr_type = derived
-            .value::<ReprRelationType>()
-            .expect("ReprRelationType required");
-        assert!(repr_expr_type.is_some());
-        let expr_type: Option<&Vec<ReprColumnType>> = repr_expr_type.as_ref();
-        let expr_equivalences = derived
-            .value::<Equivalences>()
-            .expect("Equivalences required");
+        self.checked_recur(|_| {
+            let repr_expr_type = derived
+                .value::<ReprRelationType>()
+                .expect("ReprRelationType required");
+            assert!(repr_expr_type.is_some());
+            let expr_type: Option<&Vec<ReprColumnType>> = repr_expr_type.as_ref();
+            let expr_equivalences = derived
+                .value::<Equivalences>()
+                .expect("Equivalences required");
 
-        // `None` analysis values indicate collections that can be pruned.
-        let expr_equivalences = if let Some(e) = expr_equivalences {
-            e
-        } else {
-            expr.take_safely_with_col_types(expr_type.unwrap().clone());
-            return;
-        };
+            // `None` analysis values indicate collections that can be pruned.
+            let expr_equivalences = if let Some(e) = expr_equivalences {
+                e
+            } else {
+                expr.take_safely_with_col_types(expr_type.unwrap().clone());
+                return Ok(());
+            };
 
-        // Optimize `outer_equivalences` in the context of `expr_type`.
-        // If it ends up unsatisfiable, we can replace `expr` with an empty constant of the same relation type.
-        let reducer = expr_equivalences.reducer();
-        for class in outer_equivalences.classes.iter_mut() {
-            for expr in class.iter_mut() {
-                reducer.reduce_expr(expr);
-            }
-        }
-
-        outer_equivalences.minimize(expr_type.map(|x| &x[..]));
-        if outer_equivalences.unsatisfiable() {
-            expr.take_safely_with_col_types(expr_type.unwrap().clone());
-            return;
-        }
-
-        match expr {
-            MirRelationExpr::Constant { rows, typ: _ } => {
-                if let Ok(rows) = rows {
-                    let mut datum_vec = mz_repr::DatumVec::new();
-                    // Delete any rows that violate the equivalences.
-                    // Do not delete rows that produce errors, as they are semantically important.
-                    rows.retain(|(row, _count)| {
-                        let temp_storage = mz_repr::RowArena::new();
-                        let datums = datum_vec.borrow_with(row);
-                        outer_equivalences.classes.iter().all(|class| {
-                            // Any subset of `Ok` results must equate, or we can drop the row.
-                            let mut oks = class
-                                .iter()
-                                .filter_map(|e| e.eval(&datums[..], &temp_storage).ok());
-                            if let Some(e1) = oks.next() {
-                                oks.all(|e2| e1 == e2)
-                            } else {
-                                true
-                            }
-                        })
-                    });
+            // Optimize `outer_equivalences` in the context of `expr_type`.
+            // If it ends up unsatisfiable, we can replace `expr` with an empty constant of the same relation type.
+            let reducer = expr_equivalences.reducer();
+            for class in outer_equivalences.classes.iter_mut() {
+                for expr in class.iter_mut() {
+                    reducer.reduce_expr(expr);
                 }
             }
-            MirRelationExpr::Get { id, .. } => {
-                // Install and intersect with other equivalences from other `Get` sites.
-                // These will be read out by the corresponding `Let` binding's `value`.
-                if let Some(equivs) = get_equivalences.get_mut(id) {
-                    *equivs = equivs.union(&outer_equivalences);
-                } else {
-                    get_equivalences.insert(*id, outer_equivalences);
-                }
-            }
-            MirRelationExpr::Let { id, .. } => {
-                let id = *id;
-                // Traverse `body` first to assemble equivalences to push to `value`.
-                // Descend without a key for `id`, treating the absence as the identity for union.
-                // `Get` nodes with identifier `id` will populate the equivalence classes with the intersection of their guarantees.
-                let mut children_rev = expr.children_mut().rev().zip_eq(derived.children_rev());
 
-                let body = children_rev.next().unwrap();
-                let value = children_rev.next().unwrap();
-
-                self.apply(
-                    body.0,
-                    body.1,
-                    outer_equivalences.clone(),
-                    get_equivalences,
-                    ctx,
-                );
-
-                // We expect to find `id` in `get_equivalences`, as otherwise the binding is
-                // not referenced and can be removed.
-                if let Some(equivalences) = get_equivalences.get(&Id::Local(id)) {
-                    self.apply(
-                        value.0,
-                        value.1,
-                        equivalences.clone(),
-                        get_equivalences,
-                        ctx,
-                    );
-                }
+            outer_equivalences.minimize(expr_type.map(|x| &x[..]));
+            if outer_equivalences.unsatisfiable() {
+                expr.take_safely_with_col_types(expr_type.unwrap().clone());
+                return Ok(());
             }
-            MirRelationExpr::LetRec { .. } => {
-                let mut child_iter = expr.children_mut().rev().zip_eq(derived.children_rev());
-                // Continue in `body` with the outer equivalences.
-                let (body, view) = child_iter.next().unwrap();
-                self.apply(body, view, outer_equivalences, get_equivalences, ctx);
-                // Continue recursively, but without the outer equivalences supplied to `body`.
-                for (child, view) in child_iter {
-                    self.apply(
-                        child,
-                        view,
-                        EquivalenceClasses::default(),
-                        get_equivalences,
-                        ctx,
-                    );
-                }
-            }
-            MirRelationExpr::Project { input, outputs } => {
-                // Transform `outer_equivalences` to one relevant for `input`.
-                outer_equivalences.permute(outputs);
-                self.apply(
-                    input,
-                    derived.last_child(),
-                    outer_equivalences,
-                    get_equivalences,
-                    ctx,
-                );
-            }
-            MirRelationExpr::Map { input, scalars } => {
-                // Optimize `scalars` with respect to input equivalences.
-                let input_equivalences = derived
-                    .last_child()
-                    .value::<Equivalences>()
-                    .expect("Equivalences required");
 
-                if let Some(input_equivalences_orig) = input_equivalences {
-                    // We clone `input_equivalences` only if we want to modify it, which is when
-                    // `enable_dequadratic_eqprop_map` is off. Otherwise, we work with the original
-                    // `input_equivalences`.
-                    let mut input_equivalences_cloned = None;
-                    if !ctx.features.enable_dequadratic_eqprop_map {
-                        // We mutate them for variadic Maps if the feature flag is not set.
-                        input_equivalences_cloned = Some(input_equivalences_orig.clone());
+            match expr {
+                MirRelationExpr::Constant { rows, typ: _ } => {
+                    if let Ok(rows) = rows {
+                        let mut datum_vec = mz_repr::DatumVec::new();
+                        // Delete any rows that violate the equivalences.
+                        // Do not delete rows that produce errors, as they are semantically important.
+                        rows.retain(|(row, _count)| {
+                            let temp_storage = mz_repr::RowArena::new();
+                            let datums = datum_vec.borrow_with(row);
+                            outer_equivalences.classes.iter().all(|class| {
+                                // Any subset of `Ok` results must equate, or we can drop the row.
+                                let mut oks = class
+                                    .iter()
+                                    .filter_map(|e| e.eval(&datums[..], &temp_storage).ok());
+                                if let Some(e1) = oks.next() {
+                                    oks.all(|e2| e1 == e2)
+                                } else {
+                                    true
+                                }
+                            })
+                        });
                     }
-                    // Get all output types, to reveal a prefix to each scaler expr.
-                    let input_types: &Vec<ReprColumnType> = derived
-                        .value::<ReprRelationType>()
-                        .expect("ReprRelationType required")
-                        .as_ref()
-                        .unwrap();
-                    let input_arity = input_types.len() - scalars.len();
-                    for (index, expr) in scalars.iter_mut().enumerate() {
-                        let reducer = if !ctx.features.enable_dequadratic_eqprop_map {
-                            input_equivalences_cloned
-                                .as_ref()
-                                .expect("always filled if feature flag is not set")
-                                .reducer()
-                        } else {
-                            input_equivalences_orig.reducer()
-                        };
-                        let changed = reducer.reduce_expr(expr);
-                        if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            expr.reduce(&input_types[..(input_arity + index)]);
-                        }
-                        if !ctx.features.enable_dequadratic_eqprop_map {
-                            // Unfortunately, we had to stop doing the following, because it
-                            // was making the `Map` handling quadratic.
-                            // TODO: Get back to this when we have e-graphs.
-                            // https://github.com/MaterializeInc/database-issues/issues/9157
-                            //
-                            // Introduce the fact relating the mapped expression and corresponding
-                            // column. This allows subsequent expressions to be optimized with this
-                            // information.
-                            input_equivalences_cloned
-                                .as_mut()
-                                .expect("always filled if feature flag is not set")
-                                .classes
-                                .push(vec![
-                                    expr.clone(),
-                                    MirScalarExpr::column(input_arity + index),
-                                ]);
-                            input_equivalences_cloned
-                                .as_mut()
-                                .expect("always filled if feature flag is not set")
-                                .minimize(Some(input_types));
-                        }
-                    }
-                    let input_arity = *derived
-                        .last_child()
-                        .value::<Arity>()
-                        .expect("Arity required");
-                    outer_equivalences.project(0..input_arity);
-                    self.apply(
-                        input,
-                        derived.last_child(),
-                        outer_equivalences,
-                        get_equivalences,
-                        ctx,
-                    );
                 }
-            }
-            MirRelationExpr::FlatMap { input, exprs, .. } => {
-                // Transform `exprs` by guarantees from `input` *and* from `outer`???
-                let input_equivalences = derived
-                    .last_child()
-                    .value::<Equivalences>()
-                    .expect("Equivalences required");
-
-                if let Some(input_equivalences) = input_equivalences {
-                    let input_types: &Vec<ReprColumnType> = derived
-                        .last_child()
-                        .value::<ReprRelationType>()
-                        .expect("ReprRelationType required")
-                        .as_ref()
-                        .unwrap();
-                    let reducer = input_equivalences.reducer();
-                    for expr in exprs.iter_mut() {
-                        let changed = reducer.reduce_expr(expr);
-                        if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            expr.reduce(input_types);
-                        }
-                    }
-                    let input_arity = *derived
-                        .last_child()
-                        .value::<Arity>()
-                        .expect("Arity required");
-                    outer_equivalences.project(0..input_arity);
-                    self.apply(
-                        input,
-                        derived.last_child(),
-                        outer_equivalences,
-                        get_equivalences,
-                        ctx,
-                    );
-                }
-            }
-            MirRelationExpr::Filter { input, predicates } => {
-                // Transform `predicates` by guarantees from `input` *and* from `outer`???
-                // If we reduce based on `input` guarantees, we won't be able to push those
-                // constraints down into input, which may be fine but is worth considering.
-                let input_equivalences = derived
-                    .last_child()
-                    .value::<Equivalences>()
-                    .expect("Equivalences required");
-                if let Some(input_equivalences) = input_equivalences {
-                    let input_types: &Vec<ReprColumnType> = derived
-                        .last_child()
-                        .value::<ReprRelationType>()
-                        .expect("ReprRelationType required")
-                        .as_ref()
-                        .unwrap();
-                    let reducer = input_equivalences.reducer();
-                    for expr in predicates.iter_mut() {
-                        let changed = reducer.reduce_expr(expr);
-                        if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            expr.reduce(input_types);
-                        }
-                    }
-                    // Incorporate `predicates` into `outer_equivalences`.
-                    let mut class = predicates.clone();
-                    class.push(MirScalarExpr::literal_ok(Datum::True, ReprScalarType::Bool));
-                    outer_equivalences.classes.push(class);
-                    outer_equivalences.minimize(Some(input_types));
-                    self.apply(
-                        input,
-                        derived.last_child(),
-                        outer_equivalences,
-                        get_equivalences,
-                        ctx,
-                    );
-                }
-            }
-
-            MirRelationExpr::Join {
-                inputs,
-                equivalences,
-                ..
-            } => {
-                // Certain equivalences are ensured by each of the inputs.
-                // Other equivalences are imposed by parents of the expression.
-                // We must not weaken the properties provided by the expression to its parents,
-                // meaning we can optimize `equivalences` with respect to input guarantees,
-                // but not with respect to `outer_equivalences`.
-
-                // Each child can be presented with the integration of `join_equivalences`, `outer_equivalences`,
-                // and each input equivalence *other than* their own, projected onto the input's columns.
-
-                // Enumerate locations to find each child's analysis outputs.
-                let mut children: Vec<_> = derived.children_rev().collect::<Vec<_>>();
-                children.reverse();
-
-                // Assemble the appended input types, for use in expression minimization.
-                // Do not use `expr_types`, which may reflect nullability that does not hold for the inputs.
-                let mut input_types = Some(
-                    children
-                        .iter()
-                        .flat_map(|c| {
-                            c.value::<ReprRelationType>()
-                                .expect("ReprRelationType required")
-                                .as_ref()
-                                .unwrap()
-                                .iter()
-                                .cloned()
-                        })
-                        .collect::<Vec<_>>(),
-                );
-
-                // For each child, assemble its equivalences using join-relative column numbers.
-                // Don't do anything with the children yet, as we'll want to revisit each with
-                // this information at hand.
-                let mut columns = 0;
-                let mut input_equivalences = Vec::with_capacity(children.len());
-                for child in children.iter() {
-                    let child_arity = child.value::<Arity>().expect("Arity required");
-                    let equivalences = child
-                        .value::<Equivalences>()
-                        .expect("Equivalences required")
-                        .clone();
-
-                    if let Some(mut equivalences) = equivalences {
-                        let permutation = (columns..(columns + child_arity)).collect::<Vec<_>>();
-                        equivalences.permute(&permutation);
-                        equivalences.minimize(input_types.as_ref().map(|x| &x[..]));
-                        input_equivalences.push(equivalences);
-                    }
-                    columns += child_arity;
-                }
-
-                // Form the equivalences we will use to replace `equivalences`.
-                let mut join_equivalences: EqClassesImpl =
-                    if ctx.features.enable_eq_classes_withholding_errors {
-                        EqClassesImpl::EquivalenceClassesWithholdingErrors(
-                            EquivalenceClassesWithholdingErrors::default(),
-                        )
+                MirRelationExpr::Get { id, .. } => {
+                    // Install and intersect with other equivalences from other `Get` sites.
+                    // These will be read out by the corresponding `Let` binding's `value`.
+                    if let Some(equivs) = get_equivalences.get_mut(id) {
+                        *equivs = equivs.union(&outer_equivalences);
                     } else {
-                        EqClassesImpl::EquivalenceClasses(EquivalenceClasses::default())
-                    };
-                join_equivalences.extend_equivalences(equivalences.clone());
-
-                // // Optionally, introduce `outer_equivalences` into `equivalences`.
-                // // This is not required, but it could be very helpful. To be seen.
-                // join_equivalences
-                //     .classes
-                //     .extend(outer_equivalences.classes.clone());
-
-                // Reduce join equivalences by the input equivalences.
-                for input_equivs in input_equivalences.iter() {
-                    let reducer = input_equivs.reducer();
-                    for class in join_equivalences
-                        .equivalence_classes_mut()
-                        .classes
-                        .iter_mut()
-                    {
-                        for expr in class.iter_mut() {
-                            // Semijoin elimination currently fails if you do more advanced simplification than
-                            // literal substitution.
-                            let old = expr.clone();
-                            let changed = reducer.reduce_expr(expr);
-                            let acceptable_sub = literal_domination(&old, expr);
-                            if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                                expr.reduce(input_types.as_ref().unwrap());
-                            }
-                            if !acceptable_sub && !literal_domination(&old, expr)
-                                || expr.contains_err()
-                            {
-                                expr.clone_from(&old);
-                            }
-                        }
+                        get_equivalences.insert(*id, outer_equivalences);
                     }
                 }
-                // Remove nullability information, as it has already been incorporated from input equivalences,
-                // and if it was reduced out relative to input equivalences we don't want to re-introduce it.
-                if let Some(input_types) = input_types.as_mut() {
-                    for col in input_types.iter_mut() {
-                        col.nullable = true;
-                    }
-                }
-                join_equivalences
-                    .equivalence_classes_mut()
-                    .minimize(input_types.as_ref().map(|x| &x[..]));
+                MirRelationExpr::Let { id, .. } => {
+                    let id = *id;
+                    // Traverse `body` first to assemble equivalences to push to `value`.
+                    // Descend without a key for `id`, treating the absence as the identity for union.
+                    // `Get` nodes with identifier `id` will populate the equivalence classes with the intersection of their guarantees.
+                    let mut children_rev = expr.children_mut().rev().zip_eq(derived.children_rev());
 
-                // Revisit each child, determining the information to present to it, and recurring.
-                let mut columns = 0;
-                for ((index, child), expr) in
-                    children.into_iter().enumerate().zip_eq(inputs.iter_mut())
-                {
-                    let child_arity = child.value::<Arity>().expect("Arity required");
+                    let body = children_rev.next().unwrap();
+                    let value = children_rev.next().unwrap();
 
-                    let mut push_equivalences = join_equivalences.clone();
-                    push_equivalences.extend_equivalences(outer_equivalences.classes.clone());
-
-                    for (other, input_equivs) in input_equivalences.iter().enumerate() {
-                        if index != other {
-                            push_equivalences.extend_equivalences(input_equivs.classes.clone());
-                        }
-                    }
-                    push_equivalences.project(columns..(columns + child_arity));
                     self.apply(
-                        expr,
-                        child,
-                        push_equivalences.equivalence_classes().clone(),
-                        get_equivalences,
-                        ctx,
-                    );
-
-                    columns += child_arity;
-                }
-
-                let extracted_equivalences =
-                    join_equivalences.extract_equivalences(input_types.as_ref().map(|x| &x[..]));
-
-                debug!(
-                    ?inputs,
-                    ?extracted_equivalences,
-                    "Join equivalences extracted"
-                );
-                equivalences.clone_from(&extracted_equivalences);
-            }
-            MirRelationExpr::Reduce {
-                input,
-                group_key,
-                aggregates,
-                ..
-            } => {
-                // TODO: MIN, MAX, ANY, ALL aggregates pass through all certain properties of their columns.
-                // This may involve projection and permutation, to reposition the information appropriately.
-                // TODO: Non-null constraints likely push down into the support of the aggregate expressions.
-
-                // Apply any equivalences about the input to key and aggregate expressions.
-                let input_equivalences = derived
-                    .last_child()
-                    .value::<Equivalences>()
-                    .expect("Equivalences required");
-                if let Some(input_equivalences) = input_equivalences {
-                    let input_type: &Vec<ReprColumnType> = derived
-                        .last_child()
-                        .value::<ReprRelationType>()
-                        .expect("ReprRelationType required")
-                        .as_ref()
-                        .unwrap();
-                    let reducer = input_equivalences.reducer();
-                    for key in group_key.iter_mut() {
-                        // Semijoin elimination currently fails if you do more advanced simplification than
-                        // literal substitution.
-                        let old_key = key.clone();
-                        let changed = reducer.reduce_expr(key);
-                        let acceptable_sub = literal_domination(&old_key, key);
-                        if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            key.reduce(input_type);
-                        }
-                        if !acceptable_sub && !literal_domination(&old_key, key) {
-                            key.clone_from(&old_key);
-                        }
-                    }
-                    for aggr in aggregates.iter_mut() {
-                        let changed = reducer.reduce_expr(&mut aggr.expr);
-                        if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            aggr.expr.reduce(input_type);
-                        }
-                        // A count expression over a non-null expression can discard the expression.
-                        if aggr.func == mz_expr::AggregateFunc::Count && !aggr.distinct {
-                            let mut probe = aggr.expr.clone().call_is_null();
-                            reducer.reduce_expr(&mut probe);
-                            if probe.is_literal_false() {
-                                aggr.expr = MirScalarExpr::literal_true();
-                            }
-                        }
-                    }
-                }
-
-                // To transform `outer_equivalences` to one about `input`, we will "pretend" to pre-pend all of
-                // the input columns, introduce equivalences about the evaluation of `group_key` on them
-                // and the key columns themselves, and then project onto these "input" columns.
-                let input_arity = *derived
-                    .last_child()
-                    .value::<Arity>()
-                    .expect("Arity required");
-                let output_arity = *derived.value::<Arity>().expect("Arity required");
-
-                // Permute `outer_equivalences` to reference columns `input_arity` later.
-                let permutation = (input_arity..(input_arity + output_arity)).collect::<Vec<_>>();
-                outer_equivalences.permute(&permutation[..]);
-                for (index, group) in group_key.iter().enumerate() {
-                    outer_equivalences.classes.push(vec![
-                        MirScalarExpr::column(input_arity + index),
-                        group.clone(),
-                    ]);
-                }
-                outer_equivalences.project(0..input_arity);
-                self.apply(
-                    input,
-                    derived.last_child(),
-                    outer_equivalences,
-                    get_equivalences,
-                    ctx,
-                );
-            }
-            MirRelationExpr::TopK {
-                input,
-                group_key,
-                limit,
-                ..
-            } => {
-                // We must be careful when updating `limit` to not install column references
-                // outside of `group_key`. We'll do this for now with `literal_domination`,
-                // which will ensure we only perform substitutions by a literal.
-                let input_equivalences = derived
-                    .last_child()
-                    .value::<Equivalences>()
-                    .expect("Equivalences required");
-                if let Some(input_equivalences) = input_equivalences {
-                    let input_types: &Vec<ReprColumnType> = derived
-                        .last_child()
-                        .value::<ReprRelationType>()
-                        .expect("ReprRelationType required")
-                        .as_ref()
-                        .unwrap();
-                    let reducer = input_equivalences.reducer();
-                    if let Some(expr) = limit {
-                        let old_expr = expr.clone();
-                        let changed = reducer.reduce_expr(expr);
-                        let acceptable_sub = literal_domination(&old_expr, expr);
-                        if changed || !ctx.features.enable_less_reduce_in_eqprop {
-                            expr.reduce(input_types);
-                        }
-                        if !acceptable_sub && !literal_domination(&old_expr, expr) {
-                            expr.clone_from(&old_expr);
-                        }
-                    }
-                }
-
-                // Discard equivalences among non-key columns, as it is not correct that `input` may drop rows
-                // that violate constraints among non-key columns without affecting the result.
-                // Project to the group_key column indices. After project, group_key[i] has been
-                // remapped to position i; permute restores the original indices.
-                outer_equivalences.project(group_key.iter().copied());
-                outer_equivalences.permute(&group_key[..]);
-                self.apply(
-                    input,
-                    derived.last_child(),
-                    outer_equivalences,
-                    get_equivalences,
-                    ctx,
-                );
-            }
-            MirRelationExpr::Negate { input } => {
-                self.apply(
-                    input,
-                    derived.last_child(),
-                    outer_equivalences,
-                    get_equivalences,
-                    ctx,
-                );
-            }
-            MirRelationExpr::Threshold { input } => {
-                self.apply(
-                    input,
-                    derived.last_child(),
-                    outer_equivalences,
-                    get_equivalences,
-                    ctx,
-                );
-            }
-            MirRelationExpr::Union { .. } => {
-                for (child, derived) in expr.children_mut().rev().zip_eq(derived.children_rev()) {
-                    self.apply(
-                        child,
-                        derived,
+                        body.0,
+                        body.1,
                         outer_equivalences.clone(),
                         get_equivalences,
                         ctx,
+                    )?;
+
+                    // We expect to find `id` in `get_equivalences`, as otherwise the binding is
+                    // not referenced and can be removed.
+                    if let Some(equivalences) = get_equivalences.get(&Id::Local(id)) {
+                        self.apply(
+                            value.0,
+                            value.1,
+                            equivalences.clone(),
+                            get_equivalences,
+                            ctx,
+                        )?;
+                    }
+                }
+                MirRelationExpr::LetRec { .. } => {
+                    let mut child_iter = expr.children_mut().rev().zip_eq(derived.children_rev());
+                    // Continue in `body` with the outer equivalences.
+                    let (body, view) = child_iter.next().unwrap();
+                    self.apply(body, view, outer_equivalences, get_equivalences, ctx)?;
+                    // Continue recursively, but without the outer equivalences supplied to `body`.
+                    for (child, view) in child_iter {
+                        self.apply(
+                            child,
+                            view,
+                            EquivalenceClasses::default(),
+                            get_equivalences,
+                            ctx,
+                        )?;
+                    }
+                }
+                MirRelationExpr::Project { input, outputs } => {
+                    // Transform `outer_equivalences` to one relevant for `input`.
+                    outer_equivalences.permute(outputs);
+                    self.apply(
+                        input,
+                        derived.last_child(),
+                        outer_equivalences,
+                        get_equivalences,
+                        ctx,
+                    )?;
+                }
+                MirRelationExpr::Map { input, scalars } => {
+                    // Optimize `scalars` with respect to input equivalences.
+                    let input_equivalences = derived
+                        .last_child()
+                        .value::<Equivalences>()
+                        .expect("Equivalences required");
+
+                    if let Some(input_equivalences_orig) = input_equivalences {
+                        // We clone `input_equivalences` only if we want to modify it, which is when
+                        // `enable_dequadratic_eqprop_map` is off. Otherwise, we work with the original
+                        // `input_equivalences`.
+                        let mut input_equivalences_cloned = None;
+                        if !ctx.features.enable_dequadratic_eqprop_map {
+                            // We mutate them for variadic Maps if the feature flag is not set.
+                            input_equivalences_cloned = Some(input_equivalences_orig.clone());
+                        }
+                        // Get all output types, to reveal a prefix to each scaler expr.
+                        let input_types: &Vec<ReprColumnType> = derived
+                            .value::<ReprRelationType>()
+                            .expect("ReprRelationType required")
+                            .as_ref()
+                            .unwrap();
+                        let input_arity = input_types.len() - scalars.len();
+                        for (index, expr) in scalars.iter_mut().enumerate() {
+                            let reducer = if !ctx.features.enable_dequadratic_eqprop_map {
+                                input_equivalences_cloned
+                                    .as_ref()
+                                    .expect("always filled if feature flag is not set")
+                                    .reducer()
+                            } else {
+                                input_equivalences_orig.reducer()
+                            };
+                            let changed = reducer.reduce_expr(expr);
+                            if changed || !ctx.features.enable_less_reduce_in_eqprop {
+                                expr.reduce(&input_types[..(input_arity + index)]);
+                            }
+                            if !ctx.features.enable_dequadratic_eqprop_map {
+                                // Unfortunately, we had to stop doing the following, because it
+                                // was making the `Map` handling quadratic.
+                                // TODO: Get back to this when we have e-graphs.
+                                // https://github.com/MaterializeInc/database-issues/issues/9157
+                                //
+                                // Introduce the fact relating the mapped expression and corresponding
+                                // column. This allows subsequent expressions to be optimized with this
+                                // information.
+                                input_equivalences_cloned
+                                    .as_mut()
+                                    .expect("always filled if feature flag is not set")
+                                    .classes
+                                    .push(vec![
+                                        expr.clone(),
+                                        MirScalarExpr::column(input_arity + index),
+                                    ]);
+                                input_equivalences_cloned
+                                    .as_mut()
+                                    .expect("always filled if feature flag is not set")
+                                    .minimize(Some(input_types));
+                            }
+                        }
+                        let input_arity = *derived
+                            .last_child()
+                            .value::<Arity>()
+                            .expect("Arity required");
+                        outer_equivalences.project(0..input_arity);
+                        self.apply(
+                            input,
+                            derived.last_child(),
+                            outer_equivalences,
+                            get_equivalences,
+                            ctx,
+                        )?;
+                    }
+                }
+                MirRelationExpr::FlatMap { input, exprs, .. } => {
+                    // Transform `exprs` by guarantees from `input` *and* from `outer`???
+                    let input_equivalences = derived
+                        .last_child()
+                        .value::<Equivalences>()
+                        .expect("Equivalences required");
+
+                    if let Some(input_equivalences) = input_equivalences {
+                        let input_types: &Vec<ReprColumnType> = derived
+                            .last_child()
+                            .value::<ReprRelationType>()
+                            .expect("ReprRelationType required")
+                            .as_ref()
+                            .unwrap();
+                        let reducer = input_equivalences.reducer();
+                        for expr in exprs.iter_mut() {
+                            let changed = reducer.reduce_expr(expr);
+                            if changed || !ctx.features.enable_less_reduce_in_eqprop {
+                                expr.reduce(input_types);
+                            }
+                        }
+                        let input_arity = *derived
+                            .last_child()
+                            .value::<Arity>()
+                            .expect("Arity required");
+                        outer_equivalences.project(0..input_arity);
+                        self.apply(
+                            input,
+                            derived.last_child(),
+                            outer_equivalences,
+                            get_equivalences,
+                            ctx,
+                        )?;
+                    }
+                }
+                MirRelationExpr::Filter { input, predicates } => {
+                    // Transform `predicates` by guarantees from `input` *and* from `outer`???
+                    // If we reduce based on `input` guarantees, we won't be able to push those
+                    // constraints down into input, which may be fine but is worth considering.
+                    let input_equivalences = derived
+                        .last_child()
+                        .value::<Equivalences>()
+                        .expect("Equivalences required");
+                    if let Some(input_equivalences) = input_equivalences {
+                        let input_types: &Vec<ReprColumnType> = derived
+                            .last_child()
+                            .value::<ReprRelationType>()
+                            .expect("ReprRelationType required")
+                            .as_ref()
+                            .unwrap();
+                        let reducer = input_equivalences.reducer();
+                        for expr in predicates.iter_mut() {
+                            let changed = reducer.reduce_expr(expr);
+                            if changed || !ctx.features.enable_less_reduce_in_eqprop {
+                                expr.reduce(input_types);
+                            }
+                        }
+                        // Incorporate `predicates` into `outer_equivalences`.
+                        let mut class = predicates.clone();
+                        class.push(MirScalarExpr::literal_ok(Datum::True, ReprScalarType::Bool));
+                        outer_equivalences.classes.push(class);
+                        outer_equivalences.minimize(Some(input_types));
+                        self.apply(
+                            input,
+                            derived.last_child(),
+                            outer_equivalences,
+                            get_equivalences,
+                            ctx,
+                        )?;
+                    }
+                }
+
+                MirRelationExpr::Join {
+                    inputs,
+                    equivalences,
+                    ..
+                } => {
+                    // Certain equivalences are ensured by each of the inputs.
+                    // Other equivalences are imposed by parents of the expression.
+                    // We must not weaken the properties provided by the expression to its parents,
+                    // meaning we can optimize `equivalences` with respect to input guarantees,
+                    // but not with respect to `outer_equivalences`.
+
+                    // Each child can be presented with the integration of `join_equivalences`, `outer_equivalences`,
+                    // and each input equivalence *other than* their own, projected onto the input's columns.
+
+                    // Enumerate locations to find each child's analysis outputs.
+                    let mut children: Vec<_> = derived.children_rev().collect::<Vec<_>>();
+                    children.reverse();
+
+                    // Assemble the appended input types, for use in expression minimization.
+                    // Do not use `expr_types`, which may reflect nullability that does not hold for the inputs.
+                    let mut input_types = Some(
+                        children
+                            .iter()
+                            .flat_map(|c| {
+                                c.value::<ReprRelationType>()
+                                    .expect("ReprRelationType required")
+                                    .as_ref()
+                                    .unwrap()
+                                    .iter()
+                                    .cloned()
+                            })
+                            .collect::<Vec<_>>(),
                     );
+
+                    // For each child, assemble its equivalences using join-relative column numbers.
+                    // Don't do anything with the children yet, as we'll want to revisit each with
+                    // this information at hand.
+                    let mut columns = 0;
+                    let mut input_equivalences = Vec::with_capacity(children.len());
+                    for child in children.iter() {
+                        let child_arity = child.value::<Arity>().expect("Arity required");
+                        let equivalences = child
+                            .value::<Equivalences>()
+                            .expect("Equivalences required")
+                            .clone();
+
+                        if let Some(mut equivalences) = equivalences {
+                            let permutation =
+                                (columns..(columns + child_arity)).collect::<Vec<_>>();
+                            equivalences.permute(&permutation);
+                            equivalences.minimize(input_types.as_ref().map(|x| &x[..]));
+                            input_equivalences.push(equivalences);
+                        }
+                        columns += child_arity;
+                    }
+
+                    // Form the equivalences we will use to replace `equivalences`.
+                    let mut join_equivalences: EqClassesImpl =
+                        if ctx.features.enable_eq_classes_withholding_errors {
+                            EqClassesImpl::EquivalenceClassesWithholdingErrors(
+                                EquivalenceClassesWithholdingErrors::default(),
+                            )
+                        } else {
+                            EqClassesImpl::EquivalenceClasses(EquivalenceClasses::default())
+                        };
+                    join_equivalences.extend_equivalences(equivalences.clone());
+
+                    // // Optionally, introduce `outer_equivalences` into `equivalences`.
+                    // // This is not required, but it could be very helpful. To be seen.
+                    // join_equivalences
+                    //     .classes
+                    //     .extend(outer_equivalences.classes.clone());
+
+                    // Reduce join equivalences by the input equivalences.
+                    for input_equivs in input_equivalences.iter() {
+                        let reducer = input_equivs.reducer();
+                        for class in join_equivalences
+                            .equivalence_classes_mut()
+                            .classes
+                            .iter_mut()
+                        {
+                            for expr in class.iter_mut() {
+                                // Semijoin elimination currently fails if you do more advanced simplification than
+                                // literal substitution.
+                                let old = expr.clone();
+                                let changed = reducer.reduce_expr(expr);
+                                let acceptable_sub = literal_domination(&old, expr);
+                                if changed || !ctx.features.enable_less_reduce_in_eqprop {
+                                    expr.reduce(input_types.as_ref().unwrap());
+                                }
+                                if !acceptable_sub && !literal_domination(&old, expr)
+                                    || expr.contains_err()
+                                {
+                                    expr.clone_from(&old);
+                                }
+                            }
+                        }
+                    }
+                    // Remove nullability information, as it has already been incorporated from input equivalences,
+                    // and if it was reduced out relative to input equivalences we don't want to re-introduce it.
+                    if let Some(input_types) = input_types.as_mut() {
+                        for col in input_types.iter_mut() {
+                            col.nullable = true;
+                        }
+                    }
+                    join_equivalences
+                        .equivalence_classes_mut()
+                        .minimize(input_types.as_ref().map(|x| &x[..]));
+
+                    // Revisit each child, determining the information to present to it, and recurring.
+                    let mut columns = 0;
+                    for ((index, child), expr) in
+                        children.into_iter().enumerate().zip_eq(inputs.iter_mut())
+                    {
+                        let child_arity = child.value::<Arity>().expect("Arity required");
+
+                        let mut push_equivalences = join_equivalences.clone();
+                        push_equivalences.extend_equivalences(outer_equivalences.classes.clone());
+
+                        for (other, input_equivs) in input_equivalences.iter().enumerate() {
+                            if index != other {
+                                push_equivalences.extend_equivalences(input_equivs.classes.clone());
+                            }
+                        }
+                        push_equivalences.project(columns..(columns + child_arity));
+                        self.apply(
+                            expr,
+                            child,
+                            push_equivalences.equivalence_classes().clone(),
+                            get_equivalences,
+                            ctx,
+                        )?;
+
+                        columns += child_arity;
+                    }
+
+                    let extracted_equivalences = join_equivalences
+                        .extract_equivalences(input_types.as_ref().map(|x| &x[..]));
+
+                    debug!(
+                        ?inputs,
+                        ?extracted_equivalences,
+                        "Join equivalences extracted"
+                    );
+                    equivalences.clone_from(&extracted_equivalences);
+                }
+                MirRelationExpr::Reduce {
+                    input,
+                    group_key,
+                    aggregates,
+                    ..
+                } => {
+                    // TODO: MIN, MAX, ANY, ALL aggregates pass through all certain properties of their columns.
+                    // This may involve projection and permutation, to reposition the information appropriately.
+                    // TODO: Non-null constraints likely push down into the support of the aggregate expressions.
+
+                    // Apply any equivalences about the input to key and aggregate expressions.
+                    let input_equivalences = derived
+                        .last_child()
+                        .value::<Equivalences>()
+                        .expect("Equivalences required");
+                    if let Some(input_equivalences) = input_equivalences {
+                        let input_type: &Vec<ReprColumnType> = derived
+                            .last_child()
+                            .value::<ReprRelationType>()
+                            .expect("ReprRelationType required")
+                            .as_ref()
+                            .unwrap();
+                        let reducer = input_equivalences.reducer();
+                        for key in group_key.iter_mut() {
+                            // Semijoin elimination currently fails if you do more advanced simplification than
+                            // literal substitution.
+                            let old_key = key.clone();
+                            let changed = reducer.reduce_expr(key);
+                            let acceptable_sub = literal_domination(&old_key, key);
+                            if changed || !ctx.features.enable_less_reduce_in_eqprop {
+                                key.reduce(input_type);
+                            }
+                            if !acceptable_sub && !literal_domination(&old_key, key) {
+                                key.clone_from(&old_key);
+                            }
+                        }
+                        for aggr in aggregates.iter_mut() {
+                            let changed = reducer.reduce_expr(&mut aggr.expr);
+                            if changed || !ctx.features.enable_less_reduce_in_eqprop {
+                                aggr.expr.reduce(input_type);
+                            }
+                            // A count expression over a non-null expression can discard the expression.
+                            if aggr.func == mz_expr::AggregateFunc::Count && !aggr.distinct {
+                                let mut probe = aggr.expr.clone().call_is_null();
+                                reducer.reduce_expr(&mut probe);
+                                if probe.is_literal_false() {
+                                    aggr.expr = MirScalarExpr::literal_true();
+                                }
+                            }
+                        }
+                    }
+
+                    // To transform `outer_equivalences` to one about `input`, we will "pretend" to pre-pend all of
+                    // the input columns, introduce equivalences about the evaluation of `group_key` on them
+                    // and the key columns themselves, and then project onto these "input" columns.
+                    let input_arity = *derived
+                        .last_child()
+                        .value::<Arity>()
+                        .expect("Arity required");
+                    let output_arity = *derived.value::<Arity>().expect("Arity required");
+
+                    // Permute `outer_equivalences` to reference columns `input_arity` later.
+                    let permutation =
+                        (input_arity..(input_arity + output_arity)).collect::<Vec<_>>();
+                    outer_equivalences.permute(&permutation[..]);
+                    for (index, group) in group_key.iter().enumerate() {
+                        outer_equivalences.classes.push(vec![
+                            MirScalarExpr::column(input_arity + index),
+                            group.clone(),
+                        ]);
+                    }
+                    outer_equivalences.project(0..input_arity);
+                    self.apply(
+                        input,
+                        derived.last_child(),
+                        outer_equivalences,
+                        get_equivalences,
+                        ctx,
+                    )?;
+                }
+                MirRelationExpr::TopK {
+                    input,
+                    group_key,
+                    limit,
+                    ..
+                } => {
+                    // We must be careful when updating `limit` to not install column references
+                    // outside of `group_key`. We'll do this for now with `literal_domination`,
+                    // which will ensure we only perform substitutions by a literal.
+                    let input_equivalences = derived
+                        .last_child()
+                        .value::<Equivalences>()
+                        .expect("Equivalences required");
+                    if let Some(input_equivalences) = input_equivalences {
+                        let input_types: &Vec<ReprColumnType> = derived
+                            .last_child()
+                            .value::<ReprRelationType>()
+                            .expect("ReprRelationType required")
+                            .as_ref()
+                            .unwrap();
+                        let reducer = input_equivalences.reducer();
+                        if let Some(expr) = limit {
+                            let old_expr = expr.clone();
+                            let changed = reducer.reduce_expr(expr);
+                            let acceptable_sub = literal_domination(&old_expr, expr);
+                            if changed || !ctx.features.enable_less_reduce_in_eqprop {
+                                expr.reduce(input_types);
+                            }
+                            if !acceptable_sub && !literal_domination(&old_expr, expr) {
+                                expr.clone_from(&old_expr);
+                            }
+                        }
+                    }
+
+                    // Discard equivalences among non-key columns, as it is not correct that `input` may drop rows
+                    // that violate constraints among non-key columns without affecting the result.
+                    // Project to the group_key column indices. After project, group_key[i] has been
+                    // remapped to position i; permute restores the original indices.
+                    outer_equivalences.project(group_key.iter().copied());
+                    outer_equivalences.permute(&group_key[..]);
+                    self.apply(
+                        input,
+                        derived.last_child(),
+                        outer_equivalences,
+                        get_equivalences,
+                        ctx,
+                    )?;
+                }
+                MirRelationExpr::Negate { input } => {
+                    self.apply(
+                        input,
+                        derived.last_child(),
+                        outer_equivalences,
+                        get_equivalences,
+                        ctx,
+                    )?;
+                }
+                MirRelationExpr::Threshold { input } => {
+                    self.apply(
+                        input,
+                        derived.last_child(),
+                        outer_equivalences,
+                        get_equivalences,
+                        ctx,
+                    )?;
+                }
+                MirRelationExpr::Union { .. } => {
+                    for (child, derived) in expr.children_mut().rev().zip_eq(derived.children_rev())
+                    {
+                        self.apply(
+                            child,
+                            derived,
+                            outer_equivalences.clone(),
+                            get_equivalences,
+                            ctx,
+                        )?;
+                    }
+                }
+                MirRelationExpr::ArrangeBy { input, .. } => {
+                    // TODO: Option to alter arrangement keys, though .. terrifying.
+                    self.apply(
+                        input,
+                        derived.last_child(),
+                        outer_equivalences,
+                        get_equivalences,
+                        ctx,
+                    )?;
                 }
             }
-            MirRelationExpr::ArrangeBy { input, .. } => {
-                // TODO: Option to alter arrangement keys, though .. terrifying.
-                self.apply(
-                    input,
-                    derived.last_child(),
-                    outer_equivalences,
-                    get_equivalences,
-                    ctx,
-                );
-            }
-        }
+            Ok(())
+        })
     }
 }
 
@@ -800,4 +837,44 @@ fn literal_domination(old: &MirScalarExpr, new: &MirScalarExpr) -> bool {
         }
     }
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_repr::ReprRelationType;
+    use mz_repr::optimize::OptimizerFeatures;
+
+    use crate::Transform;
+    use crate::dataflow::DataflowMetainfo;
+
+    use super::*;
+
+    /// Dismantle a deep expression iteratively, as dropping it recursively
+    /// could overflow the stack.
+    fn dismantle(expr: MirRelationExpr) {
+        let mut todo = vec![expr];
+        while let Some(mut e) = todo.pop() {
+            todo.extend(e.children_mut().map(|c| c.take_dangerous()));
+        }
+    }
+
+    #[mz_ore::test]
+    fn apply_errors_on_deep_plan() {
+        let mut expr = MirRelationExpr::constant(vec![], ReprRelationType::new(vec![]));
+        for _ in 0..RECURSION_LIMIT + 100 {
+            expr = MirRelationExpr::Filter {
+                input: Box::new(expr),
+                predicates: vec![MirScalarExpr::literal_true()],
+            };
+        }
+        let features = OptimizerFeatures::default();
+        let typecheck_ctx = crate::typecheck::empty_typechecking_context();
+        let mut df_meta = DataflowMetainfo::default();
+        let mut ctx =
+            crate::TransformCtx::local(&features, &typecheck_ctx, &mut df_meta, None, None);
+        let result =
+            EquivalencePropagation::default().actually_perform_transform(&mut expr, &mut ctx);
+        assert!(result.is_err());
+        dismantle(expr);
+    }
 }

--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -74,7 +74,7 @@ impl crate::Transform for Join {
         // LiteralLifting is removed in favor of EquivalencePropagation.
         if transformed {
             PredicatePushdown::default().action(relation, &mut BTreeMap::new())?;
-            CanonicalizeMfp.action(relation)?
+            CanonicalizeMfp::default().action(relation)?
         }
         mz_repr::explain::trace_plan(&*relation);
         Ok(())

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -637,7 +637,7 @@ impl Default for FuseAndCollapse {
                 Box::new(compound::UnionNegateFusion),
                 // This goes after union fusion so we can cancel out
                 // more branches at a time.
-                Box::new(UnionBranchCancellation),
+                Box::new(UnionBranchCancellation::default()),
                 // This should run before redundant join to ensure that key info
                 // is correct.
                 Box::new(NormalizeLets::new(false)),
@@ -874,7 +874,7 @@ impl Optimizer {
                 limit: 100,
                 transforms: vec![Box::new(JoinImplementation::default())],
             }),
-            Box::new(CanonicalizeMfp),
+            Box::new(CanonicalizeMfp::default()),
             // Identifies common relation subexpressions.
             Box::new(cse::relation_cse::RelationCSE::new(false)),
             // `RelationCSE` can create new points of interest for `ProjectionPushdown`: If an MFP
@@ -885,7 +885,7 @@ impl Optimizer {
             Box::new(ProjectionPushdown::skip_joins());
                 if ctx.features.enable_projection_pushdown_after_relation_cse,
             // Plans look nicer if we tidy MFPs again after ProjectionPushdown.
-            Box::new(CanonicalizeMfp);
+            Box::new(CanonicalizeMfp::default());
                 if ctx.features.enable_projection_pushdown_after_relation_cse,
             // Rewrite If-chains matching a single expression against literals
             // into a CaseLiteral lookup for O(log n) evaluation.
@@ -931,7 +931,7 @@ impl Optimizer {
                 name: "fixpoint_logical_cleanup_pass_01",
                 limit: 100,
                 transforms: vec![
-                    Box::new(CanonicalizeMfp),
+                    Box::new(CanonicalizeMfp::default()),
                     // Remove threshold operators which have no effect.
                     Box::new(ThresholdElision),
                     // Projection pushdown may unblock fusing joins and unions.
@@ -944,7 +944,7 @@ impl Optimizer {
                     Box::new(compound::UnionNegateFusion),
                     // This goes after union fusion so we can cancel out
                     // more branches at a time.
-                    Box::new(UnionBranchCancellation),
+                    Box::new(UnionBranchCancellation::default()),
                     // The last RelationCSE before JoinImplementation should be with
                     // inline_mfp = true.
                     Box::new(cse::relation_cse::RelationCSE::new(true)),
@@ -968,7 +968,7 @@ impl Optimizer {
         let transforms: Vec<Box<dyn Transform>> = vec![
             Box::new(canonicalization::ReduceScalars),
             Box::new(LiteralConstraints),
-            Box::new(CanonicalizeMfp),
+            Box::new(CanonicalizeMfp::default()),
             // We might have arrived at a constant, e.g., due to contradicting literal constraints.
             Box::new(Fixpoint {
                 name: "fast_path_fold_constants_fixpoint",

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -115,7 +115,7 @@ impl NormalizeLets {
         // Promote all `Let` and `LetRec` AST nodes to the roots.
         // After this, all non-`LetRec` nodes contain no further `Let` or `LetRec` nodes,
         // placing all `LetRec` nodes around the root, if not always in a single AST node.
-        let_motion::promote_let_rec(relation);
+        let_motion::promote_let_rec(relation)?;
         let_motion::assert_no_lets(relation);
         let_motion::assert_letrec_major(relation);
 
@@ -123,7 +123,7 @@ impl NormalizeLets {
         inlining::inline_lets(relation, self.inline_mfp)?;
 
         // Return to letrec-major form to refresh types.
-        let_motion::promote_let_rec(relation);
+        let_motion::promote_let_rec(relation)?;
         support::refresh_types(relation, features)?;
 
         // Renumber bindings for good measure.
@@ -345,8 +345,8 @@ mod let_motion {
     use std::collections::{BTreeMap, BTreeSet};
 
     use itertools::Itertools;
-    use mz_expr::{LetRecLimit, LocalId, MirRelationExpr};
-    use mz_ore::stack::RecursionLimitError;
+    use mz_expr::{LetRecLimit, LocalId, MirRelationExpr, RECURSION_LIMIT};
+    use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
 
     use crate::normalize_lets::support::replace_bindings_from_map;
 
@@ -354,7 +354,9 @@ mod let_motion {
     ///
     /// We cannot (without further reasoning) fuse stacked `LetRec` stages, and instead we just promote
     /// `LetRec` to the roots of their expressions (e.g. as children of another `LetRec` stage).
-    pub(crate) fn promote_let_rec(expr: &mut MirRelationExpr) {
+    ///
+    /// Returns an error if the `LetRec` nesting depth exceeds the recursion limit.
+    pub(crate) fn promote_let_rec(expr: &mut MirRelationExpr) -> Result<(), RecursionLimitError> {
         // First, promote all `LetRec` nodes above all other nodes.
         let mut worklist = vec![&mut *expr];
         while let Some(mut expr) = worklist.pop() {
@@ -366,7 +368,8 @@ mod let_motion {
         }
 
         // Harvest any potential `Let` nodes, via a post-order traversal.
-        post_order_harvest_lets(expr);
+        let guard = RecursionGuard::with_limit(RECURSION_LIMIT);
+        post_order_harvest_lets(expr, &guard)
     }
 
     /// A stand in for the types of bindings we might encounter.
@@ -508,32 +511,39 @@ mod let_motion {
 
     /// Performs a post-order traversal of the `LetRec` nodes at the root of an expression.
     ///
-    /// The traversal is only of the `LetRec` nodes, for which fear of stack exhaustion is nominal.
-    fn post_order_harvest_lets(expr: &mut MirRelationExpr) {
-        if let MirRelationExpr::LetRec {
-            ids,
-            values,
-            limits,
-            body,
-        } = expr
-        {
-            // Only recursively descend through `LetRec` stages.
-            for value in values.iter_mut() {
-                post_order_harvest_lets(value);
-            }
-
-            let mut bindings = BTreeMap::new();
-            for ((id, mut value), max_iter) in ids
-                .drain(..)
-                .zip_eq(values.drain(..))
-                .zip_eq(limits.drain(..))
+    /// The traversal is only of the `LetRec` nodes, but those can be deeply nested in each
+    /// other's values, so the recursion is checked against `guard`.
+    fn post_order_harvest_lets(
+        expr: &mut MirRelationExpr,
+        guard: &RecursionGuard,
+    ) -> Result<(), RecursionLimitError> {
+        guard.checked_recur(|_| {
+            if let MirRelationExpr::LetRec {
+                ids,
+                values,
+                limits,
+                body,
+            } = expr
             {
-                bindings.extend(harvest_non_recursive(&mut value));
-                bindings.insert(id, (value, max_iter));
+                // Only recursively descend through `LetRec` stages.
+                for value in values.iter_mut() {
+                    post_order_harvest_lets(value, guard)?;
+                }
+
+                let mut bindings = BTreeMap::new();
+                for ((id, mut value), max_iter) in ids
+                    .drain(..)
+                    .zip_eq(values.drain(..))
+                    .zip_eq(limits.drain(..))
+                {
+                    bindings.extend(harvest_non_recursive(&mut value));
+                    bindings.insert(id, (value, max_iter));
+                }
+                bindings.extend(harvest_non_recursive(body));
+                replace_bindings_from_map(bindings, ids, values, limits);
             }
-            bindings.extend(harvest_non_recursive(body));
-            replace_bindings_from_map(bindings, ids, values, limits);
-        }
+            Ok(())
+        })
     }
 
     /// Harvest any safe-to-lift non-recursive bindings from a `LetRec`
@@ -1040,5 +1050,45 @@ mod renumbering {
             worklist.extend(expr.children_mut().rev());
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_expr::LocalId;
+    use mz_expr::RECURSION_LIMIT;
+    use mz_repr::ReprRelationType;
+
+    use super::*;
+
+    /// Dismantle a deep expression iteratively, as dropping it recursively
+    /// could overflow the stack.
+    fn dismantle(expr: MirRelationExpr) {
+        let mut todo = vec![expr];
+        while let Some(mut e) = todo.pop() {
+            todo.extend(e.children_mut().map(|c| c.take_dangerous()));
+        }
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    fn action_errors_on_deep_letrec_nest() {
+        let typ = ReprRelationType::new(vec![]);
+        let mut expr = MirRelationExpr::constant(vec![], typ.clone());
+        for i in 0..u64::try_from(RECURSION_LIMIT + 100).unwrap() {
+            expr = MirRelationExpr::LetRec {
+                ids: vec![LocalId::new(i)],
+                values: vec![expr],
+                limits: vec![None],
+                body: Box::new(MirRelationExpr::constant(vec![], typ.clone())),
+            };
+        }
+        let features = OptimizerFeatures::default();
+        assert!(
+            NormalizeLets::new(false)
+                .action(&mut expr, &features)
+                .is_err()
+        );
+        dismantle(expr);
     }
 }

--- a/src/transform/src/union_cancel.rs
+++ b/src/transform/src/union_cancel.rs
@@ -10,8 +10,9 @@
 //! Detects an input being unioned with its negation and cancels them out
 
 use itertools::Itertools;
-use mz_expr::MirRelationExpr;
 use mz_expr::visit::Visit;
+use mz_expr::{MirRelationExpr, RECURSION_LIMIT};
+use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
 
 use crate::{TransformCtx, TransformError};
 
@@ -26,7 +27,23 @@ use crate::{TransformCtx, TransformError};
 /// binding (from two inputs of a Union), and then we don't make any `compare_branches` call
 /// where `relation` and `other` are in different Let bindings.
 #[derive(Debug)]
-pub struct UnionBranchCancellation;
+pub struct UnionBranchCancellation {
+    recursion_guard: RecursionGuard,
+}
+
+impl Default for UnionBranchCancellation {
+    fn default() -> UnionBranchCancellation {
+        UnionBranchCancellation {
+            recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
+        }
+    }
+}
+
+impl CheckedRecursion for UnionBranchCancellation {
+    fn recursion_guard(&self) -> &RecursionGuard {
+        &self.recursion_guard
+    }
+}
 
 impl crate::Transform for UnionBranchCancellation {
     fn name(&self) -> &'static str {
@@ -86,16 +103,16 @@ impl UnionBranchCancellation {
                                      inputs: &[MirRelationExpr],
                                      input_signs: &[bool],
                                      start_idx: usize|
-             -> Option<usize> {
+             -> Result<Option<usize>, RecursionLimitError> {
                 for i in start_idx..inputs.len() {
                     // Only compare branches with opposite signs
                     if sign != input_signs[i] {
-                        if let BranchCmp::Inverse = Self::compare_branches(input, &inputs[i]) {
-                            return Some(i);
+                        if let BranchCmp::Inverse = self.compare_branches(input, &inputs[i])? {
+                            return Ok(Some(i));
                         }
                     }
                 }
-                None
+                Ok(None)
             };
 
             let base_sign = Self::branch_sign(base);
@@ -103,7 +120,7 @@ impl UnionBranchCancellation {
 
             // Compare branches if there is at least a negated branch
             if std::iter::once(&base_sign).chain(&input_signs).any(|x| *x) {
-                if let Some(j) = matching_negation(&*base, base_sign, inputs, &input_signs, 0) {
+                if let Some(j) = matching_negation(&*base, base_sign, inputs, &input_signs, 0)? {
                     let relation_typ = base.typ();
                     **base = MirRelationExpr::constant(vec![], relation_typ.clone());
                     inputs[j] = MirRelationExpr::constant(vec![], relation_typ);
@@ -111,7 +128,7 @@ impl UnionBranchCancellation {
 
                 for i in 0..inputs.len() {
                     if let Some(j) =
-                        matching_negation(&inputs[i], input_signs[i], inputs, &input_signs, i + 1)
+                        matching_negation(&inputs[i], input_signs[i], inputs, &input_signs, i + 1)?
                     {
                         let relation_typ = inputs[i].typ();
                         inputs[i] = MirRelationExpr::constant(vec![], relation_typ.clone());
@@ -153,14 +170,20 @@ impl UnionBranchCancellation {
     /// with negated row count values, ie. one of them contains an extra Negate operator.
     /// Negate operators may appear interleaved with Map, Filter and Project
     /// operators, but these operators must appear in the same order in both branches.
-    fn compare_branches(relation: &MirRelationExpr, other: &MirRelationExpr) -> BranchCmp {
-        match (relation, other) {
+    ///
+    /// Returns an error if the branch depth exceeds the recursion limit.
+    fn compare_branches(
+        &self,
+        relation: &MirRelationExpr,
+        other: &MirRelationExpr,
+    ) -> Result<BranchCmp, RecursionLimitError> {
+        self.checked_recur(|_| match (relation, other) {
             (
                 MirRelationExpr::Negate { input: input1 },
                 MirRelationExpr::Negate { input: input2 },
-            ) => Self::compare_branches(&*input1, &*input2),
+            ) => self.compare_branches(&*input1, &*input2),
             (r, MirRelationExpr::Negate { input }) | (MirRelationExpr::Negate { input }, r) => {
-                Self::compare_branches(&*input, r).inverse()
+                Ok(self.compare_branches(&*input, r)?.inverse())
             }
             (
                 MirRelationExpr::Map {
@@ -173,9 +196,9 @@ impl UnionBranchCancellation {
                 },
             ) => {
                 if scalars1 == scalars2 {
-                    Self::compare_branches(&*input1, &*input2)
+                    self.compare_branches(&*input1, &*input2)
                 } else {
-                    BranchCmp::Distinct
+                    Ok(BranchCmp::Distinct)
                 }
             }
             (
@@ -189,9 +212,9 @@ impl UnionBranchCancellation {
                 },
             ) => {
                 if predicates1 == predicates2 {
-                    Self::compare_branches(&*input1, &*input2)
+                    self.compare_branches(&*input1, &*input2)
                 } else {
-                    BranchCmp::Distinct
+                    Ok(BranchCmp::Distinct)
                 }
             }
             (
@@ -205,18 +228,63 @@ impl UnionBranchCancellation {
                 },
             ) => {
                 if outputs1 == outputs2 {
-                    Self::compare_branches(&*input1, &*input2)
+                    self.compare_branches(&*input1, &*input2)
                 } else {
-                    BranchCmp::Distinct
+                    Ok(BranchCmp::Distinct)
                 }
             }
             _ => {
                 if relation == other {
-                    BranchCmp::Equivalent
+                    Ok(BranchCmp::Equivalent)
                 } else {
-                    BranchCmp::Distinct
+                    Ok(BranchCmp::Distinct)
                 }
             }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_expr::MirScalarExpr;
+    use mz_repr::ReprRelationType;
+
+    use super::*;
+
+    /// Dismantle a deep expression iteratively, as dropping it recursively
+    /// could overflow the stack.
+    fn dismantle(expr: MirRelationExpr) {
+        let mut todo = vec![expr];
+        while let Some(mut e) = todo.pop() {
+            todo.extend(e.children_mut().map(|c| c.take_dangerous()));
         }
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    fn action_errors_on_deep_branch_comparison() {
+        let typ = ReprRelationType::new(vec![]);
+        let mut base = MirRelationExpr::constant(vec![], typ.clone());
+        let mut other = MirRelationExpr::constant(vec![], typ);
+        for _ in 0..RECURSION_LIMIT + 100 {
+            base = MirRelationExpr::Filter {
+                input: Box::new(base),
+                predicates: vec![MirScalarExpr::literal_true()],
+            };
+            other = MirRelationExpr::Filter {
+                input: Box::new(other),
+                predicates: vec![MirScalarExpr::literal_true()],
+            };
+        }
+        let mut expr = MirRelationExpr::Union {
+            base: Box::new(base),
+            inputs: vec![other.negate()],
+        };
+        assert!(
+            UnionBranchCancellation::default()
+                .action(&mut expr)
+                .is_err()
+        );
+        dismantle(expr);
     }
 }

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -283,7 +283,9 @@ mod tests {
         // TODO(justin): is there a way to just extract these from the Optimizer list of
         // transforms?
         match name {
-            "CanonicalizeMfp" => Ok(Box::new(mz_transform::canonicalize_mfp::CanonicalizeMfp)),
+            "CanonicalizeMfp" => Ok(Box::new(
+                mz_transform::canonicalize_mfp::CanonicalizeMfp::default(),
+            )),
             "EquivalencePropagation" => Ok(Box::new(
                 mz_transform::equivalence_propagation::EquivalencePropagation::default(),
             )),
@@ -326,7 +328,7 @@ mod tests {
             ))),
             "ThresholdElision" => Ok(Box::new(mz_transform::threshold_elision::ThresholdElision)),
             "UnionBranchCancellation" => Ok(Box::new(
-                mz_transform::union_cancel::UnionBranchCancellation,
+                mz_transform::union_cancel::UnionBranchCancellation::default(),
             )),
             "UnionNegateFusion" => Ok(Box::new(mz_transform::compound::UnionNegateFusion)),
             "UnionFusion" => Ok(Box::new(mz_transform::fusion::union::Union)),

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -255,7 +255,7 @@ fn handle_apply(
         }
         "union_branch_cancellation" => {
             use mz_transform::union_cancel::UnionBranchCancellation;
-            let transform = UnionBranchCancellation;
+            let transform = UnionBranchCancellation::default();
             apply_transform(transform, catalog, input)
         }
         transform => Err(format!("unsupported pipeline transform: {transform}")),


### PR DESCRIPTION
Deep plans, such as long view chains inlined into a single dataflow, reach several MIR transforms whose recursion was unguarded and crash environmentd with a stack overflow instead of returning an error:

* EquivalencePropagation::apply (database-issues#9093)
* NormalizeLets, via post_order_harvest_lets on nested LetRec values
* CanonicalizeMfp::action
* UnionBranchCancellation::compare_branches

Guard each with CheckedRecursion, following the pattern RedundantJoin already uses, so exceeding RECURSION_LIMIT surfaces as a SQL error.

In EquivalencePropagation, additionally check the plan depth iteratively at the start of the transform. The transform clones and compares the plan with recursive derived Clone and PartialEq implementations, which overflow the stack on a too-deep plan before the recursion guard in apply can trigger.

Add per-transform regression tests that run each transform on a plan deeper than the recursion limit and assert a graceful error.

Closes: DB-162