### PR TITLE
[SQL-567] storage: error only the dropped table in MySQL snapshot setup

### DIFF
--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -116,9 +116,7 @@ use futures::{StreamExt as _, TryStreamExt};
 use itertools::Itertools;
 use mysql_async::prelude::Queryable;
 use mysql_async::{IsolationLevel, Row as MySqlRow, TxOpts};
-use mz_mysql_util::{
-    ER_NO_SUCH_TABLE, MySqlConn, MySqlError, pack_mysql_row, query_sys_var, quote_identifier,
-};
+use mz_mysql_util::{MySqlConn, MySqlError, pack_mysql_row, query_sys_var, quote_identifier};
 use mz_ore::cast::CastFrom;
 use mz_ore::future::InTask;
 use mz_ore::iter::IteratorExt;
@@ -234,7 +232,7 @@ async fn compute_sampled_splits<Q>(
     pk_col: &(String, SqlScalarType),
     worker_count: usize,
     total: u64,
-) -> Result<Option<PkBoundaries>, SnapshotSetupError>
+) -> Result<Option<PkBoundaries>, TransientError>
 where
     Q: Queryable,
 {
@@ -276,8 +274,7 @@ where
                 "SELECT {col_literal} FROM {table}{predicate} \
                  ORDER BY {col} LIMIT 1 OFFSET {offset}"
             ))
-            .await
-            .map_err(classify_query_error)?;
+            .await?;
         // Defensive: if a concurrent write shrank the range out from under us, stop and
         // use the boundaries found so far. Fewer partitions is still correct.
         let Some(mut row) = row else { break };
@@ -313,7 +310,7 @@ async fn sample_pk_bounds(
         BTreeMap<MySqlTableName, Option<PkBoundaries>>,
         BTreeMap<MySqlTableName, u64>,
     ),
-    SnapshotSetupError,
+    TransientError,
 > {
     let ssh_tunnel_manager = &config.config.connection_context.ssh_tunnel_manager;
     let worker_count = config.worker_count;
@@ -381,7 +378,7 @@ async fn sample_pk_bounds(
                     None => None,
                 };
                 pool.borrow_mut().push(conn);
-                Ok::<_, SnapshotSetupError>((table.clone(), count, splits))
+                Ok::<_, TransientError>((table.clone(), count, splits))
             }
         })
         // At most `worker_count` connections are checked out at once, so the pool
@@ -419,7 +416,7 @@ async fn lock_and_prepare_snapshot(
     task_name: &str,
     tables: &BTreeMap<MySqlTableName, Vec<SourceOutputInfo>>,
     metrics: &MySqlSnapshotMetrics,
-) -> Result<(SnapshotInfo, BTreeMap<MySqlTableName, u64>, MySqlConn), SnapshotSetupError> {
+) -> Result<(SnapshotInfo, BTreeMap<MySqlTableName, u64>, MySqlConn), TransientError> {
     let mut lock_conn = connection_config
         .connect(
             task_name,
@@ -452,7 +449,7 @@ async fn lock_and_prepare_snapshot(
     )
     .await?;
 
-    let lock_clauses = tables
+    let lock_clauses = sample_tables
         .keys()
         .map(|t| format!("{} READ", t))
         .collect::<Vec<String>>()
@@ -484,7 +481,7 @@ async fn lock_and_prepare_snapshot(
 async fn verify_output_schemas<Q>(
     conn: &mut Q,
     tables: &BTreeMap<MySqlTableName, Vec<SourceOutputInfo>>,
-) -> Result<Vec<(usize, DefiniteError)>, SnapshotSetupError>
+) -> Result<Vec<(usize, DefiniteError)>, TransientError>
 where
     Q: Queryable,
 {
@@ -800,20 +797,7 @@ pub(crate) fn render<'scope>(
                             // Broadcast the failure sentinel so non-leaders exit cleanly instead
                             // of deadlocking on the feedback loop.
                             snapshot_handle.give(&snapshot_cap_set[0], None);
-                            match err {
-                                SnapshotSetupError::Definite(e) => {
-                                    return Ok(return_definite_error(
-                                        e,
-                                        &all_outputs,
-                                        &raw_handle,
-                                        data_cap_set,
-                                        &definite_error_handle,
-                                        definite_error_cap_set,
-                                    )
-                                    .await);
-                                }
-                                SnapshotSetupError::Transient(e) => return Err(e),
-                            }
+                            return Err(err);
                         }
                     }
                 } else {
@@ -1119,39 +1103,11 @@ fn publish_snapshot_size(
     }
 }
 
-enum SnapshotSetupError {
-    Definite(DefiniteError),
-    Transient(TransientError),
-}
-
-impl From<mysql_async::Error> for SnapshotSetupError {
-    fn from(e: mysql_async::Error) -> Self {
-        SnapshotSetupError::Transient(e.into())
-    }
-}
-
-impl From<MySqlError> for SnapshotSetupError {
-    fn from(e: MySqlError) -> Self {
-        SnapshotSetupError::Transient(e.into())
-    }
-}
-
-fn classify_query_error(e: mysql_async::Error) -> SnapshotSetupError {
-    match e {
-        mysql_async::Error::Server(mysql_async::ServerError { code, message, .. })
-            if code == ER_NO_SUCH_TABLE =>
-        {
-            SnapshotSetupError::Definite(DefiniteError::TableDropped(message))
-        }
-        e => SnapshotSetupError::Transient(e.into()),
-    }
-}
-
 async fn lock_tables_and_read_gtid_set(
     lock_conn: &mut MySqlConn,
     lock_clauses: &str,
     lock_wait_timeout: Option<Duration>,
-) -> Result<String, SnapshotSetupError> {
+) -> Result<String, TransientError> {
     if let Some(timeout) = lock_wait_timeout {
         // Interpolating a `Duration` integer; not parameterizable in MySQL `SET`.
         #[allow(clippy::disallowed_methods)]
@@ -1165,11 +1121,12 @@ async fn lock_tables_and_read_gtid_set(
 
     // `lock_clauses` is built from `MySqlTableName::Display`, which escapes both
     // schema and table via `quote_identifier`.
-    #[allow(clippy::disallowed_methods)]
-    lock_conn
-        .query_drop(format!("LOCK TABLES {lock_clauses}"))
-        .await
-        .map_err(classify_query_error)?;
+    if !lock_clauses.is_empty() {
+        #[allow(clippy::disallowed_methods)]
+        lock_conn
+            .query_drop(format!("LOCK TABLES {lock_clauses}"))
+            .await?;
+    }
 
     let snapshot_gtid_set = query_sys_var(lock_conn, "global.gtid_executed").await?;
     Ok(snapshot_gtid_set)
@@ -1228,7 +1185,7 @@ struct TableStatistics {
 async fn collect_table_statistics<Q>(
     conn: &mut Q,
     table: &MySqlTableName,
-) -> Result<TableStatistics, SnapshotSetupError>
+) -> Result<TableStatistics, TransientError>
 where
     Q: Queryable,
 {
@@ -1236,15 +1193,12 @@ where
 
     // `MySqlTableName::Display` escapes both identifier components via
     // `quote_identifier`, so this interpolation is safe; not parameterizable.
-    // `classify_query_error` turns a dropped table into a definite error, matching
-    // the boundary-sampling query rather than retrying forever.
     #[allow(clippy::disallowed_methods)]
     let count_row: Option<u64> = conn
         .query_first(format!("SELECT COUNT(*) FROM {}", table))
         .wall_time()
         .set_at(&mut stats.count_latency)
-        .await
-        .map_err(classify_query_error)?;
+        .await?;
     // `COUNT(*)` returns exactly one row, so `None` should be impossible. Default to 0
     // defensively rather than failing the snapshot on a protocol quirk.
     stats.count = count_row.unwrap_or(0);

--- a/test/mysql-cdc/drop-table-before-snapshot.td
+++ b/test/mysql-cdc/drop-table-before-snapshot.td
@@ -1,0 +1,84 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for the parallel MySQL snapshot (SS-97): a table dropped
+# upstream before its snapshot is read must fail only that table's outputs, not
+# the whole source. During setup the leader counts and locks every pending table
+# before any data is read, so a dropped table makes that step fail with a
+# definite TableDropped error that must not be published to healthy siblings.
+#
+# The drop is made deterministic with the replication-factor-0 trick: while the
+# replica is down we register two new tables (both pending a fresh snapshot) and
+# drop one upstream, then resume with the other still present.
+
+$ set-sql-timeout duration=120s
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+> CREATE CONNECTION mysql_conn TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE anchor (f1 INTEGER);
+INSERT INTO anchor VALUES (1);
+
+> CREATE CLUSTER c SIZE '${arg.default-replica-size}';
+
+> BEGIN
+> CREATE SOURCE mz_source IN CLUSTER c FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE anchor FROM SOURCE mz_source (REFERENCE public.anchor);
+> COMMIT
+
+# Confirm the source is up before pausing it.
+> SELECT * FROM anchor;
+1
+
+> ALTER CLUSTER c SET (REPLICATION FACTOR 0)
+
+> SELECT count(*)
+  FROM mz_cluster_replicas cr JOIN mz_clusters c ON (c.id = cr.cluster_id)
+  WHERE c.name = 'c';
+0
+
+# Two new tables with a single-column PK so the leader splits them into
+# per-worker ranges. Both are pending a fresh snapshot when the replica resumes.
+$ mysql-execute name=mysql
+CREATE TABLE survivor (id INTEGER PRIMARY KEY);
+INSERT INTO survivor VALUES (1), (2), (3), (4);
+CREATE TABLE dropme (id INTEGER PRIMARY KEY);
+INSERT INTO dropme VALUES (1), (2);
+
+> CREATE TABLE survivor FROM SOURCE mz_source (REFERENCE public.survivor);
+> CREATE TABLE dropme FROM SOURCE mz_source (REFERENCE public.dropme);
+
+$ mysql-execute name=mysql
+DROP TABLE dropme;
+
+> ALTER CLUSTER c SET (REPLICATION FACTOR 1)
+
+# The healthy sibling must finish its snapshot. Under the bug the dropped table
+# aborts the whole source and this returns a definite error instead of rows.
+> SELECT * FROM survivor;
+1
+2
+3
+4
+
+# Only the dropped table is errored.
+! SELECT * FROM dropme;
+contains:table was dropped
+
+> DROP SOURCE mz_source CASCADE;


### PR DESCRIPTION
### Motivation

This is a follow-up to https://github.com/MaterializeInc/materialize/pull/37642

Fixes SQL-567, which Dennis flagged as a release blocker. The issue is that the full source gets jammed if a table is dropped concurrently with snapshotting. I didn't handle initially because it's not strictly a regression from previous behavior, but Dennis made a good point that the aperture for the issue has widened significantly with the slower partition computation.

### Description

A drop racing with setup after verification is now transient. The dataflow restarts and verification catches the drop on the next attempt.

Main downside to consider here is that we lose potentially a lot of work done in the setup phase if we hit a transient error. We could include an additional schema validation right before taking the locks to tighten that up at the cost of more complex code.

The flow for producing definite errors per-table now is roughly:
1. Validate schema upfront non-transactionally before taking read locks and opening txns, this produces a list of definite errors keyed by output
2. Get the snapshot started -- take the read lock for non-dropped tables, emit the general details of the snapshot, all workers open a txn
3. The legacy "is responsible for" worker that historically would have handled the table end-to-end will now be responsible for emitting a single clear definite error

### Verification

Relying on the new testdrive tests and other nightly tests more broadly.