### PR TITLE
ci: Have Dependabot cover the cargo-fuzz workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
 - package-ecosystem: cargo
-  directory: /
+  directories:
+    - /
+    - /test/cargo-fuzz
   schedule:
     interval: weekly
     day: sunday


### PR DESCRIPTION
Point the root cargo config at both `/` and `/test/cargo-fuzz` so a grouped bump of a shared dependency updates both workspaces in one PR, keeping the fuzz pins in sync with the root as enforced by bin/lint-cargo.