### PR TITLE
console: [SAS-142] Show account display names instead of UUIDs in the per-account breakdown

### DIFF
--- a/console/src/platform/billing/AccountSpendBreakdown.tsx
+++ b/console/src/platform/billing/AccountSpendBreakdown.tsx
@@ -432,7 +432,7 @@ const AccountLedgerGroup = ({
             />
             <Tooltip label={account.external_customer_id}>
               <Text whiteSpace="nowrap">
-                {shortAccountId(account.external_customer_id)}
+                {account.name || shortAccountId(account.external_customer_id)}
               </Text>
             </Tooltip>
           </LedgerCell>

--- a/console/src/platform/billing/UsagePage.test.tsx
+++ b/console/src/platform/billing/UsagePage.test.tsx
@@ -91,7 +91,7 @@ describe("UsagePage", () => {
           days: oneDay([
             {
               external_customer_id: "parent-org",
-              name: "",
+              name: "Built-Prod",
               clusters: [
                 {
                   environment_id: "environment-parent-0",
@@ -147,6 +147,10 @@ describe("UsagePage", () => {
     expect(accountRows).toHaveLength(2);
     expect(within(accountRows[0]).getByText(formatCurrency(14))).toBeVisible();
     expect(within(accountRows[1]).getByText(formatCurrency(5))).toBeVisible();
+    // The parent has a display name (SAS-142) and renders it in place of the
+    // UUID; the child has none, so its row falls back to the short UUID.
+    expect(within(accountRows[0]).getByText("Built-Prod")).toBeVisible();
+    expect(within(accountRows[1]).getByText("child-or…")).toBeVisible();
     // Each account row also shows its share of the period total (SAS-144):
     // parent 14/19 ≈ 73.7%, child 5/19 ≈ 26.3%.
     expect(within(accountRows[0]).getByText("73.7%")).toBeVisible();

--- a/console/src/platform/billing/dailyBreakdown.ts
+++ b/console/src/platform/billing/dailyBreakdown.ts
@@ -14,9 +14,9 @@ import {
 } from "~/api/cloudGlobalApi";
 
 /**
- * Names aren't available yet (SAS-141/142), so accounts are labelled by their
- * `external_customer_id` UUID. The full id is very wide for a chip or a table
- * cell, so callers show this short prefix and keep the whole id in a tooltip.
+ * Fallback label for an account whose `name` is empty. The full
+ * `external_customer_id` UUID is very wide for a chip or a table cell, so
+ * callers show this short prefix and keep the whole id in a tooltip.
  */
 export function shortAccountId(accountId: string): string {
   return `${accountId.slice(0, 8)}…`;


### PR DESCRIPTION
## Summary
- Render `account.name` as the account group label in the "Spend by account & cluster" ledger, falling back to the short UUID when `name` is empty (SAS-141/SAS-161 landed the field and regenerated types).
- The full UUID stays available in the row's tooltip for disambiguation.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test src/platform/billing` (36/36 passing), including a new case covering both the rendered name and the UUID fallback