### PR TITLE
SS-331 Webhook Source Versioning Docs + Test

### DIFF
--- a/doc/user/content/ingest-data/webhooks/change-included-headers.md
+++ b/doc/user/content/ingest-data/webhooks/change-included-headers.md
@@ -1,0 +1,148 @@
+---
+title: "Change a webhook source's included headers"
+description: "Use ALTER SCHEMA ... SWAP WITH to change which headers a webhook source exposes, without changing the endpoint URL your senders use."
+menu:
+  main:
+    parent: "webhooks"
+    name: "Changing included headers"
+    weight: 2
+---
+
+A webhook source fixes its column shape when you create it, including which
+request headers it exposes through [`INCLUDE HEADER` /
+`INCLUDE HEADERS`](/sql/create-source/webhook/#exposing-headers). You cannot alter
+the header configuration of an existing webhook source in place. To change it,
+create a new source with the header configuration you want in a separate schema,
+then swap it into place with [`ALTER SCHEMA ...
+SWAP WITH`](/sql/alter-schema/#swap-with). Because the swap only renames schemas,
+the [webhook endpoint URL](/sql/create-source/webhook/#webhook-url) that your
+senders post to stays the same.
+
+{{< tip >}}
+{{< guided-tour-blurb-for-ingest-data >}}
+{{< /tip >}}
+
+{{< warning >}}
+
+Unlike a Kafka or database source, a webhook source has no upstream system to
+re-read. The replacement source starts **empty**: it only contains webhook calls
+received **after** the swap. Events delivered to the original source are **not**
+copied to the replacement, and are lost for good once you drop the original
+source. Only perform the swap when losing the original source's history is
+acceptable, or keep the original source around to continue querying its past
+data.
+
+{{< /warning >}}
+
+## How it works
+
+The webhook endpoint URL is derived from the source's fully qualified name:
+
+```
+https://<HOST>/api/webhook/<database>/<schema>/<src_name>
+```
+
+Because the schema is part of the URL, building the replacement in a different
+schema and then swapping the two schemas atomically leaves the original URL
+resolving to the new source. Senders keep posting to the same URL, and downstream
+objects keep referencing the same name.
+
+## Before you begin
+
+You need a Materialize account and a cluster to host the source. The examples
+below use the `quickstart` cluster and omit the `CHECK` clause for brevity. In
+production, always [validate requests](/sql/create-source/webhook/#validating-requests)
+with a `CHECK` clause.
+
+## Step 1. Create the initial source
+
+Create the original source in a `prod` schema. This version exposes a single
+`foo` header as its own column:
+
+```mzsql
+CREATE SCHEMA prod;
+
+CREATE SOURCE prod.events
+  IN CLUSTER quickstart
+  FROM WEBHOOK
+  BODY FORMAT JSON
+  INCLUDE HEADER 'foo' AS foo;
+```
+
+The source has a `foo` column alongside the `body`:
+
+Column | Type    | Nullable?
+-------|---------|-----------
+ body  | `jsonb` | No
+ foo   | `text`  | Yes
+
+Point your webhook sender at
+`https://<HOST>/api/webhook/materialize/prod/events`. Incoming events accumulate
+in `prod.events`.
+
+## Step 2. Create the replacement with the new header configuration
+
+Suppose you now want to expose **all** headers except a sensitive `bar` header,
+rather than only `foo`. Build the replacement in a separate `staging` schema
+using the `INCLUDE HEADERS ( NOT ... )` syntax:
+
+```mzsql
+CREATE SCHEMA staging;
+
+CREATE SOURCE staging.events
+  IN CLUSTER quickstart
+  FROM WEBHOOK
+  BODY FORMAT JSON
+  INCLUDE HEADERS ( NOT 'bar' );
+```
+
+Instead of a single `foo` column, this version has a `headers` map column that
+contains every header except `bar`:
+
+Column  | Type                | Nullable?
+--------|---------------------|-----------
+ body   | `jsonb`             | No
+ headers | `map[text => text]` | No
+
+At this point nothing is posting to `staging.events` yet, so it is empty. Your
+senders are still delivering to `prod.events`.
+
+## Step 3. Swap the schemas
+
+Swap the two schemas to cut over. The swap is atomic:
+
+```mzsql
+ALTER SCHEMA prod SWAP WITH staging;
+```
+
+After the swap:
+
+- `prod.events` now resolves to the new source (the `headers` map version), so
+  the unchanged endpoint URL `.../materialize/prod/events` and any downstream
+  objects that reference `prod.events` immediately pick up the new shape.
+- The original source now lives at `staging.events`, retaining the data it
+  ingested before the swap.
+
+New webhook calls to `prod.events` land in the new source and expose the
+`headers` map. As noted in the warning above, the events that arrived before the
+swap remain only in `staging.events` (the old source) and are **not** present in
+the new `prod.events`.
+
+## Step 4. Clean up
+
+Once you have validated the cutover, drop the retired source. This permanently
+discards the data it ingested before the swap:
+
+```mzsql
+DROP SCHEMA staging CASCADE;
+```
+
+If you need to preserve the original source's historical events, copy them into a
+table or downstream object **before** dropping it, or leave the `staging` schema
+in place and query it as needed.
+
+## See also
+
+- [`CREATE SOURCE: Webhook`](/sql/create-source/webhook/)
+- [`ALTER SCHEMA ... SWAP WITH`](/sql/alter-schema/#swap-with)
+- [Webhooks quickstart](/ingest-data/webhooks/webhook-quickstart/)

--- a/doc/user/content/ingest-data/webhooks/change-included-headers.md
+++ b/doc/user/content/ingest-data/webhooks/change-included-headers.md
@@ -14,7 +14,7 @@ request headers it exposes through [`INCLUDE HEADER` /
 the header configuration of an existing webhook source in place. To change it,
 create a new source with the header configuration you want in a separate schema,
 then swap it into place with [`ALTER SCHEMA ...
-SWAP WITH`](/sql/alter-schema/#swap-with). Because the swap only renames schemas,
+SWAP WITH`](/sql/alter-schema/). Because the swap only renames schemas,
 the [webhook endpoint URL](/sql/create-source/webhook/#webhook-url) that your
 senders post to stays the same.
 
@@ -144,5 +144,5 @@ in place and query it as needed.
 ## See also
 
 - [`CREATE SOURCE: Webhook`](/sql/create-source/webhook/)
-- [`ALTER SCHEMA ... SWAP WITH`](/sql/alter-schema/#swap-with)
+- [`ALTER SCHEMA ... SWAP WITH`](/sql/alter-schema/)
 - [Webhooks quickstart](/ingest-data/webhooks/webhook-quickstart/)

--- a/test/testdrive/webhook-source-versioning.td
+++ b/test/testdrive/webhook-source-versioning.td
@@ -1,0 +1,112 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Exercises the blue/green schema-swap technique for versioning a webhook
+# source. A replacement webhook source with a different header configuration is
+# built in a separate schema, then swapped into place so that consumers keep
+# referencing the original name without any downtime.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_alter_swap = true;
+
+$ set-arg-default default-storage-size=scale=1,workers=1
+
+> CREATE CLUSTER webhook_versioning_cluster REPLICAS (r1 (SIZE '${arg.default-storage-size}'));
+
+> CREATE SCHEMA prod;
+
+# v1: the webhook exposes only the `app` header, projected into its own column.
+> CREATE SOURCE prod.events IN CLUSTER webhook_versioning_cluster FROM WEBHOOK
+  BODY FORMAT JSON
+  INCLUDE HEADER 'app' AS app;
+
+> SHOW COLUMNS FROM prod.events;
+name  nullable  type   comment
+-------------------------------
+app   true      text   ""
+body  false     jsonb  ""
+
+$ webhook-append database=materialize schema=prod name=events content-type=application/json app=orders
+{"id":1}
+
+$ webhook-append database=materialize schema=prod name=events content-type=application/json app=orders
+{"id":2}
+
+> SELECT body, app FROM prod.events;
+"{\"id\":1}" orders
+"{\"id\":2}" orders
+
+# Capture the original prod schema id so we can prove the swap exchanged the
+# two schemas.
+$ set-from-sql var=prod-schema-id
+SELECT id::text FROM mz_schemas WHERE name = 'prod';
+
+# v2: build the replacement in a staging schema. Unlike v1, this version
+# captures every header as a `headers` map instead of a single `app` column.
+> CREATE SCHEMA staging;
+
+> CREATE SOURCE staging.events IN CLUSTER webhook_versioning_cluster FROM WEBHOOK
+  BODY FORMAT JSON
+  INCLUDE HEADERS;
+
+> SHOW COLUMNS FROM staging.events;
+name     nullable  type   comment
+----------------------------------
+body     false     jsonb  ""
+headers  false     map    ""
+
+$ webhook-append database=materialize schema=staging name=events content-type=application/json app=orders
+{"id":100}
+
+> SELECT body, headers -> 'app' FROM staging.events;
+"{\"id\":100}" orders
+
+# Cut over: swap the staging schema into prod. Consumers keep referencing
+# `prod.events`, which now resolves to the v2 definition.
+> ALTER SCHEMA prod SWAP WITH staging;
+
+# The schema that used to be named `prod` is now named `staging`.
+> SELECT name FROM mz_schemas WHERE id = '${prod-schema-id}';
+staging
+
+# `prod.events` now has the v2 shape (a `headers` map) and serves the v2 data.
+> SHOW COLUMNS FROM prod.events;
+name     nullable  type   comment
+----------------------------------
+body     false     jsonb  ""
+headers  false     map    ""
+
+> SELECT body, headers -> 'app' FROM prod.events;
+"{\"id\":100}" orders
+
+# The retired v1 definition now lives under the staging name, keeping its data.
+> SHOW COLUMNS FROM staging.events;
+name  nullable  type   comment
+-------------------------------
+app   true      text   ""
+body  false     jsonb  ""
+
+> SELECT body, app FROM staging.events;
+"{\"id\":1}" orders
+"{\"id\":2}" orders
+
+# New posts to `prod.events` land in the v2 source, exposing the headers map.
+$ webhook-append database=materialize schema=prod name=events content-type=application/json app=payments
+{"id":200}
+
+> SELECT body, headers -> 'app' FROM prod.events;
+"{\"id\":100}" orders
+"{\"id\":200}" payments
+
+# Once the cutover is validated, drop the retired definition.
+> DROP SCHEMA staging CASCADE;
+
+> SELECT body, headers -> 'app' FROM prod.events;
+"{\"id\":100}" orders
+"{\"id\":200}" payments


### PR DESCRIPTION
Adds a how-to under `ingest-data/webhooks` explaining how to change which request headers a webhook source exposes.

A webhook source fixes its column shape (including its `INCLUDE HEADER` / `INCLUDE HEADERS` configuration) at creation and cannot be altered in place. This guide walks through building a replacement source with the new header configuration in a separate schema and swapping it into place with [`ALTER SCHEMA ... SWAP WITH`](/sql/alter-schema/#swap-with), so the endpoint URL and downstream references stay the same.

- Demonstrates the cutover with both header syntaxes: `INCLUDE HEADER 'foo' AS foo` (v1) and `INCLUDE HEADERS ( NOT 'bar' )` (v2).
- Prominently warns (via a `{{< warning >}}` admonition) that a webhook source has no upstream to re-read: the replacement starts empty and only contains webhook calls received **after** the swap; the original source's events are not copied and are lost once it is dropped.

Validated with `hugo` (builds clean) and the mz-doc-edit editorial pass (guided-tour tip + admonition padding applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)