### PR TITLE
console: serve cluster detail's clusters list from the allClusters subscribe

### DIFF
--- a/console/src/api/materialize/cluster/clusterList.test.sql.ts
+++ b/console/src/api/materialize/cluster/clusterList.test.sql.ts
@@ -30,6 +30,7 @@ describe("buildClusterSubscribe", () => {
     expect(result.rows.find((r) => r.name == "quickstart")).toEqual({
       id: expect.any(String),
       isOwner: true,
+      ownerId: expect.any(String),
       name: "quickstart",
       disk: true,
       managed: true,
@@ -66,6 +67,7 @@ describe("buildClusterSubscribe", () => {
     expect(result.rows).toEqual([
       {
         id: expect.any(String),
+        ownerId: expect.any(String),
         name: "quickstart",
         disk: true,
         managed: true,

--- a/console/src/api/materialize/cluster/clusterList.ts
+++ b/console/src/api/materialize/cluster/clusterList.ts
@@ -59,6 +59,7 @@ export const buildClustersQuery = ({
       "c.disk",
       "c.managed",
       "c.size",
+      "c.owner_id as ownerId",
       jsonArrayFrom<{
         id: string;
         name: string;

--- a/console/src/api/materialize/owners.ts
+++ b/console/src/api/materialize/owners.ts
@@ -1,0 +1,38 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { QueryKey } from "@tanstack/react-query";
+import { InferResult } from "kysely";
+
+import { executeSqlV2 } from "~/api/materialize/executeSqlV2";
+import { getOwners } from "~/api/materialize/expressionBuilders";
+
+/**
+ * Fetches all roles along with whether the current user can act as each role.
+ *
+ * Ownership can't be computed inside a SUBSCRIBE because has_role() and
+ * mz_is_superuser() can't run in a dataflow, so subscribe consumers join
+ * this against a row's owner id client-side.
+ */
+export async function fetchOwners({
+  queryKey,
+  requestOptions,
+}: {
+  queryKey: QueryKey;
+  requestOptions?: RequestInit;
+}) {
+  const compiledQuery = getOwners().compile();
+  return executeSqlV2({
+    queries: compiledQuery,
+    queryKey,
+    requestOptions,
+  });
+}
+
+export type Owner = InferResult<ReturnType<typeof getOwners>>[0];

--- a/console/src/platform/clusters/ClusterDetail.test.tsx
+++ b/console/src/platform/clusters/ClusterDetail.test.tsx
@@ -12,11 +12,13 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 import { Route, Routes } from "react-router-dom";
 
-import server from "~/api/mocks/server";
-import { validClustersResponse } from "~/test/clusterQueryBuilders";
+import { getStore } from "~/jotai";
+import { allClusters } from "~/store/allClusters";
+import { mockSubscribeState } from "~/test/mockSubscribe";
 import { renderComponent, RenderWithPathname } from "~/test/utils";
 
 import ClusterDetail from "./ClusterDetail";
+import { buildClusterServerResponse } from "./clustersTestUtils";
 
 vi.mock("~/platform/clusters/ClusterOverview", () => ({
   default: function () {
@@ -26,7 +28,18 @@ vi.mock("~/platform/clusters/ClusterOverview", () => ({
 
 describe("ClusterRoutes", () => {
   it("breadcrumb context menu allows switching clusters", async () => {
-    server.use(validClustersResponse);
+    const store = getStore();
+    store.set(
+      allClusters,
+      mockSubscribeState({
+        data: [
+          buildClusterServerResponse({ id: "u1", name: "default" }),
+          buildClusterServerResponse({ id: "u2", name: "quickstart" }),
+          buildClusterServerResponse({ id: "s1", name: "mz_system" }),
+          buildClusterServerResponse({ id: "s2", name: "mz_catalog_server" }),
+        ],
+      }),
+    );
     renderComponent(
       <RenderWithPathname>
         <Routes>

--- a/console/src/platform/clusters/ClusterDetail.tsx
+++ b/console/src/platform/clusters/ClusterDetail.tsx
@@ -27,6 +27,7 @@ import {
   ClusterParams,
 } from "~/platform/clusters/ClusterRoutes";
 import { SentryRoutes } from "~/sentry";
+import { useAllClusters } from "~/store/allClusters";
 import { assert } from "~/util";
 
 import { replaceClusterIdAndName } from "../routeHelpers";
@@ -35,7 +36,7 @@ import ClusterOverview from "./ClusterOverview";
 import ClusterReplicas from "./ClusterReplicas";
 import IndexList from "./IndexList";
 import MaterializedViewsList from "./MaterializedViewsList";
-import { useClusters } from "./queries";
+import { useOwners } from "./queries";
 import Sinks from "./Sinks";
 import Sources from "./Sources";
 import { useShowSystemObjects } from "./useShowSystemObjects";
@@ -43,15 +44,17 @@ import { useShowSystemObjects } from "./useShowSystemObjects";
 const ClusterDetailBreadcrumbs = (props: { crumbs: Breadcrumb[] }) => {
   const [showSystemObjects] = useShowSystemObjects();
   const { clusterId, clusterName } = useParams<ClusterParams>();
-  const { data: clusters, getClusterById } = useClusters();
+  const { data: clusters, getClusterById } = useAllClusters();
+  const { data: ownersById } = useOwners();
   const { pathname, search } = useLocation();
   assert(clusterId);
   assert(clusterName);
   const cluster = getClusterById(clusterId);
 
-  const clustersToShow = showSystemObjects
-    ? clusters
-    : clusters.filter((c) => c.id.startsWith("u"));
+  // The subscribe upserts by id, so the atom's order is arbitrary.
+  const clustersToShow = clusters
+    .filter((c) => showSystemObjects || c.id.startsWith("u"))
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   const menu = (
     <>
@@ -79,7 +82,16 @@ const ClusterDetailBreadcrumbs = (props: { crumbs: Breadcrumb[] }) => {
     <PageBreadcrumbs
       crumbs={props.crumbs}
       contextMenuChildren={menu}
-      rightSideChildren={cluster && <OverflowMenuContainer cluster={cluster} />}
+      rightSideChildren={
+        cluster && (
+          <OverflowMenuContainer
+            cluster={{
+              ...cluster,
+              isOwner: ownersById?.get(cluster.ownerId) ?? false,
+            }}
+          />
+        )
+      }
     />
   );
 };

--- a/console/src/platform/clusters/ClusterDetail.tsx
+++ b/console/src/platform/clusters/ClusterDetail.tsx
@@ -45,7 +45,7 @@ const ClusterDetailBreadcrumbs = (props: { crumbs: Breadcrumb[] }) => {
   const [showSystemObjects] = useShowSystemObjects();
   const { clusterId, clusterName } = useParams<ClusterParams>();
   const { data: clusters, getClusterById } = useAllClusters();
-  const { data: ownersById } = useOwners();
+  const { data: ownersById, isPending: isOwnersPending } = useOwners();
   const { pathname, search } = useLocation();
   assert(clusterId);
   assert(clusterName);
@@ -53,7 +53,7 @@ const ClusterDetailBreadcrumbs = (props: { crumbs: Breadcrumb[] }) => {
 
   // The subscribe upserts by id, so the atom's order is arbitrary.
   const clustersToShow = clusters
-    .filter((c) => showSystemObjects || c.id.startsWith("u"))
+    .filter((c) => showSystemObjects || !isSystemCluster(c.id))
     .sort((a, b) => a.name.localeCompare(b.name));
 
   const menu = (
@@ -87,7 +87,10 @@ const ClusterDetailBreadcrumbs = (props: { crumbs: Breadcrumb[] }) => {
           <OverflowMenuContainer
             cluster={{
               ...cluster,
-              isOwner: ownersById?.get(cluster.ownerId) ?? false,
+              // Treat an in-flight owners query as non-owner so owner-only menu
+              // items stay hidden until ownership is known.
+              isOwner:
+                !isOwnersPending && (ownersById?.get(cluster.ownerId) ?? false),
             }}
           />
         )

--- a/console/src/platform/clusters/ClusterReplicas.test.tsx
+++ b/console/src/platform/clusters/ClusterReplicas.test.tsx
@@ -18,6 +18,9 @@ import {
   mapKyselyToTabular,
 } from "~/api/mocks/buildSqlQueryHandler";
 import server from "~/api/mocks/server";
+import { getStore } from "~/jotai";
+import { allClusters } from "~/store/allClusters";
+import { mockSubscribeState } from "~/test/mockSubscribe";
 import { renderComponent } from "~/test/utils";
 
 import ClusterReplicas from "./ClusterReplicas";
@@ -44,11 +47,8 @@ const replicasWithUtilizationColumns = buildColumns([
   { name: "isOwner", type_oid: MzDataType.bool },
 ]);
 
-const {
-  detailPageCluster,
-  detailPageSetupHandler,
-  detailPageInitialRouteEntries,
-} = detailPageSetupHelpers();
+const { detailPageCluster, detailPageInitialRouteEntries } =
+  detailPageSetupHelpers();
 
 const emptyReplicaListHandler = buildSqlQueryHandlerV2({
   queryKey: clusterQueryKeys.replicasWithUtilization({
@@ -85,7 +85,8 @@ const validReplicaListHandler = buildSqlQueryHandlerV2({
 
 describe("ClusterReplicas", () => {
   beforeEach(() => {
-    server.use(detailPageSetupHandler);
+    const store = getStore();
+    store.set(allClusters, mockSubscribeState({ data: [detailPageCluster] }));
   });
 
   it("shows a spinner initially", async () => {

--- a/console/src/platform/clusters/ClusterReplicas.tsx
+++ b/console/src/platform/clusters/ClusterReplicas.tsx
@@ -42,6 +42,7 @@ import {
 } from "~/layouts/listPageComponents";
 import docUrls from "~/mz-doc-urls.json";
 import { ClusterParams } from "~/platform/clusters/ClusterRoutes";
+import { useAllClusters } from "~/store/allClusters";
 import { MaterializeTheme } from "~/theme";
 import { assert } from "~/util";
 
@@ -49,8 +50,8 @@ import { CLUSTERS_FETCH_ERROR_MESSAGE } from "./constants";
 import NewReplicaModal from "./NewReplicaModal";
 import {
   useClusterReplicasWithUtilization,
-  useClusters,
   useMaxReplicasPerCluster,
+  useOwners,
 } from "./queries";
 
 export const ClusterReplicasPage = () => {
@@ -70,8 +71,12 @@ const ClusterReplicasInner = () => {
 
   const { clusterId, clusterName } = useParams<ClusterParams>();
   assert(clusterId);
-  const { getClusterById } = useClusters();
+  const { getClusterById } = useAllClusters();
   const cluster = getClusterById(clusterId);
+  const { data: ownersById } = useOwners();
+  const isClusterOwner = cluster
+    ? (ownersById?.get(cluster.ownerId) ?? false)
+    : false;
   const { data: replicas, refetch } = useClusterReplicasWithUtilization({
     clusterId,
   });
@@ -93,7 +98,7 @@ const ClusterReplicasInner = () => {
         <Text textStyle="heading-sm">Replicas</Text>
         {cluster &&
           !cluster.managed &&
-          cluster.isOwner &&
+          isClusterOwner &&
           replicas &&
           maxReplicas &&
           replicas.length < maxReplicas && (

--- a/console/src/platform/clusters/ClusterReplicas.tsx
+++ b/console/src/platform/clusters/ClusterReplicas.tsx
@@ -73,10 +73,13 @@ const ClusterReplicasInner = () => {
   assert(clusterId);
   const { getClusterById } = useAllClusters();
   const cluster = getClusterById(clusterId);
-  const { data: ownersById } = useOwners();
-  const isClusterOwner = cluster
-    ? (ownersById?.get(cluster.ownerId) ?? false)
-    : false;
+  const { data: ownersById, isPending: isOwnersPending } = useOwners();
+  // Treat an in-flight owners query as non-owner so owner-only controls stay
+  // hidden until ownership is known.
+  const isClusterOwner =
+    !isOwnersPending && cluster
+      ? (ownersById?.get(cluster.ownerId) ?? false)
+      : false;
   const { data: replicas, refetch } = useClusterReplicasWithUtilization({
     clusterId,
   });

--- a/console/src/platform/clusters/ClusterRoutes.test.tsx
+++ b/console/src/platform/clusters/ClusterRoutes.test.tsx
@@ -22,7 +22,6 @@ import { allClusters } from "~/store/allClusters";
 import {
   clustersFetchColumns,
   emptyClustersResponse,
-  validClustersResponse,
 } from "~/test/clusterQueryBuilders";
 import { mockSubscribeState } from "~/test/mockSubscribe";
 import { renderComponent, RenderWithPathname } from "~/test/utils";
@@ -30,13 +29,10 @@ import { renderComponent, RenderWithPathname } from "~/test/utils";
 import ClusterRoutes from "./ClusterRoutes";
 import { buildClusterServerResponse } from "./clustersTestUtils";
 import { CLUSTERS_FETCH_ERROR_MESSAGE } from "./constants";
-import { clusterQueryKeys, useClusters } from "./queries";
+import { clusterQueryKeys } from "./queries";
 
 vi.mock("~/platform/clusters/ClusterDetail", () => ({
   default: function () {
-    // Given we're mocking the default export, we don't need to capitalize the function name
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useClusters();
     return <div>ClusterDetail component</div>;
   },
 }));
@@ -55,6 +51,7 @@ const validCluster: Cluster = {
   name: "default",
   size: "50cc",
   managed: true,
+  ownerId: "u1",
   replicas: [
     {
       id: "u678",
@@ -161,7 +158,6 @@ describe("ClusterRoutes", () => {
   });
 
   it("shows cluster details", async () => {
-    server.use(validClustersResponse);
     renderComponent(<ClusterRoutes />, {
       initialRouterEntries: ["/u1/default"],
     });
@@ -170,7 +166,6 @@ describe("ClusterRoutes", () => {
   });
 
   it("updates the path when the name has changed", async () => {
-    server.use(validClustersResponse);
     renderComponent(
       <RenderWithPathname>
         <ClusterRoutes />
@@ -185,7 +180,6 @@ describe("ClusterRoutes", () => {
   });
 
   it("updates the path when the id has changed", async () => {
-    server.use(validClustersResponse);
     renderComponent(
       <RenderWithPathname>
         <ClusterRoutes />
@@ -199,12 +193,23 @@ describe("ClusterRoutes", () => {
     expect(screen.getByText("ClusterDetail component")).toBeVisible();
   });
 
-  it("shows an error state when clusters fail to load on the details page", async () => {
-    server.use(errorClustersResponse);
+  it("still renders the details page when the clusters subscribe errors", async () => {
+    const store = getStore();
+    store.set(
+      allClusters,
+      mockSubscribeState<Cluster>({
+        data: [],
+        snapshotComplete: false,
+        error: {
+          code: ErrorCode.INTERNAL_ERROR,
+          message: "Something went wrong",
+        },
+      }),
+    );
     renderComponent(<ClusterRoutes />, {
       initialRouterEntries: ["/u1/default"],
     });
 
-    expect(await screen.findByText(CLUSTERS_FETCH_ERROR_MESSAGE)).toBeVisible();
+    expect(await screen.findByText("ClusterDetail component")).toBeVisible();
   });
 });

--- a/console/src/platform/clusters/clustersTestUtils.ts
+++ b/console/src/platform/clusters/clustersTestUtils.ts
@@ -42,6 +42,7 @@ export function buildClusterServerResponse(
     name: "default",
     size: "small",
     managed: true,
+    ownerId: "u1",
     replicas: replicas,
     latestStatusUpdate: "2024-01-01T00:00:00.000Z",
     ...overrides,
@@ -58,6 +59,7 @@ export function detailPageSetupHelpers() {
     size: "50cc",
     managed: true,
     disk: true,
+    ownerId: "u1",
     replicas: [
       {
         id: "u678",

--- a/console/src/platform/clusters/queries.ts
+++ b/console/src/platform/clusters/queries.ts
@@ -78,6 +78,7 @@ import {
 } from "~/api/materialize/cluster/replicaUtilizationHistory";
 import { fetchLagHistory } from "~/api/materialize/freshness/lagHistory";
 import { assertNoMoreThanOneRow } from "~/api/materialize/MoreThanOneRowError";
+import { fetchOwners } from "~/api/materialize/owners";
 import { useSubscribe } from "~/api/materialize/useSubscribe";
 import { DataPoint, GraphLineSeries } from "~/components/FreshnessGraph/types";
 import { useEnvironmentGate } from "~/store/environments";
@@ -164,6 +165,8 @@ export const clusterQueryKeys = {
       ...clusterQueryKeys.all(),
       buildQueryKeyPart("clusterFreshness", params),
     ] as const,
+  owners: () =>
+    [...clusterQueryKeys.all(), buildQueryKeyPart("owners")] as const,
 };
 
 export function useClusters(filters?: ClusterListFilters) {
@@ -199,6 +202,22 @@ export function useClusters(filters?: ClusterListFilters) {
     refetch,
     getClusterById,
   };
+}
+
+/**
+ * Returns a map from role id to whether the current user can act as that
+ * role, for deriving `isOwner` on rows from the allClusters subscribe.
+ */
+export function useOwners() {
+  return useQuery({
+    refetchInterval: 60_000,
+    queryKey: clusterQueryKeys.owners(),
+    queryFn: ({ queryKey, signal }) => {
+      return fetchOwners({ queryKey, requestOptions: { signal } });
+    },
+    select: (result) =>
+      new Map(result.rows.map((row) => [row.id, row.isOwner])),
+  });
 }
 
 export type AlterClusterParams = AlterClusterSettingsParams &

--- a/console/src/platform/clusters/queries.ts
+++ b/console/src/platform/clusters/queries.ts
@@ -81,6 +81,7 @@ import { assertNoMoreThanOneRow } from "~/api/materialize/MoreThanOneRowError";
 import { fetchOwners } from "~/api/materialize/owners";
 import { useSubscribe } from "~/api/materialize/useSubscribe";
 import { DataPoint, GraphLineSeries } from "~/components/FreshnessGraph/types";
+import { roleQueryKeys } from "~/platform/roles/queries";
 import { useEnvironmentGate } from "~/store/environments";
 import { notNullOrUndefined, sumPostgresIntervalMs } from "~/util";
 import { sortLagInfo } from "~/utils/freshness";
@@ -165,8 +166,6 @@ export const clusterQueryKeys = {
       ...clusterQueryKeys.all(),
       buildQueryKeyPart("clusterFreshness", params),
     ] as const,
-  owners: () =>
-    [...clusterQueryKeys.all(), buildQueryKeyPart("owners")] as const,
 };
 
 export function useClusters(filters?: ClusterListFilters) {
@@ -210,8 +209,10 @@ export function useClusters(filters?: ClusterListFilters) {
  */
 export function useOwners() {
   return useQuery({
-    refetchInterval: 60_000,
-    queryKey: clusterQueryKeys.owners(),
+    // Role mutations invalidate this key, so this long interval is only a
+    // backstop for external role changes while the page stays open.
+    refetchInterval: 300_000,
+    queryKey: roleQueryKeys.owners(),
     queryFn: ({ queryKey, signal }) => {
       return fetchOwners({ queryKey, requestOptions: { signal } });
     },

--- a/console/src/platform/roles/queries.ts
+++ b/console/src/platform/roles/queries.ts
@@ -68,6 +68,9 @@ export const roleQueryKeys = {
       ...roleQueryKeys.all(),
       buildQueryKeyPart("grantedRoles", params),
     ] as const,
+  // Which roles the current user can act as. Under the roles namespace so the
+  // role mutations' `roleQueryKeys.all()` invalidations refresh derived ownership.
+  owners: () => [...roleQueryKeys.all(), buildQueryKeyPart("owners")] as const,
   revokeRoleMember: () =>
     [...roleQueryKeys.all(), buildQueryKeyPart("revokeRoleMember")] as const,
   grantRoleMember: () =>

--- a/console/src/platform/shell/useClusterDropdown.test.sql.ts
+++ b/console/src/platform/shell/useClusterDropdown.test.sql.ts
@@ -35,6 +35,7 @@ describe("useClustersDropdown subscribe", () => {
       mz_progressed: false,
       mz_state: "upsert",
       id: expect.any(String),
+      ownerId: expect.any(String),
       name: "quickstart",
       disk: true,
       managed: true,

--- a/console/src/test/clusterQueryBuilders.ts
+++ b/console/src/test/clusterQueryBuilders.ts
@@ -28,6 +28,7 @@ export const clustersFetchColumns = [
   buildColumn({ name: "name" }),
   buildColumn({ name: "managed", type_oid: MzDataType.bool }),
   buildColumn({ name: "size" }),
+  buildColumn({ name: "ownerId" }),
   buildColumn({ name: "replicas", type_oid: MzDataType.jsonb }),
   buildColumn({ name: "latestStatusUpdate", type_oid: MzDataType.timestamptz }),
 ];
@@ -58,6 +59,7 @@ export function buildClusterServerResponse(
     name: "default",
     size: "small",
     managed: true,
+    ownerId: "u1",
     replicas: replicas,
     latestStatusUpdate: "2024-01-01T00:00:00.000Z",
     ...overrides,

--- a/console/src/test/utils.tsx
+++ b/console/src/test/utils.tsx
@@ -228,6 +228,7 @@ export function buildCluster(
     managed: true,
     disk: true,
     isOwner: true,
+    ownerId: "u1",
     replicas: replicas,
     latestStatusUpdate: "2024-01-01T00:00:00.000Z",
     ...overrides,


### PR DESCRIPTION
The cluster detail page polled the whole cluster fleet every 5s through useClusters (replica status history join plus jsonb aggregation per cluster). The console already maintains a global mz_clusters SUBSCRIBE (the allClusters atom), so the breadcrumb cluster switcher and the replicas tab now read from that instead.

Ownership was the one thing the subscribe could not provide. The poll computed isOwner server-side via has_role(), which cannot run inside a SUBSCRIBE dataflow. buildClustersQuery now also selects owner_id, and a new useOwners hook fetches the small mz_roles ownership query on a 60s interval. Consumers join ownerId to isOwner client-side.
