### PR TITLE
persist-client: make upgrade_version a no-op on tombstone shards

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -191,7 +191,14 @@ where
     pub async fn upgrade_version(&self) -> Result<RoutineMaintenance, Version> {
         let metrics = Arc::clone(&self.applier.metrics);
         let (_seqno, upgrade_result, maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.remove_rollups, |_, cfg, state| {
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.upgrade_version, |_, cfg, state| {
+                // A tombstone is terminal and version-inert, so treat the
+                // upgrade as trivially satisfied instead of committing a new
+                // state that `compute_next_state_locked` would reject.
+                if state.is_tombstone() {
+                    return Break(NoOpStateTransition(Ok(())));
+                }
+
                 if state.version <= cfg.build_version {
                     // This would be the place to remove any deprecated items from state, now
                     // that we're dropping compatibility with any previous versions.
@@ -2665,5 +2672,67 @@ pub mod tests {
 
         write.expire().await;
         reader.expire().await;
+    }
+
+    /// Regression test for a panic where `upgrade_version` tried to commit a
+    /// new state on a tombstone shard. Upgrading a tombstone must be a no-op:
+    /// the shard stays finalized and its recorded version stays unchanged.
+    #[mz_persist_proc::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // too slow
+    async fn version_upgrade_tombstone(dyncfgs: ConfigUpdates) {
+        async fn shard_version(
+            persist_client: &PersistClient,
+            shard_id: ShardId,
+        ) -> Option<semver::Version> {
+            let shard_state = persist_client.inspect_shard::<u64>(&shard_id).await.ok()?;
+            let json_state = serde_json::to_value(shard_state).expect("state serialization error");
+            let version = json_state
+                .get("applier_version")
+                .cloned()
+                .expect("missing applier_version");
+            Some(serde_json::from_value(version).expect("version deserialization error"))
+        }
+
+        let mut cache = new_test_client_cache(&dyncfgs);
+        cache.cfg.build_version = Version::new(26, 1, 0);
+        let client = cache.open(PersistLocation::new_in_mem()).await.unwrap();
+        let shard_id = ShardId::new();
+
+        // Advance since and upper to the empty antichain and finalize the
+        // shard into a tombstone.
+        let (mut write, mut read) = client.expect_open::<String, (), u64, i64>(shard_id).await;
+        read.downgrade_since(&Antichain::new()).await;
+        write.advance_upper(&Antichain::new()).await;
+        write.expire().await;
+        read.expire().await;
+        client
+            .finalize_shard::<String, (), u64, i64>(shard_id, Diagnostics::for_tests())
+            .await
+            .expect("finalization must succeed");
+
+        // Upgrading at the version that wrote the tombstone must not panic or
+        // commit a new state.
+        client
+            .upgrade_version::<String, (), u64, i64>(shard_id, Diagnostics::for_tests())
+            .await
+            .expect("upgrade on tombstone must succeed");
+
+        // Same for upgrading at a newer build version.
+        cache.cfg.build_version = Version::new(27, 1, 0);
+        let client = cache.open(PersistLocation::new_in_mem()).await.unwrap();
+        client
+            .upgrade_version::<String, (), u64, i64>(shard_id, Diagnostics::for_tests())
+            .await
+            .expect("upgrade on tombstone must succeed");
+
+        assert_eq!(
+            shard_version(&client, shard_id).await,
+            Some(Version::new(26, 1, 0)),
+        );
+        let is_finalized = client
+            .is_finalized::<String, (), u64, i64>(shard_id, Diagnostics::for_tests())
+            .await
+            .expect("invalid persist usage");
+        assert!(is_finalized, "shard must still be finalized");
     }
 }

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -408,6 +408,7 @@ impl MetricsVecs {
             init_state: self.cmd_metrics("init_state"),
             add_rollup: self.cmd_metrics("add_rollup"),
             remove_rollups: self.cmd_metrics("remove_rollups"),
+            upgrade_version: self.cmd_metrics("upgrade_version"),
             register: self.cmd_metrics("register"),
             compare_and_append: self.cmd_metrics("compare_and_append"),
             compare_and_append_noop:             registry.register(metric!(
@@ -619,6 +620,7 @@ pub struct CmdsMetrics {
     pub(crate) init_state: CmdMetrics,
     pub(crate) add_rollup: CmdMetrics,
     pub(crate) remove_rollups: CmdMetrics,
+    pub(crate) upgrade_version: CmdMetrics,
     pub(crate) register: CmdMetrics,
     pub(crate) compare_and_append: CmdMetrics,
     pub(crate) compare_and_append_noop: IntCounter,


### PR DESCRIPTION
### Motivation

`Machine::upgrade_version` has no tombstone escape hatch. On a tombstoned shard the work function still returns `Continue` (including when the state version already equals the build version, since the comparison is `<=`), so it tries to commit a new state and trips the tombstone sanity check in `compute_next_state_locked`:

```
cmd remove_rollups unexpectedly tried to commit a new state on a tombstone: ...
```

It reports `remove_rollups` because `upgrade_version` borrows that command's `CmdMetrics`, which also mislabels its telemetry.

Every other operation in the handle-open path no-ops on tombstones, so opening handles on a finalized shard is otherwise supported. Since `StorageCollections::open_data_handles` calls `upgrade_version` for every collection it opens in read-write mode, a tombstoned shard that is still referenced by the catalog makes environmentd panic during bootstrap and crash loop. We hit exactly this in production (how the shard came to be both tombstoned and still referenced is a separate storage-controller bug, tracked separately).

### Description

* `upgrade_version` breaks out with a no-op state transition when the state is a tombstone. A tombstone is terminal and version-inert, so the upgrade is trivially satisfied.
* `upgrade_version` gets its own `CmdMetrics` entry instead of borrowing `remove_rollups`. The `cmd.name` special cases in `compute_next_state_locked` only match `compare_and_append`/`add_rollup`/`become_tombstone`, so the rename is behaviorally inert, but note that the operation's command metrics move from the `remove_rollups` label to `upgrade_version`.

This is intended to be backported to stop the crash loop.

### Verification

New regression test `version_upgrade_tombstone`: finalizes a shard into a tombstone, then calls `upgrade_version` both at the version that wrote the tombstone (the production case) and at a newer build version, asserting success, that the recorded shard version is unchanged (no state committed), and that the shard stays finalized. With the fix reverted, the test panics with exactly the production message.