### PR TITLE
console: serve the largest maintained objects card from mz_object_arrangement_sizes

### DIFF
--- a/console/src/api/materialize/cluster/largestMaintainedQueries.test.sql.ts
+++ b/console/src/api/materialize/cluster/largestMaintainedQueries.test.sql.ts
@@ -10,7 +10,11 @@
 import { executeSqlHttp } from "~/test/sql/materializeSqlClient";
 import { testdrive } from "~/test/sql/mzcompose";
 
-import { buildLargestMaintainedQueriesQuery } from "./largestMaintainedQueries";
+import {
+  buildLargestMaintainedObjectSizesQuery,
+  buildLargestMaintainedQueriesQuery,
+  buildMaintainedObjectNamesQuery,
+} from "./largestMaintainedQueries";
 
 describe("buildLargestMaintainedQueriesQuery", () => {
   it(
@@ -37,6 +41,57 @@ describe("buildLargestMaintainedQueriesQuery", () => {
         name: "mz_views_ind",
         schemaName: "mz_catalog",
         size: expect.any(BigInt),
+        type: "index",
+      });
+    },
+  );
+});
+
+describe("buildLargestMaintainedObjectSizesQuery", () => {
+  it(
+    "fetches sizes from mz_object_arrangement_sizes and resolves names",
+    { timeout: 60_000 },
+    async () => {
+      const fetchSizes = () =>
+        executeSqlHttp(
+          buildLargestMaintainedObjectSizesQuery({
+            // mz_catalog_server has the stable builtin cluster id s2.
+            clusterId: "s2",
+            replicaName: "r1",
+            replicaHeapLimit: 1024 ** 4,
+            limit: 100,
+          }).compile(),
+          { sessionVariables: { cluster: "mz_catalog_server" } },
+        );
+      // The collection is fed by an introspection subscribe, so it can be
+      // briefly empty right after the stack boots.
+      let sizes = await fetchSizes();
+      for (
+        let attempt = 0;
+        attempt < 15 && sizes.rows.length === 0;
+        attempt++
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        sizes = await fetchSizes();
+      }
+      expect(sizes.rows.length).toBeGreaterThan(0);
+      expect(sizes.rows[0]).toEqual({
+        object_id: expect.any(String),
+        size: expect.any(BigInt),
+        memoryPercentage: expect.any(Number),
+      });
+
+      const namesQuery = buildMaintainedObjectNamesQuery(
+        sizes.rows.map((row) => row.object_id),
+      ).compile();
+      const names = await executeSqlHttp(namesQuery, {
+        sessionVariables: { cluster: "mz_catalog_server" },
+      });
+      expect(names.rows).toContainEqual({
+        databaseName: null,
+        id: expect.any(String),
+        name: "mz_views_ind",
+        schemaName: "mz_catalog",
         type: "index",
       });
     },

--- a/console/src/api/materialize/cluster/largestMaintainedQueries.ts
+++ b/console/src/api/materialize/cluster/largestMaintainedQueries.ts
@@ -29,8 +29,42 @@ export function buildLargestMaintainedQueriesQuery({
 }: Omit<LargestMaintainedQueriesParams, "replicaName" | "clusterName">) {
   return (
     queryBuilder
-      .selectFrom("mz_dataflow_arrangement_sizes as s")
-      .innerJoin("mz_compute_exports as ce", "ce.dataflow_id", "s.id")
+      // Per-dataflow arrangement sizes, equivalent to mz_dataflow_arrangement_sizes
+      // restricted to `size`: scanning only the two size logs avoids the view's
+      // seven other per-operator log aggregations.
+      .with("per_operator", (qb) =>
+        qb
+          .selectFrom((eb) =>
+            eb
+              .selectFrom("mz_arrangement_heap_size_raw")
+              .select("operator_id")
+              .unionAll(
+                eb
+                  .selectFrom("mz_arrangement_batcher_size_raw")
+                  .select("operator_id"),
+              )
+              .as("raw_logs"),
+          )
+          .select((eb) => ["operator_id", eb.fn.countAll<bigint>().as("size")])
+          .groupBy("operator_id"),
+      )
+      .with("per_dataflow", (qb) =>
+        qb
+          .selectFrom("per_operator as po")
+          .innerJoin(
+            "mz_dataflow_operator_dataflows as mdod",
+            "mdod.id",
+            "po.operator_id",
+          )
+          .select([
+            "mdod.dataflow_id",
+            "mdod.dataflow_name",
+            sql<bigint>`sum(${sql.ref("po.size")})::int8`.as("size"),
+          ])
+          .groupBy(["mdod.dataflow_id", "mdod.dataflow_name"]),
+      )
+      .selectFrom("per_dataflow as s")
+      .innerJoin("mz_compute_exports as ce", "ce.dataflow_id", "s.dataflow_id")
       .leftJoin("mz_objects as o", "o.id", "ce.export_id")
       .leftJoin("mz_schemas as sc", "sc.id", "o.schema_id")
       .leftJoin("mz_databases as da", "da.id", "sc.database_id")
@@ -47,8 +81,8 @@ export function buildLargestMaintainedQueriesQuery({
           sql<"materialized-view" | "index">`o.type`.as("type"),
           "sc.name as schemaName",
           "da.name as databaseName",
-          "s.id as dataflowId",
-          "s.name as dataflowName",
+          eb.ref("s.dataflow_id").$castTo<string | null>().as("dataflowId"),
+          eb.ref("s.dataflow_name").$castTo<string | null>().as("dataflowName"),
         ];
       })
       // Filter out transient dataflows
@@ -76,6 +110,105 @@ export async function fetchLargestMaintainedQueries({
       cluster: params.clusterName,
       cluster_replica: params.replicaName,
     }),
+    queries: query.compile(),
+    queryKey: queryKey,
+    requestOptions,
+  });
+}
+
+export type LargestMaintainedObjectSizesParams = {
+  clusterId: string;
+  replicaName: string;
+  replicaHeapLimit: number;
+  limit: number;
+};
+
+/**
+ * Sizes of the largest maintained objects on a replica, from
+ * `mz_object_arrangement_sizes` (Materialize >= v26.35, where sizes stay
+ * correct across replica restarts). Served by the collection's replica_id
+ * index on mz_catalog_server: no cluster or replica session variables, and
+ * no introspection dataflows on the replica being inspected.
+ */
+export function buildLargestMaintainedObjectSizesQuery({
+  clusterId,
+  replicaName,
+  replicaHeapLimit,
+  limit,
+}: LargestMaintainedObjectSizesParams) {
+  return (
+    queryBuilder
+      .selectFrom("mz_object_arrangement_sizes as s")
+      .innerJoin("mz_cluster_replicas as cr", (join) =>
+        join
+          .onRef("cr.id", "=", "s.replica_id")
+          .on("cr.cluster_id", "=", clusterId)
+          .on("cr.name", "=", replicaName),
+      )
+      .select((eb) => [
+        "s.object_id",
+        eb.ref("s.size").$castTo<bigint | null>().as("size"),
+        replicaHeapLimit
+          ? sql<number | null>`(${sql.id("s", "size")}::float8 / ${sql.raw(
+              replicaHeapLimit.toString(),
+            )}) * 100`.as("memoryPercentage")
+          : sql<null>`null`.as("memoryPercentage"),
+      ])
+      // Ties are common because sizes are 10 MiB-quantized; break them by id so
+      // rows keep a stable order across polls.
+      .orderBy("size", sql`desc NULLS LAST`)
+      .orderBy("s.object_id")
+      .limit(() => sql.raw(limit.toString()))
+  );
+}
+
+export async function fetchLargestMaintainedObjectSizes({
+  params,
+  queryKey,
+  requestOptions,
+}: {
+  params: LargestMaintainedObjectSizesParams;
+  queryKey: QueryKey;
+  requestOptions?: RequestInit;
+}) {
+  const query = buildLargestMaintainedObjectSizesQuery(params);
+  return executeSqlV2({
+    queries: query.compile(),
+    queryKey: queryKey,
+    requestOptions,
+  });
+}
+
+/**
+ * Display names for a fixed, non-empty set of object ids. Callers cache by
+ * id set: names are stable, so this only needs to run when the set changes.
+ */
+export function buildMaintainedObjectNamesQuery(objectIds: string[]) {
+  return queryBuilder
+    .selectFrom("mz_objects as o")
+    .leftJoin("mz_schemas as sc", "sc.id", "o.schema_id")
+    .leftJoin("mz_databases as da", "da.id", "sc.database_id")
+    .select([
+      "o.id",
+      "o.name",
+      sql<"materialized-view" | "index">`o.type`.as("type"),
+      "sc.name as schemaName",
+      "da.name as databaseName",
+    ])
+    .where("o.id", "in", objectIds);
+}
+
+export async function fetchMaintainedObjectNames({
+  objectIds,
+  queryKey,
+  requestOptions,
+}: {
+  objectIds: string[];
+  queryKey: QueryKey;
+  requestOptions?: RequestInit;
+}) {
+  const query = buildMaintainedObjectNamesQuery(objectIds);
+  return executeSqlV2({
     queries: query.compile(),
     queryKey: queryKey,
     requestOptions,

--- a/console/src/platform/clusters/LargestMaintainedQueries.test.tsx
+++ b/console/src/platform/clusters/LargestMaintainedQueries.test.tsx
@@ -17,8 +17,15 @@ import {
   mapKyselyToTabular,
 } from "~/api/mocks/buildSqlQueryHandler";
 import server from "~/api/mocks/server";
+import { getStore } from "~/jotai";
 import { buildValidMaterializationLagHandler } from "~/test/clusterQueryBuilders";
-import { renderComponent } from "~/test/utils";
+import {
+  defaultRegionId,
+  healthyEnvironment,
+  renderComponent,
+  setFakeEnvironment,
+} from "~/test/utils";
+import { parseDbVersion } from "~/version/api";
 
 import LargestMaintainedQueries from "./LargestMaintainedQueries";
 import { clusterQueryKeys } from "./queries";
@@ -77,9 +84,11 @@ const successfulLargestReplicaHandler = buildSqlQueryHandlerV2({
 
 const failedLargestQueriesHandler = buildSqlQueryHandlerV2({
   queryKey: clusterQueryKeys.largestMaintainedQueries({
+    clusterId: "u1",
     clusterName: "quickstart",
     replicaName: "r1",
     replicaHeapLimit: 4069523456,
+    unifiedSizes: false,
   }),
   results: {
     error: {
@@ -92,9 +101,11 @@ const failedLargestQueriesHandler = buildSqlQueryHandlerV2({
 
 const successfulLargestQueriesHandler = buildSqlQueryHandlerV2({
   queryKey: clusterQueryKeys.largestMaintainedQueries({
+    clusterId: "u1",
     clusterName: "quickstart",
     replicaName: "r1",
     replicaHeapLimit: 4069523456,
+    unifiedSizes: false,
   }),
   results: mapKyselyToTabular({
     columns: largestMaintainedQueriesColumns,
@@ -124,6 +135,30 @@ const successfulLargestQueriesHandler = buildSqlQueryHandlerV2({
     ],
   }),
 });
+
+const unifiedSizesColumns = buildColumns([
+  "object_id",
+  "size",
+  { type_oid: MzDataType.numeric, name: "memoryPercentage" },
+]);
+
+const objectNamesColumns = buildColumns([
+  "id",
+  "name",
+  "type",
+  "schemaName",
+  "databaseName",
+]);
+
+/** An environment new enough to pass the mz_object_arrangement_sizes gate. */
+const environmentV2635 = {
+  ...healthyEnvironment,
+  status: {
+    health: "healthy" as const,
+    version: parseDbVersion("v26.35.0 (ea0d129f)"),
+    errors: [],
+  },
+};
 
 describe("LargestMaintainedQueries", () => {
   it("shows an error state when the largest replica query fails", async () => {
@@ -178,5 +213,84 @@ describe("LargestMaintainedQueries", () => {
     // Also shows orphaned dataflows
     await screen.findByText("materialize.deleted_schema");
     await screen.findByText("orphaned_view");
+  });
+
+  it("renders from mz_object_arrangement_sizes on Materialize >= v26.35", async () => {
+    // Query keys embed the environment version at build time, so seed the
+    // v26.35 environment before building this test's handlers.
+    const { set } = getStore();
+    await setFakeEnvironment(set, defaultRegionId, environmentV2635);
+    server.use(
+      buildSqlQueryHandlerV2({
+        queryKey: clusterQueryKeys.largestClusterReplica({ clusterId: "u1" }),
+        results: mapKyselyToTabular({
+          columns: largestReplicaColumns,
+          rows: [
+            {
+              name: "r1",
+              size: "25cc",
+              heapLimit: "4069523456",
+              isHydrated: "t",
+            },
+          ],
+        }),
+      }),
+      buildSqlQueryHandlerV2({
+        queryKey: clusterQueryKeys.largestMaintainedQueries({
+          clusterId: "u1",
+          clusterName: "quickstart",
+          replicaName: "r1",
+          replicaHeapLimit: 4069523456,
+          unifiedSizes: true,
+        }),
+        results: mapKyselyToTabular({
+          columns: unifiedSizesColumns,
+          rows: [
+            {
+              object_id: "u188",
+              size: "5469140917",
+              memoryPercentage: "31.8345902256",
+            },
+            // Not present in the names result below: an orphaned dataflow
+            // whose object was dropped from the catalog.
+            {
+              object_id: "u999",
+              size: "424919434",
+              memoryPercentage: "11.2686157226",
+            },
+          ],
+        }),
+      }),
+      buildSqlQueryHandlerV2({
+        queryKey: clusterQueryKeys.maintainedObjectNames(["u188", "u999"]),
+        results: mapKyselyToTabular({
+          columns: objectNamesColumns,
+          rows: [
+            {
+              id: "u188",
+              name: "customer_view",
+              type: "materialized-view",
+              schemaName: "public",
+              databaseName: "materialize",
+            },
+          ],
+        }),
+      }),
+      buildValidMaterializationLagHandler({ objectIds: ["u188", "u999"] }),
+    );
+    renderComponent(
+      <LargestMaintainedQueries clusterId="u1" clusterName="quickstart" />,
+      {
+        initializeState: ({ set: initializeSet }) =>
+          setFakeEnvironment(initializeSet, defaultRegionId, environmentV2635),
+      },
+    );
+
+    expect(await screen.findByText("materialize.public")).toBeVisible();
+    expect(await screen.findByText("customer_view")).toBeVisible();
+    expect(await screen.findByText("Materialized View")).toBeVisible();
+    expect(await screen.findByText("5.09 GB (31.8%)")).toBeVisible();
+    // Objects missing from the catalog fall back to displaying their id.
+    expect(await screen.findByText("u999")).toBeVisible();
   });
 });

--- a/console/src/platform/clusters/LargestMaintainedQueries.tsx
+++ b/console/src/platform/clusters/LargestMaintainedQueries.tsx
@@ -159,6 +159,7 @@ const LargestReplicaLoader = (props: LargestMaintainedQueriesProps) => {
 };
 
 const LargestMaintainedQueriesInner = ({
+  clusterId,
   clusterName,
   replicaName,
   replicaHeapLimit,
@@ -171,6 +172,7 @@ const LargestMaintainedQueriesInner = ({
   const workflowGraphPath = useBuildWorkflowGraphPath();
 
   const { data: largestMaintainedQueries } = useLargestMaintainedQueries({
+    clusterId,
     clusterName,
     replicaName,
     replicaHeapLimit,

--- a/console/src/platform/clusters/queries.ts
+++ b/console/src/platform/clusters/queries.ts
@@ -47,7 +47,11 @@ import {
   fetchLargestClusterReplica,
   LargestClusterReplicaParams,
 } from "~/api/materialize/cluster/largestClusterReplica";
-import { fetchLargestMaintainedQueries } from "~/api/materialize/cluster/largestMaintainedQueries";
+import {
+  fetchLargestMaintainedObjectSizes,
+  fetchLargestMaintainedQueries,
+  fetchMaintainedObjectNames,
+} from "~/api/materialize/cluster/largestMaintainedQueries";
 import {
   fetchMaterializationLag,
   LagInfo,
@@ -121,7 +125,9 @@ export const clusterQueryKeys = {
       ...clusterQueryKeys.all(),
       buildQueryKeyPart("largestClusterReplica", params),
     ] as const,
-  largestMaintainedQueries: (params: UseLargestMaintainedQueriesParams) =>
+  largestMaintainedQueries: (
+    params: UseLargestMaintainedQueriesParams & { unifiedSizes: boolean },
+  ) =>
     [
       ...clusterQueryKeys.all(),
       buildQueryKeyPart("largestMaintainedQueries", params),
@@ -173,6 +179,14 @@ export const clusterQueryKeys = {
     [
       ...clusterQueryKeys.all(),
       buildQueryKeyPart("clusterFreshness", params),
+    ] as const,
+  maintainedObjectNames: (objectIds: string[]) =>
+    [
+      ...clusterQueryKeys.all(),
+      // Sort so the key tracks set membership, not the size ranking.
+      buildQueryKeyPart("maintainedObjectNames", {
+        objectIds: [...objectIds].sort().join(","),
+      }),
     ] as const,
 };
 
@@ -268,6 +282,7 @@ export function useLargestClusterReplica(params: LargestClusterReplicaParams) {
 const STRIP_DATAFLOW_PREFIX = /^Dataflow: /;
 
 export type UseLargestMaintainedQueriesParams = {
+  clusterId: string;
   clusterName: string;
   limit?: number;
   replicaName: string | undefined;
@@ -276,10 +291,19 @@ export type UseLargestMaintainedQueriesParams = {
 export function useLargestMaintainedQueries(
   params: UseLargestMaintainedQueriesParams,
 ) {
+  // mz_object_arrangement_sizes reports sizes reliably from v26.35, where
+  // they no longer go stale across replica restarts.
+  const unifiedSizes = useEnvironmentGate("26.35.0-dev") ?? false;
+  const queryClient = useQueryClient();
+  // queryClient is a stable singleton, not query input.
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps
   return useSuspenseQuery({
     refetchInterval: 60_000,
-    queryKey: clusterQueryKeys.largestMaintainedQueries(params),
-    queryFn: ({ queryKey, signal }) => {
+    queryKey: clusterQueryKeys.largestMaintainedQueries({
+      ...params,
+      unifiedSizes,
+    }),
+    queryFn: async ({ queryKey, signal }) => {
       const [, paramsFromKey] = queryKey;
       if (
         paramsFromKey.replicaHeapLimit === null ||
@@ -288,6 +312,52 @@ export function useLargestMaintainedQueries(
       )
         return null;
 
+      if (paramsFromKey.unifiedSizes) {
+        const sizes = await fetchLargestMaintainedObjectSizes({
+          queryKey,
+          params: {
+            clusterId: paramsFromKey.clusterId,
+            replicaName: paramsFromKey.replicaName,
+            replicaHeapLimit: paramsFromKey.replicaHeapLimit,
+            limit: paramsFromKey.limit ?? 10,
+          },
+          requestOptions: { signal },
+        });
+        const objectIds = sizes.rows.map((row) => row.object_id);
+        // Names are stable, so serve them from the query cache keyed by the
+        // id set: the lookup only refires when the top-N membership changes.
+        const namesById = objectIds.length
+          ? await queryClient
+              .fetchQuery({
+                queryKey: clusterQueryKeys.maintainedObjectNames(objectIds),
+                staleTime: 5 * 60_000,
+                queryFn: ({ signal: namesSignal }) =>
+                  fetchMaintainedObjectNames({
+                    objectIds,
+                    queryKey: clusterQueryKeys.maintainedObjectNames(objectIds),
+                    requestOptions: { signal: namesSignal },
+                  }),
+              })
+              .then((names) => new Map(names.rows.map((row) => [row.id, row])))
+          : undefined;
+        return {
+          ...sizes,
+          rows: sizes.rows.map((row) => {
+            const named = namesById?.get(row.object_id);
+            return {
+              id: row.object_id as string | null,
+              name: named?.name ?? null,
+              size: row.size,
+              memoryPercentage: row.memoryPercentage,
+              type: (named?.type ?? null) as "materialized-view" | "index",
+              schemaName: named?.schemaName ?? null,
+              databaseName: named?.databaseName ?? null,
+              dataflowId: null as string | null,
+              dataflowName: null as string | null,
+            };
+          }),
+        };
+      }
       return fetchLargestMaintainedQueries({
         queryKey,
         params: {
@@ -311,11 +381,14 @@ export function useLargestMaintainedQueries(
           name = row.name;
 
         if (isOrphanedDataflow) {
-          const fullyQualifiedName = row.dataflowName
+          const fullyQualifiedName = (row.dataflowName ?? "")
             .replace(STRIP_DATAFLOW_PREFIX, "")
             .split(".");
           if (fullyQualifiedName.length === 3) {
             [databaseName, schemaName, name] = fullyQualifiedName;
+          } else if (!name) {
+            // Unified rows carry no dataflow name, fall back to the object id.
+            name = row.id;
           }
         }
 

--- a/console/types/materialize.d.ts
+++ b/console/types/materialize.d.ts
@@ -2111,6 +2111,21 @@ export interface MzNoticesRedacted {
   object_id: string | null;
 }
 
+export interface MzObjectArrangementSizes {
+  /**
+   * The ID of the compute object (index or materialized view). Corresponds to `mz_objects.id`.
+   */
+  object_id: string;
+  /**
+   * The ID of the cluster replica. Corresponds to `mz_cluster_replicas.id`.
+   */
+  replica_id: string;
+  /**
+   * The total arrangement heap and batcher size in bytes for this object on this replica, rounded to the nearest 10 MiB boundary to reduce per-byte churn in the differential collection. Objects with less than 5 MiB of arrangements report a size of 0.
+   */
+  size: Int8 | null;
+}
+
 export interface MzObjectDependencies {
   /**
    * The ID of the dependent object. Corresponds to `mz_objects.id`.
@@ -4378,6 +4393,7 @@ export interface DB {
   mz_network_policy_rules: MzNetworkPolicyRules;
   mz_notices: MzNotices;
   mz_notices_redacted: MzNoticesRedacted;
+  mz_object_arrangement_sizes: MzObjectArrangementSizes;
   mz_object_dependencies: MzObjectDependencies;
   mz_object_fully_qualified_names: MzObjectFullyQualifiedNames;
   mz_object_history: MzObjectHistory;


### PR DESCRIPTION
The cluster overview's "Resource intensive objects" card ran a per-poll introspection query pinned to the customer's replica via cluster/cluster_replica session variables: nine raw-log full scans plus catalog joins, recomputed every 60s per viewer. It was the slowest query on the page (12.9s p95 in k6 against prod-analytics), and its dataflows land on the replica being inspected, right when someone is diagnosing that replica.

On Materialize >= v26.35 the card instead reads the storage-managed mz_internal.mz_object_arrangement_sizes collection: an indexed lookup on mz_catalog_server, joined against mz_cluster_replicas to resolve the replica by cluster id and name. No session variables, no work on customer replicas. Object names are fetched separately and cached by the top-N id set, so that lookup only refires when membership changes.

The gate is useEnvironmentGate("26.35.0-dev"). The collection has existed since v26.24, but only v26.35 (#37455) makes its contents trustworthy: before that, sizes went stale across replica restarts and sub-10 MiB objects were missing entirely. Queries succeed with wrong data on those versions, so the version check is the discriminator, not error handling. Gated-off environments run a rewritten introspection query that scans only the two size logs instead of mz_dataflow_arrangement_sizes' nine, itself a large improvement for older self-managed installations.

Behavior notes: collection sizes are quantized to 10 MiB (under 5 MiB reports 0); orphaned dataflows are detected by an object id missing from the catalog and display the id; a names-lookup failure fails the card rather than degrading, kept simple deliberately.


### Motivation
Fixes [CNS-116](https://linear.app/materializeinc/issue/CNS-116/fix-largest-maintained-queries-in-the-cluster-details-page)
### Verification

The fallback rewrite was proven value-identical to
mz_dataflow_arrangement_sizes with a single-timestamp EXCEPT ALL diff
on prod; the collection's top-10 matched the live introspection ground
truth exactly under the rounding contract; in k6 against prod-analytics
the card's p95 fell from 12.9s to low seconds under 100-VU saturation,
with the collection read itself returning in tens of milliseconds.