### PR TITLE
doc: design for columnar dataflow edge migration

### DIFF
--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -281,6 +281,11 @@ A plain `ColumnBuilder` drops that consolidation, a permanent regression on the 
 Consolidation inherently needs owned staging (you cannot sort a columnar batch without materialized comparable rows), so `ConsolidatingColumnBuilder` is owned-give only.
 This is not a regression: a producer computes its output `Row` fresh (`mfp_plan.evaluate` already yields an owned `Row` per record), so the owned give is a move into staging, not a new allocation or clone, exactly as pre-P1.
 The borrowed-push, no-owned-`Row` property is a CONSUMER optimization (reading an existing columnar batch, as in C1/C3/C4), not applicable to producers that compute new rows.
+
+FAST-FOLLOW (tracked, not blocking): owned-give staging holds N live owned `Row`s per batch (one heap buffer each), same as pre-P1.
+A ref-accepting consolidating builder that stages row bytes into a `Column` arena on a borrowed push and consolidates via a sorted `Vec<usize>` permutation (`RowRef: Ord`) would hold ~1 live owned `Row` plus the arena, a real allocator-churn and peak-memory win on the broad Mfp-to-sink path.
+It is a new `mz-timely-util` consolidation primitive with its own correctness surface (merge, zero-drop, stable order), so it lands as its own focused, adversarially-reviewed PR, after which the producer output-builder choice (localized) swaps to it.
+Deferred so the new-primitive risk does not block the producer wave.
 Files: `src/compute/src/render/context.rs`, `src/compute/src/render.rs`.
 Test: physical-plan goldens unchanged, plus sqllogictest for Get and Mfp chains feeding an ArrangeBy or sink.
 Base: Wave 1 complete.

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -270,10 +270,15 @@ Confirmed by inspection of `render.rs`; no separate node exists.
 NOTE for T2: the `into_vec` at 1358 and the `CollectionEdge::Vec` re-wrap at 1359 are leaf sites T2 adapts; the re-wrap re-encodes the bucketed `StreamVec` via `vec_to_columnar` (a sanctioned-decode return, see T1).
 
 **P1: columnar output for the `flat_map` family.**
-Generalize `as_collection_core` to build into a `ColumnBuilder` and return a columnar edge, which flips the Get and Mfp producers.
+Generalize `as_collection_core` to build into a `ConsolidatingColumnBuilder` and return a columnar edge, which flips the Get and Mfp producers.
 Rework its identity fast-path (`context.rs:927-929`) so it no longer delegates a `Vec` to `as_specific_collection`.
 Leave `as_specific_collection` returning `Vec` as a consumer leaf until its remaining callers are retired.
 This keeps P1's base at the arrange path and the sink, both native by Wave 2.
+
+STANDING PRODUCER RULE (all producer flips): use `ConsolidatingColumnBuilder`, not plain `ColumnBuilder`, for the producer output.
+The pre-migration producers used `ConsolidatingContainerBuilder`, which folded duplicates within a batch.
+A plain `ColumnBuilder` drops that, a permanent regression on the broad Mfp-to-sink class (more rows reach the sink `ColumnarToVec` and persist re-consolidation).
+The columnar builder copies row bytes into the column from a borrowed push either way, so `ConsolidatingColumnBuilder` keeps the borrowed push (no owned `Row` per record) and adds the within-batch consolidation, restoring parity.
 Files: `src/compute/src/render/context.rs`, `src/compute/src/render.rs`.
 Test: physical-plan goldens unchanged, plus sqllogictest for Get and Mfp chains feeding an ArrangeBy or sink.
 Base: Wave 1 complete.

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -148,7 +148,6 @@ graph TD
     C2["C2: FlatMap input decode via the edge, fueling preserved"]
     C3["C3: TopK input columnar"]
     C4["C4: linear-join input columnar"]
-    C5["C5: delta-join input columnar"]
     C6["C6: sink columnar input API"]
     C7["C7: LetRec sanctioned decode, consume edge then into_vec"]
     C8["C8: Union temporal-bucket sanctioned decode, consume edge then into_vec"]
@@ -171,7 +170,6 @@ graph TD
   end
   C1 --> C3
   C1 --> C4
-  C1 --> C5
   Wave1 ==> Wave2
   Wave2 --> T1
   T1 --> T2
@@ -243,12 +241,14 @@ Files: `src/compute/src/render/join/linear_join.rs`.
 Test: linear-join sqllogictest.
 Base: `C1`.
 
-**C5: delta-join input columnar.**
-Rework the delta-join input path to consume the columnar batch.
-This is the most intricate operator, so it is a separate node from C4.
-Files: `src/compute/src/render/join/delta_join.rs`.
-Test: delta-join sqllogictest.
-Base: `C1`.
+**C5: delta-join input.** No work, subsumed by C1.
+The premise that delta-join has an unarranged input to rework does not hold.
+Unlike linear join, delta join requires every input pre-arranged, guarded by the "Arrangement promised by the planner is absent!" panics in `delta_join.rs`.
+`render_delta_join` reads inputs only via `inputs[..].arrangement(&key)`, never `.collection`/`as_specific_collection`/`into_vec`.
+The per-relation update stream is arrangement-derived: `build_update_stream` walks an `Arranged` trace's `stream` with a batch cursor, not a raw collection.
+The `CollectionEdge` decode for delta-join inputs therefore lives entirely in `arrange_collection`, which C1 already migrated.
+Confirmed by an adversarial trace of `delta_join.rs`; no separate node exists.
+The delta-join output flip remains real and is covered by P7.
 
 **C6: sink columnar input.**
 Change the sink input path so it consumes a columnar edge.
@@ -321,7 +321,7 @@ Confirmed feasible by the prototype, builder swaps with no blocker.
 Delta join: `half_join_internal_unsafe` is generic over its output `ContainerBuilder` (`differential-dogs3 half_join2.rs:121-140`); swap `CapacityContainerBuilder<Vec>` (`delta_join.rs:406`) for `ColumnBuilder` and the heavy operator emits `Column` directly.
 Linear join: swap the `flat_map_fallible::<ConsolidatingContainerBuilder, ..>` (`linear_join.rs:300`) for the existing `ConsolidatingColumnBuilder` (`columnar/consolidate.rs`), preserving output consolidation.
 The carried-time `(Row, T)` payload is `Columnar`.
-Join input, C4 and C5, is untouched here.
+Join input is untouched here: linear-join input is C4, and delta-join input is arrangement-only, subsumed by C1.
 Files: `src/compute/src/render/join/linear_join.rs`, `src/compute/src/render/join/delta_join.rs`.
 Base: Wave 1 complete.
 
@@ -367,14 +367,16 @@ So the DAG is flattened into a single chain, managed with gh-stack, where each b
 The chain is a topological order of the DAG, so every dependency edge points backward:
 
 ```
-C1 -> C3 -> C4 -> C5 -> F1 -> C2 -> C6 -> C7 -> C8
+C1 -> C3 -> C4 -> F1 -> C2 -> C6 -> C7 -> C8
    -> P1 -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9
    -> T1 -> T2 -> T3
 ```
 
+C5 is not in the chain: delta-join input is subsumed by C1 (see the C5 node).
+
 Order constraints honored by this chain:
 
-* C1 precedes C3, C4, C5, which reuse its columnar key-forming pattern.
+* C1 precedes C3 and C4, which reuse its columnar key-forming pattern.
 * All consumer nodes, C and F, precede all producer nodes P, per the producer-flip invariant.
 * The teardown T1, T2, T3 is last, in order.
 
@@ -450,8 +452,8 @@ The C1 arrange-input key-forming pattern was already confirmed low-risk and was 
 ## Open questions
 
 * **Join node granularity.**
-  C4, C5, and P7 assume linear-input, delta-input, and a shared output flip are the right cut.
-  Whether the output flip should also split by join kind depends on how large the diffs are, resolved when the join work starts.
+  Resolved: linear-join input is C4 (landed), delta-join input is subsumed by C1 (C5 dropped), and the output flip for both join kinds is P7.
+  Whether P7 should split by join kind depends on the diff size, resolved when the producer wave starts.
 * **LetRec and Union temporal-bucketing.**
   Resolved in the prototype: both are sanctioned decode points for now, with a native fast-follow tracked if either shows up hot.
   See the C7 and C8 nodes.

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -148,7 +148,6 @@ graph TD
     C2["C2: FlatMap input decode via the edge, fueling preserved"]
     C3["C3: TopK input columnar"]
     C4["C4: linear-join input columnar"]
-    C8["C8: Union temporal-bucket sanctioned decode, consume edge then into_vec"]
   end
   subgraph Wave2["Wave 2: producers flip, every consumer already native"]
     P1["P1: as_collection_core columnar output, flips Get and Mfp"]
@@ -162,7 +161,7 @@ graph TD
     P9["P9: source and index import producers columnar"]
   end
   subgraph Wave3["Wave 3: teardown, producer half compiler-enforced"]
-    T1["T1: delete vec_to_columnar"]
+    T1["T1: retire concat_many mixed-variant upgrade branch"]
     T2["T2: collapse enum to a columnar alias, into_vec becomes a leaf fn"]
     T3["T3: de-match negate, concat_many, consolidate_named"]
   end
@@ -176,9 +175,8 @@ graph TD
 
 The bold edge from Wave 1 to Wave 2 is the producer-flip invariant: no producer node starts until every consumer node has landed.
 Within Wave 1, C1 gates the three nodes that reuse its columnar key-forming pattern.
-F1, C2, and C8 are independent roots.
+F1 and C2 are independent roots.
 F1 gives the native columnar `consolidate_named` that Union's `concat_many` then `consolidate_named` path uses once its inputs are columnar in Wave 2.
-C8 is a sanctioned decode node, so it does not depend on F1.
 Within Wave 2, each producer feeds only native consumers, so the nodes are mutually independent and land in any order.
 Wave 3 collapses the enum.
 Its producer half is compiler-enforced, see the completeness note.
@@ -263,16 +261,13 @@ The consolidation uses the raw `CollectionExt::consolidate_named` on the already
 Confirmed by inspection of `render.rs`; no separate node exists.
 NOTE for T2: `render.rs:941/997` are leaf-decode call sites T2 must adapt when `into_vec` becomes a free function.
 
-**C8: Union temporal-bucket sanctioned decode.**
-Keep the `into_vec` at `render.rs:1358` that feeds `maybe_apply_temporal_bucketing` inside a consolidating Union, adapted to consume the columnar edge.
-This is a sanctioned decode point, resolved by the prototype.
-`maybe_apply_temporal_bucketing` hardwires `StreamVec` in and out (`render.rs:1561`, `temporal_bucket.rs:49`), and the operator is the most correctness-sensitive in the migration.
-The internals are already columnar (`ColumnMergeBatcher`, `ColumnChunker`), so a native input would delete an internal `Vec` staging round-trip.
-Deferred as a fast-follow; the path is narrow, gated on `ENABLE_COMPUTE_TEMPORAL_BUCKETING`.
-The Union's own `concat_many` then `consolidate_named` path still goes native via F1 once its inputs are columnar.
-Files: `src/compute/src/render.rs`.
-Test: temporal and temporal-bucketing sqllogictest.
-Base: `upstream/main`.
+**C8: Union temporal-bucket sanctioned decode.** No work, subsumed by the #36507 scaffolding plus F1.
+Union already reads its inputs as edges directly (`render.rs:1344-1347`, no `as_specific_collection`, no pre-boundary `Vec`).
+The temporal-bucket `into_vec` at `render.rs:1358` is already a local, gated sanctioned leaf: it fires only on `strategy == TemporalBucketing && ENABLE_COMPUTE_TEMPORAL_BUCKETING`, decodes locally right before `maybe_apply_temporal_bucketing` (which hardwires `StreamVec`), and re-wraps as `CollectionEdge::Vec`; every other input keeps the edge undecoded.
+The Union body already uses the edge methods `concat_many` then `consolidate_named` (`render.rs:1370-1372`), so F1's columnar-native consolidate arm handles it once inputs are columnar.
+Native temporal-bucketing stays deferred as a fast-follow (the operator is correctness-sensitive; internals are already columnar, so native input would delete an internal `Vec` staging round-trip).
+Confirmed by inspection of `render.rs`; no separate node exists.
+NOTE for T2: the `into_vec` at 1358 and the `CollectionEdge::Vec` re-wrap at 1359 are leaf sites T2 adapts; the re-wrap re-encodes the bucketed `StreamVec` via `vec_to_columnar` (a sanctioned-decode return, see T1).
 
 **P1: columnar output for the `flat_map` family.**
 Generalize `as_collection_core` to build into a `ColumnBuilder` and return a columnar edge, which flips the Get and Mfp producers.
@@ -332,15 +327,19 @@ Files: `src/compute/src/render.rs`.
 Test: source and index import sqllogictest and testdrive coverage.
 Base: Wave 1 complete.
 
-**T1: delete `vec_to_columnar`.**
-Once every producer emits columnar, no edge carries `Vec`, so `vec_to_columnar` is dead.
-Delete it and the mixed-variant upgrade branch in `concat_many`.
+**T1: retire the `concat_many` mixed-variant upgrade branch.**
+Once every producer emits columnar, no edge carries `Vec`, so `concat_many` never sees a mixed set of arms.
+Delete its mixed-variant upgrade branch.
+Do NOT delete `vec_to_columnar`.
+It survives as a leaf ENCODE primitive for producers whose source data is genuinely row-shaped and must be placed on the columnar edge: P9 imports (row data from persist or a trace), and the sanctioned-decode returns C7 LetRec and C8 Union temporal-bucketing, which decode to `Vec`, operate via `branch_when` / `maybe_apply_temporal_bucketing` (both `Vec`-only), then re-encode to the columnar edge.
+Symmetrically `into_vec` / `columnar_to_vec` survive as leaf DECODE primitives (sinks, the same sanctioned decodes).
+The teardown collapses the enum, not the leaf conversions.
 Files: `src/compute/src/render/columnar.rs`.
 Base: all P nodes.
 
 **T2: collapse the enum.**
 Replace `CollectionEdge` with a `ColumnarCollection` type alias.
-Demote `into_vec` to a free function used only by leaf consumers that serialize rows and by any sanctioned decode point.
+Demote `into_vec` / `columnar_to_vec` (leaf decode) and `vec_to_columnar` (leaf encode) to free functions used at leaves: consumers that serialize rows, the sanctioned decode-and-re-encode points, and row-shaped producers. These leaf conversions are NOT deleted; only the enum and its arms collapse.
 Update `CollectionBundle.collection` and all construction sites.
 This is the widest diff, touching `context.rs` and every construction site, so alias the enum first and land the construction-site churn as a mechanical rename reviewed separately.
 Files: `src/compute/src/render/columnar.rs`, `src/compute/src/render/context.rs`, `src/compute/src/render.rs`, and every construction site.
@@ -361,12 +360,13 @@ So the DAG is flattened into a single chain, managed with gh-stack, where each b
 The chain is a topological order of the DAG, so every dependency edge points backward:
 
 ```
-C1 -> C3 -> C4 -> F1 -> C2 -> C8
+C1 -> C3 -> C4 -> F1 -> C2
    -> P1 -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9
    -> T1 -> T2 -> T3
 ```
 
-C5, C6, and C7 are not in the chain: delta-join input is subsumed by C1, and the sink and LetRec already leaf-decode the edge (see the C5, C6, and C7 nodes).
+C5, C6, C7, and C8 are not in the chain: delta-join input is subsumed by C1; the sink, LetRec, and Union temporal-bucketing already leaf-decode the edge (see their nodes).
+Wave 1 is complete: C1, C3, C4, F1, C2 landed and C5, C6, C7, C8 subsumed, so the chain from here is the producer wave plus teardown.
 
 Order constraints honored by this chain:
 

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -324,7 +324,9 @@ Files: `src/compute/src/render/context.rs`.
 Base: Wave 1 complete.
 
 **P6: columnar TopK output (`from_collections` paths).**
-The TopK monotonic and top1 variants build a result collection via `from_collections` (`top_k.rs:303/329`); flip these to `ConsolidatingColumnBuilder`.
+The TopK monotonic and basic variants build a result collection via `from_collections` (`top_k.rs:303/329`).
+Flip these to a plain `ColumnBuilder` with a borrowed push, NOT `ConsolidatingColumnBuilder`.
+The prior output was a non-consolidating `.map`, and both feed sites are already consolidated upstream via `consolidate_named`, so a consolidating builder here would be a wasted sort and would change the deliberate non-consolidating semantics (the same consumer carve-out as P5).
 The bucketed variant emits an arrangement (`from_columns`, `top_k.rs:206`), covered by P5's shared materialization, not here.
 Files: `src/compute/src/render/top_k.rs`.
 Base: Wave 1 complete.

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -327,7 +327,11 @@ Base: Wave 1 complete.
 Build the linear and delta join outputs into a `ColumnBuilder`.
 Confirmed feasible by the prototype, builder swaps with no blocker.
 Delta join: `half_join_internal_unsafe` is generic over its output `ContainerBuilder` (`differential-dogs3 half_join2.rs:121-140`); swap `CapacityContainerBuilder<Vec>` (`delta_join.rs:406`) for `ColumnBuilder` and the heavy operator emits `Column` directly.
-Linear join: swap the `flat_map_fallible::<ConsolidatingContainerBuilder, ..>` (`linear_join.rs:300`) for the existing `ConsolidatingColumnBuilder` (`columnar/consolidate.rs`), preserving output consolidation.
+Linear join is more intricate: `mz_join_core` emits its stage output as a `Vec` (it is bounded `C: SizableContainer + PushInto<(Item,T,Diff)>` and builds via `CapacityContainerBuilder<C>`, which `Column` does not satisfy), and this stage output is intra-operator, so it stays `Vec` (out of scope, like reduce/topk internals; a columnar `mz_join_core` is a differential-side fast-follow, not in scope here).
+Only the node's FINAL output edge is made columnar, per finalization path:
+the `Some(final_closure)` path applies the closure via `flat_map_fallible` with a `ConsolidatingColumnBuilder` output (parity, the old builder was `ConsolidatingContainerBuilder`);
+the `None` (identity) path encodes the raw stage `Vec` to `Column` via `vec_to_columnar` (the accepted leaf-encode, symmetric to P9, non-consolidating to match the old raw output).
+This adds one `VecToColumnar` operator on the common identity-closure linear join, the necessary cheap (borrowed byte-copy) cost of a `Vec`-producing operator feeding a columnar edge.
 The carried-time `(Row, T)` payload is `Columnar`.
 Join input is untouched here: linear-join input is C4, and delta-join input is arrangement-only, subsumed by C1.
 Files: `src/compute/src/render/join/linear_join.rs`, `src/compute/src/render/join/delta_join.rs`.

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -148,7 +148,6 @@ graph TD
     C2["C2: FlatMap input decode via the edge, fueling preserved"]
     C3["C3: TopK input columnar"]
     C4["C4: linear-join input columnar"]
-    C7["C7: LetRec sanctioned decode, consume edge then into_vec"]
     C8["C8: Union temporal-bucket sanctioned decode, consume edge then into_vec"]
   end
   subgraph Wave2["Wave 2: producers flip, every consumer already native"]
@@ -177,9 +176,9 @@ graph TD
 
 The bold edge from Wave 1 to Wave 2 is the producer-flip invariant: no producer node starts until every consumer node has landed.
 Within Wave 1, C1 gates the three nodes that reuse its columnar key-forming pattern.
-F1, C2, C7, and C8 are independent roots.
+F1, C2, and C8 are independent roots.
 F1 gives the native columnar `consolidate_named` that Union's `concat_many` then `consolidate_named` path uses once its inputs are columnar in Wave 2.
-C7 and C8 are sanctioned decode nodes, so they do not depend on F1.
+C8 is a sanctioned decode node, so it does not depend on F1.
 Within Wave 2, each producer feeds only native consumers, so the nodes are mutually independent and land in any order.
 Wave 3 collapses the enum.
 Its producer half is compiler-enforced, see the completeness note.
@@ -256,16 +255,13 @@ The arranged-input branch reads an arrangement via `as_collection_core`, itself 
 Confirmed by inspection of `sinks.rs`; no separate node exists.
 NOTE for T2: `sinks.rs:71` is a leaf-decode call site that T2 must adapt when `into_vec` changes from an enum method to a free function.
 
-**C7: LetRec sanctioned decode.**
-Make LetRec consume the columnar edge and decode locally via `into_vec`, keeping today's `Vec` feedback logic.
-This is a sanctioned decode point, resolved by the prototype.
-`branch_when` is container-generic and would type-check on a columnar stream, but the feedback machinery is not: `Variable::set` needs `ResultsIn` (`collection.rs:1371`, `Vec` only), `Collection::negate` needs `Negate` (`collection.rs:1350`, `Vec` only), and `leave_dynamic` (`render.rs:1001`, `dynamic/mod.rs:28`) mutates each record's time in place.
-Going native means adding `impl Negate for Column`, `impl ResultsIn for Column`, and a `columnar_leave_dynamic`, all mirroring `columnar_negate` (`columnar.rs:279`), which forks differential's `PointStamp` time arithmetic into our tree.
-Deferred as a fast-follow if the per-iteration decode shows up hot.
-LetRec already decodes at `render.rs:941/997` and consolidates on `Vec`, so it does not need F1.
-Files: `src/compute/src/render.rs`.
-Test: recursive-view sqllogictest including the iteration limit and the error-distinctness path.
-Base: `upstream/main`.
+**C7: LetRec sanctioned decode.** No work, subsumed by the #36507 scaffolding.
+LetRec already consumes `bundle.collection` (the `CollectionEdge`) directly and leaf-decodes via `into_vec` at `render.rs:941/997`, then runs `consolidate_named` + `branch_when` + the iteration limit on the resulting `Vec`.
+That is exactly the desired sanctioned-decode end state: when a producer flips columnar in Wave 2, `into_vec` decodes the columnar arm at this leaf.
+The feedback machinery stays `Vec` deliberately (`branch_when` type-checks on a columnar stream, but `Variable::set`/`Collection::negate`/`leave_dynamic` are `Vec` only; going native would fork differential's `PointStamp` arithmetic, a liability), so no native rewrite is attempted.
+The consolidation uses the raw `CollectionExt::consolidate_named` on the already-decoded `Vec`, post-decode, so F1 is irrelevant here.
+Confirmed by inspection of `render.rs`; no separate node exists.
+NOTE for T2: `render.rs:941/997` are leaf-decode call sites T2 must adapt when `into_vec` becomes a free function.
 
 **C8: Union temporal-bucket sanctioned decode.**
 Keep the `into_vec` at `render.rs:1358` that feeds `maybe_apply_temporal_bucketing` inside a consolidating Union, adapted to consume the columnar edge.
@@ -365,12 +361,12 @@ So the DAG is flattened into a single chain, managed with gh-stack, where each b
 The chain is a topological order of the DAG, so every dependency edge points backward:
 
 ```
-C1 -> C3 -> C4 -> F1 -> C2 -> C7 -> C8
+C1 -> C3 -> C4 -> F1 -> C2 -> C8
    -> P1 -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9
    -> T1 -> T2 -> T3
 ```
 
-C5 and C6 are not in the chain: delta-join input is subsumed by C1, and the sink already leaf-decodes the edge (see the C5 and C6 nodes).
+C5, C6, and C7 are not in the chain: delta-join input is subsumed by C1, and the sink and LetRec already leaf-decode the edge (see the C5, C6, and C7 nodes).
 
 Order constraints honored by this chain:
 

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -162,7 +162,8 @@ graph TD
     Ta["Ta: temporal-bucketing re-encode (into_vec to vec_to_columnar)"]
     Tb["Tb: linear-join accumulator off the edge (M1)"]
     Tc["Tc: retire as_specific_collection flag-off branch (M2)"]
-    Td["Td: retire concat_many mixed-variant branch (needs Ta)"]
+    Tp["Tp: LetRec read-edge re-encode (2nd mixed-input source)"]
+    Td["Td: retire concat_many mixed-variant branch (needs Ta + Tp)"]
     Te["Te: collapse enum to a columnar alias + de-match methods"]
   end
   C1 --> C3
@@ -171,7 +172,8 @@ graph TD
   Wave2 --> Ta
   Ta --> Tb
   Tb --> Tc
-  Tc --> Td
+  Tc --> Tp
+  Tp --> Td
   Td --> Te
 ```
 
@@ -377,12 +379,22 @@ The flag defaults true, so production already takes the columnar fueled path; de
 Files: `src/compute/src/render/context.rs`, `src/compute-types/src/dyncfgs.rs`.
 Base: `Tb`.
 
-**Td: retire the `concat_many` mixed-variant upgrade branch.**
-After Ta, no producer feeds a `Vec` edge into a `concat_many`, so the mixed-variant upgrade branch (`columnar.rs:143-146`) is dead.
-Delete it (and the now-unreachable all-`Vec` branch).
-Blocked before Ta: temporal-bucketing was the last source of mixed inputs.
-Files: `src/compute/src/render/columnar.rs`.
+**Tp: LetRec read-edge re-encode.**
+The pre-teardown review missed that LetRec is a second source of `Vec` inputs into `concat_many` (temporal-bucketing was not the last one).
+A rec binding's bundle read-edge is `CollectionEdge::Vec` (`from_collections` at `render.rs:942` in-loop feedback and `:1014` extraction; the feedback machinery `Variable::set` / `branch_when` / `leave_dynamic` is `Vec`-only, the C7 reason).
+Union reads its inputs' `.collection` raw (`render.rs:1359`), so an identity `Get` on a rec binding delivers that `Vec` edge straight into `concat_many` (proven: `WITH MUTUALLY RECURSIVE foo … Union[Get l0 raw=true, Constant]`).
+Re-encode the bundle read-edge to `Columnar` via `vec_to_columnar` at `render.rs:942` and `:1014` (wrap the `leave_dynamic` result) so `Get`s on rec bindings see `Columnar`.
+The feedback `Variable` itself (`oks_v.set` at `:1004`) STAYS `Vec` (only the read-edge is re-encoded).
+This adds a `VecToColumnar` on the feedback-read (per iteration, inside the dynamic scope) and the extraction paths, so it needs its own iterative-scope soundness check (the feedback path is delicate).
+Files: `src/compute/src/render.rs`.
 Base: `Tc`.
+
+**Td: retire the `concat_many` mixed-variant upgrade branch.**
+After Ta (temporal-bucketing) and Tp (LetRec), no producer feeds a `Vec` edge into a `concat_many`, so the mixed-variant upgrade branch (`columnar.rs:143-146`) and the now-unreachable all-`Vec` branch are dead.
+Delete them, leaving the all-`Columnar` concatenation.
+Blocked before Ta and Tp: temporal-bucketing and LetRec were the two sources of mixed inputs.
+Files: `src/compute/src/render/columnar.rs`.
+Base: `Tp`.
 
 **Te: collapse the enum and de-match the carrier methods.**
 Replace `CollectionEdge` with a `ColumnarCollection` type alias; demote `into_vec`/`columnar_to_vec`/`vec_to_columnar` to leaf free fns; update `CollectionBundle.collection` and every construction/match site; simplify `negate`, `concat_many`, `consolidate_named`, `flat_map_datums` from arm matches to single columnar implementations (the columnar `consolidate_named` becomes the sole impl).
@@ -402,7 +414,7 @@ The chain is a topological order of the DAG, so every dependency edge points bac
 ```
 C1 -> C3 -> C4 -> F1 -> C2
    -> P1 -> P2 -> P4 -> P5 -> P6 -> P7 -> P9
-   -> Ta -> Tb -> Tc -> Td -> Te
+   -> Ta -> Tb -> Tc -> Tp -> Td -> Te
 ```
 
 C5, C6, C7, C8, P3, and P8 are not in the chain (subsumed, see their nodes): delta-join input by C1; the sink, LetRec, and Union temporal-bucketing already leaf-decode the edge; the ArrangeBy passthrough by C1+P1; and the Threshold output by P5's shared arrangement materialization.
@@ -414,7 +426,7 @@ Order constraints honored by this chain:
 
 * C1 precedes C3 and C4, which reuse its columnar key-forming pattern.
 * All consumer nodes, C and F, precede all producer nodes P, per the producer-flip invariant.
-* The teardown Ta, Tb, Tc, Td, Te is last, in order (expanded from T1/T2/T3 by the pre-teardown review; Td needs Ta).
+* The teardown Ta, Tb, Tc, Tp, Td, Te is last, in order (expanded from T1/T2/T3 by the pre-teardown review, then Tp added when Td's investigation found LetRec is a second mixed-input source; Td needs both Ta and Tp).
 
 The `Base` field in each node spec records the nearest semantic dependency.
 In the chain, a branch's git base is simply the entry before it, which transitively includes every earlier dependency.

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -14,32 +14,49 @@ PR #36507 scaffolded `CollectionEdge<'scope, T>`, an enum with `Vec` and `Column
 Today no producer emits the columnar arm, so the columnar path is dead in production, and the migration from row-based to columnar edges has no plan.
 
 The risk in migrating is complexity.
-A naive migration maintains two parallel implementations per operator, or gates the change behind a feature flag, and either approach grows code complexity to unbounded levels over the course of a long migration.
+A naive migration maintains two parallel implementations per operator, or gates the change behind a per-operator progress flag, and either approach grows code complexity to unbounded levels over the course of a long migration.
 
 ## Success Criteria
 
 * Every compute dataflow edge carries columnar `Column` batches.
 * The `Vec` arm of `CollectionEdge` is deleted, and the enum collapses to a single columnar type.
-* No internal consumer decodes an edge to rows.
-  `into_vec` survives only as a leaf helper for consumers that serialize rows anyway.
+* No internal consumer decodes an edge to rows, except for a small set of explicitly sanctioned decode points named in this document.
+  `into_vec` otherwise survives only as a leaf helper for consumers that serialize rows anyway.
 * The migration proceeds as a sequence of small, independently landable pull requests, each with a test gate.
 * No single code path maintains both representations at once.
   There is no feature flag.
-* No permanent performance regression.
-  Transient regressions during the transition are acceptable.
+* No permanent performance regression, and no seam-heavy intermediate state on `main` (see the producer-flip invariant below).
+  Transient upgrade seams are acceptable.
+
+### Sanctioned decode points
+
+Two internal consumers may retain a permanent `ColumnarToVec` decode if the columnar rewrite proves infeasible.
+They do not serialize rows, so they are exceptions to the no-internal-decode criterion, not instances of it.
+
+* LetRec, if `branch_when` and the recursive feedback path cannot operate on a columnar stream (node C7).
+* Union temporal-bucketing, if `maybe_apply_temporal_bucketing` is inherently row-shaped (node C8).
+
+Their feasibility is resolved in the prototype phase, not at the end of the stack.
+If either goes native, it is not a decode point.
+If either stays a decode point, it is a leaf `columnar_to_vec` and is compatible with the final enum collapse.
 
 ## Out of Scope
 
 * **Generalizing `CollectionExt`.**
   The trait is a dead-end.
   We do not make it container-generic.
+  This is a bet that the columnar edge method set stays small.
+  Each method the migration needs gets a parallel columnar free function, as `columnar_negate` and `vec_to_columnar` already are.
+  For the current small set this is tolerable localized duplication.
+  A future feature that wants a new `CollectionExt` method on a columnar edge will add another bespoke function.
 * **Intra-operator `Vec` use.**
   `explode_one` and `ensure_monotonic` run on `Vec` collections inside reduce and top-k.
   The compute contract lets operators materialize `Vec` collections internally.
   Only the inter-node edge format is constrained, so these stay on `VecCollection`.
 * **Generalizing batcher selection.**
-  The columnar `consolidate_named` uses the `Col2KeyBatcher` family as a temporary second variant.
+  The columnar `consolidate_named` uses the `Col2KeyBatcher` family as a second variant alongside the `Vec` `KeyBatcher` variant.
   We do not invest in a generic batcher-selection abstraction.
+  When the `Vec` arm is deleted, the columnar variant becomes the sole implementation.
 * **The columnar persist blob format.**
   Sinks change to consume columnar input, but the on-blob encoding that persist writes is unchanged.
   A sink that serializes rows may decode locally at the leaf.
@@ -49,18 +66,48 @@ A naive migration maintains two parallel implementations per operator, or gates 
 Migrate consumers first, then producers, then delete the `Vec` arm.
 The enum stays as the single locus of representation-matching for the whole migration, so operators call enum methods and stay representation-agnostic, and producers flip one at a time under type unification.
 Each operator has one code path at a time.
-We accept a temporary performance impact during the transition rather than duplicating operators or feature-flagging the change.
-The migration direction for each edge is chosen to minimize churn: we pair a producer flip with the consumer work that makes its downstream native, so no decode-back seam lingers.
-The `Vec`-arm deletion is the completeness test.
-The teardown will not compile until every producer is columnar and every internal consumer is columnar-native.
+We accept transient upgrade seams during the transition rather than duplicating operators or feature-flagging the change.
+
+### The producer-flip invariant
+
+A producer flips to columnar only after every one of its consumers is columnar-native.
+
+This invariant is the core of the plan.
+It splits the work cleanly into a consumer wave and a producer wave.
+During the consumer wave every producer still emits `Vec`, so the columnar arms are dead code and there is zero runtime change on `main`.
+During the producer wave every consumer is already native, so a producer flip inserts no `ColumnarToVec` decode.
+The only seam that can appear is a cheap `VecToColumnar` upgrade at a Union that still mixes a `Vec` input with a columnar one, which copies bytes but allocates no per-record `Row`.
+The expensive direction, a `ColumnarToVec` decode that allocates an owned `Row` per record, never appears in an intermediate state.
+
+This is why the plan needs no feature flag.
+There is no seam-heavy intermediate state to roll back from.
+The consumer wave is behaviorally identical to today, and the producer wave only ever adds cheap upgrades.
+See the rollback discussion below for the residual incident story.
+
+The invariant supersedes the earlier framing of choosing a per-edge direction to minimize churn.
+Producer-first flips maximize churn, because they force the expensive decode at every not-yet-native consumer.
+Consumer-first per subgraph is the churn minimum, so we make it a hard rule rather than a per-edge judgment call.
+
+### Rollback and incident response
+
+There is no runtime kill-switch.
+The incident response to a regression introduced by a landed pull request is to revert that pull request and cut a release.
+Because later stacked pull requests may sit on top of a reverted one, the revert can require manual conflict resolution.
+
+We judge this acceptable for this migration specifically, because the producer-flip invariant removes the seam-heavy intermediate state that would otherwise be the regression risk.
+The consumer wave changes no runtime behavior, so it cannot regress.
+The producer wave only adds cheap `VecToColumnar` upgrades, bounded to mixed-input Unions.
+The residual risk is a correctness bug in a columnar arm, which a revert addresses, not a systemic performance or availability regression that would demand a fast runtime toggle.
+If a columnar arm is found to regress memory enough to threaten a replica, the mitigation is to revert the single producer flip that introduced it, which restores the `Vec` edge for that operator.
 
 ### Current operator map
 
 The table records how each Plan node reads its input and produces its output today, and the seam that blocks columnar flow.
-Verified against the tree at `cb4b1d2e6f`.
+Verified against the tree at `cb4b1d2e6f`, the parent of the commit that adds this document.
 
 | Node | Input read | Output produced | Seam today |
 |---|---|---|---|
+| Source and index imports | persist or trace | `from_collections` into `Vec` (`render.rs:374, 474, 668`) | producer emits `Vec` |
 | Constant | none | `to_stream` into `Vec` | producer emits `Vec` |
 | Get::PassArrangements | carries the bundle | passes the bundle | none |
 | Get::Arrangement, Get::Collection, Mfp | native `flat_map` or arrangement | `as_collection_core` into `Vec` | producer output builder is `Vec` |
@@ -76,69 +123,72 @@ Verified against the tree at `cb4b1d2e6f`.
 
 Three grounding mechanism facts:
 
-* `arrange_collection` in `context.rs` already emits `ColumnBuilder<((Row, Row), T, Diff)>` and arranges via `columnar_exchange` plus `Col2ValPagedBatcher`.
+* `arrange_collection` in `context.rs` already emits `ColumnBuilder<((Row, Row), T, Diff)>` (`context.rs:1147`) and arranges via `columnar_exchange` (`context.rs:1189`).
+  The batcher is `Col2ValPagedBatcher` when `ENABLE_COLUMN_PAGED_BATCHER` is set and `Col2ValBatcher` otherwise (`context.rs:1093, 1190-1206`).
   The arrangement pipeline is already columnar internally.
   The only `Vec`-ness is the input, fed by `into_vec` at `context.rs:1071`, and the passthrough re-wrap at `context.rs:1102`.
-* `as_collection_core` and `as_specific_collection` hardwire `VecCollection<Row>` output through `SharedRow` packing.
+* `as_collection_core` (`context.rs:906`) and `as_specific_collection` (`context.rs:560`) hardwire `VecCollection<Row>` output.
   Flipping the `flat_map`-family producers means building into a `ColumnBuilder` there.
-* The columnar batcher family exists: `ColumnMergeBatcher`, `Col2KeyBatcher<K, T, R>`, and the paged chunker.
+  Note `as_specific_collection` serves both a producer role and a consumer role, so it is split during the migration, see node P1.
+* The columnar batcher family exists: `ColumnMergeBatcher` (`timely-util/src/columnar/merge_batcher.rs`), `Col2KeyBatcher<K, T, R>` which is `Col2ValBatcher<K, (), T, R>` (`timely-util/src/columnar.rs:50`), and the paged `ColumnChunker` (`timely-util/src/columnar/batcher.rs`).
 
 ### Change DAG
 
 ```mermaid
 graph TD
-  subgraph Wave1["Wave 1: native consumers, columnar arm still dead, zero runtime bounce"]
+  subgraph Wave1["Wave 1: consumers native, producers still Vec, zero runtime change"]
     F1["F1: consolidate_named columnar variant via Col2KeyBatcher"]
-    C1["C1: arrange input columnar, ensure_collections and arrange_collection accept the edge, passthrough preserves variant"]
-    C2["C2: FlatMap uses flat_map_datums, drops as_specific_collection"]
+    C1["C1: arrange input columnar"]
+    C2["C2: FlatMap input decode via the edge, fueling preserved"]
+    C3["C3: TopK input columnar"]
+    C4["C4: linear-join input columnar"]
+    C5["C5: delta-join input columnar"]
     C6["C6: sink columnar input API"]
+    C7["C7: LetRec columnar or sanctioned decode"]
+    C8["C8: Union temporal-bucket columnar or sanctioned decode"]
   end
-  subgraph Wave2["Wave 2: flip producers into now-native consumers"]
-    P1["P1: as_collection_core and as_specific_collection columnar output, flips Mfp and Get"]
+  subgraph Wave2["Wave 2: producers flip, every consumer already native"]
+    P1["P1: as_collection_core columnar output, flips Get and Mfp"]
     P2["P2: Constant columnar"]
     P3["P3: ArrangeBy passthrough columnar"]
     P4["P4: FlatMap output columnar"]
-  end
-  subgraph Wave3["Wave 3: operator input and output pairs"]
-    C3P6["C3+P6: TopK input and output columnar"]
-    C4C5P7["C4, C5, P7: linear and delta join input and output columnar"]
     P5["P5: Reduce output columnar"]
+    P6["P6: TopK output columnar"]
+    P7["P7: Join output columnar"]
     P8["P8: Threshold output columnar"]
-    C7["C7: LetRec consolidate and branch_when columnar"]
-    C8["C8: Union temporal-bucket columnar"]
+    P9["P9: source and index import producers columnar"]
   end
-  subgraph Wave4["Wave 4: teardown, compiler-enforced"]
+  subgraph Wave3["Wave 3: teardown, producer half compiler-enforced"]
     T1["T1: delete vec_to_columnar"]
     T2["T2: collapse enum to a columnar alias, into_vec becomes a leaf fn"]
     T3["T3: de-match negate, concat_many, consolidate_named"]
   end
-  C1 --> P1
-  C1 --> P3
-  C2 --> P4
-  C6 --> P1
-  C1 -.pattern.-> C3P6
-  C1 -.pattern.-> C4C5P7
   F1 --> C7
   F1 --> C8
-  P1 --> T1
-  P2 --> T1
-  P3 --> T1
-  P4 --> T1
-  C3P6 --> T1
-  C4C5P7 --> T1
-  P5 --> T1
-  P8 --> T1
+  C1 --> C3
+  C1 --> C4
+  C1 --> C5
+  Wave1 ==> Wave2
+  Wave2 --> T1
   T1 --> T2
-  C6 --> T2
-  C7 --> T2
-  C8 --> T2
   T2 --> T3
 ```
 
-Wave 1 makes the high fan-out consumers columnar-native while every producer still emits `Vec`, so the columnar arm stays dead and there is zero runtime bounce, with a single code path throughout.
-Wave 2 and later flip producers paired with their now-native consumers, so no decode-back seam lingers, which is the per-subgraph churn minimization.
-The enum stays the carrier the whole time.
-Wave 4 collapses it once T1 proves no `Vec` producer remains, and the teardown is compiler-enforced.
+The bold edge from Wave 1 to Wave 2 is the producer-flip invariant: no producer node starts until every consumer node has landed.
+Within Wave 1, F1 gates the two consolidate-dependent nodes, and C1 gates the three nodes that reuse its columnar key-forming pattern.
+Within Wave 2, each producer feeds only native consumers, so the nodes are mutually independent and land in any order.
+Wave 3 collapses the enum.
+Its producer half is compiler-enforced, see the completeness note.
+
+### Completeness and its limits
+
+Deleting the `Vec` arm removes the `CollectionEdge::Vec` constructor, so every producer site must switch to columnar or fail to compile.
+This makes the producer half of the migration compiler-enforced.
+
+The consumer half is not compiler-enforced.
+`into_vec` survives as a leaf free function after T2, so an internal consumer that still calls it compiles and runs, silently inserting a `ColumnarToVec` decode.
+Consumer nativeness is therefore verified by the introspection tests described in the testing strategy, which assert that no `ColumnarToVec` operator appears on a consumer's path, plus a whole-plan differential test that renders a plan corpus both ways and asserts identical output.
+The differential test is the behavioral safety net that the type system does not provide.
 
 ### Per-node change specification
 
@@ -148,181 +198,227 @@ The base names the parent the branch stacks on.
 **F1: columnar `consolidate_named`.**
 Replace the decode, consolidate, re-encode round-trip in the `Columnar` arm of `CollectionEdge::consolidate_named` with a native consolidation using `Col2KeyBatcher`.
 Keep the `Vec` arm unchanged.
-This is the temporary second variant.
 Files: `src/compute/src/render/columnar.rs`, possibly a helper in `src/timely-util/src/columnar.rs`.
 Test: extend `consolidate_named_preserves_columnar` to assert the operator no longer contains a `ColumnarToVec`.
 Base: `upstream/main`.
 
 **C1: columnar arrange input.**
-Generalize `ensure_collections` and `arrange_collection` to accept a `CollectionEdge`.
-The `Columnar` arm iterates `data.borrow().into_index_iter()` and borrows datums from the columnar row to form the key, mirroring `flat_map_datums`.
+Generalize `ensure_collections` and `arrange_collection` (`context.rs:1129-1186`) to accept a `CollectionEdge`.
+The `Columnar` arm iterates `data.borrow().into_index_iter()` and borrows datums from the columnar row to form the key, mirroring the proven pattern in the `flat_map_datums` Columnar arm (`columnar.rs:234-242`).
 The passthrough output preserves the input variant, so `context.rs:1102` re-wraps `Columnar` when the input was columnar.
 The key-value output builder and the batcher are unchanged, since they are already columnar.
-This unblocks ArrangeBy, index-export, and every plan-inserted arrangement.
+This unblocks ArrangeBy, index-export, Reduce, and Threshold, all of which consume a plan-inserted arrangement.
 Files: `src/compute/src/render/context.rs`.
 Test: arrangement sqllogictest, plus a unit test that a columnar input yields no `ColumnarToVec` on the arrange path.
 Base: `upstream/main`.
 
-**C2: FlatMap decode via `flat_map_datums`.**
-`render_flat_map` calls `as_specific_collection` then iterates rows.
-Switch it to consume the edge through `flat_map_datums`, which handles both arms natively.
-Files: `src/compute/src/render/flat_map.rs`.
-Test: FlatMap sqllogictest, plus cross-arm agreement as in `flat_map_datums_arms_agree`.
+**C2: FlatMap input decode via the edge, fueling preserved.**
+`render_flat_map` (`flat_map.rs:44-118`) reads its input via `as_specific_collection` and expands table functions under a fuel budget (`COMPUTE_FLAT_MAP_FUEL`) with activator-based yielding.
+The fueling must survive.
+Replace only the input decode so the bespoke `FlatMapStage` reads from the columnar edge, keeping the fuel queue and re-activation.
+Do not route FlatMap through `flat_map_datums`, which drains a full batch with no fuel and would regress availability on large `generate_series`.
+Files: `src/compute/src/render/flat_map.rs`, possibly a fuel-aware columnar input helper.
+Test: FlatMap sqllogictest, plus a large `generate_series` that asserts yielding still occurs.
 Base: `upstream/main`.
 
-**C6: columnar sink input.**
-Change the sink input path so it consumes a columnar edge.
-`sinks.rs:70` clones and calls `into_vec`.
-Persist and subscribe serialize rows, so the decode is acceptable at the leaf, but the API accepts the columnar edge and decodes locally rather than forcing `into_vec` at the boundary.
-Files: `src/compute/src/render/sinks.rs`.
-Test: subscribe and materialized-view sink sqllogictest and testdrive coverage.
-Base: `upstream/main`.
-
-**P1: columnar output for the `flat_map` family.**
-Generalize `as_collection_core` and `as_specific_collection` to build into a `ColumnBuilder` and return a columnar edge.
-This flips the Mfp and Get producers.
-Files: `src/compute/src/render/context.rs`, `src/compute/src/render.rs`.
-Test: physical-plan goldens unchanged, plus sqllogictest for Get and Mfp chains feeding an ArrangeBy or sink.
-Base: `C1`, `C6`.
-
-**P2: columnar Constant.**
-Build the constant collection into a `Column` in the `Constant` arm of `render_plan_expr`.
-Files: `src/compute/src/render.rs`.
-Test: constant-fed sqllogictest.
-Base: `C1`.
-
-**P3: columnar ArrangeBy passthrough.**
-Once C1 preserves the input variant on the passthrough, ensure the passthrough emits `Columnar` when its producer is columnar, and drop any remaining `Vec` re-wrap.
-Files: `src/compute/src/render/context.rs`.
-Test: ArrangeBy followed by a consumer that reads the passthrough collection.
-Base: `C1`.
-
-**P4: columnar FlatMap output.**
-Build the FlatMap output into a `ColumnBuilder`.
-Files: `src/compute/src/render/flat_map.rs`.
-Test: FlatMap feeding a downstream arrange or union.
-Base: `C2`.
-
-**C3+P6: TopK input and output columnar.**
-TopK reads its input via `as_specific_collection(None)` then `into_vec` and arranges by a hash and group key internally.
-Form that key off the columnar batch using the C1 pattern, and build the TopK output into a `ColumnBuilder`.
+**C3: TopK input columnar.**
+TopK reads its input via `as_specific_collection(None)` then `into_vec` (`top_k.rs:67`) and arranges by a hash and group key internally.
+Form that key off the columnar batch using the C1 pattern.
 The intra-operator `explode_one` and `ensure_monotonic` on `Vec` stay unchanged.
 Files: `src/compute/src/render/top_k.rs`.
 Test: top-k sqllogictest including monotonic and limit cases.
 Base: `C1`.
 
-**C4, C5, P7: linear and delta join input and output columnar.**
-The linear-join source-key path and the delta-join input path decode via `as_specific_collection` or local `into_vec`.
-Rework each to consume the columnar batch, and build the join output into a `ColumnBuilder`.
-Split into C4 for linear-join input, C5 for delta-join input, and P7 for the shared output flip if the diffs are large.
-Files: `src/compute/src/render/join/linear_join.rs`, `src/compute/src/render/join/delta_join.rs`.
-Test: join sqllogictest across linear and delta plans.
+**C4: linear-join input columnar.**
+The linear-join source-key path decodes via `as_specific_collection` (`linear_join.rs:245`).
+Rework it to consume the columnar batch using the C1 pattern.
+Files: `src/compute/src/render/join/linear_join.rs`.
+Test: linear-join sqllogictest.
 Base: `C1`.
+
+**C5: delta-join input columnar.**
+Rework the delta-join input path to consume the columnar batch.
+This is the most intricate operator, so it is a separate node from C4.
+Files: `src/compute/src/render/join/delta_join.rs`.
+Test: delta-join sqllogictest.
+Base: `C1`.
+
+**C6: sink columnar input.**
+Change the sink input path so it consumes a columnar edge.
+`sinks.rs:71` clones and calls `into_vec`.
+Persist and subscribe serialize rows, so the decode is acceptable at the leaf, but the API accepts the columnar edge and decodes locally rather than forcing `into_vec` at the boundary.
+Files: `src/compute/src/render/sinks.rs`.
+Test: subscribe and materialized-view sink sqllogictest and testdrive coverage.
+Base: `upstream/main`.
+
+**C7: LetRec columnar or sanctioned decode.**
+Consume the LetRec edge as columnar.
+The Vec-bound surface is the whole recursive feedback path, not only `branch_when`: the feedback `Variable` (`render.rs:921-924`), its set (`render.rs:990`), `leave_dynamic` (`render.rs:1001`), and the limit branch (`render.rs:961`).
+`Variable` is container-generic, so the change is type-permitted.
+LetRec's consolidation currently calls the raw `CollectionExt::consolidate_named` on an already-decoded `Vec` (`render.rs:946`), so this node must reroute it to the edge's `consolidate_named`, which is why it depends on F1.
+If `branch_when` on columnar proves infeasible, keep LetRec as a sanctioned leaf decode instead, which is compatible with T2.
+Files: `src/compute/src/render.rs`.
+Test: recursive-view sqllogictest including the iteration limit and the error-distinctness path.
+Base: `F1`.
+
+**C8: Union temporal-bucket columnar or sanctioned decode.**
+`render.rs:1358` decodes via `into_vec` to apply temporal bucketing inside a consolidating Union.
+Make `maybe_apply_temporal_bucketing` operate on the columnar stream.
+If bucketing is inherently row-shaped, keep the decode as a sanctioned leaf.
+F1 must land first, since a columnar Union consolidate would otherwise round-trip.
+Files: `src/compute/src/render.rs`, the timestamp trait sites for `maybe_apply_temporal_bucketing`.
+Test: temporal and temporal-bucketing sqllogictest.
+Base: `F1`.
+
+**P1: columnar output for the `flat_map` family.**
+Generalize `as_collection_core` to build into a `ColumnBuilder` and return a columnar edge, which flips the Get and Mfp producers.
+Rework its identity fast-path (`context.rs:927-929`) so it no longer delegates a `Vec` to `as_specific_collection`.
+Leave `as_specific_collection` returning `Vec` as a consumer leaf until its remaining callers are retired.
+This keeps P1's base at the arrange path and the sink, both native by Wave 2.
+Files: `src/compute/src/render/context.rs`, `src/compute/src/render.rs`.
+Test: physical-plan goldens unchanged, plus sqllogictest for Get and Mfp chains feeding an ArrangeBy or sink.
+Base: Wave 1 complete.
+
+**P2: columnar Constant.**
+Build the constant collection into a `Column` in the `Constant` arm of `render_plan_expr`.
+Files: `src/compute/src/render.rs`.
+Base: Wave 1 complete.
+
+**P3: columnar ArrangeBy passthrough.**
+Ensure the passthrough emits `Columnar` when its producer is columnar, and drop any remaining `Vec` re-wrap (`context.rs:1102`).
+Files: `src/compute/src/render/context.rs`.
+Base: Wave 1 complete.
+
+**P4: columnar FlatMap output.**
+Build the FlatMap output into a `ColumnBuilder`.
+Files: `src/compute/src/render/flat_map.rs`.
+Base: Wave 1 complete.
 
 **P5: columnar Reduce output.**
 Build the final Reduce output into a `ColumnBuilder`.
 Internals stay on `Vec`.
 Files: `src/compute/src/render/reduce.rs`.
-Test: reduce sqllogictest across accumulable, hierarchical, and basic plans.
-Base: `upstream/main`, or the Wave 3 tip if it shares helpers.
+Base: Wave 1 complete.
+
+**P6: columnar TopK output.**
+Build the TopK output into a `ColumnBuilder`.
+Files: `src/compute/src/render/top_k.rs`.
+Base: Wave 1 complete.
+
+**P7: columnar Join output.**
+Build the linear and delta join outputs into a `ColumnBuilder`.
+Files: `src/compute/src/render/join/linear_join.rs`, `src/compute/src/render/join/delta_join.rs`.
+Base: Wave 1 complete.
 
 **P8: columnar Threshold output.**
 Build the Threshold output into a `ColumnBuilder`.
 Files: `src/compute/src/render/threshold.rs`.
-Test: threshold sqllogictest.
-Base: `upstream/main`.
+Base: Wave 1 complete.
 
-**C7: columnar LetRec.**
-Run the LetRec consolidation and the `branch_when` iteration-limit logic on the columnar stream.
-Depends on F1 for the native columnar consolidate.
-This is the least-trodden path.
-If `branch_when` on columnar resists, keep LetRec as a decode point longer and record why.
+**P9: columnar import producers.**
+The source imports (`render.rs:374, 474`) and the `SnapshotMode::Exclude` index import (`render.rs:647-668`) build `from_collections` with a `VecCollection`.
+Build a `Column` at these boundaries.
+Imports read from persist or a trace, so a `vec_to_columnar` upgrade at the boundary is acceptable, symmetric to the sink leaf.
 Files: `src/compute/src/render.rs`.
-Test: recursive-view sqllogictest including the iteration limit and the error-distinctness path.
-Base: `F1`.
-
-**C8: columnar Union temporal-bucket.**
-`render.rs:1358` decodes via `into_vec` to apply temporal bucketing inside a consolidating Union.
-Make `maybe_apply_temporal_bucketing` operate on the columnar stream, or keep the decode and document it as a leaf if bucketing is inherently row-shaped.
-Files: `src/compute/src/render.rs`, the timestamp trait sites for `maybe_apply_temporal_bucketing`.
-Test: temporal and temporal-bucketing sqllogictest.
-Base: `F1` if it shares the consolidate, else `upstream/main`.
+Test: source and index import sqllogictest and testdrive coverage.
+Base: Wave 1 complete.
 
 **T1: delete `vec_to_columnar`.**
 Once every producer emits columnar, no edge carries `Vec`, so `vec_to_columnar` is dead.
 Delete it and the mixed-variant upgrade branch in `concat_many`.
 Files: `src/compute/src/render/columnar.rs`.
-Base: the merge of all P nodes and the Wave 3 consumer nodes.
+Base: all P nodes.
 
 **T2: collapse the enum.**
 Replace `CollectionEdge` with a `ColumnarCollection` type alias.
-Demote `into_vec` to a free function used only by leaf consumers that serialize rows.
+Demote `into_vec` to a free function used only by leaf consumers that serialize rows and by any sanctioned decode point.
 Update `CollectionBundle.collection` and all construction sites.
+This is the widest diff, touching `context.rs` and every construction site, so alias the enum first and land the construction-site churn as a mechanical rename reviewed separately.
 Files: `src/compute/src/render/columnar.rs`, `src/compute/src/render/context.rs`, `src/compute/src/render.rs`, and every construction site.
-Base: `T1`, `C6`, `C7`, `C8`.
+Base: `T1`.
 
 **T3: de-match the carrier methods.**
 Simplify `negate`, `concat_many`, and `consolidate_named` from arm matches to single columnar implementations.
-Remove the temporary second consolidate variant.
+The columnar `consolidate_named` becomes the sole implementation.
 Files: `src/compute/src/render/columnar.rs`.
 Base: `T2`.
 
 ### Stacked pull requests
 
-The DAG is not a single chain, so it is several stacks off `upstream/main` that converge at the teardown.
+The consumer wave is several short stacks off `upstream/main`.
 
-* Lane A, off `C1`: `P1` also needs `C6`, then `P3`.
-* Lane B: `C2` then `P4`.
-* Lane C: `C6` feeds `P1` and `T2`.
-* Lane D: `F1` then `C7`, `C8`.
-* Lane E, off `C1`: `C3+P6`, `C4`, `C5`, `P7`.
-* Independent: `P2` off `C1`, `P5` and `P8` off `upstream/main`.
-* Convergence: `T1` rebases on all producer and Wave 3 consumer lanes, then `T2`, then `T3`.
+* `F1` then `C7`, `C8`.
+* `C1` then `C3`, `C4`, `C5`.
+* `C2` and `C6` are independent, off `upstream/main`.
+
+The producer wave starts only after the entire consumer wave has landed, which resolves the fan-in problem: the producer nodes and the teardown rebase on a single merged base, not on a live tangle of consumer stacks.
+Producer nodes are mutually independent.
+The teardown is a short chain `T1`, `T2`, `T3` on top of the merged producer wave.
 
 gh-stack reference: https://github.github.com/gh-stack/#get-started
 
 ### Testing strategy
 
 * Every consumer node lands a unit test that asserts the columnar path introduces no `ColumnarToVec` operator, reusing the introspection-visible seam names.
-* Every producer node keeps physical-plan goldens unchanged, since the edge representation is not part of the plan text.
+* A whole-plan differential test renders a corpus of plans both ways and asserts identical output.
+  This is the behavioral gate that the compiler does not provide, and it must pass before T2.
+* Every producer node keeps physical-plan and EXPLAIN text goldens unchanged, since the edge representation is not part of the plan text.
+* Operator-introspection goldens are a separate concern and will churn.
+  Each node that moves a seam changes the operator set in `mz_dataflow_operators` and related views.
+  Inventory the introspection-based sqllogictest goldens and the platform-checks that assert on dataflow shape up front, decide whether seam operators should be filtered from those views, and budget the golden rewrites into each pull request.
 * Cross-arm agreement follows the `flat_map_datums_arms_agree` pattern.
   The vec and columnar arms must extract identical updates.
-* A feature-benchmark reduce and top-k run guards against a regression that outlives the transition, not against transient cost.
+* A feature-benchmark reduce and top-k run guards against a regression that outlives the transition.
 
 ## Minimal Viable Prototype
 
-The prototype validates the two load-bearing mechanisms end to end: the columnar arrange input (C1) and the `flat_map`-family producer flip (P1).
-Land C1 and P1, then render a `SELECT` that flows Get into an ArrangeBy.
-Assert that the rendered dataflow contains no `ColumnarToVec` operator on that path, and that results match the row-based rendering.
-This de-risks the C1 key-forming pattern that C3, C4, and C5 reuse, before committing to the operator-local arrange diffs.
+The prototype must de-risk the mechanisms whose feasibility is genuinely uncertain, not the well-understood ones.
+It covers three throwaway spikes before the stack is committed:
+
+* C1 columnar arrange input, `Get` into `ArrangeBy`, asserting no `ColumnarToVec` on the path and identical results.
+  This validates the key-forming borrow pattern that C3, C4, and C5 reuse.
+* `branch_when` on a columnar stream, the load-bearing uncertainty for C7.
+* `maybe_apply_temporal_bucketing` on a columnar stream, the load-bearing uncertainty for C8.
+
+The enum collapse can only complete if C7 and C8 either go native or are accepted as sanctioned decode points, so their feasibility belongs in the prototype rather than at the end of a long stack.
+A columnar join output, building into a `ColumnBuilder`, is worth a fourth spike, since it is a different mechanism from the arrange input and feeds the most intricate operators.
 
 ## Alternatives
 
 * **Two parallel implementations per operator.**
   Maintain both the `Vec` and columnar code paths at every operator until the migration completes.
   Rejected because the complexity grows to unbounded levels over a long migration.
-* **Feature-flag the change.**
-  Gate columnar edges behind a config flag.
-  Rejected for the same complexity reason, and because the flag plus the enum multiplies the states to reason about.
+* **Per-operator progress flag.**
+  Gate each operator's representation behind config.
+  Rejected because it multiplies the states to reason about, the enum times the flag.
+* **Coarse force-Vec kill-switch.**
+  A single dyncfg checked once at edge construction, disabled meaning today's exact `Vec` behavior.
+  This would give a runtime rollback for an intermediate regression.
+  Not adopted, because the producer-flip invariant removes the seam-heavy intermediate state that motivates a kill-switch: the consumer wave changes no behavior and the producer wave only adds cheap upgrades.
+  The residual risk is a correctness bug, which a revert addresses.
+  Revisit this if the prototype shows the producer wave carries a memory risk after all.
 * **Generalize `CollectionExt` over its container.**
   Make the trait container-generic so a columnar collection is a first-class implementation.
   Rejected because the trait is a dead-end.
-  Behavior-specific needs are met by keeping intra-operator `Vec` uses as they are and giving `consolidate_named` a temporary second variant.
+  Intra-operator `Vec` uses stay as they are, and `consolidate_named` gets a second variant.
 * **Collapse the enum to a columnar-only edge with local adapters now.**
   Make the edge type columnar immediately and insert `vec_to_columnar` and `columnar_to_vec` adapters at unmigrated boundaries.
   Rejected because it doubles conversions at unmigrated producer-consumer pairs, a worse transient cost, and the enum-as-carrier keeps the representation-matching in one place.
-* **Strict consumer-first with a dead columnar arm throughout.**
-  Migrate every consumer natively before any producer flips, so there is no transient perf hit.
-  Not chosen as a strict rule, since it front-loads per-operator native code before any producer benefits.
-  The chosen per-subgraph direction pairs each producer flip with its consumer work instead.
+* **Producer-first, or per-edge direction chosen ad hoc.**
+  Flip producers early, or decide direction edge by edge.
+  Rejected because producer-first flips force the expensive `ColumnarToVec` decode at every not-yet-native consumer, and an ad-hoc rule lets two sessions make conflicting choices at a shared edge.
+  The producer-flip invariant is the churn minimum and is unambiguous.
 
 ## Open questions
 
 * **Join node granularity.**
-  C4, C5, and P7 are grouped.
-  The split into linear-input, delta-input, and shared-output depends on how large the diffs are, resolved when the join work starts.
+  C4, C5, and P7 assume linear-input, delta-input, and a shared output flip are the right cut.
+  Whether the output flip should also split by join kind depends on how large the diffs are, resolved when the join work starts.
 * **`branch_when` on columnar.**
-  LetRec, C7, runs the iteration-limit `branch_when` on the stream.
-  Whether that is clean on a columnar stream, or whether LetRec stays a decode point, is unresolved until C7 is attempted.
+  Resolved in the prototype.
+  If infeasible, LetRec becomes a sanctioned decode point.
 * **Union temporal-bucketing.**
-  Whether `maybe_apply_temporal_bucketing` can operate on a columnar stream, or is inherently row-shaped and stays a leaf decode, is unresolved until C8 is attempted.
+  Resolved in the prototype.
+  If inherently row-shaped, Union temporal-bucketing becomes a sanctioned decode point.
+* **Introspection golden filtering.**
+  Whether seam operators should be filtered from `mz_dataflow_operators` for the duration of the migration, or expected to churn per pull request, is decided when the golden inventory is done.

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -324,9 +324,9 @@ Files: `src/compute/src/render/top_k.rs`.
 Base: Wave 1 complete.
 
 **P7: columnar Join output.**
-Build the linear and delta join outputs into a `ColumnBuilder`.
-Confirmed feasible by the prototype, builder swaps with no blocker.
-Delta join: `half_join_internal_unsafe` is generic over its output `ContainerBuilder` (`differential-dogs3 half_join2.rs:121-140`); swap `CapacityContainerBuilder<Vec>` (`delta_join.rs:406`) for `ColumnBuilder` and the heavy operator emits `Column` directly.
+Both join algorithms are `Vec`-internal, intra-operator, out of scope (columnarizing `mz_join_core` and `half_join` is a differential-side fast-follow); the columnar edge is produced by a leaf-encode at each node's OUTPUT boundary.
+The prototype's "flip `half_join`'s generic output CB to `ColumnBuilder`" was wrong on both counts: `half_join`'s output carries a `Result<Row,_>` in the `could_error` branch (`delta_join.rs:432-434`) which `ColumnBuilder` cannot build (ok_err demux runs after the operator), and that output is not the node output anyway (each delta path then time-unpairs via `.map` and applies an optional finalization, both `Vec`, and `oks` at `delta_join.rs:312` is their concat).
+Delta join: leave the internals untouched; encode the node output `oks` (`delta_join.rs:312`) via `vec_to_columnar`, `from_collections` -> `from_edge`. One `VecToColumnar` for the whole delta output.
 Linear join is more intricate: `mz_join_core` emits its stage output as a `Vec` (it is bounded `C: SizableContainer + PushInto<(Item,T,Diff)>` and builds via `CapacityContainerBuilder<C>`, which `Column` does not satisfy), and this stage output is intra-operator, so it stays `Vec` (out of scope, like reduce/topk internals; a columnar `mz_join_core` is a differential-side fast-follow, not in scope here).
 Only the node's FINAL output edge is made columnar, per finalization path:
 the `Some(final_closure)` path applies the closure via `flat_map_fallible` with a `ConsolidatingColumnBuilder` output (parity, the old builder was `ConsolidatingContainerBuilder`);

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -307,7 +307,10 @@ Base: Wave 1 complete.
 **P5: columnar arrangement-to-collection materialization (`as_specific_collection`).**
 Producers split in two: collection producers (Get/Mfp, Constant, FlatMap, TopK monotonic/top1, join outputs) build a `ColumnBuilder` directly; arrangement producers (Reduce `from_columns`, Threshold `from_expressions`, TopK-bucketed `from_columns`) emit an arrangement, not a collection.
 An arrangement producer's arrangement is already columnar-internal (C1); its output becomes `Vec` only at the shared `as_specific_collection` arrangement-materialization path (the identity-keyed path P1 deliberately left `Vec`).
-Flip that path to pack arrangement rows into a `ConsolidatingColumnBuilder` and return a columnar edge, retiring the last Vec-producing arrangement-to-collection site.
+This path READS an already-consolidated arrangement cursor (RowRowSpine yields distinct `(row,t,diff)` per time, no within-batch dups), so it is a CONSUMER read, not a producer computing new rows.
+Therefore it uses the C1/C3/C4 consumer pattern: a plain `ColumnBuilder` with a BORROWED push of the cursor's `RowRef`, NOT `ConsolidatingColumnBuilder`.
+The standing producer rule (`ConsolidatingColumnBuilder`, owned give) does not apply here: the data is already distinct, so consolidation would be pure wasted sort and would change the deliberate non-consolidating semantics (the current builder is a non-consolidating `CapacityContainerBuilder`).
+Flip the path to build a `ColumnBuilder` borrowed and return a columnar edge, retiring the last Vec-producing arrangement-to-collection site.
 This single node covers the outputs of Reduce, Threshold, and TopK-bucketed at once.
 It is real materialization logic, not a mechanical rename, so it lands before T2 (keeping T2 mechanical), and the materialized collection becomes an internal `.collection` edge that can feed any operator, so it must be columnar by T2, not a sanctioned leaf.
 Investigate-first: map `as_specific_collection`'s callers and its two paths (the `Some(key)` arrangement-materialization path is the one to flip; the `None` `into_vec` path is the unarranged-collection consumer leaf, report its remaining callers).

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -153,10 +153,9 @@ graph TD
     P1["P1: as_collection_core columnar output, flips Get and Mfp"]
     P2["P2: Constant columnar"]
     P4["P4: FlatMap output columnar"]
-    P5["P5: Reduce output columnar"]
-    P6["P6: TopK output columnar"]
+    P5["P5: as_specific_collection arrangement materialization columnar (covers Reduce/Threshold/TopK-bucketed)"]
+    P6["P6: TopK from_collections output columnar (monotonic/top1)"]
     P7["P7: Join output columnar"]
-    P8["P8: Threshold output columnar"]
     P9["P9: source and index import producers columnar"]
   end
   subgraph Wave3["Wave 3: teardown, producer half compiler-enforced"]
@@ -305,14 +304,19 @@ Build the FlatMap output into a `ColumnBuilder`.
 Files: `src/compute/src/render/flat_map.rs`.
 Base: Wave 1 complete.
 
-**P5: columnar Reduce output.**
-Build the final Reduce output into a `ColumnBuilder`.
-Internals stay on `Vec`.
-Files: `src/compute/src/render/reduce.rs`.
+**P5: columnar arrangement-to-collection materialization (`as_specific_collection`).**
+Producers split in two: collection producers (Get/Mfp, Constant, FlatMap, TopK monotonic/top1, join outputs) build a `ColumnBuilder` directly; arrangement producers (Reduce `from_columns`, Threshold `from_expressions`, TopK-bucketed `from_columns`) emit an arrangement, not a collection.
+An arrangement producer's arrangement is already columnar-internal (C1); its output becomes `Vec` only at the shared `as_specific_collection` arrangement-materialization path (the identity-keyed path P1 deliberately left `Vec`).
+Flip that path to pack arrangement rows into a `ConsolidatingColumnBuilder` and return a columnar edge, retiring the last Vec-producing arrangement-to-collection site.
+This single node covers the outputs of Reduce, Threshold, and TopK-bucketed at once.
+It is real materialization logic, not a mechanical rename, so it lands before T2 (keeping T2 mechanical), and the materialized collection becomes an internal `.collection` edge that can feed any operator, so it must be columnar by T2, not a sanctioned leaf.
+Investigate-first: map `as_specific_collection`'s callers and its two paths (the `Some(key)` arrangement-materialization path is the one to flip; the `None` `into_vec` path is the unarranged-collection consumer leaf, report its remaining callers).
+Files: `src/compute/src/render/context.rs`.
 Base: Wave 1 complete.
 
-**P6: columnar TopK output.**
-Build the TopK output into a `ColumnBuilder`.
+**P6: columnar TopK output (`from_collections` paths).**
+The TopK monotonic and top1 variants build a result collection via `from_collections` (`top_k.rs:303/329`); flip these to `ConsolidatingColumnBuilder`.
+The bucketed variant emits an arrangement (`from_columns`, `top_k.rs:206`), covered by P5's shared materialization, not here.
 Files: `src/compute/src/render/top_k.rs`.
 Base: Wave 1 complete.
 
@@ -326,10 +330,9 @@ Join input is untouched here: linear-join input is C4, and delta-join input is a
 Files: `src/compute/src/render/join/linear_join.rs`, `src/compute/src/render/join/delta_join.rs`.
 Base: Wave 1 complete.
 
-**P8: columnar Threshold output.**
-Build the Threshold output into a `ColumnBuilder`.
-Files: `src/compute/src/render/threshold.rs`.
-Base: Wave 1 complete.
+**P8: Threshold output.** No separate work, subsumed by P5.
+Threshold emits an arrangement (`from_expressions`, `threshold.rs:85/94`), columnar-internal via C1.
+Its output materializes to a collection only through the shared `as_specific_collection` path flipped in P5, so there is no Threshold-specific output-collection site.
 
 **P9: columnar import producers.**
 The source imports (`render.rs:374, 474`) and the `SnapshotMode::Exclude` index import (`render.rs:647-668`) build `from_collections` with a `VecCollection`.
@@ -373,12 +376,14 @@ The chain is a topological order of the DAG, so every dependency edge points bac
 
 ```
 C1 -> C3 -> C4 -> F1 -> C2
-   -> P1 -> P2 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9
+   -> P1 -> P2 -> P4 -> P5 -> P6 -> P7 -> P9
    -> T1 -> T2 -> T3
 ```
 
-C5, C6, C7, and C8 are not in the chain: delta-join input is subsumed by C1; the sink, LetRec, and Union temporal-bucketing already leaf-decode the edge (see their nodes).
-Wave 1 is complete: C1, C3, C4, F1, C2 landed and C5, C6, C7, C8 subsumed, so the chain from here is the producer wave plus teardown.
+C5, C6, C7, C8, P3, and P8 are not in the chain (subsumed, see their nodes): delta-join input by C1; the sink, LetRec, and Union temporal-bucketing already leaf-decode the edge; the ArrangeBy passthrough by C1+P1; and the Threshold output by P5's shared arrangement materialization.
+Wave 1 is complete: C1, C3, C4, F1, C2 landed and C5, C6, C7, C8 subsumed.
+Producer wave in progress: P1, P2, P4 landed; P3, P8 subsumed; P5, P6, P7, P9 remain.
+The taxonomy: collection producers (P1, P2, P4, P6, P7) build a `ColumnBuilder` directly; arrangement producers (Reduce, Threshold, TopK-bucketed) are covered by P5's single `as_specific_collection` materialization flip.
 
 Order constraints honored by this chain:
 

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -152,7 +152,6 @@ graph TD
   subgraph Wave2["Wave 2: producers flip, every consumer already native"]
     P1["P1: as_collection_core columnar output, flips Get and Mfp"]
     P2["P2: Constant columnar"]
-    P3["P3: ArrangeBy passthrough columnar"]
     P4["P4: FlatMap output columnar"]
     P5["P5: Reduce output columnar"]
     P6["P6: TopK output columnar"]
@@ -295,10 +294,11 @@ Build the constant collection into a `Column` in the `Constant` arm of `render_p
 Files: `src/compute/src/render.rs`.
 Base: Wave 1 complete.
 
-**P3: columnar ArrangeBy passthrough.**
-Ensure the passthrough emits `Columnar` when its producer is columnar, and drop any remaining `Vec` re-wrap (`context.rs:1102`).
-Files: `src/compute/src/render/context.rs`.
-Base: Wave 1 complete.
+**P3: columnar ArrangeBy passthrough.** No work, subsumed by C1 + P1.
+The `Vec` force-wraps this node targeted no longer exist: C1 made `arrange_collection` return a variant-preserving passthrough (Vec arm to `CollectionEdge::Vec`, columnar arm forwards the input `Column` via `give_container` to `CollectionEdge::Columnar`), and P1's raw-collection-store rework dropped the last `CollectionEdge::Vec(oks)` wrap so `as_collection_core`'s edge is stored as-is.
+With P1 live the ArrangeBy path is columnar end to end (columnar Get/Mfp to `as_collection_core` columnar to the columnar arrange arm to a columnar passthrough), no `ColumnarToVec`.
+Covered by `arrange_collection_arms_agree` (C1) and `get_arrange_by_carries_columnar_end_to_end` (P1); T2's compiler check is the backstop.
+Confirmed by inspection of `context.rs`; no separate node exists.
 
 **P4: columnar FlatMap output.**
 Build the FlatMap output into a `ColumnBuilder`.
@@ -373,7 +373,7 @@ The chain is a topological order of the DAG, so every dependency edge points bac
 
 ```
 C1 -> C3 -> C4 -> F1 -> C2
-   -> P1 -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9
+   -> P1 -> P2 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9
    -> T1 -> T2 -> T3
 ```
 

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -275,10 +275,12 @@ Rework its identity fast-path (`context.rs:927-929`) so it no longer delegates a
 Leave `as_specific_collection` returning `Vec` as a consumer leaf until its remaining callers are retired.
 This keeps P1's base at the arrange path and the sink, both native by Wave 2.
 
-STANDING PRODUCER RULE (all producer flips): use `ConsolidatingColumnBuilder`, not plain `ColumnBuilder`, for the producer output.
-The pre-migration producers used `ConsolidatingContainerBuilder`, which folded duplicates within a batch.
-A plain `ColumnBuilder` drops that, a permanent regression on the broad Mfp-to-sink class (more rows reach the sink `ColumnarToVec` and persist re-consolidation).
-The columnar builder copies row bytes into the column from a borrowed push either way, so `ConsolidatingColumnBuilder` keeps the borrowed push (no owned `Row` per record) and adds the within-batch consolidation, restoring parity.
+STANDING PRODUCER RULE (all producer flips): use `ConsolidatingColumnBuilder` with an OWNED give, not plain `ColumnBuilder`, for the producer output.
+The pre-migration producers used `ConsolidatingContainerBuilder`, which owned-staged and folded duplicates within a batch.
+A plain `ColumnBuilder` drops that consolidation, a permanent regression on the broad Mfp-to-sink class (more rows reach the sink `ColumnarToVec` and persist re-consolidation).
+Consolidation inherently needs owned staging (you cannot sort a columnar batch without materialized comparable rows), so `ConsolidatingColumnBuilder` is owned-give only.
+This is not a regression: a producer computes its output `Row` fresh (`mfp_plan.evaluate` already yields an owned `Row` per record), so the owned give is a move into staging, not a new allocation or clone, exactly as pre-P1.
+The borrowed-push, no-owned-`Row` property is a CONSUMER optimization (reading an existing columnar batch, as in C1/C3/C4), not applicable to producers that compute new rows.
 Files: `src/compute/src/render/context.rs`, `src/compute/src/render.rs`.
 Test: physical-plan goldens unchanged, plus sqllogictest for Get and Mfp chains feeding an ArrangeBy or sink.
 Base: Wave 1 complete.

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -30,15 +30,21 @@ A naive migration maintains two parallel implementations per operator, or gates 
 
 ### Sanctioned decode points
 
-Two internal consumers may retain a permanent `ColumnarToVec` decode if the columnar rewrite proves infeasible.
+Two internal consumers retain a `ColumnarToVec` decode for now, deferring the native rewrite to a fast-follow.
 They do not serialize rows, so they are exceptions to the no-internal-decode criterion, not instances of it.
+The prototype (see below) confirmed both are feasible to make native but not worth the cost or risk on the critical path.
 
-* LetRec, if `branch_when` and the recursive feedback path cannot operate on a columnar stream (node C7).
-* Union temporal-bucketing, if `maybe_apply_temporal_bucketing` is inherently row-shaped (node C8).
+* LetRec (node C7).
+  `branch_when` is not the blocker, it is container-generic and type-checks on a columnar stream as-is.
+  The blocker is the feedback machinery: `Variable::set` needs `ResultsIn`, `Collection::negate` needs `Negate`, and `leave_dynamic` mutates each record's time in place, all impl'd only for `Vec`.
+  Going native means forking differential's `PointStamp` time arithmetic into our tree, a standing liability.
+  Decode is today's exact code, so it is deferred.
+* Union temporal-bucketing (node C8).
+  `maybe_apply_temporal_bucketing` hardwires `StreamVec` in and out, and its operator is the most correctness-sensitive in the migration (cap, peel, fuel).
+  The internals are already columnar, so native input would remove an internal `Vec` staging round-trip.
+  It fires only on a consolidating Union under `ENABLE_COMPUTE_TEMPORAL_BUCKETING`, so the decode cost is narrow, and native is a worthwhile fast-follow if it shows up hot.
 
-Their feasibility is resolved in the prototype phase, not at the end of the stack.
-If either goes native, it is not a decode point.
-If either stays a decode point, it is a leaf `columnar_to_vec` and is compatible with the final enum collapse.
+Both decode points are leaf `columnar_to_vec` calls, compatible with the final enum collapse.
 
 ## Out of Scope
 
@@ -144,8 +150,8 @@ graph TD
     C4["C4: linear-join input columnar"]
     C5["C5: delta-join input columnar"]
     C6["C6: sink columnar input API"]
-    C7["C7: LetRec columnar or sanctioned decode"]
-    C8["C8: Union temporal-bucket columnar or sanctioned decode"]
+    C7["C7: LetRec sanctioned decode, consume edge then into_vec"]
+    C8["C8: Union temporal-bucket sanctioned decode, consume edge then into_vec"]
   end
   subgraph Wave2["Wave 2: producers flip, every consumer already native"]
     P1["P1: as_collection_core columnar output, flips Get and Mfp"]
@@ -163,8 +169,6 @@ graph TD
     T2["T2: collapse enum to a columnar alias, into_vec becomes a leaf fn"]
     T3["T3: de-match negate, concat_many, consolidate_named"]
   end
-  F1 --> C7
-  F1 --> C8
   C1 --> C3
   C1 --> C4
   C1 --> C5
@@ -175,7 +179,10 @@ graph TD
 ```
 
 The bold edge from Wave 1 to Wave 2 is the producer-flip invariant: no producer node starts until every consumer node has landed.
-Within Wave 1, F1 gates the two consolidate-dependent nodes, and C1 gates the three nodes that reuse its columnar key-forming pattern.
+Within Wave 1, C1 gates the three nodes that reuse its columnar key-forming pattern.
+F1, C2, C6, C7, and C8 are independent roots.
+F1 gives the native columnar `consolidate_named` that Union's `concat_many` then `consolidate_named` path uses once its inputs are columnar in Wave 2.
+C7 and C8 are sanctioned decode nodes, so they do not depend on F1.
 Within Wave 2, each producer feeds only native consumers, so the nodes are mutually independent and land in any order.
 Wave 3 collapses the enum.
 Its producer half is compiler-enforced, see the completeness note.
@@ -251,24 +258,27 @@ Files: `src/compute/src/render/sinks.rs`.
 Test: subscribe and materialized-view sink sqllogictest and testdrive coverage.
 Base: `upstream/main`.
 
-**C7: LetRec columnar or sanctioned decode.**
-Consume the LetRec edge as columnar.
-The Vec-bound surface is the whole recursive feedback path, not only `branch_when`: the feedback `Variable` (`render.rs:921-924`), its set (`render.rs:990`), `leave_dynamic` (`render.rs:1001`), and the limit branch (`render.rs:961`).
-`Variable` is container-generic, so the change is type-permitted.
-LetRec's consolidation currently calls the raw `CollectionExt::consolidate_named` on an already-decoded `Vec` (`render.rs:946`), so this node must reroute it to the edge's `consolidate_named`, which is why it depends on F1.
-If `branch_when` on columnar proves infeasible, keep LetRec as a sanctioned leaf decode instead, which is compatible with T2.
+**C7: LetRec sanctioned decode.**
+Make LetRec consume the columnar edge and decode locally via `into_vec`, keeping today's `Vec` feedback logic.
+This is a sanctioned decode point, resolved by the prototype.
+`branch_when` is container-generic and would type-check on a columnar stream, but the feedback machinery is not: `Variable::set` needs `ResultsIn` (`collection.rs:1371`, `Vec` only), `Collection::negate` needs `Negate` (`collection.rs:1350`, `Vec` only), and `leave_dynamic` (`render.rs:1001`, `dynamic/mod.rs:28`) mutates each record's time in place.
+Going native means adding `impl Negate for Column`, `impl ResultsIn for Column`, and a `columnar_leave_dynamic`, all mirroring `columnar_negate` (`columnar.rs:279`), which forks differential's `PointStamp` time arithmetic into our tree.
+Deferred as a fast-follow if the per-iteration decode shows up hot.
+LetRec already decodes at `render.rs:941/997` and consolidates on `Vec`, so it does not need F1.
 Files: `src/compute/src/render.rs`.
 Test: recursive-view sqllogictest including the iteration limit and the error-distinctness path.
-Base: `F1`.
+Base: `upstream/main`.
 
-**C8: Union temporal-bucket columnar or sanctioned decode.**
-`render.rs:1358` decodes via `into_vec` to apply temporal bucketing inside a consolidating Union.
-Make `maybe_apply_temporal_bucketing` operate on the columnar stream.
-If bucketing is inherently row-shaped, keep the decode as a sanctioned leaf.
-F1 must land first, since a columnar Union consolidate would otherwise round-trip.
-Files: `src/compute/src/render.rs`, the timestamp trait sites for `maybe_apply_temporal_bucketing`.
+**C8: Union temporal-bucket sanctioned decode.**
+Keep the `into_vec` at `render.rs:1358` that feeds `maybe_apply_temporal_bucketing` inside a consolidating Union, adapted to consume the columnar edge.
+This is a sanctioned decode point, resolved by the prototype.
+`maybe_apply_temporal_bucketing` hardwires `StreamVec` in and out (`render.rs:1561`, `temporal_bucket.rs:49`), and the operator is the most correctness-sensitive in the migration.
+The internals are already columnar (`ColumnMergeBatcher`, `ColumnChunker`), so a native input would delete an internal `Vec` staging round-trip.
+Deferred as a fast-follow; the path is narrow, gated on `ENABLE_COMPUTE_TEMPORAL_BUCKETING`.
+The Union's own `concat_many` then `consolidate_named` path still goes native via F1 once its inputs are columnar.
+Files: `src/compute/src/render.rs`.
 Test: temporal and temporal-bucketing sqllogictest.
-Base: `F1`.
+Base: `upstream/main`.
 
 **P1: columnar output for the `flat_map` family.**
 Generalize `as_collection_core` to build into a `ColumnBuilder` and return a columnar edge, which flips the Get and Mfp producers.
@@ -307,6 +317,11 @@ Base: Wave 1 complete.
 
 **P7: columnar Join output.**
 Build the linear and delta join outputs into a `ColumnBuilder`.
+Confirmed feasible by the prototype, builder swaps with no blocker.
+Delta join: `half_join_internal_unsafe` is generic over its output `ContainerBuilder` (`differential-dogs3 half_join2.rs:121-140`); swap `CapacityContainerBuilder<Vec>` (`delta_join.rs:406`) for `ColumnBuilder` and the heavy operator emits `Column` directly.
+Linear join: swap the `flat_map_fallible::<ConsolidatingContainerBuilder, ..>` (`linear_join.rs:300`) for the existing `ConsolidatingColumnBuilder` (`columnar/consolidate.rs`), preserving output consolidation.
+The carried-time `(Row, T)` payload is `Columnar`.
+Join input, C4 and C5, is untouched here.
 Files: `src/compute/src/render/join/linear_join.rs`, `src/compute/src/render/join/delta_join.rs`.
 Base: Wave 1 complete.
 
@@ -347,9 +362,8 @@ Base: `T2`.
 
 The consumer wave is several short stacks off `upstream/main`.
 
-* `F1` then `C7`, `C8`.
 * `C1` then `C3`, `C4`, `C5`.
-* `C2` and `C6` are independent, off `upstream/main`.
+* `F1`, `C2`, `C6`, `C7`, `C8` are independent roots, off `upstream/main`.
 
 The producer wave starts only after the entire consumer wave has landed, which resolves the fan-in problem: the producer nodes and the teardown rebase on a single merged base, not on a live tangle of consumer stacks.
 Producer nodes are mutually independent.
@@ -372,16 +386,22 @@ gh-stack reference: https://github.github.com/gh-stack/#get-started
 
 ## Minimal Viable Prototype
 
-The prototype must de-risk the mechanisms whose feasibility is genuinely uncertain, not the well-understood ones.
-It covers three throwaway spikes before the stack is committed:
+The prototype de-risked the mechanisms whose feasibility was genuinely uncertain.
+It was a type-level analysis of the load-bearing trait bounds against timely 0.31, differential-dataflow 0.25, and differential-dogs3 0.25.1, resolving each verdict on whether a specific generic impl exists, named at file:line.
+Results:
 
-* C1 columnar arrange input, `Get` into `ArrangeBy`, asserting no `ColumnarToVec` on the path and identical results.
-  This validates the key-forming borrow pattern that C3, C4, and C5 reuse.
-* `branch_when` on a columnar stream, the load-bearing uncertainty for C7.
-* `maybe_apply_temporal_bucketing` on a columnar stream, the load-bearing uncertainty for C8.
+* C7 LetRec: feasible but deferred to a sanctioned decode.
+  The uncertainty was misattributed to `branch_when`; the real blocker is the `ResultsIn`, `Negate`, and `leave_dynamic` feedback machinery, all `Vec` only.
+  See the C7 node.
+* C8 Union temporal-bucketing: feasible but deferred to a sanctioned decode.
+  Not inherently row-shaped, the internals are already columnar, but the operator is correctness-sensitive and the path is narrow.
+  See the C8 node.
+* P7 join output: feasible, go native.
+  Builder swaps only, delta join included.
+  See the P7 node.
 
-The enum collapse can only complete if C7 and C8 either go native or are accepted as sanctioned decode points, so their feasibility belongs in the prototype rather than at the end of a long stack.
-A columnar join output, building into a `ColumnBuilder`, is worth a fourth spike, since it is a different mechanism from the arrange input and feeds the most intricate operators.
+Nothing was infeasible, so the enum collapse (T2) can complete and the stack is not gated by an unresolvable mechanism.
+The C1 arrange-input key-forming pattern was already confirmed low-risk and was not re-spiked.
 
 ## Alternatives
 
@@ -414,11 +434,8 @@ A columnar join output, building into a `ColumnBuilder`, is worth a fourth spike
 * **Join node granularity.**
   C4, C5, and P7 assume linear-input, delta-input, and a shared output flip are the right cut.
   Whether the output flip should also split by join kind depends on how large the diffs are, resolved when the join work starts.
-* **`branch_when` on columnar.**
-  Resolved in the prototype.
-  If infeasible, LetRec becomes a sanctioned decode point.
-* **Union temporal-bucketing.**
-  Resolved in the prototype.
-  If inherently row-shaped, Union temporal-bucketing becomes a sanctioned decode point.
+* **LetRec and Union temporal-bucketing.**
+  Resolved in the prototype: both are sanctioned decode points for now, with a native fast-follow tracked if either shows up hot.
+  See the C7 and C8 nodes.
 * **Introspection golden filtering.**
   Whether seam operators should be filtered from `mz_dataflow_operators` for the duration of the migration, or expected to churn per pull request, is decided when the golden inventory is done.

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -148,7 +148,6 @@ graph TD
     C2["C2: FlatMap input decode via the edge, fueling preserved"]
     C3["C3: TopK input columnar"]
     C4["C4: linear-join input columnar"]
-    C6["C6: sink columnar input API"]
     C7["C7: LetRec sanctioned decode, consume edge then into_vec"]
     C8["C8: Union temporal-bucket sanctioned decode, consume edge then into_vec"]
   end
@@ -178,7 +177,7 @@ graph TD
 
 The bold edge from Wave 1 to Wave 2 is the producer-flip invariant: no producer node starts until every consumer node has landed.
 Within Wave 1, C1 gates the three nodes that reuse its columnar key-forming pattern.
-F1, C2, C6, C7, and C8 are independent roots.
+F1, C2, C7, and C8 are independent roots.
 F1 gives the native columnar `consolidate_named` that Union's `concat_many` then `consolidate_named` path uses once its inputs are columnar in Wave 2.
 C7 and C8 are sanctioned decode nodes, so they do not depend on F1.
 Within Wave 2, each producer feeds only native consumers, so the nodes are mutually independent and land in any order.
@@ -250,13 +249,12 @@ The `CollectionEdge` decode for delta-join inputs therefore lives entirely in `a
 Confirmed by an adversarial trace of `delta_join.rs`; no separate node exists.
 The delta-join output flip remains real and is covered by P7.
 
-**C6: sink columnar input.**
-Change the sink input path so it consumes a columnar edge.
-`sinks.rs:71` clones and calls `into_vec`.
-Persist and subscribe serialize rows, so the decode is acceptable at the leaf, but the API accepts the columnar edge and decodes locally rather than forcing `into_vec` at the boundary.
-Files: `src/compute/src/render/sinks.rs`.
-Test: subscribe and materialized-view sink sqllogictest and testdrive coverage.
-Base: `upstream/main`.
+**C6: sink columnar input.** No work, subsumed by the #36507 scaffolding.
+The sink already consumes `bundle.collection` (the `CollectionEdge`) directly and leaf-decodes via `oks.clone().into_vec()` at `sinks.rs:71`, which is the sink render boundary right before persist/subscribe serialize rows.
+The edge stays columnar all the way to that point, with no pre-boundary `VecCollection` forced in between, so when a producer flips columnar in Wave 2 the `into_vec` decodes the columnar arm at this leaf, exactly C6's goal.
+The arranged-input branch reads an arrangement via `as_collection_core`, itself columnar-internal through C1, and produces `Vec` because the sink serializes rows, a second sanctioned leaf.
+Confirmed by inspection of `sinks.rs`; no separate node exists.
+NOTE for T2: `sinks.rs:71` is a leaf-decode call site that T2 must adapt when `into_vec` changes from an enum method to a free function.
 
 **C7: LetRec sanctioned decode.**
 Make LetRec consume the columnar edge and decode locally via `into_vec`, keeping today's `Vec` feedback logic.
@@ -367,12 +365,12 @@ So the DAG is flattened into a single chain, managed with gh-stack, where each b
 The chain is a topological order of the DAG, so every dependency edge points backward:
 
 ```
-C1 -> C3 -> C4 -> F1 -> C2 -> C6 -> C7 -> C8
+C1 -> C3 -> C4 -> F1 -> C2 -> C7 -> C8
    -> P1 -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9
    -> T1 -> T2 -> T3
 ```
 
-C5 is not in the chain: delta-join input is subsumed by C1 (see the C5 node).
+C5 and C6 are not in the chain: delta-join input is subsumed by C1, and the sink already leaf-decodes the edge (see the C5 and C6 nodes).
 
 Order constraints honored by this chain:
 

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -358,18 +358,36 @@ The columnar `consolidate_named` becomes the sole implementation.
 Files: `src/compute/src/render/columnar.rs`.
 Base: `T2`.
 
-### Stacked pull requests
+### One linear gh-stack chain
 
-The consumer wave is several short stacks off `upstream/main`.
+Work happens in a fork, and GitHub stacked pull requests require same-repository branches, so the DAG cannot be realized as parallel lanes of fork-to-upstream PRs.
+gh-stack is strictly linear anyway: each branch has exactly one parent and one child.
+So the DAG is flattened into a single chain, managed with gh-stack, where each branch is based on the one before it and carries one PR whose diff is only that layer.
 
-* `C1` then `C3`, `C4`, `C5`.
-* `F1`, `C2`, `C6`, `C7`, `C8` are independent roots, off `upstream/main`.
+The chain is a topological order of the DAG, so every dependency edge points backward:
 
-The producer wave starts only after the entire consumer wave has landed, which resolves the fan-in problem: the producer nodes and the teardown rebase on a single merged base, not on a live tangle of consumer stacks.
-Producer nodes are mutually independent.
-The teardown is a short chain `T1`, `T2`, `T3` on top of the merged producer wave.
+```
+C1 -> C3 -> C4 -> C5 -> F1 -> C2 -> C6 -> C7 -> C8
+   -> P1 -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9
+   -> T1 -> T2 -> T3
+```
 
-gh-stack reference: https://github.github.com/gh-stack/#get-started
+Order constraints honored by this chain:
+
+* C1 precedes C3, C4, C5, which reuse its columnar key-forming pattern.
+* All consumer nodes, C and F, precede all producer nodes P, per the producer-flip invariant.
+* The teardown T1, T2, T3 is last, in order.
+
+The `Base` field in each node spec records the nearest semantic dependency.
+In the chain, a branch's git base is simply the entry before it, which transitively includes every earlier dependency.
+Linearizing serializes the work: there is no cross-node parallelism, which is the cost of the fork constraint and the linear-stack model.
+
+Practical notes for the executor:
+
+* Manage the chain with the `gh-stack` skill, non-interactively: `gh stack init C1`, then `gh stack add <node>` per layer, `gh stack submit --auto` for draft PRs, `gh stack sync --prune` after a bottom PR merges.
+* The repository must have stacked PRs enabled, or `submit` exits with code 9.
+* A 21-layer chain is deep. If rebases become unwieldy, land it as three sequential sub-stacks, Wave 1 then Wave 2 then teardown, each rooted on `upstream/main` after the previous has merged.
+* There is no runtime rollback, so a layer merges only after its tests pass and its diff is reviewed.
 
 ### Testing strategy
 

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -507,3 +507,24 @@ The C1 arrange-input key-forming pattern was already confirmed low-risk and was 
   See the C7 and C8 nodes.
 * **Introspection golden filtering.**
   Whether seam operators should be filtered from `mz_dataflow_operators` for the duration of the migration, or expected to churn per pull request, is decided when the golden inventory is done.
+
+## Fast-follows
+
+All optional, none blocking the migration. Each is its own future gh-stack node with its own review.
+Ordered by expected leverage.
+
+* **Ref/permutation consolidating builder** (producer output).
+  The producer output uses `ConsolidatingColumnBuilder` with an owned give, which stages N live owned `Row`s per batch (same as the pre-migration `ConsolidatingContainerBuilder`).
+  A ref-accepting builder that stages row bytes into a `Column` arena on a borrowed push and consolidates via a sorted `Vec<usize>` permutation (`RowRef: Ord`) would hold ~1 live owned `Row` plus the arena, an allocator-churn and peak-memory win on the broad Mfp-to-sink path (better than both pre-migration and the current owned-give).
+  It is a new `mz-timely-util` consolidation primitive with its own correctness surface (merge, zero-drop, stable order), so it lands as a focused, adversarially-reviewed PR, after which the localized producer output-builder choice swaps to it.
+
+* **Columnar `mz_join_core` and `half_join`** (join algorithms).
+  Both joins are `Vec`-internal, so their output is currently a leaf-encode: linear-join's identity-closure path and the whole delta-join output each pay one `VecToColumnar`.
+  Making the differential-side `mz_join_core` and `half_join` emit `Column` directly would remove those leaf-encodes.
+  This is a differential-dogs change (their output is bounded `SizableContainer + PushInto<(Item,T,Diff)>` / carries a `Result<Row,_>` payload before the ok_err demux), out of scope for the compute-only migration.
+
+* **Native LetRec (C7) and native temporal-bucketing (C8).**
+  C7 LetRec and C8 Union temporal-bucketing are sanctioned decode points: they decode to `Vec`, operate on `Vec`-only machinery, and re-encode.
+  Native C7 needs `impl Negate for Column`, `impl ResultsIn for Column`, and a `columnar_leave_dynamic` (mirroring `columnar_negate`), which forks differential's `PointStamp` time arithmetic into our tree, a standing liability.
+  Native C8 needs `maybe_apply_temporal_bucketing` to operate on a columnar stream (its internals are already columnar, so native input would delete an internal `Vec` staging round-trip), gated on `ENABLE_COMPUTE_TEMPORAL_BUCKETING`.
+  Pursue either only if the per-iteration / per-bucket decode shows up hot.

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -158,17 +158,21 @@ graph TD
     P7["P7: Join output columnar"]
     P9["P9: source and index import producers columnar"]
   end
-  subgraph Wave3["Wave 3: teardown, producer half compiler-enforced"]
-    T1["T1: retire concat_many mixed-variant upgrade branch"]
-    T2["T2: collapse enum to a columnar alias, into_vec becomes a leaf fn"]
-    T3["T3: de-match negate, concat_many, consolidate_named"]
+  subgraph Wave3["Wave 3: teardown (expanded by the pre-teardown review)"]
+    Ta["Ta: temporal-bucketing re-encode (into_vec to vec_to_columnar)"]
+    Tb["Tb: linear-join accumulator off the edge (M1)"]
+    Tc["Tc: retire as_specific_collection flag-off branch (M2)"]
+    Td["Td: retire concat_many mixed-variant branch (needs Ta)"]
+    Te["Te: collapse enum to a columnar alias + de-match methods"]
   end
   C1 --> C3
   C1 --> C4
   Wave1 ==> Wave2
-  Wave2 --> T1
-  T1 --> T2
-  T2 --> T3
+  Wave2 --> Ta
+  Ta --> Tb
+  Tb --> Tc
+  Tc --> Td
+  Td --> Te
 ```
 
 The bold edge from Wave 1 to Wave 2 is the producer-flip invariant: no producer node starts until every consumer node has landed.
@@ -349,29 +353,43 @@ Files: `src/compute/src/render.rs`.
 Test: source and index import sqllogictest and testdrive coverage.
 Base: Wave 1 complete.
 
-**T1: retire the `concat_many` mixed-variant upgrade branch.**
-Once every producer emits columnar, no edge carries `Vec`, so `concat_many` never sees a mixed set of arms.
-Delete its mixed-variant upgrade branch.
-Do NOT delete `vec_to_columnar`.
-It survives as a leaf ENCODE primitive for producers whose source data is genuinely row-shaped and must be placed on the columnar edge: P9 imports (row data from persist or a trace), and the sanctioned-decode returns C7 LetRec and C8 Union temporal-bucketing, which decode to `Vec`, operate via `branch_when` / `maybe_apply_temporal_bucketing` (both `Vec`-only), then re-encode to the columnar edge.
-Symmetrically `into_vec` / `columnar_to_vec` survive as leaf DECODE primitives (sinks, the same sanctioned decodes).
-The teardown collapses the enum, not the leaf conversions.
-Files: `src/compute/src/render/columnar.rs`.
+The whole-branch pre-teardown review (GO, no correctness defects) refined the teardown into five ordered steps.
+Deleting the `Vec` arm compiler-reveals several legitimate internal `Vec` sites, so those are retired proactively first, keeping the final collapse mechanical.
+`into_vec` / `columnar_to_vec` (leaf decode) and `vec_to_columnar` (leaf encode) are NEVER deleted: they remain leaf conversions for sinks, the sanctioned LetRec / temporal-bucketing points, and row-shaped producers (imports, join no-closure). The teardown collapses the enum, not the leaf conversions.
+
+**Ta: temporal-bucketing re-encode.**
+The temporal-bucketing island (flag `ENABLE_COMPUTE_TEMPORAL_BUCKETING`, default off) currently `into_vec`-decodes then re-wraps `CollectionEdge::Vec` at four sites (`context.rs:1089/1130`, `render.rs:1382`, `top_k.rs:127`), feeding `Vec` inputs into a Union's `concat_many`.
+Convert each to `vec_to_columnar` re-encode so bucketed outputs are `Columnar`.
+This is the leaf-encode of a genuine `Vec`-producing island (`maybe_apply_temporal_bucketing` is `StreamVec`-only, out of scope). It unblocks Td and removes the `arrange_collection` `Vec`-arm reachability that bucketing dragged in.
+Files: `src/compute/src/render.rs`, `src/compute/src/render/context.rs`, `src/compute/src/render/top_k.rs`.
 Base: all P nodes.
 
-**T2: collapse the enum.**
-Replace `CollectionEdge` with a `ColumnarCollection` type alias.
-Demote `into_vec` / `columnar_to_vec` (leaf decode) and `vec_to_columnar` (leaf encode) to free functions used at leaves: consumers that serialize rows, the sanctioned decode-and-re-encode points, and row-shaped producers. These leaf conversions are NOT deleted; only the enum and its arms collapse.
-Update `CollectionBundle.collection` and all construction sites.
-This is the widest diff, touching `context.rs` and every construction site, so alias the enum first and land the construction-site churn as a mechanical rename reviewed separately.
-Files: `src/compute/src/render/columnar.rs`, `src/compute/src/render/context.rs`, `src/compute/src/render.rs`, and every construction site.
-Base: `T1`.
+**Tb: linear-join intra-operator accumulator off the edge (M1).**
+`mz_join_core` is `Vec`-internal, so `JoinedFlavor::Collection` currently carries a `CollectionEdge` whose `Vec` arm is the live multi-stage accumulator (`linear_join.rs:299/318`, consumed at `:559`).
+Change the accumulator to a bare `VecCollection`, encoding to a `CollectionEdge` only at the node output (P7's finalization).
+This removes the intra-operator use of the `Vec` arm ahead of the collapse.
+Files: `src/compute/src/render/join/linear_join.rs`.
+Base: `Ta`.
 
-**T3: de-match the carrier methods.**
-Simplify `negate`, `concat_many`, and `consolidate_named` from arm matches to single columnar implementations.
-The columnar `consolidate_named` becomes the sole implementation.
+**Tc: retire the `as_specific_collection` flag-off branch (M2).**
+The `ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION`-off branch (`context.rs:612`) returns a real-data `CollectionEdge::Vec` via the deprecated `as_collection`.
+The flag defaults true, so production already takes the columnar fueled path; delete the else-branch and retire the flag.
+Files: `src/compute/src/render/context.rs`, `src/compute-types/src/dyncfgs.rs`.
+Base: `Tb`.
+
+**Td: retire the `concat_many` mixed-variant upgrade branch.**
+After Ta, no producer feeds a `Vec` edge into a `concat_many`, so the mixed-variant upgrade branch (`columnar.rs:143-146`) is dead.
+Delete it (and the now-unreachable all-`Vec` branch).
+Blocked before Ta: temporal-bucketing was the last source of mixed inputs.
 Files: `src/compute/src/render/columnar.rs`.
-Base: `T2`.
+Base: `Tc`.
+
+**Te: collapse the enum and de-match the carrier methods.**
+Replace `CollectionEdge` with a `ColumnarCollection` type alias; demote `into_vec`/`columnar_to_vec`/`vec_to_columnar` to leaf free fns; update `CollectionBundle.collection` and every construction/match site; simplify `negate`, `concat_many`, `consolidate_named`, `flat_map_datums` from arm matches to single columnar implementations (the columnar `consolidate_named` becomes the sole impl).
+With Ta-Td done, the remaining `Vec` arms are only the carrier-method matches and leaf sites, so this is now mechanical, and the compiler confirms completeness (no producer emits `Vec`).
+Also fix the stale enum doc comments (`columnar.rs:16-31/67/69-71`, "Vec is today's default", "Columnar unused") the review flagged.
+Files: `src/compute/src/render/columnar.rs`, `src/compute/src/render/context.rs`, `src/compute/src/render.rs`, and every construction site.
+Base: `Td`.
 
 ### One linear gh-stack chain
 
@@ -384,7 +402,7 @@ The chain is a topological order of the DAG, so every dependency edge points bac
 ```
 C1 -> C3 -> C4 -> F1 -> C2
    -> P1 -> P2 -> P4 -> P5 -> P6 -> P7 -> P9
-   -> T1 -> T2 -> T3
+   -> Ta -> Tb -> Tc -> Td -> Te
 ```
 
 C5, C6, C7, C8, P3, and P8 are not in the chain (subsumed, see their nodes): delta-join input by C1; the sink, LetRec, and Union temporal-bucketing already leaf-decode the edge; the ArrangeBy passthrough by C1+P1; and the Threshold output by P5's shared arrangement materialization.
@@ -396,7 +414,7 @@ Order constraints honored by this chain:
 
 * C1 precedes C3 and C4, which reuse its columnar key-forming pattern.
 * All consumer nodes, C and F, precede all producer nodes P, per the producer-flip invariant.
-* The teardown T1, T2, T3 is last, in order.
+* The teardown Ta, Tb, Tc, Td, Te is last, in order (expanded from T1/T2/T3 by the pre-teardown review; Td needs Ta).
 
 The `Base` field in each node spec records the nearest semantic dependency.
 In the chain, a branch's git base is simply the entry before it, which transitively includes every earlier dependency.

--- a/doc/developer/design/20260720_columnar_dataflow_edges.md
+++ b/doc/developer/design/20260720_columnar_dataflow_edges.md
@@ -1,0 +1,328 @@
+# Columnar dataflow edges: VecCollection to Columns migration
+
+- Associated: [#36507](https://github.com/MaterializeInc/materialize/pull/36507)
+
+This document is a plan, not an implementation.
+It decomposes the migration of compute dataflow edges from row-based `VecCollection` to columnar `Column` batches into fine-grained changes with an explicit dependency DAG.
+Each change is scoped to a single stacked pull request, executed in later sessions.
+
+## The Problem
+
+Compute renders dataflow edges between Plan nodes as row-based `VecCollection` updates.
+Row-based edges force per-record handling at every consumer, and they block downstream work that wants to operate on columnar batches.
+PR #36507 scaffolded `CollectionEdge<'scope, T>`, an enum with `Vec` and `Columnar` arms, and wired it as the carrier of `CollectionBundle.collection`.
+Today no producer emits the columnar arm, so the columnar path is dead in production, and the migration from row-based to columnar edges has no plan.
+
+The risk in migrating is complexity.
+A naive migration maintains two parallel implementations per operator, or gates the change behind a feature flag, and either approach grows code complexity to unbounded levels over the course of a long migration.
+
+## Success Criteria
+
+* Every compute dataflow edge carries columnar `Column` batches.
+* The `Vec` arm of `CollectionEdge` is deleted, and the enum collapses to a single columnar type.
+* No internal consumer decodes an edge to rows.
+  `into_vec` survives only as a leaf helper for consumers that serialize rows anyway.
+* The migration proceeds as a sequence of small, independently landable pull requests, each with a test gate.
+* No single code path maintains both representations at once.
+  There is no feature flag.
+* No permanent performance regression.
+  Transient regressions during the transition are acceptable.
+
+## Out of Scope
+
+* **Generalizing `CollectionExt`.**
+  The trait is a dead-end.
+  We do not make it container-generic.
+* **Intra-operator `Vec` use.**
+  `explode_one` and `ensure_monotonic` run on `Vec` collections inside reduce and top-k.
+  The compute contract lets operators materialize `Vec` collections internally.
+  Only the inter-node edge format is constrained, so these stay on `VecCollection`.
+* **Generalizing batcher selection.**
+  The columnar `consolidate_named` uses the `Col2KeyBatcher` family as a temporary second variant.
+  We do not invest in a generic batcher-selection abstraction.
+* **The columnar persist blob format.**
+  Sinks change to consume columnar input, but the on-blob encoding that persist writes is unchanged.
+  A sink that serializes rows may decode locally at the leaf.
+
+## Solution Proposal
+
+Migrate consumers first, then producers, then delete the `Vec` arm.
+The enum stays as the single locus of representation-matching for the whole migration, so operators call enum methods and stay representation-agnostic, and producers flip one at a time under type unification.
+Each operator has one code path at a time.
+We accept a temporary performance impact during the transition rather than duplicating operators or feature-flagging the change.
+The migration direction for each edge is chosen to minimize churn: we pair a producer flip with the consumer work that makes its downstream native, so no decode-back seam lingers.
+The `Vec`-arm deletion is the completeness test.
+The teardown will not compile until every producer is columnar and every internal consumer is columnar-native.
+
+### Current operator map
+
+The table records how each Plan node reads its input and produces its output today, and the seam that blocks columnar flow.
+Verified against the tree at `cb4b1d2e6f`.
+
+| Node | Input read | Output produced | Seam today |
+|---|---|---|---|
+| Constant | none | `to_stream` into `Vec` | producer emits `Vec` |
+| Get::PassArrangements | carries the bundle | passes the bundle | none |
+| Get::Arrangement, Get::Collection, Mfp | native `flat_map` or arrangement | `as_collection_core` into `Vec` | producer output builder is `Vec` |
+| FlatMap | `as_specific_collection` then `into_vec` | `Vec` | consumer seam plus producer `Vec` |
+| Join, linear and delta | `as_specific_collection` or `flat_map` | `Vec` | consumer seam plus producer `Vec` |
+| Reduce | arranged input, internals on `Vec` intra-operator | `Vec` | producer `Vec` |
+| TopK | `as_specific_collection(None)` then `into_vec` | `Vec` | consumer seam plus producer `Vec` |
+| Negate | edge | `negate()` | native |
+| Threshold | `render_threshold` | `Vec` | producer `Vec` |
+| Union | edges | `concat_many` then `consolidate_named` | columnar consolidate round-trips |
+| ArrangeBy | `ensure_collections` then `into_vec` | arrangement plus passthrough edge | arrange input seam |
+| Let, LetRec | edge | consolidate plus `branch_when` into `Vec` | `into_vec` in the recursive path |
+
+Three grounding mechanism facts:
+
+* `arrange_collection` in `context.rs` already emits `ColumnBuilder<((Row, Row), T, Diff)>` and arranges via `columnar_exchange` plus `Col2ValPagedBatcher`.
+  The arrangement pipeline is already columnar internally.
+  The only `Vec`-ness is the input, fed by `into_vec` at `context.rs:1071`, and the passthrough re-wrap at `context.rs:1102`.
+* `as_collection_core` and `as_specific_collection` hardwire `VecCollection<Row>` output through `SharedRow` packing.
+  Flipping the `flat_map`-family producers means building into a `ColumnBuilder` there.
+* The columnar batcher family exists: `ColumnMergeBatcher`, `Col2KeyBatcher<K, T, R>`, and the paged chunker.
+
+### Change DAG
+
+```mermaid
+graph TD
+  subgraph Wave1["Wave 1: native consumers, columnar arm still dead, zero runtime bounce"]
+    F1["F1: consolidate_named columnar variant via Col2KeyBatcher"]
+    C1["C1: arrange input columnar, ensure_collections and arrange_collection accept the edge, passthrough preserves variant"]
+    C2["C2: FlatMap uses flat_map_datums, drops as_specific_collection"]
+    C6["C6: sink columnar input API"]
+  end
+  subgraph Wave2["Wave 2: flip producers into now-native consumers"]
+    P1["P1: as_collection_core and as_specific_collection columnar output, flips Mfp and Get"]
+    P2["P2: Constant columnar"]
+    P3["P3: ArrangeBy passthrough columnar"]
+    P4["P4: FlatMap output columnar"]
+  end
+  subgraph Wave3["Wave 3: operator input and output pairs"]
+    C3P6["C3+P6: TopK input and output columnar"]
+    C4C5P7["C4, C5, P7: linear and delta join input and output columnar"]
+    P5["P5: Reduce output columnar"]
+    P8["P8: Threshold output columnar"]
+    C7["C7: LetRec consolidate and branch_when columnar"]
+    C8["C8: Union temporal-bucket columnar"]
+  end
+  subgraph Wave4["Wave 4: teardown, compiler-enforced"]
+    T1["T1: delete vec_to_columnar"]
+    T2["T2: collapse enum to a columnar alias, into_vec becomes a leaf fn"]
+    T3["T3: de-match negate, concat_many, consolidate_named"]
+  end
+  C1 --> P1
+  C1 --> P3
+  C2 --> P4
+  C6 --> P1
+  C1 -.pattern.-> C3P6
+  C1 -.pattern.-> C4C5P7
+  F1 --> C7
+  F1 --> C8
+  P1 --> T1
+  P2 --> T1
+  P3 --> T1
+  P4 --> T1
+  C3P6 --> T1
+  C4C5P7 --> T1
+  P5 --> T1
+  P8 --> T1
+  T1 --> T2
+  C6 --> T2
+  C7 --> T2
+  C8 --> T2
+  T2 --> T3
+```
+
+Wave 1 makes the high fan-out consumers columnar-native while every producer still emits `Vec`, so the columnar arm stays dead and there is zero runtime bounce, with a single code path throughout.
+Wave 2 and later flip producers paired with their now-native consumers, so no decode-back seam lingers, which is the per-subgraph churn minimization.
+The enum stays the carrier the whole time.
+Wave 4 collapses it once T1 proves no `Vec` producer remains, and the teardown is compiler-enforced.
+
+### Per-node change specification
+
+Each node is one stacked pull request.
+The base names the parent the branch stacks on.
+
+**F1: columnar `consolidate_named`.**
+Replace the decode, consolidate, re-encode round-trip in the `Columnar` arm of `CollectionEdge::consolidate_named` with a native consolidation using `Col2KeyBatcher`.
+Keep the `Vec` arm unchanged.
+This is the temporary second variant.
+Files: `src/compute/src/render/columnar.rs`, possibly a helper in `src/timely-util/src/columnar.rs`.
+Test: extend `consolidate_named_preserves_columnar` to assert the operator no longer contains a `ColumnarToVec`.
+Base: `upstream/main`.
+
+**C1: columnar arrange input.**
+Generalize `ensure_collections` and `arrange_collection` to accept a `CollectionEdge`.
+The `Columnar` arm iterates `data.borrow().into_index_iter()` and borrows datums from the columnar row to form the key, mirroring `flat_map_datums`.
+The passthrough output preserves the input variant, so `context.rs:1102` re-wraps `Columnar` when the input was columnar.
+The key-value output builder and the batcher are unchanged, since they are already columnar.
+This unblocks ArrangeBy, index-export, and every plan-inserted arrangement.
+Files: `src/compute/src/render/context.rs`.
+Test: arrangement sqllogictest, plus a unit test that a columnar input yields no `ColumnarToVec` on the arrange path.
+Base: `upstream/main`.
+
+**C2: FlatMap decode via `flat_map_datums`.**
+`render_flat_map` calls `as_specific_collection` then iterates rows.
+Switch it to consume the edge through `flat_map_datums`, which handles both arms natively.
+Files: `src/compute/src/render/flat_map.rs`.
+Test: FlatMap sqllogictest, plus cross-arm agreement as in `flat_map_datums_arms_agree`.
+Base: `upstream/main`.
+
+**C6: columnar sink input.**
+Change the sink input path so it consumes a columnar edge.
+`sinks.rs:70` clones and calls `into_vec`.
+Persist and subscribe serialize rows, so the decode is acceptable at the leaf, but the API accepts the columnar edge and decodes locally rather than forcing `into_vec` at the boundary.
+Files: `src/compute/src/render/sinks.rs`.
+Test: subscribe and materialized-view sink sqllogictest and testdrive coverage.
+Base: `upstream/main`.
+
+**P1: columnar output for the `flat_map` family.**
+Generalize `as_collection_core` and `as_specific_collection` to build into a `ColumnBuilder` and return a columnar edge.
+This flips the Mfp and Get producers.
+Files: `src/compute/src/render/context.rs`, `src/compute/src/render.rs`.
+Test: physical-plan goldens unchanged, plus sqllogictest for Get and Mfp chains feeding an ArrangeBy or sink.
+Base: `C1`, `C6`.
+
+**P2: columnar Constant.**
+Build the constant collection into a `Column` in the `Constant` arm of `render_plan_expr`.
+Files: `src/compute/src/render.rs`.
+Test: constant-fed sqllogictest.
+Base: `C1`.
+
+**P3: columnar ArrangeBy passthrough.**
+Once C1 preserves the input variant on the passthrough, ensure the passthrough emits `Columnar` when its producer is columnar, and drop any remaining `Vec` re-wrap.
+Files: `src/compute/src/render/context.rs`.
+Test: ArrangeBy followed by a consumer that reads the passthrough collection.
+Base: `C1`.
+
+**P4: columnar FlatMap output.**
+Build the FlatMap output into a `ColumnBuilder`.
+Files: `src/compute/src/render/flat_map.rs`.
+Test: FlatMap feeding a downstream arrange or union.
+Base: `C2`.
+
+**C3+P6: TopK input and output columnar.**
+TopK reads its input via `as_specific_collection(None)` then `into_vec` and arranges by a hash and group key internally.
+Form that key off the columnar batch using the C1 pattern, and build the TopK output into a `ColumnBuilder`.
+The intra-operator `explode_one` and `ensure_monotonic` on `Vec` stay unchanged.
+Files: `src/compute/src/render/top_k.rs`.
+Test: top-k sqllogictest including monotonic and limit cases.
+Base: `C1`.
+
+**C4, C5, P7: linear and delta join input and output columnar.**
+The linear-join source-key path and the delta-join input path decode via `as_specific_collection` or local `into_vec`.
+Rework each to consume the columnar batch, and build the join output into a `ColumnBuilder`.
+Split into C4 for linear-join input, C5 for delta-join input, and P7 for the shared output flip if the diffs are large.
+Files: `src/compute/src/render/join/linear_join.rs`, `src/compute/src/render/join/delta_join.rs`.
+Test: join sqllogictest across linear and delta plans.
+Base: `C1`.
+
+**P5: columnar Reduce output.**
+Build the final Reduce output into a `ColumnBuilder`.
+Internals stay on `Vec`.
+Files: `src/compute/src/render/reduce.rs`.
+Test: reduce sqllogictest across accumulable, hierarchical, and basic plans.
+Base: `upstream/main`, or the Wave 3 tip if it shares helpers.
+
+**P8: columnar Threshold output.**
+Build the Threshold output into a `ColumnBuilder`.
+Files: `src/compute/src/render/threshold.rs`.
+Test: threshold sqllogictest.
+Base: `upstream/main`.
+
+**C7: columnar LetRec.**
+Run the LetRec consolidation and the `branch_when` iteration-limit logic on the columnar stream.
+Depends on F1 for the native columnar consolidate.
+This is the least-trodden path.
+If `branch_when` on columnar resists, keep LetRec as a decode point longer and record why.
+Files: `src/compute/src/render.rs`.
+Test: recursive-view sqllogictest including the iteration limit and the error-distinctness path.
+Base: `F1`.
+
+**C8: columnar Union temporal-bucket.**
+`render.rs:1358` decodes via `into_vec` to apply temporal bucketing inside a consolidating Union.
+Make `maybe_apply_temporal_bucketing` operate on the columnar stream, or keep the decode and document it as a leaf if bucketing is inherently row-shaped.
+Files: `src/compute/src/render.rs`, the timestamp trait sites for `maybe_apply_temporal_bucketing`.
+Test: temporal and temporal-bucketing sqllogictest.
+Base: `F1` if it shares the consolidate, else `upstream/main`.
+
+**T1: delete `vec_to_columnar`.**
+Once every producer emits columnar, no edge carries `Vec`, so `vec_to_columnar` is dead.
+Delete it and the mixed-variant upgrade branch in `concat_many`.
+Files: `src/compute/src/render/columnar.rs`.
+Base: the merge of all P nodes and the Wave 3 consumer nodes.
+
+**T2: collapse the enum.**
+Replace `CollectionEdge` with a `ColumnarCollection` type alias.
+Demote `into_vec` to a free function used only by leaf consumers that serialize rows.
+Update `CollectionBundle.collection` and all construction sites.
+Files: `src/compute/src/render/columnar.rs`, `src/compute/src/render/context.rs`, `src/compute/src/render.rs`, and every construction site.
+Base: `T1`, `C6`, `C7`, `C8`.
+
+**T3: de-match the carrier methods.**
+Simplify `negate`, `concat_many`, and `consolidate_named` from arm matches to single columnar implementations.
+Remove the temporary second consolidate variant.
+Files: `src/compute/src/render/columnar.rs`.
+Base: `T2`.
+
+### Stacked pull requests
+
+The DAG is not a single chain, so it is several stacks off `upstream/main` that converge at the teardown.
+
+* Lane A, off `C1`: `P1` also needs `C6`, then `P3`.
+* Lane B: `C2` then `P4`.
+* Lane C: `C6` feeds `P1` and `T2`.
+* Lane D: `F1` then `C7`, `C8`.
+* Lane E, off `C1`: `C3+P6`, `C4`, `C5`, `P7`.
+* Independent: `P2` off `C1`, `P5` and `P8` off `upstream/main`.
+* Convergence: `T1` rebases on all producer and Wave 3 consumer lanes, then `T2`, then `T3`.
+
+gh-stack reference: https://github.github.com/gh-stack/#get-started
+
+### Testing strategy
+
+* Every consumer node lands a unit test that asserts the columnar path introduces no `ColumnarToVec` operator, reusing the introspection-visible seam names.
+* Every producer node keeps physical-plan goldens unchanged, since the edge representation is not part of the plan text.
+* Cross-arm agreement follows the `flat_map_datums_arms_agree` pattern.
+  The vec and columnar arms must extract identical updates.
+* A feature-benchmark reduce and top-k run guards against a regression that outlives the transition, not against transient cost.
+
+## Minimal Viable Prototype
+
+The prototype validates the two load-bearing mechanisms end to end: the columnar arrange input (C1) and the `flat_map`-family producer flip (P1).
+Land C1 and P1, then render a `SELECT` that flows Get into an ArrangeBy.
+Assert that the rendered dataflow contains no `ColumnarToVec` operator on that path, and that results match the row-based rendering.
+This de-risks the C1 key-forming pattern that C3, C4, and C5 reuse, before committing to the operator-local arrange diffs.
+
+## Alternatives
+
+* **Two parallel implementations per operator.**
+  Maintain both the `Vec` and columnar code paths at every operator until the migration completes.
+  Rejected because the complexity grows to unbounded levels over a long migration.
+* **Feature-flag the change.**
+  Gate columnar edges behind a config flag.
+  Rejected for the same complexity reason, and because the flag plus the enum multiplies the states to reason about.
+* **Generalize `CollectionExt` over its container.**
+  Make the trait container-generic so a columnar collection is a first-class implementation.
+  Rejected because the trait is a dead-end.
+  Behavior-specific needs are met by keeping intra-operator `Vec` uses as they are and giving `consolidate_named` a temporary second variant.
+* **Collapse the enum to a columnar-only edge with local adapters now.**
+  Make the edge type columnar immediately and insert `vec_to_columnar` and `columnar_to_vec` adapters at unmigrated boundaries.
+  Rejected because it doubles conversions at unmigrated producer-consumer pairs, a worse transient cost, and the enum-as-carrier keeps the representation-matching in one place.
+* **Strict consumer-first with a dead columnar arm throughout.**
+  Migrate every consumer natively before any producer flips, so there is no transient perf hit.
+  Not chosen as a strict rule, since it front-loads per-operator native code before any producer benefits.
+  The chosen per-subgraph direction pairs each producer flip with its consumer work instead.
+
+## Open questions
+
+* **Join node granularity.**
+  C4, C5, and P7 are grouped.
+  The split into linear-input, delta-input, and shared-output depends on how large the diffs are, resolved when the join work starts.
+* **`branch_when` on columnar.**
+  LetRec, C7, runs the iteration-limit `branch_when` on the stream.
+  Whether that is clean on a columnar stream, or whether LetRec stays a decode point, is unresolved until C7 is attempted.
+* **Union temporal-bucketing.**
+  Whether `maybe_apply_temporal_bucketing` can operate on a columnar stream, or is inherently row-shaped and stays a leaf decode, is unresolved until C8 is attempted.


### PR DESCRIPTION
Plan to migrate compute dataflow edges from `VecCollection` to columnar `Column` batches, following the `CollectionEdge` scaffolding in #36507.

The doc decomposes the migration into a dependency DAG of fine-grained, independently landable changes, one per stacked PR. Key decisions: single code path with no feature flag, the `CollectionEdge` enum stays as the representation carrier until a final compiler-enforced teardown deletes the `Vec` arm, and `CollectionExt` is left as-is rather than generalized.

Design only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of [CPU-51](https://linear.app/materializeinc/issue/CPU-51)