### PR TITLE
ci: Fix nightly failures (2026-07-31)

### DIFF
--- a/misc/python/materialize/checks/all_checks/session.py
+++ b/misc/python/materialize/checks/all_checks/session.py
@@ -187,8 +187,10 @@ class SessionState(Check):
             > SHOW extra_float_digits
             0
             > RESET extra_float_digits
-            > SHOW extra_float_digits
+            >[version>=2603600] SHOW extra_float_digits
             1
+            >[version<2603600] SHOW extra_float_digits
+            3
 
             > CREATE TEMPORARY VIEW session_state_temp_view AS SELECT max(f1) AS m FROM session_state_table
             > SELECT * FROM session_state_temp_view
@@ -213,8 +215,10 @@ class SessionState(Check):
             ! SELECT * FROM session_state_temp_view2
             contains: unknown catalog item 'session_state_temp_view2'
             > RESET extra_float_digits
-            > SHOW extra_float_digits
+            >[version>=2603600] SHOW extra_float_digits
             1
+            >[version<2603600] SHOW extra_float_digits
+            3
             """))
 
 

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -2788,6 +2788,7 @@ mod tests {
     use super::{DEFAULT_ROLLOUT_REQUEST_TIMEOUT, FORCE_ROLLOUT_ANNOTATION, RolloutRequestTimeout};
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `sha256_compress` on OS `linux`
     fn force_rollout_annotation_forces_new_generation() {
         // The force-rollout annotation must feed into both the v1 rollout
         // hash (so that a rollout is requested) and the v1alpha1 force

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -32,7 +32,7 @@ statement ok
 CREATE VIEW database_privileges (name, privilege) AS SELECT name, unnest(privileges)::text FROM mz_databases;
 
 statement ok
-CREATE VIEW schema_privileges (name, privilege) AS SELECT name, unnest(privileges)::text, database_id FROM mz_schemas;
+CREATE VIEW schema_privileges (name, privilege) AS SELECT name, unnest(privileges)::text FROM mz_schemas;
 
 statement ok
 CREATE VIEW cluster_privileges (name, privilege) AS SELECT name, unnest(privileges)::text FROM mz_clusters;


### PR DESCRIPTION
Three unrelated nightly failures, each reproducing on main in
[17616](https://buildkite.com/materialize/nightly/builds/17616) and
[17621](https://buildkite.com/materialize/nightly/builds/17621).

### `:rust: Miri test (full)`

`force_rollout_annotation_forces_new_generation` reaches SHA-256 through
`generate_rollout_hash`. `mz-persist` enables `sha2/asm` for S3 upload
throughput, and Cargo unifies features across the workspace, so every `Sha256`
in a workspace-scoped build resolves to a linked static asm object.
`cpufeatures` reports no target features under Miri, so the asm fallback is
always selected and Miri cannot call into it.

Ignored under Miri, matching three sibling tests in the same file that carry
this annotation with the same reason. There is nothing wrong with the code
under test, and the assertion stays covered by the regular test job. Scoping a
build to `mz-cloud-resources` alone drops the `asm` feature, which is why that
job is green and only the workspace-scoped Miri run fails.

### `Checks 0dt upgrade across four versions`

`SHOW extra_float_digits` after a `RESET` returns 1 from 26.36.0 on and 3
before it, and the upgrade scenarios assert against whichever binary is
currently live. Gated on the server version.

The default changed in #37829, which `v26.36.0-rc.1` contains. #37935 fixed the
same-version fallout in `pgwire.rs` and `discard.slt` but not the cross-version
assertions here.

### `:bulb: SLT (2 replicas) 3`

`schema_privileges` names two columns and selects three:

```sql
CREATE VIEW schema_privileges (name, privilege) AS
  SELECT name, unnest(privileges)::text, database_id FROM mz_schemas;
```

The trailing `database_id` is a copy-paste slip. The neighbouring
`database_privileges` and `cluster_privileges` are otherwise identical without
it, and all ten queries against the view read only `name` and `privilege`.
Removing it from the select list changes no rows, so no results needed
rewriting.

### Still failing, not addressed here

`SQLsmith` is a chronic flake, red in three of the last four main nightlies and
green in two of four runs on an unrelated branch over the same period. It needs
its own investigation rather than a fix bundled here.
