### PR TITLE
compute: coalesce concurrent index peeks into one arrangement walk

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -845,6 +845,10 @@ metrics:
   help: Number of coalesced index peek groups (each served by a single arrangement walk), summed across the process's workers.
   source: src/compute/src/metrics.rs
   visibility: internal
+- name: mz_index_peek_coalesced_overflow_total
+  help: Number of coalesced index peek groups that exceeded the aggregate memory budget and fell back to serving each peek individually, summed across the process's workers.
+  source: src/compute/src/metrics.rs
+  visibility: internal
 - name: mz_index_peek_coalesced_peeks_total
   help: Number of index peeks served through coalescing, summed across the process's workers (each worker counts the same logical peeks).
   source: src/compute/src/metrics.rs

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -842,11 +842,11 @@ metrics:
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_coalesced_groups_total
-  help: Number of coalesced index peek groups (each served by a single arrangement walk).
+  help: Number of coalesced index peek groups (each served by a single arrangement walk), summed across the process's workers.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_coalesced_peeks_total
-  help: Number of index peeks served through coalescing.
+  help: Number of index peeks served through coalescing, summed across the process's workers (each worker counts the same logical peeks).
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_cursor_setup_seconds_bucket

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -841,6 +841,14 @@ metrics:
   - altered_a_cluster
   source: src/adapter/src/metrics.rs
   visibility: internal
+- name: mz_index_peek_coalesced_groups_total
+  help: Number of coalesced index peek groups (each served by a single arrangement walk).
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_coalesced_peeks_total
+  help: Number of index peeks served through coalescing.
+  source: src/compute/src/metrics.rs
+  visibility: internal
 - name: mz_index_peek_cursor_setup_seconds_bucket
   help: Time setting up cursor and literal constraints.
   labels:

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -79,6 +79,7 @@ def get_minimal_system_parameters(
         "enable_columnation_lgalloc": "false",
         "enable_compute_correction_v2": "true",
         "enable_compute_logical_backpressure": "true",
+        "enable_compute_peek_coalescing": "true",
         "enable_connection_validation_syntax": "true",
         "enable_create_table_from_source": "true",
         "enable_eager_delta_joins": "true",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1827,6 +1827,7 @@ class FlipFlagsAction(Action):
         self.flags_with_values["enable_compute_peek_response_stash"] = (
             BOOLEAN_FLAG_VALUES
         )
+        self.flags_with_values["enable_compute_peek_coalescing"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["compute_peek_response_stash_threshold_bytes"] = [
             "0",  # "force enabled"
             "1048576",  # 1 MiB, an in-between value

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -409,13 +409,16 @@ pub const ENABLE_PEEK_RESPONSE_STASH: Config<bool> = Config::new(
     "Whether to enable the peek response stash, for sending back large peek responses. Will only be used for results that exceed compute_peek_response_stash_threshold_bytes.",
 );
 
-/// Whether to coalesce index peeks that are pending against the same index at
-/// the same timestamp into a single arrangement walk, amortizing cursor setup
-/// and key/value decoding across the peeks.
+/// Whether to coalesce index peeks against the same index at the same timestamp
+/// into a single arrangement walk, amortizing cursor setup and key/value
+/// decoding across the peeks. Index peeks are deferred from the command handler
+/// into `process_peeks`, so peeks drained together in one command batch coalesce
+/// even when every one of them is ready on arrival (the common case, and the
+/// only case under Serializable isolation).
 pub const ENABLE_PEEK_COALESCING: Config<bool> = Config::new(
     "enable_compute_peek_coalescing",
     true,
-    "Whether to coalesce index peeks pending against the same index at the same timestamp into a single arrangement walk.",
+    "Whether to coalesce index peeks against the same index at the same timestamp into a single arrangement walk.",
 );
 
 /// The threshold for peek response size above which we should use the peek

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -409,6 +409,15 @@ pub const ENABLE_PEEK_RESPONSE_STASH: Config<bool> = Config::new(
     "Whether to enable the peek response stash, for sending back large peek responses. Will only be used for results that exceed compute_peek_response_stash_threshold_bytes.",
 );
 
+/// Whether to coalesce index peeks that are pending against the same index at
+/// the same timestamp into a single arrangement walk, amortizing cursor setup
+/// and key/value decoding across the peeks.
+pub const ENABLE_PEEK_COALESCING: Config<bool> = Config::new(
+    "enable_compute_peek_coalescing",
+    true,
+    "Whether to coalesce index peeks pending against the same index at the same timestamp into a single arrangement walk.",
+);
+
 /// The threshold for peek response size above which we should use the peek
 /// response stash. Only used if the peek response stash is enabled _and_ if the
 /// query is "streamable" (roughly: doesn't have an ORDER BY).
@@ -526,6 +535,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES)
         .add(&COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK)
         .add(&ENABLE_ARRANGEMENT_DICTIONARY_COMPRESSION_ALPHA)
+        .add(&ENABLE_PEEK_COALESCING)
         .add(&ENABLE_PEEK_RESPONSE_STASH)
         .add(&PEEK_RESPONSE_STASH_THRESHOLD_BYTES)
         .add(&PEEK_RESPONSE_STASH_BATCH_MAX_RUNS)

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1225,14 +1225,40 @@ impl<'a> ActiveComputeState<'a> {
             })
             .collect();
 
-        // The single shared arrangement walk.
+        // The single shared arrangement walk. Coalescing keeps every peek's
+        // result resident until this walk finishes, so a shared budget caps the
+        // group's aggregate memory at roughly one peek's worth. Use the per-query
+        // `max_result_size` as that budget: it matches what the single-peek path
+        // holds for one result, so falling back below stays within the same bound.
         let walk_start = Instant::now();
-        peek_coalesce::collect_coalesced_ok_data(peeks[0].trace_bundle.oks_mut(), &mut muxed);
+        let overflowed = peek_coalesce::collect_coalesced_ok_data(
+            peeks[0].trace_bundle.oks_mut(),
+            &mut muxed,
+            max_result_size,
+        );
         let walk_duration = walk_start.elapsed();
         self.compute_state
             .metrics
             .index_peek_row_iteration_seconds
             .observe(walk_duration.as_secs_f64());
+
+        // The group's aggregate results would exceed the memory budget. Drop the
+        // partial accumulators and serve each peek through the single-peek path,
+        // which builds and sends one result at a time. This trades the shared
+        // walk (re-scanning the arrangement per peek) for bounded peak memory,
+        // and only fires in the pathological large-result case.
+        if overflowed {
+            drop(muxed);
+            self.compute_state
+                .metrics
+                .index_peek_coalesced_overflow_total
+                .inc();
+            let mut upper = Antichain::new();
+            for peek in peeks {
+                self.process_peek(&mut upper, PendingPeek::Index(peek), true);
+            }
+            return;
+        }
 
         // Attribute the shared walk time to each peek's total-time histogram so
         // that dashboard stays populated when coalescing is on. The per-phase

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -30,13 +30,13 @@ use mz_compute_client::protocol::response::{
 };
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::{
-    ENABLE_PEEK_RESPONSE_STASH, PEEK_RESPONSE_STASH_BATCH_MAX_RUNS,
+    ENABLE_PEEK_COALESCING, ENABLE_PEEK_RESPONSE_STASH, PEEK_RESPONSE_STASH_BATCH_MAX_RUNS,
     PEEK_RESPONSE_STASH_THRESHOLD_BYTES, PEEK_STASH_BATCH_SIZE, PEEK_STASH_NUM_BATCHES,
 };
 use mz_compute_types::plan::render_plan::RenderPlan;
 use mz_dyncfg::ConfigSet;
+use mz_expr::SafeMfpPlan;
 use mz_expr::row::RowCollection;
-use mz_expr::{RowComparator, SafeMfpPlan};
 use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::{MetricsRegistry, UIntGauge};
@@ -76,6 +76,7 @@ use crate::metrics::{CollectionMetrics, WorkerMetrics};
 use crate::render::{LinearJoinSpec, StartSignal};
 use crate::server::{ComputeInstanceContext, ResponseSender};
 
+mod peek_coalesce;
 mod peek_result_iterator;
 mod peek_stash;
 
@@ -996,26 +997,7 @@ impl<'a> ActiveComputeState<'a> {
                     PeekStatus::Ready(result) => Some(result),
                     PeekStatus::NotReady => None,
                     PeekStatus::UsePeekStash => {
-                        let _span =
-                            span!(parent: &peek.span, Level::DEBUG, "process_stash_peek").entered();
-
-                        let peek_stash_batch_max_runs = PEEK_RESPONSE_STASH_BATCH_MAX_RUNS
-                            .get(&self.compute_state.worker_config);
-
-                        let stash_task = peek_stash::StashingPeek::start_upload(
-                            Arc::clone(&self.compute_state.persist_clients),
-                            self.compute_state
-                                .peek_stash_persist_location
-                                .as_ref()
-                                .expect("verified above"),
-                            peek.peek.clone(),
-                            peek.trace_bundle.clone(),
-                            peek_stash_batch_max_runs,
-                        );
-
-                        self.compute_state
-                            .pending_peeks
-                            .insert(peek.peek.uuid, PendingPeek::Stash(stash_task));
+                        self.start_stash_peek(peek);
                         return;
                     }
                 }
@@ -1055,12 +1037,178 @@ impl<'a> ActiveComputeState<'a> {
         }
     }
 
+    /// Diverts an index peek to the peek stash, spawning the async upload task.
+    ///
+    /// Callers must have verified that the peek stash is enabled and a stash
+    /// location is available.
+    fn start_stash_peek(&mut self, peek: &IndexPeek) {
+        let _span = span!(parent: &peek.span, Level::DEBUG, "process_stash_peek").entered();
+
+        let peek_stash_batch_max_runs =
+            PEEK_RESPONSE_STASH_BATCH_MAX_RUNS.get(&self.compute_state.worker_config);
+
+        let stash_task = peek_stash::StashingPeek::start_upload(
+            Arc::clone(&self.compute_state.persist_clients),
+            self.compute_state
+                .peek_stash_persist_location
+                .as_ref()
+                .expect("peek stash location available"),
+            peek.peek.clone(),
+            peek.trace_bundle.clone(),
+            peek_stash_batch_max_runs,
+        );
+
+        self.compute_state
+            .pending_peeks
+            .insert(peek.peek.uuid, PendingPeek::Stash(stash_task));
+    }
+
     /// Scan pending peeks and attempt to retire each.
+    ///
+    /// When peek coalescing is enabled, index peeks that are ready against the
+    /// same index at the same timestamp are grouped and served by a single
+    /// arrangement walk. All other peeks are retired individually.
     pub fn process_peeks(&mut self) {
         let mut upper = Antichain::new();
         let pending_peeks = std::mem::take(&mut self.compute_state.pending_peeks);
+
+        if !ENABLE_PEEK_COALESCING.get(&self.compute_state.worker_config) {
+            for (_uuid, peek) in pending_peeks {
+                self.process_peek(&mut upper, peek);
+            }
+            return;
+        }
+
+        // Partition ready index peeks into groups keyed by (index id, timestamp).
+        // Persist peeks, stash peeks, and index peeks that are not ready or that
+        // error during the readiness check are handled individually.
+        let mut groups: BTreeMap<(GlobalId, Timestamp), Vec<IndexPeek>> = BTreeMap::new();
+        let mut leftovers: Vec<PendingPeek> = Vec::new();
+
         for (_uuid, peek) in pending_peeks {
+            match peek {
+                PendingPeek::Index(mut index_peek) => match index_peek.readiness(&mut upper) {
+                    Readiness::Ready => {
+                        let key = (index_peek.peek.target.id(), index_peek.peek.timestamp);
+                        groups.entry(key).or_default().push(index_peek);
+                    }
+                    Readiness::NotReady => {
+                        let uuid = index_peek.peek.uuid;
+                        self.compute_state
+                            .pending_peeks
+                            .insert(uuid, PendingPeek::Index(index_peek));
+                    }
+                    Readiness::Error(response) => {
+                        self.send_peek_response(PendingPeek::Index(index_peek), response);
+                    }
+                },
+                other => leftovers.push(other),
+            }
+        }
+
+        for (_key, mut peeks) in groups {
+            if peeks.len() == 1 {
+                let peek = peeks.pop().expect("length checked");
+                self.process_peek(&mut upper, PendingPeek::Index(peek));
+            } else {
+                self.process_coalesced_group(peeks);
+            }
+        }
+
+        for peek in leftovers {
             self.process_peek(&mut upper, peek);
+        }
+    }
+
+    /// Fulfills a group of ready index peeks against the same index at the same
+    /// timestamp with a single arrangement walk.
+    ///
+    /// All peeks in `peeks` must be ready (their readiness verified by the
+    /// caller) and share the same target index and timestamp.
+    fn process_coalesced_group(&mut self, mut peeks: Vec<IndexPeek>) {
+        let group_size = peeks.len();
+
+        // All peeks read at the same timestamp, so a single error-trace scan
+        // applies to the entire group.
+        let error_scan_start = Instant::now();
+        let error = peeks[0].scan_error_trace();
+        self.compute_state
+            .metrics
+            .index_peek_error_scan_seconds
+            .observe(error_scan_start.elapsed().as_secs_f64());
+        if let Some(error) = error {
+            for peek in peeks {
+                self.send_peek_response(PendingPeek::Index(peek), error.clone());
+            }
+            return;
+        }
+
+        // Stash configuration, shared across the group.
+        let peek_stash_enabled = {
+            let enabled = ENABLE_PEEK_RESPONSE_STASH.get(&self.compute_state.worker_config);
+            let available = self.compute_state.peek_stash_persist_location.is_some();
+            if !available && enabled {
+                error!("missing peek_stash_persist_location but peek stash is enabled");
+            }
+            enabled && available
+        };
+        let peek_stash_threshold_bytes =
+            PEEK_RESPONSE_STASH_THRESHOLD_BYTES.get(&self.compute_state.worker_config);
+        let max_result_size = usize::cast_from(self.compute_state.max_result_size);
+
+        // Build the mux inputs. Literal constraints, map-filter-project, and
+        // finishing are cloned so the walk can demultiplex without holding the
+        // originating peeks.
+        let mut muxed: Vec<peek_coalesce::MuxedPeek> = peeks
+            .iter()
+            .map(|index_peek| {
+                let peek = &index_peek.peek;
+                let stash_eligible =
+                    peek_stash_enabled && peek.finishing.is_streamable(peek.result_desc.arity());
+                peek_coalesce::MuxedPeek {
+                    mfp: peek.map_filter_project.clone(),
+                    timestamp: peek.timestamp,
+                    target_id: peek.target.id(),
+                    literals: peek.literal_constraints.clone(),
+                    accumulator: peek_coalesce::PeekAccumulator::new(
+                        &peek.finishing,
+                        max_result_size,
+                        stash_eligible,
+                        peek_stash_threshold_bytes,
+                    ),
+                    outcome: None,
+                }
+            })
+            .collect();
+
+        // The single shared arrangement walk.
+        let walk_start = Instant::now();
+        peek_coalesce::collect_coalesced_ok_data(peeks[0].trace_bundle.oks_mut(), &mut muxed);
+        self.compute_state
+            .metrics
+            .index_peek_row_iteration_seconds
+            .observe(walk_start.elapsed().as_secs_f64());
+
+        self.compute_state
+            .metrics
+            .index_peek_coalesced_groups_total
+            .inc();
+        self.compute_state
+            .metrics
+            .index_peek_coalesced_peeks_total
+            .inc_by(u64::cast_from(group_size));
+
+        // Act on each peek's outcome. `muxed` is parallel to `peeks`.
+        let mut outcomes: Vec<_> = muxed.into_iter().map(|muxed| muxed.outcome).collect();
+        for (i, index_peek) in peeks.into_iter().enumerate() {
+            match outcomes[i].take().expect("walk populates every outcome") {
+                peek_coalesce::PeekOutcome::Response(response) => {
+                    self.send_peek_response(PendingPeek::Index(index_peek), response);
+                }
+                peek_coalesce::PeekOutcome::Stash => {
+                    self.start_stash_peek(&index_peek);
+                }
+            }
         }
     }
 
@@ -1514,6 +1662,35 @@ impl IndexPeek {
     /// then for any time `t` less or equal to `peek.timestamp` it is
     /// not the case that `upper` is less or equal to that timestamp,
     /// and so the result cannot further evolve.
+    /// Determines whether the peek's timestamp is ready to be read from the trace.
+    ///
+    /// A peek is ready once both the ok and err traces have advanced their upper
+    /// beyond `peek.timestamp`, so the output at that timestamp can no longer
+    /// change. Returns an error if the arrangement has already compacted past the
+    /// timestamp, which makes a correct read impossible.
+    fn readiness(&mut self, upper: &mut Antichain<Timestamp>) -> Readiness {
+        self.trace_bundle.oks_mut().read_upper(upper);
+        if upper.less_equal(&self.peek.timestamp) {
+            return Readiness::NotReady;
+        }
+        self.trace_bundle.errs_mut().read_upper(upper);
+        if upper.less_equal(&self.peek.timestamp) {
+            return Readiness::NotReady;
+        }
+
+        let read_frontier = self.trace_bundle.compaction_frontier();
+        if !read_frontier.less_equal(&self.peek.timestamp) {
+            let error = format!(
+                "Arrangement compaction frontier ({:?}) is beyond the time of the attempted read ({})",
+                read_frontier.elements(),
+                self.peek.timestamp,
+            );
+            return Readiness::Error(PeekResponse::Error(error));
+        }
+
+        Readiness::Ready
+    }
+
     fn seek_fulfillment(
         &mut self,
         upper: &mut Antichain<Timestamp>,
@@ -1524,23 +1701,10 @@ impl IndexPeek {
     ) -> PeekStatus {
         let method_start = Instant::now();
 
-        self.trace_bundle.oks_mut().read_upper(upper);
-        if upper.less_equal(&self.peek.timestamp) {
-            return PeekStatus::NotReady;
-        }
-        self.trace_bundle.errs_mut().read_upper(upper);
-        if upper.less_equal(&self.peek.timestamp) {
-            return PeekStatus::NotReady;
-        }
-
-        let read_frontier = self.trace_bundle.compaction_frontier();
-        if !read_frontier.less_equal(&self.peek.timestamp) {
-            let error = format!(
-                "Arrangement compaction frontier ({:?}) is beyond the time of the attempted read ({})",
-                read_frontier.elements(),
-                self.peek.timestamp,
-            );
-            return PeekStatus::Ready(PeekResponse::Error(error));
+        match self.readiness(upper) {
+            Readiness::NotReady => return PeekStatus::NotReady,
+            Readiness::Error(response) => return PeekStatus::Ready(response),
+            Readiness::Ready => {}
         }
 
         metrics
@@ -1561,18 +1725,12 @@ impl IndexPeek {
         result
     }
 
-    /// Collects data for a known-complete peek from the ok stream.
-    fn collect_finished_data(
-        &mut self,
-        max_result_size: u64,
-        peek_stash_eligible: bool,
-        peek_stash_threshold_bytes: usize,
-        metrics: &IndexPeekMetrics<'_>,
-    ) -> PeekStatus {
-        let error_scan_start = Instant::now();
-
-        // Check if there exist any errors and, if so, return whatever one we
-        // find first.
+    /// Scans the error trace and returns the first error observed at the peek's
+    /// timestamp, if any.
+    ///
+    /// A positive multiplicity yields that error as the peek response. A negative
+    /// multiplicity indicates corrupt data and yields a descriptive error.
+    fn scan_error_trace(&mut self) -> Option<PeekResponse> {
         let (mut cursor, storage) = self.trace_bundle.errs_mut().cursor();
         while cursor.key_valid(&storage) {
             let mut copies = Diff::ZERO;
@@ -1587,16 +1745,34 @@ impl IndexPeek {
                     target = %self.peek.target.id(), diff = %copies, %error,
                     "index peek encountered negative multiplicities in error trace",
                 );
-                return PeekStatus::Ready(PeekResponse::Error(format!(
+                return Some(PeekResponse::Error(format!(
                     "Invalid data in source errors, \
                     saw retractions ({}) for row that does not exist: {}",
                     -copies, error,
                 )));
             }
             if copies.is_positive() {
-                return PeekStatus::Ready(PeekResponse::Error(cursor.key(&storage).to_string()));
+                return Some(PeekResponse::Error(cursor.key(&storage).to_string()));
             }
             cursor.step_key(&storage);
+        }
+        None
+    }
+
+    /// Collects data for a known-complete peek from the ok stream.
+    fn collect_finished_data(
+        &mut self,
+        max_result_size: u64,
+        peek_stash_eligible: bool,
+        peek_stash_threshold_bytes: usize,
+        metrics: &IndexPeekMetrics<'_>,
+    ) -> PeekStatus {
+        let error_scan_start = Instant::now();
+
+        // Check if there exist any errors and, if so, return whatever one we
+        // find first.
+        if let Some(error) = self.scan_error_trace() {
+            return PeekStatus::Ready(error);
         }
 
         metrics
@@ -1633,7 +1809,6 @@ impl IndexPeek {
             >,
     {
         let max_result_size = usize::cast_from(max_result_size);
-        let count_byte_size = size_of::<NonZeroUsize>();
 
         // Cursor setup timing
         let cursor_setup_start = Instant::now();
@@ -1652,109 +1827,68 @@ impl IndexPeek {
             .cursor_setup_seconds
             .observe(cursor_setup_start.elapsed().as_secs_f64());
 
-        // Accumulated `Vec<(row, count)>` results that we are likely to return.
-        let mut results = Vec::new();
-        let mut total_size: usize = 0;
+        let mut accumulator = peek_coalesce::PeekAccumulator::new(
+            &peek.finishing,
+            max_result_size,
+            peek_stash_eligible,
+            peek_stash_threshold_bytes,
+        );
 
-        // When set, a bound on the number of records we need to return.
-        // The requirements on the records are driven by the finishing's
-        // `order_by` field. Further limiting will happen when the results
-        // are collected, so we don't need to have exactly this many results,
-        // just at least those results that would have been returned.
-        let max_results = peek.finishing.num_rows_needed();
-
-        let comparator = RowComparator::new(peek.finishing.order_by.as_slice());
+        // The result of iterating the arrangement, before turning it into a
+        // response. Kept separate so the metric observations below run on every
+        // exit path.
+        enum Outcome {
+            /// Iteration ran to completion, or the finishing collected enough
+            /// rows. Build the response from the accumulator.
+            Finished,
+            /// The peek should divert to the peek stash.
+            Stash,
+            /// The peek produced an error response.
+            Error(PeekResponse),
+        }
 
         // Row iteration timing
         let row_iteration_start = Instant::now();
-        let mut sort_time_accum = Duration::ZERO;
 
-        while let Some(row) = peek_iterator.next() {
-            let row: (Row, _) = match row {
-                Ok(row) => row,
-                Err(err) => return PeekStatus::Ready(PeekResponse::Error(err)),
+        let outcome = loop {
+            let Some(row) = peek_iterator.next() else {
+                break Outcome::Finished;
             };
-            let (row, copies) = row;
+            let (row, copies) = match row {
+                Ok(row) => row,
+                Err(err) => break Outcome::Error(PeekResponse::Error(err)),
+            };
             let copies: NonZeroUsize = NonZeroUsize::try_from(copies).expect("fits into usize");
 
-            total_size = total_size
-                .saturating_add(row.byte_len())
-                .saturating_add(count_byte_size);
-            if peek_stash_eligible && total_size > peek_stash_threshold_bytes {
-                return PeekStatus::UsePeekStash;
-            }
-            if total_size > max_result_size {
-                return PeekStatus::Ready(PeekResponse::Error(format!(
-                    "result exceeds max size of {}",
-                    ByteSize::b(u64::cast_from(max_result_size))
-                )));
-            }
-
-            results.push((row, copies));
-
-            // If we hold many more than `max_results` records, we can thin down
-            // `results` using `self.finishing.ordering`.
-            if let Some(max_results) = max_results {
-                // We use a threshold twice what we intend, to amortize the work
-                // across all of the insertions. We could tighten this, but it
-                // works for the moment.
-                if results.len() >= 2 * max_results {
-                    if peek.finishing.order_by.is_empty() {
-                        results.truncate(max_results);
-                        metrics
-                            .row_iteration_seconds
-                            .observe(row_iteration_start.elapsed().as_secs_f64());
-                        metrics
-                            .result_sort_seconds
-                            .observe(sort_time_accum.as_secs_f64());
-                        let row_collection_start = Instant::now();
-                        let collection = RowCollection::new(results, &peek.finishing.order_by);
-                        metrics
-                            .row_collection_seconds
-                            .observe(row_collection_start.elapsed().as_secs_f64());
-                        return PeekStatus::Ready(PeekResponse::Rows(vec![collection]));
-                    } else {
-                        // We can sort `results` and then truncate to `max_results`.
-                        // This has an effect similar to a priority queue, without
-                        // its interactive dequeueing properties.
-                        // TODO: Had we left these as `Vec<Datum>` we would avoid
-                        // the unpacking; we should consider doing that, although
-                        // it will require a re-pivot of the code to branch on this
-                        // inner test (as we prefer not to maintain `Vec<Datum>`
-                        // in the other case).
-                        let sort_start = Instant::now();
-                        results.sort_by(|left, right| {
-                            comparator.compare_rows(&left.0, &right.0, || left.0.cmp(&right.0))
-                        });
-                        sort_time_accum += sort_start.elapsed();
-                        let dropped = results.drain(max_results..);
-                        let dropped_size =
-                            dropped
-                                .into_iter()
-                                .fold(0, |acc: usize, (row, _count): (Row, _)| {
-                                    acc.saturating_add(
-                                        row.byte_len().saturating_add(count_byte_size),
-                                    )
-                                });
-                        total_size = total_size.saturating_sub(dropped_size);
-                    }
+            match accumulator.push(row, copies) {
+                peek_coalesce::PushOutcome::Continue => {}
+                peek_coalesce::PushOutcome::Complete => break Outcome::Finished,
+                peek_coalesce::PushOutcome::Stash => break Outcome::Stash,
+                peek_coalesce::PushOutcome::MaxSizeExceeded => {
+                    break Outcome::Error(accumulator.max_size_error());
                 }
             }
-        }
+        };
 
         metrics
             .row_iteration_seconds
             .observe(row_iteration_start.elapsed().as_secs_f64());
         metrics
             .result_sort_seconds
-            .observe(sort_time_accum.as_secs_f64());
+            .observe(accumulator.sort_time().as_secs_f64());
 
-        let row_collection_start = Instant::now();
-        let collection = RowCollection::new(results, &peek.finishing.order_by);
-        metrics
-            .row_collection_seconds
-            .observe(row_collection_start.elapsed().as_secs_f64());
-        PeekStatus::Ready(PeekResponse::Rows(vec![collection]))
+        match outcome {
+            Outcome::Stash => PeekStatus::UsePeekStash,
+            Outcome::Error(response) => PeekStatus::Ready(response),
+            Outcome::Finished => {
+                let row_collection_start = Instant::now();
+                let response = accumulator.finish();
+                metrics
+                    .row_collection_seconds
+                    .observe(row_collection_start.elapsed().as_secs_f64());
+                PeekStatus::Ready(response)
+            }
+        }
     }
 }
 
@@ -1769,6 +1903,16 @@ enum PeekStatus {
     UsePeekStash,
     /// The peek result is ready.
     Ready(PeekResponse),
+}
+
+/// Whether an index peek's timestamp can be read from its trace.
+enum Readiness {
+    /// The trace has not advanced far enough. The peek stays pending.
+    NotReady,
+    /// The peek can be read now.
+    Ready,
+    /// The read is impossible because the trace compacted past the timestamp.
+    Error(PeekResponse),
 }
 
 /// The frontiers we have reported to the controller for a collection.

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -696,7 +696,27 @@ impl<'a> ActiveComputeState<'a> {
             logger.log(&pending.as_log_event(true));
         }
 
-        self.process_peek(&mut Antichain::new(), pending);
+        // When coalescing is enabled, defer index peeks into `process_peeks`
+        // instead of retiring each one here. All peeks drained from the command
+        // channel in a single `handle_pending_commands` pass then coalesce into
+        // one arrangement walk. This is what lets ready-on-arrival peeks (the
+        // common case, and the only case under Serializable, which always reads
+        // an already-processed timestamp) coalesce at all. NotReady peeks land in
+        // the same `pending_peeks` set and are grouped identically.
+        //
+        // Deferring adds no maintenance-tick latency: the worker loop calls
+        // `process_peeks` every iteration, right after `handle_pending_commands`
+        // and before the next park (see `Worker::run_client`), so a deferred peek
+        // is retired in the same iteration it arrived. Persist peeks retire
+        // immediately as before, since they fulfill asynchronously.
+        let coalesce = ENABLE_PEEK_COALESCING.get(&self.compute_state.worker_config)
+            && matches!(pending, PendingPeek::Index(_));
+        if coalesce {
+            let uuid = pending.peek().uuid;
+            self.compute_state.pending_peeks.insert(uuid, pending);
+        } else {
+            self.process_peek(&mut Antichain::new(), pending);
+        }
     }
 
     fn handle_cancel_peek(&mut self, uuid: Uuid) {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1204,10 +1204,23 @@ impl<'a> ActiveComputeState<'a> {
         // The single shared arrangement walk.
         let walk_start = Instant::now();
         peek_coalesce::collect_coalesced_ok_data(peeks[0].trace_bundle.oks_mut(), &mut muxed);
+        let walk_duration = walk_start.elapsed();
         self.compute_state
             .metrics
             .index_peek_row_iteration_seconds
-            .observe(walk_start.elapsed().as_secs_f64());
+            .observe(walk_duration.as_secs_f64());
+
+        // Attribute the shared walk time to each peek's total-time histogram so
+        // that dashboard stays populated when coalescing is on. The per-phase
+        // histograms (cursor setup, sort, row collection, frontier check) are
+        // single-peek concepts and do not apply to the shared walk; the
+        // coalesced-group/peek counters below cover coalesced visibility.
+        for _ in 0..group_size {
+            self.compute_state
+                .metrics
+                .index_peek_total_seconds
+                .observe(walk_duration.as_secs_f64());
+        }
 
         self.compute_state
             .metrics
@@ -1670,24 +1683,20 @@ pub(crate) struct IndexPeekMetrics<'a> {
 }
 
 impl IndexPeek {
-    /// Attempts to fulfill the peek and reports success.
-    ///
-    /// To produce output at `peek.timestamp`, we must be certain that
-    /// it is no longer changing. A trace guarantees that all future
-    /// changes will be greater than or equal to an element of `upper`.
-    ///
-    /// If an element of `upper` is less or equal to `peek.timestamp`,
-    /// then there can be further updates that would change the output.
-    /// If no element of `upper` is less or equal to `peek.timestamp`,
-    /// then for any time `t` less or equal to `peek.timestamp` it is
-    /// not the case that `upper` is less or equal to that timestamp,
-    /// and so the result cannot further evolve.
     /// Determines whether the peek's timestamp is ready to be read from the trace.
     ///
-    /// A peek is ready once both the ok and err traces have advanced their upper
-    /// beyond `peek.timestamp`, so the output at that timestamp can no longer
-    /// change. Returns an error if the arrangement has already compacted past the
-    /// timestamp, which makes a correct read impossible.
+    /// To produce output at `peek.timestamp`, we must be certain that it is no
+    /// longer changing. A trace guarantees that all future changes will be
+    /// greater than or equal to an element of `upper`. If an element of `upper`
+    /// is less or equal to `peek.timestamp`, there can be further updates that
+    /// would change the output, so the peek is `NotReady`. If no element of
+    /// `upper` is less or equal to `peek.timestamp`, then for any time `t` less
+    /// or equal to `peek.timestamp` it is not the case that `upper` is less or
+    /// equal to that timestamp, and so the result cannot further evolve.
+    ///
+    /// Checks both the ok and err traces. Returns an error if the arrangement has
+    /// already compacted past the timestamp, which makes a correct read
+    /// impossible.
     fn readiness(&mut self, upper: &mut Antichain<Timestamp>) -> Readiness {
         self.trace_bundle.oks_mut().read_upper(upper);
         if upper.less_equal(&self.peek.timestamp) {
@@ -1711,6 +1720,10 @@ impl IndexPeek {
         Readiness::Ready
     }
 
+    /// Fulfills a ready single peek from its trace, or reports it not ready.
+    ///
+    /// This is the single-peek path; a group of coalesced peeks is served by
+    /// [`peek_coalesce::collect_coalesced_ok_data`] instead.
     fn seek_fulfillment(
         &mut self,
         upper: &mut Antichain<Timestamp>,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -709,13 +709,23 @@ impl<'a> ActiveComputeState<'a> {
         // and before the next park (see `Worker::run_client`), so a deferred peek
         // is retired in the same iteration it arrived. Persist peeks retire
         // immediately as before, since they fulfill asynchronously.
+        //
+        // Deferral does not change the read the peek observes. The trace bundle
+        // was cloned above, and cloning a `TraceAgent` pins an independent
+        // logical/physical compaction capability at the current `since`. An
+        // `AllowCompaction` handled later in the same command batch downgrades
+        // only the handle in `traces`, not this clone, so the deferred peek's
+        // `readiness` sees the same `since` it would have on arrival. And even if
+        // a peek's timestamp were below `since`, the protocol requires a clean
+        // `PeekResponse::Error` rather than a corrupt read (see the `Peek`
+        // contract in `ComputeCommand`), which `readiness` enforces.
         let coalesce = ENABLE_PEEK_COALESCING.get(&self.compute_state.worker_config)
             && matches!(pending, PendingPeek::Index(_));
         if coalesce {
             let uuid = pending.peek().uuid;
             self.compute_state.pending_peeks.insert(uuid, pending);
         } else {
-            self.process_peek(&mut Antichain::new(), pending);
+            self.process_peek(&mut Antichain::new(), pending, false);
         }
     }
 
@@ -952,7 +962,18 @@ impl<'a> ActiveComputeState<'a> {
     }
 
     /// Either complete the peek (and send the response) or put it in the pending set.
-    fn process_peek(&mut self, upper: &mut Antichain<Timestamp>, mut peek: PendingPeek) {
+    ///
+    /// `known_ready` is set by callers that have already verified the peek is
+    /// ready via [`IndexPeek::readiness`] earlier in the same `process_peeks`
+    /// pass, with no intervening trace mutation. It lets the index path skip the
+    /// redundant frontier read. It only affects index peeks; persist and stash
+    /// peeks ignore it.
+    fn process_peek(
+        &mut self,
+        upper: &mut Antichain<Timestamp>,
+        mut peek: PendingPeek,
+        known_ready: bool,
+    ) {
         let response = match &mut peek {
             PendingPeek::Index(peek) => {
                 let start = Instant::now();
@@ -1006,6 +1027,7 @@ impl<'a> ActiveComputeState<'a> {
                     peek_stash_enabled && peek_stash_eligible,
                     peek_stash_threshold_bytes,
                     &metrics,
+                    known_ready,
                 );
 
                 self.compute_state
@@ -1094,7 +1116,7 @@ impl<'a> ActiveComputeState<'a> {
 
         if !ENABLE_PEEK_COALESCING.get(&self.compute_state.worker_config) {
             for (_uuid, peek) in pending_peeks {
-                self.process_peek(&mut upper, peek);
+                self.process_peek(&mut upper, peek, false);
             }
             return;
         }
@@ -1128,15 +1150,17 @@ impl<'a> ActiveComputeState<'a> {
 
         for (_key, mut peeks) in groups {
             if peeks.len() == 1 {
+                // Readiness was already verified in the partition loop above, so
+                // the single-peek path can skip the recheck.
                 let peek = peeks.pop().expect("length checked");
-                self.process_peek(&mut upper, PendingPeek::Index(peek));
+                self.process_peek(&mut upper, PendingPeek::Index(peek), true);
             } else {
                 self.process_coalesced_group(peeks);
             }
         }
 
         for peek in leftovers {
-            self.process_peek(&mut upper, peek);
+            self.process_peek(&mut upper, peek, false);
         }
     }
 
@@ -1724,6 +1748,9 @@ impl IndexPeek {
     ///
     /// This is the single-peek path; a group of coalesced peeks is served by
     /// [`peek_coalesce::collect_coalesced_ok_data`] instead.
+    ///
+    /// `known_ready` skips the readiness recheck (see [`Self::readiness`]) when
+    /// the caller already verified it in the same `process_peeks` pass.
     fn seek_fulfillment(
         &mut self,
         upper: &mut Antichain<Timestamp>,
@@ -1731,18 +1758,24 @@ impl IndexPeek {
         peek_stash_eligible: bool,
         peek_stash_threshold_bytes: usize,
         metrics: &IndexPeekMetrics<'_>,
+        known_ready: bool,
     ) -> PeekStatus {
         let method_start = Instant::now();
 
-        match self.readiness(upper) {
-            Readiness::NotReady => return PeekStatus::NotReady,
-            Readiness::Error(response) => return PeekStatus::Ready(response),
-            Readiness::Ready => {}
-        }
+        // Skip the readiness recheck when the caller already verified it earlier
+        // in the same `process_peeks` pass. Nothing mutates the trace between
+        // that check and here, so the verdict cannot have changed.
+        if !known_ready {
+            match self.readiness(upper) {
+                Readiness::NotReady => return PeekStatus::NotReady,
+                Readiness::Error(response) => return PeekStatus::Ready(response),
+                Readiness::Ready => {}
+            }
 
-        metrics
-            .frontier_check_seconds
-            .observe(method_start.elapsed().as_secs_f64());
+            metrics
+                .frontier_check_seconds
+                .observe(method_start.elapsed().as_secs_f64());
+        }
 
         let result = self.collect_finished_data(
             max_result_size,

--- a/src/compute/src/compute_state/peek_coalesce.rs
+++ b/src/compute/src/compute_state/peek_coalesce.rs
@@ -1,0 +1,820 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! Coalescing of index peeks that are pending against the same arrangement.
+//!
+//! When multiple index peeks are pending against the same index at the same
+//! timestamp, fulfilling each one independently walks the arrangement once per
+//! peek. Each walk pays for cursor setup, key/value stepping, and key/value
+//! datum decoding. This module amortizes that cost by performing a single
+//! arrangement walk per group and demultiplexing each visited row into the
+//! individual peeks (applying each peek's own map-filter-project and finishing).
+//!
+//! The shared, per-row work is: cursor stepping, key/value datum extraction, and
+//! the `map_times` accumulation that yields the multiplicity at the read
+//! timestamp. The per-peek work is: evaluating that peek's `MapFilterProject`
+//! and accumulating into that peek's finishing. Because all peeks in a group
+//! read at the same timestamp, the multiplicity and the error-trace result are
+//! identical across the group and are computed once.
+
+use std::num::NonZeroUsize;
+use std::time::{Duration, Instant};
+
+use differential_dataflow::trace::cursor::{BatchCursor, CursorList};
+use differential_dataflow::trace::implementations::BatchContainer;
+use differential_dataflow::trace::{Cursor, Navigable, TraceReader};
+use mz_expr::row::RowCollection;
+use mz_expr::{RowComparator, RowSetFinishing, SafeMfpPlan};
+use mz_ore::cast::CastFrom;
+use mz_ore::result::ResultExt;
+use mz_repr::fixed_length::ExtendDatums;
+use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena, Timestamp};
+use timely::order::PartialOrder;
+
+use bytesize::ByteSize;
+use mz_compute_client::protocol::response::PeekResponse;
+
+/// The merged cursor a [`TraceReader::cursor`] hands out over all of a trace's
+/// batches.
+type TraceCursor<Tr> = CursorList<BatchCursor<Tr>>;
+/// Backing storage for a [`TraceCursor`]: the batches the cursor borrows from.
+type TraceStorage<Tr> = Vec<<Tr as TraceReader>::Batch>;
+
+/// Accumulates rows for a single peek and applies its [`RowSetFinishing`].
+///
+/// This is the per-peek half of peek fulfillment, shared between the single-peek
+/// path and the coalesced path so that finishing and thinning cannot diverge.
+pub(super) struct PeekAccumulator {
+    /// The finishing's ordering, used both for thinning and for the final
+    /// [`RowCollection`].
+    order_by: Vec<mz_expr::ColumnOrder>,
+    /// Comparator derived from `order_by`, reused across thinning passes.
+    comparator: RowComparator,
+    /// A bound on the number of rows we must retain, driven by the finishing's
+    /// limit and offset. `None` means we must retain every row.
+    max_results: Option<usize>,
+    /// The maximum permitted response size in bytes.
+    max_result_size: usize,
+    /// Whether this peek may be diverted to the peek stash on overflow.
+    stash_eligible: bool,
+    /// The byte threshold above which a stash-eligible peek diverts to the stash.
+    stash_threshold_bytes: usize,
+    /// Accumulated results that we are likely to return.
+    results: Vec<(Row, NonZeroUsize)>,
+    /// Running byte size of `results`, used for stash and max-size decisions.
+    total_size: usize,
+    /// Time spent sorting during thinning, surfaced for metrics.
+    sort_time: Duration,
+}
+
+/// The outcome of pushing a single row into a [`PeekAccumulator`].
+pub(super) enum PushOutcome {
+    /// The row was accepted. Keep feeding the accumulator.
+    Continue,
+    /// Enough rows have been collected (limit reached with no ordering). The
+    /// accumulator is complete and should be finished.
+    Complete,
+    /// The accumulator wants to divert to the peek stash: it is stash-eligible
+    /// and has exceeded the stash threshold.
+    Stash,
+    /// The result would exceed the maximum response size. Terminal error.
+    MaxSizeExceeded,
+}
+
+impl PeekAccumulator {
+    pub(super) fn new(
+        finishing: &RowSetFinishing,
+        max_result_size: usize,
+        stash_eligible: bool,
+        stash_threshold_bytes: usize,
+    ) -> Self {
+        Self {
+            order_by: finishing.order_by.clone(),
+            comparator: RowComparator::new(finishing.order_by.clone()),
+            max_results: finishing.num_rows_needed(),
+            max_result_size,
+            stash_eligible,
+            stash_threshold_bytes,
+            results: Vec::new(),
+            total_size: 0,
+            sort_time: Duration::ZERO,
+        }
+    }
+
+    /// Time spent sorting during thinning so far.
+    pub(super) fn sort_time(&self) -> Duration {
+        self.sort_time
+    }
+
+    /// Pushes a single `(row, copies)` result into the accumulator.
+    pub(super) fn push(&mut self, row: Row, copies: NonZeroUsize) -> PushOutcome {
+        let count_byte_size = size_of::<NonZeroUsize>();
+
+        self.total_size = self
+            .total_size
+            .saturating_add(row.byte_len())
+            .saturating_add(count_byte_size);
+        if self.stash_eligible && self.total_size > self.stash_threshold_bytes {
+            return PushOutcome::Stash;
+        }
+        if self.total_size > self.max_result_size {
+            return PushOutcome::MaxSizeExceeded;
+        }
+
+        self.results.push((row, copies));
+
+        // If we hold many more than `max_results` records, we can thin down
+        // `results` using the finishing's ordering.
+        if let Some(max_results) = self.max_results {
+            // We use a threshold twice what we intend, to amortize the work
+            // across all of the insertions. We could tighten this, but it works
+            // for the moment.
+            if self.results.len() >= 2 * max_results {
+                if self.order_by.is_empty() {
+                    self.results.truncate(max_results);
+                    return PushOutcome::Complete;
+                } else {
+                    // We can sort `results` and then truncate to `max_results`.
+                    // This has an effect similar to a priority queue, without its
+                    // interactive dequeueing properties.
+                    let sort_start = Instant::now();
+                    self.results.sort_by(|left, right| {
+                        self.comparator
+                            .compare_rows(&left.0, &right.0, || left.0.cmp(&right.0))
+                    });
+                    self.sort_time += sort_start.elapsed();
+                    let dropped = self.results.drain(max_results..);
+                    let dropped_size =
+                        dropped
+                            .into_iter()
+                            .fold(0, |acc: usize, (row, _count): (Row, _)| {
+                                acc.saturating_add(row.byte_len().saturating_add(count_byte_size))
+                            });
+                    self.total_size = self.total_size.saturating_sub(dropped_size);
+                }
+            }
+        }
+
+        PushOutcome::Continue
+    }
+
+    /// Consumes the accumulated results into a [`PeekResponse`].
+    ///
+    /// Takes `&mut self` and drains the results so it can be called from a
+    /// borrow held inside the coalesced walk.
+    pub(super) fn finish(&mut self) -> PeekResponse {
+        let results = std::mem::take(&mut self.results);
+        let collection = RowCollection::new(results, &self.order_by);
+        PeekResponse::Rows(vec![collection])
+    }
+
+    /// The error response for a result that exceeds the maximum response size.
+    pub(super) fn max_size_error(&self) -> PeekResponse {
+        PeekResponse::Error(format!(
+            "result exceeds max size of {}",
+            ByteSize::b(u64::cast_from(self.max_result_size))
+        ))
+    }
+}
+
+/// One index peek participating in a coalesced walk.
+///
+/// The literal constraints and finishing are captured up front so the walk can
+/// demultiplex without holding the originating `Peek`.
+pub(super) struct MuxedPeek {
+    /// The peek's map-filter-project, evaluated against every visited row.
+    pub(super) mfp: SafeMfpPlan,
+    /// The read timestamp. Identical across a group, kept for the copies filter.
+    pub(super) timestamp: Timestamp,
+    /// The target index id, for error logging.
+    pub(super) target_id: GlobalId,
+    /// The literal key constraints, or `None` for a full scan. When present, the
+    /// peek only sees rows whose key equals one of these literals. Duplicates
+    /// are preserved to match the single-peek path.
+    pub(super) literals: Option<Vec<Row>>,
+    /// Accumulates results and applies the finishing.
+    pub(super) accumulator: PeekAccumulator,
+    /// Set once the peek is retired, either with a response or a stash request.
+    pub(super) outcome: Option<PeekOutcome>,
+}
+
+/// The terminal outcome of a peek in a coalesced walk.
+pub(super) enum PeekOutcome {
+    /// The peek produced a response that should be sent to the coordinator.
+    Response(PeekResponse),
+    /// The peek should be diverted to the peek stash.
+    Stash,
+}
+
+/// A peek's literal key constraints, laid out in the trace's native key
+/// container and consumed in ascending order as the walk visits keys.
+struct LiteralKeys<Tr>
+where
+    Tr: TraceReader<Batch: Navigable>,
+    BatchCursor<Tr>: Cursor<KeyContainer: BatchContainer<Owned = Row>>,
+{
+    keys: <BatchCursor<Tr> as Cursor>::KeyContainer,
+    /// Index of the next literal not yet consumed.
+    pos: usize,
+}
+
+impl<Tr> LiteralKeys<Tr>
+where
+    Tr: TraceReader<Batch: Navigable>,
+    BatchCursor<Tr>: Cursor<KeyContainer: BatchContainer<Owned = Row>>,
+{
+    /// Builds a literal cursor from owned rows. Sorts (required for the ascending
+    /// merge and for `seek_key`, which only seeks forward).
+    fn new(mut literals: Vec<Row>) -> Self {
+        literals.sort();
+        let mut keys = <BatchCursor<Tr> as Cursor>::KeyContainer::with_capacity(literals.len());
+        for literal in &literals {
+            keys.push_own(literal);
+        }
+        Self { keys, pos: 0 }
+    }
+
+    fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    /// Returns the number of literals equal to `key`, advancing the cursor past
+    /// all literals up to and including those equal to `key`.
+    ///
+    /// Must be called with `key` values that are non-decreasing across calls,
+    /// which holds because both the trace keys and the literals are sorted
+    /// ascending.
+    fn multiplicity_at(&mut self, key: <BatchCursor<Tr> as Cursor>::Key<'_>) -> usize {
+        // The key type derives its `Ord`/`Eq` over a single lifetime, so the
+        // container item and `key` must be reborrowed to a common lifetime before
+        // comparing. `reborrow` shortens both to this call's scope.
+        while self.pos < self.keys.len() {
+            let item =
+                <BatchCursor<Tr> as Cursor>::KeyContainer::reborrow(self.keys.index(self.pos));
+            if !(item < <BatchCursor<Tr> as Cursor>::KeyContainer::reborrow(key)) {
+                break;
+            }
+            self.pos += 1;
+        }
+        let start = self.pos;
+        while self.pos < self.keys.len() {
+            let item =
+                <BatchCursor<Tr> as Cursor>::KeyContainer::reborrow(self.keys.index(self.pos));
+            if item != <BatchCursor<Tr> as Cursor>::KeyContainer::reborrow(key) {
+                break;
+            }
+            self.pos += 1;
+        }
+        self.pos - start
+    }
+}
+
+/// Represents the multiplicity of a visited row at the shared read timestamp.
+enum Copies {
+    /// The summed diff is negative: corrupt data.
+    Negative(Diff),
+    /// The summed diff is zero: the row does not exist at this timestamp.
+    Zero,
+    /// The summed diff is positive.
+    Positive(NonZeroUsize),
+}
+
+/// Walks the ok stream of `oks` once, demultiplexing each visited row into the
+/// peeks in `peeks`.
+///
+/// On return, every peek has its `outcome` populated. Peeks whose accumulation
+/// completed normally get a `Response`; peeks that overflowed the stash
+/// threshold get `Stash`; peeks that errored (map-filter-project error, negative
+/// multiplicities, or oversized result) get an error `Response`.
+///
+/// The caller is responsible for the shared readiness and error-trace checks
+/// before invoking this, and for acting on each peek's outcome afterward.
+pub(super) fn collect_coalesced_ok_data<Tr>(oks: &mut Tr, peeks: &mut [MuxedPeek])
+where
+    Tr: TraceReader<Batch: Navigable>,
+    for<'a> BatchCursor<Tr>: Cursor<
+            Key<'a>: ExtendDatums + Eq,
+            KeyContainer: BatchContainer<Owned = Row>,
+            Val<'a>: ExtendDatums,
+            TimeGat<'a>: PartialOrder<Timestamp>,
+            DiffGat<'a> = &'a Diff,
+        >,
+{
+    let (mut cursor, storage) = oks.cursor();
+
+    // Per-peek literal cursors, parallel to `peeks`. `None` marks a full scan.
+    let mut lit_cursors: Vec<Option<LiteralKeys<Tr>>> = peeks
+        .iter()
+        .map(|peek| {
+            peek.literals
+                .as_ref()
+                .map(|literals| LiteralKeys::<Tr>::new(literals.clone()))
+        })
+        .collect();
+
+    // If any peek is a full scan we must visit every key, so a linear walk is
+    // as good as it gets. Otherwise we seek through the union of all literals to
+    // preserve point-lookup efficiency.
+    let full_scan = peeks.iter().any(|peek| peek.literals.is_none());
+
+    let mut datum_vec = DatumVec::new();
+    let mut row_builder = Row::default();
+    let mut mults = vec![0usize; peeks.len()];
+
+    if full_scan {
+        while cursor.key_valid(&storage) {
+            if peeks.iter().all(|peek| peek.outcome.is_some()) {
+                break;
+            }
+            let key = cursor.key(&storage);
+            for i in 0..peeks.len() {
+                mults[i] = peek_multiplicity::<Tr>(&peeks[i], &mut lit_cursors[i], key);
+            }
+            visit_key::<Tr>(
+                &mut cursor,
+                &storage,
+                key,
+                peeks,
+                &mults,
+                &mut datum_vec,
+                &mut row_builder,
+            );
+            cursor.step_key(&storage);
+        }
+    } else {
+        // Union of all seek targets, sorted and deduplicated. Deduplication only
+        // affects seeking. Per-peek multiplicity still comes from the per-peek
+        // cursors, which keep duplicates.
+        let mut union_rows: Vec<Row> = peeks
+            .iter()
+            .filter_map(|peek| peek.literals.clone())
+            .flatten()
+            .collect();
+        union_rows.sort();
+        union_rows.dedup();
+        let union = LiteralKeys::<Tr>::new(union_rows);
+
+        for ui in 0..union.len() {
+            if peeks.iter().all(|peek| peek.outcome.is_some()) {
+                break;
+            }
+            let target = union.keys.index(ui);
+            cursor.seek_key(&storage, target);
+            if cursor.get_key(&storage) == Some(target) {
+                let key = cursor.key(&storage);
+                for i in 0..peeks.len() {
+                    mults[i] = peek_multiplicity::<Tr>(&peeks[i], &mut lit_cursors[i], key);
+                }
+                visit_key::<Tr>(
+                    &mut cursor,
+                    &storage,
+                    key,
+                    peeks,
+                    &mults,
+                    &mut datum_vec,
+                    &mut row_builder,
+                );
+            } else {
+                // No row for this union key. Still advance every literal cursor
+                // past it so their pointers stay in step with the ascending walk.
+                for lit_cursor in lit_cursors.iter_mut().flatten() {
+                    lit_cursor.multiplicity_at(target);
+                }
+            }
+        }
+    }
+
+    for peek in peeks.iter_mut() {
+        if peek.outcome.is_none() {
+            peek.outcome = Some(PeekOutcome::Response(peek.accumulator.finish()));
+        }
+    }
+}
+
+/// Computes a peek's multiplicity at `key`, advancing its literal cursor.
+///
+/// A retired peek contributes nothing. A full-scan peek is active exactly once.
+/// A literal peek is active once per matching literal.
+fn peek_multiplicity<Tr>(
+    peek: &MuxedPeek,
+    lit_cursor: &mut Option<LiteralKeys<Tr>>,
+    key: <BatchCursor<Tr> as Cursor>::Key<'_>,
+) -> usize
+where
+    Tr: TraceReader<Batch: Navigable>,
+    BatchCursor<Tr>: Cursor<KeyContainer: BatchContainer<Owned = Row>>,
+{
+    if peek.outcome.is_some() {
+        // Still advance the literal cursor so it does not fall behind the walk.
+        if let Some(lit_cursor) = lit_cursor {
+            lit_cursor.multiplicity_at(key);
+        }
+        return 0;
+    }
+    match lit_cursor {
+        Some(lit_cursor) => lit_cursor.multiplicity_at(key),
+        None => 1,
+    }
+}
+
+/// Processes all values under the current key, feeding each active peek.
+fn visit_key<Tr>(
+    cursor: &mut TraceCursor<Tr>,
+    storage: &TraceStorage<Tr>,
+    key: <BatchCursor<Tr> as Cursor>::Key<'_>,
+    peeks: &mut [MuxedPeek],
+    mults: &[usize],
+    datum_vec: &mut DatumVec,
+    row_builder: &mut Row,
+) where
+    Tr: TraceReader<Batch: Navigable>,
+    for<'a> BatchCursor<Tr>: Cursor<
+            Key<'a>: ExtendDatums + Eq,
+            KeyContainer: BatchContainer<Owned = Row>,
+            Val<'a>: ExtendDatums,
+            TimeGat<'a>: PartialOrder<Timestamp>,
+            DiffGat<'a> = &'a Diff,
+        >,
+{
+    // The timestamp is shared across the group, so the multiplicity is too.
+    let timestamp = peeks
+        .iter()
+        .find(|p| p.outcome.is_none())
+        .map(|p| p.timestamp);
+    let Some(timestamp) = timestamp else {
+        return;
+    };
+
+    while cursor.val_valid(storage) {
+        let val = cursor.val(storage);
+        let arena = RowArena::new();
+        let mut borrow = datum_vec.borrow();
+        key.extend_datums(&arena, &mut borrow, None);
+        val.extend_datums(&arena, &mut borrow, None);
+        let kv_len = borrow.len();
+
+        // Summed diff at the read timestamp. Shared across the group.
+        let mut copies = Diff::ZERO;
+        cursor.map_times(storage, |time, diff| {
+            if time.less_equal(&timestamp) {
+                copies += diff;
+            }
+        });
+        let copies = classify_copies(copies);
+
+        // A row that does not exist at this timestamp contributes to no peek.
+        if let Copies::Zero = copies {
+            drop(borrow);
+            cursor.step_val(storage);
+            continue;
+        }
+
+        for i in 0..peeks.len() {
+            let mult = mults[i];
+            if mult == 0 || peeks[i].outcome.is_some() {
+                continue;
+            }
+            let is_literal = peeks[i].literals.is_some();
+            for _ in 0..mult {
+                borrow.truncate(kv_len);
+                if is_literal {
+                    // The peek derives from an IndexedFilter join, which adds the
+                    // key columns a second time. At any visited key the matching
+                    // literal equals the key, so re-extending the key reproduces
+                    // exactly the literal columns the join would have added.
+                    key.extend_datums(&arena, &mut borrow, None);
+                }
+                match peeks[i]
+                    .mfp
+                    .evaluate_into(&mut borrow, &arena, row_builder)
+                    .map(|row| row.cloned())
+                    .map_err_to_string_with_causes()
+                {
+                    Err(err) => {
+                        peeks[i].outcome = Some(PeekOutcome::Response(PeekResponse::Error(err)));
+                        break;
+                    }
+                    Ok(None) => {
+                        // Filtered out. A repeat would filter identically.
+                        break;
+                    }
+                    Ok(Some(row)) => match &copies {
+                        Copies::Negative(copies) => {
+                            let datums = &*borrow;
+                            tracing::error!(
+                                target = %peeks[i].target_id, diff = %copies, ?datums,
+                                "index peek encountered negative multiplicities in ok trace",
+                            );
+                            peeks[i].outcome =
+                                Some(PeekOutcome::Response(PeekResponse::Error(format!(
+                                    "Invalid data in source, \
+                                     saw retractions ({}) for row that does not exist: {:?}",
+                                    -*copies, datums,
+                                ))));
+                            break;
+                        }
+                        Copies::Zero => break,
+                        Copies::Positive(copies) => match peeks[i].accumulator.push(row, *copies) {
+                            PushOutcome::Continue => {}
+                            PushOutcome::Complete => {
+                                let response = peeks[i].accumulator.finish();
+                                peeks[i].outcome = Some(PeekOutcome::Response(response));
+                                break;
+                            }
+                            PushOutcome::Stash => {
+                                peeks[i].outcome = Some(PeekOutcome::Stash);
+                                break;
+                            }
+                            PushOutcome::MaxSizeExceeded => {
+                                let response = peeks[i].accumulator.max_size_error();
+                                peeks[i].outcome = Some(PeekOutcome::Response(response));
+                                break;
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        drop(borrow);
+        cursor.step_val(storage);
+    }
+}
+
+/// Classifies a summed diff into the multiplicity cases.
+fn classify_copies(copies: Diff) -> Copies {
+    if copies.is_negative() {
+        Copies::Negative(copies)
+    } else {
+        match NonZeroUsize::new(usize::try_from(copies.into_inner()).expect("non-negative")) {
+            Some(copies) => Copies::Positive(copies),
+            None => Copies::Zero,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_expr::{ColumnOrder, RowSetFinishing};
+    use mz_ore::num::NonNeg;
+    use mz_repr::{Datum, Row};
+
+    use super::*;
+
+    fn row(i: i64) -> Row {
+        Row::pack_slice(&[Datum::Int64(i)])
+    }
+
+    fn finishing(order_by: Vec<ColumnOrder>, limit: Option<i64>, offset: usize) -> RowSetFinishing {
+        RowSetFinishing {
+            order_by,
+            limit: limit.map(|l| NonNeg::try_from(l).unwrap()),
+            offset,
+            project: vec![0],
+        }
+    }
+
+    fn one() -> NonZeroUsize {
+        NonZeroUsize::new(1).unwrap()
+    }
+
+    #[mz_ore::test]
+    fn accumulator_collects_all_without_limit() {
+        let mut acc = PeekAccumulator::new(&finishing(vec![], None, 0), usize::MAX, false, 0);
+        for i in 0..5 {
+            assert!(matches!(acc.push(row(i), one()), PushOutcome::Continue));
+        }
+        let PeekResponse::Rows(collections) = acc.finish() else {
+            panic!("expected rows");
+        };
+        let total: usize = collections.iter().map(|c| c.count()).sum();
+        assert_eq!(total, 5);
+    }
+
+    #[mz_ore::test]
+    fn accumulator_completes_on_unordered_limit() {
+        // limit 2, no order_by: completes once it holds 2 * limit rows.
+        let mut acc = PeekAccumulator::new(&finishing(vec![], Some(2), 0), usize::MAX, false, 0);
+        assert!(matches!(acc.push(row(0), one()), PushOutcome::Continue));
+        assert!(matches!(acc.push(row(1), one()), PushOutcome::Continue));
+        assert!(matches!(acc.push(row(2), one()), PushOutcome::Continue));
+        // Fourth row reaches 2 * limit and truncates to the limit.
+        assert!(matches!(acc.push(row(3), one()), PushOutcome::Complete));
+        let PeekResponse::Rows(collections) = acc.finish() else {
+            panic!("expected rows");
+        };
+        let total: usize = collections.iter().map(|c| c.count()).sum();
+        assert_eq!(total, 2);
+    }
+
+    #[mz_ore::test]
+    fn accumulator_thins_ordered_results() {
+        // limit 1 with an ascending order_by: thinning sorts and keeps the single
+        // smallest row seen so far.
+        let order_by = vec![ColumnOrder {
+            column: 0,
+            desc: false,
+            nulls_last: false,
+        }];
+        let mut acc = PeekAccumulator::new(&finishing(order_by, Some(1), 0), usize::MAX, false, 0);
+        for i in [5, 3, 4, 1, 2] {
+            let _ = acc.push(row(i), one());
+        }
+        let PeekResponse::Rows(collections) = acc.finish() else {
+            panic!("expected rows");
+        };
+        // Exactly one row retained, and it is the minimum.
+        let rows: Vec<_> = collections
+            .iter()
+            .flat_map(|c| (0..c.entries()).map(move |i| c.get(i).unwrap().0.to_owned()))
+            .collect();
+        assert_eq!(rows, vec![row(1)]);
+    }
+
+    #[mz_ore::test]
+    fn accumulator_diverts_to_stash_over_threshold() {
+        // Stash-eligible with a tiny threshold: the first row overflows.
+        let mut acc = PeekAccumulator::new(&finishing(vec![], None, 0), usize::MAX, true, 0);
+        assert!(matches!(acc.push(row(0), one()), PushOutcome::Stash));
+    }
+
+    #[mz_ore::test]
+    fn accumulator_errors_over_max_size() {
+        // Not stash-eligible with a tiny max size: the first row errors.
+        let mut acc = PeekAccumulator::new(&finishing(vec![], None, 0), 1, false, 0);
+        assert!(matches!(
+            acc.push(row(0), one()),
+            PushOutcome::MaxSizeExceeded
+        ));
+    }
+
+    #[mz_ore::test]
+    fn classify_copies_cases() {
+        assert!(matches!(classify_copies(Diff::ZERO), Copies::Zero));
+        assert!(matches!(
+            classify_copies(Diff::from(3)),
+            Copies::Positive(_)
+        ));
+        assert!(matches!(
+            classify_copies(Diff::from(-2)),
+            Copies::Negative(_)
+        ));
+    }
+
+    /// Builds a `MuxedPeek` with an identity map-filter-project of the given arity.
+    fn muxed(arity: usize, literals: Option<Vec<Row>>) -> MuxedPeek {
+        use mz_expr::MapFilterProject;
+        let mfp = MapFilterProject::new(arity)
+            .into_plan()
+            .unwrap()
+            .into_nontemporal()
+            .unwrap();
+        MuxedPeek {
+            mfp,
+            timestamp: Timestamp::from(0u64),
+            target_id: GlobalId::User(1),
+            literals,
+            accumulator: PeekAccumulator::new(&finishing(vec![], None, 0), usize::MAX, false, 0),
+            outcome: None,
+        }
+    }
+
+    /// Extracts each peek's rows as sorted `(datums, count)` tuples.
+    fn extract(outcome: Option<PeekOutcome>) -> Vec<(Vec<i64>, usize)> {
+        let Some(PeekOutcome::Response(PeekResponse::Rows(collections))) = outcome else {
+            panic!("expected a rows response");
+        };
+        let mut out = Vec::new();
+        for collection in &collections {
+            for i in 0..collection.entries() {
+                let (row_ref, count) = collection.get(i).unwrap();
+                let datums = row_ref
+                    .iter()
+                    .map(|d| match d {
+                        Datum::Int64(x) => x,
+                        other => panic!("unexpected datum {other:?}"),
+                    })
+                    .collect();
+                out.push((datums, count.get()));
+            }
+        }
+        out.sort();
+        out
+    }
+
+    /// Builds a `RowRow` arrangement over the given `(key, val)` pairs (each with
+    /// multiplicity one at time 0), then runs `body` against the sealed trace.
+    ///
+    /// The trace is compacted to time 0, mirroring how a real index peek prepares
+    /// its trace handle before reading.
+    fn with_arrangement<F>(data: Vec<(i64, i64)>, body: F)
+    where
+        F: FnOnce(&mut crate::typedefs::RowRowAgent<Timestamp, Diff>) + Send + Sync + 'static,
+    {
+        use differential_dataflow::AsCollection;
+        use mz_row_spine::{RowRowBatcher, RowRowBuilder};
+        use mz_timely_util::columnation::ColumnationChunker;
+        use timely::dataflow::operators::ToStream;
+        use timely::progress::Antichain;
+
+        use crate::extensions::arrange::MzArrange;
+
+        timely::execute_directly(move |worker| {
+            let mut trace = worker.dataflow::<Timestamp, _, _>(|scope| {
+                let updates: Vec<((Row, Row), Timestamp, Diff)> = data
+                    .iter()
+                    .map(|(k, v)| ((row(*k), row(*v)), Timestamp::from(0u64), Diff::ONE))
+                    .collect();
+                let arranged = updates
+                    .to_stream(scope)
+                    .as_collection()
+                    .mz_arrange::<
+                        ColumnationChunker<_>,
+                        RowRowBatcher<_, _>,
+                        RowRowBuilder<_, _>,
+                        _,
+                    >("test arrangement");
+                arranged.trace
+            });
+
+            // Drive the worker until the arrangement has sealed time 0.
+            let target = Antichain::from_elem(Timestamp::from(1u64));
+            worker.step_while(|| {
+                let mut upper = Antichain::new();
+                trace.read_upper(&mut upper);
+                timely::PartialOrder::less_than(&upper, &target)
+            });
+
+            // Prepare the trace handle exactly as `PendingPeek::index` would.
+            trace.set_logical_compaction(Antichain::from_elem(Timestamp::from(0u64)).borrow());
+            trace.set_physical_compaction(Antichain::new().borrow());
+
+            body(&mut trace);
+        });
+    }
+
+    #[mz_ore::test]
+    fn coalesced_full_scans_each_see_all_rows() {
+        with_arrangement(vec![(1, 10), (1, 11), (2, 20)], |trace| {
+            let mut group = vec![muxed(2, None), muxed(2, None)];
+            collect_coalesced_ok_data(trace, &mut group);
+
+            let expected = vec![(vec![1, 10], 1), (vec![1, 11], 1), (vec![2, 20], 1)];
+            assert_eq!(extract(group[0].outcome.take()), expected);
+            assert_eq!(extract(group[1].outcome.take()), expected);
+        });
+    }
+
+    #[mz_ore::test]
+    fn coalesced_mixed_full_scan_and_literal() {
+        with_arrangement(vec![(1, 10), (1, 11), (2, 20)], |trace| {
+            // A full scan and a literal peek on key = 2. The literal peek's row
+            // carries the key columns twice, mirroring an IndexedFilter join.
+            let mut group = vec![muxed(2, None), muxed(3, Some(vec![row(2)]))];
+            collect_coalesced_ok_data(trace, &mut group);
+
+            assert_eq!(
+                extract(group[0].outcome.take()),
+                vec![(vec![1, 10], 1), (vec![1, 11], 1), (vec![2, 20], 1)],
+            );
+            assert_eq!(extract(group[1].outcome.take()), vec![(vec![2, 20, 2], 1)]);
+        });
+    }
+
+    #[mz_ore::test]
+    fn coalesced_seek_mode_disjoint_literals() {
+        with_arrangement(vec![(1, 10), (1, 11), (2, 20)], |trace| {
+            // No full scan: the walk seeks through the union of literals and
+            // demultiplexes each key to the peeks that requested it.
+            let mut group = vec![muxed(3, Some(vec![row(1)])), muxed(3, Some(vec![row(2)]))];
+            collect_coalesced_ok_data(trace, &mut group);
+
+            assert_eq!(
+                extract(group[0].outcome.take()),
+                vec![(vec![1, 10, 1], 1), (vec![1, 11, 1], 1)],
+            );
+            assert_eq!(extract(group[1].outcome.take()), vec![(vec![2, 20, 2], 1)]);
+        });
+    }
+
+    #[mz_ore::test]
+    fn coalesced_duplicate_literal_repeats_key() {
+        with_arrangement(vec![(1, 10), (2, 20)], |trace| {
+            // A duplicated literal reproduces the key's rows once per occurrence,
+            // matching the single-peek path.
+            let mut group = vec![muxed(3, Some(vec![row(2), row(2)])), muxed(2, None)];
+            collect_coalesced_ok_data(trace, &mut group);
+
+            assert_eq!(
+                extract(group[0].outcome.take()),
+                vec![(vec![2, 20, 2], 1), (vec![2, 20, 2], 1)],
+            );
+            assert_eq!(
+                extract(group[1].outcome.take()),
+                vec![(vec![1, 10], 1), (vec![2, 20], 1)],
+            );
+        });
+    }
+}

--- a/src/compute/src/compute_state/peek_coalesce.rs
+++ b/src/compute/src/compute_state/peek_coalesce.rs
@@ -455,7 +455,8 @@ fn visit_key<Tr>(
         val.extend_datums(&arena, &mut borrow, None);
         let kv_len = borrow.len();
 
-        // Summed diff at the read timestamp. Shared across the group.
+        // Summed diff at the read timestamp. Shared across the group because the
+        // group reads at one timestamp.
         let mut copies = Diff::ZERO;
         cursor.map_times(storage, |time, diff| {
             if time.less_equal(&timestamp) {
@@ -464,13 +465,13 @@ fn visit_key<Tr>(
         });
         let copies = classify_copies(copies);
 
-        // A row that does not exist at this timestamp contributes to no peek.
-        if let Copies::Zero = copies {
-            drop(borrow);
-            cursor.step_val(storage);
-            continue;
-        }
-
+        // NOTE: We must not skip a zero-multiplicity row before evaluating each
+        // peek's map-filter-project. The single-peek path (`PeekResultIterator`)
+        // evaluates the MFP first and surfaces MFP errors regardless of the
+        // multiplicity, so a row that sums to zero at this timestamp (reachable
+        // for unconsolidated data before compaction) must still run every peek's
+        // MFP. The per-peek `Copies::Zero` arm below drops the row after the MFP
+        // has had its chance to error, matching the single-peek path exactly.
         for i in 0..peeks.len() {
             let mult = mults[i];
             if mult == 0 || peeks[i].outcome.is_some() {
@@ -706,10 +707,20 @@ mod tests {
 
     /// Builds a `RowRow` arrangement over the given `(key, val)` pairs (each with
     /// multiplicity one at time 0), then runs `body` against the sealed trace.
+    fn with_arrangement<F>(data: Vec<(i64, i64)>, body: F)
+    where
+        F: FnOnce(&mut crate::typedefs::RowRowAgent<Timestamp, Diff>) + Send + Sync + 'static,
+    {
+        let data = data.into_iter().map(|(k, v)| (k, v, 1)).collect();
+        with_arrangement_diffs(data, body);
+    }
+
+    /// Builds a `RowRow` arrangement over the given `(key, val, diff)` triples at
+    /// time 0, then runs `body` against the sealed trace.
     ///
     /// The trace is compacted to time 0, mirroring how a real index peek prepares
     /// its trace handle before reading.
-    fn with_arrangement<F>(data: Vec<(i64, i64)>, body: F)
+    fn with_arrangement_diffs<F>(data: Vec<(i64, i64, i64)>, body: F)
     where
         F: FnOnce(&mut crate::typedefs::RowRowAgent<Timestamp, Diff>) + Send + Sync + 'static,
     {
@@ -725,7 +736,7 @@ mod tests {
             let mut trace = worker.dataflow::<Timestamp, _, _>(|scope| {
                 let updates: Vec<((Row, Row), Timestamp, Diff)> = data
                     .iter()
-                    .map(|(k, v)| ((row(*k), row(*v)), Timestamp::from(0u64), Diff::ONE))
+                    .map(|(k, v, d)| ((row(*k), row(*v)), Timestamp::from(0u64), Diff::from(*d)))
                     .collect();
                 let arranged = updates
                     .to_stream(scope)
@@ -752,6 +763,36 @@ mod tests {
             trace.set_physical_compaction(Antichain::new().borrow());
 
             body(&mut trace);
+        });
+    }
+
+    #[mz_ore::test]
+    fn coalesced_counts_multiplicity() {
+        // A key/val with diff 3 must be reported with count 3 by every peek.
+        with_arrangement_diffs(vec![(1, 10, 3), (2, 20, 1)], |trace| {
+            let mut group = vec![muxed(2, None), muxed(2, None)];
+            collect_coalesced_ok_data(trace, &mut group);
+            let expected = vec![(vec![1, 10], 3), (vec![2, 20], 1)];
+            assert_eq!(extract(group[0].outcome.take()), expected);
+            assert_eq!(extract(group[1].outcome.take()), expected);
+        });
+    }
+
+    #[mz_ore::test]
+    fn coalesced_negative_multiplicity_errors() {
+        // A negative summed diff is corrupt data: every peek whose MFP passes the
+        // row must surface an error, matching the single-peek path. This also
+        // exercises that the MFP runs before the copies check (the error only
+        // fires once the identity MFP has accepted the row).
+        with_arrangement_diffs(vec![(1, 10, -1)], |trace| {
+            let mut group = vec![muxed(2, None), muxed(2, None)];
+            collect_coalesced_ok_data(trace, &mut group);
+            for peek in &mut group {
+                assert!(matches!(
+                    peek.outcome.take(),
+                    Some(PeekOutcome::Response(PeekResponse::Error(_)))
+                ));
+            }
         });
     }
 

--- a/src/compute/src/compute_state/peek_coalesce.rs
+++ b/src/compute/src/compute_state/peek_coalesce.rs
@@ -478,6 +478,11 @@ fn visit_key<Tr>(
                 continue;
             }
             let is_literal = peeks[i].literals.is_some();
+            // A duplicated literal re-evaluates the identical MFP per occurrence,
+            // mirroring the single-peek path (`PeekResultIterator`). The input is
+            // byte-for-byte identical across iterations, so this could evaluate
+            // once and push `mult` times, but duplicated literals are not a hot
+            // path and matching the single-peek path keeps the two in lockstep.
             for _ in 0..mult {
                 borrow.truncate(kv_len);
                 if is_literal {
@@ -855,6 +860,29 @@ mod tests {
             assert_eq!(
                 extract(group[1].outcome.take()),
                 vec![(vec![1, 10], 1), (vec![2, 20], 1)],
+            );
+        });
+    }
+
+    #[mz_ore::test]
+    fn coalesced_seek_shared_and_duplicate_literals() {
+        with_arrangement(vec![(1, 10), (2, 20), (3, 30)], |trace| {
+            // Pure-seek (no full scan). peek0 duplicates key 2; peek1 shares key
+            // 2 and adds key 1. The union dedups to [1, 2], but each per-peek
+            // cursor must still report its own multiplicity off the shared key.
+            let mut group = vec![
+                muxed(3, Some(vec![row(2), row(2)])),
+                muxed(3, Some(vec![row(1), row(2)])),
+            ];
+            collect_coalesced_ok_data(trace, &mut group);
+
+            assert_eq!(
+                extract(group[0].outcome.take()),
+                vec![(vec![2, 20, 2], 1), (vec![2, 20, 2], 1)],
+            );
+            assert_eq!(
+                extract(group[1].outcome.take()),
+                vec![(vec![1, 10, 1], 1), (vec![2, 20, 2], 1)],
             );
         });
     }

--- a/src/compute/src/compute_state/peek_coalesce.rs
+++ b/src/compute/src/compute_state/peek_coalesce.rs
@@ -108,6 +108,12 @@ impl PeekAccumulator {
         self.sort_time
     }
 
+    /// Bytes currently retained in `results`, used to bound the aggregate memory
+    /// of a coalesced group.
+    pub(super) fn total_size(&self) -> usize {
+        self.total_size
+    }
+
     /// Pushes a single `(row, copies)` result into the accumulator.
     pub(super) fn push(&mut self, row: Row, copies: NonZeroUsize) -> PushOutcome {
         let count_byte_size = size_of::<NonZeroUsize>();
@@ -284,14 +290,26 @@ enum Copies {
 /// Walks the ok stream of `oks` once, demultiplexing each visited row into the
 /// peeks in `peeks`.
 ///
-/// On return, every peek has its `outcome` populated. Peeks whose accumulation
-/// completed normally get a `Response`; peeks that overflowed the stash
-/// threshold get `Stash`; peeks that errored (map-filter-project error, negative
-/// multiplicities, or oversized result) get an error `Response`.
+/// Returns `false` when the walk completed and every peek has its `outcome`
+/// populated. Peeks whose accumulation completed normally get a `Response`;
+/// peeks that overflowed the stash threshold get `Stash`; peeks that errored
+/// (map-filter-project error, negative multiplicities, or oversized result) get
+/// an error `Response`.
+///
+/// Returns `true` when the peeks' aggregate retained bytes exceeded
+/// `group_budget`. In that case the walk aborts, `outcome`s are left
+/// unspecified, and the caller must fall back to serving each peek individually
+/// so that peak memory stays bounded to one result at a time. The budget bounds
+/// the coalesced group to roughly what a single peek would hold, since coalescing
+/// keeps every result live at once until the shared walk finishes.
 ///
 /// The caller is responsible for the shared readiness and error-trace checks
 /// before invoking this, and for acting on each peek's outcome afterward.
-pub(super) fn collect_coalesced_ok_data<Tr>(oks: &mut Tr, peeks: &mut [MuxedPeek])
+pub(super) fn collect_coalesced_ok_data<Tr>(
+    oks: &mut Tr,
+    peeks: &mut [MuxedPeek],
+    group_budget: usize,
+) -> bool
 where
     Tr: TraceReader<Batch: Navigable>,
     for<'a> BatchCursor<Tr>: Cursor<
@@ -323,6 +341,12 @@ where
     let mut row_builder = Row::default();
     let mut mults = vec![0usize; peeks.len()];
 
+    // Sum of every accumulator's retained bytes. Bounds the group's live memory:
+    // coalescing keeps all results resident until the shared walk finishes, so
+    // without this an unbounded ordered peek (never stash-eligible) multiplied by
+    // the group size could OOM the replica.
+    let mut group_total: usize = 0;
+
     if full_scan {
         while cursor.key_valid(&storage) {
             if peeks.iter().all(|peek| peek.outcome.is_some()) {
@@ -332,7 +356,7 @@ where
             for i in 0..peeks.len() {
                 mults[i] = peek_multiplicity::<Tr>(&peeks[i], &mut lit_cursors[i], key);
             }
-            visit_key::<Tr>(
+            let overflow = visit_key::<Tr>(
                 &mut cursor,
                 &storage,
                 key,
@@ -340,7 +364,12 @@ where
                 &mults,
                 &mut datum_vec,
                 &mut row_builder,
+                &mut group_total,
+                group_budget,
             );
+            if overflow {
+                return true;
+            }
             cursor.step_key(&storage);
         }
     } else {
@@ -367,7 +396,7 @@ where
                 for i in 0..peeks.len() {
                     mults[i] = peek_multiplicity::<Tr>(&peeks[i], &mut lit_cursors[i], key);
                 }
-                visit_key::<Tr>(
+                let overflow = visit_key::<Tr>(
                     &mut cursor,
                     &storage,
                     key,
@@ -375,7 +404,12 @@ where
                     &mults,
                     &mut datum_vec,
                     &mut row_builder,
+                    &mut group_total,
+                    group_budget,
                 );
+                if overflow {
+                    return true;
+                }
             } else {
                 // No row for this union key. Still advance every literal cursor
                 // past it so their pointers stay in step with the ascending walk.
@@ -391,6 +425,8 @@ where
             peek.outcome = Some(PeekOutcome::Response(peek.accumulator.finish()));
         }
     }
+
+    false
 }
 
 /// Computes a peek's multiplicity at `key`, advancing its literal cursor.
@@ -420,6 +456,9 @@ where
 }
 
 /// Processes all values under the current key, feeding each active peek.
+///
+/// Returns `true` if the group's aggregate retained bytes (`group_total`)
+/// exceeded `group_budget`, signaling the caller to abort the coalesced walk.
 fn visit_key<Tr>(
     cursor: &mut TraceCursor<Tr>,
     storage: &TraceStorage<Tr>,
@@ -428,7 +467,10 @@ fn visit_key<Tr>(
     mults: &[usize],
     datum_vec: &mut DatumVec,
     row_builder: &mut Row,
-) where
+    group_total: &mut usize,
+    group_budget: usize,
+) -> bool
+where
     Tr: TraceReader<Batch: Navigable>,
     for<'a> BatchCursor<Tr>: Cursor<
             Key<'a>: ExtendDatums + Eq,
@@ -444,7 +486,7 @@ fn visit_key<Tr>(
         .find(|p| p.outcome.is_none())
         .map(|p| p.timestamp);
     let Some(timestamp) = timestamp else {
-        return;
+        return false;
     };
 
     while cursor.val_valid(storage) {
@@ -522,23 +564,36 @@ fn visit_key<Tr>(
                             break;
                         }
                         Copies::Zero => break,
-                        Copies::Positive(copies) => match peeks[i].accumulator.push(row, *copies) {
-                            PushOutcome::Continue => {}
-                            PushOutcome::Complete => {
-                                let response = peeks[i].accumulator.finish();
-                                peeks[i].outcome = Some(PeekOutcome::Response(response));
-                                break;
+                        Copies::Positive(copies) => {
+                            // Update the group's aggregate bytes by this push's
+                            // delta (thinning can shrink it) and abort the whole
+                            // coalesced walk if it exceeds the budget.
+                            let before = peeks[i].accumulator.total_size();
+                            let outcome = peeks[i].accumulator.push(row, *copies);
+                            *group_total = group_total
+                                .saturating_sub(before)
+                                .saturating_add(peeks[i].accumulator.total_size());
+                            if *group_total > group_budget {
+                                return true;
                             }
-                            PushOutcome::Stash => {
-                                peeks[i].outcome = Some(PeekOutcome::Stash);
-                                break;
+                            match outcome {
+                                PushOutcome::Continue => {}
+                                PushOutcome::Complete => {
+                                    let response = peeks[i].accumulator.finish();
+                                    peeks[i].outcome = Some(PeekOutcome::Response(response));
+                                    break;
+                                }
+                                PushOutcome::Stash => {
+                                    peeks[i].outcome = Some(PeekOutcome::Stash);
+                                    break;
+                                }
+                                PushOutcome::MaxSizeExceeded => {
+                                    let response = peeks[i].accumulator.max_size_error();
+                                    peeks[i].outcome = Some(PeekOutcome::Response(response));
+                                    break;
+                                }
                             }
-                            PushOutcome::MaxSizeExceeded => {
-                                let response = peeks[i].accumulator.max_size_error();
-                                peeks[i].outcome = Some(PeekOutcome::Response(response));
-                                break;
-                            }
-                        },
+                        }
                     },
                 }
             }
@@ -547,6 +602,8 @@ fn visit_key<Tr>(
         drop(borrow);
         cursor.step_val(storage);
     }
+
+    false
 }
 
 /// Classifies a summed diff into the multiplicity cases.
@@ -776,7 +833,8 @@ mod tests {
         // A key/val with diff 3 must be reported with count 3 by every peek.
         with_arrangement_diffs(vec![(1, 10, 3), (2, 20, 1)], |trace| {
             let mut group = vec![muxed(2, None), muxed(2, None)];
-            collect_coalesced_ok_data(trace, &mut group);
+            let overflowed = collect_coalesced_ok_data(trace, &mut group, usize::MAX);
+            assert!(!overflowed);
             let expected = vec![(vec![1, 10], 3), (vec![2, 20], 1)];
             assert_eq!(extract(group[0].outcome.take()), expected);
             assert_eq!(extract(group[1].outcome.take()), expected);
@@ -791,7 +849,8 @@ mod tests {
         // fires once the identity MFP has accepted the row).
         with_arrangement_diffs(vec![(1, 10, -1)], |trace| {
             let mut group = vec![muxed(2, None), muxed(2, None)];
-            collect_coalesced_ok_data(trace, &mut group);
+            let overflowed = collect_coalesced_ok_data(trace, &mut group, usize::MAX);
+            assert!(!overflowed);
             for peek in &mut group {
                 assert!(matches!(
                     peek.outcome.take(),
@@ -805,7 +864,8 @@ mod tests {
     fn coalesced_full_scans_each_see_all_rows() {
         with_arrangement(vec![(1, 10), (1, 11), (2, 20)], |trace| {
             let mut group = vec![muxed(2, None), muxed(2, None)];
-            collect_coalesced_ok_data(trace, &mut group);
+            let overflowed = collect_coalesced_ok_data(trace, &mut group, usize::MAX);
+            assert!(!overflowed);
 
             let expected = vec![(vec![1, 10], 1), (vec![1, 11], 1), (vec![2, 20], 1)];
             assert_eq!(extract(group[0].outcome.take()), expected);
@@ -819,7 +879,8 @@ mod tests {
             // A full scan and a literal peek on key = 2. The literal peek's row
             // carries the key columns twice, mirroring an IndexedFilter join.
             let mut group = vec![muxed(2, None), muxed(3, Some(vec![row(2)]))];
-            collect_coalesced_ok_data(trace, &mut group);
+            let overflowed = collect_coalesced_ok_data(trace, &mut group, usize::MAX);
+            assert!(!overflowed);
 
             assert_eq!(
                 extract(group[0].outcome.take()),
@@ -835,7 +896,8 @@ mod tests {
             // No full scan: the walk seeks through the union of literals and
             // demultiplexes each key to the peeks that requested it.
             let mut group = vec![muxed(3, Some(vec![row(1)])), muxed(3, Some(vec![row(2)]))];
-            collect_coalesced_ok_data(trace, &mut group);
+            let overflowed = collect_coalesced_ok_data(trace, &mut group, usize::MAX);
+            assert!(!overflowed);
 
             assert_eq!(
                 extract(group[0].outcome.take()),
@@ -851,7 +913,8 @@ mod tests {
             // A duplicated literal reproduces the key's rows once per occurrence,
             // matching the single-peek path.
             let mut group = vec![muxed(3, Some(vec![row(2), row(2)])), muxed(2, None)];
-            collect_coalesced_ok_data(trace, &mut group);
+            let overflowed = collect_coalesced_ok_data(trace, &mut group, usize::MAX);
+            assert!(!overflowed);
 
             assert_eq!(
                 extract(group[0].outcome.take()),
@@ -874,7 +937,8 @@ mod tests {
                 muxed(3, Some(vec![row(2), row(2)])),
                 muxed(3, Some(vec![row(1), row(2)])),
             ];
-            collect_coalesced_ok_data(trace, &mut group);
+            let overflowed = collect_coalesced_ok_data(trace, &mut group, usize::MAX);
+            assert!(!overflowed);
 
             assert_eq!(
                 extract(group[0].outcome.take()),
@@ -884,6 +948,18 @@ mod tests {
                 extract(group[1].outcome.take()),
                 vec![(vec![1, 10, 1], 1), (vec![2, 20, 2], 1)],
             );
+        });
+    }
+
+    #[mz_ore::test]
+    fn coalesced_overflow_aborts_walk() {
+        // A budget below even a single retained row forces the aggregate check to
+        // trip. The walk aborts and signals the caller to fall back to individual
+        // processing; outcomes are left unspecified.
+        with_arrangement(vec![(1, 10), (2, 20)], |trace| {
+            let mut group = vec![muxed(2, None), muxed(2, None)];
+            let overflowed = collect_coalesced_ok_data(trace, &mut group, 1);
+            assert!(overflowed);
         });
     }
 }

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -71,6 +71,7 @@ pub struct ComputeMetrics {
     // Peek coalescing counters (per-cluster, no worker label)
     index_peek_coalesced_groups_total: IntCounter,
     index_peek_coalesced_peeks_total: IntCounter,
+    index_peek_coalesced_overflow_total: IntCounter,
 
     // memory usage
     shared_row_heap_capacity_bytes: raw::UIntGaugeVec,
@@ -229,6 +230,10 @@ impl ComputeMetrics {
                 name: "mz_index_peek_coalesced_peeks_total",
                 help: "Number of index peeks served through coalescing, summed across the process's workers (each worker counts the same logical peeks).",
             )),
+            index_peek_coalesced_overflow_total: registry.register(metric!(
+                name: "mz_index_peek_coalesced_overflow_total",
+                help: "Number of coalesced index peek groups that exceeded the aggregate memory budget and fell back to serving each peek individually, summed across the process's workers.",
+            )),
             replica_expiration_timestamp_seconds: registry.register(metric!(
                 name: "mz_dataflow_replica_expiration_timestamp_seconds",
                 help: "The replica expiration timestamp in seconds since epoch.",
@@ -284,6 +289,7 @@ impl ComputeMetrics {
         let index_peek_row_collection_seconds = self.index_peek_row_collection_seconds.clone();
         let index_peek_coalesced_groups_total = self.index_peek_coalesced_groups_total.clone();
         let index_peek_coalesced_peeks_total = self.index_peek_coalesced_peeks_total.clone();
+        let index_peek_coalesced_overflow_total = self.index_peek_coalesced_overflow_total.clone();
         let replica_expiration_timestamp_seconds = self
             .replica_expiration_timestamp_seconds
             .with_label_values(&[&worker]);
@@ -313,6 +319,7 @@ impl ComputeMetrics {
             index_peek_row_collection_seconds,
             index_peek_coalesced_groups_total,
             index_peek_coalesced_peeks_total,
+            index_peek_coalesced_overflow_total,
             replica_expiration_timestamp_seconds,
             replica_expiration_remaining_seconds,
             shared_row_heap_capacity_bytes,
@@ -362,6 +369,9 @@ pub struct WorkerMetrics {
     pub(crate) index_peek_coalesced_groups_total: IntCounter,
     /// Number of index peeks served through coalescing.
     pub(crate) index_peek_coalesced_peeks_total: IntCounter,
+    /// Number of coalesced groups that overflowed the aggregate memory budget and
+    /// fell back to serving each peek individually.
+    pub(crate) index_peek_coalesced_overflow_total: IntCounter,
     /// The timestamp of replica expiration.
     pub(crate) replica_expiration_timestamp_seconds: UIntGauge,
     /// Remaining seconds until replica expiration.

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -223,11 +223,11 @@ impl ComputeMetrics {
             )),
             index_peek_coalesced_groups_total: registry.register(metric!(
                 name: "mz_index_peek_coalesced_groups_total",
-                help: "Number of coalesced index peek groups (each served by a single arrangement walk).",
+                help: "Number of coalesced index peek groups (each served by a single arrangement walk), summed across the process's workers.",
             )),
             index_peek_coalesced_peeks_total: registry.register(metric!(
                 name: "mz_index_peek_coalesced_peeks_total",
-                help: "Number of index peeks served through coalescing.",
+                help: "Number of index peeks served through coalescing, summed across the process's workers (each worker counts the same logical peeks).",
             )),
             replica_expiration_timestamp_seconds: registry.register(metric!(
                 name: "mz_dataflow_replica_expiration_timestamp_seconds",

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -68,6 +68,9 @@ pub struct ComputeMetrics {
     index_peek_result_sort_seconds: Histogram,
     index_peek_frontier_check_seconds: Histogram,
     index_peek_row_collection_seconds: Histogram,
+    // Peek coalescing counters (per-cluster, no worker label)
+    index_peek_coalesced_groups_total: IntCounter,
+    index_peek_coalesced_peeks_total: IntCounter,
 
     // memory usage
     shared_row_heap_capacity_bytes: raw::UIntGaugeVec,
@@ -218,6 +221,14 @@ impl ComputeMetrics {
                 help: "Time constructing RowCollection from peek results.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             )),
+            index_peek_coalesced_groups_total: registry.register(metric!(
+                name: "mz_index_peek_coalesced_groups_total",
+                help: "Number of coalesced index peek groups (each served by a single arrangement walk).",
+            )),
+            index_peek_coalesced_peeks_total: registry.register(metric!(
+                name: "mz_index_peek_coalesced_peeks_total",
+                help: "Number of index peeks served through coalescing.",
+            )),
             replica_expiration_timestamp_seconds: registry.register(metric!(
                 name: "mz_dataflow_replica_expiration_timestamp_seconds",
                 help: "The replica expiration timestamp in seconds since epoch.",
@@ -271,6 +282,8 @@ impl ComputeMetrics {
         let index_peek_result_sort_seconds = self.index_peek_result_sort_seconds.clone();
         let index_peek_frontier_check_seconds = self.index_peek_frontier_check_seconds.clone();
         let index_peek_row_collection_seconds = self.index_peek_row_collection_seconds.clone();
+        let index_peek_coalesced_groups_total = self.index_peek_coalesced_groups_total.clone();
+        let index_peek_coalesced_peeks_total = self.index_peek_coalesced_peeks_total.clone();
         let replica_expiration_timestamp_seconds = self
             .replica_expiration_timestamp_seconds
             .with_label_values(&[&worker]);
@@ -298,6 +311,8 @@ impl ComputeMetrics {
             index_peek_result_sort_seconds,
             index_peek_frontier_check_seconds,
             index_peek_row_collection_seconds,
+            index_peek_coalesced_groups_total,
+            index_peek_coalesced_peeks_total,
             replica_expiration_timestamp_seconds,
             replica_expiration_remaining_seconds,
             shared_row_heap_capacity_bytes,
@@ -343,6 +358,10 @@ pub struct WorkerMetrics {
     pub(crate) index_peek_frontier_check_seconds: Histogram,
     /// Histogram of index peek row collection construction durations.
     pub(crate) index_peek_row_collection_seconds: Histogram,
+    /// Number of coalesced index peek groups, each served by a single arrangement walk.
+    pub(crate) index_peek_coalesced_groups_total: IntCounter,
+    /// Number of index peeks served through coalescing.
+    pub(crate) index_peek_coalesced_peeks_total: IntCounter,
     /// The timestamp of replica expiration.
     pub(crate) replica_expiration_timestamp_seconds: UIntGauge,
     /// Remaining seconds until replica expiration.


### PR DESCRIPTION
Coalesce index peeks against the same index at the same timestamp into a single arrangement walk, demultiplexing each visited row into the individual peeks. This amortizes cursor setup, key/value datum decoding, and the `map_times` multiplicity computation across the group. Literal-constrained peeks merge-seek through the union of their literals; a group containing any full scan walks the arrangement linearly. Finishing and thinning live in a shared `PeekAccumulator` used by both the single-peek and coalesced paths.

Index peeks are deferred from the command handler into `process_peeks`, so every peek drained in one `handle_pending_commands` pass coalesces regardless of readiness. This matters because a peek that is ready on arrival (always the case under Serializable isolation, which reads an already-processed timestamp) would otherwise be retired immediately and never coalesce. `process_peeks` runs every worker iteration right after command handling and before the next park, so a deferred peek is retired in the same iteration it arrived: no maintenance-tick latency is added.

Gated by the `enable_compute_peek_coalescing` dyncfg, default on.

Measured on an optimized build with persistent prepared connections, Serializable isolation, 64 clients:
* Full-scan index peek: 272 → 531 tps (+95%), latency 235 → 121 ms (−49%).
* Point lookup: unchanged — 1.29 ms at c=1 (no deferral penalty), 11.5k tps at c=64. Lookups are bound by per-peek protocol cost, not the arrangement walk, so coalescing neither helps nor hurts them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)