### PR TITLE
clusterd-test-driver: parse s/u/t-prefixed global ids in specs

### DIFF
--- a/src/clusterd-test-driver/src/script.rs
+++ b/src/clusterd-test-driver/src/script.rs
@@ -29,8 +29,10 @@
 //! deterministic regardless of how the dataflows interleave.
 //!
 //! Shards are referenced by a string alias; the first command naming an alias
-//! allocates a fresh [`ShardId`] for it. Object ids are raw `u64`s mapped to
-//! [`GlobalId::User`].
+//! allocates a fresh [`ShardId`] for it. Object ids follow [`GlobalId`]'s own
+//! text form: a bare number (`1000`) is the user namespace, or an explicit
+//! `s`/`si`/`u`/`t` prefix (`t7`, `u1000`, `s42`) selects the namespace
+//! directly.
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -100,7 +102,7 @@ pub enum ImportSpec {
     /// Import a persist-backed storage collection, as `define_index` does.
     Source {
         /// The imported source's global id.
-        id: u64,
+        id: GlobalId,
         /// Shard alias to import; allocated on first use.
         shard: String,
         /// Schema name; defaults to the built-in sample schema.
@@ -113,7 +115,7 @@ pub enum ImportSpec {
     /// and type are taken from the registry, so it must have been defined first.
     Index {
         /// The index's global id.
-        index_id: u64,
+        index_id: GlobalId,
     },
 }
 
@@ -121,7 +123,7 @@ pub enum ImportSpec {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BuildSpec {
     /// The built object's global id.
-    pub id: u64,
+    pub id: GlobalId,
     /// The computation, as a pretty-form MIR spec parsed by `mz-expr-parser`
     /// (e.g. `Reduce aggregates=[count(*)]` over `Get u1000`). It references
     /// imported or previously-built objects by their global-id name (`u<n>`); the
@@ -138,9 +140,9 @@ pub enum ExportSpec {
     /// An arrangement, peekable as an index and importable by later dataflows.
     Index {
         /// The exported index's global id.
-        index_id: u64,
+        index_id: GlobalId,
         /// The imported or built id the index arranges.
-        on_id: u64,
+        on_id: GlobalId,
         /// Columns to arrange by.
         key: Vec<usize>,
     },
@@ -148,9 +150,9 @@ pub enum ExportSpec {
     /// verified by reading the shard back with a persist `peek` of the sink id.
     MaterializedView {
         /// The sink's global id (scheduled and frontier-tracked under this id).
-        sink_id: u64,
+        sink_id: GlobalId,
         /// The imported or built id the sink writes.
-        on_id: u64,
+        on_id: GlobalId,
         /// Target shard alias; allocated on first use.
         shard: String,
         /// Output schema; defaults to the sample schema. Must match `on_id`'s type.
@@ -160,9 +162,9 @@ pub enum ExportSpec {
     /// `await-subscribe`.
     Subscribe {
         /// The sink's global id.
-        sink_id: u64,
+        sink_id: GlobalId,
         /// The imported or built id the sink streams.
-        on_id: u64,
+        on_id: GlobalId,
         /// Output schema; defaults to the sample schema. Must match `on_id`'s type.
         schema: Option<String>,
         /// Exclusive upper at which the subscribe completes; unbounded if absent.
@@ -398,9 +400,9 @@ pub enum Command {
     /// Submit (without scheduling) an index dataflow over `shard`.
     DefineIndex {
         /// The imported source's global id.
-        source_id: u64,
+        source_id: GlobalId,
         /// The exported index's global id.
-        index_id: u64,
+        index_id: GlobalId,
         /// Shard alias to import; must already exist.
         shard: String,
         /// Schema name; defaults to the built-in sample schema. Must match what was
@@ -417,12 +419,12 @@ pub enum Command {
     /// Schedule a previously-submitted collection so it makes progress.
     Schedule {
         /// The collection's global id.
-        id: u64,
+        id: GlobalId,
     },
     /// Advance an index's read frontier (`since`) via `AllowCompaction`.
     AllowCompaction {
         /// The index's global id.
-        id: u64,
+        id: GlobalId,
         /// The new read frontier.
         frontier: u64,
     },
@@ -432,12 +434,12 @@ pub enum Command {
     /// all persist writes until this is sent for its sink id.
     AllowWrites {
         /// The sink's global id.
-        id: u64,
+        id: GlobalId,
     },
     /// Wait until `id`'s output frontier reaches `ts`, or fail after the timeout.
     AwaitFrontier {
         /// The collection's global id.
-        id: u64,
+        id: GlobalId,
         /// The target output-frontier timestamp.
         ts: u64,
         /// Timeout in seconds; defaults to `DEFAULT_TIMEOUT_SECS`.
@@ -458,7 +460,7 @@ pub enum Command {
     /// export). The golden output is the count; the script's `----` block asserts it.
     Count {
         /// The index's global id.
-        id: u64,
+        id: GlobalId,
         /// The timestamp to count at.
         ts: u64,
     },
@@ -496,7 +498,7 @@ pub enum Command {
     /// generic output assertion: the script's `----` block holds the expected rows.
     Peek {
         /// The index's global id.
-        id: u64,
+        id: GlobalId,
         /// Schema name describing the peek's output; defaults to the sample schema.
         #[serde(default)]
         schema: Option<String>,
@@ -508,7 +510,7 @@ pub enum Command {
     /// The output assertion for a subscribe sink.
     AwaitSubscribe {
         /// The subscribe sink's global id.
-        id: u64,
+        id: GlobalId,
         /// The exclusive upper to wait for (typically the sink's `up_to`).
         up_to: u64,
         /// Timeout in seconds; defaults to `DEFAULT_TIMEOUT_SECS`.
@@ -553,7 +555,7 @@ pub enum Command {
 /// import or count assertion can reconstruct the import without re-declaring it.
 struct IndexEntry {
     /// The id of the collection the index arranges.
-    on_id: u64,
+    on_id: GlobalId,
     /// The columns the index is arranged by.
     key: Vec<usize>,
     /// The arranged collection's relation type (for `import_index`).
@@ -574,10 +576,10 @@ pub struct ScriptState {
     /// Alias-to-shard map; aliases are allocated lazily on first use.
     shards: BTreeMap<String, ShardId>,
     /// Exported indexes, by global id, for later import / count assertions.
-    indexes: BTreeMap<u64, IndexEntry>,
+    indexes: BTreeMap<GlobalId, IndexEntry>,
     /// Materialized-view sink outputs, by sink global id: the target shard's
     /// metadata, so a `peek` of the sink id reads its shard via a persist peek.
-    mv_outputs: BTreeMap<u64, CollectionMetadata>,
+    mv_outputs: BTreeMap<GlobalId, CollectionMetadata>,
     /// Next ephemeral id for the count sugar's dataflows.
     next_internal: u64,
 }
@@ -618,7 +620,7 @@ impl ScriptState {
     /// `Reduce` over it: build an ephemeral dataflow that index-imports `index_id`,
     /// schedule and hydrate it, then peek its single-row output. An empty result
     /// (the reduce emits no row over empty input) reads as a count of `0`.
-    async fn count_via_reduce(&mut self, index_id: u64, ts: u64) -> anyhow::Result<u64> {
+    async fn count_via_reduce(&mut self, index_id: GlobalId, ts: u64) -> anyhow::Result<u64> {
         let entry = self.indexes.get(&index_id).ok_or_else(|| {
             anyhow::anyhow!("unknown index {index_id}; define it with define_index first")
         })?;
@@ -629,8 +631,8 @@ impl ScriptState {
         let reduce_id = self.alloc_internal();
         let out_index_id = self.alloc_internal();
         let df = count_over_index(
-            GlobalId::User(index_id),
-            GlobalId::User(on_id),
+            index_id,
+            on_id,
             on_type,
             key,
             reduce_id,
@@ -696,10 +698,10 @@ impl ScriptState {
     fn check_sink_schema(
         &self,
         builder: &DataflowBuilder,
-        on_id: u64,
+        on_id: GlobalId,
         desc: &RelationDesc,
     ) -> anyhow::Result<()> {
-        let on_type = builder.get(GlobalId::User(on_id))?.typ();
+        let on_type = builder.get(on_id)?.typ();
         let want = ReprRelationType::from(desc.typ());
         anyhow::ensure!(
             on_type.column_types == want.column_types,
@@ -787,8 +789,8 @@ impl ScriptState {
                 let shard = self.shard_id(&shard);
                 let on_type = ReprRelationType::from(desc.typ());
                 let df = index_dataflow(
-                    GlobalId::User(source_id),
-                    GlobalId::User(index_id),
+                    source_id,
+                    index_id,
                     shard,
                     self.loc.clone(),
                     desc,
@@ -810,19 +812,18 @@ impl ScriptState {
                 Ok("ok".to_string())
             }
             Command::Schedule { id } => {
-                self.driver.schedule(GlobalId::User(id))?;
+                self.driver.schedule(id)?;
                 Ok("ok".to_string())
             }
             Command::AllowCompaction { id, frontier } => {
                 self.driver.send(ComputeCommand::AllowCompaction {
-                    id: GlobalId::User(id),
+                    id,
                     frontier: Antichain::from_elem(Timestamp::from(frontier)),
                 })?;
                 Ok("ok".to_string())
             }
             Command::AllowWrites { id } => {
-                self.driver
-                    .send(ComputeCommand::AllowWrites(GlobalId::User(id)))?;
+                self.driver.send(ComputeCommand::AllowWrites(id))?;
                 Ok("ok".to_string())
             }
             Command::AwaitFrontier {
@@ -834,7 +835,7 @@ impl ScriptState {
                 let timeout = Duration::from_secs(timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS));
                 let result = self
                     .driver
-                    .expect_frontier(GlobalId::User(id), Timestamp::from(ts), timeout)
+                    .expect_frontier(id, Timestamp::from(ts), timeout)
                     .await;
                 if allow_timeout {
                     // The outcome is intentionally unobserved: emit a fixed token so
@@ -879,7 +880,6 @@ impl ScriptState {
                             upper,
                         } => {
                             let desc = self.resolve_schema(&schema)?;
-                            let id = GlobalId::User(id);
                             register_catalog_object(
                                 &mut catalog,
                                 &mut name_to_id,
@@ -903,7 +903,7 @@ impl ScriptState {
                                     "unknown index {index_id}; define it before importing it"
                                 )
                             })?;
-                            let on_id = GlobalId::User(entry.on_id);
+                            let on_id = entry.on_id;
                             let key = entry.key.clone();
                             let on_type = entry.on_type.clone();
                             register_catalog_object(
@@ -912,13 +912,7 @@ impl ScriptState {
                                 on_id,
                                 SqlRelationType::from_repr(&on_type),
                             )?;
-                            builder.import_index(
-                                GlobalId::User(index_id),
-                                on_id,
-                                key,
-                                on_type,
-                                false,
-                            );
+                            builder.import_index(index_id, on_id, key, on_type, false);
                         }
                     }
                 }
@@ -928,7 +922,7 @@ impl ScriptState {
                     let mut expr = try_parse_mir(&catalog, &build.expr)
                         .map_err(|e| anyhow::anyhow!("parsing MIR for object {}: {e}", build.id))?;
                     remap_gets(&mut expr, &catalog, &name_to_id)?;
-                    let id = GlobalId::User(build.id);
+                    let id = build.id;
                     // Register the built object so later builds can `get` it.
                     register_catalog_object(
                         &mut catalog,
@@ -953,12 +947,8 @@ impl ScriptState {
                             on_id,
                             key,
                         } => {
-                            let on_type = builder.get(GlobalId::User(on_id))?.typ();
-                            builder.export_index(
-                                GlobalId::User(index_id),
-                                GlobalId::User(on_id),
-                                key.clone(),
-                            );
+                            let on_type = builder.get(on_id)?.typ();
+                            builder.export_index(index_id, on_id, key.clone());
                             new_indexes.push((index_id, on_id, key, on_type));
                         }
                         ExportSpec::MaterializedView {
@@ -972,8 +962,8 @@ impl ScriptState {
                             let shard = self.shard_id(&shard);
                             let location = self.loc.clone();
                             builder.export_materialized_view(
-                                GlobalId::User(sink_id),
-                                GlobalId::User(on_id),
+                                sink_id,
+                                on_id,
                                 desc.clone(),
                                 PersistSink {
                                     shard,
@@ -1001,12 +991,7 @@ impl ScriptState {
                         } => {
                             let desc = self.resolve_schema(&schema)?;
                             self.check_sink_schema(&builder, on_id, &desc)?;
-                            builder.export_subscribe(
-                                GlobalId::User(sink_id),
-                                GlobalId::User(on_id),
-                                desc,
-                                up_to_antichain(up_to),
-                            );
+                            builder.export_subscribe(sink_id, on_id, desc, up_to_antichain(up_to));
                             new_subscribes.push(sink_id);
                         }
                     }
@@ -1027,7 +1012,7 @@ impl ScriptState {
                     );
                 }
                 for sink_id in new_subscribes {
-                    self.driver.register_subscribe(GlobalId::User(sink_id));
+                    self.driver.register_subscribe(sink_id);
                 }
                 for (sink_id, metadata) in new_mv_outputs {
                     self.mv_outputs.insert(sink_id, metadata);
@@ -1042,12 +1027,10 @@ impl ScriptState {
                 // for the writing sink to catch up.
                 let target = match self.mv_outputs.get(&id) {
                     Some(metadata) => PeekTarget::Persist {
-                        id: GlobalId::User(id),
+                        id,
                         metadata: metadata.clone(),
                     },
-                    None => PeekTarget::Index {
-                        id: GlobalId::User(id),
-                    },
+                    None => PeekTarget::Index { id },
                 };
                 let rows = self.driver.peek(target, desc, Timestamp::from(ts)).await?;
                 Ok(render_rows(&rows))
@@ -1060,7 +1043,7 @@ impl ScriptState {
                 let timeout = Duration::from_secs(timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS));
                 let updates = self
                     .driver
-                    .await_subscribe(GlobalId::User(id), Timestamp::from(up_to), timeout)
+                    .await_subscribe(id, Timestamp::from(up_to), timeout)
                     .await?;
                 Ok(render_updates(&updates))
             }

--- a/src/clusterd-test-driver/src/text.rs
+++ b/src/clusterd-test-driver/src/text.rs
@@ -34,6 +34,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Context, anyhow, bail, ensure};
+use mz_repr::GlobalId;
 
 use crate::script::{BuildSpec, ColumnSpec, Command, ConfigSetting, ExportSpec, ImportSpec};
 
@@ -274,6 +275,22 @@ fn opt_usize(args: &BTreeMap<String, String>, key: &str) -> anyhow::Result<Optio
         .transpose()
 }
 
+/// Parse a global id argument: a bare `u64` (e.g. `1001`) is the user namespace,
+/// matching [`mz_repr::GlobalId`]'s `Display`/`FromStr` prefixes (`s`/`si`/`u`/`t`)
+/// for the other namespaces, e.g. `t7` is `GlobalId::Transient(7)`.
+fn parse_id(s: &str) -> anyhow::Result<GlobalId> {
+    if s.bytes().all(|b| b.is_ascii_digit()) {
+        let id: u64 = s.parse().with_context(|| format!("bad id `{s}`"))?;
+        Ok(GlobalId::User(id))
+    } else {
+        s.parse().with_context(|| format!("bad id `{s}`"))
+    }
+}
+
+fn req_id(args: &BTreeMap<String, String>, key: &str) -> anyhow::Result<GlobalId> {
+    parse_id(req(args, key)?)
+}
+
 fn opt_string(args: &BTreeMap<String, String>, key: &str) -> Option<String> {
     args.get(key).cloned()
 }
@@ -300,22 +317,22 @@ fn parse_usize_list(s: &str) -> anyhow::Result<Vec<usize>> {
 /// Parse an `export` sub-command into an [`ExportSpec`]. The `kind=` argument
 /// selects the variant (defaulting to `index`); each kind takes its own arguments.
 fn parse_export(args: &BTreeMap<String, String>) -> anyhow::Result<ExportSpec> {
-    let on_id = req_u64(args, "on")?;
+    let on_id = req_id(args, "on")?;
     Ok(
         match args.get("kind").map(String::as_str).unwrap_or("index") {
             "index" => ExportSpec::Index {
-                index_id: req_u64(args, "index")?,
+                index_id: req_id(args, "index")?,
                 on_id,
                 key: parse_usize_list(req(args, "key")?)?,
             },
             "materialized-view" => ExportSpec::MaterializedView {
-                sink_id: req_u64(args, "sink")?,
+                sink_id: req_id(args, "sink")?,
                 on_id,
                 shard: req(args, "shard")?.to_string(),
                 schema: opt_string(args, "schema"),
             },
             "subscribe" => ExportSpec::Subscribe {
-                sink_id: req_u64(args, "sink")?,
+                sink_id: req_id(args, "sink")?,
                 on_id,
                 schema: opt_string(args, "schema"),
                 up_to: opt_u64(args, "up-to")?,
@@ -389,13 +406,12 @@ fn parse_create_dataflow(
             "import" => {
                 if let Some(index_id) = args.get("index") {
                     imports.push(ImportSpec::Index {
-                        index_id: index_id
-                            .parse()
+                        index_id: parse_id(index_id)
                             .with_context(|| format!("bad index id `{index_id}`"))?,
                     });
                 } else {
                     imports.push(ImportSpec::Source {
-                        id: req_u64(&args, "source")?,
+                        id: req_id(&args, "source")?,
                         shard: req(&args, "shard")?.to_string(),
                         schema: opt_string(&args, "schema"),
                         upper: req_u64(&args, "upper")?,
@@ -405,7 +421,7 @@ fn parse_create_dataflow(
             "build" => {
                 ensure!(!sub_body.is_empty(), "`build` needs a MIR body");
                 builds.push(BuildSpec {
-                    id: req_u64(&args, "id")?,
+                    id: req_id(&args, "id")?,
                     expr: body_text(sub_body),
                 });
             }
@@ -457,8 +473,8 @@ fn parse_command(input: &str) -> anyhow::Result<Command> {
             rows: rows_from_body(body)?,
         },
         "define-index" => Command::DefineIndex {
-            source_id: req_u64(&args, "source")?,
-            index_id: req_u64(&args, "index")?,
+            source_id: req_id(&args, "source")?,
+            index_id: req_id(&args, "index")?,
             shard: req(&args, "shard")?.to_string(),
             schema: opt_string(&args, "schema"),
             key: parse_usize_list(req(&args, "key")?)?,
@@ -466,32 +482,32 @@ fn parse_command(input: &str) -> anyhow::Result<Command> {
             upper: req_u64(&args, "upper")?,
         },
         "schedule" => Command::Schedule {
-            id: req_u64(&args, "id")?,
+            id: req_id(&args, "id")?,
         },
         "allow-compaction" => Command::AllowCompaction {
-            id: req_u64(&args, "id")?,
+            id: req_id(&args, "id")?,
             frontier: req_u64(&args, "frontier")?,
         },
         "allow-writes" => Command::AllowWrites {
-            id: req_u64(&args, "id")?,
+            id: req_id(&args, "id")?,
         },
         "await-frontier" => Command::AwaitFrontier {
-            id: req_u64(&args, "id")?,
+            id: req_id(&args, "id")?,
             ts: req_u64(&args, "ts")?,
             timeout_secs: opt_u64(&args, "timeout-secs")?,
             allow_timeout: flags.iter().any(|f| f == "allow-timeout"),
         },
         "count" => Command::Count {
-            id: req_u64(&args, "id")?,
+            id: req_id(&args, "id")?,
             ts: req_u64(&args, "ts")?,
         },
         "peek" => Command::Peek {
-            id: req_u64(&args, "id")?,
+            id: req_id(&args, "id")?,
             schema: opt_string(&args, "schema"),
             ts: req_u64(&args, "ts")?,
         },
         "await-subscribe" => Command::AwaitSubscribe {
-            id: req_u64(&args, "id")?,
+            id: req_id(&args, "id")?,
             up_to: req_u64(&args, "up-to")?,
             timeout_secs: opt_u64(&args, "timeout-secs")?,
         },
@@ -546,7 +562,7 @@ mod tests {
         assert_eq!(
             cmd,
             Command::AwaitFrontier {
-                id: 1001,
+                id: GlobalId::User(1001),
                 ts: 1,
                 timeout_secs: Some(3),
                 allow_timeout: true,
@@ -558,8 +574,8 @@ mod tests {
         assert_eq!(
             cmd,
             Command::DefineIndex {
-                source_id: 1000,
-                index_id: 1001,
+                source_id: GlobalId::User(1000),
+                index_id: GlobalId::User(1001),
                 shard: "d".to_string(),
                 schema: None,
                 key: vec![0],
@@ -567,6 +583,37 @@ mod tests {
                 upper: 1,
             }
         );
+    }
+
+    /// An id argument accepts a bare number (user namespace) or an explicit
+    /// `s`/`si`/`u`/`t` prefix selecting the namespace directly.
+    #[mz_ore::test]
+    fn parses_prefixed_ids() {
+        assert_eq!(
+            parse_command("schedule id=1001").unwrap(),
+            Command::Schedule {
+                id: GlobalId::User(1001)
+            }
+        );
+        assert_eq!(
+            parse_command("schedule id=u1001").unwrap(),
+            Command::Schedule {
+                id: GlobalId::User(1001)
+            }
+        );
+        assert_eq!(
+            parse_command("schedule id=t7").unwrap(),
+            Command::Schedule {
+                id: GlobalId::Transient(7)
+            }
+        );
+        assert_eq!(
+            parse_command("schedule id=s42").unwrap(),
+            Command::Schedule {
+                id: GlobalId::System(42)
+            }
+        );
+        assert!(parse_command("schedule id=bogus").is_err());
     }
 
     /// `define-schema` and `write-rows` parse their indented bodies, typing values.
@@ -629,14 +676,16 @@ mod tests {
             cmd,
             Command::CreateDataflow {
                 name: Some("count".to_string()),
-                imports: vec![ImportSpec::Index { index_id: 1001 }],
+                imports: vec![ImportSpec::Index {
+                    index_id: GlobalId::User(1001)
+                }],
                 builds: vec![BuildSpec {
-                    id: 2000,
+                    id: GlobalId::User(2000),
                     expr: "Reduce aggregates=[count(*)]\n  Get u1000".to_string(),
                 }],
                 exports: vec![ExportSpec::Index {
-                    index_id: 2001,
-                    on_id: 2000,
+                    index_id: GlobalId::User(2001),
+                    on_id: GlobalId::User(2000),
                     key: vec![0]
                 }],
                 as_of: 0,
@@ -666,8 +715,8 @@ mod tests {
         assert_eq!(
             exports,
             vec![ExportSpec::MaterializedView {
-                sink_id: 2001,
-                on_id: 2000,
+                sink_id: GlobalId::User(2001),
+                on_id: GlobalId::User(2000),
                 shard: "out".to_string(),
                 schema: Some("kv".to_string()),
             }]
@@ -680,8 +729,8 @@ mod tests {
         assert_eq!(
             exports,
             vec![ExportSpec::Subscribe {
-                sink_id: 2001,
-                on_id: 2000,
+                sink_id: GlobalId::User(2001),
+                on_id: GlobalId::User(2000),
                 schema: None,
                 up_to: Some(2),
             }]
@@ -760,7 +809,7 @@ mod tests {
         assert_eq!(
             cmd,
             Command::AwaitSubscribe {
-                id: 2001,
+                id: GlobalId::User(2001),
                 up_to: 2,
                 timeout_secs: Some(5),
             }
@@ -782,7 +831,12 @@ mod tests {
             })
             .collect();
         assert_eq!(stanzas.len(), 2);
-        assert_eq!(stanzas[0].command, Command::Schedule { id: 1001 });
+        assert_eq!(
+            stanzas[0].command,
+            Command::Schedule {
+                id: GlobalId::User(1001)
+            }
+        );
         assert_eq!(stanzas[0].expected, "ok");
         assert_eq!(stanzas[1].expected, "10000");
 


### PR DESCRIPTION
### Motivation

`clusterd-test-driver` spec/text-format ids were raw `u64`s always mapped to
`GlobalId::User`, so a script had no way to target the system or transient
`GlobalId` namespaces. Some driver behavior can depend on the id's namespace,
so specs need to be able to select it explicitly.

### Description

Ids now parse the same way `GlobalId`'s own `Display` renders them: a bare
number (`1000`) defaults to the user namespace (unchanged, so every existing
`.spec` fixture keeps working as-is), and an explicit `s`/`si`/`u`/`t` prefix
(`s42`, `u1000`, `t7`) selects the namespace directly, via a new `parse_id`
helper in `text.rs`.

All `Command` and `*Spec` id fields (`ImportSpec`, `BuildSpec`, `ExportSpec`,
and the various `Command` variants) now carry `GlobalId` end to end instead of
a `u64` that got wrapped in `GlobalId::User` at each call site in `script.rs`.
`ScriptState`'s `indexes`/`mv_outputs` maps are keyed by `GlobalId` for the
same reason.

### Verification

Extended `text.rs`'s unit tests with `parses_prefixed_ids`, covering the bare,
`u`, `t`, and `s` forms plus a parse error for a garbage id. Updated the
existing tests' expectations from bare integer literals to `GlobalId::User(..)`.
Ran `cargo test -p mz-clusterd-test-driver` (25/25 pass), `cargo check`, `cargo
clippy`, and `bin/fmt`.