### PR TITLE
v26.35.0 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -100,7 +100,7 @@ For more information, refer to:
 ### Improvements {#v26.35-improvements}
 - **Faster read queries under write load**: Read-only queries (e.g., `SELECT 1`) are no longer blocked by concurrent write transactions; under high write load, victim query latency drops from multiple seconds to single-digit milliseconds.
 - **Better query plans for correlated subqueries**: Queries using patterns like `1 IN (SELECT 1 WHERE p)` and `NOT EXISTS (SELECT 1 WHERE p)` are now optimized to a simple filter, eliminating unnecessary semi/anti-joins.
-- **Console billing breakdown by account and cluster**: The billing page now shows a per-account and per-cluster cost breakdown with a stacked bar chart and expandable ledger, displaying account display names and real per-cluster usage figures.
+- **Account hierarchy billing**: Organizations running multiple Materialize accounts under one parent (e.g., separate production and staging accounts) can now see consolidated billing and usage at the parent level, broken out per child account; each child account sees only its own usage. Available on request — talk to your account executive to see if you qualify.
 - **`mz-debug` CPU profiling**: The `mz-debug` diagnostic tool now automatically collects CPU profiles alongside memory profiles for Self-Managed deployments.
 
 ### Bug Fixes {#v26.35-bug-fixes}

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -20,12 +20,11 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 {{</ note >}}
 
 ## v26.35.0
-*Released to Materialize Cloud: 2026-07-30* <br>
-*Released to Materialize Self-Managed: 2026-07-31* <br>
+*Released to Materialize Cloud: 2026-07-29* <br>
+*Released to Materialize Self-Managed: 2026-07-30* <br>
 
 ### Improvements {#v26.35-improvements}
 - **Faster read queries under write load**: Read-only queries (e.g., `SELECT 1`) are no longer blocked by concurrent write transactions; under high write load, victim query latency drops from multiple seconds to single-digit milliseconds.
-- **Faster MySQL source snapshots**: Initial snapshots for MySQL sources are now parallelized across workers, providing up to 2.7x faster snapshotting for sources with large individual tables.
 - **Better query plans for correlated subqueries**: Queries using patterns like `1 IN (SELECT 1 WHERE p)` and `NOT EXISTS (SELECT 1 WHERE p)` are now optimized to a simple filter, eliminating unnecessary semi/anti-joins.
 - **Console billing breakdown by account and cluster**: The billing page now shows a per-account and per-cluster cost breakdown with a stacked bar chart and expandable ledger, displaying account display names and real per-cluster usage figures.
 - **`mz-debug` CPU profiling**: The `mz-debug` diagnostic tool now automatically collects CPU profiles alongside memory profiles for Self-Managed deployments.

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -19,6 +19,28 @@ Starting with the v26.1.0 release, Materialize releases on a weekly schedule for
 both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for details.
 {{</ note >}}
 
+## v26.35.0
+*Released to Materialize Cloud: 2026-07-30* <br>
+*Released to Materialize Self-Managed: 2026-07-31* <br>
+
+### Improvements {#v26.35-improvements}
+- **Faster read queries under write load**: Read-only queries (e.g., `SELECT 1`) are no longer blocked by concurrent write transactions; under high write load, victim query latency drops from multiple seconds to single-digit milliseconds.
+- **Faster MySQL source snapshots**: Initial snapshots for MySQL sources are now parallelized across workers, providing up to 2.7x faster snapshotting for sources with large individual tables.
+- **Better query plans for correlated subqueries**: Queries using patterns like `1 IN (SELECT 1 WHERE p)` and `NOT EXISTS (SELECT 1 WHERE p)` are now optimized to a simple filter, eliminating unnecessary semi/anti-joins.
+- **Console billing breakdown by account and cluster**: The billing page now shows a per-account and per-cluster cost breakdown with a stacked bar chart and expandable ledger, displaying account display names and real per-cluster usage figures.
+- **`mz-debug` CPU profiling**: The `mz-debug` diagnostic tool now automatically collects CPU profiles alongside memory profiles for Self-Managed deployments.
+
+### Bug Fixes {#v26.35-bug-fixes}
+- Fixed a critical bug where a pending replacement materialized view could destroy the data of its live target materialized view after an environmentd restart.
+- Fixed `COPY FROM PARQUET` failing for columns of types `oid`, `time`, `timestamptz`, `char`, `varchar`, and `mz_timestamp`.
+- Fixed incorrect results for `variance`, `stddev`, and related aggregate functions when used with `DISTINCT` on inputs containing values that differ only in sign (e.g., `-2` and `2`).
+- Fixed `ALTER CLUSTER ... WITH (WAIT UNTIL READY ...)` hanging indefinitely and rolling back when the cluster hosts a single-replica source (PostgreSQL, MySQL, or SQL Server).
+- Fixed `mz_object_arrangement_sizes` silently omitting arrangements smaller than 10 MiB and showing stale sizes after an environmentd restart.
+- Fixed `EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW` crashing environmentd when the materialized view's cached plan referenced a since-dropped index.
+- Fixed array literals with empty dimensions (e.g., `'{{},{}}'::text[]`) and multi-dimensional `array_fill` calls silently producing incorrect results instead of returning errors matching PostgreSQL behavior.
+- Fixed replica utilization charts in the Console failing to load on initial page render and flashing a loading spinner when switching time filters.
+- Fixed replica crash and OOM markers not appearing in the "Last hour" and "Last 3 hours" Console utilization chart windows.
+
 ## v26.34.1
 *Released to Materialize Self-Managed: 2026-07-24* <br>
 

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -31,6 +31,7 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 - **`mz-debug` CPU profiling**: The `mz-debug` diagnostic tool now automatically collects CPU profiles alongside memory profiles for Self-Managed deployments.
 
 ### Bug Fixes {#v26.35-bug-fixes}
+- Fixed queries with many chained `INTERSECT` operations (e.g., 35+ inputs) exhausting environmentd memory during planning, causing the environment to become unresponsive.
 - Fixed a MySQL source stalling entirely when one of its tables was dropped while the initial snapshot was running; the dropped table now reports an error on its own and the rest of the snapshot proceeds.
 - Fixed a critical bug where a pending replacement materialized view could destroy the data of its live target materialized view after an environmentd restart.
 - Fixed `COPY FROM PARQUET` failing for columns of types `oid`, `time`, `timestamptz`, `char`, `varchar`, and `mz_timestamp`.

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -86,6 +86,17 @@ CREATE SINK avro_sink
 
 For more information, see [`CREATE SINK`: Using AWS Glue Schema Registry](/sql/create-sink/kafka/#using-aws-glue-schema-registry).
 
+### Handling Avro schema changes in Kafka sources {#v26.35-kafka-avro-schema-changes}
+
+Materialize pins a table's Avro reader schema when the table is created, so
+fields added upstream later don't appear automatically. A new guide walks
+through picking up an upstream schema change with zero downtime, using a
+blue/green cutover with [`ALTER SCHEMA ... SWAP WITH`](/sql/alter-schema/).
+
+For more information, refer to:
+- [Guide: Handling upstream schema changes with zero
+  downtime](/ingest-data/kafka/source-versioning/)
+
 ### Improvements {#v26.35-improvements}
 - **Faster read queries under write load**: Read-only queries (e.g., `SELECT 1`) are no longer blocked by concurrent write transactions; under high write load, victim query latency drops from multiple seconds to single-digit milliseconds.
 - **Better query plans for correlated subqueries**: Queries using patterns like `1 IN (SELECT 1 WHERE p)` and `NOT EXISTS (SELECT 1 WHERE p)` are now optimized to a simple filter, eliminating unnecessary semi/anti-joins.

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -86,16 +86,24 @@ CREATE SINK avro_sink
 
 For more information, see [`CREATE SINK`: Using AWS Glue Schema Registry](/sql/create-sink/kafka/#using-aws-glue-schema-registry).
 
-### Handling Avro schema changes in Kafka sources {#v26.35-kafka-avro-schema-changes}
+### Kafka: Source versioning {#v26.35-kafka-source-versioning}
 
-Materialize pins a table's Avro reader schema when the table is created, so
-fields added upstream later don't appear automatically. A new guide walks
-through picking up an upstream schema change with zero downtime, using a
-blue/green cutover with [`ALTER SCHEMA ... SWAP WITH`](/sql/alter-schema/).
+For Kafka sources, we've introduced new syntax for [`CREATE
+SOURCE`](/sql/create-source/kafka-v2/) and [`CREATE TABLE ... FROM
+SOURCE`](/sql/create-table/kafka/). This is the same source versioning syntax
+already available for PostgreSQL, MySQL, and SQL Server sources, and it allows
+you to better handle Avro schema changes in your Kafka topics.
+
+Materialize resolves the latest registered Avro schema when the `CREATE TABLE`
+statement runs, and pins it as the table's reader schema. To pick up an
+upstream schema change with zero downtime, create a new table that reads the
+evolved schema and swap it into place with a blue/green cutover.
 
 For more information, refer to:
 - [Guide: Handling upstream schema changes with zero
   downtime](/ingest-data/kafka/source-versioning/)
+- [Syntax: `CREATE SOURCE`](/sql/create-source/kafka-v2/)
+- [Syntax: `CREATE TABLE`](/sql/create-table/kafka/)
 
 ### Improvements {#v26.35-improvements}
 - **Faster read queries under write load**: Read-only queries (e.g., `SELECT 1`) are no longer blocked by concurrent write transactions; under high write load, victim query latency drops from multiple seconds to single-digit milliseconds.

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -31,6 +31,7 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 - **`mz-debug` CPU profiling**: The `mz-debug` diagnostic tool now automatically collects CPU profiles alongside memory profiles for Self-Managed deployments.
 
 ### Bug Fixes {#v26.35-bug-fixes}
+- Fixed a MySQL source stalling entirely when one of its tables was dropped while the initial snapshot was running; the dropped table now reports an error on its own and the rest of the snapshot proceeds.
 - Fixed a critical bug where a pending replacement materialized view could destroy the data of its live target materialized view after an environmentd restart.
 - Fixed `COPY FROM PARQUET` failing for columns of types `oid`, `time`, `timestamptz`, `char`, `varchar`, and `mz_timestamp`.
 - Fixed incorrect results for `variance`, `stddev`, and related aggregate functions when used with `DISTINCT` on inputs containing values that differ only in sign (e.g., `-2` and `2`).

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -23,6 +23,69 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 *Released to Materialize Cloud: 2026-07-29* <br>
 *Released to Materialize Self-Managed: 2026-07-30* <br>
 
+### Graceful Cluster Reconfiguration {#v26.35-background-cluster-reconfiguration}
+`ALTER CLUSTER` for configuration changes (such as resizing) now returns immediately and runs in the background, rather than blocking until the new replica set is ready.
+
+Because the command is now asynchronous, you can monitor the
+progress of an in-flight reconfiguration using `SHOW CLUSTERS`.
+
+```mzsql
+SHOW CLUSTERS;
+```
+```nofmt
+    name    | replicas   |           activity           | comment
+------------+------------+------------------------------+---------
+ my_cluster | r1 (400cc) | reconfiguring size to 1600cc |
+```
+
+For detailed status, query
+[`mz_internal.mz_cluster_reconfigurations`](/reference/system-catalog/mz_internal/#mz_cluster_reconfigurations),
+which reports the target shape, the deadline, and the reconfiguration's
+lifecycle `status` (`in-progress`, then a terminal `finalized`, `timed-out`,
+`cancelled`, or `resource-exhausted`):
+
+```mzsql
+SELECT cluster_id, status, deadline, on_timeout, target, changes
+FROM mz_internal.mz_cluster_reconfigurations;
+```
+
+For more information, see [`ALTER CLUSTER`: Resizing process](/sql/alter-cluster/#resizing-process).
+
+### AWS Glue Schema Registry Support for Sinks {#v26.35-aws-glue-schema-registry-support-sinks}
+
+{{< public-preview />}}
+
+Kafka sinks can now use [AWS Glue Schema
+Registry](/sql/create-connection/#aws-glue-schema-registry) for Avro schema
+management, via the new `FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY` syntax on
+[`CREATE SINK`](/sql/create-sink/kafka/).
+
+```mzsql
+-- Authenticate to AWS Glue through an AWS connection.
+CREATE CONNECTION aws_connection TO AWS (
+    ASSUME ROLE ARN = 'arn:aws:iam::123456789000:role/MaterializeGlue'
+);
+
+CREATE CONNECTION glue_connection TO AWS GLUE SCHEMA REGISTRY (
+    AWS CONNECTION = aws_connection,
+    REGISTRY = 'default-registry'
+);
+
+-- Write Avro-encoded output, registering schemas with AWS Glue.
+CREATE SINK avro_sink
+  IN CLUSTER my_io_cluster
+  FROM my_materialized_view
+  INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
+  KEY (key)
+  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_connection (
+    KEY SCHEMA NAME = 'test_topic-key',
+    VALUE SCHEMA NAME = 'test_topic-value'
+  )
+  ENVELOPE UPSERT;
+```
+
+For more information, see [`CREATE SINK`: Using AWS Glue Schema Registry](/sql/create-sink/kafka/#using-aws-glue-schema-registry).
+
 ### Improvements {#v26.35-improvements}
 - **Faster read queries under write load**: Read-only queries (e.g., `SELECT 1`) are no longer blocked by concurrent write transactions; under high write load, victim query latency drops from multiple seconds to single-digit milliseconds.
 - **Better query plans for correlated subqueries**: Queries using patterns like `1 IN (SELECT 1 WHERE p)` and `NOT EXISTS (SELECT 1 WHERE p)` are now optimized to a simple filter, eliminating unnecessary semi/anti-joins.
@@ -44,6 +107,37 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 
 ## v26.34.1
 *Released to Materialize Self-Managed: 2026-07-24* <br>
+
+### Graceful Cluster Reconfiguration {#v26.34.1-graceful-cluster-reconfiguration}
+
+<red>*Materialize Self-Managed only*</red>
+
+`ALTER CLUSTER` for configuration changes (such as resizing) now returns immediately and runs in the background, rather than blocking until the new replica set is ready.
+
+Because the command is now asynchronous, you can monitor the
+progress of an in-flight reconfiguration using `SHOW CLUSTERS`.
+
+```mzsql
+SHOW CLUSTERS;
+```
+```nofmt
+    name    | replicas   |           activity           | comment
+------------+------------+------------------------------+---------
+ my_cluster | r1 (400cc) | reconfiguring size to 1600cc |
+```
+
+For detailed status, query
+[`mz_internal.mz_cluster_reconfigurations`](/reference/system-catalog/mz_internal/#mz_cluster_reconfigurations),
+which reports the target shape, the deadline, and the reconfiguration's
+lifecycle `status` (`in-progress`, then a terminal `finalized`, `timed-out`,
+`cancelled`, or `resource-exhausted`):
+
+```mzsql
+SELECT cluster_id, status, deadline, on_timeout, target, changes
+FROM mz_internal.mz_cluster_reconfigurations;
+```
+
+For more information, see [`ALTER CLUSTER`: Resizing process](/sql/alter-cluster/#resizing-process).
 
 ### Bug Fixes {#v26.34.1-bug-fixes}
 - Fixed an issue where `ALTER CLUSTER ... WITH (WAIT UNTIL READY ...)` would deadlock on clusters hosting single-replica sources (Postgres, MySQL, SQL Server), causing graceful reconfiguration to time out and roll back without resizing.
@@ -83,43 +177,6 @@ ALTER CLUSTER my_cluster SET (
 For more information, see the `AUTO SCALING STRATEGY` option on
 [`CREATE CLUSTER`](/sql/create-cluster/#autoscaling) and
 [`ALTER CLUSTER`](/sql/alter-cluster/#speed-up-hydration-by-autoscaling-to-a-larger-size).
-
-### AWS Glue Schema Registry Support for Sinks {#v26.34-aws-glue-schema-registry-support-sinks}
-
-{{< public-preview />}}
-
-<red>*Materialize Cloud only*</red>
-
-Kafka sinks can now use [AWS Glue Schema
-Registry](/sql/create-connection/#aws-glue-schema-registry) for Avro schema
-management, via the new `FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY` syntax on
-[`CREATE SINK`](/sql/create-sink/kafka/).
-
-```mzsql
--- Authenticate to AWS Glue through an AWS connection.
-CREATE CONNECTION aws_connection TO AWS (
-    ASSUME ROLE ARN = 'arn:aws:iam::123456789000:role/MaterializeGlue'
-);
-
-CREATE CONNECTION glue_connection TO AWS GLUE SCHEMA REGISTRY (
-    AWS CONNECTION = aws_connection,
-    REGISTRY = 'default-registry'
-);
-
--- Write Avro-encoded output, registering schemas with AWS Glue.
-CREATE SINK avro_sink
-  IN CLUSTER my_io_cluster
-  FROM my_materialized_view
-  INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
-  KEY (key)
-  FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_connection (
-    KEY SCHEMA NAME = 'test_topic-key',
-    VALUE SCHEMA NAME = 'test_topic-value'
-  )
-  ENVELOPE UPSERT;
-```
-
-For more information, see [`CREATE SINK`: Using AWS Glue Schema Registry](/sql/create-sink/kafka/#using-aws-glue-schema-registry).
 
 ### Role Mapping via SCIM {#v26.34-role-mapping-scim}
 

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -23,8 +23,8 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 *Released to Materialize Cloud: 2026-07-29* <br>
 *Released to Materialize Self-Managed: 2026-07-30* <br>
 
-### Graceful Cluster Reconfiguration {#v26.35-background-cluster-reconfiguration}
-`ALTER CLUSTER` for configuration changes (such as resizing) now returns immediately and runs in the background, rather than blocking until the new replica set is ready.
+### Asynchronous Cluster Reconfiguration {#v26.35-background-cluster-reconfiguration}
+`ALTER CLUSTER` now runs configuration changes (such as resizing) in the background, rather than blocking until the new replica set is ready. This means you can start a reconfiguration and move on to other tasks while the process completes.
 
 Because the command is now asynchronous, you can monitor the
 progress of an in-flight reconfiguration using `SHOW CLUSTERS`.
@@ -58,7 +58,7 @@ For more information, see [`ALTER CLUSTER`: Resizing process](/sql/alter-cluster
 Kafka sinks can now use [AWS Glue Schema
 Registry](/sql/create-connection/#aws-glue-schema-registry) for Avro schema
 management, via the new `FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY` syntax on
-[`CREATE SINK`](/sql/create-sink/kafka/).
+[`CREATE SINK`](/sql/create-sink/kafka/). With Glue now supported on both sources and sinks, you can manage your Kafka schemas end to end on AWS.
 
 ```mzsql
 -- Authenticate to AWS Glue through an AWS connection.
@@ -88,16 +88,9 @@ For more information, see [`CREATE SINK`: Using AWS Glue Schema Registry](/sql/c
 
 ### Kafka: Source versioning {#v26.35-kafka-source-versioning}
 
-For Kafka sources, we've introduced new syntax for [`CREATE
-SOURCE`](/sql/create-source/kafka-v2/) and [`CREATE TABLE ... FROM
-SOURCE`](/sql/create-table/kafka/). This is the same source versioning syntax
-already available for PostgreSQL, MySQL, and SQL Server sources, and it allows
-you to better handle Avro schema changes in your Kafka topics.
+Kafka sources now support source versioning, so you can adopt upstream Avro schema changes without downtime. This uses the same mechanism already available for PostgreSQL, MySQL, and SQL Server sources, by creating a new table with the evolved schema and swapping it into place with a blue/green cutover.
 
-Materialize resolves the latest registered Avro schema when the `CREATE TABLE`
-statement runs, and pins it as the table's reader schema. To pick up an
-upstream schema change with zero downtime, create a new table that reads the
-evolved schema and swap it into place with a blue/green cutover.
+There is new syntax for [`CREATE SOURCE`](/sql/create-source/kafka-v2/) and [`CREATE TABLE ... FROM SOURCE`](/sql/create-table/kafka/) for creating and versioning tables independently. Materialize resolves the latest registered Avro schema when the `CREATE TABLE` statement runs, and pins it as the table's reader schema.
 
 For more information, refer to:
 - [Guide: Handling upstream schema changes with zero
@@ -107,7 +100,7 @@ For more information, refer to:
 
 ### Improvements {#v26.35-improvements}
 - **Faster read queries under write load**: Read-only queries (e.g., `SELECT 1`) are no longer blocked by concurrent write transactions; under high write load, victim query latency drops from multiple seconds to single-digit milliseconds.
-- **Better query plans for correlated subqueries**: Queries using patterns like `1 IN (SELECT 1 WHERE p)` and `NOT EXISTS (SELECT 1 WHERE p)` are now optimized to a simple filter, eliminating unnecessary semi/anti-joins.
+- **Better query plans for correlated subqueries**: Queries using patterns like `1 IN (SELECT 1 WHERE p)` and `NOT EXISTS (SELECT 1 WHERE p)` are now optimized to a simple filter, eliminating unnecessary semi/anti-joins for faster queries.
 - **Account hierarchy billing**: Organizations running multiple Materialize accounts under one parent (e.g., separate production and staging accounts) can now see consolidated billing and usage at the parent level, broken out per child account; each child account sees only its own usage. Available on request — talk to your account executive to see if you qualify.
 - **`mz-debug` CPU profiling**: The `mz-debug` diagnostic tool now automatically collects CPU profiles alongside memory profiles for Self-Managed deployments.
 
@@ -127,11 +120,11 @@ For more information, refer to:
 ## v26.34.1
 *Released to Materialize Self-Managed: 2026-07-24* <br>
 
-### Graceful Cluster Reconfiguration {#v26.34.1-graceful-cluster-reconfiguration}
+### Asynchronous Cluster Reconfiguration {#v26.34.1-graceful-cluster-reconfiguration}
 
 <red>*Materialize Self-Managed only*</red>
 
-`ALTER CLUSTER` for configuration changes (such as resizing) now returns immediately and runs in the background, rather than blocking until the new replica set is ready.
+`ALTER CLUSTER` now runs configuration changes (such as resizing) in the background, rather than blocking until the new replica set is ready. This means you can start a reconfiguration and move on to other tasks while the process completes.
 
 Because the command is now asynchronous, you can monitor the
 progress of an in-flight reconfiguration using `SHOW CLUSTERS`.

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -8,7 +8,7 @@ rows:
   - Materialize Operator: v26.35
     orchestratord version: v26.35
     environmentd version: v26.35
-    Release date: "2026-07-31"
+    Release date: "2026-07-30"
     Notes: "See [v26.35 release notes](/releases/#v26350)"
   - Materialize Operator: v26.34.1
     orchestratord version: v26.34.1

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -5,6 +5,11 @@ columns:
   - column: Release date
   - column: Notes
 rows:
+  - Materialize Operator: v26.35
+    orchestratord version: v26.35
+    environmentd version: v26.35
+    Release date: "2026-07-31"
+    Notes: "See [v26.35 release notes](/releases/#v26350)"
   - Materialize Operator: v26.34.1
     orchestratord version: v26.34.1
     environmentd version: v26.34.1


### PR DESCRIPTION
Draft — dates are provisional until the release ships. One commit is added per snapshot; the final snapshot sets the real dates.

Snapshot drafts (with PR links) in mz-skills:
- rc.1: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/rc.1/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/rc.1/omitted.md)
- rc.2: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/rc.2/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/rc.2/omitted.md)
- rc.3: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/rc.3/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/rc.3/omitted.md)
- rc.4: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/rc.4/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/rc.4/omitted.md)
- final: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/final/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/final/omitted.md)

**Borderline PRs omitted:** rc.1: 2 — [omitted.md#borderline](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/rc.1/omitted.md#borderline) · rc.2: 1 — [omitted.md#borderline](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/rc.2/omitted.md#borderline) · rc.4: 1 — [omitted.md#borderline](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.35.0/rc.4/omitted.md#borderline)

Real dates (set by final snapshot): Cloud 2026-07-29, Self-Managed 2026-07-30.

Cross-snapshot rewrite applied in the final commit: removed the rc.1 entry "Faster MySQL source snapshots" (#37642) because rc.4's #37879 defaults the parallelism off after scale tests showed it did not improve performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)