### PR TITLE
mcp: pin RBAC pass-through invariant on the developer endpoint (CLO-158)

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -630,6 +630,17 @@ impl HttpServer {
                         .allow_origin(allowed_origin.clone())
                         .allow_headers([AUTHORIZATION, CONTENT_TYPE]),
                 );
+            // On listeners with no HTTP authentication (i.e. the internal
+            // listener fronted by Teleport), trust the `x-materialize-user`
+            // header injected by the upstream proxy. This mirrors the pattern
+            // applied to `base_router` further down, and to `ws_router` at the
+            // top of this function. Without this, `/api/mcp/*` sessions
+            // silently resolve to `HTTP_DEFAULT_USER` even when Teleport
+            // injects `X-Materialize-User: mz_support`, breaking support
+            // access to `SHOW CREATE` / `EXPLAIN ANALYZE` via MCP (CLO-158).
+            if let listeners::AuthenticatorKind::None = authenticator_kind {
+                mcp_router = mcp_router.layer(middleware::from_fn(x_materialize_user_header_auth));
+            }
             router = router.merge(mcp_router);
         }
 

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -630,14 +630,9 @@ impl HttpServer {
                         .allow_origin(allowed_origin.clone())
                         .allow_headers([AUTHORIZATION, CONTENT_TYPE]),
                 );
-            // On listeners with no HTTP authentication (i.e. the internal
-            // listener fronted by Teleport), trust the `x-materialize-user`
-            // header injected by the upstream proxy. This mirrors the pattern
-            // applied to `base_router` further down, and to `ws_router` at the
-            // top of this function. Without this, `/api/mcp/*` sessions
-            // silently resolve to `HTTP_DEFAULT_USER` even when Teleport
-            // injects `X-Materialize-User: mz_support`, breaking support
-            // access to `SHOW CREATE` / `EXPLAIN ANALYZE` via MCP (CLO-158).
+            // Trust `x-materialize-user` injected by an upstream proxy on
+            // listeners without HTTP auth, matching `base_router` and
+            // `ws_router` (CLO-158).
             if let listeners::AuthenticatorKind::None = authenticator_kind {
                 mcp_router = mcp_router.layer(middleware::from_fn(x_materialize_user_header_auth));
             }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -5650,6 +5650,246 @@ fn test_mcp_developer_search_path_defense() {
     );
 }
 
+/// Pins that the developer MCP endpoint is a pass-through for RBAC: every
+/// permission check is enforced by the pgwire session's role, with no
+/// MCP-side gating or elevation on top. Prompted by a support-role scenario
+/// where the same statement failed via MCP but succeeded via psql, which
+/// turned out to be two different roles behind the two paths.
+///
+/// For each statement, the same role runs it once through MCP `query` and
+/// once through pgwire. The two results must match at every step: both
+/// denied without USAGE, both denied without SELECT after USAGE is granted,
+/// both succeeding once both privileges are in place.
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_mcp_developer_rbac_passthrough() {
+    let server = test_util::TestHarness::default()
+        .with_mcp_routes(false, true)
+        .with_system_parameter_default("enable_mcp_developer".to_string(), "true".to_string())
+        .start_blocking();
+
+    let developer_url = format!("http://{}/api/mcp/developer", server.http_local_addr());
+
+    // Mirrors an mz_support-style role: broad system grants, no USAGE on the
+    // user schema created below. RBAC must be enabled for the missing USAGE
+    // to actually deny.
+    {
+        let mut super_user = server
+            .pg_config_internal()
+            .user(&SYSTEM_USER.name)
+            .connect(postgres::NoTls)
+            .unwrap();
+
+        super_user
+            .batch_execute("ALTER SYSTEM SET enable_rbac_checks TO true")
+            .unwrap();
+        super_user
+            .batch_execute(&format!("CREATE ROLE {}", &HTTP_DEFAULT_USER.name))
+            .unwrap();
+        super_user
+            .batch_execute(&format!(
+                "GRANT ALL PRIVILEGES ON SYSTEM TO {}",
+                &HTTP_DEFAULT_USER.name
+            ))
+            .unwrap();
+        super_user
+            .batch_execute(&format!(
+                "GRANT ALL PRIVILEGES ON DATABASE materialize TO {}",
+                &HTTP_DEFAULT_USER.name
+            ))
+            .unwrap();
+        super_user
+            .batch_execute(&format!(
+                "GRANT ALL PRIVILEGES ON SCHEMA materialize.public TO {}",
+                &HTTP_DEFAULT_USER.name
+            ))
+            .unwrap();
+        super_user
+            .batch_execute(&format!(
+                "GRANT ALL PRIVILEGES ON CLUSTER quickstart TO {}",
+                &HTTP_DEFAULT_USER.name
+            ))
+            .unwrap();
+
+        super_user
+            .batch_execute("CREATE SCHEMA restricted_schema")
+            .unwrap();
+        super_user
+            .batch_execute("CREATE VIEW restricted_schema.v AS SELECT 1 AS x")
+            .unwrap();
+        super_user
+            .batch_execute(
+                "CREATE MATERIALIZED VIEW restricted_schema.mv \
+                 IN CLUSTER quickstart AS SELECT 1 AS x",
+            )
+            .unwrap();
+    }
+
+    // The developer `query` tool wraps adapter errors in `result.isError`
+    // rather than raising a JSON-RPC `error`, so both shapes have to be
+    // handled here.
+    let error_message = |body: &serde_json::Value| -> String {
+        if let Some(msg) = body["error"]["message"].as_str() {
+            return msg.to_string();
+        }
+        if body["result"]["isError"].as_bool() == Some(true) {
+            if let Some(text) = body["result"]["content"][0]["text"].as_str() {
+                return text.to_string();
+            }
+        }
+        String::new()
+    };
+
+    let mcp_query = |sql: &str, id: i64| -> String {
+        let (status, body) = mcp_post(
+            &developer_url,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "tools/call",
+                "params": {
+                    "name": "query",
+                    "arguments": {"cluster": "quickstart", "sql_query": sql},
+                }
+            }),
+        );
+        assert_eq!(status, StatusCode::OK, "unexpected HTTP status for {sql}");
+        error_message(&body)
+    };
+
+    let pgwire_query = |sql: &str| -> String {
+        let mut client = server
+            .pg_config()
+            .user(&HTTP_DEFAULT_USER.name)
+            .connect(postgres::NoTls)
+            .unwrap();
+        match client.batch_execute(sql) {
+            Ok(()) => String::new(),
+            // `postgres::Error`'s `Display` collapses to "db error" without
+            // the SQLSTATE/message chain, so unwrap the DbError explicitly.
+            Err(e) => match e.as_db_error() {
+                Some(db_err) => db_err.message().to_string(),
+                None => format!("{e:?}"),
+            },
+        }
+    };
+
+    // Asserts a permission-denied error on the schema, on both paths, for a
+    // single statement. Kept as a single helper because the interesting
+    // property is that MCP and pgwire agree, not the wording per statement.
+    let assert_both_denied = |sql: &str, id: i64| {
+        let mcp_err = mcp_query(sql, id);
+        assert!(
+            mcp_err.contains("permission denied") && mcp_err.contains("restricted_schema"),
+            "MCP `{sql}` should be denied on the schema, got: {mcp_err}"
+        );
+        let pg_err = pgwire_query(sql);
+        assert!(
+            pg_err.contains("permission denied") && pg_err.contains("restricted_schema"),
+            "pgwire `{sql}` should be denied on the schema, got: {pg_err}"
+        );
+    };
+
+    let assert_both_ok = |sql: &str, id: i64| {
+        let mcp_err = mcp_query(sql, id);
+        assert!(
+            mcp_err.is_empty(),
+            "MCP `{sql}` should succeed, got: {mcp_err}"
+        );
+        let pg_err = pgwire_query(sql);
+        assert!(
+            pg_err.is_empty(),
+            "pgwire `{sql}` should succeed, got: {pg_err}"
+        );
+    };
+
+    // Statement variants Seth's report called out (SHOW CREATE forms and
+    // EXPLAIN referencing an object in the schema). Plain EXPLAIN is used in
+    // place of EXPLAIN ANALYZE because the `AS SQL` variants of ANALYZE do
+    // not exercise the same object-resolution path.
+    let show_create_view = "SHOW CREATE VIEW restricted_schema.v";
+    let show_create_mv = "SHOW CREATE MATERIALIZED VIEW restricted_schema.mv";
+    let explain_select = "EXPLAIN SELECT * FROM restricted_schema.v";
+    let select_view = "SELECT * FROM restricted_schema.v";
+
+    // No USAGE on the schema: both paths deny on all statement shapes.
+    assert_both_denied(show_create_view, 1);
+    assert_both_denied(show_create_mv, 2);
+    assert_both_denied(explain_select, 3);
+    assert_both_denied(select_view, 4);
+
+    // Grant USAGE on the schema. SHOW CREATE and EXPLAIN then work (they do
+    // not need SELECT on the object), but a real SELECT still needs SELECT
+    // on the view, so it must stay denied on both paths.
+    {
+        let mut super_user = server
+            .pg_config_internal()
+            .user(&SYSTEM_USER.name)
+            .connect(postgres::NoTls)
+            .unwrap();
+        super_user
+            .batch_execute(&format!(
+                "GRANT USAGE ON SCHEMA restricted_schema TO {}",
+                &HTTP_DEFAULT_USER.name
+            ))
+            .unwrap();
+    }
+
+    assert_both_ok(show_create_view, 10);
+    assert_both_ok(show_create_mv, 11);
+    assert_both_ok(explain_select, 12);
+
+    // Per-object RBAC also has to match. USAGE alone is not enough for a
+    // real SELECT: the message flips to "permission denied for VIEW", and
+    // it must flip identically on both paths.
+    let mcp_err = mcp_query(select_view, 13);
+    assert!(
+        mcp_err.contains("permission denied") && mcp_err.contains("restricted_schema.v"),
+        "MCP SELECT should be denied on the view, got: {mcp_err}"
+    );
+    let pg_err = pgwire_query(select_view);
+    assert!(
+        pg_err.contains("permission denied") && pg_err.contains("restricted_schema.v"),
+        "pgwire SELECT should be denied on the view, got: {pg_err}"
+    );
+
+    // Grant SELECT on the view. Both paths now succeed.
+    {
+        let mut super_user = server
+            .pg_config_internal()
+            .user(&SYSTEM_USER.name)
+            .connect(postgres::NoTls)
+            .unwrap();
+        super_user
+            .batch_execute(&format!(
+                "GRANT SELECT ON restricted_schema.v TO {}",
+                &HTTP_DEFAULT_USER.name
+            ))
+            .unwrap();
+    }
+
+    assert_both_ok(select_view, 20);
+
+    // Revoke USAGE. Both paths must deny again, which confirms the pin
+    // holds through grant transitions in either direction.
+    {
+        let mut super_user = server
+            .pg_config_internal()
+            .user(&SYSTEM_USER.name)
+            .connect(postgres::NoTls)
+            .unwrap();
+        super_user
+            .batch_execute(&format!(
+                "REVOKE USAGE ON SCHEMA restricted_schema FROM {}",
+                &HTTP_DEFAULT_USER.name
+            ))
+            .unwrap();
+    }
+
+    assert_both_denied(show_create_view, 30);
+    assert_both_denied(select_view, 31);
+}
+
 /// Helper to POST a JSON-RPC request to an MCP endpoint and return the parsed response.
 fn mcp_post(url: &str, json: serde_json::Value) -> (reqwest::StatusCode, serde_json::Value) {
     let res = Client::new().post(url).json(&json).send().unwrap();

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -5890,6 +5890,80 @@ fn test_mcp_developer_rbac_passthrough() {
     assert_both_denied(select_view, 31);
 }
 
+/// Regression pin for CLO-158: `/api/mcp/developer` on the internal HTTP
+/// listener must honor an `x-materialize-user` header injected by a trusted
+/// upstream proxy (Teleport), matching the behavior of `/api/sql` on the same
+/// listener. Today it does not: `x_materialize_user_header_auth` is layered
+/// onto `base_router` at `http.rs:667` but not onto `mcp_router`, so MCP
+/// sessions on port 6878 always resolve to `anonymous_http_user` regardless of
+/// the injected header. That makes the endpoint unusable for support in Cloud,
+/// where Teleport injects `X-Materialize-User: mz_support` via the app rewrite
+/// (`cloud/src/environment-controller/src/controller/teleport.rs:302-310`).
+///
+/// This test is intentionally left un-ignored so it fails until the middleware
+/// is wired to `mcp_router` in the same pattern `ws_router` uses at
+/// `http.rs:336-339`. Once fixed, it becomes the regression pin that keeps
+/// this working going forward.
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)]
+#[allow(clippy::disallowed_methods)]
+fn test_mcp_developer_honors_x_materialize_user_header() {
+    let server = test_util::TestHarness::default()
+        .with_mcp_routes(false, true)
+        .with_system_parameter_default("enable_mcp_developer".to_string(), "true".to_string())
+        .start_blocking();
+
+    // Control: `/api/sql` on the same internal listener already honors the
+    // header. If this ever breaks, we want to know because it is a larger
+    // regression than CLO-158.
+    let sql_url = format!("http://{}/api/sql", server.internal_http_local_addr());
+    let sql_res = Client::new()
+        .post(&sql_url)
+        .header("x-materialize-user", "mz_support")
+        .json(&serde_json::json!({"query": "SELECT current_user"}))
+        .send()
+        .unwrap();
+    assert_eq!(sql_res.status(), StatusCode::OK);
+    let sql_text = sql_res.text().unwrap();
+    assert!(
+        sql_text.contains("mz_support"),
+        "control: /api/sql on the internal listener should resolve to mz_support, got: {sql_text}"
+    );
+
+    // The regression pin: same listener, same header, different route.
+    // MCP developer must also resolve the session as the injected user.
+    let mcp_url = format!(
+        "http://{}/api/mcp/developer",
+        server.internal_http_local_addr()
+    );
+    let res = Client::new()
+        .post(&mcp_url)
+        .header("x-materialize-user", "mz_support")
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "query_system_catalog",
+                "arguments": {
+                    "sql_query": "SELECT current_user, count(*) FROM mz_catalog.mz_databases"
+                }
+            }
+        }))
+        .send()
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: serde_json::Value = res.json().unwrap();
+    let result_text = body["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or("");
+    assert!(
+        result_text.contains("mz_support"),
+        "MCP developer on the internal listener must resolve the session to mz_support \
+         via injected x-materialize-user header, got result: {result_text}, full body: {body}"
+    );
+}
+
 /// Helper to POST a JSON-RPC request to an MCP endpoint and return the parsed response.
 fn mcp_post(url: &str, json: serde_json::Value) -> (reqwest::StatusCode, serde_json::Value) {
     let res = Client::new().post(url).json(&json).send().unwrap();

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -5954,9 +5954,7 @@ fn test_mcp_developer_honors_x_materialize_user_header() {
         .unwrap();
     assert_eq!(res.status(), StatusCode::OK);
     let body: serde_json::Value = res.json().unwrap();
-    let result_text = body["result"]["content"][0]["text"]
-        .as_str()
-        .unwrap_or("");
+    let result_text = body["result"]["content"][0]["text"].as_str().unwrap_or("");
     assert!(
         result_text.contains("mz_support"),
         "MCP developer on the internal listener must resolve the session to mz_support \

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -5650,16 +5650,8 @@ fn test_mcp_developer_search_path_defense() {
     );
 }
 
-/// Pins that the developer MCP endpoint is a pass-through for RBAC: every
-/// permission check is enforced by the pgwire session's role, with no
-/// MCP-side gating or elevation on top. Prompted by a support-role scenario
-/// where the same statement failed via MCP but succeeded via psql, which
-/// turned out to be two different roles behind the two paths.
-///
-/// For each statement, the same role runs it once through MCP `query` and
-/// once through pgwire. The two results must match at every step: both
-/// denied without USAGE, both denied without SELECT after USAGE is granted,
-/// both succeeding once both privileges are in place.
+/// Pins that the developer MCP endpoint is an RBAC pass-through: the same
+/// statement run by the same role returns the same result via MCP or pgwire.
 #[mz_ore::test]
 #[allow(clippy::disallowed_methods)]
 fn test_mcp_developer_rbac_passthrough() {
@@ -5891,19 +5883,8 @@ fn test_mcp_developer_rbac_passthrough() {
 }
 
 /// Regression pin for CLO-158: `/api/mcp/developer` on the internal HTTP
-/// listener must honor an `x-materialize-user` header injected by a trusted
-/// upstream proxy (Teleport), matching the behavior of `/api/sql` on the same
-/// listener. Today it does not: `x_materialize_user_header_auth` is layered
-/// onto `base_router` at `http.rs:667` but not onto `mcp_router`, so MCP
-/// sessions on port 6878 always resolve to `anonymous_http_user` regardless of
-/// the injected header. That makes the endpoint unusable for support in Cloud,
-/// where Teleport injects `X-Materialize-User: mz_support` via the app rewrite
-/// (`cloud/src/environment-controller/src/controller/teleport.rs:302-310`).
-///
-/// This test is intentionally left un-ignored so it fails until the middleware
-/// is wired to `mcp_router` in the same pattern `ws_router` uses at
-/// `http.rs:336-339`. Once fixed, it becomes the regression pin that keeps
-/// this working going forward.
+/// listener honors an `x-materialize-user` header injected by a trusted
+/// upstream proxy, matching `/api/sql` on the same listener.
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)]
 #[allow(clippy::disallowed_methods)]


### PR DESCRIPTION
Pins that the developer MCP endpoint is a pass-through for RBAC: same role, same result via MCP or pgwire. Prompted by a support-role case that turned out to be two different roles behind the two paths, not an MCP-side restriction.
