### PR TITLE
compute-types: fix missing MapFilterProject import in plan.rs

### DIFF
--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -15,8 +15,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use columnar::Columnar;
 use mz_expr::{
-    CollectionPlan, EvalError, Id, LetRecLimit, LocalId, MfpPlan, OptimizedMirRelationExpr,
-    SafeMfpPlan, TableFunc,
+    CollectionPlan, EvalError, Id, LetRecLimit, LocalId, MapFilterProject, MfpPlan,
+    OptimizedMirRelationExpr, SafeMfpPlan, TableFunc,
 };
 use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;


### PR DESCRIPTION
### Motivation

`main` doesn't compile. #37297 (Hydrate delta-join SELECT paths from raw collections) added a `MapFilterProject::new(...)` call in `src/compute-types/src/plan.rs` without importing the type, breaking `cargo check` for anyone building `mz-compute-types`.

### Description

Add `MapFilterProject` to the existing `use mz_expr::{...}` import list in `plan.rs`. No behavior change.

### Verification

`cargo check -p mz-compute-types` and `cargo clippy -p mz-compute-types --all-targets -- -D warnings` both pass.
