### PR TITLE
repr: Honor DateStyle MDY and two-digit-year windowing in date parsing

### DIFF
--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -813,12 +813,13 @@ impl ParsedDateTime {
     pub fn build_parsed_datetime_timestamp(
         value: &str,
         era: CalendarEra,
+        order: DateOrder,
     ) -> Result<ParsedDateTime, String> {
         let mut pdt = ParsedDateTime::default();
 
         let mut ts_actual = tokenize_time_str(value)?;
 
-        fill_pdt_date(&mut pdt, &mut ts_actual)?;
+        fill_pdt_date(&mut pdt, &mut ts_actual, order, era)?;
 
         if let CalendarEra::BC = era {
             pdt.year = pdt.year.map(|mut y| {
@@ -1080,6 +1081,8 @@ impl ParsedDateTime {
 fn fill_pdt_date(
     pdt: &mut ParsedDateTime,
     actual: &mut VecDeque<TimeStrToken>,
+    order: DateOrder,
+    era: CalendarEra,
 ) -> Result<(), String> {
     use TimeStrToken::*;
 
@@ -1124,6 +1127,26 @@ fn fill_pdt_date(
         _ => (),
     }
 
+    // PostgreSQL under the pinned `DateStyle = ISO, MDY` reads a separated
+    // date whose leading field has one or two digits as month-day-year, and
+    // only a leading field of three or more digits as year-month-day. The
+    // formats below fill fields positionally as year-month-day, so record the
+    // digit counts up front and reorder the fields after a successful fill.
+    let mdy = match (order, actual.front()) {
+        (DateOrder::Mdy, Some(&Num(_, digits))) => digits <= 2,
+        _ => false,
+    };
+    // Digit count of the third numeric field, the year in a month-day-year
+    // date, which decides two-digit-year windowing.
+    let year_digits = actual
+        .iter()
+        .take_while(|t| matches!(t, Num(..) | Dash | Delim))
+        .filter_map(|t| match t {
+            Num(_, digits) => Some(*digits),
+            _ => None,
+        })
+        .nth(2);
+
     let valid_formats = [
         [
             Num(0, 1), // year
@@ -1153,6 +1176,22 @@ fn fill_pdt_date(
     for expected in valid_formats {
         match fill_pdt_from_tokens(pdt, actual, &expected, DateTimeField::Year, 1) {
             Ok(()) => {
+                // In a month-day-year date the positional fill above put the
+                // month in `year`, the day in `month`, and the year in `day`.
+                if mdy {
+                    if let (Some(month), Some(day), Some(mut year)) = (pdt.year, pdt.month, pdt.day)
+                    {
+                        // Window two-digit years into 1970..=2069, as
+                        // PostgreSQL does. Explicit BC years are never
+                        // windowed.
+                        if era == CalendarEra::AD && year_digits.is_some_and(|d| d <= 2) {
+                            year.unit += if year.unit < 70 { 2000 } else { 1900 };
+                        }
+                        pdt.year = Some(year);
+                        pdt.month = Some(month);
+                        pdt.day = Some(day);
+                    }
+                }
                 return Ok(());
             }
             Err(_) => {
@@ -1810,10 +1849,23 @@ pub(crate) fn tokenize_time_str(value: &str) -> Result<VecDeque<TimeStrToken>, S
     Ok(toks)
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CalendarEra {
     BC,
     AD,
+}
+
+/// Determines how ambiguous all-numeric dates like `01/02/03` are interpreted.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DateOrder {
+    /// PostgreSQL semantics under the pinned `DateStyle = ISO, MDY`: a date
+    /// whose leading field has one or two digits is month-day-year, and a
+    /// two-digit year is windowed into 1970..=2069.
+    Mdy,
+    /// Always year-month-day, with no year windowing. Frozen behavior for
+    /// storage source casts, which must not change across releases (see the
+    /// stability contract in `mz_storage_types::sources::casts`).
+    LegacyYmd,
 }
 
 /// Takes a 'date timezone' 'date time timezone' string and splits it into 'date
@@ -2839,10 +2891,79 @@ mod tests {
                 ..Default::default()
             },
         );
+        // A one- or two-digit leading field starts a month-day-year date, and
+        // a two-digit year is windowed into 1970..=2069.
+        run_test_build_parsed_datetime_timestamp(
+            "01/02/03",
+            ParsedDateTime {
+                year: Some(DateTimeFieldValue::new(2003, 0)),
+                month: Some(DateTimeFieldValue::new(1, 0)),
+                day: Some(DateTimeFieldValue::new(2, 0)),
+                ..Default::default()
+            },
+        );
+        run_test_build_parsed_datetime_timestamp(
+            "01-02-70 3:4:5.6",
+            ParsedDateTime {
+                year: Some(DateTimeFieldValue::new(1970, 0)),
+                month: Some(DateTimeFieldValue::new(1, 0)),
+                day: Some(DateTimeFieldValue::new(2, 0)),
+                hour: Some(DateTimeFieldValue::new(3, 0)),
+                minute: Some(DateTimeFieldValue::new(4, 0)),
+                second: Some(DateTimeFieldValue::new(5, 600_000_000)),
+                ..Default::default()
+            },
+        );
+        // A four-digit year in month-day-year position is not windowed.
+        run_test_build_parsed_datetime_timestamp(
+            "1/2/1999",
+            ParsedDateTime {
+                year: Some(DateTimeFieldValue::new(1999, 0)),
+                month: Some(DateTimeFieldValue::new(1, 0)),
+                day: Some(DateTimeFieldValue::new(2, 0)),
+                ..Default::default()
+            },
+        );
+        // BC years are never windowed.
+        assert_eq!(
+            ParsedDateTime::build_parsed_datetime_timestamp(
+                "01/02/03",
+                CalendarEra::BC,
+                DateOrder::Mdy,
+            )
+            .unwrap(),
+            ParsedDateTime {
+                year: Some(DateTimeFieldValue::new(-3, 0)),
+                month: Some(DateTimeFieldValue::new(1, 0)),
+                day: Some(DateTimeFieldValue::new(2, 0)),
+                ..Default::default()
+            },
+        );
+        // The legacy order keeps the frozen year-month-day interpretation
+        // with no windowing.
+        assert_eq!(
+            ParsedDateTime::build_parsed_datetime_timestamp(
+                "01/02/03",
+                CalendarEra::AD,
+                DateOrder::LegacyYmd,
+            )
+            .unwrap(),
+            ParsedDateTime {
+                year: Some(DateTimeFieldValue::new(1, 0)),
+                month: Some(DateTimeFieldValue::new(2, 0)),
+                day: Some(DateTimeFieldValue::new(3, 0)),
+                ..Default::default()
+            },
+        );
 
         fn run_test_build_parsed_datetime_timestamp(test: &str, res: ParsedDateTime) {
             assert_eq!(
-                ParsedDateTime::build_parsed_datetime_timestamp(test, CalendarEra::AD).unwrap(),
+                ParsedDateTime::build_parsed_datetime_timestamp(
+                    test,
+                    CalendarEra::AD,
+                    DateOrder::Mdy
+                )
+                .unwrap(),
                 res
             );
         }

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -52,7 +52,7 @@ use uuid::Uuid;
 
 use crate::adt::array::ArrayDimension;
 use crate::adt::date::Date;
-use crate::adt::datetime::{self, DateTimeField, ParsedDateTime};
+use crate::adt::datetime::{self, DateOrder, DateTimeField, ParsedDateTime};
 use crate::adt::interval::Interval;
 use crate::adt::jsonb::{Jsonb, JsonbRef};
 use crate::adt::mz_acl_item::{AclItem, MzAclItem};
@@ -222,6 +222,18 @@ where
 pub fn parse_mz_timestamp(s: &str) -> Result<crate::Timestamp, ParseError> {
     s.trim()
         .parse()
+        .map_err(|e| ParseError::invalid_input_syntax("mz_timestamp", s).with_details(e))
+}
+
+/// Parses an `mz_timestamp` from `s` with the frozen legacy date parsing in
+/// its timestamp fallback.
+///
+/// NOTE: This exists solely to keep the storage source cast
+/// `CastStringToMzTimestamp` evaluation-stable across releases (see the
+/// stability contract in `mz_storage_types::sources::casts`). Use
+/// [`parse_mz_timestamp`] everywhere else.
+pub fn parse_mz_timestamp_legacy(s: &str) -> Result<crate::Timestamp, ParseError> {
+    crate::Timestamp::from_str_legacy(s.trim())
         .map_err(|e| ParseError::invalid_input_syntax("mz_timestamp", s).with_details(e))
 }
 
@@ -399,7 +411,10 @@ where
 /// <time zone interval> ::=
 ///     <sign> <hours value> <colon> <minutes value>
 /// ```
-fn parse_timestamp_string(s: &str) -> Result<(NaiveDate, NaiveTime, Timezone), String> {
+fn parse_timestamp_string(
+    s: &str,
+    order: DateOrder,
+) -> Result<(NaiveDate, NaiveTime, Timezone), String> {
     if s.is_empty() {
         return Err("timestamp string is empty".into());
     }
@@ -418,7 +433,7 @@ fn parse_timestamp_string(s: &str) -> Result<(NaiveDate, NaiveTime, Timezone), S
 
     let (ts_string, tz_string, era) = datetime::split_timestamp_string(s);
 
-    let pdt = ParsedDateTime::build_parsed_datetime_timestamp(ts_string, era)?;
+    let pdt = ParsedDateTime::build_parsed_datetime_timestamp(ts_string, era, order)?;
     let d: NaiveDate = pdt.compute_date()?;
     let t: NaiveTime = pdt.compute_time()?;
 
@@ -433,7 +448,21 @@ fn parse_timestamp_string(s: &str) -> Result<(NaiveDate, NaiveTime, Timezone), S
 
 /// Parses a [`Date`] from `s`.
 pub fn parse_date(s: &str) -> Result<Date, ParseError> {
-    match parse_timestamp_string(s) {
+    parse_date_inner(s, DateOrder::Mdy)
+}
+
+/// Parses a [`Date`] from `s` with the frozen legacy year-month-day
+/// interpretation of ambiguous dates.
+///
+/// NOTE: This exists solely to keep the storage source cast `CastStringToDate`
+/// evaluation-stable across releases (see the stability contract in
+/// `mz_storage_types::sources::casts`). Use [`parse_date`] everywhere else.
+pub fn parse_date_legacy(s: &str) -> Result<Date, ParseError> {
+    parse_date_inner(s, DateOrder::LegacyYmd)
+}
+
+fn parse_date_inner(s: &str, order: DateOrder) -> Result<Date, ParseError> {
+    match parse_timestamp_string(s, order) {
         Ok((date, _, _)) => Date::try_from(date).map_err(|_| ParseError::out_of_range("date", s)),
         Err(e) => Err(ParseError::invalid_input_syntax("date", s).with_details(e)),
     }
@@ -478,7 +507,25 @@ where
 
 /// Parses a `NaiveDateTime` from `s`.
 pub fn parse_timestamp(s: &str) -> Result<CheckedTimestamp<NaiveDateTime>, ParseError> {
-    match parse_timestamp_string(s) {
+    parse_timestamp_inner(s, DateOrder::Mdy)
+}
+
+/// Parses a `NaiveDateTime` from `s` with the frozen legacy year-month-day
+/// interpretation of ambiguous dates.
+///
+/// NOTE: This exists solely to keep the storage source cast
+/// `CastStringToTimestamp` evaluation-stable across releases (see the
+/// stability contract in `mz_storage_types::sources::casts`). Use
+/// [`parse_timestamp`] everywhere else.
+pub fn parse_timestamp_legacy(s: &str) -> Result<CheckedTimestamp<NaiveDateTime>, ParseError> {
+    parse_timestamp_inner(s, DateOrder::LegacyYmd)
+}
+
+fn parse_timestamp_inner(
+    s: &str,
+    order: DateOrder,
+) -> Result<CheckedTimestamp<NaiveDateTime>, ParseError> {
+    match parse_timestamp_string(s, order) {
         Ok((date, time, _)) => CheckedTimestamp::from_timestamplike(date.and_time(time))
             .map_err(|_| ParseError::out_of_range("timestamp", s)),
         Err(e) => Err(ParseError::invalid_input_syntax("timestamp", s).with_details(e)),
@@ -502,7 +549,25 @@ where
 
 /// Parses a `DateTime<Utc>` from `s`. See `mz_expr::scalar::func::timezone_timestamp` for timezone anomaly considerations.
 pub fn parse_timestamptz(s: &str) -> Result<CheckedTimestamp<DateTime<Utc>>, ParseError> {
-    parse_timestamp_string(s)
+    parse_timestamptz_inner(s, DateOrder::Mdy)
+}
+
+/// Parses a `DateTime<Utc>` from `s` with the frozen legacy year-month-day
+/// interpretation of ambiguous dates.
+///
+/// NOTE: This exists solely to keep the storage source cast
+/// `CastStringToTimestampTz` evaluation-stable across releases (see the
+/// stability contract in `mz_storage_types::sources::casts`). Use
+/// [`parse_timestamptz`] everywhere else.
+pub fn parse_timestamptz_legacy(s: &str) -> Result<CheckedTimestamp<DateTime<Utc>>, ParseError> {
+    parse_timestamptz_inner(s, DateOrder::LegacyYmd)
+}
+
+fn parse_timestamptz_inner(
+    s: &str,
+    order: DateOrder,
+) -> Result<CheckedTimestamp<DateTime<Utc>>, ParseError> {
+    parse_timestamp_string(s, order)
         .and_then(|(date, time, timezone)| {
             use Timezone::*;
             let mut dt = date.and_time(time);
@@ -2266,5 +2331,62 @@ mod tests {
         assert!(parse_oid_legacy("2147483648").is_err());
         assert!(parse_oid_legacy("4294967295").is_err());
         assert!(parse_oid_legacy("nope").is_err());
+    }
+
+    fn date(y: i32, m: u32, d: u32) -> Date {
+        Date::try_from(NaiveDate::from_ymd_opt(y, m, d).unwrap()).unwrap()
+    }
+
+    #[mz_ore::test]
+    fn test_parse_date_mdy() {
+        // Pinned `DateStyle = ISO, MDY`: a one- or two-digit leading field
+        // starts a month-day-year date, and a two-digit year is windowed
+        // into 1970..=2069.
+        assert_eq!(parse_date("01/02/03").unwrap(), date(2003, 1, 2));
+        assert_eq!(parse_date("1-2-3").unwrap(), date(2003, 1, 2));
+        assert_eq!(parse_date("01/02/69").unwrap(), date(2069, 1, 2));
+        assert_eq!(parse_date("01/02/70").unwrap(), date(1970, 1, 2));
+        assert_eq!(parse_date("01/02/1999").unwrap(), date(1999, 1, 2));
+        // A leading field of three or more digits is a year, with no
+        // windowing.
+        assert_eq!(parse_date("0099-01-08").unwrap(), date(99, 1, 8));
+        assert_eq!(parse_date("2003-01-02").unwrap(), date(2003, 1, 2));
+        // BC years are never windowed. Year 3 BC is year -2 in chrono.
+        assert_eq!(parse_date("01/02/03 BC").unwrap(), date(-2, 1, 2));
+        // A two-digit leading field is a month, so these are out of range.
+        assert!(parse_date("99-01-08").is_err());
+        assert!(parse_date("13/01/08").is_err());
+
+        assert_eq!(
+            parse_timestamp("01/02/03 04:05:06").unwrap().to_string(),
+            "2003-01-02 04:05:06"
+        );
+        assert_eq!(
+            parse_mz_timestamp("01/02/03").unwrap(),
+            parse_mz_timestamp("2003-01-02").unwrap()
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_parse_date_legacy() {
+        // The frozen behavior keeps year-month-day for ambiguous dates, with
+        // no windowing. This divergence from `parse_date` must not change
+        // (storage stability).
+        assert_eq!(parse_date_legacy("01/02/03").unwrap(), date(1, 2, 3));
+        assert_eq!(parse_date_legacy("99-01-08").unwrap(), date(99, 1, 8));
+        assert!(parse_date_legacy("01/02/1999").is_err());
+        assert_eq!(
+            parse_timestamp_legacy("01/02/03 04:05:06")
+                .unwrap()
+                .to_string(),
+            "0001-02-03 04:05:06"
+        );
+        // The mz_timestamp fallback keeps the frozen interpretation, under
+        // which 0001-02-03 is out of range.
+        assert!(parse_mz_timestamp_legacy("01/02/03").is_err());
+        assert_eq!(
+            parse_mz_timestamp_legacy("2003-01-02").unwrap(),
+            parse_mz_timestamp("2003-01-02").unwrap()
+        );
     }
 }

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -18,9 +18,12 @@ use mz_timely_util::temporal::BucketTimestamp;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize, Serializer};
 
+use chrono::{DateTime, Utc};
+
 use crate::adt::numeric::Numeric;
+use crate::adt::timestamp::CheckedTimestamp;
 use crate::refresh_schedule::RefreshSchedule;
-use crate::strconv::parse_timestamptz;
+use crate::strconv::{ParseError, parse_timestamptz, parse_timestamptz_legacy};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.timestamp.rs"));
 
@@ -536,12 +539,29 @@ impl std::str::FromStr for Timestamp {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse_with(s, parse_timestamptz)
+    }
+}
+
+impl Timestamp {
+    /// Like the [`std::str::FromStr`] impl, but the timestamp fallback uses
+    /// the frozen legacy date parsing. Solely for the storage source cast
+    /// `CastStringToMzTimestamp` (see the stability contract in
+    /// `mz_storage_types::sources::casts`).
+    pub fn from_str_legacy(s: &str) -> Result<Self, String> {
+        Self::parse_with(s, parse_timestamptz_legacy)
+    }
+
+    fn parse_with(
+        s: &str,
+        parse_fallback: fn(&str) -> Result<CheckedTimestamp<DateTime<Utc>>, ParseError>,
+    ) -> Result<Self, String> {
         Ok(Self {
             internal: s
                 .parse::<u64>()
                 .map_err(|_| "could not parse as number of milliseconds since epoch".to_string())
                 .or_else(|err_num_of_millis| {
-                    parse_timestamptz(s)
+                    parse_fallback(s)
                         .map_err(|parse_error| {
                             format!(
                                 "{}; could not parse as date and time: {}",

--- a/src/storage-types/src/sources/casts.rs
+++ b/src/storage-types/src/sources/casts.rs
@@ -220,9 +220,9 @@ impl CastFunc {
             CastFunc::CastStringToUint64 => {
                 Ok(Datum::UInt64(strconv::parse_uint64(a).map_err(parse_err)?))
             }
-            CastFunc::CastStringToDate => {
-                Ok(Datum::Date(strconv::parse_date(a).map_err(parse_err)?))
-            }
+            CastFunc::CastStringToDate => Ok(Datum::Date(
+                strconv::parse_date_legacy(a).map_err(parse_err)?,
+            )),
             CastFunc::CastStringToTime => {
                 Ok(Datum::Time(strconv::parse_time(a).map_err(parse_err)?))
             }
@@ -239,7 +239,7 @@ impl CastFunc {
                 Ok(arena.push_unary_row(jsonb.into_row()))
             }
             CastFunc::CastStringToMzTimestamp => Ok(Datum::MzTimestamp(
-                strconv::parse_mz_timestamp(a).map_err(parse_err)?,
+                strconv::parse_mz_timestamp_legacy(a).map_err(parse_err)?,
             )),
 
             // Parameterized eager casts.
@@ -253,12 +253,12 @@ impl CastFunc {
                 Ok(Datum::from(d.into_inner()))
             }
             CastFunc::CastStringToTimestamp(precision) => {
-                let out = strconv::parse_timestamp(a)?;
+                let out = strconv::parse_timestamp_legacy(a)?;
                 let updated = out.round_to_precision(*precision)?;
                 Ok(Datum::Timestamp(updated))
             }
             CastFunc::CastStringToTimestampTz(precision) => {
-                let out = strconv::parse_timestamptz(a)?;
+                let out = strconv::parse_timestamptz_legacy(a)?;
                 let updated = out.round_to_precision(*precision)?;
                 Ok(Datum::TimestampTz(updated))
             }
@@ -496,6 +496,25 @@ mod tests {
         // Parsing should succeed; just verify it's a Date datum.
         let result = expr.eval(&[Datum::String("2024-01-15")], &arena).unwrap();
         assert!(matches!(result, Datum::Date(_)));
+    }
+
+    #[mz_ore::test]
+    fn test_cast_string_to_date_frozen_ambiguous() {
+        // Ambiguous dates keep the frozen year-month-day interpretation with
+        // no two-digit-year windowing, diverging from the SQL layer's
+        // `DateStyle = ISO, MDY` semantics. This must not change (see the
+        // stability contract above).
+        let arena = RowArena::new();
+        let expr = cast_col0(CastFunc::CastStringToDate);
+        for (input, expected) in [("01/02/03", "0001-02-03"), ("99-01-08", "0099-01-08")] {
+            let result = expr.eval(&[Datum::String(input)], &arena).unwrap();
+            let Datum::Date(d) = result else {
+                panic!("expected Date, got {:?}", result);
+            };
+            let mut buf = String::new();
+            strconv::format_date(&mut buf, d);
+            assert_eq!(buf, expected, "for input {input:?}");
+        }
     }
 
     #[mz_ore::test]

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1802,3 +1802,58 @@ SELECT make_timestamp(2020, 13, 1, 0, 0, 0)
 
 query error timestamp out of range
 SELECT make_timestamp(2020, 1, 1, 12, 60, 0)
+
+# Ambiguous all-numeric dates follow the pinned DateStyle 'ISO, MDY': a one- or
+# two-digit leading field starts a month-day-year date, and a two-digit year is
+# windowed into 1970..=2069 (SQL-461).
+
+query T
+SELECT DATE '01/02/03'
+----
+2003-01-02
+
+query T
+SELECT DATE '1-2-3'
+----
+2003-01-02
+
+query T
+SELECT DATE '01/02/1999'
+----
+1999-01-02
+
+query T
+SELECT DATE '01/02/69'
+----
+2069-01-02
+
+query T
+SELECT DATE '01/02/70'
+----
+1970-01-02
+
+# A leading field of three or more digits is a year, with no windowing.
+query T
+SELECT DATE '0099-01-08'
+----
+0099-01-08
+
+query error invalid input syntax for type date: MONTH must be \[1, 12\], got 99: "99\-01\-08"
+SELECT DATE '99-01-08'
+
+# BC years are never windowed.
+query T
+SELECT DATE '01/02/03 BC'
+----
+0003-01-02 BC
+
+# Timestamps interpret the date part the same way.
+query T
+SELECT TIMESTAMP '01/02/03 04:05:06'
+----
+2003-01-02 04:05:06
+
+query T
+SELECT TIMESTAMP WITH TIME ZONE '01/02/03 04:05:06+00'
+----
+2003-01-02 04:05:06+00

--- a/test/sqllogictest/timestamptz.slt
+++ b/test/sqllogictest/timestamptz.slt
@@ -182,7 +182,7 @@ FROM (
 1␠hour␠30␠minutes true
 
 query error timestamp out of range
-select timezone('1 day'::interval, '1-12-31'::timestamptz+'262141 years'::interval)
+select timezone('1 day'::interval, '0001-12-31'::timestamptz+'262141 years'::interval)
 
 # Regression test for database-issues#CLU-92: a leap-second timestamptz combined
 # with a fixed offset that shifts the seconds off `:59` previously panicked


### PR DESCRIPTION
Interpret separated all-numeric date literals the way PostgreSQL does under the pinned DateStyle 'ISO, MDY': a one- or two-digit leading field starts a month-day-year date, and a two-digit year is windowed into 1970..=2069. A leading field of three or more digits keeps the year-month-day interpretation. This applies to date, timestamp and timestamptz parsing at the SQL layer.

      SELECT date '01/02/03';  -- now 2003-01-02, was 0001-02-03
      SELECT date '99-01-08';  -- now an error (month 99), was 0099-01-08

Storage source casts stay on new frozen legacy parse functions (parse_date_legacy and friends) so their evaluation is unchanged, per the stability contract in mz_storage_types::sources::casts.

Closes: SQL-461