### PR TITLE
pgrepr: Reject out-of-range binary time parameters

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -914,6 +914,14 @@ fn test_pgtest_mz_numeric_binary_overflow() {
 }
 
 #[mz_ore::test]
+fn test_pgtest_mz_time_binary_out_of_range() {
+    pg_test_inner(
+        Path::new("../../test/pgtest-mz/time-binary-out-of-range.pt"),
+        true,
+    );
+}
+
+#[mz_ore::test]
 fn test_pgtest_mz_parse_started() {
     pg_test_inner(Path::new("../../test/pgtest-mz/parse-started.pt"), true);
 }

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -916,7 +916,25 @@ impl Value {
             Type::Text => decode_binary_string(ty, raw).map(Value::Text),
             Type::BpChar { .. } => decode_binary_string(ty, raw).map(Value::BpChar),
             Type::VarChar { .. } => decode_binary_string(ty, raw).map(Value::VarChar),
-            Type::Time { .. } => NaiveTime::from_sql(ty.inner(), raw).map(Value::Time),
+            Type::Time { .. } => {
+                // The wire value is microseconds since midnight. Do not use
+                // `NaiveTime::from_sql`. Its duration arithmetic silently
+                // wraps around midnight, turning out-of-range values like
+                // 24:00:00 into 00:00:00. Reject them instead, including
+                // 24:00:00 itself, which `NaiveTime` cannot represent and
+                // the text path rejects too.
+                const USECS_PER_DAY: i64 = 24 * 60 * 60 * 1_000_000;
+                let usecs = i64::from_sql(ty.inner(), raw)?;
+                if !(0..USECS_PER_DAY).contains(&usecs) {
+                    return Err("time out of range".into());
+                }
+                let secs = u32::try_from(usecs / 1_000_000).expect("less than 86,400");
+                let nanos = u32::try_from(usecs % 1_000_000).expect("less than 1,000,000") * 1_000;
+                Ok(Value::Time(
+                    NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos)
+                        .expect("validated against USECS_PER_DAY"),
+                ))
+            }
             Type::TimeTz { .. } => Err("input of timetz types is not implemented".into()),
             Type::Timestamp { .. } => {
                 let ts = NaiveDateTime::from_sql(ty.inner(), raw)?;
@@ -1104,6 +1122,33 @@ mod tests {
             panic!("decode_text of a numeric must yield Value::Numeric");
         };
         assert_eq!(text, expected, "text decode did not rescale to scale 2");
+    }
+
+    /// Binary time values are microseconds since midnight. Out-of-range
+    /// values, including 24:00:00, must error rather than silently wrap
+    /// around midnight (SQL-473).
+    #[mz_ore::test]
+    fn decode_binary_time_rejects_out_of_range() {
+        const USECS_PER_DAY: i64 = 24 * 60 * 60 * 1_000_000;
+        let ty = Type::Time { precision: None };
+
+        for usecs in [USECS_PER_DAY, USECS_PER_DAY + 1, -1, i64::MIN, i64::MAX] {
+            let res = Value::decode_binary(&ty, &usecs.to_be_bytes());
+            assert_eq!(
+                res.map(|_| ()).map_err(|e| e.to_string()).unwrap_err(),
+                "time out of range",
+                "{usecs} microseconds must be rejected",
+            );
+        }
+
+        let Value::Time(t) = Value::decode_binary(&ty, &(USECS_PER_DAY - 1).to_be_bytes()).unwrap()
+        else {
+            panic!("decoding a time value must yield Value::Time");
+        };
+        assert_eq!(
+            t,
+            NaiveTime::from_hms_micro_opt(23, 59, 59, 999_999).unwrap()
+        );
     }
 
     /// Text values must never contain NUL characters, in either wire format.

--- a/test/pgtest-mz/time-binary-out-of-range.pt
+++ b/test/pgtest-mz/time-binary-out-of-range.pt
@@ -1,0 +1,51 @@
+# Regression test for SQL-473: a binary time Bind parameter of 24:00:00
+# (86_400_000_000 microseconds since midnight) silently wrapped around
+# midnight and decoded as 00:00:00. Out-of-range binary times must error
+# instead, like the text path.
+
+# 24:00:00 = 86_400_000_000 microseconds.
+send
+Parse {"query": "SELECT $1::time"}
+Bind {"param_formats": [1], "binary_values": [[0, 0, 0, 20, 29, 215, 96, 0]]}
+Execute
+Sync
+----
+
+until err_field_typs=CM
+ReadyForQuery
+----
+ParseComplete
+ErrorResponse {"fields":[{"typ":"C","value":"22023"},{"typ":"M","value":"unable to decode parameter: time out of range"}]}
+ReadyForQuery {"status":"I"}
+
+# -1 microseconds.
+send
+Parse {"query": "SELECT $1::time"}
+Bind {"param_formats": [1], "binary_values": [[255, 255, 255, 255, 255, 255, 255, 255]]}
+Execute
+Sync
+----
+
+until err_field_typs=CM
+ReadyForQuery
+----
+ParseComplete
+ErrorResponse {"fields":[{"typ":"C","value":"22023"},{"typ":"M","value":"unable to decode parameter: time out of range"}]}
+ReadyForQuery {"status":"I"}
+
+# The maximum valid value, 23:59:59.999999, still decodes.
+send
+Parse {"query": "SELECT $1::time"}
+Bind {"param_formats": [1], "binary_values": [[0, 0, 0, 20, 29, 215, 95, 255]]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["23:59:59.999999"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1361,6 +1361,12 @@ select '9::59.999999999'::time
 statement error invalid input syntax for type time: NANOSECOND
 select '9::60.1'::time
 
+# Regression test for SQL-473. 24:00:00 is rejected. The binary Bind parameter
+# path rejects it too instead of silently wrapping to 00:00:00, see
+# test/pgtest-mz/time-binary-out-of-range.pt.
+statement error invalid input syntax for type time: HOUR must be \[0, 23\], got 24: "24:00:00"
+select '24:00:00'::time
+
 # BC years are properly formatted
 # Using INTERVAL to work around the parser not supporting BC identifiers yet
 query T


### PR DESCRIPTION
A binary time Bind parameter is microseconds since midnight, but decoding went through NaiveTime::from_sql, whose duration arithmetic silently wraps around midnight. A parameter of 24:00:00 decoded as 00:00:00, and any other out-of-range value wrapped similarly.

Decode the raw microseconds directly and reject values outside [0, 24:00:00) with a "time out of range" error. This includes exactly 24:00:00, which PostgreSQL accepts but NaiveTime cannot represent and the text path already rejects.

Closes: SQL-473