### PR TITLE
SS-348: Avoid eager materialization of diff pairs in iter_diff_pairs

### DIFF
--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -42,7 +42,8 @@ where
     }
 }
 
-/// Walks `batch` and emits, for each key, the `DiffPair`s at each timestamp.
+/// Walks `batch` and emits, for each key, an iterator of the `DiffPair`s at
+/// each timestamp.
 ///
 /// Ignores updates outside the specified time range. Inclusive 'lower', exclusive 'upper'.
 ///
@@ -52,6 +53,11 @@ where
 /// no ordering is guaranteed across keys. Callers are responsible for tracking
 /// `(key, timestamp)` boundaries themselves if they need to detect groups
 /// with more than one pair (e.g., for primary-key violation checks).
+///
+/// The per-key iterator owns its data, so it can be held or consumed after the
+/// outer iterator has advanced. An update with multiplicity `n` fans out into
+/// `n` pairs lazily, cloning the value as pairs are consumed. Memory held per
+/// key is proportional to the number of distinct updates, not the fan-out.
 pub fn iter_diff_pairs<B, C>(
     batch: &B,
     lower: Option<Antichain<C::Time>>,
@@ -59,7 +65,7 @@ pub fn iter_diff_pairs<B, C>(
 ) -> impl Iterator<
     Item = (
         <C::KeyContainer as BatchContainer>::Owned,
-        Vec<(C::Time, DiffPair<C::ValOwn>)>,
+        impl Iterator<Item = (C::Time, DiffPair<C::ValOwn>)>,
     ),
 >
 where
@@ -68,16 +74,16 @@ where
     C::Time: Copy,
     C::ValOwn: 'static,
 {
-    let mut befores: Vec<(C::Time, C::ValOwn, usize)> = vec![];
-    let mut afters: Vec<(C::Time, C::ValOwn, usize)> = vec![];
-
     let mut cursor = batch.cursor();
     iter::from_fn(move || {
         while cursor.key_valid(batch) {
             let k = cursor.key(batch);
 
             // Partition updates at this key into retractions (befores) and
-            // insertions (afters).
+            // insertions (afters). The buffers move into the yielded iterator,
+            // so they are per key rather than reused across keys.
+            let mut befores: Vec<(C::Time, C::ValOwn, usize)> = vec![];
+            let mut afters: Vec<(C::Time, C::ValOwn, usize)> = vec![];
             while cursor.val_valid(batch) {
                 let v = cursor.val(batch);
                 cursor.map_times(batch, |t, diff| {
@@ -112,8 +118,8 @@ where
             // Typically, cnt = 1, and `repeat_n((t, v), cnt)` will return the original `(t, v)`.
             // `iter::repeat((t, v)).take(cnt)` would clone `v` `cnt` times even when `cnt = 1`.
             let fan_out = |(t, v, cnt): (C::Time, C::ValOwn, usize)| iter::repeat_n((t, v), cnt);
-            let befores_iter = befores.drain(..).flat_map(fan_out);
-            let afters_iter = afters.drain(..).flat_map(fan_out);
+            let befores_iter = befores.into_iter().flat_map(fan_out);
+            let afters_iter = afters.into_iter().flat_map(fan_out);
 
             let key_owned = <C::KeyContainer as BatchContainer>::into_owned(k);
 
@@ -130,8 +136,7 @@ where
                         EitherOrBoth::Right((t, after)) => (t, None, Some(after)),
                     };
                     (t, DiffPair { before, after })
-                })
-                .collect();
+                });
 
             cursor.step_key(batch);
             return Some((key_owned, pairs));
@@ -185,6 +190,8 @@ pub fn dbz_format(rp: &mut RowPacker, dp: DiffPair<Row>) {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use differential_dataflow::trace::implementations::chunker::ContainerChunker;
     use differential_dataflow::trace::implementations::{ValBatcher, ValBuilder};
     use differential_dataflow::trace::{Batcher, Builder};
@@ -195,14 +202,14 @@ mod tests {
 
     /// Seals a single batch from an unordered list of `((key, val), time, diff)`
     /// tuples upper-bounded at `upper`.
-    fn batch_from_tuples(
-        mut tuples: Vec<((String, String), u64, Diff)>,
+    fn batch_from_tuples_with<V: Ord + Clone + 'static>(
+        mut tuples: Vec<((String, V), u64, Diff)>,
         upper: u64,
-    ) -> <ValBuilder<String, String, u64, Diff> as Builder>::Output {
+    ) -> <ValBuilder<String, V, u64, Diff> as Builder>::Output {
         // The batcher consumes already-chunked input via `PushInto`; chunking
         // is the caller's responsibility.
-        let mut batcher = ValBatcher::<String, String, u64, Diff>::new(None, 0);
-        let mut chunker = ContainerChunker::<Vec<((String, String), u64, Diff)>>::default();
+        let mut batcher = ValBatcher::<String, V, u64, Diff>::new(None, 0);
+        let mut chunker = ContainerChunker::<Vec<((String, V), u64, Diff)>>::default();
         chunker.push_into(&mut tuples);
         while let Some(chunk) = chunker.extract() {
             batcher.push_into(std::mem::take(chunk));
@@ -211,7 +218,16 @@ mod tests {
             batcher.push_into(std::mem::take(chunk));
         }
         let (mut chain, description) = batcher.seal(Antichain::from_elem(upper));
-        ValBuilder::<String, String, u64, Diff>::seal(&mut chain, description)
+        ValBuilder::<String, V, u64, Diff>::seal(&mut chain, description)
+    }
+
+    /// `batch_from_tuples_with` pinned to `String` values, so call sites can
+    /// build values with `.into()`.
+    fn batch_from_tuples(
+        tuples: Vec<((String, String), u64, Diff)>,
+        upper: u64,
+    ) -> <ValBuilder<String, String, u64, Diff> as Builder>::Output {
+        batch_from_tuples_with(tuples, upper)
     }
 
     /// Collects `for_each_diff_pair` invocations into a flat, deterministically
@@ -480,5 +496,86 @@ mod tests {
         let batch = batch_from_tuples(vec![(("k1".into(), "v1".into()), 5, Diff::ONE)], 6);
         let items = collect_bounded_diff_pairs(&batch, Some(6), None);
         assert_eq!(items, vec![]);
+    }
+
+    thread_local! {
+        static TRACKED_LIVE: Cell<usize> = const { Cell::new(0) };
+        static TRACKED_PEAK: Cell<usize> = const { Cell::new(0) };
+    }
+
+    /// Value type that records the peak number of simultaneously live
+    /// instances on this thread, to observe cloning behavior.
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+    struct Tracked(String);
+
+    impl Tracked {
+        fn new(s: &str) -> Self {
+            Self::record_live();
+            Tracked(s.into())
+        }
+
+        fn record_live() {
+            let live = TRACKED_LIVE.with(|l| {
+                l.set(l.get() + 1);
+                l.get()
+            });
+            TRACKED_PEAK.with(|p| p.set(p.get().max(live)));
+        }
+
+        /// Resets the peak to the current live count and returns that count.
+        fn reset_peak() -> usize {
+            let live = TRACKED_LIVE.with(Cell::get);
+            TRACKED_PEAK.with(|p| p.set(live));
+            live
+        }
+
+        fn peak() -> usize {
+            TRACKED_PEAK.with(Cell::get)
+        }
+    }
+
+    impl Clone for Tracked {
+        fn clone(&self) -> Self {
+            Self::record_live();
+            Tracked(self.0.clone())
+        }
+    }
+
+    impl Drop for Tracked {
+        fn drop(&mut self) {
+            TRACKED_LIVE.with(|l| l.set(l.get() - 1));
+        }
+    }
+
+    #[mz_ore::test]
+    fn fan_out_clones_lazily() {
+        // A hot key: one consolidated update whose diff fans out into many
+        // pairs. Consuming the pairs one at a time must not materialize the
+        // fan-out; only the buffered update and the pair in flight may hold a
+        // clone of the value. An implementation that collects the fan-out
+        // (e.g. into a per-key Vec) peaks at FAN_OUT live clones instead and
+        // regresses sink memory in proportion to the hottest key.
+        const FAN_OUT: i64 = 1000;
+        let batch = batch_from_tuples_with(
+            vec![(("k1".into(), Tracked::new("v1")), 5, Diff::from(FAN_OUT))],
+            6,
+        );
+
+        let baseline = Tracked::reset_peak();
+        let mut pair_count = 0i64;
+        for (_key, pairs) in iter_diff_pairs(&batch, None, None) {
+            for (_time, pair) in pairs {
+                pair_count += 1;
+                drop(pair);
+            }
+        }
+        assert_eq!(pair_count, FAN_OUT);
+
+        let peak_extra = Tracked::peak() - baseline;
+        assert!(
+            peak_extra <= 3,
+            "walking the fan-out held {peak_extra} extra live values at peak, \
+             expected O(1) rather than O(FAN_OUT)"
+        );
     }
 }


### PR DESCRIPTION
Skip materialization of diff pairs (i.e. collect()) as it causes memory bloat in some cases. This PR changes the return type to a lazy iterator and adds a unit test to validate the issue and confirm the fix.

ref: @def- found a [pathological case in refactor of for_each_diff_pair that results in high memory usage ](https://github.com/MaterializeInc/materialize/pull/37759#pullrequestreview-4756022498) shortly after it was merged.