### PR TITLE
repr: bound regex compile memory, not just the pattern's byte length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8246,6 +8246,7 @@ dependencies = [
  "prost-build",
  "rand 0.9.4",
  "regex",
+ "regex-syntax",
  "ryu",
  "serde",
  "serde_json",

--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -369,6 +369,9 @@ fn build_regex(subpatterns: &[Subpattern], case_insensitive: bool) -> Result<Reg
     match Regex::new(&r, case_insensitive) {
         Ok(regex) => Ok(regex),
         Err(RegexCompilationError::PatternTooLarge { .. }) => Err(EvalError::LikePatternTooLong),
+        Err(RegexCompilationError::PatternTooExpensive { .. }) => {
+            Err(EvalError::LikePatternTooLong)
+        }
         Err(RegexCompilationError::RegexError(regex::Error::CompiledTooBig(_))) => {
             Err(EvalError::LikePatternTooLong)
         }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -61,6 +61,7 @@ ordered-float.workspace = true
 postgres-protocol.workspace = true
 prost.workspace = true
 regex.workspace = true
+regex-syntax.workspace = true
 ryu.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision", "preserve_order"] }

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -11,11 +11,13 @@
 
 use std::borrow::Cow;
 use std::cmp::Ordering;
+use std::convert::Infallible;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
 use regex::{Error, RegexBuilder};
+use regex_syntax::ast::{self, Ast, ClassSetItem, Visitor};
 use serde::de::Error as DeError;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
@@ -33,9 +35,99 @@ const MAX_REGEX_SIZE_AFTER_COMPILATION: usize = 10 * 1024 * 1024;
 /// be the case. Since we compile regexes in envd, we need strict limits to prevent envd OOMs.
 /// See <https://github.com/MaterializeInc/database-issues/issues/9907> for an example.
 ///
+/// This bounds the AST parse, which is what `estimate_compile_memory` needs before it can say
+/// anything about the pattern. It does not bound the compile itself, see
+/// `MAX_REGEX_COMPILE_MEMORY`.
+///
 /// Note: This number is mentioned in our user-facing docs at the "String operators" in the function
 /// reference.
 const MAX_REGEX_SIZE_BEFORE_COMPILATION: usize = 1 * 1024 * 1024;
+
+/// The maximum heap a single compile may be projected to allocate.
+///
+/// Neither limit above bounds what a compile actually spends. `size_limit` bounds the compiled
+/// NFA, and a pattern's byte length bounds only itself. The memory goes to `regex-syntax`
+/// translating the pattern's AST into its HIR, a stage that runs before anything `size_limit`
+/// measures. Cost there is linear in the AST's node count, but the cost *per node* spans two
+/// orders of magnitude, from a few hundred bytes for a literal or a group up to tens of kilobytes
+/// for a Unicode property under the `i` flag, so a byte budget cannot bound it. The per-kind costs
+/// themselves are a fact about the `regex-syntax` version we pin, so they are measured rather than
+/// written down here, in `regex_compile_memory_charges_cover_measured_cost`.
+///
+/// A 1 MiB pattern of `\p{L}` under the `i` flag, one byte under
+/// `MAX_REGEX_SIZE_BEFORE_COMPILATION`, therefore allocates gigabytes before returning
+/// `CompiledTooBig`. Since we compile regexes in envd, that made any `SELECT` an OOM vector,
+/// which is what this limit exists to close.
+///
+/// NOTE: a counted repetition needs no budget of its own. `\p{L}{200000}` stays two AST nodes,
+/// and the expansion happens later in the NFA compiler, where `size_limit` already rejects it
+/// incrementally.
+const MAX_REGEX_COMPILE_MEMORY: usize = 1024 * 1024 * 1024;
+
+/// Charged per AST node against `MAX_REGEX_COMPILE_MEMORY`. Covers every node kind that expands
+/// to at most a handful of Unicode ranges: literals, `.`, `[a-c]`, groups, repetitions,
+/// assertions. Sized a few times above the costliest of them so it absorbs allocator differences,
+/// but capped well under `MAX_REGEX_COMPILE_MEMORY / MAX_REGEX_SIZE_BEFORE_COMPILATION`, since a
+/// 1 MiB pattern of plain literals, which is what a machine-generated alternation looks like, has
+/// to stay within the budget. See `regex_cheap_nodes_do_not_collide_with_the_byte_limit`.
+const COMPILE_MEMORY_PER_NODE: usize = 768;
+
+/// Charged in place of `COMPILE_MEMORY_PER_NODE` for a Unicode-property or Perl class item, the
+/// node kinds that expand to hundreds of ranges.
+///
+/// Sized well above the costliest such node measured, which is what
+/// `regex_compile_memory_charges_cover_measured_cost` checks. The margin is deliberate. Which
+/// property costs the most is a fact about the Unicode tables `regex-syntax` ships, so a version
+/// bump can shift it, and no legitimate pattern carries the thousands of Unicode classes it takes
+/// to reach the budget.
+const COMPILE_MEMORY_PER_CLASS: usize = 96 * 1024;
+
+/// Sums the projected translation cost of every node in an AST.
+struct CompileMemoryEstimator {
+    estimate: usize,
+}
+
+impl Visitor for CompileMemoryEstimator {
+    type Output = usize;
+    type Err = Infallible;
+
+    fn finish(self) -> Result<usize, Infallible> {
+        Ok(self.estimate)
+    }
+
+    fn visit_pre(&mut self, ast: &Ast) -> Result<(), Infallible> {
+        self.estimate = self.estimate.saturating_add(match ast {
+            Ast::ClassUnicode(_) | Ast::ClassPerl(_) => COMPILE_MEMORY_PER_CLASS,
+            _ => COMPILE_MEMORY_PER_NODE,
+        });
+        Ok(())
+    }
+
+    fn visit_class_set_item_pre(&mut self, item: &ClassSetItem) -> Result<(), Infallible> {
+        // Items nested inside a bracketed class, e.g. the `\p{L}` in `[a\p{L}]`. Each contributes
+        // its own ranges to the one translated class, so each is charged. A union can only merge
+        // ranges, never add them, so the sum of the parts is an upper bound on the whole.
+        self.estimate = self.estimate.saturating_add(match item {
+            ClassSetItem::Unicode(_) | ClassSetItem::Perl(_) => COMPILE_MEMORY_PER_CLASS,
+            _ => COMPILE_MEMORY_PER_NODE,
+        });
+        Ok(())
+    }
+}
+
+/// Projects the heap that compiling `pattern` would allocate, or `None` if it does not parse.
+///
+/// A pattern we cannot parse is left to [`RegexBuilder`], which rejects it with the message users
+/// already see. That is not an escape hatch: both parse through the same `regex-syntax` version
+/// with the same default configuration (`nest_limit` 250, `octal` off), so a pattern that fails
+/// here fails there too.
+fn estimate_compile_memory(pattern: &str) -> Option<usize> {
+    let ast = ast::parse::Parser::new().parse(pattern).ok()?;
+    match ast::visit(&ast, CompileMemoryEstimator { estimate: 0 }) {
+        Ok(estimate) => Some(estimate),
+        Err(infallible) => match infallible {},
+    }
+}
 
 /// A hashable, comparable, and serializable regular expression type.
 ///
@@ -89,6 +181,11 @@ impl Regex {
                 pattern_size: pattern.len(),
             });
         }
+        if let Some(estimate) = estimate_compile_memory(pattern) {
+            if estimate > MAX_REGEX_COMPILE_MEMORY {
+                return Err(RegexCompilationError::PatternTooExpensive { estimate });
+            }
+        }
         let mut regex_builder = RegexBuilder::new(pattern);
         regex_builder.case_insensitive(case_insensitive);
         regex_builder.dot_matches_new_line(dot_matches_new_line);
@@ -115,6 +212,9 @@ pub enum RegexCompilationError {
     RegexError(Error),
     /// Regex pattern size exceeds MAX_REGEX_SIZE_BEFORE_COMPILATION.
     PatternTooLarge { pattern_size: usize },
+    /// Compiling the pattern is projected to allocate more than
+    /// MAX_REGEX_COMPILE_MEMORY.
+    PatternTooExpensive { estimate: usize },
 }
 
 impl fmt::Display for RegexCompilationError {
@@ -127,6 +227,12 @@ impl fmt::Display for RegexCompilationError {
                 f,
                 "regex pattern too large ({} bytes, max {} bytes)",
                 patter_size, MAX_REGEX_SIZE_BEFORE_COMPILATION
+            ),
+            RegexCompilationError::PatternTooExpensive { estimate } => write!(
+                f,
+                "regex pattern too expensive to compile (needs about {} bytes, max {} bytes); \
+                 reduce the number of character classes",
+                estimate, MAX_REGEX_COMPILE_MEMORY
             ),
         }
     }
@@ -324,7 +430,299 @@ impl<'de> Deserialize<'de> for Regex {
 
 #[cfg(test)]
 mod tests {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::cell::Cell;
+
+    use regex_syntax::hir::translate::TranslatorBuilder;
+
     use super::*;
+
+    /// Wraps the system allocator to record the peak heap the calling thread has asked for, so
+    /// [`regex_compile_memory_charges_cover_measured_cost`] can hold the charges in this module
+    /// against what `regex-syntax` actually allocates.
+    ///
+    /// Counters are per thread, so tests running in parallel do not perturb each other. What is
+    /// counted is bytes requested, not resident bytes, which makes a measurement reproducible
+    /// across allocators at the cost of running a little above true RSS.
+    struct TrackingAllocator;
+
+    thread_local! {
+        /// Bytes this thread has requested and not yet freed.
+        static LIVE_BYTES: Cell<usize> = const { Cell::new(0) };
+        /// High-water mark of `LIVE_BYTES` since the last [`peak_translate_bytes`] reset.
+        static PEAK_BYTES: Cell<usize> = const { Cell::new(0) };
+    }
+
+    /// NOTE: keep the bookkeeping allocation-free. A `Cell<usize>` behind a `const`-initialized
+    /// `thread_local!` neither allocates on first access nor registers a destructor, so it cannot
+    /// re-enter the allocator. `try_with` covers access during thread teardown.
+    fn record_alloc(size: usize) {
+        let _ = LIVE_BYTES.try_with(|live| {
+            let now = live.get().saturating_add(size);
+            live.set(now);
+            let _ = PEAK_BYTES.try_with(|peak| {
+                if now > peak.get() {
+                    peak.set(now);
+                }
+            });
+        });
+    }
+
+    fn record_dealloc(size: usize) {
+        let _ = LIVE_BYTES.try_with(|live| live.set(live.get().saturating_sub(size)));
+    }
+
+    // SAFETY: every method forwards to `System` unchanged, so the allocator contract is whatever
+    // `System` guarantees. The counters are observation only and never influence a returned
+    // pointer.
+    unsafe impl GlobalAlloc for TrackingAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            let ptr = unsafe { System.alloc(layout) };
+            if !ptr.is_null() {
+                record_alloc(layout.size());
+            }
+            ptr
+        }
+
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            let ptr = unsafe { System.alloc_zeroed(layout) };
+            if !ptr.is_null() {
+                record_alloc(layout.size());
+            }
+            ptr
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            record_dealloc(layout.size());
+            unsafe { System.dealloc(ptr, layout) }
+        }
+
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            // Charged before the call and released after, so a growing `Vec` counts both blocks
+            // at once. An out-of-place realloc does hold both, and the peak has to reflect that.
+            record_alloc(new_size);
+            let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+            record_dealloc(if new_ptr.is_null() {
+                new_size
+            } else {
+                layout.size()
+            });
+            new_ptr
+        }
+    }
+
+    #[global_allocator]
+    static ALLOC: TrackingAllocator = TrackingAllocator;
+
+    /// Peak heap the calling thread requests while parsing `pattern` and translating it to HIR,
+    /// the stage [`estimate_compile_memory`] projects.
+    ///
+    /// Compiling the NFA afterwards is deliberately left out. `size_limit` bounds it, and its
+    /// cost is close to a constant (a few times `MAX_REGEX_SIZE_AFTER_COMPILATION`) that would
+    /// swamp the per-node signal at the pattern sizes this test can afford. The translator flags
+    /// mirror what [`Regex::new_dot_matches_new_line`] hands to [`RegexBuilder`], since
+    /// `case_insensitive` alone moves a class's cost by an order of magnitude.
+    fn peak_translate_bytes(pattern: &str, case_insensitive: bool) -> usize {
+        let base = LIVE_BYTES.with(|live| live.get());
+        PEAK_BYTES.with(|peak| peak.set(base));
+        {
+            let ast = ast::parse::Parser::new()
+                .parse(pattern)
+                .expect("pattern parses");
+            let mut translator = TranslatorBuilder::new();
+            translator.case_insensitive(case_insensitive);
+            translator.dot_matches_new_line(true);
+            let hir = translator
+                .build()
+                .translate(pattern, &ast)
+                .expect("pattern translates");
+            // The HIR and the AST are both live at the peak of a real compile, so hold them here.
+            std::hint::black_box((&ast, &hir));
+        }
+        PEAK_BYTES.with(|peak| peak.get()).saturating_sub(base)
+    }
+
+    /// A class-heavy pattern one byte under `MAX_REGEX_SIZE_BEFORE_COMPILATION` used to allocate
+    /// ~7.8 GB in envd before erroring, reachable from an unprivileged `SELECT 'x' ~* <pattern>`.
+    /// It must now be rejected without compiling.
+    #[mz_ore::test]
+    fn regex_class_heavy_pattern_rejected_before_compiling() {
+        let pattern = r"\p{L}".repeat(MAX_REGEX_SIZE_BEFORE_COMPILATION / r"\p{L}".len());
+        assert!(pattern.len() <= MAX_REGEX_SIZE_BEFORE_COMPILATION);
+        // Case-insensitive is the expensive direction, but the estimate does not depend on the
+        // flag, so both must be rejected.
+        for case_insensitive in [true, false] {
+            let err = Regex::new(&pattern, case_insensitive).expect_err("must be rejected");
+            assert!(
+                matches!(err, RegexCompilationError::PatternTooExpensive { .. }),
+                "expected PatternTooExpensive, got {err:?}"
+            );
+        }
+    }
+
+    /// The guard has to charge classes nested in a bracketed class too, else `[\p{L}]` repeated
+    /// evades it while costing the same as `\p{L}` repeated.
+    #[mz_ore::test]
+    fn regex_bracketed_class_is_charged() {
+        let unit = r"[\p{L}]";
+        let pattern = unit.repeat(MAX_REGEX_SIZE_BEFORE_COMPILATION / unit.len());
+        let err = Regex::new(&pattern, true).expect_err("must be rejected");
+        assert!(
+            matches!(err, RegexCompilationError::PatternTooExpensive { .. }),
+            "expected PatternTooExpensive, got {err:?}"
+        );
+    }
+
+    /// The budget has to admit as well as reject. A pattern one class short of it must still reach
+    /// the compiler, and one class past it must not, so that the limit lands where the constants
+    /// say it does rather than somewhere earlier.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // Compiling tens of thousands of classes is far too slow under miri.
+    fn regex_budget_boundary_is_where_the_constants_put_it() {
+        let unit = r"\p{L}";
+        // The concat node holding the classes is charged too, hence the extra node.
+        let classes =
+            (MAX_REGEX_COMPILE_MEMORY - COMPILE_MEMORY_PER_NODE) / COMPILE_MEMORY_PER_CLASS;
+        assert!(unit.len() * (classes + 1) <= MAX_REGEX_SIZE_BEFORE_COMPILATION);
+
+        // Case-sensitive on purpose. The estimate does not depend on the flag, but the compile
+        // this drives all the way into the NFA compiler does, and folding costs many times the
+        // memory for no extra coverage here.
+        let err = Regex::new(&unit.repeat(classes), false).expect_err("must be rejected");
+        assert!(
+            matches!(err, RegexCompilationError::RegexError(_)),
+            "one class under the budget must reach the compiler, got {err:?}"
+        );
+
+        let err = Regex::new(&unit.repeat(classes + 1), false).expect_err("must be rejected");
+        assert!(
+            matches!(err, RegexCompilationError::PatternTooExpensive { .. }),
+            "one class over the budget must be turned away, got {err:?}"
+        );
+    }
+
+    /// The budget must not cost legitimate long patterns. A plain literal is orders of magnitude
+    /// cheaper per node than a Unicode class, so a large pattern of them still has to compile.
+    #[mz_ore::test]
+    fn regex_long_literal_pattern_still_compiles() {
+        // A long alternation of literals, the shape a generated pattern takes. Kept at 12000
+        // branches: past that the compiled NFA runs into MAX_REGEX_SIZE_AFTER_COMPILATION, which
+        // would make this pass or fail for an unrelated reason.
+        let pattern = vec!["abcdefgh"; 12_000].join("|");
+        assert!(pattern.len() > 100 * 1024);
+        assert!(Regex::new(&pattern, true).is_ok());
+    }
+
+    /// `COMPILE_MEMORY_PER_NODE` has to stay low enough that the largest pattern
+    /// `MAX_REGEX_SIZE_BEFORE_COMPILATION` admits still fits the budget when every byte is a cheap
+    /// node. Otherwise the two limits collide and the byte limit becomes unreachable, silently
+    /// tightening what users can submit.
+    #[mz_ore::test]
+    fn regex_cheap_nodes_do_not_collide_with_the_byte_limit() {
+        let pattern = "a".repeat(MAX_REGEX_SIZE_BEFORE_COMPILATION);
+        assert!(
+            estimate_compile_memory(&pattern).unwrap() <= MAX_REGEX_COMPILE_MEMORY,
+            "a pattern of single-byte nodes at the byte limit must fit the memory budget"
+        );
+    }
+
+    /// The charges are calibrated against the `regex-syntax` version we pin, so hold them against
+    /// what that version actually allocates, one case per cost tier. A bump that makes a node kind
+    /// pricier then fails here, rather than silently reopening the OOM vector the budget closes.
+    ///
+    /// Costs are measured here rather than written down, so nothing to keep in sync: the failure
+    /// message reports what a kind now costs against what it is charged, which is what a bump
+    /// needs in order to decide whether the charge or the case list has to move.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // Unicode class translation is far too slow under miri.
+    fn regex_compile_memory_charges_cover_measured_cost() {
+        /// Enough class nodes for their own cost to dominate a compile's fixed cost, few enough
+        /// that a case stays within a few tens of megabytes.
+        const CLASS_NODES: usize = 150;
+        /// Cheap nodes cost orders of magnitude less each, so they need proportionally more
+        /// repetitions to clear that same bar.
+        const CHEAP_NODES: usize = 10_000;
+
+        let cases: &[(&str, bool, usize)] = &[
+            // Unicode-property and Perl classes, charged `COMPILE_MEMORY_PER_CLASS`.
+            // `\p{Grapheme_Base}` under `i` is the costliest of these we have found.
+            (r"\p{Grapheme_Base}", true, CLASS_NODES),
+            (r"\p{XID_Continue}", true, CLASS_NODES),
+            (r"\p{Alphabetic}", true, CLASS_NODES),
+            (r"\p{L}", true, CLASS_NODES),
+            (r"\p{L}", false, CLASS_NODES),
+            (r"\w", true, CLASS_NODES),
+            (r"\W", true, CLASS_NODES),
+            (r"\d", true, CLASS_NODES),
+            (r"\s", true, CLASS_NODES),
+            // The same classes nested in a bracketed class, where each item is charged separately.
+            (r"[\p{L}]", true, CLASS_NODES),
+            (r"[a\p{L}\d]", true, CLASS_NODES),
+            // Everything else, charged `COMPILE_MEMORY_PER_NODE`. A literal under `i` is the
+            // costliest of these, since it folds to a small class rather than staying a byte.
+            ("a", true, CHEAP_NODES),
+            ("a", false, CHEAP_NODES),
+            (".", true, CHEAP_NODES),
+            ("[a-c]", true, CHEAP_NODES),
+            ("(a)", false, CHEAP_NODES),
+            ("a|", false, CHEAP_NODES),
+            ("a*", false, CHEAP_NODES),
+            ("a{2}", false, CHEAP_NODES),
+            ("^", false, CHEAP_NODES),
+        ];
+
+        for (unit, case_insensitive, repeats) in cases {
+            let pattern = unit.repeat(*repeats);
+            let charged = estimate_compile_memory(&pattern).expect("pattern parses");
+            let measured = peak_translate_bytes(&pattern, *case_insensitive);
+            assert!(
+                measured <= charged,
+                "`{unit}` x{repeats} (case_insensitive: {case_insensitive}) allocated {measured} \
+                 bytes, above the {charged} bytes charged for it, so the budget no longer bounds \
+                 what a compile spends"
+            );
+        }
+    }
+
+    /// A counted repetition needs no budget of its own: it stays small in the AST, and the NFA
+    /// compiler's incremental `size_limit` check rejects it. Pin that, since the budget
+    /// deliberately does not multiply by repetition bounds.
+    #[mz_ore::test]
+    fn regex_counted_repetition_rejected_by_size_limit() {
+        let err = Regex::new(r"\p{L}{200000}", true).expect_err("must be rejected");
+        assert!(
+            matches!(err, RegexCompilationError::RegexError(_)),
+            "expected the regex crate's own error, got {err:?}"
+        );
+    }
+
+    /// Short patterns, the overwhelmingly common case, must be unaffected.
+    #[mz_ore::test]
+    fn regex_ordinary_patterns_unaffected() {
+        for pattern in [
+            r"a+b",
+            r"^\d{3}-\d{4}$",
+            r"\p{L}+",
+            r"[a-zA-Z0-9_]*",
+            r"(?i)foo|bar",
+        ] {
+            assert!(
+                Regex::new(pattern, false).is_ok(),
+                "{pattern} should compile"
+            );
+        }
+    }
+
+    /// A pattern we cannot parse must fall through to `RegexBuilder`, so users keep getting the
+    /// regex crate's error message rather than one about the budget.
+    #[mz_ore::test]
+    fn regex_unparseable_pattern_reports_regex_error() {
+        let err = Regex::new("(", false).expect_err("must be rejected");
+        assert!(
+            matches!(err, RegexCompilationError::RegexError(_)),
+            "expected the regex crate's own error, got {err:?}"
+        );
+    }
 
     /// This was failing before due to the derived serde serialization being incorrect, because of
     /// <https://github.com/tailhook/serde-regex/issues/14>.

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -11,11 +11,13 @@
 
 use std::borrow::Cow;
 use std::cmp::Ordering;
+use std::convert::Infallible;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
 use regex::{Error, RegexBuilder};
+use regex_syntax::ast::{self, Ast, ClassSetItem, Visitor};
 use serde::de::Error as DeError;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
@@ -33,9 +35,99 @@ const MAX_REGEX_SIZE_AFTER_COMPILATION: usize = 10 * 1024 * 1024;
 /// be the case. Since we compile regexes in envd, we need strict limits to prevent envd OOMs.
 /// See <https://github.com/MaterializeInc/database-issues/issues/9907> for an example.
 ///
+/// This bounds the AST parse, which is what `estimate_compile_memory` needs before it can say
+/// anything about the pattern. It does not bound the compile itself, see
+/// `MAX_REGEX_COMPILE_MEMORY`.
+///
 /// Note: This number is mentioned in our user-facing docs at the "String operators" in the function
 /// reference.
 const MAX_REGEX_SIZE_BEFORE_COMPILATION: usize = 1 * 1024 * 1024;
+
+/// The maximum heap a single compile may be projected to allocate.
+///
+/// Neither limit above bounds what a compile actually spends. `size_limit` bounds the compiled
+/// NFA, and a pattern's byte length bounds only itself. The memory goes to `regex-syntax`
+/// translating the pattern's AST into its HIR, a stage that runs before anything `size_limit`
+/// measures. Cost there is linear in the AST's node count, but the cost *per node* spans two
+/// orders of magnitude, so a byte budget cannot bound it. Peak RSS per node, measured under the
+/// flags this module sets:
+///
+/// | node kind                                    | peak RSS per node |
+/// |----------------------------------------------|-------------------|
+/// | group, alternation, repetition, assertion    | 0.33 - 0.53 KB    |
+/// | literal, `.`, `[a-c]`                        | 0.42 - 0.60 KB    |
+/// | `\d`, `\s`                                   | 0.65 - 1.1 KB     |
+/// | `\w`, `\W`, case-sensitive `\p{L}`           | 6 - 18 KB         |
+/// | case-insensitive `\p{L}`, `\p{Alphabetic}`   | 39 - 41 KB        |
+///
+/// A 1 MiB pattern of `\p{L}` under the `i` flag, one byte under
+/// `MAX_REGEX_SIZE_BEFORE_COMPILATION`, therefore allocates ~7.8 GB before returning
+/// `CompiledTooBig`. Since we compile regexes in envd, that made any `SELECT` an OOM vector,
+/// which is what this limit exists to close.
+///
+/// NOTE: a counted repetition needs no budget of its own. `\p{L}{200000}` stays two AST nodes,
+/// and the expansion happens later in the NFA compiler, where `size_limit` already rejects it
+/// incrementally.
+const MAX_REGEX_COMPILE_MEMORY: usize = 1024 * 1024 * 1024;
+
+/// Charged per AST node against `MAX_REGEX_COMPILE_MEMORY`. Upper-bounds every node kind that
+/// expands to at most a handful of Unicode ranges: literals, `.`, `[a-c]`, `\d`, `\s`, groups,
+/// repetitions, assertions. The worst of those measured 0.60 KB, so this carries some headroom
+/// for allocator differences, but not so much that a 1 MiB pattern of plain literals, which is
+/// what a machine-generated alternation looks like and which costs ~0.5 GB, gets rejected.
+const COMPILE_MEMORY_PER_NODE: usize = 768;
+
+/// Charged in place of `COMPILE_MEMORY_PER_NODE` for a Unicode-property or Perl class item, the
+/// node kinds that expand to hundreds of ranges. Upper-bounds the worst case measured above,
+/// `\p{Alphabetic}` under the `i` flag at ~41 KB.
+const COMPILE_MEMORY_PER_CLASS: usize = 48 * 1024;
+
+/// Sums the projected translation cost of every node in an AST.
+struct CompileMemoryEstimator {
+    estimate: usize,
+}
+
+impl Visitor for CompileMemoryEstimator {
+    type Output = usize;
+    type Err = Infallible;
+
+    fn finish(self) -> Result<usize, Infallible> {
+        Ok(self.estimate)
+    }
+
+    fn visit_pre(&mut self, ast: &Ast) -> Result<(), Infallible> {
+        self.estimate = self.estimate.saturating_add(match ast {
+            Ast::ClassUnicode(_) | Ast::ClassPerl(_) => COMPILE_MEMORY_PER_CLASS,
+            _ => COMPILE_MEMORY_PER_NODE,
+        });
+        Ok(())
+    }
+
+    fn visit_class_set_item_pre(&mut self, item: &ClassSetItem) -> Result<(), Infallible> {
+        // Items nested inside a bracketed class, e.g. the `\p{L}` in `[a\p{L}]`. Each contributes
+        // its own ranges to the one translated class, so each is charged. A union can only merge
+        // ranges, never add them, so the sum of the parts is an upper bound on the whole.
+        self.estimate = self.estimate.saturating_add(match item {
+            ClassSetItem::Unicode(_) | ClassSetItem::Perl(_) => COMPILE_MEMORY_PER_CLASS,
+            _ => COMPILE_MEMORY_PER_NODE,
+        });
+        Ok(())
+    }
+}
+
+/// Projects the heap that compiling `pattern` would allocate, or `None` if it does not parse.
+///
+/// A pattern we cannot parse is left to [`RegexBuilder`], which rejects it with the message users
+/// already see. That is not an escape hatch: both parse through the same `regex-syntax` version
+/// with the same default configuration (`nest_limit` 250, `octal` off), so a pattern that fails
+/// here fails there too.
+fn estimate_compile_memory(pattern: &str) -> Option<usize> {
+    let ast = ast::parse::Parser::new().parse(pattern).ok()?;
+    match ast::visit(&ast, CompileMemoryEstimator { estimate: 0 }) {
+        Ok(estimate) => Some(estimate),
+        Err(infallible) => match infallible {},
+    }
+}
 
 /// A hashable, comparable, and serializable regular expression type.
 ///
@@ -89,6 +181,11 @@ impl Regex {
                 pattern_size: pattern.len(),
             });
         }
+        if let Some(estimate) = estimate_compile_memory(pattern) {
+            if estimate > MAX_REGEX_COMPILE_MEMORY {
+                return Err(RegexCompilationError::PatternTooExpensive { estimate });
+            }
+        }
         let mut regex_builder = RegexBuilder::new(pattern);
         regex_builder.case_insensitive(case_insensitive);
         regex_builder.dot_matches_new_line(dot_matches_new_line);
@@ -115,6 +212,9 @@ pub enum RegexCompilationError {
     RegexError(Error),
     /// Regex pattern size exceeds MAX_REGEX_SIZE_BEFORE_COMPILATION.
     PatternTooLarge { pattern_size: usize },
+    /// Compiling the pattern is projected to allocate more than
+    /// MAX_REGEX_COMPILE_MEMORY.
+    PatternTooExpensive { estimate: usize },
 }
 
 impl fmt::Display for RegexCompilationError {
@@ -127,6 +227,12 @@ impl fmt::Display for RegexCompilationError {
                 f,
                 "regex pattern too large ({} bytes, max {} bytes)",
                 patter_size, MAX_REGEX_SIZE_BEFORE_COMPILATION
+            ),
+            RegexCompilationError::PatternTooExpensive { estimate } => write!(
+                f,
+                "regex pattern too expensive to compile (needs about {} bytes, max {} bytes); \
+                 reduce the number of character classes",
+                estimate, MAX_REGEX_COMPILE_MEMORY
             ),
         }
     }
@@ -325,6 +431,102 @@ impl<'de> Deserialize<'de> for Regex {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A class-heavy pattern one byte under `MAX_REGEX_SIZE_BEFORE_COMPILATION` used to allocate
+    /// ~7.8 GB in envd before erroring, reachable from an unprivileged `SELECT 'x' ~* <pattern>`.
+    /// It must now be rejected without compiling.
+    #[mz_ore::test]
+    fn regex_class_heavy_pattern_rejected_before_compiling() {
+        let pattern = r"\p{L}".repeat(MAX_REGEX_SIZE_BEFORE_COMPILATION / r"\p{L}".len());
+        assert!(pattern.len() <= MAX_REGEX_SIZE_BEFORE_COMPILATION);
+        // Case-insensitive is the expensive direction, but the estimate does not depend on the
+        // flag, so both must be rejected.
+        for case_insensitive in [true, false] {
+            let err = Regex::new(&pattern, case_insensitive).expect_err("must be rejected");
+            assert!(
+                matches!(err, RegexCompilationError::PatternTooExpensive { .. }),
+                "expected PatternTooExpensive, got {err:?}"
+            );
+        }
+    }
+
+    /// The guard has to charge classes nested in a bracketed class too, else `[\p{L}]` repeated
+    /// evades it while costing the same as `\p{L}` repeated.
+    #[mz_ore::test]
+    fn regex_bracketed_class_is_charged() {
+        let unit = r"[\p{L}]";
+        let pattern = unit.repeat(MAX_REGEX_SIZE_BEFORE_COMPILATION / unit.len());
+        let err = Regex::new(&pattern, true).expect_err("must be rejected");
+        assert!(
+            matches!(err, RegexCompilationError::PatternTooExpensive { .. }),
+            "expected PatternTooExpensive, got {err:?}"
+        );
+    }
+
+    /// The budget must not cost legitimate long patterns. A pattern of plain literals is ~70x
+    /// cheaper per node than a Unicode class, so a large one still has to compile.
+    #[mz_ore::test]
+    fn regex_long_literal_pattern_still_compiles() {
+        // A long alternation of literals, the shape a generated pattern takes. Kept at 12000
+        // branches: past that the compiled NFA runs into MAX_REGEX_SIZE_AFTER_COMPILATION, which
+        // would make this pass or fail for an unrelated reason.
+        let pattern = vec!["abcdefgh"; 12_000].join("|");
+        assert!(pattern.len() > 100 * 1024);
+        assert!(Regex::new(&pattern, true).is_ok());
+    }
+
+    /// `COMPILE_MEMORY_PER_NODE` has to stay low enough that the largest pattern
+    /// `MAX_REGEX_SIZE_BEFORE_COMPILATION` admits still fits the budget when every byte is a cheap
+    /// node. Otherwise the two limits collide and the byte limit becomes unreachable, silently
+    /// tightening what users can submit.
+    #[mz_ore::test]
+    fn regex_cheap_nodes_do_not_collide_with_the_byte_limit() {
+        let pattern = "a".repeat(MAX_REGEX_SIZE_BEFORE_COMPILATION);
+        assert!(
+            estimate_compile_memory(&pattern).unwrap() <= MAX_REGEX_COMPILE_MEMORY,
+            "a pattern of single-byte nodes at the byte limit must fit the memory budget"
+        );
+    }
+
+    /// A counted repetition needs no budget of its own: it stays small in the AST, and the NFA
+    /// compiler's incremental `size_limit` check rejects it. Pin that, since the budget
+    /// deliberately does not multiply by repetition bounds.
+    #[mz_ore::test]
+    fn regex_counted_repetition_rejected_by_size_limit() {
+        let err = Regex::new(r"\p{L}{200000}", true).expect_err("must be rejected");
+        assert!(
+            matches!(err, RegexCompilationError::RegexError(_)),
+            "expected the regex crate's own error, got {err:?}"
+        );
+    }
+
+    /// Short patterns, the overwhelmingly common case, must be unaffected.
+    #[mz_ore::test]
+    fn regex_ordinary_patterns_unaffected() {
+        for pattern in [
+            r"a+b",
+            r"^\d{3}-\d{4}$",
+            r"\p{L}+",
+            r"[a-zA-Z0-9_]*",
+            r"(?i)foo|bar",
+        ] {
+            assert!(
+                Regex::new(pattern, false).is_ok(),
+                "{pattern} should compile"
+            );
+        }
+    }
+
+    /// A pattern we cannot parse must fall through to `RegexBuilder`, so users keep getting the
+    /// regex crate's error message rather than one about the budget.
+    #[mz_ore::test]
+    fn regex_unparseable_pattern_reports_regex_error() {
+        let err = Regex::new("(", false).expect_err("must be rejected");
+        assert!(
+            matches!(err, RegexCompilationError::RegexError(_)),
+            "expected the regex crate's own error, got {err:?}"
+        );
+    }
 
     /// This was failing before due to the derived serde serialization being incorrect, because of
     /// <https://github.com/tailhook/serde-regex/issues/14>.

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -855,5 +855,21 @@ HINT: No function matches the given name and argument types.  You might need to 
 statement error invalid regular expression: regex pattern too large \(62400000 bytes, max 1048576 bytes\)
 SELECT 'aaaaaaaaaaa' ~ repeat('vxx.0.0-rc.4 (5b079d80c)', '2600000');
 
+# A class-heavy pattern stays far under the byte limit above while costing gigabytes to compile,
+# an order of magnitude more heap per pattern byte than a plain literal costs. It has to be
+# rejected on the projected cost instead. This is the shape that made any `SELECT` an OOM vector.
+# Where exactly the budget cuts off is left to the unit tests in `mz_repr::adt::regex`, which can
+# derive it from the constants instead of restating one here.
+statement error invalid regular expression: regex pattern too expensive to compile \(needs about \d+ bytes, max \d+ bytes\); reduce the number of character classes
+SELECT 'x' ~* repeat(chr(92) || 'p{L}', 209715);
+
+# The cost is per character class, not per byte, so a pattern of the same length built from plain
+# literals must keep working. Kept below 12000 branches, past which the compiled NFA runs into the
+# separate 10 MiB size limit and stops being a test of this one.
+query B
+SELECT 'abcdefgh' ~* (repeat('abcdefgh|', 12000) || 'x');
+----
+true
+
 statement ok
 DROP CLUSTER multiprocess;

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -855,5 +855,24 @@ HINT: No function matches the given name and argument types.  You might need to 
 statement error invalid regular expression: regex pattern too large \(62400000 bytes, max 1048576 bytes\)
 SELECT 'aaaaaaaaaaa' ~ repeat('vxx.0.0-rc.4 (5b079d80c)', '2600000');
 
+# A class-heavy pattern stays far under the byte limit above while costing gigabytes to compile
+# (~7.4 KB of peak heap per pattern byte for `\p{L}` under the `i` flag, against ~0.35 KB for a
+# plain literal). It has to be rejected on the projected cost instead.
+statement error invalid regular expression: regex pattern too expensive to compile \(needs about \d+ bytes, max \d+ bytes\); reduce the number of character classes
+SELECT 'x' ~* repeat(chr(92) || 'p{L}', 21846);
+
+# Same shape, one character class short of the budget, so it must still reach the compiler and
+# fail there rather than being turned away.
+statement error invalid regular expression: Compiled regex exceeds size limit of 10485760 bytes\.
+SELECT 'x' ~* repeat(chr(92) || 'p{L}', 21845);
+
+# The cost is per character class, not per byte, so a pattern of the same length built from plain
+# literals must keep working. Kept below 12000 branches, past which the compiled NFA runs into the
+# separate 10 MiB size limit and stops being a test of this one.
+query B
+SELECT 'abcdefgh' ~* (repeat('abcdefgh|', 12000) || 'x');
+----
+true
+
 statement ok
 DROP CLUSTER multiprocess;


### PR DESCRIPTION
`MAX_REGEX_SIZE_BEFORE_COMPILATION` caps `pattern.len()` at 1 MiB to keep a
user-supplied regex from OOMing envd. A byte budget cannot do that job. The
memory goes to `regex-syntax` translating the pattern's AST into its HIR, a
stage that runs before anything `size_limit` measures, and while cost there is
linear in the AST's node count, the cost per node spans two orders of magnitude:

  group, alternation, repetition, assertion    0.33 - 0.53 KB
  literal, `.`, `[a-c]`                        0.42 - 0.60 KB
  `\d`, `\s`                                   0.65 - 1.1 KB
  `\w`, `\W`, case-sensitive `\p{L}`           6 - 18 KB
  case-insensitive `\p{L}`, `\p{Alphabetic}`   39 - 41 KB

So a pattern one byte under the limit could allocate ~7.8 GB. Confirmed on a
single-node environment with unprivileged SQL, no table and no cluster work,
from ~90 bytes of query text:

  SELECT 'x' ~* repeat(chr(92) || 'p{L}', 209715);

envd VmRSS went 320 MB -> 7 620 MB over ~18 s (VmHWM 8 303 MB) while clusterd
stayed flat at ~420 MB, and only then did the statement error with "Compiled
regex exceeds size limit". `statement_timeout` does not help, since the
allocation precedes the error. Any user who can issue a `SELECT` could do this
on demand, and two concurrent queries exceed any realistic envd memory limit.

Project the cost from the AST instead, which is cheap to obtain (~30 ms and
~10 MB at 174 KB, flat in the pattern's shape) and charge each node a
conservative upper bound: 48 KB for a Unicode-property or Perl class item, the
kinds that expand to hundreds of ranges, and 768 bytes for everything else.
Reject above 1 GiB. Classes nested in a bracketed class are charged too, else
`[\p{L}]` repeated evades the budget at the same cost.

This is additive. The byte limit stays, since it is what bounds the AST parse
this check needs, and its number stays valid in the user-facing docs. Patterns
that were cheap remain accepted: a 1 MiB pattern of plain literals, the shape a
machine-generated alternation takes, still compiles. A counted repetition needs
no budget of its own, since `\p{L}{200000}` stays two AST nodes and the NFA
compiler's incremental `size_limit` check already rejects it in 40 ms at 17 MB.

A pattern we cannot parse falls through to `RegexBuilder` so users keep its
error message. That is not an escape hatch: both parse through the same
`regex-syntax` 0.8.11 with the same default configuration, verified against 35
syntax corner cases to never split in the direction that would skip the check.
