### PR TITLE
mcp: fix stale module docs and drop needless async on infallible handlers (DEX-88)

### DIFF
--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -19,7 +19,9 @@
 //! ## Tools
 //!
 //! **Agent:** `get_data_products`, `get_data_product_details`, `read_data_product`, `query`
-//! **Developer:** `query_system_catalog`
+//! **Developer:** `query_system_catalog`, `query`
+//!
+//! `read_data_product` and both `query` tools are dyncfg-gated.
 //!
 //! Data products are discovered via `mz_internal.mz_mcp_data_products` system view.
 
@@ -338,6 +340,7 @@ const READ_ONLY_ANNOTATIONS: ToolAnnotations = ToolAnnotations {
 #[derive(Debug, Serialize)]
 struct ToolContentResult {
     content: Vec<ContentBlock>,
+    /// Always `false`: tool failures surface as JSON-RPC errors instead.
     #[serde(rename = "isError")]
     is_error: bool,
 }
@@ -646,7 +649,6 @@ async fn handle_mcp_method(
                 query_tool_enabled,
                 read_data_product_tool_enabled,
             )
-            .await
         }
         McpMethod::ToolsList => {
             debug!(endpoint = %endpoint_type, "Processing tools/list");
@@ -656,7 +658,6 @@ async fn handle_mcp_method(
                 read_data_product_tool_enabled,
                 max_response_size,
             )
-            .await
         }
         McpMethod::ToolsCall(params) => {
             debug!(tool = %params, endpoint = %endpoint_type, "Processing tools/call");
@@ -757,7 +758,7 @@ fn endpoint_instructions(
     }
 }
 
-async fn handle_initialize(
+fn handle_initialize(
     endpoint_type: McpEndpointType,
     query_tool_enabled: bool,
     read_data_product_tool_enabled: bool,
@@ -777,7 +778,7 @@ async fn handle_initialize(
     }))
 }
 
-async fn handle_tools_list(
+fn handle_tools_list(
     endpoint_type: McpEndpointType,
     query_tool_enabled: bool,
     read_data_product_tool_enabled: bool,
@@ -2081,9 +2082,7 @@ mod tests {
 
     #[mz_ore::test(tokio::test)]
     async fn test_tools_list_agent_query_tool_disabled() {
-        let result = handle_tools_list(McpEndpointType::Agent, false, true, 1_000_000)
-            .await
-            .unwrap();
+        let result = handle_tools_list(McpEndpointType::Agent, false, true, 1_000_000).unwrap();
         let McpResult::ToolsList(list) = result else {
             panic!("Expected ToolsList result");
         };
@@ -2108,9 +2107,7 @@ mod tests {
 
     #[mz_ore::test(tokio::test)]
     async fn test_tools_list_agent_query_tool_enabled() {
-        let result = handle_tools_list(McpEndpointType::Agent, true, true, 1_000_000)
-            .await
-            .unwrap();
+        let result = handle_tools_list(McpEndpointType::Agent, true, true, 1_000_000).unwrap();
         let McpResult::ToolsList(list) = result else {
             panic!("Expected ToolsList result");
         };
@@ -2135,9 +2132,7 @@ mod tests {
 
     #[mz_ore::test(tokio::test)]
     async fn test_tools_list_agent_read_data_product_tool_disabled() {
-        let result = handle_tools_list(McpEndpointType::Agent, true, false, 1_000_000)
-            .await
-            .unwrap();
+        let result = handle_tools_list(McpEndpointType::Agent, true, false, 1_000_000).unwrap();
         let McpResult::ToolsList(list) = result else {
             panic!("Expected ToolsList result");
         };
@@ -2166,9 +2161,7 @@ mod tests {
     /// instructions do not tell the agent to use a tool that isn't listed.
     #[mz_ore::test(tokio::test)]
     async fn test_tools_list_agent_both_read_tools_disabled() {
-        let result = handle_tools_list(McpEndpointType::Agent, false, false, 1_000_000)
-            .await
-            .unwrap();
+        let result = handle_tools_list(McpEndpointType::Agent, false, false, 1_000_000).unwrap();
         let McpResult::ToolsList(list) = result else {
             panic!("Expected ToolsList result");
         };
@@ -2204,9 +2197,7 @@ mod tests {
     async fn test_tools_list_developer_query_tool_disabled() {
         // Developer endpoint doesn't expose read_data_product; the flag is
         // orthogonal, so pass whichever value.
-        let result = handle_tools_list(McpEndpointType::Developer, false, true, 1_000_000)
-            .await
-            .unwrap();
+        let result = handle_tools_list(McpEndpointType::Developer, false, true, 1_000_000).unwrap();
         let McpResult::ToolsList(list) = result else {
             panic!("Expected ToolsList result");
         };
@@ -2223,9 +2214,7 @@ mod tests {
 
     #[mz_ore::test(tokio::test)]
     async fn test_tools_list_developer_query_tool_enabled() {
-        let result = handle_tools_list(McpEndpointType::Developer, true, true, 1_000_000)
-            .await
-            .unwrap();
+        let result = handle_tools_list(McpEndpointType::Developer, true, true, 1_000_000).unwrap();
         let McpResult::ToolsList(list) = result else {
             panic!("Expected ToolsList result");
         };


### PR DESCRIPTION
The module header omitted the developer endpoint's `query` tool, and `handle_initialize`/`handle_tools_list` were `async` with no await point. Also documents why `ToolContentResult::is_error` is always false. No behavior change.