### PR TITLE
v26.34.0 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -19,6 +19,43 @@ Starting with the v26.1.0 release, Materialize releases on a weekly schedule for
 both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for details.
 {{</ note >}}
 
+## v26.34.0
+*Released to Materialize Cloud: 2026-07-23* <br>
+*Released to Materialize Self-Managed: 2026-07-24* <br>
+
+### Background cluster reconfiguration {#v26.34-background-cluster-reconfiguration}
+The cluster controller is now enabled by default. `ALTER CLUSTER` for configuration changes (such as resizing) now returns immediately and converges in the background, rather than blocking until the new replica set is ready. `CREATE CLUSTER` and `ALTER CLUSTER` also accept the new `AUTO SCALING STRATEGY` option for configuring hydration-burst autoscaling behavior.
+
+### Improvements {#v26.34-improvements}
+- **Azure SQL source support**: Materialize can now ingest data from Azure SQL databases using the SQL Server source connector.
+- **AWS Glue Schema Registry for sinks**: `CREATE SINK` now supports AWS Glue Schema Registry for Avro-encoded Kafka sinks, as an alternative to Confluent Schema Registry.
+- **Configurable Iceberg sink commit interval**: The commit interval of an existing Iceberg sink can now be altered using `ALTER ... SET COMMIT INTERVAL`, with a minimum of 1 second.
+- **MCP query tool replica routing**: The MCP developer query tool now accepts a `cluster_replica` parameter, enabling `EXPLAIN ANALYZE` on clusters with more than one replica.
+- **Smaller container images**: The `environmentd` and `clusterd` container images now use a distroless base, reducing image size and attack surface for Self-Managed deployments.
+
+### Agent Skills {#v26.34-agent-skills}
+- **Materialize Terraform Provider**: New agent skill covering Terraform provider configuration for Cloud and self-managed deployments, resource conventions, cross-resource patterns, import workflows, and known gotchas.
+- **Materialize Terraform Self-Managed**: New agent skill covering the Terraform modules for deploying self-managed Materialize on AWS, Azure, and GCP, including IAM-based storage auth, upgrade procedures, and project integration patterns.
+
+### Bug Fixes {#v26.34-bug-fixes}
+- Fixed a critical bug where a pending replacement materialized view could destroy the data of its live target materialized view after an environmentd restart, by advancing the shared persist shard's since to the empty frontier.
+- Fixed a correctness bug in join processing where incoming batches could be silently dropped after trace compaction, causing lost updates without error.
+- Fixed multiple soundness bugs in persist filter pushdown that could silently drop matching rows or cause `persist filter pushdown correctness violation` panics.
+- Fixed a bug in multi-statement read transactions where a timestamp-independent first statement (e.g., a query over a constant-folded view) could cause subsequent statements to read from incorrect time domains, resulting in errors or incorrect results.
+- Fixed `ALTER MATERIALIZED VIEW ... APPLY REPLACEMENT` crashing the coordinator when a temporary view or index depended on the target materialized view.
+- Fixed non-temporary objects (views, indexes, etc.) being allowed to depend on temporary objects, which could lead to dangling references when the session ended.
+- Fixed stack overflow crashes in the adapter when processing environments with deeply nested object dependencies.
+- Fixed a stack overflow when comparing deeply nested values (e.g., deeply nested JSONB) in query result ordering.
+- Fixed a stack overflow when executing read-then-write statements (e.g., `INSERT INTO ... SELECT`) over deeply chained view hierarchies.
+- Fixed stack overflow or memory exhaustion when resolving pathologically deep or wide custom types.
+- Fixed a crash on diskless replicas where restarting upsert sources could encounter stale RocksDB state.
+- Fixed environmentd crash-looping on startup when a tombstoned persist shard was still referenced in the catalog.
+- Fixed `SET TRANSACTION ... READ WRITE` silently modifying session state before returning an error.
+- `CREATE ROLE` now rejects the reserved role specification names `current_user`, `current_role`, `session_user`, `user`, and `none`.
+- Fixed a user-created schema named `information_schema` bypassing the `mz_catalog_server` cluster restriction, allowing user queries to run on a reserved system cluster.
+- Fixed `kubectl apply --server-side` failing for Materialize v1 CRDs when managed fields were originally recorded at v1alpha1, blocking GitOps tooling in Self-Managed deployments.
+- Fixed the Self-Managed Console deriving the MCP server URL from the pgwire hostname instead of the HTTP endpoint, causing MCP connections to fail when pgwire and HTTP are served on separate hostnames.
+
 ## v26.33.0
 *Released to Materialize Cloud: 2026-07-16* <br>
 *Released to Materialize Self-Managed: 2026-07-17* <br>

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -81,7 +81,7 @@ SELECT cluster_id, status, deadline, on_timeout, target, changes
 FROM mz_internal.mz_cluster_reconfigurations;
 ```
 
-For more information, see [`ALTER CLUSTER`: Monitoring a resize](/sql/alter-cluster/#monitoring-a-resize).
+For more information, see [`ALTER CLUSTER`: Resizing process](/sql/alter-cluster/#resizing-process).
 
 ### AWS Glue Schema Registry Support for Sinks {#v26.34-aws-glue-schema-registry-support-sinks}
 

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -20,8 +20,8 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 {{</ note >}}
 
 ## v26.34.0
-*Released to Materialize Cloud: 2026-07-23* <br>
-*Released to Materialize Self-Managed: 2026-07-24* <br>
+*Released to Materialize Cloud: 2026-07-21* <br>
+*Released to Materialize Self-Managed: 2026-07-21* <br>
 
 ### Background cluster reconfiguration {#v26.34-background-cluster-reconfiguration}
 The cluster controller is now enabled by default. `ALTER CLUSTER` for configuration changes (such as resizing) now returns immediately and converges in the background, rather than blocking until the new replica set is ready. `CREATE CLUSTER` and `ALTER CLUSTER` also accept the new `AUTO SCALING STRATEGY` option for configuring hydration-burst autoscaling behavior.

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -26,6 +26,9 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 ### Background cluster reconfiguration {#v26.34-background-cluster-reconfiguration}
 The cluster controller is now enabled by default. `ALTER CLUSTER` for configuration changes (such as resizing) now returns immediately and converges in the background, rather than blocking until the new replica set is ready. `CREATE CLUSTER` and `ALTER CLUSTER` also accept the new `AUTO SCALING STRATEGY` option for configuring hydration-burst autoscaling behavior.
 
+### AWS Glue Schema Registry Support for Sinks {#v26.34-aws-glue-schema-registry-support-sinks}
+Kafka sinks can now use AWS Glue Schema Registry for Avro schema management via the new `FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY` syntax on `CREATE SINK`, as an alternative to the Confluent Schema Registry. This is currently available on Materialize Cloud only.
+
 ### Improvements {#v26.34-improvements}
 - **Azure SQL source support**: Materialize can now ingest data from Azure SQL databases using the SQL Server source connector.
 - **Configurable Iceberg sink commit interval**: The commit interval of an existing Iceberg sink can now be altered using `ALTER ... SET COMMIT INTERVAL`, with a minimum of 1 second.

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -28,7 +28,6 @@ The cluster controller is now enabled by default. `ALTER CLUSTER` for configurat
 
 ### Improvements {#v26.34-improvements}
 - **Azure SQL source support**: Materialize can now ingest data from Azure SQL databases using the SQL Server source connector.
-- **AWS Glue Schema Registry for sinks**: `CREATE SINK` now supports AWS Glue Schema Registry for Avro-encoded Kafka sinks, as an alternative to Confluent Schema Registry.
 - **Configurable Iceberg sink commit interval**: The commit interval of an existing Iceberg sink can now be altered using `ALTER ... SET COMMIT INTERVAL`, with a minimum of 1 second.
 - **MCP query tool replica routing**: The MCP developer query tool now accepts a `cluster_replica` parameter, enabling `EXPLAIN ANALYZE` on clusters with more than one replica.
 - **Smaller container images**: The `environmentd` and `clusterd` container images now use a distroless base, reducing image size and attack surface for Self-Managed deployments.

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -23,23 +23,110 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 *Released to Materialize Cloud: 2026-07-21* <br>
 *Released to Materialize Self-Managed: 2026-07-21* <br>
 
-### Graceful Cluster Reconfiguration {#v26.34-background-cluster-reconfiguration}
-`ALTER CLUSTER` for configuration changes (such as resizing) now returns immediately and converges in the background, rather than blocking until the new replica set is ready. `CREATE CLUSTER` and `ALTER CLUSTER` also accept the new `AUTO SCALING STRATEGY` option for configuring hydration-burst autoscaling behavior.
-
 ### Autoscaling to speed up hydration {#v26.34-autoscaling-hydration}
-Managed clusters can now temporarily scale up while hydrating and scale back down once caught up, reducing hydration time without permanently provisioning a larger cluster. Configure this behavior with the new `AUTO SCALING STRATEGY` option on [`CREATE CLUSTER`](/sql/create-cluster/) and `ALTER CLUSTER`.
+
+{{< public-preview />}}
+
+Managed clusters can now temporarily scale up to accelerate hydration.
+
+Using the `AUTO SCALING STRATEGY (ON HYDRATION)` strategy, Materialize runs an extra burst replica at the
+larger `HYDRATION SIZE` while the cluster's objects are un-hydrated. Once a steady-size replica hydrates, the burst replica is retired. An optional `LINGER DURATION` keeps the burst replica running for a grace period after the steady-size replicas hydrate.
+
+```mzsql
+-- Create a cluster that spins up a 1600cc burst replica while hydrating
+CREATE CLUSTER my_cluster (
+    SIZE = '400cc',
+    AUTO SCALING STRATEGY = (
+        ON HYDRATION (HYDRATION SIZE = '1600cc', LINGER DURATION = '600s')
+    )
+);
+```
+
+You can add, change, or remove the strategy on an existing cluster with
+`ALTER CLUSTER`:
+
+```mzsql
+ALTER CLUSTER my_cluster SET (
+    AUTO SCALING STRATEGY = (ON HYDRATION (HYDRATION SIZE = '1600cc'))
+);
+```
+
+For more information, see the `AUTO SCALING STRATEGY` option on
+[`CREATE CLUSTER`](/sql/create-cluster/#autoscaling) and
+[`ALTER CLUSTER`](/sql/alter-cluster/#speed-up-hydration-by-autoscaling-to-a-larger-size).
+
+### Graceful Cluster Reconfiguration {#v26.34-background-cluster-reconfiguration}
+`ALTER CLUSTER` for configuration changes (such as resizing) now returns immediately and runs in the background, rather than blocking until the new replica set is ready.
+
+Because the command is now asynchronous, you can monitor the
+progress of an in-flight reconfiguration using `SHOW CLUSTERS`.
+
+```mzsql
+SHOW CLUSTERS;
+```
+```nofmt
+    name    | replicas   |           activity           | comment
+------------+------------+------------------------------+---------
+ my_cluster | r1 (400cc) | reconfiguring size to 1600cc |
+```
+
+For detailed status, query
+[`mz_internal.mz_cluster_reconfigurations`](/reference/system-catalog/mz_internal/#mz_cluster_reconfigurations),
+which reports the target shape, the deadline, and the reconfiguration's
+lifecycle `status` (`in-progress`, then a terminal `finalized`, `timed-out`,
+`cancelled`, or `resource-exhausted`):
+
+```mzsql
+SELECT cluster_id, status, deadline, on_timeout, target, changes
+FROM mz_internal.mz_cluster_reconfigurations;
+```
+
+For more information, see [`ALTER CLUSTER`: Monitoring a resize](/sql/alter-cluster/#monitoring-a-resize).
 
 ### AWS Glue Schema Registry Support for Sinks {#v26.34-aws-glue-schema-registry-support-sinks}
 
+{{< public-preview />}}
+
 <red>*Materialize Cloud only*</red>
 
-Kafka sinks can now use [AWS Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry) for Avro schema management via the new `FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY` syntax on `CREATE SINK`, as an alternative to the Confluent Schema Registry.
+Kafka sinks can now use [AWS Glue Schema
+Registry](/sql/create-connection/#aws-glue-schema-registry) for Avro schema
+management, via the new `FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY` syntax on
+[`CREATE SINK`](/sql/create-sink/kafka/).
+
+```mzsql
+-- Authenticate to AWS Glue through an AWS connection.
+CREATE CONNECTION aws_connection TO AWS (
+    ASSUME ROLE ARN = 'arn:aws:iam::123456789000:role/MaterializeGlue'
+);
+
+CREATE CONNECTION glue_connection TO AWS GLUE SCHEMA REGISTRY (
+    AWS CONNECTION = aws_connection,
+    REGISTRY = 'default-registry'
+);
+
+-- Write Avro-encoded output, registering schemas with AWS Glue.
+CREATE SINK avro_sink
+  IN CLUSTER my_io_cluster
+  FROM my_materialized_view
+  INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
+  KEY (key)
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_connection (
+    KEY SCHEMA NAME = 'test_topic-key',
+    VALUE SCHEMA NAME = 'test_topic-value'
+  )
+  ENVELOPE UPSERT;
+```
+
+For more information, see [`CREATE SINK`: Using AWS Glue Schema Registry](/sql/create-sink/kafka/#using-aws-glue-schema-registry).
 
 ### Role Mapping via SCIM {#v26.34-role-mapping-scim}
 
+{{< private-preview />}}
+
 <red>*Materialize Cloud only*</red>
 
-You can now map identity provider groups to Materialize roles via SCIM, automatically syncing group membership from your identity provider to role assignments in Materialize. For details, see [Sync IdP groups](/security/cloud/users-service-accounts/sync-idp-groups/).
+You can now map identity provider groups to Materialize roles via SCIM, automatically syncing group membership from your identity provider to role assignments in Materialize. This keeps access in Materialize aligned with your identity provider as team membership changes, without manual role management. For details, see [Sync IdP groups](/security/cloud/users-service-accounts/sync-idp-groups/).
 
 ### Improvements {#v26.34-improvements}
 - **Azure SQL source support**: Materialize can now ingest data from Azure SQL databases using the [SQL Server source connector](/ingest-data/sql-server/).
@@ -48,6 +135,8 @@ You can now map identity provider groups to Materialize roles via SCIM, automati
 - **Smaller container images**: The `environmentd` and `clusterd` container images now use a distroless base, reducing image size and attack surface for Self-Managed deployments.
 
 ### Agent Skills {#v26.34-agent-skills}
+To start using our skills, install them with `npx skills add MaterializeInc/agent-skills`. To update your installed skills, run `npx skills update`. For more information, see [Coding agent skills](/integrations/coding-agent-skills/).
+
 - **Materialize Terraform Provider**: New agent skill covering Terraform provider configuration for Cloud and self-managed deployments, resource conventions, cross-resource patterns, import workflows, and known gotchas.
 - **Materialize Terraform Self-Managed**: New agent skill covering the Terraform modules for deploying self-managed Materialize on AWS, Azure, and GCP, including IAM-based storage auth, upgrade procedures, and project integration patterns.
 

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -23,15 +23,27 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 *Released to Materialize Cloud: 2026-07-21* <br>
 *Released to Materialize Self-Managed: 2026-07-21* <br>
 
-### Background cluster reconfiguration {#v26.34-background-cluster-reconfiguration}
-The cluster controller is now enabled by default. `ALTER CLUSTER` for configuration changes (such as resizing) now returns immediately and converges in the background, rather than blocking until the new replica set is ready. `CREATE CLUSTER` and `ALTER CLUSTER` also accept the new `AUTO SCALING STRATEGY` option for configuring hydration-burst autoscaling behavior.
+### Graceful Cluster Reconfiguration {#v26.34-background-cluster-reconfiguration}
+`ALTER CLUSTER` for configuration changes (such as resizing) now returns immediately and converges in the background, rather than blocking until the new replica set is ready. `CREATE CLUSTER` and `ALTER CLUSTER` also accept the new `AUTO SCALING STRATEGY` option for configuring hydration-burst autoscaling behavior.
+
+### Autoscaling to speed up hydration {#v26.34-autoscaling-hydration}
+Managed clusters can now temporarily scale up while hydrating and scale back down once caught up, reducing hydration time without permanently provisioning a larger cluster. Configure this behavior with the new `AUTO SCALING STRATEGY` option on [`CREATE CLUSTER`](/sql/create-cluster/) and `ALTER CLUSTER`.
 
 ### AWS Glue Schema Registry Support for Sinks {#v26.34-aws-glue-schema-registry-support-sinks}
-Kafka sinks can now use AWS Glue Schema Registry for Avro schema management via the new `FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY` syntax on `CREATE SINK`, as an alternative to the Confluent Schema Registry. This is currently available on Materialize Cloud only.
+
+<red>*Materialize Cloud only*</red>
+
+Kafka sinks can now use [AWS Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry) for Avro schema management via the new `FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY` syntax on `CREATE SINK`, as an alternative to the Confluent Schema Registry.
+
+### Role Mapping via SCIM {#v26.34-role-mapping-scim}
+
+<red>*Materialize Cloud only*</red>
+
+You can now map identity provider groups to Materialize roles via SCIM, automatically syncing group membership from your identity provider to role assignments in Materialize. For details, see [Sync IdP groups](/security/cloud/users-service-accounts/sync-idp-groups/).
 
 ### Improvements {#v26.34-improvements}
-- **Azure SQL source support**: Materialize can now ingest data from Azure SQL databases using the SQL Server source connector.
-- **Configurable Iceberg sink commit interval**: The commit interval of an existing Iceberg sink can now be altered using `ALTER ... SET COMMIT INTERVAL`, with a minimum of 1 second.
+- **Azure SQL source support**: Materialize can now ingest data from Azure SQL databases using the [SQL Server source connector](/ingest-data/sql-server/).
+- **Configurable Iceberg sink commit interval**: The [commit interval](/sql/create-sink/iceberg/#commit-interval-tradeoffs) of an existing Iceberg sink can now be altered using `ALTER ... SET COMMIT INTERVAL`, with a minimum of 1 second.
 - **MCP query tool replica routing**: The MCP developer query tool now accepts a `cluster_replica` parameter, enabling `EXPLAIN ANALYZE` on clusters with more than one replica.
 - **Smaller container images**: The `environmentd` and `clusterd` container images now use a distroless base, reducing image size and attack surface for Self-Managed deployments.
 

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -621,7 +621,7 @@ CREATE CONNECTION csr_ssh TO CONFLUENT SCHEMA REGISTRY (
 
 ### AWS Glue Schema Registry
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 An AWS Glue Schema Registry connection establishes a link to an [AWS Glue Schema
 Registry]. You can use AWS Glue Schema Registry connections in the `FORMAT`

--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -141,7 +141,7 @@ generated Avro schema.
 
 #### Using [AWS Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry)
 
-{{< private-preview />}}
+{{< public-preview />}}
 
   * Materialize registers Avro schemas for the key, if present, and the value in
     the registry named by the connection. The registry must already exist.
@@ -695,7 +695,7 @@ CREATE CONNECTION csr_basic_http
 {{< /tab >}}
 {{< tab "AWS Glue" >}}
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 ```mzsql
 CREATE CONNECTION aws_conn TO AWS (
@@ -729,7 +729,7 @@ CREATE SINK avro_sink
 {{< /tab >}}
 {{< tab "Avro AWS Glue">}}
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 The registry named by the connection must already exist. The IAM role assumed
 by the AWS connection must have the schema-write permissions listed under [AWS
@@ -781,7 +781,7 @@ CREATE SINK avro_sink
 {{< /tab >}}
 {{< tab "Avro AWS Glue">}}
 
-{{< private-preview />}}
+{{< public-preview />}}
 The registry named by the connection must already exist. The IAM role assumed
 by the AWS connection must have the schema-write permissions listed under [AWS
 Glue Schema Registry](/sql/create-connection/#aws-glue-schema-registry).
@@ -845,7 +845,7 @@ CREATE SINK compatibility_level_sink
 {{< /tab >}}
 {{< tab "Avro AWS Glue">}}
 
-{{< private-preview />}}
+{{< public-preview />}}
 ```mzsql
 CREATE SINK compatibility_level_sink
   IN CLUSTER my_io_cluster

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -5,6 +5,11 @@ columns:
   - column: Release date
   - column: Notes
 rows:
+  - Materialize Operator: v26.34
+    orchestratord version: v26.34
+    environmentd version: v26.34
+    Release date: "2026-07-24"
+    Notes: "See [v26.34 release notes](/releases/#v26340)"
   - Materialize Operator: v26.33
     orchestratord version: v26.33
     environmentd version: v26.33

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -8,7 +8,7 @@ rows:
   - Materialize Operator: v26.34
     orchestratord version: v26.34
     environmentd version: v26.34
-    Release date: "2026-07-24"
+    Release date: "2026-07-21"
     Notes: "See [v26.34 release notes](/releases/#v26340)"
   - Materialize Operator: v26.33
     orchestratord version: v26.33


### PR DESCRIPTION
Draft — dates are provisional until the final release. One commit is added per release candidate; the final run sets the real dates.

Snapshot drafts (with PR links) in mz-skills:
- final: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.34.0/release_notes.md)
