### PR TITLE
adapter: make a builtin cluster's config own its replica set

### DIFF
--- a/misc/python/materialize/checks/all_checks/builtin_cluster_replication_factor.py
+++ b/misc/python/materialize/checks/all_checks/builtin_cluster_replication_factor.py
@@ -1,0 +1,65 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.mz_version import MzVersion
+
+
+class BuiltinClusterReplicationFactor(Check):
+    """A builtin cluster's replication factor owns its replica set across restarts.
+
+    `mz_support` is the interesting cluster. It runs nothing by default, and it is
+    the break-glass path a support engineer scales up by hand. A catalog open that
+    does not read the cluster's replication factor tears that replica down, leaving
+    the cluster reporting a factor it is not honoring.
+    """
+
+    def _can_run(self, e: Executor) -> bool:
+        # Only versions that reconcile the replica set against the cluster's own
+        # replication factor keep this replica across a restart. Confine the check
+        # to scenarios whose boots are all the current version: the upgrade
+        # scenarios restart on released binaries, and `manipulate` and `validate`
+        # both run on those.
+        return self.base_version >= MzVersion.parse_cargo()
+
+    def manipulate(self) -> list[Testdrive]:
+        # `mz_support` owns its own cluster, so the ALTER has to run as that role.
+        # Its sessions default to `mz_catalog_server`, which has a replica, so a
+        # statement from this connection is safe to issue.
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                $ postgres-execute connection=postgres://mz_support:materialize@${testdrive.materialize-internal-sql-addr}
+                ALTER CLUSTER mz_support SET (REPLICATION FACTOR 1);
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(dedent("""
+            > SELECT c.replication_factor, count(r.id)
+              FROM mz_clusters c
+              LEFT JOIN mz_cluster_replicas r ON r.cluster_id = c.id
+              WHERE c.name = 'mz_support'
+              GROUP BY c.replication_factor
+            1 1
+
+            # Named by the managed-cluster rule, and owned by the cluster's owner
+            # rather than by mz_system.
+            > SELECT r.name, o.name
+              FROM mz_cluster_replicas r
+              JOIN mz_clusters c ON c.id = r.cluster_id
+              JOIN mz_roles o ON o.id = r.owner_id
+              WHERE c.name = 'mz_support'
+            r1 mz_support
+            """))

--- a/misc/python/materialize/checks/all_checks/builtin_cluster_replication_factor.py
+++ b/misc/python/materialize/checks/all_checks/builtin_cluster_replication_factor.py
@@ -35,12 +35,24 @@ class BuiltinClusterReplicationFactor(Check):
         # `mz_support` owns its own cluster, so the ALTER has to run as that role.
         # Its sessions default to `mz_catalog_server`, which has a replica, so a
         # statement from this connection is safe to issue.
+        #
+        # A restart separates the two phases, so phase 2 asserting the replica is
+        # still there is the regression assertion: the replica set has to be
+        # rederived from the cluster's factor rather than from a fixed list.
         return [
             Testdrive(dedent(s))
             for s in [
                 """
                 $ postgres-execute connection=postgres://mz_support:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER CLUSTER mz_support SET (REPLICATION FACTOR 1);
+                """,
+                """
+                > SELECT c.replication_factor, count(r.id)
+                  FROM mz_clusters c
+                  LEFT JOIN mz_cluster_replicas r ON r.cluster_id = c.id
+                  WHERE c.name = 'mz_support'
+                  GROUP BY c.replication_factor
+                1 1
                 """,
             ]
         ]

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -337,6 +337,13 @@ class UpgradeV80Migration(Scenario):
         print(
             "Upgrade path: v26.17.1 -> initialize -> v26.18.0 -> manipulate#1 -> restart -> manipulate#2 -> v26.24.0 (v82_to_v83) -> current (v83_to_v84) -> restart -> validate"
         )
+        # The factor-0 override below only applies to the boots that pass it, but
+        # it is durable: the cluster row is seeded once and a later boot honors the
+        # row rather than its own flag. So mz_system has no replica for the whole
+        # run, including the final unoverridden boots. Nothing here needs one,
+        # since the checks peek as `materialize` on `quickstart` and the mz_system
+        # connection only issues DDL. A check that peeked at a non-catalog object
+        # as `mz_system` would hang, and would need this override lifted.
         return [
             StartMz(
                 self,

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -129,9 +129,15 @@ class Materialized(Service):
         if cluster_replica_size is None:
             cluster_replica_size = cluster_replica_size_map()
         if builtin_system_cluster_replication_factor is None:
-            builtin_system_cluster_replication_factor = default_replication_factor
+            # Deliberately not `default_replication_factor`. Builtin clusters
+            # honor their replication factor, so tracking the user default here
+            # would run two mz_system and two mz_probe replicas in every
+            # composition that asks for a replicated user cluster, at no benefit
+            # to what those tests actually exercise. One replica is all these
+            # clusters need, and is what the flags below are here to guarantee.
+            builtin_system_cluster_replication_factor = 1
         if builtin_probe_cluster_replication_factor is None:
-            builtin_probe_cluster_replication_factor = default_replication_factor
+            builtin_probe_cluster_replication_factor = 1
 
         environment = [
             "MZ_NO_TELEMETRY=1",

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -129,12 +129,14 @@ class Materialized(Service):
         if cluster_replica_size is None:
             cluster_replica_size = cluster_replica_size_map()
         if builtin_system_cluster_replication_factor is None:
-            # Deliberately not `default_replication_factor`. Builtin clusters
-            # honor their replication factor, so tracking the user default here
+            # Deliberately not `default_replication_factor`. A builtin cluster
+            # honors its replication factor, so tracking the user default here
             # would run two mz_system and two mz_probe replicas in every
             # composition that asks for a replicated user cluster, at no benefit
             # to what those tests actually exercise. One replica is all these
             # clusters need, and is what the flags below are here to guarantee.
+            # A test that needs a different builtin factor, including 0, has to
+            # ask for it explicitly.
             builtin_system_cluster_replication_factor = 1
         if builtin_probe_cluster_replication_factor is None:
             builtin_probe_cluster_replication_factor = 1

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -27,14 +27,17 @@ use mz_audit_log::{
 use mz_auth::hash::scram256_hash;
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_catalog::builtin::{
-    BUILTIN_CLUSTER_REPLICAS, BUILTIN_CLUSTERS, BUILTIN_PREFIXES, BUILTIN_ROLES, BUILTINS, Builtin,
-    Fingerprint, MZ_CATALOG_RAW, RUNTIME_ALTERABLE_FINGERPRINT_SENTINEL,
+    BUILTIN_CLUSTERS, BUILTIN_PREFIXES, BUILTIN_ROLES, BUILTINS, Builtin, Fingerprint,
+    MZ_CATALOG_RAW, RUNTIME_ALTERABLE_FINGERPRINT_SENTINEL,
 };
 use mz_catalog::config::StateConfig;
 use mz_catalog::durable::objects::{
     SystemObjectDescription, SystemObjectMapping, SystemObjectUniqueIdentifier,
 };
-use mz_catalog::durable::{ClusterReplica, ClusterVariant, ClusterVariantManaged, Transaction};
+use mz_catalog::durable::{
+    ClusterReplica, ClusterVariant, ClusterVariantManaged, ReplicaConfig, ReplicaLocation,
+    Transaction, managed_cluster_replica_name,
+};
 use mz_catalog::expr_cache::{
     ExpressionCacheConfig, ExpressionCacheHandle, GlobalExpressions, LocalExpressions,
 };
@@ -210,7 +213,7 @@ impl Catalog {
                 config.boot_ts,
             )?;
             add_new_remove_old_builtin_introspection_source_migration(&mut txn)?;
-            add_new_remove_old_builtin_cluster_replicas_migration(
+            reconcile_builtin_cluster_replicas(
                 &mut txn,
                 &builtin_bootstrap_cluster_config_map,
                 config.boot_ts,
@@ -1114,67 +1117,120 @@ fn add_new_remove_old_builtin_roles_migration(
     Ok(())
 }
 
-fn add_new_remove_old_builtin_cluster_replicas_migration(
+/// Converges each builtin cluster's replica set on the cluster's own managed
+/// config.
+///
+/// Builtin clusters are managed clusters, so their replicas are derived state:
+/// exactly `replication_factor` replicas, named by
+/// [`managed_cluster_replica_name`]. Replicas this creates are shaped from the
+/// cluster's config, but an existing replica is matched by name alone and left
+/// untouched, so this converges cardinality and names rather than shape.
+///
+/// The bootstrap flags seed `replication_factor` and `size` when a cluster is
+/// first created (see [`add_new_remove_old_builtin_clusters_migration`]) and are
+/// deliberately not consulted here, so an `ALTER CLUSTER` against a builtin
+/// cluster survives a restart.
+///
+/// This is the sole owner of a builtin cluster's replica set, which is why the
+/// cluster controller excludes system clusters. Ownership sits here because this
+/// covers two windows the controller cannot: the coordinator's bootstrap brings up
+/// only replicas already recorded durably and runs before the controller task is
+/// spawned, and the controller is inactive entirely while a deployment is
+/// read-only.
+fn reconcile_builtin_cluster_replicas(
     txn: &mut Transaction<'_>,
     builtin_cluster_config_map: &BuiltinBootstrapClusterConfigMap,
     boot_ts: Timestamp,
 ) -> Result<(), AdapterError> {
-    let cluster_lookup: BTreeMap<_, _> = txn
+    let builtin_cluster_names: BTreeSet<&str> = BUILTIN_CLUSTERS
+        .iter()
+        .map(|cluster| cluster.name)
+        .collect();
+
+    // Replicas of a cluster that is no longer a builtin need no handling here:
+    // `Transaction::remove_clusters` cascades to a cluster's replicas, and the
+    // clusters migration has already run against this transaction.
+    let clusters: Vec<_> = txn
         .get_clusters()
-        .map(|cluster| (cluster.name.clone(), cluster.clone()))
+        .filter(|cluster| {
+            cluster.id.is_system() && builtin_cluster_names.contains(cluster.name.as_str())
+        })
         .collect();
 
-    let cluster_id_to_name: BTreeMap<ClusterId, String> = cluster_lookup
-        .values()
-        .map(|cluster| (cluster.id, cluster.name.clone()))
-        .collect();
+    let builtin_cluster_ids: BTreeSet<ClusterId> =
+        clusters.iter().map(|cluster| cluster.id).collect();
 
-    let mut durable_replicas: BTreeMap<ClusterId, BTreeMap<String, ClusterReplica>> = txn
+    // Only the builtin clusters' replicas. An environment can have thousands of
+    // user replicas and none of them are in scope here.
+    let mut replicas_by_cluster: BTreeMap<ClusterId, BTreeMap<String, ClusterReplica>> =
+        BTreeMap::new();
+    for replica in txn
         .get_cluster_replicas()
-        .filter(|replica| replica.replica_id.is_system())
-        .fold(BTreeMap::new(), |mut acc, replica| {
-            acc.entry(replica.cluster_id)
-                .or_insert_with(BTreeMap::new)
-                .insert(replica.name.to_string(), replica);
-            acc
-        });
+        .filter(|replica| builtin_cluster_ids.contains(&replica.cluster_id))
+    {
+        replicas_by_cluster
+            .entry(replica.cluster_id)
+            .or_default()
+            .insert(replica.name.clone(), replica);
+    }
 
-    // Add new replicas.
-    for builtin_replica in BUILTIN_CLUSTER_REPLICAS {
-        let cluster = cluster_lookup
-            .get(builtin_replica.cluster_name)
-            .expect("builtin cluster replica references non-existent cluster");
-        // `empty_map` is a hack to simplify the if statement below.
-        let mut empty_map: BTreeMap<String, ClusterReplica> = BTreeMap::new();
-        let replica_names = durable_replicas
-            .get_mut(&cluster.id)
-            .unwrap_or(&mut empty_map);
+    let mut to_drop: Vec<(String, ClusterReplica)> = Vec::new();
 
-        let builtin_cluster_bootstrap_config =
-            builtin_cluster_config_map.get_config(builtin_replica.cluster_name)?;
-        if replica_names.remove(builtin_replica.name).is_none()
-            // NOTE(SangJunBak): We need to explicitly check the replication factor because
-            // BUILT_IN_CLUSTER_REPLICAS is constant throughout all deployments but the replication
-            // factor is configurable on bootstrap.
-            && builtin_cluster_bootstrap_config.replication_factor > 0
-        {
-            let replica_size = match cluster.config.variant {
-                ClusterVariant::Managed(ClusterVariantManaged { ref size, .. }) => size.clone(),
-                ClusterVariant::Unmanaged => builtin_cluster_bootstrap_config.size.clone(),
-            };
+    for cluster in clusters {
+        // An unmanaged cluster has no replication factor, so there is no target to
+        // converge on. Its replica set is whatever an operator made it, and it is
+        // not ours to reshape.
+        let ClusterVariant::Managed(managed) = &cluster.config.variant else {
+            continue;
+        };
 
-            let config = builtin_cluster_replica_config(replica_size.clone());
+        // The bootstrap flags seed a cluster at creation and are never re-applied,
+        // which is what keeps an `ALTER CLUSTER` from being reverted on every
+        // restart. That leaves an operator who changed a flag on an existing
+        // deployment with no feedback, so say so.
+        let bootstrap_config = builtin_cluster_config_map.get_config(&cluster.name)?;
+        if bootstrap_config.replication_factor != managed.replication_factor {
+            warn!(
+                cluster = %cluster.name,
+                configured_replication_factor = managed.replication_factor,
+                bootstrap_replication_factor = bootstrap_config.replication_factor,
+                "bootstrap replication factor is not applied to an already-existing \
+                 builtin cluster. Use ALTER CLUSTER ... SET (REPLICATION FACTOR ...) \
+                 to change it",
+            );
+        }
+
+        // Reading the cluster's factor is what makes this compose with the other
+        // writers of a replica set. The refresh scheduler parks a scheduled cluster
+        // by writing its factor to 0, so converging on the factor honors that
+        // instead of resurrecting a replica the scheduler just dropped.
+        let mut surplus = replicas_by_cluster.remove(&cluster.id).unwrap_or_default();
+        for index in 0..managed.replication_factor {
+            let replica_name = managed_cluster_replica_name(index);
+            if surplus.remove(&replica_name).is_some() {
+                continue;
+            }
+
             // Builtin replicas live on system clusters. This runs inside the
-            // catalog-open transaction with no coordinator, so allocating from
-            // the same transaction is single-source and safe.
+            // catalog-open transaction with no coordinator, so allocating from the
+            // same transaction is single-source and safe.
             let replica_id = txn.allocate_system_replica_id()?;
             txn.insert_cluster_replica_with_id(
                 cluster.id,
                 replica_id,
-                builtin_replica.name,
-                config,
-                MZ_SYSTEM_ROLE_ID,
+                &replica_name,
+                managed_replica_config(managed),
+                // The cluster's owner, not `mz_system`. `mz_support` and
+                // `mz_analytics` are owned by their own roles, and replica
+                // ownership is checked against the replica's own `owner_id`, so
+                // stamping `mz_system` here would stop those roles from altering
+                // a replica of a cluster they own.
+                cluster.owner_id,
             )?;
+            info!(
+                cluster = %cluster.name, replica = %replica_name, %replica_id,
+                "creating builtin cluster replica to match the cluster's replication factor"
+            );
 
             let audit_id = txn.allocate_audit_log_id()?;
             txn.insert_audit_log_event(VersionedEvent::new(
@@ -1185,8 +1241,8 @@ fn add_new_remove_old_builtin_cluster_replicas_migration(
                     cluster_id: cluster.id.to_string(),
                     cluster_name: cluster.name.clone(),
                     replica_id: Some(replica_id.to_string()),
-                    replica_name: builtin_replica.name.to_string(),
-                    logical_size: replica_size,
+                    replica_name,
+                    logical_size: managed.size.clone(),
                     billed_as: None,
                     internal: false,
                     reason: CreateOrDropClusterReplicaReasonV1::System,
@@ -1196,21 +1252,32 @@ fn add_new_remove_old_builtin_cluster_replicas_migration(
                 boot_ts.into(),
             ));
         }
+
+        // Whatever the config does not call for is surplus: a replica left over from
+        // a higher replication factor, or a `-pending` replica belonging to a
+        // graceful reconfiguration that a restart interrupted. Dropping the latter
+        // here means `remove_pending_cluster_replicas_migration` never sees it,
+        // which matches the abort semantics it would have applied anyway.
+        to_drop.extend(
+            surplus
+                .into_values()
+                .map(|replica| (cluster.name.clone(), replica)),
+        );
     }
 
-    // Remove old replicas.
-    let old_replicas: Vec<_> = durable_replicas
-        .values()
-        .flat_map(|replicas| replicas.values())
+    // Batched: `Transaction::remove_cluster_replica` is linear in the total replica
+    // count, so it must not be called in a loop.
+    let drop_ids = to_drop
+        .iter()
+        .map(|(_cluster_name, replica)| replica.replica_id)
         .collect();
-    let old_replica_ids = old_replicas.iter().map(|r| r.replica_id).collect();
-    txn.remove_cluster_replicas(&old_replica_ids)?;
+    txn.remove_cluster_replicas(&drop_ids)?;
 
-    for replica in &old_replicas {
-        let cluster_name = cluster_id_to_name
-            .get(&replica.cluster_id)
-            .cloned()
-            .unwrap_or_else(|| "<unknown>".to_string());
+    for (cluster_name, replica) in to_drop {
+        info!(
+            cluster = %cluster_name, replica = %replica.name, replica_id = %replica.replica_id,
+            "dropping builtin cluster replica not called for by the cluster's replication factor"
+        );
 
         let audit_id = txn.allocate_audit_log_id()?;
         txn.insert_audit_log_event(VersionedEvent::new(
@@ -1221,7 +1288,7 @@ fn add_new_remove_old_builtin_cluster_replicas_migration(
                 cluster_id: replica.cluster_id.to_string(),
                 cluster_name,
                 replica_id: Some(replica.replica_id.to_string()),
-                replica_name: replica.name.clone(),
+                replica_name: replica.name,
                 reason: CreateOrDropClusterReplicaReasonV1::System,
                 scheduling_policies: None,
             }),
@@ -1231,6 +1298,33 @@ fn add_new_remove_old_builtin_cluster_replicas_migration(
     }
 
     Ok(())
+}
+
+/// The replica config implied by a managed cluster's config.
+///
+/// Every field a replica shares with its cluster is taken from the cluster.
+/// `availability_zones` is the cluster's pool, which is what the provisioning
+/// paths stamp onto a managed replica.
+///
+/// Two things the `ALTER CLUSTER` path does that this does not. It normalizes
+/// logging through the plan, which discards `log_logging` when no interval is
+/// set, so for the odd cluster config that has debugging on and logging off the
+/// two produce different records. And it validates the size against the replica
+/// size map and the role's allowed sizes, which cannot be done from here because
+/// the size map is not part of the durable catalog. A builtin cluster's size only
+/// ever comes from a bootstrap flag or an `ALTER` that already validated it.
+fn managed_replica_config(managed: &ClusterVariantManaged) -> ReplicaConfig {
+    ReplicaConfig {
+        location: ReplicaLocation::Managed {
+            size: managed.size.clone(),
+            availability_zones: managed.availability_zones.clone(),
+            billed_as: None,
+            internal: false,
+            pending: false,
+        },
+        logging: managed.logging.clone(),
+        arrangement_compression: managed.arrangement_compression,
+    }
 }
 
 /// Roles can have default values for configuration parameters, e.g. you can set a Role default for
@@ -1338,22 +1432,6 @@ fn remove_pending_cluster_replicas_migration(
     Ok(())
 }
 
-pub(crate) fn builtin_cluster_replica_config(
-    replica_size: String,
-) -> mz_catalog::durable::ReplicaConfig {
-    mz_catalog::durable::ReplicaConfig {
-        location: mz_catalog::durable::ReplicaLocation::Managed {
-            availability_zones: Vec::new(),
-            billed_as: None,
-            pending: false,
-            internal: false,
-            size: replica_size,
-        },
-        logging: default_logging_config(),
-        arrangement_compression: false,
-    }
-}
-
 fn default_logging_config() -> ReplicaLogging {
     ReplicaLogging {
         log_logging: false,
@@ -1429,4 +1507,60 @@ pub(crate) fn into_consolidatable_updates_startup(
             (kind, ts, Diff::from(diff))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_catalog::durable::ClusterVariantManaged;
+
+    use super::*;
+
+    /// A replica the reconciler creates takes every shared field from its
+    /// cluster. Nothing here may fall back to a default, or a builtin cluster
+    /// ends up running a replica that disagrees with its own config.
+    #[mz_ore::test]
+    fn test_managed_replica_config_derives_every_shared_field() {
+        let managed = ClusterVariantManaged {
+            size: "somesize".into(),
+            availability_zones: vec!["az1".into(), "az2".into()],
+            logging: ReplicaLogging {
+                log_logging: true,
+                interval: Some(Duration::from_millis(10)),
+            },
+            arrangement_compression: true,
+            replication_factor: 3,
+            optimizer_feature_overrides: Default::default(),
+            schedule: Default::default(),
+            auto_scaling_strategy: None,
+            reconfiguration: None,
+            burst: None,
+        };
+
+        let config = managed_replica_config(&managed);
+
+        assert_eq!(config.logging, managed.logging);
+        assert_eq!(
+            config.arrangement_compression,
+            managed.arrangement_compression
+        );
+        match config.location {
+            ReplicaLocation::Managed {
+                size,
+                availability_zones,
+                billed_as,
+                internal,
+                pending,
+            } => {
+                assert_eq!(size, managed.size);
+                assert_eq!(availability_zones, managed.availability_zones);
+                // A builtin replica is neither manually managed nor part of an
+                // in-flight reconfiguration, and those three traits are what
+                // exclude a replica from controller ownership.
+                assert_eq!(billed_as, None);
+                assert!(!internal);
+                assert!(!pending);
+            }
+            ReplicaLocation::Unmanaged { .. } => panic!("expected a managed location"),
+        }
+    }
 }

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1127,7 +1127,8 @@ fn add_new_remove_old_builtin_roles_migration(
 ///
 /// Replicas this creates are shaped from the cluster's config. An existing replica
 /// is matched by name alone and left untouched, so this converges cardinality and
-/// names rather than shape.
+/// names rather than shape. An internal replica is never derived state and is left
+/// alone entirely.
 ///
 /// The bootstrap flags seed `replication_factor` and `size` when a cluster is
 /// first created (see [`add_new_remove_old_builtin_clusters_migration`]) and are
@@ -1167,12 +1168,21 @@ fn reconcile_builtin_cluster_replicas(
 
     // Only the builtin clusters' replicas. An environment can have thousands of
     // user replicas and none of them are in scope here.
+    //
+    // An internal replica is deliberately out of scope. `CREATE CLUSTER REPLICA ...
+    // INTERNAL` is allowed on a managed cluster, and its name is barred from
+    // matching the derived `r1..rN` pattern so it cannot collide with one. It is a
+    // break-glass replica an operator added rather than derived state, so reaping it
+    // would undo that. The `ALTER CLUSTER` path skips it for the same reason.
     let mut replicas_by_cluster: BTreeMap<ClusterId, BTreeMap<String, ClusterReplica>> =
         BTreeMap::new();
-    for replica in txn
-        .get_cluster_replicas()
-        .filter(|replica| builtin_cluster_ids.contains(&replica.cluster_id))
-    {
+    for replica in txn.get_cluster_replicas().filter(|replica| {
+        builtin_cluster_ids.contains(&replica.cluster_id)
+            && !matches!(
+                replica.config.location,
+                ReplicaLocation::Managed { internal: true, .. }
+            )
+    }) {
         replicas_by_cluster
             .entry(replica.cluster_id)
             .or_default()

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1120,23 +1120,28 @@ fn add_new_remove_old_builtin_roles_migration(
 /// Converges each builtin cluster's replica set on the cluster's own managed
 /// config.
 ///
-/// Builtin clusters are managed clusters, so their replicas are derived state:
-/// exactly `replication_factor` replicas, named by
-/// [`managed_cluster_replica_name`]. Replicas this creates are shaped from the
-/// cluster's config, but an existing replica is matched by name alone and left
-/// untouched, so this converges cardinality and names rather than shape.
+/// A builtin cluster is normally managed, and a managed cluster's replicas are
+/// derived state: exactly `replication_factor` replicas, named by
+/// [`managed_cluster_replica_name`]. One can be altered to unmanaged, which leaves
+/// no factor to derive from, and then its replica set is the operator's.
+///
+/// Replicas this creates are shaped from the cluster's config. An existing replica
+/// is matched by name alone and left untouched, so this converges cardinality and
+/// names rather than shape.
 ///
 /// The bootstrap flags seed `replication_factor` and `size` when a cluster is
 /// first created (see [`add_new_remove_old_builtin_clusters_migration`]) and are
 /// deliberately not consulted here, so an `ALTER CLUSTER` against a builtin
 /// cluster survives a restart.
 ///
-/// This is the sole owner of a builtin cluster's replica set, which is why the
-/// cluster controller excludes system clusters. Ownership sits here because this
-/// covers two windows the controller cannot: the coordinator's bootstrap brings up
-/// only replicas already recorded durably and runs before the controller task is
-/// spawned, and the controller is inactive entirely while a deployment is
-/// read-only.
+/// This runs at catalog open so the replicas a cluster's config calls for exist as
+/// early as possible. The coordinator's bootstrap brings up only replicas already
+/// recorded durably and runs before the cluster controller is spawned, and the
+/// controller does not run at all while a deployment is read-only.
+///
+/// The controller derives its target from the same cluster config, so it converges
+/// on the same replica set rather than competing for it. It excludes system
+/// clusters today, but nothing here depends on that staying true.
 fn reconcile_builtin_cluster_replicas(
     txn: &mut Transaction<'_>,
     builtin_cluster_config_map: &BuiltinBootstrapClusterConfigMap,
@@ -1314,16 +1319,30 @@ fn reconcile_builtin_cluster_replicas(
 /// the size map is not part of the durable catalog. A builtin cluster's size only
 /// ever comes from a bootstrap flag or an `ALTER` that already validated it.
 fn managed_replica_config(managed: &ClusterVariantManaged) -> ReplicaConfig {
+    // Exhaustive destructure (no `..`): a field added to the managed config is a
+    // compile error here until we decide whether a replica has to carry it.
+    let ClusterVariantManaged {
+        size,
+        availability_zones,
+        logging,
+        arrangement_compression,
+        replication_factor: _,
+        optimizer_feature_overrides: _,
+        schedule: _,
+        auto_scaling_strategy: _,
+        reconfiguration: _,
+        burst: _,
+    } = managed;
     ReplicaConfig {
         location: ReplicaLocation::Managed {
-            size: managed.size.clone(),
-            availability_zones: managed.availability_zones.clone(),
+            size: size.clone(),
+            availability_zones: availability_zones.clone(),
             billed_as: None,
             internal: false,
             pending: false,
         },
-        logging: managed.logging.clone(),
-        arrangement_compression: managed.arrangement_compression,
+        logging: logging.clone(),
+        arrangement_compression: *arrangement_compression,
     }
 }
 
@@ -1538,12 +1557,17 @@ mod tests {
 
         let config = managed_replica_config(&managed);
 
-        assert_eq!(config.logging, managed.logging);
-        assert_eq!(
-            config.arrangement_compression,
-            managed.arrangement_compression
-        );
-        match config.location {
+        // Exhaustive destructures throughout, so a field added to either type is a
+        // compile error here rather than a silently unasserted one.
+        let ReplicaConfig {
+            location,
+            logging,
+            arrangement_compression,
+        } = config;
+
+        assert_eq!(logging, managed.logging);
+        assert_eq!(arrangement_compression, managed.arrangement_compression);
+        match location {
             ReplicaLocation::Managed {
                 size,
                 availability_zones,

--- a/src/adapter/src/coord/cluster_controller.rs
+++ b/src/adapter/src/coord/cluster_controller.rs
@@ -22,8 +22,9 @@
 //! the gate off the task does not tick, so the legacy scheduling and graceful
 //! paths remain the sole writers of the replica set. With the gate on the
 //! controller owns the *user* managed-cluster replica set; the legacy entry
-//! points no-op. (System/builtin clusters are never controller-owned. Their
-//! replicas are owned by `reconcile_builtin_cluster_replicas` at catalog open.)
+//! points no-op. (System/builtin clusters are excluded here. Their config-implied
+//! replicas are materialized by `reconcile_builtin_cluster_replicas` at catalog
+//! open, which derives the same target from the same config.)
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -58,8 +59,8 @@ use crate::error::AdapterError;
 #[derive(Debug)]
 pub enum ClusterControllerRequest {
     /// The ids of all *user* managed clusters the controller owns this tick.
-    /// System/builtin clusters are excluded. Their replica set is owned by
-    /// `reconcile_builtin_cluster_replicas` at catalog open, not the controller.
+    /// System/builtin clusters are excluded. `reconcile_builtin_cluster_replicas`
+    /// has already materialized their config-implied replicas at catalog open.
     ManagedClusterIds { tx: oneshot::Sender<Vec<ClusterId>> },
     /// A consistent durable view of the given clusters and their replicas, plus
     /// the current time.
@@ -277,13 +278,13 @@ impl Coordinator {
                     self.catalog()
                         .clusters()
                         // Only *user* managed clusters. System/builtin clusters
-                        // (mz_system, mz_catalog_server, …) are also managed, but
-                        // their replica set is owned by the catalog-open reconciler
-                        // (`reconcile_builtin_cluster_replicas`), which converges it
-                        // on the cluster's `replication_factor`. Two owners of one
-                        // replica set would fight, and only the reconciler can run
-                        // before the coordinator finishes bootstrap and while a
-                        // deployment is read-only, so it keeps them.
+                        // (mz_system, mz_catalog_server, …) are also managed, and
+                        // `reconcile_builtin_cluster_replicas` materializes their
+                        // config-implied replica set at catalog open, so those
+                        // replicas exist before the controller could ever tick.
+                        // Both derive the target from the cluster's
+                        // `replication_factor`, so extending ownership here would
+                        // converge rather than conflict.
                         .filter(|c| c.is_managed() && c.id.is_user())
                         .map(|c| c.id)
                         .collect()

--- a/src/adapter/src/coord/cluster_controller.rs
+++ b/src/adapter/src/coord/cluster_controller.rs
@@ -22,8 +22,8 @@
 //! the gate off the task does not tick, so the legacy scheduling and graceful
 //! paths remain the sole writers of the replica set. With the gate on the
 //! controller owns the *user* managed-cluster replica set; the legacy entry
-//! points no-op. (System/builtin clusters are never controller-owned. The
-//! catalog's bootstrap migration owns their replicas.)
+//! points no-op. (System/builtin clusters are never controller-owned. Their
+//! replicas are owned by `reconcile_builtin_cluster_replicas` at catalog open.)
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -58,8 +58,8 @@ use crate::error::AdapterError;
 #[derive(Debug)]
 pub enum ClusterControllerRequest {
     /// The ids of all *user* managed clusters the controller owns this tick.
-    /// System/builtin clusters are excluded. Their replica set is owned by the
-    /// catalog's bootstrap migration, not the controller.
+    /// System/builtin clusters are excluded. Their replica set is owned by
+    /// `reconcile_builtin_cluster_replicas` at catalog open, not the controller.
     ManagedClusterIds { tx: oneshot::Sender<Vec<ClusterId>> },
     /// A consistent durable view of the given clusters and their replicas, plus
     /// the current time.
@@ -278,16 +278,12 @@ impl Coordinator {
                         .clusters()
                         // Only *user* managed clusters. System/builtin clusters
                         // (mz_system, mz_catalog_server, …) are also managed, but
-                        // their replica set is owned by the bootstrap migration
-                        // (`add_new_remove_old_builtin_cluster_replicas_migration`),
-                        // which holds exactly the `BUILTIN_CLUSTER_REPLICAS`-defined
-                        // replicas regardless of the cluster's `replication_factor`.
-                        // Letting the controller own them too would make two writers
-                        // of one replica set: the baseline would, for example, add a
-                        // replica to reach a builtin cluster's `replication_factor`,
-                        // which the bootstrap migration then tears down on the next
-                        // open. The legacy scheduler likewise only ever acted on user
-                        // clusters.
+                        // their replica set is owned by the catalog-open reconciler
+                        // (`reconcile_builtin_cluster_replicas`), which converges it
+                        // on the cluster's `replication_factor`. Two owners of one
+                        // replica set would fight, and only the reconciler can run
+                        // before the coordinator finishes bootstrap and while a
+                        // deployment is read-only, so it keeps them.
                         .filter(|c| c.is_managed() && c.id.is_user())
                         .map(|c| c.id)
                         .collect()

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -14,6 +14,7 @@ use itertools::Itertools;
 use maplit::btreeset;
 use mz_adapter_types::cluster_state::ReconfigurationAudit;
 use mz_catalog::builtin::BUILTINS;
+use mz_catalog::durable::managed_cluster_replica_name;
 use mz_catalog::memory::objects::{
     ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged,
     ManagedReplicaConfigShape, ReconfigurationState, ReconfigurationStatus, ReconfigurationTarget,
@@ -2564,10 +2565,6 @@ impl Coordinator {
             }
         }
     }
-}
-
-fn managed_cluster_replica_name(index: u32) -> String {
-    format!("r{}", index + 1)
 }
 
 /// Which reconfiguration-target dimensions an `ALTER` left unset (`Unchanged`).

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -66,7 +66,6 @@ use crate::durable::objects::SystemObjectDescription;
 use crate::memory::objects::DataSourceDesc;
 
 pub const BUILTIN_PREFIXES: &[&str] = &["mz_", "pg_", "external_"];
-const BUILTIN_CLUSTER_REPLICA_NAME: &str = "r1";
 
 /// A sentinel used in place of a fingerprint that indicates that a builtin
 /// object is runtime alterable. Runtime alterable objects don't have meaningful
@@ -696,14 +695,6 @@ pub struct BuiltinCluster {
     pub owner_id: &'static RoleId,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BuiltinClusterReplica {
-    /// Name of the compute replica.
-    pub name: &'static str,
-    /// Name of the cluster that this replica belongs to.
-    pub cluster_name: &'static str,
-}
-
 /// Uniquely identifies the definition of a builtin object.
 pub trait Fingerprint {
     fn fingerprint(&self) -> String;
@@ -906,11 +897,6 @@ pub const MZ_SYSTEM_CLUSTER: BuiltinCluster = BuiltinCluster {
     ],
 };
 
-pub const MZ_SYSTEM_CLUSTER_REPLICA: BuiltinClusterReplica = BuiltinClusterReplica {
-    name: BUILTIN_CLUSTER_REPLICA_NAME,
-    cluster_name: MZ_SYSTEM_CLUSTER.name,
-};
-
 pub const MZ_CATALOG_SERVER_CLUSTER: BuiltinCluster = BuiltinCluster {
     name: "mz_catalog_server",
     owner_id: &MZ_SYSTEM_ROLE_ID,
@@ -929,11 +915,6 @@ pub const MZ_CATALOG_SERVER_CLUSTER: BuiltinCluster = BuiltinCluster {
     ],
 };
 
-pub const MZ_CATALOG_SERVER_CLUSTER_REPLICA: BuiltinClusterReplica = BuiltinClusterReplica {
-    name: BUILTIN_CLUSTER_REPLICA_NAME,
-    cluster_name: MZ_CATALOG_SERVER_CLUSTER.name,
-};
-
 pub const MZ_PROBE_CLUSTER: BuiltinCluster = BuiltinCluster {
     name: "mz_probe",
     owner_id: &MZ_SYSTEM_ROLE_ID,
@@ -950,10 +931,6 @@ pub const MZ_PROBE_CLUSTER: BuiltinCluster = BuiltinCluster {
         },
         rbac::owner_privilege(ObjectType::Cluster, MZ_SYSTEM_ROLE_ID),
     ],
-};
-pub const MZ_PROBE_CLUSTER_REPLICA: BuiltinClusterReplica = BuiltinClusterReplica {
-    name: BUILTIN_CLUSTER_REPLICA_NAME,
-    cluster_name: MZ_PROBE_CLUSTER.name,
 };
 
 pub const MZ_SUPPORT_CLUSTER: BuiltinCluster = BuiltinCluster {
@@ -1575,11 +1552,6 @@ pub const BUILTIN_CLUSTERS: &[&BuiltinCluster] = &[
     &MZ_PROBE_CLUSTER,
     &MZ_SUPPORT_CLUSTER,
     &MZ_ANALYTICS_CLUSTER,
-];
-pub const BUILTIN_CLUSTER_REPLICAS: &[&BuiltinClusterReplica] = &[
-    &MZ_SYSTEM_CLUSTER_REPLICA,
-    &MZ_CATALOG_SERVER_CLUSTER_REPLICA,
-    &MZ_PROBE_CLUSTER_REPLICA,
 ];
 
 #[allow(non_snake_case)]

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -37,7 +37,7 @@ pub use crate::durable::objects::{
     NetworkPolicy, ReconfigurationState, ReconfigurationStatus, ReconfigurationTarget,
     ReplicaConfig, ReplicaLocation, ReplicaSystemConfiguration, Role, RoleAuth, Schema,
     SourceReference, SourceReferences, StorageCollectionMetadata, SystemConfiguration,
-    SystemObjectDescription, SystemObjectMapping, UnfinalizedShard,
+    SystemObjectDescription, SystemObjectMapping, UnfinalizedShard, managed_cluster_replica_name,
 };
 pub use crate::durable::persist::shard_id;
 use crate::durable::persist::{Timestamp, UnopenedPersistCatalogState};

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -363,6 +363,22 @@ pub struct ClusterVariantManaged {
     pub burst: Option<BurstState>,
 }
 
+/// The canonical name of the `index`-th (zero-based) replica of a managed
+/// cluster.
+///
+/// A managed cluster's replicas are derived from its `replication_factor`: for a
+/// factor of N they are named `r1` through `rN`.
+///
+/// `ALTER CLUSTER` computes the replicas it creates and drops by this rule, and
+/// so does the catalog-open reconciler that materializes builtin replicas. The
+/// two have to share it, or `ALTER` cannot find the replicas it means to change.
+/// The cluster controller deliberately does not: its `ReplicaNameGen` picks names
+/// that avoid the observed set, which is why `ALTER` against a controller-owned
+/// cluster drops by observed id rather than by derived name.
+pub fn managed_cluster_replica_name(index: u32) -> String {
+    format!("r{}", index + 1)
+}
+
 /// The latest graceful reconfiguration: the config shape the cluster is moving
 /// to or most recently moved toward, plus its deadline and terminal state.
 ///

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -592,6 +592,15 @@ impl TestHarness {
         self
     }
 
+    pub fn with_builtin_support_cluster_replication_factor(
+        mut self,
+        builtin_support_cluster_replication_factor: u32,
+    ) -> Self {
+        self.builtin_support_cluster_config.replication_factor =
+            builtin_support_cluster_replication_factor;
+        self
+    }
+
     pub fn with_builtin_catalog_server_cluster_replica_size(
         mut self,
         builtin_catalog_server_cluster_replica_size: String,

--- a/src/environmentd/tests/bootstrap_builtin_clusters.rs
+++ b/src/environmentd/tests/bootstrap_builtin_clusters.rs
@@ -47,6 +47,25 @@ fn execute_as(server: &TestServerWithRuntime, user: &str, stmt: &str) {
     client.batch_execute(stmt).unwrap();
 }
 
+/// A cluster's replica names, sorted.
+///
+/// Stronger than a count when the point is which replicas survived, and usable on
+/// an unmanaged cluster, where `replication_factor` is null.
+fn replica_names(server: &TestServerWithRuntime, cluster: &str) -> Vec<String> {
+    let mut client = server.connect(postgres::NoTls).unwrap();
+    client
+        .query(
+            "SELECT r.name FROM mz_cluster_replicas r
+             JOIN mz_clusters c ON c.id = r.cluster_id
+             WHERE c.name = $1 ORDER BY r.name",
+            &[&cluster],
+        )
+        .unwrap()
+        .iter()
+        .map(|row| row.get::<_, String>(0))
+        .collect()
+}
+
 // A cluster with a replication factor of 0 should not create any replicas.
 #[mz_ore::test]
 fn test_zero_replication_factor_no_replicas() {
@@ -232,4 +251,74 @@ fn test_restart_is_idempotent() {
 
     let server = harness.start_blocking();
     assert_eq!(replica_ids(&server), before);
+}
+
+// An internal replica on a builtin cluster survives a restart. `CREATE CLUSTER
+// REPLICA ... INTERNAL` is allowed on a managed cluster, and its name is barred
+// from matching the derived `r1..rN` pattern, so it coexists with the derived
+// replicas instead of being one of them. It is the break-glass way to attach a
+// replica to a builtin cluster, and `ALTER CLUSTER` already preserves it, so
+// reconciling has to leave it alone too while still converging the derived set.
+#[mz_ore::test]
+fn test_internal_replica_survives_restart() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let harness = TestHarness::default().data_directory(data_dir.path());
+
+    {
+        let server = harness.clone().start_blocking();
+        assert_eq!(declared_and_actual(&server, "mz_system"), (1, 1));
+        execute_as(
+            &server,
+            "mz_system",
+            "CREATE CLUSTER REPLICA mz_system.breakglass SIZE 'scale=1,workers=1', INTERNAL",
+        );
+        // An internal replica is not derived from the factor, so it adds a replica
+        // without changing what the cluster declares.
+        assert_eq!(declared_and_actual(&server, "mz_system"), (1, 2));
+    }
+
+    let server = harness.start_blocking();
+    assert_eq!(declared_and_actual(&server, "mz_system"), (1, 2));
+    assert_eq!(
+        replica_names(&server, "mz_system"),
+        vec!["breakglass".to_string(), "r1".to_string()]
+    );
+}
+
+// An unmanaged builtin cluster's replica set belongs to whoever made it. There is
+// no replication factor to derive a target from, so reconciling has to skip the
+// cluster rather than treat all of its replicas as surplus.
+#[mz_ore::test]
+fn test_unmanaged_builtin_cluster_is_left_alone() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let harness = TestHarness::default()
+        .with_builtin_support_cluster_replication_factor(1)
+        .data_directory(data_dir.path());
+
+    {
+        let server = harness.clone().start_blocking();
+        assert_eq!(declared_and_actual(&server, "mz_support"), (1, 1));
+        // The conversion adopts the existing `r1`. Adding a second replica then
+        // makes the set one that no replication factor would produce.
+        execute_as(
+            &server,
+            "mz_system",
+            "ALTER CLUSTER mz_support SET (MANAGED = false)",
+        );
+        execute_as(
+            &server,
+            "mz_system",
+            "CREATE CLUSTER REPLICA mz_support.extra SIZE 'scale=1,workers=1'",
+        );
+        assert_eq!(
+            replica_names(&server, "mz_support"),
+            vec!["extra".to_string(), "r1".to_string()]
+        );
+    }
+
+    let server = harness.start_blocking();
+    assert_eq!(
+        replica_names(&server, "mz_support"),
+        vec!["extra".to_string(), "r1".to_string()]
+    );
 }

--- a/src/environmentd/tests/bootstrap_builtin_clusters.rs
+++ b/src/environmentd/tests/bootstrap_builtin_clusters.rs
@@ -300,14 +300,17 @@ fn test_unmanaged_builtin_cluster_is_left_alone() {
         assert_eq!(declared_and_actual(&server, "mz_support"), (1, 1));
         // The conversion adopts the existing `r1`. Adding a second replica then
         // makes the set one that no replication factor would produce.
+        //
+        // As `mz_support`, not `mz_system`: altering a cluster requires being its
+        // owner, and `mz_support` owns this one.
         execute_as(
             &server,
-            "mz_system",
+            "mz_support",
             "ALTER CLUSTER mz_support SET (MANAGED = false)",
         );
         execute_as(
             &server,
-            "mz_system",
+            "mz_support",
             "CREATE CLUSTER REPLICA mz_support.extra SIZE 'scale=1,workers=1'",
         );
         assert_eq!(

--- a/src/environmentd/tests/bootstrap_builtin_clusters.rs
+++ b/src/environmentd/tests/bootstrap_builtin_clusters.rs
@@ -8,31 +8,228 @@
 // by the Apache License, Version 2.0.
 
 //! Integration tests for builtin clusters on bootstrap.
+//!
+//! A builtin cluster is a managed cluster, so its `replication_factor` is the
+//! single source of truth for its replica set. These tests pin that down from
+//! both directions: the factor a deployment bootstraps with is realized, and a
+//! factor an operator sets with `ALTER CLUSTER` survives a restart.
 
-use mz_environmentd::test_util::{self};
+use mz_environmentd::test_util::{self, TestHarness, TestServerWithRuntime};
 
-// Test that a cluster with a replication factor of 0 should not create any replicas.
+/// A builtin cluster's declared replication factor and how many replicas it
+/// actually has.
+///
+/// Always read over the public port, whose session cluster is `quickstart`, so a
+/// test that drops `mz_system`'s replicas can still observe the result.
+fn declared_and_actual(server: &TestServerWithRuntime, cluster: &str) -> (i32, i32) {
+    let mut client = server.connect(postgres::NoTls).unwrap();
+    let row = client
+        .query_one(
+            "SELECT c.replication_factor::integer,
+                    (SELECT COUNT(*) FROM mz_cluster_replicas r WHERE r.cluster_id = c.id)::integer
+             FROM mz_clusters c
+             WHERE c.name = $1",
+            &[&cluster],
+        )
+        .unwrap();
+    (row.get(0), row.get(1))
+}
+
+/// Runs `stmt` as `user` over the internal port, which is where the system roles
+/// that own the builtin clusters can connect.
+fn execute_as(server: &TestServerWithRuntime, user: &str, stmt: &str) {
+    let mut config = server.pg_config_internal();
+    config.user(user);
+    let mut client = config.connect(postgres::NoTls).unwrap();
+    // The `Sql` composition wrappers are async and only defined for
+    // tokio-postgres clients, and these statements are fixed test literals.
+    #[allow(clippy::disallowed_methods)]
+    client.batch_execute(stmt).unwrap();
+}
+
+// A cluster with a replication factor of 0 should not create any replicas.
 #[mz_ore::test]
 fn test_zero_replication_factor_no_replicas() {
     let server = test_util::TestHarness::default()
         .with_builtin_system_cluster_replication_factor(0)
         .start_blocking();
 
+    assert_eq!(declared_and_actual(&server, "mz_system"), (0, 0));
+}
+
+// A replication factor above one is realized, not truncated to a single replica.
+// The bootstrap flags accept 0..=2, and the replica set is derived from the
+// factor, so asking for two replicas has to produce two.
+#[mz_ore::test]
+fn test_replication_factor_above_one_is_realized() {
+    let server = test_util::TestHarness::default()
+        .with_builtin_system_cluster_replication_factor(2)
+        .start_blocking();
+
+    assert_eq!(declared_and_actual(&server, "mz_system"), (2, 2));
+}
+
+// Scaling a builtin cluster to zero replicas sticks across a restart. The
+// bootstrap flag seeds the factor at creation and must not resurrect a replica
+// the operator removed.
+#[mz_ore::test]
+fn test_alter_to_zero_replicas_survives_restart() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let harness = TestHarness::default().data_directory(data_dir.path());
+
+    {
+        let server = harness.clone().start_blocking();
+        assert_eq!(declared_and_actual(&server, "mz_system"), (1, 1));
+        execute_as(
+            &server,
+            "mz_system",
+            "ALTER CLUSTER mz_system SET (REPLICATION FACTOR 0)",
+        );
+        assert_eq!(declared_and_actual(&server, "mz_system"), (0, 0));
+    }
+
+    let server = harness.start_blocking();
+    assert_eq!(declared_and_actual(&server, "mz_system"), (0, 0));
+}
+
+// Scaling a builtin cluster above one replica sticks across a restart.
+#[mz_ore::test]
+fn test_alter_above_one_replica_survives_restart() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let harness = TestHarness::default().data_directory(data_dir.path());
+
+    {
+        let server = harness.clone().start_blocking();
+        execute_as(
+            &server,
+            "mz_system",
+            "ALTER CLUSTER mz_system SET (REPLICATION FACTOR 2)",
+        );
+        assert_eq!(declared_and_actual(&server, "mz_system"), (2, 2));
+    }
+
+    let server = harness.start_blocking();
+    assert_eq!(declared_and_actual(&server, "mz_system"), (2, 2));
+}
+
+// A bootstrap flag that disagrees with an existing cluster's row does not act on
+// it. This is the path a helm deployment takes, since the chart defaults
+// `defaultReplicationFactor.system` to 0: install at 0, then restart with the
+// flag back at its default of 1. The row has to win, or the cluster ends up at
+// factor 0 with a live replica, which wedges every later factor `ALTER` on the
+// `(cluster_id, name)` uniqueness constraint.
+#[mz_ore::test]
+fn test_bootstrap_flag_does_not_act_on_existing_cluster() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let harness = TestHarness::default().data_directory(data_dir.path());
+
+    {
+        let server = harness
+            .clone()
+            .with_builtin_system_cluster_replication_factor(0)
+            .start_blocking();
+        assert_eq!(declared_and_actual(&server, "mz_system"), (0, 0));
+    }
+
+    // Restarting without the flag leaves it at its default of 1, which must not
+    // resurrect a replica. Each boot is scoped so the previous one is shut down
+    // before the next opens the catalog, otherwise the older instance is
+    // epoch-fenced while still running.
+    {
+        let server = harness.clone().start_blocking();
+        assert_eq!(declared_and_actual(&server, "mz_system"), (0, 0));
+    }
+
+    // Nor does raising it further.
+    let server = harness
+        .with_builtin_system_cluster_replication_factor(2)
+        .start_blocking();
+    assert_eq!(declared_and_actual(&server, "mz_system"), (0, 0));
+}
+
+// `mz_support` defaults to zero replicas and stays that way, but a support
+// engineer who scales it up keeps the replica across a restart. This is the
+// break-glass path: `mz_support` runs nothing until someone needs it.
+#[mz_ore::test]
+fn test_support_cluster_replica_survives_restart() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let harness = TestHarness::default().data_directory(data_dir.path());
+
+    {
+        let server = harness.clone().start_blocking();
+        assert_eq!(declared_and_actual(&server, "mz_support"), (0, 0));
+        execute_as(
+            &server,
+            "mz_support",
+            "ALTER CLUSTER mz_support SET (REPLICATION FACTOR 1)",
+        );
+        assert_eq!(declared_and_actual(&server, "mz_support"), (1, 1));
+    }
+
+    let server = harness.start_blocking();
+    assert_eq!(declared_and_actual(&server, "mz_support"), (1, 1));
+}
+
+// A replica the reconciler creates is owned by its cluster's owner, not by
+// `mz_system`. `mz_support` and `mz_analytics` are owned by their own roles, and
+// replica ownership is checked against the replica's own `owner_id`, so stamping
+// `mz_system` here would lock those roles out of a replica of a cluster they own.
+//
+// Bootstrapping `mz_support` above zero also pins that its replication-factor flag
+// reaches the replica set at all, which is only true because the flag seeds the
+// cluster's factor and the factor is what the replica set is derived from.
+#[mz_ore::test]
+fn test_created_replica_is_owned_by_its_cluster_owner() {
+    let server = TestHarness::default()
+        .with_builtin_support_cluster_replication_factor(1)
+        .start_blocking();
+
+    assert_eq!(declared_and_actual(&server, "mz_support"), (1, 1));
+
     let mut client = server.connect(postgres::NoTls).unwrap();
-    let system_cluster = client
+    let owner: String = client
         .query_one(
-            r#"
-    SELECT c.id, c.name, c.replication_factor::integer, COUNT(cr.id)::integer as replica_count
-    FROM mz_clusters c
-    LEFT JOIN mz_cluster_replicas cr ON c.id = cr.cluster_id
-    WHERE c.name = 'mz_system'
-    GROUP BY c.id, c.name, c.replication_factor"#,
+            "SELECT o.name FROM mz_cluster_replicas r
+             JOIN mz_clusters c ON c.id = r.cluster_id
+             JOIN mz_roles o ON o.id = r.owner_id
+             WHERE c.name = 'mz_support'",
             &[],
         )
-        .unwrap();
+        .unwrap()
+        .get(0);
+    assert_eq!(owner, "mz_support");
+}
 
-    let replication_factor: i32 = system_cluster.get(2);
-    let replica_count: i32 = system_cluster.get(3);
-    assert_eq!(replication_factor, 0);
-    assert_eq!(replica_count, 0);
+// A restart must not disturb a builtin cluster whose replica set already matches
+// its factor. Two consecutive boots leave the same replica ids in place, so
+// nothing is torn down and recreated behind the operator's back.
+#[mz_ore::test]
+fn test_restart_is_idempotent() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let harness = TestHarness::default().data_directory(data_dir.path());
+
+    let replica_ids = |server: &TestServerWithRuntime| -> Vec<String> {
+        let mut client = server.connect(postgres::NoTls).unwrap();
+        client
+            .query(
+                "SELECT r.id FROM mz_cluster_replicas r
+                 JOIN mz_clusters c ON c.id = r.cluster_id
+                 WHERE c.id LIKE 's%' ORDER BY r.id",
+                &[],
+            )
+            .unwrap()
+            .iter()
+            .map(|row| row.get::<_, String>(0))
+            .collect()
+    };
+
+    let before = {
+        let server = harness.clone().start_blocking();
+        let before = replica_ids(&server);
+        assert!(!before.is_empty(), "expected some builtin replicas");
+        before
+    };
+
+    let server = harness.start_blocking();
+    assert_eq!(replica_ids(&server), before);
 }

--- a/test/catalog-migration/incident-1007/mzcompose.py
+++ b/test/catalog-migration/incident-1007/mzcompose.py
@@ -84,10 +84,15 @@ def _mz(image: str | None) -> Materialized:
         external_metadata_store=True,
         external_blob_store=True,
         sanity_restart=False,
-        # Set the default replication factor since
-        # one of the heuristics of a "non-cloud" environment is that the
-        # replication factor is 0 for mz_system.
+        # The buggy `v80_to_v81` migration decides an environment is cloud by
+        # checking whether `mz_system`'s replication factor is above 0, so the
+        # self-managed path this test reproduces needs that factor at 0. Passed
+        # explicitly: the builtin factors do not track
+        # `default_replication_factor`, since a builtin cluster honors its own
+        # factor and most tests want one replica there regardless of what they ask
+        # for on the user cluster.
         default_replication_factor=0,
+        builtin_system_cluster_replication_factor=0,
         # MZ_SOFT_ASSERTIONS=1 turns
         # soft asserts into panics, killing environmentd mid-upgrade
         # before v83->v84 ever runs. Demote them to log-only so the upgrade


### PR DESCRIPTION
Builtin clusters became managed clusters in `76ba9e793f`, which gave them a
`replication_factor` and made the hardcoded `BUILTIN_CLUSTER_REPLICAS` list
redundant. The list stayed, and the catalog-open migration that materializes
builtin replicas was never rewired to the factor. It kept reconciling against
the list, using the bootstrap replication-factor flag only as an on/off gate and
never reading the cluster's own row.

Every other part of a builtin cluster's shape follows one rule: a const or a
bootstrap flag seeds it at creation, and the durable row plus `ALTER CLUSTER`
own it afterwards. The replica set was the sole exception, and the only part
that drifted:

- `replication_factor > 1` was silently truncated to one replica. The flags
  accept `0..=2`, and nothing else filled the gap because the cluster controller
  excludes system clusters.
- `ALTER CLUSTER mz_support SET (REPLICATION FACTOR 1)` had its replica reaped
  on every restart, since `mz_support` and `mz_analytics` are absent from the
  list. That is the support break-glass path, and
  `--bootstrap-builtin-support-cluster-replication-factor` was inert for the
  same reason.
- `ALTER CLUSTER mz_system SET (REPLICATION FACTOR 0)` was undone on the next
  boot, leaving durable factor 0 with a live replica. That state wedges later
  factor `ALTER`s on the `(cluster_id, name)` uniqueness constraint with
  `DuplicateReplica`. It needs no SQL to reach: bootstrap at 0, then restart
  without the flag. The helm chart ships `defaultReplicationFactor.system: 0`,
  so "install, then raise the factor" walked into it.
- `ALTER CLUSTER mz_system SET (REPLICATION FACTOR 2)` had `r2` reaped,
  likewise.
- A created replica took only `size` from its cluster, hardcoding a 1s
  introspection interval, no arrangement compression and no availability zones,
  so it could disagree with its own cluster's config.

## The change

One rule: for a builtin cluster, the durable managed config is the single source
of truth for its replica set.

`reconcile_builtin_cluster_replicas` replaces the migration. A managed builtin
cluster converges on exactly `replication_factor` replicas named `r1..rN`,
shaped from the cluster's size, availability zones, logging and arrangement
compression, and owned by the cluster's owner. Everything else on that cluster
is dropped, except internal replicas, which are not derived from the factor and
are left alone. An unmanaged one has no factor to converge on, so its replicas
are left to the operator.

The bootstrap flags now only seed the cluster row at creation, matching what
`--bootstrap-builtin-*-cluster-replica-size` already did. A flag that disagrees
with an existing row logs a warning naming both values and the `ALTER CLUSTER`
that would apply it, so the deliberate no-op is not silent.

`BUILTIN_CLUSTER_REPLICAS` and friends are deleted. Each entry said only "this
cluster has a replica named r1", which the factor already says and says better.
`managed_cluster_replica_name` moves to `mz_catalog::durable` so the reconciler
and the `ALTER` path derive names from one rule, since two places disagreeing on
names is what let `ALTER`'s create-and-drop-by-name miss replicas. Owning a
created replica by `cluster.owner_id` rather than `mz_system` matters now that
all five clusters are in scope, because `mz_support` and `mz_analytics` own
theirs and ownership is checked against the replica's own `owner_id`.

## Behavior changes

- `replication_factor > 1` takes effect and persists. An environment already
  carrying factor 2 converges on the first boot by gaining a replica. That would
  have been broad in CI, where the mzcompose harness tied the builtin system and
  probe factors to `default_replication_factor` and 24 compositions set it to 2.
  The coupling was incidental, so `materialized.py` pins them to 1 and CI's
  resource profile is unchanged.
- An environment whose `mz_support` or `mz_analytics` factor is above 0 gains a
  replica that now sticks.
- The bootstrap replication-factor flags become create-only, so changing
  `defaultReplicationFactor.*` in helm on an existing deployment no longer does
  anything. It previously appeared to work while leaving the wedged state above,
  so the working path (`ALTER CLUSTER`) is unchanged and the broken one is gone.
  Making the flag genuinely declarative needs a durable last-applied value and
  belongs in its own change.
- An unmanaged builtin cluster is no longer repaired at boot. `ALTER CLUSTER
  mz_catalog_server SET (MANAGED = false)` plus dropping its replica used to be
  undone on the next open. That already breaks introspection immediately, so the
  repair was papering over a self-inflicted outage. Rejecting `MANAGED = false`
  on a builtin cluster would remove the footgun and is worth doing separately.

## Testing

`src/environmentd/tests/bootstrap_builtin_clusters.rs` restarts against the same
durable catalog. Five tests fail on `main`: a bootstrap factor above one is
realized, the `mz_support` replica survives, `ALTER` to 0 sticks and a stale
flag does not resurrect it, `ALTER` to 2 keeps `r2`, and a created replica is
owned by its cluster's owner. Two more are guards that pass on both.

Replica logging and arrangement compression are not exposed per replica in the
catalog, so a unit test on `managed_replica_config` pins that every shared field
comes from the cluster config.

`builtin_cluster_replication_factor.py` covers restart survival as a platform
check, gated to scenarios whose boots are all the current version. Released
binaries reap the replica, and both `manipulate` and `validate` run on them in
the upgrade scenarios.

## Follow-up

The helm chart documents `operator.clusters.defaultReplicationFactor.*` with no
description, and those knobs are now bootstrap-only. That needs a description
and a release note pointing operators at `ALTER CLUSTER`. Not done here because
`helm-docs` generates the chart docs and CI lints them for being in sync.
