### PR TITLE
v26.34.1 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -20,7 +20,6 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 {{</ note >}}
 
 ## v26.34.1
-*Released to Materialize Cloud: 2026-07-23* <br>
 *Released to Materialize Self-Managed: 2026-07-24* <br>
 
 ### Bug Fixes {#v26.34.1-bug-fixes}

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -19,6 +19,13 @@ Starting with the v26.1.0 release, Materialize releases on a weekly schedule for
 both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for details.
 {{</ note >}}
 
+## v26.34.1
+*Released to Materialize Cloud: 2026-07-23* <br>
+*Released to Materialize Self-Managed: 2026-07-24* <br>
+
+### Bug Fixes {#v26.34.1-bug-fixes}
+- Fixed an issue where `ALTER CLUSTER ... WITH (WAIT UNTIL READY ...)` would deadlock on clusters hosting single-replica sources (Postgres, MySQL, SQL Server), causing graceful reconfiguration to time out and roll back without resizing.
+
 ## v26.34.0
 *Released to Materialize Cloud: 2026-07-21* <br>
 *Released to Materialize Self-Managed: 2026-07-21* <br>

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -5,6 +5,11 @@ columns:
   - column: Release date
   - column: Notes
 rows:
+  - Materialize Operator: v26.34.1
+    orchestratord version: v26.34.1
+    environmentd version: v26.34.1
+    Release date: "2026-07-24"
+    Notes: "See [v26.34.1 release notes](/releases/#v26341)"
   - Materialize Operator: v26.34
     orchestratord version: v26.34
     environmentd version: v26.34


### PR DESCRIPTION
Draft — dates are provisional until the release ships. One commit is added per snapshot; the final snapshot sets the real dates.

Snapshot drafts (with PR links) in mz-skills:
- final: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.34.1/final/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.34.1/final/omitted.md)

**Borderline PRs omitted:** final: see [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.34.1/final/omitted.md#borderline)
