### PR TITLE
docs: clarify transaction levels (mz vs metadata db)

### DIFF
--- a/doc/user/content/headless/self-managed-deployments/upgrade-notes/v26.0.md
+++ b/doc/user/content/headless/self-managed-deployments/upgrade-notes/v26.0.md
@@ -1,3 +1,6 @@
+---
+headless: true
+---
 - Upgrading to `v26.0.0` is a major version upgrade. To upgrade to `v26.0` from
   `v25.2.X` or `v25.1`, you must first upgrade to `v25.2.16` and then upgrade to
   `v26.0.0`.

--- a/doc/user/content/headless/self-managed-deployments/upgrade-notes/v26.1.md
+++ b/doc/user/content/headless/self-managed-deployments/upgrade-notes/v26.1.md
@@ -1,1 +1,4 @@
+---
+headless: true
+---
 - To upgrade to `v26.1` or future versions, you must first upgrade to `v26.0`

--- a/doc/user/content/headless/self-managed-deployments/upgrade-notes/v26.30.md
+++ b/doc/user/content/headless/self-managed-deployments/upgrade-notes/v26.30.md
@@ -1,3 +1,6 @@
+---
+headless: true
+---
 v26.30.0 introduces support for a new version of the Materialize CRD, `v1`,
 which provides simplified rollouts. Previously, Materialize only supported
 `v1alpha1`; `v1alpha1` remains the default.

--- a/doc/user/content/headless/self-managed-deployments/upgrade-notes/v26.33.md
+++ b/doc/user/content/headless/self-managed-deployments/upgrade-notes/v26.33.md
@@ -1,9 +1,19 @@
+---
+headless: true
+---
 Starting in v26.33, Self-Managed deployments that use a **PostgreSQL metadata
-database** can configure Materialize to run its internal consensus queries under
-`READ COMMITTED` transaction isolation instead of `SERIALIZABLE`. The consensus
-queries are linearizable under `READ COMMITTED`. `READ COMMITTED` also improves
-metadata write throughput by avoiding the serialization-failure retries
-that `SERIALIZABLE` incurs under contention.
+database** can configure Materialize to run its internal consensus queries using
+`READ COMMITTED` instead of `SERIALIZABLE` transaction isolation.
+
+{{< note >}}
+The transaction isolation levels discussed in this section refer to those of the
+PostgreSQL metadata database, not Materialize's [client transaction isolation
+levels](/reference/isolation-level/).
+{{< /note >}}
+
+The consensus queries are designed to be linearizable under `READ COMMITTED`.
+`READ COMMITTED` also improves metadata write throughput by avoiding the
+serialization-failure retries that `SERIALIZABLE` incurs under contention.
 
 To use `READ COMMITTED` with a PostgreSQL metadata database, enable the
 `persist_pg_consensus_read_committed` parameter. The parameter is **disabled by

--- a/doc/user/content/reference/isolation-level.md
+++ b/doc/user/content/reference/isolation-level.md
@@ -18,7 +18,8 @@ visible to a transaction during its execution.
 
 ## Supported isolation levels
 
-Materialize accepts the following isolation levels:
+Materialize accepts the following isolation levels for your SQL transactions
+against Materialize:
 
 {{< if-unreleased "v26.29" >}}
 | Isolation level | Behavior in Materialize |

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -48,7 +48,9 @@ notes](/self-managed-deployments/upgrading/version-notes/).
 - **`EXPLAIN ANALYZE` on multi-replica clusters via MCP**: The Materialize MCP developer endpoint's `query` tool now accepts an optional cluster replica parameter, so `EXPLAIN ANALYZE` can target a specific replica.
 - **Faster queries on busy environments**: We've improved query latency on query-heavy clusters. We've reduced by caching the catalog snapshot for the duration of a session. In our tests, we've seen QPS improvements of up to 13%.
 - **Improved responsiveness under load**: A slow timestamp oracle no longer stalls unrelated sessions that are running `EXPLAIN TIMESTAMP` or `SUBSCRIBE`.
-- **[Agent skills](/integrations/coding-agent-skills/) — dbt support**: The coding agent skills now include skills for using dbt with Materialize, so your coding agent can help you build and manage dbt models against Materialize.
+- **New materialize-dbt [agent skill](/integrations/coding-agent-skills/)**: The
+  `materialize-dbt` skill helps coding agents build and manage dbt models for
+  Materialize.
 
 ### Bug Fixes {#v26.33-bug-fixes}
 - Fixed server crashes triggered by stack overflows while computing object dependencies and read privileges.

--- a/doc/user/content/self-managed-deployments/upgrading/version-notes.md
+++ b/doc/user/content/self-managed-deployments/upgrading/version-notes.md
@@ -13,19 +13,23 @@ guides](/self-managed-deployments/upgrading/#upgrade-guides).
 
 ## Upgrading to `v26.33` and later versions
 
-{{< include-md file="shared-content/self-managed/upgrade-notes/v26.33.md" >}}
+{{% include-headless "/headless/self-managed-deployments/upgrade-notes/v26.33"
+%}}
 
 ## Upgrading to `v26.30` and later versions
 
-{{< include-md file="shared-content/self-managed/upgrade-notes/v26.30.md" >}}
+{{% include-headless "/headless/self-managed-deployments/upgrade-notes/v26.30"
+%}}
 
 ## Upgrading to `v26.1` and later versions
 
-{{< include-md file="shared-content/self-managed/upgrade-notes/v26.1.md" >}}
+{{% include-headless "/headless/self-managed-deployments/upgrade-notes/v26.1"
+%}}
 
 ## Upgrading to `v26.0`
 
-{{< include-md file="shared-content/self-managed/upgrade-notes/v26.0.md" >}}
+{{% include-headless "/headless/self-managed-deployments/upgrade-notes/v26.0"
+%}}
 
 ## Upgrading between minor versions less than `v26`
 


### PR DESCRIPTION
https://preview.materialize.com/materialize/37716/self-managed-deployments/upgrading/version-notes/#upgrading-to-v2633-and-later-versions

clarified the levels + some file movements since headless files builds dynamically as you change content unlike the shared-content files.