### PR TITLE
chore(console): [SAS-161] Regenerate API types and fix unrelated breakage.

### DIFF
--- a/console/src/api/cloudGlobalApi.ts
+++ b/console/src/api/cloudGlobalApi.ts
@@ -24,7 +24,7 @@ export type Organization = components["schemas"]["OrganizationResponse"];
 export type PlanType = components["schemas"]["PlanType"];
 export type Invoice = components["schemas"]["Invoice"];
 export type Region = components["schemas"]["Region"];
-export type Regions = components["schemas"]["Regions"];
+export type Regions = components["schemas"]["Paginated_Region"];
 export type CreditBlock = components["schemas"]["CreditBlock"];
 export type DailyCosts = components["schemas"]["DailyCostResponse"];
 export type AllCosts = components["schemas"]["AllCosts"];
@@ -266,7 +266,7 @@ export async function issueCommunityLicenseKey(
 }
 
 export async function getSelfManagedSubscription(
-  useCaseId: string | null,
+  environmentId: string | null,
   requestOptions: OpenApiRequestOptions = {},
 ) {
   const { headers, ...options } = requestOptions;
@@ -275,7 +275,7 @@ export async function getSelfManagedSubscription(
     {
       params: {
         path: {
-          useCaseId,
+          environmentId,
         },
       },
       signal: requestOptions?.signal,

--- a/console/src/api/mocks/cloudRegionApiHandlers.ts
+++ b/console/src/api/mocks/cloudRegionApiHandlers.ts
@@ -41,6 +41,7 @@ export const buildEnabledRegionReponse = (
         httpAddress:
           "47azz5yc00ab7xnu21b4p2evh.eu-west-1.aws.staging.materialize.cloud:443",
         resolvable: true,
+        upToDate: "True",
         enabledAt: "2022-11-11T00:20:14Z",
         ...regionInfo,
       },

--- a/console/src/api/schemas/global-api.ts
+++ b/console/src/api/schemas/global-api.ts
@@ -46,6 +46,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/costs/breakdown/daily": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the per-account, per-cluster cost breakdown bucketed by UTC day. */
+        get: operations["get_cost_breakdown_daily"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/costs/daily": {
         parameters: {
             query?: never;
@@ -89,7 +106,7 @@ export interface paths {
         };
         /**
          * Get recent invoices from Orb for an organization
-         * @description This endpoint returns the 20 most recent invoices for the given user,
+         *     This endpoint returns the 20 most recent invoices for the given user,
          *     including draft, paid, void, and issued invoices by default.
          */
         get: operations["get_invoices"];
@@ -111,6 +128,22 @@ export interface paths {
         get?: never;
         put?: never;
         post: operations["issue_license_key"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/license-key/revoked": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_revoked_license_keys"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -237,8 +270,10 @@ export interface components {
     schemas: {
         /** @description Costs for all tracked resources. */
         AllCosts: {
-            compute: components["schemas"]["ComputeCosts"];
-            storage: components["schemas"]["StorageCosts"];
+            /** @description Compute resource costs. */
+            compute: components["schemas"]["Cost_ComputePrice"];
+            /** @description Storage resource costs. */
+            storage: components["schemas"]["Cost_StoragePrice"];
         };
         Card: {
             /** @description The last 4 digits of the card number. */
@@ -254,17 +289,6 @@ export interface components {
              */
             expYear: number;
         };
-        ComputeCosts: {
-            /** @description The resource-specific pricing breakdown. Either `ComputePrice`,
-             *     `NetworkPrice`, or `StoragePrice`. */
-            prices: components["schemas"]["ComputePrice"][];
-            /** @description The total cost for the resource in the timeframe, excluding any
-             *     minimums and discounts. */
-            subtotal: string;
-            /** @description The total cost for the resource in the timeframe, including any
-             *     minimums and discounts. */
-            total: string;
-        };
         /** @description The price for a specific class of compute resource. */
         ComputePrice: {
             /** @description The ID of the region in which the compute resource was used (e.g., `aws/us-east-1`). */
@@ -276,8 +300,68 @@ export interface components {
             /** @description The total cost for the resource type in the region, excluding any minimums and discounts. */
             subtotal: string;
         };
+        /** @description Cost breakdown for one Orb account (parent or child) within a billing period. */
+        CostBreakdownAccount: {
+            external_customer_id: string;
+            /**
+             * @description The account's display name (Orb `Customer.name`, which the sync-server
+             *     keeps equal to the Frontegg org name). Empty when the name could not be
+             *     resolved; the breakdown itself is still returned.
+             */
+            name: string;
+            clusters: components["schemas"]["CostBreakdownCluster"][];
+        };
+        /** @description Per-cluster cost breakdown for a single Orb account within a billing period. */
+        CostBreakdownCluster: {
+            /** @description The environment that owns this cluster (event property `environment_id`). */
+            environment_id: string;
+            /**
+             * @description Human-readable cluster key in `cluster_name.replica_name` form
+             *     (event property `cluster_grouping_key`). Empty for storage/egress rows
+             *     that have no per-cluster breakdown.
+             */
+            cluster_grouping_key: string;
+            /**
+             * @description Resource category for rows that aren't a compute cluster — "Storage" or
+             *     "Egress", derived from the Orb price's item name — so storage and egress
+             *     (which share an empty `cluster_grouping_key`) render as separate rows.
+             *     Empty for compute rows, which are identified by `cluster_grouping_key`.
+             */
+            category: string;
+            /**
+             * @description Cloud region in `provider/region` form, e.g. "aws/us-east-1" (event
+             *     property `region`). Lets the frontend qualify each row ("aws/us-east-1 /
+             *     Storage"), matching the daily "Spend between …" table.
+             */
+            region: string;
+            /** @description Map from price_id to the computed dollar amount (e.g. "1.23"). */
+            amounts: {
+                [key: string]: string;
+            };
+            /**
+             * Format: double
+             * @description Usage quantity for this row, summed across every price folded into it.
+             *     In credits for compute rows, GB for storage/egress rows (see `category`).
+             */
+            usage: number;
+        };
+        /** @description Per-account cost breakdown for a single calendar day. */
+        CostBreakdownDay: {
+            /**
+             * Format: date-time
+             * @description Start of the day (inclusive).
+             */
+            startDate: string;
+            /**
+             * Format: date-time
+             * @description End of the day (exclusive).
+             */
+            endDate: string;
+            accounts: components["schemas"]["CostBreakdownAccount"][];
+        };
         /** @description The daily costs for a given customer. */
         CostBucket: {
+            /** @description All resource costs */
             costs: components["schemas"]["AllCosts"];
             /** @description The total cost for the timeframe, excluding any minimums and discounts. */
             subtotal: string;
@@ -294,12 +378,88 @@ export interface components {
              */
             endDate: string;
         };
+        Cost_ComputePrice: {
+            /**
+             * @description The resource-specific pricing breakdown. Either `ComputePrice`,
+             *     `NetworkPrice`, or `StoragePrice`.
+             */
+            prices: {
+                /** @description The ID of the region in which the compute resource was used (e.g., `aws/us-east-1`). */
+                regionId: string;
+                /** @description The size of the compute resource replica (e.g., `xsmall`) */
+                replicaSize: string;
+                /** @description The rate per unit of usage. */
+                unitAmount: string;
+                /** @description The total cost for the resource type in the region, excluding any minimums and discounts. */
+                subtotal: string;
+            }[];
+            /**
+             * @description The total cost for the resource in the timeframe, excluding any
+             *     minimums and discounts.
+             */
+            subtotal: string;
+            /**
+             * @description The total cost for the resource in the timeframe, including any
+             *     minimums and discounts.
+             */
+            total: string;
+        };
+        Cost_NetworkPrice: {
+            /**
+             * @description The resource-specific pricing breakdown. Either `ComputePrice`,
+             *     `NetworkPrice`, or `StoragePrice`.
+             */
+            prices: {
+                /** @description The ID of the region in which the network resource was used (e.g., `aws/us-east-1`). */
+                regionId: string;
+                /** @description The rate per unit of usage. */
+                unitAmount: string;
+                /** @description The total cost for the resource type in the region, excluding any minimums and discounts. */
+                subtotal: string;
+            }[];
+            /**
+             * @description The total cost for the resource in the timeframe, excluding any
+             *     minimums and discounts.
+             */
+            subtotal: string;
+            /**
+             * @description The total cost for the resource in the timeframe, including any
+             *     minimums and discounts.
+             */
+            total: string;
+        };
+        Cost_StoragePrice: {
+            /**
+             * @description The resource-specific pricing breakdown. Either `ComputePrice`,
+             *     `NetworkPrice`, or `StoragePrice`.
+             */
+            prices: {
+                /** @description The ID of the region in which the storage resource was used (e.g., `aws/us-east-1`). */
+                regionId: string;
+                /** @description The rate per unit of usage. */
+                unitAmount: string;
+                /** @description The total cost for the resource type in the region, excluding any minimums and discounts. */
+                subtotal: string;
+            }[];
+            /**
+             * @description The total cost for the resource in the timeframe, excluding any
+             *     minimums and discounts.
+             */
+            subtotal: string;
+            /**
+             * @description The total cost for the resource in the timeframe, including any
+             *     minimums and discounts.
+             */
+            total: string;
+        };
         CreateCommunityLicenseKeyRequest: {
             email: string;
+            environmentId?: string | null;
+            licenseKey?: string | null;
         };
         CreateLicenseKeyRequest: {
             /** Format: uuid */
-            useCaseId?: string | null;
+            environmentId?: string | null;
         };
         CreateLicenseKeyResponse: {
             licenseKey: string;
@@ -314,15 +474,13 @@ export interface components {
             /** @description The amount paid per credit. */
             perUnitCostBasis?: string | null;
         };
-        /** @description All API responses that return a list use this standard pagination envelope */
-        CreditBlocks: {
-            /** @description The data in this page. */
-            data: components["schemas"]["CreditBlock"][];
-            /** @description The cursor to provide to the next API call to retrieve the next
-             *     page of results.
-             *
-             *     Set to `None` if there are no further pages. */
-            nextCursor?: string | null;
+        /**
+         * @description Response for `GET /api/costs/breakdown/daily` — the per-account,
+         *     per-cluster breakdown bucketed by UTC day. Dense: one entry per UTC day in
+         *     the requested window, with empty `accounts` for days that had no usage.
+         */
+        DailyCostBreakdownResponse: {
+            days: components["schemas"]["CostBreakdownDay"][];
         };
         /** @description The daily costs for a given customer. */
         DailyCostResponse: {
@@ -351,10 +509,12 @@ export interface components {
              * @description The issue date of the invoice.
              */
             issueDate: string;
-            /** @description The URL at which a PDF representation of the invoice can be retrieved.
+            /**
+             * @description The URL at which a PDF representation of the invoice can be retrieved.
              *
              *     Typically `None` for `draft` invoices, in which case `html_url` should
-             *     be `Some`, though this is not guaranteed by the Orb API documentation. */
+             *     be `Some`, though this is not guaranteed by the Orb API documentation.
+             */
             pdfUrl?: string | null;
             /** @description An ISO 4217 currency string, or "credits" */
             currency: string;
@@ -367,29 +527,24 @@ export interface components {
              * @description The time at which the invoice was created.
              */
             createdAt: string;
-            /** @description The URL at which a web-page representation of the invoice can be retrieved.
+            /**
+             * @description The URL at which a web-page representation of the invoice can be retrieved.
              *
              *     May be `None`, typically after the invoice is well past its issue date, in which
              *     case `pdf_url` should be `Some`, although this is not guaranteed by the Orb
-             *     API documentation. */
+             *     API documentation.
+             */
             webUrl?: string | null;
             /** @description The status (see [`orb_billing::InvoiceStatusFilter`] for details). */
             status: string;
             /** @description An automatically generated number to help track and reconcile invoices. */
             invoiceNumber: string;
         };
-        /** @description All API responses that return a list use this standard pagination envelope */
-        Invoices: {
-            /** @description The data in this page. */
-            data: components["schemas"]["Invoice"][];
-            /** @description The cursor to provide to the next API call to retrieve the next
-             *     page of results.
-             *
-             *     Set to `None` if there are no further pages. */
-            nextCursor?: string | null;
-        };
         IpAddress: {
             ip: string;
+        };
+        ListRevokedLicenseKeysResponse: {
+            jtis: string[];
         };
         MakePaymentMethodDefaultRequest: {
             paymentMethodId: string;
@@ -399,17 +554,6 @@ export interface components {
          * @enum {string}
          */
         Marketplace: "aws" | "direct";
-        NetworkCosts: {
-            /** @description The resource-specific pricing breakdown. Either `ComputePrice`,
-             *     `NetworkPrice`, or `StoragePrice`. */
-            prices: components["schemas"]["NetworkPrice"][];
-            /** @description The total cost for the resource in the timeframe, excluding any
-             *     minimums and discounts. */
-            subtotal: string;
-            /** @description The total cost for the resource in the timeframe, including any
-             *     minimums and discounts. */
-            total: string;
-        };
         /** @description The price for a specific class of network resource. */
         NetworkPrice: {
             /** @description The ID of the region in which the network resource was used (e.g., `aws/us-east-1`). */
@@ -431,7 +575,7 @@ export interface components {
             blocked: boolean;
             /** @description Whether or not the organization has been flagged as having completed onboarding. */
             onboarded: boolean;
-            subscription?: components["schemas"]["Subscription"] | null;
+            subscription?: null | components["schemas"]["Subscription"];
             /**
              * Format: date-time
              * @description The date the organization's trial ends.
@@ -442,10 +586,99 @@ export interface components {
             /** @description The ID of the default payment method for the organization. */
             defaultPaymentMethodId?: string | null;
         };
+        /** @description All API responses that return a list use this standard pagination envelope */
+        Paginated_CreditBlock: {
+            /** @description The data in this page. */
+            data: {
+                /**
+                 * Format: double
+                 * @description The available value in this block of credits.
+                 */
+                balance: number;
+                /** @description The amount paid per credit. */
+                perUnitCostBasis?: string | null;
+            }[];
+            /**
+             * @description The cursor to provide to the next API call to retrieve the next
+             *     page of results.
+             *
+             *     Set to `None` if there are no further pages.
+             */
+            nextCursor?: string | null;
+        };
+        /** @description All API responses that return a list use this standard pagination envelope */
+        Paginated_Invoice: {
+            /** @description The data in this page. */
+            data: {
+                /**
+                 * Format: date-time
+                 * @description The issue date of the invoice.
+                 */
+                issueDate: string;
+                /**
+                 * @description The URL at which a PDF representation of the invoice can be retrieved.
+                 *
+                 *     Typically `None` for `draft` invoices, in which case `html_url` should
+                 *     be `Some`, though this is not guaranteed by the Orb API documentation.
+                 */
+                pdfUrl?: string | null;
+                /** @description An ISO 4217 currency string, or "credits" */
+                currency: string;
+                /** @description The total after any minimums, discounts, and taxes have been applied. */
+                total: string;
+                /** @description The amount the customer will be charged due to this invoice */
+                amountDue: string;
+                /**
+                 * Format: date-time
+                 * @description The time at which the invoice was created.
+                 */
+                createdAt: string;
+                /**
+                 * @description The URL at which a web-page representation of the invoice can be retrieved.
+                 *
+                 *     May be `None`, typically after the invoice is well past its issue date, in which
+                 *     case `pdf_url` should be `Some`, although this is not guaranteed by the Orb
+                 *     API documentation.
+                 */
+                webUrl?: string | null;
+                /** @description The status (see [`orb_billing::InvoiceStatusFilter`] for details). */
+                status: string;
+                /** @description An automatically generated number to help track and reconcile invoices. */
+                invoiceNumber: string;
+            }[];
+            /**
+             * @description The cursor to provide to the next API call to retrieve the next
+             *     page of results.
+             *
+             *     Set to `None` if there are no further pages.
+             */
+            nextCursor?: string | null;
+        };
+        /** @description All API responses that return a list use this standard pagination envelope */
+        Paginated_Region: {
+            /** @description The data in this page. */
+            data: {
+                /** @description A unique identifier for the region, e.g. `aws/us-east-1` */
+                id: string;
+                /** @description The (provider-specific) region string -- e.g. `us-east-1` */
+                name: string;
+                /** @description The cloud provider hosting the region. Currently this can only be "aws" */
+                cloudProvider: string;
+                /** @description The URL at which the Region API can be reached */
+                url: string;
+            }[];
+            /**
+             * @description The cursor to provide to the next API call to retrieve the next
+             *     page of results.
+             *
+             *     Set to `None` if there are no further pages.
+             */
+            nextCursor?: string | null;
+        };
         PaymentMethod: {
             /** @description The type of payment method (e.g. "card"). */
             type: string;
-            card?: components["schemas"]["Card"] | null;
+            card?: null | components["schemas"]["Card"];
             /** @description The ID of the payment method. */
             id: string;
             /**
@@ -472,16 +705,6 @@ export interface components {
             /** @description The URL at which the Region API can be reached */
             url: string;
         };
-        /** @description All API responses that return a list use this standard pagination envelope */
-        Regions: {
-            /** @description The data in this page. */
-            data: components["schemas"]["Region"][];
-            /** @description The cursor to provide to the next API call to retrieve the next
-             *     page of results.
-             *
-             *     Set to `None` if there are no further pages. */
-            nextCursor?: string | null;
-        };
         SetupIntent: {
             /** @description The ID of the SetupIntent. */
             id: string;
@@ -489,17 +712,6 @@ export interface components {
             clientSecret: string;
             /** @description The status of the SetupIntent. */
             status: string;
-        };
-        StorageCosts: {
-            /** @description The resource-specific pricing breakdown. Either `ComputePrice`,
-             *     `NetworkPrice`, or `StoragePrice`. */
-            prices: components["schemas"]["StoragePrice"][];
-            /** @description The total cost for the resource in the timeframe, excluding any
-             *     minimums and discounts. */
-            subtotal: string;
-            /** @description The total cost for the resource in the timeframe, including any
-             *     minimums and discounts. */
-            total: string;
         };
         /** @description The price for a specific class of storage resource. */
         StoragePrice: {
@@ -511,7 +723,9 @@ export interface components {
             subtotal: string;
         };
         Subscription: {
+            /** @description Possible plans that customers may be subscribed to. */
             type: components["schemas"]["PlanType"];
+            /** @description The marketplace the organization is billed through. */
             marketplace: components["schemas"]["Marketplace"];
         };
     };
@@ -538,7 +752,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Regions"];
+                    "application/json": components["schemas"]["Paginated_Region"];
                 };
             };
         };
@@ -565,8 +779,54 @@ export interface operations {
                     "application/json": components["schemas"]["CreateLicenseKeyResponse"];
                 };
             };
+            /** @description Invalid environment id */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Failed to issue license key */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_cost_breakdown_daily: {
+        parameters: {
+            query: {
+                /** @example 2026-06-17 */
+                startDate: string;
+                /** @example 2026-06-17 */
+                endDate: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Organization Daily Cost Breakdown */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DailyCostBreakdownResponse"];
+                };
+            };
+            /** @description Missing or invalid startDate/endDate query params */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Insufficient permissions */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -577,8 +837,8 @@ export interface operations {
     get_current_organization_daily_costs: {
         parameters: {
             query: {
-                startDate: string | null;
-                endDate: string | null;
+                startDate: string;
+                endDate: string;
             };
             header?: never;
             path?: never;
@@ -612,7 +872,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CreditBlocks"];
+                    "application/json": components["schemas"]["Paginated_CreditBlock"];
                 };
             };
         };
@@ -643,7 +903,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Invoices"];
+                    "application/json": components["schemas"]["Paginated_Invoice"];
                 };
             };
             /** @description No permissions to get invoices */
@@ -677,7 +937,7 @@ export interface operations {
                     "application/json": components["schemas"]["CreateLicenseKeyResponse"];
                 };
             };
-            /** @description Cannot specify a use case id */
+            /** @description Cannot specify an environment id */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -692,6 +952,33 @@ export interface operations {
                 content?: never;
             };
             /** @description Failed to issue license key */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_revoked_license_keys: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Revoked license key JTIs */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListRevokedLicenseKeysResponse"];
+                };
+            };
+            /** @description Failed to list revoked license keys */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -841,7 +1128,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                useCaseId: string | null;
+                environmentId: string | null;
             };
             cookie?: never;
         };
@@ -856,7 +1143,7 @@ export interface operations {
                     "application/json": components["schemas"]["GetSelfManagedSubscriptionResponse"];
                 };
             };
-            /** @description Cannot specify a use case id */
+            /** @description Cannot specify an environment id */
             400: {
                 headers: {
                     [name: string]: unknown;

--- a/console/src/api/schemas/internal-api.ts
+++ b/console/src/api/schemas/internal-api.ts
@@ -73,14 +73,14 @@ export interface paths {
         };
         /**
          * Retrieve the region (EnvironmentAssignment resource) for the provided organization_id
-         * @description in the current cloud region
+         *     in the current cloud region
          */
         get: operations["get_region_by_org"];
         put?: never;
         post?: never;
         /**
          * Disable the region (EnvironmentAssignment resource) for the provided
-         * @description organization_id in the current cloud region
+         *     organization_id in the current cloud region
          *     This sets the `disable_scheduled_at` field to a date 30 days from now
          */
         delete: operations["disable_region_for_org"];
@@ -88,7 +88,7 @@ export interface paths {
         head?: never;
         /**
          * Update (or create) the region (EnvironmentAssignment resource) for the provided
-         * @description organization_id in the current cloud region
+         *     organization_id in the current cloud region
          */
         patch: operations["enable_region_for_org"];
         trace?: never;
@@ -97,16 +97,6 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
-        /** @description All API responses that return a list use this standard pagination envelope */
-        CensusEntries: {
-            /** @description The data in this page. */
-            data: components["schemas"]["CensusEntry"][];
-            /** @description The cursor to provide to the next API call to retrieve the next
-             *     page of results.
-             *
-             *     Set to `None` if there are no further pages. */
-            nextCursor?: string | null;
-        };
         CensusEntry: {
             /** Format: uuid */
             organizationId: string;
@@ -115,6 +105,50 @@ export interface components {
         };
         /** @enum {string} */
         OrgType: "customer" | "e2e_test";
+        /** @description All API responses that return a list use this standard pagination envelope */
+        Paginated_CensusEntry: {
+            /** @description The data in this page. */
+            data: {
+                /** Format: uuid */
+                organizationId: string;
+                /** Format: int32 */
+                ordinal: number;
+            }[];
+            /**
+             * @description The cursor to provide to the next API call to retrieve the next
+             *     page of results.
+             *
+             *     Set to `None` if there are no further pages.
+             */
+            nextCursor?: string | null;
+        };
+        /** @description All API responses that return a list use this standard pagination envelope */
+        Paginated_RegionInternal: {
+            /** @description The data in this page. */
+            data: {
+                /** Format: uuid */
+                organizationId: string;
+                /** Format: date-time */
+                enabledAt?: string | null;
+                provisioned: boolean;
+                /** Format: date-time */
+                disableScheduledAt?: string | null;
+                /** Format: date-time */
+                deprovisionedAt?: string | null;
+                environmentBase32Id: string;
+                /** Format: int32 */
+                ordinal: number;
+                upToDate: boolean;
+                orgType: components["schemas"]["OrgType"];
+            }[];
+            /**
+             * @description The cursor to provide to the next API call to retrieve the next
+             *     page of results.
+             *
+             *     Set to `None` if there are no further pages.
+             */
+            nextCursor?: string | null;
+        };
         RegionInternal: {
             /** Format: uuid */
             organizationId: string;
@@ -131,19 +165,11 @@ export interface components {
             upToDate: boolean;
             orgType: components["schemas"]["OrgType"];
         };
-        /** @description All API responses that return a list use this standard pagination envelope */
-        RegionInternals: {
-            /** @description The data in this page. */
-            data: components["schemas"]["RegionInternal"][];
-            /** @description The cursor to provide to the next API call to retrieve the next
-             *     page of results.
-             *
-             *     Set to `None` if there are no further pages. */
-            nextCursor?: string | null;
-        };
         RegionRequest: {
             environmentdImageRef?: string | null;
             environmentdExtraArgs?: string[] | null;
+            environmentdCpuAllocation?: string | null;
+            environmentdMemoryAllocation?: string | null;
             forceRollout?: boolean | null;
             cancelRollout?: boolean | null;
             inPlaceRollout?: boolean | null;
@@ -175,7 +201,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CensusEntries"];
+                    "application/json": components["schemas"]["Paginated_CensusEntry"];
                 };
             };
         };
@@ -198,7 +224,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CensusEntries"];
+                    "application/json": components["schemas"]["Paginated_CensusEntry"];
                 };
             };
         };
@@ -221,7 +247,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RegionInternals"];
+                    "application/json": components["schemas"]["Paginated_RegionInternal"];
                 };
             };
         };
@@ -259,8 +285,10 @@ export interface operations {
             header?: never;
             path: {
                 seconds: number | null;
-                /** @description Whether to do a real soft-deletion
-                 *     use ?realSoftDelete=true to set this */
+                /**
+                 * @description Whether to do a real soft-deletion
+                 *     use ?realSoftDelete=true to set this
+                 */
                 realSoftDelete: boolean | null;
             };
             cookie?: never;

--- a/console/src/api/schemas/region-api.ts
+++ b/console/src/api/schemas/region-api.ts
@@ -35,7 +35,7 @@ export interface paths {
         head?: never;
         /**
          * Enable the region for the authenticated organization in the current cloud region
-         * @description If the region already exists it will be updated to match any request parameters
+         *     If the region already exists it will be updated to match any request parameters
          *     If the region is soft-deleted the deletion state will be cleared
          */
         patch: operations["enable_region"];
@@ -45,9 +45,15 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * @description Enum version of the Kubernetes Condition.status field
+         * @enum {string}
+         */
+        ConditionStatus: "True" | "False" | "Unknown";
         /** @description Cloud Region */
         Region: {
-            regionInfo?: components["schemas"]["RegionInfo"] | null;
+            regionInfo?: null | components["schemas"]["RegionInfo"];
+            /** @description This field was introduced with API Version 1 */
             regionState: components["schemas"]["RegionState"];
         };
         /** @description Connection details for an active region */
@@ -55,12 +61,15 @@ export interface components {
             sqlAddress: string;
             httpAddress: string;
             resolvable: boolean;
+            upToDate: components["schemas"]["ConditionStatus"];
             /** Format: date-time */
             enabledAt: string;
         };
         RegionRequest: {
             environmentdImageRef?: string | null;
             environmentdExtraArgs?: string[] | null;
+            environmentdCpuAllocation?: string | null;
+            environmentdMemoryAllocation?: string | null;
         };
         /** @enum {string} */
         RegionState: "enabled" | "enablement-pending" | "deletion-pending" | "soft-deleted";
@@ -113,7 +122,7 @@ export interface operations {
         parameters: {
             query?: {
                 /** @description Whether to do a hard deletion */
-                hardDelete?: boolean | null;
+                hardDelete?: boolean;
             };
             header?: never;
             path?: never;

--- a/console/src/store/environments.test.ts
+++ b/console/src/store/environments.test.ts
@@ -45,6 +45,7 @@ const enabledEnvironment: EnabledEnvironment = {
   httpAddress: "8zpze6ltqnsjok9vvf2i99st5.us-east-1.aws.example.com:443",
   sqlAddress: "8zpze6ltqnsjok9vvf2i99st5.us-east-1.aws.example.com:6875",
   resolvable: true,
+  upToDate: "True",
   enabledAt: new Date().toISOString(),
 };
 

--- a/console/src/store/environments.ts
+++ b/console/src/store/environments.ts
@@ -444,6 +444,8 @@ function buildFakeEnabledEnvironment({
     httpAddress,
     sqlAddress: "",
     resolvable: true,
+    // No real Kubernetes condition to report for a fabricated environment.
+    upToDate: "True",
     // A made up enabled at time only used during impersonation and self-managed,
     // since we don't know when the environment was enabled.
     enabledAt: fakeEnabledAt.toString(),

--- a/console/src/test/utils.tsx
+++ b/console/src/test/utils.tsx
@@ -67,6 +67,7 @@ export const healthyEnvironment: EnabledEnvironment = {
   httpAddress: "8zpze6ltqnsjok9vvf2i99st5.us-east-1.aws.example.com:443",
   sqlAddress: "8zpze6ltqnsjok9vvf2i99st5.us-east-1.aws.example.com:6875",
   resolvable: true,
+  upToDate: "True",
   enabledAt: "2023-01-10T01:59:37Z",
   state: "enabled",
   status: {


### PR DESCRIPTION
## Summary

`yarn gen:api` against current `cloud/main` picks up the `name` and `usage` fields SAS-141/SAS-145 added to the cost-breakdown response, but also pulls in ~6 other commits of unrelated API drift that accumulated in the same window. This is that regen plus the resulting fixes, landed as its own focused change so it doesn't drag unrelated region/environment-API changes into a billing-UI PR.

- `cloudGlobalApi.ts`: `Regions` type alias repointed to the schema's renamed `Paginated_Region`; `getSelfManagedSubscription`'s path param renamed `useCaseId` → `environmentId`, matching the backend's own rename.
- `upToDate` (region "up to date" Kubernetes condition) went from optional to required. Added a `"True"` default at the 3 sites that construct these objects without a real value: the region mock builder, the fabricated self-managed/impersonation environment, and 2 test fixtures.
- Restored the license header the regen silently drops from all 3 generated schema files (no banner config in `redocly.yaml`), so the diff doesn't spuriously delete headers from 3 files.

Unblocks SAS-142 (render account display names) and SAS-159 (render per-cluster usage), both otherwise stuck waiting on these regenerated types.

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [x] `yarn test --run` — 722 passed, 1 skipped, 130 files

Linear: SAS-161