### PR TITLE
compute: Materialize arrangements as the columnar edge

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -1868,7 +1868,7 @@ mod tests {
     /// The shared arrangement->collection materialization carries the columnar
     /// edge. Reduce, Threshold, and bucketed TopK emit arrangements; when their
     /// result is demanded as a collection it flows through
-    /// `as_specific_collection`, so this flip makes those outputs columnar with
+    /// `as_specific_collection`, so those outputs are columnar with
     /// no `ColumnarToVec`.
     ///
     /// Correctness: the materialized rows must equal the arranged input. Keying

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -19,7 +19,7 @@ use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::cursor::{BatchCursor, BatchKey, BatchVal};
 use differential_dataflow::trace::implementations::BatchContainer;
 use differential_dataflow::trace::{Cursor, Navigable, TraceReader};
-use differential_dataflow::{AsCollection, Data, VecCollection};
+use differential_dataflow::{AsCollection, VecCollection};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::{
     ENABLE_COLUMN_PAGED_BATCHER, ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION,
@@ -40,7 +40,7 @@ use mz_timely_util::columnar::consolidate::ConsolidatingColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, Col2ValPagedBatcher, columnar_exchange};
 use mz_timely_util::columnation::ColumnationChunker;
 use timely::ContainerBuilder;
-use timely::container::{CapacityContainerBuilder, PushInto};
+use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::operators::Capability;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
@@ -356,7 +356,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
     /// session, cannot produce errors, and returns the number of records produced (see
     /// [`Self::flat_map`] for fuel semantics). The returned err collection comes solely from
     /// the arrangement; no extra operator is built to carry an empty MFP-error stream.
-    pub fn flat_map_ok<D, DCB, L>(
+    pub fn flat_map_ok<DCB, L>(
         &self,
         key: Option<&Row>,
         max_demand: usize,
@@ -366,14 +366,16 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
     )
     where
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, T, Diff)>,
+        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
+        // call site, letting a caller push borrowed records into a columnar builder that has no
+        // owned-tuple `Push`.
+        DCB: ContainerBuilder,
         L: for<'a, 'b> FnMut(&'a mut DatumVecBorrow<'b>, T, Diff, &mut Session<T, DCB>) -> usize
             + 'static,
     {
         match &self {
             ArrangementFlavor::Local(oks, errs) => {
-                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, _, DCB, _>(
+                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, DCB, _>(
                     oks.clone(),
                     key,
                     max_demand,
@@ -384,7 +386,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
                 (oks, errs)
             }
             ArrangementFlavor::Trace(_, oks, errs) => {
-                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, _, DCB, _>(
+                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, DCB, _>(
                     oks.clone(),
                     key,
                     max_demand,
@@ -559,12 +561,18 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// If `key` is specified, the function converts the arrangement to a collection. It uses either
     /// the fueled `flat_map` or `as_collection` method, depending on the flag
     /// [`ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION`].
+    ///
+    /// The keyed path materializes the arrangement as the columnar edge, so an
+    /// arrangement-producing operator (Reduce, Threshold, bucketed TopK) whose
+    /// result is demanded as a collection carries columnar downstream. The
+    /// unkeyed path returns the unarranged `.collection` edge as-is, preserving
+    /// its variant.
     pub fn as_specific_collection(
         &self,
         key: Option<&[LirScalarExpr]>,
         config_set: &ConfigSet,
     ) -> (
-        VecCollection<'scope, T, Row, Diff>,
+        CollectionEdge<'scope, T>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
     ) {
         // Any operator that uses this method was told to use a particular
@@ -573,34 +581,35 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         //
         // If it doesn't, we panic.
         match key {
-            None => {
-                let (oks, errs) = self
-                    .collection
-                    .clone()
-                    .expect("The unarranged collection doesn't exist.");
-                (oks.into_vec(), errs)
-            }
+            None => self
+                .collection
+                .clone()
+                .expect("The unarranged collection doesn't exist."),
             Some(key) => {
                 let arranged = self.arranged.get(key).unwrap_or_else(|| {
                     panic!("The collection arranged by {:?} doesn't exist.", key)
                 });
                 if ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION.get(config_set) {
-                    // Decode all columns, pass max_demand as usize::MAX. Output is 1:1 from the
-                    // cursor (no duplicates), so a non-consolidating container builder is the
-                    // right choice.
-                    let (ok, err) = arranged
-                        .flat_map_ok::<_, CapacityContainerBuilder<Vec<(Row, T, Diff)>>, _>(
-                            None,
-                            usize::MAX,
-                            |borrow, t, r, ok_session| {
-                                ok_session.give((SharedRow::pack(borrow.iter()), t, r));
-                                1
-                            },
-                        );
-                    (ok.as_collection(), err)
+                    // Decode all columns (max_demand usize::MAX) and pack each cursor record
+                    // into a `Column`, so the materialized collection carries the columnar edge.
+                    // Output is 1:1 from the already-consolidated cursor, so a non-consolidating
+                    // `ColumnBuilder` matches the row-based `CapacityContainerBuilder` this
+                    // replaced; the packed row is pushed borrowed, holding no owned `Row` per
+                    // record.
+                    let (ok, err) = arranged.flat_map_ok::<ColumnBuilder<(Row, T, Diff)>, _>(
+                        None,
+                        usize::MAX,
+                        |borrow, t, r, ok_session| {
+                            let row = SharedRow::pack(borrow.iter());
+                            ok_session.give((&row, &t, &r));
+                            1
+                        },
+                    );
+                    (CollectionEdge::Columnar(ok.as_collection()), err)
                 } else {
                     #[allow(deprecated)]
-                    arranged.as_collection()
+                    let (oks, errs) = arranged.as_collection();
+                    (CollectionEdge::Vec(oks), errs)
                 }
             }
         }
@@ -793,7 +802,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// fallible variant for fuel semantics). Use this when the caller statically knows it
     /// will never produce `DataflowErrorSer` records, to avoid building a second output port
     /// and the empty err stream that would follow it.
-    fn flat_map_core_ok<Tr, D, DCB, L>(
+    fn flat_map_core_ok<Tr, DCB, L>(
         trace: Arranged<'scope, Tr>,
         key: Option<&<<BatchCursor<Tr> as Cursor>::KeyContainer as BatchContainer>::Owned>,
         max_demand: usize,
@@ -805,10 +814,11 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         for<'a> BatchCursor<Tr>:
             Cursor<Key<'a>: ExtendDatums, Val<'a>: ExtendDatums, Time = T, Diff = mz_repr::Diff>,
         <<BatchCursor<Tr> as Cursor>::KeyContainer as BatchContainer>::Owned: PartialEq,
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, T, Diff)>,
-        // See `flat_map_core_fallible`: `logic` takes already-decoded datums; the decode lives in
-        // the per-activation closure below.
+        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
+        // call site rather than here (see `flat_map_core_fallible`).
+        DCB: ContainerBuilder,
+        // `logic` takes already-decoded datums; the decode lives in the per-activation closure
+        // below.
         L: for<'a, 'b> FnMut(
                 &'a mut DatumVecBorrow<'b>,
                 T,
@@ -936,13 +946,10 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .collection
                     .clone()
                     .expect("The unarranged collection doesn't exist."),
-                // Keyed identity reads an existing arrangement, which is
-                // row-based. Wrap it as a `Vec` edge. `as_specific_collection`
-                // stays the consumer leaf.
-                Some(key) => {
-                    let (oks, errs) = self.as_specific_collection(Some(&key), config_set);
-                    (CollectionEdge::Vec(oks), errs)
-                }
+                // Keyed identity materializes an existing arrangement.
+                // `as_specific_collection` returns the columnar edge, so the
+                // reduce/threshold/topk result carries columnar downstream.
+                Some(key) => self.as_specific_collection(Some(&key), config_set),
             };
         }
 
@@ -1426,15 +1433,16 @@ where
 
     /// Perform roughly `fuel` work through the cursor, applying `logic` and sending results to
     /// the single output session.
-    fn do_work<D, DCB, L>(
+    fn do_work<DCB, L>(
         &mut self,
         key: Option<&C::Key<'_>>,
         logic: &mut L,
         fuel: &mut usize,
         ok_output: &mut OutputBuilderSession<'_, C::Time, DCB>,
     ) where
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, C::Time, C::Diff)>,
+        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
+        // call site rather than here.
+        DCB: ContainerBuilder,
         L: FnMut(C::Key<'_>, C::Val<'_>, C::Time, C::Diff, &mut Session<C::Time, DCB>) -> usize,
     {
         let mut ok_session = ok_output.session_with_builder(&self.capability);
@@ -1514,6 +1522,7 @@ fn walk_cursor<C, F>(
 #[cfg(test)]
 mod tests {
     use differential_dataflow::input::Input;
+    use mz_compute_types::dyncfgs::all_dyncfgs;
     use mz_expr::{EvalError, MapFilterProject};
     use mz_repr::{Datum, ReprScalarType, Timestamp};
     use timely::dataflow::operators::Capture;
@@ -1853,6 +1862,76 @@ mod tests {
             })
         });
 
+        assert_eq!(extract_row_updates(captured), expected);
+    }
+
+    /// The shared arrangement->collection materialization carries the columnar
+    /// edge. Reduce, Threshold, and bucketed TopK emit arrangements; when their
+    /// result is demanded as a collection it flows through
+    /// `as_specific_collection`, so this flip makes those outputs columnar with
+    /// no `ColumnarToVec`.
+    ///
+    /// Correctness: the materialized rows must equal the arranged input. Keying
+    /// by column 0 and thinning the value to column 1 reconstructs the original
+    /// two-column row. No-decode is a by-inspection property: the fueled path
+    /// builds a `ColumnBuilder` via `flat_map_ok` and never calls
+    /// `columnar_to_vec`; the `into_vec` below is the capture harness only.
+    #[mz_ore::test]
+    fn as_specific_collection_materializes_columnar() {
+        let rows = test_rows();
+        let key = vec![LirScalarExpr::column(0)];
+        let mut expected: Vec<(Row, Timestamp, Diff)> = rows
+            .iter()
+            .map(|(r, t)| (r.clone(), Timestamp::from(*t), Diff::ONE))
+            .collect();
+        expected.sort();
+
+        // A populated set so the fueled-materialization flag resolves to its
+        // default (`true`); `ConfigSet::default()` alone would panic on lookup.
+        let config_set = all_dyncfgs(ConfigSet::default());
+        let (is_columnar, captured) = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let (arranged, arr_errs, _passthrough) =
+                    CollectionBundle::<Timestamp>::arrange_collection(
+                        &"agg".to_string(),
+                        CollectionEdge::Vec(collection),
+                        key.clone(),
+                        vec![1],
+                        false,
+                    );
+                let err_arranged = {
+                    let kc: KeyCollection<_, _, _> = arr_errs.into();
+                    kc.mz_arrange::<
+                        ColumnationChunker<_>,
+                        ErrBatcher<_, _>,
+                        ErrBuilder<_, _>,
+                        ErrSpine<_, _>,
+                    >("agg-errs")
+                };
+                // An arrangement-only bundle, as Reduce/Threshold/TopK produce.
+                let bundle = CollectionBundle::from_columns(
+                    0..1,
+                    ArrangementFlavor::Local(arranged, err_arranged),
+                );
+                let (edge, _errs) = bundle.as_specific_collection(Some(&key), &config_set);
+                let is_columnar = matches!(edge, CollectionEdge::Columnar(_));
+                let captured = edge.into_vec().inner.capture();
+
+                let max_time = rows.iter().map(|(_, t)| *t).max().unwrap();
+                for (row, time) in rows {
+                    input.update_at(row, Timestamp::from(time), Diff::ONE);
+                }
+                input.advance_to(Timestamp::from(max_time + 1));
+                input.flush();
+                (is_columnar, captured)
+            })
+        });
+
+        assert!(
+            is_columnar,
+            "as_specific_collection must materialize the arrangement as a columnar edge"
+        );
         assert_eq!(extract_row_updates(captured), expected);
     }
 }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -672,19 +672,21 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     panic!("The collection arranged by {:?} doesn't exist.", key)
                 });
                 if ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION.get(config_set) {
-                    // Decode all columns (max_demand usize::MAX) and pack each cursor record
-                    // into a `Column`, so the materialized collection carries the columnar edge.
-                    // Output is 1:1 from the already-consolidated cursor, so a non-consolidating
-                    // `ColumnBuilder` matches the row-based `CapacityContainerBuilder` this
-                    // replaced; the packed row is pushed borrowed, holding no owned `Row` per
-                    // record.
+                    // Output is 1:1 from the already-consolidated cursor, so a
+                    // non-consolidating `ColumnBuilder` suffices. `max_demand` is
+                    // `usize::MAX` because the materialized collection carries every column.
                     let (ok, err) = arranged.flat_map_ok::<ColumnBuilder<(Row, T, Diff)>, _>(
                         None,
                         usize::MAX,
-                        |borrow, t, r, ok_session| {
-                            let row = SharedRow::pack(borrow.iter());
-                            ok_session.give((&row, &t, &r));
-                            1
+                        {
+                            // `give` copies the bytes into the column, so one buffer
+                            // serves every record.
+                            let mut row_buf = Row::default();
+                            move |borrow, t, r, ok_session| {
+                                row_buf.packer().extend(borrow.iter());
+                                ok_session.give((&row_buf, &t, &r));
+                                1
+                            }
                         },
                     );
                     (CollectionEdge::Columnar(ok.as_collection()), err)

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -369,9 +369,8 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
     )
     where
-        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
-        // call site, letting a caller push borrowed records into a columnar builder that has no
-        // owned-tuple `Push`.
+        // No push bound here: it lives at `logic`'s `give` call site, so a caller can push
+        // borrowed records into a columnar builder that has no owned-tuple `Push`.
         DCB: ContainerBuilder,
         L: for<'a, 'b> FnMut(&'a mut DatumVecBorrow<'b>, T, Diff, &mut Session<T, DCB>) -> usize
             + 'static,
@@ -644,11 +643,8 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// the fueled `flat_map` or `as_collection` method, depending on the flag
     /// [`ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION`].
     ///
-    /// The keyed path materializes the arrangement as the columnar edge, so an
-    /// arrangement-producing operator (Reduce, Threshold, bucketed TopK) whose
-    /// result is demanded as a collection carries columnar downstream. The
-    /// unkeyed path returns the unarranged `.collection` edge as-is, preserving
-    /// its variant.
+    /// The keyed path materializes the arrangement as the columnar edge. The unkeyed path
+    /// returns the unarranged `.collection` edge with its variant intact.
     pub fn as_specific_collection(
         &self,
         key: Option<&[LirScalarExpr]>,
@@ -777,8 +773,6 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         for<'a> BatchCursor<Tr>:
             Cursor<Key<'a>: ExtendDatums, Val<'a>: ExtendDatums, Time = T, Diff = mz_repr::Diff>,
         <<BatchCursor<Tr> as Cursor>::KeyContainer as BatchContainer>::Owned: PartialEq,
-        // No push bound here: it lives at `logic`'s `give` call site, so a caller can push
-        // borrowed records into a columnar builder that has no owned-tuple `Push`.
         DCB: ContainerBuilder,
         // `logic` receives the key and value already decoded into a `DatumVecBorrow`. The decode
         // (and its arena/`DatumVec`) lives in the per-activation closure below, so it is scoped to
@@ -897,11 +891,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         for<'a> BatchCursor<Tr>:
             Cursor<Key<'a>: ExtendDatums, Val<'a>: ExtendDatums, Time = T, Diff = mz_repr::Diff>,
         <<BatchCursor<Tr> as Cursor>::KeyContainer as BatchContainer>::Owned: PartialEq,
-        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
-        // call site rather than here (see `flat_map_core_fallible`).
         DCB: ContainerBuilder,
-        // `logic` takes already-decoded datums; the decode lives in the per-activation closure
-        // below.
         L: for<'a, 'b> FnMut(
                 &'a mut DatumVecBorrow<'b>,
                 T,
@@ -1505,8 +1495,6 @@ where
         fuel: &mut usize,
         ok_output: &mut OutputBuilderSession<'_, C::Time, DCB>,
     ) where
-        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
-        // call site rather than here.
         DCB: ContainerBuilder,
         L: FnMut(C::Key<'_>, C::Val<'_>, C::Time, C::Diff, &mut Session<C::Time, DCB>) -> usize,
     {
@@ -1902,17 +1890,8 @@ mod tests {
         assert_eq!(extract_row_updates(captured), expected);
     }
 
-    /// The shared arrangement->collection materialization carries the columnar
-    /// edge. Reduce, Threshold, and bucketed TopK emit arrangements; when their
-    /// result is demanded as a collection it flows through
-    /// `as_specific_collection`, so those outputs are columnar with
-    /// no `ColumnarToVec`.
-    ///
-    /// Correctness: the materialized rows must equal the arranged input. Keying
-    /// by column 0 and thinning the value to column 1 reconstructs the original
-    /// two-column row. No-decode is a by-inspection property: the fueled path
-    /// builds a `ColumnBuilder` via `flat_map_ok` and never calls
-    /// `columnar_to_vec`; the `into_vec` below is the capture harness only.
+    /// Keying by column 0 and thinning the value to column 1 reconstructs the original
+    /// two-column row. The `into_vec` below belongs to the capture harness.
     #[mz_ore::test]
     fn as_specific_collection_materializes_columnar() {
         let rows = test_rows();
@@ -1923,8 +1902,7 @@ mod tests {
             .collect();
         expected.sort();
 
-        // A populated set so the fueled-materialization flag resolves to its
-        // default (`true`); `ConfigSet::default()` alone would panic on lookup.
+        // A populated set, because `ConfigSet::default()` panics on lookup.
         let config_set = all_dyncfgs(ConfigSet::default());
         let (is_columnar, captured) = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -19,7 +19,7 @@ use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::cursor::{BatchCursor, BatchKey, BatchVal};
 use differential_dataflow::trace::implementations::BatchContainer;
 use differential_dataflow::trace::{Cursor, Navigable, TraceReader};
-use differential_dataflow::{AsCollection, Data, VecCollection};
+use differential_dataflow::{AsCollection, VecCollection};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::{
     ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION, ENABLE_COMPUTE_TEMPORAL_BUCKETING,
@@ -42,7 +42,7 @@ use mz_timely_util::columnar::{
 };
 use mz_timely_util::columnation::ColumnationChunker;
 use timely::ContainerBuilder;
-use timely::container::{CapacityContainerBuilder, PushInto};
+use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::operators::Capability;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
@@ -359,7 +359,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
     /// session, cannot produce errors, and returns the number of records produced (see
     /// [`Self::flat_map`] for fuel semantics). The returned err collection comes solely from
     /// the arrangement; no extra operator is built to carry an empty MFP-error stream.
-    pub fn flat_map_ok<D, DCB, L>(
+    pub fn flat_map_ok<DCB, L>(
         &self,
         key: Option<&Row>,
         max_demand: usize,
@@ -369,14 +369,16 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
     )
     where
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, T, Diff)>,
+        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
+        // call site, letting a caller push borrowed records into a columnar builder that has no
+        // owned-tuple `Push`.
+        DCB: ContainerBuilder,
         L: for<'a, 'b> FnMut(&'a mut DatumVecBorrow<'b>, T, Diff, &mut Session<T, DCB>) -> usize
             + 'static,
     {
         match &self {
             ArrangementFlavor::Local(oks, errs) => {
-                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, _, DCB, _>(
+                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, DCB, _>(
                     oks.clone(),
                     key,
                     max_demand,
@@ -387,7 +389,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
                 (oks, errs)
             }
             ArrangementFlavor::Trace(_, oks, errs) => {
-                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, _, DCB, _>(
+                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, DCB, _>(
                     oks.clone(),
                     key,
                     max_demand,
@@ -641,12 +643,18 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// If `key` is specified, the function converts the arrangement to a collection. It uses either
     /// the fueled `flat_map` or `as_collection` method, depending on the flag
     /// [`ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION`].
+    ///
+    /// The keyed path materializes the arrangement as the columnar edge, so an
+    /// arrangement-producing operator (Reduce, Threshold, bucketed TopK) whose
+    /// result is demanded as a collection carries columnar downstream. The
+    /// unkeyed path returns the unarranged `.collection` edge as-is, preserving
+    /// its variant.
     pub fn as_specific_collection(
         &self,
         key: Option<&[LirScalarExpr]>,
         config_set: &ConfigSet,
     ) -> (
-        VecCollection<'scope, T, Row, Diff>,
+        CollectionEdge<'scope, T>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
     ) {
         // Any operator that uses this method was told to use a particular
@@ -655,34 +663,35 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         //
         // If it doesn't, we panic.
         match key {
-            None => {
-                let (oks, errs) = self
-                    .collection
-                    .clone()
-                    .expect("The unarranged collection doesn't exist.");
-                (oks.into_vec(), errs)
-            }
+            None => self
+                .collection
+                .clone()
+                .expect("The unarranged collection doesn't exist."),
             Some(key) => {
                 let arranged = self.arranged.get(key).unwrap_or_else(|| {
                     panic!("The collection arranged by {:?} doesn't exist.", key)
                 });
                 if ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION.get(config_set) {
-                    // Decode all columns, pass max_demand as usize::MAX. Output is 1:1 from the
-                    // cursor (no duplicates), so a non-consolidating container builder is the
-                    // right choice.
-                    let (ok, err) = arranged
-                        .flat_map_ok::<_, CapacityContainerBuilder<Vec<(Row, T, Diff)>>, _>(
-                            None,
-                            usize::MAX,
-                            |borrow, t, r, ok_session| {
-                                ok_session.give((SharedRow::pack(borrow.iter()), t, r));
-                                1
-                            },
-                        );
-                    (ok.as_collection(), err)
+                    // Decode all columns (max_demand usize::MAX) and pack each cursor record
+                    // into a `Column`, so the materialized collection carries the columnar edge.
+                    // Output is 1:1 from the already-consolidated cursor, so a non-consolidating
+                    // `ColumnBuilder` matches the row-based `CapacityContainerBuilder` this
+                    // replaced; the packed row is pushed borrowed, holding no owned `Row` per
+                    // record.
+                    let (ok, err) = arranged.flat_map_ok::<ColumnBuilder<(Row, T, Diff)>, _>(
+                        None,
+                        usize::MAX,
+                        |borrow, t, r, ok_session| {
+                            let row = SharedRow::pack(borrow.iter());
+                            ok_session.give((&row, &t, &r));
+                            1
+                        },
+                    );
+                    (CollectionEdge::Columnar(ok.as_collection()), err)
                 } else {
                     #[allow(deprecated)]
-                    arranged.as_collection()
+                    let (oks, errs) = arranged.as_collection();
+                    (CollectionEdge::Vec(oks), errs)
                 }
             }
         }
@@ -874,7 +883,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// fallible variant for fuel semantics). Use this when the caller statically knows it
     /// will never produce `DataflowErrorSer` records, to avoid building a second output port
     /// and the empty err stream that would follow it.
-    fn flat_map_core_ok<Tr, D, DCB, L>(
+    fn flat_map_core_ok<Tr, DCB, L>(
         trace: Arranged<'scope, Tr>,
         key: Option<&<<BatchCursor<Tr> as Cursor>::KeyContainer as BatchContainer>::Owned>,
         max_demand: usize,
@@ -886,10 +895,11 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         for<'a> BatchCursor<Tr>:
             Cursor<Key<'a>: ExtendDatums, Val<'a>: ExtendDatums, Time = T, Diff = mz_repr::Diff>,
         <<BatchCursor<Tr> as Cursor>::KeyContainer as BatchContainer>::Owned: PartialEq,
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, T, Diff)>,
-        // See `flat_map_core_fallible`: `logic` takes already-decoded datums; the decode lives in
-        // the per-activation closure below.
+        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
+        // call site rather than here (see `flat_map_core_fallible`).
+        DCB: ContainerBuilder,
+        // `logic` takes already-decoded datums; the decode lives in the per-activation closure
+        // below.
         L: for<'a, 'b> FnMut(
                 &'a mut DatumVecBorrow<'b>,
                 T,
@@ -1020,10 +1030,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .collection
                     .clone()
                     .expect("The unarranged collection doesn't exist."),
-                Some(key) => {
-                    let (oks, errs) = self.as_specific_collection(Some(&key), config_set);
-                    (CollectionEdge::Vec(oks), errs)
-                }
+                Some(key) => self.as_specific_collection(Some(&key), config_set),
             };
         }
 
@@ -1489,15 +1496,16 @@ where
 
     /// Perform roughly `fuel` work through the cursor, applying `logic` and sending results to
     /// the single output session.
-    fn do_work<D, DCB, L>(
+    fn do_work<DCB, L>(
         &mut self,
         key: Option<&C::Key<'_>>,
         logic: &mut L,
         fuel: &mut usize,
         ok_output: &mut OutputBuilderSession<'_, C::Time, DCB>,
     ) where
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, C::Time, C::Diff)>,
+        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
+        // call site rather than here.
+        DCB: ContainerBuilder,
         L: FnMut(C::Key<'_>, C::Val<'_>, C::Time, C::Diff, &mut Session<C::Time, DCB>) -> usize,
     {
         let mut ok_session = ok_output.session_with_builder(&self.capability);
@@ -1577,6 +1585,7 @@ fn walk_cursor<C, F>(
 #[cfg(test)]
 mod tests {
     use differential_dataflow::input::Input;
+    use mz_compute_types::dyncfgs::all_dyncfgs;
     use mz_expr::{EvalError, MapFilterProject};
     use mz_repr::{Datum, ReprScalarType, Timestamp};
     use timely::dataflow::operators::Capture;
@@ -1888,6 +1897,76 @@ mod tests {
             })
         });
 
+        assert_eq!(extract_row_updates(captured), expected);
+    }
+
+    /// The shared arrangement->collection materialization carries the columnar
+    /// edge. Reduce, Threshold, and bucketed TopK emit arrangements; when their
+    /// result is demanded as a collection it flows through
+    /// `as_specific_collection`, so this flip makes those outputs columnar with
+    /// no `ColumnarToVec`.
+    ///
+    /// Correctness: the materialized rows must equal the arranged input. Keying
+    /// by column 0 and thinning the value to column 1 reconstructs the original
+    /// two-column row. No-decode is a by-inspection property: the fueled path
+    /// builds a `ColumnBuilder` via `flat_map_ok` and never calls
+    /// `columnar_to_vec`; the `into_vec` below is the capture harness only.
+    #[mz_ore::test]
+    fn as_specific_collection_materializes_columnar() {
+        let rows = test_rows();
+        let key = vec![LirScalarExpr::column(0)];
+        let mut expected: Vec<(Row, Timestamp, Diff)> = rows
+            .iter()
+            .map(|(r, t)| (r.clone(), Timestamp::from(*t), Diff::ONE))
+            .collect();
+        expected.sort();
+
+        // A populated set so the fueled-materialization flag resolves to its
+        // default (`true`); `ConfigSet::default()` alone would panic on lookup.
+        let config_set = all_dyncfgs(ConfigSet::default());
+        let (is_columnar, captured) = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let (arranged, arr_errs, _passthrough) =
+                    CollectionBundle::<Timestamp>::arrange_collection(
+                        &"agg".to_string(),
+                        CollectionEdge::Vec(collection),
+                        key.clone(),
+                        vec![1],
+                        ArrangementBatcher::Columnation,
+                    );
+                let err_arranged = {
+                    let kc: KeyCollection<_, _, _> = arr_errs.into();
+                    kc.mz_arrange::<
+                        ColumnationChunker<_>,
+                        ErrBatcher<_, _>,
+                        ErrBuilder<_, _>,
+                        ErrSpine<_, _>,
+                    >("agg-errs")
+                };
+                // An arrangement-only bundle, as Reduce/Threshold/TopK produce.
+                let bundle = CollectionBundle::from_columns(
+                    0..1,
+                    ArrangementFlavor::Local(arranged, err_arranged),
+                );
+                let (edge, _errs) = bundle.as_specific_collection(Some(&key), &config_set);
+                let is_columnar = matches!(edge, CollectionEdge::Columnar(_));
+                let captured = edge.into_vec().inner.capture();
+
+                let max_time = rows.iter().map(|(_, t)| *t).max().unwrap();
+                for (row, time) in rows {
+                    input.update_at(row, Timestamp::from(time), Diff::ONE);
+                }
+                input.advance_to(Timestamp::from(max_time + 1));
+                input.flush();
+                (is_columnar, captured)
+            })
+        });
+
+        assert!(
+            is_columnar,
+            "as_specific_collection must materialize the arrangement as a columnar edge"
+        );
         assert_eq!(extract_row_updates(captured), expected);
     }
 }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -1903,7 +1903,7 @@ mod tests {
     /// The shared arrangement->collection materialization carries the columnar
     /// edge. Reduce, Threshold, and bucketed TopK emit arrangements; when their
     /// result is demanded as a collection it flows through
-    /// `as_specific_collection`, so this flip makes those outputs columnar with
+    /// `as_specific_collection`, so those outputs are columnar with
     /// no `ColumnarToVec`.
     ///
     /// Correctness: the materialized rows must equal the arranged input. Keying

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -54,17 +54,14 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
 
         // The unarranged path (no key) reads the input `CollectionEdge` directly,
         // so the columnar arm never decodes rows at the input. The keyed path
-        // reads an existing arrangement, already columnar internally, and is
-        // presented as a `Vec` edge here.
+        // materializes an existing arrangement, which `as_specific_collection`
+        // presents as a columnar edge.
         let (edge, err_collection) = match input_key.as_deref() {
             None => input
                 .collection
                 .clone()
                 .expect("The unarranged collection doesn't exist."),
-            Some(key) => {
-                let (oks, errs) = input.as_specific_collection(Some(key), &self.config_set);
-                (CollectionEdge::Vec(oks), errs)
-            }
+            Some(key) => input.as_specific_collection(Some(key), &self.config_set),
         };
 
         let (oks, errs) = match edge {

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -53,17 +53,14 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
         let budget = COMPUTE_FLAT_MAP_FUEL.get(&self.config_set);
 
         // The unarranged path reads the edge directly, so a columnar input is never
-        // decoded here. The keyed path reads an existing arrangement, presented as a
-        // `Vec` edge.
+        // decoded here. The keyed path materializes an existing arrangement, which
+        // `as_specific_collection` presents as a columnar edge.
         let (edge, err_collection) = match input_key.as_deref() {
             None => input
                 .collection
                 .clone()
                 .expect("The unarranged collection doesn't exist."),
-            Some(key) => {
-                let (oks, errs) = input.as_specific_collection(Some(key), &self.config_set);
-                (CollectionEdge::Vec(oks), errs)
-            }
+            Some(key) => input.as_specific_collection(Some(key), &self.config_set),
         };
 
         let (oks, errs) = match edge {

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -255,14 +255,13 @@ where
                         .collection
                         .clone()
                         .expect("The unarranged collection doesn't exist."),
-                    // With a source key the input is read from an existing
-                    // arrangement, which is already columnar internally; wrap its
-                    // decoded rows as a `Vec` edge.
-                    Some(key) => {
-                        let (oks, errs) = inputs[linear_plan.source_relation]
-                            .as_specific_collection(Some(key), &self.config_set);
-                        (CollectionEdge::Vec(oks), errs)
-                    }
+                    // With a source key the input is materialized from an existing
+                    // arrangement, which `as_specific_collection` presents as a
+                    // columnar edge. `differential_join` forms the source key off
+                    // this edge below, so the columnar source has no `ColumnarToVec`
+                    // hop.
+                    Some(key) => inputs[linear_plan.source_relation]
+                        .as_specific_collection(Some(key), &self.config_set),
                 };
                 errors.push(errs.enter_region(inner));
                 let joined = joined.enter_region(inner);

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -250,13 +250,10 @@ where
                         .collection
                         .clone()
                         .expect("The unarranged collection doesn't exist."),
-                    // A source key reads from an existing arrangement, columnar internally,
-                    // whose decoded rows are wrapped as a `Vec` edge.
-                    Some(key) => {
-                        let (oks, errs) = inputs[linear_plan.source_relation]
-                            .as_specific_collection(Some(key), &self.config_set);
-                        (CollectionEdge::Vec(oks), errs)
-                    }
+                    // A source key materializes an existing arrangement, which
+                    // `as_specific_collection` presents as a columnar edge.
+                    Some(key) => inputs[linear_plan.source_relation]
+                        .as_specific_collection(Some(key), &self.config_set),
                 };
                 errors.push(errs.enter_region(inner));
                 let joined = joined.enter_region(inner);


### PR DESCRIPTION
The shared arrangement-materialization path (`as_specific_collection`, keyed identity) emits the columnar edge, covering Reduce, Threshold, and bucketed-TopK outputs at once. It reads an already-consolidated arrangement cursor, so it uses a plain `ColumnBuilder` with borrowed pushes (no redundant consolidation).


Columnar dataflow-edge migration. Design doc: `doc/developer/design/20260720_columnar_dataflow_edges.md` (#37744).

Part of [CPU-51](https://linear.app/materializeinc/issue/CPU-51).
