### PR TITLE
compute,transform: add per-crate agent guidance

### DIFF
--- a/src/compute-types/AGENTS.md
+++ b/src/compute-types/AGENTS.md
@@ -1,0 +1,16 @@
+# mz-compute-types
+
+## LIR operators
+
+This crate defines the LIR operator set (`LirRelationNode` and the render-facing `Expr`, in `src/plan.rs` and `src/plan/render_plan.rs`).
+The renderer in `mz-compute` lowers each operator against a shared inter-operator interface, `CollectionBundle` (`src/compute/src/render/context.rs`).
+The rules below are aspirational, and the current operator set does not fully meet them.
+
+LIR operators should be irreducible with respect to that interface.
+An operator should express one thing that the render boundary cannot decompose further, not bundle several.
+
+LIR operators should resist bools or variants that alter their behavior.
+The line to hold: a flag describing an optimization property of the operator itself (for example monotonicity, or whether output must be consolidated) is defensible.
+A flag that makes an operator absorb another operator's responsibility, or that changes behavior in surprising ways, is not.
+Several current variants already carry such flags (for example `Union.consolidate_output`, the `ArrangementStrategy` threaded through `Reduce` / `TopK` / `Union` / `ArrangeBy`, and `GetPlan`'s modes).
+Scrutinize before adding more.

--- a/src/compute-types/CLAUDE.md
+++ b/src/compute-types/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/compute/AGENTS.md
+++ b/src/compute/AGENTS.md
@@ -1,0 +1,35 @@
+# mz-compute
+
+## Dataflow
+
+Avoid tees in dataflow.
+They clone data.
+Tees are fine for `Rc`'ed data, such as a `Trace`.
+Where a raw data collection needs reuse, prefer a passthrough output over teeing (see the arrange operator's passthrough in `src/render/context.rs`).
+
+Operators must be data-parallel.
+Exchanging by anything other than a key is an exception that must be documented as such.
+Render exchanges route by key; the non-key exchanges live in `src/sink` (for example batch- or worker-routed output) and are documented there.
+
+## Operators
+
+Operators should be stateless unless state is explicitly required.
+When state is required, say why (for example Top-K maintains output-sized retraction state in `src/render/top_k.rs`).
+Operators should re-use allocations and aim to be linear time in the input size.
+
+Operators generally run to completion.
+The exception is yielding to enable data consolidation for other operators.
+Yielding purely for interactivity is an anti-pattern.
+The documented exception is `mz_join_core` (`src/render/join/mz_join_core.rs`), which yields within a single key because one key's work can be unbounded.
+Prefer the consolidation rationale, and treat interactivity yielding as a last resort with a written justification.
+
+## Rendering
+
+Rendering is generic.
+Do not add special-interest structures serving other parts of the code here.
+If something special is needed, build the right abstractions to absorb the special-casing in a localized implementation.
+
+## Priorities
+
+Maintainability over complexity.
+Correctness over performance.

--- a/src/compute/CLAUDE.md
+++ b/src/compute/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/transform/AGENTS.md
+++ b/src/transform/AGENTS.md
@@ -1,0 +1,17 @@
+# mz-transform
+
+## Iterative tree traversal
+
+Transforms walk `MirRelationExpr` and `MirScalarExpr` trees.
+Deep trees can overflow the stack, so prefer iterative traversal over hand-written recursion.
+This is aspirational: many transforms still recurse manually (for example `predicate_pushdown`, `join_implementation`, `equivalence_propagation`), and converting them is ongoing work.
+
+Two mechanisms already exist and should be reached for before adding new recursion:
+
+* The `Visit` trait in `mz-expr` (`src/expr/src/visit.rs`) is iterative, backed by an explicit heap work-stack.
+  Its `visit_post` / `visit_mut_post` / `try_visit_mut_post` methods are the target shape for converting recursive traversals.
+  Transforms like `fold_constants` and `normalize_lets` already use it.
+* Where manual recursion stays, guard it.
+  `mz_ore::stack` (`src/ore/src/stack.rs`) provides `maybe_grow` for stack growth and `RecursionGuard` / `CheckedRecursion` (`checked_recur`) for recursion limits.
+  Most recursive transforms already wire these in.
+  Unguarded recursion is a bug waiting to happen.

--- a/src/transform/CLAUDE.md
+++ b/src/transform/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Add `AGENTS.md` (with `CLAUDE.md` symlinks, matching the repo convention) to `mz-compute`, `mz-compute-types`, and `mz-transform`, capturing conventions that are otherwise tribal knowledge.

* `mz-transform`: prefer iterative tree traversal over recursion, with pointers to the iterative `Visit` trait and the `mz_ore::stack` recursion guards.
* `mz-compute-types`: LIR operators should stay irreducible with respect to the `CollectionBundle` interface and resist behavior-altering flags that absorb other operators' responsibility.
* `mz-compute`: avoid tees on raw data, keep operators stateless and data-parallel, run to completion, and keep rendering generic.

The guidance is aspirational, and the current code does not fully meet it. References are lead-level so an agent can follow them without pinning to specific lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)