### PR TITLE
timely-util: Reduce Columnar ship size from 2 MiB to 32 KiB

### DIFF
--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -168,11 +168,11 @@ where
     }
 }
 
-/// Words per 2 MiB. `length_in_words` returns serialized size in `u64` units,
+/// Words per 32 KiB. `length_in_words` returns serialized size in `u64` units,
 /// so this is the page count we round up to. Picked to match
 /// [`builder::ColumnBuilder`]'s output granularity so chunks shipped from the
 /// merger and chunks shipped from the builder are sized comparably.
-const SHIP_WORDS: usize = 1 << 18;
+const SHIP_WORDS: usize = 1 << 12;
 
 /// Returns true once the serialized size of `borrow` is within 10% of the next
 /// `SHIP_WORDS` boundary.
@@ -192,7 +192,7 @@ where
 impl<C: Columnar> SizableContainer for Column<C> {
     fn at_capacity(&self) -> bool {
         // Match `ColumnBuilder`'s ship heuristic: serialized size within 10%
-        // of the next 2 MiB. Aligns chunk-size choices across the two paths
+        // of the next 32 KiB. Aligns chunk-size choices across the two paths
         // and keeps recipients dealing with a single granularity.
         //
         // Serialized chunks (`Bytes` / `Align`) have no typed builder to push

--- a/src/timely-util/src/columnar/builder.rs
+++ b/src/timely-util/src/columnar/builder.rs
@@ -44,10 +44,12 @@ where
     #[inline]
     fn push_into(&mut self, item: T) {
         self.current.push(item);
-        // If there is less than 10% slop with 2MB backing allocations, mint a container.
+        // If there is less than 10% slop with the ship-size backing allocation,
+        // mint a container. Shares `SHIP_WORDS` with the merger path so builder
+        // and merger chunks are sized comparably.
         use columnar::Borrow;
         let words = indexed::length_in_words(&self.current.borrow());
-        let round = (words + ((1 << 18) - 1)) & !((1 << 18) - 1);
+        let round = (words + (super::SHIP_WORDS - 1)) & !(super::SHIP_WORDS - 1);
         if round - words < round / 10 {
             /// Move the contents from `current` to a `Vec<u64>` allocation built via
             /// `indexed::encode` (so no zero-init pre-pass), and push it to `pending`.


### PR DESCRIPTION
Lower the `Column` chunk ship threshold from 2 MiB to 32 KiB.
`SHIP_WORDS` drops from `1 << 18` to `1 << 12` words.
32 KiB is jemalloc's default `tcache_max`, so shipped chunks stay in the per-thread cache instead of hitting the arena-lock path.

The builder path previously duplicated the 2 MiB literal with its own hardcoded `1 << 18`.
It now references `super::SHIP_WORDS`, so the merger and builder ship paths share one source of truth and stay sized comparably, as the doc comment already promised.
This also prevents the two thresholds from silently diverging on future changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)