### PR TITLE
mz-commit: allow upstream branches for PR stacks

### DIFF
--- a/.agents/skills/mz-commit/SKILL.md
+++ b/.agents/skills/mz-commit/SKILL.md
@@ -81,6 +81,8 @@ GitHub is public. Linear is not.
 ## Git conventions
 
 * Work against the `main` branch of `MaterializeInc/materialize`.
-* Push branches to your fork.
+* Push branches to your fork. Exception: a PR stack needs its branches
+  in `MaterializeInc/materialize`, since each stacked PR targets the
+  branch below it. Delete the branches once the stack merges.
 * Pull requests target `main` on `MaterializeInc/materialize`.
 * Each PR should contain one semantic change.


### PR DESCRIPTION
Permits pushing branches to MaterializeInc/materialize for PR stacks, which target each other's branches and so cannot be built from fork branches. Records the cleanup obligation once a stack merges.

(No Linear reference: docs-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)