### PR TITLE
Edu 61 tabs hide levels

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -862,6 +862,19 @@ p+p {
             border: 1px solid #9c86e0;
             padding: rem(0.8) rem(0.5) rem(0.6) rem(0.6);
         }
+
+        // Headings injected for `{{< tabs level=N >}}` groups exist only to feed
+        // the table of contents. The tab strip already shows the title, so hide
+        // the in-body copy. Keep it in flow (height 0, not display:none) so the
+        // TOC scroll offset and scrollspy still resolve a real position for it.
+        > .tab-toc-heading {
+            height: 0;
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+            font-size: 0;
+            line-height: 0;
+        }
     }
 
     &.has-left-overflow .nav-tabs::before {
@@ -873,6 +886,34 @@ p+p {
     }
 
 
+}
+
+// In light mode the stock palette makes the inactive tabs (solid gray, dark
+// purple border) read heavier than the active tab (pale lavender, lighter than
+// its neighbors), so it's hard to tell which is selected. Recede the inactive
+// tabs, then give the active tab a crisper lavender fill, a bold label, and a
+// brand-colored top accent bar. The accent is an inset shadow so it adds no box
+// height and the active tab stays aligned with the rest. Dark mode already
+// distinguishes the active tab with a deep-purple fill, so scope this to light.
+body.light .code-tabs .nav-tabs li {
+    background: var(--gray-lightest);
+    border-color: var(--gray-light);
+
+    a {
+        color: var(--gray-dark);
+    }
+
+    &.active {
+        border-color: #9c86e0;
+        border-bottom-color: var(--bg);
+
+        a {
+            color: var(--purple-dark);
+            font-weight: 700;
+            background: #ece1fb;
+            box-shadow: inset 0 3px 0 var(--brand);
+        }
+    }
 }
 
 .table-scrollable {

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/azure-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/azure-deployment-guidelines.md
@@ -50,16 +50,12 @@ significantly degrade performance and is not supported.
 
 ### Swap support
 
-{{< tabs >}}
+{{< tabs level=4 >}}
 {{< tab "New Terraform" >}}
-#### New Terraform
-
 The new Materialize [Terraform module](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/azure/examples/simple) supports configuring swap out of the box.
 
 {{< /tab >}}
 {{< tab "Legacy Terraform" >}}
-#### Legacy Terraform
-
 The Legacy Terraform provider, adds preliminary swap support in v0.6.1, via the [`swap_enabled`](https://github.com/MaterializeInc/terraform-azurerm-materialize?tab=readme-ov-file#input_swap_enabled) variable.
 With this change, the Terraform:
   - Creates a node group for Materialize.

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/gcp-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/gcp-deployment-guidelines.md
@@ -78,16 +78,14 @@ significantly degrade performance and is not supported.
 
 ### Swap support
 
-{{< tabs >}}
+{{< tabs level=4 >}}
 {{< tab "New Terraform" >}}
 
-#### New Terraform
 
 The Materialize [Terraform module](https://github.com/MaterializeInc/materialize-terraform-self-managed/tree/main/gcp/examples/simple) supports configuring swap out of the box.
 
 {{< /tab >}}
 {{< tab "Legacy Terraform" >}}
-#### Legacy Terraform
 
 The Legacy Terraform provider, adds preliminary swap support in v0.6.1, via the [`swap_enabled`](https://github.com/MaterializeInc/terraform-google-materialize?tab=readme-ov-file#input_swap_enabled) variable.
 With this change, the Terraform:

--- a/doc/user/content/sql/alter-cluster-replica.md
+++ b/doc/user/content/sql/alter-cluster-replica.md
@@ -12,10 +12,8 @@ Use `ALTER CLUSTER REPLICA` to:
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Rename" >}}
-
-### Rename
 
 To rename a cluster replica:
 
@@ -27,8 +25,6 @@ You cannot rename replicas in system clusters.
 
 {{< /tab >}}
 {{< tab "Change owner" >}}
-
-### Change owner
 
 To change the owner of a cluster replica:
 

--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -20,10 +20,8 @@ general, you will not need to manually perform this operation.
 
 `ALTER CLUSTER` has the following syntax variations:
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Set a configuration" >}}
-
-### Set a configuration
 
 To set a cluster configuration:
 
@@ -32,16 +30,12 @@ To set a cluster configuration:
 {{< /tab >}}
 {{< tab "Reset to default" >}}
 
-### Reset to default
-
 To reset a cluster configuration back to its default value:
 
 {{% include-syntax file="examples/alter_cluster" example="syntax-reset-to-default" %}}
 
 {{< /tab >}}
 {{< tab "Rename" >}}
-
-### Rename
 
 To rename a cluster:
 
@@ -54,16 +48,12 @@ You cannot rename system clusters, such as `mz_system` and `mz_catalog_server`.
 {{< /tab >}}
 {{< tab "Change owner" >}}
 
-### Change owner
-
 To change the owner of a cluster:
 
 {{% include-syntax file="examples/alter_cluster" example="syntax-change-owner" %}}
 
 {{< /tab >}}
 {{< tab "Swap with" >}}
-
-### Swap with
 
 {{< important >}}
 

--- a/doc/user/content/sql/alter-connection.md
+++ b/doc/user/content/sql/alter-connection.md
@@ -16,10 +16,8 @@ Use `ALTER CONNECTION` to:
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "SET/DROP/RESET options" >}}
-
-### SET/DROP/RESET options
 
 To modify connection parameters:
 
@@ -27,8 +25,6 @@ To modify connection parameters:
 
 {{< /tab >}}
 {{< tab "ROTATE KEYS" >}}
-
-### ROTATE KEYS
 
 To rotate SSH tunnel connection key pairs:
 
@@ -39,16 +35,12 @@ To rotate SSH tunnel connection key pairs:
 
 {{< tab "Rename" >}}
 
-### Rename
-
 To rename a connection
 
 {{% include-syntax file="examples/alter_connection" example="syntax-rename" %}}
 
 {{< /tab >}}
 {{< tab "Change owner" >}}
-
-### Change owner
 
 To change the owner of a connection:
 

--- a/doc/user/content/sql/alter-database.md
+++ b/doc/user/content/sql/alter-database.md
@@ -12,10 +12,8 @@ Use `ALTER DATABASE` to:
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Rename" >}}
-
-### Rename
 
 To rename a database:
 
@@ -23,8 +21,6 @@ To rename a database:
 
 {{< /tab >}}
 {{< tab "Change owner" >}}
-
-### Change owner
 
 To change the owner of a database:
 

--- a/doc/user/content/sql/alter-default-privileges.md
+++ b/doc/user/content/sql/alter-default-privileges.md
@@ -19,9 +19,8 @@ default privilege.
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "GRANT" >}}
-### GRANT
 
 `ALTER DEFAULT PRIVILEGES` defines default privileges that will be applied to
 objects created by a role in the future. It does not affect any existing
@@ -37,7 +36,6 @@ set of roles or by all roles.
 
 {{< /tab >}}
 {{< tab "REVOKE" >}}
-### REVOKE
 
 {{< note >}}
 `ALTER DEFAULT PRIVILEGES` cannot be used to revoke the default owner privileges

--- a/doc/user/content/sql/alter-index.md
+++ b/doc/user/content/sql/alter-index.md
@@ -11,10 +11,8 @@ Use `ALTER INDEX` to:
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Rename" >}}
-
-### Rename
 
 To rename an index:
 

--- a/doc/user/content/sql/alter-materialized-view.md
+++ b/doc/user/content/sql/alter-materialized-view.md
@@ -16,10 +16,8 @@ Use `ALTER MATERIALIZED VIEW` to:
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Rename" >}}
-
-### Rename
 
 To rename a materialized view:
 
@@ -28,16 +26,12 @@ To rename a materialized view:
 {{< /tab >}}
 {{< tab "Change owner" >}}
 
-### Change owner
-
 To change the owner of a materialized view:
 
 {{% include-syntax file="examples/alter_materialized_view" example="syntax-change-owner" %}}
 
 {{< /tab >}}
 {{< tab "(Re)Set retain history config" >}}
-
-### (Re)Set retain history config
 
 To set the retention history for a materialized view:
 
@@ -49,8 +43,6 @@ To reset the retention history to the default for a materialized view:
 
 {{< /tab >}}
 {{< tab "Replace materialized view" >}}
-
-### Replace materialized view
 
 {{% include-headless "/headless/replacement-views/public-preview-annotation" %}}
 

--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -13,11 +13,9 @@ menu:
 ## Syntax
 
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 
 {{< tab "Cloud" >}}
-
-### Cloud
 
 {{% include-syntax file="examples/rbac-cloud/alter_roles" example="alter-role-syntax" %}}
 
@@ -26,7 +24,6 @@ menu:
 example="alter-role-details" %}}
 {{< /tab >}}
 {{< tab "Self-Managed" >}}
-### Self-Managed
 
 {{% include-syntax file="examples/rbac-sm/alter_roles" example="alter-role-syntax" %}}
 

--- a/doc/user/content/sql/alter-schema.md
+++ b/doc/user/content/sql/alter-schema.md
@@ -16,10 +16,8 @@ Use `ALTER SCHEMA` to:
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Swap with" >}}
-
-### Swap with
 
 To swap the name of a schema with that of another schema:
 
@@ -28,16 +26,12 @@ To swap the name of a schema with that of another schema:
 {{< /tab >}}
 {{< tab "Rename schema" >}}
 
-### Rename schema
-
 To rename a schema:
 
 {{% include-syntax file="examples/alter_schema" example="syntax-rename" %}}
 
 {{< /tab >}}
 {{< tab "Change owner to" >}}
-
-### Change owner to
 
 To change the owner of a schema:
 

--- a/doc/user/content/sql/alter-secret.md
+++ b/doc/user/content/sql/alter-secret.md
@@ -14,10 +14,8 @@ Use `ALTER SECRET` to:
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Change value" >}}
-
-### Change value
 
 To change the value of a secret:
 
@@ -26,16 +24,12 @@ To change the value of a secret:
 {{< /tab >}}
 {{< tab "Rename" >}}
 
-### Rename
-
 To rename a secret:
 
 {{% include-syntax file="examples/alter_secret" example="syntax-rename" %}}
 
 {{< /tab >}}
 {{< tab "Change owner" >}}
-
-### Change owner
 
 To change the owner of a secret:
 

--- a/doc/user/content/sql/alter-source.md
+++ b/doc/user/content/sql/alter-source.md
@@ -16,10 +16,8 @@ Use `ALTER SOURCE` to:
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Add subsource" >}}
-
-### Add subsource
 
 To add the specified upstream table(s) to the specified PostgreSQL/MySQL/SQL Server source:
 
@@ -33,8 +31,6 @@ To add the specified upstream table(s) to the specified PostgreSQL/MySQL/SQL Ser
 
 {{< tab "Rename" >}}
 
-### Rename
-
 To rename a source:
 
 {{% include-syntax file="examples/alter_source" example="syntax-rename" %}}
@@ -42,16 +38,12 @@ To rename a source:
 {{< /tab >}}
 {{< tab "Change owner" >}}
 
-### Change owner
-
 To change the owner of a source:
 
 {{% include-syntax file="examples/alter_source" example="syntax-change-owner" %}}
 
 {{< /tab >}}
 {{< tab "(Re)Set retain history config" >}}
-
-### (Re)Set retain history config
 
 To set the retention history for a source:
 
@@ -63,8 +55,6 @@ To reset the retention history to the default for a source:
 
 {{< /tab >}}
 {{< tab "(Re)Set timestamp interval" >}}
-
-### (Re)Set timestamp interval
 
 To set the timestamp interval for a source:
 

--- a/doc/user/content/sql/alter-table.md
+++ b/doc/user/content/sql/alter-table.md
@@ -14,10 +14,8 @@ Use `ALTER TABLE` to:
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Rename" >}}
-
-### Rename
 
 To rename a table:
 
@@ -26,16 +24,12 @@ To rename a table:
 {{< /tab >}}
 {{< tab "Change owner" >}}
 
-### Change owner
-
 To change the owner of a table:
 
 {{% include-syntax file="examples/alter_table" example="syntax-change-owner" %}}
 
 {{< /tab >}}
 {{< tab "(Re)Set retain history config" >}}
-
-### (Re)Set retain history config
 
 To set the retention history for a user-populated table:
 

--- a/doc/user/content/sql/alter-type.md
+++ b/doc/user/content/sql/alter-type.md
@@ -12,10 +12,8 @@ Use `ALTER TYPE` to:
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Rename" >}}
-
-### Rename
 
 To rename a type:
 
@@ -23,8 +21,6 @@ To rename a type:
 
 {{< /tab >}}
 {{< tab "Change owner" >}}
-
-### Change owner
 
 To change the owner of a type:
 

--- a/doc/user/content/sql/alter-view.md
+++ b/doc/user/content/sql/alter-view.md
@@ -12,10 +12,8 @@ Use `ALTER VIEW` to:
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Rename" >}}
-
-### Rename
 
 To rename a view:
 
@@ -23,8 +21,6 @@ To rename a view:
 
 {{< /tab >}}
 {{< tab "Change owner" >}}
-
-### Change owner
 
 To change the owner of a view:
 

--- a/doc/user/content/sql/begin.md
+++ b/doc/user/content/sql/begin.md
@@ -165,8 +165,9 @@ In Materialize, a DDL-only transaction block is a transaction that can contain
 multiple DDL statements. The following DDL statements are allowed in DDL-only
 transactions:
 
-- [`ALTER ... RENAME`](/sql/alter-schema/#rename-schema) (e.g., `ALTER TABLE ... RENAME`, `ALTER SCHEMA ... RENAME`)
-- [`ALTER ... SWAP`](/sql/alter-schema/#swap-with) (e.g., `ALTER SCHEMA ... SWAP`)
+- `ALTER ... RENAME` (e.g., [`ALTER TABLE ... RENAME`](/sql/alter-table/),
+  [`ALTER SCHEMA ... RENAME`](/sql/alter-schema/))
+- `ALTER ... SWAP` (e.g., [`ALTER SCHEMA ... SWAP`](/sql/alter-schema/))
 - [`CREATE TABLE ... FROM SOURCE`](/sql/create-table/)
 - [`CREATE SOURCE`](/sql/create-source/)
 

--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -20,9 +20,8 @@ Because indexes are scoped to a single cluster, they are most useful for acceler
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "CREATE INDEX" >}}
-### Create index
 
 Create an index using the specified columns as the index key.
 
@@ -30,7 +29,6 @@ Create an index using the specified columns as the index key.
 
 {{< /tab >}}
 {{< tab "CREATE DEFAULT INDEX" >}}
-### Create default index
 
 Create a default index using a set of columns that uniquely identify each row.
 If this set of columns cannot be inferred, all columns are used.

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -34,18 +34,14 @@ offers lower latency for direct querying within that cluster.
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "CREATE MATERIALIZED VIEW" >}}
-
-### Create materialized view
 
 {{% include-syntax file="examples/create_materialized_view" example="syntax" %}}
 
 {{< /tab >}}
 
 {{< tab "CREATE REPLACEMENT MATERIALIZED VIEW" >}}
-
-### Create replacement materialized view
 
 {{% include-headless "/headless/replacement-views/public-preview-annotation" %}}
 

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -17,11 +17,9 @@ the system.
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 
 {{< tab "Cloud" >}}
-
-### Cloud
 
 {{% include-syntax file="examples/rbac-cloud/create_roles"
 example="create-role-syntax" %}}
@@ -30,7 +28,6 @@ example="create-role-syntax" %}}
 {{% include-example file="examples/rbac-cloud/create_roles" example="create-role-details" %}}
 {{< /tab >}}
 {{< tab "Self-Managed" >}}
-### Self-Managed
 
 {{% include-syntax file="examples/rbac-sm/create_roles" example="create-role-syntax" %}}
 

--- a/doc/user/content/sql/create-type.md
+++ b/doc/user/content/sql/create-type.md
@@ -12,19 +12,16 @@ see [SQL Data Types: Custom types](../types/#custom-types).
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "Row type" >}}
-### Row type
 {{% include-syntax file="examples/create_type" example="syntax-row" %}}
 
 {{< /tab >}}
 {{< tab "List type" >}}
-### List type
 {{% include-syntax file="examples/create_type" example="syntax-list" %}}
 
 {{< /tab >}}
 {{< tab "Map type" >}}
-### Map type
 {{% include-syntax file="examples/create_type" example="syntax-map" %}}
 
 {{< /tab >}}

--- a/doc/user/content/sql/create-view.md
+++ b/doc/user/content/sql/create-view.md
@@ -16,15 +16,13 @@ of materializing the view.
 
 ## Syntax
 
-{{< tabs >}}
+{{< tabs level=3 >}}
 {{< tab "CREATE VIEW" >}}
-### Create view
 To create a view:
 
 {{% include-syntax file="examples/create_view" example="syntax" %}}
 {{< /tab >}}
 {{< tab "CREATE OR REPLACE VIEW" >}}
-### Create or replace view
 To create, or if a view exists with the same name, replace it with the view
 defined in this statement:
 

--- a/doc/user/content/sql/grant-privilege.md
+++ b/doc/user/content/sql/grant-privilege.md
@@ -29,8 +29,6 @@ clear every privilege previously granted through the same shorthand.
 
 {{< tabs >}}
 
-<!-- ============ CLUSTER syntax ==============  -->
-
 {{< tab "Cluster" >}}
 
 For specific cluster(s):
@@ -49,8 +47,6 @@ ON ALL CLUSTERS
 TO <role_name> [, ... ];
 ```
 {{</ tab >}}
-
-<!-- ================== Connection syntax ======================  -->
 
 {{< tab "Connection">}}
 
@@ -73,8 +69,6 @@ TO <role_name> [, ... ];
 
 {{</ tab >}}
 
-<!-- ================== Database syntax =====================  -->
-
 {{< tab "Database">}}
 
 For specific database(s):
@@ -94,8 +88,6 @@ TO <role_name> [, ... ];
 ```
 
 {{</ tab >}}
-
-<!-- =============== Materialized view syntax ===================  -->
 
 {{< tab "Materialized view/view/source">}}
 
@@ -125,7 +117,6 @@ TO <role_name> [, ... ];
 
 {{</ tab >}}
 
-<!-- ================== Network policy syntax ==================  -->
 
 {{< tab "Network policy">}}
 
@@ -147,7 +138,6 @@ TO <role_name> [, ... ];
 
 {{</ tab >}}
 
-<!-- ==================== Schema syntax =====================  -->
 
 {{< tab "Schema">}}
 
@@ -169,7 +159,6 @@ TO <role_name> [, ... ];
 
 {{</ tab >}}
 
-<!-- ==================== Secret syntax =====================  -->
 
 {{< tab "Secret">}}
 
@@ -191,8 +180,6 @@ TO <role_name> [, ... ];
 
 {{</ tab >}}
 
-<!-- ==================== System syntax =====================  -->
-
 {{< tab "System">}}
 
 ```mzsql
@@ -202,8 +189,6 @@ TO <role_name> [, ... ];
 ```
 
 {{</ tab >}}
-
-<!-- ==================== Type syntax =======================  -->
 
 {{< tab "Type">}}
 
@@ -225,8 +210,6 @@ TO <role_name> [, ... ];
 ```
 
 {{</ tab >}}
-
-<!-- ======================= Table syntax =====================  -->
 
 {{< tab "Table">}}
 

--- a/doc/user/content/sql/revoke-privilege.md
+++ b/doc/user/content/sql/revoke-privilege.md
@@ -30,8 +30,6 @@ have no runtime effect.
 
 {{< tabs >}}
 
-<!-- ============ CLUSTER syntax ==============  -->
-
 {{< tab "Cluster" >}}
 
 For specific cluster(s):
@@ -52,8 +50,6 @@ FROM <role_name> [, ... ]
 ;
 ```
 {{</ tab >}}
-
-<!-- ================== Connection syntax ======================  -->
 
 {{< tab "Connection">}}
 
@@ -76,8 +72,6 @@ FROM <role_name> [, ... ];
 
 {{</ tab >}}
 
-<!-- ================== Database syntax =====================  -->
-
 {{< tab "Database">}}
 
 For specific database(s):
@@ -97,8 +91,6 @@ FROM <role_name> [, ... ];
 ```
 
 {{</ tab >}}
-
-<!-- =============== Materialized view syntax ===================  -->
 
 {{< tab "Materialized view/view/source">}}
 
@@ -128,8 +120,6 @@ FROM <role_name> [, ... ];
 
 {{</ tab >}}
 
-<!-- ================== Network policy syntax ==================  -->
-
 {{< tab "Network policy">}}
 
 For specific network policies:
@@ -149,8 +139,6 @@ FROM <role_name> [, ... ];
 ```
 
 {{</ tab >}}
-
-<!-- ==================== Schema syntax =====================  -->
 
 {{< tab "Schema">}}
 
@@ -172,8 +160,6 @@ FROM <role_name> [, ... ];
 
 {{</ tab >}}
 
-<!-- ==================== Secret syntax =====================  -->
-
 {{< tab "Secret">}}
 
 For specific secret(s):
@@ -194,8 +180,6 @@ FROM <role_name> [, ... ];
 
 {{</ tab >}}
 
-<!-- ==================== System syntax =====================  -->
-
 {{< tab "System">}}
 
 ```mzsql
@@ -205,8 +189,6 @@ FROM <role_name> [, ... ];
 ```
 
 {{</ tab >}}
-
-<!-- ==================== Type syntax =======================  -->
 
 {{< tab "Type">}}
 
@@ -228,8 +210,6 @@ FROM <role_name> [, ... ];
 ```
 
 {{</ tab >}}
-
-<!-- ======================= Table syntax =====================  -->
 
 {{< tab "Table">}}
 

--- a/doc/user/data/examples/ingest_data/mysql/create_source_cloud.yml
+++ b/doc/user/data/examples/ingest_data/mysql/create_source_cloud.yml
@@ -60,16 +60,14 @@
 
 - name: "ingest-data-step"
   description: |
-    {{< tabs >}}
+    {{< tabs level=4 >}}
     {{< tab "New Syntax" >}}
-    #### New syntax
 
     {{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source" %}}
     {{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="schema-changes" %}}
     {{< /tab >}}
 
     {{< tab "Legacy Syntax" >}}
-    #### Legacy syntax
 
     {{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source-legacy" %}}
     {{% include-example file="examples/ingest_data/mysql/create_source_cloud" example="create-source-options-legacy" %}}

--- a/doc/user/data/examples/ingest_data/postgres/create_source_cloud.yml
+++ b/doc/user/data/examples/ingest_data/postgres/create_source_cloud.yml
@@ -85,16 +85,14 @@
     [Snapshotting considerations](#snapshotting) for more information.
     {{< /tip >}}
 
-    {{< tabs >}}
+    {{< tabs level=4 >}}
     {{< tab "Legacy Syntax" >}}
-    #### Legacy syntax
 
     {{% include-example file="examples/ingest_data/postgres/create_source_cloud" example="create-source-legacy" %}}
     {{% include-example file="examples/ingest_data/postgres/create_source_cloud" example="schema-changes" %}}
     {{< /tab >}}
 
     {{< tab "New Syntax" >}}
-    #### New syntax
 
     {{% include-example file="examples/ingest_data/postgres/create_source_cloud" example="create-source" %}}
     {{% include-example file="examples/ingest_data/postgres/create_source_cloud" example="schema-changes" %}}

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -156,11 +156,17 @@ document.addEventListener("DOMContentLoaded", function () {
       // Update pane ID to be unique
       pane.setAttribute("id", paneId);
 
-      // Add heading inside tab pane if level is specified
+      // When a heading level is specified, inject a heading per pane so the tab
+      // titles appear in the table of contents at that level. The heading is
+      // visually hidden (see `.tab-toc-heading` in _content.scss): the tab strip
+      // already shows the title, so a second visible copy in the pane body is
+      // redundant. It stays in the DOM (rather than being dropped) so the TOC
+      // builder and scrollspy in toc.html treat it like any other heading anchor.
       if (headingLevel) {
         const level = parseInt(headingLevel);
         if (level >= 1 && level <= 6) {
           const heading = document.createElement(`h${level}`);
+          heading.className = "tab-toc-heading";
           heading.textContent = title;
           heading.id = `${paneId}-heading`;
           pane.insertBefore(heading, pane.firstChild);

--- a/doc/user/layouts/partials/toc.html
+++ b/doc/user/layouts/partials/toc.html
@@ -83,31 +83,27 @@
         }
       });
 
-      // Generate TOC HTML
+      // Build the TOC as DOM nodes rather than an HTML string, so heading text
+      // is escaped automatically. A heading containing `<`, `>`, or `&` (e.g. a
+      // generics or comparison example) would otherwise corrupt the markup.
       if (tocItems.length > 0) {
-        let tocHTML = '<ul>';
-        tocItems.forEach(h2Item => {
-          tocHTML += `<li><a href="#${h2Item.id}">${h2Item.text}</a>`;
-          if (h2Item.children.length > 0) {
-            tocHTML += '<ul>';
-            h2Item.children.forEach(h3Item => {
-              tocHTML += `<li><a href="#${h3Item.id}">${h3Item.text}</a>`;
-              if (h3Item.children && h3Item.children.length > 0) {
-                tocHTML += '<ul>';
-                h3Item.children.forEach(h4Item => {
-                  tocHTML += `<li><a href="#${h4Item.id}">${h4Item.text}</a></li>`;
-                });
-                tocHTML += '</ul>';
-              }
-              tocHTML += '</li>';
-            });
-            tocHTML += '</ul>';
+        const buildNode = (item) => {
+          const li = document.createElement("li");
+          const a = document.createElement("a");
+          a.setAttribute("href", `#${item.id}`);
+          a.textContent = item.text;
+          li.appendChild(a);
+          if (item.children && item.children.length > 0) {
+            const ul = document.createElement("ul");
+            item.children.forEach(child => ul.appendChild(buildNode(child)));
+            li.appendChild(ul);
           }
-          tocHTML += '</li>';
-        });
-        tocHTML += '</ul>';
+          return li;
+        };
 
-        tocNav.innerHTML = tocHTML;
+        const rootUl = document.createElement("ul");
+        tocItems.forEach(item => rootUl.appendChild(buildNode(item)));
+        tocNav.replaceChildren(rootUl);
       }
     }, 50);
   });
@@ -180,113 +176,90 @@
     if (activeId) $(`.toc [href="#${activeId}"]`).addClass("active");
   });
 
+  // Fixed header height used to offset every scroll target: 65px banner + 60px
+  // menubar. Kept in one constant so hashchange and TOC-click paths land
+  // headings at the same position. NOTE: assumes the banner is present.
+  const HEADER_OFFSET = 125;
+
+  function scrollToHeading(el) {
+    const rect = el.getBoundingClientRect();
+    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+    window.scrollTo({ top: rect.top + scrollTop - HEADER_OFFSET, behavior: "smooth" });
+  }
+
+  // Activate the tab that directly owns `pane`, mirroring the class toggling in
+  // the tab initializer (head.html): within a `.code-tabs` group the nav items
+  // and panes share an index.
+  function activatePane(pane) {
+    const group = pane.closest(".code-tabs");
+    if (!group) return;
+    const navTabs = group.querySelector(".nav-tabs");
+    const tabContent = group.querySelector(".tab-content");
+    if (!navTabs || !tabContent) return;
+
+    const siblingPanes = Array.from(tabContent.children).filter(c =>
+      c.classList.contains("tab-pane")
+    );
+    const index = siblingPanes.indexOf(pane);
+    if (index === -1) return;
+
+    siblingPanes.forEach(p => p.classList.remove("active"));
+    Array.from(navTabs.children).forEach(item => item.classList.remove("active"));
+    pane.classList.add("active");
+    if (navTabs.children[index]) navTabs.children[index].classList.add("active");
+  }
+
+  // Reveal `el` by activating every tab-pane on the path down to it. Handles
+  // nested tab groups: an inner heading is only visible once its outer pane is
+  // active too. A no-op when `el` is not inside any tab.
+  function activateTabsFor(el) {
+    const panes = [];
+    let pane = el.closest(".tab-pane");
+    while (pane) {
+      panes.push(pane);
+      pane = pane.parentElement ? pane.parentElement.closest(".tab-pane") : null;
+    }
+    // Outermost first, so each pane is shown before we descend into it.
+    panes.reverse().forEach(activatePane);
+  }
+
+  // Navigate to a heading by id: reveal its tab(s), then scroll. Shared by
+  // hashchange (deep links, back/forward) and TOC clicks so both paths behave
+  // identically, including for headings inside non-default or nested tabs.
+  function navigateToHeading(targetId) {
+    const targetElement = document.getElementById(targetId);
+    if (!targetElement) return;
+
+    activateTabsFor(targetElement);
+    // Activation toggles `display`, so wait one frame for layout to settle
+    // before measuring the heading's position.
+    requestAnimationFrame(() => {
+      scrollToHeading(targetElement);
+      $(window).trigger("scroll");
+    });
+  }
+
   // Scroll to our massaged offsets on a hashchange event, to override the
   // browser's automatic scroll to the unmassaged offset.
   $(window).on("hashchange", function () {
-    const hash = window.location.hash;
-    if (hash) {
-      const targetId = hash.substring(1);
-      const targetElement = document.getElementById(targetId);
-      if (targetElement) {
-        // Wait a bit for any tab switching to complete
-        setTimeout(() => {
-          const rect = targetElement.getBoundingClientRect();
-          const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-          const targetOffset = rect.top + scrollTop - 125; // 65px banner + 60px menubar = 125px total
-          window.scrollTo({ top: targetOffset, behavior: 'smooth' });
-
-          // Update TOC highlighting after scrolling
-          setTimeout(() => {
-            $(window).trigger('scroll');
-          }, 50);
-        }, 100);
-      }
-    }
+    if (window.location.hash) navigateToHeading(window.location.hash.substring(1));
   });
 
   // Trigger an initial hash change event to handle scrolling to the page's
   // initial hash, but only if there's actually a hash in the URL.
   $(() => {
-    if (window.location.hash) {
-      $(window).trigger("hashchange");
-    }
+    if (window.location.hash) $(window).trigger("hashchange");
   });
 
-  // Handle TOC link clicks - prevent default and scroll manually to account for fixed header
-  $(document).on("click", ".toc a", function(e) {
-    const $clickedLink = $(this);
-    const href = $clickedLink.attr("href");
+  // Handle TOC link clicks: prevent the default jump, reveal any containing
+  // tab, update the URL, then scroll manually to account for the fixed header.
+  $(document).on("click", ".toc a", function (e) {
+    const href = $(this).attr("href");
     if (!href || !href.startsWith("#")) return;
+    if (!document.getElementById(href.substring(1))) return;
 
-    const targetId = href.substring(1); // Remove the # from href
-    const targetElement = document.getElementById(targetId);
-
-    if (targetElement) {
-      // Check if the target is inside a tab-pane
-      const tabPane = targetElement.closest(".tab-pane");
-
-      if (tabPane) {
-        // Prevent default anchor behavior - we'll handle scrolling manually
-        e.preventDefault();
-
-        // Find the parent tab group
-        const tabGroup = tabPane.closest(".code-tabs");
-
-        if (tabGroup) {
-          // Find the index of this tab-pane
-          const tabContent = tabGroup.querySelector(".tab-content");
-          const allPanes = Array.from(tabContent.children).filter(child =>
-            child.classList.contains("tab-pane")
-          );
-          const tabIndex = allPanes.indexOf(tabPane);
-
-          if (tabIndex !== -1) {
-            // Activate the tab
-            const navTabs = tabGroup.querySelector(".nav-tabs");
-            const navItems = navTabs.querySelectorAll(".nav-item");
-
-            // Remove active class from all tabs and panes
-            navItems.forEach(item => item.classList.remove("active"));
-            allPanes.forEach(pane => pane.classList.remove("active"));
-
-            // Add active class to the target tab and pane
-            if (navItems[tabIndex]) {
-              navItems[tabIndex].classList.add("active");
-            }
-            tabPane.classList.add("active");
-
-            // Scroll to the target heading after tab is activated
-            setTimeout(() => {
-              const rect = targetElement.getBoundingClientRect();
-              const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-              // Add extra offset (125px: 65px banner + 60px menubar) to ensure this heading is clearly the active one
-              // when there are multiple headings close together (e.g., h2 followed by h3)
-              const targetOffset = rect.top + scrollTop - 125;
-              window.scrollTo({ top: targetOffset, behavior: 'smooth' });
-
-              // Update TOC highlighting after scrolling
-              setTimeout(() => {
-                $(window).trigger('scroll');
-              }, 50);
-            }, 50);
-          }
-        }
-      } else {
-        // Regular TOC link (not in a tab) - prevent default and scroll manually
-        e.preventDefault();
-        const rect = targetElement.getBoundingClientRect();
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        const targetOffset = rect.top + scrollTop - 65;
-        window.scrollTo({ top: targetOffset, behavior: 'smooth' });
-
-        // Update URL hash without triggering hashchange
-        history.pushState(null, null, href);
-
-        // Update TOC highlighting after scrolling
-        setTimeout(() => {
-          $(window).trigger('scroll');
-        }, 50);
-      }
-    }
+    e.preventDefault();
+    history.pushState(null, null, href);
+    navigateToHeading(href.substring(1));
   });
 </script>


### PR DESCRIPTION
Our tabs shortcode support levels option which currently makes the tab render include the tab name as a section heading in the tabbed content. 
- This allows the right-hand On this page Table-of-content render correctly but,
- Depending on the level, displaying the section heading inside the tabs looks funny.  
So, this update just hides those section headings in the tab content  while still rendering in the right-hand TOC correctly.  Explicit sections within the tabs render as before. 
Also, some cleanup