### PR TITLE
docs: guide for zero-downtime PostgreSQL major-version upgrade

### DIFF
--- a/doc/user/content/ingest-data/postgres/major-version-upgrade.md
+++ b/doc/user/content/ingest-data/postgres/major-version-upgrade.md
@@ -1,0 +1,254 @@
+---
+title: "Guide: Upgrade the major version of your PostgreSQL source"
+description: "How to upgrade the major version of the PostgreSQL database behind a Materialize source with zero downtime."
+menu:
+  main:
+    parent: "postgresql"
+    name: "Upgrade the major version"
+    weight: 90
+---
+
+This guide shows you how to upgrade the **major version** (for example,
+PostgreSQL 15 to 16) of the upstream database behind a Materialize
+[PostgreSQL source](/sql/create-source/postgres/) while keeping Materialize
+serving fresh results.
+
+The challenge specific to Materialize is that the source holds an active
+[logical replication slot](https://www.postgresql.org/docs/current/logical-replication.html)
+on the upstream primary. A major-version upgrade replaces the primary with a
+new instance running the new version, and the replication slot does **not**
+carry over automatically. How you handle the slot determines whether reads stay
+fresh through the upgrade.
+
+This guide covers two approaches:
+
+| Approach | Reads stay fresh? | Who moves the data? | Use when |
+|----------|-------------------|---------------------|----------|
+| [Parallel source (self-managed)](#approach-a-parallel-source-self-managed) | **Yes, continuously** | You (native logical replication) | Zero read downtime is a hard requirement. |
+| [Amazon RDS Blue/Green](#approach-b-amazon-rds-bluegreen-managed) | No — bounded freshness gap | AWS | A brief staleness window is acceptable and you want AWS to manage the cutover. |
+
+{{< note >}}
+Both approaches involve a brief **write** freeze on the application at the
+moment of cutover, which is inherent to any major-version upgrade. The
+difference is whether Materialize keeps serving fresh **reads** throughout.
+{{< /note >}}
+
+## Approach A: Parallel source (self-managed)
+
+This is the only approach that keeps Materialize continuously fresh. You keep
+the existing source running against the old primary the entire time, build the
+new-version primary in parallel, and hydrate a second source against it before
+cutting consumers over.
+
+```text
+app writes ──▶ PG (old major) ──native logical replication──▶ PG (new major)
+                    │                                              │
+                    ▼                                              ▼
+              existing source                                new source
+              (serving fresh)                          (snapshotting + catching up)
+```
+
+### 1. Stand up the new-version primary
+
+Provision a new PostgreSQL instance running the target major version, with
+logical replication enabled (for RDS, `rds.logical_replication = 1`; see
+[enable logical replication](/ingest-data/postgres/amazon-rds/#1-enable-logical-replication)).
+
+Because logical replication does **not** replicate DDL, pre-create the schema of
+the replicated tables on the new instance to match the old one, including
+`REPLICA IDENTITY FULL`:
+
+```sql
+-- On the new-version primary, recreate the table definitions.
+ALTER TABLE my_table REPLICA IDENTITY FULL;
+```
+
+### 2. Replicate old ▶ new with native logical replication
+
+On the **old** primary, create (or reuse) a publication for the tables you
+replicate to Materialize:
+
+```sql
+-- On the old primary.
+CREATE PUBLICATION upgrade_pub FOR TABLE my_table;
+```
+
+On the **new** primary, subscribe to it:
+
+```sql
+-- On the new primary.
+CREATE SUBSCRIPTION upgrade_sub
+    CONNECTION 'host=OLD_PRIMARY_HOST port=5432 dbname=DB user=REPL_USER password=...'
+    PUBLICATION upgrade_pub;
+```
+
+A single publication can feed **multiple** subscribers, so the old primary now
+has two logical consumers at once — Materialize's slot and this subscription's
+slot — coexisting without conflict. Confirm both are active:
+
+```sql
+-- On the old primary.
+SELECT slot_name, plugin, active FROM pg_replication_slots;
+```
+
+{{< warning >}}
+Ensure the new primary can reach the old primary on the PostgreSQL port. In a
+cloud VPC, the upstream endpoint typically resolves to a **private** IP, so the
+security group must allow instance-to-instance traffic — not just the client's
+IP.
+{{< /warning >}}
+
+### 3. Create a parallel source in Materialize
+
+Leave your existing source untouched and serving. Create a **second**
+connection and source pointed at the new primary, in its own schema so the
+subsources and downstream objects don't collide:
+
+```mzsql
+CREATE SCHEMA upgrade;
+
+CREATE SOURCE upgrade.my_source
+    FROM POSTGRES CONNECTION pg_new (PUBLICATION 'upgrade_pub')
+    FOR ALL TABLES;
+```
+
+The new source begins [snapshotting](/ingest-data/#snapshotting) and then
+catches up. Snapshot time scales with data volume and is the long pole of the
+upgrade — but it happens **in the background** while the existing source keeps
+serving fresh. Recreate your downstream views and materialized views in the
+`upgrade` schema on top of the new source.
+
+### 4. Cut over
+
+Once the new source has caught up, perform a coordinated cutover:
+
+1. **Freeze application writes** to the old primary.
+1. **Drain replication:** wait until the new primary matches the old primary
+   exactly. Comparing an order-independent fingerprint across both databases is
+   a reliable check:
+
+    ```sql
+    SELECT count(*), sum(id), min(id), max(id), count(DISTINCT id) FROM my_table;
+    ```
+
+1. **Synchronize sequences.** Native logical replication does **not** advance
+   sequences on the target. Copy each sequence's value forward, or post-cutover
+   inserts will collide on the primary key:
+
+    ```sql
+    -- Read on the old primary...
+    SELECT last_value FROM my_table_id_seq;
+    -- ...then set on the new primary.
+    SELECT setval('my_table_id_seq', <last_value>);
+    ```
+
+1. **Drain both sources** in Materialize so they reflect the frozen state, then
+   verify the fingerprint matches across the old primary, new primary, existing
+   source, and new source.
+1. **Repoint consumers** from the existing source's objects to the `upgrade`
+   schema's objects.
+1. **Resume application writes**, now pointed at the new primary.
+
+Throughout the cutover, reads against Materialize stay live and fresh — the
+existing source serves until the flip, and the new source is already caught up
+at the flip.
+
+### 5. Decommission
+
+Drop the subscription on the new primary, drop the old source in Materialize,
+and decommission the old primary.
+
+## Approach B: Amazon RDS Blue/Green (managed)
+
+[Amazon RDS Blue/Green deployments](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments.html)
+let AWS build the upgraded "green" instance, keep it in sync, and swap
+endpoints at switchover. This is operationally simpler, but it **cannot keep
+Materialize continuously fresh** because of the constraint below.
+
+{{< warning >}}
+**A Blue/Green deployment cannot be created while a Materialize source is
+attached to the blue instance.** Materialize's logical replication slot counts
+as *external replication*, and RDS refuses to create the deployment
+(`CREATING_READ_REPLICA_OF_SOURCE` fails with *"external replication on the blue
+primary instance"*). You must [drop the
+source](/sql/drop-source/) first, which starts an unavoidable **freshness
+gap**. No RDS flag bypasses this.
+{{< /warning >}}
+
+### 1. Detach Materialize and create the deployment
+
+1. `DROP SOURCE` in Materialize to release the replication slot. Confirm
+   `pg_replication_slots` no longer lists Materialize's slot. **The freshness
+   gap starts here.**
+1. Create the Blue/Green deployment, targeting the new major version with a
+   parameter group that has `rds.logical_replication = 1`. Wait for the green
+   instance to become **Available** (a major-version upgrade can take tens of
+   minutes; it scales with database size).
+
+The publication and `REPLICA IDENTITY` settings are copied from blue into green.
+
+### 2. Attach Materialize to green
+
+The green instance is a logical replica that is itself a primary
+(`pg_is_in_recovery()` returns `false`), so it can host Materialize's slot.
+Create a source against **green's temporary endpoint** and let it snapshot and
+catch up:
+
+```mzsql
+CREATE SOURCE my_source
+    FROM POSTGRES CONNECTION pg_green (PUBLICATION 'mz_source')
+    FOR ALL TABLES;
+```
+
+**The freshness gap ends when this source has caught up.** As in Approach A,
+snapshot time scales with data volume.
+
+### 3. Switch over and repoint the source
+
+Trigger the Blue/Green switchover. AWS promotes green **in place** — it takes
+over the production endpoint, while the old blue is demoted and renamed. The
+switchover completes in tens of seconds, during which the application has a
+brief write pause.
+
+Because green is promoted in place (same instance, same LSN timeline), its
+replication slot is preserved. Repoint the source's connection at the
+production endpoint so Materialize resumes from the **same slot with no
+re-snapshot**:
+
+```mzsql
+ALTER CONNECTION pg_green SET (HOST = 'PRODUCTION_ENDPOINT') WITH (VALIDATE = true);
+```
+
+After the switchover, green's temporary endpoint is removed; a source restart
+would otherwise fail to resolve it, so run the `ALTER CONNECTION` promptly.
+
+{{< note >}}
+This seamless resume works **only** because a Blue/Green switchover promotes
+green in place, preserving the slot and LSN timeline. Repointing a source at an
+unrelated instance (one that doesn't carry the same slot) forces a fresh
+snapshot instead.
+{{< /note >}}
+
+### 4. Clean up
+
+Delete the Blue/Green deployment and the demoted old instance.
+
+## Considerations
+
+- **DDL is not replicated.** For Approach A, pre-create the target schema on the
+  new instance before subscribing.
+- **Sequences are not advanced on the target** by native logical replication.
+  Synchronize them at cutover (Approach A) or RDS handles it at switchover
+  (Approach B).
+- **`REPLICA IDENTITY FULL`** must be set on replicated tables so Materialize
+  captures all column values on updates and deletes.
+- **`ALTER CONNECTION ... SET (HOST = ...)`** resumes from the existing slot
+  only when the target instance preserves that slot (an in-place promotion).
+  Otherwise Materialize re-snapshots.
+
+## Related pages
+
+- [Ingest data from Amazon RDS](/ingest-data/postgres/amazon-rds/)
+- [Guide: Ingest from a dedicated PostgreSQL replica](/ingest-data/postgres/logical-replica/)
+- [Guide: Handle upstream schema changes with zero downtime](/ingest-data/postgres/source-versioning/)
+- [`ALTER CONNECTION`](/sql/alter-connection/)

--- a/doc/user/content/ingest-data/postgres/major-version-upgrade.md
+++ b/doc/user/content/ingest-data/postgres/major-version-upgrade.md
@@ -20,25 +20,26 @@ new instance running the new version, and the replication slot does **not**
 carry over automatically. How you handle the slot determines whether reads stay
 fresh through the upgrade.
 
-This guide covers two approaches:
-
-| Approach | Reads stay fresh? | Who moves the data? | Use when |
-|----------|-------------------|---------------------|----------|
-| [Parallel source (self-managed)](#approach-a-parallel-source-self-managed) | **Yes, continuously** | You (native logical replication) | Zero read downtime is a hard requirement. |
-| [Amazon RDS Blue/Green](#approach-b-amazon-rds-bluegreen-managed) | No — bounded freshness gap | AWS | A brief staleness window is acceptable and you want AWS to manage the cutover. |
-
-{{< note >}}
-Both approaches involve a brief **write** freeze on the application at the
-moment of cutover, which is inherent to any major-version upgrade. The
-difference is whether Materialize keeps serving fresh **reads** throughout.
-{{< /note >}}
-
-## Approach A: Parallel source (self-managed)
-
-This is the only approach that keeps Materialize continuously fresh. You keep
-the existing source running against the old primary the entire time, build the
+The approach in this guide keeps Materialize continuously fresh. You keep the
+existing source running against the old primary the entire time, build the
 new-version primary in parallel, and hydrate a second source against it before
 cutting consumers over.
+
+{{< note >}}
+This procedure involves a brief **write** freeze on the application at the
+moment of cutover, which is inherent to any major-version upgrade. Materialize
+keeps serving fresh **reads** throughout.
+{{< /note >}}
+
+{{< warning >}}
+Managed upgrade services that swap the primary out from under Materialize — such
+as [Amazon RDS Blue/Green
+deployments](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments.html)
+— cannot be used while a Materialize source is attached. See [Why managed
+Blue/Green deployments don't work](#why-managed-bluegreen-deployments-dont-work).
+{{< /warning >}}
+
+## Upgrade with a parallel source
 
 ```text
 app writes ──▶ PG (old major) ──native logical replication──▶ PG (new major)
@@ -145,110 +146,86 @@ Once the new source has caught up, perform a coordinated cutover:
 1. **Drain both sources** in Materialize so they reflect the frozen state, then
    verify the fingerprint matches across the old primary, new primary, existing
    source, and new source.
-1. **Repoint consumers** from the existing source's objects to the `upgrade`
-   schema's objects.
+1. **Swap the schemas.** Rather than repointing each consumer, swap the
+   production schema with the `upgrade` schema. The swap is atomic, so
+   consumers keep referencing the same schema-qualified names and move together
+   at a single instant:
+
+    ```mzsql
+    ALTER SCHEMA public SWAP WITH upgrade;
+    ```
+
+    To roll back, run the same statement again.
+
 1. **Resume application writes**, now pointed at the new primary.
 
 Throughout the cutover, reads against Materialize stay live and fresh — the
-existing source serves until the flip, and the new source is already caught up
-at the flip.
+existing source serves until the swap, and the new source is already caught up
+at the swap.
+
+{{< warning >}}
+If you have [sinks](/sql/create-sink/), create them in a **dedicated schema and
+cluster** that is excluded from the swap. Sinks must not be recreated as part of
+a blue/green cutover; instead, cut them over to the new definition of their
+upstream dependencies after the swap. This mirrors the guidance in [blue/green
+deployments with dbt](/manage/dbt/blue-green-deployments/).
+{{< /warning >}}
+
+{{< note >}}
+Any active [`SUBSCRIBE`](/sql/subscribe/) commands attached to the swapped
+cluster(s) will break at the swap. On retry, the client automatically connects
+to the newly deployed cluster.
+{{< /note >}}
 
 ### 5. Decommission
 
 Drop the subscription on the new primary, drop the old source in Materialize,
 and decommission the old primary.
 
-## Approach B: Amazon RDS Blue/Green (managed)
+## Why managed Blue/Green deployments don't work
 
 [Amazon RDS Blue/Green deployments](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments.html)
-let AWS build the upgraded "green" instance, keep it in sync, and swap
-endpoints at switchover. This is operationally simpler, but it **cannot keep
-Materialize continuously fresh** because of the constraint below.
+let AWS build the upgraded "green" instance, keep it in sync, and swap endpoints
+at switchover. This is an appealing shortcut, but it is **not compatible with an
+attached Materialize source**.
 
-{{< warning >}}
-**A Blue/Green deployment cannot be created while a Materialize source is
-attached to the blue instance.** Materialize's logical replication slot counts
-as *external replication*, and RDS refuses to create the deployment
-(`CREATING_READ_REPLICA_OF_SOURCE` fails with *"external replication on the blue
-primary instance"*). You must [drop the
-source](/sql/drop-source/) first, which starts an unavoidable **freshness
-gap**. No RDS flag bypasses this.
-{{< /warning >}}
+Creating the deployment fails at `CREATING_READ_REPLICA_OF_SOURCE` with *"external
+replication on the blue primary instance"*. One of the documented prerequisites
+is that the DB instance is not the source or target of external replication, and
+Materialize's logical replication slot is external replication. No RDS setting
+bypasses this.
 
-### 1. Detach Materialize and create the deployment
+Releasing the slot — by [dropping the source](/sql/drop-source/) — does let the
+deployment be created, but that is not a viable production step:
 
-1. `DROP SOURCE` in Materialize to release the replication slot. Confirm
-   `pg_replication_slots` no longer lists Materialize's slot. **The freshness
-   gap starts here.**
-1. Create the Blue/Green deployment, targeting the new major version with a
-   parameter group that has `rds.logical_replication = 1`. Wait for the green
-   instance to become **Available** (a major-version upgrade can take tens of
-   minutes; it scales with database size).
+- `DROP SOURCE` defaults to `RESTRICT` and fails when the source has dependents.
+  Forcing it with `CASCADE` drops the entire downstream dataflow — tables, views,
+  materialized views, indexes, and sinks — which means rebuilding and rehydrating
+  your environment, not a brief pause.
+- Even after the switchover, Materialize's original slot on blue is unusable, so
+  the new source must snapshot from scratch against green.
 
-The publication and `REPLICA IDENTITY` settings are copied from blue into green.
-
-### 2. Attach Materialize to green
-
-The green instance is a logical replica that is itself a primary
-(`pg_is_in_recovery()` returns `false`), so it can host Materialize's slot.
-Create a source against **green's temporary endpoint** and let it snapshot and
-catch up:
-
-```mzsql
-CREATE SOURCE my_source
-    FROM POSTGRES CONNECTION pg_green (PUBLICATION 'mz_source')
-    FOR ALL TABLES;
-```
-
-**The freshness gap ends when this source has caught up.** As in Approach A,
-snapshot time scales with data volume.
-
-### 3. Switch over and repoint the source
-
-Trigger the Blue/Green switchover. AWS promotes green **in place** — it takes
-over the production endpoint, while the old blue is demoted and renamed. The
-switchover completes in tens of seconds, during which the application has a
-brief write pause.
-
-Because green is promoted in place (same instance, same LSN timeline), its
-replication slot is preserved. Repoint the source's connection at the
-production endpoint so Materialize resumes from the **same slot with no
-re-snapshot**:
-
-```mzsql
-ALTER CONNECTION pg_green SET (HOST = 'PRODUCTION_ENDPOINT') WITH (VALIDATE = true);
-```
-
-After the switchover, green's temporary endpoint is removed; a source restart
-would otherwise fail to resolve it, so run the `ALTER CONNECTION` promptly.
-
-{{< note >}}
-This seamless resume works **only** because a Blue/Green switchover promotes
-green in place, preserving the slot and LSN timeline. Repointing a source at an
-unrelated instance (one that doesn't carry the same slot) forces a fresh
-snapshot instead.
-{{< /note >}}
-
-### 4. Clean up
-
-Delete the Blue/Green deployment and the demoted old instance.
+The result is a staleness window that begins when you detach from blue and lasts
+through provisioning and a full re-snapshot. Use the [parallel
+source](#upgrade-with-a-parallel-source) procedure above instead: it keeps the
+existing source serving fresh for the entire upgrade, and the only coordinated
+pause is the write freeze at cutover.
 
 ## Considerations
 
-- **DDL is not replicated.** For Approach A, pre-create the target schema on the
-  new instance before subscribing.
+- **DDL is not replicated.** Pre-create the target schema on the new instance
+  before subscribing.
 - **Sequences are not advanced on the target** by native logical replication.
-  Synchronize them at cutover (Approach A) or RDS handles it at switchover
-  (Approach B).
+  Synchronize them at cutover.
 - **`REPLICA IDENTITY FULL`** must be set on replicated tables so Materialize
   captures all column values on updates and deletes.
-- **`ALTER CONNECTION ... SET (HOST = ...)`** resumes from the existing slot
-  only when the target instance preserves that slot (an in-place promotion).
-  Otherwise Materialize re-snapshots.
+- **A publication can feed multiple subscribers**, so Materialize's slot and the
+  upgrade subscription's slot coexist on the old primary without conflict.
 
 ## Related pages
 
 - [Ingest data from Amazon RDS](/ingest-data/postgres/amazon-rds/)
 - [Guide: Ingest from a dedicated PostgreSQL replica](/ingest-data/postgres/logical-replica/)
 - [Guide: Handle upstream schema changes with zero downtime](/ingest-data/postgres/source-versioning/)
-- [`ALTER CONNECTION`](/sql/alter-connection/)
+- [Blue/green deployments with dbt](/manage/dbt/blue-green-deployments/)
+- [`ALTER SCHEMA`](/sql/alter-schema/)

--- a/doc/user/shared-content/postgresql-ingest-data-guides.md
+++ b/doc/user/shared-content/postgresql-ingest-data-guides.md
@@ -5,3 +5,4 @@
 - [Google Cloud SQL for PostgreSQL](/ingest-data/postgres/cloud-sql/)
 - [Neon](/ingest-data/postgres/neon/)
 - [Self-hosted PostgreSQL](/ingest-data/postgres/self-hosted/)
+- [Guide: Upgrade the major version of your PostgreSQL source](/ingest-data/postgres/major-version-upgrade/)


### PR DESCRIPTION
## Motivation

Users running a Materialize PostgreSQL source periodically need to upgrade the **major version** of the upstream database (e.g. PG 15 → 16). This is trickier than a normal upgrade because the source holds an active logical replication slot on the primary, and a major-version upgrade replaces that primary. There was no guidance for doing this while keeping Materialize fresh.

## What this adds

A new guide, **Guide: Upgrade the major version of your PostgreSQL source** (`ingest-data/postgres/major-version-upgrade.md`), plus a link from the PostgreSQL guides index.

**The procedure: a parallel source.** Keep the existing source serving against the old primary, feed a new-version primary via native logical replication, hydrate a second source in a separate schema in parallel, then do a coordinated cutover (freeze writes → drain → sync sequences → verify fingerprints → `ALTER SCHEMA ... SWAP WITH` → resume). Reads stay fresh throughout; the only pause is the write freeze inherent to any major-version upgrade.

**Plus a section on why managed Blue/Green deployments don't work.** Amazon RDS Blue/Green is the obvious thing to reach for, so the guide documents exactly where it blocks: creating the deployment fails at `CREATING_READ_REPLICA_OF_SOURCE` with *"external replication on the blue primary instance"*, because Materialize's slot is external replication. No RDS setting bypasses it.

## Changed from the first revision: Approach B is removed

The original version presented RDS Blue/Green as a co-equal second approach with a "bounded freshness gap." That was wrong on the guide's own terms, and reviewers should not have to re-derive why:

- The only way to create the deployment is to release the slot, and `DROP SOURCE` defaults to `RESTRICT`. Forcing it with `CASCADE` takes the entire downstream dataflow — views, materialized views, indexes, sinks. That is a rebuild, not a pause, and the original text did not say so.
- Materialize's slot on blue is unusable after switchover regardless, so the new source re-snapshots against green either way.
- The staleness window therefore spans provisioning **plus** a full re-snapshot, neither of which the user controls. A page titled "zero-downtime major-version upgrade" should not carry that as an approach.

The one thing Blue/Green offered — AWS running the switchover, with `ALTER CONNECTION ... SET (HOST = ...)` resuming from the same slot — only ever saved a *second* re-snapshot after a staleness window that was already mandatory. It rested on a single `db.t3.micro`, single-AZ, ~31k-row test whose infrastructure state no longer exists, and it was not load-bearing for the recommendation either way.

Two fixes carried over into the remaining procedure:

- The cutover said "repoint consumers," which is the same kind of hand-wave. It is now `ALTER SCHEMA ... SWAP WITH` — atomic, consumers keep their schema-qualified names, and rolling back is running it again.
- Added the blue/green caveats from the dbt guide: sinks need a dedicated schema and cluster excluded from the swap, and active `SUBSCRIBE`s break at the swap and reconnect on retry.

## Validation

The parallel-source procedure was validated end-to-end against Amazon RDS PostgreSQL 15.18 → 16.14 under continuous insert/update/delete load, with a `SUM(balance)` transactional invariant and an order-independent fingerprint confirming consistency across both upstream databases and both Materialize sources through cutover — 20/20 samples, zero violations, zero read staleness.

The RDS Blue/Green constraint is reproduced and causal: the deployment fails to create while the source is attached, and the identical command succeeds once the slot is released.

`hugo` builds clean; all shortcodes expand and every internal link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)