### PR TITLE
repr: widen nested nullability when unioning SQL types

### DIFF
--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -111,82 +111,17 @@ impl SqlColumnType {
 
     /// Compute the least upper bound of two column types at the SQL level.
     ///
-    /// Two types are compatible when they are equal, share the same base type
-    /// (differing only in modifiers), or are records with pairwise-compatible
-    /// fields.
-    /// The resulting nullability is the disjunction of the two input
-    /// nullabilities.
+    /// Nullability is the disjunction of the two inputs, at every nesting depth.
+    /// See [`SqlScalarType::sql_union`] for which types are compatible.
     ///
     /// Returns an error for incompatible types, e.g. `Text` and `Int32`, or
-    /// `Text` and `VarChar` (different base types at the SQL level).
-    /// See [`SqlColumnType::try_union`] for a fallback that handles the latter
-    /// case via repr-level union.
+    /// `Text` and `VarChar`. See [`SqlColumnType::try_union`] for a fallback
+    /// that handles the latter via repr-level union.
     pub fn sql_union(&self, other: &Self) -> Result<Self, anyhow::Error> {
-        match (&self.scalar_type, &other.scalar_type) {
-            (scalar_type, other_scalar_type) if scalar_type == other_scalar_type => {
-                Ok(SqlColumnType {
-                    scalar_type: scalar_type.clone(),
-                    nullable: self.nullable || other.nullable,
-                })
-            }
-            (scalar_type, other_scalar_type) if scalar_type.base_eq(other_scalar_type) => {
-                Ok(SqlColumnType {
-                    scalar_type: scalar_type.without_modifiers(),
-                    nullable: self.nullable || other.nullable,
-                })
-            }
-            (
-                SqlScalarType::Record { fields, custom_id },
-                SqlScalarType::Record {
-                    fields: other_fields,
-                    custom_id: other_custom_id,
-                },
-            ) => {
-                if custom_id != other_custom_id {
-                    bail!(
-                        "Can't union types: {:?} and {:?}",
-                        self.scalar_type,
-                        other.scalar_type
-                    );
-                };
-
-                if fields.len() != other_fields.len() {
-                    bail!(
-                        "Can't union types: {:?} and {:?}",
-                        self.scalar_type,
-                        other.scalar_type
-                    );
-                }
-                let mut union_fields = Vec::with_capacity(fields.len());
-                for ((name, typ), (other_name, other_typ)) in
-                    fields.iter().zip_eq(other_fields.iter())
-                {
-                    if name != other_name {
-                        bail!(
-                            "Can't union types: {:?} and {:?}",
-                            self.scalar_type,
-                            other.scalar_type
-                        );
-                    } else {
-                        let union_column_type = typ.sql_union(other_typ)?;
-                        union_fields.push((name.clone(), union_column_type));
-                    };
-                }
-
-                Ok(SqlColumnType {
-                    scalar_type: SqlScalarType::Record {
-                        fields: union_fields.into(),
-                        custom_id: *custom_id,
-                    },
-                    nullable: self.nullable || other.nullable,
-                })
-            }
-            _ => bail!(
-                "Can't union types: {:?} and {:?}",
-                self.scalar_type,
-                other.scalar_type
-            ),
-        }
+        Ok(SqlColumnType {
+            scalar_type: self.scalar_type.sql_union(&other.scalar_type)?,
+            nullable: self.nullable || other.nullable,
+        })
     }
 
     /// Compute the least upper bound of two column types.

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -3742,6 +3742,86 @@ impl SqlScalarType {
         }
     }
 
+    /// Computes the least upper bound of two SQL scalar types, or an error if
+    /// they are incompatible. Compatible types are equal, share a base type and
+    /// differ only in modifiers (which are then dropped), or are structured
+    /// types with pairwise compatible components.
+    ///
+    /// NOTE: Structured types must recurse rather than fall through to the
+    /// `base_eq` arm. `base_eq` ignores record field nullability, so returning
+    /// either side verbatim can declare a field non-nullable where the other
+    /// side puts a null.
+    pub fn sql_union(&self, other: &SqlScalarType) -> Result<SqlScalarType, anyhow::Error> {
+        use SqlScalarType::*;
+        match (self, other) {
+            (scalar_type, other_scalar_type) if scalar_type == other_scalar_type => {
+                Ok(scalar_type.clone())
+            }
+            (
+                Record { fields, custom_id },
+                Record {
+                    fields: other_fields,
+                    custom_id: other_custom_id,
+                },
+            ) if custom_id == other_custom_id && fields.len() == other_fields.len() => {
+                let mut union_fields = Vec::with_capacity(fields.len());
+                for ((name, typ), (other_name, other_typ)) in
+                    fields.iter().zip_eq(other_fields.iter())
+                {
+                    if name != other_name {
+                        bail!("Can't union types: {:?} and {:?}", self, other);
+                    }
+                    union_fields.push((name.clone(), typ.sql_union(other_typ)?));
+                }
+                Ok(Record {
+                    fields: union_fields.into(),
+                    custom_id: *custom_id,
+                })
+            }
+            (
+                List {
+                    element_type,
+                    custom_id,
+                },
+                List {
+                    element_type: other_element_type,
+                    custom_id: other_custom_id,
+                },
+            ) if custom_id == other_custom_id => Ok(List {
+                element_type: Box::new(element_type.sql_union(other_element_type)?),
+                custom_id: *custom_id,
+            }),
+            (
+                Map {
+                    value_type,
+                    custom_id,
+                },
+                Map {
+                    value_type: other_value_type,
+                    custom_id: other_custom_id,
+                },
+            ) if custom_id == other_custom_id => Ok(Map {
+                value_type: Box::new(value_type.sql_union(other_value_type)?),
+                custom_id: *custom_id,
+            }),
+            (Array(element_type), Array(other_element_type)) => {
+                Ok(Array(Box::new(element_type.sql_union(other_element_type)?)))
+            }
+            (
+                Range { element_type },
+                Range {
+                    element_type: other_element_type,
+                },
+            ) => Ok(Range {
+                element_type: Box::new(element_type.sql_union(other_element_type)?),
+            }),
+            (scalar_type, other_scalar_type) if scalar_type.base_eq(other_scalar_type) => {
+                Ok(scalar_type.without_modifiers())
+            }
+            _ => bail!("Can't union types: {:?} and {:?}", self, other),
+        }
+    }
+
     /// Determines equality among scalar types that acknowledges custom OIDs,
     /// but ignores other embedded values.
     ///

--- a/test/sqllogictest/recursive_type_unioning.slt
+++ b/test/sqllogictest/recursive_type_unioning.slt
@@ -38,3 +38,26 @@ Source materialize.public.t2
 Target cluster: quickstart
 
 EOF
+
+# Unioning record types must widen field nullability, else a null field flows
+# through a column typed non-nullable and the row fails its type check. The
+# non-nullable branch is filtered to nothing so the null row is the only one.
+
+query T
+SELECT row(a) FROM t1 WHERE a < a UNION ALL SELECT row(a) FROM t2
+----
+()
+
+# Same, with the records nested in a list. `simple` because `list` has no binary
+# output function.
+simple
+SELECT LIST[row(a)] FROM t1 WHERE a < a UNION ALL SELECT LIST[row(a)] FROM t2;
+----
+{()}
+COMPLETE 1
+
+# `CASE` unions the types of its branches the same way.
+query T
+SELECT CASE WHEN false THEN row(a) ELSE row(null::int) END FROM t1
+----
+()


### PR DESCRIPTION
`SqlColumnType::sql_union` tried its `base_eq` arm before its `Record` arm, and `base_eq` ignores the nullability of record fields. Two records with pairwise base-equal fields therefore took the left side's field nullability verbatim, leaving the `Record` arm that would have widened it unreachable. A `UNION ALL` of `row(1)` and `row(null::int)` got a column type claiming the field is non-nullable, so the null-bearing row failed its type check with an internal error.

Closes: [SQL-566](https://linear.app/materializeinc/issue/SQL-566)