### PR TITLE
compute: scope column_paged_batcher_swap_pageout to Replica

### DIFF
--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -116,7 +116,8 @@ pub const COLUMN_PAGED_BATCHER_SWAP_PAGEOUT: Config<bool> = Config::new(
     "Eagerly evict the column-paged batcher's lz4-compressed swap-backend spill chunks from RSS \
      via `MADV_PAGEOUT` (they otherwise receive no madvise and are reclaimed only lazily). Only \
      meaningful when `column_paged_batcher_lz4 = true` and the swap backend is active.",
-);
+)
+.scoped(ParameterScope::Replica);
 
 /// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
 pub const ENABLE_MZ_JOIN_CORE: Config<bool> = Config::new(


### PR DESCRIPTION
### Motivation

`COLUMN_PAGED_BATCHER_SWAP_PAGEOUT` lacked the `.scoped(ParameterScope::Replica)` annotation its three siblings carry (`enable_column_paged_batcher`, `enable_column_paged_batcher_spill`, `column_paged_batcher_lz4`), so it defaulted to `ParameterScope::Environment`.
The sync loop never built a replica context for it, so per-replica or per-size-family LaunchDarkly rules could not bind and every replica resolved the environment-wide value.
This blocked isolating the eager `MADV_PAGEOUT` layer on a single replica: in the pager hydration variant ladder a `paged_pageout` replica meant to add only the pageout layer silently equalled the `paged_lz4` rung.

Fixes CPU-177.

### Description

Add `.scoped(ParameterScope::Replica)` to match the sibling flags.

### Verification

Compiles clean (`cargo check`, `cargo clippy`).
The LaunchDarkly segment and flag rule for the pageout rung are already in place and will bind once a binary carrying the scope is deployed to staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)