### PR TITLE
sql: apply SELECT list table functions after the reduce

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2334,14 +2334,26 @@ fn plan_select_from_where(
         visitor.into_result()?
     };
     let mut table_func_names: BTreeMap<String, Ident> = BTreeMap::new();
+    // Table functions in the SELECT list apply to the output of the reduce
+    // (GROUP BY, aggregates, HAVING), but their columns must already be in
+    // scope when the SELECT list is expanded and GROUP BY items are planned,
+    // so the join is planned here regardless. Step 5 decides whether the
+    // reduce consumes this join or the saved pre-join relation, and in the
+    // latter case Step 8.5 plans the join again on top of the reduce.
+    let pre_table_funcs_arity = from_scope.len();
+    let mut pre_table_funcs_relation = None;
+    let mut table_funcs_deferred = false;
     if !table_funcs.is_empty() {
         let (expr, scope) = plan_scalar_table_funcs(
             qcx,
-            table_funcs,
+            &table_funcs,
             &mut table_func_names,
             &relation_expr,
             &from_scope,
         )?;
+        if !aggregates.is_empty() || !s.group_by.is_empty() || s.having.is_some() {
+            pre_table_funcs_relation = Some(relation_expr.clone());
+        }
         relation_expr = relation_expr.join(expr, HirScalarExpr::literal_true(), JoinKind::Inner);
         from_scope = from_scope.product(scope)?;
     }
@@ -2473,6 +2485,35 @@ fn plan_select_from_where(
                 .push(ScopeItem::from_expr(Expr::Function(sql_function.clone())));
         }
         if !agg_exprs.is_empty() || !group_key.is_empty() || s.having.is_some() {
+            // Table functions join after the reduce only when no group key or
+            // aggregate references their columns, e.g. GROUP BY on a SELECT
+            // list alias of a table function.
+            if let Some(pre_relation_expr) = pre_table_funcs_relation.take() {
+                let mut references_table_funcs = false;
+                let mut check = |column: usize| {
+                    if column >= pre_table_funcs_arity {
+                        references_table_funcs = true;
+                    }
+                };
+                for expr in &group_hir_exprs {
+                    expr.visit_columns_referring_to_root_level(&mut check);
+                }
+                for agg_expr in &agg_exprs {
+                    agg_expr
+                        .expr
+                        .visit_columns_referring_to_root_level(&mut check);
+                }
+                if !references_table_funcs {
+                    relation_expr = pre_relation_expr;
+                    // The group keys point past the table functions' columns,
+                    // which the saved relation does not have.
+                    for (i, key) in group_key.iter_mut().enumerate() {
+                        *key = pre_table_funcs_arity + i;
+                    }
+                    table_funcs_deferred = true;
+                }
+            }
+
             // apply GROUP BY / aggregates
             relation_expr = relation_expr.map(group_hir_exprs).reduce(
                 group_key,
@@ -2485,7 +2526,14 @@ fn plan_select_from_where(
             // from scope. These items need to *exist* because they might shadow
             // variables in outer scopes that would otherwise be valid to
             // reference, but accessing them needs to produce an error.
-            for i in 0..from_scope.len() {
+            // Deferred table functions' columns come back into scope in Step
+            // 8.5, so they must not be recorded as ungrouped.
+            let ungrouped_arity = if table_funcs_deferred {
+                pre_table_funcs_arity
+            } else {
+                from_scope.len()
+            };
+            for i in 0..ungrouped_arity {
                 if !select_all_mapping.contains_key(&i) {
                     let scope_item = &ecx.scope.items[i];
                     group_scope.ungrouped_columns.push(ScopeUngroupedColumn {
@@ -2578,6 +2626,25 @@ fn plan_select_from_where(
         };
         let expr = plan_expr(ecx, qualify)?.type_as(ecx, &SqlScalarType::Bool)?;
         relation_expr = relation_expr.filter(vec![expr]);
+    }
+
+    // Step 8.5. Join the table functions deferred in Step 5. Planning them
+    // again rebinds their arguments' column references to the reduced
+    // relation.
+    if table_funcs_deferred {
+        let (expr, scope) = plan_scalar_table_funcs(
+            qcx,
+            &table_funcs,
+            &mut table_func_names,
+            &relation_expr,
+            &group_scope,
+        )?;
+        relation_expr = relation_expr.join(expr, HirScalarExpr::literal_true(), JoinKind::Inner);
+        // `product` resets `ungrouped_columns`, but the ungrouped column
+        // errors from the reduce must survive for the SELECT list.
+        let ungrouped_columns = mem::take(&mut group_scope.ungrouped_columns);
+        group_scope = group_scope.product(scope)?;
+        group_scope.ungrouped_columns = ungrouped_columns;
     }
 
     // Step 9. Handle SELECT clause.
@@ -2769,7 +2836,7 @@ fn plan_select_from_where(
 
 fn plan_scalar_table_funcs(
     qcx: &QueryContext,
-    table_funcs: BTreeMap<Function<Aug>, String>,
+    table_funcs: &BTreeMap<Function<Aug>, String>,
     table_func_names: &mut BTreeMap<String, Ident>,
     relation_expr: &HirRelationExpr,
     from_scope: &Scope,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2343,6 +2343,17 @@ fn plan_select_from_where(
     let pre_table_funcs_arity = from_scope.len();
     let mut pre_table_funcs_relation = None;
     let mut table_funcs_deferred = false;
+    // `DISTINCT ON` picks its rows before the SELECT list table functions
+    // expand them, so Step 10 may have to replant this join above the top-k it
+    // plans. Only keep the pieces around when that can happen, so that other
+    // queries don't pay for the clones.
+    //
+    // PostgreSQL only postpones the expansion when the query sorts. Without an
+    // `ORDER BY` it leaves the expansion below the distinct, which collapses
+    // it to one row per group, and we match that.
+    let mut postponable_table_funcs = None;
+    let track_postponable_table_funcs =
+        matches!(s.distinct, Some(Distinct::On(_))) && !order_by_exprs.is_empty();
     if !table_funcs.is_empty() {
         let (expr, scope) = plan_scalar_table_funcs(
             qcx,
@@ -2353,6 +2364,14 @@ fn plan_select_from_where(
         )?;
         if !aggregates.is_empty() || !s.group_by.is_empty() || s.having.is_some() {
             pre_table_funcs_relation = Some(relation_expr.clone());
+        }
+        if track_postponable_table_funcs {
+            postponable_table_funcs = Some(PostponableTableFuncs {
+                input: relation_expr.clone(),
+                funcs: expr.clone(),
+                input_arity: pre_table_funcs_arity,
+                funcs_arity: scope.len(),
+            });
         }
         relation_expr = relation_expr.join(expr, HirScalarExpr::literal_true(), JoinKind::Inner);
         from_scope = from_scope.product(scope)?;
@@ -2514,6 +2533,10 @@ fn plan_select_from_where(
                 }
             }
 
+            // Either the reduce consumes the Step 3 join, which pins it below
+            // the reduce, or the join is dropped and Step 8.5 replans it.
+            postponable_table_funcs = None;
+
             // apply GROUP BY / aggregates
             relation_expr = relation_expr.map(group_hir_exprs).reduce(
                 group_key,
@@ -2593,6 +2616,11 @@ fn plan_select_from_where(
         }
         visitor.into_result()
     };
+    if !window_funcs.is_empty() {
+        // A window function runs over the expanded rows, so the join that
+        // produced them cannot move above the `DISTINCT ON`.
+        postponable_table_funcs = None;
+    }
     for window_func in window_funcs {
         let ecx = &ExprContext {
             qcx,
@@ -2614,6 +2642,9 @@ fn plan_select_from_where(
 
     // Step 8. Handle QUALIFY clause. (very similar to HAVING)
     if let Some(ref qualify) = s.qualify {
+        // The filter discards expanded rows, so the join that produced them
+        // cannot move above the `DISTINCT ON`.
+        postponable_table_funcs = None;
         let ecx = &ExprContext {
             qcx,
             name: "QUALIFY clause",
@@ -2639,6 +2670,14 @@ fn plan_select_from_where(
             &relation_expr,
             &group_scope,
         )?;
+        if track_postponable_table_funcs {
+            postponable_table_funcs = Some(PostponableTableFuncs {
+                input: relation_expr.clone(),
+                funcs: expr.clone(),
+                input_arity: group_scope.len(),
+                funcs_arity: scope.len(),
+            });
+        }
         relation_expr = relation_expr.join(expr, HirScalarExpr::literal_true(), JoinKind::Inner);
         // `product` resets `ungrouped_columns`, but the ungrouped column
         // errors from the reduce must survive for the SELECT list.
@@ -2648,6 +2687,7 @@ fn plan_select_from_where(
     }
 
     // Step 9. Handle SELECT clause.
+    let mut select_map_exprs = vec![];
     let output_columns = {
         let mut new_exprs = vec![];
         let mut new_type = qcx.relation_type(&relation_expr);
@@ -2691,6 +2731,9 @@ fn plan_select_from_where(
                     .items
                     .push(ScopeItem::from_expr(select_item.as_expr().cloned()));
             }
+        }
+        if postponable_table_funcs.is_some() {
+            select_map_exprs.clone_from(&new_exprs);
         }
         relation_expr = relation_expr.map(new_exprs);
         output_columns
@@ -2803,17 +2846,36 @@ fn plan_select_from_where(
                 // if there are any, determine the ordering within each group,
                 // per PostgreSQL semantics.
                 let distinct_len = distinct_key.len();
-                relation_expr = HirRelationExpr::top_k(
-                    relation_expr.map(map_exprs),
-                    distinct_key,
-                    order_by.iter().skip(distinct_len).cloned().collect(),
-                    Some(HirScalarExpr::literal(
-                        Datum::Int64(1),
-                        SqlScalarType::Int64,
-                    )),
-                    HirScalarExpr::literal(Datum::Int64(0), SqlScalarType::Int64),
-                    group_size_hints.distinct_on_input_group_size,
-                );
+                let top_k_order_by: Vec<_> = order_by.iter().skip(distinct_len).cloned().collect();
+
+                // The top-k belongs below a SELECT list table function join
+                // whenever it does not need what the functions produce, so
+                // that the functions expand the rows the top-k picked instead
+                // of being collapsed by it.
+                let postponed = postponable_table_funcs.take().and_then(|table_funcs| {
+                    let maps = select_map_exprs.iter().chain(map_exprs.iter());
+                    plan_distinct_on_below_table_funcs(
+                        table_funcs,
+                        maps.cloned().collect(),
+                        &distinct_key,
+                        &top_k_order_by,
+                        group_size_hints.distinct_on_input_group_size,
+                    )
+                });
+                relation_expr = match postponed {
+                    Some(postponed) => postponed,
+                    None => HirRelationExpr::top_k(
+                        relation_expr.map(map_exprs),
+                        distinct_key,
+                        top_k_order_by,
+                        Some(HirScalarExpr::literal(
+                            Datum::Int64(1),
+                            SqlScalarType::Int64,
+                        )),
+                        HirScalarExpr::literal(Datum::Int64(0), SqlScalarType::Int64),
+                        group_size_hints.distinct_on_input_group_size,
+                    ),
+                };
             }
         }
 
@@ -2832,6 +2894,141 @@ fn plan_select_from_where(
         order_by,
         project: project_key,
     })
+}
+
+/// The pieces of a `SELECT` list table function join, kept so that a
+/// `DISTINCT ON` can be planned below the join rather than above it.
+struct PostponableTableFuncs {
+    /// The relation the functions are joined onto.
+    input: HirRelationExpr,
+    /// The functions' relation. Correlated to `input` at level 1, so it stays
+    /// valid as long as `input`'s columns keep their positions.
+    funcs: HirRelationExpr,
+    /// Arity of `input`, i.e. the first column the functions contribute.
+    input_arity: usize,
+    /// Number of columns the functions contribute.
+    funcs_arity: usize,
+}
+
+/// Plans a `DISTINCT ON` below a `SELECT` list table function join instead of
+/// above it, so that the functions expand the rows the top-k picked rather
+/// than being collapsed by it. This is what PostgreSQL does whenever the
+/// distinct key and its ordering can be evaluated without the functions'
+/// output.
+///
+/// `maps` are the scalar expressions mapped onto the join, in column order, so
+/// `distinct_key` and `order_by` index the join's columns followed by `maps`.
+///
+/// Returns `None` when a distinct or ordering column needs a column the
+/// functions produce. PostgreSQL keeps the expansion below the distinct in
+/// that case too, which is what the caller has already planned.
+fn plan_distinct_on_below_table_funcs(
+    table_funcs: PostponableTableFuncs,
+    maps: Vec<HirScalarExpr>,
+    distinct_key: &[usize],
+    order_by: &[ColumnOrder],
+    expected_group_size: Option<u64>,
+) -> Option<HirRelationExpr> {
+    let PostponableTableFuncs {
+        input,
+        funcs,
+        input_arity,
+        funcs_arity,
+    } = table_funcs;
+    let join_arity = input_arity + funcs_arity;
+
+    // Which maps can be evaluated on `input` alone. A map that reads a
+    // function column, directly or through an earlier map, cannot. Maps are in
+    // dependency order, so one forward pass settles all of them.
+    let mut on_input = vec![false; maps.len()];
+    for (i, expr) in maps.iter().enumerate() {
+        let mut evaluable = true;
+        expr.visit_columns_referring_to_root_level(&mut |column| {
+            if column >= input_arity {
+                evaluable &= column >= join_arity && on_input[column - join_arity];
+            }
+        });
+        on_input[i] = evaluable;
+    }
+
+    // The top-k's own columns have to be among those, or the functions' output
+    // decides which rows survive and the join has to stay below.
+    let mut needed = vec![false; maps.len()];
+    for column in distinct_key
+        .iter()
+        .chain(order_by.iter().map(|o| &o.column))
+    {
+        if *column < input_arity {
+            continue;
+        }
+        if *column < join_arity || !on_input[*column - join_arity] {
+            return None;
+        }
+        needed[*column - join_arity] = true;
+    }
+    // Pull in what those maps read. Dependencies come earlier, so one backward
+    // pass reaches all of them.
+    for i in (0..maps.len()).rev() {
+        if needed[i] {
+            maps[i].visit_columns_referring_to_root_level(&mut |column| {
+                if column >= join_arity {
+                    needed[column - join_arity] = true;
+                }
+            });
+        }
+    }
+
+    // Re-map the needed expressions onto `input`, then project them away again
+    // so that the join sees `input` exactly as it did before.
+    let mut mapped = vec![];
+    let mut input_column = vec![None; maps.len()];
+    for (i, expr) in maps.iter().enumerate() {
+        if !needed[i] {
+            continue;
+        }
+        let mut expr = expr.clone();
+        expr.visit_columns_referring_to_root_level_mut(&mut |column| {
+            if *column >= join_arity {
+                *column = input_column[*column - join_arity]
+                    .expect("dependencies of a needed map are needed and come earlier");
+            }
+        });
+        input_column[i] = Some(input_arity + mapped.len());
+        mapped.push(expr);
+    }
+    let on_input_column = |column: usize| {
+        if column < input_arity {
+            column
+        } else {
+            input_column[column - join_arity].expect("checked above")
+        }
+    };
+
+    let top_k = input
+        .map(mapped)
+        .top_k(
+            distinct_key.iter().map(|c| on_input_column(*c)).collect(),
+            order_by
+                .iter()
+                .map(|o| ColumnOrder {
+                    column: on_input_column(o.column),
+                    desc: o.desc,
+                    nulls_last: o.nulls_last,
+                })
+                .collect(),
+            Some(HirScalarExpr::literal(
+                Datum::Int64(1),
+                SqlScalarType::Int64,
+            )),
+            HirScalarExpr::literal(Datum::Int64(0), SqlScalarType::Int64),
+            expected_group_size,
+        )
+        .project((0..input_arity).collect());
+    Some(
+        top_k
+            .join(funcs, HirScalarExpr::literal_true(), JoinKind::Inner)
+            .map(maps),
+    )
 }
 
 fn plan_scalar_table_funcs(

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2750,6 +2750,19 @@ fn plan_select_from_where(
                 relation_expr = relation_expr.distinct();
             }
             Some(Distinct::On(exprs)) => {
+                // The table functions deferred in Step 5 join below this TopK,
+                // so the distinct would collapse their expansion rather than
+                // expand the rows the distinct picks. PostgreSQL instead
+                // evaluates a SELECT list table function after the distinct
+                // whenever the query has an ORDER BY and the function's output
+                // is not itself a distinct or sort key. Reject these queries
+                // rather than answer them differently.
+                if table_funcs_deferred && !order_by_exprs.is_empty() {
+                    bail_unsupported!(
+                        "SELECT list table function with DISTINCT ON and ORDER BY over an aggregation"
+                    );
+                }
+
                 let ecx = &ExprContext {
                     qcx,
                     name: "DISTINCT ON clause",

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2347,14 +2347,26 @@ fn plan_select_from_where(
         visitor.into_result()?
     };
     let mut table_func_names: BTreeMap<String, Ident> = BTreeMap::new();
+    // Table functions in the SELECT list apply to the output of the reduce
+    // (GROUP BY, aggregates, HAVING), but their columns must already be in
+    // scope when the SELECT list is expanded and GROUP BY items are planned,
+    // so the join is planned here regardless. Step 5 decides whether the
+    // reduce consumes this join or the saved pre-join relation, and in the
+    // latter case Step 8.5 plans the join again on top of the reduce.
+    let pre_table_funcs_arity = from_scope.len();
+    let mut pre_table_funcs_relation = None;
+    let mut table_funcs_deferred = false;
     if !table_funcs.is_empty() {
         let (expr, scope) = plan_scalar_table_funcs(
             qcx,
-            table_funcs,
+            &table_funcs,
             &mut table_func_names,
             &relation_expr,
             &from_scope,
         )?;
+        if !aggregates.is_empty() || !s.group_by.is_empty() || s.having.is_some() {
+            pre_table_funcs_relation = Some(relation_expr.clone());
+        }
         relation_expr = relation_expr.join(expr, HirScalarExpr::literal_true(), JoinKind::Inner);
         from_scope = from_scope.product(scope)?;
     }
@@ -2486,6 +2498,35 @@ fn plan_select_from_where(
                 .push(ScopeItem::from_expr(Expr::Function(sql_function.clone())));
         }
         if !agg_exprs.is_empty() || !group_key.is_empty() || s.having.is_some() {
+            // Table functions join after the reduce only when no group key or
+            // aggregate references their columns, e.g. GROUP BY on a SELECT
+            // list alias of a table function.
+            if let Some(pre_relation_expr) = pre_table_funcs_relation.take() {
+                let mut references_table_funcs = false;
+                let mut check = |column: usize| {
+                    if column >= pre_table_funcs_arity {
+                        references_table_funcs = true;
+                    }
+                };
+                for expr in &group_hir_exprs {
+                    expr.visit_columns_referring_to_root_level(&mut check);
+                }
+                for agg_expr in &agg_exprs {
+                    agg_expr
+                        .expr
+                        .visit_columns_referring_to_root_level(&mut check);
+                }
+                if !references_table_funcs {
+                    relation_expr = pre_relation_expr;
+                    // The group keys point past the table functions' columns,
+                    // which the saved relation does not have.
+                    for (i, key) in group_key.iter_mut().enumerate() {
+                        *key = pre_table_funcs_arity + i;
+                    }
+                    table_funcs_deferred = true;
+                }
+            }
+
             // apply GROUP BY / aggregates
             relation_expr = relation_expr.map(group_hir_exprs).reduce(
                 group_key,
@@ -2498,7 +2539,14 @@ fn plan_select_from_where(
             // from scope. These items need to *exist* because they might shadow
             // variables in outer scopes that would otherwise be valid to
             // reference, but accessing them needs to produce an error.
-            for i in 0..from_scope.len() {
+            // Deferred table functions' columns come back into scope in Step
+            // 8.5, so they must not be recorded as ungrouped.
+            let ungrouped_arity = if table_funcs_deferred {
+                pre_table_funcs_arity
+            } else {
+                from_scope.len()
+            };
+            for i in 0..ungrouped_arity {
                 if !select_all_mapping.contains_key(&i) {
                     let scope_item = &ecx.scope.items[i];
                     group_scope.ungrouped_columns.push(ScopeUngroupedColumn {
@@ -2591,6 +2639,25 @@ fn plan_select_from_where(
         };
         let expr = plan_expr(ecx, qualify)?.type_as(ecx, &SqlScalarType::Bool)?;
         relation_expr = relation_expr.filter(vec![expr]);
+    }
+
+    // Step 8.5. Join the table functions deferred in Step 5. Planning them
+    // again rebinds their arguments' column references to the reduced
+    // relation.
+    if table_funcs_deferred {
+        let (expr, scope) = plan_scalar_table_funcs(
+            qcx,
+            &table_funcs,
+            &mut table_func_names,
+            &relation_expr,
+            &group_scope,
+        )?;
+        relation_expr = relation_expr.join(expr, HirScalarExpr::literal_true(), JoinKind::Inner);
+        // `product` resets `ungrouped_columns`, but the ungrouped column
+        // errors from the reduce must survive for the SELECT list.
+        let ungrouped_columns = mem::take(&mut group_scope.ungrouped_columns);
+        group_scope = group_scope.product(scope)?;
+        group_scope.ungrouped_columns = ungrouped_columns;
     }
 
     // Step 9. Handle SELECT clause.
@@ -2782,7 +2849,7 @@ fn plan_select_from_where(
 
 fn plan_scalar_table_funcs(
     qcx: &QueryContext,
-    table_funcs: BTreeMap<Function<Aug>, String>,
+    table_funcs: &BTreeMap<Function<Aug>, String>,
     table_func_names: &mut BTreeMap<String, Ident>,
     relation_expr: &HirRelationExpr,
     from_scope: &Scope,

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1920,3 +1920,69 @@ NULL  NULL  4  NULL  4  4  4
 NULL  NULL  3  3  3  3  3
 NULL  2  2  2  2  2  2
 1  1  1  1  1  1  1
+
+# Regression tests for SQL-479: table functions in the SELECT list combined
+# with a reduce (aggregates, GROUP BY, HAVING) failed with
+# `column "table_func_0" does not exist`. The functions apply to the output
+# of the reduce.
+
+statement ok
+CREATE TABLE srf_agg (a int, b int)
+
+statement ok
+INSERT INTO srf_agg VALUES (1, 10), (1, 20), (2, 30)
+
+query II
+SELECT max(b), generate_series(1, 3) AS g FROM srf_agg ORDER BY g DESC
+----
+30  3
+30  2
+30  1
+
+# Aggregates are computed over the input rows, not over the series expansion.
+query II
+SELECT count(*), generate_series(1, 3) FROM srf_agg ORDER BY 2
+----
+3  1
+3  2
+3  3
+
+# Global aggregation on empty input still produces one group to expand.
+query II
+SELECT max(b), generate_series(1, 2) AS g FROM srf_agg WHERE false ORDER BY g
+----
+NULL  1
+NULL  2
+
+# With GROUP BY the function applies to each reduced row, and its arguments
+# can refer to grouping columns.
+query III
+SELECT a, count(*), generate_series(1, a) AS g FROM srf_agg GROUP BY a ORDER BY a, g
+----
+1  2  1
+2  1  1
+2  1  2
+
+query error column "srf_agg.b" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT a, generate_series(1, b) FROM srf_agg GROUP BY a
+
+# Grouping by the function's output keeps grouping over the expanded rows.
+query II
+SELECT generate_series(1, 2) AS g, count(*) FROM srf_agg GROUP BY g ORDER BY g
+----
+1  3
+2  3
+
+query I
+SELECT generate_series(1, 2) AS g FROM srf_agg HAVING count(*) = 3 ORDER BY g
+----
+1
+2
+
+# Multiple table functions zip against each reduced row.
+query III
+SELECT max(b), generate_series(1, 3) AS g, generate_series(4, 5) AS h FROM srf_agg ORDER BY g
+----
+30  1  4
+30  2  5
+30  3  NULL

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1986,3 +1986,47 @@ SELECT max(b), generate_series(1, 3) AS g, generate_series(4, 5) AS h FROM srf_a
 30  1  4
 30  2  5
 30  3  NULL
+
+# A window function over the reduced rows runs before the expansion, matching
+# PostgreSQL, which evaluates table functions after window functions.
+query III
+SELECT max(b), generate_series(1, 3) AS g, row_number() OVER () AS rn FROM srf_agg ORDER BY g
+----
+30  1  1
+30  2  1
+30  3  1
+
+query IIII
+SELECT a, count(*), generate_series(1, 2) AS g, row_number() OVER (ORDER BY a) AS rn FROM srf_agg GROUP BY a ORDER BY a, g
+----
+1  2  1  1
+1  2  2  1
+2  1  1  2
+2  1  2  2
+
+# The functions join below the TopK that implements `DISTINCT ON`, so the
+# distinct would collapse their expansion. PostgreSQL expands after the
+# distinct once the query has an ORDER BY, so reject instead of answering
+# differently.
+query error SELECT list table function with DISTINCT ON and ORDER BY over an aggregation not yet supported
+SELECT DISTINCT ON (count(*)) count(*), generate_series(1, 3) AS g FROM srf_agg ORDER BY count(*)
+
+query error SELECT list table function with DISTINCT ON and ORDER BY over an aggregation not yet supported
+SELECT DISTINCT ON (a) a, count(*), generate_series(1, 3) AS g FROM srf_agg GROUP BY a ORDER BY a
+
+# Without an ORDER BY, PostgreSQL also expands before the distinct, so the
+# expansion collapsing to one row per key matches. Which row survives is
+# unspecified, hence only the count.
+query I
+SELECT count(*) FROM (SELECT DISTINCT ON (a) a, count(*), generate_series(1, 3) AS g FROM srf_agg GROUP BY a)
+----
+2
+
+# `SELECT DISTINCT` distincts on the expansion in PostgreSQL too, because every
+# SELECT list column is a distinct key there.
+query II
+SELECT DISTINCT max(b), generate_series(1, 3) AS g FROM srf_agg ORDER BY g
+----
+30  1
+30  2
+30  3

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1986,3 +1986,118 @@ SELECT max(b), generate_series(1, 3) AS g, generate_series(4, 5) AS h FROM srf_a
 30  1  4
 30  2  5
 30  3  NULL
+
+# A table function in the SELECT list applies after `DISTINCT ON` has picked
+# its rows, so the expansion multiplies the surviving rows instead of being
+# collapsed by them. This matches PostgreSQL, which only postpones the
+# expansion this way when the query sorts and when neither the distinct key nor
+# the ordering needs the function's output.
+
+statement ok
+CREATE TABLE srf_distinct (k int, n int)
+
+statement ok
+INSERT INTO srf_distinct VALUES (1, 0), (1, 2), (2, 1)
+
+query II rowsort
+SELECT DISTINCT ON (a) a, generate_series(1, 3) AS g FROM srf_agg ORDER BY a
+----
+1  1
+1  2
+1  3
+2  1
+2  2
+2  3
+
+query II rowsort
+SELECT DISTINCT ON (count(*)) count(*), generate_series(1, 3) AS g FROM srf_agg ORDER BY count(*)
+----
+3  1
+3  2
+3  3
+
+query III rowsort
+SELECT DISTINCT ON (a) a, count(*), generate_series(1, 3) AS g FROM srf_agg GROUP BY a ORDER BY a
+----
+1  2  1
+1  2  2
+1  2  3
+2  1  1
+2  1  2
+2  1  3
+
+query II rowsort
+SELECT DISTINCT ON (a) a, generate_series(1, 2) AS g FROM srf_agg GROUP BY a HAVING count(*) = 2 ORDER BY a
+----
+1  1
+1  2
+
+# The distinct key can be an expression over the reduced rows.
+query II rowsort
+SELECT DISTINCT ON (count(*) + 1) count(*) + 1 AS c, generate_series(1, 2) AS g FROM srf_agg ORDER BY count(*) + 1
+----
+4  1
+4  2
+
+# The distinct key does not have to appear in the SELECT list.
+query II rowsort
+SELECT DISTINCT ON (k) n, generate_series(1, 2) AS g FROM srf_distinct ORDER BY k, n
+----
+0  1
+0  2
+1  1
+1  2
+
+# The row the distinct picked can expand to nothing, dropping its whole group.
+query III
+SELECT DISTINCT ON (k) k, n, generate_series(1, n) AS g FROM srf_distinct ORDER BY k, n
+----
+2  1  1
+
+query III rowsort
+SELECT DISTINCT ON (a) a, generate_series(1, 3) AS g, generate_series(4, 5) AS h FROM srf_agg ORDER BY a
+----
+1  1  4
+1  2  5
+1  3  NULL
+2  1  4
+2  2  5
+2  3  NULL
+
+# Without an `ORDER BY` the expansion stays below the distinct, which collapses
+# it to one row per group. Which of the expanded rows survives is arbitrary, so
+# only the cardinality is checked.
+query I
+SELECT count(*) FROM (SELECT DISTINCT ON (count(*)) count(*) AS c, generate_series(1, 3) AS g FROM srf_agg) d
+----
+1
+
+query I
+SELECT count(*) FROM (SELECT DISTINCT ON (a) a, generate_series(1, 3) AS g FROM srf_agg) d
+----
+2
+
+# The expansion also stays below the distinct when the distinct key is the
+# function's own output.
+query II
+SELECT DISTINCT ON (g) count(*), generate_series(1, 3) AS g FROM srf_agg ORDER BY g
+----
+3  1
+3  2
+3  3
+
+# ...or when the ordering within a group needs it.
+query II
+SELECT DISTINCT ON (a) a, generate_series(1, 3) AS g FROM srf_agg ORDER BY a, g DESC
+----
+1  3
+2  3
+
+# Plain `SELECT DISTINCT` expands before deduplicating, as in PostgreSQL.
+query II rowsort
+SELECT DISTINCT a, generate_series(1, 2) AS g FROM srf_agg ORDER BY a
+----
+1  1
+1  2
+2  1
+2  2


### PR DESCRIPTION
A table function in the SELECT list was always joined to the FROM relation before planning GROUP BY, aggregates, and HAVING. The reduce then removed the function's columns from scope, so planning the SELECT list failed with `column "table_func_0" does not exist`.

Join the table functions on top of the reduce instead, so they apply to the reduced rows and their arguments can refer to grouping columns. The pre-reduce join is kept when a group key or an aggregate references the functions' columns, e.g. when grouping by a SELECT list alias of a table function, so that grouping over a function's output keeps working.

Closes: [SQL-479](https://linear.app/materializeinc/issue/SQL-479)