### PR TITLE
canary-environment: Add two large Kafka sinks for parity with iceberg

### DIFF
--- a/test/canary-environment/README.md
+++ b/test/canary-environment/README.md
@@ -64,7 +64,7 @@ original schema and the storage objects feeding them move to a parallel
 | `public_mysql_cdc` | MV `mysql_wmr` |
 | `public_mysql_cdc_sources` | MySQL source + source-tables + the `mysql_wmr` sinks |
 | `public_loadgen` | MV `sales_product_product_category` |
-| `public_loadgen_sources` | Kafka sources + source-tables + product/category seed tables + the loadgen Iceberg sinks |
+| `public_loadgen_sources` | Kafka sources + source-tables + product/category seed tables + the loadgen Kafka and Iceberg sinks |
 
 Each materialized view carries a default index on
 `qa_canary_environment_compute` and `GRANT ALL PRIVILEGES` to the canary roles.
@@ -106,6 +106,10 @@ sinks, the five `*_gcs_iceberg_sink` GCS model sinks, and both the
 disable a GCS sink, rename its `.sql` file to `.sql.disabled` (mz-deploy only
 reads `*.sql`, so it skips them) and remove the corresponding testdrive sink
 from `mzcompose.py`.
+
+The five model Kafka sinks and the testdrive-managed
+`public_table.table_mv_sink` are also active. The large loadgen tables sink to
+the `loadgen_customer` and `loadgen_sales` topics with keyed upsert envelopes.
 
 ## What `mz-deploy` does not manage
 

--- a/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/customer_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/customer_sink.sql
@@ -1,0 +1,16 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+CREATE SINK customer_sink
+    IN CLUSTER qa_canary_environment_sinks
+    FROM qa_canary_environment.public_loadgen_sources.customer_tbl
+    INTO KAFKA CONNECTION qa_canary_environment.public.kafka_connection (TOPIC 'loadgen_customer')
+    KEY (key)
+    FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION qa_canary_environment.public.csr_connection
+    ENVELOPE UPSERT;

--- a/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/sales_sink.sql
+++ b/test/canary-environment/models/qa_canary_environment/public_loadgen_sources/sales_sink.sql
@@ -1,0 +1,16 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+CREATE SINK sales_sink
+    IN CLUSTER qa_canary_environment_sinks
+    FROM qa_canary_environment.public_loadgen_sources.sales_tbl
+    INTO KAFKA CONNECTION qa_canary_environment.public.kafka_connection (TOPIC 'loadgen_sales')
+    KEY (key)
+    FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION qa_canary_environment.public.csr_connection
+    ENVELOPE UPSERT;


### PR DESCRIPTION
Noticed in https://materializeinc.slack.com/archives/C08A7H11KP0/p1784575726702849 by @ublubu . We want to also exercise Kafka sinks the same way, so adding them!