### PR TITLE
sql: Reject CREATE [MATERIALIZED] VIEW with too few column names

### DIFF
--- a/misc/python/materialize/checks/all_checks/view_column_names.py
+++ b/misc/python/materialize/checks/all_checks/view_column_names.py
@@ -1,0 +1,82 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.mz_version import MzVersion
+
+CHECK_INTRODUCED_IN = MzVersion.parse_mz("v26.36.0-dev")
+
+RELAX_CHECK = """
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET unsafe_enable_incomplete_view_column_lists = on
+""".strip()
+
+RESTORE_CHECK = """
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET unsafe_enable_incomplete_view_column_lists
+""".strip()
+
+
+class ViewColumnNameCountMismatch(Check):
+    """A view whose column name list names fewer columns than its query, as
+    accepted by versions predating the SQL-455 arity check, must keep loading
+    during bootstrap after upgrade rather than crash-looping environmentd when
+    its persisted `create_sql` is re-planned by the stricter planner."""
+
+    def _create_objects(self) -> str:
+        return dedent("""
+            > CREATE TABLE col_count_table (a INT, b INT, c INT)
+            > INSERT INTO col_count_table VALUES (1, 2, 3)
+
+            > CREATE VIEW col_count_v (x) AS SELECT a, b, c FROM col_count_table
+            > CREATE MATERIALIZED VIEW col_count_mv (x) AS SELECT a, b, c FROM col_count_table
+            """).strip()
+
+    def initialize(self) -> Testdrive:
+        create = self._create_objects()
+        if self.base_version >= CHECK_INTRODUCED_IN:
+            body = f"{RELAX_CHECK}\n\n{create}\n\n{RESTORE_CHECK}"
+        else:
+            body = create
+        return Testdrive(body)
+
+    def manipulate(self) -> list[Testdrive]:
+        check_usable = dedent("""
+            > SELECT x, b, c FROM col_count_v
+            1 2 3
+            > SELECT x, b, c FROM col_count_mv
+            1 2 3
+            """).strip()
+        return [Testdrive(check_usable), Testdrive(check_usable)]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(dedent("""
+            > SELECT o.name, c.name, c.position
+              FROM mz_columns c JOIN mz_objects o ON c.id = o.id
+              WHERE o.name IN ('col_count_v', 'col_count_mv')
+              ORDER BY o.name, c.position
+            col_count_mv x 1
+            col_count_mv b 2
+            col_count_mv c 3
+            col_count_v x 1
+            col_count_v b 2
+            col_count_v c 3
+
+            > SELECT x, b, c FROM col_count_v
+            1 2 3
+
+            > SELECT x, b, c FROM col_count_mv
+            1 2 3
+
+            ![version>=2603600] CREATE VIEW col_count_reject (x) AS SELECT a, b FROM col_count_table
+            contains: definition names 1 column, but view materialize.public.col_count_reject has 2 columns
+            """))

--- a/src/sql/src/plan/plan_utils.rs
+++ b/src/sql/src/plan/plan_utils.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use mz_repr::RelationDesc;
 
 use crate::ast::Ident;
+use crate::catalog::SessionCatalog;
 use crate::normalize;
 use crate::plan::PlanError;
 use crate::plan::query::SelectOptionExtracted;
@@ -29,18 +30,7 @@ pub fn maybe_rename_columns(
     column_names: &[Ident],
 ) -> Result<(), PlanError> {
     if column_names.len() > desc.typ().column_types.len() {
-        sql_bail!(
-            "{0} definition names {1} column{2}, but {0} has {3} column{4}",
-            context,
-            column_names.len(),
-            if column_names.len() == 1 { "" } else { "s" },
-            desc.typ().column_types.len(),
-            if desc.typ().column_types.len() == 1 {
-                ""
-            } else {
-                "s"
-            },
-        )
+        return Err(column_count_mismatch(&context, desc, column_names));
     }
 
     for (i, name) in column_names.iter().enumerate() {
@@ -48,6 +38,51 @@ pub fn maybe_rename_columns(
     }
 
     Ok(())
+}
+
+/// Like [`maybe_rename_columns`], but requires the length of `column_names`,
+/// when non-empty, to match the arity of `desc` exactly.
+///
+/// The exactness requirement is lifted while re-planning a persisted catalog
+/// item, signaled by the `unsafe_enable_incomplete_view_column_lists` flag
+/// that `SystemVars::enable_for_item_parsing` force-enables during bootstrap.
+/// A view that an earlier version accepted with fewer names than columns must
+/// keep re-planning, or rehydration would turn a graceful planning error into
+/// a fatal bootstrap panic.
+pub fn maybe_rename_columns_exact(
+    catalog: &dyn SessionCatalog,
+    context: impl fmt::Display,
+    desc: &mut RelationDesc,
+    column_names: &[Ident],
+) -> Result<(), PlanError> {
+    if !column_names.is_empty()
+        && column_names.len() < desc.typ().column_types.len()
+        && !catalog
+            .system_vars()
+            .unsafe_enable_incomplete_view_column_lists()
+    {
+        return Err(column_count_mismatch(&context, desc, column_names));
+    }
+    maybe_rename_columns(context, desc, column_names)
+}
+
+fn column_count_mismatch(
+    context: &dyn fmt::Display,
+    desc: &RelationDesc,
+    column_names: &[Ident],
+) -> PlanError {
+    sql_err!(
+        "{0} definition names {1} column{2}, but {0} has {3} column{4}",
+        context,
+        column_names.len(),
+        if column_names.len() == 1 { "" } else { "s" },
+        desc.typ().column_types.len(),
+        if desc.typ().column_types.len() == 1 {
+            ""
+        } else {
+            "s"
+        },
+    )
 }
 
 /// Specifies the side of a join.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2670,7 +2670,8 @@ pub fn plan_view(
         scx.allocate_qualified_name(normalize::unresolved_item_name(name.to_owned())?)?
     };
 
-    plan_utils::maybe_rename_columns(
+    plan_utils::maybe_rename_columns_exact(
+        scx.catalog,
         format!("view {}", scx.catalog.resolve_full_name(&name)),
         &mut desc,
         columns,
@@ -2869,7 +2870,8 @@ pub fn plan_create_materialized_view(
         ));
     }
 
-    plan_utils::maybe_rename_columns(
+    plan_utils::maybe_rename_columns_exact(
+        scx.catalog,
         format!("materialized view {}", scx.catalog.resolve_full_name(&name)),
         &mut desc,
         &stmt.columns,

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1941,6 +1941,12 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
+        name: unsafe_enable_incomplete_view_column_lists,
+        desc: "declaring a view with fewer column names than columns",
+        default: false,
+        enable_for_item_parsing: true,
+    },
+    {
         name: unsafe_enable_table_check_constraint,
         desc: "CREATE TABLE with a check constraint",
         default: false,

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -407,6 +407,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     storage_upsert_prevent_snapshot_buffering
     superuser_reserved_connections
     txn_wal_apply_ensure_schema_match
+    unsafe_enable_incomplete_view_column_lists
     unsafe_enable_table_check_constraint
     unsafe_enable_table_foreign_key
     unsafe_enable_table_keys

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -69,6 +69,9 @@ jon  12
 statement error materialized view .+ definition names 2 columns, but materialized view .+ has 1 column
 CREATE MATERIALIZED VIEW error (name, age) AS SELECT 'jon'
 
+statement error materialized view .+ definition names 1 column, but materialized view .+ has 2 columns
+CREATE MATERIALIZED VIEW error (name) AS SELECT 'jon', 12
+
 
 # Test: Materialized view can be created in another cluster.
 

--- a/test/sqllogictest/regressions.slt
+++ b/test/sqllogictest/regressions.slt
@@ -516,3 +516,43 @@ COMPLETE 0
 # grandfathered type, returning the graceful planning error rather than panicking.
 query error custom type is too complex to resolve
 SELECT NULL::wide
+
+# Regression test for SQL-455: CREATE [MATERIALIZED] VIEW must reject a column
+# name list that names fewer columns than the query produces, matching the
+# existing rejection of lists that name more.
+
+statement error view materialize.public.too_few definition names 1 column, but view materialize.public.too_few has 2 columns
+CREATE VIEW too_few (name) AS SELECT 'jon', 12
+
+statement error materialized view materialize.public.too_few definition names 1 column, but materialized view materialize.public.too_few has 2 columns
+CREATE MATERIALIZED VIEW too_few (name) AS SELECT 'jon', 12
+
+# The check is lifted while re-planning persisted catalog items during
+# bootstrap, so a view created before the check existed keeps loading after
+# upgrade instead of crash-looping the environment.
+# `unsafe_enable_incomplete_view_column_lists` is the signal, force-enabled
+# during item parsing. With it on, the otherwise rejected view plans and only
+# a prefix of its columns is renamed.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET unsafe_enable_incomplete_view_column_lists = on
+----
+COMPLETE 0
+
+statement ok
+CREATE VIEW too_few (name) AS SELECT 'jon', 12
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET unsafe_enable_incomplete_view_column_lists
+----
+COMPLETE 0
+
+query TI colnames
+SELECT * FROM too_few
+----
+name  ?column?
+jon   12
+
+# Once the check is back in force a normal session still rejects creating such
+# a view while the grandfathered one remains queryable.
+statement error materialized view materialize.public.too_few_mv definition names 1 column, but materialized view materialize.public.too_few_mv has 2 columns
+CREATE MATERIALIZED VIEW too_few_mv (name) AS SELECT 'jon', 12


### PR DESCRIPTION
CREATE VIEW v (name) AS SELECT 'jon', 12 silently renamed only a prefix of the query's columns. Require the column name list, when given, to match the query's arity exactly, matching the existing rejection of lists that name more columns. Sources and CTE aliases keep the lenient prefix-rename behavior.

The new check is lifted while re-planning persisted catalog items, signaled by the unsafe_enable_incomplete_view_column_lists flag that is force-enabled during item parsing, so views an earlier version accepted keep loading during bootstrap instead of crash-looping environmentd.

Tested with sqllogictest (regressions.slt, materialized_views.slt) and a platform check that pins restart/upgrade survival of grandfathered views.

Closes: SQL-455