### PR TITLE
Drop enable_glue_schema_registry gating flag

### DIFF
--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -416,8 +416,6 @@ impl ConnectionOptionExtracted {
                 })
             }
             CreateConnectionType::GlueSchemaRegistry => {
-                scx.require_feature_flag(&vars::ENABLE_GLUE_SCHEMA_REGISTRY)?;
-
                 let aws_connection = get_aws_connection_reference(scx, &self)?
                     .ok_or_else(|| sql_err!("AWS CONNECTION option is required"))?;
                 let registry_name = self

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2001,12 +2001,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_glue_schema_registry,
-        desc: "CREATE CONNECTION ... TO AWS GLUE SCHEMA REGISTRY",
-        default: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_alter_set_cluster,
         desc: "ALTER ... SET CLUSTER syntax",
         default: false,

--- a/test/aws-glue-schema-registry/glue-schema-registry.td
+++ b/test/aws-glue-schema-registry/glue-schema-registry.td
@@ -45,9 +45,6 @@
 # is exercised by the nested schema below: `inner_t` is defined once and
 # reused by name in the `inner2` field.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_glue_schema_registry = true;
-
 # ---------------------------------------------------------------------------
 # Schema names
 # ---------------------------------------------------------------------------

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -456,6 +456,7 @@ KNOWN_STALE_LD_FLAGS: set[str] = set("""
     enable_copy_from_remote
     enable_copy_to_expr
     enable_explain_broken
+    enable_glue_schema_registry
     enable_iceberg_sink
     enable_kafka_sink_partition_by
     enable_multi_replica_sources

--- a/test/sqllogictest/glue_schema_registry.slt
+++ b/test/sqllogictest/glue_schema_registry.slt
@@ -9,8 +9,7 @@
 
 # Tests for AWS Glue Schema Registry connections.
 #
-# Covers parsing, planning, catalog round-trip, ALTER compatibility, and the
-# `enable_glue_schema_registry` feature flag.
+# Covers parsing, planning, catalog round-trip, and ALTER compatibility.
 #
 # `validate()` performs a real `GetRegistry` call against AWS.
 # Sqllogictest has no AWS credentials, so every CREATE CONNECTION here uses
@@ -21,13 +20,6 @@ reset-server
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_connection_validation_syntax TO true;
-----
-COMPLETE 0
-
-# The feature flag is off by default; enable it for the happy-path tests.
-# A dedicated flag-off section toggles it back below.
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_glue_schema_registry TO true;
 ----
 COMPLETE 0
 
@@ -99,33 +91,6 @@ CREATE CONNECTION bad_glue TO AWS GLUE SCHEMA REGISTRY (
     REGISTRY = 'my-registry',
     PORT = 8080
 )
-
-# Feature flag gating.
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_glue_schema_registry TO false;
-----
-COMPLETE 0
-
-statement error CREATE CONNECTION \.\.\. TO AWS GLUE SCHEMA REGISTRY is not available
-CREATE CONNECTION gated_glue TO AWS GLUE SCHEMA REGISTRY (
-    AWS CONNECTION = aws_conn,
-    REGISTRY = 'my-registry'
-) WITH (VALIDATE = false)
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_glue_schema_registry TO true;
-----
-COMPLETE 0
-
-# Re-enable: works again.
-statement ok
-CREATE CONNECTION glue_conn TO AWS GLUE SCHEMA REGISTRY (
-    AWS CONNECTION = aws_conn,
-    REGISTRY = 'my-registry'
-) WITH (VALIDATE = false)
-
-statement ok
-DROP CONNECTION glue_conn
 
 statement ok
 DROP CONNECTION aws_conn


### PR DESCRIPTION
Enables Glue Schema Registry globally.

- Removes the `enable_glue_schema_registry` flag that gated access to Glue Schema Registry.
- Removes tests for the flag
- Update the LD flag check to mark it stale.
