### PR TITLE
console: scope the largest-replica hydration check to the cluster

### DIFF
--- a/console/e2e-tests/k6/cluster-detail.ts
+++ b/console/e2e-tests/k6/cluster-detail.ts
@@ -62,9 +62,18 @@ const QUERIES: CapturedQueries = loadQueries();
  * `src/platform/clusters/queries.ts`. `Infinity` = fire once on cold load.
  */
 const POLL_INTERVAL_MS: Record<string, number> = {
+  // usePollEnvironmentHealth polls SELECT mz_version() every 30s
+  // (AppInitializer.tsx), not the 5s default.
+  healthCheck: 30_000,
   "clusters.largestClusterReplica": 60_000,
   "clusters.largestMaintainedQueries": 60_000,
+  "clusters.owners": 300_000,
+  "clusters.replicaOfflineEvents": 20_000,
   "clusters.replicaUtilizationHistory": 20_000,
+  // No refetchInterval in the console: fetched on mount and window refocus
+  // only, so replay them once per VU rather than at the 5s default.
+  "clusters.clusterFreshness": Infinity,
+  "clusters.materializationLag": Infinity,
   canCreateCluster: Infinity,
   canCreateObjects: Infinity,
   currentUser: Infinity,

--- a/console/src/api/materialize/cluster/largestClusterReplica.test.sql.ts
+++ b/console/src/api/materialize/cluster/largestClusterReplica.test.sql.ts
@@ -35,10 +35,10 @@ describe("buildLargestClusterReplicaQuery", () => {
           heap_bytes double,
           heap_limit double
         );
-      > CREATE TABLE mz_hydration_statuses (
+      > CREATE TABLE mz_compute_hydration_times (
           object_id TEXT NOT NULL,
           replica_id TEXT NOT NULL,
-          hydrated boolean NOT NULL
+          time_ns bigint
         );
     `);
 
@@ -59,29 +59,48 @@ describe("buildLargestClusterReplicaQuery", () => {
         ('${r3.id}', 0, 0, 0, 0, 0, 4294967296)
     `);
 
-    // Mock hydration statuses - all replicas are hydrated
+    // All replicas fully hydrated.
     await client.query(`
-      INSERT INTO internal_test.mz_hydration_statuses VALUES
-        ('u1', '${r1.id}', true),
-        ('u2', '${r2.id}', true),
-        ('u3', '${r3.id}', true)
+      INSERT INTO internal_test.mz_compute_hydration_times VALUES
+        ('u1', '${r1.id}', 1),
+        ('u1', '${r2.id}', 1),
+        ('u1', '${r3.id}', 1)
     `);
 
     await client.query(`SET search_path TO ${mockedSearchPath};`);
 
     const query = buildLargestClusterReplicaQuery(cluster.id).compile();
-    const result = (
-      await executeSqlHttp(query, {
-        sessionVariables: {
-          search_path: mockedSearchPath,
-          cluster: QUICKSTART_CLUSTER,
-        },
-      })
-    ).rows[0];
+    const fetchLargest = async () =>
+      (
+        await executeSqlHttp(query, {
+          sessionVariables: {
+            search_path: mockedSearchPath,
+            cluster: QUICKSTART_CLUSTER,
+          },
+        })
+      ).rows[0];
 
+    const result = await fetchLargest();
     expect(result.name).toBe("r2");
     expect(result.size).toBe("scale=1,workers=1,mem=8GiB");
     expect(result.heapLimit).toBe("8589934592");
-    expect(result.isHydrated).toBe(true);
+
+    // A hydrated replica is preferred over a larger, still-hydrating one
+    // (its object is present but has no hydration time yet).
+    await client.query(`
+      UPDATE internal_test.mz_compute_hydration_times
+      SET time_ns = NULL WHERE replica_id = '${r2.id}'
+    `);
+    expect([r1.name, r3.name]).toContain((await fetchLargest()).name);
+
+    // A replica with no hydration rows at all, such as one just added, is
+    // likewise not preferred over a hydrated one. Without the `count > 0`
+    // guard its zero rows would read as fully hydrated and the largest empty
+    // replica would win.
+    await client.query(`
+      DELETE FROM internal_test.mz_compute_hydration_times
+      WHERE replica_id = '${r2.id}'
+    `);
+    expect([r1.name, r3.name]).toContain((await fetchLargest()).name);
   });
 });

--- a/console/src/api/materialize/cluster/largestClusterReplica.ts
+++ b/console/src/api/materialize/cluster/largestClusterReplica.ts
@@ -17,41 +17,34 @@ export function buildLargestClusterReplicaQuery(clusterId: string) {
   return (
     queryBuilder
       .selectFrom("mz_cluster_replicas as cr")
-      .innerJoin("mz_cluster_replica_sizes as crs", "cr.size", "crs.size")
-      .leftJoin(
-        // Sometimes system indexes on user clusters (e.g. introspection indexes)
-        // do not hydrate. Thus we filter them out first.
-        queryBuilder
-          .selectFrom("mz_hydration_statuses")
-          .select(["replica_id", "hydrated"])
-          .where("object_id", "not like", "s%")
-          .as("hs"),
-        "cr.id",
-        "hs.replica_id",
-      )
       .leftJoin(
         buildClusterReplicaHeapMetricsTable().as("crhm"),
         "crhm.replica_id",
         "cr.id",
       )
+      // Prefer a fully-hydrated replica, whose reported sizes are stable.
+      // Joining mz_compute_hydration_times before aggregating lets its
+      // replica_id index bound the scan to this cluster's replicas, unlike an
+      // aggregation over the whole environment's mz_hydration_statuses.
+      .leftJoin("mz_compute_hydration_times as ht", (join) =>
+        join
+          .onRef("ht.replica_id", "=", "cr.id")
+          // System introspection indexes may never report hydrated.
+          .on("ht.object_id", "not like", "s%"),
+      )
       .select([
         "cr.name",
         "cr.size",
         sql<string | null>`crhm.heap_limit::text`.as("heapLimit"),
-        sql<boolean>`bool_and(hs.hydrated)`.as("isHydrated"),
       ])
       .where("cr.cluster_id", "=", clusterId)
-      .groupBy([
-        "cr.name",
-        "cr.size",
-        "crs.memory_bytes",
-        "crs.disk_bytes",
-        "crs.processes",
-        "crhm.heap_limit",
-      ])
-      // Prioritize fully hydrated clusters first, then order by memory
-      .orderBy("isHydrated", sql`desc NULLS LAST`)
-      .orderBy("heapLimit", sql`desc NULLS LAST`)
+      .groupBy(["cr.id", "cr.name", "cr.size", "crhm.heap_limit"])
+      // Prefer a replica whose compute objects are all hydrated, so its
+      // reported sizes are stable. time_ns is NULL until an object hydrates. A
+      // replica with no hydration rows, such as one just added, has bool_and
+      // over an all-NULL row and so sorts last. Then order by heap limit.
+      .orderBy(sql`bool_and(ht.time_ns IS NOT NULL) DESC`)
+      .orderBy(sql`crhm.heap_limit DESC NULLS LAST`)
       .limit(1)
   );
 }


### PR DESCRIPTION
The cluster overview picks a cluster's "largest replica" to show fine-grained memory usage, preferring a fully-hydrated one so the reported sizes are stable. It derived that preference by aggregating mz_hydration_statuses, whose index is keyed on (object_id, replica_id). A per-replica aggregation cannot use that index, so it full-scanned every object's hydration across the entire environment. The cost grew with the size of the environment rather than the cluster, which made this the heaviest query on the page.

This reads the hydration preference from mz_compute_hydration_times, which is indexed by replica_id. Joining it before aggregating lets the index bound the read to this cluster's replicas. A replica is preferred when every one of its compute objects has a hydration time. A replica with no hydration rows, such as one just added, sorts last, matching the previous behavior.

Two smaller fixes in the same query. The mz_cluster_replica_sizes join is removed, since it only contributed unused GROUP BY columns.

Remove these sections if your commit already has a good description!

### Motivation
For console scalability changes,  this would make some of the queries on cluster details page a bit faster 
