### PR TITLE
sql: Constant-fold parameterized top-level LIMIT

### DIFF
--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -125,7 +125,7 @@ known_errors = [
     "window functions are not allowed in AND argument",  # wrong error message
     "window functions are not allowed in aggregate function",
     "invalid IANA Time Zone Database identifier",
-    "Top-level LIMIT must be a constant expression",
+    "Invalid LIMIT clause",
     "LIMIT must not be negative",
     "materialized view objects cannot depend on log sources",  # explain create materialized view
     "aggregate functions are not allowed in OR argument",

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -310,6 +310,7 @@ pub enum PlanError {
     NetworkPolicyInUse,
     /// Expected a constant expression that evaluates without an error to a non-null value.
     ConstantExpressionSimplificationFailed(String),
+    InvalidLimit(String),
     InvalidOffset(String),
     /// The named cursor does not exist.
     UnknownCursor(String),
@@ -876,6 +877,7 @@ impl fmt::Display for PlanError {
                 write!(f, "TIMEOUT=<duration> option is required for ALTER CLUSTER ... WITH (WAIT UNTIL READY ( ... ))")
             },
             Self::ConstantExpressionSimplificationFailed(e) => write!(f, "{}", e),
+            Self::InvalidLimit(e) => write!(f, "Invalid LIMIT clause: {}", e),
             Self::InvalidOffset(e) => write!(f, "Invalid OFFSET clause: {}", e),
             Self::UnknownCursor(name) => {
                 write!(f, "cursor {} does not exist", name.quoted())

--- a/src/sql/src/plan/hir.rs
+++ b/src/sql/src/plan/hir.rs
@@ -4199,6 +4199,18 @@ impl HirScalarExpr {
     ///
     /// Panics if this expression does not have type [`SqlScalarType::Int64`].
     pub fn try_into_literal_int64(self) -> Result<i64, PlanError> {
+        match self.clone().try_into_nullable_literal_int64()? {
+            Some(value) => Ok(value),
+            None => Err(PlanError::ConstantExpressionSimplificationFailed(format!(
+                "Expected an expression that evaluates to a non-null value, got {}",
+                self
+            ))),
+        }
+    }
+
+    /// Like [`try_into_literal_int64`](Self::try_into_literal_int64), but an expression that
+    /// evaluates to null is `Ok(None)` instead of an error.
+    pub fn try_into_nullable_literal_int64(self) -> Result<Option<i64>, PlanError> {
         // TODO: add the `is_constant` check also to all the other into_literal_... (by adding it to
         // `simplify_to_literal`), but those should be just soft_asserts at first that it doesn't
         // actually happen that it's weaker than `reduce`, and then add them for real after 1 week.
@@ -4210,19 +4222,14 @@ impl HirScalarExpr {
                 self
             )));
         }
-        self.clone()
-            .simplify_to_literal_with_result()
-            .and_then(|row| {
-                let datum = row.unpack_first();
-                if datum.is_null() {
-                    Err(PlanError::ConstantExpressionSimplificationFailed(format!(
-                        "Expected an expression that evaluates to a non-null value, got {}",
-                        self
-                    )))
-                } else {
-                    Ok(datum.unwrap_int64())
-                }
-            })
+        self.simplify_to_literal_with_result().map(|row| {
+            let datum = row.unpack_first();
+            if datum.is_null() {
+                None
+            } else {
+                Some(datum.unwrap_int64())
+            }
+        })
     }
 
     pub fn contains_parameters(&self) -> bool {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -236,20 +236,16 @@ fn plan_select_inner(
         None => None,
         Some(mut limit) => {
             limit.bind_parameters_and_simplify_offset(scx, lifetime, params)?;
-            // TODO: Call `try_into_literal_int64` instead of `as_literal`.
-            let Some(limit) = limit.as_literal() else {
-                sql_bail!(
-                    "Top-level LIMIT must be a constant expression, got {}",
-                    limit
-                )
-            };
-            match limit {
-                Datum::Null => None,
-                Datum::Int64(v) if v >= 0 => NonNeg::<i64>::try_from(v).ok(),
-                _ => {
-                    soft_panic_or_log!("Valid literal limit must be asserted in `plan_select`");
-                    sql_bail!("LIMIT must be a non-negative INT or NULL")
-                }
+            // Evaluate the expression to a literal instead of matching on a bare literal
+            // node. Parameter binding can leave the bound value wrapped in casts, e.g.
+            // `integer_to_bigint($1)`.
+            match limit
+                .try_into_nullable_literal_int64()
+                .map_err(|err| sql_err!("Invalid LIMIT clause: {}", err))?
+            {
+                None => None,
+                Some(v) if v >= 0 => NonNeg::<i64>::try_from(v).ok(),
+                Some(_) => sql_bail!("LIMIT must not be negative"),
             }
         }
     };

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -18,6 +18,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use itertools::Itertools;
 use mz_arrow_util::builder::ArrowBuilder;
 use mz_expr::{ColumnOrder, RowSetFinishing};
+use mz_ore::error::ErrorExt;
 use mz_ore::num::NonNeg;
 use mz_ore::soft_panic_or_log;
 use mz_ore::str::separated;
@@ -241,7 +242,7 @@ fn plan_select_inner(
             // `integer_to_bigint($1)`.
             match limit
                 .try_into_nullable_literal_int64()
-                .map_err(|err| sql_err!("Invalid LIMIT clause: {}", err))?
+                .map_err(|err| PlanError::InvalidLimit(err.to_string_with_causes()))?
             {
                 None => None,
                 Some(v) if v >= 0 => NonNeg::<i64>::try_from(v).ok(),

--- a/test/sqllogictest/limit_expr.slt
+++ b/test/sqllogictest/limit_expr.slt
@@ -559,3 +559,7 @@ query error value out of range: overflow
 SELECT s.state, c.name FROM
     (SELECT DISTINCT state FROM cities) s,
     LATERAL (SELECT name FROM cities LIMIT pow(10000, 1000)) c;
+
+# A LIMIT at the top level of a SELECT must be a constant.
+query error Invalid LIMIT clause: Expected a constant expression
+SELECT name FROM cities LIMIT (SELECT 1);

--- a/test/sqllogictest/limit_expr.slt
+++ b/test/sqllogictest/limit_expr.slt
@@ -563,3 +563,19 @@ SELECT s.state, c.name FROM
 # A LIMIT at the top level of a SELECT must be a constant.
 query error Invalid LIMIT clause: Expected a constant expression
 SELECT name FROM cities LIMIT (SELECT 1);
+
+# An evaluation error while folding a parameterized LIMIT is reported with LIMIT context.
+# The `::numeric` makes parameter binding wrap the bound value in a fallible cast.
+statement ok
+PREPARE p_limit_fold AS SELECT name FROM cities ORDER BY name LIMIT $1::numeric;
+
+# The numeric-to-bigint cast rounds, so this is LIMIT 3.
+query T
+EXECUTE p_limit_fold(2.6);
+----
+Austin
+Chicago
+Dallas
+
+query error Invalid LIMIT clause: "9999999999999999999999" bigint out of range
+EXECUTE p_limit_fold(9999999999999999999999);

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -647,6 +647,10 @@ def compileFastSltConfig() -> SltRunConfig:
         "test/sqllogictest/jsonb.slt",
         "test/sqllogictest/keys.slt",
         "test/sqllogictest/like.slt",
+        # Asserts that a LIMIT at the top level of a SELECT must be constant,
+        # which no longer holds once --auto-index-selects wraps the SELECT in a
+        # view, where a non-constant LIMIT is allowed.
+        "test/sqllogictest/limit_expr.slt",
         "test/sqllogictest/list.slt",
         "test/sqllogictest/list_subquery.slt",
         "test/sqllogictest/managed_cluster.slt",
@@ -1084,6 +1088,10 @@ def compileSlowSltConfig() -> SltRunConfig:
         "test/sqllogictest/typeof.slt",
         # https://github.com/MaterializeInc/database-issues/issues/9513#issuecomment-3128051157
         "test/sqllogictest/temporal.slt",
+        # Asserts that a LIMIT at the top level of a SELECT must be constant,
+        # which no longer holds once --auto-index-selects wraps the SELECT in a
+        # view, where a non-constant LIMIT is allowed.
+        "test/sqllogictest/limit_expr.slt",
         # The extra statements make it more flaky from timing issues, when expecting a refresh to not yet have happened.
         "test/sqllogictest/materialized_views.slt",
         # Asserts on exact allocated ids to force a replica/item id collision,

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -1659,7 +1659,35 @@ EXECUTE fizz_paginated(4::bigint, 2*4);
 ----
 25040  two
 
-# TODO: LIMIT currently just tries to match a literal after parameter binding. It should also do constant folding,
-# similarly to OFFSET.
-query error Top\-level LIMIT must be a constant expression, got integer_to_bigint\(4\)
+# Parameter binding wraps the int parameter in a cast to bigint, which constant folding
+# must see through (SQL-476).
+query IT
 EXECUTE fizz_paginated(4, 2*4);
+----
+25040  two
+
+# NULL LIMIT means no limit.
+query IT
+EXECUTE fizz_paginated(NULL::int, 2*4);
+----
+25040  two
+
+query error LIMIT must not be negative
+EXECUTE fizz_paginated(-1, 0);
+
+# Parameterized LIMIT, exact repro from SQL-476.
+statement ok
+CREATE TABLE r9 (a int);
+
+statement ok
+INSERT INTO r9 VALUES (1), (2), (3), (4), (5);
+
+statement ok
+PREPARE p15 AS SELECT a FROM r9 ORDER BY a LIMIT $1;
+
+query I
+EXECUTE p15(3);
+----
+1
+2
+3


### PR DESCRIPTION
Executing a prepared statement with a parameterized LIMIT failed with "Top-level LIMIT must be a constant expression, got integer_to_bigint(3)" whenever the bound parameter type was not bigint, because parameter binding wraps the value in a cast that the bare-literal check did not fold. Evaluate the expression to a literal instead, matching how OFFSET is handled. A negative LIMIT now reports "LIMIT must not be negative" instead of soft-panicking, and a non-constant LIMIT reports "Invalid LIMIT clause: ...".

Closes: [SQL-476](https://linear.app/materializeinc/issue/SQL-476)