### PR TITLE
ore/pool: swap-backed, size-classed buffer pool for columnar chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7803,6 +7803,7 @@ dependencies = [
  "itertools 0.14.0",
  "lgalloc",
  "libc",
+ "lz4_flex",
  "mz-ore",
  "mz-ore-proc",
  "native-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -693,7 +693,7 @@ trivial_numeric_casts = "warn"
 unused_lifetimes = "warn"
 unused_macro_rules = "warn"
 unused_import_braces = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(stamped, coverage, nightly_doc_features, release, tokio_unstable)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(stamped, coverage, nightly_doc_features, release, tokio_unstable, kani)'] }
 
 [workspace.lints.rustdoc]
 

--- a/misc/python/materialize/cli/gen-lints.py
+++ b/misc/python/materialize/cli/gen-lints.py
@@ -225,7 +225,7 @@ MESSAGE_LINT_INHERIT = "The lint section in {} does not inherit from the workspa
 
 EXCLUDE_CRATES: list[str] = []
 
-CHECK_CFGS = "stamped, coverage, nightly_doc_features, release, tokio_unstable"
+CHECK_CFGS = "stamped, coverage, nightly_doc_features, release, tokio_unstable, kani"
 
 
 def main() -> None:

--- a/misc/wasm/Cargo.toml
+++ b/misc/wasm/Cargo.toml
@@ -19,7 +19,7 @@ trivial_numeric_casts = "warn"
 unused_lifetimes = "warn"
 unused_macro_rules = "warn"
 unused_import_braces = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(stamped, coverage, nightly_doc_features, release, tokio_unstable)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(stamped, coverage, nightly_doc_features, release, tokio_unstable, kani)'] }
 
 [workspace.lints.rustdoc]
 

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -37,7 +37,6 @@ ipnet.workspace = true
 itertools.workspace = true
 lgalloc = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
-lz4_flex = { workspace = true, optional = true }
 mz-ore-proc = { path = "../ore-proc", default-features = false }
 num.workspace = true
 num-traits = { workspace = true, optional = true }
@@ -95,6 +94,7 @@ libc = { workspace = true }
 [dev-dependencies]
 anyhow.workspace = true
 criterion.workspace = true
+lz4_flex.workspace = true
 mz-ore = { path = "../ore", features = ["id_gen", "chrono", "test"] }
 proptest.workspace = true
 scopeguard.workspace = true
@@ -153,7 +153,7 @@ assert = ["assert-no-tracing", "ctor", "tracing"]
 proptest = ["dep:proptest", "proptest-derive"]
 overflowing = ["assert"]
 pager = ["dep:bytemuck", "libc", "rand", "dep:tracing"]
-pool = ["dep:bytemuck", "libc", "dep:tracing", "dep:lz4_flex"]
+pool = ["dep:bytemuck", "libc", "dep:tracing"]
 
 [[test]]
 name = "future"

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -37,6 +37,7 @@ ipnet.workspace = true
 itertools.workspace = true
 lgalloc = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
+lz4_flex = { workspace = true, optional = true }
 mz-ore-proc = { path = "../ore-proc", default-features = false }
 num.workspace = true
 num-traits = { workspace = true, optional = true }
@@ -85,6 +86,11 @@ console-subscriber = { workspace = true, optional = true }
 sentry-tracing = { workspace = true, optional = true }
 turmoil = { workspace = true, optional = true }
 yansi = { workspace = true, optional = true }
+
+# `memory::host_memory_bytes` reads `hw.memsize` via sysctl on macOS, in every
+# feature configuration, so the dependency cannot be optional there.
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = { workspace = true }
 
 [dev-dependencies]
 anyhow.workspace = true
@@ -147,6 +153,7 @@ assert = ["assert-no-tracing", "ctor", "tracing"]
 proptest = ["dep:proptest", "proptest-derive"]
 overflowing = ["assert"]
 pager = ["dep:bytemuck", "libc", "rand", "dep:tracing"]
+pool = ["dep:bytemuck", "libc", "dep:tracing", "dep:lz4_flex"]
 
 [[test]]
 name = "future"

--- a/src/ore/src/cgroup.rs
+++ b/src/ore/src/cgroup.rs
@@ -45,7 +45,7 @@ pub fn parse_proc_self_cgroup() -> Option<Vec<CgroupEntry>> {
     let file = BufReader::new(file);
     Some(
         file.lines()
-            .flatten()
+            .map_while(Result::ok)
             .filter_map(CgroupEntry::from_line)
             .collect(),
     )
@@ -95,7 +95,7 @@ pub fn parse_proc_self_mountinfo() -> Option<(Vec<Mountinfo>, Vec<Mountinfo>)> {
     let file = BufReader::new(file);
     Some(
         file.lines()
-            .flatten()
+            .map_while(Result::ok)
             .filter_map(Mountinfo::from_line)
             .filter(|mi| mi.fs_type == "cgroup" || mi.fs_type == "cgroup2")
             .partition(|mi| mi.fs_type == "cgroup2"),

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -50,6 +50,7 @@ pub mod hint;
 pub mod id_gen;
 pub mod iter;
 pub mod lex;
+pub mod memory;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "metrics")))]
 #[cfg(feature = "metrics")]
 pub mod metrics;
@@ -70,6 +71,9 @@ pub mod pager;
 pub mod panic;
 pub mod path;
 pub mod permutations;
+#[cfg_attr(nightly_doc_features, doc(cfg(all(feature = "pool", unix))))]
+#[cfg(all(feature = "pool", unix))]
+pub mod pool;
 #[cfg(feature = "process")]
 pub mod process;
 #[cfg(feature = "region")]

--- a/src/ore/src/memory.rs
+++ b/src/ore/src/memory.rs
@@ -15,9 +15,20 @@
 
 //! Physical memory introspection.
 
+// Only this probe uses the cgroup helpers, so the module lives here rather
+// than at the crate root. The file carries more surface than the probe
+// needs, hence the dead-code allowance.
+#[cfg(target_os = "linux")]
+#[path = "cgroup.rs"]
+#[allow(dead_code)]
+mod cgroup;
+
 /// Returns the physical memory available to this process in bytes: the
-/// host's RAM, clamped by the cgroup (v2) memory limit when one is set.
-/// `None` if detection fails.
+/// host's RAM, clamped by the cgroup memory limit when one is set. Both
+/// cgroup v1 and v2 are honored, resolved through `/proc/self/mountinfo`
+/// and `/proc/self/cgroup` rather than an assumed mount path, so containers
+/// (including host-namespace cgroup mounts) do not derive budgets from host
+/// RAM. `None` if detection fails.
 ///
 /// Deliberately distinct from any *announced* memory limit: on nodes whose
 /// disk is provisioned as swap, the announced limit includes swap so the
@@ -67,12 +78,10 @@ fn host_memory_bytes() -> Option<usize> {
     None
 }
 
-/// The cgroup v2 memory limit, if this process runs under one. The file
-/// holds `max` (no limit) or a byte count; non-numeric content yields `None`.
+/// The RAM limit of the cgroup governing this process, if any.
 #[cfg(target_os = "linux")]
 fn cgroup_memory_max() -> Option<usize> {
-    let raw = std::fs::read_to_string("/sys/fs/cgroup/memory.max").ok()?;
-    raw.trim().parse().ok()
+    cgroup::detect_memory_limit()?.max
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/src/ore/src/memory.rs
+++ b/src/ore/src/memory.rs
@@ -1,0 +1,94 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Physical memory introspection.
+
+/// Returns the physical memory available to this process in bytes: the
+/// host's RAM, clamped by the cgroup (v2) memory limit when one is set.
+/// `None` if detection fails.
+///
+/// Deliberately distinct from any *announced* memory limit: on nodes whose
+/// disk is provisioned as swap, the announced limit includes swap so the
+/// memory limiter can bound total heap. Budgets that bound *resident* bytes
+/// must instead derive from memory that can be resident, which is what this
+/// reports.
+pub fn physical_memory_bytes() -> Option<usize> {
+    let host = host_memory_bytes()?;
+    match cgroup_memory_max() {
+        Some(limit) if limit < host => Some(limit),
+        _ => Some(host),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn host_memory_bytes() -> Option<usize> {
+    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let line = meminfo.lines().find(|l| l.starts_with("MemTotal:"))?;
+    let kib: usize = line.split_whitespace().nth(1)?.parse().ok()?;
+    Some(kib * 1024)
+}
+
+#[cfg(target_os = "macos")]
+fn host_memory_bytes() -> Option<usize> {
+    let mut size: u64 = 0;
+    let mut len = std::mem::size_of::<u64>();
+    // SAFETY: `sysctlbyname` reads into an out-buffer of the size we report;
+    // `hw.memsize` is a `u64` and `len` matches.
+    let ret = unsafe {
+        libc::sysctlbyname(
+            c"hw.memsize".as_ptr(),
+            std::ptr::from_mut(&mut size).cast::<libc::c_void>(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret == 0 {
+        usize::try_from(size).ok()
+    } else {
+        None
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn host_memory_bytes() -> Option<usize> {
+    None
+}
+
+/// The cgroup v2 memory limit, if this process runs under one. The file
+/// holds `max` (no limit) or a byte count; non-numeric content yields `None`.
+#[cfg(target_os = "linux")]
+fn cgroup_memory_max() -> Option<usize> {
+    let raw = std::fs::read_to_string("/sys/fs/cgroup/memory.max").ok()?;
+    raw.trim().parse().ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn cgroup_memory_max() -> Option<usize> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn detects_some_memory() {
+        let bytes = physical_memory_bytes().expect("detection works on test platforms");
+        // Sanity: more than 64 MiB, less than 1 PiB.
+        assert!(bytes > 64 << 20);
+        assert!(bytes < 1 << 50);
+    }
+}

--- a/src/ore/src/pool.rs
+++ b/src/ore/src/pool.rs
@@ -47,11 +47,12 @@
 //! out as soon as they are written. Heap-backed chunks (oversize payloads
 //! and class-exhaustion fallbacks) sit outside the identity: they can never
 //! be evicted, so the budget is enforced against evictable bytes only.
-//! Nothing is ever both uncompressed and on the device. Pageout is observed
-//! rather than assumed: an extent counts against the compressed tier until
-//! `mincore` reports its whole range nonresident, so reclaim the kernel
-//! declines surfaces as `extent_pageout_incomplete` (and a tier settled
-//! above its capacity) instead of as RSS the ledger cannot see.
+//! Slots never reach the swap device: only compressed extents are offered
+//! to it. Pageout is observed rather than assumed: an extent counts against
+//! the compressed tier until the page table shows its whole range unmapped,
+//! so reclaim the kernel declines surfaces as `extent_pageout_incomplete`
+//! (and a tier settled above its capacity) instead of as RSS the ledger
+//! cannot see.
 //!
 //! Residency is a state, not a type. It descends through eviction and
 //! ascends through exactly one transition: an admitting read
@@ -203,8 +204,9 @@ pub struct PoolStats {
     /// stealing the slot of a clean backed victim of the same size class.
     /// The victim becomes `Evicted` with zero I/O and its extent intact.
     pub admissions_steal: u64,
-    /// Admitting reads of evicted chunks that found neither budget headroom
-    /// nor a clean victim and were served as a plain decompress instead.
+    /// Admitting reads of evicted chunks served as a plain decompress
+    /// instead: no budget headroom (or an exhausted size class), and no
+    /// clean victim whose growth the budget could absorb.
     pub admissions_denied: u64,
     /// Allocation bytes of compressed extents currently resident — the
     /// compressed-but-resident middle tier. Bounded by the RSS target;
@@ -220,11 +222,11 @@ pub struct PoolStats {
     /// Extents pushed to the swap device by RSS-target enforcement, with
     /// the whole range observed nonresident afterwards.
     pub extent_pageouts: u64,
-    /// Pageout passes whose residency observation found some of the
-    /// extent's pages still in memory: `MADV_PAGEOUT` may decline pages and
-    /// still succeed, so `mincore` decides. The extent keeps its full
-    /// resident accounting and is retried until its per-extent retry cap.
-    /// Climbing steadily on a loaded pool means pages cannot actually reach
+    /// Pageout passes whose observation found some of the extent's pages
+    /// still mapped: `MADV_PAGEOUT` may decline pages and still succeed, so
+    /// the page table decides. The extent keeps its full resident
+    /// accounting and is retried until its per-extent retry cap. Climbing
+    /// steadily on a loaded pool means pages cannot actually be unmapped to
     /// the swap device (no swap, or a cgroup that cannot reclaim).
     pub extent_pageout_incomplete: u64,
     /// Extent writes that fell back to the heap because their extent-arena
@@ -323,9 +325,11 @@ struct PoolInner {
     /// is the number of non-stale queue entries across all bands;
     /// [`PoolInner::prune_queues`] compacts the queues against it.
     live_chunks: AtomicU64,
-    /// Number of live chunks whose extent is currently resident, which is
-    /// the number of non-stale `extent_queue` entries;
-    /// [`PoolInner::prune_extent_queue`] compacts the queue against it.
+    /// Number of live chunks whose extent is currently resident, including
+    /// unreclaimable extents that deliberately hold no `extent_queue` entry
+    /// (heap-backed and retry-capped ones). It therefore upper-bounds the
+    /// queue's non-stale entries, and [`PoolInner::prune_extent_queue`]'s
+    /// compaction threshold is conservative by the unreclaimable count.
     extent_residents: AtomicU64,
     /// Single-flight claim for budget enforcement.
     enforcing: Mutex<()>,
@@ -1443,16 +1447,14 @@ impl PoolInner {
                 .resident_bytes
                 .fetch_sub(len_bytes, Ordering::Relaxed);
         }
-        if let Some(slot) = self.steal_clean_victim(class) {
-            // The victim's bytes left the ledger inside the steal and the
-            // admitted chunk's enter here. The slot's physical pages
-            // transfer deliberately, but only up to the admitted payload:
-            // the victim's pages past it would stay resident with no ledger
+        if let Some(slot) = self.steal_clean_victim(class, meta.len_bytes()) {
+            // The ledger was settled inside the steal: the victim's bytes
+            // out, the admitted chunk's in, with any growth reserved
+            // against the budget. The slot's physical pages transfer
+            // deliberately, but only up to the admitted payload: the
+            // victim's pages past it would stay resident with no ledger
             // bytes to answer for them.
             self.trim_slot_tail(class, slot, meta.len_bytes());
-            self.counters
-                .resident_bytes
-                .fetch_add(len_bytes, Ordering::Relaxed);
             self.counters
                 .admissions_steal
                 .fetch_add(1, Ordering::Relaxed);
@@ -1464,21 +1466,28 @@ impl PoolInner {
         None
     }
 
-    /// Takes the slot of a clean victim in `class`: a `BackedResident`
-    /// chunk with a clear touched bit, whose extent already duplicates its
-    /// slot, so the victim transitions to `Evicted` with zero I/O, its
-    /// extent intact, and its queue entry dropped. The returned slot keeps
-    /// its physical pages (no `dontneed`, no free-list round trip). They
-    /// hold the victim's stale bytes, and the victim's resident bytes have
-    /// left the ledger. `None` when the bounded scan finds no such victim.
+    /// Takes the slot of a clean victim in `class` for an admitted payload
+    /// of `admitted_len_bytes`: a `BackedResident` chunk with a clear
+    /// touched bit, whose extent already duplicates its slot, so the victim
+    /// transitions to `Evicted` with zero I/O, its extent intact, and its
+    /// queue entry dropped. The returned slot keeps its physical pages (no
+    /// `dontneed`, no free-list round trip). They hold the victim's stale
+    /// bytes. The ledger is settled inside the steal: the victim's bytes
+    /// leave and the admitted payload's enter in one step, and a steal that
+    /// grows resident bytes must fit the budget like any other admission
+    /// (a shrinking steal always may proceed). `None` when the bounded scan
+    /// finds no such victim, or none whose growth the budget can absorb.
     ///
     /// The caller holds its own chunk's state lock. The scan follows the
     /// enforcement discipline (deepest band first, queue guard dropped
     /// before any chunk lock, victims only ever `try_lock`ed), which is
     /// what keeps the chunk-lock-while-probing-chunk-lock window
     /// deadlock-free: two admitters stealing toward each other both fail
-    /// the `try_lock` and skip.
-    fn steal_clean_victim(&self, class: usize) -> Option<u32> {
+    /// the `try_lock` and skip. Unlike enforcement, the scan rotates
+    /// unsuitable entries (touched, wrong class, unbacked) to the back
+    /// without spending touched bits, shuffling FIFO order the way the
+    /// backing scan does.
+    fn steal_clean_victim(&self, class: usize, admitted_len_bytes: usize) -> Option<u32> {
         // Bound on entries examined per band before moving to the next.
         // The budget is per band, not shared across the scan: a deep band
         // densely populated with touched resident chunks (a probe-heavy
@@ -1524,11 +1533,31 @@ impl PoolInner {
                     self.queue(band).push_back(weak);
                     continue;
                 }
+                // Settle the ledger in one step: the victim's bytes out, the
+                // admitted payload's in. A steal that grows resident bytes
+                // is an admission and must fit the budget (against evictable
+                // bytes, as everywhere); a shrinking steal always may
+                // proceed. On failure the victim is requeued untouched.
+                let victim_len = u64::cast_from(meta.len_bytes());
+                let admitted_len = u64::cast_from(admitted_len_bytes);
+                let settled = self
+                    .counters
+                    .resident_bytes
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+                        let next = cur.checked_add(admitted_len)?.saturating_sub(victim_len);
+                        let oversize = self.counters.oversize_bytes.load(Ordering::Relaxed);
+                        (next <= cur
+                            || next.saturating_sub(oversize)
+                                <= self.budget_bytes.load(Ordering::Relaxed))
+                        .then_some(next)
+                    })
+                    .is_ok();
+                if !settled {
+                    self.queue(band).push_back(weak);
+                    continue;
+                }
                 let slot = state.slot.take().expect("backed chunk has a slot");
                 state.residency = Residency::Evicted;
-                self.counters
-                    .resident_bytes
-                    .fetch_sub(u64::cast_from(meta.len_bytes()), Ordering::Relaxed);
                 return Some(slot);
             }
         }
@@ -1536,8 +1565,8 @@ impl PoolInner {
     }
 
     /// Capacity of the compressed-resident tier: the RSS target's headroom
-    /// above the slot budget and the warm cap. Zero when no target is set —
-    /// extents then page out as soon as written, today's pre-tier behavior.
+    /// above the slot budget and the warm cap. With no target set the tier
+    /// has zero capacity, so extents page out as soon as they are written.
     fn compressed_cap(&self) -> u64 {
         let target = self.rss_target_bytes.load(Ordering::Relaxed);
         let floor = self
@@ -1677,7 +1706,7 @@ impl PoolInner {
     /// Pages out the oldest resident extents until the compressed tier falls
     /// to its capacity. The compression is already paid and the device write
     /// is the kernel's async writeback, so each pageout is one bounded
-    /// madvise plus a mincore observation; spill threads run this between
+    /// madvise plus a page-table observation; spill threads run this between
     /// jobs, and other threads only when no spill threads exist (see
     /// [`PoolInner::enforce_or_defer_compressed_cap`]). Not single-flighted:
     /// concurrent passes pop disjoint victims. Visits are bounded by the
@@ -1808,6 +1837,12 @@ impl ChunkHandle {
     /// evicting or compressing anything. When neither source yields a slot
     /// the read is served as a plain decompress and the chunk stays
     /// evicted.
+    ///
+    /// For demand reads on probe paths, where the same chunk is likely to
+    /// be read again. Merge, drain, and other consume-once paths should use
+    /// [`ChunkHandle::read_into`] or [`ChunkHandle::take`]: admitting there
+    /// churns the clean-victim stock that eager backing exists to build,
+    /// evicting probe targets to house data about to die.
     pub fn read_into_admit(&self, dst: &mut Vec<u64>) {
         self.read_impl(dst, true);
     }
@@ -1867,8 +1902,11 @@ impl ChunkHandle {
                         dst.extend_from_slice(src);
                         // Resident again: rejoin the eviction candidates.
                         // A leftover entry from before the chunk's eviction
-                        // is a harmless duplicate, since each entry is
-                        // validated against the chunk's state on visit.
+                        // stays sound (each entry is validated against the
+                        // chunk's state on visit) but costs policy: two live
+                        // entries give the enforcer two chances to spend
+                        // this chunk's single touched bit, halving its
+                        // second chance until one entry drains.
                         meta.pool
                             .queue(band(meta.depth))
                             .push_back(Arc::downgrade(&self.meta));
@@ -1879,7 +1917,11 @@ impl ChunkHandle {
                         // read takes an initialized `&mut [u8]`, so skipping
                         // the fill would mean exposing uninitialized memory
                         // through a safe reference. Callers that read
-                        // repeatedly amortize it by reusing `dst`'s capacity.
+                        // repeatedly amortize it by reusing `dst` within a
+                        // pass, shrinking it back after oversized reads (a
+                        // reused buffer otherwise ratchets to the largest
+                        // chunk it ever carried, invisible to every pool
+                        // gauge; the design doc's reader discipline).
                         dst.resize(meta.len, 0);
                         let bytes: &mut [u8] = bytemuck::cast_slice_mut(dst.as_mut_slice());
                         extent.read_into(bytes);
@@ -2113,8 +2155,8 @@ mod tests {
         assert_eq!(pool.stats().extent_resident_bytes, 0);
     }
 
-    /// With no RSS target (the default), extents page out as soon as they
-    /// are written — the pre-tier behavior.
+    /// With no RSS target (the default), the compressed tier has zero
+    /// capacity and extents page out as soon as they are written.
     #[mz_ore::test]
     fn default_target_pages_extents_immediately() {
         let pool = test_pool(256 << 20);
@@ -2650,6 +2692,148 @@ mod tests {
         assert_eq!(stats.admissions_denied, 0);
         assert_eq!(stats.resident_bytes, 0);
         assert_eq!(stats.frees, 1);
+    }
+
+    /// A steal settles the ledger with the payload difference: a shrinking
+    /// steal always proceeds, while a steal that would grow resident bytes
+    /// past the budget is denied and leaves the victim untouched.
+    #[mz_ore::test]
+    fn steal_admission_charges_the_budget() {
+        // Shrinking steal: the victim is larger than the admitted payload,
+        // so the steal lowers resident bytes and always may proceed.
+        let pool = test_pool(256 << 20);
+        let victim_orig = payload(SMALL, 84);
+        let victim = insert(&pool, &mut victim_orig.clone());
+        assert!(pool.back_step(), "victim backs");
+        let small_orig = payload(SMALL / 2, 85);
+        let handle = insert(&pool, &mut small_orig.clone());
+        pool.evict(&handle);
+        pool.set_budget(64 << 10);
+        assert_eq!(read_admit(&handle), small_orig);
+        let stats = pool.stats();
+        assert_eq!(stats.admissions_steal, 1, "no headroom, so the read steals");
+        assert_eq!(stats.resident_bytes, u64::cast_from(SMALL / 2 * 8));
+        assert_eq!(victim.residency(), Residency::Evicted);
+        assert_eq!(read(&victim), victim_orig, "victim serves from its extent");
+
+        // Growing steal: the admitted payload is larger than the only
+        // victim, and the growth does not fit the budget, so the admission
+        // is denied and the victim is left untouched.
+        let pool = test_pool(256 << 20);
+        let big_orig = payload(SMALL, 86);
+        let big = insert(&pool, &mut big_orig.clone());
+        pool.evict(&big);
+        let small_victim = insert(&pool, &mut payload(SMALL / 2, 87));
+        assert!(pool.back_step(), "victim backs");
+        pool.set_budget(32 << 10);
+        assert_eq!(read_admit(&big), big_orig);
+        let stats = pool.stats();
+        assert_eq!(stats.admissions_denied, 1, "growth exceeds the budget");
+        assert_eq!(stats.admissions_steal, 0);
+        assert_eq!(big.residency(), Residency::Evicted);
+        assert_eq!(small_victim.residency(), Residency::BackedResident);
+    }
+
+    /// Admission of a chunk whose extent was pushed to the device: the read
+    /// revives the extent into the acquired slot and re-counts it.
+    #[mz_ore::test]
+    fn admission_revives_paged_out_extent() {
+        let pool = test_pool(256 << 20);
+        let orig = payload(SMALL, 88);
+        let handle = insert(&pool, &mut orig.clone());
+        pool.evict(&handle);
+        assert_eq!(
+            pool.stats().extent_resident_bytes,
+            0,
+            "zero RSS target pages the extent out on eviction",
+        );
+        // Raise the target so the read's own tier enforcement does not
+        // page the revived extent straight back out.
+        pool.set_rss_target(1 << 30);
+        assert_eq!(read_admit(&handle), orig);
+        assert_eq!(handle.residency(), Residency::BackedResident);
+        let stats = pool.stats();
+        assert_eq!(stats.admissions_budget, 1);
+        assert!(stats.extent_resident_bytes > 0, "revived and re-counted");
+    }
+
+    /// An admitting read of a chunk that is not evicted is a plain read:
+    /// no admission counter moves and no state changes.
+    #[mz_ore::test]
+    fn admit_is_plain_read_on_non_evicted_chunks() {
+        let pool = test_pool(256 << 20);
+        let orig = payload(SMALL, 89);
+        let resident = insert(&pool, &mut orig.clone());
+        assert_eq!(read_admit(&resident), orig);
+        assert_eq!(resident.residency(), Residency::UnbackedResident);
+        let words = SIZE_CLASSES[SIZE_CLASSES.len() - 1] / 8 + 1;
+        let oversize_orig = payload(words, 90);
+        let oversize = insert(&pool, &mut oversize_orig.clone());
+        assert_eq!(read_admit(&oversize), oversize_orig);
+        let empty = insert(&pool, &mut Vec::new());
+        assert!(read_admit(&empty).is_empty());
+        let stats = pool.stats();
+        assert_eq!(stats.admissions_budget, 0);
+        assert_eq!(stats.admissions_steal, 0);
+        assert_eq!(stats.admissions_denied, 0);
+    }
+
+    /// Concurrent admitting reads with no budget headroom: every admission
+    /// must go through the steal path, racing steals against each other on
+    /// the same victims (the pool's only two-chunk lock edge). Contents are
+    /// asserted on every read.
+    #[mz_ore::test]
+    fn concurrent_admits_exercise_the_steal_path() {
+        const CHUNKS: u64 = 8;
+        let pool = test_pool(usize::MAX);
+        let origs: Vec<_> = (0..CHUNKS).map(|seed| payload(SMALL, 900 + seed)).collect();
+        let evicted: Arc<Vec<(Vec<u64>, ChunkHandle)>> = Arc::new(
+            origs
+                .iter()
+                .map(|orig| {
+                    let handle = insert(&pool, &mut orig.clone());
+                    pool.evict(&handle);
+                    (orig.clone(), handle)
+                })
+                .collect(),
+        );
+        let mut victims = Vec::new();
+        for seed in 0..CHUNKS {
+            victims.push(insert(&pool, &mut payload(SMALL, 950 + seed)));
+            assert!(pool.back_step(), "victim backs");
+        }
+        // Exactly the victims' bytes: no free headroom, so every admission
+        // steals or is denied.
+        pool.set_budget(usize::cast_from(CHUNKS) * (64 << 10));
+        let threads: Vec<_> = (0..2u64)
+            .map(|t| {
+                let evicted = Arc::clone(&evicted);
+                std::thread::spawn(move || {
+                    for round in 0..CHUNKS {
+                        let (orig, handle) = &evicted[usize::cast_from((t + round) % CHUNKS)];
+                        let mut out = Vec::new();
+                        handle.read_into_admit(&mut out);
+                        assert_eq!(&out, orig);
+                    }
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().expect("admitting thread panicked");
+        }
+        let stats = pool.stats();
+        assert!(stats.admissions_steal > 0, "no headroom forces steals");
+        assert!(
+            stats.resident_bytes <= u64::cast_from(usize::cast_from(CHUNKS) * (64 << 10)),
+            "steals never grow resident bytes past the budget",
+        );
+        // The victims were held live as steal targets; a steal leaves its
+        // victim evicted, so at least one is evicted here.
+        let stolen = victims
+            .iter()
+            .filter(|v| v.residency() == Residency::Evicted)
+            .count();
+        assert!(stolen > 0, "a steal evicts its victim");
     }
 
     /// A re-admitted chunk keeps its insert-time depth: under budget

--- a/src/ore/src/pool.rs
+++ b/src/ore/src/pool.rs
@@ -25,8 +25,8 @@
 //! extent decompressed straight into the caller's buffer, all under the
 //! chunk's state lock, so no reference into pool memory escapes the pool and
 //! a read leaves residency untouched. The backing is the swap-backed extent
-//! store of the design's Layer 1: a page-aligned anonymous allocation
-//! holding the chunk's lz4-compressed bytes.
+//! store of the design's Layer 1: a slot in a pool-owned anonymous-memory
+//! extent arena holding the chunk's lz4-compressed bytes.
 //!
 //! Memory descends a ladder of tiers, each with its own ceiling and each
 //! cheaper to vacate than the one above:
@@ -41,9 +41,12 @@
 //! * **The swap device** — overflow; reads fault and decompress.
 //!
 //! The identity `total pool RSS <= budget + warm cap + compressed cap`,
-//! where `compressed cap = rss_target - budget - warm cap`, makes every
-//! resident byte's ceiling nameable; a zero RSS target collapses the
-//! compressed tier and extents page out as soon as they are written.
+//! where `compressed cap = max(0, rss_target - budget - warm cap)`, makes
+//! every resident byte's ceiling nameable. A zero RSS target (or one below
+//! the budget plus warm cap) collapses the compressed tier and extents page
+//! out as soon as they are written. Heap-backed chunks (oversize payloads
+//! and class-exhaustion fallbacks) sit outside the identity: they can never
+//! be evicted, so the budget is enforced against evictable bytes only.
 //! Nothing is ever both uncompressed and on the device. Pageout is observed
 //! rather than assumed: an extent counts against the compressed tier until
 //! `mincore` reports its whole range nonresident, so reclaim the kernel
@@ -79,7 +82,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, Weak};
 
 use crate::cast::CastFrom;
-use crate::pool::extent::SwapExtent;
+use crate::pool::extent::{ExtentArena, Scratch, SwapExtent};
 use crate::pool::region::{Region, SIZE_CLASSES};
 
 /// Virtual reservation per size class. Purely virtual: physical memory
@@ -147,8 +150,10 @@ pub struct PoolStats {
     pub inserts: u64,
     /// Chunks freed (handle dropped).
     pub frees: u64,
-    /// Backing writes elided: chunks freed while `UnbackedResident`, dead
-    /// before any compression or extent write happened.
+    /// Backing writes elided: chunks dead before their compression
+    /// completed, so no extent write happened. Covers chunks freed while
+    /// `UnbackedResident` and chunks freed while queued for a spill thread
+    /// that had not yet compressed them.
     pub writes_elided: u64,
     /// Evictions that compressed the chunk into a new extent.
     pub evictions_compress: u64,
@@ -158,8 +163,9 @@ pub struct PoolStats {
     pub extent_bytes_written: u64,
     /// Evictions handed to spill threads.
     pub spill_scheduled: u64,
-    /// Scheduled evictions cancelled because the chunk was freed with the
-    /// write queued or in flight.
+    /// Compressions cancelled because the chunk was freed while queued or
+    /// in flight, whatever scheduled them. Eager-backing work counts here
+    /// but never in `spill_scheduled`, so this can exceed that counter.
     pub spill_cancelled: u64,
     /// Entries currently queued for or being processed by spill threads.
     pub spill_in_flight: u64,
@@ -204,6 +210,13 @@ pub struct PoolStats {
     /// compressed-but-resident middle tier. Bounded by the RSS target;
     /// exceeding it pages the oldest extents out to the swap device.
     pub extent_resident_bytes: u64,
+    /// Allocation bytes of resident extents the RSS target cannot push out:
+    /// retry-capped arena extents (the kernel declined the reclaim advice
+    /// until the retry budget ran out) and heap-fallback extents. The
+    /// compressed tier settles above its capacity by this amount. Climbing
+    /// steadily means pages cannot reach the swap device (no swap, or a
+    /// cgroup that cannot reclaim).
+    pub extent_unreclaimable_bytes: u64,
     /// Extents pushed to the swap device by RSS-target enforcement, with
     /// the whole range observed nonresident afterwards.
     pub extent_pageouts: u64,
@@ -214,6 +227,10 @@ pub struct PoolStats {
     /// Climbing steadily on a loaded pool means pages cannot actually reach
     /// the swap device (no swap, or a cgroup that cannot reclaim).
     pub extent_pageout_incomplete: u64,
+    /// Extent writes that fell back to the heap because their extent-arena
+    /// class had no free slot. Heap-backed extents stay readable but are
+    /// never paged out, so their compressed bytes hold RAM until freed.
+    pub extent_arena_fallbacks: u64,
 }
 
 #[derive(Debug, Default)]
@@ -237,6 +254,7 @@ struct Counters {
     admissions_steal: AtomicU64,
     admissions_denied: AtomicU64,
     extent_resident_bytes: AtomicU64,
+    extent_unreclaimable_bytes: AtomicU64,
     extent_pageouts: AtomicU64,
     extent_pageout_incomplete: AtomicU64,
 }
@@ -266,18 +284,23 @@ pub struct Pool(Arc<PoolInner>);
 /// for.
 #[derive(Debug)]
 struct PoolInner {
-    /// Resident-bytes target. Atomic so a running pool can be retuned in
-    /// place (operator-driven budget changes) without orphaning live
-    /// handles, which share this value through their `Arc<PoolInner>`.
+    /// Resident-bytes target, enforced against evictable bytes (resident
+    /// minus heap-backed, which no eviction can reclaim). Atomic so a
+    /// running pool can be retuned in place (operator-driven budget
+    /// changes) without orphaning live handles, which share this value
+    /// through their `Arc<PoolInner>`.
     budget_bytes: AtomicU64,
     /// Ceiling on the pool's *total* RSS: slots (the budget) plus warm free
     /// slots plus compressed-resident extents. The compressed tier's
-    /// capacity derives as `rss_target - budget - warm cap`; zero (the
-    /// default) collapses the tier, paging every extent out as soon as it
-    /// is written.
+    /// capacity derives as `max(0, rss_target - budget - warm cap)`; zero
+    /// (the default) collapses the tier, paging every extent out as soon as
+    /// it is written.
     rss_target_bytes: AtomicU64,
     /// One region per entry of [`SIZE_CLASSES`], same order.
     regions: Vec<Region>,
+    /// The arena backing extents. Shared with every live [`SwapExtent`],
+    /// whose drop returns its slot.
+    extent_arena: Arc<ExtentArena>,
     /// Second-chance FIFOs of eviction candidates, one per depth band; a
     /// chunk joins the band of its [`ChunkHints`] depth at insert and again
     /// on re-admission. Entries for freed chunks go stale in place and are
@@ -292,12 +315,18 @@ struct PoolInner {
     queues: [Mutex<VecDeque<Weak<ChunkMeta>>>; DEPTH_BANDS],
     /// FIFO of chunks whose extents are resident, oldest first — the
     /// RSS-target enforcement's victim queue. Entries go stale when an
-    /// extent pages out, is dropped, or its chunk dies; visits drop them.
+    /// extent pages out, is dropped, or its chunk dies; visits drop them,
+    /// and [`PoolInner::prune_extent_queue`] compacts dead-chunk entries
+    /// that under-cap operation never visits.
     extent_queue: Mutex<VecDeque<Weak<ChunkMeta>>>,
     /// Number of live size-classed chunks (whatever their residency), which
     /// is the number of non-stale queue entries across all bands;
     /// [`PoolInner::prune_queues`] compacts the queues against it.
     live_chunks: AtomicU64,
+    /// Number of live chunks whose extent is currently resident, which is
+    /// the number of non-stale `extent_queue` entries;
+    /// [`PoolInner::prune_extent_queue`] compacts the queue against it.
+    extent_residents: AtomicU64,
     /// Single-flight claim for budget enforcement.
     enforcing: Mutex<()>,
     counters: Counters,
@@ -456,13 +485,16 @@ impl Pool {
             .iter()
             .map(|&class_size| Region::new(class_size, class_capacity_bytes))
             .collect::<std::io::Result<Vec<_>>>()?;
+        let extent_arena = Arc::new(ExtentArena::new(class_capacity_bytes)?);
         Ok(Pool(Arc::new(PoolInner {
             budget_bytes: AtomicU64::new(u64::MAX),
             rss_target_bytes: AtomicU64::new(0),
             regions,
+            extent_arena,
             queues: std::array::from_fn(|_| Mutex::new(VecDeque::new())),
             extent_queue: Mutex::new(VecDeque::new()),
             live_chunks: AtomicU64::new(0),
+            extent_residents: AtomicU64::new(0),
             enforcing: Mutex::new(()),
             counters: Counters::default(),
             spill: Spill::default(),
@@ -482,6 +514,12 @@ impl Pool {
     /// copy straight into pool memory, paying one page population instead of
     /// staging through caller-side buffers that fault their own pages and
     /// die immediately after.
+    ///
+    /// Relies on abort-on-panic: a panic in `fill` that was caught would
+    /// leak the slot and its resident-bytes accounting. All hosting
+    /// binaries abort via `mz_ore::panic::install_enhanced_handler`, and
+    /// pool consumers are dataflow operators, never code hosted under a
+    /// `catch_unwind` boundary the way the optimizer is.
     pub fn insert_with(
         &self,
         len: usize,
@@ -536,6 +574,13 @@ impl Pool {
                 let dst = unsafe {
                     std::slice::from_raw_parts_mut(region.slot_ptr(slot).cast::<u64>(), len)
                 };
+                // The fill contract (overwrite all `len` words) is
+                // discipline-only. Poison in debug builds so an
+                // under-writing fill reads back as deterministic garbage
+                // instead of a previous occupant's bytes, which the heap
+                // path's zero fill would otherwise mask in tests.
+                #[cfg(debug_assertions)]
+                dst.fill(u64::from_ne_bytes([0xDE; 8]));
                 fill(dst);
                 ChunkMeta::new(
                     inner,
@@ -595,8 +640,10 @@ impl Pool {
             admissions_steal: c.admissions_steal.load(Ordering::Relaxed),
             admissions_denied: c.admissions_denied.load(Ordering::Relaxed),
             extent_resident_bytes: c.extent_resident_bytes.load(Ordering::Relaxed),
+            extent_unreclaimable_bytes: c.extent_unreclaimable_bytes.load(Ordering::Relaxed),
             extent_pageouts: c.extent_pageouts.load(Ordering::Relaxed),
             extent_pageout_incomplete: c.extent_pageout_incomplete.load(Ordering::Relaxed),
+            extent_arena_fallbacks: self.0.extent_arena.fallbacks(),
             spill_scheduled: c.spill_scheduled.load(Ordering::Relaxed),
             spill_cancelled: c.spill_cancelled.load(Ordering::Relaxed),
             spill_in_flight: self.0.spill.in_flight.load(Ordering::Relaxed),
@@ -709,6 +756,13 @@ impl Pool {
         true
     }
 
+    /// Test hook: runs one compressed-cap enforcement pass on the calling
+    /// thread.
+    #[cfg(test)]
+    fn enforce_compressed(&self) {
+        self.0.enforce_compressed_cap();
+    }
+
     /// Test hook: evicts cold chunks until resident bytes fall to the budget
     /// or every queued chunk has been visited once. Enforcement runs
     /// automatically on every insert and budget shrink.
@@ -735,6 +789,7 @@ impl Pool {
         // warrants an enforcement pass (a grow needs none, and inserts
         // enforce continuously anyway).
         if new < prev {
+            self.0.trim_warm_pool();
             self.0.enforce_budget();
         }
     }
@@ -757,6 +812,13 @@ impl Pool {
     #[cfg(test)]
     fn queue_len(&self) -> usize {
         (0..DEPTH_BANDS).map(|band| self.0.queue(band).len()).sum()
+    }
+
+    /// Test-only: the number of resident-extent queue entries, live and
+    /// stale.
+    #[cfg(test)]
+    fn extent_queue_len(&self) -> usize {
+        self.0.extent_queue().len()
     }
 
     /// Test hook: explicitly evicts one chunk. No-op if the chunk is already
@@ -833,7 +895,9 @@ impl PoolInner {
         self.counters
             .extent_bytes_written
             .fetch_add(u64::cast_from(extent.comp_len()), Ordering::Relaxed);
-        self.note_extent_resident(meta, extent.alloc_size());
+        // A heap-fallback extent is born permanently capped and counts as
+        // unreclaimable from the start.
+        self.note_extent_resident(meta, extent.alloc_size(), !extent.pageout_capped());
         state.extent = Some(extent);
     }
 
@@ -872,6 +936,18 @@ impl PoolInner {
         self.enforce_or_defer_compressed_cap();
     }
 
+    /// Bytes budget enforcement can actually reclaim: resident bytes minus
+    /// heap-backed (oversize and class-exhaustion) chunks, which hold no
+    /// slot and can never be evicted. Enforcing against raw resident bytes
+    /// would, once unevictable bytes alone exceed the budget, compress
+    /// every slotted chunk on arrival forever.
+    fn evictable_bytes(&self) -> u64 {
+        self.counters
+            .resident_bytes
+            .load(Ordering::Relaxed)
+            .saturating_sub(self.counters.oversize_bytes.load(Ordering::Relaxed))
+    }
+
     fn enforce_budget_inner(&self) {
         self.prune_queues();
         // Deepest band first: deep chunks are the coldest, and once eager
@@ -880,9 +956,7 @@ impl PoolInner {
         // bands cannot satisfy the budget, keeping young data's
         // die-before-write chance longest.
         for band in (0..DEPTH_BANDS).rev() {
-            if self.counters.resident_bytes.load(Ordering::Relaxed)
-                <= self.budget_bytes.load(Ordering::Relaxed)
-            {
+            if self.evictable_bytes() <= self.budget_bytes.load(Ordering::Relaxed) {
                 return;
             }
             self.enforce_budget_band(band);
@@ -890,7 +964,6 @@ impl PoolInner {
     }
 
     fn enforce_budget_band(&self, band: usize) {
-        let resident = |counters: &Counters| counters.resident_bytes.load(Ordering::Relaxed);
         // The queue holds resident chunks only (entries for evicted chunks
         // are dropped on visit and never re-added), so a full pass is
         // proportional to the resident set. Visit each queued chunk at most
@@ -899,8 +972,7 @@ impl PoolInner {
         // guaranteed to evict every chunk it saw. The bound keeps contended
         // and in-flight entries from spinning this loop forever.
         let mut remaining = self.queue(band).len().saturating_mul(2);
-        while remaining > 0 && resident(&self.counters) > self.budget_bytes.load(Ordering::Relaxed)
-        {
+        while remaining > 0 && self.evictable_bytes() > self.budget_bytes.load(Ordering::Relaxed) {
             remaining -= 1;
             let popped = self.queue(band).pop_front();
             let Some(weak) = popped else {
@@ -957,7 +1029,10 @@ impl PoolInner {
                 // lock is held, so nothing else touches the slot while this
                 // borrow is live (reads copy out under the same lock).
                 let data = unsafe { self.slot_data(meta, slot) };
-                let extent = SwapExtent::write(data);
+                // Inline eviction runs on whichever thread tripped the
+                // budget, so the compression scratch must not stay parked
+                // on it.
+                let extent = SwapExtent::write(&self.extent_arena, data, Scratch::Shrink);
                 self.counters
                     .evictions_compress
                     .fetch_add(1, Ordering::Relaxed);
@@ -1131,7 +1206,9 @@ impl PoolInner {
         // are immutable; concurrent copy-out reads take the state lock and
         // read the slot, but nothing writes it.
         let data = unsafe { self.slot_data(meta, slot) };
-        let extent = SwapExtent::write(data);
+        // Spill threads see a steady job stream, so they keep the grown
+        // compression scratch for the next job.
+        let extent = SwapExtent::write(&self.extent_arena, data, Scratch::Retain);
         // Commit under the lock.
         let mut state = meta.state();
         if state.freed {
@@ -1210,6 +1287,29 @@ impl PoolInner {
         (self.budget_bytes.load(Ordering::Relaxed) / 8).min(1 << 30)
     }
 
+    /// Cools warm free slots until `warm_bytes` falls to the warm cap. A
+    /// budget shrink lowers the cap, and warm capacity is checked only when
+    /// a slot is freed, so without this pass slots parked under the old cap
+    /// would hold their pages until same-class reuse happened to drain them,
+    /// exactly when the shrink wanted the memory back.
+    fn trim_warm_pool(&self) {
+        let mut over = self
+            .counters
+            .warm_bytes
+            .load(Ordering::Relaxed)
+            .saturating_sub(self.warm_cap());
+        for region in &self.regions {
+            if over == 0 {
+                return;
+            }
+            let cooled = u64::cast_from(region.cool_warm_slots(usize::cast_from(over)));
+            self.counters
+                .warm_bytes
+                .fetch_sub(cooled, Ordering::Relaxed);
+            over = over.saturating_sub(cooled);
+        }
+    }
+
     /// Claims warm-pool capacity for a slot of `class_size` bytes, returning
     /// whether the slot may keep its pages. The RSS overshoot the warm pool
     /// introduces is bounded by [`PoolInner::warm_cap`] and visible as the
@@ -1225,10 +1325,10 @@ impl PoolInner {
             .is_ok()
     }
 
-    /// Allocates a slot in `class` with warm-pool accounting (a warm
-    /// allocation is counted as a reuse), or `None` when the class has no
-    /// free slot.
-    fn try_alloc_slot(&self, class: usize) -> Option<u32> {
+    /// Allocates a slot in `class` for a payload of `len_bytes` with
+    /// warm-pool accounting (a warm allocation is counted as a reuse and
+    /// trimmed to the payload), or `None` when the class has no free slot.
+    fn try_alloc_slot(&self, class: usize, len_bytes: usize) -> Option<u32> {
         let (index, warm) = self.regions[class].alloc()?;
         if warm {
             // The allocation faulted no pages; its bytes leave the warm
@@ -1238,8 +1338,45 @@ impl PoolInner {
                 .warm_bytes
                 .fetch_sub(class_bytes, Ordering::Relaxed);
             self.counters.warm_reuses.fetch_add(1, Ordering::Relaxed);
+            // A warm slot keeps the prior occupant's resident pages, which
+            // may extend past the new payload while the ledger credits only
+            // `len_bytes`.
+            self.trim_slot_tail(class, index, len_bytes);
         }
         Some(index)
+    }
+
+    /// Releases a slot's pages beyond the first `len_bytes` (rounded up to
+    /// a page), so a slot reused for a smaller payload does not keep its
+    /// prior occupant's tail pages resident with no bytes in the ledger to
+    /// answer for them.
+    ///
+    /// Precondition: the caller exclusively owns the slot (freshly
+    /// allocated, or taken from a victim under the victim's state lock)
+    /// with no reference into it.
+    fn trim_slot_tail(&self, class: usize, slot: u32, len_bytes: usize) {
+        let region = &self.regions[class];
+        // Hugepage-class slots trim at huge-page granularity: a base-page
+        // trim would split the slot's `MADV_HUGEPAGE` folios, and khugepaged
+        // may later re-collapse a partially trimmed range, re-instantiating
+        // pages the ledger counts as released. Whole-folio trims leave no
+        // partial folio to split or resurrect.
+        let granule = if region.class_size() >= region::HUGE_PAGE {
+            region::HUGE_PAGE
+        } else {
+            region::page_size()
+        };
+        let keep = len_bytes.next_multiple_of(granule).min(region.class_size());
+        let tail = region.class_size() - keep;
+        if tail == 0 {
+            return;
+        }
+        // SAFETY: the caller exclusively owns the slot per the
+        // precondition, and `keep + tail` is exactly the class size, so the
+        // range stays within the slot.
+        unsafe {
+            region::dontneed(region.slot_ptr(slot).add(keep), tail);
+        }
     }
 
     /// Allocates a slot in `class` for an insert: as
@@ -1247,7 +1384,7 @@ impl PoolInner {
     /// heap fallback for a `len_bytes` payload (warned about once). `None`
     /// means the caller must degrade to the heap.
     fn alloc_slot(&self, class: usize, len_bytes: usize) -> Option<u32> {
-        match self.try_alloc_slot(class) {
+        match self.try_alloc_slot(class, len_bytes) {
             Some(index) => Some(index),
             None => {
                 self.counters
@@ -1279,17 +1416,24 @@ impl PoolInner {
         // Free budget first: reserve the bytes, then a slot. The
         // reservation never pushes resident bytes past the budget, and a
         // class with no free slot hands the reservation back rather than
-        // evicting anything to make room.
+        // evicting anything to make room. The headroom test uses evictable
+        // bytes, matching budget enforcement: unevictable heap-backed bytes
+        // must not permanently veto budget-path admissions the enforcer
+        // would never need to undo.
         let reserved = self
             .counters
             .resident_bytes
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+                // Loaded inside the closure so a CAS retry sees oversize
+                // frees that landed since the last attempt.
+                let oversize = self.counters.oversize_bytes.load(Ordering::Relaxed);
                 let next = cur.checked_add(len_bytes)?;
-                (next <= self.budget_bytes.load(Ordering::Relaxed)).then_some(next)
+                (next.saturating_sub(oversize) <= self.budget_bytes.load(Ordering::Relaxed))
+                    .then_some(next)
             })
             .is_ok();
         if reserved {
-            if let Some(slot) = self.try_alloc_slot(class) {
+            if let Some(slot) = self.try_alloc_slot(class, meta.len_bytes()) {
                 self.counters
                     .admissions_budget
                     .fetch_add(1, Ordering::Relaxed);
@@ -1302,8 +1446,10 @@ impl PoolInner {
         if let Some(slot) = self.steal_clean_victim(class) {
             // The victim's bytes left the ledger inside the steal and the
             // admitted chunk's enter here. The slot's physical pages
-            // transfer untouched, so residency moves only by the
-            // intra-class length difference between the two chunks.
+            // transfer deliberately, but only up to the admitted payload:
+            // the victim's pages past it would stay resident with no ledger
+            // bytes to answer for them.
+            self.trim_slot_tail(class, slot, meta.len_bytes());
             self.counters
                 .resident_bytes
                 .fetch_add(len_bytes, Ordering::Relaxed);
@@ -1402,29 +1548,80 @@ impl PoolInner {
     }
 
     /// Counts a newly resident extent (written, or revived by a read)
-    /// against the compressed tier and enqueues its chunk for RSS-target
-    /// enforcement. Callers hold the chunk's state lock with the extent
-    /// present and resident, and follow up with
-    /// [`PoolInner::enforce_compressed_cap`] once the lock is released.
+    /// against the compressed tier. A reclaimable extent additionally
+    /// enqueues its chunk for RSS-target enforcement; an unreclaimable one
+    /// (a heap-fallback extent, which is never advised out) counts against
+    /// the unreclaimable gauge instead and stays out of the queue, so
+    /// enforcement never walks entries it cannot act on. Callers hold the
+    /// chunk's state lock with the extent present and resident, and follow
+    /// up with [`PoolInner::enforce_compressed_cap`] once the lock is
+    /// released.
     ///
     /// Invariant: `extent_resident_bytes` equals the sum of `alloc_size`
-    /// over live chunks' extents whose `is_resident()` is true. This method
-    /// and [`PoolInner::note_extent_released`] are the only adjusters; every
+    /// over live chunks' extents whose `is_resident()` is true, and
+    /// `extent_residents` counts those extents; `extent_unreclaimable_bytes`
+    /// is the subset whose `pageout_capped()` is true. This method,
+    /// [`PoolInner::note_extent_reclaimable`],
+    /// [`PoolInner::note_extent_released`], and the pageout arms in
+    /// [`PoolInner::enforce_compressed_cap`] are the only adjusters; every
     /// flag flip pairs with one of them under the chunk's state lock.
-    fn note_extent_resident(&self, meta: &Arc<ChunkMeta>, extent_alloc: usize) {
+    fn note_extent_resident(&self, meta: &Arc<ChunkMeta>, extent_alloc: usize, reclaimable: bool) {
         self.counters
             .extent_resident_bytes
             .fetch_add(u64::cast_from(extent_alloc), Ordering::Relaxed);
+        self.extent_residents.fetch_add(1, Ordering::Relaxed);
+        if reclaimable {
+            self.prune_extent_queue();
+            self.extent_queue().push_back(Arc::downgrade(meta));
+        } else {
+            self.counters
+                .extent_unreclaimable_bytes
+                .fetch_add(u64::cast_from(extent_alloc), Ordering::Relaxed);
+        }
+    }
+
+    /// Returns a retry-capped resident extent to the reclaimable set after a
+    /// read restored its pageout budget: uncounts it from the unreclaimable
+    /// gauge and re-enqueues its chunk for RSS-target enforcement. The
+    /// caller holds the chunk's state lock with the extent present, resident,
+    /// and no longer `pageout_capped()`.
+    fn note_extent_reclaimable(&self, meta: &Arc<ChunkMeta>, extent_alloc: usize) {
+        self.counters
+            .extent_unreclaimable_bytes
+            .fetch_sub(u64::cast_from(extent_alloc), Ordering::Relaxed);
+        self.prune_extent_queue();
         self.extent_queue().push_back(Arc::downgrade(meta));
     }
 
     /// Uncounts a resident extent that is being dropped (chunk freed or
-    /// degraded). Its queue entry goes stale and is dropped on visit.
+    /// degraded). Its queue entry goes stale and is dropped on visit or by
+    /// [`PoolInner::prune_extent_queue`].
     fn note_extent_released(&self, extent: &SwapExtent) {
         if extent.is_resident() {
             self.counters
                 .extent_resident_bytes
                 .fetch_sub(u64::cast_from(extent.alloc_size()), Ordering::Relaxed);
+            self.extent_residents.fetch_sub(1, Ordering::Relaxed);
+            if extent.pageout_capped() {
+                self.counters
+                    .extent_unreclaimable_bytes
+                    .fetch_sub(u64::cast_from(extent.alloc_size()), Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Drops extent-queue entries whose chunk has been freed, mirroring
+    /// [`PoolInner::prune_queues`]: compact only when the queue outgrows
+    /// all live resident extents (plus a small floor), so the cost
+    /// amortizes to a constant per push. Enforcement drops stale entries
+    /// too, but only while the tier is over capacity. A pool that stays
+    /// under its compressed cap would otherwise accumulate an entry (and a
+    /// pin on the dead chunk's allocation) per freed extent forever.
+    fn prune_extent_queue(&self) {
+        let live = usize::cast_from(self.extent_residents.load(Ordering::Relaxed));
+        let mut queue = self.extent_queue();
+        if queue.len() > 2 * live + 16 {
+            queue.retain(|weak| weak.strong_count() > 0);
         }
     }
 
@@ -1458,8 +1655,16 @@ impl PoolInner {
     /// for the pageouts.
     fn enforce_or_defer_compressed_cap(&self) {
         if self.spill.threads.load(Ordering::Relaxed) > 0 {
+            // The inline backstop keys on the bytes enforcement can actually
+            // reclaim. Unreclaimable extents (retry-capped, heap-backed)
+            // would otherwise hold the backstop permanently over threshold
+            // and put a full enforcement pass on every caller.
             let resident = self.counters.extent_resident_bytes.load(Ordering::Relaxed);
-            if resident > self.compressed_cap().saturating_mul(2) {
+            let unreclaimable = self
+                .counters
+                .extent_unreclaimable_bytes
+                .load(Ordering::Relaxed);
+            if resident.saturating_sub(unreclaimable) > self.compressed_cap().saturating_mul(2) {
                 self.enforce_compressed_cap();
             } else {
                 self.spill.cv.notify_one();
@@ -1477,9 +1682,11 @@ impl PoolInner {
     /// [`PoolInner::enforce_or_defer_compressed_cap`]). Not single-flighted:
     /// concurrent passes pop disjoint victims. Visits are bounded by the
     /// queue's length at entry; stale entries (extent paged out, dropped, or
-    /// chunk dead) are dropped, while incomplete and retry-capped extents
-    /// are requeued with their accounting intact, so the tier may settle
-    /// above its capacity by the bytes the kernel declined to reclaim.
+    /// chunk dead) are dropped. Incomplete extents are requeued with their
+    /// accounting intact until their retry budget runs out, at which point
+    /// they leave the queue with their bytes on the unreclaimable gauge, so
+    /// the tier may settle above its capacity by the bytes the kernel
+    /// declined to reclaim without enforcement re-walking them.
     fn enforce_compressed_cap(&self) {
         let cap = self.compressed_cap();
         let resident = |c: &Counters| c.extent_resident_bytes.load(Ordering::Relaxed);
@@ -1507,28 +1714,40 @@ impl PoolInner {
             match &mut state.extent {
                 Some(extent) if extent.is_resident() => {
                     if extent.pageout_capped() {
-                        // Retry-capped: the extent stays fully counted and
-                        // is not advised again until a read resets its
-                        // budget. The requeued entry is what lets a
-                        // post-read pass find the extent, since a read of a
-                        // still-resident extent does not re-enqueue it.
-                        self.extent_queue().push_back(weak);
+                        // A leftover entry for an already-capped extent (its
+                        // capping transition below accounted it and dropped
+                        // its entry): drop this one too. The read that
+                        // restores the retry budget re-enqueues the chunk.
                     } else if extent.pageout() {
                         self.counters
                             .extent_resident_bytes
                             .fetch_sub(u64::cast_from(extent.alloc_size()), Ordering::Relaxed);
+                        self.extent_residents.fetch_sub(1, Ordering::Relaxed);
                         self.counters
                             .extent_pageouts
                             .fetch_add(1, Ordering::Relaxed);
                     } else {
                         // The advice left pages resident. The extent keeps
                         // its full accounting (the ledger may over-count
-                        // RSS, the safe direction) and its queue slot, so
-                        // later passes retry it up to the cap.
+                        // RSS, the safe direction).
                         self.counters
                             .extent_pageout_incomplete
                             .fetch_add(1, Ordering::Relaxed);
-                        self.extent_queue().push_back(weak);
+                        if extent.pageout_capped() {
+                            // The retry budget just ran out: the extent
+                            // leaves the queue and its bytes move to the
+                            // unreclaimable gauge, so enforcement and the
+                            // inline backstop stop chasing memory the kernel
+                            // will not give back. A read that restores the
+                            // budget re-counts and re-enqueues it.
+                            self.counters
+                                .extent_unreclaimable_bytes
+                                .fetch_add(u64::cast_from(extent.alloc_size()), Ordering::Relaxed);
+                        } else {
+                            // Budget remains: keep the queue slot so later
+                            // passes retry it up to the cap.
+                            self.extent_queue().push_back(weak);
+                        }
                     }
                 }
                 // Paged out already or dropped: the entry is stale. A later
@@ -1538,13 +1757,20 @@ impl PoolInner {
         }
     }
 
-    /// If the chunk is a live `UnbackedResident` and the spill threads have
-    /// capacity, transitions it to `WriteInFlight` and hands it to them,
-    /// returning `true`. The hand-off happens under the held state lock; the
-    /// spill thread blocks on that lock only after this call returns and the
-    /// caller releases it.
+    /// If the chunk is a live `UnbackedResident` holding a slot and the
+    /// spill threads have capacity, transitions it to `WriteInFlight` and
+    /// hands it to them, returning `true`. The hand-off happens under the
+    /// held state lock; the spill thread blocks on that lock only after this
+    /// call returns and the caller releases it.
     fn spill_handoff(&self, meta: &Arc<ChunkMeta>, state: &mut ChunkState) -> bool {
-        if state.residency != Residency::UnbackedResident || state.freed || !self.spill_eligible() {
+        // The slot check excludes empty chunks, which are `UnbackedResident`
+        // without a slot: handing one off would panic the spill thread on
+        // the missing slot.
+        if state.residency != Residency::UnbackedResident
+            || state.freed
+            || state.slot.is_none()
+            || !self.spill_eligible()
+        {
             return false;
         }
         state.residency = Residency::WriteInFlight;
@@ -1613,6 +1839,7 @@ impl ChunkHandle {
                 // Reading faults the extent's pages back in either way, so
                 // it is re-counted against the compressed tier below.
                 let was_resident = extent.is_resident();
+                let was_capped = extent.pageout_capped();
                 let extent_alloc = extent.alloc_size();
                 match slot {
                     Some(slot) => {
@@ -1659,8 +1886,25 @@ impl ChunkHandle {
                     }
                 }
                 if !was_resident {
-                    meta.pool.note_extent_resident(&self.meta, extent_alloc);
+                    // Revived from the device: the decompress reset any
+                    // retry budget, so the extent re-enters reclaimable.
+                    meta.pool
+                        .note_extent_resident(&self.meta, extent_alloc, true);
                     extent_revived = true;
+                } else if was_capped {
+                    // The decompress faulted every page and reset the
+                    // pageout retry budget, so a retry-capped extent is
+                    // reclaimable again. Heap-backed extents stay
+                    // structurally capped and stay out of the queue.
+                    let capped = state
+                        .extent
+                        .as_ref()
+                        .expect("evicted chunk has an extent")
+                        .pageout_capped();
+                    if !capped {
+                        meta.pool.note_extent_reclaimable(&self.meta, extent_alloc);
+                        extent_revived = true;
+                    }
                 }
             }
             Residency::UnbackedResident | Residency::BackedResident | Residency::WriteInFlight => {
@@ -2074,6 +2318,65 @@ mod tests {
             128 << 10,
             "warm pool stops at the budget/8 cap",
         );
+    }
+
+    /// A kernel that keeps declining the reclaim advice caps the extent's
+    /// retry budget: the extent leaves the enforcement queue and moves to
+    /// the unreclaimable gauge, so enforcement stops walking it, and a read
+    /// that restores the budget makes it reclaimable and pageable again.
+    #[mz_ore::test]
+    fn capped_extents_leave_the_enforcement_queue() {
+        let pool = test_pool(256 << 20);
+        let orig = payload(SMALL, 960);
+        let handle = insert(&pool, &mut orig.clone());
+        // Decline every observation: eviction's own enforcement pass plus
+        // the passes below spend the whole retry budget.
+        region::fake_residency::decline_next(u64::from(extent::PAGEOUT_RETRY_CAP));
+        pool.evict(&handle);
+        for _ in 0..extent::PAGEOUT_RETRY_CAP {
+            pool.enforce_compressed();
+        }
+        let stats = pool.stats();
+        assert_eq!(
+            stats.extent_pageout_incomplete,
+            u64::from(extent::PAGEOUT_RETRY_CAP),
+        );
+        assert!(stats.extent_unreclaimable_bytes > 0, "capped bytes counted");
+        assert_eq!(pool.extent_queue_len(), 0, "capped extents leave the queue",);
+        // Further enforcement is a no-op: nothing queued, no advice spent.
+        pool.enforce_compressed();
+        assert_eq!(
+            pool.stats().extent_pageout_incomplete,
+            u64::from(extent::PAGEOUT_RETRY_CAP),
+        );
+
+        // A read faults everything back in and restores the retry budget:
+        // the extent re-enters the reclaimable set and, with the kernel now
+        // cooperating, the read's own enforcement pass pages it out.
+        assert_eq!(read(&handle), orig);
+        let stats = pool.stats();
+        assert_eq!(stats.extent_unreclaimable_bytes, 0, "budget restored");
+        assert_eq!(stats.extent_pageouts, 1, "re-enqueued extent pages out");
+        assert_eq!(stats.extent_resident_bytes, 0);
+        assert_eq!(pool.extent_queue_len(), 0);
+    }
+
+    /// Shrinking the budget cools warm slots parked under the old, larger
+    /// cap: their pages are released and `warm_bytes` falls to the new cap
+    /// on the shrink itself, not on eventual same-class reuse.
+    #[mz_ore::test]
+    fn budget_shrink_trims_warm_pool() {
+        // Budget 8 MiB: warm cap 1 MiB, so four 64 KiB frees all park warm.
+        let pool = test_pool(8 << 20);
+        let handles: Vec<_> = (0..4)
+            .map(|seed| insert(&pool, &mut payload(SMALL, 950 + seed)))
+            .collect();
+        drop(handles);
+        assert_eq!(pool.stats().warm_bytes, 4 * (64 << 10));
+
+        // Budget 1 MiB: warm cap 128 KiB, so two of the four slots cool.
+        pool.set_budget(1 << 20);
+        assert_eq!(pool.stats().warm_bytes, 128 << 10);
     }
 
     #[mz_ore::test]
@@ -2733,6 +3036,92 @@ mod tests {
             assert_eq!(handle.residency(), Residency::Evicted);
             assert_eq!(pool.stats().resident_bytes, 0);
         }
+    }
+
+    /// Evict-then-free churn under a generous RSS target: the compressed
+    /// tier never crosses its cap, so enforcement never visits (and never
+    /// drops) extent-queue entries, and pruning alone must keep the queue
+    /// proportional to the live resident extents.
+    #[mz_ore::test]
+    fn extent_queue_stays_bounded_under_cap() {
+        let pool = test_pool(256 << 20);
+        pool.set_rss_target(1 << 40);
+        for seed in 0..rounds(1000, 48) {
+            let handle = insert(&pool, &mut payload(SMALL, seed));
+            pool.evict(&handle);
+            drop(handle);
+        }
+        assert_eq!(pool.stats().extent_resident_bytes, 0);
+        let len = pool.extent_queue_len();
+        assert!(
+            len <= 32,
+            "extent queue holds {len} entries for zero resident extents",
+        );
+    }
+
+    /// A warm slot reused for a smaller payload round-trips: the tail
+    /// release past the new payload must not disturb the payload itself,
+    /// and the ledger credits exactly the payload.
+    #[mz_ore::test]
+    fn warm_reuse_with_smaller_payload_round_trips() {
+        // Budget 8 MiB: warm cap = 1 MiB, so a 64 KiB slot parks warm.
+        let pool = test_pool(8 << 20);
+        let full = insert(&pool, &mut payload(SMALL, 60));
+        drop(full);
+        assert_eq!(pool.stats().warm_bytes, 64 << 10, "freed slot parks warm");
+        // A payload of just over a page reuses the warm slot; the slot's
+        // pages past it are released.
+        let words = 4096 / 8 + 1;
+        let orig = payload(words, 61);
+        let handle = insert(&pool, &mut orig.clone());
+        let stats = pool.stats();
+        assert_eq!(stats.warm_reuses, 1, "reused the warm slot");
+        assert_eq!(stats.resident_bytes, u64::cast_from(words * 8));
+        assert_eq!(read(&handle), orig);
+        // Round-trips through the extent as well.
+        pool.evict(&handle);
+        pool.poison_free_slots();
+        assert_eq!(read(&handle), orig);
+        drop(handle);
+        assert_eq!(pool.stats().resident_bytes, 0);
+    }
+
+    /// Heap-backed chunks count as resident but can never be evicted, so
+    /// the budget must not force slotted chunks out on their account: with
+    /// unevictable bytes alone exceeding the budget, a slotted chunk that
+    /// fits the budget stays resident.
+    #[mz_ore::test]
+    fn unevictable_bytes_do_not_force_eviction() {
+        // One 64 KiB slot per class: the second and third inserts fall
+        // back to the heap.
+        let pool = Pool::with_class_capacity(64 << 10).expect("pool creation");
+        pool.set_budget(64 << 10);
+        let slotted = insert(&pool, &mut payload(SMALL, 91));
+        let heap_a = insert(&pool, &mut payload(SMALL, 92));
+        let heap_b = insert(&pool, &mut payload(SMALL, 93));
+        assert_eq!(heap_a.residency(), Residency::Oversize);
+        assert_eq!(heap_b.residency(), Residency::Oversize);
+        let stats = pool.stats();
+        assert!(stats.oversize_bytes > 64 << 10, "unevictable exceed budget");
+        assert_eq!(slotted.residency(), Residency::UnbackedResident);
+        assert_eq!(stats.evictions_compress, 0);
+        assert_eq!(read(&slotted), payload(SMALL, 91));
+        assert_eq!(read(&heap_a), payload(SMALL, 92));
+    }
+
+    /// A slotless empty chunk survives an explicit evict with spill
+    /// scheduling enabled: nothing is handed to the spill threads and the
+    /// chunk stays readable.
+    #[mz_ore::test]
+    fn evict_of_empty_chunk_is_a_no_op() {
+        let pool = test_pool(usize::MAX);
+        pool.enable_spill_without_threads();
+        let empty = insert(&pool, &mut Vec::new());
+        pool.evict(&empty);
+        assert_eq!(empty.residency(), Residency::UnbackedResident);
+        assert!(!pool.spill_step(), "nothing was scheduled");
+        assert_eq!(pool.stats().spill_scheduled, 0);
+        assert!(read(&empty).is_empty());
     }
 
     #[mz_ore::test]

--- a/src/ore/src/pool.rs
+++ b/src/ore/src/pool.rs
@@ -1,0 +1,2290 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Prototype buffer pool for dataflow state. See
+//! `doc/developer/design/20260610_buffer_managed_state.md`.
+//!
+//! The pool is the cache: size-class anonymous virtual-memory regions whose
+//! slots hold resident chunks. Slots are scoped to residency — eviction
+//! returns a chunk's slot to the free list along with its physical pages —
+//! so slot demand tracks the resident set (bounded by the budget), not the
+//! potentially unbounded live backlog. Reads are copy-out
+//! ([`ChunkHandle::read_into`]): a resident slot is copied and an evicted
+//! extent decompressed straight into the caller's buffer, all under the
+//! chunk's state lock, so no reference into pool memory escapes the pool and
+//! a read leaves residency untouched. The backing is the swap-backed extent
+//! store of the design's Layer 1: a page-aligned anonymous allocation
+//! holding the chunk's lz4-compressed bytes.
+//!
+//! Memory descends a ladder of tiers, each with its own ceiling and each
+//! cheaper to vacate than the one above:
+//!
+//! * **Slots** (uncompressed, free reads) — bounded by the budget; crossing
+//!   it compresses the oldest chunks into extents and releases their slots.
+//! * **Warm free slots** (pages kept for fault-free reuse) — bounded by the
+//!   warm cap.
+//! * **Compressed-resident extents** (reads decompress, no device) — bounded
+//!   by the headroom the RSS target leaves above the first two; crossing it
+//!   pushes the oldest extents to the swap device with `MADV_PAGEOUT`.
+//! * **The swap device** — overflow; reads fault and decompress.
+//!
+//! The identity `total pool RSS <= budget + warm cap + compressed cap`,
+//! where `compressed cap = rss_target - budget - warm cap`, makes every
+//! resident byte's ceiling nameable; a zero RSS target collapses the
+//! compressed tier and extents page out as soon as they are written.
+//! Nothing is ever both uncompressed and on the device.
+//!
+//! Residency is a state, not a type, and it only descends: a chunk starts
+//! resident and, once evicted, serves reads from its extent for the rest of
+//! its life. Eviction I/O runs on spill threads when enabled —
+//! `WriteInFlight` marks a chunk whose compression a spill thread owns — and
+//! inline on the evicting caller otherwise. Chunks are immutable after
+//! [`Pool::insert_with`], which is what makes a `BackedResident` slot always
+//! identical to its extent and its eviction free of I/O.
+//!
+//! Freeing an `UnbackedResident` chunk is a pure memory operation — the
+//! design's "never write dead data" win, surfaced as `writes_elided` in
+//! [`PoolStats`]. Budget pressure evicts cold chunks via second-chance
+//! FIFOs banded by the caller-supplied generational depth ([`ChunkHints`]):
+//! eviction and eager backing both visit deeper (colder) bands first, so
+//! the youngest data keeps its die-before-write chance longest. Within a
+//! band the FIFO is the design's backstop policy, and unannotated chunks
+//! (depth 0) get exactly that.
+
+mod extent;
+mod region;
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, Weak};
+
+use crate::cast::CastFrom;
+use crate::pool::extent::SwapExtent;
+use crate::pool::region::{Region, SIZE_CLASSES};
+
+/// Virtual reservation per size class. Purely virtual: physical memory
+/// materializes only for slots in use, and slots are scoped to residency,
+/// so this must exceed the largest plausible *resident* set per class, the
+/// budget plus in-flight slack, not the backlog. It is deliberately enormous
+/// (address space costs nothing, and touched pages are bounded by peak
+/// residency) so that no realistic budget, on any machine size, reaches the
+/// heap-fallback path.
+const CLASS_CAPACITY_BYTES: usize = 1 << 40;
+
+/// Advisory placement hints for a chunk, supplied at insert and immutable
+/// thereafter (merges mint new chunks, so a chunk's generation never
+/// changes). Hints steer policy — eviction order and write-behind
+/// candidacy — never correctness: a mislabeled chunk performs worse, while
+/// the budget and residency invariants hold regardless.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ChunkHints {
+    /// Generational depth of the chunk in its producer's merge structure,
+    /// 0 for the youngest generation (and the unannotated default). Deeper
+    /// chunks are treated as colder: preferred write-behind candidates and
+    /// preferred eviction victims, cheap to evict once backed.
+    pub depth: u8,
+}
+
+/// Number of depth bands the eviction queues are split into; depths at or
+/// beyond the last band share it.
+const DEPTH_BANDS: usize = 4;
+
+/// The eviction-queue band for a chunk of `depth`.
+fn band(depth: u8) -> usize {
+    usize::from(depth).min(DEPTH_BANDS - 1)
+}
+
+/// Residency state of a chunk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Residency {
+    /// Lives only in the pool; no extent copy exists. Freeing it never
+    /// touches the backing store.
+    UnbackedResident,
+    /// Resident, and an identical extent copy exists; eviction releases
+    /// physical pages without I/O.
+    BackedResident,
+    /// Resident and readable, with compression into an extent scheduled on a
+    /// spill thread. Completion moves an evicting chunk to
+    /// [`Residency::Evicted`] and an eagerly backed one to
+    /// [`Residency::BackedResident`]; a free observed at dequeue cancels the
+    /// write instead.
+    WriteInFlight,
+    /// Extent copy only; the chunk holds no slot. The extent itself may
+    /// still be RAM-resident (the compressed tier) or paged out to the swap
+    /// device. Reads decompress the extent straight into the caller's
+    /// buffer; the chunk allocates no slot and stays evicted.
+    Evicted,
+    /// Larger than the largest size class; held as a plain heap allocation,
+    /// always resident. A prototype limitation, not a design state.
+    Oversize,
+}
+
+/// Snapshot of pool counters.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PoolStats {
+    /// Chunks inserted.
+    pub inserts: u64,
+    /// Chunks freed (handle dropped).
+    pub frees: u64,
+    /// Backing writes elided: chunks freed while `UnbackedResident`, dead
+    /// before any compression or extent write happened.
+    pub writes_elided: u64,
+    /// Evictions that compressed the chunk into a new extent.
+    pub evictions_compress: u64,
+    /// Evictions of `BackedResident` chunks: pure page release, no I/O.
+    pub evictions_cheap: u64,
+    /// Compressed bytes written into extents.
+    pub extent_bytes_written: u64,
+    /// Evictions handed to spill threads.
+    pub spill_scheduled: u64,
+    /// Scheduled evictions cancelled because the chunk was freed with the
+    /// write queued or in flight.
+    pub spill_cancelled: u64,
+    /// Entries currently queued for or being processed by spill threads.
+    pub spill_in_flight: u64,
+    /// Inserts that fell back to the heap because their size class had no
+    /// free slot (the live set outgrew the class reservation). Heap-backed
+    /// chunks behave like oversize ones: always resident, never paged.
+    pub slot_exhausted_fallbacks: u64,
+    /// Inserts whose payload exceeded the largest size class and therefore
+    /// went straight to a heap-backed oversize chunk.
+    pub oversize_payloads: u64,
+    /// Live size-classed chunks across all classes, whatever their residency.
+    /// For backlog-shaped consumers this tracks the un-drained backlog in
+    /// chunks. (Slots are scoped to residency, so the quantity that exhausts
+    /// a class reservation is the resident subset, bounded by the budget.)
+    pub live_chunks: u64,
+    /// Uncompressed bytes of currently resident chunks (including oversize).
+    pub resident_bytes: u64,
+    /// Uncompressed bytes of live oversize chunks.
+    pub oversize_bytes: u64,
+    /// Class bytes of free slots currently kept warm (pages resident for
+    /// fault-free reuse). Bounded by a fraction of the budget; RSS exceeds
+    /// `resident_bytes` by up to this amount.
+    pub warm_bytes: u64,
+    /// Slot allocations served from the warm list: reuses that faulted no
+    /// pages and skipped the kernel's page zeroing.
+    pub warm_reuses: u64,
+    /// Chunks eagerly compressed to `BackedResident` by idle spill threads
+    /// (write-behind): still readable in their slots, with eviction
+    /// pre-paid.
+    pub eager_backs: u64,
+    /// Allocation bytes of compressed extents currently resident — the
+    /// compressed-but-resident middle tier. Bounded by the RSS target;
+    /// exceeding it pages the oldest extents out to the swap device.
+    pub extent_resident_bytes: u64,
+    /// Extents pushed to the swap device by RSS-target enforcement.
+    pub extent_pageouts: u64,
+}
+
+#[derive(Debug, Default)]
+struct Counters {
+    inserts: AtomicU64,
+    spill_scheduled: AtomicU64,
+    spill_cancelled: AtomicU64,
+    slot_exhausted_fallbacks: AtomicU64,
+    oversize_payloads: AtomicU64,
+    frees: AtomicU64,
+    writes_elided: AtomicU64,
+    evictions_compress: AtomicU64,
+    evictions_cheap: AtomicU64,
+    extent_bytes_written: AtomicU64,
+    resident_bytes: AtomicU64,
+    oversize_bytes: AtomicU64,
+    warm_bytes: AtomicU64,
+    warm_reuses: AtomicU64,
+    eager_backs: AtomicU64,
+    extent_resident_bytes: AtomicU64,
+    extent_pageouts: AtomicU64,
+}
+
+/// A buffer pool over swap-backed extents. Cheap to clone; all clones share
+/// one budget and one backing store.
+#[derive(Debug, Clone)]
+pub struct Pool(Arc<PoolInner>);
+
+/// The shared state behind every [`Pool`] handle: the budget and RSS
+/// ledgers, the size-class slot regions and the extent arena, the eviction
+/// and backing queues, and the spill-thread hand-off. One per process in
+/// practice; [`Pool`] clones and chunk handles share it through an `Arc`,
+/// so it lives until the last handle and spill thread release it.
+///
+/// Lock order: a chunk's `state` mutex may be held while taking any of the
+/// leaf locks — the eviction `queue`, the `extent_queue`, the spill queue,
+/// and the region slot allocators — but never the reverse. The enforcement
+/// and backing scans additionally drop the queue guard before trying a
+/// chunk's state lock (and only ever `try_lock` it), so no path holds a
+/// queue lock while waiting on chunk state. Reads copy out under the chunk's
+/// state lock — the same lock eviction takes — so there is no reader-side
+/// count and no reader the evictor must account for.
+#[derive(Debug)]
+struct PoolInner {
+    /// Resident-bytes target. Atomic so a running pool can be retuned in
+    /// place (operator-driven budget changes) without orphaning live
+    /// handles, which share this value through their `Arc<PoolInner>`.
+    budget_bytes: AtomicU64,
+    /// Ceiling on the pool's *total* RSS: slots (the budget) plus warm free
+    /// slots plus compressed-resident extents. The compressed tier's
+    /// capacity derives as `rss_target - budget - warm cap`; zero (the
+    /// default) collapses the tier, paging every extent out as soon as it
+    /// is written.
+    rss_target_bytes: AtomicU64,
+    /// One region per entry of [`SIZE_CLASSES`], same order.
+    regions: Vec<Region>,
+    /// Second-chance FIFOs of eviction candidates, one per depth band; a
+    /// chunk joins the band of its [`ChunkHints`] depth at insert. Entries
+    /// for freed chunks go stale in place and are dropped by
+    /// [`PoolInner::prune_queues`].
+    ///
+    /// Two scanners walk them with different obligations, both visiting the
+    /// deepest band first. Budget enforcement is the one that ages chunks:
+    /// it spends the touched bit (second chance) and drops entries it
+    /// evicts. Eager backing ([`PoolInner::back_one`]) rotates visited
+    /// entries to the back but never spends a touched bit, so a backing
+    /// pass shuffles FIFO order without aging any chunk toward eviction.
+    queues: [Mutex<VecDeque<Weak<ChunkMeta>>>; DEPTH_BANDS],
+    /// FIFO of chunks whose extents are resident, oldest first — the
+    /// RSS-target enforcement's victim queue. Entries go stale when an
+    /// extent pages out, is dropped, or its chunk dies; visits drop them.
+    extent_queue: Mutex<VecDeque<Weak<ChunkMeta>>>,
+    /// Number of live size-classed chunks (whatever their residency), which
+    /// is the number of non-stale queue entries across all bands;
+    /// [`PoolInner::prune_queues`] compacts the queues against it.
+    live_chunks: AtomicU64,
+    /// Single-flight claim for budget enforcement.
+    enforcing: Mutex<()>,
+    counters: Counters,
+    spill: Spill,
+}
+
+/// Hand-off point between budget enforcement and spill threads. Eviction I/O
+/// (compression and the synchronous-reclaim `pageout`) runs on spill threads
+/// when enabled, keeping multi-millisecond work off the threads that trip the
+/// budget; with no spill threads, eviction runs inline on the caller.
+#[derive(Debug, Default)]
+struct Spill {
+    /// Chunks in `WriteInFlight`, awaiting a spill thread.
+    queue: Mutex<VecDeque<Arc<ChunkMeta>>>,
+    /// Parks idle spill threads. Notified when work lands in `queue`, when
+    /// eager backing turns on, and at shutdown; threads additionally wake
+    /// on a timeout so eager backing scans for write-behind work without a
+    /// dedicated wakeup per candidate.
+    cv: std::sync::Condvar,
+    /// Whether evictions are handed to spill threads. Set when threads are
+    /// first spawned; cleared to fall back to inline eviction.
+    enabled: std::sync::atomic::AtomicBool,
+    /// Whether idle spill threads eagerly compress unbacked chunks to
+    /// `BackedResident` (write-behind): the chunk stays readable in its slot
+    /// while a compressed extent accumulates on the swap device, so a later
+    /// budget-driven eviction is a pure page release instead of a
+    /// compression. Costs CPU on chunks that die before eviction would have
+    /// reached them; pays at every pressure event.
+    eager: std::sync::atomic::AtomicBool,
+    /// Number of spill threads spawned (spawn-once; later config changes
+    /// only toggle `enabled`).
+    threads: AtomicU64,
+    /// Queued plus currently-processing entries; `quiesce` waits on zero.
+    in_flight: AtomicU64,
+    /// Test-only lifecycle: production spill threads are immortal (the pool
+    /// is a process singleton), but Miri rejects a test binary exiting with
+    /// live threads, so tests stop and join them.
+    #[cfg(test)]
+    stop: std::sync::atomic::AtomicBool,
+    #[cfg(test)]
+    handles: Mutex<Vec<std::thread::JoinHandle<()>>>,
+}
+
+/// Beyond this many queued or in-flight spill entries, eviction degrades to
+/// inline on the caller: bounded memory overshoot under burst beats an
+/// unbounded queue of still-resident chunks.
+const SPILL_IN_FLIGHT_MAX: usize = 64;
+
+/// What a spill thread does with a chunk once compressed.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SpillKind {
+    /// Budget-driven: release the slot, leaving the chunk `Evicted`.
+    Evict,
+    /// Eager write-behind: keep the slot, leaving the chunk
+    /// `BackedResident`.
+    Back,
+}
+
+#[derive(Debug)]
+struct ChunkMeta {
+    pool: Arc<PoolInner>,
+    /// Length in `u64` words; immutable.
+    len: usize,
+    /// Size class for slot allocations; `None` for empty chunks and payloads
+    /// beyond the largest class. Immutable: the chunk's *slot* comes and goes
+    /// with residency, but it is always drawn from this class.
+    class: Option<usize>,
+    /// The insert-time [`ChunkHints`] depth; immutable. Names the eviction
+    /// band the chunk's queue entries belong to.
+    depth: u8,
+    state: Mutex<ChunkState>,
+}
+
+#[derive(Debug)]
+struct ChunkState {
+    residency: Residency,
+    /// Second-chance bit, set on read and cleared (in lieu of eviction) when
+    /// the budget enforcer first visits the chunk.
+    touched: bool,
+    /// Set when the owning handle is dropped, so a queue entry upgraded
+    /// concurrently with the free cannot touch a recycled slot.
+    freed: bool,
+    /// The chunk's slot index within its class's region, held exactly while
+    /// the chunk occupies pool memory (the resident states and
+    /// `WriteInFlight`). Eviction returns the slot to the region free list.
+    /// Reads copy the slot out under the state lock; no pointer into the
+    /// slot outlives the lock under which it was formed.
+    slot: Option<u32>,
+    /// The backing copy; present exactly in the `BackedResident` and
+    /// `Evicted` states.
+    extent: Option<SwapExtent>,
+    /// The payload of an `Oversize` chunk.
+    oversize: Option<Vec<u64>>,
+}
+
+impl ChunkMeta {
+    /// A fresh chunk in its insert-time state.
+    fn new(
+        pool: &Arc<PoolInner>,
+        len: usize,
+        class: Option<usize>,
+        depth: u8,
+        residency: Residency,
+        slot: Option<u32>,
+        oversize: Option<Vec<u64>>,
+    ) -> ChunkMeta {
+        ChunkMeta {
+            pool: Arc::clone(pool),
+            len,
+            class,
+            depth,
+            state: Mutex::new(ChunkState {
+                residency,
+                touched: false,
+                freed: false,
+                slot,
+                extent: None,
+                oversize,
+            }),
+        }
+    }
+
+    fn len_bytes(&self) -> usize {
+        self.len * std::mem::size_of::<u64>()
+    }
+
+    /// Locks the chunk's state.
+    fn state(&self) -> MutexGuard<'_, ChunkState> {
+        self.state.lock().expect("chunk state poisoned")
+    }
+}
+
+/// Handle to one immutable chunk in a [`Pool`]. Dropping the handle frees the
+/// chunk: the slot (if resident) returns to the region free list with its
+/// physical pages released, and the extent (if any) is deallocated,
+/// discarding any swapped copy for free. Releasing the pages keeps RSS
+/// aligned with the `resident_bytes` gauge the budget enforcer trusts;
+/// without it, freed slots would hold warm pages the enforcer cannot see.
+#[derive(Debug)]
+pub struct ChunkHandle {
+    meta: Arc<ChunkMeta>,
+}
+
+impl Pool {
+    /// Creates a pool, reserving one virtual region per size class. The
+    /// pool starts with an unlimited budget — nothing is evicted until
+    /// [`Pool::set_budget`] tunes it.
+    pub fn new() -> std::io::Result<Pool> {
+        Pool::with_class_capacity(CLASS_CAPACITY_BYTES)
+    }
+
+    /// As [`Pool::new`], with a caller-chosen virtual reservation per size
+    /// class. Small reservations let tests exercise slot exhaustion.
+    fn with_class_capacity(class_capacity_bytes: usize) -> std::io::Result<Pool> {
+        let regions = SIZE_CLASSES
+            .iter()
+            .map(|&class_size| Region::new(class_size, class_capacity_bytes))
+            .collect::<std::io::Result<Vec<_>>>()?;
+        Ok(Pool(Arc::new(PoolInner {
+            budget_bytes: AtomicU64::new(u64::MAX),
+            rss_target_bytes: AtomicU64::new(0),
+            regions,
+            queues: std::array::from_fn(|_| Mutex::new(VecDeque::new())),
+            extent_queue: Mutex::new(VecDeque::new()),
+            live_chunks: AtomicU64::new(0),
+            enforcing: Mutex::new(()),
+            counters: Counters::default(),
+            spill: Spill::default(),
+        })))
+    }
+
+    /// Allocates a chunk of `len` words and fills it in place: `fill`
+    /// receives the chunk's slot memory directly and must overwrite all of
+    /// it (the slot's prior contents are unspecified). The returned handle
+    /// starts `UnbackedResident`. A zero `len` returns a length-0 handle
+    /// holding no slot; payloads beyond the largest size class fall back to
+    /// a plain heap allocation, always resident, a prototype limitation.
+    /// `hints` steer eviction and write-behind policy; callers without
+    /// placement knowledge pass the default.
+    ///
+    /// This is the zero-staging insert: serialization can write its single
+    /// copy straight into pool memory, paying one page population instead of
+    /// staging through caller-side buffers that fault their own pages and
+    /// die immediately after.
+    pub fn insert_with(
+        &self,
+        len: usize,
+        hints: ChunkHints,
+        fill: impl FnOnce(&mut [u64]),
+    ) -> ChunkHandle {
+        let inner = &self.0;
+        inner.counters.inserts.fetch_add(1, Ordering::Relaxed);
+        let len_bytes = len * std::mem::size_of::<u64>();
+        if len == 0 {
+            fill(&mut []);
+            let meta = ChunkMeta::new(
+                inner,
+                0,
+                None,
+                hints.depth,
+                Residency::UnbackedResident,
+                None,
+                None,
+            );
+            return ChunkHandle {
+                meta: Arc::new(meta),
+            };
+        }
+        let class = region::size_class_for(len_bytes);
+        if class.is_none() {
+            // The payload exceeds the largest size class, so it goes straight
+            // to a heap-backed oversize chunk.
+            inner
+                .counters
+                .oversize_payloads
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        // A class with no free slot degrades to the heap path below: the
+        // resident set outgrew the class reservation, and an unpageable chunk
+        // beats a dead replica. Warn once; the fallback counter tracks scale.
+        let slot = class.and_then(|class| inner.alloc_slot(class, len_bytes));
+        // Whichever home the payload found, it is resident.
+        inner
+            .counters
+            .resident_bytes
+            .fetch_add(u64::cast_from(len_bytes), Ordering::Relaxed);
+        let meta = match (class, slot) {
+            (Some(class), Some(slot)) => {
+                let region = &inner.regions[class];
+                // SAFETY: the freshly allocated slot is at least `len_bytes`
+                // long (the class fits the payload) and is exclusively owned
+                // by this not-yet-shared chunk, so the mutable borrow is
+                // unique; region memory is mapped and writable, and `u64` has
+                // no validity requirements beyond size, so exposing the
+                // unspecified prior contents through `&mut [u64]` is sound.
+                let dst = unsafe {
+                    std::slice::from_raw_parts_mut(region.slot_ptr(slot).cast::<u64>(), len)
+                };
+                fill(dst);
+                ChunkMeta::new(
+                    inner,
+                    len,
+                    Some(class),
+                    hints.depth,
+                    Residency::UnbackedResident,
+                    Some(slot),
+                    None,
+                )
+            }
+            _ => {
+                let mut payload = vec![0u64; len];
+                fill(&mut payload);
+                inner
+                    .counters
+                    .oversize_bytes
+                    .fetch_add(u64::cast_from(len_bytes), Ordering::Relaxed);
+                ChunkMeta::new(
+                    inner,
+                    len,
+                    None,
+                    hints.depth,
+                    Residency::Oversize,
+                    None,
+                    Some(payload),
+                )
+            }
+        };
+        let meta = Arc::new(meta);
+        if meta.class.is_some() {
+            inner.live_chunks.fetch_add(1, Ordering::Relaxed);
+            inner
+                .queue(band(meta.depth))
+                .push_back(Arc::downgrade(&meta));
+        }
+        inner.enforce_budget();
+        ChunkHandle { meta }
+    }
+
+    /// Snapshot of the pool's counters.
+    pub fn stats(&self) -> PoolStats {
+        let c = &self.0.counters;
+        PoolStats {
+            inserts: c.inserts.load(Ordering::Relaxed),
+            frees: c.frees.load(Ordering::Relaxed),
+            writes_elided: c.writes_elided.load(Ordering::Relaxed),
+            evictions_compress: c.evictions_compress.load(Ordering::Relaxed),
+            evictions_cheap: c.evictions_cheap.load(Ordering::Relaxed),
+            extent_bytes_written: c.extent_bytes_written.load(Ordering::Relaxed),
+            resident_bytes: c.resident_bytes.load(Ordering::Relaxed),
+            oversize_bytes: c.oversize_bytes.load(Ordering::Relaxed),
+            warm_bytes: c.warm_bytes.load(Ordering::Relaxed),
+            warm_reuses: c.warm_reuses.load(Ordering::Relaxed),
+            eager_backs: c.eager_backs.load(Ordering::Relaxed),
+            extent_resident_bytes: c.extent_resident_bytes.load(Ordering::Relaxed),
+            extent_pageouts: c.extent_pageouts.load(Ordering::Relaxed),
+            spill_scheduled: c.spill_scheduled.load(Ordering::Relaxed),
+            spill_cancelled: c.spill_cancelled.load(Ordering::Relaxed),
+            spill_in_flight: self.0.spill.in_flight.load(Ordering::Relaxed),
+            slot_exhausted_fallbacks: c.slot_exhausted_fallbacks.load(Ordering::Relaxed),
+            oversize_payloads: c.oversize_payloads.load(Ordering::Relaxed),
+            live_chunks: self.0.live_chunks.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Enables or disables off-worker eviction I/O. The first call with
+    /// `threads > 0` spawns that many spill threads (spawn-once: later calls
+    /// only toggle participation); `threads == 0` falls back to inline
+    /// eviction on the caller for subsequent victims, letting any queued
+    /// work drain.
+    pub fn set_spill_threads(&self, threads: usize) {
+        if threads == 0 {
+            self.0.spill.enabled.store(false, Ordering::Relaxed);
+            return;
+        }
+        let spawned = self.0.spill.threads.load(Ordering::Relaxed);
+        if spawned == 0 {
+            let to_spawn = u64::cast_from(threads);
+            if self
+                .0
+                .spill
+                .threads
+                .compare_exchange(0, to_spawn, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                for i in 0..threads {
+                    let inner = Arc::clone(&self.0);
+                    let handle = std::thread::Builder::new()
+                        .name(format!("pool-spill-{i}"))
+                        .spawn(move || inner.spill_worker())
+                        .expect("spawn pool spill thread");
+                    #[cfg(test)]
+                    self.0
+                        .spill
+                        .handles
+                        .lock()
+                        .expect("spill handles poisoned")
+                        .push(handle);
+                    #[cfg(not(test))]
+                    drop(handle);
+                }
+            }
+        }
+        self.0.spill.enabled.store(true, Ordering::Relaxed);
+    }
+
+    /// Enables or disables eager backing: when on, idle spill threads
+    /// compress unbacked chunks to `BackedResident` ahead of pressure, so
+    /// budget-driven eviction becomes a pure page release. Only meaningful
+    /// with spill threads spawned.
+    pub fn set_eager_backing(&self, eager: bool) {
+        self.0.spill.eager.store(eager, Ordering::Relaxed);
+        if eager {
+            self.0.spill.cv.notify_all();
+        }
+    }
+
+    /// Test hook: performs one eager-backing step on the calling thread.
+    /// Returns whether progress was made.
+    #[cfg(test)]
+    fn back_step(&self) -> bool {
+        self.0.back_one()
+    }
+
+    /// Test hook: waits until the spill queue is empty and no entry is being
+    /// processed, so tests observe deterministic post-eviction states.
+    #[cfg(test)]
+    fn quiesce_spill(&self) {
+        while self.0.spill.in_flight.load(Ordering::Relaxed) > 0 {
+            std::thread::yield_now();
+        }
+    }
+
+    /// Test hook: stops and joins the spill threads, so a test binary exits
+    /// with none alive (which Miri requires). Stopped threads process no
+    /// further queued work; call [`Pool::quiesce_spill`] first when the test
+    /// depends on the queue draining.
+    #[cfg(test)]
+    fn join_spill_threads(&self) {
+        self.0.spill.stop.store(true, Ordering::Relaxed);
+        self.0.spill.cv.notify_all();
+        let handles =
+            std::mem::take(&mut *self.0.spill.handles.lock().expect("spill handles poisoned"));
+        for handle in handles {
+            handle.join().expect("spill thread panicked");
+        }
+    }
+
+    /// Test hook: enables spill scheduling without spawning threads, so tests
+    /// drive the queue deterministically via [`Pool::spill_step`].
+    #[cfg(test)]
+    fn enable_spill_without_threads(&self) {
+        self.0.spill.enabled.store(true, Ordering::Relaxed);
+    }
+
+    /// Test hook: processes one queued spill entry on the calling thread.
+    /// Returns whether an entry was processed.
+    #[cfg(test)]
+    fn spill_step(&self) -> bool {
+        let popped = self.0.spill_queue().pop_front();
+        let Some(meta) = popped else {
+            return false;
+        };
+        self.0.spill_process(&meta, SpillKind::Evict);
+        self.0.spill.in_flight.fetch_sub(1, Ordering::Relaxed);
+        true
+    }
+
+    /// Test hook: evicts cold chunks until resident bytes fall to the budget
+    /// or every queued chunk has been visited once. Enforcement runs
+    /// automatically on every insert and budget shrink.
+    #[cfg(test)]
+    fn enforce_budget(&self) {
+        self.0.enforce_budget();
+    }
+
+    /// Retunes the resident-bytes budget in place and enforces it. Live
+    /// handles share the new value immediately through their `Arc<PoolInner>`;
+    /// a shrink takes effect by evicting on this call, a grow simply leaves
+    /// more headroom for future inserts.
+    pub fn set_budget(&self, budget_bytes: usize) {
+        let new = u64::cast_from(budget_bytes);
+        let prev = self.0.budget_bytes.swap(new, Ordering::Relaxed);
+        // Config application calls this per worker per tick; only a change
+        // warrants an enforcement pass (a grow needs none, and inserts
+        // enforce continuously anyway).
+        if new < prev {
+            self.0.enforce_budget();
+        }
+    }
+
+    /// Retunes the ceiling on the pool's total RSS — slots plus warm slots
+    /// plus compressed-resident extents. The compressed tier's capacity is
+    /// the gap above the budget and warm cap; zero (the default) collapses
+    /// the tier, paging extents out as soon as they are written. A shrink
+    /// takes effect by paging out the oldest extents on this call.
+    pub fn set_rss_target(&self, target_bytes: usize) {
+        let new = u64::cast_from(target_bytes);
+        let prev = self.0.rss_target_bytes.swap(new, Ordering::Relaxed);
+        if new < prev {
+            self.0.enforce_compressed_cap();
+        }
+    }
+
+    /// Test-only: the number of entries across the second-chance queues,
+    /// live and stale.
+    #[cfg(test)]
+    fn queue_len(&self) -> usize {
+        (0..DEPTH_BANDS).map(|band| self.0.queue(band).len()).sum()
+    }
+
+    /// Test hook: explicitly evicts one chunk. No-op if the chunk is already
+    /// evicted, in flight, empty, or oversize. With spill threads enabled the
+    /// compression is handed off and completes asynchronously (observable via
+    /// [`Residency::WriteInFlight`]); without them it runs inline.
+    #[cfg(test)]
+    fn evict(&self, handle: &ChunkHandle) {
+        let meta = &handle.meta;
+        let mut state = meta.state();
+        if !meta.pool.spill_handoff(meta, &mut state) {
+            meta.pool.evict_locked(meta, &mut state);
+        }
+        drop(state);
+        meta.pool.enforce_or_defer_compressed_cap();
+    }
+
+    /// Test hook: overwrites every free slot's bytes with `0xDE`. The free
+    /// list keeps a freed slot's old bytes on platforms where
+    /// `MADV_DONTNEED` retains contents (macOS); poisoning lets tests prove
+    /// that reads of evicted chunks decompress from the extent rather than
+    /// passing stale slot memory through.
+    #[cfg(test)]
+    fn poison_free_slots(&self) {
+        for region in &self.0.regions {
+            region.poison_free_slots();
+        }
+    }
+}
+
+impl PoolInner {
+    /// Locks the eviction queue of one depth band.
+    fn queue(&self, band: usize) -> MutexGuard<'_, VecDeque<Weak<ChunkMeta>>> {
+        self.queues[band].lock().expect("pool queue poisoned")
+    }
+
+    /// Locks the resident-extent queue.
+    fn extent_queue(&self) -> MutexGuard<'_, VecDeque<Weak<ChunkMeta>>> {
+        self.extent_queue.lock().expect("extent queue poisoned")
+    }
+
+    /// Locks the spill hand-off queue.
+    fn spill_queue(&self) -> MutexGuard<'_, VecDeque<Arc<ChunkMeta>>> {
+        self.spill.queue.lock().expect("spill queue poisoned")
+    }
+
+    /// The region behind a slotted chunk's size class.
+    fn region_of(&self, meta: &ChunkMeta) -> &Region {
+        &self.regions[meta.class.expect("slotted chunk has a class")]
+    }
+
+    /// Borrows the payload of a slotted chunk.
+    ///
+    /// # Safety
+    ///
+    /// `slot` must be `meta`'s slot, its contents must be initialized (they
+    /// are from insert onward), and nothing may write the slot while the
+    /// borrow lives.
+    unsafe fn slot_data(&self, meta: &ChunkMeta, slot: u32) -> &[u64] {
+        let ptr = self
+            .region_of(meta)
+            .slot_ptr(slot)
+            .cast_const()
+            .cast::<u64>();
+        // SAFETY: per the function contract; `meta.len` words fit the class
+        // by construction.
+        unsafe { std::slice::from_raw_parts(ptr, meta.len) }
+    }
+
+    /// Records a freshly written extent under the chunk's state lock: the
+    /// compressed-bytes counter, the compressed-tier accounting, and the
+    /// state's extent field.
+    fn commit_extent(&self, meta: &Arc<ChunkMeta>, state: &mut ChunkState, extent: SwapExtent) {
+        self.counters
+            .extent_bytes_written
+            .fetch_add(u64::cast_from(extent.comp_len()), Ordering::Relaxed);
+        self.note_extent_resident(meta, extent.alloc_size());
+        state.extent = Some(extent);
+    }
+
+    /// Drops queue entries whose chunk has been freed, detected by their
+    /// `Weak` no longer holding a live chunk. Each band compacts only when
+    /// its stale entries outnumber all live chunks (plus a small floor), so
+    /// the cost amortizes to a constant per insert and the total queue
+    /// length stays proportional to the number of live slotted chunks even
+    /// when the pool never comes under budget pressure.
+    fn prune_queues(&self) {
+        let live = usize::cast_from(self.live_chunks.load(Ordering::Relaxed));
+        for band in 0..DEPTH_BANDS {
+            let mut queue = self.queue(band);
+            if queue.len() > 2 * live + 16 {
+                queue.retain(|weak| weak.strong_count() > 0);
+            }
+        }
+    }
+
+    fn enforce_budget(&self) {
+        // Single-flight: enforcement runs synchronously on whichever thread
+        // trips it (every insert), and concurrent passes would
+        // convoy on the queue mutex doing redundant scans of the same
+        // candidates. One pass at a time reaches the budget just as well;
+        // skipped callers rely on the in-progress pass. A poisoned claim
+        // means a prior pass panicked; recover and keep enforcing rather
+        // than silently disabling the budget for the process's lifetime.
+        let guard = match self.enforcing.try_lock() {
+            Ok(guard) => guard,
+            Err(std::sync::TryLockError::WouldBlock) => return,
+            Err(std::sync::TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
+        };
+        self.enforce_budget_inner();
+        drop(guard);
+        // Inline evictions above may have grown the compressed tier.
+        self.enforce_or_defer_compressed_cap();
+    }
+
+    fn enforce_budget_inner(&self) {
+        self.prune_queues();
+        // Deepest band first: deep chunks are the coldest, and once eager
+        // backing has visited them (same order) their eviction is a pure
+        // page release. The youngest band is reached only when the deeper
+        // bands cannot satisfy the budget, keeping young data's
+        // die-before-write chance longest.
+        for band in (0..DEPTH_BANDS).rev() {
+            if self.counters.resident_bytes.load(Ordering::Relaxed)
+                <= self.budget_bytes.load(Ordering::Relaxed)
+            {
+                return;
+            }
+            self.enforce_budget_band(band);
+        }
+    }
+
+    fn enforce_budget_band(&self, band: usize) {
+        let resident = |counters: &Counters| counters.resident_bytes.load(Ordering::Relaxed);
+        // The queue holds resident chunks only (entries for evicted chunks
+        // are dropped on visit and never re-added), so a full pass is
+        // proportional to the resident set. Visit each queued chunk at most
+        // twice per call: a first visit may only clear the second-chance
+        // bit, so a second is needed before an over-budget call is
+        // guaranteed to evict every chunk it saw. The bound keeps contended
+        // and in-flight entries from spinning this loop forever.
+        let mut remaining = self.queue(band).len().saturating_mul(2);
+        while remaining > 0 && resident(&self.counters) > self.budget_bytes.load(Ordering::Relaxed)
+        {
+            remaining -= 1;
+            let popped = self.queue(band).pop_front();
+            let Some(weak) = popped else {
+                break;
+            };
+            let Some(meta) = weak.upgrade() else {
+                continue;
+            };
+            let requeue = {
+                // `try_lock`: a chunk mid-eviction or mid-read holds its
+                // lock for milliseconds; skipping it beats convoying every
+                // budget enforcer in the process behind one chunk's I/O.
+                let Ok(mut state) = meta.state.try_lock() else {
+                    self.queue(band).push_back(weak);
+                    continue;
+                };
+                if state.freed {
+                    false
+                } else if matches!(state.residency, Residency::Evicted | Residency::Oversize) {
+                    // Nothing to evict: drop the entry. Evicted chunks never
+                    // rejoin the queue (reads are copy-out and leave them
+                    // evicted), so it stays proportional to the resident set
+                    // rather than accumulating every chunk ever evicted.
+                    false
+                } else if state.touched {
+                    state.touched = false;
+                    true
+                } else if self.spill_handoff(&meta, &mut state) {
+                    // Stays queued while in flight; once the spill commits to
+                    // `Evicted`, the next visit drops the entry.
+                    true
+                } else {
+                    self.evict_locked(&meta, &mut state);
+                    state.residency != Residency::Evicted
+                }
+            };
+            if requeue {
+                self.queue(band).push_back(weak);
+            }
+        }
+    }
+
+    fn evict_locked(&self, meta: &Arc<ChunkMeta>, state: &mut ChunkState) {
+        let Some(slot) = state.slot else {
+            return;
+        };
+        if state.freed {
+            return;
+        }
+        match state.residency {
+            Residency::UnbackedResident => {
+                // SAFETY: the slot belongs to this live chunk and the state
+                // lock is held, so nothing else touches the slot while this
+                // borrow is live (reads copy out under the same lock).
+                let data = unsafe { self.slot_data(meta, slot) };
+                let extent = SwapExtent::write(data);
+                self.counters
+                    .evictions_compress
+                    .fetch_add(1, Ordering::Relaxed);
+                self.commit_extent(meta, state, extent);
+            }
+            Residency::BackedResident => {
+                self.counters
+                    .evictions_cheap
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            Residency::WriteInFlight | Residency::Evicted | Residency::Oversize => return,
+        }
+        // `release_slot`'s precondition holds: the state lock is held and
+        // `!freed` was checked above under it.
+        self.release_slot(meta, state);
+        state.residency = Residency::Evicted;
+    }
+
+    /// Whether the next eviction should be handed to spill threads: enabled,
+    /// and the queue is below the backpressure bound (beyond it, callers
+    /// evict inline rather than growing an unbounded queue of still-resident
+    /// chunks).
+    fn spill_eligible(&self) -> bool {
+        self.spill.enabled.load(Ordering::Relaxed)
+            && usize::cast_from(self.spill.in_flight.load(Ordering::Relaxed)) < SPILL_IN_FLIGHT_MAX
+    }
+
+    /// Hands a `WriteInFlight` chunk to the spill threads.
+    fn spill_schedule(&self, meta: Arc<ChunkMeta>) {
+        self.counters
+            .spill_scheduled
+            .fetch_add(1, Ordering::Relaxed);
+        self.spill.in_flight.fetch_add(1, Ordering::Relaxed);
+        self.spill_queue().push_back(meta);
+        self.spill.cv.notify_one();
+    }
+
+    /// Spill-thread main loop. The thread owns an `Arc<PoolInner>`, so the
+    /// pool (a process-wide singleton in production) lives as long as its
+    /// threads. Queued (budget-driven) evictions take priority; with eager
+    /// backing enabled, idle threads compress unbacked chunks to
+    /// `BackedResident` instead of parking, and park with a timeout once
+    /// everything reachable is backed.
+    fn spill_worker(self: Arc<Self>) {
+        loop {
+            #[cfg(test)]
+            if self.spill.stop.load(Ordering::Relaxed) {
+                return;
+            }
+            // Tier-2 pageouts ride the spill threads: every pass through the
+            // loop (job completion, condvar wakeup, park timeout) trims the
+            // compressed tier if needed. A single atomic load when under cap.
+            self.enforce_compressed_cap();
+            let popped = self.spill_queue().pop_front();
+            if let Some(meta) = popped {
+                self.spill_process(&meta, SpillKind::Evict);
+                self.spill.in_flight.fetch_sub(1, Ordering::Relaxed);
+                continue;
+            }
+            if self.spill.eager.load(Ordering::Relaxed) && self.back_one() {
+                continue;
+            }
+            // Nothing to evict or back: park. Re-checking emptiness under
+            // the queue lock closes the lost-wakeup window (hand-offs push
+            // under this lock before notifying); the timeout backstops
+            // everything else (fresh inserts, tier growth, lost notifies).
+            let queue = self.spill_queue();
+            if queue.is_empty() {
+                let _ = self
+                    .spill
+                    .cv
+                    .wait_timeout(queue, std::time::Duration::from_millis(100))
+                    .expect("spill queue poisoned");
+            }
+        }
+    }
+
+    /// Eagerly compresses one unbacked chunk from the eviction queues into
+    /// `BackedResident`, returning whether a chunk was backed — `false`
+    /// means nothing was actionable (queues empty, or the bounded scans
+    /// found only already-backed, in-flight, contended, or stale entries)
+    /// and the caller should park rather than rescan. Bands are visited
+    /// deepest first, mirroring eviction order so the chunks evicted first
+    /// are the ones whose backing is already pre-paid.
+    fn back_one(&self) -> bool {
+        for band in (0..DEPTH_BANDS).rev() {
+            if self.back_one_from(band) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// One bounded backing scan over a single band's queue. Non-actionable
+    /// entries are requeued or dropped per the same rules budget
+    /// enforcement uses, except that the second-chance `touched` bit is
+    /// left alone — backing is not an eviction and must not consume a
+    /// chunk's reprieve.
+    fn back_one_from(&self, band: usize) -> bool {
+        for _ in 0..16 {
+            let popped = self.queue(band).pop_front();
+            let Some(weak) = popped else {
+                return false;
+            };
+            let Some(meta) = weak.upgrade() else {
+                continue;
+            };
+            {
+                let Ok(mut state) = meta.state.try_lock() else {
+                    self.queue(band).push_back(weak);
+                    continue;
+                };
+                if state.freed {
+                    continue;
+                }
+                match state.residency {
+                    Residency::Evicted | Residency::Oversize => {
+                        continue;
+                    }
+                    Residency::UnbackedResident => {
+                        state.residency = Residency::WriteInFlight;
+                    }
+                    Residency::BackedResident | Residency::WriteInFlight => {
+                        self.queue(band).push_back(weak);
+                        continue;
+                    }
+                }
+            }
+            self.spill.in_flight.fetch_add(1, Ordering::Relaxed);
+            self.spill_process(&meta, SpillKind::Back);
+            self.spill.in_flight.fetch_sub(1, Ordering::Relaxed);
+            // The chunk remains an eviction candidate (now a cheap one).
+            self.queue(band).push_back(weak);
+            return true;
+        }
+        false
+    }
+
+    /// Performs (or cancels) one scheduled compression. Lock discipline: the
+    /// chunk lock is held only to validate and to commit — never across the
+    /// compression or the `pageout` reclaim, which are the multi-millisecond
+    /// costs this path exists to keep off budget-enforcing threads.
+    fn spill_process(&self, meta: &Arc<ChunkMeta>, kind: SpillKind) {
+        // Validate under the lock, then release it for the I/O. The slot is
+        // captured under the lock and remains owned by this chunk for the
+        // unlocked compression: in `WriteInFlight`, eviction skips the chunk
+        // and `ChunkHandle::drop` defers slot release to this thread.
+        let slot;
+        {
+            let mut state = meta.state();
+            if state.freed {
+                // Freed while queued: the deferred cleanup is ours, and the
+                // chunk dies without ever compressing — the write-behind
+                // cancellation window. `ChunkHandle::drop` already counted
+                // the free and the live-chunks decrement.
+                self.counters
+                    .spill_cancelled
+                    .fetch_add(1, Ordering::Relaxed);
+                self.counters.writes_elided.fetch_add(1, Ordering::Relaxed);
+                self.release_slot(meta, &mut state);
+                return;
+            }
+            if state.residency != Residency::WriteInFlight {
+                return;
+            }
+            slot = state.slot.expect("write-in-flight chunk has a slot");
+        }
+        // SAFETY: the chunk is live (the queue holds an `Arc`) and in
+        // `WriteInFlight`, so the slot is not recycled (`ChunkHandle::drop`
+        // defers slot release to this thread in that state) and its contents
+        // are immutable; concurrent copy-out reads take the state lock and
+        // read the slot, but nothing writes it.
+        let data = unsafe { self.slot_data(meta, slot) };
+        let extent = SwapExtent::write(data);
+        // Commit under the lock.
+        let mut state = meta.state();
+        if state.freed {
+            // Freed during compression: the extent is garbage; cleanup is
+            // ours as above. Compression ran, so this is not an elided free.
+            self.counters
+                .spill_cancelled
+                .fetch_add(1, Ordering::Relaxed);
+            self.release_slot(meta, &mut state);
+            return;
+        }
+        self.commit_extent(meta, &mut state, extent);
+        match kind {
+            SpillKind::Back => {
+                // The slot stays for write-behind: the chunk remains
+                // readable, and the extent makes a later budget eviction a
+                // pure page release.
+                self.counters.eager_backs.fetch_add(1, Ordering::Relaxed);
+                state.residency = Residency::BackedResident;
+            }
+            SpillKind::Evict => {
+                // `release_slot`'s precondition holds: the state lock is
+                // held and `!freed` was observed under it.
+                self.counters
+                    .evictions_compress
+                    .fetch_add(1, Ordering::Relaxed);
+                self.release_slot(meta, &mut state);
+                state.residency = Residency::Evicted;
+            }
+        };
+        drop(state);
+        // Counted a fresh resident extent: the tier may need trimming. Kept
+        // here (rather than relying on the spill loop alone) so the
+        // threadless test hooks observe deterministic post-commit states.
+        self.enforce_compressed_cap();
+    }
+
+    /// Releases `state`'s slot — slot returned to the region free list,
+    /// physical pages discarded unless the slot joins the bounded warm pool —
+    /// and decrements resident bytes. Releasing pages beyond the warm pool is
+    /// what keeps RSS aligned with the `resident_bytes` gauge the budget
+    /// enforcer trusts; the warm pool relaxes that alignment by an explicit,
+    /// bounded amount (`warm_bytes`, capped at a fraction of the budget) so
+    /// slot reuse faults no pages and skips the kernel's page zeroing.
+    ///
+    /// Precondition: the caller holds the chunk's state lock, and no
+    /// reference into the slot exists — copy-out reads borrow the slot only
+    /// under that same lock, and a `WriteInFlight` chunk's unlocked
+    /// compression read belongs to the spill thread, which is the only
+    /// caller that releases the slot in that state. This is what makes the
+    /// `dontneed` below sound, and what makes keeping a warm slot's stale
+    /// contents safe: the slot's next occupant fully overwrites every byte
+    /// it reads, satisfying the contents-undefined contract either way.
+    fn release_slot(&self, meta: &ChunkMeta, state: &mut ChunkState) {
+        let slot = state.slot.take().expect("slotted chunk");
+        let region = self.region_of(meta);
+        let warm = self.try_keep_warm(region.class_size());
+        if !warm {
+            // SAFETY: no reference into the slot exists (the function-level
+            // precondition, established under the held state lock).
+            unsafe {
+                region::dontneed(region.slot_ptr(slot), region.class_size());
+            }
+        }
+        region.free(slot, warm);
+        self.counters
+            .resident_bytes
+            .fetch_sub(u64::cast_from(meta.len_bytes()), Ordering::Relaxed);
+    }
+
+    /// The warm pool's byte ceiling: an eighth of the budget, clamped at an
+    /// absolute maximum. The fraction sizes fault amortization at small
+    /// budgets; the clamp keeps large budgets from parking gigabytes of idle
+    /// warm slots no fault rate could justify.
+    fn warm_cap(&self) -> u64 {
+        (self.budget_bytes.load(Ordering::Relaxed) / 8).min(1 << 30)
+    }
+
+    /// Claims warm-pool capacity for a slot of `class_size` bytes, returning
+    /// whether the slot may keep its pages. The RSS overshoot the warm pool
+    /// introduces is bounded by [`PoolInner::warm_cap`] and visible as the
+    /// `warm_bytes` stat.
+    fn try_keep_warm(&self, class_size: usize) -> bool {
+        let cap = self.warm_cap();
+        let class_bytes = u64::cast_from(class_size);
+        self.counters
+            .warm_bytes
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+                (cur + class_bytes <= cap).then_some(cur + class_bytes)
+            })
+            .is_ok()
+    }
+
+    /// Allocates a slot in `class`: a warm allocation is counted as a reuse,
+    /// an exhausted class as a heap fallback for a `len_bytes` payload
+    /// (warned about once). `None` means the caller must degrade to the
+    /// heap.
+    fn alloc_slot(&self, class: usize, len_bytes: usize) -> Option<u32> {
+        match self.regions[class].alloc() {
+            Some((index, warm)) => {
+                if warm {
+                    // The allocation faulted no pages; its bytes leave the
+                    // warm pool.
+                    let class_bytes = u64::cast_from(self.regions[class].class_size());
+                    self.counters
+                        .warm_bytes
+                        .fetch_sub(class_bytes, Ordering::Relaxed);
+                    self.counters.warm_reuses.fetch_add(1, Ordering::Relaxed);
+                }
+                Some(index)
+            }
+            None => {
+                self.counters
+                    .slot_exhausted_fallbacks
+                    .fetch_add(1, Ordering::Relaxed);
+                static EXHAUSTED_ONCE: std::sync::Once = std::sync::Once::new();
+                EXHAUSTED_ONCE.call_once(|| {
+                    tracing::warn!(
+                        len_bytes,
+                        "buffer pool size class exhausted; falling back to heap chunks \
+                         (raise the pool's per-class virtual reservation)",
+                    );
+                });
+                None
+            }
+        }
+    }
+
+    /// Capacity of the compressed-resident tier: the RSS target's headroom
+    /// above the slot budget and the warm cap. Zero when no target is set —
+    /// extents then page out as soon as written, today's pre-tier behavior.
+    fn compressed_cap(&self) -> u64 {
+        let target = self.rss_target_bytes.load(Ordering::Relaxed);
+        let floor = self
+            .budget_bytes
+            .load(Ordering::Relaxed)
+            .saturating_add(self.warm_cap());
+        target.saturating_sub(floor)
+    }
+
+    /// Counts a newly resident extent (written, or revived by a read)
+    /// against the compressed tier and enqueues its chunk for RSS-target
+    /// enforcement. Callers hold the chunk's state lock with the extent
+    /// present and resident, and follow up with
+    /// [`PoolInner::enforce_compressed_cap`] once the lock is released.
+    ///
+    /// Invariant: `extent_resident_bytes` equals the sum of `alloc_size`
+    /// over live chunks' extents whose `is_resident()` is true. This method
+    /// and [`PoolInner::note_extent_released`] are the only adjusters; every
+    /// flag flip pairs with one of them under the chunk's state lock.
+    fn note_extent_resident(&self, meta: &Arc<ChunkMeta>, extent_alloc: usize) {
+        self.counters
+            .extent_resident_bytes
+            .fetch_add(u64::cast_from(extent_alloc), Ordering::Relaxed);
+        self.extent_queue().push_back(Arc::downgrade(meta));
+    }
+
+    /// Uncounts a resident extent that is being dropped (chunk freed or
+    /// degraded). Its queue entry goes stale and is dropped on visit.
+    fn note_extent_released(&self, extent: &SwapExtent) {
+        if extent.is_resident() {
+            self.counters
+                .extent_resident_bytes
+                .fetch_sub(u64::cast_from(extent.alloc_size()), Ordering::Relaxed);
+        }
+    }
+
+    /// Routes compressed-cap enforcement off latency-sensitive threads: with
+    /// spill threads running, wakes one to perform the pageouts
+    /// (`MADV_PAGEOUT` is synchronous reclaim — page-table walks, TLB
+    /// shootdowns, writeback submission — bounded per compressed extent but
+    /// not free at chunk rates); without them, enforces inline as the only
+    /// option.
+    ///
+    /// The routing rule across the two ceilings: budget pressure goes
+    /// through [`PoolInner::enforce_budget`], single-flighted because
+    /// concurrent passes would convoy on redundant compression scans; tier
+    /// pressure goes through this router, and the enforcement itself is
+    /// deliberately *not* single-flighted, since concurrent passes pop
+    /// disjoint victims and each visit is microseconds. Spill threads call
+    /// [`PoolInner::enforce_compressed_cap`] directly (they *are* the
+    /// deferral target), and [`Pool::set_rss_target`] enforces a shrink
+    /// inline so config changes land synchronously, mirroring `set_budget`.
+    ///
+    /// Deferral makes the target eventually-enforced with bounded lag (a
+    /// notify with every spill thread mid-job is absorbed; the next loop
+    /// pass catches up). The backstop below turns that into a bound by
+    /// construction: a caller finding the tier at double its capacity
+    /// enforces inline regardless, so sustained creation can never outrun
+    /// trimming by more than one capacity's worth.
+    ///
+    /// Deferral tests for thread existence alone, not `spill.enabled`:
+    /// spawned threads trim the tier in their loop for as long as they live,
+    /// even with eviction hand-off disabled, so they remain the better home
+    /// for the pageouts.
+    fn enforce_or_defer_compressed_cap(&self) {
+        if self.spill.threads.load(Ordering::Relaxed) > 0 {
+            let resident = self.counters.extent_resident_bytes.load(Ordering::Relaxed);
+            if resident > self.compressed_cap().saturating_mul(2) {
+                self.enforce_compressed_cap();
+            } else {
+                self.spill.cv.notify_one();
+            }
+        } else {
+            self.enforce_compressed_cap();
+        }
+    }
+
+    /// Pages out the oldest resident extents until the compressed tier falls
+    /// to its capacity. The compression is already paid and the device write
+    /// is the kernel's async writeback, so each pageout is one bounded
+    /// madvise; spill threads run this between jobs, and other threads only
+    /// when no spill threads exist (see
+    /// [`PoolInner::enforce_or_defer_compressed_cap`]). Not single-flighted:
+    /// concurrent passes pop disjoint victims. Visits are bounded by the
+    /// queue's length at entry; stale entries (extent paged out, dropped, or
+    /// chunk dead) are dropped.
+    fn enforce_compressed_cap(&self) {
+        let cap = self.compressed_cap();
+        let resident = |c: &Counters| c.extent_resident_bytes.load(Ordering::Relaxed);
+        // Under-cap is the common case: answer it with one atomic load and
+        // no queue lock, so frequent callers (the spill loop) stay cheap.
+        if resident(&self.counters) <= cap {
+            return;
+        }
+        let mut remaining = self.extent_queue().len();
+        while remaining > 0 && resident(&self.counters) > cap {
+            remaining -= 1;
+            let popped = self.extent_queue().pop_front();
+            let Some(weak) = popped else {
+                break;
+            };
+            let Some(meta) = weak.upgrade() else {
+                continue;
+            };
+            // `try_lock`: a chunk mid-read or mid-compression holds its lock
+            // for milliseconds; requeue rather than convoy behind it.
+            let Ok(mut state) = meta.state.try_lock() else {
+                self.extent_queue().push_back(weak);
+                continue;
+            };
+            match &mut state.extent {
+                Some(extent) if extent.is_resident() => {
+                    // Uncount before the flag flips.
+                    self.note_extent_released(extent);
+                    extent.pageout();
+                    self.counters
+                        .extent_pageouts
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                // Paged out already or dropped: the entry is stale. A later
+                // resident event re-enqueues.
+                _ => {}
+            }
+        }
+    }
+
+    /// If the chunk is a live `UnbackedResident` and the spill threads have
+    /// capacity, transitions it to `WriteInFlight` and hands it to them,
+    /// returning `true`. The hand-off happens under the held state lock; the
+    /// spill thread blocks on that lock only after this call returns and the
+    /// caller releases it.
+    fn spill_handoff(&self, meta: &Arc<ChunkMeta>, state: &mut ChunkState) -> bool {
+        if state.residency != Residency::UnbackedResident || state.freed || !self.spill_eligible() {
+            return false;
+        }
+        state.residency = Residency::WriteInFlight;
+        self.spill_schedule(Arc::clone(meta));
+        true
+    }
+}
+
+impl ChunkHandle {
+    /// Test hook: the chunk's current residency state.
+    #[cfg(test)]
+    fn residency(&self) -> Residency {
+        self.meta.state().residency
+    }
+
+    /// Copies the whole contents into `dst` (cleared first), leaving the
+    /// chunk's residency untouched: a resident slot is copied out directly,
+    /// and an evicted extent decompresses straight into `dst` without
+    /// allocating a slot. A read therefore never raises resident bytes,
+    /// never converts the chunk's state, and hands out no reference into
+    /// pool memory.
+    ///
+    /// The copy runs under the chunk's state lock, which is what makes the
+    /// no-reference contract cheap: eviction takes the same lock, so there
+    /// is no reader it could race.
+    pub fn read_into(&self, dst: &mut Vec<u64>) {
+        dst.clear();
+        let meta = &*self.meta;
+        if meta.len == 0 {
+            return;
+        }
+        let mut state = meta.state();
+        state.touched = true;
+        let mut extent_revived = false;
+        match state.residency {
+            Residency::Oversize => {
+                let payload = state.oversize.as_ref().expect("oversize chunk has payload");
+                dst.extend_from_slice(payload);
+            }
+            Residency::Evicted => {
+                // The zero-fill ahead of the decompress is deliberate waste
+                // (~a tenth of the decompress cost): the extent read takes an
+                // initialized `&mut [u8]`, so skipping the fill would mean
+                // exposing uninitialized memory through a safe reference.
+                // Callers that read repeatedly amortize it by reusing `dst`'s
+                // capacity.
+                dst.resize(meta.len, 0);
+                let bytes: &mut [u8] = bytemuck::cast_slice_mut(dst.as_mut_slice());
+                let extent = state.extent.as_mut().expect("evicted chunk has an extent");
+                // Reading faults the extent's pages back in; re-count it
+                // against the compressed tier.
+                let was_resident = extent.is_resident();
+                extent.read_into(bytes);
+                if !was_resident {
+                    let alloc = extent.alloc_size();
+                    meta.pool.note_extent_resident(&self.meta, alloc);
+                    extent_revived = true;
+                }
+            }
+            Residency::UnbackedResident | Residency::BackedResident | Residency::WriteInFlight => {
+                let slot = state.slot.expect("resident non-empty chunk has a slot");
+                // SAFETY: the slot belongs to this chunk while the state lock
+                // is held (eviction and free both take it).
+                let src = unsafe { meta.pool.slot_data(meta, slot) };
+                dst.extend_from_slice(src);
+            }
+        }
+        drop(state);
+        // The read revived the extent's compressed pages; the tier may need
+        // trimming. Enforcement locks chunk states itself, so it must run
+        // after the unlock.
+        if extent_revived {
+            meta.pool.enforce_or_defer_compressed_cap();
+        }
+    }
+
+    /// Copies the whole contents into `dst` (per [`ChunkHandle::read_into`])
+    /// and frees the chunk, cancelling any in-flight backing write.
+    pub fn take(self, dst: &mut Vec<u64>) {
+        self.read_into(dst);
+    }
+
+    /// Advisory a consumer may issue before a bulk read: hints the kernel to
+    /// swap an evicted chunk's extent back in, and is a no-op in every other
+    /// state. Never blocks on I/O (`MADV_WILLNEED` is asynchronous).
+    pub fn prefetch(&self) {
+        let state = self.meta.state();
+        if state.residency == Residency::Evicted {
+            let extent = state.extent.as_ref().expect("evicted chunk has an extent");
+            extent.prefetch();
+        }
+    }
+
+    /// Test hook: the byte size of the chunk's size class, or `None` for
+    /// empty and oversize chunks.
+    #[cfg(test)]
+    fn size_class_bytes(&self) -> Option<usize> {
+        self.meta.class.map(|class| SIZE_CLASSES[class])
+    }
+}
+
+impl Drop for ChunkHandle {
+    fn drop(&mut self) {
+        let pool = &self.meta.pool;
+        let mut state = self.meta.state();
+        pool.counters.frees.fetch_add(1, Ordering::Relaxed);
+        state.freed = true;
+        if self.meta.class.is_some() {
+            pool.live_chunks.fetch_sub(1, Ordering::Relaxed);
+        }
+        let len_bytes = u64::cast_from(self.meta.len_bytes());
+        // `release_slot`'s precondition holds in every arm below: the handle
+        // is being dropped, so no copy-out read (which borrows the handle)
+        // is in progress, and `freed` was set under the state lock held
+        // here, so concurrent queue visitors skip the chunk.
+        match state.residency {
+            Residency::UnbackedResident => {
+                if state.slot.is_some() {
+                    pool.counters.writes_elided.fetch_add(1, Ordering::Relaxed);
+                    pool.release_slot(&self.meta, &mut state);
+                }
+            }
+            Residency::BackedResident => {
+                pool.release_slot(&self.meta, &mut state);
+                if let Some(extent) = &state.extent {
+                    pool.note_extent_released(extent);
+                }
+                state.extent = None;
+            }
+            Residency::Evicted => {
+                // Eviction already released the slot.
+                debug_assert!(state.slot.is_none(), "evicted chunk holds no slot");
+                if let Some(extent) = &state.extent {
+                    pool.note_extent_released(extent);
+                }
+                state.extent = None;
+            }
+            Residency::WriteInFlight => {
+                // A spill thread may be reading the slot to compress it.
+                // `freed` (set above) tells it the chunk died; it owns the
+                // slot release, the `resident_bytes` decrement, and the
+                // cancellation accounting from here.
+            }
+            Residency::Oversize => {
+                pool.counters
+                    .resident_bytes
+                    .fetch_sub(len_bytes, Ordering::Relaxed);
+                pool.counters
+                    .oversize_bytes
+                    .fetch_sub(len_bytes, Ordering::Relaxed);
+                state.oversize = None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Keep test pools small: 64 MiB of virtual reservation per class.
+    /// Under Miri the backing is real interpreter heap rather than lazy
+    /// virtual memory, so shrink further. Classes above the capacity yield
+    /// empty regions whose inserts degrade to the heap fallback, which is
+    /// fine: slotted-chunk tests exercise only the smallest classes.
+    fn test_pool(budget_bytes: usize) -> Pool {
+        let capacity = if cfg!(miri) { 1 << 20 } else { 64 << 20 };
+        let pool = Pool::with_class_capacity(capacity).expect("pool creation");
+        pool.set_budget(budget_bytes);
+        pool
+    }
+
+    /// Scales an iteration count down under Miri, where one interpreted
+    /// compression costs what thousands do natively.
+    fn rounds(native: u64, miri: u64) -> u64 {
+        if cfg!(miri) { miri } else { native }
+    }
+
+    fn payload(words: usize, seed: u64) -> Vec<u64> {
+        (0..u64::cast_from(words))
+            .map(|i| seed.wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(i))
+            .collect()
+    }
+
+    /// Copies `data` into the pool and clears it.
+    fn insert(pool: &Pool, data: &mut Vec<u64>) -> ChunkHandle {
+        insert_at_depth(pool, 0, data)
+    }
+
+    /// Copies `data` into the pool at a hinted depth and clears it.
+    fn insert_at_depth(pool: &Pool, depth: u8, data: &mut Vec<u64>) -> ChunkHandle {
+        let hints = ChunkHints { depth };
+        let handle = pool.insert_with(data.len(), hints, |dst| {
+            dst.copy_from_slice(data.as_slice())
+        });
+        data.clear();
+        handle
+    }
+
+    /// Copies a chunk's contents out into a fresh buffer.
+    fn read(handle: &ChunkHandle) -> Vec<u64> {
+        let mut out = Vec::new();
+        handle.read_into(&mut out);
+        out
+    }
+
+    /// Words that fill a 64 KiB class exactly.
+    const SMALL: usize = (64 << 10) / 8;
+
+    #[allow(dead_code)]
+    fn assert_handle_send_sync() {
+        fn check<T: Send + Sync>() {}
+        check::<Pool>();
+        check::<ChunkHandle>();
+    }
+
+    /// With an RSS target set, evicted chunks keep their extents resident
+    /// (the compressed tier); shrinking the target pages the oldest extents
+    /// out; reads revive them and re-count them.
+    #[mz_ore::test]
+    fn compressed_tier_round_trip() {
+        let pool = test_pool(256 << 20);
+        pool.set_rss_target(1 << 30);
+        let orig = payload(SMALL, 21);
+        let handle = insert(&pool, &mut orig.clone());
+        pool.evict(&handle);
+        assert_eq!(handle.residency(), Residency::Evicted);
+        let stats = pool.stats();
+        assert!(
+            stats.extent_resident_bytes > 0,
+            "under the target, the extent stays resident",
+        );
+        assert_eq!(stats.extent_pageouts, 0);
+
+        // Shrinking the target to zero pages the extent out.
+        pool.set_rss_target(0);
+        let stats = pool.stats();
+        assert_eq!(stats.extent_resident_bytes, 0, "tier collapsed");
+        assert_eq!(stats.extent_pageouts, 1);
+
+        // Reading revives the extent: contents round-trip, the chunk stays
+        // evicted, and with the target restored the revived extent is
+        // counted again.
+        pool.set_rss_target(1 << 30);
+        assert_eq!(read(&handle), orig);
+        assert_eq!(handle.residency(), Residency::Evicted);
+        assert!(
+            pool.stats().extent_resident_bytes > 0,
+            "revived and counted"
+        );
+
+        // Dropping the handle uncounts the resident extent.
+        drop(handle);
+        assert_eq!(pool.stats().extent_resident_bytes, 0);
+    }
+
+    /// With no RSS target (the default), extents page out as soon as they
+    /// are written — the pre-tier behavior.
+    #[mz_ore::test]
+    fn default_target_pages_extents_immediately() {
+        let pool = test_pool(256 << 20);
+        let handle = insert(&pool, &mut payload(SMALL, 22));
+        pool.evict(&handle);
+        let stats = pool.stats();
+        assert_eq!(stats.extent_resident_bytes, 0);
+        assert_eq!(stats.extent_pageouts, 1);
+    }
+
+    /// Eager backing compresses a chunk to `BackedResident` while it stays
+    /// readable in its slot; the later budget-driven eviction is a pure page
+    /// release, and the contents round-trip through the extent.
+    #[mz_ore::test]
+    fn eager_backing_round_trip() {
+        let pool = test_pool(256 << 20);
+        let orig = payload(SMALL, 11);
+        let handle = insert(&pool, &mut orig.clone());
+        assert_eq!(handle.residency(), Residency::UnbackedResident);
+
+        assert!(pool.back_step(), "one chunk is backable");
+        assert_eq!(handle.residency(), Residency::BackedResident);
+        let stats = pool.stats();
+        assert_eq!(stats.eager_backs, 1);
+        assert_eq!(
+            stats.evictions_compress, 0,
+            "backing is not an eviction and compresses off the eviction counter",
+        );
+        assert!(stats.extent_bytes_written > 0);
+
+        // Still readable straight from the slot: the chunk is resident.
+        assert_eq!(read(&handle), orig);
+
+        // The pre-paid eviction is cheap, and the extent round-trips.
+        pool.evict(&handle);
+        assert_eq!(handle.residency(), Residency::Evicted);
+        assert_eq!(pool.stats().evictions_cheap, 1);
+        pool.poison_free_slots();
+        assert_eq!(read(&handle), orig);
+    }
+
+    /// Once everything reachable is backed, the backing scan reports no
+    /// progress so spill threads park instead of rescanning a fully-backed
+    /// queue forever.
+    #[mz_ore::test]
+    fn backing_reports_no_progress_when_all_backed() {
+        let pool = test_pool(256 << 20);
+        let _handle = insert(&pool, &mut payload(SMALL, 31));
+        assert!(pool.back_step(), "one unbacked chunk is actionable");
+        assert!(
+            !pool.back_step(),
+            "a fully-backed queue is not progress; callers must park",
+        );
+        assert_eq!(pool.stats().eager_backs, 1);
+    }
+
+    /// Freeing under the warm cap parks the slot warm; the next insert of the
+    /// same class reuses it fault-free and the accounting balances.
+    #[mz_ore::test]
+    fn warm_slot_reuse() {
+        // Budget 8 MiB: warm cap = 1 MiB, so a 64 KiB slot fits warm.
+        let pool = test_pool(8 << 20);
+        let orig = payload(SMALL, 7);
+        let handle = insert(&pool, &mut orig.clone());
+        drop(handle);
+        let after_free = pool.stats();
+        assert_eq!(after_free.warm_bytes, 64 << 10, "freed slot parks warm");
+        assert_eq!(after_free.warm_reuses, 0);
+
+        let handle = insert(&pool, &mut orig.clone());
+        let after_reuse = pool.stats();
+        assert_eq!(after_reuse.warm_reuses, 1, "second insert reuses warm slot");
+        assert_eq!(after_reuse.warm_bytes, 0, "reuse drains the warm pool");
+        // Contents are correct despite the skipped page release.
+        assert_eq!(read(&handle), orig);
+    }
+
+    /// The warm pool is capped at an eighth of the budget; frees beyond the
+    /// cap release their pages and park cold.
+    #[mz_ore::test]
+    fn warm_pool_respects_cap() {
+        // Budget 1 MiB: warm cap = 128 KiB = two 64 KiB slots.
+        let pool = test_pool(1 << 20);
+        let handles: Vec<_> = (0..4)
+            .map(|seed| insert(&pool, &mut payload(SMALL, seed)))
+            .collect();
+        drop(handles);
+        let stats = pool.stats();
+        assert_eq!(
+            stats.warm_bytes,
+            128 << 10,
+            "warm pool stops at the budget/8 cap",
+        );
+    }
+
+    #[mz_ore::test]
+    fn round_trip_resident() {
+        let pool = test_pool(256 << 20);
+        let orig = payload(1000, 1);
+        let mut data = orig.clone();
+        let capacity = data.capacity();
+        let handle = insert(&pool, &mut data);
+        assert!(data.is_empty());
+        assert_eq!(data.capacity(), capacity, "insert preserves capacity");
+        assert_eq!(handle.residency(), Residency::UnbackedResident);
+        assert_eq!(read(&handle), orig);
+        drop(handle);
+        let stats = pool.stats();
+        assert_eq!(stats.inserts, 1);
+        assert_eq!(stats.frees, 1);
+        assert_eq!(stats.resident_bytes, 0);
+    }
+
+    /// `take` is the terminal read: the contents come back and the consumed
+    /// handle frees the chunk, eliding the backing write of a chunk that was
+    /// still unbacked.
+    #[mz_ore::test]
+    fn take_reads_and_frees() {
+        let pool = test_pool(256 << 20);
+        let orig = payload(SMALL, 40);
+        let handle = insert(&pool, &mut orig.clone());
+        let mut out = Vec::new();
+        handle.take(&mut out);
+        assert_eq!(out, orig);
+        let stats = pool.stats();
+        assert_eq!(stats.frees, 1);
+        assert_eq!(stats.writes_elided, 1, "a resident take never writes");
+        assert_eq!(stats.resident_bytes, 0);
+        assert_eq!(stats.live_chunks, 0);
+    }
+
+    /// `prefetch` is safe wherever it lands: on a resident chunk (a no-op),
+    /// on an evicted chunk (whose read then round-trips), and issued with no
+    /// read following it. It never changes residency or resident bytes.
+    #[mz_ore::test]
+    fn prefetch_is_safe_in_every_state() {
+        let pool = test_pool(256 << 20);
+        let orig = payload(SMALL, 41);
+        let handle = insert(&pool, &mut orig.clone());
+        handle.prefetch();
+        assert_eq!(handle.residency(), Residency::UnbackedResident);
+        assert_eq!(read(&handle), orig);
+        pool.evict(&handle);
+        handle.prefetch();
+        assert_eq!(handle.residency(), Residency::Evicted);
+        assert_eq!(read(&handle), orig);
+        // An advisory with no read behind it leaves nothing to clean up.
+        let idle = insert(&pool, &mut payload(SMALL, 42));
+        idle.prefetch();
+        drop(idle);
+        drop(handle);
+        assert_eq!(pool.stats().resident_bytes, 0);
+    }
+
+    /// Reading an evicted chunk decompresses its extent straight into the
+    /// caller's buffer and leaves the chunk evicted. Free slots are poisoned
+    /// first, so a read passing stale slot memory through (the macOS
+    /// `MADV_DONTNEED` hazard) would fail the content check.
+    #[mz_ore::test]
+    fn evict_then_read_preserves_contents() {
+        let pool = test_pool(256 << 20);
+        let orig = payload(SMALL, 2);
+        let handle = insert(&pool, &mut orig.clone());
+        pool.evict(&handle);
+        assert_eq!(handle.residency(), Residency::Evicted);
+        let stats = pool.stats();
+        assert_eq!(stats.evictions_compress, 1);
+        assert_eq!(stats.resident_bytes, 0);
+        assert!(stats.extent_bytes_written > 0);
+        pool.poison_free_slots();
+        assert_eq!(read(&handle), orig);
+        assert_eq!(handle.residency(), Residency::Evicted);
+        assert_eq!(pool.stats().resident_bytes, 0, "reads copy out");
+    }
+
+    /// Slots are scoped to residency: eviction releases the slot, so a
+    /// capacity holding exactly one chunk can serve any number of chunks one
+    /// at a time, and reads of evicted chunks need no slot at all.
+    #[mz_ore::test]
+    fn eviction_releases_the_slot() {
+        // One 64 KiB slot per class.
+        let pool = Pool::with_class_capacity(64 << 10).expect("pool creation");
+        let a = insert(&pool, &mut payload(SMALL, 6));
+        pool.evict(&a);
+        // The class's only slot is free again: a second chunk fits without
+        // falling back to the heap.
+        let b = insert(&pool, &mut payload(SMALL, 7));
+        assert_eq!(b.residency(), Residency::UnbackedResident);
+        assert_eq!(pool.stats().slot_exhausted_fallbacks, 0);
+        // Reading `a` decompresses straight from its extent while `b` holds
+        // the class's only slot: copy-out allocates nothing.
+        assert_eq!(read(&a), payload(SMALL, 6));
+        assert_eq!(a.residency(), Residency::Evicted);
+        assert_eq!(read(&b), payload(SMALL, 7));
+    }
+
+    /// The eviction queue holds resident chunks only: an enforcement pass
+    /// drops entries for evicted chunks, and reads never re-add them, so the
+    /// scan each insert pays stays proportional to the resident set rather
+    /// than every chunk ever evicted.
+    #[mz_ore::test]
+    fn queue_holds_resident_chunks_only() {
+        let pool = test_pool(128 << 10);
+        let mut handles = Vec::new();
+        for seed in 0..8 {
+            handles.push(insert(&pool, &mut payload(SMALL, 800 + seed)));
+        }
+        // Budget pressure evicted ~6 of 8; one more pass visits the evicted
+        // entries and drops them (their first visit performed the eviction
+        // and dropped them already, but second-chance survivors may linger).
+        pool.enforce_budget();
+        let resident = handles
+            .iter()
+            .filter(|h| h.residency() != Residency::Evicted)
+            .count();
+        assert!(
+            pool.queue_len() <= resident + 1,
+            "queue ({}) tracks the resident set ({resident}), not all 8 live chunks",
+            pool.queue_len(),
+        );
+        // Reading an evicted chunk copies out of its extent and does not
+        // re-enqueue it: the queue keeps tracking the resident set.
+        let evicted = handles
+            .iter()
+            .find(|h| h.residency() == Residency::Evicted)
+            .expect("something was evicted");
+        let before = pool.queue_len();
+        assert_eq!(read(evicted).len(), SMALL);
+        assert_eq!(evicted.residency(), Residency::Evicted);
+        assert_eq!(pool.queue_len(), before, "reads leave the queue alone");
+    }
+
+    #[mz_ore::test]
+    fn dead_data_is_never_written() {
+        let pool = test_pool(256 << 20);
+        let handle = insert(&pool, &mut payload(SMALL, 7));
+        drop(handle);
+        let stats = pool.stats();
+        assert_eq!(stats.frees, 1);
+        assert_eq!(stats.writes_elided, 1);
+        assert_eq!(stats.extent_bytes_written, 0);
+        assert_eq!(stats.resident_bytes, 0);
+    }
+
+    #[mz_ore::test]
+    fn budget_is_enforced_on_insert() {
+        let budget = 128 << 10;
+        let pool = test_pool(budget);
+        let mut handles = Vec::new();
+        for seed in 0..8 {
+            handles.push(insert(&pool, &mut payload(SMALL, 100 + seed)));
+        }
+        let stats = pool.stats();
+        assert!(
+            stats.resident_bytes <= u64::cast_from(budget),
+            "resident {} exceeds budget {}",
+            stats.resident_bytes,
+            budget,
+        );
+        assert!(stats.evictions_compress >= 6);
+        let resident = handles
+            .iter()
+            .filter(|h| {
+                matches!(
+                    h.residency(),
+                    Residency::UnbackedResident | Residency::BackedResident
+                )
+            })
+            .count();
+        assert_eq!(resident, 2, "budget holds exactly two small chunks");
+    }
+
+    #[mz_ore::test]
+    fn set_budget_retunes_in_place() {
+        let pool = test_pool(usize::MAX);
+        let mut handles = Vec::new();
+        for seed in 0..8 {
+            handles.push(insert(&pool, &mut payload(SMALL, 200 + seed)));
+        }
+        assert_eq!(pool.stats().evictions_compress, 0);
+
+        // Shrinking the budget evicts immediately.
+        pool.set_budget(128 << 10);
+        let stats = pool.stats();
+        assert!(stats.resident_bytes <= 128 << 10);
+        assert!(stats.evictions_compress >= 6);
+
+        // Growing it leaves headroom: a fresh insert stays resident.
+        pool.set_budget(usize::MAX);
+        let h = insert(&pool, &mut payload(SMALL, 300));
+        assert_eq!(h.residency(), Residency::UnbackedResident);
+        for h in &handles {
+            assert_eq!(read(h).len(), SMALL);
+        }
+    }
+
+    #[mz_ore::test]
+    fn second_chance_prefers_untouched_victims() {
+        // Budget holds one and a half small chunks.
+        let pool = test_pool((64 << 10) + (32 << 10));
+        let orig_a = payload(SMALL, 8);
+        let handle_a = insert(&pool, &mut orig_a.clone());
+        assert_eq!(read(&handle_a), orig_a);
+        // Inserting B overflows the budget; A is older but touched, so the
+        // enforcer gives it a second chance and evicts untouched B instead.
+        let handle_b = insert(&pool, &mut payload(SMALL, 9));
+        assert_eq!(handle_a.residency(), Residency::UnbackedResident);
+        assert_eq!(handle_b.residency(), Residency::Evicted);
+    }
+
+    /// Depth-hinted chunks are evicted before younger ones: the deep chunk
+    /// loses even though the young chunk is older and both are untouched
+    /// (plain FIFO would have evicted the older, young one). Also exercises
+    /// band clamping: depths beyond the last band share it.
+    #[mz_ore::test]
+    fn eviction_prefers_deeper_chunks() {
+        // Budget of one small chunk.
+        let pool = test_pool(64 << 10);
+        let young = insert(&pool, &mut payload(SMALL, 900));
+        let deep = insert_at_depth(&pool, 255, &mut payload(SMALL, 901));
+        assert_eq!(young.residency(), Residency::UnbackedResident);
+        assert_eq!(deep.residency(), Residency::Evicted);
+    }
+
+    /// Eager backing visits deeper chunks first, mirroring eviction order,
+    /// so the chunks evicted first are the ones already backed.
+    #[mz_ore::test]
+    fn backing_prefers_deeper_chunks() {
+        let pool = test_pool(256 << 20);
+        let young = insert(&pool, &mut payload(SMALL, 902));
+        let deep = insert_at_depth(&pool, 2, &mut payload(SMALL, 903));
+        assert!(pool.back_step());
+        assert_eq!(deep.residency(), Residency::BackedResident);
+        assert_eq!(young.residency(), Residency::UnbackedResident);
+        assert!(pool.back_step());
+        assert_eq!(young.residency(), Residency::BackedResident);
+    }
+
+    #[mz_ore::test]
+    fn empty_insert_consumes_no_slot() {
+        let pool = test_pool(256 << 20);
+        let mut data = Vec::new();
+        let handle = insert(&pool, &mut data);
+        assert_eq!(handle.size_class_bytes(), None);
+        assert!(read(&handle).is_empty());
+        // Reads clear the destination even for empty chunks.
+        let mut out = vec![1u64, 2, 3];
+        handle.read_into(&mut out);
+        assert!(out.is_empty());
+        drop(handle);
+        let stats = pool.stats();
+        assert_eq!(stats.resident_bytes, 0);
+        assert_eq!(stats.writes_elided, 0);
+    }
+
+    #[mz_ore::test]
+    fn oversize_round_trips() {
+        let pool = test_pool(256 << 20);
+        let words = SIZE_CLASSES[SIZE_CLASSES.len() - 1] / 8 + 1;
+        let orig = payload(words, 10);
+        let handle = insert(&pool, &mut orig.clone());
+        assert_eq!(handle.residency(), Residency::Oversize);
+        assert_eq!(handle.size_class_bytes(), None);
+        let stats = pool.stats();
+        assert_eq!(stats.oversize_bytes, u64::cast_from(words * 8));
+        // The payload outgrew the largest class, and no class was exhausted.
+        assert_eq!(stats.oversize_payloads, 1);
+        assert_eq!(stats.slot_exhausted_fallbacks, 0);
+        // Explicit eviction and budget enforcement leave oversize chunks
+        // resident.
+        pool.evict(&handle);
+        pool.enforce_budget();
+        assert_eq!(handle.residency(), Residency::Oversize);
+        assert_eq!(read(&handle), orig);
+        drop(handle);
+        let stats = pool.stats();
+        assert_eq!(stats.oversize_bytes, 0);
+        assert_eq!(stats.resident_bytes, 0);
+    }
+
+    #[mz_ore::test]
+    fn payload_lands_in_smallest_fitting_class() {
+        let pool = test_pool(256 << 20);
+        let handle = insert(&pool, &mut payload((100 << 10) / 8, 11));
+        assert_eq!(handle.size_class_bytes(), Some(128 << 10));
+        let exact = insert(&pool, &mut payload(SMALL, 12));
+        assert_eq!(exact.size_class_bytes(), Some(64 << 10));
+    }
+
+    #[mz_ore::test]
+    fn multithreaded_smoke() {
+        // Budget of one small chunk: four inserting threads keep the pool
+        // over budget, so every insert's enforcement pass selects victims
+        // owned by other threads, racing cross-thread eviction against
+        // copy-out reads and frees.
+        let pool = test_pool(64 << 10);
+        let per_thread = rounds(50, 3);
+        let threads: Vec<_> = (0..4u64)
+            .map(|t| {
+                let pool = pool.clone();
+                std::thread::spawn(move || {
+                    for round in 0..per_thread {
+                        let seed = t * 1000 + round;
+                        let orig = payload(SMALL, seed);
+                        let handle = insert(&pool, &mut orig.clone());
+                        pool.evict(&handle);
+                        assert_eq!(read(&handle), orig);
+                        // Enforcement racing reads must never corrupt them.
+                        pool.enforce_budget();
+                        assert_eq!(read(&handle), orig);
+                        drop(handle);
+                    }
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().expect("worker thread panicked");
+        }
+        let stats = pool.stats();
+        assert_eq!(stats.inserts, 4 * per_thread);
+        assert_eq!(stats.frees, 4 * per_thread);
+        assert_eq!(stats.resident_bytes, 0);
+    }
+
+    #[mz_ore::test]
+    fn concurrent_read_enforce_churn() {
+        // Races the three actors that can touch one chunk's slot: readers
+        // copying shared chunks out and verifying them, an enforcer evicting
+        // them (the zero budget makes every chunk a victim), and a churner
+        // whose insert/free traffic turns the queue over. Contents are
+        // asserted on every read, so an eviction or slot recycle racing a
+        // copy-out shows up as corruption.
+        let pool = test_pool(0);
+        let shared: Arc<Vec<(Vec<u64>, ChunkHandle)>> = Arc::new(
+            (0..4u64)
+                .map(|seed| {
+                    let orig = payload(SMALL, 600 + seed);
+                    let handle = insert(&pool, &mut orig.clone());
+                    (orig, handle)
+                })
+                .collect(),
+        );
+        let churn = rounds(300, 6);
+        let mut threads = Vec::new();
+        for t in 0..2u64 {
+            let shared = Arc::clone(&shared);
+            threads.push(std::thread::spawn(move || {
+                for round in 0..churn {
+                    let (orig, handle) = &shared[usize::cast_from((t + round) % 4)];
+                    assert_eq!(&read(handle), orig);
+                }
+            }));
+        }
+        {
+            let pool = pool.clone();
+            threads.push(std::thread::spawn(move || {
+                for _ in 0..2 * churn {
+                    pool.enforce_budget();
+                }
+            }));
+        }
+        {
+            let pool = pool.clone();
+            threads.push(std::thread::spawn(move || {
+                for round in 0..churn {
+                    let orig = payload(SMALL, 700 + round);
+                    let handle = insert(&pool, &mut orig.clone());
+                    assert_eq!(read(&handle), orig);
+                }
+            }));
+        }
+        for thread in threads {
+            thread.join().expect("worker thread panicked");
+        }
+        drop(shared);
+        assert_eq!(pool.stats().resident_bytes, 0);
+    }
+
+    /// Read-only traffic never raises resident bytes: every chunk starts
+    /// evicted and is then read once, with no inserts in between. Reads copy
+    /// out of the extents and leave every chunk evicted, so a seek-heavy
+    /// phase costs no pool memory at all.
+    #[mz_ore::test]
+    fn reads_never_raise_resident_bytes() {
+        let pool = test_pool(128 << 10);
+        let origs: Vec<_> = (0..8u64).map(|seed| payload(SMALL, 300 + seed)).collect();
+        let handles: Vec<_> = origs
+            .iter()
+            .map(|o| insert(&pool, &mut o.clone()))
+            .collect();
+        for handle in &handles {
+            pool.evict(handle);
+        }
+        assert_eq!(pool.stats().resident_bytes, 0);
+        for (index, handle) in handles.iter().enumerate() {
+            assert_eq!(read(handle), origs[index]);
+            assert_eq!(handle.residency(), Residency::Evicted);
+            assert_eq!(pool.stats().resident_bytes, 0);
+        }
+    }
+
+    #[mz_ore::test]
+    fn queue_stays_bounded_under_budget() {
+        // Chunk churn that never exceeds the budget: the enforcer's eviction
+        // loop never runs, so stale queue entries must be reclaimed by
+        // pruning alone.
+        let pool = test_pool(256 << 20);
+        for seed in 0..rounds(1000, 48) {
+            let handle = insert(&pool, &mut payload(SMALL, seed));
+            drop(handle);
+        }
+        let len = pool.queue_len();
+        assert!(len <= 32, "queue holds {len} entries for zero live chunks");
+    }
+
+    #[mz_ore::test]
+    fn spill_async_evict_round_trip() {
+        let pool = test_pool(usize::MAX);
+        pool.enable_spill_without_threads();
+        let h = insert(&pool, &mut payload(SMALL, 400));
+        pool.evict(&h);
+        assert_eq!(h.residency(), Residency::WriteInFlight);
+        // Readable while in flight: the slot is still populated, and the
+        // copy-out coexists with the spill thread's compression read.
+        assert_eq!(read(&h), payload(SMALL, 400));
+        // Reads leave no trace, so the eviction commits.
+        assert!(pool.spill_step());
+        assert_eq!(h.residency(), Residency::Evicted);
+        let stats = pool.stats();
+        assert_eq!(stats.spill_scheduled, 1);
+        assert_eq!(stats.evictions_compress, 1);
+        pool.poison_free_slots();
+        assert_eq!(read(&h), payload(SMALL, 400));
+    }
+
+    #[mz_ore::test]
+    fn spill_freed_while_queued_is_elided() {
+        let pool = test_pool(usize::MAX);
+        pool.enable_spill_without_threads();
+        let h = insert(&pool, &mut payload(SMALL, 401));
+        pool.evict(&h);
+        assert_eq!(h.residency(), Residency::WriteInFlight);
+        drop(h);
+        assert!(pool.spill_step());
+        let stats = pool.stats();
+        assert_eq!(stats.spill_cancelled, 1);
+        assert_eq!(stats.writes_elided, 1, "freed before compression: elided");
+        assert_eq!(stats.extent_bytes_written, 0, "no extent was written");
+        assert_eq!(stats.resident_bytes, 0, "slot accounting settled");
+    }
+
+    /// `take` on a chunk whose backing write is still in flight copies the
+    /// contents out of the slot and cancels the write: the spill thread finds
+    /// the chunk freed, elides the extent, and settles the slot accounting.
+    #[mz_ore::test]
+    fn spill_take_in_flight_cancels_write() {
+        let pool = test_pool(usize::MAX);
+        pool.enable_spill_without_threads();
+        let orig = payload(SMALL, 402);
+        let h = insert(&pool, &mut orig.clone());
+        pool.evict(&h);
+        assert_eq!(h.residency(), Residency::WriteInFlight);
+        let mut out = Vec::new();
+        h.take(&mut out);
+        assert_eq!(out, orig);
+        assert!(pool.spill_step());
+        let stats = pool.stats();
+        assert_eq!(stats.frees, 1);
+        assert_eq!(stats.spill_cancelled, 1);
+        assert_eq!(stats.writes_elided, 1, "taken before compression: elided");
+        assert_eq!(stats.extent_bytes_written, 0, "no extent was written");
+        assert_eq!(stats.resident_bytes, 0, "slot accounting settled");
+        assert_eq!(stats.live_chunks, 0);
+    }
+
+    #[mz_ore::test]
+    fn spill_threads_end_to_end() {
+        let pool = test_pool(128 << 10);
+        pool.set_spill_threads(2);
+        let mut handles = Vec::new();
+        for seed in 0..rounds(16, 6) {
+            handles.push(insert(&pool, &mut payload(SMALL, 500 + seed)));
+        }
+        pool.quiesce_spill();
+        let stats = pool.stats();
+        assert!(
+            stats.spill_scheduled > 0,
+            "budget pressure should have scheduled spills",
+        );
+        for (i, h) in handles.iter().enumerate() {
+            assert_eq!(read(h), payload(SMALL, 500 + u64::cast_from(i)));
+        }
+        pool.join_spill_threads();
+    }
+
+    /// Races the `WriteInFlight` protocol in its true concurrent form:
+    /// spill threads compress slots without the state lock while owner
+    /// threads copy the same chunks out under it and drop chunks mid-flight
+    /// (both cancellation windows). Contents are asserted on every read, so
+    /// a compression or slot release racing a copy-out shows up as
+    /// corruption; under Miri the aliasing itself is checked.
+    #[mz_ore::test]
+    fn spill_threads_race_reads_and_drops() {
+        let pool = test_pool(usize::MAX);
+        pool.set_spill_threads(2);
+        let iters = rounds(50, 6);
+        let mut threads = Vec::new();
+        for t in 0..2u64 {
+            let pool = pool.clone();
+            threads.push(std::thread::spawn(move || {
+                for round in 0..iters {
+                    let orig = payload(SMALL, t * 10_000 + round);
+                    let handle = insert(&pool, &mut orig.clone());
+                    // Hands the chunk to the spill threads (`WriteInFlight`).
+                    pool.evict(&handle);
+                    // Copy-out read racing the unlocked compression read.
+                    assert_eq!(read(&handle), orig);
+                    if round % 2 == 0 {
+                        // Free while queued or mid-compression: the
+                        // cancellation windows own the deferred cleanup.
+                        drop(handle);
+                    } else {
+                        assert_eq!(read(&handle), orig);
+                    }
+                }
+            }));
+        }
+        for thread in threads {
+            thread.join().expect("worker thread panicked");
+        }
+        pool.quiesce_spill();
+        pool.join_spill_threads();
+        assert_eq!(pool.stats().resident_bytes, 0);
+    }
+
+    #[mz_ore::test]
+    fn insert_with_fills_in_place() {
+        let pool = test_pool(usize::MAX);
+        let want = payload(SMALL, 600);
+        let h = pool.insert_with(SMALL, ChunkHints::default(), |dst| {
+            assert_eq!(dst.len(), SMALL, "fill sees exactly the chunk length");
+            dst.copy_from_slice(&want);
+        });
+        assert_eq!(h.residency(), Residency::UnbackedResident);
+        assert_eq!(read(&h), want);
+        pool.evict(&h);
+        assert_eq!(read(&h), want, "round-trips through the extent");
+
+        // Empty and oversize take their fallback paths.
+        let empty = pool.insert_with(0, ChunkHints::default(), |dst| assert!(dst.is_empty()));
+        assert!(read(&empty).is_empty());
+        let big_len = (SIZE_CLASSES[SIZE_CLASSES.len() - 1] / 8) + 1;
+        let big = pool.insert_with(big_len, ChunkHints::default(), |dst| dst.fill(7));
+        assert_eq!(big.residency(), Residency::Oversize);
+        assert_eq!(read(&big).len(), big_len);
+    }
+
+    #[mz_ore::test]
+    fn slot_exhaustion_degrades_to_heap() {
+        // Two 64 KiB slots per class at this capacity; the third insert finds
+        // no slot and must fall back to the heap rather than panic.
+        let pool = Pool::with_class_capacity(128 << 10).expect("pool creation");
+        let a = insert(&pool, &mut payload(SMALL, 700));
+        let b = insert(&pool, &mut payload(SMALL, 701));
+        let c = insert(&pool, &mut payload(SMALL, 702));
+        assert_eq!(a.residency(), Residency::UnbackedResident);
+        assert_eq!(b.residency(), Residency::UnbackedResident);
+        assert_eq!(
+            c.residency(),
+            Residency::Oversize,
+            "fallback is heap-backed"
+        );
+        assert_eq!(pool.stats().slot_exhausted_fallbacks, 1);
+        assert_eq!(read(&c), payload(SMALL, 702));
+        // Freeing a slotted chunk lets the next insert use the region again.
+        drop(a);
+        let d = insert(&pool, &mut payload(SMALL, 703));
+        assert_eq!(d.residency(), Residency::UnbackedResident);
+        assert_eq!(read(&d), payload(SMALL, 703));
+    }
+}

--- a/src/ore/src/pool.rs
+++ b/src/ore/src/pool.rs
@@ -44,7 +44,11 @@
 //! where `compressed cap = rss_target - budget - warm cap`, makes every
 //! resident byte's ceiling nameable; a zero RSS target collapses the
 //! compressed tier and extents page out as soon as they are written.
-//! Nothing is ever both uncompressed and on the device.
+//! Nothing is ever both uncompressed and on the device. Pageout is observed
+//! rather than assumed: an extent counts against the compressed tier until
+//! `mincore` reports its whole range nonresident, so reclaim the kernel
+//! declines surfaces as `extent_pageout_incomplete` (and a tier settled
+//! above its capacity) instead of as RSS the ledger cannot see.
 //!
 //! Residency is a state, not a type, and it only descends: a chunk starts
 //! resident and, once evicted, serves reads from its extent for the rest of
@@ -185,8 +189,16 @@ pub struct PoolStats {
     /// compressed-but-resident middle tier. Bounded by the RSS target;
     /// exceeding it pages the oldest extents out to the swap device.
     pub extent_resident_bytes: u64,
-    /// Extents pushed to the swap device by RSS-target enforcement.
+    /// Extents pushed to the swap device by RSS-target enforcement, with
+    /// the whole range observed nonresident afterwards.
     pub extent_pageouts: u64,
+    /// Pageout passes whose residency observation found some of the
+    /// extent's pages still in memory: `MADV_PAGEOUT` may decline pages and
+    /// still succeed, so `mincore` decides. The extent keeps its full
+    /// resident accounting and is retried until its per-extent retry cap.
+    /// Climbing steadily on a loaded pool means pages cannot actually reach
+    /// the swap device (no swap, or a cgroup that cannot reclaim).
+    pub extent_pageout_incomplete: u64,
 }
 
 #[derive(Debug, Default)]
@@ -208,6 +220,7 @@ struct Counters {
     eager_backs: AtomicU64,
     extent_resident_bytes: AtomicU64,
     extent_pageouts: AtomicU64,
+    extent_pageout_incomplete: AtomicU64,
 }
 
 /// A buffer pool over swap-backed extents. Cheap to clone; all clones share
@@ -558,6 +571,7 @@ impl Pool {
             eager_backs: c.eager_backs.load(Ordering::Relaxed),
             extent_resident_bytes: c.extent_resident_bytes.load(Ordering::Relaxed),
             extent_pageouts: c.extent_pageouts.load(Ordering::Relaxed),
+            extent_pageout_incomplete: c.extent_pageout_incomplete.load(Ordering::Relaxed),
             spill_scheduled: c.spill_scheduled.load(Ordering::Relaxed),
             spill_cancelled: c.spill_cancelled.load(Ordering::Relaxed),
             spill_in_flight: self.0.spill.in_flight.load(Ordering::Relaxed),
@@ -676,6 +690,13 @@ impl Pool {
     #[cfg(test)]
     fn enforce_budget(&self) {
         self.0.enforce_budget();
+    }
+
+    /// Test hook: runs one compressed-cap enforcement pass inline on the
+    /// calling thread, where the fake residency observation applies.
+    #[cfg(test)]
+    fn enforce_rss_target(&self) {
+        self.0.enforce_compressed_cap();
     }
 
     /// Retunes the resident-bytes budget in place and enforces it. Live
@@ -1296,12 +1317,14 @@ impl PoolInner {
     /// Pages out the oldest resident extents until the compressed tier falls
     /// to its capacity. The compression is already paid and the device write
     /// is the kernel's async writeback, so each pageout is one bounded
-    /// madvise; spill threads run this between jobs, and other threads only
-    /// when no spill threads exist (see
+    /// madvise plus a mincore observation; spill threads run this between
+    /// jobs, and other threads only when no spill threads exist (see
     /// [`PoolInner::enforce_or_defer_compressed_cap`]). Not single-flighted:
     /// concurrent passes pop disjoint victims. Visits are bounded by the
     /// queue's length at entry; stale entries (extent paged out, dropped, or
-    /// chunk dead) are dropped.
+    /// chunk dead) are dropped, while incomplete and retry-capped extents
+    /// are requeued with their accounting intact, so the tier may settle
+    /// above its capacity by the bytes the kernel declined to reclaim.
     fn enforce_compressed_cap(&self) {
         let cap = self.compressed_cap();
         let resident = |c: &Counters| c.extent_resident_bytes.load(Ordering::Relaxed);
@@ -1328,12 +1351,30 @@ impl PoolInner {
             };
             match &mut state.extent {
                 Some(extent) if extent.is_resident() => {
-                    // Uncount before the flag flips.
-                    self.note_extent_released(extent);
-                    extent.pageout();
-                    self.counters
-                        .extent_pageouts
-                        .fetch_add(1, Ordering::Relaxed);
+                    if extent.pageout_capped() {
+                        // Retry-capped: the extent stays fully counted and
+                        // is not advised again until a read resets its
+                        // budget. The requeued entry is what lets a
+                        // post-read pass find the extent, since a read of a
+                        // still-resident extent does not re-enqueue it.
+                        self.extent_queue().push_back(weak);
+                    } else if extent.pageout() {
+                        self.counters
+                            .extent_resident_bytes
+                            .fetch_sub(u64::cast_from(extent.alloc_size()), Ordering::Relaxed);
+                        self.counters
+                            .extent_pageouts
+                            .fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        // The advice left pages resident. The extent keeps
+                        // its full accounting (the ledger may over-count
+                        // RSS, the safe direction) and its queue slot, so
+                        // later passes retry it up to the cap.
+                        self.counters
+                            .extent_pageout_incomplete
+                            .fetch_add(1, Ordering::Relaxed);
+                        self.extent_queue().push_back(weak);
+                    }
                 }
                 // Paged out already or dropped: the entry is stale. A later
                 // resident event re-enqueues.
@@ -1615,6 +1656,116 @@ mod tests {
         let stats = pool.stats();
         assert_eq!(stats.extent_resident_bytes, 0);
         assert_eq!(stats.extent_pageouts, 1);
+    }
+
+    /// A pageout pass whose residency observation finds the whole range
+    /// gone uncounts exactly the extent's allocation bytes.
+    #[mz_ore::test]
+    fn full_pageout_uncounts_exactly_the_extent() {
+        let pool = test_pool(256 << 20);
+        pool.set_rss_target(1 << 30);
+        let handle = insert(&pool, &mut payload(SMALL, 50));
+        pool.evict(&handle);
+        let counted = pool.stats().extent_resident_bytes;
+        assert!(counted > 0, "under the target, the extent stays counted");
+        pool.set_rss_target(0);
+        let stats = pool.stats();
+        assert_eq!(stats.extent_resident_bytes, 0, "exactly `counted` left");
+        assert_eq!(stats.extent_pageouts, 1);
+        assert_eq!(stats.extent_pageout_incomplete, 0);
+    }
+
+    /// A pageout pass the kernel declines leaves the extent fully counted
+    /// and queued, and increments the incomplete counter. The next pass
+    /// (advice now accepted) pages it out.
+    #[mz_ore::test]
+    fn incomplete_pageout_keeps_accounting_and_queue_position() {
+        let pool = test_pool(256 << 20);
+        pool.set_rss_target(1 << 30);
+        let handle = insert(&pool, &mut payload(SMALL, 51));
+        pool.evict(&handle);
+        let counted = pool.stats().extent_resident_bytes;
+        assert!(counted > 0);
+        region::fake_residency::decline_next(1);
+        pool.set_rss_target(0);
+        let stats = pool.stats();
+        assert_eq!(
+            stats.extent_resident_bytes, counted,
+            "full accounting stays"
+        );
+        assert_eq!(stats.extent_pageouts, 0);
+        assert_eq!(stats.extent_pageout_incomplete, 1);
+        assert_eq!(handle.residency(), Residency::Evicted);
+        // The requeued entry is retried by the next enforcement pass.
+        pool.enforce_rss_target();
+        let stats = pool.stats();
+        assert_eq!(stats.extent_resident_bytes, 0);
+        assert_eq!(stats.extent_pageouts, 1);
+        assert_eq!(stats.extent_pageout_incomplete, 1);
+    }
+
+    /// A never-reclaimable extent stops being advised after the retry cap:
+    /// the incomplete counter stops climbing, the bytes stay counted
+    /// resident, and the tier keeps paging other extents out around it.
+    #[mz_ore::test]
+    fn pageout_retry_cap_stops_advising() {
+        let pool = test_pool(256 << 20);
+        let handle = insert(&pool, &mut payload(SMALL, 52));
+        region::fake_residency::decline_next(u64::MAX);
+        // RSS target zero: the eviction's enforcement pass advises at once.
+        pool.evict(&handle);
+        for _ in 0..5 {
+            pool.enforce_rss_target();
+        }
+        let stats = pool.stats();
+        assert_eq!(
+            stats.extent_pageout_incomplete,
+            u64::from(extent::PAGEOUT_RETRY_CAP),
+            "advised exactly retry-cap times, then left alone",
+        );
+        assert_eq!(stats.extent_pageouts, 0);
+        let counted = stats.extent_resident_bytes;
+        assert!(counted > 0, "capped extent stays counted resident");
+        // The tier functions around the capped extent: a fresh extent still
+        // pages out.
+        region::fake_residency::decline_next(0);
+        let other = insert(&pool, &mut payload(SMALL, 53));
+        pool.evict(&other);
+        let stats = pool.stats();
+        assert_eq!(stats.extent_pageouts, 1);
+        assert_eq!(
+            stats.extent_resident_bytes, counted,
+            "only the capped extent remains counted",
+        );
+        assert_eq!(read(&handle).len(), SMALL, "capped extent stays readable");
+    }
+
+    /// Reading a retry-capped extent faults its pages back in and resets
+    /// the retry budget, so a later pass can page it out.
+    #[mz_ore::test]
+    fn read_resets_pageout_retry_budget() {
+        let pool = test_pool(256 << 20);
+        let orig = payload(SMALL, 54);
+        let handle = insert(&pool, &mut orig.clone());
+        region::fake_residency::decline_next(u64::MAX);
+        pool.evict(&handle);
+        for _ in 0..4 {
+            pool.enforce_rss_target();
+        }
+        assert_eq!(
+            pool.stats().extent_pageout_incomplete,
+            u64::from(extent::PAGEOUT_RETRY_CAP),
+            "capped",
+        );
+        assert!(pool.stats().extent_resident_bytes > 0);
+        region::fake_residency::decline_next(0);
+        assert_eq!(read(&handle), orig);
+        pool.enforce_rss_target();
+        let stats = pool.stats();
+        assert_eq!(stats.extent_pageouts, 1, "the budget reset re-advised it");
+        assert_eq!(stats.extent_resident_bytes, 0);
+        // The paged-out extent still round-trips.
+        assert_eq!(read(&handle), orig);
     }
 
     /// Eager backing compresses a chunk to `BackedResident` while it stays

--- a/src/ore/src/pool.rs
+++ b/src/ore/src/pool.rs
@@ -96,6 +96,44 @@ use crate::pool::region::{Region, SIZE_CLASSES};
 /// heap-fallback path.
 const CLASS_CAPACITY_BYTES: usize = 1 << 40;
 
+/// A chunk-provided transform between a chunk's body bytes and the stored
+/// bytes its extent holds. The pool owns scheduling: spill threads, the
+/// residency state machine, cancellation, and the ledger. It invokes the
+/// codec on opaque bytes at the extent boundary, `encode` when backing a
+/// chunk (on a spill thread, or inline under overload) and `decode` when
+/// reading an evicted one, under the chunk's state lock. The pool itself
+/// has no opinion on the stored form: framing, compression, and validation
+/// all belong to the codec.
+///
+/// Implementations must be pure transforms: no locking, no calls back into
+/// the pool (the state lock is held at `decode` sites), and no panic on
+/// bytes their own `encode` produced. `decode` must exactly invert
+/// `encode`, and `encode`'s output must never exceed
+/// [`max_stored_len`]`(body.len())`, the bound the extent store's size
+/// classes are provisioned to.
+pub trait ExtentCodec: std::fmt::Debug + Send + Sync {
+    /// Transforms `body` into its stored form, replacing `out`'s contents.
+    /// `out`'s capacity is reused across calls; implementations size it
+    /// themselves.
+    fn encode(&self, body: &[u8], out: &mut Vec<u8>);
+
+    /// Inverts [`ExtentCodec::encode`]: reconstructs into `body` exactly
+    /// the bytes whose encoding produced `stored`. `body` is exactly the
+    /// original body's length, and implementations must panic on a length
+    /// mismatch rather than truncate or pad.
+    fn decode(&self, stored: &[u8], body: &mut [u8]);
+}
+
+/// The largest stored form [`ExtentCodec::encode`] may produce for a
+/// `body_len`-byte body: an incompressible-input expansion matching lz4's
+/// worst case plus a four-byte length prefix. The extent store's size-class
+/// ladder is provisioned to this bound, so a codec that exceeds it can
+/// strand payloads with no class to hold them (they degrade to unpageable
+/// heap fallbacks).
+pub fn max_stored_len(body_len: usize) -> usize {
+    4 + body_len + body_len / 255 + 16
+}
+
 /// Advisory placement hints for a chunk, supplied at insert and immutable
 /// thereafter (merges mint new chunks, so a chunk's generation never
 /// changes). Hints steer policy — eviction order and write-behind
@@ -402,6 +440,10 @@ struct ChunkMeta {
     /// The insert-time [`ChunkHints`] depth; immutable. Names the eviction
     /// band the chunk's queue entries belong to.
     depth: u8,
+    /// The insert-time [`ExtentCodec`]; immutable. Encodes the chunk when it
+    /// is backed and decodes its extent on reads, so it must outlive any
+    /// extent it produced, hence `'static`.
+    codec: &'static dyn ExtentCodec,
     state: Mutex<ChunkState>,
 }
 
@@ -434,6 +476,7 @@ impl ChunkMeta {
         len: usize,
         class: Option<usize>,
         depth: u8,
+        codec: &'static dyn ExtentCodec,
         residency: Residency,
         slot: Option<u32>,
         oversize: Option<Vec<u64>>,
@@ -443,6 +486,7 @@ impl ChunkMeta {
             len,
             class,
             depth,
+            codec,
             state: Mutex::new(ChunkState {
                 residency,
                 touched: false,
@@ -520,6 +564,10 @@ impl Pool {
     /// staging through caller-side buffers that fault their own pages and
     /// die immediately after.
     ///
+    /// `codec` is the chunk's [`ExtentCodec`], fixed for its lifetime: the
+    /// pool invokes it whenever the chunk moves across the extent boundary,
+    /// and takes no interest in the stored form it produces.
+    ///
     /// Relies on abort-on-panic: a panic in `fill` that was caught would
     /// leak the slot and its resident-bytes accounting. All hosting
     /// binaries abort via `mz_ore::panic::install_enhanced_handler`, and
@@ -529,6 +577,7 @@ impl Pool {
         &self,
         len: usize,
         hints: ChunkHints,
+        codec: &'static dyn ExtentCodec,
         fill: impl FnOnce(&mut [u64]),
     ) -> ChunkHandle {
         let inner = &self.0;
@@ -541,6 +590,7 @@ impl Pool {
                 0,
                 None,
                 hints.depth,
+                codec,
                 Residency::UnbackedResident,
                 None,
                 None,
@@ -592,6 +642,7 @@ impl Pool {
                     len,
                     Some(class),
                     hints.depth,
+                    codec,
                     Residency::UnbackedResident,
                     Some(slot),
                     None,
@@ -609,6 +660,7 @@ impl Pool {
                     len,
                     None,
                     hints.depth,
+                    codec,
                     Residency::Oversize,
                     None,
                     Some(payload),
@@ -1037,7 +1089,8 @@ impl PoolInner {
                 // Inline eviction runs on whichever thread tripped the
                 // budget, so the compression scratch must not stay parked
                 // on it.
-                let extent = SwapExtent::write(&self.extent_arena, data, Scratch::Shrink);
+                let extent =
+                    SwapExtent::write(&self.extent_arena, data, meta.codec, Scratch::Shrink);
                 self.counters
                     .evictions_compress
                     .fetch_add(1, Ordering::Relaxed);
@@ -1213,7 +1266,7 @@ impl PoolInner {
         let data = unsafe { self.slot_data(meta, slot) };
         // Spill threads see a steady job stream, so they keep the grown
         // compression scratch for the next job.
-        let extent = SwapExtent::write(&self.extent_arena, data, Scratch::Retain);
+        let extent = SwapExtent::write(&self.extent_arena, data, meta.codec, Scratch::Retain);
         // Commit under the lock.
         let mut state = meta.state();
         if state.freed {
@@ -1921,7 +1974,7 @@ impl ChunkHandle {
                         let slot_bytes = unsafe {
                             std::slice::from_raw_parts_mut(region.slot_ptr(slot), meta.len_bytes())
                         };
-                        extent.read_into(slot_bytes);
+                        extent.read_into(meta.codec, slot_bytes);
                         state.slot = Some(slot);
                         state.residency = Residency::BackedResident;
                         // SAFETY: the slot belongs to this chunk while the
@@ -1953,7 +2006,12 @@ impl ChunkHandle {
                         // gauge; the design doc's reader discipline).
                         dst.resize(range.end - range.start, 0);
                         let bytes: &mut [u8] = bytemuck::cast_slice_mut(dst.as_mut_slice());
-                        extent.read_range_into(range.start * 8, bytes);
+                        extent.read_range_into(
+                            meta.codec,
+                            meta.len_bytes(),
+                            range.start * 8,
+                            bytes,
+                        );
                     }
                 }
                 // TODO: a sub-range read of a rangeable stored form (file
@@ -2092,6 +2150,7 @@ impl Drop for ChunkHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pool::extent::TEST_CODEC;
 
     /// Keep test pools small: 64 MiB of virtual reservation per class.
     /// Under Miri the backing is real interpreter heap rather than lazy
@@ -2125,7 +2184,7 @@ mod tests {
     /// Copies `data` into the pool at a hinted depth and clears it.
     fn insert_at_depth(pool: &Pool, depth: u8, data: &mut Vec<u64>) -> ChunkHandle {
         let hints = ChunkHints { depth };
-        let handle = pool.insert_with(data.len(), hints, |dst| {
+        let handle = pool.insert_with(data.len(), hints, &TEST_CODEC, |dst| {
             dst.copy_from_slice(data.as_slice())
         });
         data.clear();
@@ -3543,7 +3602,7 @@ mod tests {
     fn insert_with_fills_in_place() {
         let pool = test_pool(usize::MAX);
         let want = payload(SMALL, 600);
-        let h = pool.insert_with(SMALL, ChunkHints::default(), |dst| {
+        let h = pool.insert_with(SMALL, ChunkHints::default(), &TEST_CODEC, |dst| {
             assert_eq!(dst.len(), SMALL, "fill sees exactly the chunk length");
             dst.copy_from_slice(&want);
         });
@@ -3553,10 +3612,14 @@ mod tests {
         assert_eq!(read(&h), want, "round-trips through the extent");
 
         // Empty and oversize take their fallback paths.
-        let empty = pool.insert_with(0, ChunkHints::default(), |dst| assert!(dst.is_empty()));
+        let empty = pool.insert_with(0, ChunkHints::default(), &TEST_CODEC, |dst| {
+            assert!(dst.is_empty())
+        });
         assert!(read(&empty).is_empty());
         let big_len = (SIZE_CLASSES[SIZE_CLASSES.len() - 1] / 8) + 1;
-        let big = pool.insert_with(big_len, ChunkHints::default(), |dst| dst.fill(7));
+        let big = pool.insert_with(big_len, ChunkHints::default(), &TEST_CODEC, |dst| {
+            dst.fill(7)
+        });
         assert_eq!(big.residency(), Residency::Oversize);
         assert_eq!(read(&big).len(), big_len);
     }

--- a/src/ore/src/pool.rs
+++ b/src/ore/src/pool.rs
@@ -50,9 +50,13 @@
 //! declines surfaces as `extent_pageout_incomplete` (and a tier settled
 //! above its capacity) instead of as RSS the ledger cannot see.
 //!
-//! Residency is a state, not a type, and it only descends: a chunk starts
-//! resident and, once evicted, serves reads from its extent for the rest of
-//! its life. Eviction I/O runs on spill threads when enabled —
+//! Residency is a state, not a type. It descends through eviction and
+//! ascends through exactly one transition: an admitting read
+//! ([`ChunkHandle::read_into_admit`]) lifts an evicted chunk back to
+//! `BackedResident` when a slot is free within the budget or stealable from
+//! a clean backed victim of the same class, never by evicting or
+//! compressing anything. Plain reads ([`ChunkHandle::read_into`]) leave
+//! residency untouched. Eviction I/O runs on spill threads when enabled —
 //! `WriteInFlight` marks a chunk whose compression a spill thread owns — and
 //! inline on the evicting caller otherwise. Chunks are immutable after
 //! [`Pool::insert_with`], which is what makes a `BackedResident` slot always
@@ -128,7 +132,8 @@ enum Residency {
     /// Extent copy only; the chunk holds no slot. The extent itself may
     /// still be RAM-resident (the compressed tier) or paged out to the swap
     /// device. Reads decompress the extent straight into the caller's
-    /// buffer; the chunk allocates no slot and stays evicted.
+    /// buffer and leave the chunk evicted, except that an admitting read
+    /// may lift it back to [`Residency::BackedResident`].
     Evicted,
     /// Larger than the largest size class; held as a plain heap allocation,
     /// always resident. A prototype limitation, not a design state.
@@ -185,6 +190,16 @@ pub struct PoolStats {
     /// (write-behind): still readable in their slots, with eviction
     /// pre-paid.
     pub eager_backs: u64,
+    /// Evicted chunks re-admitted to `BackedResident` by an admitting read
+    /// out of free budget headroom.
+    pub admissions_budget: u64,
+    /// Evicted chunks re-admitted to `BackedResident` by an admitting read
+    /// stealing the slot of a clean backed victim of the same size class.
+    /// The victim becomes `Evicted` with zero I/O and its extent intact.
+    pub admissions_steal: u64,
+    /// Admitting reads of evicted chunks that found neither budget headroom
+    /// nor a clean victim and were served as a plain decompress instead.
+    pub admissions_denied: u64,
     /// Allocation bytes of compressed extents currently resident — the
     /// compressed-but-resident middle tier. Bounded by the RSS target;
     /// exceeding it pages the oldest extents out to the swap device.
@@ -218,6 +233,9 @@ struct Counters {
     warm_bytes: AtomicU64,
     warm_reuses: AtomicU64,
     eager_backs: AtomicU64,
+    admissions_budget: AtomicU64,
+    admissions_steal: AtomicU64,
+    admissions_denied: AtomicU64,
     extent_resident_bytes: AtomicU64,
     extent_pageouts: AtomicU64,
     extent_pageout_incomplete: AtomicU64,
@@ -239,9 +257,13 @@ pub struct Pool(Arc<PoolInner>);
 /// and the region slot allocators — but never the reverse. The enforcement
 /// and backing scans additionally drop the queue guard before trying a
 /// chunk's state lock (and only ever `try_lock` it), so no path holds a
-/// queue lock while waiting on chunk state. Reads copy out under the chunk's
-/// state lock — the same lock eviction takes — so there is no reader-side
-/// count and no reader the evictor must account for.
+/// queue lock while waiting on chunk state. The admitting read's victim
+/// steal is the one place a chunk's state lock is held while probing
+/// another chunk's, and the victim is only ever `try_lock`ed, so two
+/// admitters stealing toward each other skip instead of deadlocking. Reads
+/// copy out under the chunk's state lock — the same lock eviction takes —
+/// so there is no reader-side count and no reader the evictor must account
+/// for.
 #[derive(Debug)]
 struct PoolInner {
     /// Resident-bytes target. Atomic so a running pool can be retuned in
@@ -257,9 +279,9 @@ struct PoolInner {
     /// One region per entry of [`SIZE_CLASSES`], same order.
     regions: Vec<Region>,
     /// Second-chance FIFOs of eviction candidates, one per depth band; a
-    /// chunk joins the band of its [`ChunkHints`] depth at insert. Entries
-    /// for freed chunks go stale in place and are dropped by
-    /// [`PoolInner::prune_queues`].
+    /// chunk joins the band of its [`ChunkHints`] depth at insert and again
+    /// on re-admission. Entries for freed chunks go stale in place and are
+    /// dropped by [`PoolInner::prune_queues`].
     ///
     /// Two scanners walk them with different obligations, both visiting the
     /// deepest band first. Budget enforcement is the one that ages chunks:
@@ -569,6 +591,9 @@ impl Pool {
             warm_bytes: c.warm_bytes.load(Ordering::Relaxed),
             warm_reuses: c.warm_reuses.load(Ordering::Relaxed),
             eager_backs: c.eager_backs.load(Ordering::Relaxed),
+            admissions_budget: c.admissions_budget.load(Ordering::Relaxed),
+            admissions_steal: c.admissions_steal.load(Ordering::Relaxed),
+            admissions_denied: c.admissions_denied.load(Ordering::Relaxed),
             extent_resident_bytes: c.extent_resident_bytes.load(Ordering::Relaxed),
             extent_pageouts: c.extent_pageouts.load(Ordering::Relaxed),
             extent_pageout_incomplete: c.extent_pageout_incomplete.load(Ordering::Relaxed),
@@ -895,10 +920,11 @@ impl PoolInner {
                 if state.freed {
                     false
                 } else if matches!(state.residency, Residency::Evicted | Residency::Oversize) {
-                    // Nothing to evict: drop the entry. Evicted chunks never
-                    // rejoin the queue (reads are copy-out and leave them
-                    // evicted), so it stays proportional to the resident set
-                    // rather than accumulating every chunk ever evicted.
+                    // Nothing to evict: drop the entry. A chunk re-enters
+                    // the queue only when it becomes resident again (insert
+                    // or re-admission), so the queue stays proportional to
+                    // the resident set rather than accumulating every chunk
+                    // ever evicted.
                     false
                 } else if state.touched {
                     state.touched = false;
@@ -1199,24 +1225,30 @@ impl PoolInner {
             .is_ok()
     }
 
-    /// Allocates a slot in `class`: a warm allocation is counted as a reuse,
-    /// an exhausted class as a heap fallback for a `len_bytes` payload
-    /// (warned about once). `None` means the caller must degrade to the
-    /// heap.
+    /// Allocates a slot in `class` with warm-pool accounting (a warm
+    /// allocation is counted as a reuse), or `None` when the class has no
+    /// free slot.
+    fn try_alloc_slot(&self, class: usize) -> Option<u32> {
+        let (index, warm) = self.regions[class].alloc()?;
+        if warm {
+            // The allocation faulted no pages; its bytes leave the warm
+            // pool.
+            let class_bytes = u64::cast_from(self.regions[class].class_size());
+            self.counters
+                .warm_bytes
+                .fetch_sub(class_bytes, Ordering::Relaxed);
+            self.counters.warm_reuses.fetch_add(1, Ordering::Relaxed);
+        }
+        Some(index)
+    }
+
+    /// Allocates a slot in `class` for an insert: as
+    /// [`PoolInner::try_alloc_slot`], with an exhausted class counted as a
+    /// heap fallback for a `len_bytes` payload (warned about once). `None`
+    /// means the caller must degrade to the heap.
     fn alloc_slot(&self, class: usize, len_bytes: usize) -> Option<u32> {
-        match self.regions[class].alloc() {
-            Some((index, warm)) => {
-                if warm {
-                    // The allocation faulted no pages; its bytes leave the
-                    // warm pool.
-                    let class_bytes = u64::cast_from(self.regions[class].class_size());
-                    self.counters
-                        .warm_bytes
-                        .fetch_sub(class_bytes, Ordering::Relaxed);
-                    self.counters.warm_reuses.fetch_add(1, Ordering::Relaxed);
-                }
-                Some(index)
-            }
+        match self.try_alloc_slot(class) {
+            Some(index) => Some(index),
             None => {
                 self.counters
                     .slot_exhausted_fallbacks
@@ -1232,6 +1264,129 @@ impl PoolInner {
                 None
             }
         }
+    }
+
+    /// Acquires a slot for re-admitting an evicted chunk, from free budget
+    /// headroom or by stealing a clean backed victim's slot, never by
+    /// evicting or compressing anything. `None` counts a denied admission.
+    /// On success the admitted chunk's resident-bytes accounting and the
+    /// admission counter are settled, and the caller (who holds the chunk's
+    /// state lock) owns the slot: its contents are unspecified (fresh,
+    /// warm, or the victim's stale bytes) and must be fully overwritten.
+    fn admit_slot(&self, meta: &ChunkMeta) -> Option<u32> {
+        let class = meta.class.expect("evicted chunk has a class");
+        let len_bytes = u64::cast_from(meta.len_bytes());
+        // Free budget first: reserve the bytes, then a slot. The
+        // reservation never pushes resident bytes past the budget, and a
+        // class with no free slot hands the reservation back rather than
+        // evicting anything to make room.
+        let reserved = self
+            .counters
+            .resident_bytes
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+                let next = cur.checked_add(len_bytes)?;
+                (next <= self.budget_bytes.load(Ordering::Relaxed)).then_some(next)
+            })
+            .is_ok();
+        if reserved {
+            if let Some(slot) = self.try_alloc_slot(class) {
+                self.counters
+                    .admissions_budget
+                    .fetch_add(1, Ordering::Relaxed);
+                return Some(slot);
+            }
+            self.counters
+                .resident_bytes
+                .fetch_sub(len_bytes, Ordering::Relaxed);
+        }
+        if let Some(slot) = self.steal_clean_victim(class) {
+            // The victim's bytes left the ledger inside the steal and the
+            // admitted chunk's enter here. The slot's physical pages
+            // transfer untouched, so residency moves only by the
+            // intra-class length difference between the two chunks.
+            self.counters
+                .resident_bytes
+                .fetch_add(len_bytes, Ordering::Relaxed);
+            self.counters
+                .admissions_steal
+                .fetch_add(1, Ordering::Relaxed);
+            return Some(slot);
+        }
+        self.counters
+            .admissions_denied
+            .fetch_add(1, Ordering::Relaxed);
+        None
+    }
+
+    /// Takes the slot of a clean victim in `class`: a `BackedResident`
+    /// chunk with a clear touched bit, whose extent already duplicates its
+    /// slot, so the victim transitions to `Evicted` with zero I/O, its
+    /// extent intact, and its queue entry dropped. The returned slot keeps
+    /// its physical pages (no `dontneed`, no free-list round trip). They
+    /// hold the victim's stale bytes, and the victim's resident bytes have
+    /// left the ledger. `None` when the bounded scan finds no such victim.
+    ///
+    /// The caller holds its own chunk's state lock. The scan follows the
+    /// enforcement discipline (deepest band first, queue guard dropped
+    /// before any chunk lock, victims only ever `try_lock`ed), which is
+    /// what keeps the chunk-lock-while-probing-chunk-lock window
+    /// deadlock-free: two admitters stealing toward each other both fail
+    /// the `try_lock` and skip.
+    fn steal_clean_victim(&self, class: usize) -> Option<u32> {
+        // Bound on entries examined per band before moving to the next.
+        // The budget is per band, not shared across the scan: a deep band
+        // densely populated with touched resident chunks (a probe-heavy
+        // arrangement whose reads refresh every bit) would otherwise spend
+        // the entire scan on hopeless candidates and starve the shallower
+        // bands where the clean-victim stock actually sits (eager backing
+        // stocks young backed chunks in band zero). Eight visits per band
+        // absorb a handful of lock-busy or freshly touched entries without
+        // degrading a hopeless scan into a full queue walk, and cap the
+        // whole scan at eight times the band count.
+        const VISITS_PER_BAND: usize = 8;
+        for band in (0..DEPTH_BANDS).rev() {
+            let mut visits = VISITS_PER_BAND;
+            while visits > 0 {
+                let popped = self.queue(band).pop_front();
+                let Some(weak) = popped else {
+                    // Band exhausted; the next band has its own budget.
+                    break;
+                };
+                let Some(meta) = weak.upgrade() else {
+                    // Stale entries drop for free and do not spend a visit.
+                    continue;
+                };
+                visits -= 1;
+                let Ok(mut state) = meta.state.try_lock() else {
+                    self.queue(band).push_back(weak);
+                    continue;
+                };
+                if state.freed {
+                    continue;
+                }
+                match state.residency {
+                    // Entries for non-resident chunks drop, as in
+                    // enforcement.
+                    Residency::Evicted | Residency::Oversize => continue,
+                    Residency::UnbackedResident | Residency::WriteInFlight => {
+                        self.queue(band).push_back(weak);
+                        continue;
+                    }
+                    Residency::BackedResident => {}
+                }
+                if state.touched || meta.class != Some(class) {
+                    self.queue(band).push_back(weak);
+                    continue;
+                }
+                let slot = state.slot.take().expect("backed chunk has a slot");
+                state.residency = Residency::Evicted;
+                self.counters
+                    .resident_bytes
+                    .fetch_sub(u64::cast_from(meta.len_bytes()), Ordering::Relaxed);
+                return Some(slot);
+            }
+        }
+        None
     }
 
     /// Capacity of the compressed-resident tier: the RSS target's headroom
@@ -1414,8 +1569,27 @@ impl ChunkHandle {
     ///
     /// The copy runs under the chunk's state lock, which is what makes the
     /// no-reference contract cheap: eviction takes the same lock, so there
-    /// is no reader it could race.
+    /// is no reader it could race. The admitting variant is
+    /// [`ChunkHandle::read_into_admit`].
     pub fn read_into(&self, dst: &mut Vec<u64>) {
+        self.read_impl(dst, false);
+    }
+
+    /// As [`ChunkHandle::read_into`], except that an evicted chunk is
+    /// re-admitted to `BackedResident` (its extent kept, its touched bit
+    /// set) when a slot is available from free budget headroom or by
+    /// stealing from a clean backed victim of the same size class, never by
+    /// evicting or compressing anything. When neither source yields a slot
+    /// the read is served as a plain decompress and the chunk stays
+    /// evicted.
+    pub fn read_into_admit(&self, dst: &mut Vec<u64>) {
+        self.read_impl(dst, true);
+    }
+
+    /// Shared body of the copy-out reads: fills `dst` under the chunk's
+    /// state lock, re-admitting an evicted chunk when `admit` is set and a
+    /// slot is available.
+    fn read_impl(&self, dst: &mut Vec<u64>, admit: bool) {
         dst.clear();
         let meta = &*self.meta;
         if meta.len == 0 {
@@ -1430,22 +1604,62 @@ impl ChunkHandle {
                 dst.extend_from_slice(payload);
             }
             Residency::Evicted => {
-                // The zero-fill ahead of the decompress is deliberate waste
-                // (~a tenth of the decompress cost): the extent read takes an
-                // initialized `&mut [u8]`, so skipping the fill would mean
-                // exposing uninitialized memory through a safe reference.
-                // Callers that read repeatedly amortize it by reusing `dst`'s
-                // capacity.
-                dst.resize(meta.len, 0);
-                let bytes: &mut [u8] = bytemuck::cast_slice_mut(dst.as_mut_slice());
+                let slot = if admit {
+                    meta.pool.admit_slot(meta)
+                } else {
+                    None
+                };
                 let extent = state.extent.as_mut().expect("evicted chunk has an extent");
-                // Reading faults the extent's pages back in; re-count it
-                // against the compressed tier.
+                // Reading faults the extent's pages back in either way, so
+                // it is re-counted against the compressed tier below.
                 let was_resident = extent.is_resident();
-                extent.read_into(bytes);
+                let extent_alloc = extent.alloc_size();
+                match slot {
+                    Some(slot) => {
+                        // Admission: the extent decompresses straight into
+                        // the acquired slot, fully overwriting its
+                        // unspecified prior contents, and the caller's
+                        // buffer is filled from the slot.
+                        let region = meta.pool.region_of(meta);
+                        // SAFETY: the slot was acquired for this chunk
+                        // under its held state lock (freshly allocated, or
+                        // transferred from the victim under the victim's
+                        // lock), so it is exclusively owned with no other
+                        // reference into it, and `len_bytes` fits the
+                        // class.
+                        let slot_bytes = unsafe {
+                            std::slice::from_raw_parts_mut(region.slot_ptr(slot), meta.len_bytes())
+                        };
+                        extent.read_into(slot_bytes);
+                        state.slot = Some(slot);
+                        state.residency = Residency::BackedResident;
+                        // SAFETY: the slot belongs to this chunk while the
+                        // state lock is held (eviction and free both take
+                        // it).
+                        let src = unsafe { meta.pool.slot_data(meta, slot) };
+                        dst.extend_from_slice(src);
+                        // Resident again: rejoin the eviction candidates.
+                        // A leftover entry from before the chunk's eviction
+                        // is a harmless duplicate, since each entry is
+                        // validated against the chunk's state on visit.
+                        meta.pool
+                            .queue(band(meta.depth))
+                            .push_back(Arc::downgrade(&self.meta));
+                    }
+                    None => {
+                        // The zero-fill ahead of the decompress is deliberate
+                        // waste (~a tenth of the decompress cost): the extent
+                        // read takes an initialized `&mut [u8]`, so skipping
+                        // the fill would mean exposing uninitialized memory
+                        // through a safe reference. Callers that read
+                        // repeatedly amortize it by reusing `dst`'s capacity.
+                        dst.resize(meta.len, 0);
+                        let bytes: &mut [u8] = bytemuck::cast_slice_mut(dst.as_mut_slice());
+                        extent.read_into(bytes);
+                    }
+                }
                 if !was_resident {
-                    let alloc = extent.alloc_size();
-                    meta.pool.note_extent_resident(&self.meta, alloc);
+                    meta.pool.note_extent_resident(&self.meta, extent_alloc);
                     extent_revived = true;
                 }
             }
@@ -1466,8 +1680,9 @@ impl ChunkHandle {
         }
     }
 
-    /// Copies the whole contents into `dst` (per [`ChunkHandle::read_into`])
-    /// and frees the chunk, cancelling any in-flight backing write.
+    /// Copies the whole contents into `dst` (per [`ChunkHandle::read_into`],
+    /// never admitting) and frees the chunk, cancelling any in-flight
+    /// backing write.
     pub fn take(self, dst: &mut Vec<u64>) {
         self.read_into(dst);
     }
@@ -1593,6 +1808,14 @@ mod tests {
     fn read(handle: &ChunkHandle) -> Vec<u64> {
         let mut out = Vec::new();
         handle.read_into(&mut out);
+        out
+    }
+
+    /// Copies a chunk's contents out into a fresh buffer via the admitting
+    /// read.
+    fn read_admit(handle: &ChunkHandle) -> Vec<u64> {
+        let mut out = Vec::new();
+        handle.read_into_admit(&mut out);
         out
     }
 
@@ -1931,6 +2154,259 @@ mod tests {
         assert_eq!(read(&handle), orig);
         assert_eq!(handle.residency(), Residency::Evicted);
         assert_eq!(pool.stats().resident_bytes, 0, "reads copy out");
+    }
+
+    /// An admitting read of an evicted chunk with budget headroom re-admits
+    /// it: contents round-trip, the chunk lands `BackedResident` with its
+    /// extent kept, and later reads serve from the slot without touching
+    /// the extent.
+    #[mz_ore::test]
+    fn admit_from_free_budget_backs_the_chunk() {
+        let pool = test_pool(256 << 20);
+        let orig = payload(SMALL, 70);
+        let handle = insert(&pool, &mut orig.clone());
+        pool.evict(&handle);
+        assert_eq!(handle.residency(), Residency::Evicted);
+        assert_eq!(pool.stats().resident_bytes, 0);
+
+        pool.poison_free_slots();
+        assert_eq!(read_admit(&handle), orig);
+        assert_eq!(handle.residency(), Residency::BackedResident);
+        let stats = pool.stats();
+        assert_eq!(stats.admissions_budget, 1);
+        assert_eq!(stats.admissions_steal, 0);
+        assert_eq!(stats.admissions_denied, 0);
+        assert_eq!(stats.resident_bytes, 64 << 10);
+
+        // Later reads serve from the slot and never touch the extent: a
+        // decompress would revive its pages and move the revival and
+        // pageout counters.
+        let pageouts = stats.extent_pageouts;
+        let extent_resident = stats.extent_resident_bytes;
+        assert_eq!(read(&handle), orig);
+        assert_eq!(handle.residency(), Residency::BackedResident);
+        let stats = pool.stats();
+        assert_eq!(stats.extent_pageouts, pageouts);
+        assert_eq!(stats.extent_resident_bytes, extent_resident);
+
+        // The kept extent pre-pays the next eviction, and round-trips.
+        pool.evict(&handle);
+        assert_eq!(handle.residency(), Residency::Evicted);
+        let stats = pool.stats();
+        assert_eq!(stats.evictions_cheap, 1);
+        assert_eq!(stats.evictions_compress, 1, "admission wrote no extent");
+        pool.poison_free_slots();
+        assert_eq!(read(&handle), orig);
+        drop(handle);
+        assert_eq!(pool.stats().resident_bytes, 0);
+    }
+
+    /// With the budget pinned full and a clean backed victim of the same
+    /// class, an admitting read steals the victim's slot: the victim is
+    /// evicted with zero I/O and its extent intact, the admitted chunk
+    /// lands `BackedResident`, and resident bytes, warm bytes, and the
+    /// compression and pageout counters are all unchanged.
+    #[mz_ore::test]
+    fn admit_steals_clean_victim_slot() {
+        let pool = test_pool(256 << 20);
+        pool.set_rss_target(1 << 30);
+        let victim_orig = payload(SMALL, 71);
+        let target_orig = payload(SMALL, 72);
+        let victim = insert(&pool, &mut victim_orig.clone());
+        let target = insert(&pool, &mut target_orig.clone());
+        pool.evict(&target);
+        assert!(pool.back_step(), "victim is backable");
+        assert_eq!(victim.residency(), Residency::BackedResident);
+        // The budget now holds exactly the victim: no admission headroom.
+        pool.set_budget(64 << 10);
+        assert_eq!(victim.residency(), Residency::BackedResident);
+        let before = pool.stats();
+
+        assert_eq!(read_admit(&target), target_orig);
+        assert_eq!(target.residency(), Residency::BackedResident);
+        assert_eq!(victim.residency(), Residency::Evicted);
+        let after = pool.stats();
+        assert_eq!(after.admissions_steal, 1);
+        assert_eq!(after.admissions_budget, 0);
+        assert_eq!(after.admissions_denied, 0);
+        assert_eq!(
+            after.resident_bytes, before.resident_bytes,
+            "same class, same bytes",
+        );
+        assert_eq!(
+            after.evictions_compress, before.evictions_compress,
+            "no compression",
+        );
+        assert_eq!(
+            after.evictions_cheap, before.evictions_cheap,
+            "a steal is not an enforcement eviction",
+        );
+        assert_eq!(after.extent_bytes_written, before.extent_bytes_written);
+        assert_eq!(after.extent_pageouts, 0, "no pageout");
+        assert_eq!(
+            after.warm_bytes, before.warm_bytes,
+            "the stolen slot skipped the free list",
+        );
+        assert_eq!(after.warm_reuses, before.warm_reuses);
+
+        // The victim's extent is intact: its old slot now holds the
+        // admitted chunk's bytes, so a correct read must come from the
+        // extent.
+        assert_eq!(read(&victim), victim_orig);
+        assert_eq!(victim.residency(), Residency::Evicted);
+
+        drop(victim);
+        drop(target);
+        let stats = pool.stats();
+        assert_eq!(stats.resident_bytes, 0);
+        assert_eq!(stats.extent_resident_bytes, 0);
+    }
+
+    /// With the budget full and every candidate touched, the admitting read
+    /// still returns correct data, the chunk stays evicted, and the denial
+    /// counter increments.
+    #[mz_ore::test]
+    fn admit_denied_when_victims_touched() {
+        let pool = test_pool(256 << 20);
+        let victim_orig = payload(SMALL, 73);
+        let target_orig = payload(SMALL, 74);
+        let victim = insert(&pool, &mut victim_orig.clone());
+        let target = insert(&pool, &mut target_orig.clone());
+        pool.evict(&target);
+        assert!(pool.back_step());
+        // Reading the victim sets its second-chance bit, disqualifying it.
+        assert_eq!(read(&victim), victim_orig);
+        pool.set_budget(64 << 10);
+        let resident = pool.stats().resident_bytes;
+
+        assert_eq!(read_admit(&target), target_orig);
+        assert_eq!(target.residency(), Residency::Evicted);
+        assert_eq!(victim.residency(), Residency::BackedResident);
+        let stats = pool.stats();
+        assert_eq!(stats.admissions_denied, 1);
+        assert_eq!(stats.admissions_budget, 0);
+        assert_eq!(stats.admissions_steal, 0);
+        assert_eq!(stats.resident_bytes, resident);
+    }
+
+    /// An unbacked resident candidate is never stolen from: evicting it
+    /// would require the compression that admission forbids.
+    #[mz_ore::test]
+    fn admit_denied_when_victims_unbacked() {
+        let pool = test_pool(256 << 20);
+        let victim = insert(&pool, &mut payload(SMALL, 75));
+        let target_orig = payload(SMALL, 76);
+        let target = insert(&pool, &mut target_orig.clone());
+        pool.evict(&target);
+        pool.set_budget(64 << 10);
+        assert_eq!(read_admit(&target), target_orig);
+        assert_eq!(target.residency(), Residency::Evicted);
+        assert_eq!(victim.residency(), Residency::UnbackedResident);
+        assert_eq!(pool.stats().admissions_denied, 1);
+    }
+
+    /// A clean backed victim of a different size class is never stolen
+    /// from: slot reuse in place requires the classes to match.
+    #[mz_ore::test]
+    fn admit_denied_when_victims_wrong_class() {
+        let pool = test_pool(256 << 20);
+        // The victim fills the 128 KiB class; the target lives in the
+        // 64 KiB one.
+        let victim = insert(&pool, &mut payload(2 * SMALL, 77));
+        let target_orig = payload(SMALL, 78);
+        let target = insert(&pool, &mut target_orig.clone());
+        pool.evict(&target);
+        assert!(pool.back_step());
+        assert_eq!(victim.residency(), Residency::BackedResident);
+        // The budget holds exactly the victim: no headroom for the target.
+        pool.set_budget(128 << 10);
+        assert_eq!(read_admit(&target), target_orig);
+        assert_eq!(target.residency(), Residency::Evicted);
+        assert_eq!(victim.residency(), Residency::BackedResident);
+        assert_eq!(pool.stats().admissions_denied, 1);
+    }
+
+    /// Plain reads and `take` never admit: an evicted chunk with plenty of
+    /// budget headroom stays evicted through both, and neither counts a
+    /// denial.
+    #[mz_ore::test]
+    fn plain_read_and_take_never_admit() {
+        let pool = test_pool(256 << 20);
+        let orig = payload(SMALL, 79);
+        let handle = insert(&pool, &mut orig.clone());
+        pool.evict(&handle);
+        assert_eq!(read(&handle), orig);
+        assert_eq!(handle.residency(), Residency::Evicted);
+        assert_eq!(pool.stats().resident_bytes, 0);
+        let mut out = Vec::new();
+        handle.take(&mut out);
+        assert_eq!(out, orig);
+        let stats = pool.stats();
+        assert_eq!(stats.admissions_budget, 0);
+        assert_eq!(stats.admissions_steal, 0);
+        assert_eq!(stats.admissions_denied, 0);
+        assert_eq!(stats.resident_bytes, 0);
+        assert_eq!(stats.frees, 1);
+    }
+
+    /// A re-admitted chunk keeps its insert-time depth: under budget
+    /// pressure it is evicted from its own deeper band before a younger
+    /// band-0 chunk, which a re-admission into band 0 would have inverted.
+    #[mz_ore::test]
+    fn admitted_chunk_keeps_its_depth() {
+        let pool = test_pool(256 << 20);
+        let deep_orig = payload(SMALL, 80);
+        let deep = insert_at_depth(&pool, 2, &mut deep_orig.clone());
+        let young = insert(&pool, &mut payload(SMALL, 81));
+        pool.evict(&deep);
+        assert_eq!(read_admit(&deep), deep_orig);
+        assert_eq!(deep.residency(), Residency::BackedResident);
+        assert_eq!(pool.stats().admissions_budget, 1);
+
+        // Budget of one chunk: enforcement visits the deep band first.
+        pool.set_budget(64 << 10);
+        assert_eq!(deep.residency(), Residency::Evicted);
+        assert_eq!(young.residency(), Residency::UnbackedResident);
+        assert_eq!(
+            pool.stats().evictions_cheap,
+            1,
+            "the extent kept through admission pre-paid the eviction",
+        );
+    }
+
+    /// Admitting reads racing enforcement, opposing steals, and frees:
+    /// contents stay correct, contended steals degrade to skips, and the
+    /// accounting identity settles to zero.
+    #[mz_ore::test]
+    fn concurrent_admits_race_cleanly() {
+        let pool = test_pool(64 << 10);
+        let per_thread = rounds(50, 3);
+        let threads: Vec<_> = (0..4u64)
+            .map(|t| {
+                let pool = pool.clone();
+                std::thread::spawn(move || {
+                    let mut out = Vec::new();
+                    for round in 0..per_thread {
+                        let orig = payload(SMALL, t * 1000 + round);
+                        let handle = insert(&pool, &mut orig.clone());
+                        pool.evict(&handle);
+                        handle.read_into_admit(&mut out);
+                        assert_eq!(out, orig);
+                        handle.read_into_admit(&mut out);
+                        assert_eq!(out, orig);
+                        assert_eq!(read(&handle), orig);
+                    }
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().expect("worker thread panicked");
+        }
+        let stats = pool.stats();
+        assert_eq!(stats.inserts, 4 * per_thread);
+        assert_eq!(stats.frees, 4 * per_thread);
+        assert_eq!(stats.resident_bytes, 0);
+        assert_eq!(stats.extent_resident_bytes, 0);
     }
 
     /// Slots are scoped to residency: eviction releases the slot, so a

--- a/src/ore/src/pool.rs
+++ b/src/ore/src/pool.rs
@@ -79,6 +79,7 @@ mod extent;
 mod region;
 
 use std::collections::VecDeque;
+use std::ops::Range;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, Weak};
 
@@ -1827,7 +1828,20 @@ impl ChunkHandle {
     /// is no reader it could race. The admitting variant is
     /// [`ChunkHandle::read_into_admit`].
     pub fn read_into(&self, dst: &mut Vec<u64>) {
-        self.read_impl(dst, false);
+        self.read_impl(0..self.meta.len, dst, false);
+    }
+
+    /// As [`ChunkHandle::read_into`], restricted to the word range `range`
+    /// of the chunk's contents, which must lie within them. `dst` receives
+    /// exactly the range.
+    ///
+    /// The range narrows only the copy into `dst`: the swap backend's
+    /// stored form is a whole compressed block, so a cold read still
+    /// faults and decompresses the entire extent, and accounting is that
+    /// of a whole-chunk read. A backend with a rangeable stored form can
+    /// serve the same call with range-proportional I/O.
+    pub fn read_range_into(&self, range: Range<usize>, dst: &mut Vec<u64>) {
+        self.read_impl(range, dst, false);
     }
 
     /// As [`ChunkHandle::read_into`], except that an evicted chunk is
@@ -1844,16 +1858,31 @@ impl ChunkHandle {
     /// churns the clean-victim stock that eager backing exists to build,
     /// evicting probe targets to house data about to die.
     pub fn read_into_admit(&self, dst: &mut Vec<u64>) {
-        self.read_impl(dst, true);
+        self.read_impl(0..self.meta.len, dst, true);
     }
 
-    /// Shared body of the copy-out reads: fills `dst` under the chunk's
-    /// state lock, re-admitting an evicted chunk when `admit` is set and a
-    /// slot is available.
-    fn read_impl(&self, dst: &mut Vec<u64>, admit: bool) {
+    /// As [`ChunkHandle::read_into_admit`], restricted to the word range
+    /// `range` per [`ChunkHandle::read_range_into`]. Admission is
+    /// whole-chunk regardless of the range: the acquired slot holds the
+    /// entire body.
+    pub fn read_range_into_admit(&self, range: Range<usize>, dst: &mut Vec<u64>) {
+        self.read_impl(range, dst, true);
+    }
+
+    /// Shared body of the copy-out reads: fills `dst` with the word range
+    /// `range` of the chunk's contents under the chunk's state lock,
+    /// re-admitting an evicted chunk when `admit` is set and a slot is
+    /// available. An empty range returns without locking or touching the
+    /// chunk, like the whole-chunk read of an empty chunk always has.
+    fn read_impl(&self, range: Range<usize>, dst: &mut Vec<u64>, admit: bool) {
         dst.clear();
         let meta = &*self.meta;
-        if meta.len == 0 {
+        assert!(
+            range.start <= range.end && range.end <= meta.len,
+            "range {range:?} exceeds the chunk's {} words",
+            meta.len,
+        );
+        if range.is_empty() {
             return;
         }
         let mut state = meta.state();
@@ -1862,7 +1891,7 @@ impl ChunkHandle {
         match state.residency {
             Residency::Oversize => {
                 let payload = state.oversize.as_ref().expect("oversize chunk has payload");
-                dst.extend_from_slice(payload);
+                dst.extend_from_slice(&payload[range]);
             }
             Residency::Evicted => {
                 let slot = if admit {
@@ -1899,7 +1928,7 @@ impl ChunkHandle {
                         // state lock is held (eviction and free both take
                         // it).
                         let src = unsafe { meta.pool.slot_data(meta, slot) };
-                        dst.extend_from_slice(src);
+                        dst.extend_from_slice(&src[range.start..range.end]);
                         // Resident again: rejoin the eviction candidates.
                         // A leftover entry from before the chunk's eviction
                         // stays sound (each entry is validated against the
@@ -1922,11 +1951,15 @@ impl ChunkHandle {
                         // reused buffer otherwise ratchets to the largest
                         // chunk it ever carried, invisible to every pool
                         // gauge; the design doc's reader discipline).
-                        dst.resize(meta.len, 0);
+                        dst.resize(range.end - range.start, 0);
                         let bytes: &mut [u8] = bytemuck::cast_slice_mut(dst.as_mut_slice());
-                        extent.read_into(bytes);
+                        extent.read_range_into(range.start * 8, bytes);
                     }
                 }
+                // TODO: a sub-range read of a rangeable stored form (file
+                // extents, a sub-block-framed codec) revives only part of
+                // the extent; the whole-extent accounting below would then
+                // overcount and needs a partial-revival variant.
                 if !was_resident {
                     // Revived from the device: the decompress reset any
                     // retry budget, so the extent re-enters reclaimable.
@@ -1954,7 +1987,7 @@ impl ChunkHandle {
                 // SAFETY: the slot belongs to this chunk while the state lock
                 // is held (eviction and free both take it).
                 let src = unsafe { meta.pool.slot_data(meta, slot) };
-                dst.extend_from_slice(src);
+                dst.extend_from_slice(&src[range.start..range.end]);
             }
         }
         drop(state);
@@ -1982,6 +2015,15 @@ impl ChunkHandle {
             let extent = state.extent.as_ref().expect("evicted chunk has an extent");
             extent.prefetch();
         }
+    }
+
+    /// As [`ChunkHandle::prefetch`], scoped to the word range `range` of the
+    /// chunk's contents. The range is advisory: a backend hints at whatever
+    /// granularity its stored form permits, and the swap backend's stored
+    /// form is a whole compressed block, so it hints the entire extent.
+    pub fn prefetch_range(&self, range: Range<usize>) {
+        let _ = range;
+        self.prefetch();
     }
 
     /// Test hook: the byte size of the chunk's size class, or `None` for
@@ -2153,6 +2195,61 @@ mod tests {
         // Dropping the handle uncounts the resident extent.
         drop(handle);
         assert_eq!(pool.stats().extent_resident_bytes, 0);
+    }
+
+    /// A ranged read returns exactly the corresponding slice of a
+    /// whole-chunk read in every residency state, and changes residency
+    /// exactly as the equivalent whole-chunk read would.
+    #[mz_ore::test]
+    fn ranged_reads_match_full_read_slice() {
+        let pool = test_pool(256 << 20);
+        pool.set_rss_target(1 << 30);
+        let orig = payload(SMALL, 33);
+        let handle = insert(&pool, &mut orig.clone());
+        let ranges = [
+            (0usize, 7usize),
+            (13, 100),
+            (SMALL - 9, 9),
+            (0, SMALL),
+            (5, 0),
+        ];
+        let check = |label: &str| {
+            for (start, len) in ranges {
+                let mut out = Vec::new();
+                handle.read_range_into(start..start + len, &mut out);
+                assert_eq!(
+                    out,
+                    &orig[start..start + len],
+                    "{label} range ({start}, {len})"
+                );
+            }
+        };
+        assert_eq!(handle.residency(), Residency::UnbackedResident);
+        check("resident");
+        pool.evict(&handle);
+        assert_eq!(handle.residency(), Residency::Evicted);
+        check("evicted");
+        assert_eq!(
+            handle.residency(),
+            Residency::Evicted,
+            "plain ranged reads do not admit"
+        );
+        // An admitting ranged read returns the range and admits the whole
+        // chunk.
+        let mut out = Vec::new();
+        handle.read_range_into_admit(3..19, &mut out);
+        assert_eq!(out, &orig[3..19]);
+        assert_eq!(handle.residency(), Residency::BackedResident);
+        check("backed");
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "exceeds the chunk's")]
+    fn ranged_read_out_of_bounds_panics() {
+        let pool = test_pool(256 << 20);
+        let handle = insert(&pool, &mut payload(SMALL, 34));
+        let mut out = Vec::new();
+        handle.read_range_into(SMALL - 1..SMALL + 1, &mut out);
     }
 
     /// With no RSS target (the default), the compressed tier has zero

--- a/src/ore/src/pool/extent.rs
+++ b/src/ore/src/pool/extent.rs
@@ -16,13 +16,13 @@
 //! Swap-backed extents: the backing store for the buffer pool on nodes whose
 //! whole disk is provisioned as swap.
 //!
-//! An extent is a slot in the pool-owned [`ExtentArena`] holding the
-//! lz4-compressed bytes of one chunk. "Write" compresses into the slot. The
-//! slot stays resident, forming the compressed-but-resident middle tier of
-//! the pool's ladder, until the pool's RSS target forces
-//! [`SwapExtent::pageout`], which pushes the pages to the swap device with
-//! `MADV_PAGEOUT`. "Read" issues
-//! `MADV_WILLNEED` ahead of the decompress (and makes the pages resident
+//! An extent is a slot in the pool-owned [`ExtentArena`] holding the stored
+//! bytes of one chunk, produced by the chunk's [`ExtentCodec`] (lz4 in
+//! practice). "Write" encodes into the slot. The slot stays resident,
+//! forming the compressed-but-resident middle tier of the pool's ladder,
+//! until the pool's RSS target forces [`SwapExtent::pageout`], which pushes
+//! the pages to the swap device with `MADV_PAGEOUT`. "Read" issues
+//! `MADV_WILLNEED` ahead of the decode (and makes the pages resident
 //! again); "free" returns the slot to the arena with its pages discarded,
 //! which also drops any swapped copy for free. Chunk slots never reach the
 //! swap device: only these compressed extents are offered to it.
@@ -50,13 +50,8 @@ use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::cast::CastFrom;
 use crate::pool::region::{self, Region};
-
-/// Length in bytes of the little-endian `u32` uncompressed-size prefix that
-/// precedes the compressed bytes, matching the
-/// `lz4_flex::block::compress_prepend_size` framing.
-const SIZE_PREFIX: usize = 4;
+use crate::pool::{ExtentCodec, max_stored_len};
 
 /// Consecutive incomplete pageout passes after which an extent stops being
 /// advised out until a read faults it back in. Transient declines are
@@ -71,15 +66,15 @@ pub(crate) const PAGEOUT_RETRY_CAP: u8 = 3;
 
 /// The extent size-class ladder for a `page`-byte page size: `page`, then
 /// sizes of the form `2^k` and `3 * 2^(k-1)` bytes, up through the first
-/// class that fits lz4's worst case over the largest chunk size class.
-/// Every class is a multiple of `page` (the sub-page mid class between
-/// `page` and `2 * page` is skipped), so slot-granular paging advice is
-/// exact on any kernel page size. Consecutive classes above the smallest
-/// are within 1.5x of each other, which bounds a compressed payload's
-/// internal fragmentation below 1.5x (page-granular slack at the small
-/// end).
+/// class that fits [`max_stored_len`], the codec contract's worst case,
+/// over the largest chunk size class. Every class is a multiple of `page`
+/// (the sub-page mid class between `page` and `2 * page` is skipped), so
+/// slot-granular paging advice is exact on any kernel page size.
+/// Consecutive classes above the smallest are within 1.5x of each other,
+/// which bounds a stored payload's internal fragmentation below 1.5x
+/// (page-granular slack at the small end).
 fn extent_classes(page: usize) -> Vec<usize> {
-    let max_comp = SIZE_PREFIX + lz4_flex::block::get_maximum_output_size(max_chunk_bytes());
+    let max_comp = max_stored_len(max_chunk_bytes());
     let mut classes = vec![page];
     let mut base = 2 * page;
     loop {
@@ -209,21 +204,63 @@ pub(crate) enum Scratch {
 // goes through the owning chunk's state mutex.
 unsafe impl Send for SwapExtent {}
 
+/// lz4 codec for the pool's own tests, mirroring the production codec that
+/// lives with the chunk implementation: a little-endian `u32` body-length
+/// prefix followed by one lz4 block.
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct TestLz4Codec;
+
+#[cfg(test)]
+pub(crate) static TEST_CODEC: TestLz4Codec = TestLz4Codec;
+
+#[cfg(test)]
+impl ExtentCodec for TestLz4Codec {
+    fn encode(&self, body: &[u8], out: &mut Vec<u8>) {
+        let max_out = lz4_flex::block::get_maximum_output_size(body.len());
+        out.resize(4 + max_out, 0);
+        let len = u32::try_from(body.len()).expect("chunk payloads fit u32");
+        out[..4].copy_from_slice(&len.to_le_bytes());
+        let compressed = lz4_flex::block::compress_into(body, &mut out[4..])
+            .expect("output sized to the maximum");
+        out.truncate(4 + compressed);
+    }
+
+    fn decode(&self, stored: &[u8], body: &mut [u8]) {
+        let prefix: [u8; 4] = stored[..4].try_into().expect("prefix length");
+        let len = usize::try_from(u32::from_le_bytes(prefix)).expect("length fits usize");
+        assert_eq!(
+            len,
+            body.len(),
+            "destination must match the encoded body length"
+        );
+        let written = lz4_flex::block::decompress_into(&stored[4..], body)
+            .expect("stored bytes hold a valid lz4 block");
+        assert_eq!(written, body.len(), "decoded length mismatch");
+    }
+}
+
 impl SwapExtent {
-    /// Compresses `data` into a fresh extent, preferring an arena slot and
-    /// degrading to the heap when the payload's class is exhausted. The
-    /// pages stay resident; the pool's RSS-target enforcement decides when
-    /// [`SwapExtent::pageout`] pushes them to the device.
+    /// Encodes `data` through `codec` into a fresh extent, preferring an
+    /// arena slot and degrading to the heap when the payload's class is
+    /// exhausted. The pages stay resident; the pool's RSS-target
+    /// enforcement decides when [`SwapExtent::pageout`] pushes them to the
+    /// device.
     ///
-    /// Compression goes through a reused thread-local scratch buffer so the
-    /// extent slot can be chosen by the *actual* compressed payload rather
-    /// than lz4's worst case. Worst-case sizing costs ~5.6× on compressible
-    /// data, in swap capacity and in swap write bandwidth per eviction (the
-    /// whole allocation is paged out), which at hydration eviction rates
-    /// backs up device writeback and bloats the working set with swap-cache
-    /// pages. `scratch` says whether the caller's thread keeps the grown
-    /// scratch for its next job.
-    pub(crate) fn write(arena: &Arc<ExtentArena>, data: &[u64], scratch: Scratch) -> SwapExtent {
+    /// Encoding goes through a reused thread-local scratch buffer so the
+    /// extent slot can be chosen by the *actual* stored payload rather
+    /// than the codec's worst case. Worst-case sizing costs ~5.6× on
+    /// compressible data, in swap capacity and in swap write bandwidth per
+    /// eviction (the whole allocation is paged out), which at hydration
+    /// eviction rates backs up device writeback and bloats the working set
+    /// with swap-cache pages. `scratch` says whether the caller's thread
+    /// keeps the grown scratch for its next job.
+    pub(crate) fn write(
+        arena: &Arc<ExtentArena>,
+        data: &[u64],
+        codec: &dyn ExtentCodec,
+        scratch: Scratch,
+    ) -> SwapExtent {
         use std::cell::RefCell;
         thread_local! {
             static SCRATCH: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
@@ -231,14 +268,12 @@ impl SwapExtent {
         let bytes: &[u8] = bytemuck::cast_slice(data);
         SCRATCH.with(|cell| {
             let mut buf = cell.borrow_mut();
-            let max_out = lz4_flex::block::get_maximum_output_size(bytes.len());
-            buf.resize(SIZE_PREFIX + max_out, 0);
-            let uncompressed_len =
-                u32::try_from(bytes.len()).expect("chunk payloads are bounded by the size classes");
-            buf[..SIZE_PREFIX].copy_from_slice(&uncompressed_len.to_le_bytes());
-            let compressed = lz4_flex::block::compress_into(bytes, &mut buf[SIZE_PREFIX..])
-                .expect("output sized by get_maximum_output_size");
-            let comp_len = SIZE_PREFIX + compressed;
+            codec.encode(bytes, &mut buf);
+            let comp_len = buf.len();
+            debug_assert!(
+                comp_len <= max_stored_len(bytes.len()),
+                "codec output exceeds the extent-store bound",
+            );
 
             let (ptr, alloc_size, backing) = match arena.alloc(comp_len) {
                 Some((class, slot)) => (
@@ -354,31 +389,34 @@ impl SwapExtent {
         region::willneed(self.ptr, self.alloc_size);
     }
 
-    /// Decompresses the extent into `dst`, which must be exactly the chunk's
-    /// uncompressed length. Reading faults the pages back in, so the extent
-    /// is resident again afterwards; the caller owns the accounting for that
-    /// transition (the pool re-counts and re-enqueues it for the RSS target).
-    pub(crate) fn read_into(&mut self, dst: &mut [u8]) {
-        let full = self.uncompressed_len();
-        assert_eq!(
-            full,
-            dst.len(),
-            "destination must match the extent's uncompressed length"
-        );
-        self.read_range_into(0, dst);
+    /// Decodes the extent through `codec` into `dst`, which must be exactly
+    /// the chunk's body length. Reading faults the pages back in, so the
+    /// extent is resident again afterwards; the caller owns the accounting
+    /// for that transition (the pool re-counts and re-enqueues it for the
+    /// RSS target).
+    pub(crate) fn read_into(&mut self, codec: &dyn ExtentCodec, dst: &mut [u8]) {
+        self.read_range_into(codec, dst.len(), 0, dst);
     }
 
-    /// Decompresses the byte range `[offset, offset + dst.len())` of the
-    /// extent's uncompressed body into `dst`. The range must lie within the
-    /// body. Residency effects are those of [`SwapExtent::read_into`]
-    /// regardless of the range: the stored form is a whole lz4 block, so any
-    /// read faults and decompresses the entire extent, and a sub-range only
-    /// narrows the final copy. A backend whose stored form is rangeable (file
-    /// extents reading with `pread`, a sub-block-framed codec) can serve the
-    /// range with proportional I/O behind this same signature.
-    pub(crate) fn read_range_into(&mut self, offset: usize, dst: &mut [u8]) {
+    /// Decodes the byte range `[offset, offset + dst.len())` of the
+    /// extent's `body_len`-byte body into `dst`. The range must lie within
+    /// the body, and `body_len` must be the body's exact length (the codec
+    /// validates it against the stored form). Residency effects are those
+    /// of [`SwapExtent::read_into`] regardless of the range: the stored
+    /// form is one whole codec block, so any read faults and decodes the
+    /// entire extent, and a sub-range only narrows the final copy. A
+    /// backend whose stored form is rangeable (file extents reading with
+    /// `pread`, a sub-block-framed codec) can serve the range with
+    /// proportional I/O behind this same signature.
+    pub(crate) fn read_range_into(
+        &mut self,
+        codec: &dyn ExtentCodec,
+        body_len: usize,
+        offset: usize,
+        dst: &mut [u8],
+    ) {
         self.resident = true;
-        // The decompress faults every page back in, so prior incomplete
+        // The decode faults every page back in, so prior incomplete
         // pageout passes no longer describe the mapping and the retry
         // budget starts over.
         self.incomplete_passes = 0;
@@ -386,21 +424,18 @@ impl SwapExtent {
         // SAFETY: the extent exclusively owns its backing, and the first
         // `comp_len` bytes were initialized by `write`.
         let buf = unsafe { std::slice::from_raw_parts(self.ptr, self.comp_len) };
-        let uncompressed_len = self.uncompressed_len();
         let end = offset
             .checked_add(dst.len())
             .expect("range end overflows usize");
         assert!(
-            end <= uncompressed_len,
-            "range end {end} exceeds the extent's uncompressed length {uncompressed_len}",
+            end <= body_len,
+            "range end {end} exceeds the extent's body length {body_len}",
         );
-        if offset == 0 && dst.len() == uncompressed_len {
-            let written = lz4_flex::block::decompress_into(&buf[SIZE_PREFIX..], dst)
-                .expect("extent holds a valid lz4 block");
-            assert_eq!(written, dst.len(), "decompressed length mismatch");
+        if offset == 0 && dst.len() == body_len {
+            codec.decode(buf, dst);
             return;
         }
-        // A sub-range still decompresses the whole block, into a reused
+        // A sub-range still decodes the whole block, into a reused
         // thread-local scratch, and copies the range out. Reads run on
         // worker threads, so the scratch mirrors the write side's `Shrink`
         // policy: capacity beyond the ~2 MiB chunk target is released after
@@ -411,25 +446,14 @@ impl SwapExtent {
         }
         SCRATCH.with(|cell| {
             let mut scratch = cell.borrow_mut();
-            scratch.resize(uncompressed_len, 0);
-            let written = lz4_flex::block::decompress_into(&buf[SIZE_PREFIX..], &mut scratch)
-                .expect("extent holds a valid lz4 block");
-            assert_eq!(written, uncompressed_len, "decompressed length mismatch");
+            scratch.resize(body_len, 0);
+            codec.decode(buf, &mut scratch);
             dst.copy_from_slice(&scratch[offset..end]);
             if scratch.capacity() > 2 << 20 {
                 scratch.clear();
                 scratch.shrink_to_fit();
             }
         });
-    }
-
-    /// The uncompressed body length recorded in the extent's size prefix.
-    fn uncompressed_len(&self) -> usize {
-        // SAFETY: the extent exclusively owns its backing, and the prefix
-        // was initialized by `write`.
-        let buf = unsafe { std::slice::from_raw_parts(self.ptr, SIZE_PREFIX) };
-        let prefix: [u8; SIZE_PREFIX] = buf.try_into().expect("prefix length");
-        usize::cast_from(u32::from_le_bytes(prefix))
     }
 }
 
@@ -473,10 +497,11 @@ mod proofs {
     use super::*;
 
     /// The extent ladder's contract for every plausible page size: every
-    /// class is a page multiple, the top class fits lz4's worst case over
-    /// the largest chunk class, a class is found for every payload up to
-    /// that bound and fits it, and the selected class overshoots the payload
-    /// by less than 1.5x (with page-granular slack at the smallest classes).
+    /// class is a page multiple, the top class fits the codec contract's
+    /// worst case over the largest chunk class, a class is found for every
+    /// payload up to that bound and fits it, and the selected class
+    /// overshoots the payload by less than 1.5x (with page-granular slack
+    /// at the smallest classes).
     #[kani::proof]
     #[kani::unwind(64)]
     fn extent_ladder_fits_payloads() {
@@ -484,7 +509,7 @@ mod proofs {
         kani::assume(page_shift >= 12 && page_shift <= 16);
         let page = 1usize << page_shift;
         let classes = extent_classes(page);
-        let max_comp = SIZE_PREFIX + lz4_flex::block::get_maximum_output_size(max_chunk_bytes());
+        let max_comp = max_stored_len(max_chunk_bytes());
         for &class in &classes {
             assert!(class % page == 0);
         }
@@ -523,11 +548,11 @@ mod tests {
     fn round_trip() {
         let arena = arena();
         let data: Vec<u64> = (0..10_000).map(|i| i * 37).collect();
-        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
-        assert!(extent.comp_len() > SIZE_PREFIX);
+        let mut extent = SwapExtent::write(&arena, &data, &TEST_CODEC, Scratch::Shrink);
+        assert!(extent.comp_len() > 4);
         extent.prefetch();
         let mut out = vec![0u64; data.len()];
-        extent.read_into(bytemuck::cast_slice_mut(&mut out));
+        extent.read_into(&TEST_CODEC, bytemuck::cast_slice_mut(&mut out));
         assert_eq!(out, data);
     }
 
@@ -535,10 +560,10 @@ mod tests {
     fn compressible_data_shrinks() {
         let arena = arena();
         let data = vec![42u64; 100_000];
-        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let mut extent = SwapExtent::write(&arena, &data, &TEST_CODEC, Scratch::Shrink);
         assert!(extent.comp_len() < data.len() * 8 / 4);
         let mut out = vec![0u64; data.len()];
-        extent.read_into(bytemuck::cast_slice_mut(&mut out));
+        extent.read_into(&TEST_CODEC, bytemuck::cast_slice_mut(&mut out));
         assert_eq!(out, data);
     }
 
@@ -549,7 +574,7 @@ mod tests {
     fn allocation_is_sized_to_payload() {
         let arena = arena();
         let data = vec![7u64; 100_000];
-        let extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let extent = SwapExtent::write(&arena, &data, &TEST_CODEC, Scratch::Shrink);
         let page = region::page_size();
         assert!(extent.alloc_size() >= extent.comp_len());
         assert_eq!(extent.alloc_size() % page, 0, "class is a page multiple");
@@ -570,8 +595,7 @@ mod tests {
     fn ladder_shape() {
         for page in [4096usize, 16384, 65536] {
             let classes = extent_classes(page);
-            let max_comp =
-                SIZE_PREFIX + lz4_flex::block::get_maximum_output_size(max_chunk_bytes());
+            let max_comp = max_stored_len(max_chunk_bytes());
             assert!(classes.windows(2).all(|w| w[0] < w[1]), "ascending");
             assert!(classes.iter().all(|&c| c % page == 0), "page multiples");
             assert!(classes[classes.len() - 1] >= max_comp, "covers worst case");
@@ -590,19 +614,19 @@ mod tests {
         // larger class is empty.
         let arena = Arc::new(ExtentArena::new(region::page_size()).expect("arena creation"));
         let data = vec![3u64; 64];
-        let a = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let a = SwapExtent::write(&arena, &data, &TEST_CODEC, Scratch::Shrink);
         assert_eq!(arena.fallbacks(), 0);
         assert!(!a.pageout_capped(), "arena extents start with retry budget");
-        let mut b = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let mut b = SwapExtent::write(&arena, &data, &TEST_CODEC, Scratch::Shrink);
         assert_eq!(arena.fallbacks(), 1, "second same-class write degrades");
         assert!(b.pageout_capped(), "heap extents are never advised out");
         assert!(b.is_resident());
         let mut out = vec![0u64; data.len()];
-        b.read_into(bytemuck::cast_slice_mut(&mut out));
+        b.read_into(&TEST_CODEC, bytemuck::cast_slice_mut(&mut out));
         assert_eq!(out, data);
         // Freeing the arena extent frees its slot for the next write.
         drop(a);
-        let c = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let c = SwapExtent::write(&arena, &data, &TEST_CODEC, Scratch::Shrink);
         assert_eq!(arena.fallbacks(), 1, "freed slot is reused, no fallback");
         drop(c);
         drop(b);
@@ -616,9 +640,9 @@ mod tests {
         let arena = arena();
         let data: Vec<u64> = (0..10_000u64).map(|i| i.wrapping_mul(0x9E37)).collect();
         let bytes: &[u8] = bytemuck::cast_slice(&data);
-        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let mut extent = SwapExtent::write(&arena, &data, &TEST_CODEC, Scratch::Shrink);
         let mut full = vec![0u8; bytes.len()];
-        extent.read_into(&mut full);
+        extent.read_into(&TEST_CODEC, &mut full);
         assert_eq!(full, bytes);
         let page = region::page_size();
         let ranges = [
@@ -630,7 +654,7 @@ mod tests {
         ];
         for (offset, len) in ranges {
             let mut out = vec![0u8; len];
-            extent.read_range_into(offset, &mut out);
+            extent.read_range_into(&TEST_CODEC, bytes.len(), offset, &mut out);
             assert_eq!(out, &full[offset..offset + len], "range ({offset}, {len})");
         }
     }
@@ -640,9 +664,9 @@ mod tests {
     fn ranged_read_out_of_bounds_panics() {
         let arena = arena();
         let data = vec![5u64; 64];
-        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let mut extent = SwapExtent::write(&arena, &data, &TEST_CODEC, Scratch::Shrink);
         let mut out = vec![0u8; 16];
-        extent.read_range_into(64 * 8 - 8, &mut out);
+        extent.read_range_into(&TEST_CODEC, 64 * 8, 64 * 8 - 8, &mut out);
     }
 
     #[mz_ore::test]
@@ -650,9 +674,9 @@ mod tests {
     fn wrong_destination_length_panics() {
         let arena = arena();
         let data = vec![1u64; 16];
-        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let mut extent = SwapExtent::write(&arena, &data, &TEST_CODEC, Scratch::Shrink);
         let mut out = vec![0u64; 8];
-        extent.read_into(bytemuck::cast_slice_mut(&mut out));
+        extent.read_into(&TEST_CODEC, bytemuck::cast_slice_mut(&mut out));
     }
 
     /// Residency follows the observation, not the advice: a declined pass
@@ -661,7 +685,7 @@ mod tests {
     fn pageout_is_observed_not_trusted() {
         let arena = arena();
         let data = vec![9u64; 10_000];
-        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let mut extent = SwapExtent::write(&arena, &data, &TEST_CODEC, Scratch::Shrink);
         assert!(extent.is_resident());
         region::fake_residency::decline_next(1);
         assert!(!extent.pageout(), "declined pass reports incomplete");
@@ -677,7 +701,7 @@ mod tests {
     fn pageout_retry_cap_and_read_reset() {
         let arena = arena();
         let data: Vec<u64> = (0..10_000).collect();
-        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let mut extent = SwapExtent::write(&arena, &data, &TEST_CODEC, Scratch::Shrink);
         region::fake_residency::decline_next(u64::MAX);
         let mut passes = 0u8;
         while !extent.pageout_capped() {
@@ -688,7 +712,7 @@ mod tests {
         assert!(extent.is_resident(), "capped extent stays resident");
         region::fake_residency::decline_next(0);
         let mut out = vec![0u64; data.len()];
-        extent.read_into(bytemuck::cast_slice_mut(&mut out));
+        extent.read_into(&TEST_CODEC, bytemuck::cast_slice_mut(&mut out));
         assert_eq!(out, data);
         assert!(!extent.pageout_capped(), "a read resets the retry budget");
         assert!(extent.pageout());

--- a/src/ore/src/pool/extent.rs
+++ b/src/ore/src/pool/extent.rs
@@ -24,6 +24,14 @@
 //! `MADV_WILLNEED` ahead of the decompress (and makes the pages resident
 //! again); "free" is a plain deallocation, with any swapped copy discarded
 //! for free. Nothing is ever both uncompressed and on the device.
+//!
+//! Pageout is observed, never assumed: `MADV_PAGEOUT` may decline any page
+//! and still return success (a transient extra reference fails isolation,
+//! the swap device may be full or absent), so after the advice `mincore`
+//! decides whether the extent left memory, and the extent stays fully
+//! resident for accounting until its entire range is nonresident. Extents
+//! are advised `MADV_NOHUGEPAGE` at creation so the reclaim never needs to
+//! split a large folio the extent covers only partially.
 
 use std::alloc::Layout;
 
@@ -38,6 +46,16 @@ const EXTENT_ALIGN: usize = 4096;
 /// `lz4_flex::block::compress_prepend_size` framing.
 const SIZE_PREFIX: usize = 4;
 
+/// Consecutive incomplete pageout passes after which an extent stops being
+/// advised out until a read faults it back in. Transient declines (a racing
+/// read holding an extra page reference, a momentary swap-slot allocation
+/// failure) clear as soon as the racing operation finishes, so a retry or
+/// two recovers them. Persistent declines (no swap device, an exhausted or
+/// unswappable cgroup) never clear, and further advice is pure page-table
+/// walking. Three passes covers the transient causes while bounding the
+/// wasted advice at two extra passes per extent.
+pub(crate) const PAGEOUT_RETRY_CAP: u8 = 3;
+
 /// One chunk's compressed backing copy.
 #[derive(Debug)]
 pub(crate) struct SwapExtent {
@@ -45,10 +63,15 @@ pub(crate) struct SwapExtent {
     layout: Layout,
     comp_len: usize,
     /// Whether the extent's pages are (engine-)resident: set at write and by
-    /// [`SwapExtent::read_into`], cleared by [`SwapExtent::pageout`]. Drives
-    /// the pool's `extent_resident_bytes` accounting; mutated only under the
-    /// owning chunk's state mutex.
+    /// [`SwapExtent::read_into`], cleared by a [`SwapExtent::pageout`] whose
+    /// residency observation found the whole range gone. Drives the pool's
+    /// `extent_resident_bytes` accounting; mutated only under the owning
+    /// chunk's state mutex.
     resident: bool,
+    /// Consecutive pageout passes whose observation found pages still
+    /// resident. Reset by [`SwapExtent::read_into`]. At
+    /// [`PAGEOUT_RETRY_CAP`] the extent stops being advised out.
+    incomplete_passes: u8,
 }
 
 // SAFETY: the extent exclusively owns its allocation; nothing else holds a
@@ -92,6 +115,13 @@ impl SwapExtent {
             if ptr.is_null() {
                 std::alloc::handle_alloc_error(layout);
             }
+            // Opt out of transparent huge pages before first touch:
+            // `MADV_PAGEOUT` must split any large folio the advised range
+            // covers only partially, and a failed split silently leaves
+            // those pages resident. Page-rounded extents routinely cover
+            // multi-size THP folios partially, so base pages keep the
+            // reclaim page-exact.
+            region::nohugepage(ptr, layout.size());
             // SAFETY: `ptr` is a fresh allocation of at least `comp_len`
             // bytes (`extent_layout`'s contract) exclusively owned here; the
             // copy plus the tail zeroing below initialize every byte, so
@@ -107,6 +137,7 @@ impl SwapExtent {
                 layout,
                 comp_len,
                 resident: true,
+                incomplete_passes: 0,
             }
         })
     }
@@ -123,13 +154,34 @@ impl SwapExtent {
         self.resident
     }
 
+    /// Whether the extent's pageout retry budget is exhausted: consecutive
+    /// incomplete passes reached [`PAGEOUT_RETRY_CAP`], so callers stop
+    /// calling [`SwapExtent::pageout`] until a read resets the budget.
+    pub(crate) fn pageout_capped(&self) -> bool {
+        self.incomplete_passes >= PAGEOUT_RETRY_CAP
+    }
+
     /// Hints the kernel to push the extent's pages to the swap device and
-    /// marks the extent non-resident. Cheap: the compression is already
-    /// paid, the madvise is microseconds, and the device write happens on
-    /// the kernel's asynchronous writeback path.
-    pub(crate) fn pageout(&mut self) {
+    /// observes the result: returns `true`, marking the extent non-resident,
+    /// only when the observation finds the whole range out of memory. An
+    /// incomplete pass leaves the extent fully resident for accounting and
+    /// spends one unit of the retry budget. Cheap: the compression is
+    /// already paid, the madvise and mincore are microseconds, and the
+    /// device write happens on the kernel's asynchronous writeback path.
+    ///
+    /// Callers must not invoke this on a [`SwapExtent::pageout_capped`]
+    /// extent.
+    pub(crate) fn pageout(&mut self) -> bool {
+        debug_assert!(!self.pageout_capped());
         region::pageout(self.ptr, self.layout.size());
-        self.resident = false;
+        if region::nonresident(self.ptr, self.layout.size()) {
+            self.resident = false;
+            self.incomplete_passes = 0;
+            true
+        } else {
+            self.incomplete_passes += 1;
+            false
+        }
     }
 
     /// Compressed size in bytes, including the size prefix.
@@ -148,6 +200,10 @@ impl SwapExtent {
     /// transition (the pool re-counts and re-enqueues it for the RSS target).
     pub(crate) fn read_into(&mut self, dst: &mut [u8]) {
         self.resident = true;
+        // The decompress faults every page back in, so prior incomplete
+        // pageout passes no longer describe the mapping and the retry
+        // budget starts over.
+        self.incomplete_passes = 0;
         self.prefetch();
         // SAFETY: the extent exclusively owns `[ptr, ptr + layout.size())`
         // and `comp_len <= layout.size()` by construction in `write`.
@@ -259,5 +315,42 @@ mod tests {
         let mut extent = SwapExtent::write(&data);
         let mut out = vec![0u64; 8];
         extent.read_into(bytemuck::cast_slice_mut(&mut out));
+    }
+
+    /// Residency follows the observation, not the advice: a declined pass
+    /// leaves the extent resident, an accepted one marks it gone.
+    #[mz_ore::test]
+    fn pageout_is_observed_not_trusted() {
+        let data = vec![9u64; 10_000];
+        let mut extent = SwapExtent::write(&data);
+        assert!(extent.is_resident());
+        region::fake_residency::decline_next(1);
+        assert!(!extent.pageout(), "declined pass reports incomplete");
+        assert!(extent.is_resident(), "declined pass leaves it resident");
+        assert!(!extent.pageout_capped());
+        assert!(extent.pageout(), "accepted pass reports reclaimed");
+        assert!(!extent.is_resident());
+    }
+
+    /// Consecutive declined passes exhaust the retry budget. A read faults
+    /// the pages back in and restores it.
+    #[mz_ore::test]
+    fn pageout_retry_cap_and_read_reset() {
+        let data: Vec<u64> = (0..10_000).collect();
+        let mut extent = SwapExtent::write(&data);
+        region::fake_residency::decline_next(u64::MAX);
+        let mut passes = 0u8;
+        while !extent.pageout_capped() {
+            assert!(!extent.pageout());
+            passes += 1;
+        }
+        assert_eq!(passes, PAGEOUT_RETRY_CAP, "capped after exactly the cap");
+        assert!(extent.is_resident(), "capped extent stays resident");
+        region::fake_residency::decline_next(0);
+        let mut out = vec![0u64; data.len()];
+        extent.read_into(bytemuck::cast_slice_mut(&mut out));
+        assert_eq!(out, data);
+        assert!(!extent.pageout_capped(), "a read resets the retry budget");
+        assert!(extent.pageout());
     }
 }

--- a/src/ore/src/pool/extent.rs
+++ b/src/ore/src/pool/extent.rs
@@ -16,30 +16,39 @@
 //! Swap-backed extents: the backing store for the buffer pool on nodes whose
 //! whole disk is provisioned as swap.
 //!
-//! An extent is a page-aligned anonymous allocation holding the lz4-compressed
-//! bytes of one chunk. "Write" compresses into the allocation, which stays
-//! resident — the compressed-but-resident middle tier of the pool's ladder —
-//! until the pool's RSS target forces [`SwapExtent::pageout`], which pushes
-//! the pages to the swap device with `MADV_PAGEOUT`. "Read" issues
+//! An extent is a slot in the pool-owned [`ExtentArena`] holding the
+//! lz4-compressed bytes of one chunk. "Write" compresses into the slot. The
+//! slot stays resident, forming the compressed-but-resident middle tier of
+//! the pool's ladder, until the pool's RSS target forces
+//! [`SwapExtent::pageout`], which pushes the pages to the swap device with
+//! `MADV_PAGEOUT`. "Read" issues
 //! `MADV_WILLNEED` ahead of the decompress (and makes the pages resident
-//! again); "free" is a plain deallocation, with any swapped copy discarded
-//! for free. Nothing is ever both uncompressed and on the device.
+//! again); "free" returns the slot to the arena with its pages discarded,
+//! which also drops any swapped copy for free. Nothing is ever both
+//! uncompressed and on the device.
+//!
+//! The arena exists so that extent pages never belong to the global
+//! allocator: `MADV_PAGEOUT` over allocator-owned memory leaves swap-entry
+//! PTEs behind on freed ranges, which the allocator recycles into unrelated
+//! allocations that then major-fault reading dead compressed data. Arena
+//! regions are advised `MADV_NOHUGEPAGE` once at map time, so the reclaim
+//! never needs to split a large folio, and slot recycling never re-touches
+//! swap. A class whose region is exhausted degrades to a plain heap
+//! allocation (counted, never paged out) rather than failing.
 //!
 //! Pageout is observed, never assumed: `MADV_PAGEOUT` may decline any page
 //! and still return success (a transient extra reference fails isolation,
 //! the swap device may be full or absent), so after the advice `mincore`
 //! decides whether the extent left memory, and the extent stays fully
-//! resident for accounting until its entire range is nonresident. Extents
-//! are advised `MADV_NOHUGEPAGE` at creation so the reclaim never needs to
-//! split a large folio the extent covers only partially.
+//! resident for accounting until its entire range is nonresident.
 
 use std::alloc::Layout;
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::cast::CastFrom;
-use crate::pool::region;
-
-/// Alignment and size granule of extent allocations.
-const EXTENT_ALIGN: usize = 4096;
+use crate::pool::region::{self, Region};
 
 /// Length in bytes of the little-endian `u32` uncompressed-size prefix that
 /// precedes the compressed bytes, matching the
@@ -56,11 +65,96 @@ const SIZE_PREFIX: usize = 4;
 /// wasted advice at two extra passes per extent.
 pub(crate) const PAGEOUT_RETRY_CAP: u8 = 3;
 
+/// The extent size-class ladder for a `page`-byte page size: `page`, then
+/// sizes of the form `2^k` and `3 * 2^(k-1)` bytes, up through the first
+/// class that fits lz4's worst case over the largest chunk size class.
+/// Every class is a multiple of `page` (the sub-page mid class between
+/// `page` and `2 * page` is skipped), so slot-granular paging advice is
+/// exact on any kernel page size. Consecutive classes above the smallest
+/// are within 1.5x of each other, which bounds a compressed payload's
+/// internal fragmentation below 1.5x (page-granular slack at the small
+/// end).
+fn extent_classes(page: usize) -> Vec<usize> {
+    let max_comp = SIZE_PREFIX + lz4_flex::block::get_maximum_output_size(max_chunk_bytes());
+    let mut classes = vec![page];
+    let mut base = 2 * page;
+    loop {
+        classes.push(base);
+        if base >= max_comp {
+            break;
+        }
+        // `3 * 2^(k-1)`: a page multiple because `base` is at least two
+        // pages.
+        let mid = base + base / 2;
+        classes.push(mid);
+        if mid >= max_comp {
+            break;
+        }
+        base *= 2;
+    }
+    classes
+}
+
+/// The largest chunk payload the pool can ask an extent to back.
+fn max_chunk_bytes() -> usize {
+    region::SIZE_CLASSES[region::SIZE_CLASSES.len() - 1]
+}
+
+/// Pool-owned arena of anonymous-memory regions backing extents, one region
+/// per entry of the [`extent_classes`] ladder. Slots are allocated at write,
+/// freed cold (pages and any swap copy discarded) at extent drop, and never
+/// kept warm: a freed extent's compressed bytes are dead by definition.
+#[derive(Debug)]
+pub(crate) struct ExtentArena {
+    /// Ladder of extent class sizes in bytes, ascending; same order as
+    /// `regions`.
+    classes: Vec<usize>,
+    regions: Vec<Region>,
+    /// Extent writes that degraded to the heap because their class had no
+    /// free slot.
+    fallbacks: AtomicU64,
+}
+
+impl ExtentArena {
+    /// Reserves one region per extent class, `class_capacity_bytes` of
+    /// virtual space each. The reservation knob mirrors the slot regions'
+    /// so tests can exercise class exhaustion with small arenas.
+    pub(crate) fn new(class_capacity_bytes: usize) -> io::Result<ExtentArena> {
+        let classes = extent_classes(region::page_size());
+        let regions = classes
+            .iter()
+            .map(|&class_size| Region::new_nohuge(class_size, class_capacity_bytes))
+            .collect::<io::Result<Vec<_>>>()?;
+        Ok(ExtentArena {
+            classes,
+            regions,
+            fallbacks: AtomicU64::new(0),
+        })
+    }
+
+    /// Number of extent writes that degraded to the heap.
+    pub(crate) fn fallbacks(&self) -> u64 {
+        self.fallbacks.load(Ordering::Relaxed)
+    }
+
+    /// Allocates a slot fitting a compressed payload of `comp_len` bytes,
+    /// or `None` when the class is exhausted (the caller degrades to the
+    /// heap).
+    fn alloc(&self, comp_len: usize) -> Option<(usize, u32)> {
+        let class = self.classes.iter().position(|&c| c >= comp_len)?;
+        let (slot, _warm) = self.regions[class].alloc()?;
+        Some((class, slot))
+    }
+}
+
 /// One chunk's compressed backing copy.
 #[derive(Debug)]
 pub(crate) struct SwapExtent {
     ptr: *mut u8,
-    layout: Layout,
+    /// Byte size of the backing allocation (the extent's class size, or the
+    /// heap layout on the fallback path): the granule the resident
+    /// accounting and the pageout operate on.
+    alloc_size: usize,
     comp_len: usize,
     /// Whether the extent's pages are (engine-)resident: set at write and by
     /// [`SwapExtent::read_into`], cleared by a [`SwapExtent::pageout`] whose
@@ -72,72 +166,125 @@ pub(crate) struct SwapExtent {
     /// resident. Reset by [`SwapExtent::read_into`]. At
     /// [`PAGEOUT_RETRY_CAP`] the extent stops being advised out.
     incomplete_passes: u8,
+    backing: Backing,
 }
 
-// SAFETY: the extent exclusively owns its allocation; nothing else holds a
+/// Where an extent's bytes live.
+#[derive(Debug)]
+enum Backing {
+    /// A slot in the pool's extent arena.
+    Arena {
+        arena: Arc<ExtentArena>,
+        class: usize,
+        slot: u32,
+    },
+    /// Global-allocator fallback for an exhausted class. Never paged out:
+    /// `MADV_PAGEOUT` over allocator-owned pages leaves swap-entry PTEs on
+    /// freed ranges for the allocator to recycle into unrelated
+    /// allocations, which is the failure the arena exists to avoid.
+    Heap { layout: Layout },
+}
+
+/// Retention policy for the thread-local compression scratch across
+/// [`SwapExtent::write`] calls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Scratch {
+    /// Keep the grown scratch for the next job: for spill threads, whose
+    /// job stream reuses it immediately.
+    Retain,
+    /// Release the scratch after the job: for inline compression on worker
+    /// threads, where a retained scratch would park the largest class's
+    /// worst case (~8 MiB) per thread indefinitely, invisible to every
+    /// gauge.
+    Shrink,
+}
+
+// SAFETY: the extent exclusively owns its backing (an arena slot handed out
+// by the region allocator, or a heap allocation); nothing else holds a
 // pointer into it, so moving the owner across threads is sound. All access
 // goes through the owning chunk's state mutex.
 unsafe impl Send for SwapExtent {}
 
 impl SwapExtent {
-    /// Compresses `data` into a fresh extent. The pages stay resident; the
-    /// pool's RSS-target enforcement decides when [`SwapExtent::pageout`]
-    /// pushes them to the device.
+    /// Compresses `data` into a fresh extent, preferring an arena slot and
+    /// degrading to the heap when the payload's class is exhausted. The
+    /// pages stay resident; the pool's RSS-target enforcement decides when
+    /// [`SwapExtent::pageout`] pushes them to the device.
     ///
     /// Compression goes through a reused thread-local scratch buffer so the
-    /// extent allocation can be sized to the *actual* compressed payload
-    /// (rounded to the page granule) rather than lz4's worst case. Worst-case
-    /// sizing costs ~5.6× on compressible data — in swap capacity, in swap
-    /// write bandwidth per eviction (the whole allocation is paged out), and
-    /// in `alloc_zeroed` memset traffic on recycled allocations — which at
-    /// hydration eviction rates backs up device writeback and bloats the
-    /// working set with swap-cache pages.
-    pub(crate) fn write(data: &[u64]) -> SwapExtent {
+    /// extent slot can be chosen by the *actual* compressed payload rather
+    /// than lz4's worst case. Worst-case sizing costs ~5.6× on compressible
+    /// data, in swap capacity and in swap write bandwidth per eviction (the
+    /// whole allocation is paged out), which at hydration eviction rates
+    /// backs up device writeback and bloats the working set with swap-cache
+    /// pages. `scratch` says whether the caller's thread keeps the grown
+    /// scratch for its next job.
+    pub(crate) fn write(arena: &Arc<ExtentArena>, data: &[u64], scratch: Scratch) -> SwapExtent {
         use std::cell::RefCell;
         thread_local! {
             static SCRATCH: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
         }
         let bytes: &[u8] = bytemuck::cast_slice(data);
-        SCRATCH.with(|scratch| {
-            let mut scratch = scratch.borrow_mut();
+        SCRATCH.with(|cell| {
+            let mut buf = cell.borrow_mut();
             let max_out = lz4_flex::block::get_maximum_output_size(bytes.len());
-            scratch.resize(SIZE_PREFIX + max_out, 0);
+            buf.resize(SIZE_PREFIX + max_out, 0);
             let uncompressed_len =
                 u32::try_from(bytes.len()).expect("chunk payloads are bounded by the size classes");
-            scratch[..SIZE_PREFIX].copy_from_slice(&uncompressed_len.to_le_bytes());
-            let compressed = lz4_flex::block::compress_into(bytes, &mut scratch[SIZE_PREFIX..])
+            buf[..SIZE_PREFIX].copy_from_slice(&uncompressed_len.to_le_bytes());
+            let compressed = lz4_flex::block::compress_into(bytes, &mut buf[SIZE_PREFIX..])
                 .expect("output sized by get_maximum_output_size");
             let comp_len = SIZE_PREFIX + compressed;
 
-            let layout = extent_layout(comp_len);
-            // SAFETY: `layout` has nonzero size (at least one granule).
-            let ptr = unsafe { std::alloc::alloc(layout) };
-            if ptr.is_null() {
-                std::alloc::handle_alloc_error(layout);
-            }
-            // Opt out of transparent huge pages before first touch:
-            // `MADV_PAGEOUT` must split any large folio the advised range
-            // covers only partially, and a failed split silently leaves
-            // those pages resident. Page-rounded extents routinely cover
-            // multi-size THP folios partially, so base pages keep the
-            // reclaim page-exact.
-            region::nohugepage(ptr, layout.size());
-            // SAFETY: `ptr` is a fresh allocation of at least `comp_len`
-            // bytes (`extent_layout`'s contract) exclusively owned here; the
-            // copy plus the tail zeroing below initialize every byte, so
-            // later borrows of the allocation (in `read_into`) see
-            // initialized memory. The source is the scratch buffer, which
-            // cannot alias the fresh allocation.
+            let (ptr, alloc_size, backing) = match arena.alloc(comp_len) {
+                Some((class, slot)) => (
+                    arena.regions[class].slot_ptr(slot),
+                    arena.classes[class],
+                    Backing::Arena {
+                        arena: Arc::clone(arena),
+                        class,
+                        slot,
+                    },
+                ),
+                None => {
+                    arena.fallbacks.fetch_add(1, Ordering::Relaxed);
+                    let layout = heap_layout(comp_len);
+                    // SAFETY: `layout` has nonzero size (`comp_len` includes
+                    // the prefix).
+                    let ptr = unsafe { std::alloc::alloc(layout) };
+                    if ptr.is_null() {
+                        std::alloc::handle_alloc_error(layout);
+                    }
+                    (ptr, layout.size(), Backing::Heap { layout })
+                }
+            };
+            // The slack past `comp_len` is deliberately never touched: only
+            // the first `comp_len` bytes are ever read back, and writing the
+            // tail would fault pages the class's virtual slack is meant to
+            // keep free.
+            //
+            // SAFETY: the destination is exclusively owned here (a freshly
+            // allocated arena slot or heap allocation) and covers `comp_len`
+            // bytes (the selected class fits the payload; the heap layout is
+            // sized to it). The source is the scratch buffer, which cannot
+            // alias a fresh allocation.
             unsafe {
-                std::ptr::copy_nonoverlapping(scratch.as_ptr(), ptr, comp_len);
-                std::ptr::write_bytes(ptr.add(comp_len), 0, layout.size() - comp_len);
+                std::ptr::copy_nonoverlapping(buf.as_ptr(), ptr, comp_len);
+            }
+            if scratch == Scratch::Shrink {
+                buf.clear();
+                // TODO: consider retaining some capacity here (shrinking to
+                // the next power of two, say) rather than releasing all of
+                // it; measure the realloc traffic before tuning.
+                buf.shrink_to_fit();
             }
             SwapExtent {
                 ptr,
-                layout,
+                alloc_size,
                 comp_len,
                 resident: true,
                 incomplete_passes: 0,
+                backing,
             }
         })
     }
@@ -145,7 +292,7 @@ impl SwapExtent {
     /// The byte size of the extent's allocation: the granule the resident
     /// accounting and the pageout operate on.
     pub(crate) fn alloc_size(&self) -> usize {
-        self.layout.size()
+        self.alloc_size
     }
 
     /// Whether the extent's pages are engine-resident (not pushed to the
@@ -157,8 +304,13 @@ impl SwapExtent {
     /// Whether the extent's pageout retry budget is exhausted: consecutive
     /// incomplete passes reached [`PAGEOUT_RETRY_CAP`], so callers stop
     /// calling [`SwapExtent::pageout`] until a read resets the budget.
+    /// Heap-fallback extents are permanently capped: they are never advised
+    /// out and stay counted resident until freed.
     pub(crate) fn pageout_capped(&self) -> bool {
-        self.incomplete_passes >= PAGEOUT_RETRY_CAP
+        match self.backing {
+            Backing::Heap { .. } => true,
+            Backing::Arena { .. } => self.incomplete_passes >= PAGEOUT_RETRY_CAP,
+        }
     }
 
     /// Hints the kernel to push the extent's pages to the swap device and
@@ -173,8 +325,8 @@ impl SwapExtent {
     /// extent.
     pub(crate) fn pageout(&mut self) -> bool {
         debug_assert!(!self.pageout_capped());
-        region::pageout(self.ptr, self.layout.size());
-        if region::nonresident(self.ptr, self.layout.size()) {
+        region::pageout(self.ptr, self.alloc_size);
+        if region::nonresident(self.ptr, self.alloc_size) {
             self.resident = false;
             self.incomplete_passes = 0;
             true
@@ -191,7 +343,7 @@ impl SwapExtent {
 
     /// Hints the kernel to swap the extent's pages back in ahead of a read.
     pub(crate) fn prefetch(&self) {
-        region::willneed(self.ptr, self.layout.size());
+        region::willneed(self.ptr, self.alloc_size);
     }
 
     /// Decompresses the extent into `dst`, which must be exactly the chunk's
@@ -205,8 +357,8 @@ impl SwapExtent {
         // budget starts over.
         self.incomplete_passes = 0;
         self.prefetch();
-        // SAFETY: the extent exclusively owns `[ptr, ptr + layout.size())`
-        // and `comp_len <= layout.size()` by construction in `write`.
+        // SAFETY: the extent exclusively owns its backing, and the first
+        // `comp_len` bytes were initialized by `write`.
         let buf = unsafe { std::slice::from_raw_parts(self.ptr, self.comp_len) };
         let prefix: [u8; SIZE_PREFIX] = buf[..SIZE_PREFIX].try_into().expect("prefix length");
         let uncompressed_len = usize::cast_from(u32::from_le_bytes(prefix));
@@ -221,48 +373,78 @@ impl SwapExtent {
     }
 }
 
-/// The allocation layout for a compressed payload of `comp_len` bytes: the
-/// size rounded up to the extent granule, so the allocation always covers
-/// the payload with less than one granule of slack.
-fn extent_layout(comp_len: usize) -> Layout {
-    let size = comp_len.next_multiple_of(EXTENT_ALIGN);
-    Layout::from_size_align(size, EXTENT_ALIGN).expect("valid extent layout")
+/// The heap layout of a fallback extent for a compressed payload of
+/// `comp_len` bytes.
+fn heap_layout(comp_len: usize) -> Layout {
+    Layout::array::<u8>(comp_len).expect("valid extent layout")
 }
 
 impl Drop for SwapExtent {
     fn drop(&mut self) {
-        // SAFETY: `ptr` was returned by `alloc` with exactly this `layout`
-        // in `write` and is deallocated exactly once, here.
-        unsafe {
-            std::alloc::dealloc(self.ptr, self.layout);
+        match &self.backing {
+            Backing::Arena { arena, class, slot } => {
+                // Discarding the pages also drops any copy on the swap
+                // device (`MADV_DONTNEED` frees an anonymous range's swap
+                // entries), so the slot returns to the free list with no
+                // dead compressed data left to fault back in.
+                //
+                // SAFETY: the extent exclusively owns the slot and is being
+                // dropped, so no reference into it exists.
+                unsafe {
+                    region::dontneed(self.ptr, self.alloc_size);
+                }
+                arena.regions[*class].free(*slot, false);
+            }
+            Backing::Heap { layout } => {
+                // SAFETY: `ptr` was returned by `alloc` with exactly this
+                // `layout` in `write` and is deallocated exactly once, here.
+                unsafe {
+                    std::alloc::dealloc(self.ptr, *layout);
+                }
+            }
         }
     }
 }
 
-/// Kani proof harnesses over the extent layout arithmetic; see the sibling
+/// Kani proof harnesses over the extent ladder arithmetic; see the sibling
 /// module in `region.rs` for scope and run instructions.
 #[cfg(kani)]
 mod proofs {
     use super::*;
 
-    /// `extent_layout` covers every payload the size classes can produce,
-    /// with less than one granule of slack, at the granule alignment. The
-    /// bound is lz4's worst case over the largest class plus the size
-    /// prefix, which is also what justifies the unchecked `next_multiple_of`
-    /// (no overflow within the bound).
+    /// The extent ladder's contract for every plausible page size: every
+    /// class is a page multiple, the top class fits lz4's worst case over
+    /// the largest chunk class, a class is found for every payload up to
+    /// that bound and fits it, and the selected class overshoots the payload
+    /// by less than 1.5x (with page-granular slack at the smallest classes).
     #[kani::proof]
-    fn extent_layout_covers_payload() {
-        let max_comp = SIZE_PREFIX
-            + lz4_flex::block::get_maximum_output_size(
-                region::SIZE_CLASSES[region::SIZE_CLASSES.len() - 1],
-            );
+    #[kani::unwind(64)]
+    fn extent_ladder_fits_payloads() {
+        let page_shift: u32 = kani::any();
+        kani::assume(page_shift >= 12 && page_shift <= 16);
+        let page = 1usize << page_shift;
+        let classes = extent_classes(page);
+        let max_comp = SIZE_PREFIX + lz4_flex::block::get_maximum_output_size(max_chunk_bytes());
+        for &class in &classes {
+            assert!(class % page == 0);
+        }
+        assert!(classes[classes.len() - 1] >= max_comp);
         let comp_len: usize = kani::any();
         kani::assume(comp_len >= 1 && comp_len <= max_comp);
-        let layout = extent_layout(comp_len);
-        assert!(layout.size() >= comp_len);
-        assert!(layout.size() - comp_len < EXTENT_ALIGN);
-        assert!(layout.size() % EXTENT_ALIGN == 0);
-        assert_eq!(layout.align(), EXTENT_ALIGN);
+        let class = classes
+            .iter()
+            .position(|&c| c >= comp_len)
+            .expect("ladder covers every payload up to the bound");
+        assert!(classes[class] >= comp_len);
+        if class <= 1 {
+            assert!(classes[class] - comp_len < page);
+        } else {
+            // The previous class was too small and consecutive classes are
+            // within 3/2 of each other, so the allocation is below 1.5x the
+            // payload.
+            assert!(classes[class - 1] < comp_len);
+            assert!(classes[class] * 2 <= classes[class - 1] * 3);
+        }
     }
 }
 
@@ -270,10 +452,18 @@ mod proofs {
 mod tests {
     use super::*;
 
+    /// A small arena for extent tests. Under Miri the region backing is real
+    /// interpreter heap rather than lazy virtual memory, so shrink further.
+    fn arena() -> Arc<ExtentArena> {
+        let capacity = if cfg!(miri) { 1 << 20 } else { 64 << 20 };
+        Arc::new(ExtentArena::new(capacity).expect("arena creation"))
+    }
+
     #[mz_ore::test]
     fn round_trip() {
+        let arena = arena();
         let data: Vec<u64> = (0..10_000).map(|i| i * 37).collect();
-        let mut extent = SwapExtent::write(&data);
+        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
         assert!(extent.comp_len() > SIZE_PREFIX);
         extent.prefetch();
         let mut out = vec![0u64; data.len()];
@@ -283,36 +473,87 @@ mod tests {
 
     #[mz_ore::test]
     fn compressible_data_shrinks() {
+        let arena = arena();
         let data = vec![42u64; 100_000];
-        let mut extent = SwapExtent::write(&data);
+        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
         assert!(extent.comp_len() < data.len() * 8 / 4);
         let mut out = vec![0u64; data.len()];
         extent.read_into(bytemuck::cast_slice_mut(&mut out));
         assert_eq!(out, data);
     }
 
-    /// The allocation is sized to the compressed payload, not lz4's worst
-    /// case: extents must cost swap capacity and write bandwidth in
-    /// proportion to what they store.
+    /// The slot is sized to the compressed payload, not lz4's worst case:
+    /// extents must cost swap capacity and write bandwidth in proportion to
+    /// what they store.
     #[mz_ore::test]
     fn allocation_is_sized_to_payload() {
+        let arena = arena();
         let data = vec![7u64; 100_000];
-        let extent = SwapExtent::write(&data);
-        assert_eq!(
-            extent.alloc_size(),
-            extent.comp_len().next_multiple_of(EXTENT_ALIGN),
-        );
+        let extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let page = region::page_size();
+        assert!(extent.alloc_size() >= extent.comp_len());
+        assert_eq!(extent.alloc_size() % page, 0, "class is a page multiple");
         assert!(
             extent.alloc_size() < data.len() * 8 / 8,
             "compressible data must not be stored at worst-case size",
         );
+        assert!(
+            extent.alloc_size() <= (extent.comp_len() * 3 / 2).max(2 * page),
+            "the ladder bounds internal fragmentation",
+        );
+    }
+
+    /// The ladder is page-granular, strictly ascending, covers lz4's worst
+    /// case over the largest chunk class, and steps by at most 1.5x above
+    /// the smallest class.
+    #[mz_ore::test]
+    fn ladder_shape() {
+        for page in [4096usize, 16384, 65536] {
+            let classes = extent_classes(page);
+            let max_comp =
+                SIZE_PREFIX + lz4_flex::block::get_maximum_output_size(max_chunk_bytes());
+            assert!(classes.windows(2).all(|w| w[0] < w[1]), "ascending");
+            assert!(classes.iter().all(|&c| c % page == 0), "page multiples");
+            assert!(classes[classes.len() - 1] >= max_comp, "covers worst case");
+            for w in classes.windows(2).skip(1) {
+                assert!(w[1] * 2 <= w[0] * 3, "steps at most 1.5x above the base");
+            }
+        }
+    }
+
+    /// An exhausted extent class degrades to a heap-backed extent that still
+    /// round-trips, is never advised out, and is counted; freeing an arena
+    /// extent lets the next write reuse its slot.
+    #[mz_ore::test]
+    fn exhaustion_falls_back_to_heap() {
+        // One page of capacity: the smallest class holds one slot, every
+        // larger class is empty.
+        let arena = Arc::new(ExtentArena::new(region::page_size()).expect("arena creation"));
+        let data = vec![3u64; 64];
+        let a = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        assert_eq!(arena.fallbacks(), 0);
+        assert!(!a.pageout_capped(), "arena extents start with retry budget");
+        let mut b = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        assert_eq!(arena.fallbacks(), 1, "second same-class write degrades");
+        assert!(b.pageout_capped(), "heap extents are never advised out");
+        assert!(b.is_resident());
+        let mut out = vec![0u64; data.len()];
+        b.read_into(bytemuck::cast_slice_mut(&mut out));
+        assert_eq!(out, data);
+        // Freeing the arena extent frees its slot for the next write.
+        drop(a);
+        let c = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        assert_eq!(arena.fallbacks(), 1, "freed slot is reused, no fallback");
+        drop(c);
+        drop(b);
     }
 
     #[mz_ore::test]
     #[should_panic(expected = "destination must match")]
     fn wrong_destination_length_panics() {
+        let arena = arena();
         let data = vec![1u64; 16];
-        let mut extent = SwapExtent::write(&data);
+        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
         let mut out = vec![0u64; 8];
         extent.read_into(bytemuck::cast_slice_mut(&mut out));
     }
@@ -321,8 +562,9 @@ mod tests {
     /// leaves the extent resident, an accepted one marks it gone.
     #[mz_ore::test]
     fn pageout_is_observed_not_trusted() {
+        let arena = arena();
         let data = vec![9u64; 10_000];
-        let mut extent = SwapExtent::write(&data);
+        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
         assert!(extent.is_resident());
         region::fake_residency::decline_next(1);
         assert!(!extent.pageout(), "declined pass reports incomplete");
@@ -336,8 +578,9 @@ mod tests {
     /// the pages back in and restores it.
     #[mz_ore::test]
     fn pageout_retry_cap_and_read_reset() {
+        let arena = arena();
         let data: Vec<u64> = (0..10_000).collect();
-        let mut extent = SwapExtent::write(&data);
+        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
         region::fake_residency::decline_next(u64::MAX);
         let mut passes = 0u8;
         while !extent.pageout_capped() {

--- a/src/ore/src/pool/extent.rs
+++ b/src/ore/src/pool/extent.rs
@@ -24,8 +24,8 @@
 //! `MADV_PAGEOUT`. "Read" issues
 //! `MADV_WILLNEED` ahead of the decompress (and makes the pages resident
 //! again); "free" returns the slot to the arena with its pages discarded,
-//! which also drops any swapped copy for free. Nothing is ever both
-//! uncompressed and on the device.
+//! which also drops any swapped copy for free. Chunk slots never reach the
+//! swap device: only these compressed extents are offered to it.
 //!
 //! The arena exists so that extent pages never belong to the global
 //! allocator: `MADV_PAGEOUT` over allocator-owned memory leaves swap-entry
@@ -37,10 +37,13 @@
 //! allocation (counted, never paged out) rather than failing.
 //!
 //! Pageout is observed, never assumed: `MADV_PAGEOUT` may decline any page
-//! and still return success (a transient extra reference fails isolation,
-//! the swap device may be full or absent), so after the advice `mincore`
+//! and still return success (a kernel-internal pin fails isolation, the
+//! swap device may be full or absent), so after the advice the page table
 //! decides whether the extent left memory, and the extent stays fully
-//! resident for accounting until its entire range is nonresident.
+//! resident for accounting until its entire range is unmapped. The
+//! observation reads pagemap present bits rather than `mincore`, which
+//! would count the clean swap-cache copies of successfully reclaimed pages
+//! as resident.
 
 use std::alloc::Layout;
 use std::io;
@@ -56,13 +59,14 @@ use crate::pool::region::{self, Region};
 const SIZE_PREFIX: usize = 4;
 
 /// Consecutive incomplete pageout passes after which an extent stops being
-/// advised out until a read faults it back in. Transient declines (a racing
-/// read holding an extra page reference, a momentary swap-slot allocation
-/// failure) clear as soon as the racing operation finishes, so a retry or
-/// two recovers them. Persistent declines (no swap device, an exhausted or
-/// unswappable cgroup) never clear, and further advice is pure page-table
-/// walking. Three passes covers the transient causes while bounding the
-/// wasted advice at two extra passes per extent.
+/// advised out until a read faults it back in. Transient declines are
+/// kernel-internal page pins that defeat the reclaim's isolation step (a
+/// folio sitting in another CPU's LRU batch, a momentary swap-slot
+/// allocation failure); they clear as soon as the pin drains, so a retry
+/// or two recovers them. Persistent declines (no swap device, an exhausted
+/// or unswappable cgroup) never clear, and further advice is pure
+/// page-table walking. Three passes covers the transient causes while
+/// bounding the wasted advice at two extra passes per extent.
 pub(crate) const PAGEOUT_RETRY_CAP: u8 = 3;
 
 /// The extent size-class ladder for a `page`-byte page size: `page`, then
@@ -315,11 +319,15 @@ impl SwapExtent {
 
     /// Hints the kernel to push the extent's pages to the swap device and
     /// observes the result: returns `true`, marking the extent non-resident,
-    /// only when the observation finds the whole range out of memory. An
+    /// only when the observation finds the whole range unmapped (a page
+    /// whose clean copy lingers in the swap cache counts as reclaimed). An
     /// incomplete pass leaves the extent fully resident for accounting and
-    /// spends one unit of the retry budget. Cheap: the compression is
-    /// already paid, the madvise and mincore are microseconds, and the
-    /// device write happens on the kernel's asynchronous writeback path.
+    /// spends one unit of the retry budget: a single pinned page keeps the
+    /// whole extent counted, which is the safe direction, and the retry
+    /// budget exists exactly for such transient pins. Cheap: the
+    /// compression is already paid, the madvise and page-table read are
+    /// microseconds, and the device write happens on the kernel's
+    /// asynchronous writeback path.
     ///
     /// Callers must not invoke this on a [`SwapExtent::pageout_capped`]
     /// extent.

--- a/src/ore/src/pool/extent.rs
+++ b/src/ore/src/pool/extent.rs
@@ -359,6 +359,24 @@ impl SwapExtent {
     /// is resident again afterwards; the caller owns the accounting for that
     /// transition (the pool re-counts and re-enqueues it for the RSS target).
     pub(crate) fn read_into(&mut self, dst: &mut [u8]) {
+        let full = self.uncompressed_len();
+        assert_eq!(
+            full,
+            dst.len(),
+            "destination must match the extent's uncompressed length"
+        );
+        self.read_range_into(0, dst);
+    }
+
+    /// Decompresses the byte range `[offset, offset + dst.len())` of the
+    /// extent's uncompressed body into `dst`. The range must lie within the
+    /// body. Residency effects are those of [`SwapExtent::read_into`]
+    /// regardless of the range: the stored form is a whole lz4 block, so any
+    /// read faults and decompresses the entire extent, and a sub-range only
+    /// narrows the final copy. A backend whose stored form is rangeable (file
+    /// extents reading with `pread`, a sub-block-framed codec) can serve the
+    /// range with proportional I/O behind this same signature.
+    pub(crate) fn read_range_into(&mut self, offset: usize, dst: &mut [u8]) {
         self.resident = true;
         // The decompress faults every page back in, so prior incomplete
         // pageout passes no longer describe the mapping and the retry
@@ -368,16 +386,50 @@ impl SwapExtent {
         // SAFETY: the extent exclusively owns its backing, and the first
         // `comp_len` bytes were initialized by `write`.
         let buf = unsafe { std::slice::from_raw_parts(self.ptr, self.comp_len) };
-        let prefix: [u8; SIZE_PREFIX] = buf[..SIZE_PREFIX].try_into().expect("prefix length");
-        let uncompressed_len = usize::cast_from(u32::from_le_bytes(prefix));
-        assert_eq!(
-            uncompressed_len,
-            dst.len(),
-            "destination must match the extent's uncompressed length"
+        let uncompressed_len = self.uncompressed_len();
+        let end = offset
+            .checked_add(dst.len())
+            .expect("range end overflows usize");
+        assert!(
+            end <= uncompressed_len,
+            "range end {end} exceeds the extent's uncompressed length {uncompressed_len}",
         );
-        let written = lz4_flex::block::decompress_into(&buf[SIZE_PREFIX..], dst)
-            .expect("extent holds a valid lz4 block");
-        assert_eq!(written, dst.len(), "decompressed length mismatch");
+        if offset == 0 && dst.len() == uncompressed_len {
+            let written = lz4_flex::block::decompress_into(&buf[SIZE_PREFIX..], dst)
+                .expect("extent holds a valid lz4 block");
+            assert_eq!(written, dst.len(), "decompressed length mismatch");
+            return;
+        }
+        // A sub-range still decompresses the whole block, into a reused
+        // thread-local scratch, and copies the range out. Reads run on
+        // worker threads, so the scratch mirrors the write side's `Shrink`
+        // policy: capacity beyond the ~2 MiB chunk target is released after
+        // the copy rather than parked per worker.
+        use std::cell::RefCell;
+        thread_local! {
+            static SCRATCH: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+        }
+        SCRATCH.with(|cell| {
+            let mut scratch = cell.borrow_mut();
+            scratch.resize(uncompressed_len, 0);
+            let written = lz4_flex::block::decompress_into(&buf[SIZE_PREFIX..], &mut scratch)
+                .expect("extent holds a valid lz4 block");
+            assert_eq!(written, uncompressed_len, "decompressed length mismatch");
+            dst.copy_from_slice(&scratch[offset..end]);
+            if scratch.capacity() > 2 << 20 {
+                scratch.clear();
+                scratch.shrink_to_fit();
+            }
+        });
+    }
+
+    /// The uncompressed body length recorded in the extent's size prefix.
+    fn uncompressed_len(&self) -> usize {
+        // SAFETY: the extent exclusively owns its backing, and the prefix
+        // was initialized by `write`.
+        let buf = unsafe { std::slice::from_raw_parts(self.ptr, SIZE_PREFIX) };
+        let prefix: [u8; SIZE_PREFIX] = buf.try_into().expect("prefix length");
+        usize::cast_from(u32::from_le_bytes(prefix))
     }
 }
 
@@ -554,6 +606,43 @@ mod tests {
         assert_eq!(arena.fallbacks(), 1, "freed slot is reused, no fallback");
         drop(c);
         drop(b);
+    }
+
+    /// A ranged read returns exactly the corresponding slice of a full
+    /// read, at aligned and unaligned offsets, across page boundaries, and
+    /// at the body's edges.
+    #[mz_ore::test]
+    fn ranged_read_matches_full_read_slice() {
+        let arena = arena();
+        let data: Vec<u64> = (0..10_000u64).map(|i| i.wrapping_mul(0x9E37)).collect();
+        let bytes: &[u8] = bytemuck::cast_slice(&data);
+        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let mut full = vec![0u8; bytes.len()];
+        extent.read_into(&mut full);
+        assert_eq!(full, bytes);
+        let page = region::page_size();
+        let ranges = [
+            (0, 8),
+            (8, 16),
+            (page - 3, page + 7),
+            (bytes.len() - 24, 24),
+            (0, bytes.len()),
+        ];
+        for (offset, len) in ranges {
+            let mut out = vec![0u8; len];
+            extent.read_range_into(offset, &mut out);
+            assert_eq!(out, &full[offset..offset + len], "range ({offset}, {len})");
+        }
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "range end")]
+    fn ranged_read_out_of_bounds_panics() {
+        let arena = arena();
+        let data = vec![5u64; 64];
+        let mut extent = SwapExtent::write(&arena, &data, Scratch::Shrink);
+        let mut out = vec![0u8; 16];
+        extent.read_range_into(64 * 8 - 8, &mut out);
     }
 
     #[mz_ore::test]

--- a/src/ore/src/pool/extent.rs
+++ b/src/ore/src/pool/extent.rs
@@ -1,0 +1,263 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Swap-backed extents: the backing store for the buffer pool on nodes whose
+//! whole disk is provisioned as swap.
+//!
+//! An extent is a page-aligned anonymous allocation holding the lz4-compressed
+//! bytes of one chunk. "Write" compresses into the allocation, which stays
+//! resident — the compressed-but-resident middle tier of the pool's ladder —
+//! until the pool's RSS target forces [`SwapExtent::pageout`], which pushes
+//! the pages to the swap device with `MADV_PAGEOUT`. "Read" issues
+//! `MADV_WILLNEED` ahead of the decompress (and makes the pages resident
+//! again); "free" is a plain deallocation, with any swapped copy discarded
+//! for free. Nothing is ever both uncompressed and on the device.
+
+use std::alloc::Layout;
+
+use crate::cast::CastFrom;
+use crate::pool::region;
+
+/// Alignment and size granule of extent allocations.
+const EXTENT_ALIGN: usize = 4096;
+
+/// Length in bytes of the little-endian `u32` uncompressed-size prefix that
+/// precedes the compressed bytes, matching the
+/// `lz4_flex::block::compress_prepend_size` framing.
+const SIZE_PREFIX: usize = 4;
+
+/// One chunk's compressed backing copy.
+#[derive(Debug)]
+pub(crate) struct SwapExtent {
+    ptr: *mut u8,
+    layout: Layout,
+    comp_len: usize,
+    /// Whether the extent's pages are (engine-)resident: set at write and by
+    /// [`SwapExtent::read_into`], cleared by [`SwapExtent::pageout`]. Drives
+    /// the pool's `extent_resident_bytes` accounting; mutated only under the
+    /// owning chunk's state mutex.
+    resident: bool,
+}
+
+// SAFETY: the extent exclusively owns its allocation; nothing else holds a
+// pointer into it, so moving the owner across threads is sound. All access
+// goes through the owning chunk's state mutex.
+unsafe impl Send for SwapExtent {}
+
+impl SwapExtent {
+    /// Compresses `data` into a fresh extent. The pages stay resident; the
+    /// pool's RSS-target enforcement decides when [`SwapExtent::pageout`]
+    /// pushes them to the device.
+    ///
+    /// Compression goes through a reused thread-local scratch buffer so the
+    /// extent allocation can be sized to the *actual* compressed payload
+    /// (rounded to the page granule) rather than lz4's worst case. Worst-case
+    /// sizing costs ~5.6× on compressible data — in swap capacity, in swap
+    /// write bandwidth per eviction (the whole allocation is paged out), and
+    /// in `alloc_zeroed` memset traffic on recycled allocations — which at
+    /// hydration eviction rates backs up device writeback and bloats the
+    /// working set with swap-cache pages.
+    pub(crate) fn write(data: &[u64]) -> SwapExtent {
+        use std::cell::RefCell;
+        thread_local! {
+            static SCRATCH: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+        }
+        let bytes: &[u8] = bytemuck::cast_slice(data);
+        SCRATCH.with(|scratch| {
+            let mut scratch = scratch.borrow_mut();
+            let max_out = lz4_flex::block::get_maximum_output_size(bytes.len());
+            scratch.resize(SIZE_PREFIX + max_out, 0);
+            let uncompressed_len =
+                u32::try_from(bytes.len()).expect("chunk payloads are bounded by the size classes");
+            scratch[..SIZE_PREFIX].copy_from_slice(&uncompressed_len.to_le_bytes());
+            let compressed = lz4_flex::block::compress_into(bytes, &mut scratch[SIZE_PREFIX..])
+                .expect("output sized by get_maximum_output_size");
+            let comp_len = SIZE_PREFIX + compressed;
+
+            let layout = extent_layout(comp_len);
+            // SAFETY: `layout` has nonzero size (at least one granule).
+            let ptr = unsafe { std::alloc::alloc(layout) };
+            if ptr.is_null() {
+                std::alloc::handle_alloc_error(layout);
+            }
+            // SAFETY: `ptr` is a fresh allocation of at least `comp_len`
+            // bytes (`extent_layout`'s contract) exclusively owned here; the
+            // copy plus the tail zeroing below initialize every byte, so
+            // later borrows of the allocation (in `read_into`) see
+            // initialized memory. The source is the scratch buffer, which
+            // cannot alias the fresh allocation.
+            unsafe {
+                std::ptr::copy_nonoverlapping(scratch.as_ptr(), ptr, comp_len);
+                std::ptr::write_bytes(ptr.add(comp_len), 0, layout.size() - comp_len);
+            }
+            SwapExtent {
+                ptr,
+                layout,
+                comp_len,
+                resident: true,
+            }
+        })
+    }
+
+    /// The byte size of the extent's allocation: the granule the resident
+    /// accounting and the pageout operate on.
+    pub(crate) fn alloc_size(&self) -> usize {
+        self.layout.size()
+    }
+
+    /// Whether the extent's pages are engine-resident (not pushed to the
+    /// device since the last write or read).
+    pub(crate) fn is_resident(&self) -> bool {
+        self.resident
+    }
+
+    /// Hints the kernel to push the extent's pages to the swap device and
+    /// marks the extent non-resident. Cheap: the compression is already
+    /// paid, the madvise is microseconds, and the device write happens on
+    /// the kernel's asynchronous writeback path.
+    pub(crate) fn pageout(&mut self) {
+        region::pageout(self.ptr, self.layout.size());
+        self.resident = false;
+    }
+
+    /// Compressed size in bytes, including the size prefix.
+    pub(crate) fn comp_len(&self) -> usize {
+        self.comp_len
+    }
+
+    /// Hints the kernel to swap the extent's pages back in ahead of a read.
+    pub(crate) fn prefetch(&self) {
+        region::willneed(self.ptr, self.layout.size());
+    }
+
+    /// Decompresses the extent into `dst`, which must be exactly the chunk's
+    /// uncompressed length. Reading faults the pages back in, so the extent
+    /// is resident again afterwards; the caller owns the accounting for that
+    /// transition (the pool re-counts and re-enqueues it for the RSS target).
+    pub(crate) fn read_into(&mut self, dst: &mut [u8]) {
+        self.resident = true;
+        self.prefetch();
+        // SAFETY: the extent exclusively owns `[ptr, ptr + layout.size())`
+        // and `comp_len <= layout.size()` by construction in `write`.
+        let buf = unsafe { std::slice::from_raw_parts(self.ptr, self.comp_len) };
+        let prefix: [u8; SIZE_PREFIX] = buf[..SIZE_PREFIX].try_into().expect("prefix length");
+        let uncompressed_len = usize::cast_from(u32::from_le_bytes(prefix));
+        assert_eq!(
+            uncompressed_len,
+            dst.len(),
+            "destination must match the extent's uncompressed length"
+        );
+        let written = lz4_flex::block::decompress_into(&buf[SIZE_PREFIX..], dst)
+            .expect("extent holds a valid lz4 block");
+        assert_eq!(written, dst.len(), "decompressed length mismatch");
+    }
+}
+
+/// The allocation layout for a compressed payload of `comp_len` bytes: the
+/// size rounded up to the extent granule, so the allocation always covers
+/// the payload with less than one granule of slack.
+fn extent_layout(comp_len: usize) -> Layout {
+    let size = comp_len.next_multiple_of(EXTENT_ALIGN);
+    Layout::from_size_align(size, EXTENT_ALIGN).expect("valid extent layout")
+}
+
+impl Drop for SwapExtent {
+    fn drop(&mut self) {
+        // SAFETY: `ptr` was returned by `alloc` with exactly this `layout`
+        // in `write` and is deallocated exactly once, here.
+        unsafe {
+            std::alloc::dealloc(self.ptr, self.layout);
+        }
+    }
+}
+
+/// Kani proof harnesses over the extent layout arithmetic; see the sibling
+/// module in `region.rs` for scope and run instructions.
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    /// `extent_layout` covers every payload the size classes can produce,
+    /// with less than one granule of slack, at the granule alignment. The
+    /// bound is lz4's worst case over the largest class plus the size
+    /// prefix, which is also what justifies the unchecked `next_multiple_of`
+    /// (no overflow within the bound).
+    #[kani::proof]
+    fn extent_layout_covers_payload() {
+        let max_comp = SIZE_PREFIX
+            + lz4_flex::block::get_maximum_output_size(
+                region::SIZE_CLASSES[region::SIZE_CLASSES.len() - 1],
+            );
+        let comp_len: usize = kani::any();
+        kani::assume(comp_len >= 1 && comp_len <= max_comp);
+        let layout = extent_layout(comp_len);
+        assert!(layout.size() >= comp_len);
+        assert!(layout.size() - comp_len < EXTENT_ALIGN);
+        assert!(layout.size() % EXTENT_ALIGN == 0);
+        assert_eq!(layout.align(), EXTENT_ALIGN);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn round_trip() {
+        let data: Vec<u64> = (0..10_000).map(|i| i * 37).collect();
+        let mut extent = SwapExtent::write(&data);
+        assert!(extent.comp_len() > SIZE_PREFIX);
+        extent.prefetch();
+        let mut out = vec![0u64; data.len()];
+        extent.read_into(bytemuck::cast_slice_mut(&mut out));
+        assert_eq!(out, data);
+    }
+
+    #[mz_ore::test]
+    fn compressible_data_shrinks() {
+        let data = vec![42u64; 100_000];
+        let mut extent = SwapExtent::write(&data);
+        assert!(extent.comp_len() < data.len() * 8 / 4);
+        let mut out = vec![0u64; data.len()];
+        extent.read_into(bytemuck::cast_slice_mut(&mut out));
+        assert_eq!(out, data);
+    }
+
+    /// The allocation is sized to the compressed payload, not lz4's worst
+    /// case: extents must cost swap capacity and write bandwidth in
+    /// proportion to what they store.
+    #[mz_ore::test]
+    fn allocation_is_sized_to_payload() {
+        let data = vec![7u64; 100_000];
+        let extent = SwapExtent::write(&data);
+        assert_eq!(
+            extent.alloc_size(),
+            extent.comp_len().next_multiple_of(EXTENT_ALIGN),
+        );
+        assert!(
+            extent.alloc_size() < data.len() * 8 / 8,
+            "compressible data must not be stored at worst-case size",
+        );
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "destination must match")]
+    fn wrong_destination_length_panics() {
+        let data = vec![1u64; 16];
+        let mut extent = SwapExtent::write(&data);
+        let mut out = vec![0u64; 8];
+        extent.read_into(bytemuck::cast_slice_mut(&mut out));
+    }
+}

--- a/src/ore/src/pool/region.rs
+++ b/src/ore/src/pool/region.rs
@@ -1,0 +1,750 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Size-class virtual-memory regions for the buffer pool.
+//!
+//! One [`Region`] per size class, each a single anonymous `mmap` reservation.
+//! The reservation is virtual; physical memory materializes on first write to
+//! a slot. Slots are scoped to residency: eviction releases a slot's physical
+//! pages with [`dontneed`] and returns the slot index to the free list, so a
+//! chunk holds a slot only from insert until its eviction, and the pool reads
+//! slots strictly copy-out under the owning chunk's state lock.
+//!
+//! Two fault-amortization mechanisms soften the cost of cycling slots:
+//!
+//! * Regions whose class is at least one huge page are aligned to the huge
+//!   page and advised `MADV_HUGEPAGE`, so populating a large slot costs one
+//!   fault instead of one per 4 KiB.
+//! * The free list is split into a *warm* side (pages kept resident; reuse
+//!   faults nothing and skips the kernel's page zeroing) and a *cold* side
+//!   (pages released). The pool decides which side a freed slot joins,
+//!   bounding total warm bytes as a fraction of its budget.
+//!
+//! TODO: consider `mlock`ing slot regions so kernel swap can never write
+//! out pages the engine would discard or write better itself. Needs
+//! `RLIMIT_MEMLOCK` tuning before it can be on by default.
+//!
+//! All platform access goes through the [`sys`] seam: mapping, unmapping,
+//! paging advice, and the page size. Under Miri the seam swaps to a
+//! Rust-heap backing with advice as a contents-preserving no-op, so the
+//! pool's tests (including the unsafe slot borrows they exercise) run under
+//! the interpreter.
+
+use std::io;
+use std::sync::Mutex;
+
+use crate::cast::CastFrom;
+
+/// Chunk size classes in bytes, smallest first. The pool places each chunk in
+/// the smallest class that fits its payload.
+///
+/// The top classes deliberately overshoot the batchers' nominal ~2 MiB chunk
+/// target: the ship heuristic re-targets the next 2 MiB boundary whenever a
+/// single push crosses one, so real chunk sizes are multimodal with bands
+/// just under each boundary. A class that fits only the nominal target sends
+/// the higher bands to the unpageable heap fallback. Slot internal
+/// fragmentation is virtual-only — slots populate lazily, so a chunk costs
+/// physical memory for its payload, not its class size.
+pub(crate) const SIZE_CLASSES: [usize; 8] = [
+    64 << 10,
+    128 << 10,
+    256 << 10,
+    512 << 10,
+    1 << 20,
+    2 << 20,
+    4 << 20,
+    8 << 20,
+];
+
+/// The smallest size class that fits a payload of `len_bytes`, or `None`
+/// when even the largest class is too small. A selected class always fits:
+/// `SIZE_CLASSES[class] >= len_bytes`, the bound the pool turns into slice
+/// lengths over slot memory (proved by the Kani harnesses).
+pub(crate) fn size_class_for(len_bytes: usize) -> Option<usize> {
+    SIZE_CLASSES.iter().position(|&c| c >= len_bytes)
+}
+
+/// One anonymous virtual-memory reservation serving fixed-size slots of a
+/// single size class.
+#[derive(Debug)]
+pub(crate) struct Region {
+    base: *mut u8,
+    capacity: usize,
+    /// Alignment of `base`, needed to return the mapping to [`sys::unmap`].
+    align: usize,
+    class_size: usize,
+    slots: Mutex<SlotAllocator>,
+}
+
+/// Free-list-plus-bump slot allocator. A slot index returns to a free list
+/// whenever its chunk stops being resident — eviction and free alike. Warm
+/// slots keep their physical pages (reuse is fault-free); cold slots had
+/// theirs released. Never-allocated slots beyond the high-water mark are
+/// untouched virtual space and fault on first write like cold ones.
+#[derive(Debug)]
+struct SlotAllocator {
+    free_warm: Vec<u32>,
+    free_cold: Vec<u32>,
+    high_water: u32,
+    max_slots: u32,
+}
+
+impl SlotAllocator {
+    fn new(max_slots: u32) -> SlotAllocator {
+        SlotAllocator {
+            free_warm: Vec::new(),
+            free_cold: Vec::new(),
+            high_water: 0,
+            max_slots,
+        }
+    }
+
+    /// Allocates a slot index, or `None` when every slot is in use; the flag
+    /// reports whether the slot came from the warm list. Warm slots are
+    /// preferred, then cold, then never-touched bump slots.
+    fn alloc(&mut self) -> Option<(u32, bool)> {
+        if let Some(slot) = self.free_warm.pop() {
+            return Some((slot, true));
+        }
+        if let Some(slot) = self.free_cold.pop() {
+            return Some((slot, false));
+        }
+        if self.high_water == self.max_slots {
+            return None;
+        }
+        let slot = self.high_water;
+        self.high_water += 1;
+        Some((slot, false))
+    }
+
+    /// Returns a previously allocated slot to the warm or cold free list.
+    fn free(&mut self, slot: u32, warm: bool) {
+        debug_assert!(slot < self.high_water);
+        if warm {
+            self.free_warm.push(slot);
+        } else {
+            self.free_cold.push(slot);
+        }
+    }
+}
+
+// SAFETY: `base` points at an anonymous mapping owned exclusively by this
+// `Region` for its whole lifetime. Slot allocation is serialized by the
+// `slots` mutex, and access to a slot's contents is serialized by the
+// owning chunk's state mutex; the raw pointer itself carries no thread
+// affinity.
+unsafe impl Send for Region {}
+// SAFETY: see the `Send` justification; all interior mutability is behind
+// the `slots` mutex, and disjoint slots are written only by their owning
+// chunks.
+unsafe impl Sync for Region {}
+
+impl Region {
+    /// Reserves a region of `capacity_bytes` (rounded down to a whole number
+    /// of slots) for slots of `class_size` bytes.
+    ///
+    /// On Linux, regions whose class is at least [`HUGE_PAGE`] are aligned to
+    /// the huge page and advised `MADV_HUGEPAGE`: their slots tile huge-page
+    /// boundaries exactly, so populating a slot is one huge-page fault rather
+    /// than one fault per 4 KiB, and a whole-slot [`dontneed`] frees whole
+    /// huge pages without splitting any.
+    pub(crate) fn new(class_size: usize, capacity_bytes: usize) -> io::Result<Region> {
+        let page = sys::page_size();
+        assert!(class_size > 0 && class_size % page == 0);
+        let capacity = capacity_bytes - capacity_bytes % class_size;
+        if capacity == 0 {
+            // A capacity below one slot yields an empty region: `alloc`
+            // always answers `None` and the caller's exhaustion fallback
+            // carries the class. No mapping exists; drop has nothing to do.
+            return Ok(Region {
+                base: std::ptr::NonNull::<u8>::dangling().as_ptr(),
+                capacity: 0,
+                align: page,
+                class_size,
+                slots: Mutex::new(SlotAllocator::new(0)),
+            });
+        }
+        let max_slots = u32::try_from(capacity / class_size).expect("slot count fits u32");
+        let align = if cfg!(target_os = "linux") && class_size >= HUGE_PAGE {
+            HUGE_PAGE
+        } else {
+            page
+        };
+        let base = sys::map(capacity, align)?;
+        Ok(Region {
+            base,
+            capacity,
+            align,
+            class_size,
+            slots: Mutex::new(SlotAllocator::new(max_slots)),
+        })
+    }
+
+    /// Size in bytes of every slot in this region.
+    pub(crate) fn class_size(&self) -> usize {
+        self.class_size
+    }
+
+    /// Allocates a slot index, or `None` if every slot of the class is in
+    /// use; the flag reports whether the slot came from the warm list (its
+    /// pages are resident; writing it faults nothing).
+    ///
+    /// Slots are scoped to residency (eviction frees them), so demand scales
+    /// with the *resident* set — bounded by the pool budget plus in-flight
+    /// slack — and exhaustion means residency outgrew the class reservation;
+    /// callers degrade rather than fail.
+    pub(crate) fn alloc(&self) -> Option<(u32, bool)> {
+        self.slots
+            .lock()
+            .expect("region allocator poisoned")
+            .alloc()
+    }
+
+    /// Returns a slot to the warm or cold free list. The caller must be
+    /// freeing the chunk that owned the slot, must have released the slot's
+    /// physical pages iff `warm` is false, and owns the warm-bytes accounting
+    /// that bounds the warm side.
+    pub(crate) fn free(&self, slot: u32, warm: bool) {
+        self.slots
+            .lock()
+            .expect("region allocator poisoned")
+            .free(slot, warm);
+    }
+
+    /// Test hook: overwrites every free slot with `0xDE` so stale contents
+    /// cannot masquerade as correct data when a slot is reused.
+    #[cfg(test)]
+    pub(crate) fn poison_free_slots(&self) {
+        let slots = self.slots.lock().expect("region allocator poisoned");
+        for &slot in slots.free_warm.iter().chain(slots.free_cold.iter()) {
+            let offset = usize::cast_from(slot) * self.class_size;
+            // SAFETY: the slot is on a free list and the allocator mutex is
+            // held, so no chunk owns it and no allocation can race; the write
+            // stays within the region's mapping.
+            unsafe {
+                std::ptr::write_bytes(self.base.add(offset), 0xDE, self.class_size);
+            }
+        }
+    }
+
+    /// The base address of a slot, fixed while its owning chunk is resident.
+    pub(crate) fn slot_ptr(&self, slot: u32) -> *mut u8 {
+        let offset = usize::cast_from(slot) * self.class_size;
+        debug_assert!(offset + self.class_size <= self.capacity);
+        // SAFETY: `slot` was handed out by `alloc`, so `offset + class_size`
+        // lies within the single `capacity`-byte mapping that `base` points
+        // to; the add stays in bounds of one allocated object.
+        unsafe { self.base.add(offset) }
+    }
+}
+
+impl Drop for Region {
+    fn drop(&mut self) {
+        // Empty regions never created a mapping.
+        if self.capacity == 0 {
+            return;
+        }
+        // SAFETY: `base`/`capacity`/`align` describe exactly the mapping
+        // created in `new`, and dropping the region means no chunk (and
+        // hence no outstanding borrow) refers into it any longer.
+        unsafe {
+            sys::unmap(self.base, self.capacity, self.align);
+        }
+    }
+}
+
+/// The transparent-huge-page size assumed for region alignment. Linux x86-64
+/// and aarch64 (4 KiB base pages) both use 2 MiB; if a platform differs, the
+/// alignment is merely unhelpful, never wrong.
+const HUGE_PAGE: usize = 2 << 20;
+
+/// Releases the physical pages of the page-aligned subrange of
+/// `[ptr, ptr + len)`, keeping the virtual range mapped.
+///
+/// # Safety
+///
+/// The range must lie within a live mapping exclusively owned by the caller,
+/// with no outstanding references into it. After the call the range's contents
+/// are undefined: Linux replaces them with zero pages, but other systems
+/// (macOS in particular) may keep the old bytes resident, so callers must
+/// fully overwrite the range before reading it again.
+pub(crate) unsafe fn dontneed(ptr: *mut u8, len: usize) {
+    // SAFETY: forwarding this function's contract.
+    unsafe { sys::advise(ptr, len, sys::Advice::DontNeed) }
+}
+
+/// Hints the kernel to reclaim the page-aligned subrange of `[ptr, ptr + len)`
+/// immediately, writing it to the swap device. Contents are preserved; this is
+/// a non-destructive hint. No-op outside Linux.
+pub(crate) fn pageout(ptr: *mut u8, len: usize) {
+    // SAFETY: the advice is a contents-preserving hint, so the only
+    // obligation is that the range lies in a live mapping, which callers
+    // guarantee by passing a live slot or extent allocation.
+    unsafe { sys::advise(ptr, len, sys::Advice::PageOut) }
+}
+
+/// Hints the kernel to fault the page-aligned subrange of `[ptr, ptr + len)`
+/// back in ahead of need: asynchronous swap-in, the swap-backed extent store's
+/// readahead mechanism. Contents are preserved. No-op outside Linux.
+pub(crate) fn willneed(ptr: *mut u8, len: usize) {
+    // SAFETY: as in `pageout`, a contents-preserving hint over a live
+    // mapping.
+    unsafe { sys::advise(ptr, len, sys::Advice::WillNeed) }
+}
+
+/// The largest `page`-aligned subrange of `[addr, addr + len)`, as a
+/// `(byte offset from addr, subrange length)` pair, or `None` when the range
+/// covers no whole page (including on address-space overflow). `page` must
+/// be a power of two.
+///
+/// Guarantees, relied on by [`sys::advise`] for pointer arithmetic and
+/// proved by the Kani harnesses: `offset <= len`, `offset + sub_len <= len`,
+/// and both `addr + offset` and `sub_len` are `page`-aligned.
+#[cfg_attr(miri, allow(dead_code))]
+fn aligned_subrange(addr: usize, len: usize, page: usize) -> Option<(usize, usize)> {
+    debug_assert!(page.is_power_of_two());
+    let start = addr.checked_add(page - 1)? & !(page - 1);
+    let end = addr.checked_add(len)? & !(page - 1);
+    (start < end).then(|| (start - addr, end - start))
+}
+
+/// Splits an over-mapped range of `map_len` bytes at `addr` into
+/// `(head, tail)` trim amounts such that discarding `head` bytes from the
+/// front and `tail` from the back leaves an `align`-aligned range of exactly
+/// `len` bytes. `None` on address-space overflow or when the range cannot
+/// fit an aligned `len` bytes.
+///
+/// When `addr` and `len` are page-aligned and `align` is a page-multiple
+/// power of two, `head` and `tail` are page-aligned (so both trims are
+/// unmappable) — proved by the Kani harnesses.
+#[cfg_attr(miri, allow(dead_code))]
+fn align_trim(addr: usize, map_len: usize, len: usize, align: usize) -> Option<(usize, usize)> {
+    debug_assert!(align.is_power_of_two());
+    let aligned = addr.checked_next_multiple_of(align)?;
+    let head = aligned - addr;
+    let tail = map_len.checked_sub(head.checked_add(len)?)?;
+    Some((head, tail))
+}
+
+/// The platform seam: mapping, unmapping, paging advice, and the page size.
+///
+/// The `mmap` variant is production; the Miri variant backs regions with the
+/// Rust heap and treats every advice as a contents-preserving no-op — the
+/// weakest behavior the advice contracts allow — so the pool's tests run
+/// under the interpreter with full provenance and data-race checking:
+///
+/// ```text
+/// MIRIFLAGS=-Zmiri-disable-isolation cargo +nightly miri test -p mz-ore --features pool pool::
+/// ```
+///
+/// (The isolation flag is for the test harness's wall-clock log timestamps,
+/// not for anything the pool does.)
+#[cfg(not(miri))]
+mod sys {
+    use std::io;
+
+    use super::{align_trim, aligned_subrange};
+
+    /// Paging advice, in the vocabulary the pool needs.
+    pub(super) enum Advice {
+        /// Release physical pages; contents become undefined.
+        DontNeed,
+        /// Reclaim to the swap device now; contents preserved.
+        PageOut,
+        /// Fault back in ahead of need; contents preserved.
+        WillNeed,
+    }
+
+    /// Maps `len` bytes of anonymous memory with the base aligned to
+    /// `align`. `len` must be a whole number of pages and `align` a
+    /// page-multiple power of two. Alignments beyond one page over-map and
+    /// trim; huge-page alignments additionally advise `MADV_HUGEPAGE`
+    /// (best-effort; the kernel falls back to base pages under
+    /// fragmentation).
+    pub(super) fn map(len: usize, align: usize) -> io::Result<*mut u8> {
+        let page = page_size();
+        debug_assert!(len % page == 0 && align % page == 0);
+        #[cfg(target_os = "linux")]
+        let flags = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_NORESERVE;
+        #[cfg(not(target_os = "linux"))]
+        let flags = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS;
+
+        let map_len = if align > page { len + align } else { len };
+        // SAFETY: anonymous mapping with a null hint; the kernel picks a
+        // fresh range that aliases no existing Rust object. `map_len` is
+        // positive and page-aligned by construction.
+        let raw = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                map_len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                flags,
+                -1,
+                0,
+            )
+        };
+        if raw == libc::MAP_FAILED {
+            return Err(io::Error::last_os_error());
+        }
+        let raw = raw.cast::<u8>();
+        if align <= page {
+            return Ok(raw);
+        }
+
+        // Trim the over-mapped head and tail so the base is aligned and the
+        // region owns exactly `len` bytes; `unmap` releases that range.
+        let Some((head, tail)) = align_trim(raw.addr(), map_len, len, align) else {
+            // Address-space arithmetic overflowed; treat the reservation as
+            // failed rather than keep an unaligned mapping.
+            // SAFETY: unmapping the mapping created above, in full.
+            unsafe { libc::munmap(raw.cast::<libc::c_void>(), map_len) };
+            return Err(io::Error::from(io::ErrorKind::OutOfMemory));
+        };
+        // SAFETY: `head` and `tail` are page-aligned subranges of the
+        // mapping just created (`align_trim`'s contract with page-aligned
+        // inputs), disjoint from the `len` bytes the region keeps; nothing
+        // references them.
+        unsafe {
+            if head > 0 {
+                libc::munmap(raw.cast::<libc::c_void>(), head);
+            }
+            if tail > 0 {
+                libc::munmap(raw.add(head + len).cast::<libc::c_void>(), tail);
+            }
+        }
+        // SAFETY: `head` stays within the original mapping.
+        let base = unsafe { raw.add(head) };
+
+        #[cfg(target_os = "linux")]
+        if align >= super::HUGE_PAGE {
+            // SAFETY: `base`/`len` describe the live aligned mapping; the
+            // advice is a non-destructive hint and failure is ignorable.
+            unsafe {
+                libc::madvise(base.cast::<libc::c_void>(), len, libc::MADV_HUGEPAGE);
+            }
+        }
+        Ok(base)
+    }
+
+    /// Releases a mapping returned by [`map`].
+    ///
+    /// # Safety
+    ///
+    /// `ptr`, `len`, and `align` must describe exactly one prior [`map`]
+    /// result, with no outstanding references into the range.
+    pub(super) unsafe fn unmap(ptr: *mut u8, len: usize, _align: usize) {
+        // SAFETY: per the function contract.
+        unsafe {
+            libc::munmap(ptr.cast::<libc::c_void>(), len);
+        }
+    }
+
+    /// Applies `advice` to the largest page-aligned subrange of
+    /// `[ptr, ptr + len)`, rounding the start up and the end down so the
+    /// advice never spills onto pages the range only partially covers.
+    ///
+    /// # Safety
+    ///
+    /// The range must lie within a live mapping. For [`Advice::DontNeed`]
+    /// the caller must additionally uphold the exclusivity contract
+    /// documented on [`super::dontneed`]; the remaining advice values are
+    /// non-mutating hints.
+    pub(super) unsafe fn advise(ptr: *mut u8, len: usize, advice: Advice) {
+        let advice = match advice {
+            Advice::DontNeed => libc::MADV_DONTNEED,
+            #[cfg(target_os = "linux")]
+            Advice::PageOut => libc::MADV_PAGEOUT,
+            #[cfg(target_os = "linux")]
+            Advice::WillNeed => libc::MADV_WILLNEED,
+            // Reclaim and prefetch hints have no portable equivalent.
+            #[cfg(not(target_os = "linux"))]
+            Advice::PageOut | Advice::WillNeed => return,
+        };
+        let Some((offset, sub_len)) = aligned_subrange(ptr.addr(), len, page_size()) else {
+            return;
+        };
+        // SAFETY: `offset <= len` (`aligned_subrange`'s contract), so the
+        // add stays within the caller's range and preserves provenance.
+        let aligned = unsafe { ptr.byte_add(offset) }.cast::<libc::c_void>();
+        // SAFETY: pointer and length describe a fully page-aligned subrange
+        // of the caller's live mapping; destructive advice is covered by the
+        // function contract.
+        unsafe {
+            libc::madvise(aligned, sub_len, advice);
+        }
+    }
+
+    pub(super) fn page_size() -> usize {
+        // SAFETY: `sysconf` with a valid argument is safe.
+        let raw = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        let page = usize::try_from(raw).expect("page size is positive and fits usize");
+        // The alignment arithmetic (`aligned_subrange`, `align_trim`) masks
+        // with `page - 1`; a non-power-of-two page would mis-round silently.
+        assert!(page.is_power_of_two(), "page size is a power of two");
+        page
+    }
+}
+
+#[cfg(miri)]
+mod sys {
+    use std::alloc::Layout;
+    use std::io;
+
+    pub(super) enum Advice {
+        DontNeed,
+        PageOut,
+        WillNeed,
+    }
+
+    pub(super) fn map(len: usize, align: usize) -> io::Result<*mut u8> {
+        let layout = Layout::from_size_align(len, align).expect("valid region layout");
+        // SAFETY: `len` is positive (empty regions never map). The memory is
+        // deliberately left uninitialized, matching the slot contract that
+        // contents are unspecified until fully overwritten; Miri enforces
+        // that no path reads a byte before writing it.
+        let ptr = unsafe { std::alloc::alloc(layout) };
+        if ptr.is_null() {
+            std::alloc::handle_alloc_error(layout);
+        }
+        Ok(ptr)
+    }
+
+    pub(super) unsafe fn unmap(ptr: *mut u8, len: usize, align: usize) {
+        let layout = Layout::from_size_align(len, align).expect("valid region layout");
+        // SAFETY: `ptr` was returned by `map` with exactly this layout.
+        unsafe { std::alloc::dealloc(ptr, layout) }
+    }
+
+    /// Advice is a contents-preserving no-op: the weakest behavior the
+    /// contracts allow (`DontNeed` leaves contents undefined, and "old bytes
+    /// kept" is one of the permitted outcomes, as on macOS).
+    pub(super) unsafe fn advise(_ptr: *mut u8, _len: usize, _advice: Advice) {}
+
+    pub(super) fn page_size() -> usize {
+        4096
+    }
+}
+
+/// Kani proof harnesses over the pure arithmetic and the slot allocator:
+/// the sequential facts the pool's unsafe blocks rest on. Run
+/// `cargo kani --features pool` from `src/ore`; each harness is exhaustive
+/// over its symbolic inputs. Kani ships its own toolchain, so it needs a
+/// release whose rustc is at or above the workspace `rust-version` (or the
+/// manifest check bypassed for the run). Concurrency-justified claims (the
+/// lock-protocol aliasing arguments in `pool.rs`) are outside Kani's
+/// sequential model and are exercised under Miri instead.
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    /// `aligned_subrange`'s contract: the subrange lies within the input
+    /// range, is nonempty, and is page-aligned at both ends.
+    #[kani::proof]
+    fn aligned_subrange_stays_in_bounds() {
+        let addr: usize = kani::any();
+        let len: usize = kani::any();
+        let shift: u32 = kani::any();
+        kani::assume(shift < usize::BITS);
+        let page = 1usize << shift;
+        if let Some((offset, sub_len)) = aligned_subrange(addr, len, page) {
+            assert!(offset <= len);
+            assert!(sub_len <= len - offset);
+            assert!(sub_len > 0);
+            assert!((addr + offset) % page == 0);
+            assert!(sub_len % page == 0);
+        }
+    }
+
+    /// `align_trim`'s contract: head and tail partition the over-map
+    /// exactly around an aligned range of the requested length, and with
+    /// page-aligned inputs both trims are page-aligned, so each can be
+    /// unmapped independently.
+    #[kani::proof]
+    fn align_trim_partitions_the_overmap() {
+        let addr: usize = kani::any();
+        let len: usize = kani::any();
+        let page_shift: u32 = kani::any();
+        let align_shift: u32 = kani::any();
+        kani::assume(page_shift <= align_shift && align_shift < usize::BITS - 1);
+        let page = 1usize << page_shift;
+        let align = 1usize << align_shift;
+        kani::assume(addr % page == 0);
+        kani::assume(len % page == 0);
+        let Some(map_len) = len.checked_add(align) else {
+            return;
+        };
+        if let Some((head, tail)) = align_trim(addr, map_len, len, align) {
+            assert_eq!(head + len + tail, map_len);
+            assert!(head < align);
+            assert!(head % page == 0);
+            assert!(tail % page == 0);
+            assert!((addr + head) % align == 0);
+        }
+    }
+
+    /// The slot allocator, over every alloc/free sequence of a bounded
+    /// length: an allocated slot is always in range and never aliases a
+    /// live one. This is the disjointness fact `slot_ptr`'s callers turn
+    /// into non-aliasing slices.
+    #[kani::proof]
+    #[kani::unwind(8)]
+    fn slot_allocator_hands_out_disjoint_slots() {
+        const MAX: u32 = 3;
+        let mut slots = SlotAllocator::new(MAX);
+        let mut live = [false; MAX as usize];
+        for _ in 0..5 {
+            if kani::any() {
+                if let Some((slot, _warm)) = slots.alloc() {
+                    let slot = usize::try_from(slot).expect("fits");
+                    assert!(slot < live.len(), "slot out of range");
+                    assert!(!live[slot], "live slot handed out twice");
+                    live[slot] = true;
+                }
+            } else {
+                let slot: usize = kani::any();
+                kani::assume(slot < live.len());
+                if live[slot] {
+                    live[slot] = false;
+                    slots.free(u32::try_from(slot).expect("fits"), kani::any());
+                }
+            }
+        }
+    }
+
+    /// The class-selection contract the pool turns into slice bounds: a
+    /// selected class always fits the payload.
+    #[kani::proof]
+    #[kani::unwind(10)]
+    fn selected_class_fits_payload() {
+        let len_bytes: usize = kani::any();
+        if let Some(class) = size_class_for(len_bytes) {
+            assert!(class < SIZE_CLASSES.len());
+            assert!(SIZE_CLASSES[class] >= len_bytes);
+        } else {
+            assert!(len_bytes > SIZE_CLASSES[SIZE_CLASSES.len() - 1]);
+        }
+    }
+
+    /// The offset arithmetic behind `slot_ptr`: for every size class and
+    /// every slot index the allocator can hand out, the slot lies within
+    /// the region's capacity.
+    #[kani::proof]
+    #[kani::unwind(9)]
+    fn slot_offsets_lie_within_capacity() {
+        for &class_size in &SIZE_CLASSES {
+            let capacity_bytes: usize = kani::any();
+            kani::assume(capacity_bytes <= 1 << 40);
+            let capacity = capacity_bytes - capacity_bytes % class_size;
+            let max_slots = capacity / class_size;
+            let slot: usize = kani::any();
+            kani::assume(slot < max_slots);
+            let offset = slot * class_size;
+            assert!(offset + class_size <= capacity);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn alloc_free_reuses_slots() {
+        let region = Region::new(64 << 10, 1 << 20).expect("mmap");
+        let (a, warm_a) = region.alloc().expect("slot");
+        let (b, _) = region.alloc().expect("slot");
+        assert!(!warm_a, "bump slots are not warm");
+        assert_ne!(a, b);
+        assert_ne!(region.slot_ptr(a), region.slot_ptr(b));
+        let ptr_a = region.slot_ptr(a);
+        // A warm free is preferred by the next alloc and reported warm.
+        region.free(a, true);
+        let (c, warm_c) = region.alloc().expect("slot");
+        assert_eq!(c, a);
+        assert!(warm_c);
+        assert_eq!(region.slot_ptr(c), ptr_a);
+        // A cold free comes back, but not warm.
+        region.free(c, false);
+        let (d, warm_d) = region.alloc().expect("slot");
+        assert_eq!(d, a);
+        assert!(!warm_d);
+    }
+
+    /// Hugepage-class regions get a huge-page-aligned base, so slots tile
+    /// huge-page boundaries exactly.
+    #[mz_ore::test]
+    fn hugepage_class_base_is_aligned() {
+        let region = Region::new(2 << 20, 16 << 20).expect("mmap");
+        let (slot, _) = region.alloc().expect("slot");
+        if cfg!(target_os = "linux") {
+            assert_eq!(
+                region.slot_ptr(slot).addr() % HUGE_PAGE,
+                0,
+                "hugepage-class slots must be huge-page aligned",
+            );
+        }
+    }
+
+    #[mz_ore::test]
+    fn exhaustion_returns_none() {
+        let region = Region::new(64 << 10, 128 << 10).expect("mmap");
+        assert!(region.alloc().is_some());
+        assert!(region.alloc().is_some());
+        assert!(region.alloc().is_none(), "third slot exceeds capacity");
+    }
+
+    #[mz_ore::test]
+    fn slots_are_writable_and_advice_is_accepted() {
+        let region = Region::new(64 << 10, 1 << 20).expect("mmap");
+        let (slot, _) = region.alloc().expect("slot");
+        let ptr = region.slot_ptr(slot);
+        // SAFETY: freshly allocated slot, exclusively owned by this test.
+        unsafe {
+            std::ptr::write_bytes(ptr, 0xAB, region.class_size());
+        }
+        pageout(ptr, region.class_size());
+        willneed(ptr, region.class_size());
+        // SAFETY: the slot is exclusively owned and is not read again before
+        // being overwritten (it is not read again at all).
+        unsafe {
+            dontneed(ptr, region.class_size());
+        }
+    }
+
+    #[mz_ore::test]
+    fn aligned_subrange_agrees_with_examples() {
+        // Fully aligned range: identity.
+        assert_eq!(aligned_subrange(4096, 8192, 4096), Some((0, 8192)));
+        // Unaligned start rounds up, unaligned end rounds down.
+        assert_eq!(aligned_subrange(4097, 8192, 4096), Some((4095, 4096)));
+        // Too short to cover a whole page.
+        assert_eq!(aligned_subrange(4097, 4096, 4096), None);
+        assert_eq!(aligned_subrange(0, 0, 4096), None);
+    }
+
+    #[mz_ore::test]
+    fn align_trim_agrees_with_examples() {
+        // Already aligned: no head, tail is the whole over-map.
+        assert_eq!(
+            align_trim(HUGE_PAGE, 3 * HUGE_PAGE, 2 * HUGE_PAGE, HUGE_PAGE),
+            Some((0, HUGE_PAGE))
+        );
+        // Unaligned base: head consumes the misalignment.
+        assert_eq!(
+            align_trim(HUGE_PAGE + 4096, 3 * HUGE_PAGE, 2 * HUGE_PAGE, HUGE_PAGE),
+            Some((HUGE_PAGE - 4096, 4096)),
+        );
+    }
+}

--- a/src/ore/src/pool/region.rs
+++ b/src/ore/src/pool/region.rs
@@ -380,11 +380,13 @@ pub(crate) fn page_size() -> usize {
     sys::page_size()
 }
 
-/// Whether every page of the page-aligned subrange of `[ptr, ptr + len)` is
-/// out of memory, per `mincore(2)`: the observation the pageout ledger
-/// trusts instead of the reclaim advice's return value. Errs toward `false`
-/// (resident) when the observation is unavailable. In test builds the
-/// answer comes from [`fake_residency`] instead of the platform.
+/// Whether every page of the page-aligned subrange of `[ptr, ptr + len)`
+/// has been unmapped from this process, per the pagemap present bits: the
+/// observation the pageout ledger trusts instead of the reclaim advice's
+/// return value. A page unmapped to a swap entry counts as reclaimed even
+/// while its clean copy lingers in the kernel's swap cache. Errs toward
+/// `false` (resident) when the observation is unavailable. In test builds
+/// the answer comes from the `fake_residency` seam instead of the platform.
 pub(crate) fn nonresident(ptr: *mut u8, len: usize) -> bool {
     #[cfg(test)]
     {
@@ -620,8 +622,19 @@ mod sys {
     }
 
     /// Whether every page of the page-aligned subrange of `[ptr, ptr + len)`
-    /// is nonresident, per `mincore(2)`. A failed observation reports
-    /// `false`: the ledger keeps counting pages it cannot prove gone.
+    /// has been unmapped from this process, per the present bits in
+    /// `/proc/self/pagemap`. A failed observation reports `false`: the
+    /// ledger keeps counting pages it cannot prove gone.
+    ///
+    /// The present bit is the signal, deliberately not `mincore(2)`:
+    /// successful asynchronous reclaim unmaps the PTE to a swap entry while
+    /// the page's clean copy lingers in the kernel's swap cache, and mincore
+    /// reports swap-cache pages as in core. Observing in-core-ness would
+    /// therefore misclassify essentially every successful pageout on an
+    /// unpressured host (the retry advice cannot change the outcome either,
+    /// since the advice skips already-unmapped PTEs). An unmapped page is
+    /// reclaimed for this ledger's purposes: a clean swap-cache copy is
+    /// memory the kernel drops for free.
     ///
     /// Only Linux answers from the kernel. Elsewhere the reclaim advice is
     /// compiled out, so there is no reclaim to observe and the answer is
@@ -630,25 +643,47 @@ mod sys {
     pub(super) fn nonresident(ptr: *mut u8, len: usize) -> bool {
         #[cfg(target_os = "linux")]
         {
+            use std::cell::RefCell;
+            use std::os::unix::fs::FileExt;
+            use std::sync::OnceLock;
+
+            // Reading a process's own pagemap needs no privilege since
+            // Linux 4.2: unprivileged readers see zeroed frame numbers,
+            // which this probe never looks at.
+            static PAGEMAP: OnceLock<Option<std::fs::File>> = OnceLock::new();
+            let Some(pagemap) = PAGEMAP
+                .get_or_init(|| std::fs::File::open("/proc/self/pagemap").ok())
+                .as_ref()
+            else {
+                return false;
+            };
             let page = page_size();
             let Some((offset, sub_len)) = aligned_subrange(ptr.addr(), len, page) else {
                 // No whole page to observe: vacuously nonresident.
                 return true;
             };
-            // SAFETY: `offset <= len` (`aligned_subrange`'s contract), so the
-            // add stays within the caller's range and preserves provenance.
-            let aligned = unsafe { ptr.byte_add(offset) }.cast::<libc::c_void>();
-            // `sub_len` is a whole number of pages (`aligned_subrange`'s
-            // contract), one status byte each.
-            let mut status = vec![0u8; sub_len / page];
-            // SAFETY: pointer and length describe a fully page-aligned
-            // subrange of the caller's live mapping, and `status` holds one
-            // byte per page of it.
-            let rc = unsafe { libc::mincore(aligned, sub_len, status.as_mut_ptr().cast()) };
-            if rc != 0 {
-                return false;
+            let first_page = (ptr.addr() + offset) / page;
+            let pages = sub_len / page;
+            thread_local! {
+                static SCRATCH: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) };
             }
-            status.iter().all(|&page_status| page_status & 1 == 0)
+            SCRATCH.with(|scratch| {
+                let mut buf = scratch.borrow_mut();
+                buf.clear();
+                buf.resize(pages, 0);
+                let file_offset = u64::try_from(first_page).expect("page index fits u64") * 8;
+                if pagemap
+                    .read_exact_at(bytemuck::cast_slice_mut(buf.as_mut_slice()), file_offset)
+                    .is_err()
+                {
+                    return false;
+                }
+                // One native-endian u64 per page, per the kernel ABI
+                // (Documentation/admin-guide/mm/pagemap.rst); bit 63 is
+                // "present in RAM". A swap-entry PTE (bit 62) and a
+                // never-faulted zero entry are both out of memory.
+                buf.iter().all(|entry| entry & (1 << 63) == 0)
+            })
         }
         #[cfg(not(target_os = "linux"))]
         {

--- a/src/ore/src/pool/region.rs
+++ b/src/ore/src/pool/region.rs
@@ -304,6 +304,63 @@ pub(crate) fn willneed(ptr: *mut u8, len: usize) {
     unsafe { sys::advise(ptr, len, sys::Advice::WillNeed) }
 }
 
+/// Opts the page-aligned subrange of `[ptr, ptr + len)` out of transparent
+/// huge pages, so reclaim advice over the range operates on base pages and
+/// never needs a folio split. Contents are preserved. No-op outside Linux.
+pub(crate) fn nohugepage(ptr: *mut u8, len: usize) {
+    // SAFETY: as in `pageout`, a contents-preserving hint over a live
+    // mapping.
+    unsafe { sys::advise(ptr, len, sys::Advice::NoHugePage) }
+}
+
+/// Whether every page of the page-aligned subrange of `[ptr, ptr + len)` is
+/// out of memory, per `mincore(2)`: the observation the pageout ledger
+/// trusts instead of the reclaim advice's return value. Errs toward `false`
+/// (resident) when the observation is unavailable. In test builds the
+/// answer comes from [`fake_residency`] instead of the platform.
+pub(crate) fn nonresident(ptr: *mut u8, len: usize) -> bool {
+    #[cfg(test)]
+    {
+        let _ = (ptr, len);
+        fake_residency::observe()
+    }
+    #[cfg(not(test))]
+    sys::nonresident(ptr, len)
+}
+
+/// Test seam over the pageout residency observation. The decline queue is
+/// thread-local because observation runs on whichever thread enforces the
+/// compressed cap, so tests drive enforcement inline on their own thread.
+#[cfg(test)]
+pub(crate) mod fake_residency {
+    use std::cell::Cell;
+
+    thread_local! {
+        static DECLINES: Cell<u64> = const { Cell::new(0) };
+    }
+
+    /// Makes the next `n` observations on this thread report pages still
+    /// resident, modeling a kernel that declined the reclaim advice.
+    /// Replaces any previously queued declines.
+    pub(crate) fn decline_next(n: u64) {
+        DECLINES.with(|d| d.set(n));
+    }
+
+    /// One observation: consumes a queued decline (reporting the range
+    /// still resident), or reports it fully nonresident.
+    pub(super) fn observe() -> bool {
+        DECLINES.with(|d| {
+            let n = d.get();
+            if n > 0 {
+                d.set(n - 1);
+                false
+            } else {
+                true
+            }
+        })
+    }
+}
+
 /// The largest `page`-aligned subrange of `[addr, addr + len)`, as a
 /// `(byte offset from addr, subrange length)` pair, or `None` when the range
 /// covers no whole page (including on address-space overflow). `page` must
@@ -365,6 +422,8 @@ mod sys {
         PageOut,
         /// Fault back in ahead of need; contents preserved.
         WillNeed,
+        /// Exclude from transparent huge pages; contents preserved.
+        NoHugePage,
     }
 
     /// Maps `len` bytes of anonymous memory with the base aligned to
@@ -468,9 +527,11 @@ mod sys {
             Advice::PageOut => libc::MADV_PAGEOUT,
             #[cfg(target_os = "linux")]
             Advice::WillNeed => libc::MADV_WILLNEED,
-            // Reclaim and prefetch hints have no portable equivalent.
+            #[cfg(target_os = "linux")]
+            Advice::NoHugePage => libc::MADV_NOHUGEPAGE,
+            // Reclaim, prefetch, and THP hints have no portable equivalent.
             #[cfg(not(target_os = "linux"))]
-            Advice::PageOut | Advice::WillNeed => return,
+            Advice::PageOut | Advice::WillNeed | Advice::NoHugePage => return,
         };
         let Some((offset, sub_len)) = aligned_subrange(ptr.addr(), len, page_size()) else {
             return;
@@ -483,6 +544,44 @@ mod sys {
         // function contract.
         unsafe {
             libc::madvise(aligned, sub_len, advice);
+        }
+    }
+
+    /// Whether every page of the page-aligned subrange of `[ptr, ptr + len)`
+    /// is nonresident, per `mincore(2)`. A failed observation reports
+    /// `false`: the ledger keeps counting pages it cannot prove gone.
+    ///
+    /// Only Linux answers from the kernel. Elsewhere the reclaim advice is
+    /// compiled out, so there is no reclaim to observe and the answer is
+    /// `true`, keeping the compressed tier cycling on development platforms.
+    #[cfg_attr(test, allow(dead_code))]
+    pub(super) fn nonresident(ptr: *mut u8, len: usize) -> bool {
+        #[cfg(target_os = "linux")]
+        {
+            let page = page_size();
+            let Some((offset, sub_len)) = aligned_subrange(ptr.addr(), len, page) else {
+                // No whole page to observe: vacuously nonresident.
+                return true;
+            };
+            // SAFETY: `offset <= len` (`aligned_subrange`'s contract), so the
+            // add stays within the caller's range and preserves provenance.
+            let aligned = unsafe { ptr.byte_add(offset) }.cast::<libc::c_void>();
+            // `sub_len` is a whole number of pages (`aligned_subrange`'s
+            // contract), one status byte each.
+            let mut status = vec![0u8; sub_len / page];
+            // SAFETY: pointer and length describe a fully page-aligned
+            // subrange of the caller's live mapping, and `status` holds one
+            // byte per page of it.
+            let rc = unsafe { libc::mincore(aligned, sub_len, status.as_mut_ptr().cast()) };
+            if rc != 0 {
+                return false;
+            }
+            status.iter().all(|&page_status| page_status & 1 == 0)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (ptr, len);
+            true
         }
     }
 
@@ -506,6 +605,7 @@ mod sys {
         DontNeed,
         PageOut,
         WillNeed,
+        NoHugePage,
     }
 
     pub(super) fn map(len: usize, align: usize) -> io::Result<*mut u8> {
@@ -531,6 +631,13 @@ mod sys {
     /// contracts allow (`DontNeed` leaves contents undefined, and "old bytes
     /// kept" is one of the permitted outcomes, as on macOS).
     pub(super) unsafe fn advise(_ptr: *mut u8, _len: usize, _advice: Advice) {}
+
+    /// The heap backing has no residency to observe, so reclaim advice is
+    /// treated as fully effective, mirroring the non-Linux answer.
+    #[cfg_attr(test, allow(dead_code))]
+    pub(super) fn nonresident(_ptr: *mut u8, _len: usize) -> bool {
+        true
+    }
 
     pub(super) fn page_size() -> usize {
         4096

--- a/src/ore/src/pool/region.rs
+++ b/src/ore/src/pool/region.rs
@@ -159,8 +159,23 @@ impl Region {
     /// the huge page and advised `MADV_HUGEPAGE`: their slots tile huge-page
     /// boundaries exactly, so populating a slot is one huge-page fault rather
     /// than one fault per 4 KiB, and a whole-slot [`dontneed`] frees whole
-    /// huge pages without splitting any.
+    /// huge pages without splitting any. Regions whose class is below the
+    /// huge page are advised `MADV_NOHUGEPAGE` instead, so reclaim over a
+    /// single slot stays page-exact.
     pub(crate) fn new(class_size: usize, capacity_bytes: usize) -> io::Result<Region> {
+        Region::with_huge_pages(class_size, capacity_bytes, class_size >= HUGE_PAGE)
+    }
+
+    /// As [`Region::new`], but the region opts out of transparent huge pages
+    /// regardless of class size. For regions whose slots are reclaimed with
+    /// `MADV_PAGEOUT` under observed residency: reclaiming a range a large
+    /// folio covers only partially needs a folio split, and a failed split
+    /// silently leaves pages resident.
+    pub(crate) fn new_nohuge(class_size: usize, capacity_bytes: usize) -> io::Result<Region> {
+        Region::with_huge_pages(class_size, capacity_bytes, false)
+    }
+
+    fn with_huge_pages(class_size: usize, capacity_bytes: usize, huge: bool) -> io::Result<Region> {
         let page = sys::page_size();
         assert!(class_size > 0 && class_size % page == 0);
         let capacity = capacity_bytes - capacity_bytes % class_size;
@@ -177,12 +192,27 @@ impl Region {
             });
         }
         let max_slots = u32::try_from(capacity / class_size).expect("slot count fits u32");
-        let align = if cfg!(target_os = "linux") && class_size >= HUGE_PAGE {
+        let align = if cfg!(target_os = "linux") && huge {
             HUGE_PAGE
         } else {
             page
         };
         let base = sys::map(capacity, align)?;
+        if !huge {
+            // Opt the whole region out of transparent huge pages before any
+            // slot is touched. Production hosts run
+            // `transparent_hugepage=madvise`, where an unadvised region gets
+            // no fault-time folios anyway, so this is defense in depth for
+            // hosts running `always`: there, fault-time folios would straddle
+            // sub-huge-page slot boundaries, and khugepaged (which tolerates
+            // up to `max_ptes_none` empty entries) re-collapses ranges a
+            // slot-granular [`dontneed`] just reclaimed, resurrecting the
+            // released memory.
+            nohugepage(base, capacity);
+        }
+        // Pool contents are recreatable spill data: keep the (potentially
+        // huge) anonymous reservation out of core dumps.
+        dontdump(base, capacity);
         Ok(Region {
             base,
             capacity,
@@ -221,6 +251,30 @@ impl Region {
             .lock()
             .expect("region allocator poisoned")
             .free(slot, warm);
+    }
+
+    /// Moves warm free slots to the cold list, releasing their physical
+    /// pages, until at least `want_bytes` have been cooled or no warm slot
+    /// remains. Returns the bytes cooled. The caller owns the warm-bytes
+    /// accounting that bounds the warm side.
+    pub(crate) fn cool_warm_slots(&self, want_bytes: usize) -> usize {
+        let mut slots = self.slots.lock().expect("region allocator poisoned");
+        let mut cooled = 0;
+        while cooled < want_bytes {
+            let Some(slot) = slots.free_warm.pop() else {
+                break;
+            };
+            let offset = usize::cast_from(slot) * self.class_size;
+            // SAFETY: the slot is on a free list and the allocator mutex is
+            // held, so no chunk owns it and no allocation can race; the
+            // range stays within the region's mapping.
+            unsafe {
+                dontneed(self.base.add(offset), self.class_size);
+            }
+            slots.free_cold.push(slot);
+            cooled += self.class_size;
+        }
+        cooled
     }
 
     /// Test hook: overwrites every free slot with `0xDE` so stale contents
@@ -268,7 +322,7 @@ impl Drop for Region {
 /// The transparent-huge-page size assumed for region alignment. Linux x86-64
 /// and aarch64 (4 KiB base pages) both use 2 MiB; if a platform differs, the
 /// alignment is merely unhelpful, never wrong.
-const HUGE_PAGE: usize = 2 << 20;
+pub(crate) const HUGE_PAGE: usize = 2 << 20;
 
 /// Releases the physical pages of the page-aligned subrange of
 /// `[ptr, ptr + len)`, keeping the virtual range mapped.
@@ -311,6 +365,19 @@ pub(crate) fn nohugepage(ptr: *mut u8, len: usize) {
     // SAFETY: as in `pageout`, a contents-preserving hint over a live
     // mapping.
     unsafe { sys::advise(ptr, len, sys::Advice::NoHugePage) }
+}
+
+/// Excludes the page-aligned subrange of `[ptr, ptr + len)` from core dumps.
+/// Contents are preserved. No-op outside Linux.
+pub(crate) fn dontdump(ptr: *mut u8, len: usize) {
+    // SAFETY: as in `pageout`, a contents-preserving hint over a live
+    // mapping.
+    unsafe { sys::advise(ptr, len, sys::Advice::DontDump) }
+}
+
+/// The system page size.
+pub(crate) fn page_size() -> usize {
+    sys::page_size()
 }
 
 /// Whether every page of the page-aligned subrange of `[ptr, ptr + len)` is
@@ -424,6 +491,8 @@ mod sys {
         WillNeed,
         /// Exclude from transparent huge pages; contents preserved.
         NoHugePage,
+        /// Exclude from core dumps; contents preserved.
+        DontDump,
     }
 
     /// Maps `len` bytes of anonymous memory with the base aligned to
@@ -529,9 +598,12 @@ mod sys {
             Advice::WillNeed => libc::MADV_WILLNEED,
             #[cfg(target_os = "linux")]
             Advice::NoHugePage => libc::MADV_NOHUGEPAGE,
-            // Reclaim, prefetch, and THP hints have no portable equivalent.
+            #[cfg(target_os = "linux")]
+            Advice::DontDump => libc::MADV_DONTDUMP,
+            // Reclaim, prefetch, THP, and dump hints have no portable
+            // equivalent.
             #[cfg(not(target_os = "linux"))]
-            Advice::PageOut | Advice::WillNeed | Advice::NoHugePage => return,
+            Advice::PageOut | Advice::WillNeed | Advice::NoHugePage | Advice::DontDump => return,
         };
         let Some((offset, sub_len)) = aligned_subrange(ptr.addr(), len, page_size()) else {
             return;
@@ -606,6 +678,7 @@ mod sys {
         PageOut,
         WillNeed,
         NoHugePage,
+        DontDump,
     }
 
     pub(super) fn map(len: usize, align: usize) -> io::Result<*mut u8> {


### PR DESCRIPTION
### Motivation

Implements Layers 1 and 2 of the buffer-managed-state design (#37717) as a new
`mz_ore::pool` module: the swap-backed, size-classed buffer manager that replaces
the pager's blob spilling.

The pool is dead code in this PR. Nothing constructs it; the wiring arrives in the
next PR of the stack (#37719) and consumers land later. There is zero behavior
change, and every commit builds `--locked`.

### Description

Five commits, each buildable and tested on its own:

1. **The pool.** Size-classed anonymous regions, residency-scoped slots, copy-out
   reads under a per-chunk state lock, second-chance eviction banded by depth,
   spill threads for off-worker eviction I/O, warm slot reuse, budget enforcement.
2. **Observed pageout.** `MADV_PAGEOUT` is advisory, so the ledger trusts an
   observation of the mapping rather than the advice's return value, with a
   per-extent retry budget.
3. **Hot-chunk re-admission.** `read_into_admit` returns an evicted probe target
   to a slot from free-budget headroom or by stealing a clean backed victim's slot
   in place. Deadlock-free by try-lock discipline on the victim.
4. **Extent arena.** Extents move off the global allocator into pool-owned
   `MADV_NOHUGEPAGE` regions (jemalloc recycling of paged-out ranges caused
   major-fault storms and swap-slot churn). Retry-capped extents leave the
   enforcement queue onto an unreclaimable gauge so a kernel that declines reclaim
   cannot put a queue walk on every insert. Ledger fixes: budget enforced against
   evictable bytes, warm-slot trims and cooling, `MADV_DONTDUMP`, THP opt-out on
   sub-hugepage regions, cgroup v1 / nested-v2 memory detection.
5. **Page-table observation and budget-charged steals.** The pageout observation
   reads `/proc/self/pagemap` present bits rather than `mincore`, which counts the
   clean swap-cache copies of successfully reclaimed pages as resident and would
   retry-cap every extent on healthy async swap. A slot steal settles the ledger
   with the payload difference and a growing steal is charged against the budget
   like any other admission.

### Verification

68 unit and concurrency tests, all of which also run under Miri (data-race and
provenance checking, including the spill-thread and admission-steal races). 6 Kani
proof harnesses over the arithmetic the unsafe blocks rest on (size-class
selection, slot-offset bounds, extent-ladder coverage, allocator disjointness).
Linux-target cross-checks of the madvise, pagemap, and cgroup paths. The
verification footprint is roughly one line per line of pool logic.
