### PR TITLE
console: [SAS-168] Default the account ledger's expand/collapse groups to closed

### DIFF
--- a/console/src/platform/billing/AccountSpendBreakdown.tsx
+++ b/console/src/platform/billing/AccountSpendBreakdown.tsx
@@ -406,7 +406,8 @@ const TrendSparkline = ({
  * always-visible parent row (caret + color swatch + label, its share of the
  * period total, a daily-total trend, and its total cost) and its clusters are
  * indented, region-qualified child rows revealed by the disclosure. Groups
- * default open so the whole ledger is visible without interaction.
+ * default closed, so the ledger opens to a compact summary and clusters are
+ * revealed on demand.
  */
 const AccountLedgerGroup = ({
   account,
@@ -424,6 +425,7 @@ const AccountLedgerGroup = ({
   return (
     <LedgerGroup
       rowCount={account.clusters.length}
+      defaultIsOpen={false}
       data-testid="account-row"
       renderHeader={(isOpen) => (
         <>

--- a/console/src/platform/billing/UsagePage.test.tsx
+++ b/console/src/platform/billing/UsagePage.test.tsx
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import React, { ReactElement } from "react";
 
@@ -155,8 +156,10 @@ describe("UsagePage", () => {
     // parent 14/19 ≈ 73.7%, child 5/19 ≈ 26.3%.
     expect(within(accountRows[0]).getByText("73.7%")).toBeVisible();
     expect(within(accountRows[1]).getByText("26.3%")).toBeVisible();
-    // Accounts render expanded, so every cluster row is visible inline,
-    // region-qualified ("aws/us-east-1 / <cluster>").
+    // Accounts render collapsed by default (SAS-168); expand both to reveal
+    // their cluster rows, region-qualified ("aws/us-east-1 / <cluster>").
+    await userEvent.click(accountRows[0]);
+    await userEvent.click(accountRows[1]);
     for (const cluster of ["quickstart.r1", "compute.r1", "prod.r1"]) {
       expect(
         await ledger.findByText(`aws/us-east-1 / ${cluster}`),
@@ -402,17 +405,20 @@ describe("UsagePage", () => {
     const ledger = within(
       await screen.findByTestId("account-spend-ledger", {}, { timeout: 5_000 }),
     );
-    // The account renders expanded, so its clusters are visible inline. Scope
-    // lookups to the ledger table. Storage and egress (both empty
-    // cluster_grouping_key) stay on separate rows via `category`.
-    expect(await ledger.findByText("aws/us-east-1 / default.r1")).toBeVisible();
-    expect(await ledger.findByText("aws/us-east-1 / Storage")).toBeVisible();
-    expect(await ledger.findByText("aws/us-east-1 / Egress")).toBeVisible();
+    // Accounts render collapsed by default (SAS-168); expand to reveal its
+    // clusters. Scope lookups to the ledger table. Storage and egress (both
+    // empty cluster_grouping_key) stay on separate rows via `category`.
+    await userEvent.click(await ledger.findByTestId("account-row"));
+    await waitFor(() => {
+      expect(ledger.getByText("aws/us-east-1 / default.r1")).toBeVisible();
+      expect(ledger.getByText("aws/us-east-1 / Storage")).toBeVisible();
+      expect(ledger.getByText("aws/us-east-1 / Egress")).toBeVisible();
+    });
     // The compute row's usage renders in credits, the storage/egress rows'
     // in GB.
-    expect(await ledger.findByText("2.5 credits")).toBeVisible();
-    expect(await ledger.findByText("10.75 GB")).toBeVisible();
-    expect(await ledger.findByText("3 GB")).toBeVisible();
+    expect(ledger.getByText("2.5 credits")).toBeVisible();
+    expect(ledger.getByText("10.75 GB")).toBeVisible();
+    expect(ledger.getByText("3 GB")).toBeVisible();
   });
 
   it("falls back to 'Other' when a row has neither cluster key nor category", async () => {
@@ -447,8 +453,12 @@ describe("UsagePage", () => {
     const ledger = within(
       await screen.findByTestId("account-spend-ledger", {}, { timeout: 5_000 }),
     );
-    // The account renders expanded, so its one cluster row is visible inline.
-    expect(await ledger.findByText("aws/us-east-1 / Other")).toBeVisible();
+    // Accounts render collapsed by default (SAS-168); expand to reveal its
+    // one cluster row.
+    await userEvent.click(await ledger.findByTestId("account-row"));
+    await waitFor(() => {
+      expect(ledger.getByText("aws/us-east-1 / Other")).toBeVisible();
+    });
   });
 
   it("filters the ledger by region", async () => {


### PR DESCRIPTION
## Summary
- `AccountLedgerGroup` now passes `defaultIsOpen={false}` to `LedgerGroup`, so each account row starts collapsed rather than expanded, reversing the original SAS-128 choice.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test src/platform/billing` (35/35 passing, verified stable across repeated runs) — updated the tests that relied on cluster rows being visible without interaction to click the account row first