### PR TITLE
storage: introduce StorageReplicaConfig and plumb it to the storage controller

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -59,6 +59,7 @@ use mz_sql::session::user::MZ_SYSTEM_ROLE_ID;
 use mz_sql::session::vars::{VarError, VarInput};
 use mz_sql::{plan, rbac};
 use mz_sql_parser::ast::Expr;
+use mz_storage_types::configuration::{StorageReplicaConfig, StorageReplicaLogging};
 use mz_storage_types::sources::Timeline;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::notice::OptimizerNotice;
@@ -761,15 +762,22 @@ impl CatalogState {
                 );
             }
             StateDiff::Addition => {
-                let logging = ReplicaLogging {
+                let compute_logging = ReplicaLogging {
+                    log_logging: cluster_replica.config.logging.log_logging,
+                    interval: cluster_replica.config.logging.interval,
+                };
+                let storage_logging = StorageReplicaLogging {
                     log_logging: cluster_replica.config.logging.log_logging,
                     interval: cluster_replica.config.logging.interval,
                 };
                 let config = ReplicaConfig {
                     location,
                     compute: ComputeReplicaConfig {
-                        logging,
+                        logging: compute_logging,
                         arrangement_compression: cluster_replica.config.arrangement_compression,
+                    },
+                    storage: StorageReplicaConfig {
+                        logging: storage_logging,
                     },
                 };
                 let mem_cluster_replica = ClusterReplica {

--- a/src/adapter/src/coord/cluster_controller.rs
+++ b/src/adapter/src/coord/cluster_controller.rs
@@ -42,6 +42,7 @@ use mz_controller::clusters::ClusterStatus;
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_ore::task::spawn;
 use mz_repr::Timestamp;
+use mz_storage_types::configuration::{StorageReplicaConfig, StorageReplicaLogging};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
@@ -918,6 +919,12 @@ impl Coordinator {
             compute: ComputeReplicaConfig {
                 logging: shape.logging.clone(),
                 arrangement_compression: shape.arrangement_compression,
+            },
+            storage: StorageReplicaConfig {
+                logging: StorageReplicaLogging {
+                    log_logging: shape.logging.log_logging,
+                    interval: shape.logging.interval,
+                },
             },
         };
 

--- a/src/adapter/src/coord/info_metrics.rs
+++ b/src/adapter/src/coord/info_metrics.rs
@@ -348,6 +348,7 @@ mod tests {
     use mz_sql::names::ResolvedIds;
     use mz_sql::plan::{WebhookBodyFormat, WebhookHeaders};
     use mz_sql::session::user::MZ_SYSTEM_ROLE_ID;
+    use mz_storage_types::configuration::{StorageReplicaConfig, StorageReplicaLogging};
     use mz_storage_types::sinks::{
         KafkaIdStyle, KafkaSinkCompressionType, KafkaSinkConnection, KafkaSinkFormat,
         KafkaSinkFormatType, SinkEnvelope, StorageSinkConnection,
@@ -500,6 +501,9 @@ mod tests {
                 compute: ComputeReplicaConfig {
                     logging: Default::default(),
                     arrangement_compression: false,
+                },
+                storage: StorageReplicaConfig {
+                    logging: StorageReplicaLogging::default(),
                 },
             },
             owner_id: RoleId::User(1),
@@ -683,6 +687,9 @@ mod tests {
                 compute: ComputeReplicaConfig {
                     logging: Default::default(),
                     arrangement_compression: false,
+                },
+                storage: StorageReplicaConfig {
+                    logging: StorageReplicaLogging::default(),
                 },
             },
             owner_id: RoleId::User(1),

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -42,6 +42,7 @@ use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::{
     MAX_CREDIT_CONSUMPTION_RATE, MAX_REPLICAS_PER_CLUSTER, SystemVars, Var,
 };
+use mz_storage_types::configuration::{StorageReplicaConfig, StorageReplicaLogging};
 use tracing::{Instrument, Span, debug};
 
 use mz_adapter_types::dyncfgs::{
@@ -1435,6 +1436,11 @@ impl Coordinator {
             ReplicaLogging::default()
         };
 
+        let storage_logging = StorageReplicaLogging {
+            log_logging: logging.log_logging,
+            interval: logging.interval.clone(),
+        };
+
         let config = ReplicaConfig {
             location: self.catalog().concretize_replica_location(
                 location,
@@ -1447,6 +1453,9 @@ impl Coordinator {
             compute: ComputeReplicaConfig {
                 logging,
                 arrangement_compression: compute.arrangement_compression,
+            },
+            storage: StorageReplicaConfig {
+                logging: storage_logging,
             },
         };
 
@@ -1598,6 +1607,10 @@ impl Coordinator {
             } else {
                 ReplicaLogging::default()
             };
+            let storage_logging = StorageReplicaLogging {
+                log_logging: logging.log_logging,
+                interval: logging.interval.clone(),
+            };
 
             let role_id = session.role_metadata().current_role;
             let config = ReplicaConfig {
@@ -1612,6 +1625,9 @@ impl Coordinator {
                 compute: ComputeReplicaConfig {
                     logging,
                     arrangement_compression: compute.arrangement_compression,
+                },
+                storage: StorageReplicaConfig {
+                    logging: storage_logging,
                 },
             };
 
@@ -1717,6 +1733,10 @@ impl Coordinator {
         } else {
             ReplicaLogging::default()
         };
+        let storage_logging = StorageReplicaLogging {
+            log_logging: logging.log_logging,
+            interval: logging.interval.clone(),
+        };
 
         let role_id = session.role_metadata().current_role;
         let config = ReplicaConfig {
@@ -1733,6 +1753,9 @@ impl Coordinator {
             compute: ComputeReplicaConfig {
                 logging,
                 arrangement_compression: compute.arrangement_compression,
+            },
+            storage: StorageReplicaConfig {
+                logging: storage_logging,
             },
         };
 

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -39,6 +39,7 @@ use mz_ore::task::{self, AbortOnDropHandle};
 use mz_ore::{halt, instrument};
 use mz_repr::GlobalId;
 use mz_repr::adt::numeric::Numeric;
+use mz_storage_types::configuration::StorageReplicaConfig;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tokio::time;
@@ -68,6 +69,8 @@ pub struct ReplicaConfig {
     pub location: ReplicaLocation,
     /// Configuration for the compute half of the replica.
     pub compute: ComputeReplicaConfig,
+    /// Configuration for the storage half of the replica.
+    pub storage: StorageReplicaConfig,
 }
 
 /// Configures the resource allocation for a cluster replica.
@@ -502,7 +505,7 @@ impl Controller {
         }
 
         self.storage
-            .connect_replica(cluster_id, replica_id, storage_location);
+            .connect_replica(cluster_id, replica_id, storage_location, config.storage);
         self.compute.add_replica_to_instance(
             cluster_id,
             replica_id,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -39,7 +39,7 @@ use mz_persist_types::{Codec64, ShardId};
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::{Datum, Diff, GlobalId, RelationDesc, RelationVersion, Row, Timestamp};
-use mz_storage_types::configuration::StorageConfiguration;
+use mz_storage_types::configuration::{StorageConfiguration, StorageReplicaConfig};
 use mz_storage_types::connections::inline::InlinedConnection;
 use mz_storage_types::controller::{CollectionMetadata, StorageError};
 use mz_storage_types::errors::CollectionMissing;
@@ -458,6 +458,7 @@ pub trait StorageController: Debug {
         instance_id: StorageInstanceId,
         replica_id: ReplicaId,
         location: ClusterReplicaLocation,
+        config: StorageReplicaConfig,
     );
 
     /// Disconnects the storage instance from the specified replica.

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -749,6 +749,10 @@ pub(super) struct ReplicaConfig {
     pub build_info: &'static BuildInfo,
     pub location: ClusterReplicaLocation,
     pub grpc_client: GrpcClientParameters,
+    // Plumbed from the adapter but not yet consumed: no storage command carries
+    // this config to the replica, so nothing reads it. `dead_code` is allowed so
+    // the plumbing can land on its own, and is removed once the field is read.
+    #[allow(dead_code)]
     pub logging: StorageReplicaLogging,
 }
 

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -32,6 +32,7 @@ use mz_storage_client::client::{
     RunIngestionCommand, RunSinkCommand, Status, StatusUpdate, StorageCommand, StorageResponse,
 };
 use mz_storage_client::metrics::{InstanceMetrics, ReplicaMetrics};
+use mz_storage_types::configuration::StorageReplicaLogging;
 use mz_storage_types::sinks::StorageSinkDesc;
 use mz_storage_types::sources::{IngestionDescription, SourceConnection};
 use timely::progress::Antichain;
@@ -748,6 +749,7 @@ pub(super) struct ReplicaConfig {
     pub build_info: &'static BuildInfo,
     pub location: ClusterReplicaLocation,
     pub grpc_client: GrpcClientParameters,
+    pub logging: StorageReplicaLogging,
 }
 
 /// State maintained about individual replicas.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -70,7 +70,7 @@ use mz_storage_client::statistics::{
     ControllerSinkStatistics, ControllerSourceStatistics, WebhookStatistics,
 };
 use mz_storage_client::storage_collections::StorageCollections;
-use mz_storage_types::configuration::StorageConfiguration;
+use mz_storage_types::configuration::{StorageConfiguration, StorageReplicaConfig};
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::connections::inline::InlinedConnection;
 use mz_storage_types::controller::{AlterError, CollectionMetadata, StorageError, TxnsCodecRow};
@@ -598,6 +598,7 @@ impl StorageController for Controller {
         instance_id: StorageInstanceId,
         replica_id: ReplicaId,
         location: ClusterReplicaLocation,
+        config: StorageReplicaConfig,
     ) {
         let instance = self
             .instances
@@ -608,6 +609,7 @@ impl StorageController for Controller {
             build_info: self.build_info,
             location,
             grpc_client: self.config.parameters.grpc_client.clone(),
+            logging: config.logging,
         };
         instance.add_replica(replica_id, config);
     }

--- a/src/storage-types/src/configuration.rs
+++ b/src/storage-types/src/configuration.rs
@@ -9,7 +9,9 @@
 
 //! Configuration parameter types.
 
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 
 use mz_dyncfg::ConfigSet;
 
@@ -63,5 +65,40 @@ impl StorageConfiguration {
         // top-level. Eventually, all of `StorageParameters` goes away.
         parameters.dyncfg_updates.apply(&self.config_set);
         self.parameters.update(parameters);
+    }
+}
+
+/// Replica configuration
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StorageReplicaConfig {
+    /// TODO(database-issues#7533): Add documentation.
+    pub logging: StorageReplicaLogging,
+}
+
+/// Logging configuration of a replica.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize
+)]
+pub struct StorageReplicaLogging {
+    /// Whether to enable logging for the logging dataflows.
+    pub log_logging: bool,
+    /// The interval at which to log.
+    ///
+    /// A `None` value indicates that logging is disabled.
+    pub interval: Option<Duration>,
+}
+
+impl StorageReplicaLogging {
+    /// Return whether logging is enabled.
+    pub fn enabled(&self) -> bool {
+        self.interval.is_some()
     }
 }


### PR DESCRIPTION
## What

Introduces `StorageReplicaConfig` / `StorageReplicaLogging` and threads a
per-replica storage config from the adapter down to the storage controller's
per-replica `ReplicaTask`, mirroring the existing `ComputeReplicaConfig` path.

This is the **first of two stacked PRs**. It is pure plumbing: the config
reaches the storage controller but nothing acts on it yet. The follow-up
(`patrick/storage-replica-logging`, based on this branch) consumes it on the
replica.

## Notes

- The config threads through every `ReplicaConfig` construction site
  (`cluster_controller`, `sequencer`, `catalog::apply`, and the `info_metrics`
  test builders).
- A `dead_code` warning on `storage-controller`'s `ReplicaConfig.logging` is
  expected here (the field is plumbed but not yet read) and is resolved by the
  stacked follow-up, where `specialize_command` reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)