### PR TITLE
ci: Fix shard info meta-data and add bin/ci-shards

### DIFF
--- a/.agents/skills/mz-debug-ci/SKILL.md
+++ b/.agents/skills/mz-debug-ci/SKILL.md
@@ -107,6 +107,25 @@ bk job log <JOB_ID> -p <PIPELINE> -b <BUILD_NUMBER> --no-timestamps --no-pager 2
 
 Fetch multiple job logs in parallel when they are independent (e.g., clippy + lint at the same time).
 
+### Shard contents
+
+Sharded jobs (SLT, testdrive, platform checks, feature benchmark, ...) record
+the workflows/files/scenarios they ran in build meta-data. `bin/ci-shards`
+shows it:
+
+```bash
+# Mapping of every sharded job to what it ran, with a link per job whose
+# `#` fragment is the `<JOB_ID>` for `bk job log` (omit links with --no-url)
+bin/ci-shards https://buildkite.com/materialize/<PIPELINE>/builds/<BUILD_NUMBER>
+
+# What a single job ran (job link as copied from the Buildkite UI)
+bin/ci-shards 'https://buildkite.com/materialize/<PIPELINE>/builds/<BUILD_NUMBER>#<JOB_ID>'
+
+# Which job(s) ran a specific item (test file, scenario, or workflow,
+# `workflow_foo_bar` function names are matched as `foo-bar`)
+bin/ci-shards https://buildkite.com/materialize/<PIPELINE>/builds/<BUILD_NUMBER> numeric.td
+```
+
 ## Step 5: Categorize failures
 
 Use these Materialize-specific patterns to diagnose:

--- a/bin/ci-shards
+++ b/bin/ci-shards
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# ci-shards - Show which workflows/files the sharded jobs of a build ran.
+
+exec "$(dirname "$0")"/pyactivate -m materialize.cli.ci_shards "$@"

--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -183,12 +183,27 @@ def get_parallelism_count() -> int:
     return int(get_var(BuildkiteEnvVar.BUILDKITE_PARALLEL_JOB_COUNT, 1))
 
 
+# Accumulates across shard_list calls because a workflow can shard multiple
+# lists (e.g. sqllogictest shards each step's file list separately). Each
+# upload overwrites the key with the accumulated items so far.
+_shard_info_items: list[str] = []
+
+
 def _upload_shard_info_metadata(items: list[str]) -> None:
+    _shard_info_items.extend(items)
+    # The label is unique per parallel job (mkpipeline appends the shard
+    # number), so shards don't overwrite each other's entry.
     label = get_var(BuildkiteEnvVar.BUILDKITE_LABEL) or get_var(
         BuildkiteEnvVar.BUILDKITE_STEP_KEY
     )
     spawn.runv(
-        ["buildkite-agent", "meta-data", "set", f"Shard for {label}", ", ".join(items)]
+        [
+            "buildkite-agent",
+            "meta-data",
+            "set",
+            f"Shard for {label}",
+            ", ".join(_shard_info_items),
+        ]
     )
 
 

--- a/misc/python/materialize/cli/ci_shards.py
+++ b/misc/python/materialize/cli/ci_shards.py
@@ -1,0 +1,131 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# ci_shards.py - Show which workflows/files the sharded jobs of a build ran.
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+
+def fetch_build(pipeline: str, build_number: str) -> dict:
+    try:
+        output = subprocess.check_output(
+            ["bk", "api", f"/pipelines/{pipeline}/builds/{build_number}", "--no-pager"]
+        )
+    except FileNotFoundError:
+        sys.exit("error: bk CLI not found, install it and run `bk configure`")
+    except subprocess.CalledProcessError as error:
+        sys.exit(f"error: bk api failed with exit code {error.returncode}")
+    return json.loads(output)
+
+
+def natural_sort_key(label: str) -> list:
+    return [int(part) if part.isdigit() else part for part in re.split(r"(\d+)", label)]
+
+
+def hyperlink(url: str, text: str) -> str:
+    # OSC 8 terminal hyperlink, makes `text` clickable in iTerm2, kitty, etc.
+    return f"\033]8;;{url}\033\\{text}\033]8;;\033\\"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="ci-shards",
+        description="Show which workflows/files the sharded jobs of a Buildkite "
+        "build ran, based on the `Shard for <job>` build meta-data that "
+        "`buildkite.shard_list` uploads. With a job link (build URL with "
+        "`#<job-id>` fragment), show only that job's items.",
+    )
+    parser.add_argument(
+        "url",
+        help="Buildkite build or job URL, e.g. "
+        "https://buildkite.com/materialize/test/builds/129455 or "
+        "https://buildkite.com/materialize/test/builds/129455#<job-id>",
+    )
+    parser.add_argument(
+        "item",
+        nargs="?",
+        help="only show items containing this substring, e.g. a test file or "
+        "scenario name, to find the job(s) that ran it",
+    )
+    parser.add_argument(
+        "--no-url",
+        action="store_true",
+        help="do not print a link to each job",
+    )
+    args = parser.parse_args()
+
+    match = re.fullmatch(
+        r"https://buildkite\.com/[^/]+/([^/]+)/builds/(\d+)(?:#(.+))?",
+        args.url,
+    )
+    if not match:
+        sys.exit(f"error: unrecognized Buildkite build URL: {args.url}")
+    pipeline, build_number, job_id = match.groups()
+
+    build = fetch_build(pipeline, build_number)
+    shards = {
+        key.removeprefix("Shard for "): value.split(", ")
+        for key, value in build.get("meta_data", {}).items()
+        if key.startswith("Shard for ")
+    }
+    if args.item:
+        # Accept the Python function name of a workflow too: mzcompose records
+        # `workflow_foo_bar` under the name `foo-bar`.
+        needles = {args.item}
+        if args.item.startswith("workflow_"):
+            needles.add(args.item.removeprefix("workflow_").replace("_", "-"))
+        shards = {
+            label: matching
+            for label, items in shards.items()
+            if (
+                matching := [
+                    item for item in items if any(needle in item for needle in needles)
+                ]
+            )
+        }
+        if not shards:
+            sys.exit(f"error: no shard in build {build_number} ran {args.item!r}")
+
+    if job_id:
+        job = next((j for j in build["jobs"] if j.get("id") == job_id), None)
+        if job is None:
+            sys.exit(f"error: no job {job_id} in build {build_number}")
+        items = shards.get(job.get("name"))
+        if items is None:
+            sys.exit(
+                f"error: no shard info recorded for job {job.get('name')!r}, "
+                "only sharded jobs upload it"
+            )
+        print("\n".join(items))
+    else:
+        if not shards:
+            sys.exit(f"error: no shard info recorded in build {build_number}")
+        jobs_by_name = {job["name"]: job for job in build["jobs"] if "name" in job}
+        for label in sorted(shards, key=natural_sort_key):
+            items = ", ".join(shards[label])
+            url = jobs_by_name.get(label, {}).get("web_url")
+            if args.no_url or not url:
+                print(f"{label}: {items}")
+            elif sys.stdout.isatty():
+                print(f"{hyperlink(url, label)}: {items}")
+            else:
+                # Piped output gets the plain URL so it stays greppable and
+                # scripts can extract the job ID from the `#` fragment.
+                print(f"{label}: {items}")
+                print(f"  {url}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Sharded jobs record the workflows/files they ran in build meta-data under "Shard for <job label>". Accumulate items across shard_list calls so workflows that shard multiple lists (e.g. sqllogictest's steps) no longer overwrite their own entry. The label alone is a unique key since mkpipeline appends the shard number to parallel steps.

Add bin/ci-shards to show the mapping: pass a Buildkite build URL to list every sharded job with its items, or a job link for that job's items. Document it in the mz-debug-ci skill.

https://materializeinc.slack.com/archives/C01LKF361MZ/p1784895664071619