### PR TITLE
adapter: add internal subscribes for reading a mutation's input

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -96,6 +96,12 @@ metrics:
   - session_type
   source: src/adapter/src/metrics.rs
   visibility: internal
+- name: mz_active_internal_subscribes
+  help: The number of active internal subscribes, which serve frontend-sequenced read-then-write.
+  labels:
+  - session_type
+  source: src/adapter/src/metrics.rs
+  visibility: internal
 - name: mz_active_sessions
   help: The number of active coordinator sessions.
   labels:

--- a/src/adapter/src/coord/read_then_write.rs
+++ b/src/adapter/src/coord/read_then_write.rs
@@ -8,14 +8,24 @@
 // by the Apache License, Version 2.0.
 
 //! Coordinator-side support machinery for (frontend) read-then write.
+//!
+//! TODO(aljoscha): Write submission still goes through the coordinator. In the
+//! long run we want a group-commit task that runs independently, so that
+//! session tasks can submit write requests to it directly.
 
 use std::collections::BTreeSet;
 
 use mz_catalog::memory::objects::CatalogItem;
 use mz_repr::CatalogItemId;
+use mz_repr::{GlobalId, Timestamp};
 use mz_sql::catalog::CatalogItemType;
+use mz_sql::plan::SubscribeOutput;
+use tokio::sync::mpsc;
 
+use crate::PeekResponseUnary;
+use crate::active_compute_sink::{ActiveComputeSink, ActiveSubscribe};
 use crate::catalog::Catalog;
+use crate::coord::Coordinator;
 use crate::error::AdapterError;
 
 /// Adds `id` to the worklist the first time it is seen, enforcing the
@@ -39,6 +49,102 @@ fn enqueue(
         stack.push(id);
     }
     Ok(())
+}
+
+// Every handler here is driven by the read-then-write path, which lands later
+// in this stack. This attribute goes away with it.
+#[allow(dead_code)]
+impl Coordinator {
+    /// Creates a subscribe that introspection does not see.
+    ///
+    /// Takes ownership of `read_holds` and drops them only once the dataflow is
+    /// shipped, so the `since` cannot advance past `as_of` in between.
+    ///
+    /// Answers through `response_tx`, with an error if the connection went away
+    /// or if a dependency was dropped since the plan was optimized.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn handle_create_internal_subscribe(
+        &mut self,
+        df_desc: crate::optimize::LirDataflowDescription,
+        cluster_id: mz_compute_types::ComputeInstanceId,
+        replica_id: Option<mz_cluster_client::ReplicaId>,
+        depends_on: BTreeSet<GlobalId>,
+        as_of: Timestamp,
+        arity: usize,
+        sink_id: GlobalId,
+        conn_id: mz_adapter_types::connection::ConnectionId,
+        session_uuid: uuid::Uuid,
+        start_time: mz_ore::now::EpochMillis,
+        read_holds: crate::ReadHolds,
+        response_tx: tokio::sync::oneshot::Sender<
+            Result<mpsc::UnboundedReceiver<PeekResponseUnary>, AdapterError>,
+        >,
+    ) {
+        // Client disconnected while waiting for the semaphore.
+        if !self.active_conns.contains_key(&conn_id) {
+            let _ = response_tx.send(Err(AdapterError::Canceled));
+            return;
+        }
+
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        let active_subscribe = ActiveSubscribe {
+            conn_id: conn_id.clone(),
+            session_uuid,
+            channel: tx,
+            emit_progress: true, // We need progress updates for OCC
+            as_of,
+            arity,
+            cluster_id,
+            depends_on,
+            start_time,
+            output: SubscribeOutput::Diffs,
+            internal: true, // no mz_subscriptions row and no active-subscribes metric
+        };
+        active_subscribe.initialize();
+
+        // Ship the dataflow before registering the sink, so a failure has
+        // nothing to unwind.
+        //
+        // Creation can fail here: the plan was optimized against a catalog
+        // snapshot taken off the coordinator loop, so a dependency can be
+        // dropped before this message is handled. That makes it a conflict to
+        // report rather than an invariant violation, hence `try_ship_dataflow`.
+        if let Err(err) = self
+            .try_ship_dataflow(df_desc, cluster_id, replica_id)
+            .await
+        {
+            let _ = response_tx.send(Err(
+                AdapterError::concurrent_dependency_drop_from_dataflow_creation_error(err),
+            ));
+            return;
+        }
+
+        self.add_active_compute_sink(sink_id, ActiveComputeSink::Subscribe(active_subscribe))
+            .await;
+
+        if response_tx.send(Ok(rx)).is_err() {
+            // The receiver is gone, so cancellation or a statement timeout
+            // dropped the caller's future between the command being sent and
+            // this handler running. Retire the sink here, rather than leave a
+            // dataflow running against a closed channel. The cancel path
+            // retires it too, but only because its command is queued behind
+            // ours, and that ordering is not ours to depend on.
+            self.drop_internal_subscribe(sink_id).await;
+            return;
+        }
+
+        // Drop read holds only after `ship_dataflow` returns, so the since
+        // can't advance past `as_of` before the dataflow is running.
+        drop(read_holds);
+    }
+
+    /// Drop an internal subscribe.
+    pub(crate) async fn drop_internal_subscribe(&mut self, sink_id: GlobalId) {
+        // Use drop_compute_sink instead of remove_active_compute_sink to also
+        // cancel the dataflow on the compute side, not just remove bookkeeping.
+        let _ = self.drop_compute_sink(sink_id).await;
+    }
 }
 
 /// Validates that all dependencies are valid for read-then-write operations.

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -280,7 +280,20 @@ impl Coordinator {
 
         let ret_fut: BuiltinTableAppendNotify = match &active_sink {
             ActiveComputeSink::Subscribe(active_subscribe) => {
-                let table_update_fut = if !active_subscribe.internal {
+                if active_subscribe.internal {
+                    // An internal subscribe writes no `mz_subscriptions` row, so
+                    // it stays out of the public `mz_active_subscribes` gauge
+                    // too. Counting it there would report subscribes that
+                    // introspection deliberately shows nothing of. It gets its
+                    // own internal gauge instead, since it is still a dataflow
+                    // holding cluster resources.
+                    self.metrics
+                        .active_internal_subscribes
+                        .with_label_values(&[session_type])
+                        .inc();
+
+                    Box::pin(std::future::ready(()))
+                } else {
                     let update = self.catalog().state().pack_subscribe_update(
                         id,
                         active_subscribe,
@@ -288,23 +301,18 @@ impl Coordinator {
                     );
                     let update = self.catalog().state().resolve_builtin_table_update(update);
 
+                    self.metrics
+                        .active_subscribes
+                        .with_label_values(&[session_type])
+                        .inc();
+
                     // Defer the introspection-row write to a group commit instead of
                     // committing it inline. An inline `execute` would block the coordinator
                     // loop on a timestamp-oracle round trip and stall every other session.
                     // `implement_subscribe` waits for this write before returning the
                     // `SUBSCRIBE` response to the subscribing session.
                     self.builtin_table_update().defer(vec![update])
-                } else {
-                    // Internal subscribes skip the builtin table update.
-                    Box::pin(std::future::ready(()))
-                };
-
-                self.metrics
-                    .active_subscribes
-                    .with_label_values(&[session_type])
-                    .inc();
-
-                table_update_fut
+                }
             }
             ActiveComputeSink::CopyTo(_) => {
                 self.metrics
@@ -348,30 +356,36 @@ impl Coordinator {
 
             let write_notify: BuiltinTableAppendNotify = match &sink {
                 ActiveComputeSink::Subscribe(active_subscribe) => {
-                    // Internal subscribes write no introspection row.
-                    let notify = if !active_subscribe.internal {
+                    if active_subscribe.internal {
+                        // No introspection row to retract, see
+                        // `add_active_compute_sink`. The internal gauge is
+                        // decremented here to stay symmetric with it.
+                        self.metrics
+                            .active_internal_subscribes
+                            .with_label_values(&[session_type])
+                            .dec();
+
+                        Box::pin(std::future::ready(()))
+                    } else {
                         let update = self.catalog().state().pack_subscribe_update(
                             id,
                             active_subscribe,
                             Diff::MINUS_ONE,
                         );
                         let update = self.catalog().state().resolve_builtin_table_update(update);
+
+                        self.metrics
+                            .active_subscribes
+                            .with_label_values(&[session_type])
+                            .dec();
+
                         // Defer the retraction to a group commit, for the same reason we
                         // defer the insert (see `add_active_compute_sink`): committing inline
                         // would block the coordinator loop. Callers that expose the
                         // retirement wait on the notify off the coordinator loop
                         // before responding.
                         self.builtin_table_update().defer(vec![update])
-                    } else {
-                        Box::pin(std::future::ready(()))
-                    };
-
-                    self.metrics
-                        .active_subscribes
-                        .with_label_values(&[session_type])
-                        .dec();
-
-                    notify
+                    }
                 }
                 ActiveComputeSink::CopyTo(_) => {
                     self.metrics

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -21,6 +21,7 @@ pub struct Metrics {
     pub query_total: IntCounterVec,
     pub active_sessions: IntGaugeVec,
     pub active_subscribes: IntGaugeVec,
+    pub active_internal_subscribes: IntGaugeVec,
     pub active_copy_tos: IntGaugeVec,
     pub queue_busy_seconds: Histogram,
     pub determine_timestamp: IntCounterVec,
@@ -85,6 +86,11 @@ impl Metrics {
                 var_labels: ["session_type"],
                 visibility: MetricVisibility::Public,
                 tags: [MetricTag::Environment],
+            )),
+            active_internal_subscribes: registry.register(metric!(
+                name: "mz_active_internal_subscribes",
+                help: "The number of active internal subscribes, which serve frontend-sequenced read-then-write.",
+                var_labels: ["session_type"],
             )),
             active_copy_tos: registry.register(metric!(
                 name: "mz_active_copy_tos",


### PR DESCRIPTION
### Motivation

Part 5 of 7 in a stack that moves `DELETE`, `UPDATE` and `INSERT ... SELECT`
off the coordinator onto the session task, using optimistic concurrency
control. Design doc:
[`20260210_incremental_occ_read_then_write.md`](https://github.com/MaterializeInc/materialize/blob/aljoscha/occ-06-occ-path/doc/developer/design/20260210_incremental_occ_read_then_write.md)
(lands in part 6).

A read-then-write sequenced off the coordinator needs to observe its
selection as it changes, and stream the mutation's diffs rather than peek
every matched row and recompute them. A subscribe already does exactly that.
What it must not do is *appear* to be one.

Closes [SQL-591](https://linear.app/materializeinc/issue/SQL-591)

### Description

An internal subscribe writes no `mz_subscriptions` row and does not move the
active-subscribes gauge, so introspection keeps showing only the subscribes a
user started.

Creation is fallible, and that is the substantive difference from the
coordinator's own read-then-write path. Here the dataflow is optimized
against a catalog snapshot on the session task and shipped when the
coordinator handles the message, and a `DROP` of a dependency can land in
that window. The coordinator optimizes and ships in one turn of its loop and
has no such window, which is why it can treat creation as infallible. So this
returns `ConcurrentDependencyDrop` for the session to report, the same answer
the frontend peek path already gives. Shipping precedes registering the sink,
so a failure has nothing to unwind, which costs no concurrency because an
internal subscribe's registration writes no introspection row.

Read holds are passed through the stages rather than kept in the
connection-keyed `txn_read_holds` map, so concurrent operations on one
connection cannot interfere with each other's holds, and they are released
only once the dataflow is installed.

**Temporary scaffolding.** Nothing calls these handlers until part 6, so a
`dead_code` allowance keeps the crate warning-free. Part 6 removes it in the
same commit that adds the callers.

### Verification

No caller yet, so this part is carried by the tests in parts 6 and 7. Part 6
includes a test that a dependency dropped underneath a running read-then-write
produces a retryable error rather than a coordinator panic.

