### PR TITLE
[SS-372] docs: document Iceberg sinks to self-managed REST catalogs

### DIFF
--- a/doc/user/content/serve-results/sink/iceberg-rest.md
+++ b/doc/user/content/serve-results/sink/iceberg-rest.md
@@ -1,0 +1,131 @@
+---
+title: "Self-managed (REST catalog)"
+description: "How to export results from Materialize to Apache Iceberg tables in a self-managed Iceberg REST catalog and S3-compatible object storage."
+menu:
+  main:
+    parent: sink-iceberg
+    name: "Self-managed (REST catalog)"
+    weight: 30
+---
+
+{{< private-preview />}}
+
+{{< warning >}}
+Materialize does not perform Iceberg table maintenance on this path. You are
+responsible for running compaction, snapshot expiration, and orphan file
+cleanup yourself. Without maintenance, query performance on the sinked tables
+degrades over time and storage usage grows unboundedly. See
+[Table maintenance](#table-maintenance).
+{{< /warning >}}
+
+This guide walks you through the steps required to set up Iceberg sinks
+against a self-managed [Iceberg REST
+catalog](https://iceberg.apache.org/rest-catalog-spec/) backed by
+S3-compatible object storage, rather than a managed offering like AWS S3
+Tables or GCP BigLake. Materialize continuously tests this configuration
+against [Apache Polaris](https://polaris.apache.org/) and
+[MinIO](https://min.io/). Other spec-compliant catalog and storage
+combinations are expected to work but are not individually validated.
+
+## Prerequisites
+
+- An Iceberg REST catalog that implements the [Iceberg REST catalog
+  specification](https://iceberg.apache.org/rest-catalog-spec/), reachable
+  from your Materialize deployment.
+- The catalog must support **OAuth2 client credentials** authentication.
+- The catalog must support **storage credential vending** (also called access
+  delegation). When Materialize loads a table, the catalog must return the
+  storage configuration and credentials (for example `s3.access-key-id`,
+  `s3.secret-access-key`, and `s3.endpoint`) that Materialize uses to write
+  data files. There is no way to configure object storage credentials on the
+  sink directly.
+- A namespace in the catalog to hold the sinked tables.
+
+## Create the Iceberg catalog connection in Materialize
+
+In Materialize, create an **Iceberg catalog connection** for the Iceberg sink
+to use. To create, use [`CREATE CONNECTION ... TO ICEBERG
+CATALOG`](/sql/create-connection/#iceberg-catalog), replacing:
+
+- `<catalog_url>` with the base URL of your REST catalog, e.g.
+  `https://polaris.example.com/api/catalog`,
+- `<client_id>:<client_secret>` with the OAuth2 client credentials for your
+  catalog,
+- `<warehouse>` with the warehouse name as your catalog expects it, and
+- `<scope>` with the OAuth2 scope, if your catalog requires one (e.g.
+  `PRINCIPAL_ROLE:ALL` for Polaris).
+
+```mzsql
+CREATE SECRET iceberg_credential AS '<client_id>:<client_secret>';
+
+CREATE CONNECTION iceberg_catalog_connection TO ICEBERG CATALOG (
+    CATALOG TYPE = 'rest',
+    URL = '<catalog_url>',
+    CREDENTIAL = SECRET iceberg_credential,
+    WAREHOUSE = '<warehouse>',
+    SCOPE = '<scope>'
+);
+```
+
+## Create the Iceberg sink in Materialize
+
+{{% include-example file="examples/create_sink_iceberg" example="tutorial-create-sink-intro" %}}
+
+### Upsert mode
+
+{{% include-example file="examples/create_sink_iceberg" example="tutorial-create-sink-upsert-mode" %}}
+
+### Append mode
+
+{{% include-example file="examples/create_sink_iceberg" example="tutorial-create-sink-append-mode" %}}
+
+## Considerations
+
+### Table maintenance
+
+Managed Iceberg offerings like AWS S3 Tables run table maintenance for you.
+On this path there is no maintenance service, so you must run it yourself.
+Regularly perform, at minimum:
+
+- **Compaction**: Materialize commits new data files on every commit
+  interval, so tables accumulate many small files. Rewrite them into larger
+  files to keep scans efficient.
+- **Snapshot expiration**: every commit creates a new table snapshot. Expire
+  old snapshots to allow underlying data files to be removed.
+- **Orphan file cleanup**: remove files no longer referenced by any snapshot.
+
+Tools that can run these operations include [Spark stored
+procedures](https://iceberg.apache.org/docs/latest/spark-procedures/) and
+your catalog's own maintenance features, if it has any.
+
+### Commit interval tradeoffs {#commit-interval-tradeoffs}
+
+{{% include-headless "/headless/iceberg-sinks/commit-interval-tradeoffs" %}}
+
+### Exactly-once delivery
+
+{{< include-from-yaml data="examples/create_sink_iceberg"
+name="exactly-once-delivery" >}}
+
+### Type mapping
+
+{{% include-headless
+  "/headless/iceberg-sinks/type-mapping" %}}
+
+### Limitations
+
+- Materialize authenticates to object storage exclusively with the
+  credentials vended by the catalog. Catalogs that do not support credential
+  vending are not supported.
+
+{{% include-headless "/headless/iceberg-sinks/limitations-list" %}}
+
+## Troubleshooting
+
+{{% include-headless "/headless/iceberg-sinks/troubleshooting" %}}
+
+## Related pages
+
+- [`CREATE SINK`](/sql/create-sink/iceberg)
+- [`CREATE CONNECTION`](/sql/create-connection)
+- [Apache Iceberg documentation](https://iceberg.apache.org/docs/latest/)

--- a/doc/user/content/serve-results/sink/iceberg.md
+++ b/doc/user/content/serve-results/sink/iceberg.md
@@ -12,18 +12,19 @@ menu:
 {{< public-preview />}}
 
 Iceberg sinks provide exactly once delivery of updates from Materialize into
-[Apache Iceberg](https://iceberg.apache.org/)[^1] tables hosted on either
-[Amazon S3
-Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html)[^2]
-or [Google Cloud BigLake](https://cloud.google.com/biglake)[^3]. As data
-changes in Materialize, the corresponding Iceberg tables are automatically
-kept up to date. You can sink data from a materialized view, a source, or a
-table.
+[Apache Iceberg](https://iceberg.apache.org/)[^1] tables hosted on [Amazon S3
+Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html)[^2],
+[Google Cloud BigLake](https://cloud.google.com/biglake)[^3], or a
+self-managed Iceberg REST catalog backed by S3-compatible object storage. As
+data changes in Materialize, the corresponding Iceberg tables are
+automatically kept up to date. You can sink data from a materialized view, a
+source, or a table.
 
 Follow the guide for the platform hosting your Iceberg tables:
 
 - [AWS S3 Tables](/serve-results/sink/iceberg-aws/)
 - [GCP BigLake](/serve-results/sink/iceberg-gcp/) {{< private-preview-inline />}}
+- [Self-managed (REST catalog)](/serve-results/sink/iceberg-rest/) {{< private-preview-inline />}}
 
 [^1]: [Apache Iceberg](https://iceberg.apache.org/) is an open table format for
 large-scale analytics datasets.

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -928,12 +928,13 @@ CREATE CONNECTION sqlserver_connection TO SQL SERVER (
 An Iceberg catalog connection establishes a link to an [Apache Iceberg](https://iceberg.apache.org/)
 catalog. You can use Iceberg catalog connections to create [Iceberg sinks](/sql/create-sink/iceberg).
 
-Materialize supports two catalog types:
+Materialize supports the following catalog configurations:
 
 | Catalog type | Destination | Authentication |
 | --- | --- | --- |
 | `'s3tablesrest'` | [AWS S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html) | [AWS connection](#aws) |
 | `'rest'` | [Google Cloud BigLake](https://docs.cloud.google.com/lakehouse/docs/lakehouse-iceberg-rest-catalog) {{< private-preview-inline />}} | [GCP connection](#gcp) |
+| `'rest'` | [Self-managed Iceberg REST catalog](/serve-results/sink/iceberg-rest/) {{< private-preview-inline />}} | OAuth2 client credentials (`CREDENTIAL`) |
 
 #### Syntax {#iceberg-catalog-syntax}
 
@@ -948,6 +949,13 @@ Materialize supports two catalog types:
 {{< private-preview />}}
 
 {{% include-syntax file="examples/create_connection" example="syntax-iceberg-catalog-biglake" %}}
+
+{{< /tab >}}
+{{< tab "Self-managed" >}}
+
+{{< private-preview />}}
+
+{{% include-syntax file="examples/create_connection" example="syntax-iceberg-catalog-rest" %}}
 
 {{< /tab >}}
 {{< /tabs >}}
@@ -967,6 +975,14 @@ example="example-iceberg-catalog-connection" %}}
 
 {{% include-example file="examples/create_connection"
 example="example-iceberg-catalog-gcp-connection" %}}
+
+{{< /tab >}}
+{{< tab "Self-managed" >}}
+
+{{< private-preview />}}
+
+{{% include-example file="examples/create_connection"
+example="example-iceberg-catalog-rest-connection" %}}
 
 {{< /tab >}}
 {{< /tabs >}}

--- a/doc/user/data/examples/create_connection.yml
+++ b/doc/user/data/examples/create_connection.yml
@@ -777,6 +777,40 @@
 
         The name of a [GCP connection](#gcp) to use for authentication.
 
+- name: "syntax-iceberg-catalog-rest"
+  code: |
+    CREATE CONNECTION <connection_name> TO ICEBERG CATALOG (
+        CATALOG TYPE = 'rest',
+        URL = '<catalog_url>',
+        CREDENTIAL = SECRET <credential_secret>,
+        WAREHOUSE = '<warehouse>',
+        SCOPE = '<scope>'
+    );
+  syntax_elements:
+    - name: "`<connection_name>`"
+      description: |
+        A name for the connection.
+    - name: "`URL`"
+      description: |
+        *Value:* `text`. Required.
+
+        Base URL of the Iceberg REST catalog, e.g. `https://polaris.example.com/api/catalog`
+    - name: "`CREDENTIAL`"
+      description: |
+        *Value:* secret or `text`. Required.
+
+        OAuth2 client credentials for the catalog, in the form `<client_id>:<client_secret>`.
+    - name: "`WAREHOUSE`"
+      description: |
+        *Value:* `text`. Optional.
+
+        The warehouse name, as expected by the catalog.
+    - name: "`SCOPE`"
+      description: |
+        *Value:* `text`. Optional.
+
+        OAuth2 scope to request, e.g. `PRINCIPAL_ROLE:ALL` for Apache Polaris.
+
 - name: "example-iceberg-catalog-connection"
   description: |
     The following example creates an [AWS connection](/sql/create-connection/#aws) and an [Iceberg catalog connection](/sql/create-connection/#iceberg-catalog) for AWS S3 Tables:
@@ -813,5 +847,22 @@
         URL = 'https://biglake.googleapis.com/iceberg/v1/restcatalog',
         WAREHOUSE = 'gs://<bucket>',
         GCP CONNECTION = gcp_connection
+    );
+  testable: false
+
+- name: "example-iceberg-catalog-rest-connection"
+  description: |
+    The following example creates an [Iceberg catalog connection](/sql/create-connection/#iceberg-catalog) for a self-managed Iceberg REST catalog, such as Apache Polaris:
+  code: |
+    -- OAuth2 client credentials for the catalog, as client_id:client_secret.
+    CREATE SECRET iceberg_credential AS '<client_id>:<client_secret>';
+
+    -- Create the Iceberg catalog connection pointing to the REST catalog.
+    CREATE CONNECTION iceberg_catalog_connection TO ICEBERG CATALOG (
+        CATALOG TYPE = 'rest',
+        URL = 'https://polaris.example.com/api/catalog',
+        CREDENTIAL = SECRET iceberg_credential,
+        WAREHOUSE = 'my_warehouse',
+        SCOPE = 'PRINCIPAL_ROLE:ALL'
     );
   testable: false


### PR DESCRIPTION
## Motivation

Documentation. Our Iceberg sink docs cover AWS S3 Tables and GCP BigLake, but the sink also works against any spec-compliant Iceberg REST catalog with S3-compatible object storage, which is exactly the configuration our test suite exercises (Apache Polaris + MinIO). Users who prefer plain S3 with a self-managed catalog over a managed offering currently have no documented path.

## Changes

- New guide `/serve-results/sink/iceberg-rest/` ("Self-managed (REST catalog)") alongside the S3 Tables and BigLake guides, marked private preview. It documents:
  - the `CATALOG TYPE = 'rest'` connection with OAuth2 client credentials (`CREDENTIAL`, optional `SCOPE` and `WAREHOUSE`),
  - the hard requirement that the catalog supports storage credential vending: Materialize authenticates to object storage exclusively with the credentials the catalog vends on table load, and there is no way to configure storage credentials on the sink directly,
  - that table maintenance (compaction, snapshot expiration, orphan file cleanup) is the user's responsibility on this path, unlike managed offerings.
- `CREATE CONNECTION` reference: adds the self-managed REST catalog row, syntax tab, and example.
- Landing page `/serve-results/sink/iceberg/` links the new guide.

The credential vending behavior and option semantics were verified against `IcebergCatalogConnection::connect_rest` in `src/storage-types/src/connections.rs` and the planning rules in `src/sql/src/plan/statement/ddl/connection.rs`. The example mirrors `test/iceberg/catalog.td`.

Docs-only change, verified with a local Hugo build. No tests added or modified.

## Tips for reviewer

The GCP BigLake page also uses `CATALOG TYPE = 'rest'` with a GCP connection, so the catalog type table in the `CREATE CONNECTION` reference now lists `'rest'` twice, distinguished by authentication method.

## Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing $T ⇔ Proto$T mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)