### PR TITLE
mz-deploy: bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "mz-deploy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "annotate-snippets",
  "async-stream",

--- a/src/mz-deploy/Cargo.toml
+++ b/src/mz-deploy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-deploy"
 description = "Declarative SQL project tooling for Materialize: compile, test, deploy."
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
### Motivation

Bumps the `mz-deploy` CLI to `0.3.1` and cuts a new release. Since `0.3.0`, this is a patch bump per `ci/deploy_mz-deploy/README.md`.

### Bug fixes

- Support array types in the offline type-checker, fixing `mz-deploy compile` and `mz-deploy stage` failing with `type "text[]" does not exist` for projects with array-typed columns (#37876).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>