### PR TITLE
adapter: move frontend-peek registration off the coordinator

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -61,6 +61,7 @@ use crate::config::{ScopedParameters, ScopedParametersScope, SystemParameterFron
 use crate::coord::{Coordinator, ExecuteContextGuard};
 use crate::error::AdapterError;
 use crate::metrics::{self, Metrics};
+use crate::peek_registry::FrontendPeekRegistry;
 use crate::session::{
     EndTransactionAction, PreparedStatement, Session, SessionConfig, StateRevision, TransactionId,
 };
@@ -112,6 +113,10 @@ pub struct Client {
     metrics: Metrics,
     environment_id: EnvironmentId,
     segment_client: Option<mz_segment::Client>,
+    /// Registry of in-flight frontend-sequenced peeks, shared with the
+    /// coordinator. Each session's `PeekClient` registers and unregisters its
+    /// peeks here directly, off the coordinator task.
+    frontend_peek_registry: Arc<FrontendPeekRegistry>,
 }
 
 impl Client {
@@ -122,6 +127,7 @@ impl Client {
         now: NowFn,
         environment_id: EnvironmentId,
         segment_client: Option<mz_segment::Client>,
+        frontend_peek_registry: Arc<FrontendPeekRegistry>,
     ) -> Client {
         // Connection ids are 32 bits and have 3 parts.
         // 1. MSB bit is always 0 because these are interpreted as an i32, and it is possible some
@@ -139,6 +145,7 @@ impl Client {
             metrics,
             environment_id,
             segment_client,
+            frontend_peek_registry,
         }
     }
 
@@ -296,6 +303,7 @@ impl Client {
             optimizer_metrics,
             persist_client,
             statement_logging_frontend,
+            Arc::clone(&self.frontend_peek_registry),
         );
 
         let mut client = SessionClient {

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -74,6 +74,7 @@ use crate::metrics::Metrics;
 use crate::optimize::dataflows::{EvalTime, ExprPrepOneShot};
 use crate::optimize::{self, Optimize, OptimizerError};
 use crate::peek_client::{CoordinatorClient, ExecutionLogging, TakeOver};
+use crate::peek_registry::FrontendPeekRegistry;
 use crate::session::{
     EndTransactionAction, PreparedStatement, Session, SessionConfig, StateRevision, TransactionId,
     TransactionStatus,
@@ -126,6 +127,10 @@ pub struct Client {
     metrics: Metrics,
     environment_id: EnvironmentId,
     segment_client: Option<mz_segment::Client>,
+    /// Registry of in-flight frontend-sequenced peeks, shared with the
+    /// coordinator. Each session's `PeekClient` registers and unregisters its
+    /// peeks here directly, off the coordinator task.
+    frontend_peek_registry: Arc<FrontendPeekRegistry>,
 }
 
 impl Client {
@@ -136,6 +141,7 @@ impl Client {
         now: NowFn,
         environment_id: EnvironmentId,
         segment_client: Option<mz_segment::Client>,
+        frontend_peek_registry: Arc<FrontendPeekRegistry>,
     ) -> Client {
         // Connection ids are 32 bits and have 3 parts.
         // 1. MSB bit is always 0 because these are interpreted as an i32, and it is possible some
@@ -153,6 +159,7 @@ impl Client {
             metrics,
             environment_id,
             segment_client,
+            frontend_peek_registry,
         }
     }
 
@@ -325,6 +332,7 @@ impl Client {
             frontend_read_then_write_enabled,
             group_commit_notifier,
             read_only,
+            Arc::clone(&self.frontend_peek_registry),
         );
 
         let mut client = SessionClient {

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1379,6 +1379,7 @@ impl SessionClient {
                 | Command::LookupConnection { .. }
                 | Command::RegisterFrontendPeek { .. }
                 | Command::UnregisterFrontendPeek { .. }
+                | Command::InstallPeekWatchSets { .. }
                 | Command::ExplainTimestamp { .. }
                 | Command::FrontendStatementLogging(..)
                 | Command::InjectAuditEvents { .. }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -383,6 +383,23 @@ pub enum Command {
         tx: oneshot::Sender<()>,
     },
 
+    /// Install the statement-lifecycle watch sets for a peek that frontend
+    /// sequencing has already issued.
+    ///
+    /// Fire-and-forget: the peek does not wait for this, so the watch sets can
+    /// be installed after the peek has already responded. A watch set whose
+    /// frontier is already past its timestamp fires as soon as it is installed,
+    /// so a late install still records the event, only with a later `occurred_at`.
+    ///
+    /// Statement lifecycle logging is best-effort here. The peek is in flight
+    /// and cannot be failed, so a dependency that goes away before the watch
+    /// sets are installed costs the statement its lifecycle events rather than
+    /// erroring the query, which is what the blocking registration path does.
+    InstallPeekWatchSets {
+        conn_id: ConnectionId,
+        watch_set: WatchSetCreation,
+    },
+
     /// Generate a timestamp explanation.
     /// This is used when `emit_timestamp_notice` is enabled.
     ExplainTimestamp {
@@ -505,6 +522,7 @@ impl Command {
             | Command::LookupConnection { .. }
             | Command::RegisterFrontendPeek { .. }
             | Command::UnregisterFrontendPeek { .. }
+            | Command::InstallPeekWatchSets { .. }
             | Command::ExplainTimestamp { .. }
             | Command::FrontendStatementLogging(..)
             | Command::InjectAuditEvents { .. }
@@ -550,6 +568,7 @@ impl Command {
             | Command::LookupConnection { .. }
             | Command::RegisterFrontendPeek { .. }
             | Command::UnregisterFrontendPeek { .. }
+            | Command::InstallPeekWatchSets { .. }
             | Command::ExplainTimestamp { .. }
             | Command::FrontendStatementLogging(..)
             | Command::InjectAuditEvents { .. }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -207,6 +207,7 @@ use crate::explain::optimizer_trace::{DispatchGuard, OptimizerTrace};
 use crate::metrics::Metrics;
 use crate::optimize::dataflows::{ComputeInstanceSnapshot, DataflowBuilder};
 use crate::optimize::{self, Optimize, OptimizerConfig};
+use crate::peek_registry::FrontendPeekRegistry;
 use crate::session::{EndTransactionAction, Session};
 use crate::statement_logging::{
     StatementEndedExecutionReason, StatementLifecycleEvent, StatementLoggingId,
@@ -2000,6 +2001,11 @@ pub struct Coordinator {
     pending_peeks: BTreeMap<Uuid, PendingPeek>,
     /// A map from client connection ids to a set of all pending peeks for that client.
     client_pending_peeks: BTreeMap<ConnectionId, BTreeMap<Uuid, ClusterId>>,
+    /// Registry of in-flight frontend-sequenced peeks, shared with every
+    /// session's `PeekClient`. Frontend peeks register/unregister here off the
+    /// coordinator task. The coordinator only consults it to cancel a
+    /// connection's peeks (see [`Coordinator::cancel_pending_peeks`]).
+    frontend_peek_registry: Arc<FrontendPeekRegistry>,
 
     /// A map from client connection ids to pending linearize read transaction.
     pending_linearize_read_txns: BTreeMap<ConnectionId, PendingReadTxn>,
@@ -4990,6 +4996,12 @@ pub fn serve(
 
         let (group_commit_tx, group_commit_rx) = appends::notifier();
 
+        // Shared between the coordinator and every session's `PeekClient`. Fixed
+        // shard count keeps the hot-path locks contention-spread across
+        // concurrent sessions.
+        let frontend_peek_registry = Arc::new(FrontendPeekRegistry::new(64));
+        let coord_frontend_peek_registry = Arc::clone(&frontend_peek_registry);
+
         let parent_span = tracing::Span::current();
         let thread = thread::Builder::new()
             // The Coordinator thread tends to keep a lot of data on its stack. To
@@ -5038,6 +5050,7 @@ pub fn serve(
                     txn_read_holds: Default::default(),
                     pending_peeks: BTreeMap::new(),
                     client_pending_peeks: BTreeMap::new(),
+                    frontend_peek_registry: coord_frontend_peek_registry,
                     pending_linearize_read_txns: BTreeMap::new(),
                     serialized_ddl: LockedVecDeque::new(),
                     active_compute_sinks: BTreeMap::new(),
@@ -5145,6 +5158,7 @@ pub fn serve(
                     now,
                     environment_id,
                     segment_client_clone,
+                    frontend_peek_registry,
                 );
                 Ok((handle, client))
             }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -525,6 +525,7 @@ impl Message {
                 Command::LookupConnection { .. } => "lookup-connection",
                 Command::RegisterFrontendPeek { .. } => "register-frontend-peek",
                 Command::UnregisterFrontendPeek { .. } => "unregister-frontend-peek",
+                Command::InstallPeekWatchSets { .. } => "install-peek-watch-sets",
                 Command::ExplainTimestamp { .. } => "explain-timestamp",
                 Command::FrontendStatementLogging(..) => "frontend-statement-logging",
                 Command::StartCopyFromStdin { .. } => "start-copy-from-stdin",

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2129,8 +2129,9 @@ pub struct Coordinator {
     client_pending_peeks: BTreeMap<ConnectionId, BTreeMap<Uuid, ClusterId>>,
     /// Registry of in-flight frontend-sequenced peeks, shared with every
     /// session's `PeekClient`. Frontend peeks register/unregister here off the
-    /// coordinator task. The coordinator only consults it to cancel a
-    /// connection's peeks (see [`Coordinator::cancel_pending_peeks`]).
+    /// coordinator task; the coordinator reads it from its teardown paths, to
+    /// cancel a connection's peeks and to cancel peeks whose dependencies were
+    /// dropped.
     frontend_peek_registry: Arc<FrontendPeekRegistry>,
 
     /// A map from client connection ids to pending linearize read transaction.
@@ -5343,9 +5344,9 @@ pub fn serve(
 
         let (group_commit_tx, group_commit_rx) = appends::notifier();
 
-        // Shared between the coordinator and every session's `PeekClient`. Fixed
-        // shard count keeps the hot-path locks contention-spread across
-        // concurrent sessions.
+        // Shared between the coordinator and every session's `PeekClient`. The
+        // shard count is set well above the concurrent-session counts we
+        // benchmark at rather than tuned against a measurement.
         let frontend_peek_registry = Arc::new(FrontendPeekRegistry::new(64));
         let coord_frontend_peek_registry = Arc::clone(&frontend_peek_registry);
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -212,6 +212,7 @@ use crate::explain::optimizer_trace::{DispatchGuard, OptimizerTrace};
 use crate::metrics::Metrics;
 use crate::optimize::dataflows::{ComputeInstanceSnapshot, DataflowBuilder};
 use crate::optimize::{self, Optimize, OptimizerConfig};
+use crate::peek_registry::FrontendPeekRegistry;
 use crate::session::{EndTransactionAction, Session};
 use crate::statement_logging::{
     StatementEndedExecutionReason, StatementLifecycleEvent, StatementLoggingId,
@@ -2125,6 +2126,11 @@ pub struct Coordinator {
     pending_peeks: BTreeMap<Uuid, PendingPeek>,
     /// A map from client connection ids to a set of all pending peeks for that client.
     client_pending_peeks: BTreeMap<ConnectionId, BTreeMap<Uuid, ClusterId>>,
+    /// Registry of in-flight frontend-sequenced peeks, shared with every
+    /// session's `PeekClient`. Frontend peeks register/unregister here off the
+    /// coordinator task. The coordinator only consults it to cancel a
+    /// connection's peeks (see [`Coordinator::cancel_pending_peeks`]).
+    frontend_peek_registry: Arc<FrontendPeekRegistry>,
 
     /// A map from client connection ids to pending linearize read transaction.
     pending_linearize_read_txns: BTreeMap<ConnectionId, PendingReadTxn>,
@@ -5336,6 +5342,12 @@ pub fn serve(
 
         let (group_commit_tx, group_commit_rx) = appends::notifier();
 
+        // Shared between the coordinator and every session's `PeekClient`. Fixed
+        // shard count keeps the hot-path locks contention-spread across
+        // concurrent sessions.
+        let frontend_peek_registry = Arc::new(FrontendPeekRegistry::new(64));
+        let coord_frontend_peek_registry = Arc::clone(&frontend_peek_registry);
+
         let parent_span = tracing::Span::current();
         let thread = thread::Builder::new()
             // The Coordinator thread tends to keep a lot of data on its stack. To
@@ -5393,6 +5405,7 @@ pub fn serve(
                     txn_read_holds: Default::default(),
                     pending_peeks: BTreeMap::new(),
                     client_pending_peeks: BTreeMap::new(),
+                    frontend_peek_registry: coord_frontend_peek_registry,
                     pending_linearize_read_txns: BTreeMap::new(),
                     serialized_ddl: LockedVecDeque::new(),
                     active_compute_sinks: BTreeMap::new(),
@@ -5520,6 +5533,7 @@ pub fn serve(
                     now,
                     environment_id,
                     segment_client_clone,
+                    frontend_peek_registry,
                 );
                 Ok((handle, client))
             }

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -256,6 +256,7 @@ impl Coordinator {
         let mut cluster_replicas_to_drop = vec![];
         let mut active_compute_sinks_to_drop = BTreeMap::new();
         let mut peeks_to_drop = vec![];
+        let mut registry_peeks_to_drop = vec![];
         let mut copies_to_drop = vec![];
 
         // Maps for storing names of dropped objects for error messages.
@@ -892,6 +893,31 @@ impl Coordinator {
             }
         }
 
+        // Frontend-sequenced fast-path peeks live in the shared registry rather
+        // than in `pending_peeks`, so they need the same sweep. Their cancel
+        // reason has to carry the dropped dependency too: a bare `Canceled`
+        // would leave the session with no explanation for why its query died.
+        let dropped_registry_peeks = self
+            .frontend_peek_registry
+            .find_dropped(&readable_collections_to_drop, &clusters_to_drop);
+        for dropped in &dropped_registry_peeks {
+            let dep = match dropped.dropped_collection {
+                Some(id) => DroppedDependency::Relation {
+                    name: dropped_item_names
+                        .get(&id)
+                        .cloned()
+                        .expect("missing relation name"),
+                },
+                None => DroppedDependency::Cluster {
+                    name: dropped_cluster_names
+                        .get(&dropped.cluster_id)
+                        .cloned()
+                        .expect("missing cluster name"),
+                },
+            };
+            registry_peeks_to_drop.push((dep, dropped.uuid, dropped.cluster_id));
+        }
+
         // Clean up any pending `COPY` statements that rely on dropped relations or clusters.
         for (conn_id, pending_copy) in &self.active_copies {
             let dropping_table = tables_to_drop
@@ -1012,6 +1038,26 @@ impl Coordinator {
                             StatementEndedExecutionReason::Canceled,
                             pending_peek.ctx_extra.defuse(),
                         );
+                    }
+                }
+            }
+
+            if !registry_peeks_to_drop.is_empty() {
+                for (dep, uuid, cluster_id) in registry_peeks_to_drop {
+                    // Only cancel a peek this removal actually claimed. A
+                    // concurrent completion may have removed it already, and
+                    // cancelling then would race that peek's own teardown.
+                    if self.frontend_peek_registry.remove(uuid).is_some() {
+                        let cancel_reason = PeekResponse::Error(PeekError::unstructured(
+                            dep.query_terminated_error(),
+                        ));
+                        // The session observes this error on its response
+                        // stream, which also retires the statement's end of
+                        // execution, so there is nothing to retire here.
+                        let _ =
+                            self.controller
+                                .compute
+                                .cancel_peek(cluster_id, uuid, cancel_reason);
                     }
                 }
             }

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -1054,6 +1054,11 @@ impl Coordinator {
                         // The session observes this error on its response
                         // stream, which also retires the statement's end of
                         // execution, so there is nothing to retire here.
+                        //
+                        // Unlike the `pending_peeks` loop above this tolerates
+                        // a failed cancel instead of terminating: dropping the
+                        // peek's cluster removes the instance, and the peek's
+                        // own issue path already reports that to the session.
                         let _ =
                             self.controller
                                 .compute

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -597,6 +597,13 @@ impl Coordinator {
                 Command::UnregisterFrontendPeek { uuid, reason, tx } => {
                     self.handle_unregister_frontend_peek(uuid, reason, tx);
                 }
+                Command::InstallPeekWatchSets { conn_id, watch_set } => {
+                    if let Err(e) = self.install_peek_watch_sets(conn_id, watch_set) {
+                        tracing::debug!(
+                            "dropping lifecycle watch sets for an in-flight frontend peek: {e:?}"
+                        );
+                    }
+                }
                 Command::ExplainTimestamp {
                     conn_id,
                     session_wall_time,

--- a/src/adapter/src/coord/hydration_history.rs
+++ b/src/adapter/src/coord/hydration_history.rs
@@ -282,6 +282,7 @@ impl Coordinator {
             FRONTEND_READ_THEN_WRITE.get(self.catalog().system_config().dyncfgs()),
             self.group_commit_tx.clone(),
             self.controller.read_only(),
+            Arc::clone(&self.frontend_peek_registry),
         );
         Sweep {
             client,

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -963,6 +963,9 @@ impl crate::coord::Coordinator {
                 read_hold,
                 target_replica,
                 rows_tx,
+                // Classic coordinator-sequenced peek: the coordinator relies on
+                // the `PeekNotification` to retire its `pending_peeks` entry.
+                true,
             )
             .map_err(AdapterError::concurrent_dependency_drop_from_peek_error);
         if let Err(e) = peek_result {
@@ -1020,6 +1023,9 @@ impl crate::coord::Coordinator {
             persist_client,
             peek_stash_read_batch_size_bytes,
             peek_stash_read_memory_budget_bytes,
+            // Classic coordinator-sequenced peeks are tracked in `pending_peeks`,
+            // not the shared registry, so there is nothing to clean up here.
+            None,
         );
 
         Ok(crate::ExecuteResponse::SendingRowsStreaming {
@@ -1042,8 +1048,13 @@ impl crate::coord::Coordinator {
         mut persist_client: mz_persist_client::PersistClient,
         peek_stash_read_batch_size_bytes: usize,
         peek_stash_read_memory_budget_bytes: usize,
+        registration_guard: Option<crate::peek_registry::PeekRegistrationGuard>,
     ) -> impl futures::Stream<Item = PeekResponseUnary> {
         async_stream::stream!({
+            // Held for the stream's lifetime. On completion or drop it removes
+            // the peek's registry entry (frontend peeks only; `None` otherwise).
+            let _registration_guard = registration_guard;
+
             let result = rows_rx.await;
 
             let rows = match result {
@@ -1245,6 +1256,17 @@ impl crate::coord::Coordinator {
     /// Cancel and remove all pending peeks that were initiated by the client with `conn_id`.
     #[mz_ore::instrument(level = "debug")]
     pub(crate) fn cancel_pending_peeks(&mut self, conn_id: &ConnectionId) {
+        // Cancel fast-path peeks tracked in the shared registry, off-loaded from
+        // the coordinator's own `pending_peeks`. The session observes the
+        // `Canceled` response via its `rows_rx`, so no coordinator-side
+        // retirement is needed here.
+        for (uuid, cluster_id) in self.frontend_peek_registry.take_conn(conn_id) {
+            let _ = self
+                .controller
+                .compute
+                .cancel_peek(cluster_id, uuid, PeekResponse::Canceled);
+        }
+
         if let Some(uuids) = self.client_pending_peeks.remove(conn_id) {
             self.metrics
                 .canceled_peeks

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -959,6 +959,9 @@ impl crate::coord::Coordinator {
                 read_hold,
                 target_replica,
                 rows_tx,
+                // Classic coordinator-sequenced peek: the coordinator relies on
+                // the `PeekNotification` to retire its `pending_peeks` entry.
+                true,
             )
             .map_err(AdapterError::concurrent_dependency_drop_from_peek_error);
         if let Err(e) = peek_result {
@@ -1016,6 +1019,9 @@ impl crate::coord::Coordinator {
             persist_client,
             peek_stash_read_batch_size_bytes,
             peek_stash_read_memory_budget_bytes,
+            // Classic coordinator-sequenced peeks are tracked in `pending_peeks`,
+            // not the shared registry, so there is nothing to clean up here.
+            None,
         );
 
         Ok(crate::ExecuteResponse::SendingRowsStreaming {
@@ -1038,8 +1044,13 @@ impl crate::coord::Coordinator {
         mut persist_client: mz_persist_client::PersistClient,
         peek_stash_read_batch_size_bytes: usize,
         peek_stash_read_memory_budget_bytes: usize,
+        registration_guard: Option<crate::peek_registry::PeekRegistrationGuard>,
     ) -> impl futures::Stream<Item = PeekResponseUnary> {
         async_stream::stream!({
+            // Held for the stream's lifetime. On completion or drop it removes
+            // the peek's registry entry (frontend peeks only; `None` otherwise).
+            let _registration_guard = registration_guard;
+
             let result = rows_rx.await;
 
             let rows = match result {
@@ -1249,6 +1260,17 @@ impl crate::coord::Coordinator {
     /// Cancel and remove all pending peeks that were initiated by the client with `conn_id`.
     #[mz_ore::instrument(level = "debug")]
     pub(crate) fn cancel_pending_peeks(&mut self, conn_id: &ConnectionId) {
+        // Cancel fast-path peeks tracked in the shared registry, off-loaded from
+        // the coordinator's own `pending_peeks`. The session observes the
+        // `Canceled` response via its `rows_rx`, so no coordinator-side
+        // retirement is needed here.
+        for (uuid, cluster_id) in self.frontend_peek_registry.take_conn(conn_id) {
+            let _ = self
+                .controller
+                .compute
+                .cancel_peek(cluster_id, uuid, PeekResponse::Canceled);
+        }
+
         if let Some(uuids) = self.client_pending_peeks.remove(conn_id) {
             self.metrics
                 .canceled_peeks

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -1044,22 +1044,35 @@ impl crate::coord::Coordinator {
         mut persist_client: mz_persist_client::PersistClient,
         peek_stash_read_batch_size_bytes: usize,
         peek_stash_read_memory_budget_bytes: usize,
-        registration_guard: Option<crate::peek_registry::PeekRegistrationGuard>,
+        completion: Option<crate::peek_client::FrontendPeekCompletion>,
     ) -> impl futures::Stream<Item = PeekResponseUnary> {
         async_stream::stream!({
-            // Held for the stream's lifetime. On completion or drop it removes
-            // the peek's registry entry (frontend peeks only; `None` otherwise).
-            let _registration_guard = registration_guard;
+            // `Some` only for a frontend-sequenced peek, which settles its
+            // registry entry and its statement log here rather than through the
+            // coordinator. Dropping the stream before the peek responds drops
+            // this, which unregisters and logs the statement as aborted.
+            let mut completion = completion;
 
             let result = rows_rx.await;
 
             let rows = match result {
                 Ok(rows) => rows,
                 Err(e) => {
+                    if let Some(completion) = completion.take() {
+                        completion.retire_errored(e.to_string());
+                    }
                     yield PeekResponseUnary::Error(AdapterError::Unstructured(anyhow::anyhow!(e)));
                     return;
                 }
             };
+
+            // Retire against the raw response, before the finishing runs, so
+            // that both sequencing paths record the same numbers: this is the
+            // point at which the compute controller would emit the
+            // `PeekNotification` for a coordinator-sequenced peek.
+            if let Some(completion) = completion.take() {
+                completion.retire(&rows);
+            }
 
             match rows {
                 PeekResponse::Rows(rows) => {

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -54,6 +54,7 @@ pub mod config;
 pub mod flags;
 pub mod metrics;
 pub mod peek_client;
+pub mod peek_registry;
 pub mod session;
 pub mod statement_logging;
 pub mod telemetry;

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -55,6 +55,7 @@ pub mod config;
 pub mod flags;
 pub mod metrics;
 pub mod peek_client;
+pub mod peek_registry;
 pub mod session;
 pub mod statement_logging;
 pub mod telemetry;

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -38,6 +38,7 @@ use crate::catalog::Catalog;
 use crate::command::{CatalogSnapshot, Command};
 use crate::coord::peek::FastPathPlan;
 use crate::coord::{Coordinator, ExecuteContextGuard};
+use crate::peek_registry::{FrontendPeekRegistry, PeekRegistrationGuard, PendingPeekEntry};
 use crate::session::{LifecycleTimestamps, Session};
 use crate::statement_logging::{
     FrontendStatementLoggingEvent, PreparedStatementEvent, PreparedStatementLoggingInfo,
@@ -75,6 +76,10 @@ pub struct PeekClient {
     persist_client: PersistClient,
     /// Statement logging state for frontend peek sequencing.
     pub statement_logging_frontend: StatementLoggingFrontend,
+    /// Registry of in-flight frontend peeks, shared with the coordinator. Peeks
+    /// register/unregister here directly rather than through a coordinator
+    /// round-trip.
+    peek_registry: Arc<FrontendPeekRegistry>,
 }
 
 impl PeekClient {
@@ -90,6 +95,7 @@ impl PeekClient {
         optimizer_metrics: OptimizerMetrics,
         persist_client: PersistClient,
         statement_logging_frontend: StatementLoggingFrontend,
+        peek_registry: Arc<FrontendPeekRegistry>,
     ) -> Self {
         Self {
             coordinator_client,
@@ -101,6 +107,7 @@ impl PeekClient {
             statement_logging_frontend,
             oracles: Default::default(), // lazily populated
             persist_client,
+            peek_registry,
         }
     }
 
@@ -273,10 +280,10 @@ impl PeekClient {
     ///
     /// `logging_guard` owns end-of-execution logging for this statement. For a
     /// constant peek it stays armed and the caller logs the end from the
-    /// returned result. For a `PeekExisting`/`PeekPersist` peek, successful
-    /// registration with the coordinator hands ownership of the end to the
-    /// coordinator and the guard is defused here. That holds even when the
-    /// subsequent `client.peek()` fails to issue.
+    /// returned result. For a `PeekExisting`/`PeekPersist` peek the guard is
+    /// defused here once the peek is registered in the shared registry, since
+    /// end-of-execution logging is not owned by the frontend from that point.
+    /// That holds even when the subsequent `client.peek()` fails to issue.
     pub(crate) async fn implement_fast_path_peek_plan(
         &mut self,
         fast_path: FastPathPlan,
@@ -292,7 +299,10 @@ impl PeekClient {
         peek_stash_read_batch_size_bytes: usize,
         peek_stash_read_memory_budget_bytes: usize,
         conn_id: mz_adapter_types::connection::ConnectionId,
-        depends_on: std::collections::BTreeSet<mz_repr::GlobalId>,
+        // NOTE: Unused in the prototype. The coordinator used this for DROP
+        // CLUSTER teardown of registered peeks, which the shared registry does
+        // not yet implement.
+        _depends_on: std::collections::BTreeSet<mz_repr::GlobalId>,
         watch_set: Option<WatchSetCreation>,
         logging_guard: &mut StatementLoggingGuard,
     ) -> Result<crate::ExecuteResponse, AdapterError> {
@@ -411,26 +421,24 @@ impl PeekClient {
             .await
             .map_err(AdapterError::concurrent_dependency_drop_from_instance_missing)?;
 
-        // Register coordinator tracking of this peek. This has to complete before issuing the peek.
+        // Register the peek in the shared registry, off the coordinator task.
+        // This must happen strictly before the peek is issued so that a
+        // concurrent cancellation observes the entry.
         //
         // Warning: If we fail to actually issue the peek after this point, then we need to
-        // unregister it to avoid an orphaned registration.
-        self.call_coordinator(|tx| Command::RegisterFrontendPeek {
+        // remove the registration to avoid an orphaned entry.
+        self.peek_registry.register(
             uuid,
-            conn_id: conn_id.clone(),
-            cluster_id: compute_instance,
-            depends_on,
-            is_fast_path: true,
-            watch_set,
-            tx,
-        })
-        .await?;
+            PendingPeekEntry {
+                conn_id: conn_id.clone(),
+                cluster_id: compute_instance,
+            },
+        );
 
-        // The peek is registered: the coordinator's `pending_peeks` entry now
-        // owns end-of-execution logging. It logs the end on peek completion,
-        // cancellation, concurrent teardown (e.g. a DROP CLUSTER), or the
-        // unregistration below. We defuse the guard so the frontend doesn't
-        // also log the end.
+        // The peek's rows stream directly to the session and its registration is
+        // cleaned up off the coordinator task. Statement-logging end is not
+        // owned by the coordinator here, so we defuse the guard to avoid
+        // double-logging the end. For non-sampled statements this is a no-op.
         logging_guard.defuse();
 
         // Test-only synchronization point: parks a peek between registration
@@ -452,6 +460,10 @@ impl PeekClient {
                 target_read_hold,
                 target_replica,
                 rows_tx,
+                // Frontend-sequenced peek: rows stream directly to the session
+                // and the registry entry is cleaned up off the coordinator task,
+                // so no `PeekNotification` is wanted.
+                false,
             )
             .await;
 
@@ -460,22 +472,19 @@ impl PeekClient {
                 err,
                 compute_instance,
             );
-            // The peek failed to issue, so no peek response will ever arrive.
-            // The coordinator owns end-of-execution logging (see above), so we
-            // ask it to unregister the peek and retire it with this error. If
-            // a concurrent teardown already retired the peek, the end is
-            // already logged and the unregistration is a no-op.
-            self.call_coordinator(|tx| Command::UnregisterFrontendPeek {
-                uuid,
-                reason: statement_logging::StatementEndedExecutionReason::Errored {
-                    error: err.to_string(),
-                },
-                tx,
-            })
-            .await;
+            // The peek failed to issue, so no peek response will ever arrive and
+            // no response stream will be created to clean up the entry. Remove
+            // the registration here to avoid an orphan. Removal is idempotent,
+            // so a concurrent teardown that already removed it makes this a
+            // no-op.
+            let _ = self.peek_registry.remove(uuid);
             return Err(err);
         }
 
+        // Hand the registration to the response stream: it is removed when the
+        // stream completes or is dropped, keeping the registry bounded without
+        // any coordinator involvement.
+        let registration_guard = PeekRegistrationGuard::new(Arc::clone(&self.peek_registry), uuid);
         let peek_response_stream = Coordinator::create_peek_response_stream(
             rows_rx,
             finishing,
@@ -485,6 +494,7 @@ impl PeekClient {
             self.persist_client.clone(),
             peek_stash_read_batch_size_bytes,
             peek_stash_read_memory_budget_bytes,
+            Some(registration_guard),
         );
 
         Ok(crate::ExecuteResponse::SendingRowsStreaming {

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -386,10 +386,7 @@ impl PeekClient {
         peek_stash_read_batch_size_bytes: usize,
         peek_stash_read_memory_budget_bytes: usize,
         conn_id: mz_adapter_types::connection::ConnectionId,
-        // NOTE: Unused in the prototype. The coordinator used this for DROP
-        // CLUSTER teardown of registered peeks, which the shared registry does
-        // not yet implement.
-        _depends_on: std::collections::BTreeSet<mz_repr::GlobalId>,
+        depends_on: std::collections::BTreeSet<mz_repr::GlobalId>,
         watch_set: Option<WatchSetCreation>,
         logging: &mut ExecutionLogging,
     ) -> Result<crate::ExecuteResponse, AdapterError> {
@@ -524,6 +521,7 @@ impl PeekClient {
             PendingPeekEntry {
                 conn_id: conn_id.clone(),
                 cluster_id: compute_instance,
+                depends_on,
             },
         );
 

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -978,9 +978,8 @@ impl ExecutionLogging {
 /// entry goes away and the statement is logged as aborted.
 ///
 /// This is the frontend's counterpart to the coordinator's `pending_peeks`
-/// entry, which
-/// [`Coordinator::handle_peek_notification`](crate::coord::Coordinator::handle_peek_notification)
-/// retires for coordinator-sequenced peeks.
+/// entry, which `Coordinator::handle_peek_notification` retires for
+/// coordinator-sequenced peeks.
 pub(crate) struct FrontendPeekCompletion {
     /// Removes the registry entry on drop, so it is enough to hold this.
     _registration: PeekRegistrationGuard,

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -44,6 +44,7 @@ use crate::coord::appends::GroupCommitNotifier;
 use crate::coord::peek::FastPathPlan;
 use crate::coord::{Coordinator, ExecuteContextExtra, ExecuteContextGuard, Message};
 use crate::metrics::Metrics;
+use crate::peek_registry::{FrontendPeekRegistry, PeekRegistrationGuard, PendingPeekEntry};
 use crate::session::{LifecycleTimestamps, Session};
 use crate::statement_logging::{
     FrontendStatementLoggingEvent, PreparedStatementEvent, PreparedStatementLoggingInfo,
@@ -90,6 +91,10 @@ pub struct PeekClient {
     pub(crate) group_commit_notifier: GroupCommitNotifier,
     /// Whether the coordinator is in read-only mode. Mutations must be rejected.
     pub read_only: bool,
+    /// Registry of in-flight frontend peeks, shared with the coordinator. Peeks
+    /// register/unregister here directly rather than through a coordinator
+    /// round-trip.
+    peek_registry: Arc<FrontendPeekRegistry>,
 }
 
 /// A command sender that does not make background work keep the coordinator alive.
@@ -161,6 +166,7 @@ impl PeekClient {
         frontend_read_then_write_enabled: bool,
         group_commit_notifier: GroupCommitNotifier,
         read_only: bool,
+        peek_registry: Arc<FrontendPeekRegistry>,
     ) -> Self {
         Self {
             coordinator_client,
@@ -176,6 +182,7 @@ impl PeekClient {
             frontend_read_then_write_enabled,
             group_commit_notifier,
             read_only,
+            peek_registry,
         }
     }
 
@@ -357,10 +364,11 @@ impl PeekClient {
     /// into the Controller to acquire a hold on the peek target after we create the dataflow.
     ///
     /// For a constant peek the logging slot stays armed and the caller logs the
-    /// end from the returned result. For a `PeekExisting`/`PeekPersist` peek,
-    /// successful registration with the coordinator hands ownership of the end
-    /// to the coordinator and the slot is defused here. That holds even when the
-    /// subsequent `client.peek()` fails to issue.
+    /// end from the returned result. For a `PeekExisting`/`PeekPersist` peek the
+    /// slot is defused here once the peek is registered in the shared registry,
+    /// since end-of-execution logging is not owned by the frontend from that
+    /// point. That holds even when the subsequent `client.peek()` fails to
+    /// issue.
     pub(crate) async fn implement_fast_path_peek_plan(
         &mut self,
         fast_path: FastPathPlan,
@@ -376,7 +384,10 @@ impl PeekClient {
         peek_stash_read_batch_size_bytes: usize,
         peek_stash_read_memory_budget_bytes: usize,
         conn_id: mz_adapter_types::connection::ConnectionId,
-        depends_on: std::collections::BTreeSet<mz_repr::GlobalId>,
+        // NOTE: Unused in the prototype. The coordinator used this for DROP
+        // CLUSTER teardown of registered peeks, which the shared registry does
+        // not yet implement.
+        _depends_on: std::collections::BTreeSet<mz_repr::GlobalId>,
         watch_set: Option<WatchSetCreation>,
         logging: &mut ExecutionLogging,
     ) -> Result<crate::ExecuteResponse, AdapterError> {
@@ -500,26 +511,24 @@ impl PeekClient {
                 )
             })?;
 
-        // Register coordinator tracking of this peek. This has to complete before issuing the peek.
+        // Register the peek in the shared registry, off the coordinator task.
+        // This must happen strictly before the peek is issued so that a
+        // concurrent cancellation observes the entry.
         //
         // Warning: If we fail to actually issue the peek after this point, then we need to
-        // unregister it to avoid an orphaned registration.
-        self.call_coordinator(|tx| Command::RegisterFrontendPeek {
+        // remove the registration to avoid an orphaned entry.
+        self.peek_registry.register(
             uuid,
-            conn_id: conn_id.clone(),
-            cluster_id: compute_instance,
-            depends_on,
-            is_fast_path: true,
-            watch_set,
-            tx,
-        })
-        .await??;
+            PendingPeekEntry {
+                conn_id: conn_id.clone(),
+                cluster_id: compute_instance,
+            },
+        );
 
-        // The peek is registered: the coordinator's `pending_peeks` entry now
-        // owns end-of-execution logging. It logs the end on peek completion,
-        // cancellation, concurrent teardown (e.g. a DROP CLUSTER), or the
-        // unregistration below. We defuse the guard so the frontend doesn't
-        // also log the end.
+        // The peek's rows stream directly to the session and its registration is
+        // cleaned up off the coordinator task. Statement-logging end is not
+        // owned by the coordinator here, so we defuse the slot to avoid
+        // double-logging the end. For non-sampled statements this is a no-op.
         logging.defuse();
 
         // Test-only synchronization point: parks a peek between registration
@@ -541,6 +550,10 @@ impl PeekClient {
                 target_read_hold,
                 target_replica,
                 rows_tx,
+                // Frontend-sequenced peek: rows stream directly to the session
+                // and the registry entry is cleaned up off the coordinator task,
+                // so no `PeekNotification` is wanted.
+                false,
             )
             .await;
 
@@ -549,23 +562,19 @@ impl PeekClient {
                 err,
                 compute_instance,
             );
-            // The peek failed to issue, so no peek response will ever arrive.
-            // The coordinator owns end-of-execution logging (see above), so we
-            // ask it to unregister the peek and retire it with this error. If
-            // a concurrent teardown already retired the peek, the end is
-            // already logged and the unregistration is a no-op.
-            let _ = self
-                .call_coordinator(|tx| Command::UnregisterFrontendPeek {
-                    uuid,
-                    reason: statement_logging::StatementEndedExecutionReason::Errored {
-                        error: err.to_string(),
-                    },
-                    tx,
-                })
-                .await;
+            // The peek failed to issue, so no peek response will ever arrive and
+            // no response stream will be created to clean up the entry. Remove
+            // the registration here to avoid an orphan. Removal is idempotent,
+            // so a concurrent teardown that already removed it makes this a
+            // no-op.
+            let _ = self.peek_registry.remove(uuid);
             return Err(err);
         }
 
+        // Hand the registration to the response stream: it is removed when the
+        // stream completes or is dropped, keeping the registry bounded without
+        // any coordinator involvement.
+        let registration_guard = PeekRegistrationGuard::new(Arc::clone(&self.peek_registry), uuid);
         let peek_response_stream = Coordinator::create_peek_response_stream(
             rows_rx,
             finishing,
@@ -575,6 +584,7 @@ impl PeekClient {
             self.persist_client.clone(),
             peek_stash_read_batch_size_bytes,
             peek_stash_read_memory_budget_bytes,
+            Some(registration_guard),
         );
 
         Ok(crate::ExecuteResponse::SendingRowsStreaming {

--- a/src/adapter/src/peek_client.rs
+++ b/src/adapter/src/peek_client.rs
@@ -11,10 +11,12 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Weak};
 
 use differential_dataflow::consolidation::consolidate;
+use mz_compute_client::controller::PeekNotification;
 use mz_compute_client::controller::error::{CollectionMissing, InstanceMissing};
 use mz_compute_client::controller::instance_client::InstanceClient;
 use mz_compute_client::controller::instance_client::{AcquireReadHoldsError, InstanceShutDown};
 use mz_compute_client::protocol::command::PeekTarget;
+use mz_compute_client::protocol::response::PeekResponse;
 use mz_compute_types::ComputeInstanceId;
 use mz_expr::row::RowCollection;
 use mz_ore::cast::CastFrom;
@@ -48,7 +50,7 @@ use crate::peek_registry::{FrontendPeekRegistry, PeekRegistrationGuard, PendingP
 use crate::session::{LifecycleTimestamps, Session};
 use crate::statement_logging::{
     FrontendStatementLoggingEvent, PreparedStatementEvent, PreparedStatementLoggingInfo,
-    StatementLoggingFrontend, StatementLoggingId, WatchSetCreation,
+    StatementEndedExecutionReason, StatementLoggingFrontend, StatementLoggingId, WatchSetCreation,
 };
 use crate::{AdapterError, Client, CollectionIdBundle, ReadHolds, metrics, statement_logging};
 
@@ -365,10 +367,10 @@ impl PeekClient {
     ///
     /// For a constant peek the logging slot stays armed and the caller logs the
     /// end from the returned result. For a `PeekExisting`/`PeekPersist` peek the
-    /// slot is defused here once the peek is registered in the shared registry,
-    /// since end-of-execution logging is not owned by the frontend from that
-    /// point. That holds even when the subsequent `client.peek()` fails to
-    /// issue.
+    /// obligation moves out of the slot and into the returned response stream,
+    /// which retires it with the peek's outcome. A `client.peek()` that fails to
+    /// issue retires it here instead, so the slot is empty on every path that
+    /// reaches the peek.
     pub(crate) async fn implement_fast_path_peek_plan(
         &mut self,
         fast_path: FastPathPlan,
@@ -525,11 +527,22 @@ impl PeekClient {
             },
         );
 
-        // The peek's rows stream directly to the session and its registration is
-        // cleaned up off the coordinator task. Statement-logging end is not
-        // owned by the coordinator here, so we defuse the slot to avoid
-        // double-logging the end. For non-sampled statements this is a no-op.
-        logging.defuse();
+        // Statement lifecycle logging needs watch sets, which live on the
+        // coordinator's controller. Send without waiting: the peek is issued
+        // below regardless, and `Command::InstallPeekWatchSets` documents what
+        // that ordering gives up. `watch_set` is `Some` only for a sampled
+        // statement, so an unsampled peek sends nothing.
+        if let Some(watch_set) = watch_set {
+            self.coordinator_client.send(Command::InstallPeekWatchSets {
+                conn_id: conn_id.clone(),
+                watch_set,
+            });
+        }
+
+        // Take the end-of-execution obligation out of the session task's slot:
+        // the response stream outlives this call and retires it with the peek's
+        // outcome. For an unsampled statement this yields an inert guard.
+        let logging_guard = logging.take_guard();
 
         // Test-only synchronization point: parks a peek between registration
         // and issue, so a test can land a concurrent DROP CLUSTER in this
@@ -568,13 +581,27 @@ impl PeekClient {
             // so a concurrent teardown that already removed it makes this a
             // no-op.
             let _ = self.peek_registry.remove(uuid);
+            // Nothing downstream owns the end of execution now, so log it here.
+            if let Some(guard) = logging_guard {
+                guard.retire(StatementEndedExecutionReason::Errored {
+                    error: err.to_string(),
+                });
+            }
             return Err(err);
         }
 
-        // Hand the registration to the response stream: it is removed when the
-        // stream completes or is dropped, keeping the registry bounded without
-        // any coordinator involvement.
+        // Hand the registration and the end-of-execution obligation to the
+        // response stream: both are settled when the peek responds, and dropped
+        // with the stream if the client goes away first. No coordinator
+        // involvement either way.
         let registration_guard = PeekRegistrationGuard::new(Arc::clone(&self.peek_registry), uuid);
+        let completion = FrontendPeekCompletion::new(
+            registration_guard,
+            logging_guard,
+            strategy,
+            finishing.offset,
+            finishing.limit.map(usize::cast_from),
+        );
         let peek_response_stream = Coordinator::create_peek_response_stream(
             rows_rx,
             finishing,
@@ -584,7 +611,7 @@ impl PeekClient {
             self.persist_client.clone(),
             peek_stash_read_batch_size_bytes,
             peek_stash_read_memory_budget_bytes,
-            Some(registration_guard),
+            Some(completion),
         );
 
         Ok(crate::ExecuteResponse::SendingRowsStreaming {
@@ -927,6 +954,92 @@ impl ExecutionLogging {
     pub(crate) fn defuse(&mut self) {
         if let Some(guard) = self.guard.as_mut() {
             guard.defuse();
+        }
+    }
+
+    /// Moves the obligation out of the slot so a longer-lived owner on the
+    /// session task can retire it, emptying the slot.
+    ///
+    /// Unlike [`Self::release`] the obligation stays on the session side, so
+    /// the new owner must retire it or drop it, exactly as this slot would.
+    #[must_use]
+    fn take_guard(&mut self) -> Option<StatementLoggingGuard> {
+        self.guard.take()
+    }
+}
+
+/// Owns the cleanup a frontend fast-path peek still owes once it has been
+/// issued: its entry in the [`FrontendPeekRegistry`] and the end of its
+/// statement-logging execution.
+///
+/// The peek's response stream holds this until the peek responds, then retires
+/// it with the outcome. Dropping the stream first, on client disconnect or a
+/// cancellation that tears the session down, drops this instead: the registry
+/// entry goes away and the statement is logged as aborted.
+///
+/// This is the frontend's counterpart to the coordinator's `pending_peeks`
+/// entry, which
+/// [`Coordinator::handle_peek_notification`](crate::coord::Coordinator::handle_peek_notification)
+/// retires for coordinator-sequenced peeks.
+pub(crate) struct FrontendPeekCompletion {
+    /// Removes the registry entry on drop, so it is enough to hold this.
+    _registration: PeekRegistrationGuard,
+    /// `None` when the session task never held an end-of-execution obligation
+    /// for this statement. The registration still has to be held, so the
+    /// completion exists either way.
+    logging: Option<StatementLoggingGuard>,
+    strategy: statement_logging::StatementExecutionStrategy,
+    /// The peek's finishing offset and limit, needed to turn a raw
+    /// [`PeekResponse`] into the row count the statement log records.
+    offset: usize,
+    limit: Option<usize>,
+}
+
+impl FrontendPeekCompletion {
+    fn new(
+        registration: PeekRegistrationGuard,
+        logging: Option<StatementLoggingGuard>,
+        strategy: statement_logging::StatementExecutionStrategy,
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Self {
+        Self {
+            _registration: registration,
+            logging,
+            strategy,
+            offset,
+            limit,
+        }
+    }
+
+    /// Retires the peek with the outcome carried by `response`.
+    ///
+    /// The row count and result size are derived exactly as the compute
+    /// controller derives them for a `PeekNotification`, so both sequencing
+    /// paths record the same `mz_statement_execution_history` columns.
+    pub(crate) fn retire(self, response: &PeekResponse) {
+        let Some(logging) = self.logging else {
+            return;
+        };
+        let reason = match PeekNotification::new(response, self.offset, self.limit) {
+            PeekNotification::Success { rows, result_size } => {
+                StatementEndedExecutionReason::Success {
+                    result_size: Some(result_size),
+                    rows_returned: Some(rows),
+                    execution_strategy: Some(self.strategy),
+                }
+            }
+            PeekNotification::Error(error) => StatementEndedExecutionReason::Errored { error },
+            PeekNotification::Canceled => StatementEndedExecutionReason::Canceled,
+        };
+        logging.retire(reason);
+    }
+
+    /// Retires the peek as errored, for a failure that produced no
+    /// [`PeekResponse`] at all.
+    pub(crate) fn retire_errored(self, error: String) {
+        if let Some(logging) = self.logging {
+            logging.retire(StatementEndedExecutionReason::Errored { error });
         }
     }
 }

--- a/src/adapter/src/peek_registry.rs
+++ b/src/adapter/src/peek_registry.rs
@@ -1,0 +1,154 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A sharded registry of in-flight frontend-sequenced peeks, shared between the
+//! coordinator and the session-side [`PeekClient`](crate::peek_client::PeekClient)s
+//! via an `Arc`.
+//!
+//! Frontend peeks register and unregister themselves here directly, off the
+//! single coordinator task, so that the peek hot path never blocks on a
+//! coordinator round-trip. The coordinator only consults the registry when it
+//! must cancel a connection's peeks (see
+//! [`Coordinator::cancel_pending_peeks`](crate::coord::Coordinator::cancel_pending_peeks)).
+//!
+//! The registry tracks the minimum state cancellation needs: for a connection,
+//! the set of peek uuids it owns, and for each uuid the cluster it runs on.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Mutex;
+
+use mz_adapter_types::connection::ConnectionId;
+use mz_controller_types::ClusterId;
+use uuid::Uuid;
+
+/// State tracked per in-flight frontend peek.
+///
+/// This is the minimum cancellation needs: `conn -> uuid -> cluster`.
+#[derive(Debug, Clone)]
+pub struct PendingPeekEntry {
+    pub conn_id: ConnectionId,
+    pub cluster_id: ClusterId,
+}
+
+/// A sharded, lock-per-shard registry of in-flight frontend peeks.
+///
+/// The per-uuid shards carry the hot-path inserts and removes. `by_conn` is a
+/// secondary index consulted only by cancellation, which is cold.
+#[derive(Debug)]
+pub struct FrontendPeekRegistry {
+    /// Per-uuid entries, sharded to spread lock contention across concurrent
+    /// sessions. A uuid always maps to the same shard via [`Self::shard_of`].
+    shards: Box<[Mutex<BTreeMap<Uuid, PendingPeekEntry>>]>,
+    /// Secondary index from connection to its outstanding peek uuids. Used by
+    /// cancellation to find a connection's peeks without scanning every shard.
+    by_conn: Mutex<BTreeMap<ConnectionId, BTreeSet<Uuid>>>,
+}
+
+impl FrontendPeekRegistry {
+    /// Creates a registry with `shards` per-uuid shards. `shards` must be
+    /// non-zero.
+    pub fn new(shards: usize) -> Self {
+        assert!(shards > 0, "registry needs at least one shard");
+        let shards = (0..shards)
+            .map(|_| Mutex::new(BTreeMap::new()))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            shards,
+            by_conn: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Returns the shard index for `uuid`. v4 uuids are uniformly random, so the
+    /// first byte spreads uuids evenly across shards.
+    fn shard_of(&self, uuid: &Uuid) -> usize {
+        usize::from(uuid.as_bytes()[0]) % self.shards.len()
+    }
+
+    /// Registers an in-flight peek.
+    ///
+    /// Must complete before the peek is issued so that a concurrent
+    /// cancellation observes the entry.
+    pub fn register(&self, uuid: Uuid, entry: PendingPeekEntry) {
+        let conn_id = entry.conn_id.clone();
+        {
+            let mut shard = self.shards[self.shard_of(&uuid)]
+                .lock()
+                .expect("lock poisoned");
+            shard.insert(uuid, entry);
+        }
+        let mut by_conn = self.by_conn.lock().expect("lock poisoned");
+        by_conn.entry(conn_id).or_default().insert(uuid);
+    }
+
+    /// Removes an in-flight peek, returning its entry if it was present.
+    ///
+    /// Also drops the uuid from the connection's secondary index.
+    pub fn remove(&self, uuid: Uuid) -> Option<PendingPeekEntry> {
+        let entry = {
+            let mut shard = self.shards[self.shard_of(&uuid)]
+                .lock()
+                .expect("lock poisoned");
+            shard.remove(&uuid)
+        };
+        if let Some(entry) = &entry {
+            let mut by_conn = self.by_conn.lock().expect("lock poisoned");
+            if let Some(uuids) = by_conn.get_mut(&entry.conn_id) {
+                uuids.remove(&uuid);
+                if uuids.is_empty() {
+                    by_conn.remove(&entry.conn_id);
+                }
+            }
+        }
+        entry
+    }
+
+    /// Drains and returns all in-flight peeks for `conn_id`, removing them from
+    /// both the secondary index and the shards.
+    pub fn take_conn(&self, conn_id: &ConnectionId) -> Vec<(Uuid, ClusterId)> {
+        let uuids = {
+            let mut by_conn = self.by_conn.lock().expect("lock poisoned");
+            by_conn.remove(conn_id).unwrap_or_default()
+        };
+        let mut result = Vec::with_capacity(uuids.len());
+        for uuid in uuids {
+            let mut shard = self.shards[self.shard_of(&uuid)]
+                .lock()
+                .expect("lock poisoned");
+            if let Some(entry) = shard.remove(&uuid) {
+                result.push((uuid, entry.cluster_id));
+            }
+        }
+        result
+    }
+}
+
+/// RAII owner that removes a peek's registration when dropped.
+///
+/// Moved into the peek response stream so the registry entry is cleaned up when
+/// the stream completes or is dropped, keeping the registry bounded. Removal is
+/// idempotent, so a prior explicit [`FrontendPeekRegistry::remove`] or
+/// [`FrontendPeekRegistry::take_conn`] makes the drop a no-op.
+#[derive(Debug)]
+pub struct PeekRegistrationGuard {
+    registry: std::sync::Arc<FrontendPeekRegistry>,
+    uuid: Uuid,
+}
+
+impl PeekRegistrationGuard {
+    pub fn new(registry: std::sync::Arc<FrontendPeekRegistry>, uuid: Uuid) -> Self {
+        Self { registry, uuid }
+    }
+}
+
+impl Drop for PeekRegistrationGuard {
+    fn drop(&mut self) {
+        let _ = self.registry.remove(self.uuid);
+    }
+}

--- a/src/adapter/src/peek_registry.rs
+++ b/src/adapter/src/peek_registry.rs
@@ -16,23 +16,36 @@
 //! coordinator round-trip. The coordinator only consults the registry when it
 //! must cancel a connection's peeks, in `Coordinator::cancel_pending_peeks`.
 //!
-//! The registry tracks the minimum state cancellation needs: for a connection,
-//! the set of peek uuids it owns, and for each uuid the cluster it runs on.
+//! The registry tracks what the two teardown paths need: the connection that
+//! owns a peek, the cluster it runs on, and the collections it reads.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Mutex;
 
 use mz_adapter_types::connection::ConnectionId;
 use mz_controller_types::ClusterId;
+use mz_repr::GlobalId;
 use uuid::Uuid;
 
 /// State tracked per in-flight frontend peek.
-///
-/// This is the minimum cancellation needs: `conn -> uuid -> cluster`.
 #[derive(Debug, Clone)]
 pub struct PendingPeekEntry {
     pub conn_id: ConnectionId,
     pub cluster_id: ClusterId,
+    /// Every `GlobalId` the peek reads. Dependency teardown matches against
+    /// this to decide whether a dropped collection kills the peek.
+    pub depends_on: BTreeSet<GlobalId>,
+}
+
+/// A registry peek that a catalog drop has invalidated.
+#[derive(Debug)]
+pub struct DroppedPeek {
+    pub uuid: Uuid,
+    pub cluster_id: ClusterId,
+    /// The dropped collection the peek reads, or `None` when the peek matched
+    /// because its cluster is going away. The caller turns this into the
+    /// user-facing dependency name.
+    pub dropped_collection: Option<GlobalId>,
 }
 
 /// A sharded, lock-per-shard registry of in-flight frontend peeks.
@@ -125,6 +138,44 @@ impl FrontendPeekRegistry {
             }
         }
         result
+    }
+
+    /// Returns the in-flight peeks invalidated by dropping `collections` and
+    /// `clusters`, without removing them.
+    ///
+    /// A dropped collection takes precedence over a dropped cluster, matching
+    /// how the coordinator reports the dependency for its own pending peeks:
+    /// naming the relation is more useful than naming the cluster when both
+    /// went away in the same DDL.
+    ///
+    /// Finding and removing are separate because the caller cancels each peek
+    /// on the compute instance, and only a peek it actually removed may be
+    /// cancelled. A concurrent completion can remove an entry in between, and
+    /// [`Self::remove`] returning `None` is what tells the caller to skip it.
+    ///
+    /// This scans every shard, which is fine: it runs on catalog DDL, not on
+    /// the peek hot path.
+    pub fn find_dropped(
+        &self,
+        collections: &BTreeSet<GlobalId>,
+        clusters: &[ClusterId],
+    ) -> Vec<DroppedPeek> {
+        let mut dropped = Vec::new();
+        for shard in &self.shards {
+            let shard = shard.lock().expect("lock poisoned");
+            for (uuid, entry) in shard.iter() {
+                let dropped_collection = entry.depends_on.intersection(collections).next().copied();
+                if dropped_collection.is_none() && !clusters.contains(&entry.cluster_id) {
+                    continue;
+                }
+                dropped.push(DroppedPeek {
+                    uuid: *uuid,
+                    cluster_id: entry.cluster_id,
+                    dropped_collection,
+                });
+            }
+        }
+        dropped
     }
 }
 

--- a/src/adapter/src/peek_registry.rs
+++ b/src/adapter/src/peek_registry.rs
@@ -13,14 +13,14 @@
 //!
 //! Frontend peeks register and unregister themselves here directly, off the
 //! single coordinator task, so that the peek hot path never blocks on a
-//! coordinator round-trip. The coordinator only consults the registry when it
-//! must cancel a connection's peeks, in `Coordinator::cancel_pending_peeks`.
-//!
-//! The registry tracks what the two teardown paths need: the connection that
-//! owns a peek, the cluster it runs on, and the collections it reads.
+//! coordinator round-trip. The coordinator reads the registry from its two
+//! teardown paths: `Coordinator::cancel_pending_peeks` for a connection's
+//! peeks, and `catalog_implications` for peeks whose dependencies were
+//! dropped. Each entry therefore records the owning connection, the cluster,
+//! and the collections the peek reads.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use mz_adapter_types::connection::ConnectionId;
 use mz_controller_types::ClusterId;
@@ -29,23 +29,23 @@ use uuid::Uuid;
 
 /// State tracked per in-flight frontend peek.
 #[derive(Debug, Clone)]
-pub struct PendingPeekEntry {
-    pub conn_id: ConnectionId,
-    pub cluster_id: ClusterId,
+pub(crate) struct PendingPeekEntry {
+    pub(crate) conn_id: ConnectionId,
+    pub(crate) cluster_id: ClusterId,
     /// Every `GlobalId` the peek reads. Dependency teardown matches against
     /// this to decide whether a dropped collection kills the peek.
-    pub depends_on: BTreeSet<GlobalId>,
+    pub(crate) depends_on: BTreeSet<GlobalId>,
 }
 
 /// A registry peek that a catalog drop has invalidated.
 #[derive(Debug)]
-pub struct DroppedPeek {
-    pub uuid: Uuid,
-    pub cluster_id: ClusterId,
+pub(crate) struct DroppedPeek {
+    pub(crate) uuid: Uuid,
+    pub(crate) cluster_id: ClusterId,
     /// The dropped collection the peek reads, or `None` when the peek matched
     /// because its cluster is going away. The caller turns this into the
     /// user-facing dependency name.
-    pub dropped_collection: Option<GlobalId>,
+    pub(crate) dropped_collection: Option<GlobalId>,
 }
 
 /// A sharded, lock-per-shard registry of in-flight frontend peeks.
@@ -53,19 +53,24 @@ pub struct DroppedPeek {
 /// The per-uuid shards carry the hot-path inserts and removes. `by_conn` is a
 /// secondary index consulted only by cancellation, which is cold.
 #[derive(Debug)]
-pub struct FrontendPeekRegistry {
+pub(crate) struct FrontendPeekRegistry {
     /// Per-uuid entries, sharded to spread lock contention across concurrent
     /// sessions. A uuid always maps to the same shard via [`Self::shard_of`].
     shards: Box<[Mutex<BTreeMap<Uuid, PendingPeekEntry>>]>,
-    /// Secondary index from connection to its outstanding peek uuids. Used by
-    /// cancellation to find a connection's peeks without scanning every shard.
+    /// Secondary index from connection to its outstanding peek uuids, so that
+    /// cancellation need not scan every shard.
+    ///
+    /// Written on every register and every remove, so it is on the peek hot
+    /// path despite the sharding. It is also the OUTER lock: every method that
+    /// takes both takes this one first, which is what makes a registration
+    /// atomic against a concurrent [`Self::take_conn`].
     by_conn: Mutex<BTreeMap<ConnectionId, BTreeSet<Uuid>>>,
 }
 
 impl FrontendPeekRegistry {
     /// Creates a registry with `shards` per-uuid shards. `shards` must be
     /// non-zero.
-    pub fn new(shards: usize) -> Self {
+    pub(crate) fn new(shards: usize) -> Self {
         assert!(shards > 0, "registry needs at least one shard");
         let shards = (0..shards)
             .map(|_| Mutex::new(BTreeMap::new()))
@@ -87,30 +92,30 @@ impl FrontendPeekRegistry {
     ///
     /// Must complete before the peek is issued so that a concurrent
     /// cancellation observes the entry.
-    pub fn register(&self, uuid: Uuid, entry: PendingPeekEntry) {
+    pub(crate) fn register(&self, uuid: Uuid, entry: PendingPeekEntry) {
         let conn_id = entry.conn_id.clone();
-        {
-            let mut shard = self.shards[self.shard_of(&uuid)]
-                .lock()
-                .expect("lock poisoned");
-            shard.insert(uuid, entry);
-        }
+        // Both maps are updated under `by_conn`. Publishing the shard entry
+        // first and taking `by_conn` afterwards would let a `take_conn`
+        // in between drain the connection and still miss this peek, leaving it
+        // live and uncancellable.
         let mut by_conn = self.by_conn.lock().expect("lock poisoned");
+        self.shards[self.shard_of(&uuid)]
+            .lock()
+            .expect("lock poisoned")
+            .insert(uuid, entry);
         by_conn.entry(conn_id).or_default().insert(uuid);
     }
 
     /// Removes an in-flight peek, returning its entry if it was present.
     ///
     /// Also drops the uuid from the connection's secondary index.
-    pub fn remove(&self, uuid: Uuid) -> Option<PendingPeekEntry> {
-        let entry = {
-            let mut shard = self.shards[self.shard_of(&uuid)]
-                .lock()
-                .expect("lock poisoned");
-            shard.remove(&uuid)
-        };
+    pub(crate) fn remove(&self, uuid: Uuid) -> Option<PendingPeekEntry> {
+        let mut by_conn = self.by_conn.lock().expect("lock poisoned");
+        let entry = self.shards[self.shard_of(&uuid)]
+            .lock()
+            .expect("lock poisoned")
+            .remove(&uuid);
         if let Some(entry) = &entry {
-            let mut by_conn = self.by_conn.lock().expect("lock poisoned");
             if let Some(uuids) = by_conn.get_mut(&entry.conn_id) {
                 uuids.remove(&uuid);
                 if uuids.is_empty() {
@@ -123,11 +128,9 @@ impl FrontendPeekRegistry {
 
     /// Drains and returns all in-flight peeks for `conn_id`, removing them from
     /// both the secondary index and the shards.
-    pub fn take_conn(&self, conn_id: &ConnectionId) -> Vec<(Uuid, ClusterId)> {
-        let uuids = {
-            let mut by_conn = self.by_conn.lock().expect("lock poisoned");
-            by_conn.remove(conn_id).unwrap_or_default()
-        };
+    pub(crate) fn take_conn(&self, conn_id: &ConnectionId) -> Vec<(Uuid, ClusterId)> {
+        let mut by_conn = self.by_conn.lock().expect("lock poisoned");
+        let uuids = by_conn.remove(conn_id).unwrap_or_default();
         let mut result = Vec::with_capacity(uuids.len());
         for uuid in uuids {
             let mut shard = self.shards[self.shard_of(&uuid)]
@@ -154,8 +157,9 @@ impl FrontendPeekRegistry {
     /// [`Self::remove`] returning `None` is what tells the caller to skip it.
     ///
     /// This scans every shard, which is fine: it runs on catalog DDL, not on
-    /// the peek hot path.
-    pub fn find_dropped(
+    /// the peek hot path. It takes no `by_conn` lock, so it cannot invert the
+    /// order the other methods establish.
+    pub(crate) fn find_dropped(
         &self,
         collections: &BTreeSet<GlobalId>,
         clusters: &[ClusterId],
@@ -186,13 +190,13 @@ impl FrontendPeekRegistry {
 /// idempotent, so a prior explicit [`FrontendPeekRegistry::remove`] or
 /// [`FrontendPeekRegistry::take_conn`] makes the drop a no-op.
 #[derive(Debug)]
-pub struct PeekRegistrationGuard {
-    registry: std::sync::Arc<FrontendPeekRegistry>,
+pub(crate) struct PeekRegistrationGuard {
+    registry: Arc<FrontendPeekRegistry>,
     uuid: Uuid,
 }
 
 impl PeekRegistrationGuard {
-    pub fn new(registry: std::sync::Arc<FrontendPeekRegistry>, uuid: Uuid) -> Self {
+    pub(crate) fn new(registry: Arc<FrontendPeekRegistry>, uuid: Uuid) -> Self {
         Self { registry, uuid }
     }
 }

--- a/src/adapter/src/peek_registry.rs
+++ b/src/adapter/src/peek_registry.rs
@@ -14,8 +14,7 @@
 //! Frontend peeks register and unregister themselves here directly, off the
 //! single coordinator task, so that the peek hot path never blocks on a
 //! coordinator round-trip. The coordinator only consults the registry when it
-//! must cancel a connection's peeks (see
-//! [`Coordinator::cancel_pending_peeks`](crate::coord::Coordinator::cancel_pending_peeks)).
+//! must cancel a connection's peeks, in `Coordinator::cancel_pending_peeks`.
 //!
 //! The registry tracks the minimum state cancellation needs: for a connection,
 //! the set of peek uuids it owns, and for each uuid the cluster it runs on.

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -903,6 +903,7 @@ impl ComputeController {
         read_hold: ReadHold,
         target_replica: Option<ReplicaId>,
         peek_response_tx: oneshot::Sender<PeekResponse>,
+        notify_coordinator: bool,
     ) -> Result<(), PeekError> {
         use PeekError::*;
 
@@ -936,6 +937,7 @@ impl ComputeController {
                 read_hold,
                 target_replica,
                 peek_response_tx,
+                notify_coordinator,
             )
             .expect("validated")
         });

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -981,6 +981,7 @@ impl ComputeController {
         read_hold: ReadHold,
         target_replica: Option<ReplicaId>,
         peek_response_tx: oneshot::Sender<PeekResponse>,
+        notify_coordinator: bool,
     ) -> Result<(), PeekError> {
         use PeekError::*;
 
@@ -1014,6 +1015,7 @@ impl ComputeController {
                 read_hold,
                 target_replica,
                 peek_response_tx,
+                notify_coordinator,
             )
             .expect("validated")
         });

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -144,7 +144,7 @@ pub enum PeekNotification {
 impl PeekNotification {
     /// Construct a new [`PeekNotification`] from a [`PeekResponse`]. The `offset` and `limit`
     /// parameters are used to calculate the number of rows in the peek result.
-    fn new(peek_response: &PeekResponse, offset: usize, limit: Option<usize>) -> Self {
+    pub fn new(peek_response: &PeekResponse, offset: usize, limit: Option<usize>) -> Self {
         match peek_response {
             PeekResponse::Rows(rows) => {
                 let num_rows = u64::cast_from(RowCollection::offset_limit(

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1745,6 +1745,7 @@ impl Instance {
         mut read_hold: ReadHold,
         target_replica: Option<ReplicaId>,
         peek_response_tx: oneshot::Sender<PeekResponse>,
+        notify_coordinator: bool,
     ) -> Result<(), PeekError> {
         use PeekError::*;
 
@@ -1777,6 +1778,7 @@ impl Instance {
                 peek_response_tx,
                 limit: finishing.limit.map(usize::cast_from),
                 offset: finishing.offset,
+                notify_coordinator,
             },
         );
 
@@ -1809,15 +1811,19 @@ impl Instance {
         self.metrics
             .observe_peek_response(&PeekResponse::Canceled, duration);
 
-        // Enqueue a notification for the cancellation.
-        let otel_ctx = peek.otel_ctx.clone();
-        otel_ctx.attach_as_parent();
+        // Enqueue a notification for the cancellation. Frontend-sequenced peeks
+        // opt out: they observe the cancellation via their response channel and
+        // do not want the coordinator woken.
+        if peek.notify_coordinator {
+            let otel_ctx = peek.otel_ctx.clone();
+            otel_ctx.attach_as_parent();
 
-        self.deliver_response(ComputeControllerResponse::PeekNotification(
-            uuid,
-            PeekNotification::Canceled,
-            otel_ctx,
-        ));
+            self.deliver_response(ComputeControllerResponse::PeekNotification(
+                uuid,
+                PeekNotification::Canceled,
+                otel_ctx,
+            ));
+        }
 
         // Finish the peek.
         // This will also propagate the cancellation to the replicas.
@@ -2104,14 +2110,18 @@ impl Instance {
         let duration = peek.requested_at.elapsed();
         self.metrics.observe_peek_response(&response, duration);
 
-        let notification = PeekNotification::new(&response, peek.offset, peek.limit);
-        // NOTE: We use the `otel_ctx` from the response, not the pending peek, because we
-        // currently want the parent to be whatever the compute worker did with this peek.
-        self.deliver_response(ComputeControllerResponse::PeekNotification(
-            uuid,
-            notification,
-            otel_ctx,
-        ));
+        // Frontend-sequenced peeks stream their rows directly to the session and
+        // track completion off the coordinator task, so skip the notification.
+        if peek.notify_coordinator {
+            let notification = PeekNotification::new(&response, peek.offset, peek.limit);
+            // NOTE: We use the `otel_ctx` from the response, not the pending peek, because we
+            // currently want the parent to be whatever the compute worker did with this peek.
+            self.deliver_response(ComputeControllerResponse::PeekNotification(
+                uuid,
+                notification,
+                otel_ctx,
+            ));
+        }
 
         self.finish_peek(uuid, response)
     }
@@ -3061,6 +3071,14 @@ struct PendingPeek {
     limit: Option<usize>,
     /// The offset into the peek's result.
     offset: usize,
+    /// Whether to emit a `PeekNotification` to the controller response channel
+    /// on completion or cancellation.
+    ///
+    /// Classic coordinator-sequenced peeks set this so the coordinator can
+    /// retire their `pending_peeks` entry. Frontend-sequenced peeks stream rows
+    /// directly to the session and track themselves off the coordinator task, so
+    /// they set this `false` to keep the response side off the coordinator too.
+    notify_coordinator: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1763,6 +1763,7 @@ impl Instance {
         mut read_hold: ReadHold,
         target_replica: Option<ReplicaId>,
         peek_response_tx: oneshot::Sender<PeekResponse>,
+        notify_coordinator: bool,
     ) -> Result<(), PeekError> {
         use PeekError::*;
 
@@ -1795,6 +1796,7 @@ impl Instance {
                 peek_response_tx,
                 limit: finishing.limit.map(usize::cast_from),
                 offset: finishing.offset,
+                notify_coordinator,
             },
         );
 
@@ -1827,15 +1829,19 @@ impl Instance {
         self.metrics
             .observe_peek_response(&PeekResponse::Canceled, duration);
 
-        // Enqueue a notification for the cancellation.
-        let otel_ctx = peek.otel_ctx.clone();
-        otel_ctx.attach_as_parent();
+        // Enqueue a notification for the cancellation. Frontend-sequenced peeks
+        // opt out: they observe the cancellation via their response channel and
+        // do not want the coordinator woken.
+        if peek.notify_coordinator {
+            let otel_ctx = peek.otel_ctx.clone();
+            otel_ctx.attach_as_parent();
 
-        self.deliver_response(ComputeControllerResponse::PeekNotification(
-            uuid,
-            PeekNotification::Canceled,
-            otel_ctx,
-        ));
+            self.deliver_response(ComputeControllerResponse::PeekNotification(
+                uuid,
+                PeekNotification::Canceled,
+                otel_ctx,
+            ));
+        }
 
         // Finish the peek.
         // This will also propagate the cancellation to the replicas.
@@ -2122,14 +2128,18 @@ impl Instance {
         let duration = peek.requested_at.elapsed();
         self.metrics.observe_peek_response(&response, duration);
 
-        let notification = PeekNotification::new(&response, peek.offset, peek.limit);
-        // NOTE: We use the `otel_ctx` from the response, not the pending peek, because we
-        // currently want the parent to be whatever the compute worker did with this peek.
-        self.deliver_response(ComputeControllerResponse::PeekNotification(
-            uuid,
-            notification,
-            otel_ctx,
-        ));
+        // Frontend-sequenced peeks stream their rows directly to the session and
+        // track completion off the coordinator task, so skip the notification.
+        if peek.notify_coordinator {
+            let notification = PeekNotification::new(&response, peek.offset, peek.limit);
+            // NOTE: We use the `otel_ctx` from the response, not the pending peek, because we
+            // currently want the parent to be whatever the compute worker did with this peek.
+            self.deliver_response(ComputeControllerResponse::PeekNotification(
+                uuid,
+                notification,
+                otel_ctx,
+            ));
+        }
 
         self.finish_peek(uuid, response)
     }
@@ -3079,6 +3089,14 @@ struct PendingPeek {
     limit: Option<usize>,
     /// The offset into the peek's result.
     offset: usize,
+    /// Whether to emit a `PeekNotification` to the controller response channel
+    /// on completion or cancellation.
+    ///
+    /// Classic coordinator-sequenced peeks set this so the coordinator can
+    /// retire their `pending_peeks` entry. Frontend-sequenced peeks stream rows
+    /// directly to the session and track themselves off the coordinator task, so
+    /// they set this `false` to keep the response side off the coordinator too.
+    notify_coordinator: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/compute-client/src/controller/instance_client.rs
+++ b/src/compute-client/src/controller/instance_client.rs
@@ -235,6 +235,7 @@ impl InstanceClient {
         target_read_hold: ReadHold,
         target_replica: Option<ReplicaId>,
         peek_response_tx: oneshot::Sender<PeekResponse>,
+        notify_coordinator: bool,
     ) -> Result<(), PeekError> {
         self.call_sync(move |i| {
             i.peek(
@@ -248,6 +249,7 @@ impl InstanceClient {
                 target_read_hold,
                 target_replica,
                 peek_response_tx,
+                notify_coordinator,
             )
         })
         .await?

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4620,13 +4620,13 @@ def workflow_test_drop_cluster_during_registered_peeks_fast_path(
     teardown race (slow-path variant:
     `workflow_test_drop_cluster_during_registered_peeks`).
 
-    A `PeekExisting` fast-path peek registers with the coordinator and only
-    *then* issues `client.peek()`; registration hands ownership of
-    end-of-execution logging to the coordinator. If a `DROP CLUSTER` lands in
-    that window, the teardown retires the pending peek and logs its end,
-    `client.peek()` fails, and the frontend's `UnregisterFrontendPeek` must be
-    a no-op. Historically the frontend ended the statement itself here, and
-    the double end panicked and aborted environmentd.
+    A `PeekExisting` fast-path peek registers in the shared peek registry and
+    only *then* issues `client.peek()`. If a `DROP CLUSTER` lands in that
+    window, the coordinator's teardown claims the registry entry and cancels
+    it, `client.peek()` then fails on the missing instance, and the frontend
+    must end the statement exactly once. Both a double end and a missing end
+    are failures here: the former panicked and aborted environmentd when the
+    coordinator still owned end-of-execution logging.
 
     The window is a sub-millisecond cross-thread gap, so we make it
     deterministic with the `peek_after_register_before_issue` failpoint: pause


### PR DESCRIPTION
**Draft.** The earlier spec-sheet numbers in this description were wrong and have been retracted, see "Measurements".

## Motivation

Fast-path point-lookup peeks are throughput-capped by the single `coordinator` thread even with `enable_frontend_peek_sequencing` on. The row and data path already bypasses the coordinator, but two per-peek bookkeeping interactions still funnel through it:

* the blocking `Command::RegisterFrontendPeek` round-trip, which records the peek in coordinator-owned `pending_peeks`/`client_pending_peeks` for cancellation;
* the `ComputeControllerResponse::PeekNotification`, drained only by the coordinator `select!` loop.

## Change

A sharded, `Arc`-shared `FrontendPeekRegistry` (`peek_registry.rs`) that the session-side `PeekClient` inserts into directly, with no coordinator round-trip, and that cancellation consults directly. An RAII guard in the response stream removes the entry on completion or drop. `notify_coordinator` on the instance's `PendingPeek` suppresses the `PeekNotification` for frontend peeks, so the response side leaves the coordinator too.

The coordinator's `pending_peeks` entry owned two pieces of statement logging, which the registry has to take over rather than drop: the end-of-execution record that `handle_peek_notification` derived from the `PeekNotification`, and the lifecycle watch sets that `install_peek_watch_sets` installed during registration. `FrontendPeekCompletion` carries the registry guard and the logging guard together into the peek response stream, which retires both against the raw `PeekResponse` using `PeekNotification::new`, the same derivation the compute controller uses, so both sequencing paths record identical columns. `Command::InstallPeekWatchSets` hands the watch sets to the coordinator without a round-trip.

That entry also drove dependency teardown. `PendingPeekEntry` therefore carries the peek's `depends_on` set, and `FrontendPeekRegistry::find_dropped` reports the entries that a set of dropped collections and clusters invalidates, which `catalog_implications` sweeps alongside `pending_peeks`. Finding and removing are separate steps, because only a peek that the sweep actually removed may be cancelled, exactly as `remove_pending_peek` gates the existing path against a concurrent completion. The cancellation carries the dropped dependency rather than a bare `Canceled`, so the session still gets `query could not complete because ... was dropped`.

## Measurements

**Retraction.** This description previously reported +23% to +53% from a spec-sheet A/B. That comparison was invalid. Both builds compile with LTO, but the staging harness deploys a mutable dev tag and `mzbuild.publish_multiarch_images` only pushes a tag that does not already exist. The base commit had been tagged earlier the same morning by a test-pipeline build, which builds with `CI_LTO: 0`, so the baseline region ran optimized images while the branch region ran LTO. The tagging job's log shows it directly: the branch build emits `docker manifest create` and `docker manifest push` for every image, the baseline build emits none. Release over optimized is worth about 1.44x on its own, which is the bulk of what that table reported.

**Throughput is +12% to +15%**, measured in review with both sides on the same profile. That is the number to quote. It cannot be reproduced on a developer box: the run queue reaches roughly 47 on 32 cores from work outside the container, and the same binary has measured 8k and 14k tps on consecutive runs.

**The mechanism reproduces independently.** Coordinator messages per fast-path peek, a ratio of counters over one window and therefore insensitive to machine load:

| | base | branch | removed |
| --- | --- | --- | --- |
| measured in review | 3.04 | 1.04 | 2.00 |
| measured locally, 3 runs each, order rotated | 3.53 | 1.45 | 2.08 |

The ratios differ because the local runs use strict serializable, which adds one per-peek message to both sides, but the absolute effect agrees: this removes two coordinator messages per fast-path peek. Local coordinator CPU per peek, measured as the slope of coordinator-thread CPU against offered rate so the loop's fixed work cancels, falls from 33.9% to 24.0% at 3000 peeks/sec.

**Latency is essentially unchanged.** At a matched 3000 peeks/sec on an idle machine, pgbench per-transaction percentiles over 180k samples per run give p50 2.09 to 2.02 ms, p90 2.71 to 2.57 ms, and p99 14.5 to 14.3 ms, so the body improves by 3% to 5% and the tail does not move. dbbench agrees: the branch shifts 2.6 percentage points of transactions from its 2.1 to 4.2 ms bucket into its 1.0 to 2.1 ms bucket, while the three tail buckets are identical within noise. The gain is a constant of roughly 0.07 ms per peek rather than reduced queueing, which fits a coordinator that is only 30% to 40% busy at that rate. This change raises the ceiling, it does not improve what a session feels at moderate load.

Statement logging is verified rather than assumed. Counting rows for a benchmark's peeks in `mz_statement_execution_history` and `mz_statement_lifecycle_history`:

| Variant | Logged | With end | Strategy | Rows | Size | Fast-path | Lifecycle events |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `main` | 563 | 563 | 563 | 563 | 563 | 563 | 563 |
| Logging dropped | 563 | 0 | 0 | 0 | 0 | 0 | 0 |
| This branch | 563 | 563 | 563 | 563 | 563 | 563 | 563 |

Without that commit every fast-path peek is logged as permanently unfinished, which also fails the `statement-logging` workflow in `test/cluster`.

## Merit

At +12% to +15% this is worth weighing against its complexity, and against #37586, which review measured at +46% to +53% for comparable complexity. Review also could not measure a difference between #37586 alone and #37586 combined with this change. Driving coordinator messages per fast-path peek to approximately zero appears to need both, so the open question is sequencing rather than whether this work is wanted.

## Open

A stable 0.7% of fast-path peeks land in the 8 to 16 ms bucket against a 2 ms median, identically on both sides. Whatever produces that tail is not coordinator queueing, since it survives removing two thirds of the coordinator messages. It is unrelated to this change and is a larger lever than this change offers.

Smaller items:

* Dependency teardown retires the statement as `Errored` carrying the dropped-dependency message, where the coordinator path retires it as `Canceled`. Carrying the reason is more informative, but it is a difference between the two paths.
* `by_conn` is a single `Mutex` taken on every register and every remove, which leaves the 64 uuid shards carrying little of the contention. Sharding by `conn_id` instead, with the guard carrying it, gives one lock per operation and colocates a connection's peeks for cancellation.
* `metrics.canceled_peeks` is not incremented for registry peeks.
* The registry does not appear in `Coordinator::dump()`.
* No feature flag, so the coordinator path cannot be restored at runtime.
* No unit tests for `peek_registry.rs`.
* `Register`/`UnregisterFrontendPeek` are left in place but unused by the fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)