### PR TITLE
sql: Fix BC year numbering in extract and make_timestamp

### DIFF
--- a/src/expr/src/scalar/func/impls/date.rs
+++ b/src/expr/src/scalar/func/impls/date.rs
@@ -139,7 +139,7 @@ pub fn extract_date_inner(units: DateTimeUnits, date: NaiveDate) -> Result<Numer
         DateTimeUnits::Millennium => Ok(Numeric::from(date.millennium())),
         DateTimeUnits::Century => Ok(Numeric::from(date.century())),
         DateTimeUnits::Decade => Ok(Numeric::from(date.decade())),
-        DateTimeUnits::Year => Ok(Numeric::from(date.year())),
+        DateTimeUnits::Year => Ok(Numeric::from(date.extract_year())),
         DateTimeUnits::Quarter => Ok(Numeric::from(date.quarter())),
         DateTimeUnits::Week => Ok(Numeric::from(date.iso_week_number())),
         DateTimeUnits::Month => Ok(Numeric::from(date.month())),

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -417,7 +417,7 @@ where
         DateTimeUnits::Millennium => Ok(D::from(ts.millennium())),
         DateTimeUnits::Century => Ok(D::from(ts.century())),
         DateTimeUnits::Decade => Ok(D::from(ts.decade())),
-        DateTimeUnits::Year => Ok(D::from(ts.year())),
+        DateTimeUnits::Year => Ok(D::from(ts.extract_year())),
         DateTimeUnits::Quarter => Ok(D::from(ts.quarter())),
         DateTimeUnits::Week => Ok(D::from(ts.iso_week_number())),
         DateTimeUnits::Month => Ok(D::from(ts.month())),

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -1056,7 +1056,6 @@ fn make_mz_acl_item(
 }
 
 #[sqlfunc(sqlname = "makets")]
-// TODO(benesch): remove potentially dangerous usage of `as`.
 #[allow(clippy::as_conversions)]
 fn make_timestamp(
     year: i64,
@@ -1066,36 +1065,37 @@ fn make_timestamp(
     minute: i64,
     second_float: f64,
 ) -> Result<Option<CheckedTimestamp<NaiveDateTime>>, EvalError> {
-    let year: i32 = match year.try_into() {
-        Ok(year) => year,
-        Err(_) => return Ok(None),
-    };
-    let month: u32 = match month.try_into() {
-        Ok(month) => month,
-        Err(_) => return Ok(None),
-    };
-    let day: u32 = match day.try_into() {
-        Ok(day) => day,
-        Err(_) => return Ok(None),
-    };
-    let hour: u32 = match hour.try_into() {
-        Ok(hour) => hour,
-        Err(_) => return Ok(None),
-    };
-    let minute: u32 = match minute.try_into() {
-        Ok(minute) => minute,
-        Err(_) => return Ok(None),
-    };
-    let second = second_float as u32;
-    let micros = ((second_float - second as f64) * 1_000_000.0) as u32;
-    let date = match NaiveDate::from_ymd_opt(year, month, day) {
-        Some(date) => date,
-        None => return Ok(None),
-    };
-    let timestamp = match date.and_hms_micro_opt(hour, minute, second, micros) {
-        Some(timestamp) => timestamp,
-        None => return Ok(None),
-    };
+    // NOTE: This function never returns `Ok(None)`. The `Option` stays so
+    // that the derived `introduces_nulls` (and with it the nullability of
+    // existing objects planned with this function) does not change.
+
+    // Negative years are BC and there is no year 0. Chrono's astronomical
+    // numbering has 1 BC as year 0, so BC years shift by one.
+    if year == 0 {
+        return Err(EvalError::DateOutOfRange);
+    }
+    let year = if year < 0 { year + 1 } else { year };
+    let year: i32 = year.try_into().map_err(|_| EvalError::DateOutOfRange)?;
+    let month: u32 = month.try_into().map_err(|_| EvalError::DateOutOfRange)?;
+    let day: u32 = day.try_into().map_err(|_| EvalError::DateOutOfRange)?;
+    let date = NaiveDate::from_ymd_opt(year, month, day).ok_or(EvalError::DateOutOfRange)?;
+    // Allow exactly 24:00:00 (rolls over to midnight of the next day) and
+    // 60 seconds (rolls over into the next minute).
+    if !(0..=24).contains(&hour)
+        || !(0..=59).contains(&minute)
+        || !(0.0..=60.0).contains(&second_float)
+        || (hour == 24 && (minute > 0 || second_float > 0.0))
+    {
+        return Err(EvalError::TimestampOutOfRange);
+    }
+    // The cast is exact: second_float is in [0, 60].
+    let micros = (second_float * 1_000_000.0).round() as i64;
+    let time = chrono::Duration::microseconds((hour * 60 + minute) * 60 * 1_000_000 + micros);
+    let timestamp = date
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .checked_add_signed(time)
+        .ok_or(EvalError::TimestampOutOfRange)?;
     Ok(Some(timestamp.try_into()?))
 }
 

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -184,6 +184,14 @@ pub trait DateLike: chrono::Datelike {
         naive_date.and_utc().timestamp()
     }
 
+    /// The year in SQL's numbering, where 1 BC is year -1 and there is no
+    /// year 0. Chrono's `year` uses astronomical numbering, where 1 BC is
+    /// year 0.
+    fn extract_year(&self) -> i32 {
+        let year = self.year();
+        if year <= 0 { year - 1 } else { year }
+    }
+
     fn millennium(&self) -> i32 {
         (self.year() + if self.year() > 0 { 999 } else { -1_000 }) / 1_000
     }

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1752,3 +1752,53 @@ query T
 SELECT timestamp::timestamp from t ORDER BY t.timestamp;
 ----
 2012-03-05 00:00:00
+
+# Regression tests for SQL-467.
+
+# BC years in extract are numbered with 1 BC as year -1, there is no year 0.
+query RRR
+SELECT extract(year FROM DATE '2020-08-11 BC'),
+       extract(year FROM TIMESTAMP '2020-08-11 12:00:00 BC'),
+       extract(year FROM TIMESTAMPTZ '2020-08-11 12:00:00+00 BC')
+----
+-2020  -2020  -2020
+
+query RR
+SELECT extract(year FROM DATE '0001-08-11 BC'), extract(year FROM DATE '0001-08-11')
+----
+-1  1
+
+# make_timestamp rejects year 0 and treats negative years as BC.
+query error date out of range
+SELECT make_timestamp(0, 7, 15, 12, 30, 15)
+
+query T
+SELECT make_timestamp(-1, 7, 15, 12, 30, 15)
+----
+0001-07-15 12:30:15 BC
+
+query T
+SELECT make_timestamp(-2020, 8, 11, 12, 30, 15)
+----
+2020-08-11 12:30:15 BC
+
+# make_timestamp allows exactly 24:00:00 and 60 seconds, which roll over.
+query T
+SELECT make_timestamp(1999, 12, 31, 24, 0, 0)
+----
+2000-01-01 00:00:00
+
+query T
+SELECT make_timestamp(2013, 7, 15, 12, 30, 60)
+----
+2013-07-15 12:31:00
+
+query error timestamp out of range
+SELECT make_timestamp(1999, 12, 31, 24, 0, 1)
+
+# Invalid fields are errors, not NULL.
+query error date out of range
+SELECT make_timestamp(2020, 13, 1, 0, 0, 0)
+
+query error timestamp out of range
+SELECT make_timestamp(2020, 1, 1, 12, 60, 0)

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -421,10 +421,27 @@ EOF
 
 # VARIADIC FUNCTIONS that introduce nulls
 
-query BBBBBBB
-SELECT COALESCE(NULLIF('a', 'a')) IS NULL, GREATEST(NULLIF('a', 'a')) IS NULL, LEAST(NULLIF('a', 'a')) IS NULL, MAKE_TIMESTAMP(2023, 1, 1, 0, 0, 11111) IS NULL, (ARRAY[1, 2])[3] IS NULL, (LIST[1, 2])[3] IS NULL, REGEXP_MATCH('a', 'b')  IS NULL;
+query BBBBBB
+SELECT COALESCE(NULLIF('a', 'a')) IS NULL, GREATEST(NULLIF('a', 'a')) IS NULL, LEAST(NULLIF('a', 'a')) IS NULL, (ARRAY[1, 2])[3] IS NULL, (LIST[1, 2])[3] IS NULL, REGEXP_MATCH('a', 'b')  IS NULL;
 ----
-true  true  true  true  true  true  true
+true  true  true  true  true  true
+
+# MAKE_TIMESTAMP errors on invalid fields rather than returning NULL, but its
+# return type stays nullable, so it still propagates as NULL-able.
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(types, no fast path, humanized expressions) AS VERBOSE TEXT FOR SELECT MAKE_TIMESTAMP(col_not_null, 1, 1, 0, 0, 0) FROM int_table;
+----
+Explained Query:
+  Project (#2) // { types: "(r_timestamp?)" }
+    Map (makets(integer_to_bigint(#1{col_not_null}), 1, 1, 0, 0, 0)) // { types: "(r_int32?, r_int32, r_timestamp?)" }
+      ReadStorage materialize.public.int_table // { types: "(r_int32?, r_int32)" }
+
+Source materialize.public.int_table
+
+Target cluster: quickstart
+
+EOF
 
 # BINARY FUNCTIONS that introduce nulls
 # MapGetValue and ListLengthMax not covered


### PR DESCRIPTION
EXTRACT(YEAR ...) on dates and timestamps returned chrono's astronomical year numbering, where 1 BC is year 0, so BC years were off by one: 1 BC must be year -1 and there is no year 0.

make_timestamp passed its year argument straight to chrono, accepting year 0 and shifting BC years by one. It also returned NULL for invalid field values instead of erroring, and rejected 24:00:00 and 60 seconds instead of rolling them over into the next day or minute.

Closes: SQL-467