### PR TITLE
cluster: give timely worker OS threads distinguishable names

### DIFF
--- a/src/cluster/src/client.rs
+++ b/src/cluster/src/client.rs
@@ -264,6 +264,11 @@ pub trait ClusterSpec: Clone + Send + Sync + 'static {
             let span = info_span!("timely", name = Self::NAME, worker_id = worker_idx);
             let _span_guard = span.enter();
 
+            // Every Timely instance in this process names its threads `timely:work-N`, restarting
+            // the index at 0, so storage and compute worker threads collide under the same OS
+            // thread name. Rename to disambiguate them for profilers and `top -H`.
+            mz_ore::process::set_current_thread_name(&format!("{}:{worker_idx}", Self::NAME));
+
             let _tokio_guard = tokio_executor.enter();
             let client_rx = client_rxs.lock().unwrap()[worker_idx % config.workers]
                 .take()

--- a/src/ore/src/process.rs
+++ b/src/ore/src/process.rs
@@ -81,3 +81,28 @@ pub fn exit_thread_safe(error_code: i32) -> ! {
     // [1]: https://github.com/rust-lang/rust/issues/126600
     unsafe { libc::_exit(error_code) };
 }
+
+/// Sets the OS-level name of the calling thread, visible to tools like `top -H`, `perf`,
+/// `samply`, and `/proc/<pid>/task/*/comm`.
+///
+/// Linux truncates thread names to 15 bytes (16 with the NUL terminator); `name` is truncated to
+/// fit. Best-effort: a no-op on non-Linux platforms, and silently does nothing if the underlying
+/// syscall fails.
+pub fn set_current_thread_name(name: &str) {
+    #[cfg(target_os = "linux")]
+    {
+        let mut truncated = name.to_string();
+        while truncated.len() > 15 {
+            truncated.pop();
+        }
+        if let Ok(name) = std::ffi::CString::new(truncated) {
+            unsafe {
+                libc::pthread_setname_np(libc::pthread_self(), name.as_ptr());
+            }
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = name;
+    }
+}


### PR DESCRIPTION
### Motivation

Every Timely instance names its worker threads `timely:work-N` (hardcoded in
`timely_communication`), with the index restarting at 0 per instance. A
`clusterd` process runs separate storage and compute Timely instances, so
their worker threads collide under the same OS thread name. Profilers and
tools that read `/proc/<pid>/task/*/comm` (`top -H`, `samply`, `perf`) can't
tell storage and compute workers apart. The only existing distinguisher is
the tracing span (`name = "compute"` vs `"storage"`), which is log-only.

### Description

Adds `mz_ore::process::set_current_thread_name`, a best-effort wrapper
around `pthread_setname_np` that truncates to Linux's 15-byte thread name
limit and no-ops on non-Linux platforms or syscall failure.

Calls it from the shared worker closure in `ClusterClient::build_cluster`
(`src/cluster/src/client.rs`), using `{cluster_name}:{worker_idx}` (e.g.
`storage:0`, `compute:0`). This covers both storage and compute in one
place, since each `ClusterSpec` impl already supplies its own `NAME`.

### Verification

Built `environmentd`/`clusterd` in `--optimized` mode and inspected
`/proc/<pid>/task/*/comm` for a running `clusterd` process hosting both a
storage and a compute Timely instance. Before this change both showed as
`timely:work-0`; after, they show as distinct `storage:0` and `compute:0`.