### PR TITLE
compute: Emit dataflow import outputs as the columnar edge

### DIFF
--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -165,7 +165,7 @@ use crate::extensions::temporal_bucket::TemporalBucketing;
 use crate::logging::compute::{
     ComputeEvent, DataflowGlobal, LirMapping, LirMetadata, LogDataflowErrors, OperatorHydration,
 };
-use crate::render::columnar::CollectionEdge;
+use crate::render::columnar::{CollectionEdge, vec_to_columnar};
 use crate::render::context::{ArrangementFlavor, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{ErrBatcher, ErrBuilder, ErrSpine, KeyBatcher, MzTimestamp};
@@ -374,8 +374,11 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    let bundle = crate::render::CollectionBundle::from_collections(
-                        oks.enter(region),
+                    // Imports read row-shaped data from persist; encode it to the
+                    // columnar edge at the boundary. The batches are already
+                    // consolidated, so this leaf-encode is non-consolidating.
+                    let bundle = crate::render::CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks.enter(region))),
                         errs.enter(region),
                     );
                     // Associate collection bundle with the source identifier.
@@ -474,8 +477,11 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    let bundle = crate::render::CollectionBundle::from_collections(
-                        oks.enter_region(region),
+                    // Imports read row-shaped data from persist; encode it to the
+                    // columnar edge at the boundary. The batches are already
+                    // consolidated, so this leaf-encode is non-consolidating.
+                    let bundle = crate::render::CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks.enter_region(region))),
                         errs.enter_region(region),
                     );
                     // Associate collection bundle with the source identifier.
@@ -667,7 +673,13 @@ where
                         start_signal,
                         |e, _| e.clone(),
                     );
-                    CollectionBundle::from_collections(oks, errs)
+                    // The filtered index collection is row-shaped; encode it to
+                    // the columnar edge at the boundary. It is already
+                    // consolidated, so this leaf-encode is non-consolidating.
+                    CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks)),
+                        errs,
+                    )
                 }
             };
             self.update_id(Id::Global(idx.on_id), bundle);

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -374,7 +374,7 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    // Imports read row-shaped data from persist; encode it to the
+                    // Imports read row-shaped data from persist. Encode it to the
                     // columnar edge at the boundary. The batches are already
                     // consolidated, so this leaf-encode is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
@@ -477,7 +477,7 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    // Imports read row-shaped data from persist; encode it to the
+                    // Imports read row-shaped data from persist. Encode it to the
                     // columnar edge at the boundary. The batches are already
                     // consolidated, so this leaf-encode is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
@@ -673,7 +673,7 @@ where
                         start_signal,
                         |e, _| e.clone(),
                     );
-                    // The filtered index collection is row-shaped; encode it to
+                    // The filtered index collection is row-shaped. Encode it to
                     // the columnar edge at the boundary. It is already
                     // consolidated, so this leaf-encode is non-consolidating.
                     CollectionBundle::from_edge(

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -375,9 +375,8 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    // Imports read row-shaped data from persist. Encode it to the
-                    // columnar edge at the boundary. The batches are already
-                    // consolidated, so this leaf-encode is non-consolidating.
+                    // Persist batches are row-shaped and already consolidated, so the
+                    // encode here is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
                         CollectionEdge::Columnar(vec_to_columnar(oks.enter(region))),
                         errs.enter(region),
@@ -478,9 +477,8 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    // Imports read row-shaped data from persist. Encode it to the
-                    // columnar edge at the boundary. The batches are already
-                    // consolidated, so this leaf-encode is non-consolidating.
+                    // Persist batches are row-shaped and already consolidated, so the
+                    // encode here is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
                         CollectionEdge::Columnar(vec_to_columnar(oks.enter_region(region))),
                         errs.enter_region(region),
@@ -674,9 +672,8 @@ where
                         start_signal,
                         |e, _| e.clone(),
                     );
-                    // The filtered index collection is row-shaped. Encode it to
-                    // the columnar edge at the boundary. It is already
-                    // consolidated, so this leaf-encode is non-consolidating.
+                    // The filtered index collection is row-shaped and already
+                    // consolidated, so the encode here is non-consolidating.
                     CollectionBundle::from_edge(
                         CollectionEdge::Columnar(vec_to_columnar(oks)),
                         errs,

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -375,7 +375,7 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    // Imports read row-shaped data from persist; encode it to the
+                    // Imports read row-shaped data from persist. Encode it to the
                     // columnar edge at the boundary. The batches are already
                     // consolidated, so this leaf-encode is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
@@ -478,7 +478,7 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    // Imports read row-shaped data from persist; encode it to the
+                    // Imports read row-shaped data from persist. Encode it to the
                     // columnar edge at the boundary. The batches are already
                     // consolidated, so this leaf-encode is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
@@ -674,7 +674,7 @@ where
                         start_signal,
                         |e, _| e.clone(),
                     );
-                    // The filtered index collection is row-shaped; encode it to
+                    // The filtered index collection is row-shaped. Encode it to
                     // the columnar edge at the boundary. It is already
                     // consolidated, so this leaf-encode is non-consolidating.
                     CollectionBundle::from_edge(

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -166,7 +166,7 @@ use crate::extensions::temporal_bucket::TemporalBucketing;
 use crate::logging::compute::{
     ComputeEvent, DataflowGlobal, LirMapping, LirMetadata, LogDataflowErrors, OperatorHydration,
 };
-use crate::render::columnar::CollectionEdge;
+use crate::render::columnar::{CollectionEdge, vec_to_columnar};
 use crate::render::context::{ArrangementFlavor, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{ErrBatcher, ErrBuilder, ErrSpine, KeyBatcher, MzTimestamp};
@@ -375,8 +375,11 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    let bundle = crate::render::CollectionBundle::from_collections(
-                        oks.enter(region),
+                    // Imports read row-shaped data from persist; encode it to the
+                    // columnar edge at the boundary. The batches are already
+                    // consolidated, so this leaf-encode is non-consolidating.
+                    let bundle = crate::render::CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks.enter(region))),
                         errs.enter(region),
                     );
                     // Associate collection bundle with the source identifier.
@@ -475,8 +478,11 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    let bundle = crate::render::CollectionBundle::from_collections(
-                        oks.enter_region(region),
+                    // Imports read row-shaped data from persist; encode it to the
+                    // columnar edge at the boundary. The batches are already
+                    // consolidated, so this leaf-encode is non-consolidating.
+                    let bundle = crate::render::CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks.enter_region(region))),
                         errs.enter_region(region),
                     );
                     // Associate collection bundle with the source identifier.
@@ -668,7 +674,13 @@ where
                         start_signal,
                         |e, _| e.clone(),
                     );
-                    CollectionBundle::from_collections(oks, errs)
+                    // The filtered index collection is row-shaped; encode it to
+                    // the columnar edge at the boundary. It is already
+                    // consolidated, so this leaf-encode is non-consolidating.
+                    CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks)),
+                        errs,
+                    )
                 }
             };
             self.update_id(Id::Global(idx.on_id), bundle);

--- a/test/sqllogictest/introspection/relations.slt
+++ b/test/sqllogictest/introspection/relations.slt
@@ -65,9 +65,10 @@ FormArrangementKey  Concatenate  alloc::vec::Vec<(mz_compute::render::errors::Da
 InputRegion:␠materialize.public.test_primary_idx  BuildRegion:␠materialize.public.test_primary_idx  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 InputRegion:␠materialize.public.test_primary_idx  BuildRegion:␠materialize.public.test_primary_idx  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  Probe  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-LogOperatorHydration␠(1)  FormArrangementKey  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+LogOperatorHydration␠(1)  FormArrangementKey  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 OkErr  SuppressEarlyProgress  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 SuppressEarlyProgress  LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+VecToColumnar  BuildingObject(User(2))  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 decode_backpressure_probe(u1)  Feedback  alloc::vec::Vec<core::convert::Infallible>
 expire_stream_at(materialize.public.test_primary_idx_export_index_errs)  LogDataflowErrorsStream  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyBatch<mz_compute::typedefs::spines::MzStack<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 expire_stream_at(materialize.public.test_primary_idx_export_index_oks)  InspectBatch  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
@@ -97,11 +98,12 @@ GROUP BY type;
 2  alloc::vec::Vec<(usize,␠mz_persist_client::fetch::ExchangeableBatchPart<mz_repr::timestamp::Timestamp>)>
 2  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
 4  alloc::vec::Vec<(core::result::Result<mz_repr::row::Row,␠mz_compute::render::errors::DataflowErrorSer>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
+4  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 5  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyBatch<mz_compute::typedefs::spines::MzStack<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 5  alloc::vec::Vec<core::convert::Infallible>
 6  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+6  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 6  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
-9  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 
 query TTT rowsort
 SELECT mdod_from.name AS from_name,

--- a/test/sqllogictest/introspection/relations.slt
+++ b/test/sqllogictest/introspection/relations.slt
@@ -65,9 +65,10 @@ FormArrangementKey  Concatenate  alloc::vec::Vec<(mz_compute::render::errors::Da
 InputRegion:␠materialize.public.test_primary_idx  BuildRegion:␠materialize.public.test_primary_idx  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 InputRegion:␠materialize.public.test_primary_idx  BuildRegion:␠materialize.public.test_primary_idx  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  Probe  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-LogOperatorHydration␠(1)  FormArrangementKey  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+LogOperatorHydration␠(1)  FormArrangementKey  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 OkErr  SuppressEarlyProgress  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 SuppressEarlyProgress  LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+VecToColumnar  BuildingObject(User(2))  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 decode_backpressure_probe(u1)  Feedback  alloc::vec::Vec<core::convert::Infallible>
 expire_stream_at(materialize.public.test_primary_idx_export_index_errs)  LogDataflowErrorsStream  alloc::vec::Vec<mz_row_spine::arc_batch::ArcBatch<differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyBatch<mz_compute::typedefs::spines::MzStack<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 expire_stream_at(materialize.public.test_primary_idx_export_index_oks)  InspectBatch  alloc::vec::Vec<mz_row_spine::arc_batch::ArcBatch<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
@@ -97,11 +98,12 @@ GROUP BY type;
 2  alloc::vec::Vec<(usize,␠mz_persist_client::fetch::ExchangeableBatchPart<mz_repr::timestamp::Timestamp>)>
 2  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
 4  alloc::vec::Vec<(core::result::Result<mz_repr::row::Row,␠mz_compute::render::errors::DataflowErrorSer>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
+4  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 5  alloc::vec::Vec<core::convert::Infallible>
 5  alloc::vec::Vec<mz_row_spine::arc_batch::ArcBatch<differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyBatch<mz_compute::typedefs::spines::MzStack<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 6  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+6  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 6  alloc::vec::Vec<mz_row_spine::arc_batch::ArcBatch<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
-9  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 
 query TTT rowsort
 SELECT mdod_from.name AS from_name,


### PR DESCRIPTION
Dataflow imports (persist sources, index/trace imports) emit the columnar edge via a `vec_to_columnar` leaf-encode at the import output. Includes the `relations.slt` golden update for the resulting `VecToColumnar` boundary operator.


Columnar dataflow-edge migration. Design doc: `doc/developer/design/20260720_columnar_dataflow_edges.md` (#37744).

Part of [CPU-51](https://linear.app/materializeinc/issue/CPU-51).
