### PR TITLE
compute: Re-encode LetRec read-edges to the columnar edge

### DIFF
--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -937,9 +937,19 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 let (err_v, err_collection) =
                     Variable::new(self.scope, Product::new(Default::default(), inner));
 
+                // Re-encode the read-edge to columnar so `Get`s on this rec
+                // binding (e.g. as a Union input) see a columnar edge. The
+                // feedback `Variable` itself stays `Vec` (set at `oks_v.set`
+                // below); the recursive value flows `Vec` through the loop, and
+                // only the externally-visible collection is re-containered. The
+                // re-encode is a stateless, timestamp-agnostic pass-through, so
+                // it does not alter the iterative frontier or fixpoint behavior.
                 self.insert_id(
                     Id::Local(*id),
-                    CollectionBundle::from_collections(oks_collection, err_collection),
+                    CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks_collection)),
+                        err_collection,
+                    ),
                 );
                 variables.insert(Id::Local(*id), (oks_v, err_v));
             }
@@ -1009,10 +1019,14 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 let bundle = self.remove_id(Id::Local(id)).unwrap();
                 let (oks, err) = bundle.collection.unwrap();
                 let oks = oks.into_vec();
+                // Extract into the outer scope and re-encode the read-edge to
+                // columnar, so `Get`s on the extracted binding see a columnar
+                // edge. `leave_dynamic` has already stripped the iteration
+                // coordinate, so this runs in the parent scope.
                 self.insert_id(
                     Id::Local(id),
-                    CollectionBundle::from_collections(
-                        oks.leave_dynamic(level + 1),
+                    CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks.leave_dynamic(level + 1))),
                         err.leave_dynamic(level + 1),
                     ),
                 );

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -940,7 +940,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // Re-encode the read-edge to columnar so `Get`s on this rec
                 // binding (e.g. as a Union input) see a columnar edge. The
                 // feedback `Variable` itself stays `Vec` (set at `oks_v.set`
-                // below); the recursive value flows `Vec` through the loop, and
+                // below). The recursive value flows `Vec` through the loop, and
                 // only the externally-visible collection is re-containered. The
                 // re-encode is a stateless, timestamp-agnostic pass-through, so
                 // it does not alter the iterative frontier or fixpoint behavior.

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -950,7 +950,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // Re-encode the read-edge to columnar so `Get`s on this rec
                 // binding (e.g. as a Union input) see a columnar edge. The
                 // feedback `Variable` itself stays `Vec` (set at `oks_v.set`
-                // below); the recursive value flows `Vec` through the loop, and
+                // below). The recursive value flows `Vec` through the loop, and
                 // only the externally-visible collection is re-containered. The
                 // re-encode is a stateless, timestamp-agnostic pass-through, so
                 // it does not alter the iterative frontier or fixpoint behavior.

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -963,14 +963,11 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                     Variable::new(self.scope, Product::new(Default::default(), inner));
 
                 if variable_read.contains(id) {
-                    // Re-encode the read-edge to columnar so `Get`s on this rec
-                    // binding (e.g. as a Union input) see a columnar edge. The
-                    // feedback `Variable` itself stays `Vec` (set at `oks_v.set`
-                    // below), so each iteration crosses the container boundary
-                    // twice: encoded here for the readers, decoded once per
-                    // binding where the value is fed back. The re-encode is a
-                    // stateless, timestamp-agnostic pass-through, so it does not
-                    // alter the iterative frontier or fixpoint behavior.
+                    // The feedback `Variable` stays `Vec`, so each iteration crosses
+                    // the container boundary twice, encoded here for the readers and
+                    // decoded where the value is fed back. The encode is a stateless,
+                    // timestamp-agnostic pass-through, so it leaves the iterative
+                    // frontier and the fixpoint alone.
                     self.insert_id(
                         Id::Local(*id),
                         CollectionBundle::from_edge(
@@ -981,9 +978,8 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 }
                 variables.insert(Id::Local(*id), (oks_v, err_v));
             }
-            // Now render each of the rec bindings. The decoded value is kept so
-            // the extraction below reuses it instead of decoding the same stream
-            // a second time.
+            // The decoded value is kept so the extraction below reuses it rather than
+            // decoding the same stream twice.
             let mut decoded_oks = BTreeMap::new();
             let mut rec_iter = recs.into_iter().peekable();
             while let Some(RecBind { id, value, limit }) = rec_iter.next() {
@@ -1058,10 +1054,8 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 let oks = decoded_oks
                     .remove(&id)
                     .expect("rec binding decoded while rendering above");
-                // Extract into the outer scope and re-encode the read-edge to
-                // columnar, so `Get`s on the extracted binding see a columnar
-                // edge. `leave_dynamic` has already stripped the iteration
-                // coordinate, so this runs in the parent scope.
+                // `leave_dynamic` has already stripped the iteration coordinate, so
+                // this encode runs in the parent scope.
                 self.insert_id(
                     Id::Local(id),
                     CollectionBundle::from_edge(

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -950,10 +950,11 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // Re-encode the read-edge to columnar so `Get`s on this rec
                 // binding (e.g. as a Union input) see a columnar edge. The
                 // feedback `Variable` itself stays `Vec` (set at `oks_v.set`
-                // below). The recursive value flows `Vec` through the loop, and
-                // only the externally-visible collection is re-containered. The
-                // re-encode is a stateless, timestamp-agnostic pass-through, so
-                // it does not alter the iterative frontier or fixpoint behavior.
+                // below), so each iteration crosses the container boundary
+                // twice: encoded here for the readers, decoded once per binding
+                // where the value is fed back. The re-encode is a stateless,
+                // timestamp-agnostic pass-through, so it does not alter the
+                // iterative frontier or fixpoint behavior.
                 self.insert_id(
                     Id::Local(*id),
                     CollectionBundle::from_edge(
@@ -963,7 +964,10 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 );
                 variables.insert(Id::Local(*id), (oks_v, err_v));
             }
-            // Now render each of the rec bindings.
+            // Now render each of the rec bindings. The decoded value is kept so
+            // the extraction below reuses it instead of decoding the same stream
+            // a second time.
+            let mut decoded_oks = BTreeMap::new();
             let mut rec_iter = recs.into_iter().peekable();
             while let Some(RecBind { id, value, limit }) = rec_iter.next() {
                 let last = rec_iter.peek().is_none();
@@ -973,6 +977,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // here to cause that to happen.
                 let (oks, mut err) = bundle.collection.clone().unwrap();
                 let oks = oks.into_vec();
+                decoded_oks.insert(id, oks.clone());
                 // Collapses what forward reads see. `err_v` below feeds reads rendered before this
                 // binding and is collapsed separately; without this, a `Get` in a later rec binding
                 // or in the body resolves to the bundle stored here and compounds level over level,
@@ -1032,8 +1037,10 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
             // Now extract each of the rec bindings into the outer scope.
             for id in rec_ids.into_iter() {
                 let bundle = self.remove_id(Id::Local(id)).unwrap();
-                let (oks, err) = bundle.collection.unwrap();
-                let oks = oks.into_vec();
+                let (_, err) = bundle.collection.unwrap();
+                let oks = decoded_oks
+                    .remove(&id)
+                    .expect("rec binding decoded while rendering above");
                 // Extract into the outer scope and re-encode the read-edge to
                 // columnar, so `Get`s on the extracted binding see a columnar
                 // edge. `leave_dynamic` has already stripped the iteration

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -947,9 +947,19 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 let (err_v, err_collection) =
                     Variable::new(self.scope, Product::new(Default::default(), inner));
 
+                // Re-encode the read-edge to columnar so `Get`s on this rec
+                // binding (e.g. as a Union input) see a columnar edge. The
+                // feedback `Variable` itself stays `Vec` (set at `oks_v.set`
+                // below); the recursive value flows `Vec` through the loop, and
+                // only the externally-visible collection is re-containered. The
+                // re-encode is a stateless, timestamp-agnostic pass-through, so
+                // it does not alter the iterative frontier or fixpoint behavior.
                 self.insert_id(
                     Id::Local(*id),
-                    CollectionBundle::from_collections(oks_collection, err_collection),
+                    CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks_collection)),
+                        err_collection,
+                    ),
                 );
                 variables.insert(Id::Local(*id), (oks_v, err_v));
             }
@@ -1024,10 +1034,14 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 let bundle = self.remove_id(Id::Local(id)).unwrap();
                 let (oks, err) = bundle.collection.unwrap();
                 let oks = oks.into_vec();
+                // Extract into the outer scope and re-encode the read-edge to
+                // columnar, so `Get`s on the extracted binding see a columnar
+                // edge. `leave_dynamic` has already stripped the iteration
+                // coordinate, so this runs in the parent scope.
                 self.insert_id(
                     Id::Local(id),
-                    CollectionBundle::from_collections(
-                        oks.leave_dynamic(level + 1),
+                    CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks.leave_dynamic(level + 1))),
                         err.leave_dynamic(level + 1),
                     ),
                 );

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -935,6 +935,21 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
 
             let rec_ids: Vec<_> = recs.iter().map(|r| r.id).collect();
 
+            // A binding's `Variable` serves the `Get`s rendered before the rec
+            // loop binds the real value, which are exactly the values of
+            // `recs[0..=i]`. A binding no such value reads has no use for a
+            // `Variable`-backed bundle, and installing one would build a
+            // re-encode that repacks the whole collection once per iteration
+            // with nothing to consume it.
+            let mut variable_read = BTreeSet::new();
+            let mut read_so_far = BTreeSet::new();
+            for rec in recs.iter() {
+                read_so_far.extend(rec.value.depends());
+                if read_so_far.contains(&Id::Local(rec.id)) {
+                    variable_read.insert(rec.id);
+                }
+            }
+
             // Define variables for rec bindings.
             // It is important that we only use the `Variable` until the object is bound.
             // At that point, all subsequent uses should have access to the object itself.
@@ -947,21 +962,23 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 let (err_v, err_collection) =
                     Variable::new(self.scope, Product::new(Default::default(), inner));
 
-                // Re-encode the read-edge to columnar so `Get`s on this rec
-                // binding (e.g. as a Union input) see a columnar edge. The
-                // feedback `Variable` itself stays `Vec` (set at `oks_v.set`
-                // below), so each iteration crosses the container boundary
-                // twice: encoded here for the readers, decoded once per binding
-                // where the value is fed back. The re-encode is a stateless,
-                // timestamp-agnostic pass-through, so it does not alter the
-                // iterative frontier or fixpoint behavior.
-                self.insert_id(
-                    Id::Local(*id),
-                    CollectionBundle::from_edge(
-                        CollectionEdge::Columnar(vec_to_columnar(oks_collection)),
-                        err_collection,
-                    ),
-                );
+                if variable_read.contains(id) {
+                    // Re-encode the read-edge to columnar so `Get`s on this rec
+                    // binding (e.g. as a Union input) see a columnar edge. The
+                    // feedback `Variable` itself stays `Vec` (set at `oks_v.set`
+                    // below), so each iteration crosses the container boundary
+                    // twice: encoded here for the readers, decoded once per
+                    // binding where the value is fed back. The re-encode is a
+                    // stateless, timestamp-agnostic pass-through, so it does not
+                    // alter the iterative frontier or fixpoint behavior.
+                    self.insert_id(
+                        Id::Local(*id),
+                        CollectionBundle::from_edge(
+                            CollectionEdge::Columnar(vec_to_columnar(oks_collection)),
+                            err_collection,
+                        ),
+                    );
+                }
                 variables.insert(Id::Local(*id), (oks_v, err_v));
             }
             // Now render each of the rec bindings. The decoded value is kept so

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -419,14 +419,6 @@ pub struct CollectionBundle<'scope, T: RenderTimestamp> {
 }
 
 impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
-    /// Construct a new collection bundle from update streams.
-    pub fn from_collections(
-        oks: VecCollection<'scope, T, Row, Diff>,
-        errs: VecCollection<'scope, T, DataflowErrorSer, Diff>,
-    ) -> Self {
-        Self::from_edge(CollectionEdge::Vec(oks), errs)
-    }
-
     /// Construct a new collection bundle from a [`CollectionEdge`] and an error stream.
     pub fn from_edge(
         oks: CollectionEdge<'scope, T>,

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -454,14 +454,6 @@ pub struct CollectionBundle<'scope, T: RenderTimestamp> {
 }
 
 impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
-    /// Construct a new collection bundle from update streams.
-    pub fn from_collections(
-        oks: VecCollection<'scope, T, Row, Diff>,
-        errs: VecCollection<'scope, T, DataflowErrorSer, Diff>,
-    ) -> Self {
-        Self::from_edge(CollectionEdge::Vec(oks), errs)
-    }
-
     /// Construct a new collection bundle from a [`CollectionEdge`] and an error stream.
     pub fn from_edge(
         oks: CollectionEdge<'scope, T>,

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -670,6 +670,19 @@ WITH MUTUALLY RECURSIVE
     bar(x list_numeric_scale_2) as (SELECT LIST['1'::TEXT])
 SELECT x FROM bar
 
+# A distinct `UNION` whose recursive term is a bare identity `Get` on the rec
+# binding, placed directly as a `Union` input alongside a `Constant`. The
+# identity `Get` returns the binding's collection edge as-is, so this exercises
+# a recursive binding feeding a `Union` unchanged. The union is idempotent under
+# `distinct`, so the binding reaches a fixed point of {1, 2}.
+query I rowsort
+WITH MUTUALLY RECURSIVE
+  foo (x int) AS (VALUES (1), (2) UNION SELECT * FROM foo)
+SELECT * FROM foo
+----
+1
+2
+
 ## Adapted from https://www.sqlite.org/lang_with.html#outlandish_recursive_query_examples
 query T multiline
 WITH MUTUALLY RECURSIVE


### PR DESCRIPTION
Re-encode LetRec recursive-binding read-edges to the columnar edge; the feedback `Variable` stays `Vec`. Removes the second mixed-variant edge source feeding `concat_many`.


Columnar dataflow-edge migration. Design doc: `doc/developer/design/20260720_columnar_dataflow_edges.md` (#37744).

Part of [CPU-51](https://linear.app/materializeinc/issue/CPU-51).
