### PR TITLE
adapter,catalog: add fine-grained metrics for catalog transact phases

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -394,20 +394,20 @@ metrics:
   source: src/catalog/src/durable/metrics.rs
   visibility: internal
 - name: mz_catalog_transact_phase_seconds_bucket
-  help: Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent.
+  help: Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent. Phases overlap and do not sum to mz_catalog_transact_seconds. The transact phase includes the durable catalog sync and commit.
   labels:
   - le
   - phase
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_catalog_transact_phase_seconds_count
-  help: Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent.
+  help: Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent. Phases overlap and do not sum to mz_catalog_transact_seconds. The transact phase includes the durable catalog sync and commit.
   labels:
   - phase
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_catalog_transact_phase_seconds_sum
-  help: Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent.
+  help: Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent. Phases overlap and do not sum to mz_catalog_transact_seconds. The transact phase includes the durable catalog sync and commit.
   labels:
   - phase
   source: src/adapter/src/metrics.rs

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -334,8 +334,18 @@ metrics:
   help: Count of snapshot consolidation passes.
   source: src/catalog/src/durable/metrics.rs
   visibility: internal
-- name: mz_catalog_snapshot_latency_seconds
-  help: Total latency for fetching a snapshot of the durable catalog.
+- name: mz_catalog_snapshot_latency_seconds_bucket
+  help: Latency for fetching a snapshot of the durable catalog.
+  labels:
+  - le
+  source: src/catalog/src/durable/metrics.rs
+  visibility: internal
+- name: mz_catalog_snapshot_latency_seconds_count
+  help: Latency for fetching a snapshot of the durable catalog.
+  source: src/catalog/src/durable/metrics.rs
+  visibility: internal
+- name: mz_catalog_snapshot_latency_seconds_sum
+  help: Latency for fetching a snapshot of the durable catalog.
   source: src/catalog/src/durable/metrics.rs
   visibility: internal
 - name: mz_catalog_snapshot_max_entries
@@ -365,13 +375,42 @@ metrics:
   help: Count of snapshots taken.
   source: src/catalog/src/durable/metrics.rs
   visibility: internal
-- name: mz_catalog_sync_latency_seconds
-  help: Total latency for syncing the in-memory state of the durable catalog with the persisted contents.
+- name: mz_catalog_sync_latency_seconds_bucket
+  help: Latency for syncing the in-memory state of the durable catalog with the persisted contents.
+  labels:
+  - le
+  source: src/catalog/src/durable/metrics.rs
+  visibility: internal
+- name: mz_catalog_sync_latency_seconds_count
+  help: Latency for syncing the in-memory state of the durable catalog with the persisted contents.
+  source: src/catalog/src/durable/metrics.rs
+  visibility: internal
+- name: mz_catalog_sync_latency_seconds_sum
+  help: Latency for syncing the in-memory state of the durable catalog with the persisted contents.
   source: src/catalog/src/durable/metrics.rs
   visibility: internal
 - name: mz_catalog_syncs
   help: Count of catalog syncs.
   source: src/catalog/src/durable/metrics.rs
+  visibility: internal
+- name: mz_catalog_transact_phase_seconds_bucket
+  help: Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent.
+  labels:
+  - le
+  - phase
+  source: src/adapter/src/metrics.rs
+  visibility: internal
+- name: mz_catalog_transact_phase_seconds_count
+  help: Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent.
+  labels:
+  - phase
+  source: src/adapter/src/metrics.rs
+  visibility: internal
+- name: mz_catalog_transact_phase_seconds_sum
+  help: Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent.
+  labels:
+  - phase
+  source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_catalog_transact_seconds_bucket
   help: The time it takes to run various catalog transact methods.
@@ -392,8 +431,18 @@ metrics:
   - method
   source: src/adapter/src/metrics.rs
   visibility: internal
-- name: mz_catalog_transaction_commit_latency_seconds
-  help: Total latency for committing a durable catalog transactions.
+- name: mz_catalog_transaction_commit_latency_seconds_bucket
+  help: Latency for committing a durable catalog transaction.
+  labels:
+  - le
+  source: src/catalog/src/durable/metrics.rs
+  visibility: internal
+- name: mz_catalog_transaction_commit_latency_seconds_count
+  help: Latency for committing a durable catalog transaction.
+  source: src/catalog/src/durable/metrics.rs
+  visibility: internal
+- name: mz_catalog_transaction_commit_latency_seconds_sum
+  help: Latency for committing a durable catalog transaction.
   source: src/catalog/src/durable/metrics.rs
   visibility: internal
 - name: mz_catalog_transaction_commits

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -26,6 +26,7 @@ use mz_cluster_client::ReplicaId;
 use mz_controller::clusters::ReplicaLocation;
 use mz_controller_types::ClusterId;
 use mz_ore::instrument;
+use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::now::to_datetime;
 use mz_ore::retry::Retry;
 use mz_ore::task;
@@ -125,16 +126,30 @@ impl Coordinator {
             "coordinator inconsistency detected"
         );
 
+        let side_effects_seconds = self
+            .metrics
+            .catalog_transact_phase_seconds
+            .with_label_values(&["side_effects"]);
+        let table_updates_wait = self
+            .metrics
+            .catalog_transact_phase_seconds
+            .with_label_values(&["table_updates_wait"]);
         let side_effects_fut = side_effect(self, ctx);
 
         // Run our side effects concurrently with the table updates.
         let ((), ()) = futures::future::join(
-            side_effects_fut.instrument(info_span!(
-                "coord::catalog_transact_with_side_effects::side_effects_fut"
-            )),
-            table_updates.instrument(info_span!(
-                "coord::catalog_transact_with_side_effects::table_updates"
-            )),
+            side_effects_fut
+                .wall_time()
+                .observe(side_effects_seconds)
+                .instrument(info_span!(
+                    "coord::catalog_transact_with_side_effects::side_effects_fut"
+                )),
+            table_updates
+                .wall_time()
+                .observe(table_updates_wait)
+                .instrument(info_span!(
+                    "coord::catalog_transact_with_side_effects::table_updates"
+                )),
         )
         .await;
 
@@ -166,6 +181,10 @@ impl Coordinator {
 
         let (table_updates, catalog_updates) = self.catalog_transact_inner(conn_id, ops).await?;
 
+        let table_updates_wait = self
+            .metrics
+            .catalog_transact_phase_seconds
+            .with_label_values(&["table_updates_wait"]);
         let apply_catalog_implications_fut = self.apply_catalog_implications(ctx, catalog_updates);
 
         // Apply catalog implications concurrently with the table updates.
@@ -173,9 +192,12 @@ impl Coordinator {
             apply_catalog_implications_fut.instrument(info_span!(
                 "coord::catalog_transact_with_context::side_effects_fut"
             )),
-            table_updates.instrument(info_span!(
-                "coord::catalog_transact_with_context::table_updates"
-            )),
+            table_updates
+                .wall_time()
+                .observe(table_updates_wait)
+                .instrument(info_span!(
+                    "coord::catalog_transact_with_context::table_updates"
+                )),
         )
         .await;
 
@@ -319,6 +341,9 @@ impl Coordinator {
 
         event!(Level::TRACE, ops = format!("{:?}", ops));
 
+        let phase_seconds = self.metrics.catalog_transact_phase_seconds.clone();
+        let phase_start = Instant::now();
+
         let mut webhook_sources_to_restart = BTreeSet::new();
         let mut clusters_to_drop = vec![];
         let mut cluster_replicas_to_drop = vec![];
@@ -459,6 +484,10 @@ impl Coordinator {
 
         self.validate_resource_limits(&ops, conn_id.unwrap_or(&SYSTEM_CONN_ID))?;
 
+        phase_seconds
+            .with_label_values(&["prep"])
+            .observe(phase_start.elapsed().as_secs_f64());
+
         // This will produce timestamps that are guaranteed to increase on each
         // call, and also never be behind the system clock. If the system clock
         // hasn't advanced (or has gone backward), it will increment by 1. For
@@ -467,7 +496,11 @@ impl Coordinator {
         // always going up, and believe we will always be close to the system
         // clock because it is well configured (chrony) and so may only rarely
         // regress or pause for 10s.
-        let oracle_write_ts = self.get_catalog_write_ts().await;
+        let oracle_write_ts = self
+            .get_catalog_write_ts()
+            .wall_time()
+            .observe(phase_seconds.with_label_values(&["write_ts"]))
+            .await;
 
         let Coordinator {
             catalog,
@@ -490,6 +523,8 @@ impl Coordinator {
                 conn,
                 ops,
             )
+            .wall_time()
+            .observe(phase_seconds.with_label_values(&["transact"]))
             .await?;
 
         for (cluster_id, replica_id) in &cluster_replicas_to_drop {
@@ -517,7 +552,13 @@ impl Coordinator {
 
         // Append our builtin table updates, then return the notify so we can run other tasks in
         // parallel.
+        let stage_start = Instant::now();
         let builtin_update_notify = self.builtin_table_update().execute(builtin_table_updates);
+        phase_seconds
+            .with_label_values(&["stage_builtin"])
+            .observe(stage_start.elapsed().as_secs_f64());
+
+        let finalize_start = Instant::now();
 
         // No error returns are allowed after this point. Enforce this at compile time
         // by using this odd structure so we don't accidentally add a stray `?`.
@@ -596,6 +637,10 @@ impl Coordinator {
                 );
             }
         }
+
+        phase_seconds
+            .with_label_values(&["finalize"])
+            .observe(finalize_start.elapsed().as_secs_f64());
 
         Ok((builtin_update_notify, catalog_updates))
     }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -118,6 +118,14 @@ impl Coordinator {
         // thing to do is panic and let restart/bootstrap handle it.
         apply_implications_res.expect("cannot fail to apply catalog update implications");
 
+        // NOTE: `check_consistency` only runs with soft assertions enabled, so
+        // this phase reads about zero in production. We time it because a local
+        // rig debugging a transact stall commonly has them on, where the check is
+        // O(catalog size) and would otherwise appear as an unexplained remainder
+        // against the wrapper metric. The observation stays outside the macro,
+        // anything inside it compiles out exactly where soft assertions are off.
+        let consistency_start = Instant::now();
+
         // Note: It's important that we keep the function call inside macro, this way we only run
         // the consistency checks if soft assertions are enabled.
         mz_ore::soft_assert_eq_no_log!(
@@ -126,14 +134,23 @@ impl Coordinator {
             "coordinator inconsistency detected"
         );
 
+        self.metrics
+            .catalog_transact_phase_seconds
+            .with_label_values(&["consistency_check"])
+            .observe(consistency_start.elapsed().as_secs_f64());
+
         let side_effects_seconds = self
             .metrics
             .catalog_transact_phase_seconds
             .with_label_values(&["side_effects"]);
+        // Distinct from `table_updates_wait` in `catalog_transact_with_context`.
+        // Here the group commit has already been running concurrently with
+        // `apply_catalog_implications` above, so this wrapper is first polled
+        // late and only records the residual wait.
         let table_updates_wait = self
             .metrics
             .catalog_transact_phase_seconds
-            .with_label_values(&["table_updates_wait"]);
+            .with_label_values(&["table_updates_residual_wait"]);
         let side_effects_fut = side_effect(self, ctx);
 
         // Run our side effects concurrently with the table updates.
@@ -206,6 +223,10 @@ impl Coordinator {
         // let restart/bootstrap handle it.
         combined_apply_res.expect("cannot fail to apply catalog implications");
 
+        // See the note in `catalog_transact_with_side_effects` on why this is
+        // timed outside the macro and reads about zero in production.
+        let consistency_start = Instant::now();
+
         // Note: It's important that we keep the function call inside macro, this way we only run
         // the consistency checks if soft assertions are enabled.
         mz_ore::soft_assert_eq_no_log!(
@@ -213,6 +234,11 @@ impl Coordinator {
             Ok(()),
             "coordinator inconsistency detected"
         );
+
+        self.metrics
+            .catalog_transact_phase_seconds
+            .with_label_values(&["consistency_check"])
+            .observe(consistency_start.elapsed().as_secs_f64());
 
         self.metrics
             .catalog_transact_seconds
@@ -273,19 +299,42 @@ impl Coordinator {
             return Err(AdapterError::DDLTransactionRace);
         }
 
+        // The per-statement phases of a DDL transaction carry their own labels.
+        // The work differs from a real transaction's phases, and it is billed
+        // once per statement rather than once per transaction, so pooling the two
+        // populations under one label would blur both.
+        let phase_seconds = self.metrics.catalog_transact_phase_seconds.clone();
+
         // Clone what we need from the session before taking &mut below.
+        let clone_start = Instant::now();
         let txn_ops_clone = txn_ops.clone();
         let txn_state_clone = txn_state.clone();
+        // NOTE: `txn_snapshot` is a deep clone of the durable `Snapshot`, which is
+        // O(catalog size) in allocations, once per statement. `txn_state` next to
+        // it is cheap, `CatalogState` holds its large collections in `imbl` maps.
         let prev_snapshot = txn_snapshot.clone();
+        phase_seconds
+            .with_label_values(&["ddl_txn_snapshot_clone"])
+            .observe(clone_start.elapsed().as_secs_f64());
 
         // Validate resource limits with all accumulated + new ops (cheap O(N) counting).
+        let prep_start = Instant::now();
         let mut combined_ops = txn_ops_clone;
         combined_ops.extend(ops.iter().cloned());
         let conn_id = ctx.session().conn_id().clone();
-        self.validate_resource_limits(&combined_ops, &conn_id)?;
+        let validate_res = self.validate_resource_limits(&combined_ops, &conn_id);
+        phase_seconds
+            .with_label_values(&["ddl_txn_prep"])
+            .observe(prep_start.elapsed().as_secs_f64());
+        validate_res?;
 
         // Get oracle timestamp for audit log entries.
-        let oracle_write_ts = self.get_local_write_ts().await.timestamp;
+        let oracle_write_ts = self
+            .get_local_write_ts()
+            .wall_time()
+            .observe(phase_seconds.with_label_values(&["ddl_txn_write_ts"]))
+            .await
+            .timestamp;
 
         // Get ConnMeta for the session.
         let conn = self.active_conns.get(ctx.session().conn_id());
@@ -304,6 +353,8 @@ impl Coordinator {
                 prev_snapshot,
                 oracle_write_ts,
             )
+            .wall_time()
+            .observe(phase_seconds.with_label_values(&["ddl_txn_dry_run"]))
             .await?;
 
         // Accumulate ops for eventual COMMIT.
@@ -482,11 +533,13 @@ impl Coordinator {
             }
         }
 
-        self.validate_resource_limits(&ops, conn_id.unwrap_or(&SYSTEM_CONN_ID))?;
-
+        // Observe before propagating, so a transaction rejected on resource
+        // limits still accounts for the op scan it burned on the loop.
+        let validate_res = self.validate_resource_limits(&ops, conn_id.unwrap_or(&SYSTEM_CONN_ID));
         phase_seconds
             .with_label_values(&["prep"])
             .observe(phase_start.elapsed().as_secs_f64());
+        validate_res?;
 
         // This will produce timestamps that are guaranteed to increase on each
         // call, and also never be behind the system clock. If the system clock
@@ -512,6 +565,14 @@ impl Coordinator {
         let catalog = Arc::make_mut(catalog);
         let conn = conn_id.map(|id| active_conns.get(id).expect("connection must exist"));
 
+        // NOTE: This phase contains every durable `sync` and `commit` a catalog
+        // transaction performs, which is what makes `transact` minus those two
+        // histograms an estimate of the in-memory work. Two caveats. More than
+        // one sync happens per transaction, so the subtraction is only valid on
+        // rates of `_sum`, never on per-observation means. And durable
+        // `allocate_id` (user ID pool refills, storage usage batch IDs) observes
+        // into the same histograms from outside any catalog transaction, so the
+        // estimate is biased low while allocation is active.
         let TransactionResult {
             builtin_table_updates,
             catalog_updates,

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -282,7 +282,7 @@ impl Metrics {
             )),
             catalog_transact_phase_seconds: registry.register(metric!(
                 name: "mz_catalog_transact_phase_seconds",
-                help: "Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent.",
+                help: "Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent. Phases overlap and do not sum to mz_catalog_transact_seconds. The transact phase includes the durable catalog sync and commit.",
                 var_labels: ["phase"],
                 buckets: histogram_seconds_buckets(0.000_128, 32.0),
             )),

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -57,6 +57,7 @@ pub struct Metrics {
     pub catalog_arc_weak_count: UIntGauge,
     pub pgwire_recv_scheduling_delay_ms: HistogramVec,
     pub catalog_transact_seconds: HistogramVec,
+    pub catalog_transact_phase_seconds: HistogramVec,
     pub apply_catalog_implications_seconds: Histogram,
     pub group_commit_catalog_upper_seconds: Histogram,
 }
@@ -278,6 +279,12 @@ impl Metrics {
                 help: "The time it takes to run various catalog transact methods.",
                 var_labels: ["method"],
                 buckets: histogram_seconds_buckets(0.001, 32.0),
+            )),
+            catalog_transact_phase_seconds: registry.register(metric!(
+                name: "mz_catalog_transact_phase_seconds",
+                help: "Wall time of the individual phases of a coordinator catalog transaction, to attribute where transact time is spent.",
+                var_labels: ["phase"],
+                buckets: histogram_seconds_buckets(0.000_128, 32.0),
             )),
             apply_catalog_implications_seconds: registry.register(metric!(
                 name: "mz_apply_catalog_implications_seconds",

--- a/src/catalog/src/durable/metrics.rs
+++ b/src/catalog/src/durable/metrics.rs
@@ -12,17 +12,17 @@
 use mz_ore::metric;
 use mz_ore::metrics::{IntCounter, MetricsRegistry};
 use mz_ore::stats::histogram_seconds_buckets;
-use prometheus::{Counter, Histogram, IntGauge, IntGaugeVec};
+use prometheus::{Histogram, IntGauge, IntGaugeVec};
 
 #[derive(Debug, Clone)]
 pub struct Metrics {
     pub transactions_started: IntCounter,
     pub transaction_commits: IntCounter,
-    pub transaction_commit_latency_seconds: Counter,
+    pub transaction_commit_latency_seconds: Histogram,
     pub snapshots_taken: IntCounter,
-    pub snapshot_latency_seconds: Counter,
+    pub snapshot_latency_seconds: Histogram,
     pub syncs: IntCounter,
-    pub sync_latency_seconds: Counter,
+    pub sync_latency_seconds: Histogram,
     pub collection_entries: IntGaugeVec,
     pub allocate_id_seconds: Histogram,
     pub snapshot_consolidations: IntCounter,
@@ -43,7 +43,8 @@ impl Metrics {
             )),
             transaction_commit_latency_seconds: registry.register(metric!(
                 name: "mz_catalog_transaction_commit_latency_seconds",
-                help: "Total latency for committing a durable catalog transactions.",
+                help: "Latency for committing a durable catalog transaction.",
+                buckets: histogram_seconds_buckets(0.000_128, 32.0),
             )),
             snapshots_taken: registry.register(metric!(
                 name: "mz_catalog_snapshots_taken",
@@ -51,7 +52,8 @@ impl Metrics {
             )),
             snapshot_latency_seconds: registry.register(metric!(
                 name: "mz_catalog_snapshot_latency_seconds",
-                help: "Total latency for fetching a snapshot of the durable catalog.",
+                help: "Latency for fetching a snapshot of the durable catalog.",
+                buckets: histogram_seconds_buckets(0.000_128, 32.0),
             )),
             syncs: registry.register(metric!(
                 name: "mz_catalog_syncs",
@@ -59,7 +61,8 @@ impl Metrics {
             )),
             sync_latency_seconds: registry.register(metric!(
                 name: "mz_catalog_sync_latency_seconds",
-                help: "Total latency for syncing the in-memory state of the durable catalog with the persisted contents.",
+                help: "Latency for syncing the in-memory state of the durable catalog with the persisted contents.",
+                buckets: histogram_seconds_buckets(0.000_128, 32.0),
             )),
             collection_entries: registry.register(metric!(
                 name: "mz_catalog_collection_entries",

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -534,10 +534,10 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
     #[mz_ore::instrument(level = "debug")]
     pub(crate) async fn sync(&mut self, target_upper: Timestamp) -> Result<(), FenceError> {
         self.metrics.syncs.inc();
-        let counter = self.metrics.sync_latency_seconds.clone();
+        let histogram = self.metrics.sync_latency_seconds.clone();
         self.sync_inner(target_upper)
             .wall_time()
-            .inc_by(counter)
+            .observe(histogram)
             .await
     }
 
@@ -1926,10 +1926,10 @@ impl DurableCatalogState for PersistCatalogState {
             Ok(next_upper)
         }
         self.metrics.transaction_commits.inc();
-        let counter = self.metrics.transaction_commit_latency_seconds.clone();
+        let histogram = self.metrics.transaction_commit_latency_seconds.clone();
         commit_transaction_inner(self, txn_batch, commit_ts)
             .wall_time()
-            .inc_by(counter)
+            .observe(histogram)
             .await
     }
 
@@ -2038,10 +2038,10 @@ async fn snapshot_binary(
     metrics: &Arc<Metrics>,
 ) -> impl Iterator<Item = StateUpdate<StateUpdateKindJson>> + DoubleEndedIterator + use<> {
     metrics.snapshots_taken.inc();
-    let counter = metrics.snapshot_latency_seconds.clone();
+    let histogram = metrics.snapshot_latency_seconds.clone();
     snapshot_binary_inner(read_handle, as_of)
         .wall_time()
-        .inc_by(counter)
+        .observe(histogram)
         .await
 }
 


### PR DESCRIPTION
### Motivation

Nearly all of the slow coordinator messages we track in `mz_slow_message_handling` funnel into `catalog_transact*`, which runs inline on the coordinator main loop, and Grafana shows `mz_catalog_transact_seconds` spiking in those cases. But that metric wraps the whole call, so we cannot tell *where* the time goes: preparatory work, the timestamp-oracle round trip, the durable persist commit, staging builtin-table writes, or waiting on the group committer. This attribution decides how we tackle the rest of the milestone.

Fixes [SQL-584](https://linear.app/materializeinc/issue/SQL-584)

### Description

Adds `mz_catalog_transact_phase_seconds{phase}`. For a catalog transaction: `prep` (op scan + resource-limit validation), `write_ts` (timestamp-oracle round trip), `transact` (all of `Catalog::transact`), `stage_builtin` (builtin-table staging incl. row consolidation), `finalize` (config fanout, webhook-source restarts, audit events), `consistency_check`, and the concurrently-joined tails `side_effects` and `table_updates_wait` / `table_updates_residual_wait`. The two wait labels are deliberately distinct: in `catalog_transact_with_side_effects` the group commit has already been running alongside the catalog implications, so that site sees only a residual wait, while `catalog_transact_with_context` sees the full one.

Also covers the per-statement DDL-transaction path, which ran entirely uninstrumented on the loop, under its own labels (`ddl_txn_snapshot_clone`, `ddl_txn_prep`, `ddl_txn_write_ts`, `ddl_txn_dry_run`). The deep durable `Snapshot` clone gets its own phase because it is O(catalog size) once per statement and the prime suspect there. Follow-up for the fix: [SQL-586](https://linear.app/materializeinc/issue/SQL-586).

Converts the durable catalog latency metrics `mz_catalog_transaction_commit_latency_seconds`, `mz_catalog_sync_latency_seconds`, and `mz_catalog_snapshot_latency_seconds` from avg-only `Counter`s to histograms. They were invisible at p99 by construction. Metric names are unchanged, but Prometheus now exposes them as `_bucket`/`_sum`/`_count`, so **existing dashboard queries need `_sum` appended** (and gain `histogram_quantile`).

`doc/user/data/metrics.yml` regenerated via `bin/gen-metrics-catalog`.

#### Estimating the in-memory work

The phases overlap and do not sum to `mz_catalog_transact_seconds`. `transact` contains every durable sync and commit a transaction performs, so subtracting those two histograms estimates the in-memory portion:

```promql
rate(mz_catalog_transact_phase_seconds_sum{phase="transact"}[5m])
  - rate(mz_catalog_sync_latency_seconds_sum[5m])
  - rate(mz_catalog_transaction_commit_latency_seconds_sum[5m])
```

Two caveats, both also recorded at the call site. More than one sync happens per transaction, so this is only valid on rates of `_sum`, never on per-observation means (sync's mean is taken over several times as many observations). And durable `allocate_id` observes into the same histograms from outside any catalog transaction (user ID pool refills, storage usage batch IDs), so the estimate is biased low while allocation is active.

### Verification

Metrics-only change, no behavior change. `cargo check`, `cargo clippy`, `bin/fmt`, and the metrics-catalog lint pass locally. Attribution will be validated by watching the new phase histograms alongside `mz_catalog_transact_seconds` on the environmentd health dashboard.
