### PR TITLE
testdrive: report missing records instead of panicking on empty Glue batch

### DIFF
--- a/src/testdrive/src/action/kafka/verify_data.rs
+++ b/src/testdrive/src/action/kafka/verify_data.rs
@@ -284,6 +284,25 @@ pub async fn run_verify_data(
         (key_schema, value_schema)
     };
 
+    // The Glue path resolves schemas from the received records, so an empty batch
+    // leaves the schema unset. Parsing the (required, non-empty) expected messages
+    // would then unwrap a `None` schema and panic. Turn that into the normal
+    // "sink produced no output" diagnostic instead.
+    if glue {
+        if matches!(format.value, Format::Avro) && value_schema.is_none() {
+            bail!(
+                "kafka-verify-data glue=true: no records received to resolve the \
+                 value schema from Glue (did the sink produce no output?)"
+            );
+        }
+        if format.requires_key && matches!(format.key, Format::Avro) && key_schema.is_none() {
+            bail!(
+                "kafka-verify-data glue=true: no keyed records received to resolve \
+                 the key schema from Glue (did the sink produce no output?)"
+            );
+        }
+    }
+
     let mut actual_messages =
         decode_messages(actual_bytes, &key_schema, &value_schema, &format, glue)?;
 


### PR DESCRIPTION
`kafka-verify-data glue=true` resolves the Avro schema from the received records. When the sink emits nothing, the schema stays None and parsing the (required, non-empty) expected messages unwraps it and aborts the whole process. Guard for the empty-batch case and bail with the normal "sink produced no output" diagnostic instead.

Test run: https://buildkite.com/materialize/nightly/builds/17410