### PR TITLE
adapter: don't panic when shutdown drops a retiring execute context

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1733,6 +1733,10 @@ impl ExecuteContext {
     /// (possibly wrapped in a new `ExecuteContext`) is passed back to the coordinator for
     /// eventual retirement. The returned response barriers must stay attached
     /// to the user-visible response path.
+    ///
+    /// The returned parts lose the `Drop` backstop that answers the client on shutdown, so they
+    /// must not be held across an await point. A bare `ClientTransmitter` panics when dropped
+    /// unsent.
     pub fn into_parts(
         mut self,
     ) -> (
@@ -1755,26 +1759,23 @@ impl ExecuteContext {
     /// Retire the execution, by sending a message to the coordinator.
     #[instrument(level = "debug")]
     pub fn retire(mut self, result: Result<ExecuteResponse, AdapterError>) {
-        let ExecuteContextInner {
-            tx,
-            internal_cmd_tx,
-            session,
-            extra,
-            response_barriers,
-        } = *self.inner.take().expect("only consumed by value");
+        let response_barriers = std::mem::take(&mut self.response_barriers);
         if response_barriers.is_empty() {
+            let (tx, internal_cmd_tx, session, extra, _) = self.into_parts();
             retire_execution_context(tx, internal_cmd_tx, session, extra, result);
-        } else {
-            spawn(
-                || "execute_context::retire_after_response_barriers",
-                async move {
-                    for barrier in response_barriers {
-                        barrier.await;
-                    }
-                    retire_execution_context(tx, internal_cmd_tx, session, extra, result);
-                },
-            );
+            return;
         }
+        // Keep `self` intact across the wait: if shutdown drops this task, the context's `Drop`
+        // backstop answers the client. Barriers are empty on re-entry, so this terminates.
+        spawn(
+            || "execute_context::retire_after_response_barriers",
+            async move {
+                for barrier in response_barriers {
+                    barrier.await;
+                }
+                self.retire(result);
+            },
+        );
     }
 
     /// Delays sending this statement's response until `barrier` resolves.
@@ -5515,6 +5516,46 @@ pub(crate) fn infer_sql_type_for_catalog(
     let mut typ = hir_expr.top_level_typ();
     typ.backport_nullability_and_keys(&mir_expr.typ());
     typ
+}
+
+#[cfg(test)]
+mod execute_context_tests {
+    use tokio::sync::{mpsc, oneshot};
+
+    use super::*;
+    use crate::session::Session;
+    use crate::util::ClientTransmitter;
+
+    /// Runtime shutdown drops the barrier-waiting task that `retire` spawns. The context's `Drop`
+    /// backstop must answer the client, rather than panicking on an unsent `ClientTransmitter`.
+    #[mz_ore::test]
+    fn test_retire_answers_client_when_runtime_shuts_down() {
+        let runtime = tokio::runtime::Runtime::new().expect("can build runtime");
+
+        let (client_tx, mut client_rx) = oneshot::channel();
+        let (internal_cmd_tx, _internal_cmd_rx) = mpsc::unbounded_channel();
+
+        runtime.block_on(async {
+            let ctx = ExecuteContext::from_parts_with_response_barriers(
+                ClientTransmitter::new(client_tx, internal_cmd_tx.clone()),
+                internal_cmd_tx,
+                Session::dummy(),
+                ExecuteContextGuard::default(),
+                // Stands in for a group commit that shutdown will never apply.
+                vec![Box::pin(std::future::pending())],
+            );
+            ctx.retire(Ok(ExecuteResponse::StartedTransaction));
+        });
+
+        drop(runtime);
+
+        let response = client_rx.try_recv().expect("client must be answered");
+        assert!(
+            matches!(response.result, Err(AdapterError::Internal(_))),
+            "expected an internal error, got {:?}",
+            response.result
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -52,7 +52,7 @@ const COPY_FROM_STDIN_MAX_WORKERS: usize = 8;
 impl Coordinator {
     pub(crate) async fn sequence_copy_from(
         &mut self,
-        ctx: ExecuteContext,
+        mut ctx: ExecuteContext,
         plan: plan::CopyFromPlan,
         target_cluster: TargetCluster,
     ) {
@@ -69,24 +69,16 @@ impl Coordinator {
         // CopyData/CopyDone exchange. URL/S3 sources stage a one-shot ingestion
         // server-side and fall through to the rest of this function.
         if let CopyFromSource::Stdin = plan.source {
-            let (tx, _, session, ctx_extra, response_barriers) = ctx.into_parts();
-            let response = Ok(ExecuteResponse::CopyFrom {
+            // The statement-logging obligation moves into the response, pgwire carries it onward.
+            // `ctx` stays intact so `retire` can wait out any response barriers safely.
+            let ctx_extra = std::mem::take(ctx.extra_mut());
+            ctx.retire(Ok(ExecuteResponse::CopyFrom {
                 target_id: plan.target_id,
                 target_name: plan.target_name,
                 columns: plan.columns,
                 params: plan.params,
                 ctx_extra,
-            });
-            if response_barriers.is_empty() {
-                tx.send(response, session);
-            } else {
-                mz_ore::task::spawn(|| "copy_from_stdin_after_response_barriers", async move {
-                    for barrier in response_barriers {
-                        barrier.await;
-                    }
-                    tx.send(response, session);
-                });
-            }
+            }));
             return;
         }
 


### PR DESCRIPTION
### Motivation

Closes [SQL-594](https://linear.app/materializeinc/issue/SQL-594)

CI runs abort during shutdown with:

```
thread 'tokio-rt-worker' panicked at src/adapter/src/util.rs:197:13:
client transmitter dropped without send
   7: core::ptr::drop_in_place::<<mz_adapter::coord::ExecuteContext>::retire::{closure#1}>
  13: <tokio::runtime::task::list::OwnedTasks<...>>::close_and_shutdown_all
```

When a context has response barriers attached, `ExecuteContext::retire`
destructured it into raw parts and moved those into a spawned task that waits
for the barriers before answering the client. Runtime shutdown drops un-polled
tasks, dropping the captured `ClientTransmitter` unsent, which panics.
`ExecuteContext` already has a `Drop` backstop that answers the client for
exactly this case, and pulling out the parts before awaiting defeated it.

This path is hot: every `COMMIT`/`ROLLBACK` attaches a barrier (the group
commit completion), so any shutdown races against in-flight transactions.

### Is this a production issue?

No, tests only. The panic needs a tokio runtime to be *dropped*.
`environmentd` never drops one: its `main` parks forever, and every exit path
(`halt!`/`exit!` via `libc::_exit`, the abort-on-panic handler, termination
signals) skips destructors. Runtime drop happens in the sqllogictest runner
(fresh runtime per test file and per `reset-server`) and in Rust tests. There
is also no client-hang risk from the barriers themselves: each one is a
`oneshot` receiver that resolves as soon as its sender drops.

So: a blocker for CI signal, not for availability or correctness.

### Description

Move the intact `ExecuteContext` into the barrier-waiting task, so a shutdown
drop hits its `Drop` backstop and the client gets an error instead of a panic.
The invariant, now documented on `into_parts`: the parts lose the backstop, so
they must not be held across an await point.

The `COPY FROM STDIN` path had hand-rolled the same barrier wait, with the same
latent trap. It now delegates to `retire`, a net deletion.

Two sites remain that hold a bare transmitter across an await:
`sequence_execute_single_statement_transaction` and `sequence_read_then_write`.
They can't take this fix, since the session is owned by an inner context for
the whole wait, so there is no context to keep intact. Closing them needs a
small design decision (session-less responses, a single-owner restructure, or
an explicit abandon path) and is left for a follow-up. Note for triage: this
issue's `ci-regexp` also matches the panic from those two sites.

### Verification

Adds `test_retire_answers_client_when_runtime_shuts_down`: retires a context
whose barrier never resolves, drops the runtime, and asserts the client is
answered with an internal error. On unfixed code it reproduces the panic
deterministically, same thread name and location as the CI reports.
