### PR TITLE
mcp: bound the catalog snapshot so a stall cannot outlive the request timeout (DEX-92)

### DIFF
--- a/src/environmentd/src/http/mcp.rs
+++ b/src/environmentd/src/http/mcp.rs
@@ -473,7 +473,22 @@ async fn handle_mcp_request(
         |status: McpCallStatus| metrics.record_request(endpoint_label, &method_label, status);
 
     // Check the per-endpoint feature flag via a catalog snapshot, similar to frontend_peek.rs.
-    let catalog = client.client.catalog_snapshot("mcp").await;
+    // The configured `MCP_REQUEST_TIMEOUT` lives in the snapshot we are about
+    // to fetch, so bound this phase with the compiled-in default. Without it a
+    // stalled snapshot would hang the request past any configured timeout.
+    let catalog = match tokio::time::timeout(
+        *MCP_REQUEST_TIMEOUT.default(),
+        client.client.catalog_snapshot("mcp"),
+    )
+    .await
+    {
+        Ok(catalog) => catalog,
+        Err(_elapsed) => {
+            warn!(endpoint = %endpoint_type, "MCP catalog snapshot timed out");
+            record_request(McpCallStatus::Timeout);
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
     let dyncfgs = catalog.system_config().dyncfgs();
     let enabled = match endpoint_type {
         McpEndpointType::Agent => ENABLE_MCP_AGENT.get(dyncfgs),


### PR DESCRIPTION
`MCP_REQUEST_TIMEOUT` only wrapped the handler body, so a stalled `catalog_snapshot` could hang a request indefinitely. Since the configured value lives in that same snapshot, this bounds the fetch with the dyncfg's compiled-in default and returns 503, matching the existing pre-flight failure path.