### PR TITLE
[EXPERIMENTAL — DO NOT MERGE] Ory Talos derive-based app-password authenticator (spike)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6277,6 +6277,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tokio",
  "tokio-postgres",
  "tracing",
  "url",

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -24,6 +24,8 @@ pub enum AuthenticatorKind {
     Sasl,
     /// Authenticated via OIDC (JWT tokens).
     Oidc,
+    /// Authenticated via an Ory Talos app password (derived-JWT exchange).
+    Talos,
     /// No authentication performed.
     #[default]
     None,

--- a/src/authenticator/Cargo.toml
+++ b/src/authenticator/Cargo.toml
@@ -16,6 +16,7 @@ mz-frontegg-auth = { path = "../frontegg-auth", default-features = false }
 mz-ore = { path = "../ore", features = ["assert"] }
 mz-pgwire-common = { path = "../pgwire-common", default-features = false }
 reqwest.workspace = true
+tokio.workspace = true
 tokio-postgres.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/src/authenticator/src/lib.rs
+++ b/src/authenticator/src/lib.rs
@@ -26,6 +26,7 @@ pub enum Authenticator {
     Password(AdapterClient),
     Sasl(AdapterClient),
     Oidc(GenericOidcAuthenticator),
+    Talos(TalosAuthenticator),
     None,
 }
 
@@ -36,6 +37,7 @@ impl Authenticator {
             Authenticator::Password(_) => AuthenticatorKind::Password,
             Authenticator::Sasl(_) => AuthenticatorKind::Sasl,
             Authenticator::Oidc(_) => AuthenticatorKind::Oidc,
+            Authenticator::Talos(_) => AuthenticatorKind::Talos,
             Authenticator::None => AuthenticatorKind::None,
         }
     }

--- a/src/authenticator/src/lib.rs
+++ b/src/authenticator/src/lib.rs
@@ -8,11 +8,15 @@
 // by the Apache License, Version 2.0.
 
 pub mod oidc;
+pub mod talos;
 
 use mz_adapter::Client as AdapterClient;
 use mz_frontegg_auth::Authenticator as FronteggAuthenticator;
 
 pub use oidc::{GenericOidcAuthenticator, OidcClaims, OidcError, ValidatedClaims};
+pub use talos::{
+    DeriveCredential, TalosAuthenticator, TalosConfig, TalosError, ValidatedTalosClaims,
+};
 
 use mz_auth::AuthenticatorKind;
 

--- a/src/authenticator/src/lib.rs
+++ b/src/authenticator/src/lib.rs
@@ -15,7 +15,8 @@ use mz_frontegg_auth::Authenticator as FronteggAuthenticator;
 
 pub use oidc::{GenericOidcAuthenticator, OidcClaims, OidcError, ValidatedClaims};
 pub use talos::{
-    DeriveCredential, TalosAuthenticator, TalosConfig, TalosError, ValidatedTalosClaims,
+    DeriveCredential, TalosAuthenticator, TalosConfig, TalosError, TalosSessionHandle,
+    ValidatedTalosClaims,
 };
 
 use mz_auth::AuthenticatorKind;

--- a/src/authenticator/src/talos.rs
+++ b/src/authenticator/src/talos.rs
@@ -47,18 +47,26 @@ use mz_auth::Authenticated;
 use mz_pgwire_common::{ErrorResponse, Severity};
 use reqwest::Client as HttpClient;
 use serde::Deserialize;
+use tokio::sync::watch;
 use tokio_postgres::error::SqlState;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 use url::Url;
+use zeroize::Zeroizing;
 
 /// Path of the Talos admin endpoint that exchanges an API key for a JWT.
 const DERIVE_PATH: &str = "v2alpha1/admin/apiKeys:derive";
 /// Path of the derived-keys JWKS used to validate derived JWTs locally.
 const JWKS_PATH: &str = "v2alpha1/derivedKeys/jwks.json";
 /// TTL requested for derived tokens. Kept short: the token only has to live
-/// long enough to be validated once (and, once the session cache lands, to
-/// pace re-derivation), so a short TTL tightens the revocation window.
+/// long enough to be validated once at connection time; it is not reused after
+/// that, so a short TTL keeps the minted-token exposure minimal.
 const DEFAULT_DERIVED_TOKEN_TTL: Duration = Duration::from_secs(300);
+/// How often an established connection re-derives to confirm its key is still
+/// live. A revoked key makes `derive` fail (it re-checks parent status), which
+/// tears the connection down — so this bounds the revocation latency for live
+/// connections. Talos derived tokens are NOT individually revocable (revocation
+/// is TTL-bound), so this periodic re-derive is the revocation mechanism.
+const DEFAULT_REVOCATION_CHECK_INTERVAL: Duration = Duration::from_secs(300);
 /// Timeout for the derive and JWKS HTTP calls.
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -220,6 +228,9 @@ pub struct TalosConfig {
     pub key_prefix: String,
     /// TTL requested for derived tokens.
     pub derived_token_ttl: Duration,
+    /// How often a live connection re-derives to confirm its key is still
+    /// valid (the revocation-latency bound for established connections).
+    pub revocation_check_interval: Duration,
 }
 
 impl TalosConfig {
@@ -229,6 +240,7 @@ impl TalosConfig {
             derive_credential,
             key_prefix,
             derived_token_ttl: DEFAULT_DERIVED_TOKEN_TTL,
+            revocation_check_interval: DEFAULT_REVOCATION_CHECK_INTERVAL,
         }
     }
 }
@@ -248,6 +260,7 @@ struct TalosAuthenticatorInner {
     derive_credential: DeriveCredential,
     key_prefix: String,
     derived_token_ttl: Duration,
+    revocation_check_interval: Duration,
     /// kid -> decoding key cache for the derived-keys JWKS, refreshed on miss.
     decoding_keys: Mutex<BTreeMap<String, DecodingKey>>,
 }
@@ -268,6 +281,7 @@ impl TalosAuthenticator {
                 derive_credential: config.derive_credential,
                 key_prefix: config.key_prefix,
                 derived_token_ttl: config.derived_token_ttl,
+                revocation_check_interval: config.revocation_check_interval,
                 decoding_keys: Mutex::new(BTreeMap::new()),
             }),
         })
@@ -280,20 +294,124 @@ impl TalosAuthenticator {
     }
 
     /// Authenticates a presented Talos key: derive a JWT, validate it locally,
-    /// map it to an identity, and confirm the role may log in.
+    /// map it to an identity, confirm the role may log in, and return a session
+    /// handle that keeps confirming the key stays live.
+    ///
+    /// Unlike the Frontegg authenticator, there is no shared, secret-keyed
+    /// session cache: each connection gets its own handle and its own
+    /// liveness-check task. That trades a per-connection derive for
+    /// per-connection isolation (no cross-connection shared session state) and
+    /// keeps the raw secret out of any long-lived shared map — it lives only,
+    /// zeroized, inside this connection's refresh task.
     pub async fn authenticate(
         &self,
         password: &str,
         expected_user: Option<&str>,
-    ) -> Result<(ValidatedTalosClaims, Authenticated), TalosError> {
+    ) -> Result<(TalosSessionHandle, Authenticated), TalosError> {
         if !self.is_talos_key(password) {
             return Err(TalosError::NotTalosKey);
         }
         let token = self.inner.derive(password).await?;
         let validated = self.inner.validate(&token, expected_user).await?;
         self.inner.check_role_login(&validated.user).await?;
-        Ok((validated, Authenticated))
+
+        let claims = Arc::new(validated);
+        // `valid` starts true; the refresh task flips it to false (or drops the
+        // sender, closing the channel) when the key is definitively no longer
+        // valid, which `TalosSessionHandle::expired` awaits.
+        let (valid_tx, valid_rx) = watch::channel(true);
+        spawn_revocation_check(
+            Arc::clone(&self.inner),
+            Zeroizing::new(password.to_string()),
+            claims.key_id.clone(),
+            valid_tx,
+        );
+        Ok((TalosSessionHandle { claims, valid_rx }, Authenticated))
     }
+}
+
+/// A handle to an authenticated Talos session.
+///
+/// While the handle is alive, a background task periodically re-derives the
+/// key to confirm it is still valid; if the key is revoked or expires,
+/// [`TalosSessionHandle::expired`] completes and the caller (pgwire) tears the
+/// connection down. Dropping the handle closes the channel, which stops the
+/// background task.
+#[derive(Debug)]
+pub struct TalosSessionHandle {
+    claims: Arc<ValidatedTalosClaims>,
+    valid_rx: watch::Receiver<bool>,
+}
+
+impl TalosSessionHandle {
+    /// The login user (the key owner's email).
+    pub fn user(&self) -> &str {
+        &self.claims.user
+    }
+
+    /// The Ory actor (identity) id the key is bound to, if present.
+    pub fn actor_id(&self) -> Option<&str> {
+        self.claims.actor_id.as_deref()
+    }
+
+    /// The organization the key owner belongs to, if stamped.
+    pub fn organization_id(&self) -> Option<&str> {
+        self.claims.organization_id.as_deref()
+    }
+
+    /// The Talos key id (derived-token subject).
+    pub fn key_id(&self) -> &str {
+        &self.claims.key_id
+    }
+
+    /// Completes when the session is no longer valid — either the background
+    /// check found the key revoked/expired (value set to `false`) or the task
+    /// ended and dropped the sender (channel closed).
+    pub async fn expired(&mut self) {
+        // `wait_for` resolves when the predicate is true; it returns `Err` if
+        // the sender was dropped (channel closed), which we also treat as
+        // expired. Either way this future completes only once the session is
+        // no longer usable.
+        let _ = self.valid_rx.wait_for(|valid| !*valid).await;
+    }
+}
+
+/// Spawns the background task that bounds revocation latency for one live
+/// connection by periodically re-deriving the key.
+fn spawn_revocation_check(
+    inner: Arc<TalosAuthenticatorInner>,
+    secret: Zeroizing<String>,
+    key_id: String,
+    valid_tx: watch::Sender<bool>,
+) {
+    let task_name = format!("talos-revocation-check-{key_id}");
+    mz_ore::task::spawn(|| task_name, async move {
+        let interval = inner.revocation_check_interval;
+        loop {
+            tokio::select! {
+                // Stop as soon as the connection (the only receiver) goes away.
+                _ = valid_tx.closed() => break,
+                _ = tokio::time::sleep(interval) => {}
+            }
+            match inner.derive(&secret).await {
+                Ok(_) => {
+                    // Key still valid; discard the freshly derived token.
+                }
+                // Definitive: the key is revoked, expired, or gone. Signal the
+                // connection to tear down and stop checking.
+                Err(TalosError::InvalidKey) => {
+                    info!(%key_id, "Talos key no longer valid; expiring session");
+                    let _ = valid_tx.send(false);
+                    break;
+                }
+                // Transient (network/Talos outage): fail OPEN — do not kill a
+                // live session over a blip. Try again next interval.
+                Err(e) => {
+                    warn!(%key_id, error = %e, "Talos revocation check failed transiently; will retry");
+                }
+            }
+        }
+    });
 }
 
 impl TalosAuthenticatorInner {
@@ -672,5 +790,50 @@ mod tests {
             !rendered.contains("super-secret"),
             "credential must not leak in Debug: {rendered}"
         );
+    }
+
+    fn test_handle(valid_rx: watch::Receiver<bool>) -> TalosSessionHandle {
+        TalosSessionHandle {
+            claims: Arc::new(ValidatedTalosClaims {
+                user: "user@example.com".to_string(),
+                actor_id: Some("actor".to_string()),
+                organization_id: Some("org".to_string()),
+                key_id: "key".to_string(),
+                _private: (),
+            }),
+            valid_rx,
+        }
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn handle_expires_when_revoked() {
+        let (tx, rx) = watch::channel(true);
+        let mut handle = test_handle(rx);
+        // The revocation-check task would do this on a revoked key.
+        tx.send(false).expect("receiver alive");
+        // Must complete promptly; the test harness would hang otherwise.
+        handle.expired().await;
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn handle_expires_when_check_task_ends() {
+        let (tx, rx) = watch::channel(true);
+        let mut handle = test_handle(rx);
+        // Dropping the sender models the background task exiting; a closed
+        // channel must also count as expired so the connection never hangs.
+        drop(tx);
+        handle.expired().await;
+    }
+
+    #[mz_ore::test(tokio::test)]
+    async fn handle_stays_live_while_valid() {
+        let (tx, rx) = watch::channel(true);
+        let mut handle = test_handle(rx);
+        // While valid, expired() must NOT complete.
+        tokio::select! {
+            _ = handle.expired() => panic!("session expired while still valid"),
+            _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+        }
+        drop(tx);
     }
 }

--- a/src/authenticator/src/talos.rs
+++ b/src/authenticator/src/talos.rs
@@ -836,4 +836,131 @@ mod tests {
         }
         drop(tx);
     }
+
+    /// Live contract test against a REAL Ory Talos (e.g. the Ory Network dev
+    /// project). Exercises the exact validation code path — issue a key with
+    /// email/organization_id metadata, derive a JWT, fetch the derived-keys
+    /// JWKS, and validate/map with our own `parse_derived_jwks` +
+    /// `validate_derived_token` + `map_claims`. Confirms the claims contract
+    /// (sub/act/meta) and EdDSA JWKS shape hold on the real service, not just
+    /// Talos OSS.
+    ///
+    /// Skipped unless `ORY_PROJECT_URL` and `ORY_PROJECT_API_KEY` are set:
+    /// ```text
+    /// ORY_PROJECT_URL=https://<slug>.projects.oryapis.com \
+    /// ORY_PROJECT_API_KEY=<project api key> \
+    /// cargo test -p mz-authenticator live_talos -- --nocapture
+    /// ```
+    #[mz_ore::test(tokio::test)]
+    async fn live_talos_derive_and_validate() {
+        let (Ok(url), Ok(api_key)) = (
+            std::env::var("ORY_PROJECT_URL"),
+            std::env::var("ORY_PROJECT_API_KEY"),
+        ) else {
+            eprintln!("ORY_PROJECT_URL/ORY_PROJECT_API_KEY not set; skipping live Talos test");
+            return;
+        };
+        let url = url.trim_end_matches('/').to_string();
+        let http = reqwest::Client::new();
+        let actor = "talos-live-test-actor";
+        let email = "talos-live-test@materialize.com";
+        let org = "talos-live-test-org";
+
+        // Issue a key with the same metadata the sync-server stamps.
+        let issued: serde_json::Value = http
+            .post(format!("{url}/v2alpha1/admin/issuedApiKeys"))
+            .bearer_auth(&api_key)
+            .json(&serde_json::json!({
+                "actor_id": actor,
+                "name": "authenticator-live-test",
+                "metadata": { "source": "console", "email": email, "organization_id": org },
+            }))
+            .send()
+            .await
+            .expect("issue request")
+            .error_for_status()
+            .expect("issue status")
+            .json()
+            .await
+            .expect("issue body");
+        let key_id = issued["issued_api_key"]["key_id"]
+            .as_str()
+            .expect("key_id")
+            .to_string();
+        let secret = issued["secret"].as_str().expect("secret").to_string();
+        eprintln!("issued key {key_id}");
+
+        // Derive a JWT from the presented secret.
+        let derived: serde_json::Value = http
+            .post(format!("{url}/v2alpha1/admin/apiKeys:derive"))
+            .bearer_auth(&api_key)
+            .json(&serde_json::json!({
+                "credential": secret,
+                "algorithm": "TOKEN_ALGORITHM_JWT",
+                "ttl": "300s",
+            }))
+            .send()
+            .await
+            .expect("derive request")
+            .error_for_status()
+            .expect("derive status")
+            .json()
+            .await
+            .expect("derive body");
+        let jwt = derived["token"]["token"]
+            .as_str()
+            .expect("derived jwt")
+            .to_string();
+
+        // Fetch the derived-keys JWKS and parse it with OUR envelope-aware parser.
+        let jwks_body = http
+            .get(format!("{url}/v2alpha1/derivedKeys/jwks.json"))
+            .send()
+            .await
+            .expect("jwks request")
+            .error_for_status()
+            .expect("jwks status")
+            .text()
+            .await
+            .expect("jwks body");
+        let keys = parse_derived_jwks(&jwks_body).expect("parse real derived-keys JWKS");
+        assert!(!keys.is_empty(), "real JWKS must contain signing keys");
+
+        // Validate + map with OUR code, exactly as a connection would.
+        let header = jsonwebtoken::decode_header(&jwt).expect("jwt header");
+        eprintln!("derived JWT alg={:?} kid={:?}", header.alg, header.kid);
+        let kid = header.kid.expect("jwt kid");
+        let key = keys.get(&kid).expect("kid present in JWKS");
+        let claims = validate_derived_token(&jwt, key).expect("validate real derived token");
+        let identity = map_claims(claims, Some(email)).expect("map real claims");
+
+        assert_eq!(
+            identity.user, email,
+            "meta.email must round-trip through derive"
+        );
+        assert_eq!(
+            identity.organization_id.as_deref(),
+            Some(org),
+            "meta.organization_id must round-trip through derive"
+        );
+        assert_eq!(identity.key_id, key_id, "sub must be the key id");
+        eprintln!(
+            "VALIDATED: user={} org={:?} actor={:?} key_id={}",
+            identity.user, identity.organization_id, identity.actor_id, identity.key_id
+        );
+
+        // Cleanup: revoke the test key.
+        let _ = http
+            .post(format!(
+                "{url}/v2alpha1/admin/issuedApiKeys/{key_id}:revoke"
+            ))
+            .bearer_auth(&api_key)
+            .json(&serde_json::json!({
+                "reason": "REVOCATION_REASON_UNSPECIFIED",
+                "description": "authenticator live test cleanup",
+            }))
+            .send()
+            .await;
+        eprintln!("revoked key {key_id}");
+    }
 }

--- a/src/authenticator/src/talos.rs
+++ b/src/authenticator/src/talos.rs
@@ -1,0 +1,676 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Ory Talos authentication for pgwire/HTTP connections.
+//!
+//! Talos issues opaque API keys (the Ory-native replacement for Frontegg app
+//! passwords). Rather than verifying a presented key on every connection (a
+//! remote call on the hot path), we follow the "derive, not verify" design:
+//! exchange the key once via the Talos `apiKeys:derive` admin endpoint for a
+//! short-lived JWT, then validate that JWT locally against the derived-keys
+//! JWKS. This mirrors the frontegg-auth architecture (exchange → local JWT
+//! validation), so the session-cache and background-refresh machinery that
+//! bounds revocation latency transfers directly; that layer is added together
+//! with the pgwire/HTTP listener wiring, which is what consumes the
+//! per-session `expired()` signal.
+//!
+//! Two contract facts about Talos shape this module (validated against Talos
+//! OSS in the cloud repo's `src/sync/tests/talos_contract.rs`):
+//!
+//!   * The derived JWT carries `sub` = the key id, `act` = the actor id, and
+//!     the key's issuance `metadata` verbatim under `meta`. The sync-server
+//!     stamps the user's email and organization id into that metadata at
+//!     issuance, so we read the connecting identity straight off the token —
+//!     no directory lookup on the connection hot path.
+//!
+//!   * The derived-keys JWKS endpoint wraps the key set in a non-standard
+//!     `{"jwks": {"keys": [...]}}` envelope rather than a bare RFC 7517
+//!     `{"keys": [...]}`, and signs with EdDSA/Ed25519 in the reference
+//!     config. We unwrap the envelope and let `jsonwebtoken` pick the
+//!     algorithm from the JWK/header so Ed25519 validates without any
+//!     algorithm-specific code (as the OIDC authenticator already does).
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use jsonwebtoken::DecodingKey;
+use jsonwebtoken::jwk::JwkSet;
+use mz_adapter::{AdapterError, AuthenticationError, Client as AdapterClient};
+use mz_auth::Authenticated;
+use mz_pgwire_common::{ErrorResponse, Severity};
+use reqwest::Client as HttpClient;
+use serde::Deserialize;
+use tokio_postgres::error::SqlState;
+use tracing::{debug, warn};
+use url::Url;
+
+/// Path of the Talos admin endpoint that exchanges an API key for a JWT.
+const DERIVE_PATH: &str = "v2alpha1/admin/apiKeys:derive";
+/// Path of the derived-keys JWKS used to validate derived JWTs locally.
+const JWKS_PATH: &str = "v2alpha1/derivedKeys/jwks.json";
+/// TTL requested for derived tokens. Kept short: the token only has to live
+/// long enough to be validated once (and, once the session cache lands, to
+/// pace re-derivation), so a short TTL tightens the revocation window.
+const DEFAULT_DERIVED_TOKEN_TTL: Duration = Duration::from_secs(300);
+/// Timeout for the derive and JWKS HTTP calls.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Errors that can occur during Talos authentication.
+#[derive(Debug)]
+pub enum TalosError {
+    /// The presented password does not carry the Talos key prefix. Callers use
+    /// this to fall through to another authenticator rather than fail the
+    /// connection outright.
+    NotTalosKey,
+    /// Failed to reach Talos to derive a token from the presented key.
+    DeriveRequestFailed { error_message: String },
+    /// Talos rejected the presented key (revoked, expired, or unknown).
+    InvalidKey,
+    /// Failed to fetch the derived-keys JWKS.
+    FetchJwksFailed { url: String, error_message: String },
+    /// The derived token header has no key id.
+    MissingKid,
+    /// No JWKS key matched the derived token's key id.
+    NoMatchingKey { key_id: String },
+    /// The derived token failed signature/shape validation.
+    Jwt,
+    /// The derived token's signature has expired.
+    ExpiredSignature,
+    /// The derived token is missing the email metadata needed to map it to a
+    /// Materialize role (the sync-server stamps this at issuance).
+    MissingEmail,
+    /// The connecting username does not match the key owner's email.
+    WrongUser,
+    /// The role exists but does not have the LOGIN attribute.
+    NonLogin,
+    /// Unexpected error while checking whether the role can log in.
+    LoginCheckError,
+}
+
+impl std::fmt::Display for TalosError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TalosError::NotTalosKey => write!(f, "not a Talos app password"),
+            TalosError::DeriveRequestFailed { .. } => write!(f, "failed to contact Talos"),
+            TalosError::InvalidKey => write!(f, "invalid app password"),
+            TalosError::FetchJwksFailed { .. } => write!(f, "failed to fetch Talos signing keys"),
+            TalosError::MissingKid => write!(f, "missing key ID in derived token header"),
+            TalosError::NoMatchingKey { .. } => write!(f, "no matching Talos signing key"),
+            TalosError::Jwt => write!(f, "failed to validate derived token"),
+            TalosError::ExpiredSignature => write!(f, "authentication credentials have expired"),
+            TalosError::MissingEmail => write!(f, "app password is missing owner metadata"),
+            TalosError::WrongUser => write!(f, "wrong user"),
+            TalosError::NonLogin => write!(f, "role is not allowed to login"),
+            TalosError::LoginCheckError => write!(f, "unexpected error checking if role can login"),
+        }
+    }
+}
+
+impl std::error::Error for TalosError {}
+
+impl TalosError {
+    pub fn code(&self) -> SqlState {
+        SqlState::INVALID_AUTHORIZATION_SPECIFICATION
+    }
+
+    pub fn detail(&self) -> Option<String> {
+        match self {
+            TalosError::NoMatchingKey { key_id } => {
+                Some(format!("Derived token key ID \"{key_id}\" was not found."))
+            }
+            TalosError::MissingEmail => Some(
+                "The app password was issued without an owner email; re-create it from the console."
+                    .into(),
+            ),
+            TalosError::NonLogin => Some("The role does not have the LOGIN attribute.".into()),
+            _ => None,
+        }
+    }
+
+    pub fn into_response(self) -> ErrorResponse {
+        ErrorResponse {
+            severity: Severity::Fatal,
+            code: self.code(),
+            message: self.to_string(),
+            detail: self.detail(),
+            hint: None,
+            position: None,
+        }
+    }
+}
+
+/// Issuance metadata Talos surfaces under `meta` in the derived JWT. The
+/// sync-server stamps these at key creation (see the cloud repo's
+/// `ory::talos::TalosClient::issue_api_key`).
+#[derive(Debug, Clone, Default, Deserialize)]
+struct TalosMeta {
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    organization_id: Option<String>,
+}
+
+/// Claims of a Talos-derived JWT. See the module docs for the contract.
+#[derive(Debug, Clone, Deserialize)]
+struct TalosClaims {
+    /// Subject: the Talos key id.
+    sub: String,
+    /// Actor: the Ory identity (actor) the key is bound to.
+    #[serde(default)]
+    act: Option<String>,
+    /// Issuance metadata carried verbatim from the key.
+    #[serde(default)]
+    meta: TalosMeta,
+}
+
+/// The identity established by a validated Talos key.
+#[derive(Debug, Clone)]
+pub struct ValidatedTalosClaims {
+    /// The login user: the key owner's email.
+    pub user: String,
+    /// The Ory actor (identity) id the key is bound to.
+    pub actor_id: Option<String>,
+    /// The organization the key owner belongs to, if stamped.
+    pub organization_id: Option<String>,
+    /// The Talos key id (derived-token subject); useful for audit/logging.
+    pub key_id: String,
+    // Prevent construction outside of `TalosAuthenticator::validate`.
+    _private: (),
+}
+
+/// Credential Talos requires to call the `apiKeys:derive` admin endpoint.
+///
+/// How this credential is provisioned to environmentd/balancerd (a scoped
+/// project key, a per-environment key, or a region-api proxy) is a deployment
+/// decision tracked in the Ory migration design doc; this type only carries
+/// whatever credential that decision produces, with a redacted `Debug`.
+#[derive(Clone)]
+pub struct DeriveCredential(String);
+
+impl DeriveCredential {
+    pub fn new(credential: String) -> Self {
+        DeriveCredential(credential)
+    }
+}
+
+impl std::fmt::Debug for DeriveCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("DeriveCredential")
+            .field(&"<redacted>")
+            .finish()
+    }
+}
+
+/// Configuration for a [`TalosAuthenticator`].
+#[derive(Clone, Debug)]
+pub struct TalosConfig {
+    /// Base URL of the Talos API (e.g. the Ory project URL). The derive and
+    /// JWKS endpoints are resolved relative to this.
+    pub base_url: Url,
+    /// Credential for the `apiKeys:derive` admin endpoint.
+    pub derive_credential: DeriveCredential,
+    /// Prefix that identifies a presented password as a Talos key.
+    pub key_prefix: String,
+    /// TTL requested for derived tokens.
+    pub derived_token_ttl: Duration,
+}
+
+impl TalosConfig {
+    pub fn new(base_url: Url, derive_credential: DeriveCredential, key_prefix: String) -> Self {
+        TalosConfig {
+            base_url,
+            derive_credential,
+            key_prefix,
+            derived_token_ttl: DEFAULT_DERIVED_TOKEN_TTL,
+        }
+    }
+}
+
+/// Authenticates pgwire/HTTP connections presenting an Ory Talos API key.
+#[derive(Clone, Debug)]
+pub struct TalosAuthenticator {
+    inner: Arc<TalosAuthenticatorInner>,
+}
+
+#[derive(Debug)]
+struct TalosAuthenticatorInner {
+    adapter_client: AdapterClient,
+    http_client: HttpClient,
+    derive_url: Url,
+    jwks_url: Url,
+    derive_credential: DeriveCredential,
+    key_prefix: String,
+    derived_token_ttl: Duration,
+    /// kid -> decoding key cache for the derived-keys JWKS, refreshed on miss.
+    decoding_keys: Mutex<BTreeMap<String, DecodingKey>>,
+}
+
+impl TalosAuthenticator {
+    pub fn new(
+        config: TalosConfig,
+        adapter_client: AdapterClient,
+    ) -> Result<Self, url::ParseError> {
+        let derive_url = config.base_url.join(DERIVE_PATH)?;
+        let jwks_url = config.base_url.join(JWKS_PATH)?;
+        Ok(TalosAuthenticator {
+            inner: Arc::new(TalosAuthenticatorInner {
+                adapter_client,
+                http_client: HttpClient::new(),
+                derive_url,
+                jwks_url,
+                derive_credential: config.derive_credential,
+                key_prefix: config.key_prefix,
+                derived_token_ttl: config.derived_token_ttl,
+                decoding_keys: Mutex::new(BTreeMap::new()),
+            }),
+        })
+    }
+
+    /// Whether a presented password looks like a Talos key. Dispatch uses this
+    /// to route between authenticators without attempting a derive.
+    pub fn is_talos_key(&self, password: &str) -> bool {
+        password.starts_with(&self.inner.key_prefix)
+    }
+
+    /// Authenticates a presented Talos key: derive a JWT, validate it locally,
+    /// map it to an identity, and confirm the role may log in.
+    pub async fn authenticate(
+        &self,
+        password: &str,
+        expected_user: Option<&str>,
+    ) -> Result<(ValidatedTalosClaims, Authenticated), TalosError> {
+        if !self.is_talos_key(password) {
+            return Err(TalosError::NotTalosKey);
+        }
+        let token = self.inner.derive(password).await?;
+        let validated = self.inner.validate(&token, expected_user).await?;
+        self.inner.check_role_login(&validated.user).await?;
+        Ok((validated, Authenticated))
+    }
+}
+
+impl TalosAuthenticatorInner {
+    /// Exchanges an opaque Talos key for a short-lived JWT via `apiKeys:derive`.
+    async fn derive(&self, credential: &str) -> Result<String, TalosError> {
+        let ttl = format!("{}s", self.derived_token_ttl.as_secs());
+        let response = self
+            .http_client
+            .post(self.derive_url.clone())
+            .timeout(HTTP_TIMEOUT)
+            .bearer_auth(&self.derive_credential.0)
+            .json(&serde_json::json!({
+                "credential": credential,
+                "algorithm": "TOKEN_ALGORITHM_JWT",
+                "ttl": ttl,
+            }))
+            .send()
+            .await
+            .map_err(|e| TalosError::DeriveRequestFailed {
+                error_message: e.to_string(),
+            })?;
+
+        // A rejected key (revoked/expired/unknown) is a client auth failure,
+        // distinct from Talos being unreachable.
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED
+            || status == reqwest::StatusCode::FORBIDDEN
+            || status == reqwest::StatusCode::NOT_FOUND
+            || status == reqwest::StatusCode::BAD_REQUEST
+        {
+            debug!(%status, "Talos rejected the presented key");
+            return Err(TalosError::InvalidKey);
+        }
+        let response =
+            response
+                .error_for_status()
+                .map_err(|e| TalosError::DeriveRequestFailed {
+                    error_message: e.to_string(),
+                })?;
+
+        let derived: DeriveResponse =
+            response
+                .json()
+                .await
+                .map_err(|e| TalosError::DeriveRequestFailed {
+                    error_message: e.to_string(),
+                })?;
+        Ok(derived.token.token)
+    }
+
+    /// Validates a derived JWT against the derived-keys JWKS and maps it to an
+    /// identity.
+    async fn validate(
+        &self,
+        token: &str,
+        expected_user: Option<&str>,
+    ) -> Result<ValidatedTalosClaims, TalosError> {
+        let header = jsonwebtoken::decode_header(token).map_err(|e| {
+            debug!("failed to decode derived token header: {e:?}");
+            TalosError::Jwt
+        })?;
+        let kid = header.kid.ok_or(TalosError::MissingKid)?;
+        let decoding_key = self.find_key(&kid).await?;
+        let claims = validate_derived_token(token, &decoding_key)?;
+        map_claims(claims, expected_user)
+    }
+
+    /// Finds the decoding key for `kid`, refetching the JWKS on a cache miss.
+    async fn find_key(&self, kid: &str) -> Result<DecodingKey, TalosError> {
+        {
+            let keys = self.decoding_keys.lock().expect("lock poisoned");
+            if let Some(key) = keys.get(kid) {
+                return Ok(key.clone());
+            }
+        }
+
+        let fresh = self.fetch_jwks().await?;
+        let found = fresh.get(kid).cloned();
+        {
+            let mut keys = self.decoding_keys.lock().expect("lock poisoned");
+            *keys = fresh;
+        }
+        found.ok_or_else(|| TalosError::NoMatchingKey {
+            key_id: kid.to_string(),
+        })
+    }
+
+    /// Fetches and parses the derived-keys JWKS.
+    async fn fetch_jwks(&self) -> Result<BTreeMap<String, DecodingKey>, TalosError> {
+        let url = self.jwks_url.clone();
+        let response = self
+            .http_client
+            .get(url.clone())
+            .timeout(HTTP_TIMEOUT)
+            .send()
+            .await
+            .map_err(|e| TalosError::FetchJwksFailed {
+                url: url.to_string(),
+                error_message: e.to_string(),
+            })?
+            .error_for_status()
+            .map_err(|e| TalosError::FetchJwksFailed {
+                url: url.to_string(),
+                error_message: e.to_string(),
+            })?;
+        let body = response
+            .text()
+            .await
+            .map_err(|e| TalosError::FetchJwksFailed {
+                url: url.to_string(),
+                error_message: e.to_string(),
+            })?;
+        parse_derived_jwks(&body).map_err(|e| TalosError::FetchJwksFailed {
+            url: url.to_string(),
+            error_message: e,
+        })
+    }
+
+    /// Checks whether the role has the LOGIN attribute. Mirrors the OIDC
+    /// authenticator: an unknown role is auto-provisioned at startup, so it is
+    /// allowed here.
+    async fn check_role_login(&self, role_name: &str) -> Result<(), TalosError> {
+        match self.adapter_client.role_can_login(role_name).await {
+            Ok(()) => Ok(()),
+            Err(AdapterError::AuthenticationError(AuthenticationError::RoleNotFound)) => Ok(()),
+            Err(AdapterError::AuthenticationError(AuthenticationError::NonLogin)) => {
+                Err(TalosError::NonLogin)
+            }
+            Err(e) => {
+                warn!(?e, "unexpected error checking Talos role login");
+                Err(TalosError::LoginCheckError)
+            }
+        }
+    }
+}
+
+/// Parses the non-standard `{"jwks": {"keys": [...]}}` derived-keys envelope
+/// into a kid -> decoding key map. Keys that fail to parse are skipped rather
+/// than failing the whole set.
+fn parse_derived_jwks(body: &str) -> Result<BTreeMap<String, DecodingKey>, String> {
+    #[derive(Deserialize)]
+    struct Envelope {
+        jwks: JwkSet,
+    }
+    let envelope: Envelope = serde_json::from_str(body).map_err(|e| e.to_string())?;
+    let mut keys = BTreeMap::new();
+    for jwk in envelope.jwks.keys {
+        let Some(kid) = jwk.common.key_id.clone() else {
+            continue;
+        };
+        match DecodingKey::from_jwk(&jwk) {
+            Ok(key) => {
+                keys.insert(kid, key);
+            }
+            Err(e) => warn!("failed to parse derived-keys JWK {kid}: {e}"),
+        }
+    }
+    Ok(keys)
+}
+
+/// Validates a derived token's signature and expiry against `decoding_key`.
+///
+/// The algorithm is taken from the token header (as the OIDC authenticator
+/// does): the decoding key comes from the JWKS, so its key type fixes the
+/// admissible algorithm family and Ed25519 validates with no special-casing.
+fn validate_derived_token(
+    token: &str,
+    decoding_key: &DecodingKey,
+) -> Result<TalosClaims, TalosError> {
+    let header = jsonwebtoken::decode_header(token).map_err(|e| {
+        debug!("failed to decode derived token header: {e:?}");
+        TalosError::Jwt
+    })?;
+    let mut validation = jsonwebtoken::Validation::new(header.alg);
+    // Derived tokens are minted by our own derive call, not a third party, so
+    // there is no meaningful audience/issuer to pin; expiry is still enforced.
+    validation.validate_aud = false;
+    validation.required_spec_claims = ["exp"].into_iter().map(String::from).collect();
+
+    let data = jsonwebtoken::decode::<TalosClaims>(token, decoding_key, &validation).map_err(
+        |e| match e.kind() {
+            jsonwebtoken::errors::ErrorKind::ExpiredSignature => TalosError::ExpiredSignature,
+            other => {
+                debug!("derived token validation failed: {other:?}");
+                TalosError::Jwt
+            }
+        },
+    )?;
+    Ok(data.claims)
+}
+
+/// Maps validated claims to an identity, enforcing that the login user matches
+/// the key owner's email.
+fn map_claims(
+    claims: TalosClaims,
+    expected_user: Option<&str>,
+) -> Result<ValidatedTalosClaims, TalosError> {
+    let user = claims.meta.email.ok_or(TalosError::MissingEmail)?;
+    if let Some(expected) = expected_user {
+        if expected != user {
+            return Err(TalosError::WrongUser);
+        }
+    }
+    Ok(ValidatedTalosClaims {
+        user,
+        actor_id: claims.act,
+        organization_id: claims.meta.organization_id,
+        key_id: claims.sub,
+        _private: (),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct DeriveResponse {
+    token: DeriveToken,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeriveToken {
+    token: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use jsonwebtoken::{Algorithm, EncodingKey, Header};
+    use serde_json::json;
+
+    use super::*;
+
+    /// A fixed Ed25519 keypair so tests can sign a derived token and validate
+    /// it end-to-end without a live Talos or a keygen dependency. Generated
+    /// once with the `cryptography` library; the JWK below is the public half.
+    const TEST_ED25519_PKCS8_DER: &[u8] = &[
+        0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04,
+        0x20, 0x75, 0xc3, 0xe0, 0x9b, 0xf5, 0x7a, 0x4e, 0x39, 0x11, 0x6c, 0x53, 0x15, 0xe3, 0x89,
+        0x24, 0xaa, 0x88, 0xe9, 0xbe, 0x17, 0x27, 0x1e, 0x3b, 0x43, 0x41, 0x56, 0x45, 0x06, 0x9b,
+        0x32, 0x74, 0x16,
+    ];
+    const TEST_JWK_X: &str = "vnBhUCmNjKrAQ3c84khoNqGwC9AYusg8ZtLezZ-hts8";
+    const TEST_KID: &str = "test-derived-key-1";
+
+    fn derived_keys_jwks() -> String {
+        json!({
+            "jwks": {
+                "keys": [{
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "use": "sig",
+                    "alg": "EdDSA",
+                    "kid": TEST_KID,
+                    "x": TEST_JWK_X,
+                }]
+            }
+        })
+        .to_string()
+    }
+
+    /// Sign a derived-token payload with the test key.
+    fn sign(claims: serde_json::Value) -> String {
+        let mut header = Header::new(Algorithm::EdDSA);
+        header.kid = Some(TEST_KID.to_string());
+        let key = EncodingKey::from_ed_der(TEST_ED25519_PKCS8_DER);
+        jsonwebtoken::encode(&header, &claims, &key).expect("sign derived token")
+    }
+
+    fn future_exp() -> i64 {
+        // Comfortably in the future so default expiry validation passes.
+        4_102_444_800 // 2100-01-01
+    }
+
+    #[mz_ore::test]
+    fn parse_derived_jwks_unwraps_envelope() {
+        let keys = parse_derived_jwks(&derived_keys_jwks()).expect("parse envelope");
+        assert!(
+            keys.contains_key(TEST_KID),
+            "kid must be extracted from the jwks envelope"
+        );
+    }
+
+    #[mz_ore::test]
+    fn parse_bare_jwks_is_rejected() {
+        // A bare RFC 7517 key set (no `jwks` envelope) must not parse — this is
+        // the shape difference we are guarding against.
+        let bare = json!({ "keys": [] }).to_string();
+        assert!(parse_derived_jwks(&bare).is_err());
+    }
+
+    #[mz_ore::test]
+    fn validate_and_map_full_identity() {
+        let keys = parse_derived_jwks(&derived_keys_jwks()).unwrap();
+        let key = keys.get(TEST_KID).unwrap();
+        let token = sign(json!({
+            "sub": "key-abc",
+            "act": "actor-xyz",
+            "exp": future_exp(),
+            "meta": {
+                "source": "console",
+                "email": "user@example.com",
+                "organization_id": "org-123",
+            },
+        }));
+        let claims = validate_derived_token(&token, key).expect("validate derived token");
+        let identity = map_claims(claims, Some("user@example.com")).expect("map claims");
+        assert_eq!(identity.user, "user@example.com");
+        assert_eq!(identity.actor_id.as_deref(), Some("actor-xyz"));
+        assert_eq!(identity.organization_id.as_deref(), Some("org-123"));
+        assert_eq!(identity.key_id, "key-abc");
+    }
+
+    #[mz_ore::test]
+    fn expired_token_is_rejected() {
+        let keys = parse_derived_jwks(&derived_keys_jwks()).unwrap();
+        let key = keys.get(TEST_KID).unwrap();
+        let token = sign(json!({
+            "sub": "key-abc",
+            "act": "actor-xyz",
+            "exp": 1_000_000_000, // 2001, well in the past
+            "meta": { "email": "user@example.com" },
+        }));
+        assert!(matches!(
+            validate_derived_token(&token, key),
+            Err(TalosError::ExpiredSignature)
+        ));
+    }
+
+    #[mz_ore::test]
+    fn wrong_signing_key_is_rejected() {
+        // A token whose kid we know but signed by a different key must fail.
+        let keys = parse_derived_jwks(&derived_keys_jwks()).unwrap();
+        let key = keys.get(TEST_KID).unwrap();
+        // Tamper with the payload after signing to break the signature.
+        let token = sign(json!({ "sub": "k", "exp": future_exp(), "meta": {"email": "u@e.com"} }));
+        let mut parts: Vec<&str> = token.split('.').collect();
+        parts[1] = "eyJzdWIiOiJoYWNrZWQifQ"; // {"sub":"hacked"}
+        let tampered = parts.join(".");
+        assert!(matches!(
+            validate_derived_token(&tampered, key),
+            Err(TalosError::Jwt)
+        ));
+    }
+
+    #[mz_ore::test]
+    fn missing_email_is_rejected() {
+        let claims = TalosClaims {
+            sub: "key-abc".to_string(),
+            act: Some("actor-xyz".to_string()),
+            meta: TalosMeta::default(),
+        };
+        assert!(matches!(
+            map_claims(claims, None),
+            Err(TalosError::MissingEmail)
+        ));
+    }
+
+    #[mz_ore::test]
+    fn wrong_user_is_rejected() {
+        let claims = TalosClaims {
+            sub: "key-abc".to_string(),
+            act: None,
+            meta: TalosMeta {
+                email: Some("owner@example.com".to_string()),
+                organization_id: None,
+            },
+        };
+        assert!(matches!(
+            map_claims(claims, Some("someone-else@example.com")),
+            Err(TalosError::WrongUser)
+        ));
+    }
+
+    #[mz_ore::test]
+    fn derive_credential_debug_is_redacted() {
+        let cred = DeriveCredential::new("super-secret-derive-key".to_string());
+        let rendered = format!("{cred:?}");
+        assert!(
+            !rendered.contains("super-secret"),
+            "credential must not leak in Debug: {rendered}"
+        );
+    }
+}

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -1439,6 +1439,9 @@ async fn get_authenticator(
             }
             _ => Authenticator::Oidc(oidc_rx.clone().await.expect("sender not dropped")),
         },
+        // Talos HTTP listeners are rejected at startup config validation, so
+        // this arm is unreachable; fall back to no-op auth rather than panic.
+        listeners::AuthenticatorKind::Talos => Authenticator::None,
         listeners::AuthenticatorKind::None => Authenticator::None,
     }
 }
@@ -1543,6 +1546,14 @@ async fn auth(
             // We shouldn't ever end up here as the configuration is validated at startup.
             // If we do, it's a server misconfiguration.
             // Just in case, we return a 401 rather than panic.
+            return Err(AuthError::MissingHttpAuthentication {
+                challenges: challenges.clone(),
+            });
+        }
+        Authenticator::Talos(_) => {
+            // Talos auth is wired for pgwire only so far; HTTP Talos listeners
+            // are rejected at startup config validation, so this is
+            // unreachable. Return a 401 rather than panic if misconfigured.
             return Err(AuthError::MissingHttpAuthentication {
                 challenges: challenges.clone(),
             });

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -299,6 +299,10 @@ impl Listener<SqlListenerConfig> {
                 authenticator_kind: self.config.authenticator_kind,
                 frontegg,
                 oidc,
+                // TODO(ory-talos): construct a TalosAuthenticator from CLI/config
+                // once the derive-credential custody decision is settled; until
+                // then Talos pgwire listeners are plumbed but unconfigured.
+                talos: None,
                 metrics,
                 active_connection_counter,
                 helm_chart_version,

--- a/src/mz-debug/src/utils.rs
+++ b/src/mz-debug/src/utils.rs
@@ -110,7 +110,9 @@ pub async fn get_k8s_auth_mode(
                 ))
             }
         }
-        AuthenticatorKind::Frontegg => Err(anyhow::anyhow!(
+        // Talos uses derived-JWT app passwords rather than a username/password
+        // mz-debug can present, so it is unsupported here (like Frontegg).
+        AuthenticatorKind::Frontegg | AuthenticatorKind::Talos => Err(anyhow::anyhow!(
             "Unsupported authenticator kind: {:?}",
             authenticator_kind
         )),

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -33,7 +33,7 @@ use mz_adapter::{
 use mz_adapter_types::dyncfgs::OIDC_GROUP_CLAIM;
 use mz_auth::Authenticated;
 use mz_auth::password::Password;
-use mz_authenticator::{Authenticator, GenericOidcAuthenticator};
+use mz_authenticator::{Authenticator, GenericOidcAuthenticator, TalosAuthenticator};
 use mz_frontegg_auth::Authenticator as FronteggAuthenticator;
 use mz_ore::cast::CastFrom;
 use mz_ore::netio::AsyncReady;
@@ -119,6 +119,8 @@ where
     pub frontegg: Option<FronteggAuthenticator>,
     /// OIDC authenticator.
     pub oidc: GenericOidcAuthenticator,
+    /// Ory Talos authenticator, if this listener authenticates Talos keys.
+    pub talos: Option<TalosAuthenticator>,
     /// The authentication method defined by the server's listener
     /// configuration.
     pub authenticator_kind: listeners::AuthenticatorKind,
@@ -152,6 +154,7 @@ pub async fn run<'a, A, I>(
         mut params,
         frontegg,
         oidc,
+        talos,
         authenticator_kind,
         active_connection_counter,
         helm_chart_version,
@@ -175,7 +178,7 @@ where
     let user = params.remove("user").unwrap_or_else(String::new);
     let options = parse_options(params.get("options").unwrap_or(&String::new()));
     let authenticator =
-        get_authenticator(authenticator_kind, frontegg, oidc, adapter_client.clone());
+        get_authenticator(authenticator_kind, frontegg, oidc, talos, adapter_client.clone());
     // TODO move this somewhere it can be shared with HTTP
     let is_internal_user = INTERNAL_USER_NAMES.contains(&user);
     // this is a superset of internal users
@@ -279,6 +282,65 @@ where
                         );
                         // No invalidation of the auth session once authenticated,
                         // so auth session lasts indefinitely.
+                        (session, pending().right_future())
+                    }
+                    Err(err) => {
+                        warn!(?err, "pgwire connection failed authentication");
+                        return conn.send(err.into_response()).await;
+                    }
+                }
+            } else {
+                let session = match authenticate_with_password(
+                    conn,
+                    &adapter_client,
+                    user,
+                    Password(password),
+                    conn_uuid,
+                    helm_chart_version,
+                )
+                .await
+                {
+                    Ok(session) => session,
+                    Err(PasswordRequestError::IoError(e)) => return Err(e),
+                    Err(PasswordRequestError::InvalidPasswordError(e)) => {
+                        return conn.send(e).await;
+                    }
+                };
+                (session, pending().right_future())
+            }
+        }
+        Authenticator::Talos(talos) => {
+            // Talos listener: accepts an Ory Talos app password (derive-based
+            // exchange, prefix-detected) or a plain SQL password.
+            let password = match request_cleartext_password(conn).await {
+                Ok(password) => password,
+                Err(PasswordRequestError::IoError(e)) => return Err(e),
+                Err(PasswordRequestError::InvalidPasswordError(e)) => {
+                    return conn.send(e).await;
+                }
+            };
+            if talos.is_talos_key(&password) {
+                let auth_response = talos.authenticate(&password, Some(&user)).await;
+                match auth_response {
+                    Ok((claims, authenticated)) => {
+                        let session = adapter_client.new_session(
+                            SessionConfig {
+                                conn_id: conn.conn_id().clone(),
+                                uuid: conn_uuid,
+                                user: claims.user,
+                                client_ip: conn.peer_addr().clone(),
+                                external_metadata_rx: None,
+                                helm_chart_version,
+                                authenticator_kind,
+                                groups: None,
+                            },
+                            authenticated,
+                        );
+                        // Revocation takes effect on reconnect: a new connection
+                        // re-derives and fails if the key was revoked. Live
+                        // teardown of an established session via a background
+                        // refresh loop is a follow-up (OIDC has the same
+                        // limitation today).
                         (session, pending().right_future())
                     }
                     Err(err) => {
@@ -3348,6 +3410,7 @@ fn get_authenticator(
     authenticator_kind: listeners::AuthenticatorKind,
     frontegg: Option<FronteggAuthenticator>,
     oidc: GenericOidcAuthenticator,
+    talos: Option<TalosAuthenticator>,
     adapter_client: mz_adapter::Client,
 ) -> Authenticator {
     match authenticator_kind {
@@ -3357,6 +3420,9 @@ fn get_authenticator(
         listeners::AuthenticatorKind::Password => Authenticator::Password(adapter_client),
         listeners::AuthenticatorKind::Sasl => Authenticator::Sasl(adapter_client),
         listeners::AuthenticatorKind::Oidc => Authenticator::Oidc(oidc),
+        listeners::AuthenticatorKind::Talos => Authenticator::Talos(talos.expect(
+            "Talos authenticator should exist with listeners::AuthenticatorKind::Talos",
+        )),
         listeners::AuthenticatorKind::None => Authenticator::None,
     }
 }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -177,8 +177,13 @@ where
 
     let user = params.remove("user").unwrap_or_else(String::new);
     let options = parse_options(params.get("options").unwrap_or(&String::new()));
-    let authenticator =
-        get_authenticator(authenticator_kind, frontegg, oidc, talos, adapter_client.clone());
+    let authenticator = get_authenticator(
+        authenticator_kind,
+        frontegg,
+        oidc,
+        talos,
+        adapter_client.clone(),
+    );
     // TODO move this somewhere it can be shared with HTTP
     let is_internal_user = INTERNAL_USER_NAMES.contains(&user);
     // this is a superset of internal users
@@ -239,7 +244,7 @@ where
                         authenticated,
                     );
                     let expired = async move { auth_session.expired().await };
-                    (session, expired.left_future())
+                    (session, expired.boxed())
                 }
                 Err(err) => {
                     warn!(?err, "pgwire connection failed authentication");
@@ -282,7 +287,7 @@ where
                         );
                         // No invalidation of the auth session once authenticated,
                         // so auth session lasts indefinitely.
-                        (session, pending().right_future())
+                        (session, pending().boxed())
                     }
                     Err(err) => {
                         warn!(?err, "pgwire connection failed authentication");
@@ -306,7 +311,7 @@ where
                         return conn.send(e).await;
                     }
                 };
-                (session, pending().right_future())
+                (session, pending().boxed())
             }
         }
         Authenticator::Talos(talos) => {
@@ -322,12 +327,12 @@ where
             if talos.is_talos_key(&password) {
                 let auth_response = talos.authenticate(&password, Some(&user)).await;
                 match auth_response {
-                    Ok((claims, authenticated)) => {
+                    Ok((mut handle, authenticated)) => {
                         let session = adapter_client.new_session(
                             SessionConfig {
                                 conn_id: conn.conn_id().clone(),
                                 uuid: conn_uuid,
-                                user: claims.user,
+                                user: handle.user().into(),
                                 client_ip: conn.peer_addr().clone(),
                                 external_metadata_rx: None,
                                 helm_chart_version,
@@ -336,12 +341,11 @@ where
                             },
                             authenticated,
                         );
-                        // Revocation takes effect on reconnect: a new connection
-                        // re-derives and fails if the key was revoked. Live
-                        // teardown of an established session via a background
-                        // refresh loop is a follow-up (OIDC has the same
-                        // limitation today).
-                        (session, pending().right_future())
+                        // The handle's background task re-derives periodically;
+                        // `expired()` completes when the key is revoked/expired,
+                        // tearing the connection down (bounded revocation).
+                        let expired = async move { handle.expired().await };
+                        (session, expired.boxed())
                     }
                     Err(err) => {
                         warn!(?err, "pgwire connection failed authentication");
@@ -365,7 +369,7 @@ where
                         return conn.send(e).await;
                     }
                 };
-                (session, pending().right_future())
+                (session, pending().boxed())
             }
         }
         Authenticator::Password(adapter_client) => {
@@ -393,7 +397,7 @@ where
                 }
             };
             // No frontegg check, so auth session lasts indefinitely.
-            (session, pending().right_future())
+            (session, pending().boxed())
         }
         Authenticator::Sasl(adapter_client) => {
             // Start the handshake
@@ -577,7 +581,7 @@ where
                 authenticated,
             );
             // No frontegg check, so auth session lasts indefinitely.
-            let auth_session = pending().right_future();
+            let auth_session = pending().boxed();
             (session, auth_session)
         }
 
@@ -596,7 +600,7 @@ where
                 Authenticated,
             );
             // No frontegg check, so auth session lasts indefinitely.
-            let auth_session = pending().right_future();
+            let auth_session = pending().boxed();
             (session, auth_session)
         }
     };
@@ -3420,9 +3424,11 @@ fn get_authenticator(
         listeners::AuthenticatorKind::Password => Authenticator::Password(adapter_client),
         listeners::AuthenticatorKind::Sasl => Authenticator::Sasl(adapter_client),
         listeners::AuthenticatorKind::Oidc => Authenticator::Oidc(oidc),
-        listeners::AuthenticatorKind::Talos => Authenticator::Talos(talos.expect(
-            "Talos authenticator should exist with listeners::AuthenticatorKind::Talos",
-        )),
+        listeners::AuthenticatorKind::Talos => {
+            Authenticator::Talos(talos.expect(
+                "Talos authenticator should exist with listeners::AuthenticatorKind::Talos",
+            ))
+        }
         listeners::AuthenticatorKind::None => Authenticator::None,
     }
 }

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use mz_authenticator::GenericOidcAuthenticator;
+use mz_authenticator::{GenericOidcAuthenticator, TalosAuthenticator};
 use mz_frontegg_auth::Authenticator as FronteggAuthenticator;
 use mz_ore::now::{SYSTEM_TIME, epoch_to_uuid_v7};
 use mz_pgwire_common::{
@@ -49,6 +49,8 @@ pub struct Config {
     pub frontegg: Option<FronteggAuthenticator>,
     /// OIDC authenticator.
     pub oidc: GenericOidcAuthenticator,
+    /// Ory Talos authenticator, if this listener authenticates Talos keys.
+    pub talos: Option<TalosAuthenticator>,
     /// The authentication method defined by the server's listener
     /// configuration.
     pub authenticator_kind: AuthenticatorKind,
@@ -69,6 +71,7 @@ pub struct Server {
     authenticator_kind: AuthenticatorKind,
     frontegg: Option<FronteggAuthenticator>,
     oidc: GenericOidcAuthenticator,
+    talos: Option<TalosAuthenticator>,
     metrics: Metrics,
     active_connection_counter: ConnectionCounter,
     helm_chart_version: Option<String>,
@@ -104,6 +107,7 @@ impl Server {
             authenticator_kind: config.authenticator_kind,
             frontegg: config.frontegg,
             oidc: config.oidc,
+            talos: config.talos,
             metrics: Metrics::new(config.metrics, config.label),
             active_connection_counter: config.active_connection_counter,
             helm_chart_version: config.helm_chart_version,
@@ -121,6 +125,7 @@ impl Server {
         let authenticator_kind = self.authenticator_kind;
         let frontegg = self.frontegg.clone();
         let oidc = self.oidc.clone();
+        let talos = self.talos.clone();
         let tls = self.tls.clone();
         let metrics = self.metrics.clone();
         let active_connection_counter = self.active_connection_counter.clone();
@@ -214,6 +219,7 @@ impl Server {
                                     params,
                                     frontegg,
                                     oidc,
+                                    talos,
                                     authenticator_kind,
                                     active_connection_counter,
                                     helm_chart_version,

--- a/src/server-core/src/listeners.rs
+++ b/src/server-core/src/listeners.rs
@@ -32,6 +32,8 @@ pub enum AuthenticatorKind {
     Sasl,
     /// Authenticate users using OIDC (JWT tokens).
     Oidc,
+    /// Authenticate users using Ory Talos app passwords (derived-JWT exchange).
+    Talos,
     /// Do not authenticate users. Trust they are who they say they are without verification.
     #[default]
     None,
@@ -215,10 +217,16 @@ impl ListenerConfig for HttpListenerConfig {
     }
 
     fn validate(&self) -> Result<(), String> {
-        if self.authenticator_kind == AuthenticatorKind::Sasl {
-            Err("SASL authentication is not supported for HTTP listeners".to_string())
-        } else {
-            Ok(())
+        match self.authenticator_kind {
+            AuthenticatorKind::Sasl => {
+                Err("SASL authentication is not supported for HTTP listeners".to_string())
+            }
+            // Talos derive-based auth is wired for pgwire only so far; the HTTP
+            // path is not yet supported.
+            AuthenticatorKind::Talos => {
+                Err("Talos authentication is not yet supported for HTTP listeners".to_string())
+            }
+            _ => Ok(()),
         }
     }
 }


### PR DESCRIPTION
> ⚠️ **EXPERIMENTAL — DO NOT MERGE.** This is a spike branch opened for
> visibility and discussion, not for merging. It is missing production wiring
> (see "Not included") and depends on open architecture decisions with Ory.

## What this is

A spike of connection-time authentication for **Ory Talos** app passwords in
environmentd, using the "derive, not verify" model: exchange a presented Talos
API key via `apiKeys:derive` for a short-lived JWT, then validate that JWT
locally against the derived-keys JWKS. This is the Ory-native replacement for
Frontegg app passwords on the connection path.

It slots into the existing `Authenticator` abstraction as a new `Talos`
variant alongside `Frontegg`/`Oidc`/`Password`, reusing the OIDC authenticator's
JWKS machinery.

## What's here

- **`src/authenticator/src/talos.rs`** — `TalosAuthenticator`:
  - `apiKeys:derive` exchange (opaque key → short-lived JWT), with a
    redacted-`Debug` `DeriveCredential`.
  - **EdDSA/Ed25519 JWKS validation** reusing the OIDC kid-cache pattern, and
    unwrapping Talos's non-standard `{"jwks":{"keys":[…]}}` envelope. Algorithm
    is taken from the JWK/header, so Ed25519 validates with no special-casing.
  - Claims mapping per the Talos contract (`sub`=key id, `act`=actor,
    issuance `meta` carries email/organization_id → no directory lookup on the
    connection hot path).
  - **Per-connection revocation refresh:** `authenticate` returns a
    `TalosSessionHandle` whose background task periodically re-derives; a
    revoked/expired key makes derive fail, which fires `expired()` and tears the
    connection down. Talos derived tokens are not individually revocable
    (revocation is TTL-bound), so this re-derive is the revocation mechanism.
- **pgwire dispatch wiring** — `AuthenticatorKind::Talos` (in `mz_auth` and
  `mz_server_core::listeners`), `Authenticator::Talos`, `get_authenticator`, and
  a full pgwire auth arm (prefix-detect → derive → validate → session).
- HTTP path is intentionally **not** supported yet: Talos HTTP listeners are
  rejected at config validation.

## Verification

- 12 unit tests (incl. a real Ed25519 sign→validate round-trip and the
  revocation-handle signal); clippy + fmt clean; compiles across
  environmentd / pgwire / orchestratord / mz-debug.
- An env-gated **live contract test** (`live_talos_derive_and_validate`) was run
  against a real Ory Network dev project: issue key with metadata → derive
  (EdDSA) → validate with this code → `sub`/`actor`/`meta.email`/
  `meta.organization_id` all round-trip.

## Not included (why "do not merge")

- environmentd CLI/config to actually **construct** a `TalosAuthenticator`
  (currently `talos: None`) — gated on the derive-credential custody decision.
- balancerd resolver and the HTTP path.
- The **custody / tenancy** decision is open and partly depends on Ory
  capabilities (dynamic per-tenant provisioning; scoped project API keys).

## Design context

Design docs live in `MaterializeInc/cloud` (`doc/design/`):
`20260710_ory_auth_migration.md`,
`20260717_talos_app_password_custody_and_tenancy.md` (the custody/tenancy
analysis and open questions for Ory). The cloud-side half (stamping
email/organization_id into Talos key metadata at issuance) is on
`MaterializeInc/cloud@ory-prototype`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
