### PR TITLE
adapter: make DISCARD ALL reset session vars durably (SQL-529)

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -554,6 +554,11 @@ impl Coordinator {
                         let (_, retire_notify) = self.clear_transaction(ctx.session_mut()).await;
                         ctx.delay_response_until(retire_notify);
                         self.drop_temp_items(ctx.session().conn_id()).await;
+                        // NOTE: `reset()` resets session variables durably (see
+                        // `SessionVars::reset_all`). This must stay durable and
+                        // must not be reordered to depend on a transaction
+                        // commit: the transaction was just cleared above, so
+                        // there is no commit left to promote a staged reset.
                         ctx.session_mut().reset();
                         Ok(ExecuteResponse::DiscardedAll)
                     } else {

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -515,6 +515,53 @@ async fn test_startup_params_survive_reset() {
     }
 }
 
+// SQL-529: DISCARD ALL has to reset session variables over the extended query
+// protocol as well as the simple one. tokio-postgres `execute`/`query` run over
+// the extended protocol, while `batch_execute` runs over the simple one, so the
+// existing simple-protocol tests never caught this bug.
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+#[allow(clippy::disallowed_methods)]
+async fn test_discard_all_resets_over_extended_protocol() {
+    let server = test_util::TestHarness::default().start().await;
+
+    async fn show(client: &tokio_postgres::Client, name: &str) -> String {
+        client
+            .query_one(&format!("SHOW {name}"), &[])
+            .await
+            .unwrap()
+            .get(0)
+    }
+
+    // A plain SET is reset back to the compiled-in default.
+    {
+        let client = server.connect().await.unwrap();
+        client
+            .execute("SET extra_float_digits = 1", &[])
+            .await
+            .unwrap();
+        assert_eq!(show(&client, "extra_float_digits").await, "1");
+        client.execute("DISCARD ALL", &[]).await.unwrap();
+        assert_eq!(show(&client, "extra_float_digits").await, "3");
+    }
+
+    // A startup-supplied default survives DISCARD ALL rather than reverting to
+    // the compiled-in default.
+    {
+        let client = server
+            .connect()
+            .application_name("startup_app")
+            .await
+            .unwrap();
+        client
+            .execute("SET application_name = 'changed_app'", &[])
+            .await
+            .unwrap();
+        assert_eq!(show(&client, "application_name").await, "changed_app");
+        client.execute("DISCARD ALL", &[]).await.unwrap();
+        assert_eq!(show(&client, "application_name").await, "startup_app");
+    }
+}
+
 #[mz_ore::test]
 #[allow(clippy::disallowed_methods)]
 fn test_conn_user() {

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -560,6 +560,26 @@ async fn test_discard_all_resets_over_extended_protocol() {
         client.execute("DISCARD ALL", &[]).await.unwrap();
         assert_eq!(show(&client, "application_name").await, "startup_app");
     }
+
+    // A role-supplied default (ALTER ROLE ... SET) survives DISCARD ALL rather
+    // than reverting to the compiled-in default.
+    {
+        let client = server.connect().await.unwrap();
+        client
+            .execute("ALTER ROLE materialize SET database = role_db", &[])
+            .await
+            .unwrap();
+
+        let client = server.connect().await.unwrap();
+        assert_eq!(show(&client, "database").await, "role_db");
+        client
+            .execute("SET database = other_db", &[])
+            .await
+            .unwrap();
+        assert_eq!(show(&client, "database").await, "other_db");
+        client.execute("DISCARD ALL", &[]).await.unwrap();
+        assert_eq!(show(&client, "database").await, "role_db");
+    }
 }
 
 #[mz_ore::test]

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -312,6 +312,20 @@ impl SessionVar {
         }
     }
 
+    /// Resets the variable to its default, discarding any session, staged, or
+    /// local override. Unlike [`SessionVar::reset`], which stages the reset for
+    /// the current transaction, this takes effect immediately and does not
+    /// depend on a later [`SessionVar::end_transaction`] commit.
+    ///
+    /// `DISCARD ALL` requires this: it ends the transaction before resetting, so
+    /// there is no commit left to promote a staged value. `default_value` (the
+    /// system/role/startup default) is deliberately preserved.
+    pub fn reset_durable(&mut self) {
+        self.local_value = None;
+        self.staged_value = None;
+        self.session_value = None;
+    }
+
     /// Returns a possibly new SessionVar if this needs to mutate at transaction end.
     #[must_use]
     pub fn end_transaction(&self, action: EndTransactionAction) -> Option<Self> {
@@ -520,11 +534,16 @@ impl SessionVars {
         .chain(std::iter::once(self.mz_version.as_var()))
     }
 
-    /// Resets all variables to their default value.
+    /// Durably resets all variables to their default value.
+    ///
+    /// Unlike a staged [`SessionVar::reset`], this takes effect immediately and
+    /// does not depend on a later transaction commit. Used by `DISCARD ALL`,
+    /// which ends the transaction before resetting, so there is no commit left
+    /// to promote a staged value. System/role/startup defaults are preserved.
     pub fn reset_all(&mut self) {
         let names: Vec<_> = self.vars.keys().copied().collect();
         for name in names {
-            self.vars[name].reset(false);
+            self.vars[name].reset_durable();
         }
     }
 
@@ -2575,5 +2594,83 @@ mod isolation_feature_flag_tests {
             &system_vars,
         )
         .expect("unrelated var ignored");
+    }
+}
+
+#[cfg(test)]
+mod reset_all_tests {
+    use super::*;
+    use crate::session::user::SYSTEM_USER;
+
+    fn test_vars() -> SessionVars {
+        SessionVars::new_unchecked(&mz_build_info::DUMMY_BUILD_INFO, SYSTEM_USER.clone(), None)
+    }
+
+    // `reset_all` (used by `DISCARD ALL`) must clear a committed session
+    // override durably, without depending on a later transaction commit to
+    // promote the reset. Regression coverage for SQL-529.
+    #[mz_ore::test]
+    fn reset_all_clears_committed_session_value() {
+        let system_vars = SystemVars::new();
+        let mut vars = test_vars();
+        let default = vars.application_name().to_string();
+
+        // Set non-locally and commit, so the override lives in `session_value`.
+        vars.set(
+            &system_vars,
+            "application_name",
+            VarInput::Flat("custom"),
+            false,
+        )
+        .expect("set");
+        vars.end_transaction(EndTransactionAction::Commit);
+        assert_eq!(vars.application_name(), "custom");
+        assert_eq!(
+            vars.inspect("application_name")
+                .unwrap()
+                .inspect_session_value()
+                .map(|v| v.format()),
+            Some("custom".to_string())
+        );
+
+        vars.reset_all();
+
+        // The value falls back to the default, the var is unset, and it will
+        // not mutate at a later transaction end.
+        let var = vars.inspect("application_name").unwrap();
+        assert_eq!(vars.application_name(), default);
+        assert_eq!(var.inspect_session_value(), None);
+        assert!(!var.is_mutating());
+    }
+
+    // `reset_all` must fall back to a system/role/startup default installed via
+    // `set_default`, not the compiled-in default. Guards the "startup/role
+    // defaults survive DISCARD ALL" contract.
+    #[mz_ore::test]
+    fn reset_all_preserves_installed_default() {
+        let system_vars = SystemVars::new();
+        let mut vars = test_vars();
+
+        vars.set_default("application_name", VarInput::Flat("startup_default"))
+            .expect("set_default");
+        vars.set(
+            &system_vars,
+            "application_name",
+            VarInput::Flat("custom"),
+            false,
+        )
+        .expect("set");
+        vars.end_transaction(EndTransactionAction::Commit);
+        assert_eq!(vars.application_name(), "custom");
+
+        vars.reset_all();
+
+        assert_eq!(vars.application_name(), "startup_default");
+        assert_eq!(
+            vars.inspect("application_name")
+                .unwrap()
+                .inspect_session_value(),
+            None
+        );
     }
 }

--- a/test/sqllogictest/discard.slt
+++ b/test/sqllogictest/discard.slt
@@ -88,3 +88,22 @@ SHOW cluster
 ----
 baz
 COMPLETE 1
+
+# DISCARD ALL must reset session variables over the extended query protocol as
+# well as the simple one (SQL-529). Records without the `simple` directive run
+# over the extended protocol.
+statement ok
+SET extra_float_digits = 1
+
+query T
+SHOW extra_float_digits
+----
+1
+
+statement ok
+DISCARD ALL
+
+query T
+SHOW extra_float_digits
+----
+3


### PR DESCRIPTION
Problem:
Over the extended query protocol, `DISCARD ALL` did not reset session variables to their defaults. It ended the transaction first and then staged the resets, but with no transaction left to commit the staged values were never promoted. Under the simple protocol the next implicit transaction happened to commit them, so the bug was invisible to the existing simple-protocol coverage.

Solution:
Add `SessionVar::reset_durable`, which clears the local, staged, and session values immediately, leaving `default_value` (the system/role/ startup default) intact so `value_dyn` falls through to it. Switch `SessionVars::reset_all` (the sole path used by `DISCARD ALL`) to use it, so the reset no longer depends on a later transaction commit and behaves identically across the simple and extended protocols.

Tests:
- test/sqllogictest/discard.slt: extended-protocol reset-to-default case.
- src/sql/src/session/vars.rs: unit tests for durable reset and for falling back to an installed (startup/role) default.
- src/environmentd/tests/pgwire.rs: extended-protocol integration test driving DISCARD ALL via the extended protocol.

Fixes [SQL-529](https://linear.app/materializeinc/issue/SQL-529)