### PR TITLE
mz-deploy: support array types in the offline type-checker

### DIFF
--- a/src/mz-deploy/src/project/compiler/typecheck/catalog.rs
+++ b/src/mz-deploy/src/project/compiler/typecheck/catalog.rs
@@ -885,6 +885,29 @@ impl CatalogRuntime {
             Builtin::Connection(connection) => connection.oid,
         };
 
+        // An element type reaches its array type through its own `array_id`,
+        // which is what name resolution follows to resolve `text[]`. The
+        // builtin definitions leave `array_id` unset, so each array type has
+        // to point its element type back at itself as it is registered.
+        // `BUILTINS::iter()` yields element types before the array types that
+        // reference them, the same ordering `resolve_builtin_type_references`
+        // already relies on.
+        if let Some(CatalogTypeDetails {
+            typ: CatalogType::Array { element_reference },
+            ..
+        }) = &type_details
+        {
+            let element = self
+                .items_by_id
+                .get_mut(element_reference)
+                .expect("element type registered before its array type");
+            Arc::make_mut(element)
+                .type_details
+                .as_mut()
+                .expect("array element reference points at a type")
+                .array_id = Some(item_id);
+        }
+
         let item = LocalItem {
             name: name.clone(),
             id: item_id,
@@ -2524,6 +2547,90 @@ mod tests {
         assert!(
             result.is_ok(),
             "stub table with date column failed: {:?}",
+            result.err()
+        );
+    }
+
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    #[mz_ore::test]
+    fn test_resolve_array_types() {
+        let catalog = CatalogRuntime::new().expect("catalog creation should succeed");
+        for element_name in [
+            "text",
+            "int4",
+            "int8",
+            "bool",
+            "date",
+            "timestamptz",
+            "uuid",
+        ] {
+            let partial = PartialItemName {
+                database: None,
+                schema: None,
+                item: format!("_{element_name}"),
+            };
+            let array_type = catalog
+                .resolve_type(&partial)
+                .unwrap_or_else(|e| panic!("resolve_type(_{element_name}) failed: {e:?}"));
+            let element_type = catalog
+                .resolve_type(&PartialItemName {
+                    database: None,
+                    schema: None,
+                    item: element_name.to_string(),
+                })
+                .unwrap_or_else(|e| panic!("resolve_type({element_name}) failed: {e:?}"));
+            assert_eq!(
+                element_type
+                    .type_details()
+                    .expect("element is a type")
+                    .array_id,
+                Some(array_type.id()),
+                "{element_name} does not point at its array type"
+            );
+        }
+    }
+
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    #[mz_ore::test]
+    fn test_stub_table_with_array_column() {
+        let mut runtime = CatalogRuntime::new().expect("catalog creation should succeed");
+        runtime.ensure_user_schema("test_db", "test_schema");
+        let object_id = ObjectId::new("test_db".into(), "test_schema".into(), "test_table".into());
+        let mut columns = BTreeMap::new();
+        columns.insert(
+            "operations".to_string(),
+            ColumnType {
+                r#type: "text[]".into(),
+                nullable: false,
+                position: 0,
+                comment: None,
+            },
+        );
+        columns.insert(
+            "counts".to_string(),
+            ColumnType {
+                r#type: "int4[]".into(),
+                nullable: true,
+                position: 1,
+                comment: None,
+            },
+        );
+        let result = runtime.create_stub_table(&object_id, &columns);
+        assert!(
+            result.is_ok(),
+            "stub table with array column failed: {:?}",
+            result.err()
+        );
+
+        let view_id = ObjectId::new("test_db".into(), "test_schema".into(), "test_view".into());
+        let sql = r#"CREATE VIEW "test_db"."test_schema"."test_view" AS
+            SELECT array_length("operations", 1) AS len, unnest("operations") AS op
+            FROM "test_db"."test_schema"."test_table"
+            WHERE 'launch' = ANY("operations")"#;
+        let result = runtime.create_item(&view_id, sql);
+        assert!(
+            result.is_ok(),
+            "view using array operations failed: {:?}",
             result.err()
         );
     }

--- a/src/mz-deploy/src/project/compiler/typecheck/catalog.rs
+++ b/src/mz-deploy/src/project/compiler/typecheck/catalog.rs
@@ -2634,4 +2634,63 @@ mod tests {
             result.err()
         );
     }
+
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    #[mz_ore::test]
+    fn test_stub_table_with_multi_dimensional_array_column() {
+        let mut runtime = CatalogRuntime::new().expect("catalog creation should succeed");
+        runtime.ensure_user_schema("test_db", "test_schema");
+        let object_id = ObjectId::new("test_db".into(), "test_schema".into(), "test_table".into());
+        let mut columns = BTreeMap::new();
+        // Dimensionality is a property of the value, not the type. `text[][]`
+        // and `int4[2][2]` denote the same types as `text[]` and `int4[]`, so
+        // both spellings have to resolve through the element type's array_id.
+        columns.insert(
+            "grid".to_string(),
+            ColumnType {
+                r#type: "text[][]".into(),
+                nullable: false,
+                position: 0,
+                comment: None,
+            },
+        );
+        columns.insert(
+            "matrix".to_string(),
+            ColumnType {
+                r#type: "int4[2][2]".into(),
+                nullable: true,
+                position: 1,
+                comment: None,
+            },
+        );
+        let result = runtime.create_stub_table(&object_id, &columns);
+        assert!(
+            result.is_ok(),
+            "stub table with multi-dimensional array column failed: {:?}",
+            result.err()
+        );
+
+        let view_id = ObjectId::new("test_db".into(), "test_schema".into(), "test_view".into());
+        let sql = r#"CREATE VIEW "test_db"."test_schema"."test_view" AS
+            SELECT "grid"[1][2] AS cell,
+                   array_length("matrix", 2) AS cols,
+                   ARRAY[ARRAY[1, 2], ARRAY[3, 4]] AS literal
+            FROM "test_db"."test_schema"."test_table""#;
+        let desc = runtime
+            .create_item(&view_id, sql)
+            .unwrap_or_else(|e| panic!("view using multi-dimensional arrays failed: {e:?}"));
+        let types: Vec<_> = desc
+            .iter()
+            .map(|(name, typ)| (name.as_str(), typ))
+            .collect();
+        assert_eq!(types[0].0, "cell");
+        assert_eq!(types[0].1.scalar_type, SqlScalarType::String);
+        assert_eq!(types[1].0, "cols");
+        assert_eq!(types[1].1.scalar_type, SqlScalarType::Int32);
+        assert_eq!(types[2].0, "literal");
+        assert_eq!(
+            types[2].1.scalar_type,
+            SqlScalarType::Array(Box::new(SqlScalarType::Int32))
+        );
+    }
 }


### PR DESCRIPTION
### Motivation

`mz-deploy compile` failed to type-check any project whose declared dependencies included an array-typed column, reporting:

```
error: type "text[]" does not exist
```

Because `stage` runs `compile` first, this blocked deployment outright rather than just local checks. Any project referencing an array-typed source column was undeployable.

### Root cause

Array types are not resolved structurally. When name resolution encounters `text[]`, it resolves the element type `text` and then follows that item's `type_details.array_id` to reach the `_text` array type (`src/sql/src/names.rs`). When `array_id` is `None`, resolution bails with the error above.

Builtin type definitions declare `array_id: None` statically. The adapter catalog populates it during bootstrap: as each `Builtin::Type` that is a `CatalogType::Array` is inserted, it reaches back into its element type and sets `array_id` to its own id (`src/adapter/src/catalog/apply.rs`).

mz-deploy's offline catalog copied `array_id` from the builtin definition verbatim, so it was always `None`. The array types themselves were registered correctly all along. Nothing could ever reach them.

This also explains why hand-editing `types.lock` to retype the column as `text` got past the load and instead failed on the model's array operations. The type existed. Only the element-to-array link was missing.

It also left the two halves of the round-trip inconsistent: `lock` recorded `type = "text[]"` faithfully, and `compile` then rejected what `lock` had written.

### Changes

Mirror the adapter's back-patch when seeding builtin types in the offline catalog. The ordering this depends on, element types registered before the array types referencing them, is the same ordering `resolve_builtin_type_references` already relies on, so no new assumption is introduced. The fix is generic over all array builtins rather than special-cased to `text[]`.

The `TaskCatalog` overlay needs no change, as builtin types live only in the shared base catalog.

### Tests

* `test_resolve_array_types` asserts that each of a set of element types points at its corresponding array type via `array_id`.
* `test_stub_table_with_array_column` builds a stub table with `text[]` and `int4[]` columns and then type-checks a view over it that uses `array_length`, `unnest` and `= ANY(...)`, covering the array operations that previously produced follow-on `function ... does not exist` errors.

Both were confirmed to fail before the fix, reproducing the reported error exactly.

I separately verified the wider lock/compile round-trip over the other composite types `lock` can emit: `text[][]`, `uint4[]`, `"char"[]`, `mz_timestamp[]`, `mz_aclitem[]`, `text list`, `text list list`, `map[text=>text]`, `map[text=>int4]`, `int4range`, and the parameterized `numeric(5)`, `varchar(10)`, `char(3)`, `timestamp(3)`. All resolve correctly.

One narrower gap remains and is left for separate work. A dependency with an anonymous record column causes `lock` to write `type = "record"`, and compile then fails with `cannot reference pseudo type pg_catalog.record`. Unlike arrays this is not a missing link. `record` is a pseudo-type with no nameable SQL spelling, so Materialize itself also rejects it as a column declaration. Addressing it needs a different approach, either a structural stub or an explicit unsupported-type diagnostic raised at `lock` time so the failure surfaces early with a clear message.

### Release notes

This release will fix `mz-deploy compile` and `mz-deploy stage` failing with `type "text[]" does not exist` for projects whose dependencies have array-typed columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)