### PR TITLE
testdrive: add built-in mz_system and materialize connections

### DIFF
--- a/.agents/skills/mz-limits-test/SKILL.md
+++ b/.agents/skills/mz-limits-test/SKILL.md
@@ -42,7 +42,7 @@ class Generator:
         """Records EXPLAIN query for timing and prints `> {query}`."""
 ```
 
-`header()` is inherited - it resets the `public` schema and grants privileges. `footer()` prints a blank line. `generate()` calls `header()` → `body()` → `footer()`.
+`header()` is inherited - it resets the `public` schema and grants privileges. `footer()` prints a blank line. `generate()` calls `header()` → `body()` → `footer()`. `mz_system` is a built-in testdrive connection, so `$ postgres-execute connection=mz_system` works in `body()` without any registration.
 
 ## How to Add a New Limits Test
 

--- a/.agents/skills/mz-test/SKILL.md
+++ b/.agents/skills/mz-test/SKILL.md
@@ -84,18 +84,16 @@ bin/mzcompose --find testdrive run default -- FILENAME.td
 
 `FILENAME.td` is a file in `test/testdrive/`, relative to that directory (not the repo root).
 
-`connection=mz_system` is NOT a built-in testdrive connection. A `.td` that uses
-`$ postgres-execute connection=mz_system` (e.g. for `ALTER SYSTEM SET`) must
-first register it:
+`mz_system` and `materialize` are built-in testdrive connections, so
+`$ postgres-execute connection=mz_system` (e.g. for `ALTER SYSTEM SET`) works
+without a prior registration. Any other connection name must first be
+registered:
 
 ```
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+$ postgres-connect name=conn1 url=postgres://materialize:materialize@${testdrive.materialize-sql-addr}
 ```
 
-Omitting the line fails in CI with `connection 'mz_system' not found`. When
-verifying a `.td` locally, run it as written (bare `mz_system` name), not a copy
-with the full URL hand-substituted into `connection=...`, since the URL form
-passes locally while the committed bare-name form fails CI.
+Using an unregistered name fails with `connection 'conn1' not found`.
 
 Some compositions (e.g. platform-checks, upgrade, pg-cdc multi-version) run the
 same `.td` file against multiple Materialize versions. When a change alters

--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -572,6 +572,13 @@ CREATE TABLE postgres_execute (f1 INTEGER);
 
 If any of the statements fail, the entire test will fail. Any result sets returned from the server are ignored and not checked for correctness.
 
+Two connection names are built in and can be used without a prior `$ postgres-connect` registration: `mz_system` connects as the `mz_system` user via the internal SQL address (e.g. for `ALTER SYSTEM SET`), and `materialize` connects as the `materialize` user via the external SQL address. The connection is established on first use and is then cached like a named connection created by `$ postgres-connect`, so repeated uses share a session. An explicit `$ postgres-connect` with the same name takes precedence.
+
+```
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET max_tables = 1000;
+```
+
 With `background=true` (only valid for URL connections), the statements execute in the background while the test continues. The task is joined at the end of the file, and a failure or a task that does not complete within the default timeout fails the test.
 
 #### `$ postgres-connect name=.... url=...`

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -219,7 +219,6 @@ class Insert(DML):
 
     def benchmark(self) -> MeasurementSource:
         return Td(f"""
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_result_size = 17179869184;
 
@@ -417,7 +416,6 @@ class InsertAndSelect(DML):
 
     def benchmark(self) -> MeasurementSource:
         return Td(f"""
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_result_size = 17179869184;
 
@@ -970,7 +968,6 @@ class DifferentialJoinColumnPaged(Dataflow):
         return [
             self.view_ten(),
             TdAction(f"""
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET enable_column_paged_batcher = true;
 
@@ -1033,7 +1030,6 @@ class DifferentialJoinHydration(Dataflow):
     def init(self) -> list[Action]:
         return [
             TdAction(f"""
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
 $ postgres-execute connection=mz_system
 {self.dyncfgs()}
 """),
@@ -1826,7 +1822,6 @@ $ kafka-ingest format=avro topic=many-kafka-sources-{i} schema=${{schema}} repea
 
     def init(self) -> Action:
         return TdAction(f"""
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_sources = {self.n() * 4};
 ALTER SYSTEM SET max_tables = {self.n() * 4};
@@ -2568,7 +2563,6 @@ $ kafka-ingest format=avro topic=startup-time schema=${schema} repeat=1
 """ for i in range(0, self.n()))
 
         return TdAction(f"""
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_objects_per_schema = {self.n() * 10};
 ALTER SYSTEM SET max_materialized_views = {self.n() * 2};
@@ -2658,7 +2652,6 @@ class StartupTpch(Scenario):
 """ for q, query in enumerate(queries) for i in range(0, self.n()))
 
         return TdAction(f"""
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_objects_per_schema = {self.n() * 100};
 ALTER SYSTEM SET max_materialized_views = {self.n() * 100};

--- a/src/testdrive/src/action/postgres/execute.rs
+++ b/src/testdrive/src/action/postgres/execute.rs
@@ -15,6 +15,24 @@ use crate::action::{BackgroundTask, ControlFlow, State};
 use crate::parser::BuiltinCommand;
 use crate::util::postgres::postgres_client;
 
+/// URLs for built-in connection names that resolve without a prior
+/// `postgres-connect` registration. An explicit `postgres-connect` with the
+/// same name takes precedence, since `state.postgres_clients` is consulted
+/// first.
+fn builtin_connection_url(state: &State, name: &str) -> Option<String> {
+    match name {
+        "mz_system" => Some(format!(
+            "postgres://mz_system:materialize@{}",
+            state.materialize.internal_sql_addr
+        )),
+        "materialize" => Some(format!(
+            "postgres://materialize:materialize@{}",
+            state.materialize.sql_addr
+        )),
+        _ => None,
+    }
+}
+
 async fn execute_input(cmd: BuiltinCommand, client: &Client) -> Result<(), anyhow::Error> {
     for query in cmd.input {
         println!(">> {}", query);
@@ -63,6 +81,12 @@ pub async fn run_execute(
             execute_input(cmd, &client_inner).await?;
         }
         (false, false) => {
+            if !state.postgres_clients.contains_key(&connection)
+                && let Some(url) = builtin_connection_url(state, &connection)
+            {
+                let (client, _) = postgres_client(&url, state.default_timeout).await?;
+                state.postgres_clients.insert(connection.clone(), client);
+            }
             let client = state
                 .postgres_clients
                 .get(&connection)

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -533,7 +533,6 @@ SCENARIOS = [
         + KafkaScenario.END_MARKER
         # Ensure this config works.
         + dedent("""
-            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
             $ postgres-execute connection=mz_system
             ALTER SYSTEM SET storage_upsert_max_snapshot_batch_buffering = 2;
             """)
@@ -608,7 +607,6 @@ SCENARIOS = [
     Scenario(
         name="table-insert-delete",
         pre_restart=dedent("""
-            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
             $ postgres-execute connection=mz_system
             ALTER SYSTEM SET max_result_size = 2147483648;
 
@@ -873,7 +871,6 @@ SCENARIOS = [
     Scenario(
         name="cardinality-estimate-disjunction",
         pre_restart=dedent("""
-            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
             $ postgres-execute connection=mz_system
             ALTER SYSTEM SET ENABLE_CARDINALITY_ESTIMATES TO TRUE;
 
@@ -1190,7 +1187,6 @@ SCENARIOS = [
             # * Lgalloc disabled to force more memory pressure.
             # * Index options to enable retained history.
             # * Finally, enable backpressure.
-            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
             $ postgres-execute connection=mz_system
             ALTER SYSTEM SET min_timestamp_interval = '10ms';
             ALTER SYSTEM SET enable_lgalloc = false;
@@ -1299,7 +1295,6 @@ SCENARIOS = [
     Scenario(
         name="copy-to-from-s3",
         pre_restart=dedent(f"""
-            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
             $ postgres-execute connection=mz_system
             ALTER SYSTEM SET max_result_size = 2147483648;
 

--- a/test/cluster/query-without-default-cluster/query-without-default-cluster.td
+++ b/test/cluster/query-without-default-cluster/query-without-default-cluster.td
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $ postgres-execute connection=mz_system
 DROP CLUSTER quickstart CASCADE
 

--- a/test/cluster/resources/resource-limits.td
+++ b/test/cluster/resources/resource-limits.td
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-connect name=mz_analytics url=postgres://mz_analytics:materialize@${testdrive.materialize-internal-sql-addr}
 
 ! ALTER SYSTEM SET max_tables TO 42

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -223,7 +223,6 @@ def workflow_default(c: Composition) -> None:
             c.testdrive(
                 "\n".join(
                     [
-                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
                         "$ postgres-execute connection=mz_system",
                         command,
                     ]
@@ -390,7 +389,6 @@ def run_scoped_feature_flag_cases(
             c.testdrive(
                 "\n".join(
                     [
-                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
                         "$ postgres-execute connection=mz_system",
                         "CREATE CLUSTER ld_legacy SIZE 'scale=1,workers=1,legacy'",
                         "CREATE CLUSTER ld_role SIZE 'scale=1,workers=1,legacy'",
@@ -436,7 +434,6 @@ def run_scoped_feature_flag_cases(
             c.testdrive(
                 "\n".join(
                     [
-                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
                         "$ postgres-execute connection=mz_system",
                         "DROP CLUSTER ld_role",
                         "CREATE CLUSTER ld_role SIZE 'scale=1,workers=1,legacy'",
@@ -562,7 +559,6 @@ def run_scoped_feature_flag_cases(
             c.testdrive(
                 "\n".join(
                     [
-                        "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}",
                         "$ postgres-execute connection=mz_system",
                         "CREATE CLUSTER ld_sync SIZE 'scale=1,workers=1,legacy'",
                     ]

--- a/test/legacy-upgrade/create-in-v0.131.0-alter-table.td
+++ b/test/legacy-upgrade/create-in-v0.131.0-alter-table.td
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET enable_alter_table_add_column = true;
 

--- a/test/legacy-upgrade/create-in-v0.62.0-returning-keyword.td
+++ b/test/legacy-upgrade/create-in-v0.62.0-returning-keyword.td
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-connect name=materialize url=postgres://materialize:materialize@${testdrive.materialize-sql-addr}
-
 # In v0.62+, `returning` must be quoted when used as an identifier.
 $ postgres-execute connection=materialize
 CREATE VIEW view_with_returning AS SELECT "returning" FROM (VALUES (1)) _ ("returning")

--- a/test/legacy-upgrade/create-in-v0.68.0-comment.td
+++ b/test/legacy-upgrade/create-in-v0.68.0-comment.td
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $[version<=12600] postgres-execute connection=mz_system
 ALTER SYSTEM SET enable_comment = true;
 

--- a/test/legacy-upgrade/create-in-v0.71.0-role-var.td
+++ b/test/legacy-upgrade/create-in-v0.71.0-role-var.td
@@ -7,6 +7,4 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 > ALTER ROLE materialize SET application_name TO foo_bar_baz;

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -91,9 +91,6 @@ class Generator:
     @classmethod
     def header(cls) -> None:
         print(f"\n#\n# {cls}\n#\n")
-        print(
-            "$ postgres-connect name=mz_system url=postgres://mz_system@materialized:6877/materialize"
-        )
         print("$ postgres-execute connection=mz_system")
         print("DROP SCHEMA IF EXISTS public CASCADE;")
         print(f"CREATE SCHEMA public /* {cls} */;")

--- a/test/mysql-cdc-old-syntax/mysql-cdc.td
+++ b/test/mysql-cdc-old-syntax/mysql-cdc.td
@@ -131,7 +131,6 @@ CREATE TABLE another_schema.another_table (f1 TEXT);
 INSERT INTO another_schema.another_table VALUES ('123');
 
 # Sneak in a test for mysql_source_snapshot_max_execution_time
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET mysql_source_snapshot_max_execution_time = 1000
 
@@ -150,7 +149,6 @@ $ postgres-execute connection=mz_system
 ALTER SYSTEM SET mysql_source_snapshot_max_execution_time = 0
 
 # Validate mysql_source_snapshot_lock_wait_timeout
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET mysql_source_snapshot_lock_wait_timeout = 1
 

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -131,7 +131,6 @@ CREATE TABLE another_schema.another_table (f1 TEXT);
 INSERT INTO another_schema.another_table VALUES ('123');
 
 # Sneak in a test for mysql_source_snapshot_max_execution_time
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET mysql_source_snapshot_max_execution_time = 10000
 
@@ -152,7 +151,6 @@ $ postgres-execute connection=mz_system
 ALTER SYSTEM SET mysql_source_snapshot_max_execution_time = 0
 
 # Validate mysql_source_snapshot_lock_wait_timeout
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET mysql_source_snapshot_lock_wait_timeout = 1
 

--- a/test/mysql-cdc/proxied/connect_timeout.td
+++ b/test/mysql-cdc/proxied/connect_timeout.td
@@ -13,7 +13,6 @@
 > DROP SECRET IF EXISTS mysql_pass;
 
 # Override MySQL connect timeout to 3s
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET mysql_source_connect_timeout = '3s';
 

--- a/test/mysql-cdc/proxied/connect_timeout_latency.td
+++ b/test/mysql-cdc/proxied/connect_timeout_latency.td
@@ -13,7 +13,6 @@
 > DROP SECRET IF EXISTS mysql_pass;
 
 # Override MySQL connect timeout to 2s
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET mysql_source_connect_timeout = '2s';
 
@@ -41,7 +40,6 @@ $ http-request method=POST url=http://toxiproxy:8474/proxies/mysql/toxics conten
 contains:connection attempt timed out after 2s
 
 # Override MySQL connect timeout to 30s
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET mysql_source_connect_timeout = '30s';
 

--- a/test/pg-cdc-old-syntax/pg-cdc.td
+++ b/test/pg-cdc-old-syntax/pg-cdc.td
@@ -156,7 +156,6 @@ CREATE PUBLICATION another_publication FOR TABLE another_schema.another_table;
 # $ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=materialize_% active=false
 
 # Sneak in a test for pg_source_snapshot_statement_timeout, pg_source_wal_sender_timeout
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET pg_source_snapshot_statement_timeout = 1000;
 ALTER SYSTEM SET pg_source_wal_sender_timeout = 0;

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -161,7 +161,6 @@ CREATE PUBLICATION another_publication FOR TABLE another_schema.another_table;
 # $ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=materialize_% active=false
 
 # Sneak in a test for pg_source_snapshot_statement_timeout, pg_source_wal_sender_timeout
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET pg_source_snapshot_statement_timeout = 1000;
 ALTER SYSTEM SET pg_source_wal_sender_timeout = 0;

--- a/test/pg-cdc/verify-offset-committed-on-startup.td
+++ b/test/pg-cdc/verify-offset-committed-on-startup.td
@@ -46,7 +46,6 @@ ANALYZE;
 
 # Configure Materialize
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET storage_statistics_collection_interval = 100
 ALTER SYSTEM SET storage_statistics_interval = 200

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -294,8 +294,6 @@ def workflow_allowed_cluster_replica_sizes(c: Composition) -> None:
     c.testdrive(
         service="testdrive_no_reset",
         input=dedent("""
-            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
             # We can create a cluster with sizes 'scale=1,workers=1' and 'scale=1,workers=2'
             > CREATE CLUSTER test REPLICAS (r1 (SIZE 'scale=1,workers=1'), r2 (SIZE 'scale=1,workers=2'))
 
@@ -319,8 +317,6 @@ def workflow_allowed_cluster_replica_sizes(c: Composition) -> None:
     c.testdrive(
         service="testdrive_no_reset",
         input=dedent("""
-            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
             # Cluster replica of disallowed sizes still exist
             > SHOW CLUSTER REPLICAS WHERE cluster = 'test'
             test r1 scale=1,workers=1 true ""
@@ -353,8 +349,6 @@ def workflow_allowed_cluster_replica_sizes(c: Composition) -> None:
         input=dedent("""
             > SHOW allowed_cluster_replica_sizes
             "\\"scale=1,workers=1\\", \\"scale=1,workers=2\\""
-
-            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 
             # Reset for following tests
             $ postgres-execute connection=mz_system

--- a/test/sql-feature-flags/mzcompose.py
+++ b/test/sql-feature-flags/mzcompose.py
@@ -30,9 +30,6 @@ SERVICES = [
     Testdrive(no_reset=True, seed=1),
 ]
 
-MZ_SYSTEM_CONNECTION_URL = (
-    "postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}"
-)
 USER_CONNECTION_URL = (
     "postgres://materialize:materialize@${testdrive.materialize-sql-addr}"
 )
@@ -52,10 +49,9 @@ def header(test_name: str, drop_schema: bool) -> str:
             CREATE SCHEMA public /* {test_name} */;
             GRANT ALL PRIVILEGES ON SCHEMA public TO materialize;
             """)
-    # Create connections.
+    # Create connections. mz_system is a built-in testdrive connection.
     header += dedent(f"""
         $ postgres-connect name=user url={USER_CONNECTION_URL}
-        $ postgres-connect name=mz_system url={MZ_SYSTEM_CONNECTION_URL}
         """)
     return header.strip()
 

--- a/test/testdrive-old-kafka-src-syntax/privilege_checks.td
+++ b/test/testdrive-old-kafka-src-syntax/privilege_checks.td
@@ -12,8 +12,6 @@
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_connection_validation_syntax = true
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO true;
 CREATE CONNECTION kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);

--- a/test/testdrive/arrangement-sizes.td
+++ b/test/testdrive/arrangement-sizes.td
@@ -18,8 +18,6 @@ $ set-arg-default default-replica-size=scale=1,workers=1
 
 # Shorten the snapshot cadence so the first snapshot arrives within
 # this test's timeout rather than at the 1h production default.
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET arrangement_size_history_collection_interval = '2s';
 

--- a/test/testdrive/cancel-subscribe-rbac.td
+++ b/test/testdrive/cancel-subscribe-rbac.td
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET enable_rbac_checks = true;
 CREATE ROLE cancel_owner_${testdrive.seed} LOGIN PASSWORD 'ownerpass';

--- a/test/testdrive/github-11231.td
+++ b/test/testdrive/github-11231.td
@@ -14,8 +14,6 @@
 
 $ set-sql-timeout duration=60s
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true
 ALTER SYSTEM SET wallclock_lag_recording_interval = '1s'

--- a/test/testdrive/materialization-lag.td
+++ b/test/testdrive/materialization-lag.td
@@ -19,8 +19,6 @@
 
 $ set-sql-timeout duration=60s
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_clusters = 15
 # The controller reconciles a replica-set change asynchronously; drive the tick

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -500,7 +500,6 @@ true
 
 # Creating an unbilled replica on a `SCHEDULE = ON REFRESH` cluster shouldn't blow things up.
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
 CREATE CLUSTER REPLICA scheduled_cluster.unbilled SIZE 'scale=2,workers=2', BILLED AS 'free', INTERNAL;
 

--- a/test/testdrive/oom.td
+++ b/test/testdrive/oom.td
@@ -9,8 +9,6 @@
 
 # Test that we generate errors instead of crashing due to out of memory issues
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_result_size = '1MB'
 

--- a/test/testdrive/postgres-execute-builtin-connections.td
+++ b/test/testdrive/postgres-execute-builtin-connections.td
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Verify the built-in postgres-execute connections that work without a prior
+# postgres-connect registration.
+
+# mz_system connects as the mz_system user via the internal SQL address.
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET max_tables = 12345;
+
+> SHOW max_tables
+12345
+
+# The lazily created client is cached, so repeated uses share a session, just
+# like a connection registered via postgres-connect.
+$ postgres-execute connection=materialize
+CREATE TABLE builtin_connection_t (f1 INT);
+BEGIN;
+INSERT INTO builtin_connection_t VALUES (1);
+
+$ postgres-execute connection=materialize
+COMMIT;
+
+> SELECT * FROM builtin_connection_t
+1
+
+# An explicit postgres-connect with the same name still works and takes
+# precedence over the built-in.
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET max_tables = 54321;
+
+> SHOW max_tables
+54321
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM RESET max_tables;

--- a/test/testdrive/privilege-checks.td
+++ b/test/testdrive/privilege-checks.td
@@ -12,8 +12,6 @@
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_connection_validation_syntax = true
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO true;
 CREATE CONNECTION kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);

--- a/test/testdrive/show_columns.td
+++ b/test/testdrive/show_columns.td
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-connect name=mz_support url=postgres://mz_support:materialize@${testdrive.materialize-internal-sql-addr}
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 
 > CREATE TABLE t(a int)
 

--- a/test/testdrive/subscribe-output.td
+++ b/test/testdrive/subscribe-output.td
@@ -14,8 +14,6 @@ ALTER SYSTEM SET compute_subscribe_snapshot_optimization = true;
 
 $ set-regex match=\d{13,20} replacement=<TIMESTAMP>
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 > BEGIN
 > DECLARE c CURSOR FOR SUBSCRIBE (SELECT 1 as a, 2 as b union select 2, 1) WITHIN TIMESTAMP ORDER BY a, mz_diff
 > FETCH 1 c

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -14,8 +14,6 @@ $ set-arg-default default-replica-size=scale=1,workers=1
 $ skip-if
 SELECT ${arg.replicas} > 1;
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $ postgres-execute connection=mz_system
 > SELECT name FROM (SHOW CLUSTERS)
 mz_analytics

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 # Without EXTENDED, SHOW TYPES shouldn't have anything to return.
 > SHOW TYPES
 

--- a/test/testdrive/wallclock-lag.td
+++ b/test/testdrive/wallclock-lag.td
@@ -14,8 +14,6 @@
 
 $ set-sql-timeout duration=120s
 
-$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET wallclock_lag_recording_interval = '1s'
 


### PR DESCRIPTION
postgres-execute now resolves the bare connection names mz_system and materialize without a prior postgres-connect registration. The connection is established lazily on first use and cached like an explicitly registered one, and an explicit postgres-connect with the same name still takes precedence. Remove the now-redundant registration lines from the .td files that carried them.

Closes: [QAR-138](https://linear.app/materializeinc/issue/QAR-138)