### PR TITLE
pgwire: announce parameter reverts at implicit transaction end

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -1022,6 +1022,11 @@ fn test_pgtest_mz_stray_copy() {
 }
 
 #[mz_ore::test]
+fn test_pgtest_mz_set_local() {
+    pg_test_inner(Path::new("../../test/pgtest-mz/set-local.pt"), true);
+}
+
+#[mz_ore::test]
 fn test_pgtest_mz_transactions() {
     pg_test_inner(Path::new("../../test/pgtest-mz/transactions.pt"), true);
 }

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -43,6 +43,9 @@
 //! The default is `CMS` (code, message, severity). For example: `until
 //! err_field_typs=SC` would return the severity and code fields in any
 //! ErrorResponse message.
+//! - `parameter_status` names the parameters whose `ParameterStatus` messages
+//! are recorded. All others are skipped. For example `until
+//! parameter_status=application_name`.
 //!
 //! For example, to execute a simple prepared statement:
 //! ```pgtest
@@ -135,7 +138,12 @@ impl PgConn {
             Message::AuthenticationOk => {}
             _ => bail!("expected AuthenticationOk"),
         };
-        conn.until(vec!["ReadyForQuery"], vec!['C', 'S', 'M'], BTreeSet::new())?;
+        conn.until(
+            vec!["ReadyForQuery"],
+            vec!['C', 'S', 'M'],
+            BTreeSet::new(),
+            &BTreeSet::new(),
+        )?;
         Ok(conn)
     }
 
@@ -150,6 +158,7 @@ impl PgConn {
         until: Vec<&str>,
         err_field_typs: Vec<char>,
         ignore: BTreeSet<String>,
+        parameter_status: &BTreeSet<String>,
     ) -> anyhow::Result<Vec<String>> {
         let mut msgs = Vec::with_capacity(until.len());
         for expect in until {
@@ -296,7 +305,19 @@ impl PgConn {
                             parameters: body.parameters().collect().unwrap(),
                         })?,
                     ),
-                    Message::ParameterStatus(_) => continue,
+                    Message::ParameterStatus(body) => {
+                        let name = body.name()?;
+                        if !parameter_status.contains(name) {
+                            continue;
+                        }
+                        (
+                            "ParameterStatus",
+                            serde_json::to_string(&ParameterStatus {
+                                name: name.to_string(),
+                                value: body.value()?.to_string(),
+                            })?,
+                        )
+                    }
                     Message::NoData => ("NoData", "".to_string()),
                     Message::EmptyQueryResponse => ("EmptyQueryResponse", "".to_string()),
                     _ => ("UNKNOWN", format!("'{}'", ch)),
@@ -414,9 +435,10 @@ impl PgTest {
         until: Vec<&str>,
         err_field_typs: Vec<char>,
         ignore: BTreeSet<String>,
+        parameter_status: &BTreeSet<String>,
     ) -> anyhow::Result<Vec<String>> {
         let conn = self.get_conn(conn, options)?;
-        conn.until(until, err_field_typs, ignore)
+        conn.until(until, err_field_typs, ignore, parameter_status)
     }
 }
 
@@ -456,6 +478,12 @@ pub struct ParameterDescription {
 #[derive(Serialize)]
 pub struct CommandComplete {
     pub tag: String,
+}
+
+#[derive(Serialize)]
+pub struct ParameterStatus {
+    pub name: String,
+    pub value: String,
 }
 
 #[derive(Serialize)]
@@ -618,14 +646,26 @@ pub fn run_test(tf: &mut datadriven::TestFile, addr: String, user: String, timeo
                         ignore.insert(v);
                     }
                 }
+                let parameter_status: BTreeSet<String> = args
+                    .remove("parameter_status")
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect();
                 if !args.is_empty() {
                     panic!("extra until arguments: {:?}", args);
                 }
                 format!(
                     "{}\n",
-                    pgt.until(conn, options, lines.collect(), err_field_typs, ignore)
-                        .unwrap()
-                        .join("\n")
+                    pgt.until(
+                        conn,
+                        options,
+                        lines.collect(),
+                        err_field_typs,
+                        ignore,
+                        &parameter_status,
+                    )
+                    .unwrap()
+                    .join("\n")
                 )
             }
             _ => panic!("unknown directive {}", tc.input),

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1442,15 +1442,53 @@ where
     }
 
     /// End a transaction and report to the user if an error occurred.
+    ///
+    /// The parameters this changes must be announced, exactly as an explicit
+    /// `COMMIT`/`ROLLBACK` announces them. Otherwise a `SET LOCAL` outside an
+    /// explicit transaction announces its new value and never its revert, and a
+    /// client that caches parameters keeps the reverted value.
     #[instrument(level = "debug")]
     async fn end_transaction(&mut self, action: EndTransactionAction) -> Result<(), io::Error> {
         self.txn_needs_commit = false;
-        let resp = self.adapter_client.end_transaction(action).await;
-        if let Err(err) = resp {
-            self.send(BackendMessage::ErrorResponse(
-                err.into_response(Severity::Error),
-            ))
-            .await?;
+        match self.adapter_client.end_transaction(action).await {
+            Ok(
+                ExecuteResponse::TransactionCommitted { params }
+                | ExecuteResponse::TransactionRolledBack { params },
+            ) => {
+                self.send_parameter_statuses(params).await?;
+            }
+            Ok(_) => {}
+            Err(err) => {
+                self.send(BackendMessage::ErrorResponse(
+                    err.into_response(Severity::Error),
+                ))
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Announces changed parameters, restricted to those the client is told
+    /// about at startup.
+    #[instrument(level = "debug")]
+    async fn send_parameter_statuses(
+        &mut self,
+        params: BTreeMap<&'static str, String>,
+    ) -> Result<(), io::Error> {
+        let notify_set: mz_ore::collections::HashSet<String> = self
+            .adapter_client
+            .session()
+            .vars()
+            .notify_set()
+            .map(|v| v.name().to_string())
+            .collect();
+
+        for (name, value) in params
+            .into_iter()
+            .filter(|(name, _value)| notify_set.contains(*name))
+        {
+            self.send(BackendMessage::ParameterStatus(name, value))
+                .await?;
         }
         Ok(())
     }
@@ -2366,22 +2404,7 @@ where
             }
             ExecuteResponse::TransactionCommitted { params }
             | ExecuteResponse::TransactionRolledBack { params } => {
-                let notify_set: mz_ore::collections::HashSet<String> = self
-                    .adapter_client
-                    .session()
-                    .vars()
-                    .notify_set()
-                    .map(|v| v.name().to_string())
-                    .collect();
-
-                // Only report on parameters that are in the notify set.
-                for (name, value) in params
-                    .into_iter()
-                    .filter(|(name, _v)| notify_set.contains(*name))
-                {
-                    let msg = BackendMessage::ParameterStatus(name, value);
-                    self.send(msg).await?;
-                }
+                self.send_parameter_statuses(params).await?;
                 command_complete!()
             }
 

--- a/test/pgtest-mz/set-local.pt
+++ b/test/pgtest-mz/set-local.pt
@@ -1,0 +1,75 @@
+# Unlike Postgres, which refuses `SET LOCAL` outside a transaction block, we
+# apply it for the duration of the implicit transaction and revert it at commit.
+# A client that caches `ParameterStatus` (pgjdbc, psycopg) has to hear about the
+# revert too, otherwise it keeps serving a value the server has discarded.
+
+# A session value to revert to. Promoting a non-local SET from staged to session
+# does not change the value, so that commit announces nothing.
+send
+Query {"query": "SET application_name = 'session_value'"}
+----
+
+until parameter_status=application_name
+ReadyForQuery
+----
+ParameterStatus {"name":"application_name","value":"session_value"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+
+# Simple protocol: committed at the end of the Query message.
+send
+Query {"query": "SET LOCAL application_name = 'simple_local'"}
+Query {"query": "SHOW application_name"}
+----
+
+until parameter_status=application_name
+ReadyForQuery
+ReadyForQuery
+----
+ParameterStatus {"name":"application_name","value":"simple_local"}
+CommandComplete {"tag":"SET"}
+ParameterStatus {"name":"application_name","value":"session_value"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"application_name"}]}
+DataRow {"fields":["session_value"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# Extended protocol: committed at Sync.
+send
+Parse {"query": "SET LOCAL application_name = 'extended_local'"}
+Bind
+Execute
+Sync
+----
+
+until parameter_status=application_name
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+ParameterStatus {"name":"application_name","value":"extended_local"}
+CommandComplete {"tag":"SET"}
+ParameterStatus {"name":"application_name","value":"session_value"}
+ReadyForQuery {"status":"I"}
+
+# Explicit COMMIT already announced the revert; guard the shared path.
+send
+Query {"query": "BEGIN"}
+Query {"query": "SET LOCAL application_name = 'txn_local'"}
+Query {"query": "COMMIT"}
+----
+
+until parameter_status=application_name
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+ParameterStatus {"name":"application_name","value":"txn_local"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"T"}
+ParameterStatus {"name":"application_name","value":"session_value"}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Ending an implicit transaction can change session parameters, but pgwire's `end_transaction` threw away the whole `ExecuteResponse` and only inspected the error case. Explicit COMMIT/ROLLBACK announced those changes already, so only the implicit paths were silent.

`SET LOCAL` outside an explicit transaction is what makes this observable. The SET announces the new value and the implicit commit reverts it, so a client that caches ParameterStatus (pgjdbc, psycopg) serves the reverted value for the rest of the session. The same asymmetry hit a plain SET whose staged value a later statement error rolled back.

Closes: [SQL-490](https://linear.app/materializeinc/issue/SQL-490)