### PR TITLE
mz-debug-ci: add reference for triggering and scoping CI runs

### DIFF
--- a/.agents/skills/mz-debug-ci/SKILL.md
+++ b/.agents/skills/mz-debug-ci/SKILL.md
@@ -140,3 +140,52 @@ Group failures by **root cause**, not by job name. Typically many failing jobs s
 2. **Root cause B** — description, which jobs it affects, what to fix
 
 Distinguish between issues that are clearly caused by the PR's changes vs. pre-existing flaky tests. The annotations often link to known flaky test issues (GitHub `database-issues` links) — use these to identify pre-existing flakes vs. regressions introduced by the PR.
+
+## Reference: triggering and scoping CI runs
+
+The steps above diagnose a build that already ran. These recipes trigger a new
+run or narrow one to the steps you care about.
+
+### Manually trigger a nightly
+
+The `nightly` pipeline restricts API builds to release branches
+(`branch_configuration: v*`). Triggering it on `main` (or any non-`v*` branch)
+via the API returns `422 Branches have been disabled for this pipeline` unless
+you pass `--ignore-branch-filters` (`-i`). Scheduled runs bypass the filter; API
+triggers do not.
+
+```bash
+bk build create -p nightly -b main -c <sha> -i -m "why this run exists"
+```
+
+### Scope a build to specific steps
+
+`ci/mkpipeline.py` reads two env vars at pipeline-upload time and marks every
+step whose `id` is not selected as `skip` (build steps are always kept):
+
+- `CI_TEST_SELECTION=<step-id,...>` by readable step id; use this one
+- `CI_TEST_IDS=<index,...>` by positional integer index; fragile, avoid
+
+Selection is step-granular. There is no file-granular selection: a testdrive
+step always runs its whole `*.td` glob. To run a single `.td` file, run it
+locally instead: `bin/mzcompose --find testdrive run default <file>.td`.
+
+```bash
+bk build create -p nightly -b main -c <sha> -i -e CI_TEST_SELECTION=redpanda-testdrive
+```
+
+### Testdrive coverage across pipelines
+
+The same `.td` file gets different coverage per pipeline:
+
+| Pipeline | Testdrive coverage |
+|---|---|
+| `test` (PR gate) | one default-config step, sharded x20; each `.td` runs once |
+| `nightly` | 9 mzcompose config variants: `redpanda-testdrive`, `testdrive-partitions-5`, `testdrive-replicas-4`, `testdrive-size-1`, `testdrive-size-8`, `azurite-testdrive`, `azurite-testdrive-size-8`, `testdrive-fdb`, `testdrive-alloydb`; `persistence-testdrive` is skipped |
+| `release-qualification` | one pass in the cloudtest/K8s harness (`testdrive-in-cloudtest`, `-m=long`); whole build runs ~24h |
+
+Nightly is the broad testdrive-config exerciser. Release-qualification adds
+harness realism (Materialize as real K8s pods), not more config permutations,
+and most of its ~24h is large-scale parallel-workload scenarios, not testdrive.
+Templates: `ci/nightly/pipeline.template.yml`,
+`ci/release-qualification/pipeline.template.yml`.


### PR DESCRIPTION
## Summary

Adds a "Reference: triggering and scoping CI runs" section to the mz-debug-ci skill, capturing three things that came up while investigating a PR's CI coverage but weren't documented:

- **Manually triggering a nightly on `main`.** The `nightly` pipeline's `branch_configuration: v*` blocks API builds on non-`v*` branches with `422 Branches have been disabled`; pass `--ignore-branch-filters` (`-i`). Scheduled runs bypass the filter.
- **Scoping a build to specific steps** via `CI_TEST_SELECTION` (step ids) / `CI_TEST_IDS` (indices), read by `ci/mkpipeline.py`. Selection is step-granular; there is no single-`.td`-file selection in CI (run those locally).
- **Testdrive coverage across pipelines** - `test` (1 default config, sharded x20), `nightly` (9 mzcompose config variants), `release-qualification` (1 cloudtest/K8s pass, ~24h build).

Pure docs addition to the skill; no behavior change.

## Files

- `.agents/skills/mz-debug-ci/SKILL.md` (+49 lines)

## Test plan

- [x] ASCII-only, matches the skill's existing terse/code-block style.
- [x] Facts verified against `ci/mkpipeline.py`, `ci/nightly/pipeline.template.yml`, `ci/release-qualification/pipeline.template.yml`, and live Buildkite builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
