### PR TITLE
pgrepr: reject numeric infinity as a binary parameter

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -978,6 +978,14 @@ fn test_pgtest_mz_notice() {
 }
 
 #[mz_ore::test]
+fn test_pgtest_mz_numeric_binary_infinity() {
+    pg_test_inner(
+        Path::new("../../test/pgtest-mz/numeric-binary-infinity.pt"),
+        true,
+    );
+}
+
+#[mz_ore::test]
 fn test_pgtest_mz_numeric_binary_overflow() {
     pg_test_inner(
         Path::new("../../test/pgtest-mz/numeric-binary-overflow.pt"),

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -918,6 +918,16 @@ impl Value {
             }
             Type::Numeric { constraints } => {
                 let n = Numeric::from_sql(ty.inner(), raw)?;
+                // The wire format's `0xD000`/`0xF000` sign words spell
+                // `±Infinity`, which `Numeric::from_sql` decodes because it also
+                // decodes query *results*, where an infinite numeric is
+                // legitimate (aggregation overflow produces one). As a parameter
+                // it must be rejected: the text path rejects `'Infinity'::numeric`
+                // (`strconv::parse_numeric`), so accepting the binary spelling
+                // would let a client smuggle in a value no SQL literal can name.
+                if n.0.0.is_infinite() {
+                    return Err("numeric infinity is not supported".into());
+                }
                 Ok(Value::Numeric(Numeric(rescale_numeric(
                     n.0,
                     constraints.as_ref(),
@@ -1238,6 +1248,38 @@ mod tests {
             panic!("decode_text of a numeric must yield Value::Numeric");
         };
         assert_eq!(text, expected, "text decode did not rescale to scale 2");
+    }
+
+    /// The numeric wire format's `±Infinity` sign words must be rejected as a
+    /// parameter, matching the text path, which rejects `'Infinity'::numeric`.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // numeric/decimal contexts unsupported under miri
+    fn decode_binary_numeric_rejects_infinity() {
+        let ty = Type::Numeric { constraints: None };
+        // units = 0, weight = 0, sign, dscale = 0.
+        let header = |sign: u16| {
+            let mut b = Vec::new();
+            b.extend_from_slice(&0i16.to_be_bytes());
+            b.extend_from_slice(&0i16.to_be_bytes());
+            b.extend_from_slice(&sign.to_be_bytes());
+            b.extend_from_slice(&0i16.to_be_bytes());
+            b
+        };
+        // +Infinity and -Infinity.
+        for sign in [0xD000, 0xF000] {
+            let res = Value::decode_binary(&ty, &header(sign));
+            assert_eq!(
+                res.map(|_| ()).map_err(|e| e.to_string()).unwrap_err(),
+                "numeric infinity is not supported",
+                "sign {sign:#x} must be rejected",
+            );
+        }
+        // NaN, which the text path does accept, still decodes.
+        let Value::Numeric(Numeric(nan)) = Value::decode_binary(&ty, &header(0xC000)).unwrap()
+        else {
+            panic!("decode_binary of a numeric must yield Value::Numeric");
+        };
+        assert_eq!(nan, strconv::parse_numeric("NaN").unwrap());
     }
 
     /// Binary time values are microseconds since midnight. Out-of-range

--- a/test/pgtest-mz/numeric-binary-infinity.pt
+++ b/test/pgtest-mz/numeric-binary-infinity.pt
@@ -1,0 +1,73 @@
+# Regression test for `±Infinity` smuggled in as a binary numeric Bind
+# parameter. The text path rejects `'Infinity'::numeric`, so the binary path
+# must reject the wire format's infinity sign words too, or a client can
+# produce a `Datum::Numeric(Infinity)` that no SQL literal can name.
+#
+# The numeric binary header is ndigits/weight/sign/dscale, four big-endian
+# 16-bit words. Sign 0xD000 is +Infinity and 0xF000 is -Infinity. An infinite
+# value carries no digit words, so the eight-byte header is the whole parameter.
+
+# +Infinity: ndigits=0, weight=0, sign=0xD000, dscale=0.
+send
+Parse {"query": "SELECT $1::numeric"}
+Bind {"param_formats": [1], "binary_values": [[0, 0, 0, 0, 208, 0, 0, 0]]}
+Execute
+Sync
+----
+
+until err_field_typs=CM
+ReadyForQuery
+----
+ParseComplete
+ErrorResponse {"fields":[{"typ":"C","value":"22023"},{"typ":"M","value":"unable to decode parameter: numeric infinity is not supported"}]}
+ReadyForQuery {"status":"I"}
+
+# -Infinity: sign=0xF000.
+send
+Parse {"query": "SELECT $1::numeric"}
+Bind {"param_formats": [1], "binary_values": [[0, 0, 0, 0, 240, 0, 0, 0]]}
+Execute
+Sync
+----
+
+until err_field_typs=CM
+ReadyForQuery
+----
+ParseComplete
+ErrorResponse {"fields":[{"typ":"C","value":"22023"},{"typ":"M","value":"unable to decode parameter: numeric infinity is not supported"}]}
+ReadyForQuery {"status":"I"}
+
+# NaN, which the text path accepts, still decodes. sign=0xC000.
+send
+Parse {"query": "SELECT $1::numeric"}
+Bind {"param_formats": [1], "binary_values": [[0, 0, 0, 0, 192, 0, 0, 0]]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["NaN"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# A finite value, 1, still decodes: ndigits=1, weight=0, sign=0, dscale=0,
+# digit[0]=1.
+send
+Parse {"query": "SELECT $1::numeric"}
+Bind {"param_formats": [1], "binary_values": [[0, 1, 0, 0, 0, 0, 0, 0, 0, 1]]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
The numeric wire format's `0xD000`/`0xF000` sign words spell `±Infinity`, and
`Numeric::from_sql` decodes them because it also decodes query *results*, where
an infinite numeric is legitimate: aggregation overflow produces one. As a
parameter it has to be rejected. The text path already rejects
`'Infinity'::numeric` in `strconv::parse_numeric`, so accepting the binary
spelling let a client smuggle in a `Datum::Numeric` value that no SQL literal
can name.

Covered by a pgtest pinning both signs, and pinning that `NaN`, which the text
path does accept, and a finite value still decode.
