### PR TITLE
doc: add consensus db sizing recommendation based on object count

### DIFF
--- a/doc/user/content/headless/self-managed-deployments/metadata-database-sizing.md
+++ b/doc/user/content/headless/self-managed-deployments/metadata-database-sizing.md
@@ -1,0 +1,28 @@
+Self-managed Materialize uses an external PostgreSQL **metadata database** to
+store its catalog and to coordinate the state of the objects it keeps up to
+date. Every durable object that updates continuously (materialized views,
+sources, and tables) produces a steady stream of small writes to the metadata
+database. Metadata-database load therefore scales with the **number of
+continuously-updating objects**, not with the volume of data flowing through
+them.
+
+{{< note >}}
+The sizing figures below assume the
+[`persist_pg_consensus_read_committed`](/self-managed-deployments/configuration-system-parameters/)
+system parameter is **enabled**. Enable it before sizing against these
+numbers.
+{{< /note >}}
+
+### Safe operating point
+
+They key parameter that dictates the size of the metadata database is the number
+of durable objects Materialize keeps continuously fresh (materialized views,
+sources, and tables). Data volume, the query rate against Materialize, and
+cluster size do not materially change metadata-database load. A larger cluster
+running the same number of materialized views places roughly the same load on
+the metadata database.
+
+It is recommended that you size the metadata database so that its
+**steady-state CPU stays below 60%**. The headroom between ~60% and full
+utilization absorbs everyday load variance, background database maintenance,
+and Materialize zero downtime upgrades.

--- a/doc/user/content/headless/self-managed-deployments/metadata-database-sizing.md
+++ b/doc/user/content/headless/self-managed-deployments/metadata-database-sizing.md
@@ -1,8 +1,12 @@
+---
+headless: true
+---
+
 Self-managed Materialize uses an external PostgreSQL **metadata database** to
 store its catalog and to coordinate the state of the objects it keeps up to
 date. Every durable object that updates continuously (materialized views,
-sources, and tables) produces a steady stream of small writes to the metadata
-database. Metadata-database load therefore scales with the **number of
+sources, sinks, and tables) produces a steady stream of small writes to the
+metadata database. Metadata-database load therefore scales with the **number of
 continuously-updating objects**, not with the volume of data flowing through
 them.
 
@@ -10,19 +14,19 @@ them.
 The sizing figures below assume the
 [`persist_pg_consensus_read_committed`](/self-managed-deployments/configuration-system-parameters/)
 system parameter is **enabled**. Enable it before sizing against these
-numbers.
+numbers. Materialize version `v26.33+` is required to set this parameter.
 {{< /note >}}
 
 ### Safe operating point
 
-They key parameter that dictates the size of the metadata database is the number
-of durable objects Materialize keeps continuously fresh (materialized views,
-sources, and tables). Data volume, the query rate against Materialize, and
-cluster size do not materially change metadata-database load. A larger cluster
-running the same number of materialized views places roughly the same load on
-the metadata database.
+The primary factor that dictates the size of the metadata database is the
+number of durable objects Materialize keeps continuously fresh (materialized
+views, sources, sinks, and tables). Data volume, the query rate against
+Materialize, and cluster size do not materially change metadata database load.
+For example, a larger cluster running the same number of materialized views
+places roughly the same load on the metadata database.
 
 It is recommended that you size the metadata database so that its
 **steady-state CPU stays below 60%**. The headroom between ~60% and full
-utilization absorbs everyday load variance, background database maintenance,
-and Materialize zero downtime upgrades.
+utilization provides capacity to absorb everyday load variance, background
+database maintenance, and Materialize zero-downtime upgrades.

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
@@ -59,6 +59,23 @@ If deploying `v25.2`, Materialize clusters will not automatically use swap unles
 {{< /tab >}}
 {{< /tabs >}}
 
+## Recommended metadata database sizing
+
+{{< include-md file="shared-content/self-managed/metadata-database-sizing.md" >}}
+
+### RDS instance types
+
+For the RDS PostgreSQL metadata database, we recommend:
+
+- **Graviton (ARM)** memory-optimized instances (the `r6g` / `r7g` families).
+- **Multi-AZ** for production.
+- **gp3** storage.
+
+| Deployment size | Instance | vCPU / memory | Continuously-active objects (~60% CPU) |
+|---|---|---|---|
+| Entry / small production | `db.r6g.large` | 2 / 16 GiB | ~4,500 |
+| Recommended default | `db.r6g.2xlarge` | 8 / 64 GiB | ~18,000 |
+
 ## TLS
 
 When running with TLS in production, run with certificates from an official

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/aws-deployment-guidelines.md
@@ -61,7 +61,7 @@ If deploying `v25.2`, Materialize clusters will not automatically use swap unles
 
 ## Recommended metadata database sizing
 
-{{< include-md file="shared-content/self-managed/metadata-database-sizing.md" >}}
+{{< include-md file="content/headless/self-managed-deployments/metadata-database-sizing.md" >}}
 
 ### RDS instance types
 

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/azure-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/azure-deployment-guidelines.md
@@ -76,6 +76,24 @@ If deploying `v25.2`, Materialize clusters will not automatically use swap unles
 Materialize writes **block** blobs on Azure. As a general guideline, we
 recommend **Premium block blob** storage accounts.
 
+## Recommended metadata database sizing
+
+{{< include-md file="shared-content/self-managed/metadata-database-sizing.md" >}}
+
+### Flexible Server SKUs
+
+For the Azure Database for PostgreSQL flexible server that backs the metadata
+database, we recommend:
+
+- The **Memory Optimized** tier (E-series), which provides the 1:8
+  vCore-to-memory ratio recommended for the metadata database.
+- **Zone-redundant high availability** for production.
+
+| Deployment size | `sku_name` | vCores / memory | Continuously-active objects (~60% CPU) |
+|---|---|---|---|
+| Entry / small production | `MO_Standard_E4ds_v5` | 4 / 32 GiB | ~4,500 |
+| Recommended default | `MO_Standard_E16ds_v5` | 16 / 128 GiB | ~18,000 |
+
 ## TLS
 
 When running with TLS in production, run with certificates from an official

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/azure-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/azure-deployment-guidelines.md
@@ -78,7 +78,7 @@ recommend **Premium block blob** storage accounts.
 
 ## Recommended metadata database sizing
 
-{{< include-md file="shared-content/self-managed/metadata-database-sizing.md" >}}
+{{< include-md file="content/headless/self-managed-deployments/metadata-database-sizing.md" >}}
 
 ### Flexible Server SKUs
 

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/gcp-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/gcp-deployment-guidelines.md
@@ -109,7 +109,7 @@ to substantially improve the performance of compute-bound workloads.
 
 ## Recommended metadata database sizing
 
-{{< include-md file="shared-content/self-managed/metadata-database-sizing.md" >}}
+{{< include-md file="content/headless/self-managed-deployments/metadata-database-sizing.md" >}}
 
 ### Cloud SQL machine types
 

--- a/doc/user/content/self-managed-deployments/deployment-guidelines/gcp-deployment-guidelines.md
+++ b/doc/user/content/self-managed-deployments/deployment-guidelines/gcp-deployment-guidelines.md
@@ -107,6 +107,26 @@ It is strongly recommended to enable the Kubernetes `static` [CPU management pol
 This ensures that each worker thread of Materialize is given exclusively access to a vCPU. Our benchmarks have shown this
 to substantially improve the performance of compute-bound workloads.
 
+## Recommended metadata database sizing
+
+{{< include-md file="shared-content/self-managed/metadata-database-sizing.md" >}}
+
+### Cloud SQL machine types
+
+For the Cloud SQL for PostgreSQL instance that backs the metadata database, we
+recommend:
+
+- The **Enterprise Plus** edition with a **performance-optimized (N-series)**
+  machine type, which provides the 1:8 vCPU-to-memory ratio recommended for the
+  metadata database. Avoid shared-core machine types (`db-f1-micro`,
+  `db-g1-small`) in production.
+- A **regional (highly available)** configuration for production.
+
+| Deployment size | `tier` | vCPU / memory | Continuously-active objects (~60% CPU) |
+|---|---|---|---|
+| Entry / small production | `db-perf-optimized-N-4` | 4 / 32 GB | ~4,500 |
+| Recommended default | `db-perf-optimized-N-16` | 16 / 128 GB | ~18,000 |
+
 ## TLS
 
 When running with TLS in production, run with certificates from an official


### PR DESCRIPTION
### Motivation

Adds deployment sizing recommendation for the consensus database based on the results of recent benchmarking against all three cloud providers.
