### PR TITLE
pgwire: drop the frame-level request size check

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1986,22 +1986,36 @@ fn test_default_cluster_sizes() {
 }
 
 #[mz_ore::test]
-#[ignore] // TODO: Reenable when https://linear.app/materializeinc/issue/SQL-411 is fixed
+#[cfg_attr(miri, ignore)] // too slow
 #[allow(clippy::disallowed_methods)]
 fn test_max_request_size() {
     let statement = "SELECT $1::text";
     let statement_size = statement.bytes().count();
     let server = test_util::TestHarness::default().start_blocking();
 
-    // pgwire
+    // pgwire. A request past the size that used to be rejected at the frame
+    // layer must keep the connection usable. Oversized SQL text still errors,
+    // but from the parser's statement batch limit, and an oversized parameter
+    // is simply accepted, as PostgreSQL accepts it.
     {
-        let param_size = mz_pgwire_common::MAX_REQUEST_SIZE - statement_size + 1;
-        let param = std::iter::repeat("1").take(param_size).join("");
+        let big = std::iter::repeat("1")
+            .take(mz_pgwire_common::MAX_REQUEST_SIZE + 1024)
+            .join("");
         let mut client = server.connect(postgres::NoTls).unwrap();
 
-        let err = client.query(statement, &[&param]).unwrap_db_error();
-        assert_contains!(err.message(), "request larger than");
-        assert_err!(client.is_valid(Duration::from_secs(2)));
+        let returned: String = client.query_one(statement, &[&big]).unwrap().get(0);
+        assert_eq!(returned.len(), big.len());
+
+        let err = client
+            .batch_execute(&format!("SELECT '{big}'"))
+            .unwrap_db_error();
+        assert_eq!(&SqlState::PROGRAM_LIMIT_EXCEEDED, err.code());
+        assert_contains!(err.message(), "statement batch size cannot exceed");
+
+        // Neither request may take the connection down with it.
+        client.is_valid(Duration::from_secs(2)).unwrap();
+        let one: i32 = client.query_one("SELECT 1", &[]).unwrap().get(0);
+        assert_eq!(one, 1);
     }
 
     // http

--- a/src/pgwire/src/codec.rs
+++ b/src/pgwire/src/codec.rs
@@ -18,17 +18,14 @@ use std::net::IpAddr;
 
 use async_trait::async_trait;
 use bytes::{Buf, BufMut, BytesMut};
-use bytesize::ByteSize;
 use futures::{SinkExt, TryStreamExt, sink};
 use itertools::Itertools;
 use mz_adapter_types::connection::ConnectionId;
-use mz_ore::cast::CastFrom;
 use mz_ore::future::OreSinkExt;
 use mz_ore::netio::AsyncReady;
 use mz_pgwire_common::{
-    ChannelBinding, Conn, Cursor, DecodeState, ErrorResponse, FrontendMessage, GS2Header,
-    MAX_REQUEST_SIZE, Pgbuf, SASLClientFinalResponse, SASLInitialResponse, input_err,
-    parse_frame_len,
+    ChannelBinding, Conn, Cursor, DecodeState, ErrorResponse, FrontendMessage, GS2Header, Pgbuf,
+    SASLClientFinalResponse, SASLInitialResponse, input_err, parse_frame_len,
 };
 use tokio::io::{self, AsyncRead, AsyncWrite, Interest, Ready};
 use tokio::time::{self, Duration};
@@ -148,15 +145,6 @@ where
         codec.text_settings = text_settings;
     }
 
-    /// Enables or disables copy mode on the codec.
-    ///
-    /// When copy mode is enabled, the aggregate buffer size check in the
-    /// decoder is skipped. This is needed during COPY FROM STDIN because
-    /// many small CopyData frames can accumulate in the TCP read buffer.
-    pub fn set_copy_mode(&mut self, enabled: bool) {
-        self.inner.get_mut().codec_mut().in_copy_mode = enabled;
-    }
-
     /// Waits for the connection to be closed.
     ///
     /// Returns a "connection closed" error when the connection is closed. If
@@ -222,12 +210,6 @@ pub struct Codec {
     encode_state: Vec<(mz_pgrepr::Type, mz_pgwire_common::Format)>,
     /// The session's text encoding settings when `encode_state` was installed.
     text_settings: mz_pgrepr::TextEncodeSettings,
-    /// When true, skip the aggregate buffer size check in `decode()`.
-    /// During COPY FROM STDIN, many small CopyData frames accumulate in the
-    /// TCP read buffer and can exceed MAX_REQUEST_SIZE even though individual
-    /// frames are small. Individual frame lengths are still validated by
-    /// `parse_frame_len()`.
-    in_copy_mode: bool,
 }
 
 impl Codec {
@@ -237,7 +219,6 @@ impl Codec {
             decode_state: DecodeState::Head,
             encode_state: vec![],
             text_settings: mz_pgrepr::TextEncodeSettings::STABLE,
-            in_copy_mode: false,
         }
     }
 }
@@ -514,15 +495,6 @@ impl Decoder for Codec {
     type Error = io::Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<FrontendMessage>, io::Error> {
-        if !self.in_copy_mode && src.len() > MAX_REQUEST_SIZE {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "request larger than {}",
-                    ByteSize::b(u64::cast_from(MAX_REQUEST_SIZE))
-                ),
-            ));
-        }
         loop {
             match self.decode_state {
                 DecodeState::Head => {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -644,7 +644,7 @@ where
 
     select! {
         r = machine.run() => {
-            // Errors produced internally (like MAX_REQUEST_SIZE being exceeded) should send an
+            // Errors produced internally (like a malformed frame header) should send an
             // error to the client informing them why the connection was closed. We still want to
             // return the original error up the stack, though, so we skip error checking during conn
             // operations.
@@ -2986,9 +2986,6 @@ where
             }
         };
 
-        // Enable copy mode on the codec to skip aggregate buffer size checks.
-        self.conn.set_copy_mode(true);
-
         // Batch size for splitting raw data across parallel workers (~32MB).
         const BATCH_SIZE: usize = 32 * 1024 * 1024;
         let max_copy_from_row_size = self
@@ -3079,7 +3076,6 @@ where
                     );
                     // Drop the writer to signal cancellation to the background tasks.
                     drop(writer);
-                    self.conn.set_copy_mode(false);
                     return self
                         .send_error_and_get_state(ErrorResponse::error(
                             SqlState::QUERY_CANCELED,
@@ -3097,7 +3093,6 @@ where
                         },
                     );
                     drop(writer);
-                    self.conn.set_copy_mode(false);
                     return self
                         .send_error_and_get_state(ErrorResponse::error(
                             SqlState::PROTOCOL_VIOLATION,
@@ -3107,7 +3102,6 @@ where
                 }
                 None => {
                     drop(writer);
-                    self.conn.set_copy_mode(false);
                     return Ok(State::Done);
                 }
             }
@@ -3133,7 +3127,6 @@ where
                             },
                         );
                         drop(writer);
-                        self.conn.set_copy_mode(false);
                         return self
                             .send_error_and_get_state(ErrorResponse::error(
                                 SqlState::PROTOCOL_VIOLATION,
@@ -3143,7 +3136,6 @@ where
                     }
                     None => {
                         drop(writer);
-                        self.conn.set_copy_mode(false);
                         return Ok(State::Done);
                     }
                 }
@@ -3156,13 +3148,10 @@ where
                 StatementEndedExecutionReason::Errored { error: msg.clone() },
             );
             drop(writer);
-            self.conn.set_copy_mode(false);
             return self
                 .send_error_and_get_state(ErrorResponse::error(code, msg))
                 .await;
         }
-
-        self.conn.set_copy_mode(false);
 
         // Drop all senders to signal EOF to the background batch builders.
         // If copy_err is set, a worker already failed — dropping the senders


### PR DESCRIPTION
A frontend message over MAX_REQUEST_SIZE failed the codec with an io::Error, which propagates out of the connection's state machine and replies FATAL 08006 before closing the socket. A 2 MiB query cost the client its session.

Nothing is lost by deleting the check. Oversized SQL text is already rejected recoverably one layer up, by the parser's MAX_STATEMENT_BATCH_SIZE guard, which is the SQLSTATE 54000 tier clients already see. An oversized parameter is now simply accepted, as PostgreSQL accepts it. Messages stay bounded by netio::MAX_FRAME_SIZE.

The check also never bounded what it looked like it bounded. src.reserve() runs on the frame header, before any body arrives, so the buffer was already sized from the declared length. The check only limited bytes accepted afterwards, and it fired on whatever a single read delivered, which is why test_max_request_size was flaky enough to be ignored ([SQL-411](https://linear.app/materializeinc/issue/SQL-411)). That test is re-enabled and now asserts the connection survives a request past the old limit.

Closes: [SQL-489](https://linear.app/materializeinc/issue/SQL-489)