### PR TITLE
SS-199 storage: thread replica logging interval into storage instance config

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2453,6 +2453,7 @@ impl Coordinator {
                 ClusterConfig {
                     arranged_logs: instance.log_indexes.clone(),
                     workload_class: instance.config.workload_class.clone(),
+                    replica_logging_interval: instance.config.replica_logging_interval(),
                 },
             )?;
             for replica in instance.replicas() {

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -617,6 +617,7 @@ impl Coordinator {
                             mz_controller::clusters::ClusterConfig {
                                 arranged_logs,
                                 workload_class: cluster.config.workload_class.clone(),
+                                replica_logging_interval: cluster.config.replica_logging_interval(),
                             },
                         )
                         .expect("creating cluster must not fail");

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -17,7 +17,8 @@ use mz_ore::error::ErrorExt;
 use mz_service::params::GrpcClientParameters;
 use mz_sql::session::vars::SystemVars;
 use mz_storage_types::parameters::{
-    PgSourceSnapshotConfig, StorageMaxInflightBytesConfig, StorageParameters,
+    PgSourceSnapshotConfig, REPLICA_LOGGING_INTERVAL_DEFAULT, StorageMaxInflightBytesConfig,
+    StorageParameters,
 };
 use mz_tracing::params::TracingParameters;
 
@@ -143,6 +144,10 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
         },
         user_storage_managed_collections_batch_duration: config
             .user_storage_managed_collections_batch_duration(),
+        // Overridden per-instance from the cluster's logging config in
+        // `StorageController::create_instance`; this base value is only a
+        // fallback.
+        replica_logging_interval: Some(REPLICA_LOGGING_INTERVAL_DEFAULT),
         dyncfg_updates: config.dyncfg_updates(),
     }
 }

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -3297,6 +3297,17 @@ impl ClusterConfig {
             ClusterVariant::Unmanaged => None,
         }
     }
+
+    /// The interval at which the cluster's replicas log introspection data.
+    ///
+    /// `None` if logging is disabled or the cluster is unmanaged (unmanaged
+    /// replicas carry their own logging configuration).
+    pub fn replica_logging_interval(&self) -> Option<Duration> {
+        match &self.variant {
+            ClusterVariant::Managed(managed) => managed.logging.interval,
+            ClusterVariant::Unmanaged => None,
+        }
+    }
 }
 
 impl From<ClusterConfig> for durable::ClusterConfig {

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -56,6 +56,11 @@ pub struct ClusterConfig {
     /// An optional arbitrary string that describes the class of the workload
     /// this cluster is running (e.g., `production` or `staging`).
     pub workload_class: Option<String>,
+    /// The interval at which the cluster's replicas log introspection data.
+    ///
+    /// Threaded into the storage instance's configuration at creation. `None`
+    /// indicates that replica logging is disabled.
+    pub replica_logging_interval: Option<Duration>,
 }
 
 /// The status of a cluster.
@@ -415,8 +420,11 @@ impl Controller {
         id: ClusterId,
         config: ClusterConfig,
     ) -> Result<(), anyhow::Error> {
-        self.storage
-            .create_instance(id, config.workload_class.clone());
+        self.storage.create_instance(
+            id,
+            config.workload_class.clone(),
+            config.replica_logging_interval,
+        );
         self.compute
             .create_instance(id, config.arranged_logs, config.workload_class)?;
         Ok(())

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -382,7 +382,12 @@ pub trait StorageController: Debug {
     /// created with zero replicas.
     ///
     /// Panics if a storage instance with the given ID already exists.
-    fn create_instance(&mut self, id: StorageInstanceId, workload_class: Option<String>);
+    fn create_instance(
+        &mut self,
+        id: StorageInstanceId,
+        workload_class: Option<String>,
+        replica_logging_interval: Option<Duration>,
+    );
 
     /// Drops the storage instance with the given ID.
     ///

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -506,10 +506,17 @@ impl StorageController for Controller {
         self.storage_collections.check_exists(id)
     }
 
-    fn create_instance(&mut self, id: StorageInstanceId, workload_class: Option<String>) {
+    fn create_instance(
+        &mut self,
+        id: StorageInstanceId,
+        workload_class: Option<String>,
+        replica_logging_interval: Option<Duration>,
+    ) {
         let metrics = self.metrics.for_instance(id);
+        let mut parameters = self.config.parameters.clone();
+        parameters.replica_logging_interval = replica_logging_interval;
         let mut instance = Instance::new(
-            self.config.parameters.clone(),
+            parameters,
             workload_class,
             metrics,
             self.now.clone(),

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -98,6 +98,11 @@ pub struct StorageParameters {
     pub pg_snapshot_config: PgSourceSnapshotConfig,
     /// Duration that we wait to batch rows for user owned, storage managed, collections.
     pub user_storage_managed_collections_batch_duration: Duration,
+    /// The interval at which the instance's replicas log introspection data, as
+    /// derived from the cluster's replica logging configuration
+    /// (`ComputeReplicaLogging`). `None` indicates that replica logging is
+    /// disabled.
+    pub replica_logging_interval: Option<Duration>,
 
     /// Updates used to update `StorageConfiguration::config_set`.
     pub dyncfg_updates: mz_dyncfg::ConfigUpdates,
@@ -108,6 +113,9 @@ pub const STATISTICS_COLLECTION_INTERVAL_DEFAULT: Duration = Duration::from_secs
 pub const STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT: Duration = Duration::from_secs(1);
 pub const REPLICA_STATUS_HISTORY_RETENTION_WINDOW_DEFAULT: Duration =
     Duration::from_secs(30 * 24 * 60 * 60); // 30 days
+// NOTE: Must match `mz_compute_types::DEFAULT_COMPUTE_REPLICA_LOGGING_INTERVAL`.
+// storage-types does not depend on compute-types, so the value is duplicated here.
+pub const REPLICA_LOGGING_INTERVAL_DEFAULT: Duration = Duration::from_secs(1);
 
 // Implement `Default` manually, so that the default can match the
 // LD default. This is not strictly necessary, but improves clarity.
@@ -143,6 +151,7 @@ impl Default for StorageParameters {
             pg_snapshot_config: Default::default(),
             user_storage_managed_collections_batch_duration:
                 STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT,
+            replica_logging_interval: Some(REPLICA_LOGGING_INTERVAL_DEFAULT),
             dyncfg_updates: Default::default(),
         }
     }
@@ -203,6 +212,7 @@ impl StorageParameters {
             statistics_collection_interval,
             pg_snapshot_config,
             user_storage_managed_collections_batch_duration,
+            replica_logging_interval,
             dyncfg_updates,
         }: StorageParameters,
     ) {
@@ -236,6 +246,7 @@ impl StorageParameters {
         self.pg_snapshot_config = pg_snapshot_config;
         self.user_storage_managed_collections_batch_duration =
             user_storage_managed_collections_batch_duration;
+        self.replica_logging_interval = replica_logging_interval;
         self.dyncfg_updates.extend(dyncfg_updates);
     }
 


### PR DESCRIPTION
## Motivation

Builds on #37677, which makes the storage-controller `Instance` take its
`StorageParameters` at construction time. This PR carries the cluster's replica
logging interval (`ReplicaLogging.interval`) into those parameters, so the value
is available on the storage instance from the moment it is created rather than
being absent from its configuration.

> **Stacked on #37677.** This PR's branch is based on `ss-199`, so until #37677
> merges the diff here also shows that PR's commit (`storage-controller:
> configure Instance at construction time`). Review only the top commit,
> `plumb logging interval through to storage instance`, and merge this after
> #37677.

## Description

- Add a `replica_logging_interval: Option<Duration>` field to `StorageParameters`
  (with `Default` and `update()` support). `None` means replica logging is
  disabled. The default matches `DEFAULT_COMPUTE_REPLICA_LOGGING_INTERVAL`
  (duplicated as `REPLICA_LOGGING_INTERVAL_DEFAULT`, since `storage-types` does
  not depend on `compute-types`).
- Thread the value from the cluster configuration: add `replica_logging_interval`
  to the runtime `mz_controller::clusters::ClusterConfig`, populated at its
  construction sites from a new `ClusterConfig::replica_logging_interval()`
  helper on the catalog cluster config (returns the managed cluster's
  `logging.interval`, `None` for unmanaged clusters).
- `Controller::create_cluster` passes the interval to `StorageController::create_instance`,
  which sets it on the `StorageParameters` clone before constructing the `Instance`.

## Tests

The existing `instance::tests::new_seeds_configuration` roundtrips the full
`StorageParameters` through instance construction, so it now also covers the new
field. `cargo check --workspace --tests` and the storage-controller /
storage-types unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)