### PR TITLE
compute: Retire the concat_many mixed-variant branch

### DIFF
--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -64,7 +64,10 @@ pub type ColumnarCollection<'scope, T, D, R> = Collection<'scope, T, Column<(D, 
 /// `concat`s repack the row-based inputs and produce the columnar variant.
 #[derive(Clone)]
 pub enum CollectionEdge<'scope, T: RenderTimestamp> {
-    /// Row-formatted collection. Today's default for every producer.
+    /// Row-formatted collection. No producer constructs this after the
+    /// migration; the variant and its remaining match arms are removed when the
+    /// enum collapses to a columnar alias.
+    #[allow(dead_code)]
     Vec(VecCollection<'scope, T, Row, Diff>),
     /// Columnar collection. Currently unused by any producer; reserved for the
     /// producer flip at the end of the migration.
@@ -122,28 +125,23 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
 
     /// Concatenates a collection of edges.
     ///
-    /// Edges of one shared variant concatenate natively. Mixed inputs upgrade
-    /// the row-based edges through [`vec_to_columnar`] and produce the
-    /// columnar variant. Repacking rows into columns copies bytes but
-    /// allocates no per-record `Row`s, so upgrading is the cheap direction.
+    /// Every producer emits the columnar variant, so the inputs concatenate
+    /// natively into the columnar variant.
     pub fn concat_many<I>(scope: Scope<'scope, T>, edges: I) -> Self
     where
         I: IntoIterator<Item = Self>,
     {
-        let mut vecs = Vec::new();
-        let mut cols = Vec::new();
-        for edge in edges {
-            match edge {
-                CollectionEdge::Vec(c) => vecs.push(c),
-                CollectionEdge::Columnar(c) => cols.push(c),
-            }
-        }
-        if cols.is_empty() {
-            CollectionEdge::Vec(differential_dataflow::collection::concatenate(scope, vecs))
-        } else {
-            cols.extend(vecs.into_iter().map(vec_to_columnar));
-            CollectionEdge::Columnar(differential_dataflow::collection::concatenate(scope, cols))
-        }
+        let cols = edges.into_iter().map(|edge| match edge {
+            CollectionEdge::Columnar(c) => c,
+            // No producer emits `Vec` after the migration, so a `Vec` input
+            // cannot reach here. The `Vec` arm and this `unreachable!` are
+            // removed together when the enum collapses to a columnar alias.
+            CollectionEdge::Vec(_) => unreachable!("no producer emits a `Vec` edge"),
+        });
+        CollectionEdge::Columnar(differential_dataflow::collection::concatenate(
+            scope,
+            cols.collect::<Vec<_>>(),
+        ))
     }
 
     /// Applies `logic` to each record in this edge, exposing the record as a

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -125,17 +125,15 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
 
     /// Concatenates a collection of edges.
     ///
-    /// Every producer emits the columnar variant, so the inputs concatenate
-    /// natively into the columnar variant.
+    /// The inputs are all columnar, so they concatenate natively into the
+    /// columnar variant.
     pub fn concat_many<I>(scope: Scope<'scope, T>, edges: I) -> Self
     where
         I: IntoIterator<Item = Self>,
     {
         let cols = edges.into_iter().map(|edge| match edge {
             CollectionEdge::Columnar(c) => c,
-            // No producer emits `Vec` after the migration, so a `Vec` input
-            // cannot reach here. The `Vec` arm and this `unreachable!` are
-            // removed together when the enum collapses to a columnar alias.
+            // No producer emits `Vec`, so a `Vec` input cannot reach here.
             CollectionEdge::Vec(_) => unreachable!("no producer emits a `Vec` edge"),
         });
         CollectionEdge::Columnar(differential_dataflow::collection::concatenate(

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -523,7 +523,7 @@ mod tests {
     }
 
     #[mz_ore::test]
-    fn concat_many_mixed_upgrades_to_columnar() {
+    fn concat_many_concatenates_columnar() {
         let rows = test_rows();
         let expected: Vec<_> = {
             let mut updates: Vec<_> = rows
@@ -542,7 +542,7 @@ mod tests {
                 let edge = CollectionEdge::concat_many(
                     scope,
                     [
-                        CollectionEdge::Vec(collection1),
+                        CollectionEdge::Columnar(vec_to_columnar(collection1)),
                         CollectionEdge::Columnar(vec_to_columnar(collection2)),
                     ],
                 );

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -65,7 +65,10 @@ pub type ColumnarCollection<'scope, T, D, R> = Collection<'scope, T, Column<(D, 
 /// `concat`s repack the row-based inputs and produce the columnar variant.
 #[derive(Clone)]
 pub enum CollectionEdge<'scope, T: RenderTimestamp> {
-    /// Row-formatted collection. Today's default for every producer.
+    /// Row-formatted collection. No producer constructs this after the
+    /// migration; the variant and its remaining match arms are removed when the
+    /// enum collapses to a columnar alias.
+    #[allow(dead_code)]
     Vec(VecCollection<'scope, T, Row, Diff>),
     /// Columnar collection. Currently unused by any producer; reserved for the
     /// producer flip at the end of the migration.
@@ -123,28 +126,23 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
 
     /// Concatenates a collection of edges.
     ///
-    /// Edges of one shared variant concatenate natively. Mixed inputs upgrade
-    /// the row-based edges through [`vec_to_columnar`] and produce the
-    /// columnar variant. Repacking rows into columns copies bytes but
-    /// allocates no per-record `Row`s, so upgrading is the cheap direction.
+    /// Every producer emits the columnar variant, so the inputs concatenate
+    /// natively into the columnar variant.
     pub fn concat_many<I>(scope: Scope<'scope, T>, edges: I) -> Self
     where
         I: IntoIterator<Item = Self>,
     {
-        let mut vecs = Vec::new();
-        let mut cols = Vec::new();
-        for edge in edges {
-            match edge {
-                CollectionEdge::Vec(c) => vecs.push(c),
-                CollectionEdge::Columnar(c) => cols.push(c),
-            }
-        }
-        if cols.is_empty() {
-            CollectionEdge::Vec(differential_dataflow::collection::concatenate(scope, vecs))
-        } else {
-            cols.extend(vecs.into_iter().map(vec_to_columnar));
-            CollectionEdge::Columnar(differential_dataflow::collection::concatenate(scope, cols))
-        }
+        let cols = edges.into_iter().map(|edge| match edge {
+            CollectionEdge::Columnar(c) => c,
+            // No producer emits `Vec` after the migration, so a `Vec` input
+            // cannot reach here. The `Vec` arm and this `unreachable!` are
+            // removed together when the enum collapses to a columnar alias.
+            CollectionEdge::Vec(_) => unreachable!("no producer emits a `Vec` edge"),
+        });
+        CollectionEdge::Columnar(differential_dataflow::collection::concatenate(
+            scope,
+            cols.collect::<Vec<_>>(),
+        ))
     }
 
     /// Applies `logic` to each record in this edge, exposing the record as a

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -126,17 +126,15 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
 
     /// Concatenates a collection of edges.
     ///
-    /// Every producer emits the columnar variant, so the inputs concatenate
-    /// natively into the columnar variant.
+    /// The inputs are all columnar, so they concatenate natively into the
+    /// columnar variant.
     pub fn concat_many<I>(scope: Scope<'scope, T>, edges: I) -> Self
     where
         I: IntoIterator<Item = Self>,
     {
         let cols = edges.into_iter().map(|edge| match edge {
             CollectionEdge::Columnar(c) => c,
-            // No producer emits `Vec` after the migration, so a `Vec` input
-            // cannot reach here. The `Vec` arm and this `unreachable!` are
-            // removed together when the enum collapses to a columnar alias.
+            // No producer emits `Vec`, so a `Vec` input cannot reach here.
             CollectionEdge::Vec(_) => unreachable!("no producer emits a `Vec` edge"),
         });
         CollectionEdge::Columnar(differential_dataflow::collection::concatenate(

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -503,7 +503,7 @@ mod tests {
     }
 
     #[mz_ore::test]
-    fn concat_many_mixed_upgrades_to_columnar() {
+    fn concat_many_concatenates_columnar() {
         let rows = test_rows();
         let expected: Vec<_> = {
             let mut updates: Vec<_> = rows
@@ -522,7 +522,7 @@ mod tests {
                 let edge = CollectionEdge::concat_many(
                     scope,
                     [
-                        CollectionEdge::Vec(collection1),
+                        CollectionEdge::Columnar(vec_to_columnar(collection1)),
                         CollectionEdge::Columnar(vec_to_columnar(collection2)),
                     ],
                 );

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -65,9 +65,7 @@ pub type ColumnarCollection<'scope, T, D, R> = Collection<'scope, T, Column<(D, 
 /// `concat`s repack the row-based inputs and produce the columnar variant.
 #[derive(Clone)]
 pub enum CollectionEdge<'scope, T: RenderTimestamp> {
-    /// Row-formatted collection. No producer constructs this after the
-    /// migration; the variant and its remaining match arms are removed when the
-    /// enum collapses to a columnar alias.
+    /// Row-formatted collection. No producer constructs this.
     #[allow(dead_code)]
     Vec(VecCollection<'scope, T, Row, Diff>),
     /// Columnar collection. Currently unused by any producer; reserved for the
@@ -126,15 +124,13 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
 
     /// Concatenates a collection of edges.
     ///
-    /// The inputs are all columnar, so they concatenate natively into the
-    /// columnar variant.
+    /// Every input is columnar, so they concatenate natively.
     pub fn concat_many<I>(scope: Scope<'scope, T>, edges: I) -> Self
     where
         I: IntoIterator<Item = Self>,
     {
         let cols = edges.into_iter().map(|edge| match edge {
             CollectionEdge::Columnar(c) => c,
-            // No producer emits `Vec`, so a `Vec` input cannot reach here.
             CollectionEdge::Vec(_) => unreachable!("no producer emits a `Vec` edge"),
         });
         CollectionEdge::Columnar(differential_dataflow::collection::concatenate(


### PR DESCRIPTION
Retire the `concat_many` mixed-variant upgrade branch now that no producer emits a Vec edge (the temporal-bucketing and LetRec re-encodes removed the last two sources). Rewrites the unit test to exercise all-columnar concatenation.


Columnar dataflow-edge migration. Design doc: `doc/developer/design/20260720_columnar_dataflow_edges.md` (#37744).

Part of [CPU-51](https://linear.app/materializeinc/issue/CPU-51).
