### PR TITLE
expr, transform: Add cargo-fuzz targets

### DIFF
--- a/src/expr/fuzz/.gitignore
+++ b/src/expr/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/expr/fuzz/Cargo.toml
+++ b/src/expr/fuzz/Cargo.toml
@@ -1,0 +1,104 @@
+# Fuzz crate for mz-expr proto round-trip properties.
+#
+# Excluded from the main workspace because libFuzzer requires nightly Rust.
+# Run via the repo-wide runner: `bin/ci-builder run nightly ci/test/cargo-fuzz.sh`,
+# or locally:
+#     cd src/expr/fuzz
+#     cargo +nightly fuzz run eval_error_proto_roundtrip -- -max_total_time=60
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-expr-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-expr = { path = "..", features = ["proptest"] }
+mz-repr = { path = "../../repr" }
+mz-pgtz = { path = "../../pgtz" }
+chrono = { version = "0.4", default-features = false }
+mz-proto = { path = "../../proto" }
+prost = "0.14.3"
+proptest = "1"
+
+[[bin]]
+name = "eval_error_proto_roundtrip"
+path = "fuzz_targets/eval_error_proto_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "like_pattern_compile"
+path = "fuzz_targets/like_pattern_compile.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "mir_scalar_reduce"
+path = "fuzz_targets/mir_scalar_reduce.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "mfp_optimize"
+path = "fuzz_targets/mfp_optimize.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "agg_decompose"
+path = "fuzz_targets/agg_decompose.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "build_regex"
+path = "fuzz_targets/build_regex.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "timezone_convert"
+path = "fuzz_targets/timezone_convert.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "jsonb_get"
+path = "fuzz_targets/jsonb_get.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "like_pattern_escape"
+path = "fuzz_targets/like_pattern_escape.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "cast_string"
+path = "fuzz_targets/cast_string.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "jsonb_path"
+path = "fuzz_targets/jsonb_path.rs"
+test = false
+doc = false
+bench = false

--- a/src/expr/fuzz/fuzz_targets/agg_decompose.rs
+++ b/src/expr/fuzz/fuzz_targets/agg_decompose.rs
@@ -1,0 +1,324 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: aggregate functions must obey the decomposition laws that
+//! Materialize's *incremental* reduce relies on. The dataflow engine never
+//! re-aggregates a group from scratch. It maintains aggregates by combining
+//! partial results, so each aggregate must satisfy:
+//!
+//!  * **Permutation invariance** (every order-insensitive aggregate): the result
+//!    must not depend on the order the inputs arrive in. Accumulable maintenance
+//!    (sum, count) applies updates in arrival order, so any order-dependence is a
+//!    correctness bug.
+//!  * **Hierarchical re-aggregation** (min/max/any/all, idempotent aggregates
+//!    whose output type equals their input type): `agg(whole)` must equal
+//!    `agg([agg(chunk0), agg(chunk1), ...])` over the non-empty chunks of an
+//!    arbitrary partition. This is exactly how the bucketed hierarchical reduce
+//!    computes min/max, and it must hold even with nulls present in the data.
+//!  * **Additive decomposition**: `count(whole)` must equal the sum of the
+//!    per-chunk counts. Likewise `sum(whole)` must equal the sum of the
+//!    per-chunk sums (this is exactly how accumulable maintenance combines
+//!    partial sums across batches). We check the sum law for the *integer* sums
+//!    (`SumInt32`/`SumInt64`), where the per-chunk combination is exact.
+//!
+//! We generate a random multiset of nullable datums in one of several type
+//! groups, a random permutation of it, and a random partition into chunks, then
+//! check the applicable laws for each aggregate over the chosen group.
+//!
+//! Groups: `int4`/`int8`/`bool` (exact integers/booleans, plain equality
+//! oracle), `text` (lexicographic min/max), plus `float8` and `numeric`. The
+//! float/numeric groups exercise the `OrderedFloat`/`OrderedDecimal` ordering
+//! used by min/max and feed in the tricky special values (`NaN`, `±Inf`,
+//! `-0.0`). We only apply min/max to the float/numeric groups: floating-point
+//! and bounded-decimal *sum* is not
+//! associative under rounding, so an additive/permutation law over it would be
+//! a generator artifact rather than a real product invariant. Datum equality is
+//! `OrderedFloat`-based (so `NaN == NaN`), so it is a sound oracle for the
+//! ordering aggregates even with NaN present.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::AggregateFunc;
+use mz_repr::{Datum, Diff, RowArena};
+
+const MAX_ROWS: usize = 24;
+const MAX_CHUNKS: usize = 4;
+
+#[derive(Clone, Copy)]
+enum Group {
+    Int32,
+    Int64,
+    Bool,
+    Float64,
+    Numeric,
+    Str,
+}
+
+/// A small fixed pool of `'static` strings for the text min/max group. Keeping
+/// them `'static` lets text datums flow through the same `Datum<'static>`
+/// shuffle/partition machinery as the scalar groups. The set is deliberately
+/// tiny so duplicates and ties are common (which is what stresses min/max's
+/// hierarchical tie-breaking), and includes the empty string and a prefix pair
+/// (`"a"`/`"ab"`) where lexicographic ordering is subtle.
+const POOL_STR: &[&str] = &["", "a", "ab", "abc", "b", "Z", "z", "10", "9"];
+
+/// Which decomposition laws apply to an aggregate (permutation invariance always
+/// applies and is checked separately).
+enum Law {
+    /// Idempotent, output type == input type: `agg(whole) == agg(map(agg, parts))`.
+    Hierarchical,
+    /// `count(whole) == sum(map(count, parts))`.
+    AdditiveCount,
+    /// `sum(whole) == sum(map(sum, parts))`, with null partials (empty/all-null
+    /// chunks) skipped. Only sound for the exact-integer sums.
+    AdditiveSum,
+}
+
+/// Float values worth probing: ordinary magnitudes plus the IEEE-754 corners
+/// that the `OrderedFloat` total order has to canonicalize (NaN as the maximum,
+/// the two infinities, and signed zeros, where `-0.0 == 0.0` but distinct bits).
+const SPECIAL_F64: &[f64] = &[
+    0.0,
+    -0.0,
+    1.0,
+    -1.0,
+    f64::INFINITY,
+    f64::NEG_INFINITY,
+    f64::NAN,
+    f64::MIN,
+    f64::MAX,
+];
+
+fn gen_datum(u: &mut Unstructured, group: Group) -> arbitrary::Result<Datum<'static>> {
+    if u.ratio(1u8, 5u8)? {
+        return Ok(Datum::Null);
+    }
+    Ok(match group {
+        Group::Int32 => Datum::Int32(i32::arbitrary(u)?),
+        Group::Int64 => Datum::Int64(i64::arbitrary(u)?),
+        Group::Bool => {
+            if bool::arbitrary(u)? {
+                Datum::True
+            } else {
+                Datum::False
+            }
+        }
+        Group::Float64 => {
+            // Bias toward the special values so min/max actually has to order
+            // NaN/Inf/-0.0 against ordinary numbers. Otherwise a fully random
+            // f64 almost never lands on a corner case.
+            let f = if u.ratio(1u8, 2u8)? {
+                let i = u.int_in_range(0..=SPECIAL_F64.len() - 1)?;
+                SPECIAL_F64[i]
+            } else {
+                f64::arbitrary(u)?
+            };
+            Datum::from(f)
+        }
+        Group::Numeric => {
+            // Integer-valued numerics keep min/max exact and easy to read. The
+            // point of the group is the `OrderedDecimal` comparison path, not
+            // fractional precision.
+            Datum::from(i128::from(i64::arbitrary(u)?))
+        }
+        Group::Str => {
+            let i = u.int_in_range(0..=POOL_STR.len() - 1)?;
+            Datum::String(POOL_STR[i])
+        }
+    })
+}
+
+fn aggregates(group: Group) -> Vec<(AggregateFunc, Law)> {
+    match group {
+        Group::Int32 => vec![
+            (AggregateFunc::MaxInt32, Law::Hierarchical),
+            (AggregateFunc::MinInt32, Law::Hierarchical),
+            (AggregateFunc::SumInt32, Law::AdditiveSum),
+            (AggregateFunc::Count, Law::AdditiveCount),
+        ],
+        Group::Int64 => vec![
+            (AggregateFunc::MaxInt64, Law::Hierarchical),
+            (AggregateFunc::MinInt64, Law::Hierarchical),
+            (AggregateFunc::SumInt64, Law::AdditiveSum),
+            (AggregateFunc::Count, Law::AdditiveCount),
+        ],
+        Group::Bool => vec![
+            (AggregateFunc::MaxBool, Law::Hierarchical),
+            (AggregateFunc::MinBool, Law::Hierarchical),
+            (AggregateFunc::Any, Law::Hierarchical),
+            (AggregateFunc::All, Law::Hierarchical),
+            (AggregateFunc::Count, Law::AdditiveCount),
+        ],
+        // Float/numeric sum is not exactly associative under rounding, so we only
+        // assert the ordering laws (min/max are total-order selections and stay
+        // exact, NaN included) and the count law.
+        Group::Float64 => vec![
+            (AggregateFunc::MaxFloat64, Law::Hierarchical),
+            (AggregateFunc::MinFloat64, Law::Hierarchical),
+            (AggregateFunc::Count, Law::AdditiveCount),
+        ],
+        Group::Numeric => vec![
+            (AggregateFunc::MaxNumeric, Law::Hierarchical),
+            (AggregateFunc::MinNumeric, Law::Hierarchical),
+            (AggregateFunc::Count, Law::AdditiveCount),
+        ],
+        // Text min/max select by lexicographic byte order, output type == input
+        // type, so the hierarchical re-aggregation law applies.
+        Group::Str => vec![
+            (AggregateFunc::MaxString, Law::Hierarchical),
+            (AggregateFunc::MinString, Law::Hierarchical),
+            (AggregateFunc::Count, Law::AdditiveCount),
+        ],
+    }
+}
+
+/// A Fisher-Yates shuffle driven by the fuzz input.
+fn shuffle(
+    u: &mut Unstructured,
+    input: &[Datum<'static>],
+) -> arbitrary::Result<Vec<Datum<'static>>> {
+    let mut v = input.to_vec();
+    for i in (1..v.len()).rev() {
+        let j = u.int_in_range(0..=i)?;
+        v.swap(i, j);
+    }
+    Ok(v)
+}
+
+/// Randomly assign each input to one of `1..=MAX_CHUNKS` chunks (some may be
+/// empty). The chunks' concatenation is a permutation of the input multiset.
+fn partition(
+    u: &mut Unstructured,
+    input: &[Datum<'static>],
+) -> arbitrary::Result<Vec<Vec<Datum<'static>>>> {
+    let k = u.int_in_range(1usize..=MAX_CHUNKS)?;
+    let mut chunks = vec![Vec::new(); k];
+    for &d in input {
+        let b = u.int_in_range(0..=k - 1)?;
+        chunks[b].push(d);
+    }
+    Ok(chunks)
+}
+
+fn as_count(d: Datum) -> i64 {
+    match d {
+        Datum::Int64(n) => n,
+        other => panic!("Count produced a non-int8 datum: {other:?}"),
+    }
+}
+
+/// Decode an integer-sum result datum to an exact `i128`. `SumInt32` yields an
+/// `Int64`, `SumInt64` yields an (integer-valued) `Numeric`. An empty/all-null
+/// chunk yields `Null` (returned as `None`). The values are bounded (<= 24
+/// inputs of at most i64 magnitude), so every partial sum fits an `i128`
+/// exactly and the per-chunk combination below is lossless.
+fn as_sum(d: Datum) -> Option<i128> {
+    match d {
+        Datum::Null => None,
+        Datum::Int64(n) => Some(i128::from(n)),
+        Datum::Numeric(n) => {
+            Some(i128::try_from(n.0).expect("integer-valued sum must fit an i128"))
+        }
+        other => panic!("integer sum produced an unexpected datum: {other:?}"),
+    }
+}
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    let group = match u.int_in_range(0u8..=5)? {
+        0 => Group::Int32,
+        1 => Group::Int64,
+        2 => Group::Bool,
+        3 => Group::Float64,
+        4 => Group::Numeric,
+        _ => Group::Str,
+    };
+
+    let n = u.int_in_range(0usize..=MAX_ROWS)?;
+    let mut input = Vec::with_capacity(n);
+    for _ in 0..n {
+        input.push(gen_datum(u, group)?);
+    }
+    let permuted = shuffle(u, &input)?;
+    let chunks = partition(u, &input)?;
+
+    let arena = RowArena::new();
+    for (agg, law) in aggregates(group) {
+        // `AggregateFunc::eval` consumes `(datum, multiplicity)` pairs. Each
+        // generated row has multiplicity one, so pair every datum with
+        // `Diff::ONE`.
+        let whole = agg.eval(input.iter().map(|&d| (d, Diff::ONE)), &arena);
+
+        // Permutation invariance: order must never matter.
+        let shuffled = agg.eval(permuted.iter().map(|&d| (d, Diff::ONE)), &arena);
+        assert_eq!(
+            whole, shuffled,
+            "{agg:?} is not permutation-invariant\n  input    = {input:?}\n  permuted = {permuted:?}"
+        );
+
+        match law {
+            Law::Hierarchical => {
+                // agg(whole) == agg(map(agg, non-empty chunks)). Empty chunks are
+                // skipped: an empty chunk aggregates to null, and for any/all
+                // (three-valued) a stray null would corrupt an otherwise false/true
+                // result (`false OR null = null`). Min/max absorb null as their
+                // identity, but skipping is correct for all of them.
+                let partials: Vec<Datum> = chunks
+                    .iter()
+                    .filter(|c| !c.is_empty())
+                    .map(|c| agg.eval(c.iter().map(|&d| (d, Diff::ONE)), &arena))
+                    .collect();
+                let reaggregated = agg.eval(partials.iter().map(|&d| (d, Diff::ONE)), &arena);
+                assert_eq!(
+                    whole, reaggregated,
+                    "{agg:?} fails hierarchical re-aggregation\n  input  = {input:?}\n  chunks = {chunks:?}\n  partials = {partials:?}"
+                );
+            }
+            Law::AdditiveCount => {
+                // count(whole) == sum(map(count, chunks))
+                let total: i64 = chunks
+                    .iter()
+                    .map(|c| as_count(agg.eval(c.iter().map(|&d| (d, Diff::ONE)), &arena)))
+                    .sum();
+                assert_eq!(
+                    as_count(whole),
+                    total,
+                    "{agg:?} fails additive decomposition\n  input  = {input:?}\n  chunks = {chunks:?}"
+                );
+            }
+            Law::AdditiveSum => {
+                // sum(whole) == sum(map(sum, chunks)), combining the non-null
+                // per-chunk partials. A chunk that is empty or all-null sums to
+                // Null and contributes nothing. If *every* element is null the
+                // whole is also Null, so both sides are "no partials" and match.
+                let partials: Vec<i128> = chunks
+                    .iter()
+                    .filter_map(|c| as_sum(agg.eval(c.iter().map(|&d| (d, Diff::ONE)), &arena)))
+                    .collect();
+                let combined: Option<i128> = if partials.is_empty() {
+                    None
+                } else {
+                    Some(partials.iter().sum())
+                };
+                assert_eq!(
+                    as_sum(whole),
+                    combined,
+                    "{agg:?} fails additive sum decomposition\n  input  = {input:?}\n  chunks = {chunks:?}"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/expr/fuzz/fuzz_targets/build_regex.rs
+++ b/src/expr/fuzz/fuzz_targets/build_regex.rs
@@ -1,0 +1,209 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `func::build_regex` compiles an untrusted regular expression
+//! (and flags) for the `regexp_*` SQL functions, and the result matches
+//! untrusted text. A user controls both, so a panic compiling or matching is a
+//! real availability bug. (The `regex` crate is linear-time and size-limited,
+//! so an oversized pattern returns an error rather than hanging or OOMing.)
+//!
+//! A random pattern often compiles, but random *text* rarely matches it, so the
+//! match-found paths (capture extraction, `replace_all`, `split` on real splits)
+//! stay under-exercised. So most inputs are generated: a structured pattern over
+//! the regex feature set (classes, groups, alternation, quantifiers, anchors,
+//! escapes) drawn from a small alphabet, plus text drawn from that *same*
+//! alphabet so matches actually fire. A quarter of inputs are still raw
+//! pattern/text bytes so the compiler's parse/reject paths keep their coverage.
+//!
+//! Beyond compile+match, we also exercise:
+//!  * `replace_all` with a replacement string carrying capture references
+//!    (`$1`, `${name}`, `$0`, a literal `$$`), so the regex crate's replacement
+//!    interpolation runs against the captures the generated text actually fills.
+//!  * occasional near-size-limit patterns built from nested counted quantifiers,
+//!    which push the compiler toward its state-count / size limit (where it must
+//!    return an error rather than hang or OOM) and toward deep AST nesting.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::func;
+
+/// Shared alphabet for pattern literals and text, so generated text tends to
+/// match the generated pattern.
+const ALPHA: &[char] = &['a', 'b', 'c', '0', '1', ' '];
+
+/// Return the longest prefix of `s` with at most `max` chars.
+fn cap(s: &str, max: usize) -> &str {
+    match s.char_indices().nth(max) {
+        Some((i, _)) => &s[..i],
+        None => s,
+    }
+}
+
+fn maybe_quantifier(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    match u.int_in_range(0u8..=5)? {
+        0 => out.push('*'),
+        1 => out.push('+'),
+        2 => out.push('?'),
+        3 => out.push_str(&format!("{{{}}}", u.int_in_range(0u32..=5)?)),
+        4 => out.push_str(&format!("{{{},}}", u.int_in_range(0u32..=3)?)),
+        _ => out.push_str(&format!(
+            "{{{},{}}}",
+            u.int_in_range(0u32..=2)?,
+            u.int_in_range(2u32..=5)?
+        )),
+    }
+    if u.int_in_range(0u8..=2)? == 0 {
+        out.push('?'); // lazy
+    }
+    Ok(())
+}
+
+fn gen_regex(
+    u: &mut Unstructured,
+    depth: u32,
+    name_id: &mut u32,
+    out: &mut String,
+) -> arbitrary::Result<()> {
+    if depth == 0 || u.is_empty() || out.len() > 256 {
+        match u.int_in_range(0u8..=3)? {
+            0 => out.push(*u.choose(ALPHA)?),
+            1 => out.push('.'),
+            2 => out.push_str(u.choose(&["\\d", "\\w", "\\s", "\\b", "\\.", "\\*", "\\p{L}"])?),
+            _ => {
+                out.push('[');
+                if u.int_in_range(0u8..=2)? == 0 {
+                    out.push('^');
+                }
+                for _ in 0..u.int_in_range(1usize..=3)? {
+                    out.push(*u.choose(ALPHA)?);
+                }
+                if u.int_in_range(0u8..=1)? == 0 {
+                    out.push_str("a-c");
+                }
+                out.push(']');
+            }
+        }
+        return Ok(());
+    }
+    let d = depth - 1;
+    match u.int_in_range(0u8..=5)? {
+        0 => gen_regex(u, d, name_id, out)?,
+        1 => {
+            for _ in 0..u.int_in_range(2usize..=3)? {
+                gen_regex(u, d, name_id, out)?;
+            }
+        }
+        2 => {
+            gen_regex(u, d, name_id, out)?;
+            out.push('|');
+            gen_regex(u, d, name_id, out)?;
+        }
+        3 => {
+            out.push('(');
+            // Mix non-capturing, plain-capturing, and named-capturing groups so
+            // both `$N` and `${name}` replacement refs resolve to real captures.
+            // Names must be unique, so derive one from a per-pattern counter.
+            match u.int_in_range(0u8..=2)? {
+                0 => out.push_str("?:"),
+                1 => {
+                    out.push_str(&format!("?P<g{}>", *name_id));
+                    *name_id += 1;
+                }
+                _ => {}
+            }
+            gen_regex(u, d, name_id, out)?;
+            out.push(')');
+            maybe_quantifier(u, out)?;
+        }
+        4 => {
+            gen_regex(u, d, name_id, out)?;
+            maybe_quantifier(u, out)?;
+        }
+        _ => {
+            if u.int_in_range(0u8..=1)? == 0 {
+                out.push('^');
+            }
+            gen_regex(u, d, name_id, out)?;
+            if u.int_in_range(0u8..=1)? == 0 {
+                out.push('$');
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Builds a deeply nested chain of counted quantifiers whose multiplied bounds
+/// approach the regex crate's compiled-size limit, e.g. `(?:(?:a{40}){40}){40}`.
+/// `build_regex` must reject this with an error (PatternTooLarge or the regex
+/// crate's CompiledTooBig) rather than hang or OOM.
+fn gen_near_limit(u: &mut Unstructured, out: &mut String) -> arbitrary::Result<()> {
+    let layers = u.int_in_range(2usize..=5)?;
+    for _ in 0..layers {
+        out.push_str("(?:");
+    }
+    out.push(*u.choose(ALPHA)?);
+    for _ in 0..layers {
+        out.push_str(&format!("){{{}}}", u.int_in_range(2u32..=60)?));
+    }
+    Ok(())
+}
+
+/// A replacement string mixing several capture-reference forms so the regex
+/// crate's interpolation runs against whatever captures the match produced:
+/// numbered (`$1`), named-braced (`${g0}`), the whole match (`$0`), a literal
+/// `$$`, and an out-of-range index (`$99`, which interpolates to empty).
+const REPLACEMENT: &str = "x$1-${g0}-$0-$$-$99y";
+
+fn drive(pattern: &str, flags: &str, text: &str) {
+    let pattern = cap(pattern, 4096);
+    let text = cap(text, 4096);
+    let Ok(regex) = func::build_regex(pattern, flags) else {
+        return;
+    };
+    let _ = regex.is_match(text);
+    let _ = regex.find(text);
+    let _ = regex.captures(text);
+    // Plain deletion plus capture-ref interpolation (exercises the replacement
+    // parser and capture-group lookup against real matches).
+    let _ = regex.replace_all(text, "");
+    let _ = regex.replace_all(text, REPLACEMENT);
+    let _ = regex.split(text).count();
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let flags = *u.choose(&["", "i", "c", "ic", "ci"])?;
+    // A quarter of the time, raw pattern/text bytes (the compiler's parse paths).
+    if u.int_in_range(0u8..=3)? == 0 {
+        let pattern: String = u.arbitrary()?;
+        let text: String = u.arbitrary()?;
+        drive(&pattern, flags, &text);
+        return Ok(());
+    }
+    let mut pattern = String::new();
+    // Occasionally emit a near-size-limit nested-quantifier pattern (the
+    // compiler must reject it cleanly). Otherwise the structured generator.
+    if u.int_in_range(0u8..=7)? == 0 {
+        gen_near_limit(&mut u, &mut pattern)?;
+    } else {
+        let mut name_id = 0u32;
+        gen_regex(&mut u, 3, &mut name_id, &mut pattern)?;
+    }
+    let mut text = String::new();
+    for _ in 0..u.int_in_range(0usize..=24)? {
+        text.push(*u.choose(ALPHA)?);
+    }
+    drive(&pattern, flags, &text);
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/expr/fuzz/fuzz_targets/cast_string.rs
+++ b/src/expr/fuzz/fuzz_targets/cast_string.rs
@@ -1,0 +1,163 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: the string->scalar cast functions parse untrusted text into a
+//! typed value (`'...'::bigint`, `'...'::uuid`). These are hand-written parsers
+//! reached directly from user SQL, so a panic on crafted input is an
+//! availability bug. `cast_string_to_uuid` in particular wraps the `uuid`
+//! crate, whose parser has panicked on malformed input before. We evaluate each
+//! cast on the text and require it to return an `EvalError`, not panic.
+//!
+//! Purely random text almost never resembles a UUID or a boundary integer, so a
+//! raw `&str` plateaus on the early-reject paths and barely reaches the parsers'
+//! interesting branches. Instead we mostly *construct* the candidate string:
+//!  * UUID-shaped strings: 32 hex digits with dashes placed at the canonical
+//!    8/12/16/20 offsets (and off-by-one offsets), optional `{...}` / `urn:uuid:`
+//!    wrappers, off-by-one digit counts, and an occasional embedded NUL, to
+//!    drive the hyphen-position / length / wrapper handling in the uuid parser.
+//!  * Boundary `int64` strings: values around `i64::{MIN,MAX}`, off-by-one past
+//!    them (overflow path), leading `+`/`-`/zeros/whitespace, and embedded NUL.
+//! A fraction of inputs remain fully arbitrary text so the early-reject paths
+//! keep their coverage.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::{func, Eval, MirScalarExpr, UnaryFunc};
+use mz_repr::{Datum, ReprScalarType, RowArena};
+
+const HEX: &[u8] = b"0123456789abcdefABCDEF";
+
+/// Builds a UUID-shaped candidate string: hex body, dashes at chosen offsets,
+/// optional wrapper, occasionally perturbed so it lands just off a valid form.
+fn gen_uuid_like(u: &mut Unstructured) -> arbitrary::Result<String> {
+    // Number of hex digits: usually 32 (canonical), sometimes off-by-one.
+    let n_hex = match u.int_in_range(0u8..=4)? {
+        0 => 31usize,
+        1 => 33,
+        _ => 32,
+    };
+    let mut hex = String::with_capacity(n_hex);
+    for _ in 0..n_hex {
+        hex.push(*u.choose(HEX)? as char);
+    }
+
+    // Dash placement: canonical 8/12/16/20, off-by-one, none, or scattered.
+    let body = match u.int_in_range(0u8..=4)? {
+        0 => hex.clone(), // no dashes (uuid::simple form)
+        1 => insert_dashes(&hex, &[8, 12, 16, 20]),
+        2 => insert_dashes(&hex, &[8, 12, 16, 20]), // canonical, weighted
+        3 => insert_dashes(&hex, &[7, 12, 16, 20]), // off-by-one first group
+        _ => {
+            // Scatter a few dashes at fuzzer-chosen positions.
+            let mut positions = Vec::new();
+            for _ in 0..u.int_in_range(0usize..=5)? {
+                positions.push(u.int_in_range(0usize..=hex.len())?);
+            }
+            positions.sort_unstable();
+            insert_dashes(&hex, &positions)
+        }
+    };
+
+    // Optional wrapper.
+    let mut s = match u.int_in_range(0u8..=3)? {
+        0 => format!("{{{body}}}"),
+        1 => format!("urn:uuid:{body}"),
+        2 => format!("{{urn:uuid:{body}}}"),
+        _ => body,
+    };
+
+    // Occasionally embed a NUL or stray byte to probe parser robustness.
+    if u.int_in_range(0u8..=7)? == 0 {
+        let pos = u.int_in_range(0usize..=s.len())?;
+        // Find a char boundary at or before `pos`.
+        let pos = (0..=pos)
+            .rev()
+            .find(|&p| s.is_char_boundary(p))
+            .unwrap_or(0);
+        s.insert(pos, '\0');
+    }
+    Ok(s)
+}
+
+/// Inserts `-` into `hex` at the given (ascending) char offsets.
+fn insert_dashes(hex: &str, offsets: &[usize]) -> String {
+    let mut out = String::with_capacity(hex.len() + offsets.len());
+    for (i, c) in hex.chars().enumerate() {
+        if offsets.contains(&i) {
+            out.push('-');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Builds a boundary-ish int64 string: values near the i64 limits, just past
+/// them, with leading sign/zeros/whitespace, or an embedded NUL.
+fn gen_int_like(u: &mut Unstructured) -> arbitrary::Result<String> {
+    let base: &str = u.choose(&[
+        "0",
+        "-0",
+        "+0",
+        "9223372036854775807",  // i64::MAX
+        "9223372036854775808",  // i64::MAX + 1 (overflow)
+        "-9223372036854775808", // i64::MIN
+        "-9223372036854775809", // i64::MIN - 1 (overflow)
+        "99999999999999999999", // way past
+        "-1",
+        "+1",
+    ])?;
+    let mut s = String::new();
+    // Optional leading whitespace / extra zeros / sign.
+    match u.int_in_range(0u8..=4)? {
+        0 => s.push_str("  "),
+        1 => s.push('\t'),
+        2 => s.push('+'),
+        3 => s.push_str("000"),
+        _ => {}
+    }
+    s.push_str(base);
+    // Optional trailing junk / NUL.
+    match u.int_in_range(0u8..=5)? {
+        0 => s.push_str("  "),
+        1 => s.push('\0'),
+        2 => s.push('x'),
+        _ => {}
+    }
+    Ok(s)
+}
+
+fn drive(s: &str) {
+    let arena = RowArena::new();
+    let input = || MirScalarExpr::literal_ok(Datum::String(s), ReprScalarType::String);
+
+    let _ = input()
+        .call_unary(UnaryFunc::CastStringToInt64(func::CastStringToInt64))
+        .eval(&[], &arena);
+    let _ = input()
+        .call_unary(UnaryFunc::CastStringToUuid(func::CastStringToUuid))
+        .eval(&[], &arena);
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let s = match u.int_in_range(0u8..=4)? {
+        // Mostly UUID-shaped (the uuid crate is the higher-risk parser).
+        0 | 1 | 2 => gen_uuid_like(&mut u)?,
+        3 => gen_int_like(&mut u)?,
+        // A fraction fully arbitrary, preserving the early-reject coverage.
+        _ => u.arbitrary()?,
+    };
+    drive(&s);
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/expr/fuzz/fuzz_targets/eval_error_proto_roundtrip.rs
+++ b/src/expr/fuzz/fuzz_targets/eval_error_proto_roundtrip.rs
@@ -1,0 +1,90 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `EvalError` must survive a proto re-encode + re-decode with the
+//! same value, exercising lossy proto conversions where the wire form decodes
+//! into a value that doesn't round-trip back to itself.
+//!
+//! Two input modes share the byte stream (the first byte selects the mode):
+//!
+//!   * Mode A (Arbitrary): drive proptest's `Arbitrary` impl for `EvalError`
+//!     from the libFuzzer byte stream to synthesize a *valid, deeply nested*
+//!     `EvalError` (one of 80+ variants, several carrying `char`, `usize`,
+//!     nested `NumericMaxScale`/`InvalidArrayError`/`DomainLimit` invariants).
+//!     We then assert `from_proto(into_proto(v)) == v`. Random bytes decoded as
+//!     a proto almost always yield near-empty/default messages, so this arm is
+//!     what actually reaches the interesting variants and their narrowing /
+//!     validation logic (`char::from_proto`, `usize`/`u32` casts, etc.).
+//!
+//!   * Mode B (raw bytes): decode the remaining bytes directly as
+//!     `ProtoEvalError` and, if it converts to Rust, assert it round-trips.
+//!     Kept for robustness against hand-crafted / malformed wire forms that the
+//!     structured generator would never produce.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mz_expr::{EvalError, ProtoEvalError};
+use mz_proto::ProtoType;
+use proptest::strategy::{Strategy, ValueTree};
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+use prost::Message;
+
+/// Assert that a `EvalError` survives encode -> decode -> into_rust unchanged.
+fn assert_roundtrip(orig: &EvalError) {
+    let proto = <ProtoEvalError as ProtoType<EvalError>>::from_rust(orig);
+    let bytes = proto.encode_to_vec();
+    let decoded = ProtoEvalError::decode(bytes.as_slice())
+        .expect("re-encode of valid EvalError must decode");
+    let round: EvalError = decoded
+        .into_rust()
+        .expect("re-encoded EvalError must convert back to Rust");
+    assert_eq!(orig, &round, "EvalError changed across proto roundtrip");
+}
+
+/// Decode `data` directly as a `ProtoEvalError`. If it converts to a Rust
+/// `EvalError`, assert that value round-trips.
+fn raw_bytes_arm(data: &[u8]) {
+    let Ok(proto) = ProtoEvalError::decode(data) else {
+        return;
+    };
+    let orig: EvalError = match proto.into_rust() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    assert_roundtrip(&orig);
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Some((&mode, rest)) = data.split_first() else {
+        return;
+    };
+
+    if mode & 1 == 0 {
+        // Mode A: structured Arbitrary generation. Derive a 32-byte seed from
+        // the remaining bytes (cycled / zero-padded) so even short inputs are
+        // usable, then drive proptest's Arbitrary impl from it.
+        let mut seed = [0u8; 32];
+        if !rest.is_empty() {
+            for (i, slot) in seed.iter_mut().enumerate() {
+                *slot = rest[i % rest.len()];
+            }
+        }
+        let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &seed);
+        let mut runner = TestRunner::new_with_rng(Config::default(), rng);
+        let value = <EvalError as proptest::arbitrary::Arbitrary>::arbitrary()
+            .new_tree(&mut runner)
+            .expect("valuetree")
+            .current();
+        assert_roundtrip(&value);
+    } else {
+        // Mode B: raw wire bytes.
+        raw_bytes_arm(rest);
+    }
+});

--- a/src/expr/fuzz/fuzz_targets/jsonb_get.rs
+++ b/src/expr/fuzz/fuzz_targets/jsonb_get.rs
@@ -1,0 +1,145 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: the jsonb access operators `->` / `->>` (field/element). A user
+//! controls both the jsonb value (parsed from untrusted text) and the key/index,
+//! and the operators traverse arbitrary nested structure, so a panic accessing
+//! into a crafted document is an availability bug. We parse untrusted JSON, then
+//! apply all four single-step accessors and require none to panic:
+//!  * `jsonb -> '<key>'`  and `jsonb -> <int>`   (return jsonb)
+//!  * `jsonb ->> '<key>'` and `jsonb ->> <int>`  (the `Stringify` variants, which
+//!    additionally run `jsonb_stringify` on the accessed element, a distinct
+//!    text-rendering path over the same crafted sub-document).
+//!
+//! Random text almost never parses as JSON, so a raw input would just bail at
+//! `from_str` and the access operators would barely run. We instead generate a
+//! valid JSON document (objects with keys from a small set, arrays, scalars) and
+//! generate the access key/index from that same set, so the accessors hit real
+//! fields/elements (the success + traversal paths) as well as missing ones, and
+//! the index includes out-of-range and extreme values for the array-bounds path.
+
+#![no_main]
+
+use std::str::FromStr;
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::{func, Eval, MirScalarExpr};
+use mz_repr::adt::jsonb::Jsonb;
+use mz_repr::{Datum, ReprScalarType, RowArena};
+
+/// Object keys, kept to a small set so generated access keys hit real fields.
+const KEYS: &[&str] = &["a", "b", "c", "x"];
+
+fn gen_json(u: &mut Unstructured, depth: u32, out: &mut String) -> arbitrary::Result<()> {
+    let leaf = depth == 0 || u.is_empty();
+    match if leaf {
+        u.int_in_range(0u8..=3)?
+    } else {
+        u.int_in_range(0u8..=5)?
+    } {
+        0 => out.push_str("null"),
+        1 => out.push_str(if u.int_in_range(0u8..=1)? == 0 {
+            "true"
+        } else {
+            "false"
+        }),
+        2 => out.push_str(&i64::from(u.arbitrary::<i32>()?).to_string()),
+        3 => {
+            out.push('"');
+            for _ in 0..u.int_in_range(0usize..=4)? {
+                out.push(*u.choose(&['a', 'z', '0', ' '])?);
+            }
+            out.push('"');
+        }
+        4 => {
+            out.push('[');
+            let n = u.int_in_range(0usize..=4)?;
+            for i in 0..n {
+                if i > 0 {
+                    out.push(',');
+                }
+                gen_json(u, depth - 1, out)?;
+            }
+            out.push(']');
+        }
+        _ => {
+            out.push('{');
+            let n = u.int_in_range(0usize..=4)?;
+            for i in 0..n {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push('"');
+                out.push_str(u.choose(KEYS)?);
+                out.push_str("\":");
+                gen_json(u, depth - 1, out)?;
+            }
+            out.push('}');
+        }
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let mut json = String::new();
+    gen_json(&mut u, 5, &mut json)?;
+    let Ok(jsonb) = Jsonb::from_str(&json) else {
+        return Ok(());
+    };
+    let value = jsonb.as_ref().into_datum();
+    let arena = RowArena::new();
+
+    // Key: usually a real field name (hit), sometimes a miss / arbitrary string.
+    let key_buf;
+    let key: &str = if u.int_in_range(0u8..=2)? == 0 {
+        let n = u.int_in_range(0usize..=4)?;
+        let mut s = String::new();
+        for _ in 0..n {
+            s.push(u.int_in_range(0x20u8..=0x7e)? as char);
+        }
+        key_buf = s;
+        &key_buf
+    } else {
+        u.choose(KEYS)?
+    };
+    // Index: usually small (in/just-past array bounds), sometimes extreme.
+    let index: i64 = if u.int_in_range(0u8..=3)? == 0 {
+        u.arbitrary::<i64>()?
+    } else {
+        i64::from(u.int_in_range(-3i32..=8)?)
+    };
+
+    let key_expr = || MirScalarExpr::literal_ok(Datum::String(key), ReprScalarType::String);
+    let index_expr = || MirScalarExpr::literal_ok(Datum::Int64(index), ReprScalarType::Int64);
+    let jsonb_expr = || MirScalarExpr::literal_ok(value, ReprScalarType::Jsonb);
+
+    // jsonb -> '<key>'  (object field access, returns jsonb)
+    let _ = jsonb_expr()
+        .call_binary(key_expr(), func::JsonbGetString)
+        .eval(&[], &arena);
+    // jsonb ->> '<key>'  (object field access, returns text via jsonb_stringify)
+    let _ = jsonb_expr()
+        .call_binary(key_expr(), func::JsonbGetStringStringify)
+        .eval(&[], &arena);
+
+    // jsonb -> <index>  (array element access, returns jsonb)
+    let _ = jsonb_expr()
+        .call_binary(index_expr(), func::JsonbGetInt64)
+        .eval(&[], &arena);
+    // jsonb ->> <index>  (array element access, returns text via jsonb_stringify)
+    let _ = jsonb_expr()
+        .call_binary(index_expr(), func::JsonbGetInt64Stringify)
+        .eval(&[], &arena);
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/expr/fuzz/fuzz_targets/jsonb_path.rs
+++ b/src/expr/fuzz/fuzz_targets/jsonb_path.rs
@@ -1,0 +1,176 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: the jsonb path-access operators `#>` / `#>>`. A user controls
+//! both the jsonb value (parsed from untrusted text) and a `text[]` path, and
+//! the operators walk the path into arbitrary nested structure, so a panic on a
+//! crafted document/path is an availability bug. We parse untrusted JSON, build
+//! a `text[]` path from the fuzzed components, then apply `jsonb #> path`
+//! (returns jsonb) and `jsonb #>> path` (returns text), requiring neither to
+//! panic. Complements `jsonb_get`, which covers the single-step `->` / `->>`
+//! operators.
+//!
+//! Random text almost never parses as JSON, so a raw input would bail at
+//! `from_str` and the path walk would barely run. We instead generate a valid
+//! JSON document (objects with keys from a small set, arrays, scalars) and a
+//! path whose components are drawn from that same set, so the walk descends
+//! through real nested structure (the multi-step traversal the operators exist
+//! for), with some missing components and numeric-looking array indices mixed in.
+//!
+//! Array-index components are not just `"0".."3"`: the list step runs
+//! `strconv::parse_int64` on the component and, for a negative index, computes
+//! `list.len().wrapping_sub(index)` to count from the end. So we also emit
+//! negative (`"-1"`), out-of-range/huge (`"99999999999"`), boundary
+//! (`"-9223372036854775808"` = `i64::MIN`, whose `unsigned_abs` is one past
+//! `i64::MAX`), and malformed-but-numeric-looking (`"+0"`, `" 1"`, `"1.0"`,
+//! `"0x10"`) strings, covering the parse-failure short-circuit and the
+//! wrapping-subtraction index arithmetic.
+
+#![no_main]
+
+use std::str::FromStr;
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::{func, Eval, MirScalarExpr};
+use mz_repr::adt::array::{ArrayDimension, InvalidArrayError};
+use mz_repr::adt::jsonb::Jsonb;
+use mz_repr::{Datum, ReprScalarType, RowArena};
+
+/// Object keys / path components, kept small so the path hits real fields.
+const KEYS: &[&str] = &["a", "b", "c", "x"];
+
+/// Numeric-looking array-index components exercising the list step's
+/// `parse_int64` + negative-index `wrapping_sub` arithmetic: in-range,
+/// negative (count-from-end), huge/out-of-range, the `i64::MIN` boundary, and
+/// malformed-but-numeric-looking strings that `parse_int64` should reject.
+const INDICES: &[&str] = &[
+    "0",
+    "1",
+    "2",
+    "3",
+    "-1",
+    "-2",
+    "99999999999",
+    "-99999999999",
+    "9223372036854775807",  // i64::MAX
+    "-9223372036854775808", // i64::MIN (unsigned_abs is i64::MAX + 1)
+    "+0",
+    " 1",
+    "1.0",
+    "0x10",
+    "",
+];
+
+fn gen_json(u: &mut Unstructured, depth: u32, out: &mut String) -> arbitrary::Result<()> {
+    let leaf = depth == 0 || u.is_empty();
+    match if leaf {
+        u.int_in_range(0u8..=3)?
+    } else {
+        u.int_in_range(0u8..=5)?
+    } {
+        0 => out.push_str("null"),
+        1 => out.push_str(if u.int_in_range(0u8..=1)? == 0 {
+            "true"
+        } else {
+            "false"
+        }),
+        2 => out.push_str(&i64::from(u.arbitrary::<i32>()?).to_string()),
+        3 => {
+            out.push('"');
+            for _ in 0..u.int_in_range(0usize..=4)? {
+                out.push(*u.choose(&['a', 'z', '0', ' '])?);
+            }
+            out.push('"');
+        }
+        4 => {
+            out.push('[');
+            let n = u.int_in_range(0usize..=4)?;
+            for i in 0..n {
+                if i > 0 {
+                    out.push(',');
+                }
+                gen_json(u, depth - 1, out)?;
+            }
+            out.push(']');
+        }
+        _ => {
+            out.push('{');
+            let n = u.int_in_range(0usize..=4)?;
+            for i in 0..n {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push('"');
+                out.push_str(u.choose(KEYS)?);
+                out.push_str("\":");
+                gen_json(u, depth - 1, out)?;
+            }
+            out.push('}');
+        }
+    }
+    Ok(())
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let mut json = String::new();
+    gen_json(&mut u, 5, &mut json)?;
+    let Ok(jsonb) = Jsonb::from_str(&json) else {
+        return Ok(());
+    };
+    let value = jsonb.as_ref().into_datum();
+    let arena = RowArena::new();
+
+    // Path components: object keys (hits), array indices ("0".."3"), and an
+    // occasional miss, so the walk descends real structure and also dead-ends.
+    let n = u.int_in_range(0usize..=5)?;
+    let mut path: Vec<&str> = Vec::with_capacity(n);
+    for _ in 0..n {
+        path.push(match u.int_in_range(0u8..=4)? {
+            0 | 1 => u.choose(KEYS)?,
+            2 | 3 => *u.choose(INDICES)?,
+            _ => "missing",
+        });
+    }
+
+    let dims = if path.is_empty() {
+        Vec::new()
+    } else {
+        vec![ArrayDimension {
+            lower_bound: 1,
+            length: path.len(),
+        }]
+    };
+    let path_datum = match arena.try_make_datum::<_, InvalidArrayError>(|packer| {
+        packer.try_push_array(&dims, path.iter().map(|s| Datum::String(s)))
+    }) {
+        Ok(d) => d,
+        Err(_) => return Ok(()),
+    };
+    let path_ty = ReprScalarType::Array(Box::new(ReprScalarType::String));
+
+    // jsonb #> '{a,b,...}'  (returns jsonb)
+    let get_path = MirScalarExpr::literal_ok(value, ReprScalarType::Jsonb).call_binary(
+        MirScalarExpr::literal_ok(path_datum, path_ty.clone()),
+        func::JsonbGetPath,
+    );
+    let _ = get_path.eval(&[], &arena);
+
+    // jsonb #>> '{a,b,...}'  (returns text)
+    let get_path_stringify = MirScalarExpr::literal_ok(value, ReprScalarType::Jsonb).call_binary(
+        MirScalarExpr::literal_ok(path_datum, path_ty),
+        func::JsonbGetPathStringify,
+    );
+    let _ = get_path_stringify.eval(&[], &arena);
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/expr/fuzz/fuzz_targets/like_pattern_compile.rs
+++ b/src/expr/fuzz/fuzz_targets/like_pattern_compile.rs
@@ -1,0 +1,110 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `like_pattern::compile` turns an untrusted SQL `LIKE`/`ILIKE`
+//! pattern into a matcher (a string automaton or a compiled regex). A user
+//! controls the pattern, so a panic or pathological build here is a real
+//! availability bug. We check two things:
+//!
+//!  1. Compiling an arbitrary pattern and matching arbitrary text never panics.
+//!  2. A pattern built by escaping every wildcard/escape character in `text` is
+//!     a pure literal, and `LIKE` is anchored, so it must match exactly `text`.
+//!
+//! A pattern/text pair of random Unicode rarely contains the wildcard/escape
+//! metacharacters or the literal overlap that drives the interesting code, so it
+//! plateaus on shallow shapes. Instead we mostly draw both the pattern and the
+//! match text from a tiny shared alphabet of literals plus the LIKE
+//! metacharacters `%`, `_`, and `\`. Generating *multiple* `%` is deliberate: at
+//! two-or-more `%` (`many_subpatterns > 1`) `compile` abandons the backtracking
+//! string matcher and routes to the linear-time regex engine, a boundary the
+//! string-only inputs never reach. Drawing the text from the same alphabet means
+//! it actually matches the wildcards, exercising the `%`-suffix-search /
+//! backtracking and the regex path on real (not always-empty) matches.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::like_pattern;
+
+/// Literals shared between pattern and text, so wildcards match real characters.
+const LITERALS: &[char] = &['a', 'b', 'c'];
+
+/// Builds a LIKE pattern over the literal alphabet plus the `%`/`_`/`\`
+/// metacharacters, weighted toward emitting several `%` so the >1-`%` regex
+/// routing boundary is crossed.
+fn gen_pattern(u: &mut Unstructured) -> arbitrary::Result<String> {
+    let mut p = String::new();
+    let n = u.int_in_range(0usize..=16)?;
+    for _ in 0..n {
+        match u.int_in_range(0u8..=6)? {
+            // Weight `%` heavily (3/7) so multiple-`%` patterns are common.
+            0 | 1 | 2 => p.push('%'),
+            3 => p.push('_'),
+            4 => {
+                // Escape sequence: `\` followed by a metachar or literal. A bare
+                // trailing `\` (the unterminated-escape arm) is intentionally
+                // reachable when this is the last iteration.
+                p.push('\\');
+                if u.int_in_range(0u8..=3)? != 0 {
+                    p.push(*u.choose(&['%', '_', '\\', 'a'])?);
+                }
+            }
+            _ => p.push(*u.choose(LITERALS)?),
+        }
+    }
+    Ok(p)
+}
+
+/// Builds match text over the same literal alphabet.
+fn gen_text(u: &mut Unstructured) -> arbitrary::Result<String> {
+    let mut t = String::new();
+    for _ in 0..u.int_in_range(0usize..=24)? {
+        t.push(*u.choose(LITERALS)?);
+    }
+    Ok(t)
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let case_insensitive = u.arbitrary()?;
+
+    // Pattern/text: usually from the shared alphabet, sometimes raw bytes so the
+    // compiler's reject/parse paths over arbitrary Unicode keep their coverage.
+    let (pattern, text) = if u.int_in_range(0u8..=3)? == 0 {
+        (u.arbitrary::<String>()?, u.arbitrary::<String>()?)
+    } else {
+        (gen_pattern(&mut u)?, gen_text(&mut u)?)
+    };
+
+    // (1) Arbitrary pattern + arbitrary text: compile and match must not panic.
+    if let Ok(matcher) = like_pattern::compile(&pattern, case_insensitive) {
+        let _ = matcher.is_match(&text);
+    }
+
+    // (2) Escape every LIKE metacharacter in `text` to get a literal pattern,
+    // which must match exactly its own source text.
+    let mut literal = String::with_capacity(text.len() + 8);
+    for c in text.chars() {
+        if matches!(c, '%' | '_' | '\\') {
+            literal.push('\\');
+        }
+        literal.push(c);
+    }
+    if let Ok(matcher) = like_pattern::compile(&literal, case_insensitive) {
+        assert!(
+            matcher.is_match(&text),
+            "literal LIKE pattern {literal:?} must match its source text {text:?}"
+        );
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/expr/fuzz/fuzz_targets/like_pattern_escape.rs
+++ b/src/expr/fuzz/fuzz_targets/like_pattern_escape.rs
@@ -1,0 +1,77 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `like_pattern::normalize_pattern` rewrites a `LIKE ... ESCAPE c`
+//! pattern (custom escape character) into the default-escape form before
+//! compilation. The user controls both the pattern and the escape character, so
+//! the custom-escape rewrite, a char-by-char parser with escape state, must
+//! not panic on any input, and its output must still compile and match. This is
+//! the `ESCAPE`-clause path that `like_pattern_compile` (default escape only)
+//! never exercises.
+//!
+//! With a fully arbitrary escape char and a fully arbitrary pattern, the escape
+//! char almost never coincides with a character actually in the pattern, so the
+//! two branches that matter stay cold: the custom-escape *consume* branch (where
+//! the escape char is followed by another char) and the trailing *unterminated*
+//! escape arm (where the escape char is the final character). To light both up
+//! we draw the pattern over a tiny alphabet of LIKE metacharacters plus a couple
+//! literals, and draw the escape char from that *same* alphabet, so it lands on
+//! the pattern's own characters and the escape state machine runs in earnest,
+//! including the off-by-one trailing-escape case.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::like_pattern::{self, EscapeBehavior};
+
+/// Shared alphabet for the pattern and the escape char, so the escape char
+/// frequently matches characters in the pattern and the consume/unterminated
+/// branches fire. Includes the LIKE metacharacters and a few literals.
+const ALPHA: &[char] = &['%', '_', '\\', 'a', 'b', 'c'];
+
+fn gen_pattern(u: &mut Unstructured) -> arbitrary::Result<String> {
+    let mut p = String::new();
+    for _ in 0..u.int_in_range(0usize..=20)? {
+        p.push(*u.choose(ALPHA)?);
+    }
+    Ok(p)
+}
+
+fn run(mut u: Unstructured) -> arbitrary::Result<()> {
+    let case_insensitive = u.arbitrary()?;
+
+    let (pattern, escape_char) = if u.int_in_range(0u8..=3)? == 0 {
+        // Some fully-arbitrary inputs keep the raw-Unicode reject coverage.
+        (u.arbitrary::<String>()?, u.arbitrary::<char>()?)
+    } else {
+        (gen_pattern(&mut u)?, *u.choose(ALPHA)?)
+    };
+    // Text from the same literal-ish alphabet so the compiled matcher can match.
+    let mut text = String::new();
+    for _ in 0..u.int_in_range(0usize..=20)? {
+        text.push(*u.choose(ALPHA)?);
+    }
+
+    for behavior in [EscapeBehavior::Char(escape_char), EscapeBehavior::Disabled] {
+        let Ok(normalized) = like_pattern::normalize_pattern(&pattern, behavior) else {
+            continue;
+        };
+        // The rewritten pattern is in default-escape form and must compile and
+        // match arbitrary text without panicking.
+        if let Ok(matcher) = like_pattern::compile(&normalized, case_insensitive) {
+            let _ = matcher.is_match(&text);
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = run(Unstructured::new(data));
+});

--- a/src/expr/fuzz/fuzz_targets/mfp_optimize.rs
+++ b/src/expr/fuzz/fuzz_targets/mfp_optimize.rs
@@ -1,0 +1,536 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `MapFilterProject::optimize` must preserve evaluation.
+//!
+//! A `MapFilterProject` (MFP) is the linear map/filter/project pipeline that
+//! runs in essentially every dataflow operator. `optimize` fuses and reorders
+//! maps and predicates, drops unused map expressions, and canonicalizes the
+//! projection. A miscompile here silently corrupts query results, so it is a
+//! high-value correctness target.
+//!
+//! We build a random, well-typed MFP over an `int4`/`int8`/`bool` input schema
+//! (map expressions can reference earlier columns, and predicates and the
+//! projection reference any column), with a scalar vocabulary that includes
+//! `int4`/`int8` arithmetic and the `int4`↔`int8` casts (the latter is fallible,
+//! so it feeds optimize's error-handling). The target runs in one of two modes:
+//!
+//!  * **Non-temporal preservation.** Evaluate the original and the `optimize`d
+//!    clone on a batch of random input rows. The oracle is one-directional,
+//!    mirroring the contract optimize actually owes: optimize is allowed to
+//!    *drop* an error or a row that the original would reject, because it removes
+//!    unused map expressions and reorders predicates. But for every input row the
+//!    *original* passes through cleanly with output `out`, the optimized plan
+//!    must also pass it through with the byte-identical `out`. (When the original
+//!    errors or filters a row we assert nothing.)
+//!
+//!  * **Temporal lowering.** Add predicates of the form `mz_now() <cmp> e` (and
+//!    conjunctions of them) over a bounded `mz_timestamp` expression `e`, then
+//!    lower the MFP to a temporal `MfpPlan` (`into_plan`, which runs `optimize`
+//!    and `extract_temporal_bounds`, the operator/`StepMzTimestamp` translation
+//!    that the non-temporal path bails on). The plan defines a per-row validity
+//!    interval `[lower, upper)`. We read that interval off a single `evaluate`
+//!    and check, for a batch of concrete logical times `T`, that "the row is live
+//!    at `T`" (`lower <= T < upper`, with the non-temporal predicates also
+//!    passing) agrees with a substitution reference: the same MFP with every
+//!    `mz_now()` replaced by the literal `mz_timestamp` `T`, evaluated
+//!    non-temporally. The compared timestamps are kept well below `u64::MAX` so
+//!    `StepMzTimestamp` (the `+1` the lowering inserts for `<=`/`>`/`=`) never
+//!    overflows, which keeps the substitution equivalence exact. As above the
+//!    oracle is one-directional: if the reference errors at `T` we assert
+//!    nothing.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::{func, EvalError, MapFilterProject, MirScalarExpr, UnmaterializableFunc};
+use mz_repr::{Datum, Diff, ReprScalarType, Row, RowArena, Timestamp};
+
+// Input schema: int4 columns, then int8 columns, then bool columns.
+const N_IN_INT: usize = 2;
+const N_IN_LONG: usize = 1;
+const N_IN_BOOL: usize = 2;
+const N_INPUT: usize = N_IN_INT + N_IN_LONG + N_IN_BOOL;
+const MAX_MAPS: usize = 4;
+const MAX_FILTERS: usize = 3;
+const SCALAR_DEPTH: u32 = 4;
+const ROWS_PER_MFP: usize = 8;
+// Concrete logical times probed against the temporal plan's validity interval.
+const TIMES_PER_MFP: usize = 6;
+
+#[derive(Clone, Copy, PartialEq)]
+enum Ty {
+    Int,
+    Long,
+    Bool,
+}
+
+fn scalar_ty(ty: Ty) -> ReprScalarType {
+    match ty {
+        Ty::Int => ReprScalarType::Int32,
+        Ty::Long => ReprScalarType::Int64,
+        Ty::Bool => ReprScalarType::Bool,
+    }
+}
+
+fn input_types() -> Vec<Ty> {
+    let mut v = vec![Ty::Int; N_IN_INT];
+    v.extend(std::iter::repeat(Ty::Long).take(N_IN_LONG));
+    v.extend(std::iter::repeat(Ty::Bool).take(N_IN_BOOL));
+    v
+}
+
+fn rand_ty(u: &mut Unstructured) -> arbitrary::Result<Ty> {
+    Ok(match u.int_in_range(0u8..=2)? {
+        0 => Ty::Int,
+        1 => Ty::Long,
+        _ => Ty::Bool,
+    })
+}
+
+fn datum_of(u: &mut Unstructured, ty: Ty, nullable: bool) -> arbitrary::Result<Datum<'static>> {
+    if nullable && u.ratio(1u8, 4u8)? {
+        return Ok(Datum::Null);
+    }
+    Ok(match ty {
+        Ty::Int => Datum::Int32(i32::arbitrary(u)?),
+        Ty::Long => Datum::Int64(i64::arbitrary(u)?),
+        Ty::Bool => {
+            if bool::arbitrary(u)? {
+                Datum::True
+            } else {
+                Datum::False
+            }
+        }
+    })
+}
+
+/// Pick the index of an available column whose type is `want`, if any exists.
+fn pick_col(u: &mut Unstructured, cols: &[Ty], want: Ty) -> arbitrary::Result<Option<usize>> {
+    let matching: Vec<usize> = cols
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| **t == want)
+        .map(|(i, _)| i)
+        .collect();
+    if matching.is_empty() {
+        return Ok(None);
+    }
+    let i = u.int_in_range(0..=matching.len() - 1)?;
+    Ok(Some(matching[i]))
+}
+
+fn gen_leaf(u: &mut Unstructured, want: Ty, cols: &[Ty]) -> arbitrary::Result<MirScalarExpr> {
+    let st = scalar_ty(want);
+    // Prefer a column reference when one of the right type is available. This is
+    // what makes optimize's unused-map / projection reasoning interesting.
+    if u.ratio(1u8, 2u8)? {
+        if let Some(col) = pick_col(u, cols, want)? {
+            return Ok(MirScalarExpr::column(col));
+        }
+    }
+    Ok(match u.int_in_range(0u8..=1)? {
+        0 => MirScalarExpr::literal_ok(datum_of(u, want, false)?, st),
+        _ => MirScalarExpr::literal_null(st),
+    })
+}
+
+fn gen_scalar(
+    u: &mut Unstructured,
+    want: Ty,
+    cols: &[Ty],
+    depth: u32,
+) -> arbitrary::Result<MirScalarExpr> {
+    if depth == 0 || u.ratio(2u8, 5u8)? {
+        return gen_leaf(u, want, cols);
+    }
+    let d = depth - 1;
+    match want {
+        Ty::Int => match u.int_in_range(0u8..=5)? {
+            0 => {
+                let cond = gen_scalar(u, Ty::Bool, cols, d)?;
+                let then = gen_scalar(u, Ty::Int, cols, d)?;
+                let els = gen_scalar(u, Ty::Int, cols, d)?;
+                Ok(cond.if_then_else(then, els))
+            }
+            1 => Ok(gen_scalar(u, Ty::Int, cols, d)?
+                .call_binary(gen_scalar(u, Ty::Int, cols, d)?, func::AddInt32)),
+            2 => Ok(gen_scalar(u, Ty::Int, cols, d)?
+                .call_binary(gen_scalar(u, Ty::Int, cols, d)?, func::SubInt32)),
+            3 => Ok(gen_scalar(u, Ty::Int, cols, d)?
+                .call_binary(gen_scalar(u, Ty::Int, cols, d)?, func::MulInt32)),
+            4 => Ok(gen_scalar(u, Ty::Int, cols, d)?
+                .call_binary(gen_scalar(u, Ty::Int, cols, d)?, func::ModInt32)),
+            // int8 -> int4 (fallible: out-of-range overflows).
+            _ => Ok(gen_scalar(u, Ty::Long, cols, d)?.call_unary(func::CastInt64ToInt32)),
+        },
+        Ty::Long => match u.int_in_range(0u8..=4)? {
+            0 => {
+                let cond = gen_scalar(u, Ty::Bool, cols, d)?;
+                let then = gen_scalar(u, Ty::Long, cols, d)?;
+                let els = gen_scalar(u, Ty::Long, cols, d)?;
+                Ok(cond.if_then_else(then, els))
+            }
+            1 => Ok(gen_scalar(u, Ty::Long, cols, d)?
+                .call_binary(gen_scalar(u, Ty::Long, cols, d)?, func::AddInt64)),
+            2 => Ok(gen_scalar(u, Ty::Long, cols, d)?
+                .call_binary(gen_scalar(u, Ty::Long, cols, d)?, func::SubInt64)),
+            3 => Ok(gen_scalar(u, Ty::Long, cols, d)?
+                .call_binary(gen_scalar(u, Ty::Long, cols, d)?, func::MulInt64)),
+            // int4 -> int8 (infallible widening).
+            _ => Ok(gen_scalar(u, Ty::Int, cols, d)?.call_unary(func::CastInt32ToInt64)),
+        },
+        Ty::Bool => match u.int_in_range(0u8..=5)? {
+            0 => {
+                let cond = gen_scalar(u, Ty::Bool, cols, d)?;
+                let then = gen_scalar(u, Ty::Bool, cols, d)?;
+                let els = gen_scalar(u, Ty::Bool, cols, d)?;
+                Ok(cond.if_then_else(then, els))
+            }
+            1 => Ok(gen_scalar(u, Ty::Bool, cols, d)?.and(gen_scalar(u, Ty::Bool, cols, d)?)),
+            2 => Ok(gen_scalar(u, Ty::Bool, cols, d)?.or(gen_scalar(u, Ty::Bool, cols, d)?)),
+            3 => Ok(gen_scalar(u, Ty::Bool, cols, d)?.not()),
+            4 => {
+                let t = rand_ty(u)?;
+                let a = gen_scalar(u, t, cols, d)?;
+                let b = gen_scalar(u, t, cols, d)?;
+                Ok(match u.int_in_range(0u8..=4)? {
+                    0 => a.call_binary(b, func::Eq),
+                    1 => a.call_binary(b, func::Lt),
+                    2 => a.call_binary(b, func::Gt),
+                    3 => a.call_binary(b, func::Lte),
+                    _ => a.call_binary(b, func::Gte),
+                })
+            }
+            _ => {
+                let t = rand_ty(u)?;
+                Ok(gen_scalar(u, t, cols, d)?.call_is_null())
+            }
+        },
+    }
+}
+
+fn gen_input_row(u: &mut Unstructured, types: &[Ty]) -> arbitrary::Result<Row> {
+    let mut row = Row::default();
+    let mut packer = row.packer();
+    for ty in types {
+        packer.push(datum_of(u, *ty, true)?);
+    }
+    drop(packer);
+    Ok(row)
+}
+
+/// `mz_now()`.
+fn mz_now() -> MirScalarExpr {
+    MirScalarExpr::CallUnmaterializable(UnmaterializableFunc::MzNow)
+}
+
+/// An `mz_timestamp` literal.
+fn ts_literal(t: u64) -> MirScalarExpr {
+    MirScalarExpr::literal_ok(
+        Datum::MzTimestamp(Timestamp::new(t)),
+        ReprScalarType::MzTimestamp,
+    )
+}
+
+/// A bounded `mz_timestamp`-typed expression to compare `mz_now()` against.
+/// Sometimes a bare literal, sometimes derived from an `int8` column via
+/// `CastInt64ToMzTimestamp` so the bound depends on the row. Either way the
+/// value is kept well below `u64::MAX` so the `StepMzTimestamp` (`+1`) that the
+/// lowering inserts for `<=`/`>`/`=` cannot overflow, keeping the substitution
+/// oracle exact.
+fn gen_ts_expr(u: &mut Unstructured, cols: &[Ty]) -> arbitrary::Result<MirScalarExpr> {
+    if u.ratio(1u8, 2u8)? {
+        if let Some(col) = pick_col(u, cols, Ty::Long)? {
+            // The column holds an arbitrary i64. Clamp it into [0, BOUND) with a
+            // modulo so the cast can't go out of range or near the step overflow.
+            let masked = MirScalarExpr::column(col)
+                .call_binary(ts_bound_i64(), func::ModInt64)
+                .call_unary(func::AbsInt64)
+                .call_unary(func::CastInt64ToMzTimestamp);
+            return Ok(masked);
+        }
+    }
+    let t = u.int_in_range(0u64..=TS_BOUND)?;
+    Ok(ts_literal(t))
+}
+
+/// Upper bound (exclusive) on generated timestamp magnitudes, far from
+/// `u64::MAX` so `StepMzTimestamp` never overflows.
+const TS_BOUND: u64 = 1_000_000;
+
+fn ts_bound_i64() -> MirScalarExpr {
+    MirScalarExpr::literal_ok(
+        Datum::Int64(i64::try_from(TS_BOUND).unwrap()),
+        ReprScalarType::Int64,
+    )
+}
+
+/// A single temporal predicate `mz_now() <cmp> e`.
+fn gen_temporal_pred(u: &mut Unstructured, cols: &[Ty]) -> arbitrary::Result<MirScalarExpr> {
+    let e = gen_ts_expr(u, cols)?;
+    Ok(match u.int_in_range(0u8..=4)? {
+        0 => mz_now().call_binary(e, func::Eq),
+        1 => mz_now().call_binary(e, func::Lt),
+        2 => mz_now().call_binary(e, func::Lte),
+        3 => mz_now().call_binary(e, func::Gt),
+        _ => mz_now().call_binary(e, func::Gte),
+    })
+}
+
+/// Build the reference plan for a temporal MFP at a concrete logical time `t`:
+/// take the original MFP, replace every `mz_now()` with the literal
+/// `mz_timestamp` `t`, and lower it. After substitution there are no temporal
+/// expressions, so the plan is non-temporal by construction. Returns `None` if
+/// lowering rejects it (treated as "assert nothing at this `t`"). The result
+/// depends only on `t`, not on any row, so callers build it once per `t`.
+fn reference_plan(mfp: &MapFilterProject, t: u64) -> Option<mz_expr::SafeMfpPlan> {
+    let mut substituted = mfp.clone();
+    let subst = |e: &mut MirScalarExpr| {
+        e.visit_pre_mut(|node| {
+            if let MirScalarExpr::CallUnmaterializable(UnmaterializableFunc::MzNow) = node {
+                *node = ts_literal(t);
+            }
+        });
+    };
+    for expr in &mut substituted.expressions {
+        subst(expr);
+    }
+    for (_, pred) in &mut substituted.predicates {
+        subst(pred);
+    }
+    substituted.into_plan().ok()?.into_nontemporal().ok()
+}
+
+/// Evaluate a reference plan on a row: `Some(pass)` for a clean pass/fail, `None`
+/// on an evaluation error.
+fn reference_present(plan: &mz_expr::SafeMfpPlan, row: &Row) -> Option<bool> {
+    let arena = RowArena::new();
+    let mut datums: Vec<Datum> = row.iter().collect();
+    let mut buf = Row::default();
+    match plan.evaluate_into(&mut datums, &arena, &mut buf) {
+        Ok(Some(_)) => Some(true),
+        Ok(None) => Some(false),
+        Err(_) => None,
+    }
+}
+
+/// Read the validity interval a temporal plan assigns to `row`, evaluating once
+/// with `time = 0`, `diff = +1`, and an always-valid frontier. Returns:
+///  * `Err(())` if evaluation errored,
+///  * `Ok(None)` if the (non-temporal part of the) plan rejected the row,
+///  * `Ok(Some((lower, upper)))` for the half-open interval `[lower, upper)`
+///    (`upper == None` means unbounded above).
+type Interval = Option<(Timestamp, Option<Timestamp>)>;
+fn temporal_interval(plan: &mz_expr::MfpPlan, row: &Row) -> Result<Interval, ()> {
+    let arena = RowArena::new();
+    let mut datums: Vec<Datum> = row.iter().collect();
+    let mut row_builder = Row::default();
+    let mut lower: Option<Timestamp> = None;
+    let mut upper: Option<Timestamp> = None;
+    let mut errored = false;
+    let mut produced = false;
+    for result in plan.evaluate::<EvalError, _>(
+        &mut datums,
+        &arena,
+        Timestamp::new(0),
+        Diff::ONE,
+        |_t| true,
+        &mut row_builder,
+    ) {
+        produced = true;
+        match result {
+            Ok((_, t, diff)) => {
+                if diff == Diff::ONE {
+                    lower = Some(t);
+                } else {
+                    upper = Some(t);
+                }
+            }
+            Err(_) => errored = true,
+        }
+    }
+    if errored {
+        return Err(());
+    }
+    if !produced {
+        return Ok(None);
+    }
+    Ok(Some((lower.unwrap_or_else(|| Timestamp::new(0)), upper)))
+}
+
+/// Non-temporal preservation: the original optimize-vs-clone output equivalence.
+fn run_nontemporal(
+    u: &mut Unstructured,
+    mfp: MapFilterProject,
+    types: &[Ty],
+) -> arbitrary::Result<()> {
+    let mut optimized = mfp.clone();
+    optimized.optimize();
+
+    let Ok(plan_orig) = mfp.into_plan() else {
+        return Ok(());
+    };
+    let Ok(safe_orig) = plan_orig.into_nontemporal() else {
+        return Ok(());
+    };
+    let Ok(plan_opt) = optimized.into_plan() else {
+        return Ok(());
+    };
+    let Ok(safe_opt) = plan_opt.into_nontemporal() else {
+        return Ok(());
+    };
+
+    for _ in 0..ROWS_PER_MFP {
+        let row = gen_input_row(u, types)?;
+        let arena = RowArena::new();
+
+        let mut datums_o: Vec<Datum> = row.iter().collect();
+        let mut buf_o = Row::default();
+        // Reduce the result to pass/fail/error, ending the borrow of `buf_o`.
+        let orig = match safe_orig.evaluate_into(&mut datums_o, &arena, &mut buf_o) {
+            Ok(Some(_)) => Some(true),
+            Ok(None) => Some(false),
+            Err(_) => None,
+        };
+
+        // Only a row the original passes through cleanly constrains the optimized
+        // plan. An error or a filtered row lets optimize legitimately differ.
+        if orig != Some(true) {
+            continue;
+        }
+
+        let mut datums_p: Vec<Datum> = row.iter().collect();
+        let mut buf_p = Row::default();
+        match safe_opt.evaluate_into(&mut datums_p, &arena, &mut buf_p) {
+            Ok(Some(out)) => assert_eq!(
+                &buf_o, out,
+                "optimize changed the projected output\n  row = {row:?}\n  out_orig = {buf_o:?}\n  out_opt  = {out:?}"
+            ),
+            Ok(None) => panic!("optimize filtered out a row the original passed\n  row = {row:?}"),
+            Err(e) => panic!(
+                "optimize errored on a row the original passed cleanly\n  row = {row:?}\n  err = {e:?}"
+            ),
+        }
+    }
+    Ok(())
+}
+
+/// Temporal lowering: validity interval from the lowered plan vs. the
+/// `mz_now()`-substitution reference.
+fn run_temporal(
+    u: &mut Unstructured,
+    mfp: MapFilterProject,
+    types: &[Ty],
+) -> arbitrary::Result<()> {
+    // `into_plan` runs `optimize` and `extract_temporal_bounds`. An Err means an
+    // unsupported temporal shape, which is a legitimate rejection, not a bug.
+    let Ok(plan) = mfp.clone().into_plan() else {
+        return Ok(());
+    };
+
+    // Sample the logical times to probe, and build each substitution reference
+    // plan once (it depends only on `t`, not on the row). A reference plan that
+    // fails to lower is dropped: we simply assert nothing at that time.
+    let mut times: Vec<(u64, mz_expr::SafeMfpPlan)> = Vec::with_capacity(TIMES_PER_MFP);
+    for _ in 0..TIMES_PER_MFP {
+        let t = u.int_in_range(0u64..=TS_BOUND + 2)?;
+        if let Some(ref_plan) = reference_plan(&mfp, t) {
+            times.push((t, ref_plan));
+        }
+    }
+
+    for _ in 0..ROWS_PER_MFP {
+        let row = gen_input_row(u, types)?;
+        let interval = temporal_interval(&plan, &row);
+        // A plan that errors on this row lets the lowered plan legitimately
+        // differ from the substitution reference, so assert nothing.
+        let interval = match interval {
+            Err(()) => continue,
+            Ok(iv) => iv,
+        };
+
+        for (t, ref_plan) in &times {
+            // One-directional: only constrain the plan when the reference is a
+            // clean pass/fail. A reference error lets the lowered plan differ.
+            let Some(present_ref) = reference_present(ref_plan, &row) else {
+                continue;
+            };
+            let present_plan = match &interval {
+                // Plan rejects the row at every time (non-temporal predicate
+                // failed): it is absent at every `t`.
+                None => false,
+                Some((lower, upper)) => {
+                    let tt = Timestamp::new(*t);
+                    *lower <= tt && upper.map(|up| tt < up).unwrap_or(true)
+                }
+            };
+            assert_eq!(
+                present_plan, present_ref,
+                "temporal lowering disagrees with substitution at t={t}\n  interval = {interval:?}\n  row = {row:?}\n  mfp = {mfp:?}"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    let types = input_types();
+    // Columns available to later expressions: input columns plus appended maps.
+    let mut cols = types.clone();
+
+    let temporal = u.ratio(1u8, 2u8)?;
+
+    let n_maps = u.int_in_range(0..=MAX_MAPS)?;
+    let mut maps = Vec::with_capacity(n_maps);
+    for _ in 0..n_maps {
+        let t = rand_ty(u)?;
+        maps.push(gen_scalar(u, t, &cols, SCALAR_DEPTH)?);
+        cols.push(t);
+    }
+
+    let n_filters = u.int_in_range(0..=MAX_FILTERS)?;
+    let mut filters = Vec::with_capacity(n_filters);
+    for _ in 0..n_filters {
+        // In temporal mode, mix in `mz_now()` predicates alongside ordinary ones.
+        if temporal && u.ratio(3u8, 5u8)? {
+            filters.push(gen_temporal_pred(u, &cols)?);
+        } else {
+            filters.push(gen_scalar(u, Ty::Bool, &cols, SCALAR_DEPTH)?);
+        }
+    }
+    // Guarantee at least one temporal predicate in temporal mode so the lowering
+    // path is actually exercised.
+    if temporal && !filters.iter().any(|f| f.contains_temporal()) {
+        filters.push(gen_temporal_pred(u, &cols)?);
+    }
+
+    let n_proj = u.int_in_range(0..=cols.len())?;
+    let mut projection = Vec::with_capacity(n_proj);
+    for _ in 0..n_proj {
+        projection.push(u.int_in_range(0..=cols.len() - 1)?);
+    }
+
+    let mfp = MapFilterProject::new(N_INPUT)
+        .map(maps)
+        .filter(filters)
+        .project(projection);
+
+    if temporal {
+        run_temporal(u, mfp, &types)
+    } else {
+        run_nontemporal(u, mfp, &types)
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/expr/fuzz/fuzz_targets/mir_scalar_reduce.rs
+++ b/src/expr/fuzz/fuzz_targets/mir_scalar_reduce.rs
@@ -1,0 +1,438 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: `MirScalarExpr::reduce` must preserve successful evaluations.
+//! The optimizer folds constants, simplifies `If`, and propagates nulls via
+//! `reduce`, and downstream passes trust the reduced expression to evaluate to
+//! the same value as the original.
+//!
+//! We generate a random, well-typed expression over a fixed `int4`/`int8`/
+//! `bool`/`text` schema, tracking the type of every subexpression during
+//! generation so the result is well-typed by construction and `eval` can't
+//! panic on a type mismatch. The function vocabulary spans the folder's
+//! trickiest areas: integer arithmetic (`+`/`-`/`*`/`%`, negate, abs) on both
+//! `int4` and `int8`, the boolean connectives `AND`/`OR`/`NOT`, comparisons and
+//! `IS NULL` over every type, text concatenation/length, the `If` rewrites, and
+//! a cast matrix (`int4`↔`int8`, `int`/`bool`→`text`, `text`→`int`, `int`→
+//! `bool`), many of which are *fallible* (overflow, parse failure, division by
+//! zero), exercising reduce's error propagation.
+//!
+//! Crucially, alongside the binary `a AND b` / `a OR b` shapes, we also emit
+//! *n-ary* `CallVariadic(And/Or, ..)` nodes with 3+ operands that nest other
+//! n-ary And/Or directly inside (an `And` of `Or`s of `And`s, …). This is the
+//! input shape that reaches reduce's variadic AND/OR machinery:
+//! `flatten_associative` (collapsing same-func nests), `reduce_and_canonicalize`
+//! (sort/dedup/short-circuit), `demorgans`, and especially `undistribute_and_or`
+//! (factoring `(a&&b)||(a&&c)` into `a&&(b||c)`), which only fires on wide,
+//! repeated-operand AND/OR trees that a purely binary generator essentially
+//! never produces.
+//!
+//! We reduce a clone with the accurate column types and check evaluation on a
+//! batch of random rows. The check is mostly one-directional: reduce is allowed
+//! to *eliminate* a runtime error (e.g. `If(c, x, x)` becomes `x`, dropping `c`,
+//! and `x AND false` becomes `false`), so we only require that a successful
+//! `Ok(v)` result is preserved exactly. The exception is non-strict AND/OR
+//! error absorption, where the oracle allows a reduced error if the original
+//! row succeeded by absorbing an operand error. Every value type compared is
+//! exact (no float/numeric normalization), so equality is the right oracle.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::func::variadic::{And, Or};
+use mz_expr::{func, Eval, EvalError, MirScalarExpr, VariadicFunc};
+use mz_repr::{Datum, ReprColumnType, ReprScalarType, Row, RowArena};
+
+// Column layout: a contiguous block per type. Columns are nullable.
+const N_INT: usize = 2; // int4   [COL_INT0, COL_LONG0)
+const N_LONG: usize = 1; // int8  [COL_LONG0, COL_BOOL0)
+const N_BOOL: usize = 2; // bool  [COL_BOOL0, COL_STR0)
+const N_STR: usize = 1; // text   [COL_STR0, N_COLS)
+const COL_INT0: usize = 0;
+const COL_LONG0: usize = COL_INT0 + N_INT;
+const COL_BOOL0: usize = COL_LONG0 + N_LONG;
+const COL_STR0: usize = COL_BOOL0 + N_BOOL;
+const N_COLS: usize = COL_STR0 + N_STR;
+const MAX_DEPTH: u32 = 6;
+const ROWS_PER_EXPR: usize = 8;
+
+#[derive(Clone, Copy)]
+enum Ty {
+    Int,
+    Long,
+    Bool,
+    Str,
+}
+
+fn scalar_ty(ty: Ty) -> ReprScalarType {
+    match ty {
+        Ty::Int => ReprScalarType::Int32,
+        Ty::Long => ReprScalarType::Int64,
+        Ty::Bool => ReprScalarType::Bool,
+        Ty::Str => ReprScalarType::String,
+    }
+}
+
+fn col_ty(col: usize) -> Ty {
+    if col < COL_LONG0 {
+        Ty::Int
+    } else if col < COL_BOOL0 {
+        Ty::Long
+    } else if col < COL_STR0 {
+        Ty::Bool
+    } else {
+        Ty::Str
+    }
+}
+
+fn col_types() -> Vec<ReprColumnType> {
+    (0..N_COLS)
+        .map(|c| scalar_ty(col_ty(c)).nullable(true))
+        .collect()
+}
+
+fn rand_ty(u: &mut Unstructured) -> arbitrary::Result<Ty> {
+    Ok(match u.int_in_range(0u8..=3)? {
+        0 => Ty::Int,
+        1 => Ty::Long,
+        2 => Ty::Bool,
+        _ => Ty::Str,
+    })
+}
+
+/// A short, bounded string drawn from an alphabet that sometimes parses as an
+/// integer (so the `text`→`int` casts hit both the success and error paths).
+fn gen_string(u: &mut Unstructured) -> arbitrary::Result<String> {
+    const ALPHABET: &[u8] = b"01239-+ aZ";
+    let n = u.int_in_range(0usize..=5)?;
+    let mut s = String::with_capacity(n);
+    for _ in 0..n {
+        let i = u.int_in_range(0usize..=ALPHABET.len() - 1)?;
+        s.push(ALPHABET[i] as char);
+    }
+    Ok(s)
+}
+
+/// A `'static` datum for the non-text types (text needs borrowed backing
+/// storage and is handled inline at each call site).
+fn nonstr_datum(u: &mut Unstructured, ty: Ty) -> arbitrary::Result<Datum<'static>> {
+    Ok(match ty {
+        Ty::Int => Datum::Int32(i32::arbitrary(u)?),
+        Ty::Long => Datum::Int64(i64::arbitrary(u)?),
+        Ty::Bool => {
+            if bool::arbitrary(u)? {
+                Datum::True
+            } else {
+                Datum::False
+            }
+        }
+        Ty::Str => unreachable!("text datums are built from borrowed storage"),
+    })
+}
+
+fn gen_leaf(u: &mut Unstructured, ty: Ty) -> arbitrary::Result<MirScalarExpr> {
+    let st = scalar_ty(ty);
+    Ok(match u.int_in_range(0u8..=3)? {
+        0 => {
+            let col = match ty {
+                Ty::Int => COL_INT0 + u.int_in_range(0..=N_INT - 1)?,
+                Ty::Long => COL_LONG0 + u.int_in_range(0..=N_LONG - 1)?,
+                Ty::Bool => COL_BOOL0 + u.int_in_range(0..=N_BOOL - 1)?,
+                Ty::Str => COL_STR0 + u.int_in_range(0..=N_STR - 1)?,
+            };
+            MirScalarExpr::column(col)
+        }
+        1 => match ty {
+            Ty::Str => {
+                let s = gen_string(u)?;
+                MirScalarExpr::literal_ok(Datum::String(&s), st)
+            }
+            _ => MirScalarExpr::literal_ok(nonstr_datum(u, ty)?, st),
+        },
+        2 => MirScalarExpr::literal_null(st),
+        // An error literal exercises reduce's error propagation/ordering.
+        _ => MirScalarExpr::literal(Err(EvalError::DivisionByZero), st),
+    })
+}
+
+/// Generate a small pool of bool "atoms", bounded subexpressions that the
+/// wide-And/Or builder draws operands from *with repetition*. Reuse is the whole
+/// point: `undistribute_and_or` only fires when the same operand appears across
+/// several branches (e.g. `(a&&b)||(a&&c)`), and `reduce_and_canonicalize`'s
+/// sort/dedup/short-circuit paths likewise need duplicates and unit/zero
+/// literals to bite. A purely independent recursive generator almost never
+/// repeats a subterm, so we seed the pool explicitly.
+fn gen_bool_atoms(u: &mut Unstructured, depth: u32) -> arbitrary::Result<Vec<MirScalarExpr>> {
+    let n = u.int_in_range(2usize..=4)?;
+    let mut atoms = Vec::with_capacity(n + 2);
+    for _ in 0..n {
+        atoms.push(gen_expr(u, Ty::Bool, depth)?);
+    }
+    // Seed unit/zero literals so canonicalization's true/false handling fires.
+    atoms.push(MirScalarExpr::literal_ok(Datum::True, scalar_ty(Ty::Bool)));
+    atoms.push(MirScalarExpr::literal_ok(Datum::False, scalar_ty(Ty::Bool)));
+    Ok(atoms)
+}
+
+/// Generate an n-ary `CallVariadic(And/Or, ..)` with 3+ operands, nesting other
+/// n-ary And/Or directly inside so reduce's `flatten_associative` and
+/// `undistribute_and_or` paths are reached. Operands are drawn (with repetition)
+/// from a shared atom pool, which is what lets the undistribution and
+/// dedup/short-circuit rewrites actually match.
+fn gen_wide_and_or(u: &mut Unstructured, depth: u32) -> arbitrary::Result<MirScalarExpr> {
+    let outer_is_and = bool::arbitrary(u)?;
+    let atoms = gen_bool_atoms(u, depth.saturating_sub(1))?;
+    let pick =
+        |u: &mut Unstructured, atoms: &[MirScalarExpr]| -> arbitrary::Result<MirScalarExpr> {
+            let i = u.int_in_range(0..=atoms.len() - 1)?;
+            Ok(atoms[i].clone())
+        };
+
+    let n_operands = u.int_in_range(3usize..=6)?;
+    let mut operands = Vec::with_capacity(n_operands);
+    for _ in 0..n_operands {
+        // With some probability nest an inner And/Or (often the *opposite*
+        // connective, the `(a&&b)||(a&&c)` distribution shape, sometimes the
+        // same one to exercise `flatten_associative`).
+        if depth > 0 && u.ratio(2u8, 5u8)? {
+            let inner_is_and = if u.ratio(3u8, 4u8)? {
+                !outer_is_and
+            } else {
+                outer_is_and
+            };
+            let n_inner = u.int_in_range(2usize..=4)?;
+            let mut inner = Vec::with_capacity(n_inner);
+            for _ in 0..n_inner {
+                inner.push(pick(u, &atoms)?);
+            }
+            operands.push(if inner_is_and {
+                MirScalarExpr::call_variadic(And, inner)
+            } else {
+                MirScalarExpr::call_variadic(Or, inner)
+            });
+        } else {
+            operands.push(pick(u, &atoms)?);
+        }
+    }
+    Ok(if outer_is_and {
+        MirScalarExpr::call_variadic(And, operands)
+    } else {
+        MirScalarExpr::call_variadic(Or, operands)
+    })
+}
+
+fn gen_expr(u: &mut Unstructured, ty: Ty, depth: u32) -> arbitrary::Result<MirScalarExpr> {
+    if depth == 0 || u.ratio(2u8, 5u8)? {
+        return gen_leaf(u, ty);
+    }
+    let d = depth - 1;
+    match ty {
+        Ty::Int => match u.int_in_range(0u8..=7)? {
+            // If { cond: bool, then: int, els: int }
+            0 => {
+                let cond = gen_expr(u, Ty::Bool, d)?;
+                let then = gen_expr(u, Ty::Int, d)?;
+                let els = gen_expr(u, Ty::Int, d)?;
+                Ok(cond.if_then_else(then, els))
+            }
+            // int4 arithmetic. `+`/`-`/`*`/`%` may overflow or divide by zero,
+            // producing an EvalError tolerated by the one-directional oracle.
+            1 => Ok(gen_expr(u, Ty::Int, d)?.call_binary(gen_expr(u, Ty::Int, d)?, func::AddInt32)),
+            2 => Ok(gen_expr(u, Ty::Int, d)?.call_binary(gen_expr(u, Ty::Int, d)?, func::SubInt32)),
+            3 => Ok(gen_expr(u, Ty::Int, d)?.call_binary(gen_expr(u, Ty::Int, d)?, func::MulInt32)),
+            4 => Ok(gen_expr(u, Ty::Int, d)?.call_binary(gen_expr(u, Ty::Int, d)?, func::ModInt32)),
+            5 => Ok(gen_expr(u, Ty::Int, d)?.call_unary(func::NegInt32)),
+            6 => Ok(gen_expr(u, Ty::Int, d)?.call_unary(func::AbsInt32)),
+            // Casts that produce an int4.
+            _ => match u.int_in_range(0u8..=2)? {
+                0 => Ok(gen_expr(u, Ty::Long, d)?.call_unary(func::CastInt64ToInt32)),
+                1 => Ok(gen_expr(u, Ty::Str, d)?.call_unary(func::CastStringToInt32)),
+                _ => Ok(gen_expr(u, Ty::Str, d)?.call_unary(func::ByteLengthString)),
+            },
+        },
+        Ty::Long => {
+            match u.int_in_range(0u8..=4)? {
+                0 => {
+                    let cond = gen_expr(u, Ty::Bool, d)?;
+                    let then = gen_expr(u, Ty::Long, d)?;
+                    let els = gen_expr(u, Ty::Long, d)?;
+                    Ok(cond.if_then_else(then, els))
+                }
+                1 => Ok(gen_expr(u, Ty::Long, d)?
+                    .call_binary(gen_expr(u, Ty::Long, d)?, func::AddInt64)),
+                2 => Ok(gen_expr(u, Ty::Long, d)?
+                    .call_binary(gen_expr(u, Ty::Long, d)?, func::SubInt64)),
+                3 => Ok(gen_expr(u, Ty::Long, d)?
+                    .call_binary(gen_expr(u, Ty::Long, d)?, func::MulInt64)),
+                // Casts that produce an int8.
+                _ => match u.int_in_range(0u8..=1)? {
+                    0 => Ok(gen_expr(u, Ty::Int, d)?.call_unary(func::CastInt32ToInt64)),
+                    _ => Ok(gen_expr(u, Ty::Str, d)?.call_unary(func::CastStringToInt64)),
+                },
+            }
+        }
+        Ty::Bool => match u.int_in_range(0u8..=7)? {
+            0 => {
+                let cond = gen_expr(u, Ty::Bool, d)?;
+                let then = gen_expr(u, Ty::Bool, d)?;
+                let els = gen_expr(u, Ty::Bool, d)?;
+                Ok(cond.if_then_else(then, els))
+            }
+            1 => Ok(gen_expr(u, Ty::Bool, d)?.and(gen_expr(u, Ty::Bool, d)?)),
+            2 => Ok(gen_expr(u, Ty::Bool, d)?.or(gen_expr(u, Ty::Bool, d)?)),
+            3 => Ok(gen_expr(u, Ty::Bool, d)?.not()),
+            // A wide, nested n-ary And/Or with shared operands, the shape that
+            // reaches flatten_associative / undistribute_and_or.
+            7 => gen_wide_and_or(u, d),
+            // A comparison of two operands of a common type yields a bool.
+            4 => {
+                let t = rand_ty(u)?;
+                let a = gen_expr(u, t, d)?;
+                let b = gen_expr(u, t, d)?;
+                Ok(match u.int_in_range(0u8..=4)? {
+                    0 => a.call_binary(b, func::Eq),
+                    1 => a.call_binary(b, func::Lt),
+                    2 => a.call_binary(b, func::Gt),
+                    3 => a.call_binary(b, func::Lte),
+                    _ => a.call_binary(b, func::Gte),
+                })
+            }
+            // IS NULL of any-typed operand yields a bool.
+            5 => {
+                let t = rand_ty(u)?;
+                Ok(gen_expr(u, t, d)?.call_is_null())
+            }
+            // int4 -> bool cast.
+            _ => Ok(gen_expr(u, Ty::Int, d)?.call_unary(func::CastInt32ToBool)),
+        },
+        Ty::Str => match u.int_in_range(0u8..=3)? {
+            0 => {
+                let cond = gen_expr(u, Ty::Bool, d)?;
+                let then = gen_expr(u, Ty::Str, d)?;
+                let els = gen_expr(u, Ty::Str, d)?;
+                Ok(cond.if_then_else(then, els))
+            }
+            1 => Ok(gen_expr(u, Ty::Str, d)?
+                .call_binary(gen_expr(u, Ty::Str, d)?, func::TextConcatBinary)),
+            2 => Ok(gen_expr(u, Ty::Int, d)?.call_unary(func::CastInt32ToString)),
+            _ => Ok(gen_expr(u, Ty::Bool, d)?.call_unary(func::CastBoolToString)),
+        },
+    }
+}
+
+fn gen_row(u: &mut Unstructured) -> arbitrary::Result<Row> {
+    let mut row = Row::default();
+    let mut packer = row.packer();
+    for c in 0..N_COLS {
+        if u.ratio(1u8, 4u8)? {
+            packer.push(Datum::Null);
+            continue;
+        }
+        match col_ty(c) {
+            Ty::Str => {
+                let s = gen_string(u)?;
+                packer.push(Datum::String(&s));
+            }
+            ty => packer.push(nonstr_datum(u, ty)?),
+        }
+    }
+    drop(packer);
+    Ok(row)
+}
+
+fn absorbs_and_or_operand_error<'a>(
+    expr: &'a MirScalarExpr,
+    datums: &[Datum<'a>],
+    arena: &'a RowArena,
+) -> bool {
+    match expr {
+        MirScalarExpr::Column(..)
+        | MirScalarExpr::Literal(..)
+        | MirScalarExpr::CallUnmaterializable(_) => false,
+        MirScalarExpr::CallUnary { expr, .. } => absorbs_and_or_operand_error(expr, datums, arena),
+        MirScalarExpr::CallBinary { expr1, expr2, .. } => {
+            absorbs_and_or_operand_error(expr1, datums, arena)
+                || absorbs_and_or_operand_error(expr2, datums, arena)
+        }
+        MirScalarExpr::CallVariadic { func, exprs } => {
+            let nested = exprs
+                .iter()
+                .any(|expr| absorbs_and_or_operand_error(expr, datums, arena));
+
+            if !matches!(func, VariadicFunc::And(_) | VariadicFunc::Or(_)) {
+                return nested;
+            }
+
+            let is_and = matches!(func, VariadicFunc::And(_));
+            let mut has_absorbing_value = false;
+            let mut has_error = false;
+            for expr in exprs {
+                match expr.eval(datums, arena) {
+                    Ok(Datum::False) if is_and => has_absorbing_value = true,
+                    Ok(Datum::True) if !is_and => has_absorbing_value = true,
+                    Err(_) => has_error = true,
+                    _ => {}
+                }
+            }
+
+            nested || (has_absorbing_value && has_error)
+        }
+        MirScalarExpr::If { cond, then, els } => {
+            if absorbs_and_or_operand_error(cond, datums, arena) {
+                return true;
+            }
+            match cond.eval(datums, arena) {
+                Ok(Datum::True) => absorbs_and_or_operand_error(then, datums, arena),
+                Ok(Datum::False | Datum::Null) => absorbs_and_or_operand_error(els, datums, arena),
+                _ => false,
+            }
+        }
+    }
+}
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    let types = col_types();
+    let top_ty = rand_ty(u)?;
+    let expr = gen_expr(u, top_ty, MAX_DEPTH)?;
+
+    let mut reduced = expr.clone();
+    reduced.reduce(&types);
+
+    for _ in 0..ROWS_PER_EXPR {
+        let row = gen_row(u)?;
+        let datums: Vec<Datum> = row.iter().collect();
+        let arena = RowArena::new();
+        let original = expr.eval(&datums, &arena);
+        let folded = reduced.eval(&datums, &arena);
+        // The invariant is one-directional. `reduce` is permitted to eliminate
+        // a runtime error, for example when `reduce_if` collapses `If(c, x, x)`
+        // to `x` and drops `c`. So an `Err` original may become anything. The
+        // known exception in the other direction: non-strict AND/OR error
+        // absorption, where a successful `false AND <error>` or
+        // `true OR <error>` may reduce through the absorbed error. Outer
+        // expressions can then fold that error into another value, for example
+        // `IS NULL` reducing to `false`, so skip the whole known shape.
+        if original.is_ok() {
+            if absorbs_and_or_operand_error(&expr, &datums, &arena) {
+                continue;
+            }
+            assert_eq!(
+                original, folded,
+                "reduce changed a successful evaluation\n  expr     = {expr:?}\n  reduced  = {reduced:?}\n  row      = {row:?}"
+            );
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/expr/fuzz/fuzz_targets/timezone_convert.rs
+++ b/src/expr/fuzz/fuzz_targets/timezone_convert.rs
@@ -1,0 +1,96 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: the `AT TIME ZONE` conversion math. Parsing an untrusted
+//! timezone and applying it to a timestamp does non-trivial offset arithmetic
+//! (DST transition lookups, leap-second-aware add/sub, Duration math), all of
+//! which must return an `EvalError` rather than panic on any input. We exercise
+//! both directions: TIMESTAMP -> TIMESTAMPTZ and TIMESTAMPTZ -> TIMESTAMP.
+//!
+//! An arbitrary `&str` almost never parses to a `Timezone`, and when it does
+//! it's overwhelmingly a trivial `FixedOffset`, so the interesting code (the
+//! named-zone DST-transition lookup, ambiguous/nonexistent local times) would
+//! barely run. So most of the time we pick a real IANA zone *with DST* (and a
+//! few fixed offsets) so the transition math actually executes. A minority arm
+//! still feeds an arbitrary string to keep the parser's reject paths covered.
+
+#![no_main]
+
+use chrono::DateTime;
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::{Eval, MirScalarExpr, UnaryFunc, func};
+use mz_pgtz::timezone::{Timezone, TimezoneSpec};
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::{Datum, ReprScalarType, RowArena};
+
+/// Real zones whose offsets shift (DST / sub-hour / historical), plus a couple
+/// of fixed offsets, the inputs that actually exercise the conversion math.
+const ZONES: &[&str] = &[
+    "America/New_York",
+    "America/Los_Angeles",
+    "Europe/London",
+    "Europe/Berlin",
+    "Europe/Lisbon",
+    "Australia/Lord_Howe", // 30-minute DST shift
+    "Pacific/Chatham",     // :45 offset with DST
+    "Antarctica/Troll",    // 2-hour DST jump
+    "Asia/Kolkata",        // :30, no DST
+    "America/Sao_Paulo",
+    "UTC",
+    "+05:30",
+    "-08",
+];
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    // 3-in-4: a real (mostly DST-bearing) zone, otherwise an arbitrary string.
+    let tz = if u.int_in_range(0u8..=3)? != 0 {
+        let Ok(tz) = Timezone::parse(u.choose(ZONES)?, TimezoneSpec::Iso) else {
+            return Ok(());
+        };
+        tz
+    } else {
+        let tz_str = <&str>::arbitrary(u)?;
+        let spec = if bool::arbitrary(u)? {
+            TimezoneSpec::Iso
+        } else {
+            TimezoneSpec::Posix
+        };
+        let Ok(tz) = Timezone::parse(tz_str, spec) else {
+            return Ok(());
+        };
+        tz
+    };
+    let secs = u.int_in_range(-8_000_000_000_000i64..=8_000_000_000_000)?;
+    let nanos = u.int_in_range(0u32..=999_999_999)?;
+    let Some(dt) = DateTime::from_timestamp(secs, nanos) else {
+        return Ok(());
+    };
+    let arena = RowArena::new();
+
+    // TIMESTAMP `AT TIME ZONE tz` -> TIMESTAMPTZ.
+    if let Ok(ts) = CheckedTimestamp::from_timestamplike(dt.naive_utc()) {
+        let expr = MirScalarExpr::literal_ok(Datum::Timestamp(ts), ReprScalarType::Timestamp)
+            .call_unary(UnaryFunc::TimezoneTimestamp(func::TimezoneTimestamp(tz)));
+        let _ = expr.eval(&[], &arena);
+    }
+
+    // TIMESTAMPTZ `AT TIME ZONE tz` -> TIMESTAMP.
+    if let Ok(tstz) = CheckedTimestamp::from_timestamplike(dt) {
+        let expr = MirScalarExpr::literal_ok(Datum::TimestampTz(tstz), ReprScalarType::TimestampTz)
+            .call_unary(UnaryFunc::TimezoneTimestampTz(func::TimezoneTimestampTz(tz)));
+        let _ = expr.eval(&[], &arena);
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/transform/fuzz/.gitignore
+++ b/src/transform/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/src/transform/fuzz/Cargo.toml
+++ b/src/transform/fuzz/Cargo.toml
@@ -1,0 +1,51 @@
+# Fuzz crate for mz-transform optimizer transforms (shape/`typ` preservation).
+#
+# Excluded from the main workspace because libFuzzer requires nightly Rust.
+# Run via the repo-wide runner, or locally:
+#     cd src/transform/fuzz
+#     cargo +nightly fuzz run mir_relation_transforms -- -max_total_time=60
+
+[package]
+workspace = "../../../test/cargo-fuzz"
+name = "mz-transform-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+mz-expr = { path = "../../expr" }
+mz-repr = { path = "../../repr" }
+mz-transform = { path = ".." }
+
+# Shared generators and oracle helpers used by every target below.
+[lib]
+name = "mz_transform_fuzz"
+path = "src/lib.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "mir_relation_transforms"
+path = "fuzz_targets/mir_relation_transforms.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "full_optimizer_equiv"
+path = "fuzz_targets/full_optimizer_equiv.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "optimizer_symbolic_equiv"
+path = "fuzz_targets/optimizer_symbolic_equiv.rs"
+test = false
+doc = false
+bench = false

--- a/src/transform/fuzz/fuzz_targets/full_optimizer_equiv.rs
+++ b/src/transform/fuzz/fuzz_targets/full_optimizer_equiv.rs
@@ -1,0 +1,84 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: the full logical optimizer must preserve results over plans
+//! rooted at literal `Constant`s. We build a random, well-typed plan over the
+//! bug-rich relational operators (`Join`, `Reduce`, `TopK`, `Threshold`,
+//! `Union`, and the map/filter/project/negate/distinct set), run the entire
+//! `Optimizer::logical_optimizer` pipeline, and check the optimized plan folds
+//! to the same `(row, diff)` multiset as the input.
+//!
+//! # Why this target as well as `optimizer_symbolic_equiv`
+//!
+//! On a `Constant`-rooted plan the optimizer's first constant folding (at the
+//! tail of the first `fuse_and_collapse_fixpoint`, roughly the sixth transform)
+//! collapses the whole plan to a single `Constant`. Every later stage
+//! (predicate/equivalence propagation, reduction pushdown, join
+//! ordering/implementation, CSE, literal lifting) then runs on that bare
+//! `Constant` and is a no-op. So for those stages this target contributes
+//! nothing and `optimizer_symbolic_equiv`, which keeps its `Get`s opaque so real
+//! relational planning happens, strictly dominates.
+//!
+//! What this target uniquely covers is the *other* side of that coin: the
+//! transforms that DO run here see literal `Constant` subtrees, which carry
+//! exact information a symbolic `Get` withholds:
+//!
+//!  * refined nullability (`Constant::typ` marks a column non-nullable when no
+//!    row is null in it), and
+//!  * exact keys and cardinality inferred from the actual rows.
+//!
+//! `NonNullRequirements`, `Demand`, `ReduceElision` (group key provably unique),
+//! `RedundantJoin`, and `SemijoinIdempotence` all take code paths off that exact
+//! information that opaque, all-nullable `Get`s never trigger. And they run here
+//! in real pipeline order with their interactions, which the per-transform
+//! `mir_relation_transforms` target (transforms in isolation) also cannot reach.
+//! So this target sits in a real gap between the other two.
+//!
+//! Oracle: fold the input to its `(row, diff)` multiset, run the optimizer, fold
+//! the result. When both fold to a constant, the multisets must be equal. A
+//! divergence is a miscompile. The comparison is conservative (we only assert
+//! when both sides fold, and skip when the optimizer returns an error, e.g. the
+//! `Typecheck` pass rejecting a plan shape), so a surviving assertion failure or
+//! a panic inside the optimizer is a genuine finding.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::Unstructured;
+use libfuzzer_sys::fuzz_target;
+use mz_transform_fuzz::{fold_to_multiset, gen_constant, gen_rel, optimize};
+
+fn run(u: &mut Unstructured) -> libfuzzer_sys::arbitrary::Result<()> {
+    let mut leaf = gen_constant;
+    let (rel, _schema, _nn) = gen_rel(u, 4, &mut leaf)?;
+
+    // The input must fold to actual rows for there to be anything to compare.
+    let Some(baseline) = fold_to_multiset(rel.clone()) else {
+        return Ok(());
+    };
+
+    let Some(optimized) = optimize(rel.clone()) else {
+        return Ok(());
+    };
+
+    // The optimizer is semantics-preserving: the optimized plan must fold to the
+    // same multiset. We only assert when the optimized plan also folds (it should,
+    // since all leaves are constant), staying conservative about fold limitations.
+    if let Some(after) = fold_to_multiset(optimized) {
+        assert_eq!(
+            baseline, after,
+            "the optimizer changed the result multiset\n{rel:?}"
+        );
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/transform/fuzz/fuzz_targets/mir_relation_transforms.rs
+++ b/src/transform/fuzz/fuzz_targets/mir_relation_transforms.rs
@@ -1,0 +1,272 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: optimizer transforms on `MirRelationExpr` must preserve a
+//! relation's shape and results. We build a random, well-typed plan rooted at
+//! `Constant` collections (so it is fully constant-foldable and every scalar
+//! subexpression is well-typed by construction), then for each transform check:
+//!
+//!  1. Shape preservation: arity and per-column scalar types are unchanged
+//!     (nullability and keys may be refined).
+//!  2. Result equivalence: because the plan is fully constant, `FoldConstants`
+//!     evaluates it to a `Constant`, giving the actual result rows. Folding the
+//!     transformed plan must yield the same consolidated `(row, diff)` multiset
+//!     as folding the original plan, a genuine correctness check.
+//!
+//! Transforms exercised: `FoldConstants` itself, `CanonicalizeMfp` (Map/Filter/
+//! Project chains), `UnionBranchCancellation`, the structural fusions
+//! (`Filter`/`Project`/`Map`/`Negate`/`Union`) and `ProjectionExtraction`, plus
+//! a hand-written semantics-preserving structural rewrite. Where
+//! `full_optimizer_equiv` runs the whole pipeline over constant-rooted plans,
+//! this target checks each transform in isolation, so a divergence points at a
+//! single transform rather than an interaction.
+//!
+//! The scalar and constant generators ([`gen_scalar`], [`gen_constant`]) are
+//! shared with the other targets. What is specific here is a `Union` generator
+//! whose branches are NOT simply `x ∪ -x`: a branch is unioned with a
+//! `Map`/`Filter`/`Project`-wrapped negation of an *equal* branch (so the real
+//! `compare_branches` recursion through interleaved structural ops must run to
+//! detect the `Inverse`), interspersed with a genuinely distinct extra branch
+//! that must NOT cancel. This drives `UnionBranchCancellation`'s matching logic
+//! instead of only its top-level `x ∪ -x` fast path.
+
+#![no_main]
+
+use std::collections::BTreeMap;
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::{MirRelationExpr, MirScalarExpr};
+use mz_repr::{Diff, ReprRelationType, Row};
+use mz_transform::canonicalization::ProjectionExtraction;
+use mz_transform::canonicalize_mfp::CanonicalizeMfp;
+use mz_transform::fold_constants::FoldConstants;
+use mz_transform::fusion;
+use mz_transform::union_cancel::UnionBranchCancellation;
+use mz_transform_fuzz::{
+    Ty, apply_recursively, fold_to_multiset, gen_constant, gen_scalar, rand_ty,
+};
+
+fn gen_rel(u: &mut Unstructured, depth: u32) -> arbitrary::Result<(MirRelationExpr, Vec<Ty>)> {
+    if depth == 0 || u.ratio(2u8, 5u8)? {
+        return gen_constant(u);
+    }
+    let (inner, schema) = gen_rel(u, depth - 1)?;
+    Ok(match u.int_in_range(0u8..=5)? {
+        // Filter: 1-2 boolean predicates over the input columns, shape unchanged.
+        0 => {
+            let n = u.int_in_range(1usize..=2)?;
+            let preds = (0..n)
+                .map(|_| gen_scalar(u, Ty::Bool, &schema, 2))
+                .collect::<arbitrary::Result<Vec<_>>>()?;
+            (inner.filter(preds), schema)
+        }
+        // Map: append one computed column.
+        1 => {
+            let ty = rand_ty(u)?;
+            let e = gen_scalar(u, ty, &schema, 2)?;
+            let mut s = schema.clone();
+            s.push(ty);
+            (inner.map(vec![e]), s)
+        }
+        // Project: pick a (possibly reordered/duplicated) subset of columns.
+        2 => {
+            let len = schema.len();
+            let k = u.int_in_range(1usize..=len)?;
+            let mut outputs = Vec::with_capacity(k);
+            for _ in 0..k {
+                outputs.push(u.int_in_range(0..=len - 1)?);
+            }
+            let s = outputs.iter().map(|&i| schema[i]).collect();
+            (inner.project(outputs), s)
+        }
+        3 => (inner.negate(), schema),
+        4 => (inner.distinct(), schema),
+        // Union `inner` with a cancelling counterpart. Instead of the trivial
+        // `inner ∪ -inner`, the counterpart is `inner` wrapped in a random chain
+        // of Map/Filter/Project/Negate carrying an *odd* number of Negates, with
+        // the *same* scalars on both sides, so `UnionBranchCancellation`'s
+        // `compare_branches` recursion through interleaved structural ops must run
+        // to recognize the `Inverse`. A genuinely distinct extra branch (with a
+        // fresh predicate) is interspersed and must NOT cancel. The schema is
+        // unchanged and the cancelling pair sums to zero, so the result is just
+        // `distinct`'s contribution, unaffected by whether the transform fires.
+        _ => {
+            // Build a Map/Filter/Project wrapper applied identically to two clones
+            // of `inner`, with an extra Negate on exactly one of them so the pair
+            // cancels. `compare_branches` requires the structural ops to appear in
+            // the same order with equal arguments, which this construction
+            // guarantees by replaying the same recorded steps on both sides.
+            enum Step {
+                Map(MirScalarExpr),
+                Filter(MirScalarExpr),
+                Negate,
+            }
+            let n_steps = u.int_in_range(0usize..=3)?;
+            let mut steps = Vec::with_capacity(n_steps);
+            let mut wrapped_schema = schema.clone();
+            for _ in 0..n_steps {
+                match u.int_in_range(0u8..=2)? {
+                    0 => {
+                        let ty = rand_ty(u)?;
+                        let e = gen_scalar(u, ty, &wrapped_schema, 2)?;
+                        wrapped_schema.push(ty);
+                        steps.push(Step::Map(e));
+                    }
+                    1 => steps.push(Step::Filter(gen_scalar(u, Ty::Bool, &wrapped_schema, 2)?)),
+                    _ => steps.push(Step::Negate),
+                }
+            }
+            let replay = |mut rel: MirRelationExpr, extra_negate: bool| {
+                if extra_negate {
+                    rel = rel.negate();
+                }
+                for step in &steps {
+                    rel = match step {
+                        Step::Map(e) => rel.map(vec![e.clone()]),
+                        Step::Filter(p) => rel.filter(vec![p.clone()]),
+                        Step::Negate => rel.negate(),
+                    };
+                }
+                rel
+            };
+            // The wrapped pair shares the wrapped schema. Project both back to the
+            // original arity so the whole union keeps `inner`'s schema.
+            let proj: Vec<usize> = (0..schema.len()).collect();
+            let left = replay(inner.clone(), false).project(proj.clone());
+            let right = replay(inner.clone(), true).project(proj.clone());
+            // An extra, genuinely-distinct branch that must survive cancellation:
+            // `inner` filtered by a fresh predicate.
+            let distinct_pred = gen_scalar(u, Ty::Bool, &schema, 2)?;
+            let extra = inner.clone().filter(vec![distinct_pred]);
+            // Randomize branch order so the matcher's position search is exercised
+            // (`.union` flattens, so this yields a single 3-input `Union`).
+            let [b0, b1, b2] = match u.int_in_range(0u8..=2)? {
+                0 => [right, extra, left],
+                1 => [extra, left, right],
+                _ => [left, right, extra],
+            };
+            (b0.union(b1).union(b2), schema)
+        }
+    })
+}
+
+/// Wrap `rel` in a transformation that preserves its `(row, diff)` multiset.
+fn wrap_preserving(
+    u: &mut Unstructured,
+    rel: MirRelationExpr,
+    arity: usize,
+) -> arbitrary::Result<MirRelationExpr> {
+    let identity = || (0..arity).collect::<Vec<_>>();
+    Ok(match u.int_in_range(0u8..=3)? {
+        0 => rel.project(identity()),
+        1 => rel.filter(vec![MirScalarExpr::literal_true()]),
+        2 => rel.negate().negate(),
+        _ => rel
+            .map(vec![MirScalarExpr::literal_true()])
+            .project(identity()),
+    })
+}
+
+fn assert_shape(
+    before: &ReprRelationType,
+    after: &ReprRelationType,
+    who: &str,
+    rel: &MirRelationExpr,
+) {
+    assert_eq!(
+        before.column_types.len(),
+        after.column_types.len(),
+        "{who} changed the number of columns:\n{rel:?}"
+    );
+    for (b, a) in before.column_types.iter().zip(after.column_types.iter()) {
+        assert_eq!(
+            b.scalar_type, a.scalar_type,
+            "{who} changed a column's scalar type:\n{rel:?}"
+        );
+    }
+}
+
+/// If both the baseline and the transformed plan fold to constants, require the
+/// result multisets to match.
+fn assert_same_rows(
+    baseline: &Option<BTreeMap<Row, Diff>>,
+    transformed: MirRelationExpr,
+    who: &str,
+    orig: &MirRelationExpr,
+) {
+    if let (Some(b), Some(t)) = (baseline.as_ref(), fold_to_multiset(transformed)) {
+        assert_eq!(*b, t, "{who} changed the fold result:\n{orig:?}");
+    }
+}
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    let (rel, schema) = gen_rel(u, 5)?;
+    let baseline = fold_to_multiset(rel.clone());
+
+    // A hand-written semantics-preserving structural rewrite.
+    let rewrite = wrap_preserving(u, rel.clone(), schema.len())?;
+    assert_same_rows(&baseline, rewrite, "structural rewrite", &rel);
+
+    // CanonicalizeMfp: canonicalizes Map/Filter/Project chains.
+    {
+        let mut r = rel.clone();
+        let before = r.typ();
+        if CanonicalizeMfp.action(&mut r).is_ok() {
+            assert_shape(&before, &r.typ(), "CanonicalizeMfp", &rel);
+            assert_same_rows(&baseline, r, "CanonicalizeMfp", &rel);
+        }
+    }
+
+    // UnionBranchCancellation: cancels a branch unioned with its negation.
+    {
+        let mut r = rel.clone();
+        let before = r.typ();
+        if apply_recursively(UnionBranchCancellation, &mut r).is_ok() {
+            assert_shape(&before, &r.typ(), "UnionBranchCancellation", &rel);
+            assert_same_rows(&baseline, r, "UnionBranchCancellation", &rel);
+        }
+    }
+
+    // Structural fusions. Each is a purely local, semantics-preserving rewrite
+    // applied across the whole tree (pre-order, matching their real drivers).
+    // None changes the result multiset or the output shape, on any input.
+    for (who, action) in [
+        (
+            "FilterFusion",
+            fusion::filter::Filter::action as fn(&mut MirRelationExpr),
+        ),
+        ("ProjectFusion", fusion::project::Project::action),
+        ("MapFusion", fusion::map::Map::action),
+        ("NegateFusion", fusion::negate::Negate::action),
+        ("UnionFusion", fusion::union::Union::action),
+        ("ProjectionExtraction", ProjectionExtraction::action),
+    ] {
+        let mut r = rel.clone();
+        let before = r.typ();
+        r.visit_pre_mut(action);
+        assert_shape(&before, &r.typ(), who, &rel);
+        assert_same_rows(&baseline, r, who, &rel);
+    }
+
+    // FoldConstants: the evaluator itself must at least preserve shape.
+    {
+        let mut r = rel;
+        let before = r.typ();
+        if apply_recursively(FoldConstants { limit: None }, &mut r).is_ok() {
+            assert_shape(&before, &r.typ(), "FoldConstants", &r);
+        }
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/transform/fuzz/fuzz_targets/optimizer_symbolic_equiv.rs
+++ b/src/transform/fuzz/fuzz_targets/optimizer_symbolic_equiv.rs
@@ -1,0 +1,195 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Fuzz target: the logical optimizer must preserve results over *symbolic*
+//! inputs. `full_optimizer_equiv` builds plans rooted at `Constant`s, so the
+//! optimizer constant-folds everything away before the interesting relational
+//! planning (join ordering/implementation, predicate and projection pushdown
+//! through `Get`s, key inference) ever runs. This target instead roots the plan
+//! at `Get`s, opaque relations, exactly what the optimizer sees when planning a
+//! real query against catalog objects, so that planning actually happens, while
+//! still retaining a ground-truth oracle.
+//!
+//! Each `Get` is bound (in a side table) to a concrete, fuzzed constant
+//! collection. The oracle:
+//!
+//!   1. `baseline = collapse(substitute(plan))`. Inline each `Get`'s data, then
+//!      fold to the actual result rows.
+//!   2. `optimized = optimize(plan)`. Run the full logical optimizer with the
+//!      `Get`s still symbolic, so join/pushdown/key planning runs for real.
+//!   3. `after = collapse(substitute(optimized))`. Inline the same data into the
+//!      optimized plan and fold.
+//!   4. assert `baseline == after`.
+//!
+//! `substitute` replaces only the global `Get`s we created. The optimizer's own
+//! `Let`/local `Get` bindings (e.g. from CSE) are collapsed by `collapse`, which
+//! iterates `FoldConstants` + `NormalizeLets` until the plan reduces to a
+//! `Constant`. The comparison is conservative (only asserted when both sides
+//! fold, a `Typecheck`/optimizer error is a skip), so a surviving divergence or
+//! an optimizer panic is a genuine finding. It covers the symbolic-input
+//! planning that the constant-rooted target cannot reach.
+
+#![no_main]
+
+use std::collections::BTreeMap;
+
+use libfuzzer_sys::arbitrary::{self, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use mz_expr::{Id, MirRelationExpr};
+use mz_repr::optimize::OptimizerFeatures;
+use mz_repr::{Diff, GlobalId, Row};
+use mz_transform::fold_constants::FoldConstants;
+use mz_transform::normalize_lets::NormalizeLets;
+use mz_transform_fuzz::{Ty, apply_recursively, gen_constant, gen_rel, optimize};
+
+/// A symbolic `Get` leaf bound (in `data`) to a fresh constant collection.
+fn gen_get(
+    u: &mut Unstructured,
+    next_id: &mut u64,
+    data: &mut BTreeMap<u64, MirRelationExpr>,
+) -> arbitrary::Result<(MirRelationExpr, Vec<Ty>)> {
+    let (constant, schema) = gen_constant(u)?;
+    // The `Get`'s declared type is the constant's *stored* (all-nullable) type,
+    // not `constant.typ()`, which would refine nullability from the data. Keeping
+    // it loose is the whole point: the optimizer must plan against an opaque
+    // relation, without the exact nullability/keys a `Constant` would reveal.
+    let MirRelationExpr::Constant { typ, .. } = &constant else {
+        unreachable!("gen_constant returns a Constant");
+    };
+    let typ = typ.clone();
+
+    let id = *next_id;
+    *next_id += 1;
+    data.insert(id, constant);
+
+    Ok((MirRelationExpr::global_get(GlobalId::User(id), typ), schema))
+}
+
+/// Replace every global `Get` we created with its bound constant collection.
+/// Local `Get`s (introduced by the optimizer's `Let`s) are left for `collapse`.
+fn substitute(mut rel: MirRelationExpr, data: &BTreeMap<u64, MirRelationExpr>) -> MirRelationExpr {
+    rel.visit_pre_mut(|e| {
+        let replacement = match e {
+            MirRelationExpr::Get {
+                id: Id::Global(GlobalId::User(uid)),
+                ..
+            } => data.get(&*uid).cloned(),
+            _ => None,
+        };
+        if let Some(c) = replacement {
+            *e = c;
+        }
+    });
+    rel
+}
+
+/// Outcome of trying to fold a (`Get`-free) plan all the way to a `Constant`.
+enum Collapse {
+    /// Reduced to a `Constant` of `Ok` rows. The consolidated `(row, diff)`
+    /// multiset is the actual result.
+    Const(BTreeMap<Row, Diff>),
+    /// Reached a fixpoint of `FoldConstants` + `NormalizeLets` (applying them no
+    /// longer changes the plan) that is *not* a constant, e.g. the plan errors,
+    /// or folding genuinely cannot evaluate it. This is a legitimate
+    /// fold-limitation skip, not a coverage gap.
+    StuckFixpoint,
+    /// Hit the iteration budget without reaching either a constant or a
+    /// fixpoint. The plan was still simplifying when we ran out of passes. Kept
+    /// distinct from `StuckFixpoint` only to name the two skip reasons.
+    /// `FoldConstants` does not promise a constant input collapses to a
+    /// `Constant` within any limit, so this is a conservative skip too.
+    BudgetExhausted,
+}
+
+/// Fold a (now `Get`-free) plan to a `Constant` by iterating `FoldConstants` +
+/// `NormalizeLets` (to collapse any `Let`s the optimizer's CSE introduced) until
+/// it either becomes a `Constant`, reaches a fixpoint, or exhausts the budget.
+///
+/// This loops to a genuine fixpoint (stops only when a pass leaves the plan
+/// unchanged), so a plan that just needs a few more passes converges rather than
+/// being dropped. The budget is a generous guard against a non-terminating
+/// rewrite.
+fn collapse(mut rel: MirRelationExpr) -> Collapse {
+    let features = OptimizerFeatures::default();
+    const BUDGET: usize = 64;
+    for _ in 0..BUDGET {
+        let before = rel.clone();
+        if apply_recursively(FoldConstants { limit: None }, &mut rel).is_err() {
+            return Collapse::StuckFixpoint;
+        }
+        if rel.as_const().is_some() {
+            break;
+        }
+        if NormalizeLets::new(true)
+            .action(&mut rel, &features)
+            .is_err()
+        {
+            return Collapse::StuckFixpoint;
+        }
+        // A full pass that changed nothing means we will never reach a constant.
+        if rel == before {
+            return Collapse::StuckFixpoint;
+        }
+    }
+    let Some(constant) = rel.as_const() else {
+        // Still simplifying when the budget ran out.
+        return Collapse::BudgetExhausted;
+    };
+    let (Ok(rows), _) = constant else {
+        return Collapse::StuckFixpoint;
+    };
+    let mut multiset: BTreeMap<Row, Diff> = BTreeMap::new();
+    for (row, diff) in rows {
+        *multiset.entry(row.clone()).or_insert(Diff::ZERO) += *diff;
+    }
+    multiset.retain(|_, d| *d != Diff::ZERO);
+    Collapse::Const(multiset)
+}
+
+fn run(u: &mut Unstructured) -> arbitrary::Result<()> {
+    let mut next_id = 0u64;
+    let mut data = BTreeMap::new();
+    let (plan, _schema, _nn) = {
+        let mut leaf = |u: &mut Unstructured| gen_get(u, &mut next_id, &mut data);
+        gen_rel(u, 3, &mut leaf)?
+    };
+
+    // Ground truth: inline the data into the input plan and fold. Only proceed
+    // when the *input* (which has no optimizer-introduced `Let`s) folds to a
+    // constant, that is what gives us a result to compare against.
+    let baseline = match collapse(substitute(plan.clone(), &data)) {
+        Collapse::Const(b) => b,
+        Collapse::StuckFixpoint | Collapse::BudgetExhausted => return Ok(()),
+    };
+
+    // Optimize with the Gets still symbolic, then inline the same data and fold.
+    let Some(optimized) = optimize(plan.clone()) else {
+        return Ok(());
+    };
+    match collapse(substitute(optimized, &data)) {
+        Collapse::Const(after) => assert_eq!(
+            baseline, after,
+            "optimizer changed the result over symbolic inputs\nplan = {plan:?}\ndata = {data:?}"
+        ),
+        // The optimized plan did not fold to a constant: either a non-constant
+        // fixpoint (an operator `FoldConstants` cannot evaluate) or still
+        // simplifying when the 64-pass budget ran out. `FoldConstants` does not
+        // promise a constant input reduces to a `Constant` within a limit, and
+        // the optimizer legitimately reshapes plans (CSE into `Let` nesting)
+        // into forms this two-pass loop may not drive to a fixpoint here. Both
+        // are conservative skips, not divergences, matching `full_optimizer_equiv`.
+        Collapse::StuckFixpoint | Collapse::BudgetExhausted => {}
+    }
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+    let _ = run(&mut u);
+});

--- a/src/transform/fuzz/src/lib.rs
+++ b/src/transform/fuzz/src/lib.rs
@@ -1,0 +1,477 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Shared generators and oracle helpers for the `mz-transform` fuzz targets.
+//!
+//! The three targets (`mir_relation_transforms`, `full_optimizer_equiv`,
+//! `optimizer_symbolic_equiv`) all build random, well-typed `MirRelationExpr`
+//! plans over an `int4`/`int8`/`bool` schema and check result preservation with
+//! a `FoldConstants`-based oracle. They differ only in what they root the plan
+//! at (literal `Constant`s vs opaque `Get`s) and which transforms they drive.
+//! Everything they have in common lives here:
+//!
+//!  * [`gen_scalar`] builds well-typed scalar expressions (arithmetic per width,
+//!    the boolean connectives, `Eq`, `If`, and the int/bool casts).
+//!  * [`gen_constant`] builds a random literal `Constant` collection.
+//!  * [`gen_rel`] builds a random relation over the bug-rich relational
+//!    operators (`Join`, `Reduce`, `TopK`, `Threshold`, `Union`, and the
+//!    map/filter/project/negate/distinct set), parameterized by a `leaf` closure
+//!    so a caller can root it at `Constant`s or symbolic `Get`s.
+//!  * [`apply_recursively`], [`fold_to_multiset`], and [`optimize`] are the
+//!    oracle machinery.
+
+use std::collections::BTreeMap;
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use mz_expr::{
+    AggregateExpr, AggregateFunc, ColumnOrder, EvalError, MirRelationExpr, MirScalarExpr, func,
+};
+use mz_repr::optimize::OptimizerFeatures;
+use mz_repr::{Datum, Diff, GlobalId, ReprColumnType, ReprRelationType, ReprScalarType, Row};
+use mz_transform::dataflow::DataflowMetainfo;
+use mz_transform::fold_constants::FoldConstants;
+use mz_transform::{Optimizer, Transform, TransformCtx, TransformError, typecheck};
+
+/// The scalar types the fuzz targets generate over.
+#[derive(Clone, Copy, PartialEq)]
+pub enum Ty {
+    Int32,
+    Int64,
+    Bool,
+}
+
+fn scalar_ty(ty: Ty) -> ReprScalarType {
+    match ty {
+        Ty::Int32 => ReprScalarType::Int32,
+        Ty::Int64 => ReprScalarType::Int64,
+        Ty::Bool => ReprScalarType::Bool,
+    }
+}
+
+/// Pick a random column type.
+pub fn rand_ty(u: &mut Unstructured) -> arbitrary::Result<Ty> {
+    Ok(match u.int_in_range(0u8..=2)? {
+        0 => Ty::Int32,
+        1 => Ty::Int64,
+        _ => Ty::Bool,
+    })
+}
+
+fn gen_datum(u: &mut Unstructured, ty: Ty) -> arbitrary::Result<Datum<'static>> {
+    if u.ratio(1u8, 5u8)? {
+        return Ok(Datum::Null);
+    }
+    Ok(match ty {
+        Ty::Int32 => Datum::Int32(i32::arbitrary(u)?),
+        Ty::Int64 => Datum::Int64(i64::arbitrary(u)?),
+        Ty::Bool => {
+            if bool::arbitrary(u)? {
+                Datum::True
+            } else {
+                Datum::False
+            }
+        }
+    })
+}
+
+fn cols_of(schema: &[Ty], ty: Ty) -> Vec<usize> {
+    schema
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| **t == ty)
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// A well-typed scalar expression of type `ty` over a relation with column types
+/// `schema`. Column references only target columns of the requested type, and
+/// every leaf may also be a literal (constant, null, or a poison error to
+/// exercise error-propagation paths). Includes `Add`/`Sub`/`Mul`/`Mod` per
+/// integer width, the boolean connectives, `Eq` across a random type, `If`, and
+/// the `int4`<->`int8`/`int4`<->`bool` casts so neither integer width is a leaf.
+pub fn gen_scalar(
+    u: &mut Unstructured,
+    ty: Ty,
+    schema: &[Ty],
+    depth: u32,
+) -> arbitrary::Result<MirScalarExpr> {
+    let st = scalar_ty(ty);
+    if depth == 0 || u.ratio(1u8, 2u8)? {
+        let cols = cols_of(schema, ty);
+        if !cols.is_empty() && bool::arbitrary(u)? {
+            let idx = u.int_in_range(0..=cols.len() - 1)?;
+            return Ok(MirScalarExpr::column(cols[idx]));
+        }
+        return Ok(match u.int_in_range(0u8..=2)? {
+            0 => MirScalarExpr::literal_ok(gen_datum(u, ty)?, st),
+            1 => MirScalarExpr::literal_null(st),
+            _ => MirScalarExpr::literal(Err(EvalError::DivisionByZero), st),
+        });
+    }
+    let d = depth - 1;
+    // An `If`/`then`/`else` of the requested type, available for every `ty`.
+    let gen_if = |u: &mut Unstructured| -> arbitrary::Result<MirScalarExpr> {
+        let c = gen_scalar(u, Ty::Bool, schema, d)?;
+        let t = gen_scalar(u, ty, schema, d)?;
+        let f = gen_scalar(u, ty, schema, d)?;
+        Ok(c.if_then_else(t, f))
+    };
+    Ok(match ty {
+        Ty::Int32 => match u.int_in_range(0u8..=5)? {
+            0 => gen_scalar(u, Ty::Int32, schema, d)?
+                .call_binary(gen_scalar(u, Ty::Int32, schema, d)?, func::AddInt32),
+            1 => gen_scalar(u, Ty::Int32, schema, d)?
+                .call_binary(gen_scalar(u, Ty::Int32, schema, d)?, func::SubInt32),
+            2 => gen_scalar(u, Ty::Int32, schema, d)?
+                .call_binary(gen_scalar(u, Ty::Int32, schema, d)?, func::MulInt32),
+            3 => gen_scalar(u, Ty::Int32, schema, d)?
+                .call_binary(gen_scalar(u, Ty::Int32, schema, d)?, func::ModInt32),
+            // Narrowing cast from int8 (may error on overflow, folds to an error).
+            4 => gen_scalar(u, Ty::Int64, schema, d)?.call_unary(func::CastInt64ToInt32),
+            _ => gen_if(u)?,
+        },
+        Ty::Int64 => match u.int_in_range(0u8..=5)? {
+            0 => gen_scalar(u, Ty::Int64, schema, d)?
+                .call_binary(gen_scalar(u, Ty::Int64, schema, d)?, func::AddInt64),
+            1 => gen_scalar(u, Ty::Int64, schema, d)?
+                .call_binary(gen_scalar(u, Ty::Int64, schema, d)?, func::SubInt64),
+            2 => gen_scalar(u, Ty::Int64, schema, d)?
+                .call_binary(gen_scalar(u, Ty::Int64, schema, d)?, func::MulInt64),
+            3 => gen_scalar(u, Ty::Int64, schema, d)?
+                .call_binary(gen_scalar(u, Ty::Int64, schema, d)?, func::ModInt64),
+            // Widening cast from int4.
+            4 => gen_scalar(u, Ty::Int32, schema, d)?.call_unary(func::CastInt32ToInt64),
+            _ => gen_if(u)?,
+        },
+        Ty::Bool => match u.int_in_range(0u8..=5)? {
+            0 => gen_scalar(u, Ty::Bool, schema, d)?.and(gen_scalar(u, Ty::Bool, schema, d)?),
+            1 => gen_scalar(u, Ty::Bool, schema, d)?.or(gen_scalar(u, Ty::Bool, schema, d)?),
+            2 => gen_scalar(u, Ty::Bool, schema, d)?.not(),
+            3 => {
+                let t = rand_ty(u)?;
+                let a = gen_scalar(u, t, schema, d)?;
+                let b = gen_scalar(u, t, schema, d)?;
+                a.call_binary(b, func::Eq)
+            }
+            // Cast int4 -> bool (nonzero is true).
+            4 => gen_scalar(u, Ty::Int32, schema, d)?.call_unary(func::CastInt32ToBool),
+            _ => gen_if(u)?,
+        },
+    })
+}
+
+/// A random literal `Constant` collection (1-3 columns, 0-4 rows), returned with
+/// its column schema. All columns are declared nullable.
+pub fn gen_constant(u: &mut Unstructured) -> arbitrary::Result<(MirRelationExpr, Vec<Ty>)> {
+    let ncols = u.int_in_range(1usize..=3)?;
+    let schema: Vec<Ty> = (0..ncols)
+        .map(|_| rand_ty(u))
+        .collect::<arbitrary::Result<_>>()?;
+    let col_types: Vec<ReprColumnType> = schema
+        .iter()
+        .map(|t| scalar_ty(*t).nullable(true))
+        .collect();
+    let nrows = u.int_in_range(0usize..=4)?;
+    let mut rows = Vec::with_capacity(nrows);
+    for _ in 0..nrows {
+        let mut row = Vec::with_capacity(ncols);
+        for t in &schema {
+            row.push(gen_datum(u, *t)?);
+        }
+        rows.push(row);
+    }
+    Ok((
+        MirRelationExpr::constant(rows, ReprRelationType::new(col_types)),
+        schema,
+    ))
+}
+
+/// One aggregate over `schema`, plus the scalar type of its output column.
+///
+/// The aggregated input is a freshly generated scalar expression of the
+/// function's required input type (not just a bare column reference), so the
+/// reduction sees `max(a + b)`, `sum(if p then x else y)`, etc., exercising
+/// aggregate-input simplification and the reduce MFP.
+fn gen_aggregate(u: &mut Unstructured, schema: &[Ty]) -> arbitrary::Result<(AggregateExpr, Ty)> {
+    // (func, required input type, output type).
+    let opts: &[(AggregateFunc, Ty, Ty)] = &[
+        (AggregateFunc::MaxInt32, Ty::Int32, Ty::Int32),
+        (AggregateFunc::MinInt32, Ty::Int32, Ty::Int32),
+        (AggregateFunc::SumInt32, Ty::Int32, Ty::Int64),
+        (AggregateFunc::MaxInt64, Ty::Int64, Ty::Int64),
+        (AggregateFunc::MinInt64, Ty::Int64, Ty::Int64),
+        (AggregateFunc::Any, Ty::Bool, Ty::Bool),
+        (AggregateFunc::All, Ty::Bool, Ty::Bool),
+        (AggregateFunc::Count, Ty::Int32, Ty::Int64),
+    ];
+    let idx = u.int_in_range(0..=opts.len() - 1)?;
+    let (func, in_ty, out) = opts[idx].clone();
+    // A computed input of the required type. The aggregate `expr` can be any
+    // well-typed scalar, not just a column. Depth keeps it bounded.
+    let expr = gen_scalar(u, in_ty, schema, 2)?;
+    Ok((
+        AggregateExpr {
+            func,
+            expr,
+            distinct: bool::arbitrary(u)?,
+        },
+        out,
+    ))
+}
+
+/// Generate a random relation, returning it, its column schema, and whether it
+/// is guaranteed to have non-negative multiplicities.
+///
+/// `leaf` produces the base relations the plan is rooted at. The constant-rooted
+/// targets return a literal `Constant`; the symbolic target returns an opaque
+/// `Get` (and records its backing data on the side). Either way `leaf` returns a
+/// relation and its column schema; leaves are assumed non-negative.
+///
+/// The non-negativity flag is the contract `TopK` (and every dataflow reduction)
+/// requires of its input, so we only place a `TopK` directly over a non-negative
+/// subtree. See the `TopK` arm.
+pub fn gen_rel<F>(
+    u: &mut Unstructured,
+    depth: u32,
+    leaf: &mut F,
+) -> arbitrary::Result<(MirRelationExpr, Vec<Ty>, bool)>
+where
+    F: FnMut(&mut Unstructured) -> arbitrary::Result<(MirRelationExpr, Vec<Ty>)>,
+{
+    if depth == 0 || u.ratio(2u8, 5u8)? {
+        let (rel, schema) = leaf(u)?;
+        return Ok((rel, schema, true));
+    }
+    let (inner, schema, inner_nn) = gen_rel(u, depth - 1, leaf)?;
+    let arity = schema.len();
+    Ok(match u.int_in_range(0u8..=9)? {
+        // Filter
+        0 => {
+            let n = u.int_in_range(1usize..=2)?;
+            let preds = (0..n)
+                .map(|_| gen_scalar(u, Ty::Bool, &schema, 2))
+                .collect::<arbitrary::Result<Vec<_>>>()?;
+            (inner.filter(preds), schema, inner_nn)
+        }
+        // Map one column
+        1 => {
+            let ty = rand_ty(u)?;
+            let e = gen_scalar(u, ty, &schema, 2)?;
+            let mut s = schema.clone();
+            s.push(ty);
+            (inner.map(vec![e]), s, inner_nn)
+        }
+        // Project a (reordered/duplicated) subset
+        2 => {
+            let k = u.int_in_range(1usize..=arity)?;
+            let mut outputs = Vec::with_capacity(k);
+            for _ in 0..k {
+                outputs.push(u.int_in_range(0..=arity - 1)?);
+            }
+            let s = outputs.iter().map(|&i| schema[i]).collect();
+            (inner.project(outputs), s, inner_nn)
+        }
+        3 => (inner.negate(), schema, false),
+        4 => (inner.distinct(), schema, true),
+        5 => (inner.threshold(), schema, true),
+        // Union with a same-schema relation (self, or self negated).
+        6 => {
+            let (other, union_nn) = if bool::arbitrary(u)? {
+                // `inner + inner`: non-negative exactly when `inner` is.
+                (inner.clone(), inner_nn)
+            } else {
+                // `inner + (-inner)` cancels to an empty (hence non-negative)
+                // collection regardless of `inner`'s sign.
+                (inner.clone().negate(), true)
+            };
+            (inner.union(other), schema, union_nn)
+        }
+        // Join 2-4 relations with multiple equi-join equivalence classes that
+        // chain inputs together (e.g. `in0.x = in1.x` and `in1.y = in2.y`). This
+        // is what makes join ordering/implementation planning and equality
+        // propagation actually run, unlike a 2-way single-equivalence join.
+        7 => {
+            let n_extra = u.int_in_range(1usize..=3)?;
+            let mut inputs = vec![inner];
+            // Per-input absolute schema, used only to find type-matching join cols.
+            let mut input_schemas = vec![schema.clone()];
+            // A join's multiplicities are the product of its inputs', so the
+            // result is non-negative exactly when every input is.
+            let mut join_nn = inner_nn;
+            for _ in 0..n_extra {
+                let (other, oschema, other_nn) = gen_rel(u, depth - 1, leaf)?;
+                join_nn &= other_nn;
+                input_schemas.push(oschema);
+                inputs.push(other);
+            }
+            // For each newly added input `r`, try to add one equivalence per type
+            // linking it to some earlier input `l < r` with a column of that type.
+            let mut variables: Vec<Vec<(usize, usize)>> = Vec::new();
+            for r in 1..inputs.len() {
+                for ty in [Ty::Int32, Ty::Int64, Ty::Bool] {
+                    let rc = cols_of(&input_schemas[r], ty);
+                    if rc.is_empty() || !bool::arbitrary(u)? {
+                        continue;
+                    }
+                    // Pick an earlier input that also has a column of this type.
+                    let candidates: Vec<usize> = (0..r)
+                        .filter(|&l| !cols_of(&input_schemas[l], ty).is_empty())
+                        .collect();
+                    if candidates.is_empty() {
+                        continue;
+                    }
+                    let l = candidates[u.int_in_range(0..=candidates.len() - 1)?];
+                    let lc = cols_of(&input_schemas[l], ty);
+                    let li = lc[u.int_in_range(0..=lc.len() - 1)?];
+                    let rj = rc[u.int_in_range(0..=rc.len() - 1)?];
+                    variables.push(vec![(l, li), (r, rj)]);
+                }
+            }
+            let mut s = schema.clone();
+            for os in &input_schemas[1..] {
+                s.extend(os.iter().copied());
+            }
+            (MirRelationExpr::join(inputs, variables), s, join_nn)
+        }
+        // Reduce: a distinct subset group key plus 0..=2 aggregates.
+        8 => {
+            let mut group_key = Vec::new();
+            for c in 0..arity {
+                if bool::arbitrary(u)? {
+                    group_key.push(c);
+                }
+            }
+            let n_agg = u.int_in_range(0usize..=2)?;
+            let mut aggregates = Vec::with_capacity(n_agg);
+            let mut out: Vec<Ty> = group_key.iter().map(|&k| schema[k]).collect();
+            for _ in 0..n_agg {
+                let (a, t) = gen_aggregate(u, &schema)?;
+                aggregates.push(a);
+                out.push(t);
+            }
+            if group_key.is_empty() && aggregates.is_empty() {
+                aggregates.push(AggregateExpr {
+                    func: AggregateFunc::Count,
+                    expr: MirScalarExpr::column(0),
+                    distinct: false,
+                });
+                out.push(Ty::Int64);
+            }
+            (inner.reduce(group_key, aggregates, None), out, true)
+        }
+        // TopK over the input.
+        _ => {
+            let mut group_key = Vec::new();
+            for c in 0..arity {
+                if u.ratio(1u8, 3u8)? {
+                    group_key.push(c);
+                }
+            }
+            // Order by *every* column (in a random direction each) so the order
+            // is total: distinct rows never tie, hence which rows a LIMIT/OFFSET
+            // keeps is unambiguous and the result multiset is deterministic. (A
+            // partial order would let the optimizer legitimately keep different
+            // tied rows, a spurious divergence rather than a bug.)
+            let mut order_key = Vec::with_capacity(arity);
+            for column in 0..arity {
+                order_key.push(ColumnOrder {
+                    column,
+                    desc: bool::arbitrary(u)?,
+                    nulls_last: bool::arbitrary(u)?,
+                });
+            }
+            let limit = if bool::arbitrary(u)? {
+                Some(MirScalarExpr::literal_ok(
+                    Datum::Int64(u.int_in_range(0i64..=3)?),
+                    ReprScalarType::Int64,
+                ))
+            } else {
+                None
+            };
+            let offset = u.int_in_range(0usize..=2)?;
+            // `TopK`, like every dataflow reduction, is only defined over
+            // non-negative collections. When `inner` can be net-negative, wrap
+            // it in a `Threshold` to drop the negative-diff rows. Without this a
+            // no-op `TopK` over a `Negate` diverges: the unguarded `TopKElision`
+            // removes it in the optimized plan, exposing negatives that the input
+            // plan's `fold_topk_constant` had zeroed. `Threshold` folds to a real
+            // non-negative constant (a `Reduce`/`distinct` would instead error on
+            // negatives), and its `ThresholdElision` is guarded by the
+            // `NonNegative` analysis, so it is not elided over this
+            // not-provably-non-negative input. Both fold paths thus agree.
+            let input = if inner_nn { inner } else { inner.threshold() };
+            (
+                input.top_k(group_key, order_key, limit, offset, None),
+                schema,
+                true,
+            )
+        }
+    })
+}
+
+/// Apply `transform` over the whole plan through its recursive driver
+/// (`Transform::transform` -> `actually_perform_transform`), not `action`.
+///
+/// NOTE: Some transforms' `action` (e.g. `FoldConstants`, `UnionBranchCancellation`)
+/// only rewrites the single node it is handed, expecting its caller to have
+/// already handled the children. Calling `action` on the plan root therefore
+/// folds/cancels nothing below the root, which would leave the
+/// result-equivalence oracle inert on every plan deeper than one operator.
+pub fn apply_recursively<T: Transform>(
+    transform: T,
+    rel: &mut MirRelationExpr,
+) -> Result<(), TransformError> {
+    let features = OptimizerFeatures::default();
+    let typecheck_ctx = typecheck::empty_typechecking_context();
+    let mut df_meta = DataflowMetainfo::default();
+    let mut ctx = TransformCtx::local(
+        &features,
+        &typecheck_ctx,
+        &mut df_meta,
+        None,
+        Some(GlobalId::Transient(1)),
+    );
+    transform.transform(rel, &mut ctx)
+}
+
+/// Fold `rel`. If it reduces to a `Constant` of `Ok` rows, return the
+/// consolidated `(row, diff)` multiset, otherwise `None`.
+pub fn fold_to_multiset(mut rel: MirRelationExpr) -> Option<BTreeMap<Row, Diff>> {
+    apply_recursively(FoldConstants { limit: None }, &mut rel).ok()?;
+    let (Ok(rows), _) = rel.as_const()? else {
+        return None;
+    };
+    let mut multiset: BTreeMap<Row, Diff> = BTreeMap::new();
+    for (row, diff) in rows {
+        *multiset.entry(row.clone()).or_insert(Diff::ZERO) += *diff;
+    }
+    multiset.retain(|_, d| *d != Diff::ZERO);
+    Some(multiset)
+}
+
+/// Run the full logical optimizer. Returns `None` if it errors (e.g. the
+/// `Typecheck` pass rejects the plan). Only a panic is a finding here.
+#[allow(deprecated)]
+pub fn optimize(rel: MirRelationExpr) -> Option<MirRelationExpr> {
+    let features = OptimizerFeatures::default();
+    let typecheck_ctx = typecheck::empty_typechecking_context();
+    let mut df_meta = DataflowMetainfo::default();
+    let mut ctx = TransformCtx::local(
+        &features,
+        &typecheck_ctx,
+        &mut df_meta,
+        None,
+        Some(GlobalId::Transient(1)),
+    );
+    let optimizer = Optimizer::logical_optimizer(&mut ctx);
+    optimizer
+        .optimize(rel, &mut ctx)
+        .ok()
+        .map(|o| o.into_inner())
+}


### PR DESCRIPTION
Part 4 of the cargo-fuzz suite split from #36982 (10 parts total; parts 1-3, 5-7, and 9 are already merged).

Reworked into a proper GitHub stack (Stacked PR beta). Replaces the previous standalone PR #37384.

## Summary
- Adds `expr` cargo-fuzz targets for scalar reduction, MFP optimization, JSONB, regex, casts, and like patterns.
- Adds `transform` cargo-fuzz targets for optimizer equivalence and MIR relation transforms.

## Review notes
- Focus review on oracle soundness and whether generated inputs preserve each target's assumptions.

## Verification
- Rebased cleanly onto current `upstream/main`; `git range-diff` against the pre-restack commit is identical (no content change), and `git diff --check` passes.

## Context
- Original monolithic PR: #36982
- Merged foundation: #37381, #37382, #37383, #37385, #37386, #37387, #37389

## Stack (bottom → top)
- #37707 — expr, transform: Add cargo-fuzz targets 👈 **this PR**
- #37708 — persist-client: Add cargo-fuzz targets
- #37709 — ci: Run cargo-fuzz in release qualification
