### PR TITLE
adapter: restore primary link of MV storage collections at bootstrap

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3241,6 +3241,10 @@ impl Coordinator {
                     // versions have higher `GlobalId`s, so each link points
                     // at a lower id, which the storage layer's registration
                     // order requires.
+                    //
+                    // NOTE: Tables chain in the opposite direction, there the
+                    // latest version owns the shard, matching how each type's
+                    // runtime operations create the links.
                     let mut prev_gid = mv
                         .replacement_target
                         .map(|target_id| catalog.get_entry(&target_id).latest_global_id());

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3227,9 +3227,27 @@ impl Coordinator {
                     };
                 }
                 CatalogItem::MaterializedView(mv) => {
+                    // All versions of a materialized view write to the same
+                    // persist shard, and the `primary` link records shard
+                    // ownership: a collection whose `primary` is set does not
+                    // own the shard, so dropping it must neither release the
+                    // shard's since nor finalize the shard.
+                    //
+                    // We restore the links the way runtime operations create
+                    // them: the earliest version owns the shard, every later
+                    // version (added by a replacement apply) points at the
+                    // version it replaced, and a pending replacement MV
+                    // points at the latest collection of its target. Later
+                    // versions have higher `GlobalId`s, so each link points
+                    // at a lower id, which the storage layer's registration
+                    // order requires.
+                    let mut prev_gid = mv
+                        .replacement_target
+                        .map(|target_id| catalog.get_entry(&target_id).latest_global_id());
                     let collection_descs = mv.collection_descs().map(|(gid, _version, desc)| {
-                        let collection_desc =
+                        let mut collection_desc =
                             CollectionDescription::for_other(desc, mv.initial_as_of.clone());
+                        collection_desc.primary = prev_gid.replace(gid);
                         (gid, collection_desc)
                     });
 

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1306,7 +1306,7 @@ impl StorageCollections for StorageCollectionsImpl {
         init_ids: BTreeSet<GlobalId>,
     ) -> Result<(), StorageError> {
         let metadata = txn.get_collection_metadata();
-        let existing_metadata: BTreeSet<_> = metadata.into_iter().map(|(id, _)| id).collect();
+        let existing_metadata: BTreeSet<_> = metadata.iter().map(|(id, _)| *id).collect();
 
         // Determine which collections we do not yet have metadata for.
         let new_collections: BTreeSet<GlobalId> =
@@ -1327,7 +1327,24 @@ impl StorageCollections for StorageCollectionsImpl {
         // dropped from the catalog, but the dataflow is still running on a
         // worker, assuming the shard is safe to finalize on reboot may cause
         // the cluster to panic.
-        let unfinalized_shards = txn.get_unfinalized_shards().into_iter().collect_vec();
+        let unfinalized_shards = txn.get_unfinalized_shards();
+
+        // Defense in depth: never finalize a shard that a live collection
+        // still maps to, no matter how it ended up in the unfinalized set.
+        // See the matching guard in `prepare_state`. We also scrub such
+        // shards from the durable set, their presence there can only be the
+        // artifact of a bug.
+        let in_use: BTreeSet<_> = metadata.into_values().collect();
+        let (still_in_use, unfinalized_shards): (BTreeSet<_>, BTreeSet<_>) = unfinalized_shards
+            .into_iter()
+            .partition(|shard| in_use.contains(shard));
+        if !still_in_use.is_empty() {
+            mz_ore::soft_panic_or_log!(
+                "unfinalized shards are still mapped by live collections, refusing \
+                 to finalize them: {still_in_use:?}"
+            );
+            txn.mark_shards_as_finalized(still_in_use);
+        }
 
         info!(?unfinalized_shards, "initializing finalizable_shards");
 
@@ -1670,6 +1687,37 @@ impl StorageCollections for StorageCollectionsImpl {
                 }
             }
         }
+
+        // Defense in depth: never finalize a shard that another live
+        // collection still maps to durably, no matter what the in-memory
+        // `primary` links say. Collections share shards (replacement MVs and
+        // their targets, versions of one table or MV), and a bug that loses a
+        // `primary` link would otherwise tombstone a live shard.
+        //
+        // NOTE: This guard and the one in `drop_collections_unvalidated` are
+        // both load-bearing: this one stops the durable finalization
+        // pipeline, the other stops the shard's since from being released,
+        // which feeds finalization through a separate in-memory path.
+        if !dropped_shards.is_empty() {
+            let remaining = txn.get_collection_metadata();
+            let still_in_use: Vec<_> = remaining
+                .iter()
+                .filter(|(_id, shard)| dropped_shards.contains(*shard))
+                .collect();
+            if !still_in_use.is_empty() {
+                mz_ore::soft_panic_or_log!(
+                    "dropped collections marked shards for finalization that other \
+                     live collections still map to, refusing to finalize them: \
+                     {still_in_use:?}"
+                );
+                let in_use_shards: BTreeSet<_> = still_in_use
+                    .into_iter()
+                    .map(|(_id, shard)| *shard)
+                    .collect();
+                dropped_shards.retain(|shard| !in_use_shards.contains(shard));
+            }
+        }
+
         txn.insert_unfinalized_shards(dropped_shards)?;
 
         // Reconcile any shards we've successfully finalized with the shard
@@ -2195,6 +2243,15 @@ impl StorageCollections for StorageCollectionsImpl {
 
         let mut self_collections = self.collections.lock().expect("lock poisoned");
 
+        // Shards that live collections still map to durably. Needed below to
+        // guard against releasing a shared shard's since out from under its
+        // surviving users.
+        let shards_in_use: BTreeSet<_> = storage_metadata
+            .collection_metadata
+            .values()
+            .copied()
+            .collect();
+
         // Policies that advance the since to the empty antichain. We do still
         // honor outstanding read holds, and collections will only be dropped
         // once those are removed as well.
@@ -2210,15 +2267,33 @@ impl StorageCollections for StorageCollectionsImpl {
                 continue;
             };
 
-            // Unless the collection has a primary, its shard must have been previously removed
-            // by `StorageCollections::prepare_state`.
             if collection.primary.is_none() {
+                // Unless the collection has a primary, its shard must have been previously removed
+                // by `StorageCollections::prepare_state`.
                 let metadata = storage_metadata.get_collection_shard(id);
                 mz_ore::soft_assert_or_log!(
                     matches!(metadata, Err(StorageError::IdentifierMissing(_))),
                     "dropping {id}, but drop was not synchronized with storage \
                      controller via `prepare_state`"
                 );
+
+                // Defense in depth: a collection without a primary owns its
+                // shard and releasing its since lets persist compact the
+                // shard away. If another live collection still maps to the
+                // shard durably, the in-memory `primary` links must be wrong
+                // (a shard's owner is only ever dropped together with all
+                // collections that share the shard). We refuse to drop, which
+                // leaks the collection state until the next restart but keeps
+                // the shard's data intact. See also the matching guard in
+                // `prepare_state`.
+                let data_shard = collection.collection_metadata.data_shard;
+                if shards_in_use.contains(&data_shard) {
+                    mz_ore::soft_panic_or_log!(
+                        "dropping {id} would release the since of shard {data_shard}, \
+                         which another live collection still maps to, refusing to drop"
+                    );
+                    continue;
+                }
             }
 
             finalized_policies.push((id, ReadPolicy::ValidFrom(Antichain::new())));

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1899,17 +1899,24 @@ impl StorageCollections for StorageCollectionsImpl {
                         // We don't care about the dependency since when the
                         // write frontier is empty. In that case, no-one can
                         // write down any more updates.
-                        mz_ore::soft_assert_or_log!(
-                            write_frontier.elements() == &[Timestamp::MIN]
-                                || write_frontier.is_empty()
-                                || PartialOrder::less_than(&dependency_since, write_frontier),
-                            "dependency ({dep}) since has advanced past dependent ({id}) upper \n
-                            dependent ({id}): since {:?}, upper {:?} \n
-                            dependency ({dep}): since {:?}",
-                            data_shard_since,
-                            write_frontier,
-                            dependency_since
-                        );
+                        //
+                        // The invariant is about remap shards, so `primary`
+                        // links are exempt: there the "dependency" is another
+                        // version of the same shard and its since can validly
+                        // sit at the dependent's upper.
+                        if description.primary.is_none() {
+                            mz_ore::soft_assert_or_log!(
+                                write_frontier.elements() == &[Timestamp::MIN]
+                                    || write_frontier.is_empty()
+                                    || PartialOrder::less_than(&dependency_since, write_frontier),
+                                "dependency ({dep}) since has advanced past dependent ({id}) upper \n
+                                dependent ({id}): since {:?}, upper {:?} \n
+                                dependency ({dep}): since {:?}",
+                                data_shard_since,
+                                write_frontier,
+                                dependency_since
+                            );
+                        }
 
                         dependency_since
                     } else {

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -7333,10 +7333,15 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
         CREATE MATERIALIZED VIEW mv IN CLUSTER stalled AS SELECT * FROM t;
         CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv
             IN CLUSTER stalled AS SELECT * FROM t;
+        CREATE MATERIALIZED VIEW mv_plain IN CLUSTER stalled AS SELECT * FROM t;
         """)
 
     [(mv_id,)] = c.sql_query("SELECT id FROM mz_materialized_views WHERE name = 'mv'")
     mv_shard = storage_metadata()["collection_metadata"][mv_id]
+    [(mv_plain_id,)] = c.sql_query(
+        "SELECT id FROM mz_materialized_views WHERE name = 'mv_plain'"
+    )
+    mv_plain_shard = storage_metadata()["collection_metadata"][mv_plain_id]
 
     # Restart envd. Bootstrap re-creates the in-memory storage collections
     # state, including the replacement's `primary` link to its target.
@@ -7353,6 +7358,16 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
     unfinalized = storage_metadata()["unfinalized_shards"]
     assert mv_shard not in unfinalized, (
         f"dropping the replacement marked the target's shard {mv_shard} for"
+        " finalization"
+    )
+
+    # The inverse direction: a plain MV still owns its shard after a restart,
+    # so dropping it must mark the shard as finalizable. This guards against
+    # bootstrap over-linking collections, which would leak shards on drop.
+    c.sql("DROP MATERIALIZED VIEW mv_plain")
+    unfinalized = storage_metadata()["unfinalized_shards"]
+    assert mv_plain_shard in unfinalized, (
+        f"dropping a plain MV did not mark its shard {mv_plain_shard} for"
         " finalization"
     )
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -7296,6 +7296,84 @@ def workflow_github_11322(c: Composition) -> None:
     assert rp_id not in collection_metadata
 
 
+def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
+    """
+    Regression test for incident 1136: dropping a replacement MV after an
+    envd restart destroys the target MV's persist shard.
+
+    Bootstrap does not restore the `primary` link of replacement-MV storage
+    collections, so dropping a replacement MV after an envd restart marks the
+    target MV's shard as finalizable. The shard finalization task then seals
+    and tombstones the target's live shard, permanently losing the target
+    MV's data. Before materialize#37696, a subsequent CREATE REPLACEMENT
+    MATERIALIZED VIEW, which registers a new storage collection on the
+    tombstoned shard, additionally panicked envd with "cmd remove_rollups
+    unexpectedly tried to commit a new state on a tombstone" and left the
+    environment crash-looping during bootstrap.
+
+    The MVs live in a cluster with no replicas so that no dataflow holds a
+    persist read lease on the target's shard. Leases of readers that died
+    with the envd restart expire only after 15 minutes, and an unexpired
+    lease would keep the finalization task from tombstoning the shard within
+    the runtime of this test.
+    """
+
+    def storage_metadata() -> dict:
+        port = c.port("materialized", 6878)
+        resp = requests.get(f"http://localhost:{port}/api/catalog/dump")
+        resp.raise_for_status()
+        return resp.json()["storage_metadata"]
+
+    c.down(destroy_volumes=True)
+    c.up("materialized")
+
+    c.sql("""
+        CREATE CLUSTER stalled SIZE 'scale=1,workers=1', REPLICATION FACTOR 0;
+        CREATE TABLE t (a int);
+        CREATE MATERIALIZED VIEW mv IN CLUSTER stalled AS SELECT * FROM t;
+        CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv
+            IN CLUSTER stalled AS SELECT * FROM t;
+        """)
+
+    [(mv_id,)] = c.sql_query("SELECT id FROM mz_materialized_views WHERE name = 'mv'")
+    mv_shard = storage_metadata()["collection_metadata"][mv_id]
+
+    # Restart envd. Bootstrap re-creates the in-memory storage collections
+    # state, including the replacement's `primary` link to its target.
+    c.kill("materialized")
+    c.up("materialized")
+
+    # Drop the replacement without applying it.
+    c.sql("DROP MATERIALIZED VIEW rp")
+
+    # The drop must not have marked the target's shard as finalizable. This
+    # check must happen right after the drop: once the finalization task has
+    # tombstoned the shard, the next catalog transaction removes it from
+    # unfinalized_shards again, hiding the damage from this check.
+    unfinalized = storage_metadata()["unfinalized_shards"]
+    assert mv_shard not in unfinalized, (
+        f"dropping the replacement marked the target's shard {mv_shard} for"
+        " finalization"
+    )
+
+    # Re-creating a replacement registers a new storage collection on the
+    # target's shard. Before materialize#37696 this panicked envd when the
+    # shard had already been tombstoned.
+    c.sql(
+        "CREATE REPLACEMENT MATERIALIZED VIEW rp2 FOR mv"
+        " IN CLUSTER stalled AS SELECT * FROM t"
+    )
+
+    # The target's shard must not have been sealed.
+    upper_empty = c.sql_query("""
+        SELECT write_frontier IS NULL
+        FROM mz_internal.mz_frontiers
+        JOIN mz_materialized_views ON id = object_id
+        WHERE name = 'mv'
+        """)[0][0]
+    assert not upper_empty, "the target MV's shard was sealed, its data is lost"
+
+
 def workflow_test_github_10102(c: Composition) -> None:
     """
     Regression test for database-issues#10102:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -7301,15 +7301,15 @@ def workflow_test_replacement_mv_drop_after_restart(c: Composition) -> None:
     Regression test for incident 1136: dropping a replacement MV after an
     envd restart destroys the target MV's persist shard.
 
-    Bootstrap does not restore the `primary` link of replacement-MV storage
-    collections, so dropping a replacement MV after an envd restart marks the
-    target MV's shard as finalizable. The shard finalization task then seals
-    and tombstones the target's live shard, permanently losing the target
-    MV's data. Before materialize#37696, a subsequent CREATE REPLACEMENT
-    MATERIALIZED VIEW, which registers a new storage collection on the
-    tombstoned shard, additionally panicked envd with "cmd remove_rollups
-    unexpectedly tried to commit a new state on a tombstone" and left the
-    environment crash-looping during bootstrap.
+    Bootstrap used to rebuild the storage collection of a replacement MV
+    without its `primary` link, so dropping a replacement MV after an envd
+    restart marked the target MV's shard as finalizable. The shard
+    finalization task then sealed and tombstoned the target's live shard,
+    permanently losing the target MV's data. Before materialize#37696, a
+    subsequent CREATE REPLACEMENT MATERIALIZED VIEW, which registers a new
+    storage collection on the tombstoned shard, additionally panicked envd
+    with "cmd remove_rollups unexpectedly tried to commit a new state on a
+    tombstone" and left the environment crash-looping during bootstrap.
 
     The MVs live in a cluster with no replicas so that no dataflow holds a
     persist read lease on the target's shard. Leases of readers that died


### PR DESCRIPTION
### Motivation

Fixes SQL-536 (incident 1136).

Coordinator bootstrap rebuilds the in-memory storage collection state from the durable catalog. For versioned tables it restores the `primary` link that records which collection owns the persist shard, but for materialized views it left `primary` empty.

Replacement MVs (`CREATE REPLACEMENT MATERIALIZED VIEW ... FOR ...`) don't get their own shard: they are registered against the shard of the MV they intend to replace, with `primary` pointing at the target so the storage layer knows they don't own it. After an environmentd restart that link was gone, so a pending replacement looked like the sole owner of its target's shard. Dropping the pending replacement then released the shard's since to the empty frontier and marked the shard for finalization, tombstoning the live target MV's shard and permanently destroying its data. Recreating a replacement against the tombstoned shard subsequently panicked in persist's `upgrade_version` and left environmentd crash looping (that panic was separately fixed in #37696, which also makes the data destruction silent, hence the urgency of this fix).

### Changes

* `bootstrap_storage_collections` now restores the `primary` links for materialized view collections the way runtime operations create them: the earliest version owns the shard, every later version (added by a replacement apply) points at the version it replaced, and a pending replacement points at the latest collection of its target.
* The dependency-since soft assert in `StorageCollections::create_collections_for_bootstrap` now exempts `primary` links, mirroring the guard the storage controller already has. The invariant is about remap shards, and with `primary` restored for MV collections the assert could fire spuriously for versions of the same shard.
* Defense in depth: the destructive drop decisions no longer trust the in-memory `primary` links alone, they also consult the durable collection metadata, which is authoritative for which collections map to which shard. `prepare_state` refuses to mark a shard for finalization while another live collection still maps to it, `drop_collections_unvalidated` refuses to release the since of such a shard (leaking the in-memory collection state until the next restart instead of destroying data), and `initialize_state` scrubs still-mapped shards from the durable unfinalized set, so a shard poisoned into that set by a build without these guards is not tombstoned after an upgrade. All three cases are bugs, so they soft-panic in test builds. With these guards in place, an incident-1136-class bug degrades from data destruction to an error log and a leaked in-memory collection.

### Tests

* Includes the repro from #37699 (thanks @def-): restart environmentd, drop the pending replacement, and assert the target's shard is neither marked for finalization nor sealed, then recreate a replacement against it.
* Extends that test with the inverse direction: dropping a plain MV after a restart must still mark its shard for finalization, guarding against bootstrap over-linking collections (which would leak shards on drop).

### Notes for reviewers

* Ordering: the storage layer registers non-table collections in ascending `GlobalId` order and requires a collection's `primary` to be registered first. The restored links always point at lower ids: later MV versions have strictly higher gids, and a pending replacement is created after its target's latest version. Only one pending replacement can exist per target, so the target's latest gid cannot change while a replacement is pending.
* Tables chain in the opposite direction (latest version owns the shard). Both directions match what the respective runtime operations create, and the registration sort handles each (tables register in descending gid order).
* After this fix is deployed, MVs affected by the incident still have tombstoned shards / stale data and need to be dropped and recreated together with their dependent sinks. That recovery is operational and not part of this change.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.