### PR TITLE
console: mention that snapshot progress and row counts are estimates

### DIFF
--- a/console/src/platform/object-explorer/SourceDetailRoutes.test.tsx
+++ b/console/src/platform/object-explorer/SourceDetailRoutes.test.tsx
@@ -318,6 +318,11 @@ describe("SourceDetailRoutes", () => {
       expect(screen.getByText("100,000 rows")).toBeVisible();
       expect(screen.getByText("17,000")).toBeVisible();
       expect(screen.getByText("17%")).toBeVisible();
+      expect(
+        screen.getByText(
+          "Snapshot progress and row counts are estimates, based on table statistics.",
+        ),
+      ).toBeVisible();
     });
   });
 

--- a/console/src/platform/sources/SourceOverview/SnapshotProgress.tsx
+++ b/console/src/platform/sources/SourceOverview/SnapshotProgress.tsx
@@ -35,6 +35,24 @@ const mapSourceTypeToProgressUnit = (type: string, count: number) => {
       return pluralize(count, "record", "records");
   }
 };
+
+// The known count for database sources comes from table statistics (Postgres
+// `reltuples` and equivalents), which are estimates that drift until an ANALYZE.
+// Kafka derives it from offset watermarks, which overcount compacted or
+// transactional topics, so the note stays type-specific rather than claiming
+// table statistics everywhere.
+const mapSourceTypeToEstimateNote = (type: string) => {
+  switch (type) {
+    case "postgres":
+    case "mysql":
+    case "sql-server":
+      return "Snapshot progress and row counts are estimates, based on table statistics.";
+    case "kafka":
+      return "Snapshot progress and message counts are estimates.";
+    default:
+      return "Snapshot progress and record counts are estimates.";
+  }
+};
 export const SnapshotProgress = ({
   snapshotRecordsKnown,
   snapshotRecordsStaged,
@@ -93,6 +111,9 @@ export const SnapshotProgress = ({
             {mapSourceTypeToProgressUnit(source.type, snapshotRecordsKnown)}
           </Text>
         </HStack>
+        <Text textStyle="text-small" color={colors.foreground.secondary}>
+          {mapSourceTypeToEstimateNote(source.type)}
+        </Text>
       </VStack>
     </VStack>
   );


### PR DESCRIPTION

The snapshotting progress card reports a known record count that, for database sources, comes from table statistics (Postgres `reltuples` and equivalents) and is only an estimate. Add a line under the metrics saying so. Kafka derives the count from offset watermarks, so it gets a generic "are estimates" note rather than claiming table statistics.


### Motivation
Fixes [CNS-117](https://linear.app/materializeinc/issue/CNS-117)