### PR TITLE
avro: bound an OCF block's object count and stop block bleed-through

### DIFF
--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -1048,6 +1048,54 @@ fn min_encoded_len_piece(
     }
 }
 
+/// Bounds the object count an object-container-file block declares against the
+/// payload that is supposed to hold those objects.
+///
+/// The count comes straight off the wire, and `util::safe_len` alone caps it at
+/// `MAX_ALLOCATION_BYTES` — a sensible ceiling for a byte length, an enormous one
+/// for a count, and in no way related to the block it describes. `payload_len` is
+/// the block's *decompressed* length.
+///
+/// Which bound applies is decided the same way as for an array block, and for the
+/// same reason (see [`min_encoded_len`]): the byte floor when the object schema has
+/// a proven positive one, otherwise the node-weighted cap, because a zero-width
+/// object — an empty record, or a record of only `null`/empty-record fields —
+/// encodes to no bytes at all, so no payload length can constrain how many of them
+/// a block may claim.
+///
+/// Unlike an array block, the two bounds are *alternatives* rather than both being
+/// applied. An array materializes all of its elements at once, so its cap is about
+/// retained memory; a block's objects are yielded and dropped one at a time, so the
+/// cap here is about work amplified out of a few bytes. Once the byte floor holds,
+/// the work is linear in the file and needs no further ceiling — and capping nodes
+/// as well would reject a legitimate large block of small records.
+///
+/// Not charged against [`DECODE_NODES`]: that budget is per top-level datum and
+/// each object in a block is its own datum. This is a standalone check on the
+/// block header.
+pub(crate) fn bound_block_object_count(
+    schema: SchemaNode,
+    count: usize,
+    payload_len: usize,
+) -> Result<(), AvroError> {
+    let min_bytes = min_encoded_len(schema);
+    if min_bytes > 0 {
+        if count.saturating_mul(min_bytes) > payload_len {
+            return Err(AvroError::Decode(DecodeError::Custom(format!(
+                "Avro block object count {count} exceeds block payload ({payload_len} bytes)"
+            ))));
+        }
+        return Ok(());
+    }
+    let nodes = count.saturating_mul(min_value_nodes(schema));
+    if nodes > MAX_VALUE_NODES {
+        return Err(AvroError::Decode(DecodeError::Custom(format!(
+            "Avro block object count {count} exceeds limit {MAX_VALUE_NODES} decoded values"
+        ))));
+    }
+    Ok(())
+}
+
 /// A *lower* bound on the number of `Value` nodes a single value of `schema`
 /// materializes into when decoded.
 ///

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -259,6 +259,16 @@ impl<R: AvroRead> Reader<R> {
         }
 
         self.inner.read_exact(&mut self.buf[..n])?;
+        // Cut the buffer down to exactly this block's payload. The resize above
+        // only ever grows, so a block shorter than a previous one would otherwise
+        // leave that block's tail visible past its own payload, and everything
+        // downstream reads the buffer by its length: `read_next` slices
+        // `self.buf[self.buf_idx..]`, and `Codec::decompress` hands the whole
+        // buffer to the decompressor. A block whose declared object count outruns
+        // its own bytes would then decode stale bytes as values instead of hitting
+        // the end of the block. `truncate` keeps the allocation, so the buffer is
+        // still reused across blocks.
+        self.buf.truncate(n);
         self.buf_idx = 0;
         Ok(())
     }
@@ -956,6 +966,61 @@ mod tests {
     use crate::types::{Record, ToAvro};
 
     use super::*;
+
+    /// Assemble an object-container file: header (writer schema, `null` codec,
+    /// sync marker) followed by `blocks`. Each block is given as `(declared
+    /// count, declared byte size, payload)` so a test can lie about the framing
+    /// the way a corrupt or hostile file does.
+    fn ocf(schema_json: &str, blocks: &[(i64, i64, &[u8])]) -> Vec<u8> {
+        fn blob(bytes: &[u8], out: &mut Vec<u8>) {
+            util::zig_i64(bytes.len() as i64, out);
+            out.extend_from_slice(bytes);
+        }
+
+        let marker = [7u8; 16];
+        let mut out = b"Obj\x01".to_vec();
+        util::zig_i64(2, &mut out); // metadata map: one block of two entries
+        blob(b"avro.schema", &mut out);
+        blob(schema_json.as_bytes(), &mut out);
+        blob(b"avro.codec", &mut out);
+        blob(b"null", &mut out);
+        util::zig_i64(0, &mut out); // end of metadata map
+        out.extend_from_slice(&marker);
+        for (count, size, payload) in blocks {
+            util::zig_i64(*count, &mut out);
+            util::zig_i64(*size, &mut out);
+            out.extend_from_slice(payload);
+            out.extend_from_slice(&marker);
+        }
+        out
+    }
+
+    #[mz_ore::test]
+    fn reader_does_not_decode_a_previous_blocks_bytes() {
+        // One buffer is reused across blocks, so a block shorter than its
+        // predecessor must not leave that predecessor's tail readable. Block 2
+        // here declares two objects but carries only one, and its payload is
+        // shorter than block 1's, whose bytes are arranged so that what lands
+        // past block 2's payload would decode as a perfectly good `"x"`. The
+        // second decode has to run out of input instead.
+        //
+        // The block bound does not catch this: `string` has a one-byte floor and
+        // the block claims 2 objects in 3 bytes.
+        let long = &[0x0a, b'A', b'B', 0x02, b'x', b'C'][..]; // one 5-char string
+        let short = &[0x04, b'a', b'b'][..]; // one 2-char string
+        let file = ocf(
+            r#""string""#,
+            &[(1, long.len() as i64, long), (2, short.len() as i64, short)],
+        );
+
+        let items: Vec<_> = Reader::new(&file[..]).expect("OCF header parses").collect();
+        assert_eq!(items.len(), 3, "expected two values then an error");
+        assert_eq!(
+            items[1].as_ref().expect("block 2's real value decodes"),
+            &Value::String("ab".into())
+        );
+        assert_err!(&items[2]);
+    }
 
     #[mz_ore::test]
     fn reader_rejects_huge_block_object_count() {

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -29,7 +29,7 @@ use std::str::{FromStr, from_utf8};
 use aws_lc_rs::digest;
 use serde_json::from_slice;
 
-use crate::decode::{AvroRead, decode};
+use crate::decode::{AvroRead, bound_block_object_count, decode};
 use crate::error::{DecodeError, Error as AvroError};
 use crate::schema::{
     FullName, NamedSchemaPiece, ParseSchemaError, RecordField, ResolvedDefaultValueField,
@@ -304,6 +304,18 @@ impl<R: AvroRead> Reader<R> {
                 // We can address this by using some "limited read" type to decode directly
                 // into the buffer. But this is fine, for now.
                 self.header.codec.decompress(&mut self.buf)?;
+
+                // `safe_len` above bounds the object count only by
+                // `MAX_ALLOCATION_BYTES`, which says nothing about the block that
+                // is supposed to contain those objects: a zero-width schema
+                // encodes every object to no bytes, so a handful of wire bytes can
+                // claim hundreds of millions of them and the reader will decode
+                // every one. Bound it against the payload now that the payload is
+                // known, which is only here, since the declared byte size is the
+                // *compressed* size.
+                let count = self.messages_remaining;
+                let payload_len = self.buf.len();
+                bound_block_object_count(self.schema().top_node(), count, payload_len)?;
 
                 Ok(())
             }
@@ -995,6 +1007,10 @@ mod tests {
         out
     }
 
+    /// A record of only `null` fields: valid, and encodes to zero bytes.
+    const ZERO_WIDTH_SCHEMA: &str =
+        r#"{"type":"record","name":"R","fields":[{"name":"g","type":"null"}]}"#;
+
     #[mz_ore::test]
     fn reader_does_not_decode_a_previous_blocks_bytes() {
         // One buffer is reused across blocks, so a block shorter than its
@@ -1020,6 +1036,51 @@ mod tests {
             &Value::String("ab".into())
         );
         assert_err!(&items[2]);
+    }
+
+    #[mz_ore::test]
+    fn reader_rejects_zero_width_block_count_within_allocation_budget() {
+        // `safe_len` accepts any count up to `MAX_ALLOCATION_BYTES`, and a
+        // zero-width object consumes no input, so nothing but the block bound
+        // stops a 0-byte payload from claiming 100M objects and being believed.
+        // Regression for a reader_decode cargo-fuzz timeout.
+        let file = ocf(ZERO_WIDTH_SCHEMA, &[(100_000_000, 0, &[])]);
+        let err = Reader::new(&file[..])
+            .expect("OCF header parses")
+            .find_map(|item| item.err())
+            .expect("the oversized count must be rejected");
+        assert!(
+            err.to_string().contains("exceeds limit"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[mz_ore::test]
+    fn reader_accepts_honest_zero_width_block() {
+        // The bound above must not reject a real zero-width block: the whole
+        // point of the node weighting is that a byte count cannot judge one.
+        let file = ocf(ZERO_WIDTH_SCHEMA, &[(3, 0, &[])]);
+        let values: Vec<Value> = Reader::new(&file[..])
+            .expect("OCF header parses")
+            .collect::<Result<_, _>>()
+            .expect("an honest zero-width block must decode");
+        assert_eq!(values.len(), 3);
+    }
+
+    #[mz_ore::test]
+    fn reader_rejects_block_count_exceeding_payload() {
+        // A `string` occupies at least its one-byte length varint, so 100 of them
+        // cannot fit in three bytes however the payload is arranged.
+        let payload = &[0x04, b'a', b'b'][..];
+        let file = ocf(r#""string""#, &[(100, payload.len() as i64, payload)]);
+        let err = Reader::new(&file[..])
+            .expect("OCF header parses")
+            .find_map(|item| item.err())
+            .expect("a count larger than the payload must be rejected");
+        assert!(
+            err.to_string().contains("exceeds block payload"),
+            "unexpected error: {err}"
+        );
     }
 
     #[mz_ore::test]


### PR DESCRIPTION
Two fixes to the Avro object-container-file reader. Both are on the path that
decodes an OCF supplied by a source, so the bytes are untrusted.

* **A block could read the previous block's bytes.** `Reader` reuses one buffer
  across blocks and `fill_buf` only ever grew it, so a block shorter than its
  predecessor left that predecessor's tail readable past its own payload,
  because everything downstream reads the buffer by its length (`read_next` slices
  `self.buf[self.buf_idx..]`, and `Codec::decompress` hands the whole buffer to
  the decompressor). A block whose declared object count outran its own bytes
  then decoded stale bytes into values instead of running out of input.
  Truncating to the payload after reading fixes it. `Vec::truncate` keeps the
  allocation, so the buffer is still reused.

* **A block's object count was effectively unbounded.** The count is read
  straight off the wire and `safe_len` capped it only at
  `MAX_ALLOCATION_BYTES`, a sensible ceiling for a byte length, an enormous one
  for a count, and unrelated to the block it describes. A zero-width schema
  (an empty record, or a record of only `null` fields) encodes every object to
  no bytes, so a handful of wire bytes could claim hundreds of millions of
  objects and the reader would decode every one, allocating a `Vec` and
  per-field `String` each time. Measured: a ~30-byte file spends 47s on 100M
  objects, minutes at the old ceiling.

  The count is now bounded against the block that is supposed to hold those
  objects, choosing the bound the way `decode.rs` already does for an array
  block: the byte floor when the object schema has a proven positive one,
  otherwise the node-weighted `MAX_VALUE_NODES` cap, since no payload length
  can constrain a count of zero-width objects. Unlike an array block the two
  are alternatives rather than both applied. An array materializes all its
  elements at once so its cap is about retained memory, while a block's objects
  are yielded and dropped one at a time, so this cap is about work amplified
  out of a few bytes. Once the byte floor holds, the work is linear in the file,
  and capping nodes as well would reject a legitimate large block of small
  records. The bound is applied after decompression, since the declared byte
  size is the compressed size.

### Tests

Both are covered by the `reader_decode` cargo-fuzz target, which timed out
within seconds of drawing block counts from the range `safe_len` accepted. That
target is sharpened in #37979, which should land after this.
