### PR TITLE
sql: keep fields above interval range qualifiers

### DIFF
--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -735,7 +735,10 @@ impl ParsedDateTime {
             if fmt.is_none() {
                 fmt = match value_parts.pop_front() {
                     Some(next_part) => {
-                        match determine_format_w_datetimefield(next_part.clone(), None)? {
+                        match determine_format_w_datetimefield(
+                            next_part.clone(),
+                            leading_time_precision,
+                        )? {
                             Some(TimePartFormat::SqlStandard(f)) => {
                                 match f {
                                     // Do not capture this token because expression

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -448,27 +448,6 @@ impl Interval {
         Ok(Duration::from_micros(micros))
     }
 
-    /// Truncate the "head" of the interval, removing all time units greater than `f`.
-    pub fn truncate_high_fields(&mut self, f: DateTimeField) {
-        match f {
-            DateTimeField::Year => {}
-            DateTimeField::Month => self.months %= 12,
-            DateTimeField::Day => self.months = 0,
-            DateTimeField::Hour | DateTimeField::Minute | DateTimeField::Second => {
-                self.months = 0;
-                self.days = 0;
-                self.micros %= f.next_largest().micros_multiplier()
-            }
-            DateTimeField::Millennium
-            | DateTimeField::Century
-            | DateTimeField::Decade
-            | DateTimeField::Milliseconds
-            | DateTimeField::Microseconds => {
-                unreachable!("Cannot truncate interval by {f}");
-            }
-        }
-    }
-
     /// Truncate the "tail" of the interval, removing all time units less than `f`.
     /// # Arguments
     /// - `f`: Round the interval down to the specified time unit.
@@ -1287,99 +1266,6 @@ mod test {
             if i != j {
                 panic!(
                     "test_interval_value_truncate_low_fields failed on {} \n actual: {:?} \n expected: {:?}",
-                    test.0, i, j
-                );
-            }
-        }
-    }
-
-    #[mz_ore::test]
-    fn test_interval_value_truncate_high_fields() {
-        use DateTimeField::*;
-
-        // (month, day, microsecond) tuples
-        let mut test_cases = [
-            (
-                Year,
-                (
-                    321,
-                    7,
-                    (13 * 60 * 60 * 1_000_000) + (45 * 60 * 1_000_000) + (21 * 1_000_000),
-                ),
-                (
-                    321,
-                    7,
-                    (13 * 60 * 60 * 1_000_000) + (45 * 60 * 1_000_000) + (21 * 1_000_000),
-                ),
-            ),
-            (
-                Month,
-                (
-                    321,
-                    7,
-                    (13 * 60 * 60 * 1_000_000) + (45 * 60 * 1_000_000) + (21 * 1_000_000),
-                ),
-                (
-                    9,
-                    7,
-                    (13 * 60 * 60 * 1_000_000) + (45 * 60 * 1_000_000) + (21 * 1_000_000),
-                ),
-            ),
-            (
-                Day,
-                (
-                    321,
-                    7,
-                    (13 * 60 * 60 * 1_000_000) + (45 * 60 * 1_000_000) + (21 * 1_000_000),
-                ),
-                (
-                    0,
-                    7,
-                    (13 * 60 * 60 * 1_000_000) + (45 * 60 * 1_000_000) + (21 * 1_000_000),
-                ),
-            ),
-            (
-                Hour,
-                (
-                    321,
-                    7,
-                    (13 * 60 * 60 * 1_000_000) + (45 * 60 * 1_000_000) + (21 * 1_000_000),
-                ),
-                (
-                    0,
-                    0,
-                    (13 * 60 * 60 * 1_000_000) + (45 * 60 * 1_000_000) + (21 * 1_000_000),
-                ),
-            ),
-            (
-                Minute,
-                (
-                    321,
-                    7,
-                    (13 * 60 * 60 * 1_000_000) + (45 * 60 * 1_000_000) + (21 * 1_000_000),
-                ),
-                (0, 0, (45 * 60 * 1_000_000) + (21 * 1_000_000)),
-            ),
-            (
-                Second,
-                (
-                    321,
-                    7,
-                    (13 * 60 * 60 * 1_000_000) + (45 * 60 * 1_000_000) + (21 * 1_000_000),
-                ),
-                (0, 0, 21 * 1_000_000),
-            ),
-        ];
-
-        for test in test_cases.iter_mut() {
-            let mut i = Interval::new((test.1).0, (test.1).1, (test.1).2);
-            let j = Interval::new((test.2).0, (test.2).1, (test.2).2);
-
-            i.truncate_high_fields(test.0);
-
-            if i != j {
-                panic!(
-                    "test_interval_value_truncate_high_fields failed on {} \n actual: {:?} \n expected: {:?}",
                     test.0, i, j
                 );
             }

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -249,8 +249,9 @@ impl FromStr for DateTimeField {
 pub struct IntervalValue {
     /// The raw `[value]` that was present in `INTERVAL '[value]'`
     pub value: String,
-    /// The most significant DateTimeField to propagate to Interval in
-    /// compute_interval.
+    /// The high end of the range qualifier, e.g. HOUR in `INTERVAL '...'
+    /// HOUR TO MINUTE`. Only disambiguates parsing of ambiguous time-like
+    /// parts of `value`. Fields above it are kept, as in PostgreSQL.
     pub precision_high: DateTimeField,
     /// The least significant DateTimeField to propagate to Interval in
     /// compute_interval.

--- a/src/sql/src/plan/literal.rs
+++ b/src/sql/src/plan/literal.rs
@@ -27,7 +27,9 @@ pub fn plan_interval(iv: &IntervalValue) -> Result<Interval, PlanError> {
         },
         parser_datetimefield_to_adt(iv.precision_low),
     )?;
-    i.truncate_high_fields(parser_datetimefield_to_adt(iv.precision_high));
+    // Like PostgreSQL, the range qualifier only disambiguates parsing and
+    // discards fields below precision_low. Fields above precision_high are
+    // kept as written.
     i.truncate_low_fields(
         parser_datetimefield_to_adt(iv.precision_low),
         iv.fsec_max_precision,

--- a/test/sqllogictest/cockroach/interval.slt
+++ b/test/sqllogictest/cockroach/interval.slt
@@ -194,77 +194,61 @@ SELECT interval '1 2:03:04' day to second
 query error invalid input syntax for type interval: Cannot determine format of all parts\. Add explicit time components, e\.g\. INTERVAL '1 day' or INTERVAL '1' DAY: "1 2"
 SELECT interval '1 2' hour to minute
 
-# SQL-474 (https://linear.app/materializeinc/issue/SQL-474): Materialize drops
-# interval fields to the left of the range qualifier's leading unit, even when
-# they were written explicitly. PG and CockroachDB keep every explicitly-written
-# field and only use the qualifier to resolve ambiguity. Some inputs also change
-# magnitude. The commented "PG/CRDB:" lines are the outputs to restore on fix.
-
-# SQL-474 PG/CRDB: 1 day 02:03:00
 query T
 SELECT interval '1 2:03' hour to minute
 ----
-02:03:00
+1 day 02:03:00
 
-# SQL-474 PG/CRDB: 1 day 02:03:00
 query T
 SELECT interval '1 2:03:04' hour to minute
 ----
-02:03:00
+1 day 02:03:00
 
 query error invalid input syntax for type interval: Cannot determine format of all parts\. Add explicit time components, e\.g\. INTERVAL '1 day' or INTERVAL '1' DAY: "1 2"
 SELECT interval '1 2' hour to second
 
-# SQL-474 PG/CRDB: 1 day 02:03:00
 query T
 SELECT interval '1 2:03' hour to second
 ----
-02:03:00
+1 day 02:03:00
 
-# SQL-474 PG/CRDB: 1 day 02:03:04
 query T
 SELECT interval '1 2:03:04' hour to second
 ----
-02:03:04
+1 day 02:03:04
 
 query error invalid input syntax for type interval: Cannot determine format of all parts\. Add explicit time components, e\.g\. INTERVAL '1 day' or INTERVAL '1' DAY: "1 2"
 SELECT interval '1 2' minute to second
 
-# SQL-474 PG/CRDB: 1 day 00:02:03 (MZ also mis-scales "2:03" as MM instead of MM:SS)
 query T
 SELECT interval '1 2:03' minute to second
 ----
-00:03:00
+1 day 00:02:03
 
-# SQL-474 PG/CRDB: 1 day 02:03:04
 query T
 SELECT interval '1 2:03:04' minute to second
 ----
-00:03:04
+1 day 02:03:04
 
-# SQL-474 PG/CRDB: 1 day 00:02:03
 query T
 SELECT interval '1 +2:03' minute to second
 ----
-00:03:00
+1 day 00:02:03
 
-# SQL-474 PG/CRDB: 1 day 02:03:04
 query T
 SELECT interval '1 +2:03:04' minute to second
 ----
-00:03:04
+1 day 02:03:04
 
-# SQL-474 PG/CRDB: 1 day -00:02:03
 query T
 SELECT interval '1 -2:03' minute to second
 ----
--00:03:00
+1 day -00:02:03
 
-# SQL-474 PG/CRDB: 1 day -02:03:04
 query T
 SELECT interval '1 -2:03:04' minute to second
 ----
--00:03:04
+1 day -02:03:04
 
 # Not supported by Materialize.
 onlyif cockroach
@@ -334,32 +318,28 @@ SELECT interval '1 2:03:04.5678' day to second(2)
 query error invalid input syntax for type interval: Cannot determine format of all parts\. Add explicit time components, e\.g\. INTERVAL '1 day' or INTERVAL '1' DAY: "1 2\.345"
 SELECT interval '1 2.345' hour to second(2)
 
-# SQL-474 PG/CRDB: 1 day 00:02:03.46
 query T
 SELECT interval '1 2:03.45678' hour to second(2)
 ----
-00:02:03.46
+1 day 00:02:03.46
 
-# SQL-474 PG/CRDB: 1 day 02:03:04.57
 query T
 SELECT interval '1 2:03:04.5678' hour to second(2)
 ----
-02:03:04.57
+1 day 02:03:04.57
 
 query error invalid input syntax for type interval: Cannot determine format of all parts\. Add explicit time components, e\.g\. INTERVAL '1 day' or INTERVAL '1' DAY: "1 2\.3456"
 SELECT interval '1 2.3456' minute to second(2)
 
-# SQL-474 PG/CRDB: 1 day 00:02:03.57
 query T
 SELECT interval '1 2:03.5678' minute to second(2)
 ----
-00:02:03.57
+1 day 00:02:03.57
 
-# SQL-474 PG/CRDB: 1 day 02:03:04.57
 query T
 SELECT interval '1 2:03:04.5678' minute to second(2)
 ----
-00:03:04.57
+1 day 02:03:04.57
 
 # Extra regression tests found when fixing this bug.
 subtest regression_43074

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -116,16 +116,17 @@ SELECT INTERVAL '1-2 3 4:5:6.7' SECOND;
 ----
 1 year 2 months 3 days 04:05:06.7
 
-# Treat trailing DateTimeFields as range of components to process.
+# Range qualifiers discard fields less significant than the range's low end,
+# but keep more significant fields, matching PostgreSQL.
 query T
 SELECT INTERVAL '1-2 3 4:5:6.7' MONTH TO MINUTE;
 ----
-2 months 3 days 04:05:00
+1 year 2 months 3 days 04:05:00
 
 query T
 SELECT INTERVAL '1-2 3 4:5:6.7' DAY TO HOUR;
 ----
-3 days 04:00:00
+1 year 2 months 3 days 04:00:00
 
 query T
 SELECT INTERVAL '12:34';
@@ -195,7 +196,7 @@ SELECT INTERVAL '12:34:56' HOUR TO SECOND;
 query T
 SELECT INTERVAL '12:34:56' MINUTE TO SECOND;
 ----
-00:34:56
+12:34:56
 
 query T
 SELECT INTERVAL '12:34' DAY TO SECOND;
@@ -206,6 +207,18 @@ query T
 SELECT INTERVAL '12:34' MONTH TO SECOND;
 ----
 12:34:00
+
+# Regression tests for SQL-474: fields above the range qualifier are kept, and
+# MINUTE TO SECOND reads ambiguous a:b values as minutes:seconds.
+query T
+SELECT INTERVAL '1 2:03' HOUR TO MINUTE;
+----
+1 day 02:03:00
+
+query T
+SELECT INTERVAL '1 2:03' MINUTE TO SECOND;
+----
+1 day 00:02:03
 
 # Disallow ranges where trailing element is greater than lead.
 statement error
@@ -522,7 +535,7 @@ SELECT INTERVAL '1.5555 month 2 3:4:5.6' HOUR;
 query T
 SELECT INTERVAL '1.5555 month 2 3:4:5.6' DAY TO HOUR;
 ----
-18 days 19:00:00
+1 month 18 days 19:00:00
 
 # Only allow disambiguation if ambiguous element
 # is final element of interval string.
@@ -602,7 +615,7 @@ SELECT INTERVAL '-1.555555555 years 2.555555555 months -3.555555555 days 4.55555
 query T
 SELECT INTERVAL '1:2:31.23456789' MINUTE TO SECOND(2);
 ----
-00:02:31.23
+01:02:31.23
 
 # Do not allow more than 9 places of precision
 query T


### PR DESCRIPTION
Interval range qualifiers like HOUR TO MINUTE now only resolve ambiguous parts and discard fields below the range's low end, matching PostgreSQL. Previously fields above the range's high end were dropped, and a leading day component caused "a:b" values to be read as hours:minutes even under MINUTE TO SECOND:

    SELECT interval '1 2:03' hour to minute;   -- was 02:03:00, now 1 day 02:03:00
    SELECT interval '1 2:03' minute to second; -- was 00:03:00, now 1 day 00:02:03

Closes: SQL-474