### PR TITLE
fix(console): [CNS-111] derive the self-managed MCP URL from the HTTP endpoint 

### DIFF
--- a/console/src/components/McpConnectInstructions.tsx
+++ b/console/src/components/McpConnectInstructions.tsx
@@ -74,15 +74,14 @@ const McpConnectInstructions = ({
 
   if (!envAddress) return null;
 
-  const balancerdHost =
-    appConfig.mode === "self-managed"
-      ? appConfig.balancerdDnsNames?.[0]
-      : undefined;
+  // MCP is served on the HTTP endpoint, so build its URL from the HTTP host.
+  // `envAddress` is `currentEnvironment.httpAddress`, the same address the
+  // console uses for its own HTTP API calls (for self-managed, the console's
+  // own host, which nginx proxies to environmentd). The pgwire host advertised
+  // in `balancerdDnsNames` does not serve MCP.
   const baseUrl = isCloud
     ? `https://${envAddress.split(":")[0]}`
-    : balancerdHost
-      ? `https://${balancerdHost}`
-      : "<your-materialize-host>";
+    : `${appConfig.environmentdScheme}://${envAddress}`;
 
   const user = userStr || "<user>";
   const base64Command = `printf '${user}:<password>' | base64 -w0`;


### PR DESCRIPTION
The MCP server is served on Materialize's HTTP endpoint, but the self-managed branch of McpConnectInstructions built its URL from `appConfig.balancerdDnsNames[0]`, which is the pgwire/SQL host (used elsewhere with `:6875` for psql). When an operator puts pgwire and HTTP on separate hostnames the console printed e.g.
`https://prod.context-graph.materialize.com/api/mcp/agent`, HTTPS aimed at the pgwire listener, which does not serve MCP and fails to connect.

Build the URL from `currentEnvironment.httpAddress` instead, the same address the console already uses for all its own HTTP API calls (for self-managed, the console's own host, which nginx proxies to environmentd). This yields the working
`https://console.prod.context-graph.materialize.com/api/mcp/agent`. psql instructions are unaffected, as they correctly use the SQL host.

