### PR TITLE
compute: release cached batch entries when the trace drops

### DIFF
--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -288,6 +288,13 @@ where
                     output.session(&time).give_container(data);
                 });
                 let Some(trace) = trace.upgrade() else {
+                    // Invariant: `batches` holds no entries once the trace is gone. Each entry's
+                    // `Weak` keeps its batch's `RcBox` allocation reserved, and the `retain` below
+                    // that would drop it is unreachable on this path, so the entries have to go
+                    // here. The upgrade cannot start succeeding again, hence clearing on every
+                    // activation that takes this path also covers batches that arrive on the
+                    // input afterwards.
+                    batches.clear();
                     return;
                 };
 


### PR DESCRIPTION
The arrangement-size operator caches per-batch heap figures behind a `Weak<B>`, keyed by the batch pointer. The only pruning happens in the `retain` that runs after the trace upgrade. Once the trace drops, the upgrade fails permanently and every later activation returns before that `retain`, so the entries survive for the lifetime of the operator. Each retained `Weak` keeps its batch's `RcBox` allocation reserved, so the leak is one shell per batch, the header words plus the inline `B`. The batch's heap-owned contents are already freed, those were dropped in place when the strong count hit zero.

Clear the map on the failed-upgrade path. Clearing unconditionally rather than once also covers batches that arrive on the input after the trace is gone, since `input.for_each` runs before the upgrade. Behaviour on the live path is unchanged, both in what is logged and how the figures are computed.

The pointer key is left as is. Address reuse cannot substitute a new batch for a dead entry, for the same reason the leak exists: the entry's `Weak` keeps the allocation reserved, so no other `Rc<B>` can exist at that address while the entry lives.

No test. `log_arrangement_size_inner` early-returns unless the worker has a registered compute logger, the cache is a closure local with no accessor, and the leak is `RcBox` shells only, invisible to both `Rc::weak_count` from outside and to any figure the operator logs. Detecting it needs allocator residency measurement, which the crate has no test support for.

Known remaining gap, not addressed here: `strong_count > 0` cannot distinguish the trace holding a batch from a downstream consumer holding it, so a batch outliving the trace still counts against this arrangement. Telling those apart requires owning the batch type.

Tracks [CPU-191](https://linear.app/materializeinc/issue/CPU-191/compute-release-cached-batch-entries-when-the-trace-drops).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

[https://claude.ai/code/session_014yzb7eNxMLi2miMbKRqQCX](<https://claude.ai/code/session_014yzb7eNxMLi2miMbKRqQCX>)