### PR TITLE
mz-deploy: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "mz-deploy"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "annotate-snippets",
  "async-stream",

--- a/src/mz-deploy/Cargo.toml
+++ b/src/mz-deploy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-deploy"
 description = "Declarative SQL project tooling for Materialize: compile, test, deploy."
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
Bumps the `mz-deploy` CLI to `0.3.0` and cuts a new release.

Since `0.2.0`, the tool gained a new feature and a batch of bug fixes, so this is a minor version bump per `ci/deploy_mz-deploy/README.md`.

**New feature**
- Support for cluster autoscaling strategies (#37791, #37671).

**Bug fixes**
- Run the roles phase before clusters in `apply-all` so a cluster grant can reference a project role (DEX-49, #37379).
- Roll back metadata on a failed stage recording (DEX-40, #37376).
- Accept system-catalog dependencies during validation (DEX-42, #37378).
- Route dev-overlay references by object, not by schema (DEX-43, #37375).
- Restore stub table columns in schema position order (DEX-38, DEX-44, #37372).
- Several LSP robustness fixes: guard against positions past end of document (DEX-55), mid-char replacement ranges (DEX-58), and non-char-boundary diagnostic ranges (DEX-56, DEX-57).

After this merges, the release is completed by tagging the merged commit `mz-deploy-v0.3.0` and triggering the Buildkite deploy pipeline, followed by the Homebrew tap update.

### Release notes

This release bumps the `mz-deploy` CLI to 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)