### PR TITLE
adapter: optimizer and dyncfg cleanups for OCC read-then-write

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -281,7 +281,7 @@ impl CatalogState {
         }
 
         if update_system_config {
-            self.system_configuration.dyncfg_updates();
+            self.system_configuration.sync_dyncfgs();
         }
 
         Ok((builtin_table_updates, catalog_updates))

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -313,6 +313,17 @@ impl Catalog {
             .await;
         builtin_table_updates.extend(builtin_table_update);
 
+        // Both the `system_parameter_defaults` set above and the durable
+        // `SystemConfiguration` values applied via `pre_item_updates` live in
+        // the `SystemVars` value map by now. Mirror their effective values into
+        // the dyncfg `ConfigSet`, so that startup-only reads observe configured
+        // values rather than compile-time defaults, `ENABLE_EXPRESSION_CACHE`
+        // just below being one of them. `apply_updates` only
+        // syncs the `ConfigSet` when a `SystemConfiguration` update is present,
+        // and a deployment configured purely via `system_parameter_default` has
+        // none, so sync explicitly here.
+        state.system_config().sync_dyncfgs();
+
         // Ensure mz_system has a password if configured to have one.
         // It's important we do this after the `pre_item_updates` so that
         // the mz_system role exists in the catalog.

--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -370,11 +370,9 @@ impl Coordinator {
                 session: &session_meta,
                 catalog_state,
             };
-            let mut optimizer = optimize::view::Optimizer::new_with_prep_no_limit(
-                optimizer_config.clone(),
-                None,
-                prep,
-            );
+            let mut optimizer =
+                optimize::view::Optimizer::new_with_prep(optimizer_config.clone(), None, prep)
+                    .without_fold_constants_limit();
 
             let hir = mz_sql::plan::plan_copy_from(
                 &pcx,

--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -90,9 +90,8 @@ use crate::TimestampContext;
 /// A type for a [`DataflowDescription`] backed by `Mir~` plans. Used internally
 /// by the optimizer implementations.
 type MirDataflowDescription = DataflowDescription<OptimizedMirRelationExpr>;
-/// A type for a [`DataflowDescription`] backed by `Lir~` plans. Used internally
-/// by the optimizer implementations.
-type LirDataflowDescription = DataflowDescription<LirRelationExpr>;
+/// A type for a [`DataflowDescription`] backed by `Lir~` plans.
+pub type LirDataflowDescription = DataflowDescription<LirRelationExpr>;
 
 // Core API
 // --------

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -17,8 +17,9 @@ use differential_dataflow::lattice::Lattice;
 use mz_compute_types::ComputeInstanceId;
 use mz_compute_types::plan::LirRelationExpr;
 use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, SubscribeSinkConnection};
+use mz_expr::{ColumnOrder, MirRelationExpr};
 use mz_ore::soft_assert_or_log;
-use mz_repr::{GlobalId, Timestamp};
+use mz_repr::{GlobalId, RelationDesc, Timestamp};
 use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::{HirToMirConfig, SubscribeFrom, SubscribePlan};
 use mz_transform::TransformCtx;
@@ -114,6 +115,118 @@ impl Optimizer {
     pub fn sink_id(&self) -> GlobalId {
         self.sink_id
     }
+
+    /// The single subscribe optimization pipeline. Every subscribe, whatever it
+    /// reads from, goes through here, so a prep or metainfo step added here
+    /// applies to all of them.
+    fn optimize_inner(
+        &mut self,
+        source: SubscribeSource,
+        output: Vec<ColumnOrder>,
+    ) -> Result<GlobalMirPlan<Unresolved>, OptimizerError> {
+        let time = Instant::now();
+
+        let mut df_builder = {
+            let compute = self.compute_instance.clone();
+            DataflowBuilder::new(&*self.catalog, compute).with_config(&self.config)
+        };
+        let mut df_desc = MirDataflowDescription::new(self.debug_name.clone());
+        let mut df_meta = DataflowMetainfo::default();
+
+        let (from, from_desc) = match source {
+            SubscribeSource::Id(from_id) => {
+                let from_desc = self
+                    .catalog
+                    .get_entry(&from_id)
+                    .relation_desc()
+                    .expect("subscribes can only be run on items with descs")
+                    .into_owned();
+
+                df_builder.import_into_dataflow(&from_id, &mut df_desc, &self.config.features)?;
+
+                (from_id, from_desc)
+            }
+            SubscribeSource::Query { expr, from_desc } => {
+                // MIR ⇒ MIR optimization (local)
+                let mut transform_ctx = TransformCtx::local(
+                    &self.config.features,
+                    &self.typecheck_ctx,
+                    &mut df_meta,
+                    Some(&mut self.metrics),
+                    Some(self.view_id),
+                );
+                let expr = optimize_mir_local(expr, &mut transform_ctx)?;
+
+                df_builder.import_view_into_dataflow(
+                    &self.view_id,
+                    &expr,
+                    &mut df_desc,
+                    &self.config.features,
+                )?;
+
+                (self.view_id, from_desc)
+            }
+        };
+        df_builder.maybe_reoptimize_imported_views(&mut df_desc, &self.config)?;
+
+        // Make SinkDesc
+        let sink_description = ComputeSinkDesc {
+            from,
+            from_desc,
+            connection: ComputeSinkConnection::Subscribe(SubscribeSinkConnection { output }),
+            with_snapshot: self.with_snapshot,
+            up_to: self.up_to.map(Antichain::from_elem).unwrap_or_default(),
+            // No `FORCE NOT NULL` for subscribes
+            non_null_assertions: vec![],
+            // No `REFRESH` for subscribes
+            refresh_schedule: None,
+        };
+        df_desc.export_sink(self.sink_id, sink_description);
+
+        // Prepare expressions in the assembled dataflow.
+        let style = ExprPrepMaintained;
+        df_desc.visit_children(
+            |r| style.prep_relation_expr(r),
+            |s| style.prep_scalar_expr(s),
+        )?;
+
+        // Construct TransformCtx for global optimization.
+        let mut transform_ctx = TransformCtx::global(
+            &df_builder,
+            &mz_transform::EmptyStatisticsOracle, // TODO: wire proper stats
+            &self.config.features,
+            &self.typecheck_ctx,
+            &mut df_meta,
+            Some(&mut self.metrics),
+        );
+        // Run global optimization.
+        mz_transform::optimize_dataflow(&mut df_desc, &mut transform_ctx, false)?;
+
+        if self.config.mode == OptimizeMode::Explain {
+            // Collect the list of indexes used by the dataflow at this point.
+            trace_plan!(at: "global", &df_meta.used_indexes(&df_desc));
+        }
+
+        self.duration += time.elapsed();
+
+        // Return the (sealed) plan at the end of this optimization step.
+        Ok(GlobalMirPlan {
+            df_desc,
+            df_meta,
+            phantom: PhantomData::<Unresolved>,
+        })
+    }
+}
+
+/// What a subscribe reads from, with any HIR ⇒ MIR lowering already done.
+enum SubscribeSource {
+    /// An existing collection, imported by id.
+    Id(GlobalId),
+    /// A query, imported into the dataflow as a view under `view_id`.
+    Query {
+        expr: MirRelationExpr,
+        from_desc: RelationDesc,
+    },
 }
 
 /// The (sealed intermediate) result after:
@@ -171,122 +284,32 @@ impl Optimize<SubscribePlan> for Optimizer {
     type To = GlobalMirPlan<Unresolved>;
 
     fn optimize(&mut self, plan: SubscribePlan) -> Result<Self::To, OptimizerError> {
-        let output = plan.output;
-        let plan = plan.from;
-        let time = Instant::now();
+        let output = plan.output.row_order().to_vec();
 
-        let mut df_builder = {
-            let compute = self.compute_instance.clone();
-            DataflowBuilder::new(&*self.catalog, compute).with_config(&self.config)
-        };
-        let mut df_desc = MirDataflowDescription::new(self.debug_name.clone());
-        let mut df_meta = DataflowMetainfo::default();
-
-        match plan {
-            SubscribeFrom::Id(from_id) => {
-                let from = self.catalog.get_entry(&from_id);
-                let from_desc = from
-                    .relation_desc()
-                    .expect("subscribes can only be run on items with descs")
-                    .into_owned();
-
-                df_builder.import_into_dataflow(&from_id, &mut df_desc, &self.config.features)?;
-                df_builder.maybe_reoptimize_imported_views(&mut df_desc, &self.config)?;
-
-                // Make SinkDesc
-                let sink_description = ComputeSinkDesc {
-                    from: from_id,
-                    from_desc,
-                    connection: ComputeSinkConnection::Subscribe(SubscribeSinkConnection {
-                        output: output.row_order().to_vec(),
-                    }),
-                    with_snapshot: self.with_snapshot,
-                    up_to: self.up_to.map(Antichain::from_elem).unwrap_or_default(),
-                    // No `FORCE NOT NULL` for subscribes
-                    non_null_assertions: vec![],
-                    // No `REFRESH` for subscribes
-                    refresh_schedule: None,
-                };
-                df_desc.export_sink(self.sink_id, sink_description);
-            }
+        match plan.from {
+            SubscribeFrom::Id(from_id) => self.optimize_inner(SubscribeSource::Id(from_id), output),
             SubscribeFrom::Query { expr, desc } => {
                 // TODO: Change the `expr` type to be `HirRelationExpr` and run
                 // HIR ⇒ MIR lowering and decorrelation here. This would allow
                 // us implement something like `EXPLAIN RAW PLAN FOR SUBSCRIBE.`
                 //
                 // let typ = expr.top_level_typ();
-                // let expr = expr.lower(&self.config)?;
 
-                // MIR ⇒ MIR optimization (local)
-                let mut transform_ctx = TransformCtx::local(
-                    &self.config.features,
-                    &self.typecheck_ctx,
-                    &mut df_meta,
-                    Some(&mut self.metrics),
-                    Some(self.view_id),
-                );
-
+                // Lowering counts towards the reported optimization time, so we
+                // time it here and `optimize_inner` times the rest.
+                let time = Instant::now();
                 let expr = expr.lower(HirToMirConfig::from(&self.config), None)?;
-                let expr = optimize_mir_local(expr, &mut transform_ctx)?;
+                self.duration += time.elapsed();
 
-                df_builder.import_view_into_dataflow(
-                    &self.view_id,
-                    &expr,
-                    &mut df_desc,
-                    &self.config.features,
-                )?;
-                df_builder.maybe_reoptimize_imported_views(&mut df_desc, &self.config)?;
-
-                // Make SinkDesc
-                let sink_description = ComputeSinkDesc {
-                    from: self.view_id,
-                    from_desc: desc.clone(),
-                    connection: ComputeSinkConnection::Subscribe(SubscribeSinkConnection {
-                        output: output.row_order().to_vec(),
-                    }),
-                    with_snapshot: self.with_snapshot,
-                    up_to: self.up_to.map(Antichain::from_elem).unwrap_or_default(),
-                    // No `FORCE NOT NULL` for subscribes
-                    non_null_assertions: vec![],
-                    // No `REFRESH` for subscribes
-                    refresh_schedule: None,
-                };
-                df_desc.export_sink(self.sink_id, sink_description);
+                self.optimize_inner(
+                    SubscribeSource::Query {
+                        expr,
+                        from_desc: desc,
+                    },
+                    output,
+                )
             }
-        };
-
-        // Prepare expressions in the assembled dataflow.
-        let style = ExprPrepMaintained;
-        df_desc.visit_children(
-            |r| style.prep_relation_expr(r),
-            |s| style.prep_scalar_expr(s),
-        )?;
-
-        // Construct TransformCtx for global optimization.
-        let mut transform_ctx = TransformCtx::global(
-            &df_builder,
-            &mz_transform::EmptyStatisticsOracle, // TODO: wire proper stats
-            &self.config.features,
-            &self.typecheck_ctx,
-            &mut df_meta,
-            Some(&mut self.metrics),
-        );
-        // Run global optimization.
-        mz_transform::optimize_dataflow(&mut df_desc, &mut transform_ctx, false)?;
-
-        if self.config.mode == OptimizeMode::Explain {
-            // Collect the list of indexes used by the dataflow at this point.
-            trace_plan!(at: "global", &df_meta.used_indexes(&df_desc));
         }
-
-        self.duration += time.elapsed();
-
-        // Return the (sealed) plan at the end of this optimization step.
-        Ok(GlobalMirPlan {
-            df_desc,
-            df_meta,
-            phantom: PhantomData::<Unresolved>,
-        })
     }
 }
 

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -53,23 +53,19 @@ pub struct Optimizer<S> {
 
 impl Optimizer<ExprPrepNoop> {
     /// Creates an optimizer instance that does not perform any expression
-    /// preparation. Additionally, this instance calls constant folding with a size limit.
+    /// preparation.
     pub fn new(config: OptimizerConfig, metrics: Option<OptimizerMetrics>) -> Self {
-        Self {
-            typecheck_ctx: empty_typechecking_context(),
-            config,
-            metrics,
-            expr_prep_style: ExprPrepNoop,
-            fold_constants_limit: true,
-        }
+        Self::new_with_prep(config, metrics, ExprPrepNoop)
     }
 }
 
 impl<S> Optimizer<S> {
     /// Creates an optimizer instance that takes an [`ExprPrep`] to handle
-    /// unmaterializable functions. Additionally, this instance calls constant
-    /// folding without a size limit.
-    pub fn new_with_prep_no_limit(
+    /// unmaterializable functions.
+    ///
+    /// Constant folding runs with the usual size limit, see
+    /// [`Self::without_fold_constants_limit`].
+    pub fn new_with_prep(
         config: OptimizerConfig,
         metrics: Option<OptimizerMetrics>,
         expr_prep_style: S,
@@ -79,8 +75,15 @@ impl<S> Optimizer<S> {
             config,
             metrics,
             expr_prep_style,
-            fold_constants_limit: false,
+            fold_constants_limit: true,
         }
+    }
+
+    /// Folds constants of any size, instead of giving up above the configured
+    /// limit.
+    pub fn without_fold_constants_limit(mut self) -> Self {
+        self.fold_constants_limit = false;
+        self
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2052,6 +2052,10 @@ impl SystemVars {
         *self.expect_value(&SCRAM_ITERATIONS)
     }
 
+    /// Computes an update for every dyncfg from its configured value.
+    ///
+    /// This does not touch our own [`ConfigSet`]. Callers that need this
+    /// process's dyncfgs to reflect the result want [`Self::sync_dyncfgs`].
     pub fn dyncfg_updates(&self) -> ConfigUpdates {
         let mut updates = ConfigUpdates::default();
         for entry in self.dyncfgs.entries() {
@@ -2079,6 +2083,18 @@ impl SystemVars {
             };
             updates.add_dynamic(entry.name(), val);
         }
+        updates
+    }
+
+    /// Applies the configured dyncfg values to our own [`ConfigSet`], and
+    /// returns them.
+    ///
+    /// Two callers own keeping this process's dyncfgs in step with the
+    /// catalog: catalog open, and every durable system-config change. Everyone
+    /// else only forwards the updates elsewhere and wants
+    /// [`Self::dyncfg_updates`] instead.
+    pub fn sync_dyncfgs(&self) -> ConfigUpdates {
+        let updates = self.dyncfg_updates();
         updates.apply(&self.dyncfgs);
         updates
     }


### PR DESCRIPTION
### Motivation

Part 2 of 7 in a stack that moves `DELETE`, `UPDATE` and `INSERT ... SELECT`
off the coordinator onto the session task, using optimistic concurrency
control.

Two independent cleanups that the later parts need, both of which stand on
their own. The first is a live bug.

Closes [SQL-588](https://linear.app/materializeinc/issue/SQL-588)

### Description

**`ConfigSet` sync at catalog open.** `apply_updates` only mirrors
`SystemVars` into the dyncfg `ConfigSet` when a durable
`SystemConfiguration` update is present. A deployment that configures a
parameter purely through `system_parameter_default` has no such update, so
nothing syncs, and anything reading that dyncfg during bootstrap sees the
compile-time default instead of the configured value. `ENABLE_EXPRESSION_CACHE`
is read a few lines below and is affected today. Syncing the effective
values once, after both the defaults and the durable configuration are in
the map, fixes every such read.

**One subscribe optimization pipeline.** Subscribe optimization had two
entry points that differed only in whether the source was a query or an
existing id, and each rebuilt the same pipeline around that one decision.
Both rebuilt the same `SinkDesc` verbatim, down to the same three comments,
and differed only in whether the source needed HIR lowering first. Taking the source as a `SubscribeSource` and the output shape as a
parameter leaves the pipeline in one place. The view optimizer's
expression-preparation variants collapse the same way, into one constructor
plus a builder method for the constant folding limit.

The dyncfg commit also splits `dyncfg_updates`, which computed the updates
and applied them to its own `ConfigSet` in one method. The only two callers
of the applying behavior are the ones that discard the result, so the call
sites read like a getter whose value is thrown away, and a later change
making the getter pure would compile cleanly while silently reintroducing
the bug. `sync_dyncfgs` names that intent. The six callers that forward the
updates to metrics or the controllers keep the pure `dyncfg_updates`.

### Verification

Existing subscribe and `COPY FROM` coverage. No behavior change is intended
for the optimizer part. The dyncfg change is observable as
`ENABLE_EXPRESSION_CACHE` now taking effect when set only via
`system_parameter_default`.


