### PR TITLE
persist: instrument shard_source descs/fetch delivery (INSTR, do not merge)

### DIFF
--- a/doc/developer/design/20260721_async_operator_nested_scope_delivery.md
+++ b/doc/developer/design/20260721_async_operator_nested_scope_delivery.md
@@ -1,0 +1,133 @@
+# Async operator input starvation in nested timely scopes
+
+## Status
+
+Root cause located and measured on staging.
+The fix is not yet designed.
+This document records the findings so the fix for the async operator bridge can be designed from a clean context.
+
+## Symptom
+
+Compute hydration reading a large persist snapshot from S3 runs at about 90 MB/s.
+Both CPU (about 4 percent) and network sit far below saturation, so the process is mostly parked, not compute or bandwidth bound.
+The effect only appears against real S3.
+Reproduction attempts against the file backend and against minio both failed to show it.
+
+## Conclusion first
+
+A `builder_async` async operator that runs inside a nested timely scope receives its input in a dribble of about one to three records per operator schedule.
+The identical async operator running in the outer (root) scope receives the whole upstream flood at once.
+This starves the persist fetch operator, which is one such nested async operator, so it issues about one blob fetch at a time instead of filling its concurrency budget.
+
+The throttle is the interaction between the async operator bridge (`src/timely-util/src/builder_async.rs`) and nested scope scheduling.
+It is not persist, not the fetch loop, not the byte semaphore, not backpressure, and not the timely exchange.
+
+## Why S3 only
+
+The nested scope delivers input at roughly the downstream retirement rate, which during hydration equals the fetch completion rate.
+Against minio or the file backend each blob get completes in well under a millisecond, so a one to three record per schedule intake still keeps up and hydration looks fast.
+Against S3 each part is about 45 MB fetched as a single stream at about 100 MB/s, so a fetch takes about 0.45 s.
+At that latency the one to three record per schedule intake caps the pipeline at about two parts per second, about 90 MB/s.
+
+## The pipeline
+
+The persist source wraps its operators like this.
+
+```mermaid
+flowchart LR
+  subgraph outer["outer (root) scope"]
+    descs["shard_source_descs (async)\nchosen worker emits all snapshot parts"]
+  end
+  subgraph nested["nested scope: outer.scoped(granular_backpressure)"]
+    enter["Enter (region ingress)"]
+    fetch["shard_source_fetch (async)\nExchange by worker_idx"]
+  end
+  descs -->|descs.enter(scope)| enter --> fetch
+  fetch -->|completed_fetches feedback| descs
+```
+
+The nested scope is created unconditionally in `src/storage-operators/src/persist_source.rs` by `scope.scoped("granular_backpressure", ...)`.
+The backpressure operator is only inserted inside it when `max_inflight_bytes` is `Some`.
+On the measured hydration `max_inflight_bytes` is `None`, so the backpressure operator is absent and the nested scope carries no flow control.
+The fetch operator still runs inside that nested scope because `descs.enter(scope)` moves the descs output into it.
+
+## Measurements
+
+All numbers are from staging, an isolated single dataflow: a default index over `materialize.sf100.lineitem`, a single 59 GB persist shard, on a fresh `M.1-8xlarge` replica, replication factor 0 then 1.
+Instrumentation lives on branch `mh/hydration-instr-main`, PR 37771.
+
+Effective concurrent blob get, measured as `rate(mz_persist_read_batch_part_seconds)`, sits at about 0.9 the whole time.
+Throughput is about 90 MB/s.
+Hydration of the shard takes about 13 to 14 minutes.
+
+The `descs` operator emits the whole snapshot at once.
+The chosen worker logs a single emit of about 1333 parts, batched into 38 containers of about 35 parts each, in one operator schedule, then never emits the snapshot again.
+So the source floods, it does not dribble.
+
+Three probe operators, all reading the same `descs` output for the same shard on the chosen worker, isolate the throttle.
+
+* Outer scope, `Pipeline` pact, no exchange: pulls 38 in one go, `accepted_total` reaches 38 by schedule 3.
+  This is bulk.
+* Nested scope reached through `descs.enter(scope)`, `Pipeline` pact, no exchange: pulls one to three per schedule, `accepted_total` crawls from 3 to 15 over about six seconds while schedules climb from 3 to 20.
+  This is a dribble.
+* Nested scope, real `Exchange` pact, the actual fetch input: pulls one per schedule across all workers.
+  This is a dribble.
+
+The nested `Pipeline` probe has no exchange and still dribbles.
+The outer `Pipeline` probe uses the same async bridge and is bulk.
+The single variable that changes the outcome is outer versus nested scope.
+
+The fetch operator itself is not scheduling starved in the sense of a busy loop.
+The `accept_input` probe shows it scheduled a few times per second, and on almost every schedule the timely input channel holds only one to two messages.
+`accept_input` drains everything available, so the channel genuinely holds one to two.
+The fetch loop drains its whole backlog per activation, so admitting more per activation does not help: there is nothing queued to admit.
+
+## What was ruled out, with evidence
+
+* The column pager. Hydration is neutral to it and CPU is low with it both on and off.
+* The fetch concurrency knob `persist_source_fetch_concurrency`. Set to 32, later 64, no change.
+* The fetch byte semaphore. `mz_persist_semaphore_blocking_seconds` is 0 throughout. Raising `persist_fetch_semaphore_permit_adjustment` from 0.1 to 1.0 left L at 0.9 and hydration still about 14 minutes.
+* The backpressure operator. `mz_persist_backpressure_emitted_bytes` is 0 for the shard, so it is not in this dataflow's path.
+* The arrangement. A full read that pulls every column is no faster.
+* Thread starvation. Ambient and isolated runtimes both have about 62 threads.
+* The timely exchange. The nested `Pipeline` probe has no exchange and dribbles anyway.
+* The async bridge in general. The outer `Pipeline` probe uses the bridge and delivers bulk.
+* Message granularity, payload size, scope feedback, and connected inputs. Five in process microrepros in `src/timely-util/src/builder_async.rs` tests reproduce the one part per message symptom and various topologies, and all of them ramp to the concurrency cap. They do not reproduce the dribble, because an in process two worker exchange delivers a one schedule flood in bulk.
+
+## The open question the fix must answer
+
+Why does an async operator in a nested scope observe only one to three input records per schedule when the upstream pushed the whole batch at once, while the same operator in the outer scope observes the whole batch.
+
+Candidate mechanisms, to be confirmed while designing the fix.
+
+* The region ingress operator that `enter` inserts may forward only a bounded amount per schedule into the nested subgraph.
+* The nested subgraph may be stepped by the parent only a bounded number of times per parent schedule, so the async operator inside runs rarely.
+* The async bridge activation may not propagate out of the nested subgraph to the parent, so the operator is only re-scheduled when something else steps the subgraph, and each step delivers whatever arrived in the meantime.
+
+The relevant code is `src/timely-util/src/builder_async.rs`, specifically `build` and `build_reschedule`, `accept_input`, and the `TimelyWaker` activation path, together with how timely steps a nested `Subgraph` and how `Enter` delivers into it.
+
+## Fix direction
+
+The real fix is at the async bridge level, so that async operators in a nested scope receive their input in bulk, the same as in the outer scope.
+This benefits every nested async operator, not only persist.
+The design needs to identify which of the candidate mechanisms above is responsible and correct it without breaking progress tracking or the activation contract.
+
+A narrower alternative exists but is not the chosen fix.
+When `max_inflight_bytes` is `None` the persist source could skip the `granular_backpressure` nested scope and run in the outer scope.
+That removes the dribble for this path only and leaves the general bridge bug in place, so it is recorded here only as a fallback.
+
+## Reproduction and instrumentation
+
+Branch `mh/hydration-instr-main`, PR 37771.
+The instrumentation logs under target `mz_persist_client::operators::shard_source` at info, greppable by `INSTR`.
+
+* `INSTR descs emit`: parts emitted per descs batch.
+* `INSTR fetch recv` and `INSTR fetch loop`: fetch intake and in flight depth.
+* `INSTR accept`: messages an async operator pulls from its timely channel per schedule, tagged with the operator name.
+* `INSTR send`: messages an async operator pushes to its output per schedule.
+
+The probe operators `shard_source_fetch_probe` (outer, `Pipeline`) and `shard_source_fetch_nprobe` (nested, `Pipeline`) are the decisive comparison and live in the `shard_source` wrapper.
+All instrumentation is diagnostic and must be removed or gated before any fix lands.
+
+The staging harness is `.experiment/fetch_concurrency_remeasure.py`, subcommand `run`.
+Loki datasource uid is `c90a4f6e-0536-4f9a-aa1c-92d9aaeefa10`, Prometheus uid is `Ks85Oh14z`.

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -1953,10 +1953,10 @@ mod tests {
         // just the peak (an initial flood can spike the peak while steady state
         // trickles).
         let samples = Arc::new(std::sync::Mutex::new(Vec::<usize>::new()));
-        let sampler = {
+        let _sampler = {
             let concurrent = Arc::clone(&concurrent);
             let samples = Arc::clone(&samples);
-            tokio::spawn(async move {
+            mz_ore::task::spawn(|| "latency-fetch-sampler", async move {
                 loop {
                     tokio::time::sleep(Duration::from_millis(200)).await;
                     samples
@@ -1965,6 +1965,7 @@ mod tests {
                         .push(concurrent.load(Ordering::SeqCst));
                 }
             })
+            .abort_on_drop()
         };
 
         let client_for_source = persist_client.clone();
@@ -2009,7 +2010,6 @@ mod tests {
             eprintln!("LATENCY-FETCH hydration timed_out={timed_out}");
         });
 
-        sampler.abort();
         let mc = max_concurrent.load(Ordering::SeqCst);
         let g = gets.load(Ordering::SeqCst);
         let s = samples.lock().unwrap();

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -1776,4 +1776,212 @@ mod tests {
 
         read_handle.downgrade_since(&since).await;
     }
+
+    /// Measures the peak concurrent `blob.get` the fetch operator achieves while
+    /// hydrating a many-part snapshot, with artificial per-get latency injected.
+    ///
+    /// The staging hydration slowness is S3-only (file/minio do not reproduce
+    /// it): the fetch operator settles at ~1 concurrent get. This test injects a
+    /// fixed per-get delay into an in-mem blob (wrapped in `Tasked` just like
+    /// prod, so each get spawns) and reports the peak concurrency reached. If it
+    /// reaches the fetch-concurrency cap, latency alone does not reproduce the
+    /// throttle on a single worker; if it settles near 1, latency-coupling of
+    /// the descs->fetch delivery is reproduced locally.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 8))]
+    #[ignore = "diagnostic: the execute_directly + step_or_park harness cannot sustain \
+                async-operator throughput under real per-get latency, so it does not \
+                faithfully measure steady-state fetch concurrency"]
+    async fn test_shard_source_fetch_concurrency_under_latency() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::{Duration, Instant};
+
+        use async_trait::async_trait;
+        use bytes::Bytes;
+        use mz_ore::bytes::SegmentedBytes;
+        use mz_ore::metrics::MetricsRegistry;
+        use mz_persist::location::{BlobMetadata, ExternalError, Tasked};
+        use mz_persist::mem::{MemBlob, MemBlobConfig, MemConsensus};
+
+        use crate::async_runtime::IsolatedRuntime;
+        use crate::cache::StateCache;
+        use crate::cfg::SOURCE_FETCH_CONCURRENCY;
+        use crate::internal::metrics::Metrics;
+        use crate::rpc::NoopPubSubSender;
+        use crate::{PersistClient, PersistConfig};
+
+        /// Blob wrapper that sleeps on every `get`, tracking the peak number of
+        /// gets in flight simultaneously.
+        #[derive(Debug)]
+        struct LatencyBlob {
+            inner: Arc<dyn Blob>,
+            delay: Duration,
+            concurrent: Arc<AtomicUsize>,
+            max_concurrent: Arc<AtomicUsize>,
+            gets: Arc<AtomicUsize>,
+        }
+
+        #[async_trait]
+        impl Blob for LatencyBlob {
+            async fn get(&self, key: &str) -> Result<Option<SegmentedBytes>, ExternalError> {
+                let n = self.concurrent.fetch_add(1, Ordering::SeqCst) + 1;
+                self.max_concurrent.fetch_max(n, Ordering::SeqCst);
+                self.gets.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(self.delay).await;
+                let r = self.inner.get(key).await;
+                self.concurrent.fetch_sub(1, Ordering::SeqCst);
+                r
+            }
+            async fn list_keys_and_metadata(
+                &self,
+                key_prefix: &str,
+                f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
+            ) -> Result<(), ExternalError> {
+                self.inner.list_keys_and_metadata(key_prefix, f).await
+            }
+            async fn set(&self, key: &str, value: Bytes) -> Result<(), ExternalError> {
+                self.inner.set(key, value).await
+            }
+            async fn delete(&self, key: &str) -> Result<Option<usize>, ExternalError> {
+                self.inner.delete(key).await
+            }
+            async fn restore(&self, key: &str) -> Result<(), ExternalError> {
+                self.inner.restore(key).await
+            }
+        }
+
+        const N_BATCHES: u64 = 200;
+        const FETCH_CONCURRENCY: usize = 64;
+
+        let concurrent = Arc::new(AtomicUsize::new(0));
+        let max_concurrent = Arc::new(AtomicUsize::new(0));
+        let gets = Arc::new(AtomicUsize::new(0));
+
+        let mut cfg = PersistConfig::new_for_tests();
+        // Keep every batch a distinct part, mirroring a held-back `since`.
+        cfg.compaction_enabled = false;
+        cfg.set_config(&SOURCE_FETCH_CONCURRENCY, FETCH_CONCURRENCY);
+        // Force every write to a blob part (not inline in consensus), so the
+        // fetch operator actually issues `blob.get`s we can meter.
+        cfg.set_config(&INLINE_WRITES_SINGLE_MAX_BYTES, 0);
+        cfg.set_config(&INLINE_WRITES_TOTAL_MAX_BYTES, 0);
+        let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
+
+        let mem_blob: Arc<dyn Blob> = Arc::new(MemBlob::open(MemBlobConfig::default()));
+        let latency_blob = Arc::new(LatencyBlob {
+            inner: mem_blob,
+            delay: Duration::from_millis(25),
+            concurrent: Arc::clone(&concurrent),
+            max_concurrent: Arc::clone(&max_concurrent),
+            gets: Arc::clone(&gets),
+        });
+        // Wrap in `Tasked` exactly as `PersistClientCache::open` does, so each
+        // get runs on its own spawned task and can run in parallel.
+        let blob = Arc::new(Tasked(latency_blob));
+        let consensus = Arc::new(MemConsensus::default());
+
+        let persist_client = PersistClient::new(
+            cfg,
+            blob,
+            consensus,
+            metrics,
+            Arc::new(IsolatedRuntime::new_for_tests()),
+            Arc::new(StateCache::new_no_metrics()),
+            Arc::new(NoopPubSubSender),
+        )
+        .expect("client construction failed");
+
+        let shard_id = ShardId::new();
+        let mut write = persist_client
+            .open_writer::<String, String, u64, u64>(
+                shard_id,
+                Arc::new(StringSchema),
+                Arc::new(StringSchema),
+                Diagnostics::for_tests(),
+            )
+            .await
+            .expect("invalid usage");
+        // `N_BATCHES` distinct single-timestamp batches => a snapshot with that
+        // many parts.
+        for t in 0..N_BATCHES {
+            let row = ((format!("k{t}"), format!("v{t}")), t, 1u64);
+            write.expect_compare_and_append(&[row], t, t + 1).await;
+        }
+
+        // Ignore any gets issued during setup; measure only the hydration read.
+        max_concurrent.store(0, Ordering::SeqCst);
+        gets.store(0, Ordering::SeqCst);
+
+        // Sample in-flight gets over time to see STEADY-STATE concurrency, not
+        // just the peak (an initial flood can spike the peak while steady state
+        // trickles).
+        let samples = Arc::new(std::sync::Mutex::new(Vec::<usize>::new()));
+        let sampler = {
+            let concurrent = Arc::clone(&concurrent);
+            let samples = Arc::clone(&samples);
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    samples
+                        .lock()
+                        .unwrap()
+                        .push(concurrent.load(Ordering::SeqCst));
+                }
+            })
+        };
+
+        let client_for_source = persist_client.clone();
+        timely::execute::execute_directly(move |worker| {
+            let (probe, _token) = worker.dataflow::<u64, _, _>(|outer| {
+                let (stream, token) = outer.scoped::<u64, _, _>("hybrid", |scope| {
+                    let (stream, tokens) = shard_source::<String, String, u64, u64, _, _, _>(
+                        outer,
+                        scope,
+                        "test_source",
+                        move || std::future::ready(client_for_source.clone()),
+                        shard_id,
+                        // Snapshot at the last written time: the whole history
+                        // is one snapshot flood of ~N_BATCHES parts.
+                        Some(Antichain::from_elem(N_BATCHES - 1)),
+                        SnapshotMode::Include,
+                        Antichain::from_elem(N_BATCHES),
+                        Some(move |_, descs, _| (descs, vec![])),
+                        Arc::new(StringSchema),
+                        Arc::new(StringSchema),
+                        FilterResult::keep_all,
+                        false.then_some(|| unreachable!()),
+                        async {},
+                        ErrorHandler::Halt("test"),
+                    );
+                    (stream.leave(outer), tokens)
+                });
+                let probe = ProbeHandle::new();
+                let _stream = stream.probe_with(&probe);
+                (probe, token)
+            });
+
+            let deadline = Instant::now() + Duration::from_secs(10);
+            let mut timed_out = false;
+            while !probe.with_frontier(|f| f.is_empty()) {
+                if Instant::now() >= deadline {
+                    timed_out = true;
+                    break;
+                }
+                worker.step_or_park(Some(Duration::from_millis(1)));
+            }
+            eprintln!("LATENCY-FETCH hydration timed_out={timed_out}");
+        });
+
+        sampler.abort();
+        let mc = max_concurrent.load(Ordering::SeqCst);
+        let g = gets.load(Ordering::SeqCst);
+        let s = samples.lock().unwrap();
+        eprintln!(
+            "LATENCY-FETCH RESULT: max_concurrent_gets={mc} total_gets={g} \
+             (N_BATCHES={N_BATCHES}, delay=25ms, fetch_concurrency={FETCH_CONCURRENCY})"
+        );
+        eprintln!(
+            "LATENCY-FETCH in-flight-gets samples (every 200ms): {:?}",
+            &*s
+        );
+    }
 }

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -518,6 +518,8 @@ where
             let (parts, progress) = shard_stream.next().await.expect("infinite stream");
 
             let mut batch_bytes: u64 = 0;
+            // INSTR: count parts emitted per shard_stream batch (one persist batch).
+            let mut dbg_given: u64 = 0;
 
             // Emit the part at the `(ts, 0)` time. The `granular_backpressure`
             // operator will refine this further, if its enabled.
@@ -598,6 +600,17 @@ where
                 let (part, lease) = part_desc.into_exchangeable_part();
                 leases.borrow_mut().push_at(current_ts.clone(), lease);
                 descs_output.give(&session_cap, (worker_idx, part));
+                dbg_given += 1;
+            }
+
+            // INSTR: how many parts this operator emitted in one shard_stream
+            // batch. Answers whether the source floods (single big batch) or
+            // trickles.
+            if dbg_given > 0 {
+                tracing::info!(
+                    target: "mz_persist_client::operators::shard_source",
+                    "INSTR descs emit: gave parts={dbg_given} in one shard_stream batch"
+                );
             }
 
             current_frontier.join_assign(&progress);
@@ -741,6 +754,11 @@ where
         let mut in_flight = FuturesUnordered::new();
         let mut input_done = false;
 
+        // INSTR: cumulative parts accepted from the input, plus a 1s heartbeat
+        // to sample loop depth even while parked in `descs_input.next()`.
+        let mut dbg_pushed: u64 = 0;
+        let mut dbg_tick = tokio::time::interval(std::time::Duration::from_secs(1));
+
         loop {
             // Start fetches up to the concurrency cap.
             while in_flight.len() < max_concurrency {
@@ -773,13 +791,37 @@ where
                         Some(Event::Data(caps, data)) => {
                             // `LeasedBatchPart`es cannot be dropped at this point
                             // w/o panicking, so swap them to an owned version.
+                            let mut dbg_n: u64 = 0;
                             for (_idx, part) in data {
                                 pending.push_back((caps.clone(), part));
+                                dbg_n += 1;
                             }
+                            dbg_pushed += dbg_n;
+                            // INSTR: parts delivered by ONE descs_input event.
+                            // The key number: does the Exchange surface a full
+                            // batch here, or ~1 per event?
+                            tracing::info!(
+                                target: "mz_persist_client::operators::shard_source",
+                                "INSTR fetch recv: descs_event parts={dbg_n} pending_now={} in_flight={} pushed_total={dbg_pushed}",
+                                pending.len(),
+                                in_flight.len(),
+                            );
                         }
                         Some(Event::Progress(_)) => {}
                         None => input_done = true,
                     }
+                }
+                // INSTR: 1s heartbeat. Fires when the loop is parked (idle) since
+                // biased order checks in_flight/descs first; a repeatedly-low
+                // in_flight with a nonempty pending would indict the fetch loop,
+                // low in_flight with empty pending indicts upstream delivery.
+                _ = dbg_tick.tick() => {
+                    tracing::info!(
+                        target: "mz_persist_client::operators::shard_source",
+                        "INSTR fetch loop: in_flight={} pending={} pushed_total={dbg_pushed} max_concurrency={max_concurrency}",
+                        in_flight.len(),
+                        pending.len(),
+                    );
                 }
                 // Input is exhausted and no fetches remain: we're done.
                 else => break,

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -229,6 +229,24 @@ where
     );
     tokens.push(descs_token);
 
+    // PROBE (diagnostic): consume the descs output directly on the chosen worker
+    // via Pipeline, before the scope `enter` and the fetch-input exchange. This
+    // is a pure async->async, same-worker, no-exchange delivery. Its "INSTR
+    // accept" logs (op=..._probe) localize the trickle: if this delivery is also
+    // ~1-2 per activation, the async bridge itself is the throttle; if it is
+    // bulk, the enter/exchange path downstream is.
+    {
+        let mut probe =
+            AsyncOperatorBuilder::new(format!("shard_source_fetch_probe({})", name), outer.clone());
+        let mut probe_input = probe.new_disconnected_input(descs.clone(), Pipeline);
+        let probe_button = probe.build(move |_caps| async move {
+            while let Some(event) = probe_input.next().await {
+                let _ = event;
+            }
+        });
+        tokens.push(probe_button.press_on_drop());
+    }
+
     let descs = descs.enter(scope);
     let descs = match desc_transformer {
         Some(desc_transformer) => {

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -791,18 +791,38 @@ where
                         Some(Event::Data(caps, data)) => {
                             // `LeasedBatchPart`es cannot be dropped at this point
                             // w/o panicking, so swap them to an owned version.
-                            let mut dbg_n: u64 = 0;
+                            let mut first_parts: u64 = 0;
                             for (_idx, part) in data {
                                 pending.push_back((caps.clone(), part));
-                                dbg_n += 1;
+                                first_parts += 1;
                             }
-                            dbg_pushed += dbg_n;
-                            // INSTR: parts delivered by ONE descs_input event.
-                            // The key number: does the Exchange surface a full
-                            // batch here, or ~1 per event?
+                            // INSTR + candidate fix: after the first event, drain
+                            // every other event already sitting in the input queue
+                            // NOW, admitting the whole backlog in one activation
+                            // instead of one event per schedule. `drained_*`
+                            // measures how deep the backlog was: near-zero means
+                            // the exchange only surfaces ~1 event per activation
+                            // (a delivery trickle); large means the backlog was
+                            // there and this drain lets `in_flight` fill.
+                            let mut drained_events: u64 = 0;
+                            let mut drained_parts: u64 = 0;
+                            loop {
+                                match descs_input.next_sync() {
+                                    Some(Event::Data(caps2, data2)) => {
+                                        drained_events += 1;
+                                        for (_idx, part) in data2 {
+                                            pending.push_back((caps2.clone(), part));
+                                            drained_parts += 1;
+                                        }
+                                    }
+                                    Some(Event::Progress(_)) => {}
+                                    None => break,
+                                }
+                            }
+                            dbg_pushed += first_parts + drained_parts;
                             tracing::info!(
                                 target: "mz_persist_client::operators::shard_source",
-                                "INSTR fetch recv: descs_event parts={dbg_n} pending_now={} in_flight={} pushed_total={dbg_pushed}",
+                                "INSTR fetch recv: first_parts={first_parts} drained_events={drained_events} drained_parts={drained_parts} pending_now={} in_flight={} pushed_total={dbg_pushed}",
                                 pending.len(),
                                 in_flight.len(),
                             );

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -257,6 +257,26 @@ where
         None => descs,
     };
 
+    // PROBE (diagnostic): consume the entered descs stream inside the NESTED
+    // scope via Pipeline (no exchange, stays on the chosen worker). Compared to
+    // the outer-scope probe above (which pulls bulk) and the real fetch input
+    // (exchange, which dribbles), this isolates whether the throttle is the
+    // scope enter / nested-subgraph scheduling (this dribbles too) or the
+    // exchange redistribution (this stays bulk). Logs op=..._nprobe.
+    {
+        let mut nprobe = AsyncOperatorBuilder::new(
+            format!("shard_source_fetch_nprobe({})", name),
+            scope.clone(),
+        );
+        let mut nprobe_input = nprobe.new_disconnected_input(descs.clone(), Pipeline);
+        let nprobe_button = nprobe.build(move |_caps| async move {
+            while let Some(event) = nprobe_input.next().await {
+                let _ = event;
+            }
+        });
+        tokens.push(nprobe_button.press_on_drop());
+    }
+
     let (parts, completed_fetches_stream, fetch_token) = shard_source_fetch::<K, V, TOuter, D, T>(
         descs,
         name,

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -1444,4 +1444,157 @@ mod test {
              max_parts_per_event={mppe} recv_events={re} (N={N}, cap={MAX_CONCURRENCY})"
         );
     }
+
+    // MICROREPRO variant: faithful topology, but the producer gives each part at
+    // a DISTINCT timestamp (like the real refined part times). Distinct times
+    // force the output to flush one part per message (matching the observed
+    // parts=1 per event on staging). Tests whether per-part timestamps collapse
+    // the fetch ramp.
+    #[mz_ore::test]
+    fn microrepro_distinct_times() {
+        use std::convert::Infallible;
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use futures_util::stream::FuturesUnordered;
+        use mz_ore::cast::CastFrom;
+        use timely::dataflow::channels::pact::Exchange;
+        use timely::dataflow::operators::{
+            Capability, CapabilitySet, ConnectLoop, Enter, Feedback, Leave,
+        };
+
+        const N: usize = 200;
+        const MAX_CONCURRENCY: usize = 32;
+        const FETCH_POLLS: usize = 80;
+
+        struct FetchSim(usize);
+        impl Future for FetchSim {
+            type Output = ();
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+                if self.0 == 0 {
+                    Poll::Ready(())
+                } else {
+                    self.0 -= 1;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+        }
+
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let max_parts_per_event = Arc::new(AtomicUsize::new(0));
+        let recv_events = Arc::new(AtomicUsize::new(0));
+
+        let mif = Arc::clone(&max_in_flight);
+        let mppe = Arc::clone(&max_parts_per_event);
+        let re = Arc::clone(&recv_events);
+
+        let (builders, other) = timely::CommunicationConfig::Process(2).try_build().unwrap();
+        timely::execute::execute_from(builders, other, WorkerConfig::default(), move |worker| {
+            let index = worker.index();
+            let mif = Arc::clone(&mif);
+            let mppe = Arc::clone(&mppe);
+            let re = Arc::clone(&re);
+            let tokens = worker.dataflow::<u64, _, _>(move |outer| {
+                outer.clone().scoped::<u64, _, _>("inner", move |inner| {
+                    let (fb_handle, fb_stream) = inner.feedback(Default::default());
+
+                    let mut producer = OperatorBuilder::new("producer".to_string(), outer.clone());
+                    let (descs_out, descs_stream) =
+                        producer.new_output::<CapacityContainerBuilder<Vec<(usize, usize)>>>();
+                    let mut fb_input =
+                        producer.new_disconnected_input(fb_stream.leave(outer.clone()), Pipeline);
+                    let producer_button = producer.build(move |caps| async move {
+                        let mut cap_set =
+                            CapabilitySet::from_elem(caps.into_iter().next().unwrap());
+                        if index == 0 {
+                            // Each part at a DISTINCT time => one flush (message)
+                            // per part.
+                            for i in 0..N {
+                                let t = u64::cast_from(i);
+                                descs_out.give(&cap_set.delayed(&t), (1usize, i));
+                            }
+                        }
+                        let empty: [u64; 0] = [];
+                        cap_set.downgrade(empty.iter());
+                        while (fb_input.next().await).is_some() {}
+                    });
+
+                    let descs_entered = descs_stream.enter(inner);
+                    let mut fetch = OperatorBuilder::new("fetch".to_string(), inner.clone());
+                    let (fetched_out, _fetched_stream) =
+                        fetch.new_output::<CapacityContainerBuilder<Vec<()>>>();
+                    let (_completed_out, completed_stream) =
+                        fetch.new_output::<CapacityContainerBuilder<Vec<Infallible>>>();
+                    let mut descs_input = fetch.new_input_for_many(
+                        descs_entered,
+                        Exchange::new(|&(i, _): &(usize, usize)| u64::cast_from(i)),
+                        [&fetched_out, &_completed_out],
+                    );
+                    let fetch_button = fetch.build(move |_caps| async move {
+                        let mut pending: VecDeque<[Capability<u64>; 2]> = VecDeque::new();
+                        let mut in_flight = FuturesUnordered::new();
+                        let mut input_done = false;
+                        loop {
+                            while in_flight.len() < MAX_CONCURRENCY {
+                                match pending.pop_front() {
+                                    Some(caps) => in_flight.push(async move {
+                                        FetchSim(FETCH_POLLS).await;
+                                        caps
+                                    }),
+                                    None => break,
+                                }
+                            }
+                            mif.fetch_max(in_flight.len(), Ordering::SeqCst);
+
+                            tokio::select! {
+                                biased;
+                                Some(caps) = in_flight.next(), if !in_flight.is_empty() => {
+                                    let [c0, _c1] = caps;
+                                    fetched_out.give(&c0, ());
+                                }
+                                event = descs_input.next(), if !input_done => {
+                                    match event {
+                                        Some(Event::Data(caps, data)) => {
+                                            let n = data.len();
+                                            mppe.fetch_max(n, Ordering::SeqCst);
+                                            re.fetch_add(1, Ordering::SeqCst);
+                                            for _ in data {
+                                                pending.push_back(caps.clone());
+                                            }
+                                        }
+                                        Some(Event::Progress(_)) => {}
+                                        None => input_done = true,
+                                    }
+                                }
+                                else => break,
+                            }
+                        }
+                    });
+                    completed_stream.connect_loop(fb_handle);
+
+                    (
+                        producer_button.press_on_drop(),
+                        fetch_button.press_on_drop(),
+                    )
+                })
+            });
+
+            for _ in 0..200_000 {
+                worker.step();
+            }
+            drop(tokens);
+        })
+        .expect("timely panicked");
+
+        let mif = max_in_flight.load(Ordering::SeqCst);
+        let mppe = max_parts_per_event.load(Ordering::SeqCst);
+        let re = recv_events.load(Ordering::SeqCst);
+        eprintln!(
+            "MICROREPRO DISTINCT-TIMES RESULT: max_in_flight={mif} \
+             max_parts_per_event={mppe} recv_events={re} (N={N}, cap={MAX_CONCURRENCY})"
+        );
+    }
 }

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -1277,4 +1277,171 @@ mod test {
              recv_events={re} (N={N}, payload={PAYLOAD_BYTES}B, cap={MAX_CONCURRENCY})"
         );
     }
+
+    // MICROREPRO variant: faithful `shard_source` TOPOLOGY. Producer (descs
+    // substitute) runs in the OUTER scope and floods N parts at one time; the
+    // stream `enter`s a nested scope where the consumer (fetch substitute) runs
+    // with a CONNECTED input (`new_input_for_many` -> two outputs) and a
+    // `completed`-fetches FEEDBACK loop back to the producer, exactly like
+    // `persist_client::operators::shard_source`. The fetch is simulated as a
+    // latent future. If in_flight stays ~1 here (but ramped in the flat repro),
+    // the nested-scope + feedback topology is the hydration throttle.
+    #[mz_ore::test]
+    fn microrepro_nested_scope_feedback() {
+        use std::convert::Infallible;
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use futures_util::stream::FuturesUnordered;
+        use mz_ore::cast::CastFrom;
+        use timely::dataflow::channels::pact::Exchange;
+        use timely::dataflow::operators::{
+            Capability, CapabilitySet, ConnectLoop, Enter, Feedback, Leave,
+        };
+
+        const N: usize = 200;
+        const MAX_CONCURRENCY: usize = 32;
+        const FETCH_POLLS: usize = 80;
+
+        struct FetchSim(usize);
+        impl Future for FetchSim {
+            type Output = ();
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+                if self.0 == 0 {
+                    Poll::Ready(())
+                } else {
+                    self.0 -= 1;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+        }
+
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let max_parts_per_event = Arc::new(AtomicUsize::new(0));
+        let recv_events = Arc::new(AtomicUsize::new(0));
+
+        let mif = Arc::clone(&max_in_flight);
+        let mppe = Arc::clone(&max_parts_per_event);
+        let re = Arc::clone(&recv_events);
+
+        let (builders, other) = timely::CommunicationConfig::Process(2).try_build().unwrap();
+        timely::execute::execute_from(builders, other, WorkerConfig::default(), move |worker| {
+            let index = worker.index();
+            let mif = Arc::clone(&mif);
+            let mppe = Arc::clone(&mppe);
+            let re = Arc::clone(&re);
+            let tokens = worker.dataflow::<u64, _, _>(move |outer| {
+                outer.clone().scoped::<u64, _, _>("inner", move |inner| {
+                    // Feedback lives in the nested scope; it leaves to the outer
+                    // scope to feed the producer, mirroring
+                    // `completed_fetches_feedback_stream.leave(outer)`.
+                    let (fb_handle, fb_stream) = inner.feedback(Default::default());
+
+                    // Producer (descs substitute) in the OUTER scope.
+                    let mut producer = OperatorBuilder::new("producer".to_string(), outer.clone());
+                    let (descs_out, descs_stream) =
+                        producer.new_output::<CapacityContainerBuilder<Vec<(usize, usize)>>>();
+                    let mut fb_input =
+                        producer.new_disconnected_input(fb_stream.leave(outer.clone()), Pipeline);
+                    let producer_button = producer.build(move |caps| async move {
+                        let mut cap_set =
+                            CapabilitySet::from_elem(caps.into_iter().next().unwrap());
+                        if index == 0 {
+                            let cap = cap_set.delayed(&0u64);
+                            // Route every part to worker 1 (cross-thread exchange).
+                            for i in 0..N {
+                                descs_out.give(&cap, (1usize, i));
+                            }
+                            drop(cap);
+                        }
+                        // Release our capability so the consumer observes end of
+                        // input once it has drained.
+                        let empty: [u64; 0] = [];
+                        cap_set.downgrade(empty.iter());
+                        // Drain the feedback (progress only) to keep the operator
+                        // alive until the loop closes, like `shard_source`'s
+                        // lease-returner.
+                        while (fb_input.next().await).is_some() {}
+                    });
+
+                    // Fetch (consumer substitute) in the NESTED scope, reached via
+                    // `enter`, with a connected input to two outputs.
+                    let descs_entered = descs_stream.enter(inner);
+                    let mut fetch = OperatorBuilder::new("fetch".to_string(), inner.clone());
+                    let (fetched_out, _fetched_stream) =
+                        fetch.new_output::<CapacityContainerBuilder<Vec<()>>>();
+                    let (_completed_out, completed_stream) =
+                        fetch.new_output::<CapacityContainerBuilder<Vec<Infallible>>>();
+                    let mut descs_input = fetch.new_input_for_many(
+                        descs_entered,
+                        Exchange::new(|&(i, _): &(usize, usize)| u64::cast_from(i)),
+                        [&fetched_out, &_completed_out],
+                    );
+                    let fetch_button = fetch.build(move |_caps| async move {
+                        let mut pending: VecDeque<[Capability<u64>; 2]> = VecDeque::new();
+                        let mut in_flight = FuturesUnordered::new();
+                        let mut input_done = false;
+                        loop {
+                            while in_flight.len() < MAX_CONCURRENCY {
+                                match pending.pop_front() {
+                                    Some(caps) => in_flight.push(async move {
+                                        FetchSim(FETCH_POLLS).await;
+                                        caps
+                                    }),
+                                    None => break,
+                                }
+                            }
+                            mif.fetch_max(in_flight.len(), Ordering::SeqCst);
+
+                            tokio::select! {
+                                biased;
+                                Some(caps) = in_flight.next(), if !in_flight.is_empty() => {
+                                    let [c0, _c1] = caps;
+                                    fetched_out.give(&c0, ());
+                                }
+                                event = descs_input.next(), if !input_done => {
+                                    match event {
+                                        Some(Event::Data(caps, data)) => {
+                                            let n = data.len();
+                                            mppe.fetch_max(n, Ordering::SeqCst);
+                                            re.fetch_add(1, Ordering::SeqCst);
+                                            for _ in data {
+                                                pending.push_back(caps.clone());
+                                            }
+                                        }
+                                        Some(Event::Progress(_)) => {}
+                                        None => input_done = true,
+                                    }
+                                }
+                                else => break,
+                            }
+                        }
+                    });
+                    completed_stream.connect_loop(fb_handle);
+
+                    (
+                        producer_button.press_on_drop(),
+                        fetch_button.press_on_drop(),
+                    )
+                })
+            });
+
+            for _ in 0..200_000 {
+                worker.step();
+            }
+            drop(tokens);
+        })
+        .expect("timely panicked");
+
+        let mif = max_in_flight.load(Ordering::SeqCst);
+        let mppe = max_parts_per_event.load(Ordering::SeqCst);
+        let re = recv_events.load(Ordering::SeqCst);
+        eprintln!(
+            "MICROREPRO NESTED+FEEDBACK RESULT: max_in_flight={mif} \
+             max_parts_per_event={mppe} recv_events={re} (N={N}, cap={MAX_CONCURRENCY})"
+        );
+    }
 }

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -41,6 +41,12 @@ use timely::{Bincode, Container, ContainerBuilder, PartialOrder};
 
 use crate::containers::stack::FueledBuilder;
 
+thread_local! {
+    /// INSTR: counts messages pushed to timely outputs on this worker thread.
+    /// Read as a per-schedule delta to measure the descs->fabric send rate.
+    static DBG_OUTPUT_PUSHES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
 /// Builds async operators with generic shape.
 pub struct OperatorBuilder<'scope, T: Timestamp> {
     builder: OperatorBuilderRc<'scope, T>,
@@ -230,6 +236,7 @@ impl<T: Timestamp, CB: ContainerBuilder> AsyncOutputHandleInner<T, CB> {
         while let Some(container) = self.builder.finish() {
             self.output
                 .give(self.capability.as_ref().expect("must exist"), container);
+            DBG_OUTPUT_PUSHES.with(|c| c.set(c.get() + 1));
         }
     }
 
@@ -260,6 +267,7 @@ impl<T: Timestamp, CB: ContainerBuilder> AsyncOutputHandleInner<T, CB> {
         while let Some(container) = self.builder.extract() {
             self.output
                 .give(self.capability.as_ref().expect("must exist"), container);
+            DBG_OUTPUT_PUSHES.with(|c| c.set(c.get() + 1));
         }
     }
 }
@@ -279,6 +287,7 @@ where
         let mut inner = self.inner.borrow_mut();
         inner.flush();
         inner.output.give(cap, container);
+        DBG_OUTPUT_PUSHES.with(|c| c.set(c.get() + 1));
     }
 }
 
@@ -583,8 +592,11 @@ impl<'scope, T: Timestamp> OperatorBuilder<'scope, T> {
         let mut input_queues = self.input_queues;
         let mut output_flushes = self.output_flushes;
         let mut shutdown_handle = self.shutdown_handle;
-        // INSTR: gate delivery-probe logging to the fetch operator only.
+        // INSTR: gate delivery-probe logging. `descs` name matches both
+        // shard_source_descs and shard_source_descs_return; only the former has
+        // an output, so the return operator logs nothing.
         let dbg_is_fetch = self.name.contains("shard_source_fetch");
+        let dbg_is_descs = self.name.contains("shard_source_descs");
         self.builder.build_reschedule(move |caps| {
             let mut logic_fut = Some(Box::pin(constructor(caps)));
             // INSTR: cumulative schedules and messages accepted, to see whether
@@ -592,6 +604,11 @@ impl<'scope, T: Timestamp> OperatorBuilder<'scope, T> {
             // dribble) or seldom with a bulk pull.
             let mut dbg_schedules: u64 = 0;
             let mut dbg_accepted_total: usize = 0;
+            // INSTR (send side): messages this operator pushes to the fabric per
+            // schedule. Answers whether descs flushes the whole flood in one
+            // poll (fabric then buffers) or dribbles it out over many polls.
+            let mut dbg_send_schedules: u64 = 0;
+            let mut dbg_send_pushed_total: u64 = 0;
             move |new_frontiers| {
                 operator_waker.active.store(true, Ordering::SeqCst);
                 let mut dbg_accepted_now: usize = 0;
@@ -639,6 +656,8 @@ impl<'scope, T: Timestamp> OperatorBuilder<'scope, T> {
                         true
                     }
                 } else {
+                    // INSTR: fabric pushes before this schedule's poll+flush.
+                    let dbg_pushes_before = DBG_OUTPUT_PUSHES.with(|c| c.get());
                     // Schedule the logic future if any of the wakers above marked the task as ready
                     if let Some(fut) = logic_fut.as_mut() {
                         if operator_waker.task_ready.load(Ordering::SeqCst) {
@@ -653,6 +672,23 @@ impl<'scope, T: Timestamp> OperatorBuilder<'scope, T> {
                             for flush in output_flushes.iter_mut() {
                                 (flush)();
                             }
+                        }
+                    }
+                    if dbg_is_descs {
+                        let dbg_pushed = DBG_OUTPUT_PUSHES
+                            .with(|c| c.get())
+                            .wrapping_sub(dbg_pushes_before);
+                        dbg_send_schedules += 1;
+                        // Log when this schedule pushed anything. `pushes` per
+                        // log is how many messages left the operator in one poll;
+                        // if descs ever logs ~1333 the send is bulk and the fabric
+                        // buffers, if it dribbles ~1 the send itself is paced.
+                        if dbg_pushed > 0 {
+                            dbg_send_pushed_total += dbg_pushed;
+                            tracing::info!(
+                                target: "mz_persist_client::operators::shard_source",
+                                "INSTR send: pushes={dbg_pushed} send_schedules={dbg_send_schedules} pushed_total={dbg_send_pushed_total}"
+                            );
                         }
                     }
 

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -44,6 +44,8 @@ use crate::containers::stack::FueledBuilder;
 /// Builds async operators with generic shape.
 pub struct OperatorBuilder<'scope, T: Timestamp> {
     builder: OperatorBuilderRc<'scope, T>,
+    /// The operator name, retained for diagnostics.
+    name: String,
     /// The activator for this operator
     activator: Activator,
     /// The waker set up to activate this timely operator when woken
@@ -64,8 +66,9 @@ pub struct OperatorBuilder<'scope, T: Timestamp> {
 /// A helper trait abstracting over an input handle. It facilitates keeping around type erased
 /// handles for each of the operator inputs.
 trait InputQueue<T: Timestamp> {
-    /// Accepts all available input into local queues.
-    fn accept_input(&mut self);
+    /// Accepts all available input into local queues. Returns the number of
+    /// data messages pulled from the timely channel this call.
+    fn accept_input(&mut self) -> usize;
 
     /// Drains all available input and empties the local queue.
     fn drain_input(&mut self);
@@ -81,19 +84,20 @@ where
     C: InputConnection<T> + 'static,
     P: Pull<Message<T, D>> + 'static,
 {
-    fn accept_input(&mut self) {
+    fn accept_input(&mut self) -> usize {
         let mut queue = self.queue.borrow_mut();
-        let mut new_data = false;
+        let mut pulled = 0;
         self.handle.for_each(|cap, data| {
-            new_data = true;
+            pulled += 1;
             let cap = self.connection.accept(cap);
             queue.push_back(Event::Data(cap, std::mem::take(data)));
         });
-        if new_data {
+        if pulled > 0 {
             if let Some(waker) = self.waker.take() {
                 waker.wake();
             }
         }
+        pulled
     }
 
     fn drain_input(&mut self) {
@@ -435,7 +439,7 @@ impl<T: Timestamp, CB: ContainerBuilder> OutputIndex for AsyncOutputHandle<T, CB
 impl<'scope, T: Timestamp> OperatorBuilder<'scope, T> {
     /// Allocates a new generic async operator builder from its containing scope.
     pub fn new(name: String, scope: Scope<'scope, T>) -> Self {
-        let builder = OperatorBuilderRc::new(name, scope);
+        let builder = OperatorBuilderRc::new(name.clone(), scope);
         let info = builder.operator_info();
         let activator = scope.activator_for(Rc::clone(&info.address));
         let sync_activator = scope.worker().sync_activator_for(info.address.to_vec());
@@ -448,6 +452,7 @@ impl<'scope, T: Timestamp> OperatorBuilder<'scope, T> {
 
         OperatorBuilder {
             builder,
+            name,
             activator,
             operator_waker: Arc::new(operator_waker),
             input_frontiers: Default::default(),
@@ -578,10 +583,18 @@ impl<'scope, T: Timestamp> OperatorBuilder<'scope, T> {
         let mut input_queues = self.input_queues;
         let mut output_flushes = self.output_flushes;
         let mut shutdown_handle = self.shutdown_handle;
+        // INSTR: gate delivery-probe logging to the fetch operator only.
+        let dbg_is_fetch = self.name.contains("shard_source_fetch");
         self.builder.build_reschedule(move |caps| {
             let mut logic_fut = Some(Box::pin(constructor(caps)));
+            // INSTR: cumulative schedules and messages accepted, to see whether
+            // the operator is scheduled often with ~1 message each (fabric
+            // dribble) or seldom with a bulk pull.
+            let mut dbg_schedules: u64 = 0;
+            let mut dbg_accepted_total: usize = 0;
             move |new_frontiers| {
                 operator_waker.active.store(true, Ordering::SeqCst);
+                let mut dbg_accepted_now: usize = 0;
                 for (i, queue) in input_queues.iter_mut().enumerate() {
                     // First, discover if there are any frontier notifications
                     let cur = &mut input_frontiers[i];
@@ -592,9 +605,23 @@ impl<'scope, T: Timestamp> OperatorBuilder<'scope, T> {
                     }
                     // Then accept all input into local queues. This step registers the received
                     // messages with progress tracking.
-                    queue.accept_input();
+                    dbg_accepted_now += queue.accept_input();
                 }
                 operator_waker.active.store(false, Ordering::SeqCst);
+                if dbg_is_fetch {
+                    dbg_schedules += 1;
+                    dbg_accepted_total += dbg_accepted_now;
+                    // Log only when we actually pulled data. The `schedules`
+                    // delta between consecutive logs is how many times the
+                    // operator ran without new input, i.e. how much slack there
+                    // was to pull more if the fabric had it.
+                    if dbg_accepted_now > 0 {
+                        tracing::info!(
+                            target: "mz_persist_client::operators::shard_source",
+                            "INSTR accept: pulled={dbg_accepted_now} schedules={dbg_schedules} accepted_total={dbg_accepted_total}"
+                        );
+                    }
+                }
 
                 // If our worker pressed the button we stop scheduling the logic future and/or
                 // draining the input handles to stop producing data and frontier updates

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -893,4 +893,388 @@ mod test {
         })
         .expect("timely panicked");
     }
+
+    // MICROREPRO: does a flood of N records given via an Exchange pact at one
+    // timestamp arrive at an async consumer in bulk (letting a bounded-concurrency
+    // fetch loop ramp `in_flight` to the cap), or ~1 per schedule?
+    //
+    // Mirrors shard_source_fetch: producer floods N parts at one time; consumer
+    // runs the same `tokio::select! { biased; in_flight.next(); input.next() }`
+    // loop with a simulated fetch that stays in flight for a fixed number of
+    // polls. Reports the max `in_flight` depth reached and parts-per-event.
+    #[mz_ore::test]
+    fn microrepro_exchange_delivery() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use futures_util::stream::FuturesUnordered;
+        use timely::dataflow::channels::pact::Exchange;
+
+        const N: usize = 200;
+        const MAX_CONCURRENCY: usize = 32;
+        // Each simulated fetch stays in flight for this many polls (models blob
+        // fetch latency in units of operator schedules).
+        const FETCH_POLLS: usize = 80;
+
+        // A future that stays Pending for `0` polls, self-waking each time so the
+        // operator is rescheduled, then completes.
+        struct FetchSim(usize);
+        impl Future for FetchSim {
+            type Output = ();
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+                if self.0 == 0 {
+                    Poll::Ready(())
+                } else {
+                    self.0 -= 1;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+        }
+
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let max_parts_per_event = Arc::new(AtomicUsize::new(0));
+        let schedules_with_recv = Arc::new(AtomicUsize::new(0));
+
+        let mif = Arc::clone(&max_in_flight);
+        let mppe = Arc::clone(&max_parts_per_event);
+        let swr = Arc::clone(&schedules_with_recv);
+
+        let (builders, other) = timely::CommunicationConfig::Process(2).try_build().unwrap();
+        timely::execute::execute_from(builders, other, WorkerConfig::default(), move |worker| {
+            let index = worker.index();
+            let mif = Arc::clone(&mif);
+            let mppe = Arc::clone(&mppe);
+            let swr = Arc::clone(&swr);
+            let tokens = worker.dataflow::<u64, _, _>(move |scope| {
+                let mut producer = OperatorBuilder::new("producer".to_string(), scope.clone());
+                let (output, output_stream) =
+                    producer.new_output::<CapacityContainerBuilder<Vec<usize>>>();
+                let producer_button = producer.build(move |mut caps| async move {
+                    let cap = caps.pop().unwrap();
+                    // Only worker 0 produces; all records route to worker 1.
+                    if index == 0 {
+                        for i in 0..N {
+                            output.give(&cap, i);
+                        }
+                    }
+                    // Returning drops `cap`, advancing the frontier to empty so
+                    // the consumer observes end-of-input.
+                });
+
+                let mut consumer = OperatorBuilder::new("consumer".to_string(), scope.clone());
+                // Route every record to worker 1, exercising the inter-thread
+                // exchange channel exactly like `shard_source`'s pact.
+                let mut input =
+                    consumer.new_disconnected_input(output_stream, Exchange::new(|_: &usize| 1u64));
+                let consumer_button = consumer.build(move |_caps| async move {
+                    let mut pending: VecDeque<usize> = VecDeque::new();
+                    let mut in_flight = FuturesUnordered::new();
+                    let mut input_done = false;
+                    loop {
+                        while in_flight.len() < MAX_CONCURRENCY {
+                            match pending.pop_front() {
+                                Some(_) => in_flight.push(FetchSim(FETCH_POLLS)),
+                                None => break,
+                            }
+                        }
+                        let cur = in_flight.len();
+                        mif.fetch_max(cur, Ordering::SeqCst);
+
+                        tokio::select! {
+                            biased;
+                            Some(()) = in_flight.next(), if !in_flight.is_empty() => {}
+                            event = input.next(), if !input_done => {
+                                match event {
+                                    Some(Event::Data(_cap, data)) => {
+                                        let n = data.len();
+                                        mppe.fetch_max(n, Ordering::SeqCst);
+                                        swr.fetch_add(1, Ordering::SeqCst);
+                                        for x in data {
+                                            pending.push_back(x);
+                                        }
+                                        eprintln!(
+                                            "RECV parts={n} pending_now={} in_flight={}",
+                                            pending.len(),
+                                            in_flight.len(),
+                                        );
+                                    }
+                                    Some(Event::Progress(_)) => {}
+                                    None => input_done = true,
+                                }
+                            }
+                            else => break,
+                        }
+                    }
+                });
+
+                (
+                    producer_button.press_on_drop(),
+                    consumer_button.press_on_drop(),
+                )
+            });
+
+            // Step until the dataflow quiesces (consumer finished draining and
+            // all simulated fetches completed).
+            for _ in 0..200_000 {
+                worker.step();
+            }
+            drop(tokens);
+        })
+        .expect("timely panicked");
+
+        let mif = max_in_flight.load(Ordering::SeqCst);
+        let mppe = max_parts_per_event.load(Ordering::SeqCst);
+        let swr = schedules_with_recv.load(Ordering::SeqCst);
+        eprintln!(
+            "MICROREPRO RESULT: max_in_flight={mif} max_parts_per_event={mppe} \
+             recv_events={swr} (N={N}, cap={MAX_CONCURRENCY})"
+        );
+    }
+
+    // MICROREPRO variant: producer emits ONE record per container (=> one timely
+    // Message per record), mirroring the real shard_source observation of
+    // `parts=1` per event. Tests whether N separate messages sent in one
+    // producer schedule arrive at the consumer's `accept_input` in bulk (all N
+    // ready next schedule) or trickle ~1 per `worker.step()`.
+    #[mz_ore::test]
+    fn microrepro_exchange_delivery_one_msg_per_record() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use futures_util::stream::FuturesUnordered;
+        use timely::dataflow::channels::pact::Exchange;
+
+        const N: usize = 200;
+        const MAX_CONCURRENCY: usize = 32;
+        const FETCH_POLLS: usize = 80;
+
+        struct FetchSim(usize);
+        impl Future for FetchSim {
+            type Output = ();
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+                if self.0 == 0 {
+                    Poll::Ready(())
+                } else {
+                    self.0 -= 1;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+        }
+
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let max_parts_per_event = Arc::new(AtomicUsize::new(0));
+        let recv_events = Arc::new(AtomicUsize::new(0));
+
+        let mif = Arc::clone(&max_in_flight);
+        let mppe = Arc::clone(&max_parts_per_event);
+        let re = Arc::clone(&recv_events);
+
+        let (builders, other) = timely::CommunicationConfig::Process(2).try_build().unwrap();
+        timely::execute::execute_from(builders, other, WorkerConfig::default(), move |worker| {
+            let index = worker.index();
+            let mif = Arc::clone(&mif);
+            let mppe = Arc::clone(&mppe);
+            let re = Arc::clone(&re);
+            let tokens = worker.dataflow::<u64, _, _>(move |scope| {
+                let mut producer = OperatorBuilder::new("producer".to_string(), scope.clone());
+                let (output, output_stream) =
+                    producer.new_output::<CapacityContainerBuilder<Vec<usize>>>();
+                let producer_button = producer.build(move |mut caps| async move {
+                    let cap = caps.pop().unwrap();
+                    if index == 0 {
+                        // One record per container => one timely Message each,
+                        // all at the same timestamp.
+                        for i in 0..N {
+                            let mut container = vec![i];
+                            output.give_container(&cap, &mut container);
+                        }
+                    }
+                });
+
+                let mut consumer = OperatorBuilder::new("consumer".to_string(), scope.clone());
+                let mut input =
+                    consumer.new_disconnected_input(output_stream, Exchange::new(|_: &usize| 1u64));
+                let consumer_button = consumer.build(move |_caps| async move {
+                    let mut pending: VecDeque<usize> = VecDeque::new();
+                    let mut in_flight = FuturesUnordered::new();
+                    let mut input_done = false;
+                    loop {
+                        while in_flight.len() < MAX_CONCURRENCY {
+                            match pending.pop_front() {
+                                Some(_) => in_flight.push(FetchSim(FETCH_POLLS)),
+                                None => break,
+                            }
+                        }
+                        mif.fetch_max(in_flight.len(), Ordering::SeqCst);
+
+                        tokio::select! {
+                            biased;
+                            Some(()) = in_flight.next(), if !in_flight.is_empty() => {}
+                            event = input.next(), if !input_done => {
+                                match event {
+                                    Some(Event::Data(_cap, data)) => {
+                                        let n = data.len();
+                                        mppe.fetch_max(n, Ordering::SeqCst);
+                                        re.fetch_add(1, Ordering::SeqCst);
+                                        for x in data {
+                                            pending.push_back(x);
+                                        }
+                                    }
+                                    Some(Event::Progress(_)) => {}
+                                    None => input_done = true,
+                                }
+                            }
+                            else => break,
+                        }
+                    }
+                });
+
+                (
+                    producer_button.press_on_drop(),
+                    consumer_button.press_on_drop(),
+                )
+            });
+
+            for _ in 0..200_000 {
+                worker.step();
+            }
+            drop(tokens);
+        })
+        .expect("timely panicked");
+
+        let mif = max_in_flight.load(Ordering::SeqCst);
+        let mppe = max_parts_per_event.load(Ordering::SeqCst);
+        let re = recv_events.load(Ordering::SeqCst);
+        eprintln!(
+            "MICROREPRO 1-MSG RESULT: max_in_flight={mif} max_parts_per_event={mppe} \
+             recv_events={re} (N={N}, cap={MAX_CONCURRENCY})"
+        );
+    }
+
+    // MICROREPRO variant: LARGE per-record payloads (like ExchangeableBatchPart),
+    // to see whether timely's exchange stops coalescing above a per-message byte
+    // threshold => many small receive events => does the fetch loop still ramp?
+    #[mz_ore::test]
+    fn microrepro_exchange_delivery_large_payload() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use futures_util::stream::FuturesUnordered;
+        use timely::dataflow::channels::pact::Exchange;
+
+        const N: usize = 200;
+        const MAX_CONCURRENCY: usize = 32;
+        const FETCH_POLLS: usize = 80;
+        // ~256 KiB per record, comparable order to a real part descriptor's
+        // inline footprint being non-trivial.
+        const PAYLOAD_BYTES: usize = 256 * 1024;
+
+        struct FetchSim(usize);
+        impl Future for FetchSim {
+            type Output = ();
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+                if self.0 == 0 {
+                    Poll::Ready(())
+                } else {
+                    self.0 -= 1;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+        }
+
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let max_parts_per_event = Arc::new(AtomicUsize::new(0));
+        let recv_events = Arc::new(AtomicUsize::new(0));
+
+        let mif = Arc::clone(&max_in_flight);
+        let mppe = Arc::clone(&max_parts_per_event);
+        let re = Arc::clone(&recv_events);
+
+        let (builders, other) = timely::CommunicationConfig::Process(2).try_build().unwrap();
+        timely::execute::execute_from(builders, other, WorkerConfig::default(), move |worker| {
+            let index = worker.index();
+            let mif = Arc::clone(&mif);
+            let mppe = Arc::clone(&mppe);
+            let re = Arc::clone(&re);
+            let tokens = worker.dataflow::<u64, _, _>(move |scope| {
+                let mut producer = OperatorBuilder::new("producer".to_string(), scope.clone());
+                let (output, output_stream) =
+                    producer.new_output::<CapacityContainerBuilder<Vec<Vec<u8>>>>();
+                let producer_button = producer.build(move |mut caps| async move {
+                    let cap = caps.pop().unwrap();
+                    if index == 0 {
+                        for _ in 0..N {
+                            output.give(&cap, vec![0u8; PAYLOAD_BYTES]);
+                        }
+                    }
+                });
+
+                let mut consumer = OperatorBuilder::new("consumer".to_string(), scope.clone());
+                let mut input = consumer
+                    .new_disconnected_input(output_stream, Exchange::new(|_: &Vec<u8>| 1u64));
+                let consumer_button = consumer.build(move |_caps| async move {
+                    let mut pending: VecDeque<Vec<u8>> = VecDeque::new();
+                    let mut in_flight = FuturesUnordered::new();
+                    let mut input_done = false;
+                    loop {
+                        while in_flight.len() < MAX_CONCURRENCY {
+                            match pending.pop_front() {
+                                Some(_) => in_flight.push(FetchSim(FETCH_POLLS)),
+                                None => break,
+                            }
+                        }
+                        mif.fetch_max(in_flight.len(), Ordering::SeqCst);
+
+                        tokio::select! {
+                            biased;
+                            Some(()) = in_flight.next(), if !in_flight.is_empty() => {}
+                            event = input.next(), if !input_done => {
+                                match event {
+                                    Some(Event::Data(_cap, data)) => {
+                                        let n = data.len();
+                                        mppe.fetch_max(n, Ordering::SeqCst);
+                                        re.fetch_add(1, Ordering::SeqCst);
+                                        for x in data {
+                                            pending.push_back(x);
+                                        }
+                                    }
+                                    Some(Event::Progress(_)) => {}
+                                    None => input_done = true,
+                                }
+                            }
+                            else => break,
+                        }
+                    }
+                });
+
+                (
+                    producer_button.press_on_drop(),
+                    consumer_button.press_on_drop(),
+                )
+            });
+
+            for _ in 0..200_000 {
+                worker.step();
+            }
+            drop(tokens);
+        })
+        .expect("timely panicked");
+
+        let mif = max_in_flight.load(Ordering::SeqCst);
+        let mppe = max_parts_per_event.load(Ordering::SeqCst);
+        let re = recv_events.load(Ordering::SeqCst);
+        eprintln!(
+            "MICROREPRO LARGE RESULT: max_in_flight={mif} max_parts_per_event={mppe} \
+             recv_events={re} (N={N}, payload={PAYLOAD_BYTES}B, cap={MAX_CONCURRENCY})"
+        );
+    }
 }

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -597,6 +597,7 @@ impl<'scope, T: Timestamp> OperatorBuilder<'scope, T> {
         // an output, so the return operator logs nothing.
         let dbg_is_fetch = self.name.contains("shard_source_fetch");
         let dbg_is_descs = self.name.contains("shard_source_descs");
+        let dbg_name = self.name.clone();
         self.builder.build_reschedule(move |caps| {
             let mut logic_fut = Some(Box::pin(constructor(caps)));
             // INSTR: cumulative schedules and messages accepted, to see whether
@@ -635,7 +636,7 @@ impl<'scope, T: Timestamp> OperatorBuilder<'scope, T> {
                     if dbg_accepted_now > 0 {
                         tracing::info!(
                             target: "mz_persist_client::operators::shard_source",
-                            "INSTR accept: pulled={dbg_accepted_now} schedules={dbg_schedules} accepted_total={dbg_accepted_total}"
+                            "INSTR accept: op={dbg_name} pulled={dbg_accepted_now} schedules={dbg_schedules} accepted_total={dbg_accepted_total}"
                         );
                     }
                 }


### PR DESCRIPTION
Diagnostic-only branch off `upstream/main` to locate the hydration read throttle (slow persist snapshot read: ~90 MB/s, CPU ~4%, network low), independent of the pager/deasync work.

Adds INFO `INSTR` logs to the async `shard_source` operators:

* descs operator: parts emitted per `shard_stream` batch.
* fetch operator: parts per `descs_input` event, plus a 1s heartbeat of `in_flight` / `pending` / cumulative pushed.

Confirms on main whether descs→fetch delivery trickles ~1 part/event or surfaces full batches, and whether the fetch loop is desc-starved.

Not for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)