### PR TITLE
console: fix subscribes that never sends and re-subscribe loading flashes for replica utilization charts

### DIFF
--- a/console/src/api/materialize/SubscribeManager.ts
+++ b/console/src/api/materialize/SubscribeManager.ts
@@ -41,6 +41,8 @@ export interface SubscribeState<T> {
   /** The current values at the most recent closed timestamp */
   data: T[];
   snapshotComplete: boolean;
+  /** True while a re-subscribe holds the previous snapshot as `data`. */
+  resubscribing?: boolean;
   error: SubscribeError | undefined;
 }
 
@@ -83,19 +85,25 @@ export class SubscribeManager<T extends object, R> implements Connectable {
    * The subscribe statement must include WITH (PROGRESS) and ENVELOPE UPSERT.
    */
   upsert?: UpsertSubscribeOptions<T>;
-  /** The snapshot state exposed to listeners */
+  /**
+   * The snapshot state exposed to listeners. Normally a projection of
+   * `currentState`, but through a re-subscribe it holds the previous
+   * connection's view until the new snapshot completes (see `onOpen`).
+   */
   snapshotState: SubscribeState<R>;
   private sqlRequest: SqlRequest | undefined;
   private listeners = new Set<() => void>();
   private columns: ColumnMetadata[] = [];
   private closeSocketOnComplete: boolean = false;
   private querySent: boolean = false;
+  /** True when the socket signalled ready before any request was set. */
+  private readyAwaitingRequest: boolean = false;
   private currentTimestamp: number | undefined;
   /** Holds completed timestamp messages, waiting for the flush interval */
   private closedTimestampBuffer: SubscribeRow<T>[] = [];
   /** Holds messages from the socket until the timestamp is closed */
   private currentTimestampBuffer = new Map<number, Array<SubscribeRow<T>>>();
-  /** The current state used internally */
+  /** Per-connection accumulation that `setState` projects into `snapshotState`. */
   private currentState: SubscribeState<SubscribeRow<T>> = {
     data: [],
     snapshotComplete: false,
@@ -141,8 +149,20 @@ export class SubscribeManager<T extends object, R> implements Connectable {
     );
   };
 
+  /** Returns true if a query was already sent on the current connection. */
+  hasActiveQuery() {
+    return this.querySent;
+  }
+
   setRequest = (request: SqlRequest) => {
     this.sqlRequest = request;
+    // ReadyForQuery fires once per connection. If it already fired with no
+    // request set, send now or the query would never be issued.
+    if (this.readyAwaitingRequest && !this.querySent && this.isConnected()) {
+      this.readyAwaitingRequest = false;
+      this.socket.send(request);
+      this.querySent = true;
+    }
   };
 
   disconnect = () => {
@@ -186,11 +206,7 @@ export class SubscribeManager<T extends object, R> implements Connectable {
   }
 
   reset = () => {
-    this.columns = [];
-    this.querySent = false;
-    this.closedTimestampBuffer = [];
-    this.currentTimestamp = undefined;
-    this.currentTimestampBuffer = new Map();
+    this.resetForNewConnection();
     this.setState({
       data: [],
       snapshotComplete: false,
@@ -198,10 +214,36 @@ export class SubscribeManager<T extends object, R> implements Connectable {
     });
   };
 
+  /** Clears connection state and internal buffers without touching the exposed snapshot. */
+  private resetForNewConnection = () => {
+    this.columns = [];
+    this.querySent = false;
+    this.readyAwaitingRequest = false;
+    this.closedTimestampBuffer = [];
+    this.currentTimestamp = undefined;
+    this.currentTimestampBuffer = new Map();
+    this.currentState = {
+      data: [],
+      snapshotComplete: false,
+      error: undefined,
+    };
+  };
+
   onOpen = () => {
-    // We wait until the socket opens successfully to reset state so that we can continue
-    // to show stale data if the socket is closed unexpectedly.
-    this.reset();
+    // Keep showing the previous data until the new snapshot arrives, rather
+    // than flashing the loading state on every reconnect. `resubscribing`
+    // marks the held data. Any following setState clears it.
+    this.resetForNewConnection();
+    if (this.snapshotState.snapshotComplete || this.snapshotState.error) {
+      this.snapshotState = {
+        ...this.snapshotState,
+        resubscribing: this.snapshotState.snapshotComplete,
+        error: undefined,
+      };
+      for (const callback of this.listeners) {
+        callback();
+      }
+    }
   };
 
   onChange = (callback: () => void) => {
@@ -245,6 +287,8 @@ export class SubscribeManager<T extends object, R> implements Connectable {
     if (this.sqlRequest) {
       this.socket.send(this.sqlRequest);
       this.querySent = true;
+    } else {
+      this.readyAwaitingRequest = true;
     }
   };
 

--- a/console/src/api/materialize/useSubscribe.ts
+++ b/console/src/api/materialize/useSubscribe.ts
@@ -44,6 +44,8 @@ export type UseSubscribeReturn<T> = {
   data: T[];
   isError: boolean;
   snapshotComplete: boolean;
+  /** True while a re-subscribe holds the previous data. */
+  resubscribing: boolean;
   error: SubscribeError | undefined;
 };
 
@@ -84,10 +86,8 @@ export function useSubscribe<T extends object, R = SubscribeRow<T>>(
     request,
   });
 
-  const { data, error, snapshotComplete } = React.useSyncExternalStore(
-    subscribe.onChange,
-    subscribe.getSnapshot,
-  );
+  const { data, error, snapshotComplete, resubscribing } =
+    React.useSyncExternalStore(subscribe.onChange, subscribe.getSnapshot);
 
   return {
     data,
@@ -96,6 +96,7 @@ export function useSubscribe<T extends object, R = SubscribeRow<T>>(
     error,
     isError: Boolean(error),
     snapshotComplete,
+    resubscribing: Boolean(resubscribing),
   };
 }
 
@@ -195,10 +196,11 @@ export function useSubscribeManager<T extends object, R = SubscribeRow<T>>({
     }),
   });
 
-  const { data, error, snapshotComplete } = React.useSyncExternalStore(
-    subscribeInstance.onChange,
-    subscribeInstance.getSnapshot,
-  );
+  const { data, error, snapshotComplete, resubscribing } =
+    React.useSyncExternalStore(
+      subscribeInstance.onChange,
+      subscribeInstance.getSnapshot,
+    );
 
   return {
     data,
@@ -207,6 +209,7 @@ export function useSubscribeManager<T extends object, R = SubscribeRow<T>>({
     error,
     isError: Boolean(error),
     snapshotComplete,
+    resubscribing: Boolean(resubscribing),
   };
 }
 

--- a/console/src/hooks/useAutomaticallyConnectSocket.ts
+++ b/console/src/hooks/useAutomaticallyConnectSocket.ts
@@ -79,8 +79,11 @@ export const useAutomaticallyConnectSocket = <T extends object, R>({
     if (!subscribe || !request) return;
     if (previousRequest === request) return;
     subscribe.setRequest(request);
-    // The manager owns the initial connect; only force a reconnect on changes.
-    if (previousRequest === undefined) return;
+    // The manager owns the initial connect, so a request appearing on a
+    // pristine connection needs no reconnect. If a query already ran on this
+    // connection (the request was cleared and set again), reconnect to
+    // replace it, since a connection runs at most one subscribe.
+    if (previousRequest === undefined && !subscribe.hasActiveQuery()) return;
     managerRef.current?.reconnect();
   }, [subscribe, request, previousRequest]);
 

--- a/console/src/platform/clusters/ClusterOverview.tsx
+++ b/console/src/platform/clusters/ClusterOverview.tsx
@@ -91,7 +91,8 @@ const ClusterOverview = () => {
     replicaId,
   });
 
-  const { data, isLoading, isError } = replicaUtilizationHistoryData;
+  const { data, isLoading, isRefreshing, isError } =
+    replicaUtilizationHistoryData;
 
   const { graphData } = data ?? {};
 
@@ -164,6 +165,9 @@ const ClusterOverview = () => {
               Resource Usage
             </Text>
             <HStack>
+              {isRefreshing && (
+                <Spinner size="sm" data-testid="refreshing-spinner" />
+              )}
               {cluster && (
                 <LabeledSelect
                   label="Replicas"

--- a/console/src/platform/clusters/queries.ts
+++ b/console/src/platform/clusters/queries.ts
@@ -489,7 +489,7 @@ function useReplicaUtilizationHistorySubscribe(
     );
   }, [enabled, clusterIdsKey, timePeriodMinutes]);
 
-  const { data, isError, snapshotComplete } = useSubscribe({
+  const { data, isError, snapshotComplete, resubscribing } = useSubscribe({
     subscribe,
     upsertKey: (row) => `${row.data.replicaId} ${row.data.occurredAt}`,
     select: (row) => ({
@@ -520,6 +520,7 @@ function useReplicaUtilizationHistorySubscribe(
   return {
     data: result,
     isLoading: enabled && !snapshotComplete,
+    isRefreshing: enabled && resubscribing,
     isError,
   };
 }
@@ -549,7 +550,7 @@ function useReplicaUtilizationHistoryBinnedSubscribe(
     );
   }, [enabled, clusterIdsKey, timePeriodMinutes]);
 
-  const { data, isError, snapshotComplete } = useSubscribe({
+  const { data, isError, snapshotComplete, resubscribing } = useSubscribe({
     subscribe,
     upsertKey: (row) => `${row.data.replicaId} ${row.data.bucketStart}`,
     select: (row) => parseBinnedSubscribeRow(row.data),
@@ -559,9 +560,13 @@ function useReplicaUtilizationHistoryBinnedSubscribe(
     const endDate = new Date();
     const startDate = subMinutes(endDate, timePeriodMinutes);
 
-    const rows = replicaId
-      ? data.filter((row) => row.replicaId === replicaId)
-      : [...data];
+    // Clip to the window like the SQL does. Held rows from a previous wider
+    // window would otherwise stretch the chart domain past the selected range.
+    const rows = data.filter(
+      (row) =>
+        row.bucketStart.getTime() >= startDate.getTime() &&
+        (!replicaId || row.replicaId === replicaId),
+    );
     // ENVELOPE UPSERT yields an unordered keyed set; the chart needs time order.
     rows.sort((a, b) => a.bucketStart.getTime() - b.bucketStart.getTime());
 
@@ -575,6 +580,7 @@ function useReplicaUtilizationHistoryBinnedSubscribe(
   return {
     data: result,
     isLoading: enabled && !snapshotComplete,
+    isRefreshing: enabled && resubscribing,
     isError,
   };
 }
@@ -647,6 +653,11 @@ export function useReplicaUtilizationHistory(
     data: active.data,
     isLoading: active.isLoading,
     isError: active.isError,
+    isRefreshing: useUnbinnedSubscribe
+      ? unbinnedResult.isRefreshing
+      : useBinnedSubscribe
+        ? binnedResult.isRefreshing
+        : false,
   };
 }
 

--- a/console/src/test/mockSubscribe.ts
+++ b/console/src/test/mockSubscribe.ts
@@ -23,6 +23,7 @@ export function mockUpsertSubscribe<T>(
     data: [],
     isError: false,
     snapshotComplete: true,
+    resubscribing: false,
     error: undefined,
     ...overrides,
   };


### PR DESCRIPTION
### Motivation

We made a switch for replica utilization query to use  subscribe instead of polling the  catalog for metrics.  But for replica utilization queries, we wait for an env check to complete and build the subscribe request asychronously. And the request never got fired so the socket was idle and chart doesn't render until a remount.  setRequest now sends immediately when the socket is ready and idle so that forces a reconnect.

Reconnecting to change the query (switching the time filters in the chart would resubscribe) reset the exposed snapshot along wiht the connction state and flashes the loading container again.  Reset the connection state to separate from the exposed snapshot and hold the previous data until a new snapshot replaces it. Introduced a new state "resubscribing" in the subscribe manager that will also show a small header spinner on the utilization charts to show when the data is refreshing.  Also clipped the binned chart hook rows ot the selected window

Fixes [CNS-115](https://linear.app/materializeinc/issue/CNS-115/resource-usage-graph-failing-and-taking-too-long-to-load)

### Verification

Verified by teleporting in the prod analytics environment in an incognito environment and fixed the behavior in the issue.

https://github.com/user-attachments/assets/01e7f76f-a802-45af-bb15-52d9714dcb12