### PR TITLE
docs: Document autoscaling strategy inheritance in dbt blue/green deployments

### DIFF
--- a/doc/user/content/manage/dbt/blue-green-deployments.md
+++ b/doc/user/content/manage/dbt/blue-green-deployments.md
@@ -78,6 +78,17 @@ These environments are later swapped transparently.
     schema named `<schema_name>_dbt_deploy` using the same configuration
     as the current environment to swap with (including privileges).
 
+    If the production cluster has an [autoscaling strategy](/sql/create-cluster/#autoscaling)
+    configured, the deployment cluster inherits it, so the deployment
+    environment temporarily bursts to the configured hydration size while it
+    hydrates ahead of the cutover. To speed up blue/green deployments of a
+    cluster without a strategy, you can configure one using the
+    `alter_cluster_auto_scaling_strategy` operation before running `deploy_init`:
+
+    ```bash
+    dbt run-operation alter_cluster_auto_scaling_strategy --args '{cluster_name: <cluster_name>, auto_scaling_strategy: {on_hydration: {hydration_size: "<size>"}}}'
+    ```
+
 1. Run the dbt project containing the code changes against the new deployment
    environment.
 


### PR DESCRIPTION
Documents that `deploy_init` copies the production cluster's autoscaling strategy to the deployment cluster during dbt blue/green deployments, and shows how to configure a strategy with the `alter_cluster_auto_scaling_strategy` operation to speed up hydration ahead of cutover. Split out of #37800 because the page links to the `/sql/create-cluster/#autoscaling` anchor, which only exists once #37714 merges, so this should land after both.
