### PR TITLE
nickmcavoy/mz commit linear conventions

### DIFF
--- a/.agents/skills/mz-commit/SKILL.md
+++ b/.agents/skills/mz-commit/SKILL.md
@@ -48,6 +48,33 @@ Never regenerate the entire Cargo.lock — bare `cargo update` bumps every semve
   Pin back anything that moved unexpectedly: `cargo update -p <crate> --precise <old-version>`.
 * **After rebase conflicts in Cargo.lock**: resolve by taking HEAD's version then running `cargo check` (not `cargo update`). This preserves existing pins while adding only what the new commits require.
 
+## Linear references and confidentiality
+
+GitHub is public. Linear is not.
+
+* Link the Linear issue a PR addresses with a magic word and bare ID
+  in the PR description, e.g. `Closes CS-639`. A branch name
+  containing the issue ID links the PR even without a magic word.
+* Closing words move the issue to Done when the PR merges:
+  close(s/d/ing), fix(es/ed/ing), resolve(s/d/ing), complete(s/d/ing),
+  implement(s/ed/ing).
+* Non-closing words link the PR and advance the issue without closing
+  it on merge: ref(s), references, part of, related to, relates to,
+  contributes to, toward(s).
+* Pick by situation: a ticket done in a single PR gets a closing word.
+  A ticket spanning several PRs gets non-closing words (`Part of
+  ENG-123`) on all but the last. Only the capstone PR, for stacked
+  PRs the top of the stack, says `Closes`.
+* Do not mention other Linear issues (follow-ups, related tickets) in
+  PR titles or descriptions. Besides leaking internal references,
+  those phrases are magic words: they link the PR to that issue and
+  advance its state.
+* Never include linear.app URLs.
+* Never name customers in commit messages, PR titles, or PR
+  descriptions. Write "a customer" instead.
+* Word lists current as of July 2026; full reference:
+  https://linear.app/docs/github#link-through-pull-requests
+
 ## Git conventions
 
 * Work against the `main` branch of `MaterializeInc/materialize`.


### PR DESCRIPTION
Records the Linear/GitHub linking conventions and confidentiality rules in the mz-commit skill: magic words and their closing vs non-closing behavior, choosing between them for single-PR and multi-PR tickets, no linear.app URLs, no mentions of other Linear issues in PR text (such phrases are themselves magic words and mutate the referenced issue), and no customer names. These conventions previously existed only as oral tradition.

(No Linear reference: docs-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)