### PR TITLE
storage: estimate MySQL snapshot row counts for large tables

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -696,6 +696,11 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "kafka_buffered_event_resize_threshold_elements",
     "kafka_low_watermark_check",
     "mysql_replication_heartbeat_interval",
+    # Not varied here because statistics tests assert exact
+    # snapshot_records_known values, which only hold on the exact-count path.
+    # The estimated path is covered explicitly in mysql-cdc/statistics.td and
+    # by parallel-workload.
+    "mysql_source_snapshot_exact_count_max_rows",
     "postgres_fetch_slot_resume_lsn_interval",
     "pg_schema_validation_interval",
     "pg_source_validate_timeline",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1909,6 +1909,12 @@ class FlipFlagsAction(Action):
             "0.5",
         ]
         self.flags_with_values["enable_upsert_paged_spill"] = BOOLEAN_FLAG_VALUES
+        # 0 forces the estimated-size path for every table, the default forces
+        # the exact COUNT(*) path for workload-sized tables.
+        self.flags_with_values["mysql_source_snapshot_exact_count_max_rows"] = [
+            "0",
+            "1000000",
+        ]
         self.flags_with_values["webhook_max_request_size_bytes"] = [
             # 1 MiB, 5 MiB (default), 10 MiB
             "1048576",

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -215,6 +215,16 @@ pub static MYSQL_SOURCE_SNAPSHOT_PARALLELISM: Config<bool> = Config::new(
     "Whether to split MySQL snapshot reads across workers by primary-key ranges.",
 );
 
+/// The largest optimizer-estimated table size for which the MySQL snapshot size
+/// gauge is computed with an exact `COUNT(*)`. Larger tables report the
+/// `information_schema` estimate directly, skipping the O(rows) count.
+pub static MYSQL_SOURCE_SNAPSHOT_EXACT_COUNT_MAX_ROWS: Config<usize> = Config::new(
+    "mysql_source_snapshot_exact_count_max_rows",
+    1_000_000,
+    "Maximum estimated table size for which MySQL snapshots compute an exact COUNT(*) \
+     for the size gauge; larger tables report the information_schema estimate.",
+);
+
 // Postgres
 
 /// Interval to poll `confirmed_flush_lsn` to get a resumption lsn.
@@ -427,6 +437,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&KAFKA_SINK_BATCH_SIZE)
         .add(&KAFKA_SINK_BATCH_NUM_MESSAGES)
         .add(&MYSQL_REPLICATION_HEARTBEAT_INTERVAL)
+        .add(&MYSQL_SOURCE_SNAPSHOT_EXACT_COUNT_MAX_ROWS)
         .add(&MYSQL_SOURCE_SNAPSHOT_PARALLELISM)
         .add(&ORE_OVERFLOWING_BEHAVIOR)
         .add(&PG_FETCH_SLOT_RESUME_LSN_INTERVAL)

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -215,9 +215,8 @@ pub static MYSQL_SOURCE_SNAPSHOT_PARALLELISM: Config<bool> = Config::new(
     "Whether to split MySQL snapshot reads across workers by primary-key ranges.",
 );
 
-/// The largest optimizer-estimated table size for which the MySQL snapshot size
-/// gauge is computed with an exact `COUNT(*)`. Larger tables report the
-/// `information_schema` estimate directly, skipping the O(rows) count.
+/// If the optimizer estimates the table has fewer rows than this, compute the exact row count
+/// with `COUNT(*)`. Otherwise, report the `information_schema` estimate directly.
 pub static MYSQL_SOURCE_SNAPSHOT_EXACT_COUNT_MAX_ROWS: Config<usize> = Config::new(
     "mysql_source_snapshot_exact_count_max_rows",
     1_000_000,

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -222,10 +222,12 @@ fn worker_pk_range(
 
 /// Walks the primary key index in steps of about `total / worker_count`, taking the key
 /// at each step's `OFFSET`. The per-step OFFSET scans sum to a full index pass, so this
-/// is O(total). Worker count is small, so the OFFSET scans dominate. `total` is the exact
-/// row count supplied by the caller, read on the same `READ ONLY` transaction as this
-/// walk, so the partitions are exact. Returns None if the primary key column type is not
-/// supported or the table is too small to split.
+/// is O(total). Worker count is small, so the OFFSET scans dominate. `total` is the row
+/// count supplied by the caller. It can be an optimizer estimate for large tables, so
+/// the partitions are approximate. An overestimate walks off the end of the index and
+/// stops with fewer boundaries, an underestimate leaves a larger final partition, both
+/// still correctly partition the table. Returns None if the primary key column type is
+/// not supported or the table is too small to split.
 async fn compute_sampled_splits<Q>(
     conn: &mut Q,
     table: &MySqlTableName,
@@ -295,10 +297,11 @@ where
     }))
 }
 
-/// For every table, read the exact row count and, for a supported single-column primary
-/// key, compute the PK-range split boundaries, concurrently over at most `worker_count`
-/// connections. `None` bounds means single-worker fallback for that table. The counts are
-/// reused for both the sampling stride and the snapshot size gauge.
+/// For every table, read the row count (exact only for small tables) and, for a
+/// supported single-column primary key, compute the PK-range split boundaries,
+/// concurrently over at most `worker_count` connections. `None` bounds means
+/// single-worker fallback for that table. The counts are reused for both the sampling
+/// stride and the snapshot size gauge.
 async fn sample_pk_bounds(
     config: &RawSourceCreationConfig,
     connection_config: &mz_mysql_util::Config,
@@ -324,6 +327,10 @@ async fn sample_pk_bounds(
     // they feed the snapshot size gauge.
     let parallelism_enabled = mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARALLELISM
         .get(config.config.config_set());
+    let exact_count_max_rows = u64::cast_from(
+        mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_EXACT_COUNT_MAX_ROWS
+            .get(config.config.config_set()),
+    );
 
     let pooled_conns: Rc<RefCell<Vec<MySqlConn>>> = Rc::new(RefCell::new(Vec::new()));
     // Counting and boundary-sampling each walk a table's index (O(rows)), so run tables
@@ -355,10 +362,13 @@ async fn sample_pk_bounds(
                         conn
                     }
                 };
-                // Exact row count, reused for the sampling stride and the size gauge.
-                // It runs on the same `READ ONLY` transaction as the boundary walk in
-                // `compute_sampled_splits`, so both see one consistent snapshot.
-                let stats = collect_table_statistics(&mut *conn, table).await?;
+                // Row count, reused for the sampling stride and the size gauge. When it
+                // is counted exactly it runs on the same `READ ONLY` transaction as the
+                // boundary walk in `compute_sampled_splits`, so both see one consistent
+                // snapshot. For large tables it is an optimizer estimate instead, which
+                // `compute_sampled_splits` tolerates.
+                let stats =
+                    collect_table_statistics(&mut *conn, table, exact_count_max_rows).await?;
                 metrics.record_table_count_latency(
                     table.1.clone(),
                     table.0.clone(),
@@ -744,7 +754,7 @@ pub(crate) fn render<'scope>(
                     .await?;
                 let task_name = format!("timely-{worker_id} MySQL snapshotter");
 
-                // Exact per-table row counts, computed once during PK sampling and reused
+                // Per-table row counts, computed once during PK sampling and reused
                 // by the leader to publish the snapshot size gauge.
                 let mut snapshot_counts: BTreeMap<MySqlTableName, u64> = BTreeMap::new();
 
@@ -1080,7 +1090,7 @@ pub(crate) fn render<'scope>(
     )
 }
 
-/// Publish the exact snapshot size to each table's statistics gauges, using the counts
+/// Publish the snapshot size to each table's statistics gauges, using the counts
 /// computed once during PK sampling. Called leader-only so the summed worker-local gauges
 /// reflect the upstream total without double-counting.
 fn publish_snapshot_size(
@@ -1188,26 +1198,51 @@ struct TableStatistics {
     count: u64,
 }
 
+/// Row count for the snapshot size gauge. Tables whose optimizer row estimate exceeds
+/// `exact_count_max_rows` report the estimate directly, everything else is counted
+/// exactly with `COUNT(*)`. The gauge only drives progress reporting, and an estimate is
+/// a fair trade for skipping an O(rows) index walk on a large table.
 async fn collect_table_statistics<Q>(
     conn: &mut Q,
     table: &MySqlTableName,
+    exact_count_max_rows: u64,
 ) -> Result<TableStatistics, TransientError>
 where
     Q: Queryable,
 {
     let mut stats = TableStatistics::default();
 
-    // `MySqlTableName::Display` escapes both identifier components via
-    // `quote_identifier`, so this interpolation is safe; not parameterizable.
-    #[allow(clippy::disallowed_methods)]
-    let count_row: Option<u64> = conn
-        .query_first(format!("SELECT COUNT(*) FROM {}", table))
+    // The optimizer's row estimate for the table. InnoDB keeps it roughly current
+    // (within the churn since the last stats recalculation), but it can be NULL or
+    // stale-at-zero, in which case we fall through to the exact count.
+    let estimate: Option<Option<u64>> = conn
+        .exec_first(
+            "SELECT table_rows FROM information_schema.tables \
+             WHERE table_schema = ? AND table_name = ?",
+            (&table.0, &table.1),
+        )
         .wall_time()
         .set_at(&mut stats.count_latency)
         .await?;
-    // `COUNT(*)` returns exactly one row, so `None` should be impossible. Default to 0
-    // defensively rather than failing the snapshot on a protocol quirk.
-    stats.count = count_row.unwrap_or(0);
+    match estimate.flatten() {
+        Some(estimate) if estimate > exact_count_max_rows => {
+            stats.count = estimate;
+        }
+        _ => {
+            // `MySqlTableName::Display` escapes both identifier components via
+            // `quote_identifier`, so this interpolation is safe; not parameterizable.
+            #[allow(clippy::disallowed_methods)]
+            let count_row: Option<u64> = conn
+                .query_first(format!("SELECT COUNT(*) FROM {}", table))
+                .wall_time()
+                .set_at(&mut stats.count_latency)
+                .await?;
+            // `COUNT(*)` returns exactly one row, so `None` should be impossible.
+            // Default to 0 defensively rather than failing the snapshot on a protocol
+            // quirk.
+            stats.count = count_row.unwrap_or(0);
+        }
+    }
 
     Ok(stats)
 }

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -220,14 +220,15 @@ fn worker_pk_range(
     })
 }
 
-/// Walks the primary key index in steps of about `total / worker_count`, taking the key
+/// Walks the primary key index in steps of about `row_count / worker_count`, taking the key
 /// at each step's `OFFSET`. The per-step OFFSET scans sum to a full index pass, so this
-/// is O(total). Worker count is small, so the OFFSET scans dominate. `total` is the row
-/// count supplied by the caller. It can be an optimizer estimate for large tables, so
-/// the partitions are approximate. An overestimate walks off the end of the index and
-/// stops with fewer boundaries, an underestimate leaves a larger final partition, both
-/// still correctly partition the table. Returns None if the primary key column type is
-/// not supported or the table is too small to split.
+/// function has a time complexity of O(row_count). Worker count is small, so the OFFSET
+/// scans dominate the runtime. `row_count` can be an optimizer estimate for large tables,
+/// so the partitions are approximate. An overestimate walks off the end of the index and stops
+/// with fewer boundaries, resulting in some workers receiving less or no work. An underestimate
+/// leaves a larger final partition for the last worker, however both still correctly partition
+/// the table. Returns None if the primary key column type is not supported or the table is too
+/// small to split.
 async fn compute_sampled_splits<Q>(
     conn: &mut Q,
     table: &MySqlTableName,
@@ -301,7 +302,10 @@ where
 /// supported single-column primary key, compute the PK-range split boundaries,
 /// concurrently over at most `worker_count` connections. `None` bounds means
 /// single-worker fallback for that table. The counts are reused for both the sampling
-/// stride and the snapshot size gauge.
+/// stride and the snapshot size gauge. Snapshot size gauge is a metric for the snapshot
+/// size used to report how many rows we need to process. "Sampling stride" refers to
+/// the number of rows we use to page through the table to find roughly evenly spaced
+/// primary keys to use as partition boundaries.
 async fn sample_pk_bounds(
     config: &RawSourceCreationConfig,
     connection_config: &mz_mysql_util::Config,
@@ -1213,8 +1217,9 @@ where
     let mut stats = TableStatistics::default();
 
     // The optimizer's row estimate for the table. InnoDB keeps it roughly current
-    // (within the churn since the last stats recalculation), but it can be NULL or
-    // stale-at-zero, in which case we fall through to the exact count.
+    // (within the churn since the last stats recalculation), but it can be
+    // stale-at-zero, in which case we fall through to the exact count. We don't expect
+    // it to be null, but also fall back to count(*) in that case.
     let estimate: Option<Option<u64>> = conn
         .exec_first(
             "SELECT table_rows FROM information_schema.tables \

--- a/test/mysql-cdc/statistics.td
+++ b/test/mysql-cdc/statistics.td
@@ -247,3 +247,46 @@ t2 true
 t1 1
 
 > DROP CLUSTER stats_cluster CASCADE
+
+#
+# Estimated snapshot size. Lowering mysql_source_snapshot_exact_count_max_rows
+# below the table size makes the leader report the optimizer's row estimate
+# instead of an exact COUNT(*). The estimate is approximate, so the gauge is
+# only asserted to land in a sane band, while the staged count stays exact.
+#
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET mysql_source_snapshot_exact_count_max_rows = 100
+
+$ mysql-execute name=mysql
+USE public;
+CREATE TABLE big1 (f1 INT PRIMARY KEY);
+SET @i := 0;
+INSERT INTO big1 SELECT @i := @i + 1 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000;
+ANALYZE TABLE big1;
+
+> CREATE CLUSTER estimate_cluster SIZE '${arg.default-replica-size}'
+
+> CREATE SOURCE estimate_source IN CLUSTER estimate_cluster FROM MYSQL CONNECTION mysqc;
+> CREATE TABLE big1 FROM SOURCE estimate_source (REFERENCE public.big1);
+
+> SELECT COUNT(*) FROM big1;
+1000
+
+> SELECT
+    s.name,
+    SUM(u.snapshot_records_known) BETWEEN 800 AND 1200,
+    SUM(u.snapshot_records_staged)
+  FROM mz_internal.mz_source_statuses s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name = 'big1'
+  GROUP BY s.name
+big1 true 1000
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET mysql_source_snapshot_exact_count_max_rows
+
+> DROP CLUSTER estimate_cluster CASCADE
+
+$ mysql-execute name=mysql
+DROP TABLE big1;


### PR DESCRIPTION
### Motivation

Part of [SS-360](https://linear.app/materializeinc/issue/SS-360).

Count(*) can be very slow and we can speed it up with using table size statistics.

### Description

If size estimate is > 1M just use the size estimate. Otherwise still use count(*).

This broadly matches how Postgres handles grabbing/reporting the full row-count and is inspired by that. Row count is used for Reporting progress in the frontend and if we roll out parallel snapshotting for partitioning data. Accuracy is not critical for correctness.

