### PR TITLE
storage: default MySQL snapshot PK-range parallelism to off

### DIFF
--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -211,7 +211,7 @@ pub const MYSQL_REPLICATION_HEARTBEAT_INTERVAL: Config<Duration> = Config::new(
 /// whole by a single worker.
 pub static MYSQL_SOURCE_SNAPSHOT_PARALLELISM: Config<bool> = Config::new(
     "mysql_source_snapshot_parallelism",
-    true,
+    false,
     "Whether to split MySQL snapshot reads across workers by primary-key ranges.",
 );
 


### PR DESCRIPTION
### Motivation
Scale tests are showing that for large MySQL tables this change does not improve performance. I tested on a 1B row table and while the test is still running, the old version is on pace to complete faster than the parallelized implementation.

### Description

Defaults MySQL parallelism to be off. It does not disable the new parallelism-supporting structure.

### Verification

