### PR TITLE
timestamp-oracle: Halve group-commit oracle traffic, overlap and pipeline reads

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -742,6 +742,9 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "read_then_write_max_dependencies",
     "enable_hydration_burst",
     "default_hydration_burst_linger",
+    # Only takes effect while zero SQL connections exist, which tests don't
+    # meaningfully exercise; randomizing it would only obscure timing issues.
+    "coord_idle_advance_timelines_multiplier",
 ]
 
 

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1718,6 +1718,15 @@ class FlipFlagsAction(Action):
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_public_metrics_endpoint"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_scoped_system_parameters"] = BOOLEAN_FLAG_VALUES
+        # Only takes effect while zero SQL connections exist, which never
+        # happens during the workload, but flipping it exercises the setting
+        # path and any value is safe: a new connection's mz_sessions write
+        # forces an immediate table advancement.
+        self.flags_with_values["coord_idle_advance_timelines_multiplier"] = [
+            "1",
+            "2",
+            "10",
+        ]
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [
             "0",
             "1",

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -139,6 +139,21 @@ pub const READ_THEN_WRITE_MAX_DEPENDENCIES: Config<usize> = Config::new(
      statement before it is rejected.",
 );
 
+/// While no SQL connections exist, only every Nth tick of the periodic
+/// table-advancement interval runs a group commit. Each such group commit
+/// costs timestamp oracle queries and a persist append, so this multiplier
+/// directly divides the steady-state load an idle environment puts on the
+/// metadata store. The freshness cost is bounded: connection startup writes
+/// to mz_sessions, which forces an immediate group commit, and the first
+/// query of a new connection waits for that write.
+pub const COORD_IDLE_ADVANCE_TIMELINES_MULTIPLIER: Config<usize> = Config::new(
+    "coord_idle_advance_timelines_multiplier",
+    1,
+    "The multiple of default_timestamp_interval at which to run the periodic \
+     table-advancement group commit while no SQL connections exist \
+     (1 = advance on every tick).",
+);
+
 /// OIDC issuer URL.
 pub const OIDC_ISSUER: Config<Option<&'static str>> =
     Config::new("oidc_issuer", None, "OIDC issuer URL.");
@@ -433,6 +448,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_EXPRESSION_CACHE)
         .add(&ENABLE_PASSWORD_AUTH)
         .add(&READ_THEN_WRITE_MAX_DEPENDENCIES)
+        .add(&COORD_IDLE_ADVANCE_TIMELINES_MULTIPLIER)
         .add(&OIDC_ISSUER)
         .add(&OIDC_AUDIENCE)
         .add(&OIDC_AUTHENTICATION_CLAIM)

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -342,7 +342,12 @@ pub enum Message {
     /// Initiates a group commit.
     GroupCommitInitiate(Span, Option<GroupCommitPermit>),
     DeferredStatementReady,
-    AdvanceTimelines,
+    AdvanceTimelines {
+        /// The oracle read timestamp that resulted from the `apply_write` of
+        /// the group commit that triggered this message, if any. Used to
+        /// downgrade read holds without another oracle round trip.
+        epoch_ms_read_ts: Option<Timestamp>,
+    },
     ClusterEvent(ClusterEvent),
     CancelPendingPeeks {
         conn_id: ConnectionId,
@@ -499,7 +504,7 @@ impl Message {
             Message::CreateConnectionValidationReady(_) => "create_connection_validation_ready",
             Message::TryDeferred { .. } => "try_deferred",
             Message::GroupCommitInitiate(..) => "group_commit_initiate",
-            Message::AdvanceTimelines => "advance_timelines",
+            Message::AdvanceTimelines { .. } => "advance_timelines",
             Message::ClusterEvent(_) => "cluster_event",
             Message::CancelPendingPeeks { .. } => "cancel_pending_peeks",
             Message::LinearizeReads => "linearize_reads",
@@ -2998,11 +3003,9 @@ impl Coordinator {
             .append_table(write_ts.clone(), advance_to, appends)
             .expect("invalid updates");
 
-        self.apply_local_write(write_ts).await;
-
         // Add builtin table updates the clear the contents of all system tables
         debug!("coordinator init: resetting system tables");
-        let read_ts = self.get_local_read_ts().await;
+        let read_ts = self.apply_local_write(write_ts).await;
 
         // Filter out the 'mz_storage_usage_by_shard' table since we need to retain that info for
         // billing purposes.
@@ -3949,7 +3952,9 @@ impl Coordinator {
                         // read-only mode we send this message directly because
                         // we're not doing group commits.
                         if self.controller.read_only() {
-                            messages.push(Message::AdvanceTimelines);
+                            messages.push(Message::AdvanceTimelines {
+                                epoch_ms_read_ts: None,
+                            });
                         } else {
                             messages.push(Message::GroupCommitInitiate(span, None));
                         }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2047,6 +2047,18 @@ pub struct Coordinator {
     /// it manually.
     advance_timelines_interval: Interval,
 
+    /// The largest oracle write timestamp that this process has observed from
+    /// `write_ts` calls. Group commit uses it as a pacing hint to decide
+    /// whether to wait for the wall clock to catch up before committing,
+    /// without paying an oracle round trip for a `peek_write_ts`.
+    ///
+    /// This is a lower bound on the oracle's write timestamp, not
+    /// linearizability-relevant state: an underestimate only means a group
+    /// commit proceeds immediately and gets a timestamp ahead of `now()`,
+    /// which group commit explicitly tolerates. The bound self-corrects with
+    /// the `write_ts` result of that same commit.
+    last_seen_oracle_write_ts: Timestamp,
+
     /// Serialized DDL. DDL must be serialized because:
     /// - Many of them do off-thread work and need to verify the catalog is in a valid state, but
     ///   [`PlanValidity`] does not currently support tracking all changes. Doing that correctly
@@ -5037,6 +5049,7 @@ pub fn serve(
                     deferred_write_ops: BTreeMap::new(),
                     pending_writes: Vec::new(),
                     advance_timelines_interval,
+                    last_seen_oracle_write_ts: Timestamp::MIN,
                     secrets_controller,
                     caching_secrets_reader,
                     cloud_resource_controller,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2059,6 +2059,11 @@ pub struct Coordinator {
     /// the `write_ts` result of that same commit.
     last_seen_oracle_write_ts: Timestamp,
 
+    /// How many consecutive ticks of `advance_timelines_interval` were
+    /// skipped because no SQL connections existed. See
+    /// [`mz_adapter_types::dyncfgs::COORD_IDLE_ADVANCE_TIMELINES_MULTIPLIER`].
+    idle_advance_timelines_ticks_skipped: usize,
+
     /// Serialized DDL. DDL must be serialized because:
     /// - Many of them do off-thread work and need to verify the catalog is in a valid state, but
     ///   [`PlanValidity`] does not currently support tracking all changes. Doing that correctly
@@ -3968,7 +3973,22 @@ impl Coordinator {
                                 epoch_ms_read_ts: None,
                             });
                         } else {
-                            messages.push(Message::GroupCommitInitiate(span, None));
+                            // While no SQL connections exist, only run the
+                            // table-advancement group commit on every Nth
+                            // tick. Nothing observes the skipped
+                            // advancements: a new connection's mz_sessions
+                            // write forces an immediate group commit, and the
+                            // first query of that connection waits for it.
+                            use mz_adapter_types::dyncfgs::COORD_IDLE_ADVANCE_TIMELINES_MULTIPLIER;
+                            let idle_multiplier = COORD_IDLE_ADVANCE_TIMELINES_MULTIPLIER
+                                .get(self.catalog().system_config().dyncfgs());
+                            let skipped = self.idle_advance_timelines_ticks_skipped;
+                            if self.active_conns.is_empty() && skipped + 1 < idle_multiplier {
+                                self.idle_advance_timelines_ticks_skipped += 1;
+                            } else {
+                                self.idle_advance_timelines_ticks_skipped = 0;
+                                messages.push(Message::GroupCommitInitiate(span, None));
+                            }
                         }
                     },
                     // Re-check pending strict serializable reads. Deliberately
@@ -5050,6 +5070,7 @@ pub fn serve(
                     pending_writes: Vec::new(),
                     advance_timelines_interval,
                     last_seen_oracle_write_ts: Timestamp::MIN,
+                    idle_advance_timelines_ticks_skipped: 0,
                     secrets_controller,
                     caching_secrets_reader,
                     cloud_resource_controller,

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -599,7 +599,7 @@ impl Coordinator {
                 };
 
                 // Apply the write by marking the timestamp as complete on the timeline.
-                apply_write_fut
+                let oracle_read_ts = apply_write_fut
                     .instrument(debug_span!("group_commit_apply::append_write_fut"))
                     .await;
 
@@ -617,7 +617,9 @@ impl Coordinator {
                 drop(group_write_locks);
 
                 // Advance other timelines.
-                if let Err(e) = internal_cmd_tx.send(Message::AdvanceTimelines) {
+                if let Err(e) = internal_cmd_tx.send(Message::AdvanceTimelines {
+                    epoch_ms_read_ts: Some(oracle_read_ts),
+                }) {
                     warn!("Server closed with non-advanced timelines, {e}");
                 }
 

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -285,7 +285,15 @@ impl Coordinator {
     /// writes.
     #[instrument(level = "debug")]
     pub(crate) async fn try_group_commit(&mut self, permit: Option<GroupCommitPermit>) {
-        let timestamp = self.peek_local_write_ts().await;
+        // The pacing check below only needs a lower bound on the oracle's
+        // write timestamp, so use the locally tracked one instead of paying an
+        // oracle round trip for a `peek_write_ts`. An underestimate means we
+        // commit immediately and the chosen timestamp may end up ahead of
+        // `now()`, which `group_commit` explicitly tolerates (see the comment
+        // on the `write_ts` call there). The bound self-corrects with the
+        // `write_ts` result of that commit, so a wait-loop can only be missed
+        // once per external advancement of the oracle.
+        let timestamp = self.last_seen_oracle_write_ts;
         let now = Timestamp::from((self.catalog().config().now)());
 
         // HACK: This is a special case to allow writes to the mz_sessions table to proceed even

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -105,8 +105,8 @@ impl Coordinator {
                     .boxed_local()
                     .await
             }
-            Message::AdvanceTimelines => {
-                self.advance_timelines().boxed_local().await;
+            Message::AdvanceTimelines { epoch_ms_read_ts } => {
+                self.advance_timelines(epoch_ms_read_ts).boxed_local().await;
             }
             Message::ClusterEvent(event) => self.message_cluster_event(event).boxed_local().await,
             Message::CancelPendingPeeks { conn_id } => {

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -123,12 +123,16 @@ impl Coordinator {
     /// timestamp to ensure they are not visible to any real-time earlier reads.
     #[instrument(name = "coord::get_local_write_ts")]
     pub(crate) async fn get_local_write_ts(&mut self) -> WriteTimestamp {
-        self.global_timelines
+        let write_ts = self
+            .global_timelines
             .get_mut(&Timeline::EpochMilliseconds)
             .expect("no realtime timeline")
             .oracle
             .write_ts()
-            .await
+            .await;
+        self.last_seen_oracle_write_ts =
+            std::cmp::max(self.last_seen_oracle_write_ts, write_ts.timestamp);
+        write_ts
     }
 
     /// Peek the current timestamp used for operations on local inputs. Used to determine how much

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -138,10 +138,13 @@ impl Coordinator {
     }
 
     /// Marks a write at `timestamp` as completed, using a [`TimestampOracle`].
+    ///
+    /// The returned future resolves to the oracle read timestamp that resulted
+    /// from applying the write, see [`TimestampOracle::apply_write`].
     pub(crate) fn apply_local_write(
         &self,
         timestamp: Timestamp,
-    ) -> impl Future<Output = ()> + Send + 'static {
+    ) -> impl Future<Output = Timestamp> + Send + 'static {
         let now = self.now().into();
 
         let upper_bound = upper_bound(&now);
@@ -279,8 +282,15 @@ impl Coordinator {
         became_empty
     }
 
+    /// Advances the timestamp oracles of all timelines and downgrades the
+    /// per-timeline read holds to the current oracle read timestamp.
+    ///
+    /// `epoch_ms_read_ts` is the oracle read timestamp that resulted from the
+    /// `apply_write` of the group commit that triggered this call, if any. It
+    /// is used to downgrade the [`Timeline::EpochMilliseconds`] read holds
+    /// without another oracle round trip.
     #[instrument(level = "debug")]
-    pub(crate) async fn advance_timelines(&mut self) {
+    pub(crate) async fn advance_timelines(&mut self, epoch_ms_read_ts: Option<Timestamp>) {
         let global_timelines = std::mem::take(&mut self.global_timelines);
         for (
             timeline,
@@ -292,7 +302,10 @@ impl Coordinator {
         {
             // Timeline::EpochMilliseconds is advanced in group commits and doesn't need to be
             // manually advanced here.
-            if timeline != Timeline::EpochMilliseconds && !self.read_only_controllers {
+            let mut known_read_ts = None;
+            if timeline == Timeline::EpochMilliseconds {
+                known_read_ts = epoch_ms_read_ts;
+            } else if !self.read_only_controllers {
                 // For non realtime sources, we define now as the largest timestamp, not in
                 // advance of any object's upper. This is the largest timestamp that is closed
                 // to writes.
@@ -304,17 +317,25 @@ impl Coordinator {
                 if !id_bundle.is_empty() {
                     let least_valid_write = self.least_valid_write(&id_bundle);
                     let now = Self::largest_not_in_advance_of_upper(&least_valid_write);
-                    oracle.apply_write(now).await;
+                    let read_ts = oracle.apply_write(now).await;
+                    known_read_ts = Some(read_ts);
                     debug!(
                         least_valid_write = ?least_valid_write,
-                        oracle_read_ts = ?oracle.read_ts().await,
+                        oracle_read_ts = ?read_ts,
                         "advanced {:?} to {}",
                         timeline,
                         now,
                     );
                 }
             };
-            let read_ts = oracle.read_ts().await;
+            // Downgrading to a read timestamp observed slightly in the past is
+            // just as valid as calling read_ts here: the oracle's read
+            // timestamp never regresses, so future queries always get
+            // timestamps >= the downgrade target.
+            let read_ts = match known_read_ts {
+                Some(read_ts) => read_ts,
+                None => oracle.read_ts().await,
+            };
             read_holds.downgrade(read_ts);
             self.global_timelines
                 .insert(timeline, TimelineState { oracle, read_holds });

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -293,13 +293,19 @@ impl PeekClient {
         // handle is dropped. A wasted read joins a batch in the batching
         // oracle, so its marginal cost on the backing store is negligible.
         let isolation_level = session.vars().transaction_isolation().clone();
-        let may_need_linearized_read_ts =
-            matches!(
-                isolation_level,
-                IsolationLevel::StrictSerializable
-                    | IsolationLevel::StrongSessionSerializable
-                    | IsolationLevel::BoundedStaleness(_)
-            ) && session.get_transaction_timestamp_determination().is_none();
+        let may_need_linearized_read_ts = matches!(
+            isolation_level,
+            IsolationLevel::StrictSerializable
+                | IsolationLevel::StrongSessionSerializable
+                | IsolationLevel::BoundedStaleness(_)
+        ) && session.get_transaction_timestamp_determination().is_none()
+            // While the session's startup builtin-table writes are pending, a
+            // query on those tables must observe them: it waits on
+            // `waiting_on_startup_appends` below and needs an oracle read
+            // taken after that wait (and thus after the writes' apply_write).
+            // A speculative read taken here would predate the writes, so a
+            // session's first query does not speculate.
+            && !session.has_builtin_table_updates();
         let early_oracle_read_ts = if may_need_linearized_read_ts {
             match self.ensure_oracle(Timeline::EpochMilliseconds).await {
                 Ok(oracle) => {

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -36,6 +36,7 @@ use mz_sql::rbac;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::IsolationLevel;
 use mz_sql_parser::ast::{CopyDirection, ExplainStage, ShowStatement, Statement};
+use mz_storage_types::sources::Timeline;
 use mz_transform::EmptyStatisticsOracle;
 use mz_transform::dataflow::DataflowMetainfo;
 use opentelemetry::trace::TraceContextExt;
@@ -281,6 +282,41 @@ impl PeekClient {
                 metrics::statement_type_label_value(&stmt),
             ])
             .inc();
+
+        // Optimistically kick off an oracle read for the common case, a
+        // linearized read in the EpochMilliseconds timeline, so that the
+        // oracle round trip overlaps with name resolution, planning, and RBAC
+        // below. The read is started after this query arrived, so using its
+        // result keeps the query's timestamp within its real-time bounds. If
+        // the query turns out not to need a linearized read timestamp, or is
+        // in a different timeline, or reuses a transaction timestamp, the
+        // handle is dropped. A wasted read joins a batch in the batching
+        // oracle, so its marginal cost on the backing store is negligible.
+        let isolation_level = session.vars().transaction_isolation().clone();
+        let may_need_linearized_read_ts =
+            matches!(
+                isolation_level,
+                IsolationLevel::StrictSerializable
+                    | IsolationLevel::StrongSessionSerializable
+                    | IsolationLevel::BoundedStaleness(_)
+            ) && session.get_transaction_timestamp_determination().is_none();
+        let early_oracle_read_ts = if may_need_linearized_read_ts {
+            match self.ensure_oracle(Timeline::EpochMilliseconds).await {
+                Ok(oracle) => {
+                    let oracle = Arc::clone(oracle);
+                    Some(mz_ore::task::spawn(
+                        || "frontend_peek_early_oracle_read",
+                        async move { oracle.read_ts().await },
+                    ))
+                }
+                // Speculation must not introduce a new error path. The
+                // non-speculative oracle lookup below will surface the error
+                // if the query does need the oracle.
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
 
         // # From handle_execute_inner
 
@@ -588,16 +624,23 @@ impl PeekClient {
 
         // # From peek_linearize_timestamp
 
-        let isolation_level = session.vars().transaction_isolation().clone();
         let timeline = Coordinator::get_timeline(&timeline_context);
         let needs_linearized_read_ts =
             Coordinator::needs_linearized_read_ts(&isolation_level, when);
 
         let oracle_read_ts = match timeline {
             Some(timeline) if needs_linearized_read_ts => {
-                let oracle = self.ensure_oracle(timeline).await?;
-                let oracle_read_ts = oracle.read_ts().await;
-                Some(oracle_read_ts)
+                match early_oracle_read_ts {
+                    // Use the speculative read if it matches the query's
+                    // timeline. It was started during this query's handling,
+                    // so it is within the query's real-time bounds.
+                    Some(handle) if timeline == Timeline::EpochMilliseconds => Some(handle.await),
+                    _ => {
+                        let oracle = self.ensure_oracle(timeline).await?;
+                        let oracle_read_ts = oracle.read_ts().await;
+                        Some(oracle_read_ts)
+                    }
+                }
             }
             Some(_) | None => None,
         };

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -920,6 +920,13 @@ impl Session {
         mz_ore::soft_assert_or_log!(prev.is_none(), "replacing old builtin table notify");
     }
 
+    /// Reports whether this session's startup builtin-table writes are still
+    /// pending, i.e. whether [`Session::clear_builtin_table_updates`] would
+    /// return a future to wait on.
+    pub fn has_builtin_table_updates(&self) -> bool {
+        self.builtin_updates.is_some()
+    }
+
     /// Takes the stashed `BuiltinTableAppendNotify`, if one exists, and returns a [`Future`] that
     /// waits for the writes to complete.
     pub fn clear_builtin_table_updates(&mut self) -> Option<impl Future<Output = ()> + 'static> {

--- a/src/persist-cli/src/maelstrom/services.rs
+++ b/src/persist-cli/src/maelstrom/services.rs
@@ -474,10 +474,11 @@ impl<T: TimestampManipulation> TimestampOracle<T> for MemTimestampOracle<T> {
         read_ts.clone()
     }
 
-    async fn apply_write(&self, lower_bound: T) {
+    async fn apply_write(&self, lower_bound: T) -> T {
         let (read_ts, write_ts) = &mut *self.read_write_ts.lock().expect("lock poisoned");
         *read_ts = std::cmp::max(read_ts.clone(), lower_bound);
-        *write_ts = std::cmp::max(read_ts, write_ts).clone();
+        *write_ts = std::cmp::max(read_ts.clone(), write_ts.clone());
+        read_ts.clone()
     }
 }
 

--- a/src/timestamp-oracle/examples/tsoracle_bench.rs
+++ b/src/timestamp-oracle/examples/tsoracle_bench.rs
@@ -86,8 +86,10 @@ fn parse_args() -> Result<Args, String> {
 
     let mut it = std::env::args().skip(1);
     while let Some(arg) = it.next() {
-        let mut value =
-            |name: &str| it.next().ok_or_else(|| format!("{} requires a value", name));
+        let mut value = |name: &str| {
+            it.next()
+                .ok_or_else(|| format!("{} requires a value", name))
+        };
         match arg.as_str() {
             "--url" => args.url = value("--url")?,
             "--mode" => args.mode = value("--mode")?,

--- a/src/timestamp-oracle/examples/tsoracle_bench.rs
+++ b/src/timestamp-oracle/examples/tsoracle_bench.rs
@@ -1,0 +1,377 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A closed-loop benchmark for timestamp oracle implementations.
+//!
+//! Drives a [`TimestampOracle`] (by default wrapped in the
+//! [`BatchingTimestampOracle`], like the adapter does) against a real backing
+//! store and reports client-side throughput and latency percentiles as well as
+//! the number of queries that actually hit the backing store. The latter is
+//! what "load on the backing store" means for oracle scaling purposes.
+//!
+//! Modes:
+//!
+//! - `read`: N concurrent tasks calling `read_ts` in a closed loop, for each
+//!   requested concurrency level. Shows how far batching collapses concurrent
+//!   reads and where the latency ceiling is.
+//! - `write`: a single loop that mimics the oracle traffic of the adapter's
+//!   group commit: `peek_write_ts`, `write_ts`, a sleep standing in for the
+//!   persist append, `apply_write`, and a trailing `read_ts` standing in for
+//!   the read-hold downgrade in `advance_timelines`. Flags allow skipping the
+//!   peek and the trailing read to model protocol changes.
+//! - `mixed`: both at the same time.
+//!
+//! Example:
+//!
+//! ```text
+//! cargo run --release -p mz-timestamp-oracle --example tsoracle_bench -- \
+//!     --url postgres://postgres@localhost:15432/postgres \
+//!     --mode read --concurrency 1,8,64,512 --duration 10
+//! ```
+
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use mz_ore::cast::CastLossy;
+use mz_ore::metrics::MetricsRegistry;
+use mz_ore::now::SYSTEM_TIME;
+use mz_ore::url::SensitiveUrl;
+use mz_repr::Timestamp;
+use mz_timestamp_oracle::batching_oracle::BatchingTimestampOracle;
+use mz_timestamp_oracle::{TimestampOracle, TimestampOracleConfig};
+
+#[derive(Clone)]
+struct Args {
+    url: String,
+    mode: String,
+    concurrency: Vec<usize>,
+    duration: Duration,
+    append_ms: u64,
+    skip_peek: bool,
+    skip_advance_read: bool,
+    raw: bool,
+}
+
+const USAGE: &str = "\
+tsoracle_bench [options]
+
+  --url URL              backing store URL (or env METADATA_BACKEND_URL)
+  --mode MODE            read | write | mixed (default: read)
+  --concurrency N,N,...  read concurrency levels (default: 1,8,64,512)
+  --duration SECS        seconds per measurement (default: 10)
+  --append-ms MS         simulated persist append duration in write mode (default: 10)
+  --skip-peek            write mode: skip the pacing peek_write_ts
+  --skip-advance-read    write mode: skip the trailing read_ts
+  --raw                  don't wrap the oracle in BatchingTimestampOracle
+";
+
+fn parse_args() -> Result<Args, String> {
+    let mut args = Args {
+        url: std::env::var("METADATA_BACKEND_URL").unwrap_or_default(),
+        mode: "read".to_string(),
+        concurrency: vec![1, 8, 64, 512],
+        duration: Duration::from_secs(10),
+        append_ms: 10,
+        skip_peek: false,
+        skip_advance_read: false,
+        raw: false,
+    };
+
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        let mut value =
+            |name: &str| it.next().ok_or_else(|| format!("{} requires a value", name));
+        match arg.as_str() {
+            "--url" => args.url = value("--url")?,
+            "--mode" => args.mode = value("--mode")?,
+            "--concurrency" => {
+                args.concurrency = value("--concurrency")?
+                    .split(',')
+                    .map(|s| s.parse::<usize>().map_err(|e| e.to_string()))
+                    .collect::<Result<_, _>>()?;
+            }
+            "--duration" => {
+                args.duration = Duration::from_secs(
+                    value("--duration")?
+                        .parse()
+                        .map_err(|e| format!("--duration: {}", e))?,
+                )
+            }
+            "--append-ms" => {
+                args.append_ms = value("--append-ms")?
+                    .parse()
+                    .map_err(|e| format!("--append-ms: {}", e))?
+            }
+            "--skip-peek" => args.skip_peek = true,
+            "--skip-advance-read" => args.skip_advance_read = true,
+            "--raw" => args.raw = true,
+            "--help" | "-h" => return Err(USAGE.to_string()),
+            other => return Err(format!("unknown argument: {}\n{}", other, USAGE)),
+        }
+    }
+
+    if args.url.is_empty() {
+        return Err(format!(
+            "--url or METADATA_BACKEND_URL is required\n{}",
+            USAGE
+        ));
+    }
+    match args.mode.as_str() {
+        "read" | "write" | "mixed" => {}
+        other => return Err(format!("unknown mode: {}\n{}", other, USAGE)),
+    }
+
+    Ok(args)
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let rank = f64::cast_lossy(sorted.len() - 1) * p / 100.0;
+    let idx = usize::cast_lossy(rank.round());
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn micros(d: Duration) -> u64 {
+    u64::try_from(d.as_micros()).unwrap_or(u64::MAX)
+}
+
+struct LatencySummary {
+    count: usize,
+    p50: u64,
+    p95: u64,
+    p99: u64,
+    max: u64,
+}
+
+fn summarize(mut latencies: Vec<u64>) -> LatencySummary {
+    latencies.sort_unstable();
+    LatencySummary {
+        count: latencies.len(),
+        p50: percentile(&latencies, 50.0),
+        p95: percentile(&latencies, 95.0),
+        p99: percentile(&latencies, 99.0),
+        max: latencies.last().copied().unwrap_or(0),
+    }
+}
+
+async fn read_workload(
+    oracle: Arc<dyn TimestampOracle<Timestamp> + Send + Sync>,
+    concurrency: usize,
+    duration: Duration,
+) -> Vec<u64> {
+    let deadline = Instant::now() + duration;
+    let mut handles = Vec::with_capacity(concurrency);
+    for i in 0..concurrency {
+        let oracle = Arc::clone(&oracle);
+        let handle = mz_ore::task::spawn(|| format!("tsoracle-bench-reader-{}", i), async move {
+            let mut latencies = Vec::new();
+            while Instant::now() < deadline {
+                let start = Instant::now();
+                let _ts = oracle.read_ts().await;
+                latencies.push(micros(start.elapsed()));
+            }
+            latencies
+        });
+        handles.push(handle);
+    }
+    let mut all = Vec::new();
+    for handle in handles {
+        all.extend(handle.await);
+    }
+    all
+}
+
+struct WriteResult {
+    commits: usize,
+    backend_ops: u64,
+    peek: Vec<u64>,
+    write: Vec<u64>,
+    apply: Vec<u64>,
+    advance_read: Vec<u64>,
+}
+
+/// Mimics the oracle traffic of one group commit per iteration.
+async fn write_workload(
+    oracle: Arc<dyn TimestampOracle<Timestamp> + Send + Sync>,
+    args: Args,
+) -> WriteResult {
+    let deadline = Instant::now() + args.duration;
+    let mut result = WriteResult {
+        commits: 0,
+        backend_ops: 0,
+        peek: Vec::new(),
+        write: Vec::new(),
+        apply: Vec::new(),
+        advance_read: Vec::new(),
+    };
+    while Instant::now() < deadline {
+        if !args.skip_peek {
+            let start = Instant::now();
+            let _ts = oracle.peek_write_ts().await;
+            result.peek.push(micros(start.elapsed()));
+            result.backend_ops += 1;
+        }
+
+        let start = Instant::now();
+        let write_ts = oracle.write_ts().await;
+        result.write.push(micros(start.elapsed()));
+        result.backend_ops += 1;
+
+        tokio::time::sleep(Duration::from_millis(args.append_ms)).await;
+
+        let start = Instant::now();
+        oracle.apply_write(write_ts.timestamp).await;
+        result.apply.push(micros(start.elapsed()));
+        result.backend_ops += 1;
+
+        if !args.skip_advance_read {
+            let start = Instant::now();
+            let _ts = oracle.read_ts().await;
+            result.advance_read.push(micros(start.elapsed()));
+        }
+
+        result.commits += 1;
+    }
+    result
+}
+
+fn report_read(concurrency: usize, duration: Duration, latencies: Vec<u64>, backend_selects: u64) {
+    let summary = summarize(latencies);
+    let ops_per_s = f64::cast_lossy(summary.count) / duration.as_secs_f64();
+    let backend_per_s = f64::cast_lossy(backend_selects) / duration.as_secs_f64();
+    let avg_batch = if backend_selects > 0 {
+        f64::cast_lossy(summary.count) / f64::cast_lossy(backend_selects)
+    } else {
+        0.0
+    };
+    println!(
+        "RESULT mode=read concurrency={} ops={} ops_per_s={:.1} backend_selects={} \
+         backend_selects_per_s={:.1} avg_batch_size={:.1} p50_us={} p95_us={} p99_us={} max_us={}",
+        concurrency,
+        summary.count,
+        ops_per_s,
+        backend_selects,
+        backend_per_s,
+        avg_batch,
+        summary.p50,
+        summary.p95,
+        summary.p99,
+        summary.max,
+    );
+}
+
+fn report_write(args: &Args, result: WriteResult) {
+    let commits_per_s = f64::cast_lossy(result.commits) / args.duration.as_secs_f64();
+    let backend_per_commit = if result.commits > 0 {
+        f64::cast_lossy(result.backend_ops) / f64::cast_lossy(result.commits)
+    } else {
+        0.0
+    };
+    let op_summary = |name: &str, lat: Vec<u64>| {
+        if lat.is_empty() {
+            return String::new();
+        }
+        let s = summarize(lat);
+        format!(" {}_p50_us={} {}_p99_us={}", name, s.p50, name, s.p99)
+    };
+    println!(
+        "RESULT mode=write commits={} commits_per_s={:.1} append_ms={} backend_write_ops={} \
+         backend_write_ops_per_commit={:.1} skip_peek={} skip_advance_read={}{}{}{}{}",
+        result.commits,
+        commits_per_s,
+        args.append_ms,
+        result.backend_ops,
+        backend_per_commit,
+        args.skip_peek,
+        args.skip_advance_read,
+        op_summary("peek", result.peek),
+        op_summary("write_ts", result.write),
+        op_summary("apply_write", result.apply),
+        op_summary("advance_read", result.advance_read),
+    );
+}
+
+#[tokio::main]
+async fn main() {
+    let args = match parse_args() {
+        Ok(args) => args,
+        Err(msg) => {
+            eprintln!("{}", msg);
+            std::process::exit(1);
+        }
+    };
+
+    let url = SensitiveUrl::from_str(&args.url).expect("invalid URL");
+    let registry = MetricsRegistry::new();
+    let config = TimestampOracleConfig::from_url(&url, &registry).expect("unsupported URL");
+    let metrics = config.metrics();
+
+    let timeline = format!("tsoracle-bench-{}", uuid::Uuid::new_v4());
+    let inner = config
+        .open(
+            timeline,
+            Timestamp::MIN,
+            SYSTEM_TIME.clone(),
+            false, /* read_only */
+        )
+        .await;
+
+    let oracle: Arc<dyn TimestampOracle<Timestamp> + Send + Sync> = if args.raw {
+        inner
+    } else {
+        Arc::new(BatchingTimestampOracle::new(Arc::clone(&metrics), inner))
+    };
+
+    println!(
+        "# url={} mode={} duration={:?} raw={}",
+        url, args.mode, args.duration, args.raw
+    );
+
+    match args.mode.as_str() {
+        "read" => {
+            for &concurrency in &args.concurrency {
+                let selects_before = metrics.batching.read_ts.batches_count.get();
+                let latencies =
+                    read_workload(Arc::clone(&oracle), concurrency, args.duration).await;
+                // Without the batching wrapper every read_ts is a backend
+                // query, but the batching metrics don't tick.
+                let backend_selects = if args.raw {
+                    u64::try_from(latencies.len()).expect("count fits in u64")
+                } else {
+                    metrics.batching.read_ts.batches_count.get() - selects_before
+                };
+                report_read(concurrency, args.duration, latencies, backend_selects);
+            }
+        }
+        "write" => {
+            let result = write_workload(Arc::clone(&oracle), args.clone()).await;
+            report_write(&args, result);
+        }
+        "mixed" => {
+            for &concurrency in &args.concurrency {
+                let selects_before = metrics.batching.read_ts.batches_count.get();
+                let write_oracle = Arc::clone(&oracle);
+                let write_args = args.clone();
+                let writer = mz_ore::task::spawn(|| "tsoracle-bench-writer", async move {
+                    write_workload(write_oracle, write_args).await
+                });
+                let latencies =
+                    read_workload(Arc::clone(&oracle), concurrency, args.duration).await;
+                let write_result = writer.await;
+                let backend_selects = metrics.batching.read_ts.batches_count.get() - selects_before;
+                report_read(concurrency, args.duration, latencies, backend_selects);
+                report_write(&args, write_result);
+            }
+        }
+        _ => unreachable!("validated in parse_args"),
+    }
+}

--- a/src/timestamp-oracle/src/batching_oracle.rs
+++ b/src/timestamp-oracle/src/batching_oracle.rs
@@ -33,7 +33,7 @@ use crate::{TimestampOracle, WriteTimestamp};
 /// can only make it so that we return later timestamps. Those later timestamps
 /// still fall within the duration of the `read_ts` call and so are linearized.
 ///
-/// Batches are processed by [`READ_TS_PIPELINE_DEPTH`] workers, so a new batch
+/// Batches are processed by `READ_TS_PIPELINE_DEPTH` workers, so a new batch
 /// can be gathered and its backing read issued while previous batches are
 /// still in flight. This pipelining is correct for the same reason batching
 /// is: each worker drains its batch _before_ issuing the backing `read_ts`, so

--- a/src/timestamp-oracle/src/batching_oracle.rs
+++ b/src/timestamp-oracle/src/batching_oracle.rs
@@ -120,7 +120,7 @@ where
             .expect("worker task cannot stop while there are outstanding commands/requests")
     }
 
-    async fn apply_write(&self, write_ts: T) {
+    async fn apply_write(&self, write_ts: T) -> T {
         self.inner.apply_write(write_ts).await
     }
 }

--- a/src/timestamp-oracle/src/batching_oracle.rs
+++ b/src/timestamp-oracle/src/batching_oracle.rs
@@ -32,10 +32,31 @@ use crate::{TimestampOracle, WriteTimestamp};
 /// result as of an earlier moment, but batching them up is correct because this
 /// can only make it so that we return later timestamps. Those later timestamps
 /// still fall within the duration of the `read_ts` call and so are linearized.
+///
+/// Batches are processed by [`READ_TS_PIPELINE_DEPTH`] workers, so a new batch
+/// can be gathered and its backing read issued while previous batches are
+/// still in flight. This pipelining is correct for the same reason batching
+/// is: each worker drains its batch _before_ issuing the backing `read_ts`, so
+/// the returned timestamp is determined during every waiter's `read_ts` call.
+/// Distinct callers whose calls overlap may observe timestamps in either
+/// completion order, which linearizability allows for concurrent operations.
+/// Calls that do not overlap stay ordered: a call that starts after another
+/// completed is served by a backing read issued after the earlier one
+/// finished, and the backing oracle's read timestamp never regresses.
 pub struct BatchingTimestampOracle<T> {
     inner: Arc<dyn TimestampOracle<T> + Send + Sync>,
     command_tx: UnboundedSender<Command<T>>,
 }
+
+/// The number of concurrent read batches that may be in flight against the
+/// backing oracle.
+///
+/// A depth of 1 gives strictly serialized batches: while a batch is in flight,
+/// waiters queue up for the next batch, adding up to a full backing-oracle
+/// round trip of latency. A depth of 2 lets the next batch be issued
+/// immediately, cutting that queueing delay, in exchange for up to twice the
+/// query rate against the backing store when reads are saturated.
+const READ_TS_PIPELINE_DEPTH: usize = 2;
 
 /// A command on the internal batching command stream.
 enum Command<T> {
@@ -54,40 +75,63 @@ where
 {
     /// Crates a [`BatchingTimestampOracle`] that uses the given inner oracle.
     pub fn new(metrics: Arc<Metrics>, oracle: Arc<dyn TimestampOracle<T> + Send + Sync>) -> Self {
-        let (command_tx, mut command_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (command_tx, command_rx) = tokio::sync::mpsc::unbounded_channel();
+        let command_rx = Arc::new(tokio::sync::Mutex::new(command_rx));
 
-        let task_oracle = Arc::clone(&oracle);
+        for worker_id in 0..READ_TS_PIPELINE_DEPTH {
+            let task_oracle = Arc::clone(&oracle);
+            let metrics = Arc::clone(&metrics);
+            let command_rx = Arc::clone(&command_rx);
 
-        mz_ore::task::spawn(|| "BatchingTimestampOracle Worker Task", async move {
-            let read_ts_metrics = &metrics.batching.read_ts;
+            mz_ore::task::spawn(
+                move || format!("BatchingTimestampOracle Worker Task {}", worker_id),
+                async move {
+                    let read_ts_metrics = &metrics.batching.read_ts;
 
-            // See comment on `BatchingTimestampOracle` for why this batching is
-            // correct.
-            while let Some(cmd) = command_rx.recv().await {
-                let mut pending_cmds = vec![cmd];
-                while let Ok(cmd) = command_rx.try_recv() {
-                    pending_cmds.push(cmd);
-                }
+                    // See comment on `BatchingTimestampOracle` for why this
+                    // batching and pipelining is correct.
+                    loop {
+                        // NOTE: The receiver lock must be released before the
+                        // backing read_ts call below, so that another worker
+                        // can gather the next batch while this one's read is
+                        // in flight. A worker parked on `recv` holds the lock,
+                        // which is fine: exactly one worker gathers commands
+                        // at a time, the others park on the lock.
+                        let pending_cmds = {
+                            let mut command_rx = command_rx.lock().await;
+                            match command_rx.recv().await {
+                                Some(cmd) => {
+                                    let mut pending_cmds = vec![cmd];
+                                    while let Ok(cmd) = command_rx.try_recv() {
+                                        pending_cmds.push(cmd);
+                                    }
+                                    pending_cmds
+                                }
+                                None => break,
+                            }
+                        };
 
-                read_ts_metrics
-                    .ops_count
-                    .inc_by(u64::cast_from(pending_cmds.len()));
-                read_ts_metrics.batches_count.inc();
+                        read_ts_metrics
+                            .ops_count
+                            .inc_by(u64::cast_from(pending_cmds.len()));
+                        read_ts_metrics.batches_count.inc();
 
-                let ts = task_oracle.read_ts().await;
-                for cmd in pending_cmds {
-                    match cmd {
-                        Command::ReadTs(response_tx) => {
-                            // It's okay if the receiver drops, just means
-                            // they're not interested anymore.
-                            let _ = response_tx.send(ts.clone());
+                        let ts = task_oracle.read_ts().await;
+                        for cmd in pending_cmds {
+                            match cmd {
+                                Command::ReadTs(response_tx) => {
+                                    // It's okay if the receiver drops, just means
+                                    // they're not interested anymore.
+                                    let _ = response_tx.send(ts.clone());
+                                }
+                            }
                         }
                     }
-                }
-            }
 
-            tracing::debug!("shutting down BatchingTimestampOracle task");
-        });
+                    tracing::debug!("shutting down BatchingTimestampOracle task");
+                },
+            );
+        }
 
         Self {
             inner: oracle,

--- a/src/timestamp-oracle/src/foundationdb_oracle.rs
+++ b/src/timestamp-oracle/src/foundationdb_oracle.rs
@@ -435,7 +435,7 @@ where
         &self,
         trx: &Transaction,
         write_ts: Timestamp,
-    ) -> Result<(), FdbTransactError> {
+    ) -> Result<Timestamp, FdbTransactError> {
         // Update read_ts = GREATEST(read_ts, write_ts)
         let current_read = trx.get(&self.read_ts_key, false).await?;
         let current_read_ts: PackableTimestamp = match current_read {
@@ -447,10 +447,13 @@ where
             }
         };
 
-        if write_ts > current_read_ts.0 {
+        let new_read_ts = if write_ts > current_read_ts.0 {
             let new_ts_packed = pack(&PackableTimestamp(write_ts));
             trx.set(&self.read_ts_key, &new_ts_packed);
-        }
+            write_ts
+        } else {
+            current_read_ts.0
+        };
 
         // Update write_ts = GREATEST(write_ts, write_ts_param)
         let current_write = trx.get(&self.write_ts_key, false).await?;
@@ -468,7 +471,7 @@ where
             trx.set(&self.write_ts_key, &new_ts_packed);
         }
 
-        Ok::<_, FdbTransactError>(())
+        Ok::<_, FdbTransactError>(new_read_ts)
     }
 }
 
@@ -581,12 +584,13 @@ where
         read_ts
     }
 
-    async fn apply_write(&self, write_ts: Timestamp) {
+    async fn apply_write(&self, write_ts: Timestamp) -> Timestamp {
         if self.read_only {
             panic!("attempting apply_write in read-only mode");
         }
 
-        self.metrics
+        let read_ts = self
+            .metrics
             .oracle
             .apply_write
             .run_op(|| async {
@@ -610,8 +614,11 @@ where
         debug!(
             timeline = ?self.timeline,
             write_ts = ?write_ts,
+            read_ts = ?read_ts,
             "returning from apply_write()"
         );
+
+        read_ts
     }
 }
 

--- a/src/timestamp-oracle/src/lib.rs
+++ b/src/timestamp-oracle/src/lib.rs
@@ -64,7 +64,12 @@ pub trait TimestampOracle<T>: std::fmt::Debug {
     ///
     /// All subsequent values of `self.read_ts()` will be greater or equal to
     /// `write_ts`.
-    async fn apply_write(&self, lower_bound: T);
+    ///
+    /// Returns the read timestamp that resulted from applying this write, as
+    /// if by an atomic `apply_write` immediately followed by a `read_ts`.
+    /// Callers can use it in place of a subsequent `read_ts` call, saving a
+    /// round trip to the backing store.
+    async fn apply_write(&self, lower_bound: T) -> T;
 }
 
 /// A [`NowFn`] that is generic over the timestamp.
@@ -159,13 +164,17 @@ pub mod tests {
         assert_eq!(oracle.peek_write_ts().await, Timestamp::from(0u64));
         assert_eq!(oracle.peek_write_ts().await, Timestamp::from(0u64));
 
-        // Interesting scenarios around apply_write, from its rustdoc.
+        // Interesting scenarios around apply_write, from its rustdoc. The
+        // return value of apply_write must match a subsequent read_ts.
         //
         // Scenario #1:
         // input <= r_0 <= w_0 -> r_1 = r_0 and w_1 = w_0
         let timeline = uuid::Uuid::new_v4().to_string();
         let oracle = new_fn(timeline, NowFn::from(|| 0u64), 10u64.into()).await;
-        oracle.apply_write(5u64.into()).await;
+        assert_eq!(
+            oracle.apply_write(5u64.into()).await,
+            Timestamp::from(10u64)
+        );
         assert_eq!(oracle.peek_write_ts().await, Timestamp::from(10u64));
         assert_eq!(oracle.read_ts().await, Timestamp::from(10u64));
 
@@ -178,7 +187,7 @@ pub mod tests {
         assert_eq!(oracle.write_ts().await.timestamp, Timestamp::from(2u64));
         assert_eq!(oracle.write_ts().await.timestamp, Timestamp::from(3u64));
         assert_eq!(oracle.write_ts().await.timestamp, Timestamp::from(4u64));
-        oracle.apply_write(2u64.into()).await;
+        assert_eq!(oracle.apply_write(2u64.into()).await, Timestamp::from(2u64));
         assert_eq!(oracle.peek_write_ts().await, Timestamp::from(4u64));
         assert_eq!(oracle.read_ts().await, Timestamp::from(2u64));
 
@@ -186,10 +195,10 @@ pub mod tests {
         // r_0 <= w_0 <= input -> r_1 = input and w_1 = input
         let timeline = uuid::Uuid::new_v4().to_string();
         let oracle = new_fn(timeline, NowFn::from(|| 0u64), 0u64.into()).await;
-        oracle.apply_write(2u64.into()).await;
+        assert_eq!(oracle.apply_write(2u64.into()).await, Timestamp::from(2u64));
         assert_eq!(oracle.peek_write_ts().await, Timestamp::from(2u64));
         assert_eq!(oracle.read_ts().await, Timestamp::from(2u64));
-        oracle.apply_write(4u64.into()).await;
+        assert_eq!(oracle.apply_write(4u64.into()).await, Timestamp::from(4u64));
         assert_eq!(oracle.peek_write_ts().await, Timestamp::from(4u64));
         assert_eq!(oracle.read_ts().await, Timestamp::from(4u64));
 

--- a/src/timestamp-oracle/src/postgres_oracle.rs
+++ b/src/timestamp-oracle/src/postgres_oracle.rs
@@ -861,27 +861,36 @@ where
     }
 
     #[mz_ore::instrument(name = "oracle::apply_write")]
-    async fn fallible_apply_write(&self, write_ts: Timestamp) -> Result<(), anyhow::Error> {
+    async fn fallible_apply_write(&self, write_ts: Timestamp) -> Result<Timestamp, anyhow::Error> {
         if self.read_only {
             panic!("attempting apply_write in read-only mode");
         }
 
+        // RETURNING gives us the post-update read_ts within the same
+        // (implicit) transaction, so it is a linearized read that comes for
+        // free with the round trip we pay anyway.
         let q = r#"
             UPDATE timestamp_oracle SET write_ts = GREATEST(write_ts, $2), read_ts = GREATEST(read_ts, $2)
-                WHERE timeline = $1;
+                WHERE timeline = $1
+            RETURNING read_ts;
         "#;
         let client = self.get_connection().await?;
         let statement = client.prepare_cached(q).await?;
         let write_ts = Self::ts_to_decimal(write_ts);
 
-        let _ = pg_execute_prepared(&client, &statement, &[&self.timeline, &write_ts]).await?;
+        let result =
+            pg_query_one_prepared(&client, &statement, &[&self.timeline, &write_ts]).await?;
+
+        let read_ts: Numeric = result.try_get("read_ts").expect("missing column read_ts");
+        let read_ts = Self::decimal_to_ts(read_ts);
 
         debug!(
             timeline = ?self.timeline,
             write_ts = ?write_ts,
+            read_ts = ?read_ts,
             "returning from apply_write()");
 
-        Ok(())
+        Ok(read_ts)
     }
 
     // We could add `From` impls for these but for now keep the code local to
@@ -956,7 +965,7 @@ where
     }
 
     #[instrument]
-    async fn apply_write(&self, write_ts: Timestamp) {
+    async fn apply_write(&self, write_ts: Timestamp) -> Timestamp {
         let metrics = &self.metrics.retries.apply_write;
 
         let res = retry_fallible(metrics, || {


### PR DESCRIPTION
### Motivation

Every timestamp oracle operation is a query against the backing metadata store. Profiling the
oracle traffic of a running environment showed three fixed costs:

* A group commit costs **4 oracle queries**: `peek_write_ts` (pacing), `write_ts`,
  `apply_write`, and a trailing `read_ts` from `advance_timelines` for read-hold downgrades.
  Two of these run on the coordinator main loop, so at realistic metadata-store round-trip
  times they also block everything else.
* An idle environment generates a constant **~4.4 oracle queries/s** from the 1s
  table-advancement tick, forever, per environment.
* The read side is batched, but batches were strictly serialized: the backing query rate pins
  at ~1/RTT and a loaded `read_ts` waits ~2 RTTs (queue behind the in-flight batch, then ride
  the next one).

This PR adds a benchmark that demonstrates those limits and then removes about half of the
per-commit and idle oracle traffic and hides most of the per-query oracle latency, one change
per commit.

### The changes

1. **`tsoracle_bench` example** (`src/timestamp-oracle/examples/tsoracle_bench.rs`): drives the
   real `BatchingTimestampOracle`/`PostgresTimestampOracle` stack against a backing store and
   reports client throughput, latency percentiles, and the number of queries that actually hit
   the backing store. `write` mode replicates the group-commit protocol, with flags to model
   protocol changes.
2. **`apply_write` returns the resulting `read_ts`** via `RETURNING` on the UPDATE it already
   pays for. That value is a linearized read for any caller already waiting when the call was
   made (the same argument that makes the batching oracle correct). Group commit forwards it
   with `AdvanceTimelines`, eliminating the trailing `read_ts` query per commit.
3. **Group-commit pacing without `peek_write_ts`**: the pacing check only needs a lower bound
   on the oracle write timestamp, so track the largest `write_ts` this process has observed.
   An underestimate means the commit proceeds and lands ahead of `now()`, which group commit
   already explicitly tolerates, and the bound self-corrects with that commit's own `write_ts`.
4. **Pipelined read batches**: two batching workers instead of one, so the next batch is
   gathered and issued while the previous one is in flight. Correct because each batch's
   backing read is issued after all its requests arrived; non-overlapping calls stay ordered
   because the backing read timestamp never regresses.
5. **Overlap the oracle read with planning in frontend peeks**: kick the `read_ts` off
   speculatively at the start of sequencing and await it at timestamp selection, hiding the
   round trip behind name resolution, planning, and RBAC. The read starts after the query
   arrived, so real-time bounds hold exactly as before. Wasted speculative reads join a batch,
   so their marginal backing-store cost is negligible.
6. **Idle tick backoff** (`coord_idle_advance_timelines_multiplier` dyncfg, default 1 = today's
   behavior): while zero SQL connections exist, only every Nth tick runs the empty group
   commit. Safe because nobody can observe the skipped advancements: a new connection's
   `mz_sessions` write forces an immediate group commit, and the connection's first query
   waits for it (verified: first query after idle returns fresh results in ~30ms including
   connection setup).

### Measurements

Setup: local `environmentd` (optimized build, single writer) with only the timestamp oracle
routed through a toxiproxy adding 2ms RTT to Postgres, so oracle round trips are visible the
way they are against a real CRDB/Postgres deployment. Client: autocommit `INSERT`s on one
connection, single-row strict-serializable `SELECT`s. Oracle query counts come from
`mz_ts_oracle_*` metrics and are deterministic; latencies are medians of repeated runs.

| Metric | Baseline | After this PR | Change |
|---|---|---|---|
| Oracle queries per group commit | 4.00 | 2.00 | **-2x** |
| Idle oracle queries/s (default config) | 4.40 | 2.33 | **-1.9x** |
| Idle oracle queries/s (multiplier 10) | 4.40 | 0.53 | **-8.3x** |
| INSERT p50 | 11.15ms | 6.46ms | **-42%** |
| INSERT throughput (1 conn) | 89/s | 154/s | **+72%** |
| SELECT p50 (1 conn) | ~9.4ms | ~4.8ms | **-49%** |

Micro-benchmark (read mode, 2ms RTT, 8 concurrent readers): +29% `read_ts` throughput, mean
latency 4.4ms to 3.4ms. The pipelining change is a deliberate latency-for-load tradeoff: under
fully saturated reads the backing query rate cap doubles (still bounded at depth/RTT). The
other changes strictly reduce load.

The INSERT improvements come from two round trips removed per commit, one of which
(`peek_write_ts`) ran on the coordinator main loop and the other (`advance_timelines`
`read_ts`) blocked the loop between commits. The SELECT improvement combines the pipelined
batches with the planning overlap (the overlap alone accounts for ~1.3ms of the 2.2ms RTT,
measured on stable repeated runs).

### Testing

* The trait-level contract tests (`timestamp_oracle_impl_test`) now assert the return value of
  `apply_write` in all three of its rustdoc scenarios, and run against real Postgres for the
  Postgres and batching oracles.
* The `tsoracle_bench` example is the reproduction harness for all numbers above.
* Each commit was additionally validated against a live environmentd (thousands of inserts and
  selects per commit, plus the reconnect-after-idle freshness check for the tick backoff).

### Notes for reviewers

* The pipeline depth of 2 is a crate-level constant for now; if we want to tune it per
  deployment it should move into `TimestampOracleParameters`.
* `coord_idle_advance_timelines_multiplier` ships default-off (1). Picking a fleet default is
  a product decision; the mechanism and its safety argument are what this PR establishes.
* The FoundationDB oracle change returns the new `read_ts` from the same transaction that
  applies the write; the maelstrom `MemTimestampOracle` is updated likewise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
