### PR TITLE
parallel-workload: do not index an empty cluster reconfiguration poll

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2785,10 +2785,20 @@ class ReconfigureClusterAction(Action):
                 f"WHERE c.name = '{name_literal}'"
             )
             status = None
+            seen = False
             deadline = time.time() + 180
             while time.time() < deadline:
                 exe.execute(query)
-                size, status = exe.cur.fetchall()[0]
+                rows = exe.cur.fetchall()
+                if not rows:
+                    # `mz_clusters` is a builtin table, so the read can lag a
+                    # concurrent rename or swap of this cluster and not show
+                    # the polled name yet. Keep polling and let the deadline
+                    # below decide, rather than indexing an empty result.
+                    time.sleep(1)
+                    continue
+                seen = True
+                size, status = rows[0]
                 if size == new_size:
                     cluster.size = new_size
                     return True
@@ -2798,6 +2808,12 @@ class ReconfigureClusterAction(Action):
                 ):
                     return True
                 time.sleep(1)
+            if not seen:
+                raise ValueError(
+                    f"Cluster {cluster} was never observed in mz_clusters under the "
+                    f"name the reconfiguration to size {new_size} polled for, so the "
+                    f"name the workload holds does not match the catalog"
+                )
             raise ValueError(
                 f"Graceful reconfiguration of cluster {cluster} to size {new_size} "
                 f"did not complete (reconfiguration status: {status})"


### PR DESCRIPTION
### Motivation

`ReconfigureClusterAction` polls for convergence with a query keyed on the
cluster's name, and read the first row unconditionally:

```python
size, status = exe.cur.fetchall()[0]
```

When the name matches nothing the result is empty, so the action died with
`IndexError: list index out of range` instead of reporting anything about the
cluster it was watching. Observed once on a nightly Parallel Workload (rename +
naughty identifiers) run.

The name can fail to match two ways, and both are specific to that variant.
`mz_clusters` is a builtin table, so the read can lag a concurrent rename or
swap of the cluster. `SwapClusterAction` is applicable only in
`Scenario.Rename`, and it renames clusters and then swaps the `cluster_id` and
`rename` fields that `Cluster.name()` is derived from. That lag is a transient
condition the surrounding code already reasons about for the reconfiguration
status, in the comment above this loop, but not for whether the row exists at
all.

Separately, with `--naughty-identifiers` the name carries arbitrary bytes from
the naughty-strings list and is interpolated as a SQL string literal with only
`'` doubled, so a name that does not round-trip through that comparison never
matches.

### Description

An empty result keeps polling, so the lag case resolves itself and the existing
deadline stays the thing that decides failure. A name that is never observed in
`mz_clusters` fails at the deadline saying so, rather than being reported as a
reconfiguration that did not converge, which it isn't.

`Executor.execute` takes no query parameters and can route a statement over
HTTP, so passing the name as a bind parameter to fix the escaping is not
available here.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly
  considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog entry.
