### PR TITLE
compute: measure index peek row workloads

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -1032,6 +1032,20 @@ metrics:
   help: Time checking trace frontiers.
   source: src/compute/src/metrics.rs
   visibility: internal
+- name: mz_index_peek_result_sort_rows_bucket
+  help: Number of intermediate result rows sorted during peek collection, summed across sort operations.
+  labels:
+  - le
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_result_sort_rows_count
+  help: Number of intermediate result rows sorted during peek collection, summed across sort operations.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_result_sort_rows_sum
+  help: Number of intermediate result rows sorted during peek collection, summed across sort operations.
+  source: src/compute/src/metrics.rs
+  visibility: internal
 - name: mz_index_peek_result_sort_seconds_bucket
   help: Time sorting intermediate results during peek collection.
   labels:
@@ -1058,6 +1072,20 @@ metrics:
   visibility: internal
 - name: mz_index_peek_row_collection_seconds_sum
   help: Time constructing RowCollection from peek results.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_row_iteration_rows_bucket
+  help: Number of arrangement rows evaluated by the index peek result iterator.
+  labels:
+  - le
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_row_iteration_rows_count
+  help: Number of arrangement rows evaluated by the index peek result iterator.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_row_iteration_rows_sum
+  help: Number of arrangement rows evaluated by the index peek result iterator.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_bucket

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1042,7 +1042,9 @@ impl<'a> ActiveComputeState<'a> {
                         .compute_state
                         .metrics
                         .index_peek_row_iteration_seconds,
+                    row_iteration_rows: &self.compute_state.metrics.index_peek_row_iteration_rows,
                     result_sort_seconds: &self.compute_state.metrics.index_peek_result_sort_seconds,
+                    result_sort_rows: &self.compute_state.metrics.index_peek_result_sort_rows,
                     row_collection_seconds: &self
                         .compute_state
                         .metrics
@@ -1567,7 +1569,9 @@ pub(crate) struct IndexPeekMetrics<'a> {
     pub error_scan_seconds: &'a prometheus::Histogram,
     pub cursor_setup_seconds: &'a prometheus::Histogram,
     pub row_iteration_seconds: &'a prometheus::Histogram,
+    pub row_iteration_rows: &'a prometheus::Histogram,
     pub result_sort_seconds: &'a prometheus::Histogram,
+    pub result_sort_rows: &'a prometheus::Histogram,
     pub row_collection_seconds: &'a prometheus::Histogram,
 }
 
@@ -1738,6 +1742,7 @@ impl IndexPeek {
         // Row iteration timing
         let row_iteration_start = Instant::now();
         let mut sort_time_accum = Duration::ZERO;
+        let mut rows_sorted = 0usize;
 
         while let Some(row) = peek_iterator.next() {
             let row: (Row, _) = match row {
@@ -1775,8 +1780,14 @@ impl IndexPeek {
                             .row_iteration_seconds
                             .observe(row_iteration_start.elapsed().as_secs_f64());
                         metrics
+                            .row_iteration_rows
+                            .observe(f64::cast_lossy(peek_iterator.rows_processed()));
+                        metrics
                             .result_sort_seconds
                             .observe(sort_time_accum.as_secs_f64());
+                        metrics
+                            .result_sort_rows
+                            .observe(f64::cast_lossy(rows_sorted));
                         let row_collection_start = Instant::now();
                         let collection = RowCollection::new(results, &peek.finishing.order_by);
                         metrics
@@ -1793,6 +1804,7 @@ impl IndexPeek {
                         // inner test (as we prefer not to maintain `Vec<Datum>`
                         // in the other case).
                         let sort_start = Instant::now();
+                        rows_sorted = rows_sorted.saturating_add(results.len());
                         results.sort_by(|left, right| {
                             comparator.compare_rows(&left.0, &right.0, || left.0.cmp(&right.0))
                         });
@@ -1816,8 +1828,14 @@ impl IndexPeek {
             .row_iteration_seconds
             .observe(row_iteration_start.elapsed().as_secs_f64());
         metrics
+            .row_iteration_rows
+            .observe(f64::cast_lossy(peek_iterator.rows_processed()));
+        metrics
             .result_sort_seconds
             .observe(sort_time_accum.as_secs_f64());
+        metrics
+            .result_sort_rows
+            .observe(f64::cast_lossy(rows_sorted));
 
         let row_collection_start = Instant::now();
         let collection = RowCollection::new(results, &peek.finishing.order_by);

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -36,6 +36,7 @@ where
     row_builder: Row,
     datum_vec: DatumVec,
     literals: Option<Literals<Tr>>,
+    rows_processed: usize,
 }
 
 /// Helper to handle literals in peeks
@@ -140,7 +141,13 @@ where
             row_builder: Row::default(),
             datum_vec: DatumVec::new(),
             literals,
+            rows_processed: 0,
         }
+    }
+
+    /// Returns the number of rows evaluated by the iterator.
+    pub fn rows_processed(&self) -> usize {
+        self.rows_processed
     }
 
     /// Returns `true` if the iterator has no more literals to process, or if there are no literals at all.
@@ -192,6 +199,7 @@ where
                 }
             }
 
+            self.rows_processed = self.rows_processed.saturating_add(1);
             match self.extract_current_row() {
                 Ok(Some(row)) => break Ok(row),
                 Ok(None) => {

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -65,7 +65,9 @@ pub struct ComputeMetrics {
     index_peek_error_scan_seconds: Histogram,
     index_peek_cursor_setup_seconds: Histogram,
     index_peek_row_iteration_seconds: Histogram,
+    index_peek_row_iteration_rows: Histogram,
     index_peek_result_sort_seconds: Histogram,
+    index_peek_result_sort_rows: Histogram,
     index_peek_frontier_check_seconds: Histogram,
     index_peek_row_collection_seconds: Histogram,
 
@@ -86,6 +88,9 @@ pub struct ComputeMetrics {
 impl ComputeMetrics {
     pub fn register_with(registry: &MetricsRegistry) -> Self {
         let workload_class = Arc::new(Mutex::new(None));
+        let mut index_peek_row_buckets =
+            prometheus::exponential_buckets(1.0, 2.0, 25).expect("valid parameters");
+        index_peek_row_buckets.insert(0, 0.0);
 
         // Apply a `workload_class` label to all metrics in the registry when we
         // have a known workload class.
@@ -203,10 +208,20 @@ impl ComputeMetrics {
                 help: "Time iterating rows and evaluating MFP.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             )),
+            index_peek_row_iteration_rows: registry.register(metric!(
+                name: "mz_index_peek_row_iteration_rows",
+                help: "Number of arrangement rows evaluated by the index peek result iterator.",
+                buckets: index_peek_row_buckets.clone(),
+            )),
             index_peek_result_sort_seconds: registry.register(metric!(
                 name: "mz_index_peek_result_sort_seconds",
                 help: "Time sorting intermediate results during peek collection.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
+            )),
+            index_peek_result_sort_rows: registry.register(metric!(
+                name: "mz_index_peek_result_sort_rows",
+                help: "Number of intermediate result rows sorted during peek collection, summed across sort operations.",
+                buckets: index_peek_row_buckets,
             )),
             index_peek_frontier_check_seconds: registry.register(metric!(
                 name: "mz_index_peek_frontier_check_seconds",
@@ -268,7 +283,9 @@ impl ComputeMetrics {
         let index_peek_error_scan_seconds = self.index_peek_error_scan_seconds.clone();
         let index_peek_cursor_setup_seconds = self.index_peek_cursor_setup_seconds.clone();
         let index_peek_row_iteration_seconds = self.index_peek_row_iteration_seconds.clone();
+        let index_peek_row_iteration_rows = self.index_peek_row_iteration_rows.clone();
         let index_peek_result_sort_seconds = self.index_peek_result_sort_seconds.clone();
+        let index_peek_result_sort_rows = self.index_peek_result_sort_rows.clone();
         let index_peek_frontier_check_seconds = self.index_peek_frontier_check_seconds.clone();
         let index_peek_row_collection_seconds = self.index_peek_row_collection_seconds.clone();
         let replica_expiration_timestamp_seconds = self
@@ -295,7 +312,9 @@ impl ComputeMetrics {
             index_peek_error_scan_seconds,
             index_peek_cursor_setup_seconds,
             index_peek_row_iteration_seconds,
+            index_peek_row_iteration_rows,
             index_peek_result_sort_seconds,
+            index_peek_result_sort_rows,
             index_peek_frontier_check_seconds,
             index_peek_row_collection_seconds,
             replica_expiration_timestamp_seconds,
@@ -337,8 +356,12 @@ pub struct WorkerMetrics {
     pub(crate) index_peek_cursor_setup_seconds: Histogram,
     /// Histogram of index peek row iteration durations.
     pub(crate) index_peek_row_iteration_seconds: Histogram,
+    /// Histogram of index peek rows processed by the result iterator.
+    pub(crate) index_peek_row_iteration_rows: Histogram,
     /// Histogram of index peek result sort durations.
     pub(crate) index_peek_result_sort_seconds: Histogram,
+    /// Histogram of index peek rows sorted across all result sort operations.
+    pub(crate) index_peek_result_sort_rows: Histogram,
     /// Histogram of index peek frontier check durations.
     pub(crate) index_peek_frontier_check_seconds: Histogram,
     /// Histogram of index peek row collection construction durations.


### PR DESCRIPTION
## Motivation

The existing index peek metrics expose phase durations but not the amount of work behind row iteration and intermediate result sorting. This makes it difficult to distinguish slow per-row processing from peeks that simply process more rows.

## Changes

- Add a per-peek histogram for arrangement rows evaluated by the result iterator, including rows removed by MFP evaluation.
- Add a per-peek histogram for intermediate result rows sorted. This sums input rows across repeated thinning sorts to align with the existing accumulated sort-duration metric.
- Use exponential row-count buckets with an explicit zero bucket and regenerate the metrics catalog.

## Tests

No new tests were added. Existing compute unit tests, compilation, formatting, Clippy, and metrics-catalog validation cover the changed instrumentation and registration paths.