### PR TITLE
adapter: preserve reconfiguration deadline on unrelated ALTER

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -26,6 +26,7 @@ use mz_controller_types::{ClusterId, DEFAULT_REPLICA_LOGGING_INTERVAL, ReplicaId
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::instrument;
+use mz_repr::Timestamp;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::role_id::RoleId;
 use mz_sql::ast::{Ident, QualifiedReplica};
@@ -724,40 +725,59 @@ impl Coordinator {
         // record the controller aborts asynchronously.
         self.validate_reconfiguration_resource_limits(cluster_id, &target)?;
 
-        // Resolve the deadline and the on-timeout action from the existing
-        // `WITH (WAIT ...)` surface. Both are written relative to the current time
-        // so they survive session disconnect and restart. Unlike the target, which
-        // folds per-dimension onto the in-flight one, the deadline and `on_timeout`
-        // are replaced wholesale by the latest `ALTER`'s `WAIT` clause (they are
-        // resolved fresh here, not merged), so re-issuing an `ALTER` with a
-        // different `ON TIMEOUT` overwrites the prior action.
-        //   - no `WAIT`         -> the system-default timeout and the implicit
-        //                          `on_timeout` default (`ROLLBACK`).
+        // Resolve the deadline and the on-timeout action, both written relative
+        // to the current time so they survive session disconnect and restart.
+        // The target folds per-dimension onto the in-flight one. The deadline
+        // and `on_timeout`, in contrast, are the contract carried by a `WAIT`
+        // clause, so how a folding `ALTER` treats them depends on whether it
+        // carries one:
+        //   - no `WAIT`, reconfiguration in flight -> keep the in-flight
+        //                          record's deadline and `on_timeout`. The
+        //                          statement carries no contract of its own, so
+        //                          an unrelated config-shape `ALTER` must not
+        //                          silently reset the deadline and action the
+        //                          user set on the reconfiguration in progress.
+        //   - no `WAIT`, nothing in flight -> the system-default timeout and the
+        //                          implicit `on_timeout` default (`ROLLBACK`).
         //   - `WAIT FOR`        -> sugar for `ON TIMEOUT COMMIT` (cut over at the
         //                          deadline regardless of hydration).
         //   - `WAIT UNTIL READY -> the explicit `TIMEOUT` / `ON TIMEOUT`, with
         //                          `ON TIMEOUT` defaulting to `ROLLBACK` when
-        //                          omitted. The safe default for the controller
-        //                          path reverts an un-hydrated reconfiguration to
-        //                          its pre-reconfiguration shape rather than
-        //                          cutting over to a not-yet-hydrated target
-        //                          (which could induce downtime). The legacy
-        //                          foreground path uses implicit `COMMIT`.
-        let (timeout, on_timeout) = match strategy {
-            AlterClusterPlanStrategy::None => (
-                DEFAULT_CLUSTER_RECONFIGURATION_TIMEOUT
-                    .get(self.catalog().system_config().dyncfgs()),
-                OnTimeoutAction::Rollback,
-            ),
-            AlterClusterPlanStrategy::For(timeout) => (*timeout, OnTimeoutAction::Commit),
+        //                          omitted.
+        // An explicit `WAIT` clause is folded onto an in-flight record wholesale,
+        // which lets a later `ALTER` steer the deadline and timeout action of a
+        // reconfiguration in progress without discarding the hydration progress
+        // its target may already have. `ROLLBACK` (the default) reverts an
+        // un-hydrated reconfiguration to its pre-reconfiguration shape rather
+        // than cutting over to a not-yet-hydrated target, which could induce
+        // downtime. The legacy foreground path uses implicit `COMMIT`.
+        let now = self.now();
+        let deadline_from = |timeout: Duration| -> Timestamp {
+            now.saturating_add(u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX))
+                .into()
+        };
+        let (deadline, on_timeout) = match strategy {
+            AlterClusterPlanStrategy::None => match &in_flight {
+                Some(record) => (record.deadline, record.on_timeout),
+                None => (
+                    deadline_from(
+                        DEFAULT_CLUSTER_RECONFIGURATION_TIMEOUT
+                            .get(self.catalog().system_config().dyncfgs()),
+                    ),
+                    OnTimeoutAction::Rollback,
+                ),
+            },
+            AlterClusterPlanStrategy::For(timeout) => {
+                (deadline_from(*timeout), OnTimeoutAction::Commit)
+            }
             AlterClusterPlanStrategy::UntilReady {
                 timeout,
                 on_timeout,
-            } => (*timeout, on_timeout.unwrap_or(OnTimeoutAction::Rollback)),
+            } => (
+                deadline_from(*timeout),
+                on_timeout.unwrap_or(OnTimeoutAction::Rollback),
+            ),
         };
-        let deadline = self
-            .now()
-            .saturating_add(u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX));
 
         // Build the durable write from `new_config`, which carries every field the
         // `ALTER` changed, then reset the config *shape* (size, replication factor,
@@ -794,7 +814,7 @@ impl Coordinator {
         };
         let record = ReconfigurationState {
             target: target.clone(),
-            deadline: deadline.into(),
+            deadline,
             on_timeout,
             status,
         };

--- a/test/testdrive/cluster-controller.td
+++ b/test/testdrive/cluster-controller.td
@@ -402,6 +402,52 @@ true scale=1,workers=4
 
 > DROP CLUSTER cc_force_existing CASCADE
 
+# A folding ALTER without a WAIT clause must not touch the in-flight deadline
+# and on-timeout action. Those are the contract the ALTER that started the
+# reconfiguration set, and an unrelated config-shape ALTER (here a system-issued
+# arrangement-compression flip, the shape it can share with an in-flight
+# reconfiguration) carries no contract of its own. Overwriting them with the
+# system default would silently stretch a user's short ROLLBACK deadline to the
+# 24h default, leaving the reconfiguration parked in-progress instead of rolling
+# back on time.
+> CREATE CLUSTER cc_preserve (SIZE 'scale=1,workers=1', REPLICATION FACTOR 1)
+
+> CREATE TABLE cc_preserve_t (id int)
+
+> INSERT INTO cc_preserve_t VALUES (1)
+
+# A sleeping view keeps the target from hydrating, so the reconfiguration stays
+# in-progress and only the deadline could resolve it.
+> CREATE MATERIALIZED VIEW cc_preserve_slow IN CLUSTER cc_preserve AS
+  SELECT mz_unsafe.mz_sleep(id * 3600) AS s FROM cc_preserve_t
+
+> ALTER CLUSTER cc_preserve SET (SIZE 'scale=1,workers=4') WITH (WAIT UNTIL READY (TIMEOUT '600s', ON TIMEOUT 'ROLLBACK'))
+
+> SELECT recon.status, recon.on_timeout
+  FROM mz_internal.mz_cluster_reconfigurations recon
+  JOIN mz_clusters c ON c.id = recon.cluster_id
+  WHERE c.name = 'cc_preserve'
+in-progress rollback
+
+$ set-from-sql var=cc_preserve_deadline
+SELECT recon.deadline::text
+FROM mz_internal.mz_cluster_reconfigurations recon
+JOIN mz_clusters c ON c.id = recon.cluster_id
+WHERE c.name = 'cc_preserve'
+
+# An unrelated no-WAIT ALTER folds onto the record. The size dimension it did
+# not mention keeps the in-flight target's workers=4, and the deadline and
+# on-timeout action are preserved unchanged.
+> ALTER CLUSTER cc_preserve SET (EXPERIMENTAL ARRANGEMENT COMPRESSION = true)
+
+> SELECT recon.status, recon.on_timeout, recon.deadline::text = '${cc_preserve_deadline}', recon.target->>'size'
+  FROM mz_internal.mz_cluster_reconfigurations recon
+  JOIN mz_clusters c ON c.id = recon.cluster_id
+  WHERE c.name = 'cc_preserve'
+in-progress rollback true scale=1,workers=4
+
+> DROP CLUSTER cc_preserve CASCADE
+
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET unsafe_enable_unstable_dependencies = false
 


### PR DESCRIPTION
## Motivation

A config-shape `ALTER CLUSTER` that arrives while a graceful reconfiguration is
already in flight folds onto the in-flight durable reconfiguration record. The
target shape folds per dimension, but the record's `deadline` and `on_timeout`
action were recomputed from scratch from the *new* statement's `WITH (WAIT ...)`
surface and written wholesale, even when the new statement carried no `WAIT`
clause at all.

A statement with no `WAIT` clause has no deadline contract of its own: it
resolves to the `default_cluster_reconfiguration_timeout` default (24h) and an
implicit `ON TIMEOUT ROLLBACK`. Folding it onto an in-flight record therefore
silently replaced the deadline and timeout action that the statement which
*started* the reconfiguration had set. An unrelated `ALTER` from another session
could stretch a user's explicit short deadline out to 24h.

That is the nightly failure this closes. A user `ALTER` started a 120s
`ON TIMEOUT ROLLBACK` reconfiguration on a cluster. Roughly 14s later an
unrelated, system-issued `ALTER CLUSTER ... SET (EXPERIMENTAL ARRANGEMENT
COMPRESSION = true)` landed on the same cluster. Arrangement compression is a
replica-shape dimension, so that statement folds onto the in-flight record too,
and being a no-`WAIT` `ALTER` it reset the deadline to ~24h out. The
reconfiguration could no longer roll back at its 120s deadline, so it stayed
parked `in-progress`, and the test observed `Graceful reconfiguration ... did
not complete (reconfiguration status: in-progress)`.

## Description

Resolve the deadline and on-timeout action based on whether the folding `ALTER`
carries a `WAIT` clause:

- **No `WAIT` clause, reconfiguration in flight:** keep the in-flight record's
  `deadline` and `on_timeout`. The statement carries no contract of its own, so
  it must not touch the one the user set on the reconfiguration in progress.
- **No `WAIT` clause, nothing in flight:** unchanged. The system-default timeout
  and the implicit `ROLLBACK` action.
- **Explicit `WAIT FOR` / `WAIT UNTIL READY`:** unchanged. Their deadline and
  action fold onto the in-flight record wholesale, which is what lets a user
  *steer* an in-flight reconfiguration (adjust the deadline or the timeout
  action) without discarding hydration progress already made on the target.

Only the no-`WAIT`-onto-in-flight case changes behavior.

User-visible effect: an unrelated `ALTER CLUSTER` that omits `WITH (WAIT ...)`
no longer resets the deadline or `ON TIMEOUT` action of a graceful
reconfiguration already in progress. The contract set by the `ALTER` that
started (or last steered) the reconfiguration is preserved.

## Out of scope

Whether to outright *deny* config-shape `ALTER`s while a reconfiguration is in
flight (today only `SCHEDULE` and `REPLICATION FACTOR` changes are rejected) is
a separate design question, deferred.

## Tests

Added a case to `test/testdrive/cluster-controller.td`: a sleeping materialized
view keeps a target from hydrating, an `ALTER` starts a reconfiguration with
`WAIT UNTIL READY (TIMEOUT '600s', ON TIMEOUT 'ROLLBACK')`, then an unrelated
no-`WAIT` `SET (EXPERIMENTAL ARRANGEMENT COMPRESSION = true)` folds on. The test
asserts the deadline is unchanged, `on_timeout` stays `rollback`, status stays
`in-progress`, and the size dimension the second `ALTER` did not mention keeps
the in-flight target's value. Before the fix the deadline jumped to `now + 24h`,
failing the equality assertion.

Fixes SQL-568.

https://linear.app/materializeinc/issue/SQL-568/graceful-reconfiguration-of-cluster-cluster-3-to-size-scale1workers1
