### PR TITLE
docs: rename Claude Desktop to Claude Cowork in MCP server docs

### DIFF
--- a/doc/user/content/integrations/mcp-server/mcp-agent.md
+++ b/doc/user/content/integrations/mcp-server/mcp-agent.md
@@ -20,7 +20,7 @@ external server is required.
 
 The `materialize-agent` MCP server lets AI agents query business-facing data
 products over HTTP. You can connect an MCP-compatible client (such as Claude
-Code, Claude Desktop, or Cursor) to the MCP server and ask the agent to discover
+Code, Claude Cowork, or Cursor) to the MCP server and ask the agent to discover
 and query your data products using either natural language or SQL:
 
 - *SELECT * FROM mcp_product_performance LIMIT 5;*
@@ -365,9 +365,9 @@ In the following, replace `<baseURL>` with the MCP server URL from [Step
 
 {{< /tab >}}
 
-{{< tab "Claude Desktop/Chrome" >}}
+{{< tab "Claude Cowork/Chrome" >}}
 
-To configure Claude Desktop/Chrome, add a custom connector. The exact steps
+To configure Claude Cowork/Chrome, add a custom connector. The exact steps
 depend on your Claude plan; for example:
 
 - **Organization settings** → **Connectors** → **Add** → **Custom** → **Web**,
@@ -703,9 +703,9 @@ When saving your credentials or other sensitive information in a config file, do
 
 {{< /tab >}}
 
-{{< tab "Claude Desktop" >}}
+{{< tab "Claude Cowork" >}}
 
-Claude Desktop's `claude_desktop_config.json` does not connect to a remote MCP
+Claude Cowork's `claude_desktop_config.json` does not connect to a remote MCP
 server directly. Use the
 [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge, which runs
 locally and forwards requests to the `materialize-agent` MCP server over HTTP.
@@ -719,7 +719,7 @@ specific version rather than pulling the latest release. Review the tool and
 update the pinned version as appropriate for your environment.
 {{< /note >}}
 
-1. Add the `materialize-agent` MCP server entry to your Claude Desktop
+1. Add the `materialize-agent` MCP server entry to your Claude Cowork
    configuration (`claude_desktop_config.json`).
    - When merging into an existing `mcpServers` object, remember to add commas
      between entries.
@@ -751,7 +751,7 @@ update the pinned version as appropriate for your environment.
 
    {{% include-headless "/headless/mcp-endpoint-config-replacements" %}}
 
-1. Restart Claude Desktop to pick up the new setting.
+1. Restart Claude Cowork to pick up the new setting.
 
 {{< /tab >}}
 

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -18,7 +18,7 @@ process or external server is required.
 
 ## Overview
 
-You can connect an MCP-compatible client (such as Claude Code, Claude Desktop,
+You can connect an MCP-compatible client (such as Claude Code, Claude Cowork,
 or Cursor) to the MCP server to:
 
 - Ask questions about the Materialize system
@@ -123,9 +123,9 @@ your MCP client. The `materialize-developer` MCP server URL has the form:
 
 {{< /tab >}}
 
-{{< tab "Claude Desktop/Chrome" >}}
+{{< tab "Claude Cowork/Chrome" >}}
 
-To configure Claude Desktop/Chrome, add a custom connector. The exact steps
+To configure Claude Cowork/Chrome, add a custom connector. The exact steps
 depend on your Claude plan; for example:
 
 - **Organization settings** → **Connectors** → **Add** → **Custom** → **Web**,
@@ -385,9 +385,9 @@ When saving your credentials or other sensitive information in a config file, do
 
 {{< /tab >}}
 
-{{< tab "Claude Desktop" >}}
+{{< tab "Claude Cowork" >}}
 
-Claude Desktop's `claude_desktop_config.json` does not connect to a remote MCP
+Claude Cowork's `claude_desktop_config.json` does not connect to a remote MCP
 server directly. Use the
 [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge, which runs
 locally and forwards requests to the `materialize-developer` MCP server over
@@ -402,7 +402,7 @@ specific version rather than pulling the latest release. Review the tool and
 update the pinned version as appropriate for your environment.
 {{< /note >}}
 
-1. Add the `materialize-developer` MCP server entry to your Claude Desktop
+1. Add the `materialize-developer` MCP server entry to your Claude Cowork
    configuration (`claude_desktop_config.json`).
    - When merging into an existing `mcpServers` object, remember to add commas
      between entries.
@@ -434,7 +434,7 @@ update the pinned version as appropriate for your environment.
 
    {{% include-headless "/headless/mcp-endpoint-config-replacements" %}}
 
-1. Restart Claude Desktop to pick up the new setting.
+1. Restart Claude Cowork to pick up the new setting.
 
 1. Upon successful connection, you can [Start asking
    questions](#start-asking-questions).


### PR DESCRIPTION
### Motivation

Our MCP server connection documentation referred to the Anthropic client as
"Claude Desktop". This updates that name to "Claude Cowork".

### Description

Renames "Claude Desktop" to "Claude Cowork" throughout the MCP server
connection documentation:

- `doc/user/content/integrations/mcp-server/mcp-developer.md`
- `doc/user/content/integrations/mcp-server/mcp-agent.md`

This covers the client mentions in the overview text, the connector tab labels
(`Claude Desktop/Chrome` → `Claude Cowork/Chrome` and `Claude Desktop` →
`Claude Cowork`), and the step instructions ("Restart Claude Cowork", "add the
entry to your Claude Cowork configuration").

The `claude_desktop_config.json` filename is intentionally left unchanged, since
that is the actual configuration file the client reads and renaming it would
make the instructions incorrect.

Other references to "Claude Desktop" outside the connection docs (historical
release notes, source-code comments, the console UI component, and a design
doc) were left untouched, as they are not part of the connection documentation.

### Verification

Documentation-only change. Confirmed via grep that no "Claude Desktop" product
references remain in `doc/user/content/integrations/mcp-server/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMfLoPpb7LX7qTsJak2x4w

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMfLoPpb7LX7qTsJak2x4w)_