### PR TITLE
mcp: drop stale dead_code allow on MethodNotFound (DEX-91)

### DIFF
--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -74,7 +74,6 @@ enum McpRequestError {
     #[error("Invalid JSON-RPC version: expected 2.0")]
     InvalidJsonRpcVersion,
     #[error("Method not found: {0}")]
-    #[allow(dead_code)] // Handled by serde deserialization, kept for error mapping
     MethodNotFound(String),
     #[error("Tool not found: {0}")]
     ToolNotFound(String),


### PR DESCRIPTION
The `MethodNotFound` variant is constructed in the unknown-method dispatch arm, so the `#[allow(dead_code)]` and its comment claiming otherwise are stale. Naming the actual method in the error needs a raw-body pre-parse and is deferred to [DEX-81](https://linear.app/materializeinc/issue/DEX-81), which introduces that step.