### PR TITLE
scratch: set required ownership tags on launched instances

### DIFF
--- a/misc/completions/bash/_scratch
+++ b/misc/completions/bash/_scratch
@@ -4,7 +4,7 @@ _shtab_scratch_subparsers=('login' 'create' 'list' 'ls' 'ssh' 'sftp' 'destroy' '
 
 _shtab_scratch_option_strings=('-h' '--help')
 _shtab_scratch_login_option_strings=('-h' '--help')
-_shtab_scratch_create_option_strings=('-h' '--help' '--key-name' '--security-group-name' '--extra-tags' '--instance-profile' '--output-format' '--git-rev' '--ssh' '--instance-type' '--size-gb' '--max-age-days')
+_shtab_scratch_create_option_strings=('-h' '--help' '--key-name' '--security-group-name' '--extra-tags' '--team' '--instance-profile' '--output-format' '--git-rev' '--ssh' '--instance-type' '--size-gb' '--max-age-days')
 _shtab_scratch_list_option_strings=('-h' '--help' '--all' '--output-format')
 _shtab_scratch_ls_option_strings=('-h' '--help' '--all' '--output-format')
 _shtab_scratch_ssh_option_strings=('-h' '--help')
@@ -14,8 +14,8 @@ _shtab_scratch_rm_option_strings=('-h' '--help' '--all-mine' '-y' '--yes' '--out
 _shtab_scratch_push_option_strings=('-h' '--help' '--rev')
 _shtab_scratch_completion_option_strings=('-h' '--help')
 _shtab_scratch_forward_option_strings=('-h' '--help')
-_shtab_scratch_go_option_strings=('-h' '--help' '--instance-type' '--size-gb' '--max-age-days')
-_shtab_scratch_claude_option_strings=('-h' '--help' '--instance-type' '--size-gb' '--max-age-days')
+_shtab_scratch_go_option_strings=('-h' '--help' '--instance-type' '--size-gb' '--max-age-days' '--team')
+_shtab_scratch_claude_option_strings=('-h' '--help' '--instance-type' '--size-gb' '--max-age-days' '--team')
 
 
 

--- a/misc/completions/zsh/_scratch
+++ b/misc/completions/zsh/_scratch
@@ -34,6 +34,7 @@ _shtab_scratch_claude_options=(
   "--instance-type[Override the EC2 instance type. The AMI is derived from its architecture. May be used without a machine config.]:instance_type:"
   "--size-gb[Override the root volume size in GiB.]:size_gb:"
   "--max-age-days[Maximum age for scratch instance in days. Defaults to 1.5]:max_age_days:"
+  "--team[Value for the \`team\` tag required by the scratch account. Defaults to \`engineering\`.]:team:"
   ":Machine config name from misc\/scratch (e.g. dev-box).:"
 )
 
@@ -54,6 +55,7 @@ _shtab_scratch_create_options=(
   "--key-name[Optional EC2 Key Pair name]:key_name:"
   "--security-group-name[EC2 Security Group name. Defaults to Materialize scratch account.]:security_group_name:"
   "--extra-tags[Additional tags\/labels for created instance. Format\: \{\"key\"\: \"value\"\}]:extra_tags:"
+  "--team[Value for the \`team\` tag required by the scratch account. Defaults to \`engineering\`.]:team:"
   "--instance-profile[EC2 instance profile \/ IAM role. Defaults to \`admin-instance\`.]:instance_profile:"
   "--output-format[]:output_format:(table csv)"
   "--git-rev[Git revision of \`materialize\` codebase to push to scratch instance. Defaults to \`HEAD\`]:git_rev:"
@@ -92,6 +94,7 @@ _shtab_scratch_go_options=(
   "--instance-type[Override the EC2 instance type. The AMI is derived from its architecture. May be used without a machine config.]:instance_type:"
   "--size-gb[Override the root volume size in GiB.]:size_gb:"
   "--max-age-days[Maximum age for scratch instance in days. Defaults to 1.5]:max_age_days:"
+  "--team[Value for the \`team\` tag required by the scratch account. Defaults to \`engineering\`.]:team:"
   ":Machine config name from misc\/scratch (e.g. dev-box). Used only when creating a new instance.:"
 )
 

--- a/misc/python/materialize/cli/scratch/claude.py
+++ b/misc/python/materialize/cli/scratch/claude.py
@@ -53,6 +53,12 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         default=MAX_AGE_DAYS,
         help="Maximum age for scratch instance in days. Defaults to 1.5",
     )
+    parser.add_argument(
+        "--team",
+        type=str,
+        default="engineering",
+        help="Value for the `team` tag required by the scratch account. Defaults to `engineering`.",
+    )
 
 
 def run(args: argparse.Namespace) -> None:
@@ -104,7 +110,7 @@ def run(args: argparse.Namespace) -> None:
     if instance is None:
         say(f"Creating from {label}...")
         max_age = datetime.timedelta(days=args.max_age_days)
-        extra_tags = {"LaunchedBy": whoami()}
+        extra_tags = {"LaunchedBy": whoami(), "team": args.team}
         instances = launch_cluster(
             descs,
             extra_tags=extra_tags,

--- a/misc/python/materialize/cli/scratch/create.py
+++ b/misc/python/materialize/cli/scratch/create.py
@@ -147,6 +147,12 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         help='Additional tags/labels for created instance. Format: {"key": "value"}',
     )
     parser.add_argument(
+        "--team",
+        type=str,
+        default="engineering",
+        help="Value for the `team` tag required by the scratch account. Defaults to `engineering`.",
+    )
+    parser.add_argument(
         "--instance-profile",
         type=str,
         default=DEFAULT_INSTANCE_PROFILE_NAME,
@@ -217,6 +223,8 @@ def run(args: argparse.Namespace) -> None:
 
     check_required_vars()
     extra_tags["LaunchedBy"] = whoami()
+    # --extra-tags wins if it also specifies a team.
+    extra_tags.setdefault("team", args.team)
 
     if args.ssh and len(descs) != 1:
         raise RuntimeError(f"Cannot use `--ssh` with {len(descs)} instances")

--- a/misc/python/materialize/cli/scratch/go.py
+++ b/misc/python/materialize/cli/scratch/go.py
@@ -56,6 +56,12 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         default=MAX_AGE_DAYS,
         help="Maximum age for scratch instance in days. Defaults to 1.5",
     )
+    parser.add_argument(
+        "--team",
+        type=str,
+        default="engineering",
+        help="Value for the `team` tag required by the scratch account. Defaults to `engineering`.",
+    )
 
 
 def run(args: argparse.Namespace) -> None:
@@ -89,7 +95,7 @@ def run(args: argparse.Namespace) -> None:
     say(f"No existing instance found, creating from {label}...")
 
     max_age = datetime.timedelta(days=args.max_age_days)
-    extra_tags = {"LaunchedBy": whoami()}
+    extra_tags = {"LaunchedBy": whoami(), "team": args.team}
     instances = launch_cluster(
         descs,
         extra_tags=extra_tags,

--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -417,7 +417,7 @@ def launch(
     # caller didn't provide explicitly.
     tags.setdefault("owner", tags.get("LaunchedBy") or whoami())
     tags.setdefault("reason", "scratch instance")
-    tags.setdefault("team", "unknown")
+    tags.setdefault("team", "engineering")
     tags.setdefault(
         "deleteAfter",
         delete_after.astimezone(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -411,6 +411,18 @@ def launch(
     tags["git_ref"] = git.describe()
     tags["ami-user"] = ami_user
 
+    # The scratch account denies resource creation unless the `owner`,
+    # `reason`, `team`, and `deleteAfter` tags are all present (see the
+    # RequireTagsScratch SCP in MaterializeInc/i2). Default any that the
+    # caller didn't provide explicitly.
+    tags.setdefault("owner", tags.get("LaunchedBy") or whoami())
+    tags.setdefault("reason", "scratch instance")
+    tags.setdefault("team", "unknown")
+    tags.setdefault(
+        "deleteAfter",
+        delete_after.astimezone(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+
     ec2 = boto3.client("ec2")
     groups = ec2.describe_security_groups()
     security_group_id = None
@@ -462,7 +474,13 @@ def launch(
             {
                 "ResourceType": "instance",
                 "Tags": [{"Key": k, "Value": v} for (k, v) in tags.items()],
-            }
+            },
+            # Tag the root volume too: the RequireTagsScratch SCP applies to
+            # the volumes created by RunInstances, not just the instance.
+            {
+                "ResourceType": "volume",
+                "Tags": [{"Key": k, "Value": v} for (k, v) in tags.items()],
+            },
         ],
         "NetworkInterfaces": [network_interface],
         "BlockDeviceMappings": [


### PR DESCRIPTION
## Motivation

Pre-requisite for MaterializeInc/i2#3620, which attaches a `RequireTagsScratch` SCP to the scratch AWS account denying `ec2:RunInstances` (and other create actions) unless the `owner`, `reason`, `team`, and `deleteAfter` tags are all present on the request.

## Changes

- `scratch.launch()` now defaults the four required tags, so every launch path (`bin/scratch create`/`go`/`claude`, `ci/load/periodic.py`, `cloudbench.py`) satisfies the policy:
  - `owner`: the existing `LaunchedBy` tag if set, otherwise the STS caller identity
  - `reason`: `scratch instance` (override via machine config or `--extra-tags`)
  - `team`: `engineering`, overridable via a new `--team` flag on `create`/`go`/`claude` (or machine config / `--extra-tags`)
  - `deleteAfter`: ISO-8601 UTC rendering of the existing `delete_after` deadline
- `RunInstances` now also tags the created volumes, which the SCP covers too.

## Tips for reviewer

Callers can override any of these via `MachineDesc.tags` or `--extra-tags`; the defaults only fill gaps.

## Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing $T ⇔ Proto$T mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

