### PR TITLE
adapter: fix unknown-connection panic on abandoned failed startup

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,7 +20,7 @@ retries = 2
 priority = 100
 
 [[profile.default.overrides]]
-filter = "package(mz-environmentd) and test(test_concurrent_id_reuse)"
+filter = "package(mz-environmentd) and test(test_termination_races)"
 priority = 100
 
 [[profile.default.overrides]]

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -250,11 +250,18 @@ impl Client {
         // This guard prevents a race where the startup command finishes, but the Future returned
         // by this function is concurrently dropped, so we never create a `SessionClient` and thus
         // never cleanup the initialized Session.
-        let rx = rx.with_guard(|_| {
-            self.send(Command::Terminate {
-                conn_id: conn_id.clone(),
-                tx: None,
-            });
+        //
+        // NOTE: Terminate must only be sent for a successful startup. On a failed startup the
+        // Coordinator never registered the connection, so a Terminate for it would trip the
+        // Coordinator's "unknown connection" assertion. There is also nothing that needs
+        // cleaning up, see the invariant on `Coordinator::handle_startup_inner`.
+        let rx = rx.with_guard(|resp: Result<StartupResponse, _>| {
+            if resp.is_ok() {
+                self.send(Command::Terminate {
+                    conn_id: conn_id.clone(),
+                    tx: None,
+                });
+            }
         });
 
         self.send(Command::Startup {

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -130,8 +130,11 @@ impl Coordinator {
                     application_name,
                     notice_tx,
                 } => {
-                    // Note: We purposefully do not use a ClientTransmitter here because startup
-                    // handles errors and cleanup of sessions itself.
+                    // Note: A ClientTransmitter is not applicable here. Its purpose is to
+                    // rescue the Session from an undeliverable Response, and startup
+                    // responses carry no Session, the Session stays with the client. An
+                    // undeliverable startup response is instead handled by handle_startup's
+                    // failed-send path together with the cleanup guard in Client::startup.
                     self.handle_startup(
                         tx,
                         user,
@@ -910,19 +913,29 @@ impl Coordinator {
                 }
             }
             Err(e) => {
-                // Error during startup or sending to adapter. A user may have been created and
-                // it can stay; no need to delete it.
-                // Note: Temporary schemas are created lazily, so there's nothing to clean up here.
-
-                // Communicate the error back to the client. No need to
-                // handle failures to send the error back; we've already
-                // cleaned up all necessary state.
+                // Nothing to clean up and `handle_terminate` must not be called. Per the
+                // `handle_startup_inner` invariant, no per-connection state exists and the
+                // connection was never registered in `active_conns`. An auto-provisioned role
+                // stays, it is role-scoped rather than tied to this connection. Temporary
+                // schemas are created lazily, so none exists yet. For the same reason, a
+                // failure to send the error back to the client needs no handling.
                 let _ = tx.send(Err(e));
             }
         }
     }
 
-    // Failible startup work that needs to be cleaned up on error.
+    /// Fallible startup work.
+    ///
+    /// Invariant: when this returns an error, no per-connection coordinator
+    /// state exists. Per-connection state is registered only in
+    /// `handle_startup`'s Ok arm, after this function has succeeded. The
+    /// cleanup guard in `Client::startup` relies on this invariant by not
+    /// sending `Terminate` when startup fails, and `handle_terminate` panics
+    /// on connections it does not know about.
+    ///
+    /// Durable catalog changes made before an error (an auto-provisioned
+    /// role, synced role memberships) are role-scoped rather than
+    /// connection-scoped and are intentionally kept.
     async fn handle_startup_inner(
         &mut self,
         user: &User,
@@ -1965,6 +1978,11 @@ impl Coordinator {
     /// Handle termination of a client session.
     ///
     /// This cleans up any state in the coordinator associated with the session.
+    ///
+    /// Must only be called for connections that completed a successful
+    /// startup, i.e. that are present in `active_conns`. A failed startup
+    /// leaves no state behind (see `handle_startup_inner`), so no Terminate
+    /// may be sent for it.
     #[mz_ore::instrument(level = "debug")]
     async fn handle_terminate(&mut self, conn_id: ConnectionId) {
         // If the session doesn't exist in `active_conns`, then this method will panic later on.

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -889,6 +889,8 @@ impl Listeners {
         Ok(Server {
             sql_listener_handles,
             http_listener_handles,
+            #[cfg(feature = "test")]
+            adapter_client,
             _adapter_handle: adapter_handle,
         })
     }
@@ -913,5 +915,15 @@ pub struct Server {
     // Drop order matters for these fields.
     pub sql_listener_handles: BTreeMap<String, ListenerHandle>,
     pub http_listener_handles: BTreeMap<String, ListenerHandle>,
+    #[cfg(feature = "test")]
+    adapter_client: AdapterClient,
     _adapter_handle: mz_adapter::Handle,
+}
+
+impl Server {
+    /// A client for the adapter, letting tests drive the adapter API directly.
+    #[cfg(feature = "test")]
+    pub fn adapter_client(&self) -> &AdapterClient {
+        &self.adapter_client
+    }
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -30,7 +30,9 @@ use futures::FutureExt;
 use http::Request;
 use itertools::Itertools;
 use jsonwebtoken::{DecodingKey, EncodingKey};
+use mz_adapter::session::SessionConfig;
 use mz_auth::password::Password;
+use mz_auth::{Authenticated, AuthenticatorKind};
 use mz_environmentd::test_util::{self, Ca, KAFKA_ADDRS, PostgresErrorExt, make_pg_tls};
 use mz_environmentd::{WebSocketAuth, WebSocketResponse};
 use mz_frontegg_auth::{
@@ -2754,10 +2756,14 @@ async fn test_max_connections_limits() {
     }
 }
 
+// Exercises races between session termination and connection startup: a
+// terminating connection must not tear down another session's state via a
+// reused connection ID, and a client abandoning a failed startup must not
+// panic the Coordinator.
 #[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // too slow
 #[allow(clippy::disallowed_methods)]
-async fn test_concurrent_id_reuse() {
+async fn test_termination_races() {
     let server = test_util::TestHarness::default().start().await;
 
     {
@@ -2806,6 +2812,67 @@ async fn test_concurrent_id_reuse() {
 
     let client = server.connect().await.unwrap();
     client.batch_execute("SELECT 1").await.unwrap();
+
+    // Reuse the running server to also exercise a second connection-lifecycle
+    // regression: a client abandoning a failed startup. When startup fails,
+    // the Coordinator never registers the connection in `active_conns`, so
+    // the cleanup guard in `Client::startup` must not send a `Terminate`
+    // command for it when the startup future is dropped without observing the
+    // error response. A Terminate for an unknown connection panics the
+    // Coordinator.
+
+    // This phase does not prepare statements, disable the failpoint anyway to
+    // keep the phases independent.
+    fail::cfg("async_prepare", "off").unwrap();
+
+    // Make startup fail deterministically for user roles.
+    let system_client = server.connect().internal().await.unwrap();
+    system_client
+        .batch_execute("ALTER SYSTEM SET allow_user_sessions = false")
+        .await
+        .unwrap();
+
+    let adapter_client = server.inner.adapter_client();
+    let conn_id = adapter_client.new_conn_id().unwrap();
+    let session = adapter_client.new_session(
+        SessionConfig {
+            conn_id,
+            uuid: Uuid::new_v4(),
+            user: "materialize".to_string(),
+            client_ip: None,
+            external_metadata_rx: None,
+            helm_chart_version: None,
+            authenticator_kind: AuthenticatorKind::None,
+            groups: None,
+        },
+        Authenticated,
+    );
+
+    // Box the future so that dropping it below drops the future itself, not
+    // just a reference to it.
+    let mut fut = Box::pin(adapter_client.startup(session));
+    // The first poll sends the Startup command to the Coordinator and installs
+    // the cleanup guard around the response channel.
+    assert!(futures::poll!(&mut fut).is_pending());
+    // Wait for the Coordinator to process the Startup command and place the
+    // startup error in the response channel. Commands on the client channel
+    // are processed in order, so a completed round trip implies the Startup
+    // command has been processed.
+    let _ = adapter_client.get_system_vars().await;
+    // Drop the future without observing the response. The cleanup guard must
+    // not send a Terminate command for the never-registered connection.
+    drop(fut);
+
+    // The Coordinator must be unharmed. System sessions are exempt from
+    // `allow_user_sessions`, so a working internal connection shows the
+    // Coordinator is still alive.
+    let check = async {
+        let client = server.connect().internal().await.unwrap();
+        client.batch_execute("SELECT 1").await.unwrap();
+    };
+    tokio::time::timeout(Duration::from_secs(30), check)
+        .await
+        .expect("coordinator did not survive an abandoned failed startup");
 }
 
 #[mz_ore::test]


### PR DESCRIPTION
### Motivation

Fixes a Coordinator panic seen in incident-1183 (https://materializeinc.slack.com/archives/C0BLZBH1SEA):

```
unknown connection: Dynamic(IdHandleInner { id: ..., .. })
```

A connection is registered in `active_conns` only when startup succeeds. The cleanup guard in `Client::startup` sent a `Terminate` command whenever the startup response was left unobserved, including when it was an error, which happens when a client abandons a startup that failed (realistically via the HTTP endpoint, whose handler futures are dropped when the client disconnects or times out). The Coordinator then hit the "unknown connection" assertion in `handle_terminate` and aborted.

The fix sends `Terminate` only when the unobserved response was a successful startup. A failed startup leaves no per-connection state anywhere in the Coordinator, so there is nothing to clean up. This invariant is now documented on `handle_startup_inner`, and the related comments on the startup error path, `handle_terminate`, and the `Command::Startup` dispatch site state it as well.

### Testing

* Extended `test_concurrent_id_reuse` (renamed to `test_termination_races`, nextest override updated) with a deterministic second phase on the same server: it abandons a failed startup and asserts the Coordinator survives. Without the fix, the phase fails with the exact production panic. It adds no measurable runtime to the test.
* `environmentd::Server` now exposes the adapter client for tests, gated behind the `test` feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)