### PR TITLE
[SS-97] Tests and benchmarks for MySQL snapshot

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -2060,6 +2060,164 @@ INSERT INTO pk_table SELECT @i:=@i+1, @i*@i FROM mysql.time_zone t1, mysql.time_
             """)
 
 
+class MySqlInitialLoadMultiWorkerSampled(MySqlCdc):
+    """Measure an 8-worker snapshot across 20 tables with a single-column
+    non-integer primary key (a CHAR(26) ULID-like key)."""
+
+    RELATIVE_THRESHOLD: dict[MeasurementType, float] = {
+        MeasurementType.WALLCLOCK: 0.10,
+        MeasurementType.MEMORY_MZ: 0.60,
+        MeasurementType.MEMORY_CLUSTERD: 0.60,
+    }
+
+    # Cap scale so each per-table load fits one mysql.time_zone self-join
+    # (~3M rows), so a single INSERT per table suffices.
+    MAX_SCALE = 6
+
+    # Number of tables to snapshot. Their row counts sum to n() (spread across the
+    # tables, not n() each) so total snapshot volume stays at n().
+    TABLES = 20
+
+    def rows_per_table(self) -> list[int]:
+        """Per-table row counts, one entry per table, summing to exactly n().
+        Any remainder from an uneven split lands in the last table."""
+        base = self.n() // self.TABLES
+        counts = [base] * self.TABLES
+        counts[-1] += self.n() - base * self.TABLES
+        return counts
+
+    def shared(self) -> Action:
+        row_values = "LPAD(CONV(@i := @i + 1, 10, 36), 26, '0'), @i"
+        row_counts = self.rows_per_table()
+        table_blocks = []
+        for i in range(self.TABLES):
+            table = f"pk_table{i + 1}"
+            table_blocks.append(
+                f"CREATE TABLE {table} (pk CHAR(26) PRIMARY KEY, f2 BIGINT);\n"
+                f"SET @i := 0;\n"
+                f"INSERT INTO {table} SELECT {row_values} "
+                f"FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT {row_counts[i]};"
+            )
+        load = "\n".join(table_blocks)
+        return TdAction(f"""
+$ mysql-connect name=mysql url=mysql://root@mysql password=${{arg.mysql-root-password}}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+
+{load}
+""")
+
+    def before(self) -> Action:
+        return TdAction("""
+> DROP SOURCE IF EXISTS mz_source_mysqlcdc CASCADE;
+> DROP CLUSTER IF EXISTS source_cluster CASCADE
+            """)
+
+    def benchmark(self) -> MeasurementSource:
+        # The first CREATE TABLE carries the /* A */ start marker and the last
+        # count carries /* B */, so the measured window spans creating every
+        # subsource and hydrating all the tables' snapshots.
+        creates = []
+        for i in range(self.TABLES):
+            table = f"pk_table{i + 1}"
+            stmt = (
+                f"> CREATE TABLE {table} FROM SOURCE mz_source_mysqlcdc "
+                f"(REFERENCE public.{table});"
+            )
+            if i == 0:
+                stmt += "\n  /* A */"
+            creates.append(stmt)
+        row_counts = self.rows_per_table()
+        counts = []
+        for i in range(self.TABLES):
+            table = f"pk_table{i + 1}"
+            marker = "  /* B */\n" if i == self.TABLES - 1 else ""
+            counts.append(f"> SELECT count(*) FROM {table}\n{marker}{row_counts[i]}")
+        create_stmts = "\n".join(creates)
+        count_stmts = "\n".join(counts)
+        return Td(f"""
+> CREATE SECRET IF NOT EXISTS mysqlpass AS '${{arg.mysql-root-password}}'
+> CREATE CONNECTION IF NOT EXISTS mysql_conn TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+> CREATE CLUSTER source_cluster SIZE 'scale=1,workers=8', REPLICATION FACTOR 1;
+
+> CREATE SOURCE mz_source_mysqlcdc
+  IN CLUSTER source_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+
+{create_stmts}
+
+{count_stmts}
+            """)
+
+
+class MySqlInitialLoadMultiWorkerSingleTable(MySqlCdc):
+    """Measure an 8-worker snapshot of a single table of n() rows with a
+    single-column non-integer primary key (a CHAR(26) ULID-like key). The
+    single-table companion to MySqlInitialLoadMultiWorkerSampled."""
+
+    RELATIVE_THRESHOLD: dict[MeasurementType, float] = {
+        MeasurementType.WALLCLOCK: 0.10,
+        MeasurementType.MEMORY_MZ: 0.60,
+        MeasurementType.MEMORY_CLUSTERD: 0.60,
+    }
+
+    # Cap scale so the load fits one mysql.time_zone self-join (~3M rows), so a
+    # single INSERT suffices.
+    MAX_SCALE = 6
+
+    def shared(self) -> Action:
+        # The PK is a CHAR(26) holding the base-36 sequence value, left-padded to a
+        # fixed width so the keys sort lexicographically.
+        return TdAction(f"""
+$ mysql-connect name=mysql url=mysql://root@mysql password=${{arg.mysql-root-password}}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+
+CREATE TABLE pk_table (pk CHAR(26) PRIMARY KEY, f2 BIGINT);
+SET @i := 0;
+INSERT INTO pk_table SELECT LPAD(CONV(@i := @i + 1, 10, 36), 26, '0'), @i FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT {self.n()};
+""")
+
+    def before(self) -> Action:
+        return TdAction("""
+> DROP SOURCE IF EXISTS mz_source_mysqlcdc CASCADE;
+> DROP CLUSTER IF EXISTS source_cluster CASCADE
+            """)
+
+    def benchmark(self) -> MeasurementSource:
+        return Td(f"""
+> CREATE SECRET IF NOT EXISTS mysqlpass AS '${{arg.mysql-root-password}}'
+> CREATE CONNECTION IF NOT EXISTS mysql_conn TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+> CREATE CLUSTER source_cluster SIZE 'scale=1,workers=8', REPLICATION FACTOR 1;
+
+> CREATE SOURCE mz_source_mysqlcdc
+  IN CLUSTER source_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE pk_table FROM SOURCE mz_source_mysqlcdc (REFERENCE public.pk_table);
+  /* A */
+
+> SELECT count(*) FROM pk_table
+  /* B */
+{self.n()}
+            """)
+
+
 class MySqlStreaming(MySqlCdc):
     """Measure the time it takes to ingest records from MySQL post-snapshot"""
 

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -556,6 +556,304 @@ true
 
 > DROP SOURCE large_cluster_source CASCADE;
 
+$ mysql-execute name=mysql
+DROP TABLE IF EXISTS pk_range_test;
+CREATE TABLE pk_range_test (id BIGINT PRIMARY KEY, val BIGINT);
+SET @i := 0;
+INSERT INTO pk_range_test SELECT @i := @i + 1, @i * 7 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000;
+
+> CREATE CLUSTER pk_range_cluster SIZE 'scale=1,workers=4'
+
+> CREATE SOURCE pk_range_source
+  IN CLUSTER pk_range_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE pk_range_table FROM SOURCE pk_range_source (REFERENCE public.pk_range_test);
+
+# Exact row count
+> SELECT COUNT(*) FROM pk_range_table;
+1000
+
+# No duplicates: distinct count must equal total count
+> SELECT COUNT(DISTINCT id) = COUNT(*) FROM pk_range_table;
+true
+
+# Full key range present (ids 1..1000)
+> SELECT MIN(id), MAX(id) FROM pk_range_table;
+1 1000
+
+# Checksum: val = id * 7, so SUM(val) = 7 * SUM(1..1000) = 7 * 500500
+> SELECT SUM(val) FROM pk_range_table;
+3503500
+
+> DROP SOURCE pk_range_source CASCADE;
+> DROP CLUSTER pk_range_cluster CASCADE;
+
+$ mysql-execute name=mysql
+DROP TABLE pk_range_test;
+
+#
+# Same, but for a single-column non-integer (char) PK.
+#
+
+$ mysql-execute name=mysql
+DROP TABLE IF EXISTS pk_char_test;
+CREATE TABLE pk_char_test (id CHAR(26) PRIMARY KEY, val BIGINT);
+SET @i := 0;
+INSERT INTO pk_char_test SELECT LPAD(CONV(@i := @i + 1, 10, 36), 26, '0'), @i FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000;
+
+> CREATE CLUSTER pk_char_cluster SIZE 'scale=1,workers=4'
+
+> CREATE SOURCE pk_char_source
+  IN CLUSTER pk_char_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE pk_char_table FROM SOURCE pk_char_source (REFERENCE public.pk_char_test);
+
+# Exact count and no duplicate/missing keys
+> SELECT COUNT(*), COUNT(DISTINCT id) FROM pk_char_table;
+1000 1000
+
+# Checksum: val = row number, so SUM(val) = SUM(1..1000) = 500500
+> SELECT SUM(val) FROM pk_char_table;
+500500
+
+> DROP SOURCE pk_char_source CASCADE;
+> DROP CLUSTER pk_char_cluster CASCADE;
+
+$ mysql-execute name=mysql
+DROP TABLE pk_char_test;
+
+#
+# Same, but for a composite (char, int) primary key.
+#
+
+$ mysql-execute name=mysql
+DROP TABLE IF EXISTS pk_comp_test;
+CREATE TABLE pk_comp_test (region CHAR(2) NOT NULL, id INT NOT NULL, val BIGINT, PRIMARY KEY (region, id));
+SET @i := 0;
+INSERT INTO pk_comp_test SELECT ELT((@i := @i + 1) % 5 + 1, 'aa', 'bb', 'cc', 'dd', 'ee'), @i, @i FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000;
+
+> CREATE CLUSTER pk_comp_cluster SIZE 'scale=1,workers=4'
+
+> CREATE SOURCE pk_comp_source
+  IN CLUSTER pk_comp_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE pk_comp_table FROM SOURCE pk_comp_source (REFERENCE public.pk_comp_test);
+
+# Exact count and no duplicate/missing keys (id alone is unique here)
+> SELECT COUNT(*), COUNT(DISTINCT id) FROM pk_comp_table;
+1000 1000
+
+# Every region partition is present and complete
+> SELECT region, COUNT(*) FROM pk_comp_table GROUP BY region ORDER BY region;
+aa 200
+bb 200
+cc 200
+dd 200
+ee 200
+
+# Checksum: val = row number, so SUM(val) = SUM(1..1000) = 500500
+> SELECT SUM(val) FROM pk_comp_table;
+500500
+
+> DROP SOURCE pk_comp_source CASCADE;
+> DROP CLUSTER pk_comp_cluster CASCADE;
+
+$ mysql-execute name=mysql
+DROP TABLE pk_comp_test;
+
+$ mysql-execute name=mysql
+DROP TABLE IF EXISTS pk_surplus_test;
+CREATE TABLE pk_surplus_test (id CHAR(26) PRIMARY KEY, val BIGINT);
+SET @i := 0;
+INSERT INTO pk_surplus_test SELECT LPAD(CONV(@i := @i + 1, 10, 36), 26, '0'), @i FROM mysql.time_zone t1 LIMIT 3;
+
+> CREATE CLUSTER pk_surplus_cluster SIZE 'scale=1,workers=16'
+
+> CREATE SOURCE pk_surplus_source
+  IN CLUSTER pk_surplus_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE pk_surplus_table FROM SOURCE pk_surplus_source (REFERENCE public.pk_surplus_test);
+
+# All rows present exactly once
+> SELECT COUNT(*), COUNT(DISTINCT id) FROM pk_surplus_table;
+3 3
+
+# Checksum: val = row number, so SUM(val) = 1 + 2 + 3 = 6
+> SELECT SUM(val) FROM pk_surplus_table;
+6
+
+> DROP SOURCE pk_surplus_source CASCADE;
+> DROP CLUSTER pk_surplus_cluster CASCADE;
+
+$ mysql-execute name=mysql
+DROP TABLE pk_surplus_test;
+
+#
+# Empty table.
+#
+
+$ mysql-execute name=mysql
+DROP TABLE IF EXISTS pk_empty_test;
+CREATE TABLE pk_empty_test (id CHAR(26) PRIMARY KEY, val BIGINT);
+
+> CREATE CLUSTER pk_empty_cluster SIZE 'scale=1,workers=4'
+
+> CREATE SOURCE pk_empty_source
+  IN CLUSTER pk_empty_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE pk_empty_table FROM SOURCE pk_empty_source (REFERENCE public.pk_empty_test);
+
+> SELECT COUNT(*) FROM pk_empty_table;
+0
+
+> DROP SOURCE pk_empty_source CASCADE;
+> DROP CLUSTER pk_empty_cluster CASCADE;
+
+$ mysql-execute name=mysql
+DROP TABLE pk_empty_test;
+
+#
+# BIGINT UNSIGNED PK with keys spanning the full unsigned domain, including
+# values above i64::MAX.
+#
+
+$ mysql-execute name=mysql
+DROP TABLE IF EXISTS pk_uint_test;
+CREATE TABLE pk_uint_test (id BIGINT UNSIGNED PRIMARY KEY, val BIGINT);
+SET @i := 0;
+INSERT INTO pk_uint_test SELECT @i := @i + 1, @i FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 500;
+SET @j := 0;
+INSERT INTO pk_uint_test SELECT 18446744073709551115 + (@j := @j + 1), -@j FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 500;
+
+> CREATE CLUSTER pk_uint_cluster SIZE 'scale=1,workers=4'
+
+> CREATE SOURCE pk_uint_source
+  IN CLUSTER pk_uint_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE pk_uint_table FROM SOURCE pk_uint_source (REFERENCE public.pk_uint_test);
+
+# Exact count and no duplicate/missing keys
+> SELECT COUNT(*), COUNT(DISTINCT id) FROM pk_uint_table;
+1000 1000
+
+# Keys span from 1 to the top of the u64 domain
+> SELECT MIN(id), MAX(id) FROM pk_uint_table;
+1 18446744073709551615
+
+# Checksum cancels: val = 1..500 for the low keys and -(1..500) for the high keys
+> SELECT SUM(val) FROM pk_uint_table;
+0
+
+> DROP SOURCE pk_uint_source CASCADE;
+> DROP CLUSTER pk_uint_cluster CASCADE;
+
+$ mysql-execute name=mysql
+DROP TABLE pk_uint_test;
+
+#
+# Multibyte utf8mb4 PK with a binary collation. Keys mix 2-, 3-, and 4-byte code
+# points (accented Latin, Greek, CJK, and emoji), assembled from their utf8 bytes
+# so the test file stays ASCII.
+#
+
+$ mysql-execute name=mysql
+DROP TABLE IF EXISTS pk_charset_test;
+CREATE TABLE pk_charset_test (id VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin PRIMARY KEY, val BIGINT);
+SET @i := 0;
+INSERT INTO pk_charset_test SELECT CONCAT(ELT((n % 6) + 1, CHAR(0xC3B1 USING utf8mb4), CHAR(0xCEA9 USING utf8mb4), CHAR(0xE4B8AD USING utf8mb4), CHAR(0xE7958C USING utf8mb4), CHAR(0xF09F9880 USING utf8mb4), CHAR(0xF09D958F USING utf8mb4)), LPAD(CONV(n, 10, 36), 8, '0')), n FROM (SELECT @i := @i + 1 AS n FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000) seq;
+
+> CREATE CLUSTER pk_charset_cluster SIZE 'scale=1,workers=4'
+
+> CREATE SOURCE pk_charset_source
+  IN CLUSTER pk_charset_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE pk_charset_table FROM SOURCE pk_charset_source (REFERENCE public.pk_charset_test);
+
+# Exact count and no duplicate/missing keys
+> SELECT COUNT(*), COUNT(DISTINCT id) FROM pk_charset_table;
+1000 1000
+
+# Checksum: val = row number, so SUM(val) = SUM(1..1000) = 500500
+> SELECT SUM(val) FROM pk_charset_table;
+500500
+
+> DROP SOURCE pk_charset_source CASCADE;
+> DROP CLUSTER pk_charset_cluster CASCADE;
+
+$ mysql-execute name=mysql
+DROP TABLE pk_charset_test;
+
+#
+# Non-utf8mb4 charset PK: a latin1 column with a binary collation. Keys carry
+# high-byte latin1 characters (the 0xC0-0xDF range), built from their bytes.
+#
+
+$ mysql-execute name=mysql
+DROP TABLE IF EXISTS pk_latin1_test;
+CREATE TABLE pk_latin1_test (id VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_bin PRIMARY KEY, val BIGINT);
+SET @i := 0;
+INSERT INTO pk_latin1_test SELECT CONCAT(CHAR(0xC0 + (n % 32) USING latin1), CONVERT(LPAD(CONV(n, 10, 36), 8, '0') USING latin1)), n FROM (SELECT @i := @i + 1 AS n FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000) seq;
+
+> CREATE CLUSTER pk_latin1_cluster SIZE 'scale=1,workers=4'
+
+> CREATE SOURCE pk_latin1_source
+  IN CLUSTER pk_latin1_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE pk_latin1_table FROM SOURCE pk_latin1_source (REFERENCE public.pk_latin1_test);
+
+# Exact count and no duplicate/missing keys
+> SELECT COUNT(*), COUNT(DISTINCT id) FROM pk_latin1_table;
+1000 1000
+
+# Checksum: val = row number, so SUM(val) = SUM(1..1000) = 500500
+> SELECT SUM(val) FROM pk_latin1_table;
+500500
+
+> DROP SOURCE pk_latin1_source CASCADE;
+> DROP CLUSTER pk_latin1_cluster CASCADE;
+
+$ mysql-execute name=mysql
+DROP TABLE pk_latin1_test;
+
+#
+# Concurrent DML on a multibyte-keyed table. Inserts and deletes are issued right
+# after the source starts, so they race the snapshot. Whatever the interleaving,
+# the output must converge to the final upstream state exactly once per key.
+#
+
+$ mysql-execute name=mysql
+DROP TABLE IF EXISTS pk_conc_test;
+CREATE TABLE pk_conc_test (id VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin PRIMARY KEY, val BIGINT);
+SET @i := 0;
+INSERT INTO pk_conc_test SELECT CONCAT(ELT((n % 6) + 1, CHAR(0xC3B1 USING utf8mb4), CHAR(0xCEA9 USING utf8mb4), CHAR(0xE4B8AD USING utf8mb4), CHAR(0xE7958C USING utf8mb4), CHAR(0xF09F9880 USING utf8mb4), CHAR(0xF09D958F USING utf8mb4)), LPAD(CONV(n, 10, 36), 8, '0')), n FROM (SELECT @i := @i + 1 AS n FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000) seq;
+
+> CREATE CLUSTER pk_conc_cluster SIZE 'scale=1,workers=4'
+
+> CREATE SOURCE pk_conc_source
+  IN CLUSTER pk_conc_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE pk_conc_table FROM SOURCE pk_conc_source (REFERENCE public.pk_conc_test);
+
+# Insert 1000 more rows (sequence continues at 1001..2000) and delete the first 500,
+# all while the snapshot is likely still in flight.
+$ mysql-execute name=mysql
+INSERT INTO pk_conc_test SELECT CONCAT(ELT((n % 6) + 1, CHAR(0xC3B1 USING utf8mb4), CHAR(0xCEA9 USING utf8mb4), CHAR(0xE4B8AD USING utf8mb4), CHAR(0xE7958C USING utf8mb4), CHAR(0xF09F9880 USING utf8mb4), CHAR(0xF09D958F USING utf8mb4)), LPAD(CONV(n, 10, 36), 8, '0')), n FROM (SELECT @i := @i + 1 AS n FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000) seq;
+DELETE FROM pk_conc_test WHERE val <= 500;
+
+# Final upstream state is val 501..2000, each key exactly once.
+> SELECT COUNT(*), COUNT(DISTINCT id) FROM pk_conc_table;
+1500 1500
+
+# Checksum: SUM(501..2000) = SUM(1..2000) - SUM(1..500) = 2001000 - 125250
+> SELECT SUM(val) FROM pk_conc_table;
+1875750
+
+> DROP SOURCE pk_conc_source CASCADE;
+> DROP CLUSTER pk_conc_cluster CASCADE;
+
+$ mysql-execute name=mysql
+DROP TABLE pk_conc_test;
+
 #
 # Remove all data on the Postgres side
 #


### PR DESCRIPTION
### Motivation
Setting up tests and benchmarks for https://github.com/MaterializeInc/materialize/pull/37642 ahead of time where possible.

### Description
- 8-worker benchmark for a single 1M row table (which should get faster if we parallelize)
- 8-worker benchmark for many tables to prevent regressions
- Varied test-drive tests to help ensure no regressions in correctness

### Verification

The first benchmark was used to show the speedup, the second caught a regression in the original version of the PR, and the testdrive tests should help with any obvious/simple correctness issues.

