### PR TITLE
sql-parser: only start a map literal when a bracket follows MAP

### DIFF
--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -333,9 +333,12 @@ impl Ident {
                         // (`list[1]` is a valid one-element list), so a bare `list`
                         // identifier that gets subscripted — `"list"[1]` — would
                         // reparse as a list literal instead of a subscript. (`ARRAY`
-                        // is reserved-in-scalar-expression and so already quoted;
-                        // `MAP[...]` requires `=>`, so `map[1]` is unambiguously a
-                        // subscript.)
+                        // is reserved-in-scalar-expression and so already quoted.
+                        // `MAP` needs no clause here even though `map[…]` is a
+                        // literal too: `MAP` is a context-sensitive keyword, so
+                        // `write_subscript_receiver` parenthesizes the receiver into
+                        // `(map)[1]`, and every grammar that starts a map literal
+                        // requires a `[` right after the keyword.)
                         || kw == LIST
                         // `DEALLOCATE [PREPARE] <name>` accepts an optional
                         // `PREPARE` keyword before the name, so a bare `prepare`

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5721,6 +5721,15 @@ impl<'a> Parser<'a> {
     fn parse_option_map(
         &mut self,
     ) -> Result<Option<BTreeMap<String, WithOptionValue<Raw>>>, ParserError> {
+        // `MAP` only begins a map literal when a `[` follows it. Committing on
+        // the keyword alone makes a bare `map` in an option-value position a hard
+        // error on the missing bracket, rather than falling through to the item
+        // name it is: `TOPIC CONFIG = "map"` prints as `TOPIC CONFIG = map`,
+        // since `map` is a legal bare identifier everywhere else, and that output
+        // then failed to reparse.
+        if !(self.peek_keyword(MAP) && self.peek_nth_token(1) == Some(Token::LBracket)) {
+            return Ok(None);
+        }
         Ok(if self.parse_keyword(MAP) {
             self.expect_token(&Token::LBracket)?;
             let mut map = BTreeMap::new();

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -880,6 +880,29 @@ fn test_list_keyword_bare_identifier_subscript_display_roundtrip() {
 
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+fn test_map_keyword_bare_identifier_option_value_display_roundtrip() {
+    // A `MAP` that no `[` follows is the item name `map`, which is how a quoted
+    // `"map"` prints. `parse_option_map` used to commit on the keyword alone, so
+    // the printed form failed to reparse in every generic option-value position.
+    // Regression for the sql_roundtrip fuzz finding `(TOPIC = "map")`.
+    for sql in [
+        r#"CREATE SINK s FROM t INTO KAFKA CONNECTION c (TOPIC = "map") FORMAT BYTES ENVELOPE DEBEZIUM"#,
+        r#"CREATE SOURCE s FROM KAFKA CONNECTION c (TOPIC = "map") FORMAT BYTES"#,
+        r#"CREATE MATERIALIZED VIEW v WITH (PARTITION BY = "map") AS SELECT 1"#,
+        // A real map-literal option value still takes the map branch.
+        r#"CREATE SINK s FROM t INTO KAFKA CONNECTION c (TOPIC = 't', TOPIC CONFIG = MAP['a' => 'b']) FORMAT BYTES ENVELOPE DEBEZIUM"#,
+        // Expression position needs no quoting: a subscripted receiver prints as
+        // `(map)[1]`, which is why `can_be_printed_bare` has no `MAP` clause.
+        r#"SELECT "map""#,
+        r#"SELECT "map"[1]"#,
+        r#"SELECT map['a' => 1]"#,
+    ] {
+        assert_display_roundtrips(sql);
+    }
+}
+
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
 fn test_table_function_special_name_display_roundtrip() {
     // `extract`/`position` carry a special `extract(a FROM b)` / `position(a IN
     // b)` display that only reparses in scalar-expression position. As table

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -3781,3 +3781,13 @@ CREATE SINK snk FROM t INTO KAFKA CONNECTION conn1 (TOPIC 'topic') FORMAT AVRO U
 CREATE SINK snk FROM t INTO KAFKA CONNECTION conn1 (TOPIC = 'topic') FORMAT AVRO USING AWS GLUE SCHEMA REGISTRY CONNECTION glue_conn (KEY SCHEMA NAME = 'k', VALUE SCHEMA NAME = 'v', KEY COMPATIBILITY LEVEL = 'BACKWARD', VALUE COMPATIBILITY LEVEL = 'FULL') ENVELOPE UPSERT
 =>
 CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("snk")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("t")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }], key: None, headers: None }, format: Some(Bare(Avro(Glue { connection: Name(UnresolvedItemName([Ident("glue_conn")])), with_options: [GlueAvroOption { name: KeySchemaName, value: Some(Value(String("k"))) }, GlueAvroOption { name: ValueSchemaName, value: Some(Value(String("v"))) }, GlueAvroOption { name: KeyCompatibilityLevel, value: Some(Value(String("BACKWARD"))) }, GlueAvroOption { name: ValueCompatibilityLevel, value: Some(Value(String("FULL"))) }], seed: None }))), envelope: Some(Upsert), mode: None, with_options: [] })
+
+# An option value that is the bare identifier `map`. `MAP` only starts a map
+# literal when a `[` follows, so this is the item name `map`, which is what
+# `AstDisplay` prints for a quoted `"map"`.
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC CONFIG = "map")
+----
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC CONFIG = map)
+=>
+CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("foo")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: TopicConfig, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("map")]))) }], key: None, headers: None }, format: None, envelope: None, mode: None, with_options: [] })


### PR DESCRIPTION
`parse_option_map` committed on the `MAP` keyword alone and then demanded
`[`, so a bare `map` in an option-value position was a hard parse error
rather than falling through to the item name it is.

`map` is a legal bare identifier everywhere else. `SELECT "map"` prints as
`SELECT map` and reparses fine, so `AstDisplay` prints an option value that
is the item name `map` unquoted, and that output failed to reparse:

    CREATE SINK s FROM t INTO KAFKA CONNECTION c (TOPIC = "map")

printed `TOPIC = map` and then failed with "Expected left square bracket,
found right parenthesis". Every generic option value was affected, a
materialized view's `PARTITION BY` among them.

Look ahead for the bracket instead. The alternative, quoting `map` in
`can_be_printed_bare`, would change the printed form of every `map`
identifier in every position, and would change what `quote_ident('map')`
returns, to work around one non-backtracking call site. The sibling
branches of `parse_option_value` all backtrack already.

Expression position never needed that quoting, but the comment in
`can_be_printed_bare` gave the wrong reason: the map-literal dispatch keys
off the `[`, not the `=>` the comment cited, so `map[1]` is not
"unambiguously a subscript" on its own. What keeps a bare `map` safe there
is `write_subscript_receiver`, which parenthesizes a context-sensitive
keyword receiver into `(map)[1]`. Corrected in place, no behavior change.

Found by the sql_roundtrip cargo-fuzz target. The datadriven case pins the
printed form and AST. The added parser test covers the sink, source and
materialized-view option positions, a genuine `MAP['a' => 'b']` option
value that must still take the map branch, and the expression forms the
corrected comment relies on.

