### PR TITLE
storage/adapter: fix graceful cluster reconfiguration for clusters with single-replica sources

### DIFF
--- a/src/adapter/src/coord/cluster_controller.rs
+++ b/src/adapter/src/coord/cluster_controller.rs
@@ -41,6 +41,7 @@ use mz_cluster_controller::strategy::{
     GRACEFUL_RECONFIGURATION_STRATEGY_NAME, HYDRATION_BURST_STRATEGY_NAME,
 };
 use mz_compute_types::config::ComputeReplicaConfig;
+use mz_controller::clusters::ClusterStatus;
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_ore::task::spawn;
 use mz_repr::Timestamp;
@@ -48,7 +49,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
 use crate::catalog::{DropObjectInfo, Op, ReplicaCreateDropReason};
-use crate::coord::{Coordinator, Message};
+use crate::coord::{ClusterReplicaStatuses, Coordinator, Message};
 use crate::error::AdapterError;
 
 /// A request the controller task marshals to the Coordinator to satisfy one
@@ -69,7 +70,8 @@ pub enum ClusterControllerRequest {
         clusters: Vec<ClusterId>,
         tx: oneshot::Sender<(Vec<ClusterState>, Timestamp)>,
     },
-    /// Of `replicas` on `cluster`, which have all current collections hydrated.
+    /// Of `replicas` on `cluster`, which are online and have all current
+    /// collections hydrated.
     HydratedReplicas {
         cluster_id: ClusterId,
         replicas: Vec<ReplicaId>,
@@ -385,9 +387,9 @@ impl Coordinator {
 
     /// Starts per-replica hydration checks for `cluster_id`.
     ///
-    /// Returns only checks that are already storage-hydrated and known to the
-    /// compute controller. The compute receiver completes off the coordinator
-    /// loop.
+    /// Returns only checks for replicas whose processes are all online, that
+    /// are already storage-hydrated, and that are known to the compute
+    /// controller. The compute receiver completes off the coordinator loop.
     fn start_hydration_checks(
         &self,
         cluster_id: ClusterId,
@@ -419,6 +421,16 @@ impl Coordinator {
 
         let mut checks = Vec::new();
         for replica_id in replicas {
+            // Skip replicas that are not online. We wait for a replica to be
+            // online even when it has no objects that need hydration on it
+            // (e.g. a single-replica source).
+            let status = self
+                .cluster_replica_statuses
+                .try_get_cluster_replica_statuses(cluster_id, replica_id)
+                .map(ClusterReplicaStatuses::cluster_replica_status);
+            if !matches!(status, Some(ClusterStatus::Online)) {
+                continue;
+            }
             let exclude: BTreeSet<mz_repr::GlobalId> = pinned_mvs
                 .iter()
                 .filter(|(target, _)| *target != replica_id)

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -20,7 +20,7 @@ use mz_catalog::memory::objects::{
 };
 use mz_compute_types::config::ComputeReplicaConfig;
 use mz_controller::clusters::{
-    ManagedReplicaLocation, ReplicaConfig, ReplicaLocation, ReplicaLogging,
+    ClusterStatus, ManagedReplicaLocation, ReplicaConfig, ReplicaLocation, ReplicaLogging,
 };
 use mz_controller_types::{ClusterId, DEFAULT_REPLICA_LOGGING_INTERVAL, ReplicaId};
 use mz_ore::cast::CastFrom;
@@ -56,8 +56,8 @@ use crate::config::{
 };
 use crate::coord::{
     AlterCluster, AlterClusterAwaitReconfiguration, AlterClusterFinalize,
-    AlterClusterWaitForHydrated, ClusterStage, Coordinator, Message, PlanValidity, StageResult,
-    Staged,
+    AlterClusterWaitForHydrated, ClusterReplicaStatuses, ClusterStage, Coordinator, Message,
+    PlanValidity, StageResult, Staged,
 };
 use crate::{AdapterError, ExecuteContext, ExecuteResponse, session::Session};
 
@@ -1070,8 +1070,22 @@ impl Coordinator {
         let storage_hydrated = self
             .controller
             .storage
-            .collections_hydrated_on_replicas(Some(pending_replicas), &cluster.id, &[].into())
+            .collections_hydrated_on_replicas(
+                Some(pending_replicas.clone()),
+                &cluster.id,
+                &[].into(),
+            )
             .map_err(|e| AdapterError::internal("Failed to check hydration", e))?;
+
+        // Also require every pending replica to be online, in case it has no
+        // objects that need hydration on it (e.g. a single-replica source).
+        let replicas_online = pending_replicas.iter().all(|replica_id| {
+            let status = self
+                .cluster_replica_statuses
+                .try_get_cluster_replica_statuses(cluster.id, *replica_id)
+                .map(ClusterReplicaStatuses::cluster_replica_status);
+            matches!(status, Some(ClusterStatus::Online))
+        });
 
         let span = Span::current();
         Ok(StageResult::Handle(mz_ore::task::spawn(
@@ -1081,7 +1095,7 @@ impl Coordinator {
                     .await
                     .map_err(|e| AdapterError::internal("Failed to check hydration", e))?;
 
-                if compute_hydrated && storage_hydrated {
+                if compute_hydrated && storage_hydrated && replicas_online {
                     // We're done
                     Ok(Box::new(ClusterStage::Finalize(AlterClusterFinalize {
                         validity,

--- a/src/cluster-controller/src/ctx.rs
+++ b/src/cluster-controller/src/ctx.rs
@@ -266,9 +266,9 @@ pub trait ClusterControllerCtx: Send {
     /// The ids of all managed clusters the controller owns this tick.
     async fn managed_cluster_ids(&mut self) -> Vec<ClusterId>;
 
-    /// Of `replicas` on `cluster`, which have *all* current (non-transient)
-    /// collections on the cluster hydrated. The returned set is a subset of
-    /// `replicas`.
+    /// Of `replicas` on `cluster`, which are online and have *all* current
+    /// (non-transient) collections on the cluster hydrated. The returned set
+    /// is a subset of `replicas`.
     ///
     /// Callers should request only replicas their strategy currently needs. This
     /// keeps live-signal dependencies local to the strategies that consume them.

--- a/src/cluster-controller/src/strategy.rs
+++ b/src/cluster-controller/src/strategy.rs
@@ -143,8 +143,8 @@ pub struct ConfigSignals {
 /// only read what it declared in [`Strategy::signal_request`].
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct LiveSignals {
-    /// The replicas observed this tick to have *all* current collections on the
-    /// cluster hydrated.
+    /// The replicas observed this tick to be online and to have *all* current
+    /// collections on the cluster hydrated.
     pub hydrated_replicas: BTreeSet<ReplicaId>,
     /// Whether the cluster has at least one hydratable object. `false` when not
     /// requested.

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -331,6 +331,11 @@ pub trait StorageController: Debug {
     /// Returns `true` if each non-transient, non-excluded collection is
     /// hydrated on at least one of the provided replicas.
     ///
+    /// Collections that are not scheduled on any of the provided replicas do
+    /// not count against hydration: a single-replica source keeps running on
+    /// its current replica and can never hydrate on a replica it is not
+    /// scheduled on.
+    ///
     /// If no replicas are provided, this checks for hydration on _any_ replica.
     ///
     /// This also returns `true` in case this cluster does not have any

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -739,7 +739,6 @@ impl Instance {
     /// object (ingestion, ingestion export (aka. subsource), or export).
     pub fn get_active_replicas_for_object(&self, id: &GlobalId) -> BTreeSet<ReplicaId> {
         if let Some(ingestion_id) = self.ingestion_exports.get(id) {
-            // Right now, only ingestions can have per-replica scheduling decisions.
             match self.active_ingestions.get(ingestion_id) {
                 Some(ingestion) => ingestion.active_replicas.clone(),
                 None => {
@@ -747,8 +746,15 @@ impl Instance {
                     BTreeSet::new()
                 }
             }
+        } else if let Some(ingestion) = self.active_ingestions.get(id) {
+            // A new-syntax source lists only its tables in `source_exports`, so
+            // the primary ingestion id is not in `ingestion_exports`.
+            ingestion.active_replicas.clone()
+        } else if let Some(export) = self.active_exports.get(id) {
+            export.active_replicas.clone()
         } else {
-            // For non-ingestion objects, all replicas are active
+            // For objects that have no per-replica scheduling (e.g. tables and
+            // webhooks), all replicas are active.
             self.replicas.keys().copied().collect()
         }
     }

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -100,6 +100,17 @@ struct ActiveExport {
     active_replicas: BTreeSet<ReplicaId>,
 }
 
+/// Which replicas actively run a given object, as resolved by
+/// [`Instance::active_replica_ids`].
+enum ActiveReplicas<'a> {
+    /// The object has per-replica scheduling and runs on exactly these
+    /// replicas. The set is empty when it currently runs nowhere, e.g. it has
+    /// been compacted away or is not yet scheduled onto a replica.
+    Scheduled(&'a BTreeSet<ReplicaId>),
+    /// The object has no per-replica scheduling, so every replica runs it.
+    All,
+}
+
 impl Instance {
     /// Creates a new [`Instance`].
     pub fn new(
@@ -652,70 +663,56 @@ impl Instance {
         }
     }
 
-    /// Returns the replicas that are actively running the given object (ingestion or export).
-    fn active_replicas(&mut self, id: &GlobalId) -> Box<dyn Iterator<Item = &mut Replica> + '_> {
+    /// Resolves an object to the replicas actively running it.
+    ///
+    /// Shared by [`Self::active_replicas`], [`Self::is_active_replica`], and
+    /// [`Self::get_active_replicas_for_object`], which differ only in how they
+    /// project the result.
+    fn active_replica_ids(&self, id: &GlobalId) -> ActiveReplicas<'_> {
+        // An empty set to borrow for objects whose scheduling target is gone.
+        static EMPTY: BTreeSet<ReplicaId> = BTreeSet::new();
+
         if let Some(ingestion_id) = self.ingestion_exports.get(id) {
             match self.active_ingestions.get(ingestion_id) {
-                Some(ingestion) => Box::new(self.replicas.iter_mut().filter_map(
-                    move |(replica_id, replica)| {
-                        if ingestion.active_replicas.contains(replica_id) {
-                            Some(replica)
-                        } else {
-                            None
-                        }
-                    },
-                )),
-                None => {
-                    // The ingestion has already been compacted away (aka. stopped).
-                    Box::new(std::iter::empty())
-                }
+                Some(ingestion) => ActiveReplicas::Scheduled(&ingestion.active_replicas),
+                // The ingestion has already been compacted away (aka. stopped).
+                None => ActiveReplicas::Scheduled(&EMPTY),
             }
         } else if let Some(ingestion) = self.active_ingestions.get(id) {
-            Box::new(
-                self.replicas
-                    .iter_mut()
-                    .filter_map(move |(replica_id, replica)| {
-                        if ingestion.active_replicas.contains(replica_id) {
-                            Some(replica)
-                        } else {
-                            None
-                        }
-                    }),
-            )
+            // A new-syntax source lists only its tables in `source_exports`, so
+            // the primary ingestion id is not in `ingestion_exports`.
+            ActiveReplicas::Scheduled(&ingestion.active_replicas)
         } else if let Some(export) = self.active_exports.get(id) {
-            Box::new(
-                self.replicas
-                    .iter_mut()
-                    .filter_map(move |(replica_id, replica)| {
-                        if export.active_replicas.contains(replica_id) {
-                            Some(replica)
-                        } else {
-                            None
-                        }
-                    }),
-            )
+            ActiveReplicas::Scheduled(&export.active_replicas)
         } else {
-            Box::new(self.replicas.values_mut())
+            // Objects that have no per-replica scheduling (e.g. tables and
+            // webhooks) run on all replicas.
+            ActiveReplicas::All
+        }
+    }
+
+    /// Returns the replicas that are actively running the given object (ingestion or export).
+    fn active_replicas(&mut self, id: &GlobalId) -> Box<dyn Iterator<Item = &mut Replica> + '_> {
+        // Take an owned copy of the scheduled set so the immutable borrow of
+        // `self` ends before we borrow `self.replicas` mutably below. The set
+        // is tiny (one entry per replica) and this is not a per-row path.
+        let scheduled = match self.active_replica_ids(id) {
+            ActiveReplicas::All => None,
+            ActiveReplicas::Scheduled(replicas) => Some(replicas.clone()),
+        };
+        match scheduled {
+            None => Box::new(self.replicas.values_mut()),
+            Some(scheduled) => Box::new(self.replicas.iter_mut().filter_map(
+                move |(replica_id, replica)| scheduled.contains(replica_id).then_some(replica),
+            )),
         }
     }
 
     /// Returns whether the given replica is actively running the given object (ingestion or export).
     fn is_active_replica(&self, id: &GlobalId, replica_id: &ReplicaId) -> bool {
-        if let Some(ingestion_id) = self.ingestion_exports.get(id) {
-            match self.active_ingestions.get(ingestion_id) {
-                Some(ingestion) => ingestion.active_replicas.contains(replica_id),
-                None => {
-                    // The ingestion has already been compacted away (aka. stopped).
-                    false
-                }
-            }
-        } else if let Some(ingestion) = self.active_ingestions.get(id) {
-            ingestion.active_replicas.contains(replica_id)
-        } else if let Some(export) = self.active_exports.get(id) {
-            export.active_replicas.contains(replica_id)
-        } else {
-            // For non-ingestion objects, all replicas are active
-            true
+        match self.active_replica_ids(id) {
+            ActiveReplicas::All => true,
+            ActiveReplicas::Scheduled(replicas) => replicas.contains(replica_id),
         }
     }
 
@@ -738,24 +735,9 @@ impl Instance {
     /// Returns the set of replica IDs that are actively running the given
     /// object (ingestion, ingestion export (aka. subsource), or export).
     pub fn get_active_replicas_for_object(&self, id: &GlobalId) -> BTreeSet<ReplicaId> {
-        if let Some(ingestion_id) = self.ingestion_exports.get(id) {
-            match self.active_ingestions.get(ingestion_id) {
-                Some(ingestion) => ingestion.active_replicas.clone(),
-                None => {
-                    // The ingestion has already been compacted away (aka. stopped).
-                    BTreeSet::new()
-                }
-            }
-        } else if let Some(ingestion) = self.active_ingestions.get(id) {
-            // A new-syntax source lists only its tables in `source_exports`, so
-            // the primary ingestion id is not in `ingestion_exports`.
-            ingestion.active_replicas.clone()
-        } else if let Some(export) = self.active_exports.get(id) {
-            export.active_replicas.clone()
-        } else {
-            // For objects that have no per-replica scheduling (e.g. tables and
-            // webhooks), all replicas are active.
-            self.replicas.keys().copied().collect()
+        match self.active_replica_ids(id) {
+            ActiveReplicas::All => self.replicas.keys().copied().collect(),
+            ActiveReplicas::Scheduled(replicas) => replicas.clone(),
         }
     }
 }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -384,6 +384,8 @@ impl StorageController for Controller {
         let target_replicas: Option<BTreeSet<ReplicaId>> =
             target_replica_ids.map(|ids| ids.into_iter().collect());
 
+        let instance = self.instances.get(target_cluster_id);
+
         let mut all_hydrated = true;
         for (collection_id, collection_state) in self.collections.iter() {
             if collection_id.is_transient() || exclude_collections.contains(collection_id) {
@@ -395,7 +397,23 @@ impl StorageController for Controller {
                         continue;
                     }
                     match &target_replicas {
-                        Some(target_replicas) => !state.hydrated_on.is_disjoint(target_replicas),
+                        Some(target_replicas) => {
+                            // Not scheduled on any target replica means it can
+                            // never hydrate there, so it does not count (see
+                            // the trait docs). If the instance is unknown (the
+                            // cluster is being dropped concurrently) the
+                            // scheduled set is empty and every ingestion is
+                            // skipped. Readiness callers gate on replica health
+                            // separately, which covers that window.
+                            let scheduled_on = instance
+                                .map(|i| i.get_active_replicas_for_object(collection_id))
+                                .unwrap_or_default();
+                            if scheduled_on.is_disjoint(target_replicas) {
+                                true
+                            } else {
+                                !state.hydrated_on.is_disjoint(target_replicas)
+                            }
+                        }
                         None => {
                             // Not target replicas, so check that it's hydrated
                             // on at least one replica.

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -93,8 +93,10 @@ pub struct IngestionDescription<S: 'static = (), C: ConnectionAccess = InlinedCo
     ///
     ///   Re-rendering/executing the source after making these modifications
     ///   adds and drops the subsource, respectively.
-    /// - This field includes the primary source's ID, which might need to be
-    ///   filtered out to understand which exports are explicit ingestion exports.
+    /// - For old-syntax sources this field includes the primary source's ID,
+    ///   which might need to be filtered out to understand which exports are
+    ///   explicit ingestion exports. New-syntax sources (with source tables)
+    ///   list only their exports here.
     /// - This field does _not_ include the remap collection, which is tracked
     ///   in its own field.
     pub source_exports: BTreeMap<GlobalId, SourceExport<S>>,

--- a/test/pg-cdc/cluster-graceful-reconfiguration.td
+++ b/test/pg-cdc/cluster-graceful-reconfiguration.td
@@ -1,0 +1,133 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for SQL-530: a graceful cluster reconfiguration (WAIT UNTIL
+# READY) of a cluster hosting a Postgres source must resize and cut over
+# instead of waiting forever for the source to hydrate on the new replica.
+#
+# A Postgres source prefers a single replica, so the controller keeps its
+# ingestion on the replica it already runs on and never schedules it onto the
+# new replica until cut-over drops the old one. Readiness must therefore not
+# wait for the source to hydrate on the target, but must still wait for the
+# target's processes to come online before cutting over.
+#
+# Both reconfiguration paths are exercised below, the legacy foreground path
+# and the controller-owned path. The path-selection flags are pinned
+# explicitly so the test does not depend on the harness defaults.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+INSERT INTO t1 VALUES (1), (2), (3);
+
+CREATE PUBLICATION mz_source FOR TABLE t1;
+
+# Host the source on its own single-replica cluster so the reconfiguration has
+# exactly one source replica to replace.
+> CREATE CLUSTER source_reconfig (SIZE 'scale=1,workers=1', REPLICATION FACTOR 1)
+
+> CREATE SOURCE mz_source
+  IN CLUSTER source_reconfig
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+
+> CREATE TABLE t1 FROM SOURCE mz_source (REFERENCE t1)
+
+> SELECT * FROM t1
+1
+2
+3
+
+# ----- Legacy foreground path -----
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_cluster_controller = false
+ALTER SYSTEM SET enable_background_alter_cluster = false
+
+# The ALTER blocks until readiness passes. Before the fix it would block until
+# the deadline rolls the resize back, failing the test at the statement
+# timeout. The raised timeout only gives the success path headroom on slow CI.
+$ set-sql-timeout duration=120s
+
+> ALTER CLUSTER source_reconfig SET (SIZE 'scale=1,workers=2') WITH (WAIT UNTIL READY (TIMEOUT '300s', ON TIMEOUT 'ROLLBACK'))
+
+$ set-sql-timeout duration=default
+
+# The realized size advanced to the target: the cut-over happened.
+> SELECT size FROM mz_clusters WHERE name = 'source_reconfig'
+"scale=1,workers=2"
+
+# The source still serves its data after cut-over.
+> SELECT * FROM t1
+1
+2
+3
+
+# And it keeps ingesting on the promoted replica.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t1 VALUES (4), (5);
+
+> SELECT * FROM t1
+1
+2
+3
+4
+5
+
+# ----- Controller-owned path -----
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_cluster_controller = true
+ALTER SYSTEM SET enable_background_alter_cluster = true
+
+# With the background flag on the ALTER returns immediately and the controller
+# drives readiness and cut-over. Before the fix the resize would roll back at
+# its deadline and the realized size below would never advance.
+> ALTER CLUSTER source_reconfig SET (SIZE 'scale=1,workers=1') WITH (WAIT UNTIL READY (TIMEOUT '300s', ON TIMEOUT 'ROLLBACK'))
+
+# The raised timeout covers replica boot plus the controller's tick cadence.
+$ set-sql-timeout duration=120s
+
+> SELECT size FROM mz_clusters WHERE name = 'source_reconfig'
+"scale=1,workers=1"
+
+$ set-sql-timeout duration=default
+
+# The source keeps serving and ingesting after the controller-driven cut-over.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t1 VALUES (6);
+
+> SELECT * FROM t1
+1
+2
+3
+4
+5
+6
+
+> DROP SOURCE mz_source CASCADE
+> DROP CLUSTER source_reconfig
+> DROP CONNECTION pg
+> DROP SECRET pgpass


### PR DESCRIPTION
### Motivation

`ALTER CLUSTER ... WITH (WAIT UNTIL READY ...)` never completes on a cluster
hosting a single-replica source (Postgres, MySQL, SQL Server). The readiness
check gates cut-over on every ingestion reporting hydrated on the pending
replicas, but a single-replica source stays scheduled on the replica it
already runs on and is never placed on a pending replica until cut-over drops
the old one. It can never report hydrated there, so the reconfiguration
deadlocks until its deadline and, with `ON TIMEOUT ROLLBACK`, reverts without
ever resizing.

Fixes SQL-530

### Description

Two commits that together make the readiness check sound:

**storage-controller: don't wait for off-target ingestions in hydration
checks.** `collections_hydrated_on_replicas` now skips ingestions whose
scheduled replica set is disjoint from the target replicas: they cannot
hydrate there, so they must not count against the target's hydration.
Multi-replica ingestions get scheduled onto pending replicas too and keep the
existing hydrated-on-target requirement. This also fixes
`Instance::get_active_replicas_for_object`, which only resolved
ingestion-export ids and fell back to "all replicas" otherwise: a new-syntax
source's primary collection id is not an ingestion export, so the skip would
never have fired for it. The helper now resolves primaries and exports
directly, like its siblings `active_replicas` and `is_active_replica`.

**adapter: gate reconfiguration cut-over on pending replicas being online.**
With off-target ingestions skipped, a cluster hosting only single-replica
sources reports hydrated vacuously the moment its pending replicas are
created, so cut-over could hand the sources to replicas whose processes never
came up. Both readiness paths, the legacy foreground path and the
controller-owned path, now additionally require every pending replica to be
online per the coordinator's replica status tracking (the signal behind
`mz_cluster_replica_statuses`). Replica health deliberately stays a caller
concern, composed in the adapter, outside the storage controller's hydration
check.

Non-obvious behavior notes:

* With more than one pending replica the legacy path is deliberately
  tightened: previously cut-over could fire once collections hydrated on one
  healthy pending replica while another never came up. Requiring the full
  pending set online matches the controller-owned path, which already
  requires replication-factor-many hydrated target replicas.
* The hydration-burst strategy's steady checks share the hydrated-replicas
  signal, so an orchestrator readiness flap on a steady replica can arm a
  burst one tick early, but never skips a needed one.
* Sinks are unaffected: the hydration check already treats exports as always
  hydrated.

### Verification

New regression test `test/pg-cdc/cluster-graceful-reconfiguration.td`: a
Postgres source on a cluster undergoing graceful reconfiguration, exercising
both the legacy foreground path and the controller-owned background path by
pinning the path-selection flags each way, and asserting that the resize
completes and data keeps flowing across cut-over. Both sections deadlock
without the fix.
