### PR TITLE
parallel-workload: add a correctness oracle for read-then-write

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -784,6 +784,80 @@ class InsertAction(Action):
         return True
 
 
+class InsertSelectAction(Action):
+    """INSERT INTO ... SELECT ... FROM ... WHERE ..., the read-dependent INSERT.
+
+    A constant VALUES list is a blind write. Only a source query over a
+    persisted collection makes the statement a read-then-write, which is the
+    branch this action exists to cover."""
+
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
+        result = super().errors_to_ignore(exe)
+        result.extend(
+            [
+                "canceling statement due to statement timeout",
+                # A random expression can evaluate to NULL (e.g. a map-key
+                # miss) even for a NOT NULL column, which is a legitimate
+                # rejection. The base list only ignores it for DDL complexity.
+                "violates not-null constraint",
+            ]
+        )
+        if exe.db.complexity == Complexity.DDL or exe.db.scenario == Scenario.Rename:
+            result.extend(
+                [
+                    "does not exist",
+                ]
+            )
+        return result
+
+    def run(self, exe: Executor) -> bool:
+        # Temp tables can only be read and written by their creating session
+        tables = [
+            table
+            for table in exe.db.tables
+            if table.num_rows < MAX_ROWS
+            and (not table.temp or table in exe.temp_objects)
+        ]
+        if not tables:
+            return False
+        table = self.rng.choice(tables)
+        # Reading the insert target itself makes the target a read dependency
+        # too, the most contended shape a read-then-write can have.
+        source = table if self.rng.choice([True, False]) else self.rng.choice(tables)
+
+        column_names = ", ".join(column.name(True) for column in table.columns)
+        # The cast is an identity cast: `expression` returns the requested type
+        # and `Column.create` declares the column with the same type name. It is
+        # there so an expression that degenerates to a bare literal projects the
+        # column's type rather than an untyped literal the INSERT would have to
+        # coerce.
+        expressions = ", ".join(
+            f"({expression(column.data_type, source.columns, self.rng, kind=ExprKind.WRITE)})::{column.data_type.name()}"
+            for column in table.columns
+        )
+        # `num_rows` can be stale, so clamp instead of trusting the filter
+        # above. The LIMIT keeps a self-insert from doubling the table on every
+        # attempt.
+        limit = self.rng.randint(1, max(1, min(100, MAX_ROWS - table.num_rows)))
+        query = (
+            f"INSERT INTO {table} ({column_names}) SELECT {expressions} FROM {source}"
+            f" WHERE {expression(Boolean, source.columns, self.rng, kind=ExprKind.WRITE)}"
+            f" LIMIT {limit}"
+        )
+        if self.rng.choice([True, False]):
+            self.stmt_id += 1
+            self.exe_prepared(query, f"insert_select{self.stmt_id}", exe)
+        else:
+            exe.execute(query, http=Http.RANDOM)
+        # The source query decides how many rows landed, and the statement may
+        # have run as a prepared statement or over HTTP/WS, where the cursor's
+        # rowcount is meaningless. Resync the estimate from the table. It only
+        # gates insert-type actions, so races with concurrent writers are fine.
+        exe.execute(f"SELECT count(*) FROM {table}", http=Http.NO)
+        table.num_rows = exe.cur.fetchall()[0][0]
+        return True
+
+
 class CopyFromStdinAction(Action):
     def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
@@ -982,6 +1056,39 @@ class UpdateAction(Action):
         else:
             exe.execute(query, http=Http.RANDOM)
         exe.insert_table = table.table_id
+        return True
+
+
+class ReadThenWriteCounterUpdateAction(Action):
+    """Increment the dedicated single-row counter with a read-then-write UPDATE.
+
+    Every worker aims at the same row, so these statements contend with each
+    other on whichever read-then-write path is enabled. Each attempt's outcome is
+    recorded so that the end-of-run check can bound the counter's value, see
+    `ReadThenWriteCounter`."""
+
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
+        return [
+            "canceling statement due to statement timeout",
+        ] + super().errors_to_ignore(exe)
+
+    def run(self, exe: Executor) -> bool:
+        counter = exe.db.read_then_write_counter
+        # pg wire only (http=Http.NO): the oracle needs an unambiguous outcome
+        # per attempt, and on the HTTP and WS paths a client-side timeout or a
+        # dropped response leaves it undecided far more often.
+        try:
+            exe.execute(f"UPDATE {counter} SET v = v + 1 WHERE id = 1", http=Http.NO)
+        except QueryError as e:
+            counter.record_failure(e.msg)
+            raise
+        except Exception:
+            # Not a query error, so there is no error text to classify. Recording
+            # it as undecided keeps the tally complete: an unrecorded attempt
+            # that did commit would break the upper bound.
+            counter.record_unknown()
+            raise
+        counter.record_committed()
         return True
 
 
@@ -3863,6 +3970,11 @@ dml_nontrans_action_list = ActionList(
         (DeleteAction, 10),
         (UpdateAction, 10),
         (InsertReturningAction, 10),
+        (InsertSelectAction, 5),
+        # Same weight as the other read-then-write actions: about a sixth of
+        # this list, often enough that every worker on it contends on the one
+        # counter row, not often enough to starve the rest of the workload.
+        (ReadThenWriteCounterUpdateAction, 10),
         # COPY FROM is oneshot ingestion, it can't run inside a transaction
         (CopyFromS3Action, 10),
         (CommentAction, 5),

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -893,6 +893,146 @@ class S3Object(DBObject):
         return self.name()
 
 
+# A fixed name, never run through `naughtify`, in `materialize.public` rather
+# than one of the workload's own databases: no action creates, renames, swaps or
+# drops that database or schema, so the name resolves for a whole run and the
+# end-of-run check is guaranteed to find the table.
+READ_THEN_WRITE_COUNTER_NAME = "materialize.public.pw_rtw_counter"
+
+# Error texts that prove an increment did not land.
+#
+# A concurrently modified dependency is what the coordinator reports when it
+# revalidates a plan before sequencing it, which is before any write. The other
+# is a cluster-resolution failure during planning, which the workload provokes
+# on purpose by pointing the default cluster at a nonexistent one, so the
+# statement never reaches a write path at all. The trailing quote keeps it from
+# matching "unknown cluster replica size" errors.
+#
+# Every other failure counts as unknown, a statement timeout and a cancellation
+# included, because either can race a commit that did happen. A wrong entry here
+# makes healthy runs fail, an unnecessary unknown only widens the upper bound.
+DEFINITELY_NOT_COMMITTED_ERRORS = (
+    "was concurrently modified",
+    "unknown cluster '",
+)
+
+
+class ReadThenWriteCounter:
+    """A single-row counter table that `ReadThenWriteCounterUpdateAction`
+    increments with read-then-write UPDATEs, plus the tallies of the outcomes its
+    workers saw.
+
+    The table is registered in none of the `Database` object lists and lives
+    outside the workload's own databases, so no other action writes to, renames,
+    alters or drops it. That is what makes it an oracle: every increment of `v`
+    comes from one recorded attempt, so
+
+        definitely_committed <= v <= definitely_committed + unknown
+
+    must hold at the end of a run. A violation means a lost update, an update
+    applied twice, a success reported for a write that never landed, or an error
+    reported for a write that did land. The lower bound is
+    dropped in the backup-restore scenario, see `validate`.
+    """
+
+    lock: threading.Lock
+    definitely_committed: int
+    definitely_not_committed: int
+    unknown: int
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.definitely_committed = 0
+        self.definitely_not_committed = 0
+        self.unknown = 0
+
+    def __str__(self) -> str:
+        return READ_THEN_WRITE_COUNTER_NAME
+
+    def create(self, exe: Executor) -> None:
+        """Creates and seeds the table, once per run.
+
+        Assumes the harness has already granted all privileges on tables to
+        PUBLIC, so that a worker which reconnected as a random role can still
+        increment the counter."""
+        exe.execute(f"DROP TABLE IF EXISTS {self} CASCADE")
+        exe.execute(f"CREATE TABLE {self} (id int, v bigint)")
+        exe.execute(f"INSERT INTO {self} VALUES (1, 0)")
+
+    def drop(self, exe: Executor) -> None:
+        exe.execute(f"DROP TABLE IF EXISTS {self} CASCADE")
+
+    def record_committed(self) -> None:
+        with self.lock:
+            self.definitely_committed += 1
+
+    def record_unknown(self) -> None:
+        with self.lock:
+            self.unknown += 1
+
+    def record_failure(self, error: str) -> None:
+        """Classifies a failed increment, see `DEFINITELY_NOT_COMMITTED_ERRORS`.
+        An error this cannot classify counts as unknown."""
+        if not any(known in error for known in DEFINITELY_NOT_COMMITTED_ERRORS):
+            self.record_unknown()
+            return
+        with self.lock:
+            self.definitely_not_committed += 1
+
+    def validate(self, exe: Executor) -> None:
+        """Checks the conservation invariant, raising if it is violated.
+
+        Must run after all workers have joined, otherwise an in-flight increment
+        can land between reading the tallies and reading the table."""
+        with self.lock:
+            committed = self.definitely_committed
+            unknown = self.unknown
+            tallies = (
+                f"definitely_committed={committed} "
+                f"definitely_not_committed={self.definitely_not_committed} "
+                f"unknown={unknown}"
+            )
+        print(f"read-then-write counter tallies: {tallies}")
+
+        # A restore rolls the whole instance back to the backup point, so
+        # increments that committed after it are gone and the lower bound does
+        # not hold in that scenario. Rolling back can only lose increments, never
+        # invent them, so the upper bound holds everywhere and stays sharp.
+        lower = 0 if exe.db.scenario == Scenario.BackupRestore else committed
+        upper = committed + unknown
+
+        # `FlipFlagsAction` points the system-wide default cluster at a
+        # nonexistent one to hunt for panics, and it can still be doing that when
+        # the run ends. This session inherits that default, so the read below
+        # needs a cluster that is certainly there. quickstart is the only one the
+        # harness guarantees: the workload creates and drops its own clusters,
+        # but never that one.
+        exe.execute("SET cluster = quickstart")
+        exe.execute(f"SELECT id, v FROM {self}")
+        rows = exe.cur.fetchall()
+        if len(rows) != 1 or rows[0][0] != 1:
+            message = (
+                f"read-then-write counter table should hold exactly the seeded row "
+                f"(1, v), "
+                f"found {rows} ({tallies})"
+            )
+            print(f"+++ {message}")
+            raise ValueError(message)
+        value = rows[0][1]
+        if not lower <= value <= upper:
+            message = (
+                f"read-then-write counter conservation invariant violated: "
+                f"observed v={value}, "
+                f"expected {lower} <= v <= {upper} ({tallies})"
+            )
+            print(f"+++ {message}")
+            raise ValueError(message)
+        print(
+            f"read-then-write counter conservation invariant holds: "
+            f"{lower} <= v={value} <= {upper}"
+        )
+
+
 class Index:
     _name: str
     schema: Schema
@@ -1042,6 +1182,7 @@ class Database:
     kafka_sink_id: int
     s3_path: int
     s3_objects: list[S3Object]
+    read_then_write_counter: ReadThenWriteCounter
     lock: threading.Lock
     seed: str
     sqlsmith_state: str
@@ -1130,6 +1271,7 @@ class Database:
         self.sql_server_source_id = len(self.sql_server_sources)
         self.iceberg_sink_id = len(self.iceberg_sinks)
         self.kafka_sink_id = len(self.kafka_sinks)
+        self.read_then_write_counter = ReadThenWriteCounter()
         self.lock = threading.Lock()
         self.sqlsmith_state = ""
         self.flags = {}
@@ -1254,6 +1396,10 @@ class Database:
                 "INSERT INTO materialize.public.repeat_row_source VALUES (1), (1), (-1), (-1), (0)"
             )
 
+        # Created and seeded exactly once per run: re-seeding mid-run would reset
+        # `v` while the workers' tallies keep growing.
+        self.read_then_write_counter.create(exe)
+
         print("Creating relations")
 
         for relation in self:
@@ -1272,6 +1418,10 @@ class Database:
         # self.sqlsmith_state = result.stdout
 
     def drop(self, exe: Executor) -> None:
+        # The counter table lives outside the workload's databases, so dropping
+        # them does not reclaim it.
+        self.read_then_write_counter.drop(exe)
+
         for db in self.dbs:
             print(f"Dropping database {db}")
             db.drop(exe)

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -416,9 +416,15 @@ def run(
     conn.autocommit = True
 
     with conn.cursor() as cur:
+        exe = Executor(rng, cur, None, database)
+
+        # Before the drop, and only now that every worker has joined, so that no
+        # increment can still be in flight.
+        database.read_then_write_counter.validate(exe)
+
         # Dropping the database also releases the long running connections
         # used by database objects.
-        database.drop(Executor(rng, cur, None, database))
+        database.drop(exe)
 
         # Make sure all unreachable connections are closed too
         gc.collect()


### PR DESCRIPTION
### Motivation

Part 1 of 7 in a stack that moves `DELETE`, `UPDATE` and `INSERT ... SELECT`
off the coordinator onto the session task, using optimistic concurrency
control. Design doc:
[`20260210_incremental_occ_read_then_write.md`](https://github.com/MaterializeInc/materialize/blob/aljoscha/occ-06-occ-path/doc/developer/design/20260210_incremental_occ_read_then_write.md)
(lands in part 6).

That change replaces mutual exclusion on a table with conflict detection
after the fact, so the interesting failure mode is a lost update: two
concurrent mutations both read the same snapshot and one silently
overwrites the other. Parallel workload had no way to notice that. It
checks for panics and unexpected errors, and its existing assertions do not
constrain the *value* a table ends up with.

### Description

`ReadThenWriteCounter` is a dedicated single-row table that every worker
increments with a read-then-write `UPDATE`, next to a Python-side tally of
how each attempt ended: definitely committed, definitely not committed, or
undecided. At the end of a run the counter's value has to satisfy
`committed <= v <= committed + unknown`. The lower bound catches a lost
write, the upper bound catches a write reported as failed that committed
anyway.

The oracle says nothing about *how* a read-then-write is sequenced, so it
holds for the coordinator's lock-based path as much as for anything that
replaces it. That is deliberate. It has to be able to pass today before it
is evidence about anything, and it stays useful after this stack lands.

`InsertSelectAction` covers the read-dependent `INSERT`. A constant `VALUES`
list is a blind write, so only a source query over a persisted collection
reaches the read-then-write branch, and pointing it at its own target is the
most contended shape such a statement can have.

### Verification

Ran parallel workload against the current lock-based path with the oracle
enabled. Nightly runs it as part of the existing parallel workload suites.
