### PR TITLE
persist: log full error chain for indeterminate compare_and_append er…

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -512,7 +512,7 @@ where
                     info!(
                         "compare_and_append received an indeterminate error, retrying in {:?}: {}",
                         retry.next_sleep(),
-                        err
+                        err.display_with_causes()
                     );
                     if indeterminate.is_none() {
                         indeterminate = Some(err);


### PR DESCRIPTION
### Motivation

Unable to see detailed error about why persist failed to compare_and_append.

"compare_and_append received an indeterminate error, retrying in 16s: indeterminate: db error"

### Description

Format with display_with_causes(), matching retry_external, so the cause chain reaches the log line.

### Verification

