### PR TITLE
console: surface offline events in the <=3h utilization windows

### DIFF
--- a/console/src/api/materialize/cluster/replicaUtilizationBinning.test.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationBinning.test.ts
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 import {
+  attachOfflineEvents,
   Bucket,
   bucketRowsToBucketsByReplicaId,
   maxByMetric,
@@ -175,6 +176,55 @@ describe("rebucketUtilizationSamples", () => {
     expect(rows[0].bucketStart.getTime()).toBeLessThan(
       rows[1].bucketStart.getTime(),
     );
+  });
+});
+
+describe("attachOfflineEvents", () => {
+  const mkEvent = (overrides: Partial<OfflineEvent> = {}): OfflineEvent => ({
+    replicaId: "u1",
+    occurredAt: new Date(30_000).toISOString(),
+    status: "offline",
+    reason: "oom-killed",
+    ...overrides,
+  });
+
+  it("attaches events to the matching (replica, bucket) row", () => {
+    const rows = [
+      mkBucketRow(),
+      mkBucketRow({
+        bucketStart: new Date(MINUTE),
+        bucketEnd: new Date(2 * MINUTE),
+      }),
+    ];
+    const result = attachOfflineEvents(rows, [mkEvent()], MINUTE);
+    expect(result[0].offlineEvents).toEqual([mkEvent()]);
+    expect(result[1].offlineEvents).toBeNull();
+  });
+
+  it("drops events with no matching bucket", () => {
+    const rows = [mkBucketRow()];
+    const result = attachOfflineEvents(
+      rows,
+      [
+        mkEvent({ occurredAt: new Date(5 * MINUTE).toISOString() }),
+        mkEvent({ replicaId: "u2" }),
+      ],
+      MINUTE,
+    );
+    expect(result[0].offlineEvents).toBeNull();
+  });
+
+  it("aggregates multiple events in the same bucket", () => {
+    const rows = [mkBucketRow()];
+    const result = attachOfflineEvents(
+      rows,
+      [
+        mkEvent({ occurredAt: new Date(10_000).toISOString() }),
+        mkEvent({ occurredAt: new Date(50_000).toISOString(), reason: null }),
+      ],
+      MINUTE,
+    );
+    expect(result[0].offlineEvents).toHaveLength(2);
   });
 });
 

--- a/console/src/api/materialize/cluster/replicaUtilizationBinning.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationBinning.ts
@@ -16,7 +16,7 @@ export type OfflineEvent = {
   replicaId: string;
   occurredAt: string;
   status: string;
-  reason: string;
+  reason: string | null;
 };
 
 export type Bucket = {
@@ -193,6 +193,36 @@ export function rebucketUtilizationSamples(
 
   rows.sort((a, b) => a.bucketStart.getTime() - b.bucketStart.getTime());
   return rows;
+}
+
+/**
+ * Attach offline events to their (replica, bucket) rows. The un-binned 3h base
+ * carries no status columns, so the <=3h tier fetches events separately and
+ * merges them here. Events with no matching bucket are dropped, like the
+ * binned views' LEFT JOIN from the metrics-derived buckets.
+ */
+export function attachOfflineEvents(
+  rows: UtilizationBucketRow[],
+  events: OfflineEvent[],
+  bucketSizeMs: number,
+): UtilizationBucketRow[] {
+  if (events.length === 0) return rows;
+  const eventsByBucket = new Map<string, OfflineEvent[]>();
+  for (const event of events) {
+    const bucketStartMs =
+      Math.floor(new Date(event.occurredAt).getTime() / bucketSizeMs) *
+      bucketSizeMs;
+    const key = `${event.replicaId} ${bucketStartMs}`;
+    const bucketEvents = eventsByBucket.get(key) ?? [];
+    bucketEvents.push(event);
+    eventsByBucket.set(key, bucketEvents);
+  }
+  return rows.map((row) => {
+    const bucketEvents = eventsByBucket.get(
+      `${row.replicaId} ${row.bucketStart.getTime()}`,
+    );
+    return bucketEvents ? { ...row, offlineEvents: bucketEvents } : row;
+  });
 }
 
 /**

--- a/console/src/api/materialize/cluster/replicaUtilizationHistory.test.sql.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationHistory.test.sql.ts
@@ -18,8 +18,13 @@ import {
 import { testdrive } from "~/test/sql/mzcompose";
 
 import {
+  attachOfflineEvents,
+  rebucketUtilizationSamples,
+} from "./replicaUtilizationBinning";
+import {
   buildConsoleClusterUtilizationOverviewQuery,
   buildConsoleClusterUtilizationUnbinned3hQuery,
+  buildReplicaOfflineEventsQuery,
   buildReplicaUtilizationHistoryQuery,
 } from "./replicaUtilizationHistory";
 
@@ -505,6 +510,115 @@ describe("console cluster utilization indexed views", () => {
     });
     expect(res.rows[0].bucketStart.toISOString()).toEqual(
       "2030-01-01T01:00:00.000Z",
+    );
+  });
+
+  // The <=3h tier reads `_overview_3h`, which
+  // has no status columns, so offline/OOM events are fetched separately
+  // (buildReplicaOfflineEventsQuery) and merged into the client-binned buckets
+  // (attachOfflineEvents). The ad-hoc path joins status history in SQL, so
+  // both paths must surface the same OOM.
+  it("surfaces OOM/offline events in the <=3h unbinned path", async () => {
+    const client = await getMaterializeClient();
+
+    await testdrive(`
+        > DROP CLUSTER IF EXISTS c CASCADE;
+        > CREATE CLUSTER c REPLICAS (r1 (SIZE 'scale=1,workers=1'));
+        > CREATE SCHEMA IF NOT EXISTS internal_test;
+        > SET schema = internal_test;
+        # Qualify the drops. An unqualified name that is missing from
+        # internal_test falls through the search path to the system table.
+        > DROP TABLE IF EXISTS internal_test.mz_cluster_replica_metrics_history;
+        > DROP TABLE IF EXISTS internal_test.mz_cluster_replica_status_history;
+        > DROP TABLE IF EXISTS internal_test.mz_cluster_replica_sizes;
+        > DROP TABLE IF EXISTS internal_test.mz_console_cluster_utilization_overview_3h;
+        > CREATE TABLE mz_cluster_replica_metrics_history (
+            occurred_at TIMESTAMP NOT NULL, replica_id TEXT NOT NULL, process_id uint8 NOT NULL,
+            cpu_nano_cores double, memory_bytes double, disk_bytes double, heap_bytes double, heap_limit double);
+        > CREATE TABLE mz_cluster_replica_status_history (
+            replica_id TEXT NOT NULL, process_id uint8 NOT NULL, occurred_at TIMESTAMP NOT NULL,
+            status TEXT NOT NULL, reason TEXT);
+        > CREATE TABLE mz_cluster_replica_sizes (
+            size TEXT NOT NULL, processes uint8 NOT NULL, cpu_nano_cores uint8 NOT NULL,
+            memory_bytes uint8 NOT NULL, disk_bytes uint8);
+        > INSERT INTO internal_test.mz_cluster_replica_sizes VALUES
+            ('scale=1,workers=1', 1, ${size25cc.cpuNanoCores}, ${size25cc.memoryBytes}, ${size25cc.diskBytes});
+        # The un-binned 3h view has no status/offline columns.
+        > CREATE TABLE mz_console_cluster_utilization_overview_3h (
+            replica_id TEXT, cluster_id TEXT, size TEXT, name TEXT, occurred_at TIMESTAMPTZ, cpu_percent DOUBLE,
+            memory_percent DOUBLE, disk_percent DOUBLE, heap_percent DOUBLE, memory_and_disk_percent DOUBLE);
+    `);
+
+    await client.query(`SET search_path TO ${mockedSearchPath};`);
+
+    const {
+      rows: [cluster],
+    } = await client.query("select id from mz_clusters where name = 'c'");
+    const {
+      rows: [replica],
+    } = await client.query(
+      `SELECT id, name FROM mz_cluster_replicas WHERE cluster_id = '${cluster.id}' ORDER BY id`,
+    );
+
+    const startTime = "2030-01-01T00:00:00Z";
+    const ts = "2030-01-01T00:00:30.000Z";
+
+    // A utilization sample and a coincident OOM for the same replica and bucket.
+    await client.query(`INSERT INTO internal_test.mz_cluster_replica_metrics_history VALUES
+      (TIMESTAMP '${ts}', '${replica.id}', 0, 5789441, 46788608, 937984, NULL, NULL)`);
+    await client.query(`INSERT INTO internal_test.mz_cluster_replica_status_history VALUES
+      ('${replica.id}', 0, TIMESTAMP '${ts}', 'offline', 'oom-killed')`);
+    await client.query(`INSERT INTO internal_test.mz_console_cluster_utilization_overview_3h VALUES
+      ('${replica.id}', '${cluster.id}', 'scale=1,workers=1', '${replica.name}', '${ts}', 0.1, 0.2, 0.3, 0.4, 0.5)`);
+
+    // The ad-hoc path surfaces the OOM in SQL.
+    const adHoc = (
+      await run(
+        buildReplicaUtilizationHistoryQuery({
+          startDate: startTime,
+          bucketSizeMs: 60_000,
+          clusterIds: [cluster.id],
+        }).compile(),
+      )
+    ).rows;
+    expect(adHoc.find((r) => r.offlineEvents)?.offlineEvents).toEqual([
+      {
+        replicaId: replica.id,
+        reason: "oom-killed",
+        status: "offline",
+        occurredAt: "2030-01-01 00:00:30",
+      },
+    ]);
+
+    // The un-binned path: bin the samples, fetch events, and merge.
+    const samples = (
+      await run(
+        buildConsoleClusterUtilizationUnbinned3hQuery({
+          clusterIds: [cluster.id],
+        }).compile(),
+      )
+    ).rows;
+    const offlineEvents = (
+      await run(
+        buildReplicaOfflineEventsQuery({
+          clusterIds: [cluster.id],
+          startDate: startTime,
+        }).compile(),
+      )
+    ).rows;
+    const rows = attachOfflineEvents(
+      rebucketUtilizationSamples(
+        samples,
+        60_000,
+        new Date(startTime).getTime(),
+      ),
+      offlineEvents,
+      60_000,
+    );
+    expect(rows.length).toBeGreaterThan(0);
+    const events = rows.flatMap((r) => r.offlineEvents ?? []);
+    expect(events).toContainEqual(
+      expect.objectContaining({ status: "offline", reason: "oom-killed" }),
     );
   });
 });

--- a/console/src/api/materialize/cluster/replicaUtilizationHistory.ts
+++ b/console/src/api/materialize/cluster/replicaUtilizationHistory.ts
@@ -15,6 +15,7 @@ import { buildSubscribeQuery } from "~/api/materialize/buildSubscribeQuery";
 
 import { fetchClusterDeploymentLineage } from "./clusterDeploymentLineage";
 import {
+  attachOfflineEvents,
   bucketRowsToBucketsByReplicaId,
   rebucketUtilizationSamples,
   UtilizationBucketRow,
@@ -627,6 +628,95 @@ export function buildConsoleClusterUtilizationOverview24hSubscribe<T>(
   );
 }
 
+/**
+ * Offline events for a cluster's replicas since `startDate`, one row per
+ * event. The un-binned 3h view carries no status columns, so the <=3h tier
+ * fetches events with this query and merges them client-side
+ * (`attachOfflineEvents`).
+ */
+export function buildReplicaOfflineEventsQuery({
+  clusterIds,
+  startDate,
+  resolveLineage = false,
+}: {
+  clusterIds?: string[];
+  startDate: string;
+  // When true, expand clusterIds to past blue-green deployments in SQL, like
+  // the utilization builders. The poll path passes pre-expanded ids instead.
+  resolveLineage?: boolean;
+}) {
+  let query = queryBuilder
+    .with("charted_replicas", (qb) => {
+      const history = qb
+        .selectFrom("mz_cluster_replica_history")
+        .select(["replica_id", "cluster_id"]);
+      // Union the current replicas since mz_cluster_replica_history doesn't
+      // include system clusters.
+      const current = qb
+        .selectFrom("mz_cluster_replicas")
+        .select(["id as replica_id", "cluster_id"]);
+      return history.union(current);
+    })
+    .selectFrom("mz_cluster_replica_status_history as rsh")
+    .innerJoin("charted_replicas as r", "r.replica_id", "rsh.replica_id")
+    .select([
+      "rsh.replica_id as replicaId",
+      // Via timestamptz so the text carries an explicit offset. A naive
+      // timestamp string would parse as local time in the browser.
+      sql<string>`rsh.occurred_at::timestamptz::text`.as("occurredAt"),
+      "rsh.status",
+      "rsh.reason",
+    ])
+    // Processes should share the same state, so take the first process's.
+    .where("rsh.process_id", "=", "0")
+    .where("rsh.status", "=", "offline")
+    .where(
+      "rsh.occurred_at",
+      ">=",
+      sql<Date>`${sql.lit(startDate)}::timestamptz`,
+    );
+
+  if (clusterIds !== undefined && clusterIds.length > 0) {
+    if (resolveLineage) {
+      query = query.where((eb) =>
+        eb.or([
+          eb(
+            "r.cluster_id",
+            "in",
+            eb
+              .selectFrom("mz_cluster_deployment_lineage")
+              .select("cluster_id")
+              .where("current_deployment_cluster_id", "in", clusterIds),
+          ),
+          eb("r.cluster_id", "in", clusterIds),
+        ]),
+      );
+    } else {
+      query = query.where("r.cluster_id", "in", clusterIds);
+    }
+  }
+
+  return query;
+}
+
+export async function fetchReplicaOfflineEvents({
+  params,
+  queryKey,
+  requestOptions,
+}: {
+  params: Parameters<typeof buildReplicaOfflineEventsQuery>[0];
+  queryKey: QueryKey;
+  requestOptions?: RequestInit;
+}) {
+  const res = await executeSqlV2({
+    queries: buildReplicaOfflineEventsQuery(params).compile(),
+    queryKey,
+    requestOptions,
+    sessionVariables: { transaction_isolation: "serializable" },
+  });
+  return res.rows;
+}
+
 export async function fetchReplicaUtilizationHistory({
   params,
   queryKey,
@@ -668,19 +758,34 @@ export async function fetchReplicaUtilizationHistory({
 
   if (params.utilizationView === "unbinned3h") {
     // Un-binned 3h base: cheap indexed point-lookup, then bin client-side.
-    const unbinnedRes = await executeSqlV2({
-      queries: buildConsoleClusterUtilizationUnbinned3hQuery({
-        clusterIds: clusterIdsFilter,
-        replicaId: params.replicaId,
-      }).compile(),
-      queryKey,
-      requestOptions,
-      sessionVariables: { transaction_isolation: "serializable" },
-    });
-    rows = rebucketUtilizationSamples(
-      unbinnedRes.rows,
+    // Offline events aren't in the un-binned view, so fetch them alongside.
+    const [unbinnedRes, offlineEvents] = await Promise.all([
+      executeSqlV2({
+        queries: buildConsoleClusterUtilizationUnbinned3hQuery({
+          clusterIds: clusterIdsFilter,
+          replicaId: params.replicaId,
+        }).compile(),
+        queryKey,
+        requestOptions,
+        sessionVariables: { transaction_isolation: "serializable" },
+      }),
+      fetchReplicaOfflineEvents({
+        params: {
+          clusterIds: clusterIdsFilter,
+          startDate: params.startDate,
+        },
+        queryKey: [...queryKey, "offlineEvents"],
+        requestOptions,
+      }),
+    ]);
+    rows = attachOfflineEvents(
+      rebucketUtilizationSamples(
+        unbinnedRes.rows,
+        params.bucketSizeMs,
+        new Date(params.startDate).getTime(),
+      ),
+      offlineEvents,
       params.bucketSizeMs,
-      new Date(params.startDate).getTime(),
     );
   } else {
     let utilizationQuery;

--- a/console/src/platform/clusters/queries.ts
+++ b/console/src/platform/clusters/queries.ts
@@ -63,6 +63,7 @@ import {
   fetchClusterReplicasWithUtilization,
 } from "~/api/materialize/cluster/replicasWithUtilization";
 import {
+  attachOfflineEvents,
   BinnedSubscribeRow,
   bucketRowsToBucketsByReplicaId,
   parseBinnedSubscribeRow,
@@ -73,6 +74,7 @@ import {
 import {
   buildConsoleClusterUtilizationOverview24hSubscribe,
   buildConsoleClusterUtilizationUnbinned3hSubscribe,
+  fetchReplicaOfflineEvents,
   fetchReplicaUtilizationHistory,
   ReplicaUtilizationHistoryParameters,
 } from "~/api/materialize/cluster/replicaUtilizationHistory";
@@ -158,6 +160,14 @@ export const clusterQueryKeys = {
     [
       ...clusterQueryKeys.all(),
       buildQueryKeyPart("replicaUtilizationHistory", params),
+    ] as const,
+  replicaOfflineEvents: (params: {
+    clusterIdsKey: string;
+    timePeriodMinutes: number;
+  }) =>
+    [
+      ...clusterQueryKeys.all(),
+      buildQueryKeyPart("replicaOfflineEvents", params),
     ] as const,
   clusterFreshness: (params: ClusterFreshnessParams) =>
     [
@@ -498,6 +508,33 @@ function useReplicaUtilizationHistorySubscribe(
     }),
   });
 
+  // Offline events aren't in the un-binned view, so poll them separately and
+  // merge into the client-binned buckets. Without this the <=3h windows would
+  // hide replica crashes and OOMs that every other tier surfaces.
+  const { data: offlineEvents } = useQuery({
+    queryKey: clusterQueryKeys.replicaOfflineEvents({
+      clusterIdsKey,
+      timePeriodMinutes,
+    }),
+    refetchInterval: 20_000,
+    enabled: enabled && clusterIdsKey.length > 0,
+    queryFn: async ({ queryKey, signal }) => {
+      const [, queryKeyParams] = queryKey;
+      const clusterIds = queryKeyParams.clusterIdsKey
+        ? queryKeyParams.clusterIdsKey.split(",")
+        : [];
+      const startDate = subMinutes(
+        new Date(),
+        queryKeyParams.timePeriodMinutes,
+      ).toISOString();
+      return fetchReplicaOfflineEvents({
+        params: { clusterIds, startDate, resolveLineage: true },
+        queryKey,
+        requestOptions: { signal },
+      });
+    },
+  });
+
   const result = useMemo(() => {
     const endDate = new Date();
     const startDate = subMinutes(endDate, timePeriodMinutes);
@@ -505,17 +542,17 @@ function useReplicaUtilizationHistorySubscribe(
     const samples = replicaId
       ? data.filter((sample) => sample.replicaId === replicaId)
       : data;
-    const rows = rebucketUtilizationSamples(
-      samples,
+    const rows = attachOfflineEvents(
+      rebucketUtilizationSamples(samples, bucketSizeMs, startDate.getTime()),
+      offlineEvents ?? [],
       bucketSizeMs,
-      startDate.getTime(),
     );
     return toReplicaUtilizationGraphData(
       bucketRowsToBucketsByReplicaId(rows),
       startDate,
       endDate,
     );
-  }, [data, replicaId, timePeriodMinutes, bucketSizeMs]);
+  }, [data, replicaId, timePeriodMinutes, bucketSizeMs, offlineEvents]);
 
   return {
     data: result,


### PR DESCRIPTION
The <=3h tier reads the un-binned 3h view, which carries no status columns, and the client binner filled offlineEvents with null. So the "Last hour" and "Last 3 hours" windows, the ones used during an incident, silently omitted the replica crash and OOM markers that every other tier surfaces.

Fetch offline events for the charted cluster separately from mz_cluster_replica_status_history and merge them into the client-binned buckets. The subscribe tier polls them alongside the streamed samples.

Fixes [CNS 114](https://linear.app/materializeinc/issue/CNS-114/console-replica-utilization-history-has-issues) partially for the offline fixes that we caught 

### Verification

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
