### PR TITLE
sql: Validate array literals and array_fill dimensions fully

### DIFF
--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -267,6 +267,11 @@ fn array_fill<'a>(
         return Err(EvalError::MustNotBeNull(NULL_ARR_ERR.into()));
     };
 
+    // The dimensions array must be one-dimensional.
+    if arr.dims().ndims() > 1 {
+        return Err(EvalError::ArrayFillWrongArraySubscripts);
+    }
+
     let dimensions = arr
         .elements()
         .iter()
@@ -281,6 +286,11 @@ fn array_fill<'a>(
             let Some(arr) = d else {
                 return Err(EvalError::MustNotBeNull(NULL_ARR_ERR.into()));
             };
+
+            // The lower bounds array must be one-dimensional.
+            if arr.dims().ndims() > 1 {
+                return Err(EvalError::ArrayFillWrongArraySubscripts);
+            }
 
             arr.elements()
                 .iter()

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -940,7 +940,7 @@ where
             }
 
             if builder.elements.is_empty() {
-                // Per PG, empty arrays are represented by empty dimensions
+                // Empty arrays are represented by empty dimensions
                 // rather than one dimension with 0 length.
                 return Ok((vec![], vec![]));
             }
@@ -1039,7 +1039,14 @@ where
             // Commit an element of this dimension
             self.commit_element(false)?;
 
+            let ndims = self.dimensions.len();
             let d = &mut self.dimensions[self.current_dim];
+
+            // Empty dimensions are only permitted in one-dimensional
+            // arrays, i.e. the only valid empty array literal is `{}`.
+            if d.committed_element_count == 0 && ndims > 1 {
+                return Err(UnexpectedChar(self.current_command_char));
+            }
 
             // Ensure that the elements in this dimension conform to the expected shape.
             match d.length {

--- a/test/sqllogictest/array_fill.slt
+++ b/test/sqllogictest/array_fill.slt
@@ -77,6 +77,13 @@ SELECT array_fill(5, array[]::int[], array[2, 1])
 query error wrong number of array subscripts
 SELECT array_fill(5, array[3, 1], array[]::int[])
 
+# Dimension and lower bound arrays must be one-dimensional
+query error wrong number of array subscripts
+SELECT array_fill(1, array[[1, 2], [3, 4]])
+
+query error wrong number of array subscripts
+SELECT array_fill(1, array[2, 3], array[[1, 2]])
+
 # Reveal structure of array
 query T
 SELECT

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -1152,18 +1152,11 @@ FROM (
         ('{{{a}},{{a}}}'),
         ('{{{a}},{{null}}}'),
         ('{}'),
-        ('{{},{}}'),
-        ('{{{}},{{}}}'),
-        ('{{{null}},{{null}}}'),
-        -- Can exceed max dims with empty array which consolidates down
-        ('{{{{{{{},{}}}}}}}')
+        ('{{{null}},{{null}}}')
     ) AS x (a)
 ) AS x (v);
 ----
 end
-{}	end
-{}	end
-{}	end
 {}	end
 {""}	1		end
 {'}	1	'	end
@@ -1296,7 +1289,7 @@ SELECT '{{a}'::int[];
 query error invalid input syntax for type array: Junk after closing right brace\.: "\{a\}\}"
 SELECT '{a}}'::int[];
 
-query error invalid input syntax for type array: Unexpected end of input\.: "\{\{\}"
+query error invalid input syntax for type array: Unexpected "\}" character\.: "\{\{\}"
 SELECT '{{}'::int[];
 
 query error invalid input syntax for type array: Junk after closing right brace\.: "\{\}\}"
@@ -1308,7 +1301,7 @@ SELECT '{  {a}'::int[];
 query error invalid input syntax for type array: Junk after closing right brace\.: "\{  a\}\}"
 SELECT '{  a}}'::int[];
 
-query error invalid input syntax for type array: Unexpected end of input\.: "\{\{  \}"
+query error invalid input syntax for type array: Unexpected "\}" character\.: "\{\{  \}"
 SELECT '{{  }'::int[];
 
 query error invalid input syntax for type array: Junk after closing right brace\.: "\{\}  \}"
@@ -1325,7 +1318,7 @@ SELECT '{{1}{1}}'::text[];
 query error invalid input syntax for type array: Junk after closing right brace\.: "\{\}\{\}"
 SELECT '{}{}'::text[];
 
-query error invalid input syntax for type array: Unexpected "\{" character\.: "\{\{\}\{\}\}"
+query error invalid input syntax for type array: Unexpected "\}" character\.: "\{\{\}\{\}\}"
 SELECT '{{}{}}'::text[];
 
 #
@@ -1347,16 +1340,16 @@ SELECT '{{1},{{2}}}'::text[];
 query error invalid input syntax for type array: Unexpected array element\.: "\{\{\{1\}\},\{2\}\}"
 SELECT '{{{1}},{2}}'::text[];
 
-query error invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{\},\{\{\}\}\}"
+query error invalid input syntax for type array: Unexpected "\}" character\.: "\{\{\},\{\{\}\}\}"
 SELECT '{{},{{}}}'::text[];
 
-query error invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{\{\}\},\{\}\}"
+query error invalid input syntax for type array: Unexpected "\}" character\.: "\{\{\{\}\},\{\}\}"
 SELECT '{{{}},{}}'::text[];
 
-query error invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{1\},\{\}\}"
+query error invalid input syntax for type array: Unexpected "\}" character\.: "\{\{1\},\{\}\}"
 SELECT '{{1},{}}'::text[];
 
-query error invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{\},\{1\}\}"
+query error invalid input syntax for type array: Unexpected "\}" character\.: "\{\{\},\{1\}\}"
 SELECT '{{},{1}}'::text[];
 
 query error invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{1,2\},\{1\}\}"
@@ -1370,8 +1363,16 @@ SELECT '{null, {1}}'::text[];
 query error invalid input syntax for type array: Unexpected array element\.: "\{\{1\}, null\}"
 SELECT '{{1}, null}'::text[];
 
-query error invalid input syntax for type array: Multidimensional arrays must have sub\-arrays with matching dimensions\.: "\{\{\{null\}\},\{\{\}\}\}"
+query error invalid input syntax for type array: Unexpected "\}" character\.: "\{\{\{null\}\},\{\{\}\}\}"
 SELECT '{{{null}},{{}}}'::text[];
+
+#
+# Empty dimensions are only allowed in one-dimensional arrays
+query error invalid input syntax for type array: Unexpected "\}" character\.: "\{\{\}\}"
+SELECT '{{}}'::text[];
+
+query error invalid input syntax for type array: Unexpected "\}" character\.: "\{\{\},\{\}\}"
+SELECT '{{},{}}'::text[];
 
 # Exceeded dimensions
 query error number of array dimensions \(7\) exceeds the maximum allowed \(6\)
@@ -1418,7 +1419,7 @@ statement ok
 CREATE TABLE t5 (row_index int, multi_dim_text_array_empty TEXT[][], multi_dim_text_array_two_elem TEXT[][]);
 
 statement ok
-INSERT INTO t5 SELECT 0, '{{}}'::TEXT[][], '{{a, b}, {a, A}}'::TEXT[][];
+INSERT INTO t5 SELECT 0, '{}'::TEXT[][], '{{a, b}, {a, A}}'::TEXT[][];
 
 query T
 SELECT ((multi_dim_text_array_empty) @> (multi_dim_text_array_two_elem)) FROM t5;


### PR DESCRIPTION
Per PG, empty dimensions in array literals are only valid in one-dimensional arrays, so '{{},{}}'::text[] is now rejected instead of parsing as {}. Also per PG, the dimensions and lower bounds arguments of array_fill must be one-dimensional, so
array_fill(1, array[[1,2],[3,4]]) now errors instead of inventing a 4-D array.

Closes: SQL-480