### PR TITLE
adapter,pgwire: make an extended-protocol pipeline an implicit transaction

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1128,6 +1128,16 @@ impl SessionClient {
         catalog.system_config().enable_statement_arrival_logging()
     }
 
+    /// Reports whether `enable_extended_protocol_implicit_transaction` is on.
+    pub async fn extended_protocol_implicit_transaction_enabled(&mut self) -> bool {
+        let catalog = self
+            .catalog_snapshot("extended_protocol_implicit_transaction")
+            .await;
+        catalog
+            .system_config()
+            .enable_extended_protocol_implicit_transaction()
+    }
+
     /// Dumps the catalog to a JSON string.
     ///
     /// No authorization is performed, so access to this function must be limited to internal

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1253,6 +1253,10 @@ impl Coordinator {
         //    DDL. If the lock could not be acquired, the DDL is put into the VecDeque where it
         //    awaits dequeuing caused by the lock being released.
 
+        // For `Started`, this separates the first statement of an extended-protocol
+        // pipeline from a later one that joins the ops staged before it.
+        let txn_contains_ops = ctx.session().transaction().contains_ops();
+
         // Verify that this statement type can be executed in the current
         // transaction state.
         match ctx.session().transaction() {
@@ -1270,7 +1274,7 @@ impl Coordinator {
             // being executed, but there might be others after it before the Sync (commit)
             // message. Postgres handles this by teaching Started to eagerly commit certain
             // statements that can't be run in a transaction block.
-            TransactionStatus::Started(_) => {
+            TransactionStatus::Started(_) if !txn_contains_ops => {
                 if let Statement::Declare(_) = &*stmt {
                     // Declare is an exception. Although it's not against any spec to execute
                     // it, it will always result in nothing happening, since all portals will be
@@ -1291,7 +1295,13 @@ impl Coordinator {
             // transactions can do unless there's some additional checking to make sure
             // something disallowed in explicit transactions did not previously take place
             // in the implicit portion.
-            TransactionStatus::InTransactionImplicit(_) | TransactionStatus::InTransaction(_) => {
+            //
+            // A `Started` transaction with staged ops belongs here too: this statement
+            // runs alongside them, so a DDL or read-then-write that cannot see them must
+            // be rejected rather than run against a state that lacks them.
+            TransactionStatus::Started(_)
+            | TransactionStatus::InTransactionImplicit(_)
+            | TransactionStatus::InTransaction(_) => {
                 match &*stmt {
                     // Statements that are safe in a transaction. We still need to verify that we
                     // don't interleave reads and writes since we can't perform those serializably.

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -551,7 +551,12 @@ impl Coordinator {
                     ctx.retire(Ok(ExecuteResponse::DiscardedTemp));
                 }
                 Plan::DiscardAll => {
-                    let ret = if let TransactionStatus::Started(_) = ctx.session().transaction() {
+                    // Clearing the transaction would silently discard writes staged by an
+                    // earlier statement of the same pipeline.
+                    let txn = ctx.session().transaction();
+                    let discardable =
+                        matches!(txn, TransactionStatus::Started(_)) && !txn.contains_ops();
+                    let ret = if discardable {
                         let (_, retire_notify) = self.clear_transaction(ctx.session_mut()).await;
                         ctx.delay_response_until(retire_notify);
                         self.drop_temp_items(ctx.session().conn_id()).await;

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1097,15 +1097,13 @@ impl LifecycleTimestamps {
 pub enum TransactionStatus {
     /// Idle. Matches `TBLOCK_DEFAULT`.
     Default,
-    /// Running a single-query transaction. Matches
+    /// Running a transaction started outside of any `BEGIN`. Matches
     /// `TBLOCK_STARTED`. In PostgreSQL, when using the extended query protocol, this
     /// may be upgraded into multi-statement implicit query (see [`Self::InTransactionImplicit`]).
     /// Additionally, some statements may trigger an eager commit of the implicit transaction,
     /// see: <https://git.postgresql.org/gitweb/?p=postgresql.git&a=commitdiff&h=f92944137>. In
-    /// Materialize however, we eagerly commit all statements outside of an explicit transaction
-    /// when using the extended query protocol. Therefore, we can guarantee that this state will
-    /// always be a single-query transaction and never be upgraded into a multi-statement implicit
-    /// query.
+    /// Materialize we never upgrade it. We eagerly commit it unless it can take on further
+    /// statements of the same pipeline, see [`Self::may_span_pipeline`].
     Started(Transaction),
     /// Currently in a transaction issued from a `BEGIN`. Matches `TBLOCK_INPROGRESS`.
     InTransaction(Transaction),
@@ -1171,6 +1169,30 @@ impl TransactionStatus {
             TransactionStatus::Started(_) | TransactionStatus::InTransactionImplicit(_) => true,
             TransactionStatus::Default
             | TransactionStatus::InTransaction(_)
+            | TransactionStatus::Failed(_) => false,
+        }
+    }
+
+    /// Whether this implicit transaction may stay open for the rest of its
+    /// extended-protocol pipeline, so that the pipeline commits or rolls back as a
+    /// unit like PostgreSQL's.
+    ///
+    /// Only writes may, because they are merely staged. A read already pinned its
+    /// timestamp without timedomain read holds, so a second read could neither join
+    /// that timestamp nor pick its own.
+    pub fn may_span_pipeline(&self) -> bool {
+        match self {
+            TransactionStatus::Started(txn) => match &txn.ops {
+                TransactionOps::Writes(_) => true,
+                TransactionOps::None
+                | TransactionOps::Peeks { .. }
+                | TransactionOps::Subscribe
+                | TransactionOps::SingleStatement { .. }
+                | TransactionOps::DDL { .. } => false,
+            },
+            TransactionStatus::Default
+            | TransactionStatus::InTransaction(_)
+            | TransactionStatus::InTransactionImplicit(_)
             | TransactionStatus::Failed(_) => false,
         }
     }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1009,17 +1009,28 @@ where
                 // trigger an eager commit of the current implicit transaction,
                 // see: <https://git.postgresql.org/gitweb/?p=postgresql.git&a=commitdiff&h=f92944137>.
                 //
-                // In Materialize, however, we eagerly commit every statement outside of an explicit
-                // transaction when using the extended query protocol. This allows us to eliminate
-                // the possibility of a multiple statement implicit transaction, which in turn
-                // allows us to apply single-statement optimizations to queries issued in implicit
-                // transactions in the extended query protocol.
+                // In Materialize we instead eagerly commit every implicit transaction that
+                // cannot take on further statements of the same pipeline, which keeps the
+                // single-statement optimizations available to queries issued in the extended
+                // query protocol. The ones that can stay open, so that the pipeline commits
+                // or rolls back as a unit. See `TransactionStatus::may_span_pipeline`.
                 //
                 // We don't immediately commit here to allow users to page through the portal if
                 // necessary. Committing the transaction would destroy the portal before the next
                 // Execute command has a chance to resume it. So we instead mark the transaction
                 // for commit the next time that `ensure_transaction` is called.
-                if self.adapter_client.session().transaction().is_implicit() {
+                let (is_implicit, may_span_pipeline) = {
+                    let txn = self.adapter_client.session().transaction();
+                    (txn.is_implicit(), txn.may_span_pipeline())
+                };
+                // Ordered so that only a write reads the flag, keeping the catalog
+                // snapshot off the read path.
+                let spans_pipeline = may_span_pipeline
+                    && self
+                        .adapter_client
+                        .extended_protocol_implicit_transaction_enabled()
+                        .await;
+                if is_implicit && !spans_pipeline {
                     self.txn_needs_commit = true;
                 }
                 state

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1310,6 +1310,7 @@ impl SystemVars {
             &STATEMENT_LOGGING_MAX_DATA_CREDIT,
             &ENABLE_INTERNAL_STATEMENT_LOGGING,
             &ENABLE_STATEMENT_ARRIVAL_LOGGING,
+            &ENABLE_EXTENDED_PROTOCOL_IMPLICIT_TRANSACTION,
             &OPTIMIZER_STATS_TIMEOUT,
             &OPTIMIZER_ONESHOT_STATS_TIMEOUT,
             &PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE,
@@ -2275,6 +2276,12 @@ impl SystemVars {
     /// Returns the `enable_statement_arrival_logging` configuration parameter.
     pub fn enable_statement_arrival_logging(&self) -> bool {
         *self.expect_value(&ENABLE_STATEMENT_ARRIVAL_LOGGING)
+    }
+
+    /// Returns the `enable_extended_protocol_implicit_transaction` configuration
+    /// parameter.
+    pub fn enable_extended_protocol_implicit_transaction(&self) -> bool {
+        *self.expect_value(&ENABLE_EXTENDED_PROTOCOL_IMPLICIT_TRANSACTION)
     }
 
     /// Returns the `optimizer_stats_timeout` configuration parameter.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1426,6 +1426,19 @@ pub static ENABLE_STATEMENT_ARRIVAL_LOGGING: VarDefinition = VarDefinition::new(
     false,
 );
 
+/// Off is the escape hatch for clients that pipeline statements Materialize
+/// cannot run in one transaction, for example a read or a DDL after a write.
+/// Those fail while this is on, rather than silently committing the writes
+/// staged before them.
+pub static ENABLE_EXTENDED_PROTOCOL_IMPLICIT_TRANSACTION: VarDefinition = VarDefinition::new(
+    "enable_extended_protocol_implicit_transaction",
+    value!(bool; true),
+    "Whether an implicit write transaction started by the extended query \
+    protocol spans the whole pipeline up to the client's Sync, so that the \
+    pipeline commits or rolls back atomically as in PostgreSQL (Materialize).",
+    false,
+);
+
 pub static AUTO_ROUTE_CATALOG_QUERIES: VarDefinition = VarDefinition::new(
     "auto_route_catalog_queries",
     value!(bool; true),

--- a/test/lang/python/smoketest.py
+++ b/test/lang/python/smoketest.py
@@ -77,6 +77,34 @@ class SmokeTest(unittest.TestCase):
                     row = cur.fetchone()
                     self.assertEqual(row, ([1, 2, 3],))
 
+    def test_psycopg3_pipeline_is_implicit_transaction(self) -> None:
+        """The statements of a pipeline commit or roll back as a unit (SQL-470)."""
+        with psycopg.connect(MATERIALIZED_URL, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute("DROP TABLE IF EXISTS pipeline_t")
+                cur.execute("CREATE TABLE pipeline_t (a int)")
+
+            with self.assertRaises(psycopg.errors.DivisionByZero):
+                with conn.pipeline():
+                    with conn.cursor() as cur:
+                        cur.execute("INSERT INTO pipeline_t VALUES (1)")
+                        cur.execute("INSERT INTO pipeline_t VALUES (2)")
+                        cur.execute("SELECT 1 / 0")
+
+            with conn.cursor() as cur:
+                cur.execute("SELECT count(*) FROM pipeline_t")
+                self.assertEqual(cur.fetchone(), (0,))
+
+            # A pipeline that reaches its sync commits all of its writes.
+            with conn.pipeline():
+                with conn.cursor() as cur:
+                    cur.execute("INSERT INTO pipeline_t VALUES (1)")
+                    cur.execute("INSERT INTO pipeline_t VALUES (2)")
+
+            with conn.cursor() as cur:
+                cur.execute("SELECT count(*) FROM pipeline_t")
+                self.assertEqual(cur.fetchone(), (2,))
+
     def test_sqlalchemy(self) -> None:
         engine = sqlalchemy.engine.create_engine(MATERIALIZED_URL)
         with engine.connect() as connection:

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -250,6 +250,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_dequadratic_eqprop_map
     enable_envelope_materialize
     enable_eq_classes_withholding_errors
+    enable_extended_protocol_implicit_transaction
     enable_fixed_correlated_cte_lowering
     enable_frontend_subscribes
     enable_hydration_burst

--- a/test/pgtest-mz/ddl-extended.pt
+++ b/test/pgtest-mz/ddl-extended.pt
@@ -1,4 +1,6 @@
-# Test that multiple DDL statements in the same extended request are supported
+# Test that multiple DDL statements in the same extended request are supported.
+# Unlike PostgreSQL, our DDL commits as it executes, so it survives a later
+# failure in the same pipeline. The pipeline's writes do not.
 
 send
 Query {"query": "DROP TABLE IF EXISTS a"}
@@ -49,12 +51,15 @@ BindComplete
 ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"22012"},{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"I"}
 RowDescription {"fields":[{"name":"a"}]}
-DataRow {"fields":["1"]}
-CommandComplete {"tag":"SELECT 1"}
+CommandComplete {"tag":"SELECT 0"}
 ReadyForQuery {"status":"I"}
 
+# Both tables exist, but the row the failed pipeline inserted does not.
 send
 Parse {"query": "SELECT * FROM a"}
+Bind
+Execute
+Parse {"query": "SELECT * FROM b"}
 Bind
 Execute
 Sync
@@ -65,6 +70,8 @@ ReadyForQuery
 ----
 ParseComplete
 BindComplete
-DataRow {"fields":["1"]}
-CommandComplete {"tag":"SELECT 1"}
+CommandComplete {"tag":"SELECT 0"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"SELECT 0"}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest-mz/transactions.pt
+++ b/test/pgtest-mz/transactions.pt
@@ -51,8 +51,9 @@ ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
 
-# Unlike PostgreSQL, we do not upgrade implicit transactions in the
-# extended protocol
+# A pipeline's writes stay staged until the Sync, so a `BEGIN` mid-pipeline
+# upgrades them into the explicit transaction and they share its fate. As in
+# PostgreSQL, these two cases only live here because our error fields differ.
 send
 Parse {"query": "INSERT INTO t VALUES (2)"}
 Bind
@@ -135,26 +136,25 @@ ParseComplete
 BindComplete
 DataRow {"fields":["1"]}
 DataRow {"fields":["2"]}
-DataRow {"fields":["3"]}
-CommandComplete {"tag":"SELECT 3"}
+CommandComplete {"tag":"SELECT 2"}
 ReadyForQuery {"status":"I"}
 
-# Verify eager committing in implicit transactions for the extended protocol.
-# In Materialize we eagerly commit all statements in an implicit transaction
-# for the extended protocol. This differs from PostgreSQL, which only eagerly
-# commits certain statements.
+# PostgreSQL rolls a pipeline back atomically no matter what it contains. We
+# cannot interleave a timestamped read with staged writes, so the read is
+# rejected and the pipeline's writes are discarded. A Sync before it would have
+# let it succeed.
 send
 Parse {"query": "INSERT INTO t VALUES (4)"}
 Bind
 Execute
-Parse {"query": "SELECT 1/(SELECT 0)"}
+Parse {"query": "SELECT a FROM t"}
 Bind
 Execute
 Sync
-Query {"query": "SELECT * FROM t"}
+Query {"query": "SELECT a FROM t"}
 ----
 
-until
+until err_field_typs=CM ignore=RowDescription
 ReadyForQuery
 ReadyForQuery
 ----
@@ -163,14 +163,69 @@ BindComplete
 CommandComplete {"tag":"INSERT 0 1"}
 ParseComplete
 BindComplete
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"22012"},{"typ":"M","value":"division by zero"}]}
+ErrorResponse {"fields":[{"typ":"C","value":"25000"},{"typ":"M","value":"transaction in write-only mode"}]}
 ReadyForQuery {"status":"I"}
-RowDescription {"fields":[{"name":"a"}]}
 DataRow {"fields":["1"]}
 DataRow {"fields":["2"]}
-DataRow {"fields":["3"]}
-DataRow {"fields":["4"]}
-CommandComplete {"tag":"SELECT 4"}
+CommandComplete {"tag":"SELECT 2"}
+ReadyForQuery {"status":"I"}
+
+# Likewise a DDL, which we cannot run in a transaction at all.
+send
+Parse {"query": "INSERT INTO t VALUES (4)"}
+Bind
+Execute
+Parse {"query": "CREATE TABLE u (a INT)"}
+Bind
+Execute
+Sync
+Query {"query": "SELECT a FROM t"}
+----
+
+until err_field_typs=CM ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"CREATE TABLE u (a int4) cannot be run inside a transaction block"}]}
+ReadyForQuery {"status":"I"}
+DataRow {"fields":["1"]}
+DataRow {"fields":["2"]}
+CommandComplete {"tag":"SELECT 2"}
+ReadyForQuery {"status":"I"}
+
+# `DISCARD ALL` clears the transaction, which would drop the staged writes
+# without telling anyone, so it is rejected too. PostgreSQL also refuses it
+# mid-pipeline.
+send
+Parse {"query": "INSERT INTO t VALUES (4)"}
+Bind
+Execute
+Parse {"query": "DISCARD ALL"}
+Bind
+Execute
+Sync
+Query {"query": "SELECT a FROM t"}
+----
+
+until err_field_typs=CM ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot be run inside a transaction block"}]}
+ReadyForQuery {"status":"I"}
+DataRow {"fields":["1"]}
+DataRow {"fields":["2"]}
+CommandComplete {"tag":"SELECT 2"}
 ReadyForQuery {"status":"I"}
 
 # Verify that we don't eagerly commit in implicit transactions for the simple
@@ -191,7 +246,5 @@ ReadyForQuery {"status":"I"}
 RowDescription {"fields":[{"name":"a"}]}
 DataRow {"fields":["1"]}
 DataRow {"fields":["2"]}
-DataRow {"fields":["3"]}
-DataRow {"fields":["4"]}
-CommandComplete {"tag":"SELECT 4"}
+CommandComplete {"tag":"SELECT 2"}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest/range.pt
+++ b/test/pgtest/range.pt
@@ -1,25 +1,28 @@
 # test that our range types' binary functions have the same implementation/results as PG
 
+# The tables are created in their own pipeline: a pipeline is one implicit
+# transaction, and Materialize cannot run a DDL in a transaction.
 send
 Parse {"query": "CREATE TABLE int4range_values (a int4range)"}
-Bind
-Execute
-Parse {"query": "INSERT INTO int4range_values VALUES ('[,1)'), ('[,1]'), ('[,)'), ('[,]'), ('(,1)'), ('(,1]'), ('(,)'), ('(,]'), ('[-1,1)'), ('[-1,1]'), ('(-1,1)'), ('(-1,1]'), ('[0,0)'), ('[0,0]'), ('(0,0)'), ('(0,0]'), ('[1,)'), ('[1,]'), ('(1,)'), ('(1,]')"}
 Bind
 Execute
 Parse {"query": "CREATE TABLE int4range_test_values (v int4range)"}
 Bind
 Execute
-Parse {"query": "INSERT INTO int4range_test_values VALUES ('empty'), ('(,)'), ('(,1)'), ('(-1,)'), ('[-1,1)'), ('[-99,-50)'), ('[50,99)')"}
-Bind
-Execute
 Parse {"query": "CREATE TABLE numrange_values (a numrange)"}
 Bind
 Execute
-Parse {"query": "INSERT INTO numrange_values VALUES ('[,1)'), ('[,1]'), ('[,)'), ('[,]'), ('(,1)'), ('(,1]'), ('(,)'), ('(,]'), ('[-1,1)'), ('[-1,1]'), ('(-1,1)'), ('(-1,1]'), ('[0,0)'), ('[0,0]'), ('(0,0)'), ('(0,0]'), ('[1,)'), ('[1,]'), ('(1,)'), ('(1,]')"}
+Parse {"query": "CREATE TABLE numrange_test_values (v numrange)"}
 Bind
 Execute
-Parse {"query": "CREATE TABLE numrange_test_values (v numrange)"}
+Sync
+Parse {"query": "INSERT INTO int4range_values VALUES ('[,1)'), ('[,1]'), ('[,)'), ('[,]'), ('(,1)'), ('(,1]'), ('(,)'), ('(,]'), ('[-1,1)'), ('[-1,1]'), ('(-1,1)'), ('(-1,1]'), ('[0,0)'), ('[0,0]'), ('(0,0)'), ('(0,0]'), ('[1,)'), ('[1,]'), ('(1,)'), ('(1,]')"}
+Bind
+Execute
+Parse {"query": "INSERT INTO int4range_test_values VALUES ('empty'), ('(,)'), ('(,1)'), ('(-1,)'), ('[-1,1)'), ('[-99,-50)'), ('[50,99)')"}
+Bind
+Execute
+Parse {"query": "INSERT INTO numrange_values VALUES ('[,1)'), ('[,1]'), ('[,)'), ('[,]'), ('(,1)'), ('(,1]'), ('(,)'), ('(,]'), ('[-1,1)'), ('[-1,1]'), ('(-1,1)'), ('(-1,1]'), ('[0,0)'), ('[0,0]'), ('(0,0)'), ('(0,0]'), ('[1,)'), ('[1,]'), ('(1,)'), ('(1,]')"}
 Bind
 Execute
 Parse {"query": "INSERT INTO numrange_test_values VALUES ('empty'), ('(,)'), ('(,1)'), ('(-1,)'), ('[-1,1)'), ('[-99,-50)'), ('[50,99)')"}
@@ -30,28 +33,30 @@ Sync
 
 until
 ReadyForQuery
+ReadyForQuery
 ----
 ParseComplete
 BindComplete
 CommandComplete {"tag":"CREATE TABLE"}
 ParseComplete
 BindComplete
-CommandComplete {"tag":"INSERT 0 20"}
+CommandComplete {"tag":"CREATE TABLE"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"CREATE TABLE"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 20"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"INSERT 0 7"}
 ParseComplete
 BindComplete
-CommandComplete {"tag":"CREATE TABLE"}
-ParseComplete
-BindComplete
 CommandComplete {"tag":"INSERT 0 20"}
-ParseComplete
-BindComplete
-CommandComplete {"tag":"CREATE TABLE"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"INSERT 0 7"}

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -656,3 +656,120 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
+
+# Regression test for SQL-470: the statements between two Syncs are one
+# implicit transaction, so a failure anywhere before the Sync rolls back the
+# writes of every statement in the pipeline. Verified against PostgreSQL 17.
+send
+Query {"query": "CREATE TABLE pipeline_t (a INT)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
+Parse {"query": "INSERT INTO pipeline_t VALUES (1)"}
+Bind
+Execute
+Parse {"query": "INSERT INTO pipeline_t VALUES (2)"}
+Bind
+Execute
+Parse {"query": "INSERT INTO pipeline_t VALUES (3)"}
+Bind
+Execute
+Parse {"query": "SELECT 1/(SELECT 0)"}
+Bind
+Execute
+Sync
+Query {"query": "SELECT count(*) FROM pipeline_t"}
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ReadyForQuery {"status":"I"}
+DataRow {"fields":["0"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# The failing statement can be a write itself. An INSERT whose values fail to
+# evaluate rolls back the writes staged before it, and every statement after
+# the error is skipped until the Sync, so the last INSERT never runs either.
+send
+Parse {"query": "INSERT INTO pipeline_t VALUES (4)"}
+Bind
+Execute
+Parse {"query": "INSERT INTO pipeline_t VALUES (5)"}
+Bind
+Execute
+Parse {"query": "INSERT INTO pipeline_t VALUES (1/(SELECT 0))"}
+Bind
+Execute
+Parse {"query": "INSERT INTO pipeline_t VALUES (6)"}
+Bind
+Execute
+Sync
+Query {"query": "SELECT count(*) FROM pipeline_t"}
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ReadyForQuery {"status":"I"}
+DataRow {"fields":["0"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# A pipeline that reaches its Sync commits all of its writes together.
+send
+Parse {"query": "INSERT INTO pipeline_t VALUES (1)"}
+Bind
+Execute
+Parse {"query": "INSERT INTO pipeline_t VALUES (2)"}
+Bind
+Execute
+Sync
+Query {"query": "SELECT a FROM pipeline_t ORDER BY a"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ReadyForQuery {"status":"I"}
+DataRow {"fields":["1"]}
+DataRow {"fields":["2"]}
+CommandComplete {"tag":"SELECT 2"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
PostgreSQL treats the statements between two Syncs as one implicit transaction, so a failure anywhere in a pipeline rolls the whole pipeline back. We committed after every Execute instead, so pgx's SendBatch, psycopg pipeline mode and libpq pipelining all got partial writes:

    pipeline: INSERT 1; INSERT 2; INSERT 3; SELECT 1/0; Sync
      PostgreSQL: count(*) = 0
      before:     count(*) = 3

Leave the implicit transaction open across the pipeline while its ops are writes, which are merely staged. Reads still commit right away: a read pinned its timestamp without timedomain read holds, so a second read could neither join that timestamp nor pick its own, and taking the holds up front would tax nearly every query.

A statement that cannot run alongside staged writes is now rejected mid-pipeline rather than silently committing them first: a timestamped read, anything that must run singly such as a DDL or a read-then-write, and DISCARD ALL, whose transaction clearing would otherwise drop the writes without reporting anything. Those are the errors BEGIN/COMMIT already produces. `enable_extended_protocol_implicit_transaction`, default on, restores the old per-statement commits.

Closes: [SQL-470](https://linear.app/materializeinc/issue/SQL-470)