### PR TITLE
adapter: stage a blind read-then-write, let a read-dependent one stand alone

### DIFF
--- a/doc/developer/design/20260210_incremental_occ_read_then_write.md
+++ b/doc/developer/design/20260210_incremental_occ_read_then_write.md
@@ -49,9 +49,13 @@ a subscribe that continually tracks the current state of the data.
 - Removing the in-process locks immediately. During rollout, the old lock-based
   path and the new OCC path coexist behind a feature flag. The locks can be
   removed once the OCC path is fully rolled out.
-- Mixed read/write transactions. A write on this path commits at the frontier it
-  observed, which it cannot postpone until COMMIT, so it runs only as a single
-  statement.
+- Mixed read/write transactions. A write that reads persisted state commits at
+  the frontier it observed, which it cannot postpone until COMMIT, so it runs
+  only as a single statement. A write that reads nothing does compose with
+  transactions: its diffs are frontier-independent, so they are buffered as
+  session write ops and land when the transaction commits. That covers, for
+  example, `INSERT INTO t SELECT generate_series(1, 20000)`, whose values are
+  constant but too large to fold into a literal.
 
 ## Overview
 

--- a/doc/developer/design/20260210_incremental_occ_read_then_write.md
+++ b/doc/developer/design/20260210_incremental_occ_read_then_write.md
@@ -336,6 +336,20 @@ that the next reader does not take them for bugs.
   because it hands the read-then-write's inner peek a trivial logging context
   and so logs nothing for it. We keep the extra event, it is real information
   about a statement the user did run.
+- **`execution_timestamp` for a write that reads.** The frontend path records an
+  `execution_timestamp` in `mz_statement_execution_history` for a read-then-write
+  that reads persisted state, the coordinator path leaves it NULL. The OCC loop
+  picks the write timestamp inside the statement's lifetime, so there is
+  something true to record. The coordinator stages the diffs instead, and the
+  statement retires before the commit that gives them a timestamp, so nothing
+  back-fills it. We keep the frontend's: it is accurate, it is additive, and a
+  query that tolerates NULL today keeps working. Enabling the path therefore
+  starts populating the column for `UPDATE`, `DELETE` and `INSERT ... SELECT`.
+- **`execution_timestamp` for a write that reads nothing (parity).** Such a
+  write stages its rows on both paths, so its rows take the transaction's commit
+  timestamp rather than one the statement chose, and neither path records
+  anything. `test_statement_logging_dml_path_parity` pins both of these cases,
+  so the divergence above cannot spread to the rest by accident.
 - **`max_result_size` accounting.** The coordinator sums one row length per diff
   entry before consolidation. The frontend recomputes the total from the
   consolidated set, which counts one row length per distinct row and ignores

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -117,7 +117,8 @@ pub const PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION: Config<Dura
 pub const ENABLE_EXPRESSION_CACHE: Config<bool> = Config::new(
     "enable_expression_cache",
     true,
-    "Use a cache to store optimized expressions to help speed up start times.",
+    "Use a cache to store optimized expressions to help speed up start times. \
+     Read at startup, so changing it takes effect on the next restart.",
 );
 
 /// Whether to enable password authentication.
@@ -416,7 +417,8 @@ pub const FRONTEND_READ_THEN_WRITE: Config<bool> = Config::new(
     "enable_adapter_frontend_occ_read_then_write",
     false,
     "Use frontend sequencing (with optimistic concurrency control) for \
-     DELETE, UPDATE, and INSERT operations.",
+     DELETE, UPDATE, and INSERT operations. Read at startup, so changing it \
+     takes effect on the next restart.",
 );
 
 /// Adds the full set of all adapter `Config`s.

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1957,7 +1957,9 @@ impl SessionClient {
         // execute a dataflow for a statement we would then refuse.
         {
             let session = self.session.as_ref().expect("SessionClient invariant");
-            let in_transaction = session.transaction().is_effectively_multi_statement();
+            let in_transaction = session
+                .transaction()
+                .may_share_transaction_with_other_statements();
             let depends_on = rtw_plan.selection.depends_on();
             if in_transaction && !depends_on.is_empty() {
                 // Everything that holds wherever the statement runs is reported

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1942,26 +1942,24 @@ impl SessionClient {
             }
         };
 
-        // Only single-statement (`Started` without staged write ops)
-        // transactions may enter the OCC loop, its writes commit immediately
-        // and cannot be rolled back at transaction end. Multi-statement
-        // transactions reach this point only for AST-constant INSERTs whose
-        // planned expression turned out non-constant. Match the coordinator's
-        // error precedence: `mz_now()` gets its dedicated error, everything
-        // else is prohibited in a transaction block. The coordinator's
-        // lock-based path additionally supports INSERTs of volatile constants
-        // (for example `random()`) in transaction blocks by buffering the diffs
-        // until commit, which the OCC path cannot do.
+        // The syntactic predicate for "reads persisted state", see the module
+        // docs on `frontend_read_then_write`. Inside a transaction, only a write
+        // that reads nothing can run on this path.
+        //
+        // The AST gate above is not enough to establish this. It admits
+        // INSERTs whose source is constant in the AST, and such a statement can
+        // still plan to a selection with `Get` nodes, because SQL-implemented
+        // builtins (`pg_get_viewdef`, `text` to `reg*` casts, ...) read system
+        // relations. So decide on the planned selection, and do it before we
+        // execute a dataflow for a statement we would then refuse.
         {
             let session = self.session.as_ref().expect("SessionClient invariant");
-            let single_statement = matches!(session.transaction(), TransactionStatus::Started(_))
-                && !session.transaction().contains_ops();
-            if !single_statement {
-                if crate::frontend_read_then_write::contains_mz_now(&rtw_plan) {
-                    return Err(AdapterError::Unsupported(
-                        "calls to mz_now in write statements",
-                    ));
-                }
+            // `is_in_multi_statement_transaction` reports false for `Started`,
+            // but an extended-protocol pipeline stays `Started` while it
+            // accumulates write ops, and this statement runs alongside them.
+            let in_transaction = session.transaction().is_in_multi_statement_transaction()
+                || session.transaction().contains_ops();
+            if in_transaction && !rtw_plan.selection.depends_on().is_empty() {
                 return Err(prohibited_in_transaction(&stmt));
             }
         }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -65,7 +65,9 @@ use crate::command::{
 use crate::config::{ScopedParameters, ScopedParametersScope, SystemParameterFrontend};
 use crate::coord::{Coordinator, ExecuteContextGuard};
 use crate::error::AdapterError;
-use crate::frontend_read_then_write::{FrontendWriteAttemptState, FrontendWriteCancellation};
+use crate::frontend_read_then_write::{
+    FrontendWriteAttemptState, FrontendWriteCancellation, contains_mz_now,
+};
 use crate::metrics::Metrics;
 use crate::optimize::dataflows::{EvalTime, ExprPrepOneShot};
 use crate::optimize::{self, Optimize, OptimizerError};
@@ -1956,6 +1958,20 @@ impl SessionClient {
             let session = self.session.as_ref().expect("SessionClient invariant");
             let in_transaction = session.transaction().is_effectively_multi_statement();
             if in_transaction && !rtw_plan.selection.depends_on().is_empty() {
+                // `mz_now` outranks the transaction state, matching the lock
+                // path, which admits this class of statement past its own
+                // transaction gate and then reports `mz_now` while sequencing
+                // it. Both errors are reachable from one statement: the AST gate
+                // above admits an INSERT whose values are constant to the
+                // parser, and such a statement can carry both `mz_now()` and a
+                // builtin that reads a system relation. Reporting the
+                // transaction would be the worse answer of the two, because it
+                // suggests the statement works outside a transaction.
+                if contains_mz_now(&rtw_plan) {
+                    return Err(AdapterError::Unsupported(
+                        "calls to mz_now in write statements",
+                    ));
+                }
                 return Err(prohibited_in_transaction(&stmt));
             }
         }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -67,6 +67,7 @@ use crate::coord::{Coordinator, ExecuteContextGuard};
 use crate::error::AdapterError;
 use crate::frontend_read_then_write::{
     FrontendWriteAttemptState, FrontendWriteCancellation, contains_mz_now,
+    validate_selection_dependencies,
 };
 use crate::metrics::Metrics;
 use crate::optimize::dataflows::{EvalTime, ExprPrepOneShot};
@@ -1957,21 +1958,21 @@ impl SessionClient {
         {
             let session = self.session.as_ref().expect("SessionClient invariant");
             let in_transaction = session.transaction().is_effectively_multi_statement();
-            if in_transaction && !rtw_plan.selection.depends_on().is_empty() {
-                // `mz_now` outranks the transaction state, matching the lock
-                // path, which admits this class of statement past its own
-                // transaction gate and then reports `mz_now` while sequencing
-                // it. Both errors are reachable from one statement: the AST gate
-                // above admits an INSERT whose values are constant to the
-                // parser, and such a statement can carry both `mz_now()` and a
-                // builtin that reads a system relation. Reporting the
-                // transaction would be the worse answer of the two, because it
-                // suggests the statement works outside a transaction.
+            let depends_on = rtw_plan.selection.depends_on();
+            if in_transaction && !depends_on.is_empty() {
+                // Everything that holds wherever the statement runs is reported
+                // before the transaction state, which only holds here. A
+                // statement carrying `mz_now` or reading a system table never
+                // works, so answering with the transaction suggests it would
+                // work outside one. The lock path reports these two the same
+                // way, since its own transaction gate admits this class of
+                // statement and leaves both to sequencing.
                 if contains_mz_now(&rtw_plan) {
                     return Err(AdapterError::Unsupported(
                         "calls to mz_now in write statements",
                     ));
                 }
+                validate_selection_dependencies(&catalog, &depends_on)?;
                 return Err(prohibited_in_transaction(&stmt));
             }
         }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1954,11 +1954,7 @@ impl SessionClient {
         // execute a dataflow for a statement we would then refuse.
         {
             let session = self.session.as_ref().expect("SessionClient invariant");
-            // `is_in_multi_statement_transaction` reports false for `Started`,
-            // but an extended-protocol pipeline stays `Started` while it
-            // accumulates write ops, and this statement runs alongside them.
-            let in_transaction = session.transaction().is_in_multi_statement_transaction()
-                || session.transaction().contains_ops();
+            let in_transaction = session.transaction().is_effectively_multi_statement();
             if in_transaction && !rtw_plan.selection.depends_on().is_empty() {
                 return Err(prohibited_in_transaction(&stmt));
             }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1962,13 +1962,12 @@ impl SessionClient {
                 .may_share_transaction_with_other_statements();
             let depends_on = rtw_plan.selection.depends_on();
             if in_transaction && !depends_on.is_empty() {
-                // Everything that holds wherever the statement runs is reported
-                // before the transaction state, which only holds here. A
-                // statement carrying `mz_now` or reading a system table never
-                // works, so answering with the transaction suggests it would
-                // work outside one. The lock path reports these two the same
-                // way, since its own transaction gate admits this class of
-                // statement and leaves both to sequencing.
+                // Report the reasons that hold wherever the statement runs
+                // before the one that holds only here. A statement carrying
+                // `mz_now`, or reading a system table, never works anywhere.
+                // Answering with the transaction state names the one condition
+                // the caller could remove, which tells them to retry outside a
+                // transaction and get the same refusal again.
                 if contains_mz_now(&rtw_plan) {
                     return Err(AdapterError::Unsupported(
                         "calls to mz_now in write statements",

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -20,7 +20,9 @@ use futures::{Future, StreamExt, future};
 use itertools::Itertools;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
-use mz_adapter_types::dyncfgs::{ENABLE_PASSWORD_AUTH, READ_THEN_WRITE_MAX_DEPENDENCIES};
+use mz_adapter_types::dyncfgs::{
+    ENABLE_PASSWORD_AUTH, FRONTEND_READ_THEN_WRITE, READ_THEN_WRITE_MAX_DEPENDENCIES,
+};
 use mz_catalog::memory::error::ErrorKind;
 use mz_catalog::memory::objects::{
     CatalogItem, Connection, DataSourceDesc, Sink, Source, Table, TableDataSource, Type,
@@ -75,7 +77,7 @@ use mz_sql::plan::{
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::user::UserKind;
 use mz_sql::session::vars::{
-    self, IsolationLevel, NETWORK_POLICY, OwnedVarInput, SCHEMA_ALIAS,
+    self, IsolationLevel, MAX_CONCURRENT_OCC_WRITES, NETWORK_POLICY, OwnedVarInput, SCHEMA_ALIAS,
     TRANSACTION_ISOLATION_VAR_NAME, Var, VarError, VarInput,
 };
 use mz_sql::{plan, rbac};
@@ -4235,6 +4237,7 @@ impl Coordinator {
         };
         self.catalog_transact(Some(session), vec![op]).await?;
 
+        Self::notice_if_startup_only(session, &name);
         session.add_notice(AdapterNotice::VarDefaultUpdated {
             role: None,
             var_name: Some(name),
@@ -4251,6 +4254,7 @@ impl Coordinator {
         self.is_user_allowed_to_alter_system(session, Some(&name))?;
         let op = catalog::Op::ResetSystemConfiguration { name: name.clone() };
         self.catalog_transact(Some(session), vec![op]).await?;
+        Self::notice_if_startup_only(session, &name);
         session.add_notice(AdapterNotice::VarDefaultUpdated {
             role: None,
             var_name: Some(name),
@@ -4265,13 +4269,77 @@ impl Coordinator {
         _: plan::AlterSystemResetAllPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.is_user_allowed_to_alter_system(session, None)?;
+        // Which parameters `RESET ALL` changes has to be read before the
+        // transaction applies it, afterwards they all read as their default.
+        let startup_only_changed = self.startup_only_vars_changed_by_reset_all();
         let op = catalog::Op::ResetAllSystemConfiguration;
         self.catalog_transact(Some(session), vec![op]).await?;
+        for name in startup_only_changed {
+            session.add_notice(AdapterNotice::StartupOnlyVarUpdated {
+                var_name: name.to_string(),
+            });
+        }
         session.add_notice(AdapterNotice::VarDefaultUpdated {
             role: None,
             var_name: None,
         });
         Ok(ExecuteResponse::AlteredSystemConfiguration)
+    }
+
+    /// System parameters whose value `environmentd` samples once at startup.
+    ///
+    /// `enable_adapter_frontend_occ_read_then_write` selects between the
+    /// lock-based and the OCC read-then-write path. Both are never live in one
+    /// process, so the choice is fixed at boot and every session inherits it.
+    /// `max_concurrent_occ_writes` sizes the OCC semaphore at boot.
+    ///
+    /// `ALTER SYSTEM` on one of these is allowed to go through. The catalog
+    /// value is what the next process start reads, and the running process
+    /// cannot observe it, so there is no window where two code paths are live at
+    /// once.
+    fn startup_only_vars() -> [&'static str; 2] {
+        [
+            FRONTEND_READ_THEN_WRITE.name(),
+            MAX_CONCURRENT_OCC_WRITES.name(),
+        ]
+    }
+
+    /// Warns that `name` is only read at startup, so the running process keeps
+    /// the value it sampled at boot.
+    fn notice_if_startup_only(session: &Session, name: &str) {
+        if Self::startup_only_vars()
+            .iter()
+            .any(|n| n.eq_ignore_ascii_case(name))
+        {
+            session.add_notice(AdapterNotice::StartupOnlyVarUpdated {
+                var_name: name.to_string(),
+            });
+        }
+    }
+
+    /// The startup-only parameters whose value `ALTER SYSTEM RESET ALL` would
+    /// change. Parameters already at their effective default are untouched, so
+    /// they are not reported.
+    fn startup_only_vars_changed_by_reset_all(&self) -> Vec<&'static str> {
+        // Value-based, unlike `notice_if_startup_only`, which warns whenever an
+        // operator names one of these parameters. `RESET ALL` names every
+        // parameter, so only a value that actually moves is worth a warning.
+        let config = self.catalog().system_config();
+        let defaults = config.defaults();
+        Self::startup_only_vars()
+            .into_iter()
+            .filter(|name| {
+                // Both names are registered system vars, a lookup failure
+                // would mean the definitions and this list have drifted apart.
+                let current = config
+                    .get(name)
+                    .expect("startup-only parameter is a registered system var")
+                    .value();
+                defaults
+                    .get(*name)
+                    .is_some_and(|default| default != &current)
+            })
+            .collect()
     }
 
     // TODO(jkosh44) Move this into rbac.rs once RBAC is always on.

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -21,7 +21,8 @@ use itertools::Itertools;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
 use mz_adapter_types::dyncfgs::{
-    ENABLE_PASSWORD_AUTH, FRONTEND_READ_THEN_WRITE, READ_THEN_WRITE_MAX_DEPENDENCIES,
+    ENABLE_EXPRESSION_CACHE, ENABLE_PASSWORD_AUTH, FRONTEND_READ_THEN_WRITE,
+    READ_THEN_WRITE_MAX_DEPENDENCIES,
 };
 use mz_catalog::memory::error::ErrorKind;
 use mz_catalog::memory::objects::{
@@ -4292,15 +4293,18 @@ impl Coordinator {
     /// lock-based and the OCC read-then-write path. Both are never live in one
     /// process, so the choice is fixed at boot and every session inherits it.
     /// `max_concurrent_occ_writes` sizes the OCC semaphore at boot.
+    /// `enable_expression_cache` decides whether catalog open builds the cache,
+    /// which has already happened by the time a session can ask.
     ///
     /// `ALTER SYSTEM` on one of these is allowed to go through. The catalog
     /// value is what the next process start reads, and the running process
     /// cannot observe it, so there is no window where two code paths are live at
     /// once.
-    fn startup_only_vars() -> [&'static str; 2] {
+    fn startup_only_vars() -> [&'static str; 3] {
         [
             FRONTEND_READ_THEN_WRITE.name(),
             MAX_CONCURRENT_OCC_WRITES.name(),
+            ENABLE_EXPRESSION_CACHE.name(),
         ]
     }
 
@@ -4329,7 +4333,7 @@ impl Coordinator {
         Self::startup_only_vars()
             .into_iter()
             .filter(|name| {
-                // Both names are registered system vars, a lookup failure
+                // These names are all registered system vars, a lookup failure
                 // would mean the definitions and this list have drifted apart.
                 let current = config
                     .get(name)

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -77,10 +77,12 @@
 //! `frontend_read_then_write` re-checks the syntactic predicate before running a
 //! dataflow, which catches a caller that skipped the gate. If the syntactic
 //! predicate were laxer than the dynamic one, that check would pass and a write
-//! meant for staging would commit on its own, so the loop's `Committed` arm
-//! soft-panics when it has a write timestamp for a statement we meant to stage.
-//! By then the write is durable, so all that arm can do is make the
-//! disagreement loud.
+//! meant for staging would commit on its own, so the loop asserts wherever the
+//! two answers can be compared. The `Committed` arm catches a write timestamp
+//! for a statement we meant to stage, and the zero-row arm catches a read
+//! timestamp for one. Neither can undo anything by then, the write is already
+//! durable in the first case and there was never anything to write in the
+//! second, so all they do is make the disagreement loud.
 //!
 //! ## Rollout note
 //!
@@ -885,6 +887,18 @@ impl PeekClient {
                 // selection from state a later strict-serializable read cannot
                 // see yet, and that read finds the rows we said were not
                 // there.
+                //
+                // An `observed_ts` for a statement we meant to stage is the
+                // same predicate disagreement the `Committed` arm guards
+                // against: the syntactic answer said it reads nothing, the
+                // subscribe then read persisted state. Nothing is durable here,
+                // so there is nothing to undo, but the disagreement itself is
+                // the bug and it would otherwise park silently.
+                soft_assert_or_log!(
+                    !(stages_rows && observed_ts.is_some()),
+                    "read-then-write observed a read timestamp for a statement \
+                     it meant to stage"
+                );
                 end_own_transaction(session, stages_rows);
                 match observed_ts {
                     Some(observed_ts) => {

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -309,6 +309,36 @@ fn end_own_transaction(session: &mut Session, stages_rows: bool) {
     }
 }
 
+/// Checks that a read-then-write may read what its selection depends on.
+///
+/// An invalid selection is invalid wherever the statement runs, so a caller with
+/// something contextual to report, such as the transaction state, must ask this
+/// first. Reporting the transaction for a statement that can never work suggests
+/// it would work outside one.
+///
+/// `catalog` must be the snapshot the plan was built against. A missing item
+/// means the caller mixed snapshots, which is reported as a catalog error rather
+/// than treated as a dropped dependency.
+pub(crate) fn validate_selection_dependencies(
+    catalog: &Catalog,
+    depends_on: &BTreeSet<GlobalId>,
+) -> Result<(), AdapterError> {
+    let dependency_ids = depends_on
+        .iter()
+        .copied()
+        .map(|gid| {
+            catalog.try_resolve_item_id(&gid).ok_or_else(|| {
+                AdapterError::Catalog(mz_catalog::memory::error::Error {
+                    kind: ErrorKind::Sql(CatalogError::UnknownItem(gid.to_string())),
+                })
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let max_rw_dependencies = mz_adapter_types::dyncfgs::READ_THEN_WRITE_MAX_DEPENDENCIES
+        .get(catalog.system_config().dyncfgs());
+    validate_read_then_write_dependencies(catalog, dependency_ids, max_rw_dependencies)
+}
+
 /// Validates a read-then-write and resolves the context the rest of the
 /// pipeline runs against.
 ///
@@ -339,22 +369,7 @@ fn validate_read_then_write(
     // timeline validation below.
     let depends_on = plan.selection.depends_on();
 
-    // Validate read dependencies. A missing item would mean `catalog` is
-    // not the snapshot the plan was built against, so fail cleanly.
-    let dependency_ids = depends_on
-        .iter()
-        .copied()
-        .map(|gid| {
-            catalog.try_resolve_item_id(&gid).ok_or_else(|| {
-                AdapterError::Catalog(mz_catalog::memory::error::Error {
-                    kind: ErrorKind::Sql(CatalogError::UnknownItem(gid.to_string())),
-                })
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let max_rw_dependencies = mz_adapter_types::dyncfgs::READ_THEN_WRITE_MAX_DEPENDENCIES
-        .get(catalog.system_config().dyncfgs());
-    validate_read_then_write_dependencies(catalog, dependency_ids, max_rw_dependencies)?;
+    validate_selection_dependencies(catalog, &depends_on)?;
 
     let cluster = catalog.resolve_target_cluster(target_cluster, session)?;
     let cluster_id = cluster.id;

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -43,20 +43,44 @@
 //! correspondingly stricter than the dynamic one, since it refuses a sealed-MV
 //! `INSERT ... SELECT` in a transaction that would technically be bufferable.
 //!
-//! The answer decides where the diffs go. Diffs from a selection that reads
-//! persisted state are only correct at the frontier they were observed at, so
-//! they commit inside the OCC loop. Diffs from a selection that reads nothing
-//! are frontier-independent, so the caller of the loop either submits them
-//! right after it or, inside a multi-statement transaction, buffers them as
-//! session write ops that land at COMMIT.
+//! The two answers are used for different things, and that separation matters.
+//!
+//! The syntactic answer decides whether the statement can belong to a
+//! transaction. A selection that reads nothing produces diffs that are valid at
+//! any timestamp, so they are staged as session write ops and land when the
+//! transaction commits, which is what makes the statement atomic with whatever
+//! surrounds it. A selection that reads persisted state cannot belong to a
+//! transaction, and we refuse it in an explicit one. An extended-protocol
+//! pipeline is an implicit transaction, so it must not quietly join one either:
+//! it ends its own transaction instead of spanning the rest of the pipeline,
+//! which is how PostgreSQL treats statements that cannot run in a transaction
+//! block. It is durable once it reports success, and a later failure in the
+//! pipeline does not undo it.
+//!
+//! The dynamic answer only decides how the write is submitted, a timestamped
+//! write from inside the loop or a blind submission after it. It cannot decide
+//! transaction membership, because it is a property of the inputs rather than
+//! of the statement. A sealed input closes the subscribe cleanly, so an
+//! `INSERT ... SELECT` over a `REFRESH AT` materialized view past its last
+//! refresh takes the blind exit while still reading persisted state. Its diffs
+//! really are frontier-independent and staging them would be safe, and we still
+//! do not stage them. Otherwise whether a statement's rows survive a failure
+//! later in the pipeline would depend on whether one of its inputs happened to
+//! pass its last refresh, which no one reading the statement could predict.
+//!
+//! Staging is also what earns the right to span a pipeline in the first place.
+//! `TransactionStatus::may_span_pipeline` lets an implicit transaction stay open
+//! only for writes, precisely because they are merely staged. A statement that
+//! committed on its own has no business claiming it.
 //!
 //! Disagreement is caught on both sides, and only one side can still refuse.
 //! `frontend_read_then_write` re-checks the syntactic predicate before running a
 //! dataflow, which catches a caller that skipped the gate. If the syntactic
-//! predicate were laxer than the dynamic one, that check would pass and the
-//! write would commit mid-transaction, so the loop's `Committed` arm soft-panics
-//! when it has a write timestamp to apply inside a transaction. By then the
-//! write is durable, so all that arm can do is make the disagreement loud.
+//! predicate were laxer than the dynamic one, that check would pass and a write
+//! meant for staging would commit on its own, so the loop's `Committed` arm
+//! soft-panics when it has a write timestamp for a statement we meant to stage.
+//! By then the write is durable, so all that arm can do is make the
+//! disagreement loud.
 //!
 //! ## Rollout note
 //!
@@ -265,6 +289,21 @@ fn classify_write_result(
         WriteResult::Indeterminate => WriteOutcome::Failed(AdapterError::Internal(
             "write outcome is indeterminate because the group committer shut down".into(),
         )),
+    }
+}
+
+/// Ends the implicit transaction that a statement which cannot run in a
+/// transaction block opened for itself.
+///
+/// A read-then-write that reads persisted state is refused inside a transaction,
+/// so it must not quietly become part of one. Clearing the ops it staged leaves
+/// [`crate::session::TransactionStatus::may_span_pipeline`] false, so pgwire
+/// commits the implicit transaction rather than letting the rest of an
+/// extended-protocol pipeline join it. The write is already durable at this
+/// point, and the caller has established there is nothing else staged to lose.
+fn end_own_transaction(session: &mut Session, stages_rows: bool) {
+    if !stages_rows {
+        session.clear_transaction_ops();
     }
 }
 
@@ -580,21 +619,29 @@ impl PeekClient {
             table_desc,
         } = validation_result;
 
-        // Mark this as a write transaction in the session state machine. For a
-        // single statement that lets auto-commit handle the write correctly.
-        // The rows are added later: either the coordinator's group commit
-        // applies them directly, or, in a transaction, they are buffered as
-        // write ops once we know them.
-        session.add_transaction_ops(TransactionOps::Writes(vec![]))?;
+        // A write that reads no persisted state may join a surrounding
+        // transaction. Its rows do not come from a snapshot, so staging them
+        // and letting the transaction flush them keeps them atomic with
+        // everything else the transaction does.
+        //
+        // A write that does read persisted state may not. We refuse it in an
+        // explicit transaction, and an extended-protocol pipeline is an
+        // implicit transaction, so it must not silently span one either. It
+        // runs as its own transaction instead, which is how PostgreSQL treats
+        // statements that cannot run in a transaction block.
+        let stages_rows = depends_on.is_empty();
 
-        // Inside a transaction only a write that reads nothing gets here, see
-        // the module docs. The syntactic check lives in
-        // `SessionClient::try_frontend_read_then_write`.
-        let defer_write = session.transaction().is_in_multi_statement_transaction();
-        if defer_write && !depends_on.is_empty() {
-            // Defense in depth for the check named above. Rejecting here, before
-            // we run a dataflow, is the only place left where refusing is still
-            // possible: past the OCC loop the write may already be durable.
+        // Snapshot this before the marker op below, which makes `contains_ops`
+        // true unconditionally.
+        let in_transaction = session.transaction().is_in_multi_statement_transaction()
+            || session.transaction().contains_ops();
+
+        if !stages_rows && in_transaction {
+            // Defense in depth for the gate in
+            // `SessionClient::try_frontend_read_then_write`. Rejecting here,
+            // before we run a dataflow, is the last point where refusing is
+            // still possible: past the OCC loop the write may already be
+            // durable.
             soft_panic_or_log!(
                 "read-dependent read-then-write reached the OCC path inside a transaction"
             );
@@ -602,6 +649,11 @@ impl PeekClient {
                 "read-then-write cannot be run inside a transaction block".into(),
             ));
         }
+
+        // Mark this as a write transaction in the session state machine, so
+        // auto-commit treats the statement as a write. The rows follow once we
+        // know them.
+        session.add_transaction_ops(TransactionOps::Writes(vec![]))?;
 
         // Prepare expressions (resolve unmaterializable functions like
         // current_user())
@@ -809,17 +861,18 @@ impl PeekClient {
         let mut permit = Some(permit);
         let response = match result {
             Ok(OccOutcome::Committed { response, write_ts }) => {
-                // A committed write timestamp inside a transaction means the
-                // two predicates disagreed: the syntactic one let us defer,
-                // the subscribe then read persisted state. The write is
-                // already durable, so there is nothing to refuse, and
-                // `apply_write` still has to run to keep the session's read
-                // timestamps ahead of it.
+                // A committed write timestamp for a statement we meant to
+                // stage means the two predicates disagreed: the syntactic one
+                // said it reads nothing, the subscribe then read persisted
+                // state. The write is already durable, so there is nothing to
+                // refuse, and `apply_write` still has to run to keep the
+                // session's read timestamps ahead of it.
                 soft_assert_or_log!(
-                    !defer_write,
-                    "read-then-write committed a write inside a transaction"
+                    !stages_rows,
+                    "read-then-write committed a write it meant to stage"
                 );
                 session.apply_write(write_ts);
+                end_own_transaction(session, stages_rows);
                 Ok(response)
             }
             Ok(OccOutcome::NoRowsMatched {
@@ -832,6 +885,7 @@ impl PeekClient {
                 // selection from state a later strict-serializable read cannot
                 // see yet, and that read finds the rows we said were not
                 // there.
+                end_own_transaction(session, stages_rows);
                 match observed_ts {
                     Some(observed_ts) => {
                         // Nothing is left to write and `run_occ_loop` consumed
@@ -850,15 +904,19 @@ impl PeekClient {
                     None => Ok(response),
                 }
             }
-            Ok(OccOutcome::Blind { response, diffs }) if defer_write => {
-                // NOTE: A buffered session write carries no target-generation
-                // guard. The immediate path pins `target_global_id` and group
-                // commit re-validates it, but a `WriteOp` only names the
-                // `CatalogItemId` and commit staging resolves whatever global
-                // id is current then. So an `ALTER TABLE ... ADD COLUMN` that
-                // lands between here and COMMIT appends rows of the old arity
-                // under the new schema. This holds for every buffered write,
-                // not just ours.
+            Ok(OccOutcome::Blind { response, diffs }) if stages_rows => {
+                // Staging rather than writing here is what makes the statement
+                // atomic with its transaction. An extended-protocol pipeline is
+                // an implicit transaction, and it may still fail after us, so a
+                // write of our own would survive a rollback that discards
+                // everything around it.
+                //
+                // NOTE: A staged session write carries no target-generation
+                // guard. A `WriteOp` only names the `CatalogItemId`, and commit
+                // staging resolves whatever global id is current then. So an
+                // `ALTER TABLE ... ADD COLUMN` that lands between here and the
+                // commit appends rows of the old arity under the new schema.
+                // This holds for every staged write, not just ours.
                 session
                     .add_transaction_ops(TransactionOps::Writes(vec![WriteOp {
                         id: target_id,
@@ -867,6 +925,14 @@ impl PeekClient {
                     .map(|()| response)
             }
             Ok(OccOutcome::Blind { response, diffs }) => {
+                // The subscribe closed on its own even though the selection
+                // reads persisted state, so the input is sealed and the diffs
+                // are frontier-independent after all. Staging them would be
+                // safe for that reason, and we still do not, because it would
+                // make a statement's transaction semantics depend on whether an
+                // input happens to be past its last refresh. What the statement
+                // reads decides, so this commits as its own transaction like
+                // any other read-dependent write.
                 match self
                     .submit_blind_write(
                         conn_id,
@@ -880,6 +946,7 @@ impl PeekClient {
                 {
                     Ok(write_ts) => {
                         session.apply_write(write_ts);
+                        end_own_transaction(session, stages_rows);
                         Ok(response)
                     }
                     Err(err) => Err(err),
@@ -1055,6 +1122,55 @@ impl PeekClient {
             let wait_ms = u64::from(as_of.saturating_sub(oracle_ts));
             let wait = Duration::from_millis(wait_ms).min(Duration::from_secs(1));
             tokio::time::sleep(wait).await;
+        }
+    }
+
+    /// Submits frontier-independent diffs to group commit, which picks the
+    /// write timestamp, and returns the timestamp the write committed at.
+    ///
+    /// Only valid for diffs that do not depend on an observed read frontier:
+    /// the write lands at a timestamp this caller does not choose.
+    async fn submit_blind_write(
+        &self,
+        conn_id: mz_adapter_types::connection::ConnectionId,
+        target_id: CatalogItemId,
+        target_global_id: GlobalId,
+        diffs: Vec<(Row, Diff)>,
+        statement_logging_id: Option<StatementLoggingId>,
+        attempt_state: &FrontendWriteAttemptState,
+    ) -> Result<Timestamp, AdapterError> {
+        attempt_state.mark_write_submitted();
+        let result = self
+            .call_coordinator(|tx| Command::AttemptWrite {
+                conn_id,
+                target_id,
+                target_global_id,
+                diffs,
+                write_ts: None,
+                tx,
+            })
+            .await;
+
+        // Every outcome here terminates the attempt, so `write_submitted`
+        // stays set per its contract.
+        match classify_write_result(result, target_id, attempt_state) {
+            WriteOutcome::Committed(timestamp) => {
+                if let Some(id) = statement_logging_id {
+                    self.log_set_timestamp(id, timestamp);
+                }
+                Ok(timestamp)
+            }
+            WriteOutcome::Failed(err) => Err(err),
+            WriteOutcome::Conflict { .. } => {
+                // Unreachable: a write that requests no timestamp cannot have
+                // one pass. Group commit resolves it through
+                // `UserWriteResponder::Internal`, which only reports a conflict
+                // to a write that asked for a specific timestamp.
+                soft_panic_or_log!("blind read-then-write unexpectedly got TimestampPassed");
+                Err(AdapterError::Internal(
+                    "blind write unexpectedly got TimestampPassed".into(),
+                ))
+            }
         }
     }
 
@@ -1370,55 +1486,6 @@ impl PeekClient {
         };
 
         (state.retry_count, result)
-    }
-
-    /// Submits frontier-independent diffs to group commit, which picks the
-    /// write timestamp, and returns the timestamp the write committed at.
-    ///
-    /// Only valid for diffs that do not depend on an observed read frontier:
-    /// the write lands at a timestamp this caller does not choose.
-    async fn submit_blind_write(
-        &self,
-        conn_id: mz_adapter_types::connection::ConnectionId,
-        target_id: CatalogItemId,
-        target_global_id: GlobalId,
-        diffs: Vec<(Row, Diff)>,
-        statement_logging_id: Option<StatementLoggingId>,
-        attempt_state: &FrontendWriteAttemptState,
-    ) -> Result<Timestamp, AdapterError> {
-        attempt_state.mark_write_submitted();
-        let result = self
-            .call_coordinator(|tx| Command::AttemptWrite {
-                conn_id,
-                target_id,
-                target_global_id,
-                diffs,
-                write_ts: None,
-                tx,
-            })
-            .await;
-
-        // Every outcome here terminates the attempt, so `write_submitted`
-        // stays set per its contract.
-        match classify_write_result(result, target_id, attempt_state) {
-            WriteOutcome::Committed(timestamp) => {
-                if let Some(id) = statement_logging_id {
-                    self.log_set_timestamp(id, timestamp);
-                }
-                Ok(timestamp)
-            }
-            WriteOutcome::Failed(err) => Err(err),
-            WriteOutcome::Conflict { .. } => {
-                // Unreachable: a write that requests no timestamp cannot have
-                // one pass. Group commit resolves it through
-                // `UserWriteResponder::Internal`, which only reports a conflict
-                // to a write that asked for a specific timestamp.
-                soft_panic_or_log!("blind read-then-write unexpectedly got TimestampPassed");
-                Err(AdapterError::Internal(
-                    "blind write unexpectedly got TimestampPassed".into(),
-                ))
-            }
-        }
     }
 }
 

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -650,7 +650,9 @@ impl PeekClient {
 
         // Snapshot this before the marker op below, which makes the predicate
         // true unconditionally.
-        let in_transaction = session.transaction().is_effectively_multi_statement();
+        let in_transaction = session
+            .transaction()
+            .may_share_transaction_with_other_statements();
 
         if !stages_rows && in_transaction {
             // Defense in depth for the gate in

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -633,10 +633,9 @@ impl PeekClient {
         // statements that cannot run in a transaction block.
         let stages_rows = depends_on.is_empty();
 
-        // Snapshot this before the marker op below, which makes `contains_ops`
+        // Snapshot this before the marker op below, which makes the predicate
         // true unconditionally.
-        let in_transaction = session.transaction().is_in_multi_statement_transaction()
-            || session.transaction().contains_ops();
+        let in_transaction = session.transaction().is_effectively_multi_statement();
 
         if !stages_rows && in_transaction {
             // Defense in depth for the gate in

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -46,14 +46,17 @@
 //! The answer decides where the diffs go. Diffs from a selection that reads
 //! persisted state are only correct at the frontier they were observed at, so
 //! they commit inside the OCC loop. Diffs from a selection that reads nothing
-//! are frontier-independent, so the caller of the loop submits them right after
-//! it.
+//! are frontier-independent, so the caller of the loop either submits them
+//! right after it or, inside a multi-statement transaction, buffers them as
+//! session write ops that land at COMMIT.
 //!
-//! A write on this path commits immediately and cannot be rolled back at
-//! transaction end, so `frontend_read_then_write` refuses to run a dataflow
-//! inside a multi-statement transaction at all. That refusal sits behind the
-//! gate in `SessionClient::try_frontend_read_then_write` as defense in depth,
-//! and it is the last point where refusing is still possible.
+//! Disagreement is caught on both sides, and only one side can still refuse.
+//! `frontend_read_then_write` re-checks the syntactic predicate before running a
+//! dataflow, which catches a caller that skipped the gate. If the syntactic
+//! predicate were laxer than the dynamic one, that check would pass and the
+//! write would commit mid-transaction, so the loop's `Committed` arm soft-panics
+//! when it has a write timestamp to apply inside a transaction. By then the
+//! write is durable, so all that arm can do is make the disagreement loud.
 //!
 //! ## Rollout note
 //!
@@ -83,13 +86,14 @@ use mz_expr::Eval;
 use mz_expr::row::RowCollection;
 use mz_expr::{CollectionPlan, Id, LocalId, MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::cast::CastFrom;
-use mz_ore::soft_panic_or_log;
+use mz_ore::{soft_assert_or_log, soft_panic_or_log};
 use mz_repr::optimize::OverrideFrom;
 use mz_repr::{CatalogItemId, Diff, GlobalId, RelationDesc, Row, RowArena, Timestamp};
 use mz_sql::catalog::CatalogError;
 use mz_sql::plan::{self, MutationKind, QueryWhen};
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::IsolationLevel;
+use mz_storage_client::client::TableData;
 use mz_storage_types::sources::Timeline;
 use prometheus::Histogram;
 use timely::progress::Antichain;
@@ -105,7 +109,7 @@ use crate::coord::{Coordinator, TargetCluster};
 use crate::error::AdapterError;
 use crate::optimize::Optimize;
 use crate::optimize::dataflows::{ComputeInstanceSnapshot, EvalTime, ExprPrep, ExprPrepOneShot};
-use crate::session::{Session, TransactionOps};
+use crate::session::{Session, TransactionOps, WriteOp};
 use crate::statement_logging::{StatementLifecycleEvent, StatementLoggingId};
 use crate::{PeekClient, PeekResponseUnary, TimelineContext, optimize};
 
@@ -583,13 +587,17 @@ impl PeekClient {
         // write ops once we know them.
         session.add_transaction_ops(TransactionOps::Writes(vec![]))?;
 
-        // A write on this path commits immediately and cannot be rolled back at
-        // transaction end, so only a single-statement transaction may reach it.
-        // The check lives in `SessionClient::try_frontend_read_then_write`, and
-        // this is defense in depth for it: rejecting here, before we run a
-        // dataflow, is the last point where refusing is still possible.
-        if session.transaction().is_in_multi_statement_transaction() {
-            soft_panic_or_log!("read-then-write reached the OCC path inside a transaction");
+        // Inside a transaction only a write that reads nothing gets here, see
+        // the module docs. The syntactic check lives in
+        // `SessionClient::try_frontend_read_then_write`.
+        let defer_write = session.transaction().is_in_multi_statement_transaction();
+        if defer_write && !depends_on.is_empty() {
+            // Defense in depth for the check named above. Rejecting here, before
+            // we run a dataflow, is the only place left where refusing is still
+            // possible: past the OCC loop the write may already be durable.
+            soft_panic_or_log!(
+                "read-dependent read-then-write reached the OCC path inside a transaction"
+            );
             return Err(AdapterError::Internal(
                 "read-then-write cannot be run inside a transaction block".into(),
             ));
@@ -801,6 +809,16 @@ impl PeekClient {
         let mut permit = Some(permit);
         let response = match result {
             Ok(OccOutcome::Committed { response, write_ts }) => {
+                // A committed write timestamp inside a transaction means the
+                // two predicates disagreed: the syntactic one let us defer,
+                // the subscribe then read persisted state. The write is
+                // already durable, so there is nothing to refuse, and
+                // `apply_write` still has to run to keep the session's read
+                // timestamps ahead of it.
+                soft_assert_or_log!(
+                    !defer_write,
+                    "read-then-write committed a write inside a transaction"
+                );
                 session.apply_write(write_ts);
                 Ok(response)
             }
@@ -831,6 +849,22 @@ impl PeekClient {
                     }
                     None => Ok(response),
                 }
+            }
+            Ok(OccOutcome::Blind { response, diffs }) if defer_write => {
+                // NOTE: A buffered session write carries no target-generation
+                // guard. The immediate path pins `target_global_id` and group
+                // commit re-validates it, but a `WriteOp` only names the
+                // `CatalogItemId` and commit staging resolves whatever global
+                // id is current then. So an `ALTER TABLE ... ADD COLUMN` that
+                // lands between here and COMMIT appends rows of the old arity
+                // under the new schema. This holds for every buffered write,
+                // not just ours.
+                session
+                    .add_transaction_ops(TransactionOps::Writes(vec![WriteOp {
+                        id: target_id,
+                        rows: TableData::Rows(diffs),
+                    }]))
+                    .map(|()| response)
             }
             Ok(OccOutcome::Blind { response, diffs }) => {
                 match self

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -912,11 +912,23 @@ impl PeekClient {
                 // everything around it.
                 //
                 // NOTE: A staged session write carries no target-generation
-                // guard. A `WriteOp` only names the `CatalogItemId`, and commit
-                // staging resolves whatever global id is current then. So an
-                // `ALTER TABLE ... ADD COLUMN` that lands between here and the
-                // commit appends rows of the old arity under the new schema.
-                // This holds for every staged write, not just ours.
+                // guard the way the immediate path's `target_global_id` does. A
+                // `WriteOp` only names the `CatalogItemId`, and commit staging
+                // resolves whatever global id is current then. What keeps it
+                // safe is a check at the far end: group commit compares the
+                // arity of the rows each staged write carries against the
+                // target's latest `RelationDesc` and rolls the transaction back
+                // with `ConcurrentDependencyMutation` instead of encoding old
+                // rows against a new schema. So an `ALTER TABLE ... ADD COLUMN`
+                // landing between here and the commit becomes the same
+                // retryable failure the immediate path reports as
+                // `TargetChanged`. The comparison reads one row per staged
+                // write and looks only at arity, so it stands in for the
+                // descriptor rather than pinning it.
+                //
+                // Missing the pin is true of every staged write. The arity
+                // check is not: rows staged as a batch, which is how `COPY
+                // FROM` arrives, carry their schema into persist instead.
                 session
                     .add_transaction_ops(TransactionOps::Writes(vec![WriteOp {
                         id: target_id,

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -132,6 +132,12 @@ pub enum AdapterNotice {
         role: Option<String>,
         var_name: Option<String>,
     },
+    /// An `ALTER SYSTEM` statement named a system parameter that
+    /// `environmentd` only reads at startup, so the running process keeps the
+    /// value it sampled at boot.
+    StartupOnlyVarUpdated {
+        var_name: String,
+    },
     Welcome(String),
     PlanInsights(String),
     IntrospectionClusterUsage,
@@ -217,6 +223,7 @@ impl AdapterNotice {
             AdapterNotice::DroppedInUseIndex { .. } => Severity::Notice,
             AdapterNotice::PerReplicaLogRead { .. } => Severity::Notice,
             AdapterNotice::VarDefaultUpdated { .. } => Severity::Notice,
+            AdapterNotice::StartupOnlyVarUpdated { .. } => Severity::Warning,
             AdapterNotice::Welcome(_) => Severity::Notice,
             AdapterNotice::PlanInsights(_) => Severity::Notice,
             AdapterNotice::IntrospectionClusterUsage => Severity::Warning,
@@ -340,6 +347,7 @@ impl AdapterNotice {
             AdapterNotice::WebhookSourceCreated { .. } => SqlState::SUCCESSFUL_COMPLETION,
             AdapterNotice::PerReplicaLogRead { .. } => SqlState::SUCCESSFUL_COMPLETION,
             AdapterNotice::VarDefaultUpdated { .. } => SqlState::SUCCESSFUL_COMPLETION,
+            AdapterNotice::StartupOnlyVarUpdated { .. } => SqlState::WARNING,
             AdapterNotice::Welcome(_) => SqlState::SUCCESSFUL_COMPLETION,
             AdapterNotice::PlanInsights(_) => SqlState::from_code("MZ001"),
             AdapterNotice::IntrospectionClusterUsage => SqlState::WARNING,
@@ -526,6 +534,11 @@ impl fmt::Display for AdapterNotice {
                     "{vars} updated for {target}, this will have no effect on the current session"
                 )
             }
+            AdapterNotice::StartupOnlyVarUpdated { var_name } => write!(
+                f,
+                "changes to {} only take effect when environmentd restarts",
+                var_name.quoted()
+            ),
             AdapterNotice::Welcome(message) => message.fmt(f),
             AdapterNotice::PlanInsights(message) => message.fmt(f),
             AdapterNotice::IntrospectionClusterUsage => write!(

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1209,6 +1209,29 @@ impl TransactionStatus {
         }
     }
 
+    /// Whether statements other than the current one can belong to this
+    /// transaction.
+    ///
+    /// This is [`Self::is_in_multi_statement_transaction`] widened to cover the
+    /// `Started` trap. An extended-protocol pipeline stays `Started` from its
+    /// first statement until `Sync`, so a `Started` transaction already holding
+    /// ops has a pipeline accumulating in it, and a statement running now runs
+    /// alongside those ops.
+    ///
+    /// Callers must evaluate this before the current statement stages ops of
+    /// its own. Afterwards `contains_ops` reports the statement's own ops and
+    /// every statement looks like it shares a transaction.
+    ///
+    /// Reports true for a `Failed` transaction that holds ops, where the
+    /// match-shaped gates in `client.rs` and the coordinator's `handle_execute`
+    /// classify the same state the other way. Nothing reaches those callers in
+    /// that state, since pgwire admits only `COMMIT` and `ROLLBACK` once a
+    /// transaction has failed, so folding those gates into this method needs an
+    /// argument this doc cannot give.
+    pub fn is_effectively_multi_statement(&self) -> bool {
+        self.is_in_multi_statement_transaction() || self.contains_ops()
+    }
+
     /// Whether we are in a multi-statement transaction, AND the query is immediate.
     pub fn in_immediate_multi_stmt_txn(&self, when: &QueryWhen) -> bool {
         self.is_in_multi_statement_transaction() && when == &QueryWhen::Immediately

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1222,12 +1222,12 @@ impl TransactionStatus {
     /// its own. Afterwards `contains_ops` reports the statement's own ops and
     /// every statement looks like it shares a transaction.
     ///
-    /// Reports true for a `Failed` transaction that holds ops, where the
-    /// match-shaped gates in `client.rs` and the coordinator's `handle_execute`
-    /// classify the same state the other way. Nothing reaches those callers in
-    /// that state, since pgwire admits only `COMMIT` and `ROLLBACK` once a
-    /// transaction has failed, so folding those gates into this method needs an
-    /// argument this doc cannot give.
+    /// Reports true for a `Failed` transaction that holds ops, since
+    /// `contains_ops` reads through to the inner transaction in that state.
+    /// Callers that treat a failed transaction as one a statement may run in
+    /// need their own check, because pgwire admits only `COMMIT` and `ROLLBACK`
+    /// once a transaction has failed and so nothing else can observe the
+    /// difference.
     pub fn may_share_transaction_with_other_statements(&self) -> bool {
         self.is_in_multi_statement_transaction() || self.contains_ops()
     }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1209,8 +1209,8 @@ impl TransactionStatus {
         }
     }
 
-    /// Whether statements other than the current one can belong to this
-    /// transaction.
+    /// Whether a statement other than the current one can belong to this
+    /// transaction, so committing here would commit more than this statement.
     ///
     /// This is [`Self::is_in_multi_statement_transaction`] widened to cover the
     /// `Started` trap. An extended-protocol pipeline stays `Started` from its
@@ -1228,7 +1228,7 @@ impl TransactionStatus {
     /// that state, since pgwire admits only `COMMIT` and `ROLLBACK` once a
     /// transaction has failed, so folding those gates into this method needs an
     /// argument this doc cannot give.
-    pub fn is_effectively_multi_statement(&self) -> bool {
+    pub fn may_share_transaction_with_other_statements(&self) -> bool {
         self.is_in_multi_statement_transaction() || self.contains_ops()
     }
 

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -1277,8 +1277,10 @@ fn test_many_bind_params() {
     assert_eq!(row.get::<_, i32>(0), LAST_VALUE);
 }
 
-/// The frontend OCC read-then-write path must refuse DML that is pipelined
-/// behind a write in the same extended-protocol implicit transaction.
+/// How the frontend OCC read-then-write path behaves inside an extended-protocol
+/// pipeline: a write that reads nothing stages its rows and rolls back with the
+/// pipeline, one that reads persisted state is either refused or commits as its
+/// own transaction.
 #[mz_ore::test]
 fn test_pgtest_mz_frontend_occ_pipelined_dml() {
     pg_test_harness(

--- a/src/environmentd/tests/read_then_write.rs
+++ b/src/environmentd/tests/read_then_write.rs
@@ -1721,3 +1721,164 @@ fn test_zero_row_write_does_not_wait_for_keepalive() {
          interval rather than a nudged group commit (total {elapsed:?})"
     );
 }
+
+/// An INSERT whose values read no persisted state may run in a transaction,
+/// even when the values are too large to fold into a literal. The rows are
+/// buffered as session write ops, so they commit with the transaction and
+/// disappear if it does not commit.
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_nonconstant_insert_in_transaction() {
+    // Above `FOLD_CONSTANTS_LIMIT`, so the planned values stay a dataflow
+    // instead of folding into a constant.
+    const BIG_INSERT: &str = "INSERT INTO t SELECT generate_series(1, 20000)";
+
+    let server = frontend_occ_harness().unsafe_mode().start_blocking();
+
+    let mut client = server.connect(postgres::NoTls).unwrap();
+    client.batch_execute("CREATE TABLE t (a int)").unwrap();
+
+    let count = |client: &mut postgres::Client| {
+        client
+            .query_one("SELECT count(*)::int4 FROM t", &[])
+            .unwrap()
+            .get::<_, i32>(0)
+    };
+
+    client
+        .batch_execute(&format!("BEGIN; {BIG_INSERT}; COMMIT;"))
+        .unwrap();
+    assert_eq!(count(&mut client), 20000);
+
+    client
+        .batch_execute(&format!("BEGIN; {BIG_INSERT}; ROLLBACK;"))
+        .unwrap();
+    assert_eq!(count(&mut client), 20000, "rolled back write must not land");
+
+    // A later error in the same implicit batch aborts the transaction, so the
+    // write must not be visible.
+    let err = client
+        .batch_execute(&format!("{BIG_INSERT}; SELECT 1/0;"))
+        .unwrap_err();
+    let db_err = err.as_db_error().expect("expected db error");
+    assert!(
+        db_err.message().contains("division by zero"),
+        "unexpected error: {err:?}"
+    );
+    let _ = client.batch_execute("ROLLBACK");
+    assert_eq!(count(&mut client), 20000, "aborted write must not land");
+
+    // Outside a transaction the same statement commits on its own.
+    client.batch_execute(BIG_INSERT).unwrap();
+    assert_eq!(count(&mut client), 40000);
+
+    // The command tag counts diffs, not distinct rows: 20000 copies of the
+    // same row consolidate into one row with diff 20000.
+    client.batch_execute("BEGIN").unwrap();
+    let inserted = client
+        .execute("INSERT INTO t SELECT 1 FROM generate_series(1, 20000)", &[])
+        .unwrap();
+    assert_eq!(inserted, 20000);
+    client.batch_execute("COMMIT").unwrap();
+    assert_eq!(count(&mut client), 60000);
+
+    // Deferred and constant writes mix freely in one transaction and all land
+    // at COMMIT.
+    client.batch_execute("BEGIN").unwrap();
+    assert_eq!(client.execute(BIG_INSERT, &[]).unwrap(), 20000);
+    assert_eq!(client.execute(BIG_INSERT, &[]).unwrap(), 20000);
+    assert_eq!(client.execute("INSERT INTO t VALUES (1)", &[]).unwrap(), 1);
+    client.batch_execute("COMMIT").unwrap();
+    assert_eq!(count(&mut client), 100001);
+
+    // Constraint violations are caught while the diffs are being collected, so
+    // the statement fails and the transaction buffers nothing.
+    client
+        .batch_execute("CREATE TABLE nn (a int NOT NULL)")
+        .unwrap();
+    client.batch_execute("BEGIN").unwrap();
+    let err = client
+        .execute(
+            "INSERT INTO nn SELECT CASE WHEN g = 5 THEN NULL ELSE g END \
+             FROM generate_series(1, 20000) g",
+            &[],
+        )
+        .unwrap_err();
+    let db_err = err.as_db_error().expect("expected db error");
+    assert!(
+        db_err.message().contains("violates not-null constraint"),
+        "unexpected error: {err:?}"
+    );
+    let _ = client.batch_execute("ROLLBACK");
+    let nn_count = client
+        .query_one("SELECT count(*)::int4 FROM nn", &[])
+        .unwrap()
+        .get::<_, i32>(0);
+    assert_eq!(nn_count, 0, "failed write must not land");
+
+    // RETURNING needs the rows to be visible now, so it cannot wait for
+    // COMMIT. The transaction gate rejects it whether or not the values fold.
+    client.batch_execute("BEGIN").unwrap();
+    let err = client
+        .query(&format!("{BIG_INSERT} RETURNING a"), &[])
+        .unwrap_err();
+    let db_err = err.as_db_error().expect("expected db error");
+    assert!(
+        db_err
+            .message()
+            .contains("cannot be run inside a transaction block"),
+        "unexpected error: {err:?}"
+    );
+    let _ = client.batch_execute("ROLLBACK");
+}
+
+/// A transaction that has committed itself to DDL or to a subscribe cannot
+/// take a write. The reported error must be the one the coordinator reports,
+/// not whatever the write-op merge in the session state machine happens to
+/// produce.
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_rejected_in_non_writable_transaction() {
+    const BIG_INSERT: &str = "INSERT INTO t SELECT generate_series(1, 20000)";
+
+    let server = frontend_occ_harness().unsafe_mode().start_blocking();
+
+    let mut client = server.connect(postgres::NoTls).unwrap();
+    client.batch_execute("CREATE TABLE t (a int)").unwrap();
+    client.batch_execute("CREATE TABLE z (a int)").unwrap();
+    client.batch_execute("CREATE TABLE u (a int)").unwrap();
+    client.batch_execute("INSERT INTO u VALUES (1)").unwrap();
+
+    let assert_read_only = |client: &mut postgres::Client, setup: &[&str]| {
+        client.batch_execute("BEGIN").unwrap();
+        for stmt in setup {
+            client.batch_execute(stmt).unwrap();
+        }
+        let err = client.execute(BIG_INSERT, &[]).unwrap_err();
+        let db_err = err.as_db_error().expect("expected db error");
+        assert!(
+            db_err.message().contains("transaction in read-only mode"),
+            "after {setup:?}, unexpected error: {err:?}"
+        );
+        // The failed statement aborts the transaction, so the rollback is what
+        // hands the session back in a usable state for the next case.
+        let _ = client.batch_execute("ROLLBACK");
+    };
+
+    // Each case rolls back, so the catalog changes never apply and the next
+    // case starts from the same state.
+    assert_read_only(&mut client, &["ALTER TABLE z RENAME TO z2"]);
+    assert_read_only(&mut client, &["CREATE TABLE zz (i int)"]);
+    // The FETCH is what pins the transaction to the subscribe, the DECLARE
+    // alone leaves it undecided.
+    assert_read_only(
+        &mut client,
+        &["DECLARE c CURSOR FOR SUBSCRIBE u", "FETCH 1 c"],
+    );
+
+    let count = client
+        .query_one("SELECT count(*)::int4 FROM t", &[])
+        .unwrap()
+        .get::<_, i32>(0);
+    assert_eq!(count, 0, "no rejected write may have landed");
+}

--- a/src/environmentd/tests/read_then_write.rs
+++ b/src/environmentd/tests/read_then_write.rs
@@ -12,11 +12,11 @@
 //! path.
 //!
 //! Most tests here enable `enable_adapter_frontend_occ_read_then_write` and so
-//! cover the frontend OCC path. `test_counts_query_total` runs with the flag
-//! both off and on, because the property it checks must hold whichever path
-//! sequenced the statement. `test_cancel_read_then_write` covers the
-//! coordinator path only, and is the other half of the cancellation behavior
-//! its OCC counterpart pins.
+//! cover the frontend OCC path. `test_counts_query_total` and
+//! `test_constant_insert_reading_catalog_in_transaction` run with the flag both
+//! off and on, because what they check is how the two paths compare.
+//! `test_cancel_read_then_write` covers the coordinator path only, and is the
+//! other half of the cancellation behavior its OCC counterpart pins.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
@@ -1720,6 +1720,82 @@ fn test_zero_row_write_does_not_wait_for_keepalive() {
         "zero-row writes averaged {per_statement:?} each, which is the keepalive \
          interval rather than a nudged group commit (total {elapsed:?})"
     );
+}
+
+/// An INSERT whose values are constant to the parser can still plan to a
+/// selection that reads persisted state, because SQL-implemented builtins expand
+/// to queries over system relations. The AST gate cannot see that, so the
+/// decision falls to the planned selection.
+///
+/// Such a statement is invalid whatever the transaction state, since a
+/// read-then-write may not read a system table. What this pins is which reason
+/// each path reports, because reporting the transaction state suggests the
+/// statement would work outside a transaction when it never does.
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_constant_insert_reading_catalog_in_transaction() {
+    // `pg_get_viewdef` expands to `(SELECT definition FROM mz_catalog.mz_views
+    // WHERE name = $1)`, so the planned selection carries a dependency while the
+    // AST holds only a function call. `ConstantVisitor` rejects `Show` and
+    // `Table` references, nothing else, so the entry gate admits both of these.
+    const READS_CATALOG: &str = "INSERT INTO t VALUES (pg_get_viewdef('v'))";
+    const READS_CATALOG_AND_MZ_NOW: &str =
+        "INSERT INTO t VALUES (pg_get_viewdef('v') || mz_now()::text)";
+
+    let error_code = |client: &mut postgres::Client, sql: &str| {
+        let err = client.execute(sql, &[]).unwrap_err();
+        err.as_db_error()
+            .unwrap_or_else(|| panic!("{sql} did not fail on the server: {err}"))
+            .code()
+            .clone()
+    };
+
+    for frontend in [false, true] {
+        let server = test_util::TestHarness::default()
+            .with_system_parameter_default(
+                "enable_adapter_frontend_occ_read_then_write".to_string(),
+                frontend.to_string(),
+            )
+            .start_blocking();
+        let mut client = server.connect(postgres::NoTls).unwrap();
+        client.batch_execute("CREATE TABLE t (a text)").unwrap();
+        client.batch_execute("CREATE VIEW v AS SELECT 1").unwrap();
+
+        // Reading a system table is what makes these invalid, and both paths
+        // agree on that when no transaction is in the way.
+        assert_eq!(
+            error_code(&mut client, READS_CATALOG),
+            SqlState::INVALID_TRANSACTION_STATE,
+            "frontend={frontend}: a read-then-write may not read a system table"
+        );
+
+        // `mz_now` outranks the transaction state on both paths. Answering the
+        // transaction question first would report 25001 and hide the reason the
+        // statement can never work.
+        client.batch_execute("BEGIN").unwrap();
+        assert_eq!(
+            error_code(&mut client, READS_CATALOG_AND_MZ_NOW),
+            SqlState::FEATURE_NOT_SUPPORTED,
+            "frontend={frontend}: mz_now must outrank the transaction refusal"
+        );
+        client.batch_execute("ROLLBACK").unwrap();
+
+        // The dependency question is where the paths still differ. The frontend
+        // refuses on transaction state before it validates dependencies, so it
+        // reports the transaction where the lock path reports the selection.
+        client.batch_execute("BEGIN").unwrap();
+        let expected = if frontend {
+            SqlState::ACTIVE_SQL_TRANSACTION
+        } else {
+            SqlState::INVALID_TRANSACTION_STATE
+        };
+        assert_eq!(
+            error_code(&mut client, READS_CATALOG),
+            expected,
+            "frontend={frontend}: unexpected reason reported in a transaction"
+        );
+        client.batch_execute("ROLLBACK").unwrap();
+    }
 }
 
 /// An INSERT whose values read no persisted state may run in a transaction,

--- a/src/environmentd/tests/read_then_write.rs
+++ b/src/environmentd/tests/read_then_write.rs
@@ -1728,9 +1728,9 @@ fn test_zero_row_write_does_not_wait_for_keepalive() {
 /// decision falls to the planned selection.
 ///
 /// Such a statement is invalid whatever the transaction state, since a
-/// read-then-write may not read a system table. What this pins is which reason
-/// each path reports, because reporting the transaction state suggests the
-/// statement would work outside a transaction when it never does.
+/// read-then-write may not read a system table. What this pins is that both
+/// paths say so, rather than reporting the transaction state, which would
+/// suggest the statement works outside a transaction when it never does.
 #[mz_ore::test]
 #[allow(clippy::disallowed_methods)]
 fn test_constant_insert_reading_catalog_in_transaction() {
@@ -1780,19 +1780,13 @@ fn test_constant_insert_reading_catalog_in_transaction() {
         );
         client.batch_execute("ROLLBACK").unwrap();
 
-        // The dependency question is where the paths still differ. The frontend
-        // refuses on transaction state before it validates dependencies, so it
-        // reports the transaction where the lock path reports the selection.
+        // A transaction does not change the answer. Both paths still report the
+        // selection, which is the reason that holds either way.
         client.batch_execute("BEGIN").unwrap();
-        let expected = if frontend {
-            SqlState::ACTIVE_SQL_TRANSACTION
-        } else {
-            SqlState::INVALID_TRANSACTION_STATE
-        };
         assert_eq!(
             error_code(&mut client, READS_CATALOG),
-            expected,
-            "frontend={frontend}: unexpected reason reported in a transaction"
+            SqlState::INVALID_TRANSACTION_STATE,
+            "frontend={frontend}: the invalid selection must outrank the transaction"
         );
         client.batch_execute("ROLLBACK").unwrap();
     }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -6777,3 +6777,94 @@ fn test_shutdown_with_inflight_writes() {
         tracing::info!("round {round} survived");
     }
 }
+
+/// Changing a startup-only parameter is allowed and warns that it only takes
+/// effect after a restart. The running process keeps its sampled value, so the
+/// routing decision cannot change underneath open sessions. A change that is
+/// rejected, or a `RESET ALL` that leaves the parameter where it was, must not
+/// warn.
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_startup_only_system_var_warns() {
+    let server = test_util::TestHarness::default()
+        .unsafe_mode()
+        .start_blocking();
+
+    let (tx, mut rx) = futures::channel::mpsc::unbounded();
+    let mut client = server
+        .pg_config_internal()
+        .notice_callback(move |notice| tx.unbounded_send(notice).expect("send notice"))
+        .connect(postgres::NoTls)
+        .unwrap();
+
+    const WARNING: &str = "only take effect when environmentd restarts";
+    let drain = |rx: &mut futures::channel::mpsc::UnboundedReceiver<_>| -> Vec<String> {
+        std::iter::from_fn(|| rx.try_recv().ok())
+            .map(|notice: postgres::error::DbError| notice.message().to_string())
+            .collect()
+    };
+
+    for stmt in [
+        "ALTER SYSTEM SET enable_adapter_frontend_occ_read_then_write = true",
+        "ALTER SYSTEM RESET enable_adapter_frontend_occ_read_then_write",
+    ] {
+        client.batch_execute(stmt).unwrap();
+        let notices = drain(&mut rx);
+        assert!(
+            notices.iter().any(|message| message.contains(WARNING)),
+            "{stmt} did not warn, notices: {notices:?}"
+        );
+    }
+
+    // A rejected change must not warn: the catalog value does not move, so a
+    // restart would not pick anything new up.
+    let err = client
+        .batch_execute("ALTER SYSTEM SET max_concurrent_occ_writes = 'not-a-number'")
+        .unwrap_err();
+    let db_err = err.as_db_error().expect("expected db error");
+    assert!(
+        db_err
+            .message()
+            .contains("requires a \"unsigned integer\" value"),
+        "unexpected error: {err:?}"
+    );
+    let notices = drain(&mut rx);
+    assert!(
+        !notices.iter().any(|message| message.contains(WARNING)),
+        "rejected change warned, notices: {notices:?}"
+    );
+
+    // Zero permits would block every read-then-write until its statement
+    // timeout, so the parameter is constrained to at least 1.
+    let err = client
+        .batch_execute("ALTER SYSTEM SET max_concurrent_occ_writes = 0")
+        .unwrap_err();
+    let db_err = err.as_db_error().expect("expected db error");
+    assert!(
+        db_err
+            .message()
+            .contains("only supports values in range 1.."),
+        "unexpected error: {err:?}"
+    );
+
+    // `RESET ALL` also goes through, and warns for the parameter it changes.
+    client
+        .batch_execute("ALTER SYSTEM SET enable_adapter_frontend_occ_read_then_write = true")
+        .unwrap();
+    let _ = drain(&mut rx);
+    client.batch_execute("ALTER SYSTEM RESET ALL").unwrap();
+    let notices = drain(&mut rx);
+    assert!(
+        notices.iter().any(|message| message.contains(WARNING)),
+        "RESET ALL did not warn, notices: {notices:?}"
+    );
+
+    // Everything is at its effective default now, so a second `RESET ALL`
+    // changes no startup-only parameter and must stay quiet about them.
+    client.batch_execute("ALTER SYSTEM RESET ALL").unwrap();
+    let notices = drain(&mut rx);
+    assert!(
+        !notices.iter().any(|message| message.contains(WARNING)),
+        "RESET ALL warned without changing anything, notices: {notices:?}"
+    );
+}

--- a/src/environmentd/tests/statement_logging.rs
+++ b/src/environmentd/tests/statement_logging.rs
@@ -1256,11 +1256,14 @@ const DML_LOGGING_PARITY_CASES: &[DmlLoggingCase] = &[
         after: &[],
         frontend_only_execution_timestamp: true,
     },
+    // Reads nothing, so both paths stage the rows and the write timestamp is
+    // chosen when the transaction commits rather than by the statement. Neither
+    // path records an execution timestamp for it.
     DmlLoggingCase {
         before: &[],
         sql: "INSERT INTO parity_t VALUES (100) RETURNING x",
         after: &[],
-        frontend_only_execution_timestamp: true,
+        frontend_only_execution_timestamp: false,
     },
     // A RETURNING insert that matches no rows. Both paths report a row count
     // rather than an empty result set, so this pins the response kind (and with

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -31,6 +31,7 @@ import websocket
 from psycopg import Cursor, sql
 from psycopg.errors import (
     DatabaseError,
+    DivisionByZero,
     InternalError_,
     OperationalError,
     QueryCanceled,
@@ -4893,6 +4894,109 @@ def workflow_test_occ_zero_row_write_linearization(c: Composition) -> None:
                     "state without first submitting a write, so the window was never "
                     "observed"
                 )
+
+
+def workflow_test_occ_sealed_input_write_stands_alone(c: Composition) -> None:
+    """A read-then-write whose selection reads persisted state must commit as
+    its own transaction, including when its subscribe ends on its own.
+
+    The OCC path stages a mutation's diffs only when the selection reads
+    nothing, because only then is the statement one that may belong to a
+    transaction. A selection that reads persisted state commits inside the OCC
+    loop and ends the implicit transaction it opened instead of spanning the
+    rest of an extended-protocol pipeline, so a later failure there cannot undo
+    it.
+
+    Which of the two happens is decided twice, and the answers differ. Before
+    the dataflow runs it is `depends_on()` on the selection. Once it runs it is
+    whether the subscribe closed on its own, which it also does for a sealed
+    persisted input: a `REFRESH AT` materialized view past its last refresh has
+    an empty write frontier, so the sink's output frontier reaches the empty
+    antichain. An `INSERT ... SELECT` over such a view reads persisted state and
+    still takes the closed-channel exit. Only the syntactic answer may decide
+    transaction membership, or whether a statement's rows survive would turn on
+    an input passing its last refresh rather than on the statement.
+    """
+
+    def rows_surviving(write: str) -> int:
+        """Rows left in `dst` once `write` has succeeded and the pipeline behind
+        it has failed. Leaves `dst` empty again.
+
+        `write` is sent as one extended-protocol pipeline with a failing
+        statement behind it and no `Sync` between them. A pipeline is an
+        implicit transaction, so rows going missing here is exactly `write`
+        having joined that transaction instead of committing on its own.
+        """
+        with c.sql_connection() as conn:
+            try:
+                # psycopg pipelines the extended protocol only, and syncs when
+                # the block ends. Autocommit keeps a `BEGIN` off the front,
+                # which the OCC path would refuse outright.
+                with conn.cursor() as cur, conn.pipeline():
+                    cur.execute(write.encode())
+                    cur.execute(b"SELECT 1 / 0")
+            except DivisionByZero:
+                pass
+            else:
+                raise AssertionError(f"the statement behind {write!r} succeeded")
+        rows = c.sql_query("SELECT count(*) FROM dst")[0][0]
+        c.sql("DELETE FROM dst")
+        return rows
+
+    with c.override(
+        Materialized(
+            # Sampled once at startup, so this cannot be an `ALTER SYSTEM SET`.
+            additional_system_parameter_defaults={
+                "enable_adapter_frontend_occ_read_then_write": "true"
+            },
+        )
+    ):
+        c.up("materialized")
+        c.sql(dedent("""
+                CREATE TABLE src (a int);
+                INSERT INTO src VALUES (1), (2), (3);
+                CREATE TABLE dst (a int);
+                CREATE MATERIALIZED VIEW sealed WITH (REFRESH AT CREATION) AS
+                    SELECT a FROM src;
+                """))
+
+        # An empty write frontier is what closes the subscribe, and it surfaces
+        # as a NULL `write_frontier`. Hydration alone is not enough, so wait for
+        # the seal rather than for the first successful read.
+        sealed = """SELECT f.write_frontier IS NULL
+                    FROM mz_internal.mz_frontiers f
+                    JOIN mz_materialized_views m ON (m.id = f.object_id)
+                    WHERE m.name = 'sealed'"""
+        deadline = time.time() + 120
+        while c.sql_query(sealed) != [(True,)]:
+            assert (
+                time.time() < deadline
+            ), "the REFRESH AT CREATION materialized view never sealed"
+            time.sleep(0.1)
+
+        # Control: the same pipeline over `src`, whose subscribe never ends on
+        # its own. It pins the harness, since rows lost here would mean the
+        # pipeline was never an open transaction to begin with.
+        write = "INSERT INTO dst SELECT a FROM src"
+        rows = rows_surviving(write)
+        assert rows == 3, f"{write} succeeded, then lost {3 - rows} of its 3 rows"
+
+        # Ask the process rather than the catalog which path that took: the
+        # write only reaches the histogram if the frontend sequenced it, and on
+        # the coordinator's lock path none of this is about read-then-write
+        # transaction handling at all.
+        metrics = c.exec(
+            "materialized", "curl", "localhost:6878/metrics", capture=True
+        ).stdout
+        assert any(
+            line.startswith("mz_occ_read_then_write_retry_count_count ")
+            and float(line.split()[1]) > 0
+            for line in metrics.splitlines()
+        ), "no read-then-write went through the OCC path"
+
+        write = "INSERT INTO dst SELECT a FROM sealed"
+        rows = rows_surviving(write)
+        assert rows == 3, f"{write} succeeded, then lost {3 - rows} of its 3 rows"
 
 
 def workflow_test_refresh_mv_warmup(

--- a/test/pgtest-mz/frontend-occ-pipelined-dml.pt
+++ b/test/pgtest-mz/frontend-occ-pipelined-dml.pt
@@ -1,11 +1,18 @@
-# Test that a read-then-write pipelined behind a write in the same
-# extended-protocol implicit transaction is rejected.
+# How the frontend OCC read-then-write path behaves inside an extended-protocol
+# pipeline.
 #
-# An extended-protocol pipeline keeps the transaction in the `Started` state
-# until `Sync`, accumulating the earlier statement's write ops. A DELETE cannot
-# see those ops, so running it would commit durably against a snapshot that
-# lacks them. That reorders the DELETE before the INSERT, and the DELETE would
-# survive the rollback that the failing pipeline performs on the INSERT.
+# A pipeline is an implicit transaction: the transaction stays `Started` until
+# `Sync`, so statements that follow can still fail and roll the whole thing
+# back. Two kinds of read-then-write meet that differently.
+#
+# A write that reads no persisted state stages its rows, so it commits or rolls
+# back with everything else in the pipeline.
+#
+# A write that reads persisted state cannot be part of a transaction at all, we
+# refuse it in an explicit one. So it commits as its own transaction and does
+# not span the pipeline, the way PostgreSQL treats statements that cannot run in
+# a transaction block. It is durable once it reports success, and a later
+# failure in the pipeline does not undo it.
 
 send
 Query {"query": "DROP TABLE IF EXISTS t"}
@@ -21,6 +28,9 @@ ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"CREATE TABLE"}
 ReadyForQuery {"status":"I"}
 
+# A read-dependent write pipelined behind a staged write is refused. It cannot
+# see those staged rows, so running it would compute its diffs from a snapshot
+# that lacks them.
 send
 Parse {"query": "INSERT INTO t VALUES (1)"}
 Bind
@@ -42,7 +52,171 @@ BindComplete
 ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"25001"},{"typ":"M","value":"DELETE FROM t WHERE a = 1 cannot be run inside a transaction block"}]}
 ReadyForQuery {"status":"I"}
 
-# The pipeline failed, so the INSERT rolled back too and the table is empty.
+# The pipeline failed, so the staged INSERT rolled back too.
+send
+Query {"query": "SELECT count(*) FROM t"}
+----
+
+until
+ReadyForQuery
+----
+RowDescription {"fields":[{"name":"count"}]}
+DataRow {"fields":["0"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# A blind write pipelined behind a staged write. 20000 rows is above the
+# constant-folding limit, so the values stay a dataflow and take the
+# read-then-write path rather than being folded and staged by the constant
+# insert path. It reads nothing, so it is admitted, and it must stage its rows
+# rather than write them: writing would order them ahead of the earlier
+# `VALUES (1)` op and leave them behind when the pipeline rolls that op back.
+send
+Parse {"query": "INSERT INTO t VALUES (1)"}
+Bind
+Execute
+Parse {"query": "INSERT INTO t SELECT generate_series(1, 20000)"}
+Bind
+Execute
+Parse {"query": "SELECT 1/0"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=SC
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 20000"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"22012"}]}
+ReadyForQuery {"status":"I"}
+
+# Neither INSERT survives: the blind write joined the transaction that the
+# division by zero rolled back.
+send
+Query {"query": "SELECT count(*) FROM t"}
+----
+
+until
+ReadyForQuery
+----
+RowDescription {"fields":[{"name":"count"}]}
+DataRow {"fields":["0"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# A blind write that opens the pipeline. Nothing is staged in front of it, so
+# neither transaction predicate reports a transaction, but the pipeline is still
+# one and can still fail after it. It stages its rows all the same.
+send
+Parse {"query": "INSERT INTO t SELECT generate_series(1, 20000)"}
+Bind
+Execute
+Parse {"query": "SELECT 1/0"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=SC
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 20000"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"22012"}]}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "SELECT count(*) FROM t"}
+----
+
+until
+ReadyForQuery
+----
+RowDescription {"fields":[{"name":"count"}]}
+DataRow {"fields":["0"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "INSERT INTO t VALUES (1), (2), (3)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"INSERT 0 3"}
+ReadyForQuery {"status":"I"}
+
+# A read-dependent write that opens the pipeline commits as its own
+# transaction. The later division by zero fails on its own and does not undo it,
+# because the DELETE was never part of that transaction.
+send
+Parse {"query": "DELETE FROM t WHERE a = 1"}
+Bind
+Execute
+Parse {"query": "SELECT 1/0"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=SC
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"DELETE 1"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"22012"}]}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "SELECT count(*) FROM t"}
+----
+
+until
+ReadyForQuery
+----
+RowDescription {"fields":[{"name":"count"}]}
+DataRow {"fields":["2"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# Because each read-dependent write ends its own transaction, a second one in
+# the same pipeline is not refused for running alongside staged ops. Both apply.
+send
+Parse {"query": "DELETE FROM t WHERE a = 2"}
+Bind
+Execute
+Parse {"query": "DELETE FROM t WHERE a = 3"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"DELETE 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"DELETE 1"}
+ReadyForQuery {"status":"I"}
+
 send
 Query {"query": "SELECT count(*) FROM t"}
 ----


### PR DESCRIPTION
### Motivation

Part 7 of 7 in a stack that moves `DELETE`, `UPDATE` and `INSERT ... SELECT` off the coordinator onto the session task, using optimistic concurrency control. Design doc: [`20260210_incremental_occ_read_then_write.md`](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20260210_incremental_occ_read_then_write.md).

Part 6 refuses a read-then-write inside a multi-statement transaction, because a write that commits immediately cannot be rolled back at transaction end. That is the right answer only for a write that reads persisted state. This part works out what the right answer is for the other kind, and what "inside a transaction" actually means.

Closes [SQL-593](https://linear.app/materializeinc/issue/SQL-593)

### An extended-protocol pipeline is an implicit transaction

This is the fact the whole change turns on. `Parse`/`Bind`/`Execute` repeated and then `Sync` is one implicit transaction in PostgreSQL: if any statement fails, everything the pipeline wrote rolls back. Clients rely on it, `pgx SendBatch`, psycopg pipeline mode and libpq pipelining all do. [SQL-470](https://linear.app/materializeinc/issue/SQL-470) fixed exactly this for Materialize and was marked High.

In the session state machine that pipeline is `TransactionStatus::Started`, and `is_implicit()` returns true for it. `Started` is genuinely ambiguous, as the comment at `command_handler.rs:1357` says: it is either exactly one statement from the simple protocol, or some statement from the extended protocol that may have others after it before `Sync`. Nothing at execute time can tell the two apart.

An implicit transaction is allowed to stay open across a pipeline only under a specific condition, spelled out on `TransactionStatus::may_span_pipeline`: only writes may, **"because they are merely staged"**. Staging is what earns the right to span.

### What was wrong

The OCC path marked the session with `Writes` ops, which buys that right, and then wrote its rows anyway. The transaction stayed open on the promise that the rows were merely staged, while they were already durable. A later failure in the pipeline rolled back nothing.

The gate keyed on `is_in_multi_statement_transaction()`, which reports false for `Started`. Keying it on `contains_ops()` as well fixes only the case where something is staged in front of the statement. A read-then-write that *opens* a pipeline has nothing in front of it and was equally broken, in both directions:

```
Parse "INSERT INTO t SELECT generate_series(1, 20000)"; Bind; Execute
Parse "SELECT 1/0"; Bind; Execute
Sync
-- PostgreSQL: 0 rows.  Before this PR: 20000 rows.
```

### The semantics this PR settles

Two kinds of read-then-write meet a transaction differently, split on the predicate that already exists, whether the selection reads persisted state.

**A write that reads nothing can belong to a transaction.** Its diffs do not come from a snapshot, so they are valid at any timestamp. We stage them as session write ops and let the transaction flush them, exactly as a constant `INSERT` already does from this same path. It commits or rolls back with everything around it.

**A write that reads persisted state cannot belong to one.** Its diffs are only correct at the frontier they were observed at, so they commit inside the OCC loop, and we already refuse such a statement in an explicit transaction. It must not quietly join an implicit one either. So it commits as its own transaction and clears the ops it staged, which leaves `may_span_pipeline` false and makes pgwire end the transaction rather than let the rest of the pipeline join it.

**Only the syntactic predicate may decide this.** The two predicates answer different questions and they disagree for a sealed input. A `REFRESH AT` materialized view past its last refresh has an empty write frontier, so the subscribe over it closes on its own, and an `INSERT ... SELECT` over that view reads persisted state while still taking the closed-channel exit. Its diffs really are frontier-independent, so staging them would be safe, and we still do not stage them. Otherwise whether a statement's rows survive a later failure in the pipeline would depend on whether one of its inputs happened to pass its last refresh, which nobody reading the statement could predict. That case takes the blind submission and then ends its own transaction like any other read-dependent write.

That second rule is not an invention. It is how PostgreSQL treats statements that cannot run in a transaction block, and it is what the `Started` comment in `command_handler` already describes as PostgreSQL's approach. The resulting guarantee is worth stating plainly, because it is a deliberate divergence from PostgreSQL, where `DELETE` *is* transactional:

> A read-then-write that reads persisted state is durable once it reports success. A later failure in the same pipeline does not undo it.

We can say that because Materialize already refuses these statements in a transaction block, so no user can be relying on them being transactional. Making them genuinely transactional would mean re-validating the OCC conflict check at commit time, which is a larger design and not in this PR.

One welcome side effect: because such a statement now ends its own transaction, a second one in the same pipeline is no longer refused for running alongside staged ops.

### Consequences worth knowing

Staging a blind write removes a coordinator round trip rather than adding one. The rows ride along in the commit that was already going to happen, instead of taking a separate `Command::AttemptWrite` first and then committing anyway. `submit_blind_write` is deleted.

A staged `WriteOp` names only the `CatalogItemId`, so it does not carry the target-generation guard that the immediate path got from pinning `target_global_id`. An `ALTER TABLE ... ADD COLUMN` landing between execution and commit would append rows of the old arity. This is true of every staged write, including constant `INSERT` and the lock-based path, so blind writes now share the existing guarantee rather than a weaker one of their own. Read-dependent writes still commit in the loop and keep the pinned generation, which `test_write_racing_alter_table_add_column` covers. Carrying the expected generation into staged writes would fix this for all of them and is worth doing separately.

### Statement logging

A staged write does not choose its own write timestamp, so it no longer records an `execution_timestamp` in `mz_statement_execution_history`. This matters because the frontend path is going to become the default, so what it records is what users will see.

The reason is structural rather than incidental, and it is the same on both paths. `GroupCommitApplied` back-fills the execution timestamp only for statements still live at commit, since "retiring ends the statement execution and drops its logging record", and `PendingWriteTxn::User` attributes it to whichever context is committing. A staged write reports its result and retires before the commit that gives its rows a timestamp, so nothing back-fills it. The coordinator has always behaved this way for every read-then-write. `test_statement_logging_dml_path_parity` is updated to expect the two paths to agree on `INSERT ... VALUES ... RETURNING`.

So this makes the eventual flag flip invisible for blind writes rather than swapping one behavior for another. Read-dependent writes are the opposite case and the divergence there is deliberate: the OCC loop picks a write timestamp inside the statement's lifetime, so the frontend records one where the coordinator never could. Turning the flag on will start populating `execution_timestamp` for `UPDATE`, `DELETE` and `INSERT ... SELECT`. That is accurate and strictly more information, and the parity test pins it per case so it cannot drift unnoticed.

### Verification

`test/pgtest-mz/frontend-occ-pipelined-dml.pt` pins all six pipeline cases, each with a comment saying which rule it exercises:

| pipeline | expected |
| --- | --- |
| staged write, then read-dependent write | refused, 25001 |
| staged write, then blind write, then `1/0` | both roll back |
| blind write opening the pipeline, then `1/0` | rolls back |
| read-dependent write opening the pipeline, then `1/0` | commits, survives |
| two read-dependent writes in one pipeline | both apply, neither refused |

The two blind-write cases were verified to fail before the change (20000 rows instead of 0) and pass after. The read-dependent cases pin semantics rather than catching a regression, and are commented as such.

`test/cluster/mzcompose.py` adds `test-occ-sealed-input-write-stands-alone`, which covers the sealed-input case that the pgtest cannot: it needs a `REFRESH AT CREATION` materialized view to seal, so it waits on `mz_frontiers` for an empty write frontier before writing. It sends the write and a failing statement as one psycopg pipeline, checks `mz_occ_read_then_write_retry_count` to confirm the frontend actually sequenced the write rather than the coordinator, and uses a table-backed control write to prove the harness really does leave a transaction open. Thanks to @def- for writing it.

Full `read_then_write` suite (27 tests) and the `pgwire` suite pass.

### Unrelated, in the same PR

`max_concurrent_occ_writes` is sampled once at startup, so `ALTER SYSTEM SET` on it silently did nothing. The statement is still accepted, and now warns that the change takes effect when environmentd restarts. `RESET ALL` names every parameter rather than one, so it compares values instead of names. The parameter also gets a domain constraint of at least 1, since zero permits would leave every read-then-write waiting out its `statement_timeout`.

