### PR TITLE
repr: Quote array elements matching NULL case-insensitively in text output

### DIFF
--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -1778,8 +1778,10 @@ struct ListElementEscaper;
 
 impl ElementEscaper for ListElementEscaper {
     fn needs_escaping(elem: &[u8]) -> bool {
+        // The parser treats any case variant of unquoted "NULL" as null, so
+        // any such element must be quoted to round-trip.
         elem.is_empty()
-            || elem == b"NULL"
+            || elem.eq_ignore_ascii_case(b"NULL")
             || elem
                 .iter()
                 .any(|c| matches!(c, b'{' | b'}' | b',' | b'"' | b'\\') || c.is_ascii_whitespace())
@@ -1795,7 +1797,7 @@ struct MapElementEscaper;
 impl ElementEscaper for MapElementEscaper {
     fn needs_escaping(elem: &[u8]) -> bool {
         elem.is_empty()
-            || elem == b"NULL"
+            || elem.eq_ignore_ascii_case(b"NULL")
             || elem.iter().any(|c| {
                 matches!(c, b'{' | b'}' | b',' | b'"' | b'=' | b'>' | b'\\')
                     || c.is_ascii_whitespace()

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -523,7 +523,7 @@ fn miri_test_format_list() {
     .unwrap();
     assert_eq!(
         out,
-        r#"{a,"a\"b","",NULL,"NULL",nUlL,"  spaces ","a,b","\\","a\\b\"c\\d\""}"#
+        r#"{a,"a\"b","",NULL,"NULL","nUlL","  spaces ","a,b","\\","a\\b\"c\\d\""}"#
     );
 }
 

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -1179,7 +1179,7 @@ end
 {{c,d},{c,d},{c,d}}	3	2	c	end
 {{{NULL}},{{NULL}}}	2	1	1	end
 {{{b},{b}},{{b},{b}}}	2	2	1	b	end
-{{c,NULL},{NULL,d},{null,NULL}}	3	2	c	end
+{{c,NULL},{NULL,d},{"null",NULL}}	3	2	c	end
 {{{{b},{b}}},{{{b},{b}}},{{{b},{b}}}}	3	1	2	1	b	end
 
 # Test that whitespace produces same results
@@ -1489,3 +1489,16 @@ SELECT ARRAY[NULL::BIGINT[], ARRAY[]::BIGINT[], NULL::BIGINT[]];
 
 query error number of array elements \(3\) does not match declared cardinality \(2\)
 SELECT ARRAY[ARRAY[1, 2], ARRAY[3, 4, 5], ARRAY[6]];
+
+# Regression test for SQL-466: string elements matching "NULL" in any case
+# must be quoted in text output, so that they round-trip.
+
+query TT
+SELECT ARRAY['null']::text, (ARRAY['null']::text)::text[] = ARRAY['null'];
+----
+{"null"}  true
+
+query T
+SELECT ARRAY['null', 'NuLl', NULL, 'nullish']::text;
+----
+{"null","NuLl",NULL,nullish}

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -92,7 +92,7 @@ SELECT (LIST[1, null] :: TEXT LIST)::text
 query T
 SELECT (LIST['foo', 'f}o', '"\', null, 'null', 'NULL'])::text
 ----
-{foo,"f}o","\"\\",NULL,null,"NULL"}
+{foo,"f}o","\"\\",NULL,"null","NULL"}
 
 query T
 SELECT (list[list[list['"']]])::text

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -984,3 +984,11 @@ query T
 SELECT unnest('{a=>NULL}'::map[text=>int4]);
 ----
 (a,)
+
+# Regression test for SQL-466: string values matching "NULL" in any case
+# must be quoted in text output, so that they round-trip.
+
+query T
+SELECT MAP['k' => 'null']::text;
+----
+{k=>"null"}


### PR DESCRIPTION
The text output of arrays, lists, and maps only quoted elements exactly equal to "NULL", but the parser treats any case variant of unquoted "NULL" as null. A string element like 'null' was printed unquoted and did not round-trip: ARRAY['null'] printed as {null}, which parses back as {NULL}. Quote any element matching "NULL" case-insensitively, matching PostgreSQL.

Closes: SQL-466