### PR TITLE
adapter: restore replacement MV shard ownership on bootstrap

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2637,6 +2637,11 @@ impl Coordinator {
                 }
                 CatalogItem::View(_) => (),
                 CatalogItem::MaterializedView(mview) => {
+                    // Each version receives a read policy when it is created. Bootstrap
+                    // must restore every policy because the oldest version owns the shared
+                    // Persist shard and capability changes reach it through each newer
+                    // version's primary link. A `NoPolicy` version would block that
+                    // propagation and pin compaction.
                     policies_to_set
                         .entry(policy.expect("materialized views have a compaction window"))
                         .or_insert_with(Default::default)

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2641,7 +2641,7 @@ impl Coordinator {
                         .entry(policy.expect("materialized views have a compaction window"))
                         .or_insert_with(Default::default)
                         .storage_ids
-                        .insert(mview.global_id_writes());
+                        .extend(mview.global_ids());
 
                     let mut df_desc = self
                         .catalog()

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3227,9 +3227,18 @@ impl Coordinator {
                     };
                 }
                 CatalogItem::MaterializedView(mv) => {
+                    // Applying a replacement preserves the ownership link established when the
+                    // replacement was created. The oldest collection owns the shard, each applied
+                    // replacement points to its predecessor, and a pending replacement starts by
+                    // pointing to its target's latest collection.
+                    let mut primary = mv
+                        .replacement_target
+                        .map(|target_id| catalog.get_entry(&target_id).latest_global_id());
                     let collection_descs = mv.collection_descs().map(|(gid, _version, desc)| {
-                        let collection_desc =
+                        let mut collection_desc =
                             CollectionDescription::for_other(desc, mv.initial_as_of.clone());
+                        collection_desc.primary = primary;
+                        primary = Some(gid);
                         (gid, collection_desc)
                     });
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3236,6 +3236,9 @@ impl Coordinator {
                     // replacement was created. The oldest collection owns the shard, each applied
                     // replacement points to its predecessor, and a pending replacement starts by
                     // pointing to its target's latest collection.
+                    //
+                    // NOTE: Versioned tables chain in the opposite direction because their latest
+                    // version owns the shard. Each chain matches its runtime replacement path.
                     let mut primary = mv
                         .replacement_target
                         .map(|target_id| catalog.get_entry(&target_id).latest_global_id());

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -2809,7 +2809,7 @@ impl StorageTxn for Transaction<'_> {
         Ok(())
     }
 
-    fn mark_shards_as_finalized(&mut self, shards: BTreeSet<ShardId>) {
+    fn remove_unfinalized_shards(&mut self, shards: BTreeSet<ShardId>) {
         let ks: Vec<_> = shards
             .into_iter()
             .map(|shard| UnfinalizedShardKey { shard })

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -253,16 +253,20 @@ pub trait StorageTxn {
     /// include these keys.
     fn delete_collection_metadata(&mut self, ids: BTreeSet<GlobalId>) -> Vec<(GlobalId, ShardId)>;
 
-    /// Retrieve all of the shards that are no longer in use by an active
-    /// collection but are yet to be finalized.
+    /// Retrieve the durable set of shards recorded as unfinalized.
+    ///
+    /// Entries must be reconciled with active collection metadata before
+    /// finalization because stale entries can refer to active collections.
     fn get_unfinalized_shards(&self) -> BTreeSet<ShardId>;
 
     /// Insert the specified values as unfinalized shards.
     fn insert_unfinalized_shards(&mut self, s: BTreeSet<ShardId>) -> Result<(), StorageError>;
 
-    /// Mark the specified shards as finalized, deleting them from the
-    /// unfinalized shard collection.
-    fn mark_shards_as_finalized(&mut self, shards: BTreeSet<ShardId>);
+    /// Removes the specified shards from the unfinalized shard collection.
+    ///
+    /// Missing shards are ignored. This only updates transaction metadata and
+    /// does not finalize the underlying Persist shards.
+    fn remove_unfinalized_shards(&mut self, shards: BTreeSet<ShardId>);
 
     /// Get the txn WAL shard for this environment if it exists.
     fn get_txn_wal_shard(&self) -> Option<ShardId>;

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1706,6 +1706,16 @@ impl StorageCollections for StorageCollectionsImpl {
                 }
             }
         }
+        let remaining_metadata = txn.get_collection_metadata();
+        let remaining_ids = remaining_metadata.keys().copied().collect();
+        let (referenced_shards, dropped_shards) =
+            partition_finalizable_shards(remaining_metadata, &remaining_ids, dropped_shards);
+        if !referenced_shards.is_empty() {
+            mz_ore::soft_panic_or_log!(
+                "dropped collections would finalize shards that active collections still use: \
+                 {referenced_shards:?}"
+            );
+        }
         txn.insert_unfinalized_shards(dropped_shards)?;
 
         // Reconcile any shards we've successfully finalized with the shard
@@ -1935,17 +1945,22 @@ impl StorageCollections for StorageCollectionsImpl {
                         // We don't care about the dependency since when the
                         // write frontier is empty. In that case, no-one can
                         // write down any more updates.
-                        mz_ore::soft_assert_or_log!(
-                            write_frontier.elements() == &[Timestamp::MIN]
-                                || write_frontier.is_empty()
-                                || PartialOrder::less_than(&dependency_since, write_frontier),
-                            "dependency ({dep}) since has advanced past dependent ({id}) upper \n
-                            dependent ({id}): since {:?}, upper {:?} \n
-                            dependency ({dep}): since {:?}",
-                            data_shard_since,
-                            write_frontier,
-                            dependency_since
-                        );
+                        // This invariant applies to remap dependencies. A `primary`
+                        // dependency is another version of the same shard, whose since can
+                        // validly equal the dependent's upper.
+                        if description.primary.is_none() {
+                            mz_ore::soft_assert_or_log!(
+                                write_frontier.elements() == &[Timestamp::MIN]
+                                    || write_frontier.is_empty()
+                                    || PartialOrder::less_than(&dependency_since, write_frontier),
+                                "dependency ({dep}) since has advanced past dependent ({id}) upper \n
+                                dependent ({id}): since {:?}, upper {:?} \n
+                                dependency ({dep}): since {:?}",
+                                data_shard_since,
+                                write_frontier,
+                                dependency_since
+                            );
+                        }
 
                         dependency_since
                     } else {
@@ -2223,6 +2238,11 @@ impl StorageCollections for StorageCollectionsImpl {
         debug!(?identifiers, "drop_collections_unvalidated");
 
         let mut self_collections = self.collections.lock().expect("lock poisoned");
+        let shards_in_use: BTreeSet<_> = storage_metadata
+            .collection_metadata
+            .values()
+            .copied()
+            .collect();
 
         // Policies that advance the since to the empty antichain. We do still
         // honor outstanding read holds, and collections will only be dropped
@@ -2248,6 +2268,18 @@ impl StorageCollections for StorageCollectionsImpl {
                     "dropping {id}, but drop was not synchronized with storage \
                      controller via `prepare_state`"
                 );
+
+                // Releasing the owner's since can destroy a shared shard even if the
+                // finalization WAL is guarded. Prefer leaking this collection state over
+                // destroying data when durable metadata contradicts the primary links.
+                let data_shard = collection.collection_metadata.data_shard;
+                if shards_in_use.contains(&data_shard) {
+                    mz_ore::soft_panic_or_log!(
+                        "dropping {id} would release the since of shard {data_shard}, \
+                         which an active collection still uses"
+                    );
+                    continue;
+                }
             }
 
             finalized_policies.push((id, ReadPolicy::ValidFrom(Antichain::new())));

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1683,6 +1683,20 @@ impl StorageCollections for StorageCollectionsImpl {
         ids_to_drop: BTreeSet<GlobalId>,
         ids_to_register: BTreeMap<GlobalId, ShardId>,
     ) -> Result<(), StorageError> {
+        // Durable metadata can outlive its collection. Reconcile it with live
+        // collection state so orphaned mappings do not block finalization.
+        let mut active_collection_ids: BTreeSet<_> = {
+            let collections = self.collections.lock().expect("poisoned");
+            collections
+                .iter()
+                .filter_map(|(id, collection)| {
+                    (!ids_to_drop.contains(id) && !collection.is_dropped()).then_some(*id)
+                })
+                .collect()
+        };
+        active_collection_ids.extend(ids_to_add.iter().copied());
+        active_collection_ids.extend(ids_to_register.keys().copied());
+
         txn.insert_collection_metadata(
             ids_to_add
                 .into_iter()
@@ -1707,9 +1721,11 @@ impl StorageCollections for StorageCollectionsImpl {
             }
         }
         let remaining_metadata = txn.get_collection_metadata();
-        let remaining_ids = remaining_metadata.keys().copied().collect();
-        let (referenced_shards, dropped_shards) =
-            partition_finalizable_shards(remaining_metadata, &remaining_ids, dropped_shards);
+        let (referenced_shards, dropped_shards) = partition_finalizable_shards(
+            remaining_metadata,
+            &active_collection_ids,
+            dropped_shards,
+        );
         if !referenced_shards.is_empty() {
             mz_ore::soft_panic_or_log!(
                 "dropped collections would finalize shards that active collections still use: \
@@ -2238,10 +2254,19 @@ impl StorageCollections for StorageCollectionsImpl {
         debug!(?identifiers, "drop_collections_unvalidated");
 
         let mut self_collections = self.collections.lock().expect("lock poisoned");
+        // Durable metadata can outlive its collection. Reconcile it with live
+        // collection state so orphaned mappings do not block finalization.
+        let dropping: BTreeSet<_> = identifiers.iter().copied().collect();
+        let active_collection_ids: BTreeSet<_> = self_collections
+            .iter()
+            .filter_map(|(id, collection)| {
+                (!dropping.contains(id) && !collection.is_dropped()).then_some(*id)
+            })
+            .collect();
         let shards_in_use: BTreeSet<_> = storage_metadata
             .collection_metadata
-            .values()
-            .copied()
+            .iter()
+            .filter_map(|(id, shard)| active_collection_ids.contains(id).then_some(*shard))
             .collect();
 
         // Policies that advance the since to the empty antichain. We do still

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1362,7 +1362,7 @@ impl StorageCollections for StorageCollectionsImpl {
             // Collection metadata is authoritative. Removing these entries in
             // the initialization transaction keeps them out of the finalizer
             // queue.
-            txn.mark_shards_as_finalized(referenced_shards);
+            txn.remove_unfinalized_shards(referenced_shards);
         }
 
         info!(?unfinalized_shards, "initializing finalizable_shards");
@@ -1711,7 +1711,7 @@ impl StorageCollections for StorageCollectionsImpl {
         // Reconcile any shards we've successfully finalized with the shard
         // finalization collection.
         let finalized_shards = self.finalized_shards.lock().iter().copied().collect();
-        txn.mark_shards_as_finalized(finalized_shards);
+        txn.remove_unfinalized_shards(finalized_shards);
 
         Ok(())
     }

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1297,6 +1297,29 @@ impl StorageCollectionsImpl {
     }
 }
 
+/// Partitions the finalization WAL by whether an active collection references
+/// each shard.
+fn partition_finalizable_shards(
+    collection_metadata: BTreeMap<GlobalId, ShardId>,
+    active_collection_ids: &BTreeSet<GlobalId>,
+    unfinalized_shards: BTreeSet<ShardId>,
+) -> (BTreeSet<ShardId>, BTreeSet<ShardId>) {
+    let active_shards: BTreeSet<_> = collection_metadata
+        .into_iter()
+        .filter_map(|(id, shard)| active_collection_ids.contains(&id).then_some(shard))
+        .collect();
+    let referenced_shards = unfinalized_shards
+        .intersection(&active_shards)
+        .copied()
+        .collect();
+    let finalizable_shards = unfinalized_shards
+        .difference(&active_shards)
+        .copied()
+        .collect();
+
+    (referenced_shards, finalizable_shards)
+}
+
 // See comments on the above impl for StorageCollectionsImpl.
 #[async_trait]
 impl StorageCollections for StorageCollectionsImpl {
@@ -1320,14 +1343,27 @@ impl StorageCollections for StorageCollectionsImpl {
         )
         .await?;
 
-        // All shards that belong to collections dropped in the last epoch are
-        // eligible for finalization.
+        // All unreferenced shards that belong to collections dropped in the
+        // last epoch are eligible for finalization. Active collection metadata
+        // is authoritative over stale finalization WAL entries.
         //
-        // n.b. this introduces an unlikely race condition: if a collection is
-        // dropped from the catalog, but the dataflow is still running on a
-        // worker, assuming the shard is safe to finalize on reboot may cause
-        // the cluster to panic.
-        let unfinalized_shards = txn.get_unfinalized_shards().into_iter().collect_vec();
+        // A dropped collection can still have a dataflow running on a worker.
+        // Finalizing its shard on reboot can cause that worker to panic.
+        let (referenced_shards, unfinalized_shards) = partition_finalizable_shards(
+            txn.get_collection_metadata(),
+            &init_ids,
+            txn.get_unfinalized_shards(),
+        );
+        if !referenced_shards.is_empty() {
+            warn!(
+                ?referenced_shards,
+                "removing active collection shards from the finalization WAL"
+            );
+            // Collection metadata is authoritative. Removing these entries in
+            // the initialization transaction keeps them out of the finalizer
+            // queue.
+            txn.mark_shards_as_finalized(referenced_shards);
+        }
 
         info!(?unfinalized_shards, "initializing finalizable_shards");
 
@@ -3190,6 +3226,28 @@ mod tests {
     use mz_secrets::InMemorySecretsController;
 
     use super::*;
+
+    #[mz_ore::test]
+    fn test_partition_finalizable_shards() {
+        let active_shard = ShardId::new();
+        let dropped_shard = ShardId::new();
+        let collection_metadata = BTreeMap::from([
+            (GlobalId::User(1), active_shard),
+            (GlobalId::User(2), active_shard),
+            (GlobalId::User(3), dropped_shard),
+        ]);
+        let active_collection_ids = BTreeSet::from([GlobalId::User(1), GlobalId::User(2)]);
+        let unfinalized_shards = BTreeSet::from([active_shard, dropped_shard]);
+
+        let (referenced_shards, finalizable_shards) = partition_finalizable_shards(
+            collection_metadata,
+            &active_collection_ids,
+            unfinalized_shards,
+        );
+
+        assert_eq!(referenced_shards, BTreeSet::from([active_shard]));
+        assert_eq!(finalizable_shards, BTreeSet::from([dropped_shard]));
+    }
 
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: integer-to-pointer casts and `ptr::from_exposed_addr`

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -7297,26 +7297,7 @@ def workflow_github_11322(c: Composition) -> None:
 
 
 def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
-    """
-    Regression test for incident 1136: dropping a replacement MV after an
-    envd restart destroys the target MV's persist shard.
-
-    Bootstrap does not restore the `primary` link of replacement-MV storage
-    collections, so dropping a replacement MV after an envd restart marks the
-    target MV's shard as finalizable. The shard finalization task then seals
-    and tombstones the target's live shard, permanently losing the target
-    MV's data. Before materialize#37696, a subsequent CREATE REPLACEMENT
-    MATERIALIZED VIEW, which registers a new storage collection on the
-    tombstoned shard, additionally panicked envd with "cmd remove_rollups
-    unexpectedly tried to commit a new state on a tombstone" and left the
-    environment crash-looping during bootstrap.
-
-    The MVs live in a cluster with no replicas so that no dataflow holds a
-    persist read lease on the target's shard. Leases of readers that died
-    with the envd restart expire only after 15 minutes, and an unexpired
-    lease would keep the finalization task from tombstoning the shard within
-    the runtime of this test.
-    """
+    """Dropping a replacement MV after restart must preserve the target shard."""
 
     def storage_metadata() -> dict:
         port = c.port("materialized", 6878)
@@ -7327,6 +7308,8 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
     c.down(destroy_volumes=True)
     c.up("materialized")
 
+    # Without a replica, no dataflow holds a persist read lease after restart.
+    # Such a lease would delay finalization beyond the runtime of this test.
     c.sql("""
         CREATE CLUSTER stalled SIZE 'scale=1,workers=1', REPLICATION FACTOR 0;
         CREATE TABLE t (a int);
@@ -7346,19 +7329,14 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
     # Drop the replacement without applying it.
     c.sql("DROP MATERIALIZED VIEW rp")
 
-    # The drop must not have marked the target's shard as finalizable. This
-    # check must happen right after the drop: once the finalization task has
-    # tombstoned the shard, the next catalog transaction removes it from
-    # unfinalized_shards again, hiding the damage from this check.
+    # The finalization record is removed by the next catalog transaction after
+    # finalization completes, so inspect it immediately after the drop.
     unfinalized = storage_metadata()["unfinalized_shards"]
     assert mv_shard not in unfinalized, (
         f"dropping the replacement marked the target's shard {mv_shard} for"
         " finalization"
     )
 
-    # Re-creating a replacement registers a new storage collection on the
-    # target's shard. Before materialize#37696 this panicked envd when the
-    # shard had already been tombstoned.
     c.sql(
         "CREATE REPLACEMENT MATERIALIZED VIEW rp2 FOR mv"
         " IN CLUSTER stalled AS SELECT * FROM t"

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -7318,7 +7318,7 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
     def data_shard(collection_state: str) -> str:
         match = re.search(r"data_shard: ShardId\(([^)]+)\)", collection_state)
         assert match is not None, collection_state
-        return match.group(1)
+        return f"s{match.group(1)}"
 
     c.down(destroy_volumes=True)
     c.up("materialized")
@@ -7376,7 +7376,7 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
     unfinalized = storage_metadata()["unfinalized_shards"]
     assert mv_shard not in unfinalized, (
         f"dropping the replacement marked the target's shard {mv_shard} for"
-        " finalization"
+        f" finalization. Unfinalized shards: {unfinalized}"
     )
 
     # A plain MV still owns its shard after bootstrap, so dropping it must
@@ -7385,7 +7385,7 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
     unfinalized = storage_metadata()["unfinalized_shards"]
     assert plain_mv_shard in unfinalized, (
         f"dropping a plain MV did not mark its shard {plain_mv_shard} for"
-        " finalization"
+        f" finalization. Unfinalized shards: {unfinalized}"
     )
 
     c.sql(

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -7305,29 +7305,64 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
         resp.raise_for_status()
         return resp.json()["storage_metadata"]
 
+    def storage_collection_states() -> dict[str, str]:
+        port = c.port("materialized", 6878)
+        resp = requests.get(f"http://localhost:{port}/api/coordinator/dump")
+        resp.raise_for_status()
+        return resp.json()["controller"]["storage_collections"]["collections"]
+
+    def debug_global_id(global_id: str) -> str:
+        assert global_id.startswith("u"), global_id
+        return f"User({global_id[1:]})"
+
+    def data_shard(collection_state: str) -> str:
+        match = re.search(r"data_shard: ShardId\(([^)]+)\)", collection_state)
+        assert match is not None, collection_state
+        return match.group(1)
+
     c.down(destroy_volumes=True)
     c.up("materialized")
 
-    # Without a replica, no dataflow holds a persist read lease after restart.
-    # Such a lease would delay finalization beyond the runtime of this test.
     c.sql("""
-        CREATE CLUSTER stalled SIZE 'scale=1,workers=1', REPLICATION FACTOR 0;
+        CREATE CLUSTER stalled SIZE 'scale=1,workers=1', REPLICATION FACTOR 1;
         CREATE TABLE t (a int);
         CREATE MATERIALIZED VIEW mv IN CLUSTER stalled AS SELECT * FROM t;
-        CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv
+        CREATE REPLACEMENT MATERIALIZED VIEW rp1 FOR mv
             IN CLUSTER stalled AS SELECT * FROM t;
         """)
 
     [(mv_id,)] = c.sql_query("SELECT id FROM mz_materialized_views WHERE name = 'mv'")
-    mv_shard = storage_metadata()["collection_metadata"][mv_id]
+    [(rp1_id,)] = c.sql_query("SELECT id FROM mz_materialized_views WHERE name = 'rp1'")
 
-    # Restart envd. Bootstrap re-creates the in-memory storage collections
-    # state, including the replacement's `primary` link to its target.
+    c.sql("""
+        ALTER MATERIALIZED VIEW mv APPLY REPLACEMENT rp1;
+        CREATE REPLACEMENT MATERIALIZED VIEW rp2 FOR mv
+            IN CLUSTER stalled AS SELECT * FROM t;
+        ALTER CLUSTER stalled SET (REPLICATION FACTOR 0);
+        """)
+    [(rp2_id,)] = c.sql_query("SELECT id FROM mz_materialized_views WHERE name = 'rp2'")
+
+    # Without a replica, no dataflow holds a persist read lease after restart.
+    # Such a lease would delay finalization beyond the runtime of this test.
     c.kill("materialized")
     c.up("materialized")
 
-    # Drop the replacement without applying it.
-    c.sql("DROP MATERIALIZED VIEW rp")
+    collection_states = storage_collection_states()
+    mv_state = collection_states[mv_id]
+    rp1_state = collection_states[rp1_id]
+    rp2_state = collection_states[rp2_id]
+    mv_shard = data_shard(mv_state)
+
+    assert data_shard(rp1_state) == mv_shard
+    assert data_shard(rp2_state) == mv_shard
+    assert "primary: None" in mv_state, mv_state
+    assert f"primary: Some({debug_global_id(mv_id)})" in rp1_state, rp1_state
+    assert f"primary: Some({debug_global_id(rp1_id)})" in rp2_state, rp2_state
+    for collection_state in (mv_state, rp1_state, rp2_state):
+        assert "read_policy: LagWriteFrontier" in collection_state, collection_state
+
+    # Drop the staged replacement without applying it.
+    c.sql("DROP MATERIALIZED VIEW rp2")
 
     # The finalization record is removed by the next catalog transaction after
     # finalization completes, so inspect it immediately after the drop.
@@ -7338,7 +7373,7 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
     )
 
     c.sql(
-        "CREATE REPLACEMENT MATERIALIZED VIEW rp2 FOR mv"
+        "CREATE REPLACEMENT MATERIALIZED VIEW rp3 FOR mv"
         " IN CLUSTER stalled AS SELECT * FROM t"
     )
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -7296,6 +7296,84 @@ def workflow_github_11322(c: Composition) -> None:
     assert rp_id not in collection_metadata
 
 
+def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
+    """
+    Regression test for incident 1136: dropping a replacement MV after an
+    envd restart destroys the target MV's persist shard.
+
+    Bootstrap does not restore the `primary` link of replacement-MV storage
+    collections, so dropping a replacement MV after an envd restart marks the
+    target MV's shard as finalizable. The shard finalization task then seals
+    and tombstones the target's live shard, permanently losing the target
+    MV's data. Before materialize#37696, a subsequent CREATE REPLACEMENT
+    MATERIALIZED VIEW, which registers a new storage collection on the
+    tombstoned shard, additionally panicked envd with "cmd remove_rollups
+    unexpectedly tried to commit a new state on a tombstone" and left the
+    environment crash-looping during bootstrap.
+
+    The MVs live in a cluster with no replicas so that no dataflow holds a
+    persist read lease on the target's shard. Leases of readers that died
+    with the envd restart expire only after 15 minutes, and an unexpired
+    lease would keep the finalization task from tombstoning the shard within
+    the runtime of this test.
+    """
+
+    def storage_metadata() -> dict:
+        port = c.port("materialized", 6878)
+        resp = requests.get(f"http://localhost:{port}/api/catalog/dump")
+        resp.raise_for_status()
+        return resp.json()["storage_metadata"]
+
+    c.down(destroy_volumes=True)
+    c.up("materialized")
+
+    c.sql("""
+        CREATE CLUSTER stalled SIZE 'scale=1,workers=1', REPLICATION FACTOR 0;
+        CREATE TABLE t (a int);
+        CREATE MATERIALIZED VIEW mv IN CLUSTER stalled AS SELECT * FROM t;
+        CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv
+            IN CLUSTER stalled AS SELECT * FROM t;
+        """)
+
+    [(mv_id,)] = c.sql_query("SELECT id FROM mz_materialized_views WHERE name = 'mv'")
+    mv_shard = storage_metadata()["collection_metadata"][mv_id]
+
+    # Restart envd. Bootstrap re-creates the in-memory storage collections
+    # state, including the replacement's `primary` link to its target.
+    c.kill("materialized")
+    c.up("materialized")
+
+    # Drop the replacement without applying it.
+    c.sql("DROP MATERIALIZED VIEW rp")
+
+    # The drop must not have marked the target's shard as finalizable. This
+    # check must happen right after the drop: once the finalization task has
+    # tombstoned the shard, the next catalog transaction removes it from
+    # unfinalized_shards again, hiding the damage from this check.
+    unfinalized = storage_metadata()["unfinalized_shards"]
+    assert mv_shard not in unfinalized, (
+        f"dropping the replacement marked the target's shard {mv_shard} for"
+        " finalization"
+    )
+
+    # Re-creating a replacement registers a new storage collection on the
+    # target's shard. Before materialize#37696 this panicked envd when the
+    # shard had already been tombstoned.
+    c.sql(
+        "CREATE REPLACEMENT MATERIALIZED VIEW rp2 FOR mv"
+        " IN CLUSTER stalled AS SELECT * FROM t"
+    )
+
+    # The target's shard must not have been sealed.
+    upper_empty = c.sql_query("""
+        SELECT write_frontier IS NULL
+        FROM mz_internal.mz_frontiers
+        JOIN mz_materialized_views ON id = object_id
+        WHERE name = 'mv'
+        """)[0][0]
+    assert not upper_empty, "the target MV's shard was sealed, its data is lost"
+
+
 def workflow_test_github_10102(c: Composition) -> None:
     """
     Regression test for database-issues#10102:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -7327,11 +7327,15 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
         CREATE CLUSTER stalled SIZE 'scale=1,workers=1', REPLICATION FACTOR 1;
         CREATE TABLE t (a int);
         CREATE MATERIALIZED VIEW mv IN CLUSTER stalled AS SELECT * FROM t;
+        CREATE MATERIALIZED VIEW plain_mv IN CLUSTER stalled AS SELECT * FROM t;
         CREATE REPLACEMENT MATERIALIZED VIEW rp1 FOR mv
             IN CLUSTER stalled AS SELECT * FROM t;
         """)
 
     [(mv_id,)] = c.sql_query("SELECT id FROM mz_materialized_views WHERE name = 'mv'")
+    [(plain_mv_id,)] = c.sql_query(
+        "SELECT id FROM mz_materialized_views WHERE name = 'plain_mv'"
+    )
     [(rp1_id,)] = c.sql_query("SELECT id FROM mz_materialized_views WHERE name = 'rp1'")
 
     c.sql("""
@@ -7351,14 +7355,17 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
     mv_state = collection_states[mv_id]
     rp1_state = collection_states[rp1_id]
     rp2_state = collection_states[rp2_id]
+    plain_mv_state = collection_states[plain_mv_id]
     mv_shard = data_shard(mv_state)
+    plain_mv_shard = data_shard(plain_mv_state)
 
     assert data_shard(rp1_state) == mv_shard
     assert data_shard(rp2_state) == mv_shard
     assert "primary: None" in mv_state, mv_state
     assert f"primary: Some({debug_global_id(mv_id)})" in rp1_state, rp1_state
     assert f"primary: Some({debug_global_id(rp1_id)})" in rp2_state, rp2_state
-    for collection_state in (mv_state, rp1_state, rp2_state):
+    assert "primary: None" in plain_mv_state, plain_mv_state
+    for collection_state in (mv_state, rp1_state, rp2_state, plain_mv_state):
         assert "read_policy: LagWriteFrontier" in collection_state, collection_state
 
     # Drop the staged replacement without applying it.
@@ -7369,6 +7376,15 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
     unfinalized = storage_metadata()["unfinalized_shards"]
     assert mv_shard not in unfinalized, (
         f"dropping the replacement marked the target's shard {mv_shard} for"
+        " finalization"
+    )
+
+    # A plain MV still owns its shard after bootstrap, so dropping it must
+    # enqueue that shard for finalization.
+    c.sql("DROP MATERIALIZED VIEW plain_mv")
+    unfinalized = storage_metadata()["unfinalized_shards"]
+    assert plain_mv_shard in unfinalized, (
+        f"dropping a plain MV did not mark its shard {plain_mv_shard} for"
         " finalization"
     )
 


### PR DESCRIPTION
### Motivation

A replacement materialized view shares its target's persist shard. The storage controller uses an in-memory `primary` link to distinguish the shard owner from collections that merely reference the shard.

The create path installs this link, but coordinator bootstrap did not reconstruct it for materialized views. A pending replacement therefore became an apparent shard owner after an environmentd restart. Dropping that replacement advanced the shared shard's critical since to the empty frontier and recorded the shard for finalization, permanently destroying the live target materialized view. The persist tombstone handling in #37696 prevents the resulting bootstrap panic, but it cannot prevent or recover the data loss.

This is a user-visible correctness fix. Restarts and deployment restaging no longer allow a pending replacement materialized view to destroy its live target or wedge dependent sinks.

### Description

Reconstruct materialized view shard ownership while bootstrapping storage collections from the durable catalog. The oldest applied collection remains the owner, each applied replacement points to its predecessor, and a pending replacement points to its target's latest collection. This matches the ownership relationships established by the create and apply paths before a restart.

Materialized view ownership runs in the opposite direction from versioned table ownership, so the bootstrap logic reconstructs the materialized view chain explicitly rather than reusing the table algorithm. Bootstrap also initializes compaction policies for every historical materialized view collection. This ensures capability changes reach the collection that owns the shard and continues to drive compaction.

Storage initialization reconciles the shard-finalization WAL against active catalog collection metadata. If an older environmentd recorded a still-live shard for finalization but restarted before the finalizer began processing it, the active mapping wins and the stale finalization record is removed before the finalizer starts. The transaction API names this operation as metadata removal and explicitly does not claim that the underlying Persist shard was finalized.

The destructive drop paths also verify shard ownership against durable collection metadata. If the in-memory `primary` links claim a collection owns a shard that another active collection still uses, storage refuses to release the shard's since or record it for finalization. This leaks collection state rather than risking data loss and reports the violated invariant. Bootstrap also excludes `primary` dependencies from a frontier assertion that applies only to source remap dependencies, matching the storage controller's runtime check.

### Verification

Expands the cluster regression from #37699 to apply one replacement, stage another, restart environmentd, and verify the complete ownership chain and compaction policies through the coordinator dump. It then drops the staged replacement and verifies that the shared target shard is neither marked for finalization nor sealed and remains usable by another replacement. The same workflow drops a plain materialized view after restart and verifies that its owned shard is still eligible for finalization, guarding against ownership links that are too broad.

Adds focused storage-client coverage that partitions stale finalization records into active shards that must be rescued and genuinely unreferenced shards that remain eligible for finalization.

Fixes [SQL-536](https://linear.app/materializeinc/issue/SQL-536/fix-replacement-mvs-tombstoning-live-materialized-view-shards).
