### PR TITLE
SS-356: docs: document AWS Glue Schema Registry support for Kafka sinks

### DIFF
--- a/doc/user/content/serve-results/sink/kafka.md
+++ b/doc/user/content/serve-results/sink/kafka.md
@@ -109,8 +109,8 @@ By default, Materialize assigns a partition to each message using the following
 strategy:
 
   1. Encode the message's key in the specified format.
-  2. If the format uses a Confluent Schema Registry, strip out the
-     schema ID from the encoded bytes.
+  2. If the format uses a schema registry (Confluent or AWS Glue), strip out
+     the header carrying the schema ID from the encoded bytes.
   3. Hash the remaining encoded bytes using [SeaHash].
   4. Divide the hash value by the topic's partition count and assign the
      remainder as the message's partition.

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -625,8 +625,8 @@ CREATE CONNECTION csr_ssh TO CONFLUENT SCHEMA REGISTRY (
 
 An AWS Glue Schema Registry connection establishes a link to an [AWS Glue Schema
 Registry]. You can use AWS Glue Schema Registry connections in the `FORMAT`
-clause of [`CREATE SOURCE`] statements to decode Avro-encoded messages whose
-schemas are managed in AWS Glue.
+clause of [`CREATE SOURCE`] statements to decode Avro-encoded messages, and of
+[`CREATE SINK`] statements to encode them, with schemas managed in AWS Glue.
 
 The connection authenticates to AWS through a separate [AWS connection](#aws),
 which supplies the credentials and region. See [AWS](#aws) for how to grant
@@ -651,15 +651,21 @@ CREATE CONNECTION glue_conn TO AWS GLUE SCHEMA REGISTRY (
 
 #### Permissions {#glue-permissions}
 
-The IAM role assumed by the [AWS connection](#aws) must be allowed to read
-schemas from the registry. Materialize uses the following AWS Glue actions:
+The IAM role assumed by the [AWS connection](#aws) must be allowed to access the
+registry. Sources only read. Sinks also register schemas. Materialize uses the
+following AWS Glue actions:
 
 | Action | When it is used |
 |--------|-----------------|
 | `glue:GetRegistry` | At connection creation, to validate the connection. Only required when `VALIDATE` is `true` (the default). |
-| `glue:GetSchemaVersion` | When a source is created, to pin the schema, and at runtime, to fetch the writer schema for each new schema version encountered. Always required. |
+| `glue:GetSchemaVersion` | Source: when the source is created, to pin the schema, and at runtime, to fetch the writer schema for each new schema version encountered. Sink: to poll a newly registered schema version until it becomes available. Always required. |
+| `glue:GetSchemaByDefinition` | Sink, to find an existing version matching the schema being registered. |
+| `glue:RegisterSchemaVersion` | Sink, to add a version to an existing schema. |
+| `glue:CreateSchema` | Sink, to create a schema on its first publish. |
+| `glue:GetSchema` | Sink, to read an existing schema's compatibility level and warn when it differs from the requested one. Optional. |
 
-A least-privilege policy scoped to a single registry looks like:
+A least-privilege policy for a source, scoped to a single registry, grants only
+the read actions:
 
 ```json
 {
@@ -680,9 +686,35 @@ A least-privilege policy scoped to a single registry looks like:
 }
 ```
 
+A sink additionally needs the schema-write actions on the same resources:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "glue:GetRegistry",
+                "glue:GetSchemaVersion",
+                "glue:GetSchemaByDefinition",
+                "glue:RegisterSchemaVersion",
+                "glue:CreateSchema",
+                "glue:GetSchema"
+            ],
+            "Resource": [
+                "arn:aws:glue:<region>:<account>:registry/<registry-name>",
+                "arn:aws:glue:<region>:<account>:schema/<registry-name>/*"
+            ]
+        }
+    ]
+}
+```
+
 If you create the connection with `WITH (VALIDATE = false)`, you can omit
-`glue:GetRegistry` and grant only `glue:GetSchemaVersion`. For details on
-creating and authorizing the AWS connection, see [AWS](#aws).
+`glue:GetRegistry`. The registry itself must already exist. Materialize sinks
+create and version schemas within it but never create the registry. For details
+on creating and authorizing the AWS connection, see [AWS](#aws).
 
 ### MySQL
 

--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -134,6 +134,47 @@ When using a Confluent Schema Registry:
 
   * You can [add `doc` fields](#avro-schema-documentation) to the Avro schemas.
 
+  * You can set the compatibility level for a subject with the `KEY COMPATIBILITY
+    LEVEL` and `VALUE COMPATIBILITY LEVEL` [options](#schema-compatibility-levels).
+    The level is applied only when the subject has no compatibility level yet. If
+    the subject already has one, it is left unchanged.
+
+When using an [AWS Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry):
+
+  * Materialize registers Avro schemas for the key, if present, and the value in
+    the registry named by the connection. The registry must already exist.
+
+  * By default, each schema is named after the topic (`<topic>-value`, and
+    `<topic>-key` when a key is present). You can override these with the
+    `KEY SCHEMA NAME` and `VALUE SCHEMA NAME` options.
+
+  * You can set the compatibility level applied to a newly created schema with
+    the `KEY COMPATIBILITY LEVEL` and `VALUE COMPATIBILITY LEVEL`
+    [options](#syntax), defaulting to `BACKWARD` when omitted. The level is set
+    only when Materialize creates the schema. If the schema already exists, the
+    sink adds a new version to it and leaves its compatibility level unchanged.
+
+  * The `AVRO ... FULLNAME`, `NULL DEFAULTS`, and `doc` options are not supported.
+
+Compatibility levels use the Confluent spelling and map to their AWS Glue
+equivalent. Glue's `DISABLED` level is not supported.
+
+Compatibility level | AWS Glue equivalent
+--------------------|--------------------
+`BACKWARD`          | `BACKWARD`
+`BACKWARD_TRANSITIVE` | `BACKWARD_ALL`
+`FORWARD`           | `FORWARD`
+`FORWARD_TRANSITIVE` | `FORWARD_ALL`
+`FULL`              | `FULL`
+`FULL_TRANSITIVE`   | `FULL_ALL`
+`NONE`              | `NONE`
+
+With either registry, Materialize publishes the schemas when the sink starts
+running, not when you run `CREATE SINK`. The schema names and definitions are not
+validated against the registry at `CREATE SINK` time, so registry errors (for
+example a name that collides with an incompatible existing schema) surface once
+the sink starts publishing rather than at creation.
+
 SQL types are converted to Avro types according to the following conversion
 table:
 
@@ -392,8 +433,8 @@ By default, Materialize assigns a partition to each message using the following
 strategy:
 
   1. Encode the message's key in the specified format.
-  2. If the format uses a Confluent Schema Registry, strip out the
-     schema ID from the encoded bytes.
+  2. If the format uses a schema registry (Confluent or AWS Glue), strip out
+     the header carrying the schema ID from the encoded bytes.
   3. Hash the remaining encoded bytes using [SeaHash].
   4. Divide the hash value by the topic's partition count and assign the
      remainder as the message's partition.
@@ -637,6 +678,45 @@ CREATE CONNECTION csr_basic_http
 
 {{< /tab >}}
 {{< /tabs >}}
+
+#### AWS Glue Schema Registry
+
+{{< private-preview />}}
+
+```mzsql
+CREATE CONNECTION aws_conn TO AWS (
+    ASSUME ROLE ARN = 'arn:aws:iam::123456789000:role/MaterializeGlue'
+);
+
+CREATE CONNECTION glue_conn TO AWS GLUE SCHEMA REGISTRY (
+    AWS CONNECTION = aws_conn,
+    REGISTRY = 'my-registry'
+);
+```
+
+The registry named by the connection must already exist. The IAM role assumed
+by the AWS connection must have the schema-write permissions listed under [AWS
+Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry).
+
+```mzsql
+CREATE SINK glue_sink
+  IN CLUSTER my_io_cluster
+  FROM <source, table or mview>
+  INTO KAFKA CONNECTION kafka_connection (
+    TOPIC 'test_avro_topic',
+  )
+  KEY (key_col)
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (
+    KEY SCHEMA NAME = 'my_key_schema',
+    VALUE SCHEMA NAME = 'my_value_schema',
+    KEY COMPATIBILITY LEVEL = 'FORWARD',
+    VALUE COMPATIBILITY LEVEL = 'FULL'
+  )
+  ENVELOPE UPSERT;
+```
+
+See [Avro](#avro) for the schema-name defaults and how compatibility levels map
+to their AWS Glue equivalents.
 
 ### Creating a sink
 

--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -119,7 +119,7 @@ For example, consider a table with two columns named `col-a` and `col@a`.
 Materialize will use the names `col_a` and `col_a1`, respectively, in the
 generated Avro schema.
 
-When using a Confluent Schema Registry:
+#### When using a Confluent Schema Registry:
 
   * Materialize will automatically publish Avro schemas for the key, if present,
     and the value to the registry.
@@ -139,7 +139,9 @@ When using a Confluent Schema Registry:
     The level is applied only when the subject has no compatibility level yet. If
     the subject already has one, it is left unchanged.
 
-When using an [AWS Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry):
+#### When using an [AWS Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry):
+
+{{< private-preview />}}
 
   * Materialize registers Avro schemas for the key, if present, and the value in
     the registry named by the connection. The registry must already exist.
@@ -156,8 +158,12 @@ When using an [AWS Glue Schema Registry](/sql/create-connection/#aws-glue-schema
 
   * The `AVRO ... FULLNAME`, `NULL DEFAULTS`, and `doc` options are not supported.
 
-Compatibility levels use the Confluent spelling and map to their AWS Glue
-equivalent. Glue's `DISABLED` level is not supported.
+##### Compatibility levels
+
+To specify compatibility levels, use the Confluent compatibility level names shown
+below. The table also shows the equivalent AWS Glue compatibility levels for
+reference. AWS Glue's `DISABLED` compatibility level has no equivalent Confluent
+compatibility level and is not supported.
 
 Compatibility level | AWS Glue equivalent
 --------------------|--------------------
@@ -168,6 +174,9 @@ Compatibility level | AWS Glue equivalent
 `FULL`              | `FULL`
 `FULL_TRANSITIVE`   | `FULL_ALL`
 `NONE`              | `NONE`
+
+
+#### Publishing Schemas
 
 With either registry, Materialize publishes the schemas when the sink starts
 running, not when you run `CREATE SINK`. The schema names and definitions are not
@@ -643,7 +652,11 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 {{< /tab >}}
 {{< /tabs >}}
 
-#### Confluent Schema Registry
+#### Schema Registry
+
+
+{{< tabs tabID="1" >}}
+{{< tab "Confluent" >}}
 
 {{< tabs tabID="1" >}}
 {{< tab "SSL">}}
@@ -679,7 +692,8 @@ CREATE CONNECTION csr_basic_http
 {{< /tab >}}
 {{< /tabs >}}
 
-#### AWS Glue Schema Registry
+{{< /tab >}}
+{{< tab "AWS Glue" >}}
 
 {{< private-preview />}}
 
@@ -694,36 +708,15 @@ CREATE CONNECTION glue_conn TO AWS GLUE SCHEMA REGISTRY (
 );
 ```
 
-The registry named by the connection must already exist. The IAM role assumed
-by the AWS connection must have the schema-write permissions listed under [AWS
-Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry).
-
-```mzsql
-CREATE SINK glue_sink
-  IN CLUSTER my_io_cluster
-  FROM <source, table or mview>
-  INTO KAFKA CONNECTION kafka_connection (
-    TOPIC 'test_avro_topic',
-  )
-  KEY (key_col)
-  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (
-    KEY SCHEMA NAME = 'my_key_schema',
-    VALUE SCHEMA NAME = 'my_value_schema',
-    KEY COMPATIBILITY LEVEL = 'FORWARD',
-    VALUE COMPATIBILITY LEVEL = 'FULL'
-  )
-  ENVELOPE UPSERT;
-```
-
-See [Avro](#avro) for the schema-name defaults and how compatibility levels map
-to their AWS Glue equivalents.
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Creating a sink
 
 #### Upsert envelope
 
 {{< tabs >}}
-{{< tab "Avro">}}
+{{< tab "Avro Confluent">}}
 
 ```mzsql
 CREATE SINK avro_sink
@@ -733,6 +726,27 @@ CREATE SINK avro_sink
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
   ENVELOPE UPSERT;
 ```
+{{< /tab >}}
+{{< tab "Avro AWS Glue">}}
+
+The registry named by the connection must already exist. The IAM role assumed
+by the AWS connection must have the schema-write permissions listed under [AWS
+Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry).
+
+```mzsql
+CREATE SINK glue_sink
+  IN CLUSTER my_io_cluster
+  FROM <source, table or mview>
+  INTO KAFKA CONNECTION kafka_connection (
+    TOPIC 'test_avro_topic'
+  )
+  KEY (key_col)
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn
+  ENVELOPE UPSERT;
+```
+
+See [Avro](#avro) for the schema-name defaults and how compatibility levels map
+to their AWS Glue equivalents.
 
 {{< /tab >}}
 {{< tab "JSON">}}
@@ -752,7 +766,7 @@ CREATE SINK json_sink
 #### Debezium envelope
 
 {{< tabs >}}
-{{< tab "Avro">}}
+{{< tab "Avro Confluent">}}
 
 ```mzsql
 CREATE SINK avro_sink
@@ -761,6 +775,31 @@ CREATE SINK avro_sink
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
   ENVELOPE DEBEZIUM;
 ```
+
+{{< /tab >}}
+{{< tab "Avro AWS Glue">}}
+
+{{< private-preview />}}
+The registry named by the connection must already exist. The IAM role assumed
+by the AWS connection must have the schema-write permissions listed under [AWS
+Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry).
+
+```mzsql
+CREATE SINK glue_sink
+  IN CLUSTER my_io_cluster
+  FROM <source, table or mview>
+  INTO KAFKA CONNECTION kafka_connection (
+    TOPIC 'test_avro_topic'
+  )
+  KEY (key_col)
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn
+  ENVELOPE DEBEZIUM;
+```
+
+See [Avro](#avro) for the schema-name defaults and how compatibility levels map
+to their AWS Glue equivalents.
+
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -783,12 +822,16 @@ CREATE SINK custom_topic_sink
 
 #### Schema compatibility levels
 
+
+{{< tabs >}}
+{{< tab "Avro Confluent">}}
+
 ```mzsql
 CREATE SINK compatibility_level_sink
   IN CLUSTER my_io_cluster
   FROM <source, table or mview>
   INTO KAFKA CONNECTION kafka_connection (
-    TOPIC 'test_avro_topic',
+    TOPIC 'test_avro_topic'
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection (
     KEY COMPATIBILITY LEVEL 'BACKWARD',
@@ -797,7 +840,34 @@ CREATE SINK compatibility_level_sink
   ENVELOPE UPSERT;
 ```
 
+{{< /tab >}}
+{{< tab "Avro AWS Glue">}}
+
+{{< private-preview />}}
+```mzsql
+CREATE SINK compatibility_level_sink
+  IN CLUSTER my_io_cluster
+  FROM <source, table or mview>
+  INTO KAFKA CONNECTION kafka_connection (
+    TOPIC 'test_avro_topic'
+  )
+  KEY (key_col)
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (
+    KEY COMPATIBILITY LEVEL 'BACKWARD',
+    VALUE COMPATIBILITY LEVEL 'FULL'
+  )
+  ENVELOPE UPSERT;
+```
+
+See [Avro](#avro) for the schema-name defaults and how compatibility levels map
+to their AWS Glue equivalents.
+
+
+{{< /tab >}}
+{{< /tabs >}}
+
 #### Documentation comments
+
 
 Consider the following sink, `docs_sink`, built on top of a relation `t` with
 several [SQL comments](/sql/comment-on) attached.

--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -119,7 +119,7 @@ For example, consider a table with two columns named `col-a` and `col@a`.
 Materialize will use the names `col_a` and `col_a1`, respectively, in the
 generated Avro schema.
 
-#### When using a Confluent Schema Registry:
+#### Using Confluent Schema Registry
 
   * Materialize will automatically publish Avro schemas for the key, if present,
     and the value to the registry.
@@ -139,7 +139,7 @@ generated Avro schema.
     The level is applied only when the subject has no compatibility level yet. If
     the subject already has one, it is left unchanged.
 
-#### When using an [AWS Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry):
+#### Using [AWS Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry)
 
 {{< private-preview />}}
 
@@ -728,6 +728,8 @@ CREATE SINK avro_sink
 ```
 {{< /tab >}}
 {{< tab "Avro AWS Glue">}}
+
+{{< private-preview />}}
 
 The registry named by the connection must already exist. The IAM role assumed
 by the AWS connection must have the schema-write permissions listed under [AWS

--- a/doc/user/data/examples/create_connection.yml
+++ b/doc/user/data/examples/create_connection.yml
@@ -381,8 +381,10 @@
       description: |
         *Value:* `text`. Required.
 
-        The name of the AWS Glue Schema Registry to read schemas from (for
-        example, `default-registry`). Must not be empty.
+        The name of the AWS Glue Schema Registry to use (for example,
+        `default-registry`). Sources read schemas from the registry, and sinks
+        register schemas in it. The registry must already exist. Must not be
+        empty.
     - name: "`WITH (<with_options>)`"
       description: |
         The following `<with_options>` are supported:

--- a/doc/user/data/examples/create_sink_kafka.yml
+++ b/doc/user/data/examples/create_sink_kafka.yml
@@ -15,16 +15,25 @@
     )
     [KEY ( <key_col1> [, ...] ) [NOT ENFORCED]]
     [HEADERS <headers_column>]
-    FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name> [
-      (
-        [AVRO KEY FULLNAME '<avro_key_fullname>']
-        [, AVRO VALUE FULLNAME '<avro_value_fullname>']
-        [, NULL DEFAULTS <null_defaults>]
-        [, DOC ON <doc_on_option> [, ...]]
-        [, KEY COMPATIBILITY LEVEL '<key_compatibility_level>']
-        [, VALUE COMPATIBILITY LEVEL '<value_compatibility_level>']
-      )
-    ]
+    FORMAT AVRO
+        USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name> [
+          (
+            [AVRO KEY FULLNAME '<avro_key_fullname>']
+            [, AVRO VALUE FULLNAME '<avro_value_fullname>']
+            [, NULL DEFAULTS <null_defaults>]
+            [, DOC ON <doc_on_option> [, ...]]
+            [, KEY COMPATIBILITY LEVEL '<key_compatibility_level>']
+            [, VALUE COMPATIBILITY LEVEL '<value_compatibility_level>']
+          )
+        ]
+      | USING AWS GLUE SCHEMA REGISTRY CONNECTION <glue_connection_name> [
+          (
+            [KEY SCHEMA NAME '<key_schema_name>']
+            [, VALUE SCHEMA NAME '<value_schema_name>']
+            [, KEY COMPATIBILITY LEVEL '<key_compatibility_level>']
+            [, VALUE COMPATIBILITY LEVEL '<value_compatibility_level>']
+          )
+        ]
     [ENVELOPE DEBEZIUM | UPSERT]
     [WITH (SNAPSHOT = <snapshot>)]
   syntax_elements:
@@ -76,15 +85,31 @@
     - name: "**FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION** `<csr_connection_name>`"
       description: |
         Encode messages using Avro format with schemas published to the Confluent Schema Registry.
+    - name: "**FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION** `<glue_connection_name>`"
+      description: |
+        ***Private preview.** This feature is under active development.*
+
+        Encode messages using Avro format with schemas registered in the AWS
+        Glue Schema Registry named by the [AWS Glue Schema Registry
+        connection](/sql/create-connection/#aws-glue-schema-registry). The
+        registry must already exist. Only the `KEY SCHEMA NAME`, `VALUE SCHEMA
+        NAME`, `KEY COMPATIBILITY LEVEL`, and `VALUE COMPATIBILITY LEVEL`
+        options are supported. See [Avro](#avro) for details.
     - name: "**AVRO KEY FULLNAME** `'<avro_key_fullname>'`"
       description: |
-        Optional. Default: `row`. Sets the Avro fullname on the generated key schema, if a `KEY` is specified. When used, a value must be specified for `AVRO VALUE FULLNAME`.
+        Optional, Confluent Schema Registry only. Default: `row`. Sets the Avro fullname on the generated key schema, if a `KEY` is specified. When used, a value must be specified for `AVRO VALUE FULLNAME`.
     - name: "**AVRO VALUE FULLNAME** `'<avro_value_fullname>'`"
       description: |
-        Optional. Default: `envelope`. Sets the Avro fullname on the generated value schema. When `KEY` is specified, `AVRO KEY FULLNAME` must additionally be specified.
+        Optional, Confluent Schema Registry only. Default: `envelope`. Sets the Avro fullname on the generated value schema. When `KEY` is specified, `AVRO KEY FULLNAME` must additionally be specified.
     - name: "**NULL DEFAULTS** `<null_defaults>`"
       description: |
-        Optional. Default: `false`. Whether to automatically default nullable fields to `null` in the generated schemas.
+        Optional, Confluent Schema Registry only. Default: `false`. Whether to automatically default nullable fields to `null` in the generated schemas.
+    - name: "**KEY SCHEMA NAME** `'<key_schema_name>'`"
+      description: |
+        Optional, AWS Glue Schema Registry only. The name under which the key schema is registered, if a `KEY` is specified. Default: `<topic>-key`.
+    - name: "**VALUE SCHEMA NAME** `'<value_schema_name>'`"
+      description: |
+        Optional, AWS Glue Schema Registry only. The name under which the value schema is registered. Default: `<topic>-value`.
     - name: "**DOC ON** `<doc_on_option>` [, ...]"
       description: |
         Optional. Add a documentation comment to the generated Avro schemas.
@@ -102,10 +127,10 @@
         on how documentation comments are added to the generated Avro schemas.
     - name: "**KEY COMPATIBILITY LEVEL** `'<key_compatibility_level>'`"
       description: |
-        Optional. If specified, set the [Compatibility Level](https://docs.confluent.io/platform/7.6/schema-registry/fundamentals/schema-evolution.html#schema-evolution-and-compatibility) for the generated key schema to one of: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, `NONE`.
+        Optional. If specified, set the [Compatibility Level](https://docs.confluent.io/platform/7.6/schema-registry/fundamentals/schema-evolution.html#schema-evolution-and-compatibility) for the generated key schema to one of: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, `NONE`. With AWS Glue, the level is applied only when the sink creates the schema and maps to the [Glue equivalent](#avro).
     - name: "**VALUE COMPATIBILITY LEVEL** `'<value_compatibility_level>'`"
       description: |
-        Optional. If specified, set the [Compatibility Level](https://docs.confluent.io/platform/7.6/schema-registry/fundamentals/schema-evolution.html#schema-evolution-and-compatibility) for the generated value schema to one of: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, `NONE`.
+        Optional. If specified, set the [Compatibility Level](https://docs.confluent.io/platform/7.6/schema-registry/fundamentals/schema-evolution.html#schema-evolution-and-compatibility) for the generated value schema to one of: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, `NONE`. With AWS Glue, the level is applied only when the sink creates the schema and maps to the [Glue equivalent](#avro).
     - name: "**ENVELOPE** `<envelope>`"
       description: |
         Optional. Specifies how changes to the sink's upstream relation are mapped to Kafka messages. Valid envelope types:
@@ -316,6 +341,14 @@
     --       [, VALUE COMPATIBILITY LEVEL '<value_compatibility_level>']
     --     )
     -- ]
+    -- | AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION <glue_connection_name> [
+    --     (
+    --       [KEY SCHEMA NAME '<key_schema_name>']
+    --       [, VALUE SCHEMA NAME '<value_schema_name>']
+    --       [, KEY COMPATIBILITY LEVEL '<key_compatibility_level>']
+    --       [, VALUE COMPATIBILITY LEVEL '<value_compatibility_level>']
+    --     )
+    -- ]
     -- | JSON | TEXT | BYTES
     [ENVELOPE DEBEZIUM | UPSERT]
     [WITH (SNAPSHOT = <snapshot>)]
@@ -367,10 +400,10 @@
         Optional. A column containing headers to add to each Kafka message emitted by the sink. The column must be of type `map[text => text]` or `map[text => bytea]`. See [Headers](#headers) for details.
     - name: "**KEY FORMAT** `<key_format>`"
       description: |
-        Set the key encoding explicitly. Supported formats: `AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `JSON`, `TEXT`, `BYTES`.
+        Set the key encoding explicitly. Supported formats: `AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION <glue_connection_name>`, `JSON`, `TEXT`, `BYTES`.
     - name: "**VALUE FORMAT** `<value_format>`"
       description: |
-        Set the value encoding explicitly. Supported formats: `AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `JSON`, `TEXT`, `BYTES`.
+        Set the value encoding explicitly. Supported formats: `AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION <glue_connection_name>`, `JSON`, `TEXT`, `BYTES`.
     - name: "**ENVELOPE** `<envelope>`"
       description: |
         Optional. Specifies how changes to the sink's upstream relation are mapped to Kafka messages. Valid envelope types:

--- a/doc/user/data/examples/create_sink_kafka.yml
+++ b/doc/user/data/examples/create_sink_kafka.yml
@@ -112,7 +112,7 @@
         Optional, AWS Glue Schema Registry only. The name under which the value schema is registered. Default: `<topic>-value`.
     - name: "**DOC ON** `<doc_on_option>` [, ...]"
       description: |
-        Optional. Add a documentation comment to the generated Avro schemas.
+        Optional, Confluent Schema Registry only. Add a documentation comment to the generated Avro schemas.
 
         | Option | Description |
         |--------|-------------|

--- a/doc/user/data/examples/explain_schema.yml
+++ b/doc/user/data/examples/explain_schema.yml
@@ -70,7 +70,7 @@
         Optional. A column containing headers to add to each Kafka message emitted by the sink. The column must be of type `map[text => text]` or `map[text => bytea]`. See [Headers](/sql/create-sink/kafka/#headers) for details.
     - name: "**FORMAT** `<sink_format_spec>`"
       description: |
-        Optional. Specifies the format to use for both keys and values: `AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `JSON`, `TEXT`, or `BYTES`. See [Formats](/sql/create-sink/kafka/#formats) for details.
+        Optional. Specifies the format to use for both keys and values: `AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION <csr_connection_name>`, `AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION <glue_connection_name>`, `JSON`, `TEXT`, or `BYTES`. See [Formats](/sql/create-sink/kafka/#formats) for details.
     - name: "**KEY FORMAT** `<sink_format_spec>` **VALUE FORMAT** `<sink_format_spec>`"
       description: |
         Optional. Specifies the key format and value formats separately. See [Formats](/sql/create-sink/kafka/#formats) for details.


### PR DESCRIPTION
Update the user documentation with AWS Glue schema registry for Kafka Sink.


- Document schema-name and compatibility-level options and default values
- List Confluent to Glue compatibility level mapping
- Document set-if-unset compatibility behavior shared with Confluent Schema Registry
- Update IAM permissions in `CREATE CONNECTION` to include sink


This will be available in the v26.34 release
