### PR TITLE
console: [SAS-167] Show account display names instead of UUIDs in the Last 30 days plan-details breakdown

### DIFF
--- a/console/src/platform/billing/PlanDetails.tsx
+++ b/console/src/platform/billing/PlanDetails.tsx
@@ -296,7 +296,7 @@ export const AccountSpendPlanDetails = ({
               last30.accounts.map((account) => (
                 <PlanSectionItem
                   key={account.id}
-                  title={shortAccountId(account.id)}
+                  title={account.name || shortAccountId(account.id)}
                   value={formatCurrency(account.total)}
                 />
               ))}

--- a/console/src/platform/billing/UsagePage.test.tsx
+++ b/console/src/platform/billing/UsagePage.test.tsx
@@ -300,7 +300,7 @@ describe("UsagePage", () => {
           days: oneDay([
             {
               external_customer_id: "parent-org",
-              name: "",
+              name: "Built-Prod",
               clusters: [
                 {
                   environment_id: "environment-parent-0",
@@ -353,6 +353,10 @@ describe("UsagePage", () => {
     // biggest spender first, under the window total.
     expect(await planDetails.findByText(formatCurrency(14))).toBeVisible();
     expect(await planDetails.findByText(formatCurrency(5))).toBeVisible();
+    // The parent has a display name (SAS-167) and renders it in place of the
+    // UUID; the child has none, so its row falls back to the short UUID.
+    expect(await planDetails.findByText("Built-Prod")).toBeVisible();
+    expect(await planDetails.findByText("child-or…")).toBeVisible();
   });
 
   it("renders storage and egress as distinct region-qualified rows, each with its own usage unit (SAS-159)", async () => {

--- a/console/src/platform/billing/dailyBreakdown.ts
+++ b/console/src/platform/billing/dailyBreakdown.ts
@@ -179,15 +179,17 @@ export function accountIdsByTotal(series: Map<string, number[]>): string[] {
  * broken by id, matching `accountIdsByTotal`), plus the window total. Used to
  * itemize the "Last 30 days" row by account. `null` if there's no data.
  */
-export function breakdownByAccount(
-  days: CostBreakdownDay[] | null,
-): { total: number; accounts: { id: string; total: number }[] } | null {
+export function breakdownByAccount(days: CostBreakdownDay[] | null): {
+  total: number;
+  accounts: { id: string; name: string; total: number }[];
+} | null {
   if (!days || days.length === 0) {
     return null;
   }
   const accounts = aggregateDays(days)
     .accounts.map((account) => ({
       id: account.external_customer_id,
+      name: account.name,
       total: accountTotal(account),
     }))
     .sort((a, b) => b.total - a.total || a.id.localeCompare(b.id));


### PR DESCRIPTION
## Summary
- `breakdownByAccount` now carries each account's `name` alongside `id`/`total`.
- The Plan details "Last 30 days" itemization renders `account.name || shortAccountId(account.id)`, matching the fallback pattern SAS-142 already shipped for the main ledger.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test src/platform/billing` (35/35 passing), including a case asserting both the rendered name and the UUID fallback