### PR TITLE
docs: add coding agent setup to the Emulator guide and document unauthenticated MCP access

### DIFF
--- a/doc/user/content/get-started/install-materialize-emulator.md
+++ b/doc/user/content/get-started/install-materialize-emulator.md
@@ -122,9 +122,9 @@ Skills](/integrations/coding-agent-skills/).
 #### Connect to the MCP server
 
 The Materialize Emulator includes a built-in `materialize-developer` [MCP
-server](/integrations/mcp-server/mcp-developer/) (port `6876`) for
-troubleshooting and observability. The Emulator does not require
-authentication, so your MCP client only needs the MCP server URL
+server](/integrations/mcp-server/mcp-developer/) for troubleshooting and
+observability. The Emulator does not require authentication, so your MCP
+client only needs the MCP server URL
 `http://localhost:6876/api/mcp/developer`.
 
 1. Configure your MCP client with the Emulator's MCP server URL. For example,

--- a/doc/user/content/get-started/install-materialize-emulator.md
+++ b/doc/user/content/get-started/install-materialize-emulator.md
@@ -123,27 +123,17 @@ Skills](/integrations/coding-agent-skills/).
 
 The Materialize Emulator includes a built-in `materialize-developer` [MCP
 server](/integrations/mcp-server/mcp-developer/) (port `6876`) for
-troubleshooting and observability. To connect, your MCP client needs an MCP
-token and the MCP server URL.
+troubleshooting and observability. The Emulator does not require
+authentication, so your MCP client only needs the MCP server URL
+`http://localhost:6876/api/mcp/developer`.
 
-1. Generate the MCP token by Base64-encoding the credentials of the default
-   `materialize` user (the Emulator does not support passwords):
-
-   ```sh
-   printf 'materialize:' | base64
-   ```
-
-1. Configure your MCP client with the MCP token and the Emulator's MCP server
-   URL `http://localhost:6876/api/mcp/developer`. For example, if using [Claude
-   Code](https://docs.anthropic.com/en/docs/claude-code):
+1. Configure your MCP client with the Emulator's MCP server URL. For example,
+   if using [Claude Code](https://docs.anthropic.com/en/docs/claude-code):
 
    ```sh
    claude mcp add --transport http materialize-developer \
-     http://localhost:6876/api/mcp/developer \
-     --header "Authorization: Basic <mcp-token>"
+     http://localhost:6876/api/mcp/developer
    ```
-
-   Replace `<mcp-token>` with the token generated in the previous step.
 
 1. Restart your MCP client to pick up the new setting. Once connected, you can
    ask questions like *Why is my materialized view stale?* or *How much memory

--- a/doc/user/content/get-started/install-materialize-emulator.md
+++ b/doc/user/content/get-started/install-materialize-emulator.md
@@ -38,7 +38,7 @@ not suitable for full feature set evaluations or production workloads.
 - Docker. If [Docker](https://www.docker.com/) is not installed, refer to its
 [official documentation](https://docs.docker.com/get-docker/) to install.
 
-### Run Materialize Emulator
+### Install and run the Materialize Emulator
 
 {{< note >}}
 
@@ -69,9 +69,8 @@ not suitable for full feature set evaluations or production workloads.
 
    Open the Materialize Console in your browser at [http://localhost:6874](http://localhost:6874).
 
-   To streamline development and troubleshooting, we recommend configuring our
-   [MCP
-   Server](https://materialize.com/docs/integrations/mcp-server/mcp-developer/).
+   To streamline development and troubleshooting, we recommend [setting up
+   your coding agents](#setup-your-coding-agents).
 
    You can also connect to the Materialize Emulator using your
    preferred SQL client, using the following connection field values:
@@ -91,6 +90,67 @@ not suitable for full feature set evaluations or production workloads.
 
 1. Once connected, you can get started with the
    [Quickstart](/get-started/quickstart).
+
+### Setup your coding agents
+
+To streamline development and troubleshooting, you can set up coding agents
+like [Claude Code](https://docs.anthropic.com/en/docs/claude-code),
+[Codex](https://openai.com/index/codex/), and [Cursor](https://www.cursor.com/)
+to work with your Materialize Emulator.
+
+#### Install the Materialize agent skills
+
+Materialize provides open-source [agent
+skills](/integrations/coding-agent-skills/) that give your coding agent access
+to Materialize documentation and reference material, so it can provide more
+accurate assistance when writing queries, setting up sources, creating
+materialized views, and more.
+
+1. If [Node.js](https://nodejs.org/) (v16 or later) is not installed, refer to
+   its [official documentation](https://nodejs.org/en/download) to install.
+
+1. In a terminal, issue the following command to install the Materialize agent
+   skills:
+
+   ```bash
+   npx skills add MaterializeInc/agent-skills
+   ```
+
+For more details on the available skills, see [Agent
+Skills](/integrations/coding-agent-skills/).
+
+#### Connect to the MCP server
+
+The Materialize Emulator includes a built-in `materialize-developer` [MCP
+server](/integrations/mcp-server/mcp-developer/) (port `6876`) for
+troubleshooting and observability. To connect, your MCP client needs an MCP
+token and the MCP server URL.
+
+1. Generate the MCP token by Base64-encoding the credentials of the default
+   `materialize` user (the Emulator does not support passwords):
+
+   ```sh
+   printf 'materialize:' | base64
+   ```
+
+1. Configure your MCP client with the MCP token and the Emulator's MCP server
+   URL `http://localhost:6876/api/mcp/developer`. For example, if using [Claude
+   Code](https://docs.anthropic.com/en/docs/claude-code):
+
+   ```sh
+   claude mcp add --transport http materialize-developer \
+     http://localhost:6876/api/mcp/developer \
+     --header "Authorization: Basic <mcp-token>"
+   ```
+
+   Replace `<mcp-token>` with the token generated in the previous step.
+
+1. Restart your MCP client to pick up the new setting. Once connected, you can
+   ask questions like *Why is my materialized view stale?* or *How much memory
+   is my cluster using?*
+
+For more details, including instructions for other MCP clients, see [MCP Server
+for Developers](/integrations/mcp-server/mcp-developer/).
 
 ### Next steps
 

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -554,11 +554,40 @@ curl -X POST http://localhost:6876/api/mcp/developer \
 {{< /tab >}}
 {{< /tabs >}}
 
+#### Run the agent as a specific role
+
 Unauthenticated requests run as the `anonymous_http_user` role. To run the
-agent's queries as a specific role instead, pass the role's Base64-encoded
-credentials (`printf '<role>:' | base64`, the Emulator does not support
-passwords) as an MCP token, as in [Method 2: Token-based
-authentication](#method-2-token-based-authentication).
+agent's queries as a specific role instead, pass that role's credentials as an
+MCP token:
+
+1. Connect to the Emulator with a [SQL
+   client](/get-started/install-materialize-emulator/#materialize-emulator-connect-client)
+   and create the role, if it does not already exist:
+
+   ```mzsql
+   CREATE ROLE my_agent;
+   ```
+
+1. Base64-encode the role's credentials `<role>:` to create the MCP token.
+   Unlike Materialize Cloud and Materialize Self-Managed, the Emulator does
+   not support passwords, so the credentials do not include a password after
+   the `:`:
+
+   ```bash
+   printf 'my_agent:' | base64
+   ```
+
+1. Configure your MCP client with the MCP token, as described in [Method 2,
+   Step 3. Configure your MCP client](#step-3-configure-your-mcp-client). For
+   example, if using Claude Code:
+
+   ```sh
+   claude mcp add --transport http materialize-developer \
+     http://localhost:6876/api/mcp/developer \
+     --header "Authorization: Basic <mcp-token>"
+   ```
+
+   Replace `<mcp-token>` with the token generated in the previous step.
 
 ## Start asking questions
 

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -30,8 +30,7 @@ or Cursor) to the MCP server to:
 
 ## Connect to the MCP server
 
-How you connect to the `materialize-developer` MCP server depends on your
-deployment:
+There are two ways to authenticate to the `materialize-developer` MCP server:
 
 - **OAuth**: Starting in v26.30, your MCP client can sign you in through your
   browser; no token to generate or store. Available for **Cloud** and for
@@ -39,9 +38,6 @@ deployment:
 
 - **Token-based**: You provide Base64-encoded credentials (the MCP token) to the
   client. Available for **Cloud** and **Self-Managed**.
-
-- **No authentication**: The **Emulator** does not require authentication. Your
-  MCP client only needs the MCP server URL.
 
 ### Method 1: OAuth
 

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -30,14 +30,18 @@ or Cursor) to the MCP server to:
 
 ## Connect to the MCP server
 
-There are two ways to authenticate to the `materialize-developer` MCP server:
+How you connect to the `materialize-developer` MCP server depends on your
+deployment:
 
 - **OAuth**: Starting in v26.30, your MCP client can sign you in through your
   browser; no token to generate or store. Available for **Cloud** and for
   **Self-Managed** [using SSO](/security/self-managed/sso/).
 
 - **Token-based**: You provide Base64-encoded credentials (the MCP token) to the
-  client. Available for **Cloud**, **Self-Managed**, and the **Emulator**.
+  client. Available for **Cloud** and **Self-Managed**.
+
+- **No authentication**: The **Emulator** does not require authentication. Your
+  MCP client only needs the MCP server URL.
 
 ### Method 1: OAuth
 
@@ -46,9 +50,10 @@ There are two ways to authenticate to the `materialize-developer` MCP server:
 {{< note >}}
 
 The OAuth method is available for **Cloud** and for **Self-Managed** deployments
-using [SSO](/security/self-managed/sso/). For the **Emulator** (or Self-Managed
-not using SSO), use [Method 2: Token-based
-authentication](#method-2-token-based-authentication).
+using [SSO](/security/self-managed/sso/). For Self-Managed deployments not using
+SSO, use [Method 2: Token-based
+authentication](#method-2-token-based-authentication). For the **Emulator**, use
+[Method 3: No authentication](#method-3-no-authentication-emulator).
 
 {{< /note >}}
 
@@ -256,26 +261,6 @@ base64-encoded and not encrypted.
 
 {{< /tab >}}
 
-{{< tab "Emulator" >}}
-
-To connect to the MCP server for your Emulator, you can create a role for your
-specific AI agent or use the default `materialize` user:
-
-1. You can create a role for your specific AI agent (the Emulator does not
-   support the `LOGIN PASSWORD` option):
-
-   ```mzsql
-   CREATE ROLE my_dev_agent;
-   ```
-
-1. Base64-encode your agent role's credentials `<role>:<password>` to create the
-   MCP token (the Emulator does not support passwords):
-
-   ```bash
-   printf 'my_dev_agent:' | base64
-   ```
-
-{{< /tab >}}
 {{< /tabs >}}
 
 #### Step 2. Get your MCP server URL
@@ -362,18 +347,6 @@ server URL: `<baseURL>/api/mcp/developer`.
 {{< /tab >}}
 {{< /tabs >}}
 {{< /tab >}}
-{{< tab "Emulator" >}}
-
-For the Emulator, your MCP URL is:
-
-```
-http://localhost:6876/api/mcp/developer
-```
-
-where `http://localhost:6876` is your base URL.
-
-{{< /tab >}}
-
 {{< /tabs >}}
 
 #### Step 3. Configure your MCP client
@@ -509,6 +482,83 @@ curl -X POST <baseURL>/api/mcp/developer \
 
 {{< /tab >}}
 {{< /tabs >}}
+
+### Method 3: No authentication (Emulator)
+
+The [Materialize Emulator](/get-started/install-materialize-emulator/) does not
+require authentication. Your MCP client only needs the `materialize-developer`
+MCP server URL:
+
+```
+http://localhost:6876/api/mcp/developer
+```
+
+{{< tabs >}}
+{{< tab "Claude Code" >}}
+
+1. Add the `materialize-developer` MCP server as [local-scoped
+   server](https://code.claude.com/docs/en/mcp#local-scope) (i.e., the
+   configurations are stored in `~/.claude.json`):
+
+   ```sh
+   claude mcp add --transport http materialize-developer \
+     http://localhost:6876/api/mcp/developer
+   ```
+
+1. Restart Claude Code to pick up the new setting.
+
+1. Upon successful connection, you can [Start asking
+   questions](#start-asking-questions).
+
+{{< /tab >}}
+
+{{< tab "Cursor" >}}
+
+1. Add the `materialize-developer` MCP server entry to your local MCP settings
+   file (`~/.cursor/mcp.json`).
+   - When merging into an existing `mcpServers` object, remember to add commas
+     between entries.
+   - If the `mcpServers` field does not already exist, add it as well.
+
+   ```json {hl_lines="3-5"}
+   {
+     "mcpServers": {
+       "materialize-developer": {
+         "url": "http://localhost:6876/api/mcp/developer"
+       }
+     }
+   }
+   ```
+
+1. Restart Cursor to pick up the new setting.
+
+1. Upon successful connection, you can [Start asking
+   questions](#start-asking-questions).
+
+{{< /tab >}}
+
+{{< tab "Generic HTTP" >}}
+
+Any MCP-compatible client can connect by sending JSON-RPC 2.0 requests:
+
+```bash
+curl -X POST http://localhost:6876/api/mcp/developer \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/list"
+  }'
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+Unauthenticated requests run as the `anonymous_http_user` role. To run the
+agent's queries as a specific role instead, pass the role's Base64-encoded
+credentials (`printf '<role>:' | base64`, the Emulator does not support
+passwords) as an MCP token, as in [Method 2: Token-based
+authentication](#method-2-token-based-authentication).
 
 ## Start asking questions
 

--- a/doc/user/content/integrations/mcp-server/mcp-developer.md
+++ b/doc/user/content/integrations/mcp-server/mcp-developer.md
@@ -37,7 +37,7 @@ There are two ways to authenticate to the `materialize-developer` MCP server:
   **Self-Managed** [using SSO](/security/self-managed/sso/).
 
 - **Token-based**: You provide Base64-encoded credentials (the MCP token) to the
-  client. Available for **Cloud** and **Self-Managed**.
+  client. Available for **Cloud**, **Self-Managed**, and the **Emulator**.
 
 ### Method 1: OAuth
 
@@ -257,6 +257,31 @@ base64-encoded and not encrypted.
 
 {{< /tab >}}
 
+{{< tab "Emulator" >}}
+
+The Emulator [does not require
+authentication](#method-3-no-authentication-emulator). You can still pass a
+role's credentials as an MCP token to run the agent's queries as that role:
+
+1. Connect to the Emulator with a [SQL
+   client](/get-started/install-materialize-emulator/#materialize-emulator-connect-client)
+   and create the role, if it does not already exist:
+
+   ```mzsql
+   CREATE ROLE my_agent;
+   ```
+
+1. Base64-encode the role's credentials `<role>:` to create the MCP token.
+   Unlike Materialize Cloud and Materialize Self-Managed, the Emulator does
+   not support passwords, so the credentials do not include a password after
+   the `:`:
+
+   ```bash
+   printf 'my_agent:' | base64
+   ```
+
+{{< /tab >}}
+
 {{< /tabs >}}
 
 #### Step 2. Get your MCP server URL
@@ -343,6 +368,18 @@ server URL: `<baseURL>/api/mcp/developer`.
 {{< /tab >}}
 {{< /tabs >}}
 {{< /tab >}}
+{{< tab "Emulator" >}}
+
+For the Emulator, your MCP URL is:
+
+```
+http://localhost:6876/api/mcp/developer
+```
+
+where `http://localhost:6876` is your base URL.
+
+{{< /tab >}}
+
 {{< /tabs >}}
 
 #### Step 3. Configure your MCP client
@@ -550,40 +587,10 @@ curl -X POST http://localhost:6876/api/mcp/developer \
 {{< /tab >}}
 {{< /tabs >}}
 
-#### Run the agent as a specific role
-
 Unauthenticated requests run as the `anonymous_http_user` role. To run the
-agent's queries as a specific role instead, pass that role's credentials as an
-MCP token:
-
-1. Connect to the Emulator with a [SQL
-   client](/get-started/install-materialize-emulator/#materialize-emulator-connect-client)
-   and create the role, if it does not already exist:
-
-   ```mzsql
-   CREATE ROLE my_agent;
-   ```
-
-1. Base64-encode the role's credentials `<role>:` to create the MCP token.
-   Unlike Materialize Cloud and Materialize Self-Managed, the Emulator does
-   not support passwords, so the credentials do not include a password after
-   the `:`:
-
-   ```bash
-   printf 'my_agent:' | base64
-   ```
-
-1. Configure your MCP client with the MCP token, as described in [Method 2,
-   Step 3. Configure your MCP client](#step-3-configure-your-mcp-client). For
-   example, if using Claude Code:
-
-   ```sh
-   claude mcp add --transport http materialize-developer \
-     http://localhost:6876/api/mcp/developer \
-     --header "Authorization: Basic <mcp-token>"
-   ```
-
-   Replace `<mcp-token>` with the token generated in the previous step.
+agent's queries as a specific role instead, pass the role's credentials as an
+MCP token, as described in [Method 2: Token-based
+authentication](#method-2-token-based-authentication).
 
 ## Start asking questions
 


### PR DESCRIPTION
### Motivation

The Materialize Emulator guide is the entry point for local evaluation, but it only mentioned the developer MCP server in passing via an external link and said nothing about the Materialize agent skills. Users setting up coding agents (Claude Code, Codex, Cursor) against the Emulator had to piece the setup together from other pages. Additionally, the MCP Server for Developers page documented a token flow for the Emulator, but the Emulator's MCP server does not require authentication at all.

### Description

Changes to `doc/user/content/get-started/install-materialize-emulator/`:

- Rename the "Run Materialize Emulator" section to "Install and run the Materialize Emulator".
- Add a "Setup your coding agents" section after it, with two subsections:
  - **Install the Materialize agent skills**: the `npx skills add MaterializeInc/agent-skills` command, linking to [Agent Skills](https://materialize.com/docs/integrations/coding-agent-skills/) for details.
  - **Connect to the MCP server**: the Emulator MCP URL `http://localhost:6876/api/mcp/developer` and a direct, no-authentication `claude mcp add` example, linking to [MCP Server for Developers](https://materialize.com/docs/integrations/mcp-server/mcp-developer/) for other clients.
- Point the inline MCP recommendation in the run steps at the new section instead of the external MCP page link.

Changes to `doc/user/content/integrations/mcp-server/mcp-developer/`:

- Add "Method 3: No authentication (Emulator)" with Claude Code, Cursor, and generic HTTP examples that connect without credentials, plus a note that unauthenticated requests run as `anonymous_http_user`. The OAuth method's note routes Emulator users there.
- Rework the Emulator tabs in the token-based method: since the Emulator needs no token to connect, its tabs now document the optional flow for running the agent's queries as a specific role (`CREATE ROLE`, then Base64-encode the passwordless `<role>:` credentials), which Method 3 cross-references.

### Verification

- Ran the Emulator image the docs reference (`materialize/materialized:v26.35.0`, what `{{< version >}}` currently resolves to) with the documented `docker run` command and confirmed against it:
  - `POST /api/mcp/developer` with no `Authorization` header succeeds for `tools/list` and for `tools/call` of both `query_system_catalog` and `query` (including reads of user objects), running as `anonymous_http_user`.
  - The documented role flow works: `CREATE ROLE my_agent` succeeds, `LOGIN PASSWORD` is rejected on the Emulator, and a request with `Authorization: Basic $(printf 'my_agent:' | base64)` runs as `my_agent` per `current_role()`.
  - The exact documented command `claude mcp add --transport http materialize-developer http://localhost:6876/api/mcp/developer` results in `claude mcp list` reporting the server as Connected.
- Confirmed `npx skills add <owner/repo>` is valid syntax for the `skills` CLI.
- Built the docs site with the CI-pinned Hugo (v0.152.2) and verified the rendered pages: heading anchors resolve, cross-page links target pages that exist in the build output, tab shortcodes are balanced, and all code blocks render.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSiYk2AdLMMu1JM7G55Eoo