### PR TITLE
mz-commit: require a Linear issue reference on every PR

### DIFF
--- a/.agents/skills/mz-commit/SKILL.md
+++ b/.agents/skills/mz-commit/SKILL.md
@@ -52,9 +52,12 @@ Never regenerate the entire Cargo.lock — bare `cargo update` bumps every semve
 
 GitHub is public. Linear is not.
 
-* Link the Linear issue a PR addresses with a magic word and bare ID
-  in the PR description, e.g. `Closes CS-639`. A branch name
-  containing the issue ID links the PR even without a magic word.
+* Every PR links a Linear issue with a magic word and bare ID in the
+  PR description, e.g. `Closes CS-639`. A branch name containing the
+  issue ID links the PR even without a magic word.
+* Exception: a docs-only change needs no issue. Say so in the
+  description with a parenthetical: "(No Linear reference: docs-only
+  change.)"
 * Closing words move the issue to Done when the PR merges:
   close(s/d/ing), fix(es/ed/ing), resolve(s/d/ing), complete(s/d/ing),
   implement(s/ed/ing).


### PR DESCRIPTION
Adds the rule that every PR links a Linear issue, with an exception for docs-only changes, which note the exception in a parenthetical. Split into its own PR because it's the most debatable rule in the stack. This PR's own description demonstrates the exception.

(No Linear reference: docs-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)