### PR TITLE
secrets: support internal, name-keyed secrets alongside user secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7647,6 +7647,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sysinfo",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/src/aws-secrets-controller/src/lib.rs
+++ b/src/aws-secrets-controller/src/lib.rs
@@ -20,7 +20,7 @@ use aws_sdk_secretsmanager::error::SdkError;
 use aws_sdk_secretsmanager::primitives::Blob;
 use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType, Tag};
 use mz_repr::CatalogItemId;
-use mz_secrets::{SecretsController, SecretsReader};
+use mz_secrets::{SecretsController, SecretsReader, validate_internal_secret_name};
 use tracing::info;
 use uuid::Uuid;
 
@@ -64,16 +64,14 @@ impl AwsSecretsController {
             .map(|(key, value)| Tag::builder().key(key).value(value).build())
             .collect()
     }
-}
 
-#[async_trait]
-impl SecretsController for AwsSecretsController {
-    async fn ensure(&self, id: CatalogItemId, contents: &[u8]) -> Result<(), anyhow::Error> {
+    /// Creates or updates the secret with the given full name.
+    async fn ensure_by_name(&self, name: String, contents: &[u8]) -> Result<(), anyhow::Error> {
         match self
             .client
             .client
             .create_secret()
-            .name(self.client.secret_name(id))
+            .name(&name)
             .kms_key_id(self.kms_key_alias.clone())
             .secret_binary(Blob::new(contents))
             .set_tags(Some(self.tags()))
@@ -85,7 +83,7 @@ impl SecretsController for AwsSecretsController {
                 self.client
                     .client
                     .put_secret_value()
-                    .secret_id(self.client.secret_name(id))
+                    .secret_id(&name)
                     .secret_binary(Blob::new(contents))
                     .send()
                     .await?;
@@ -95,12 +93,14 @@ impl SecretsController for AwsSecretsController {
         Ok(())
     }
 
-    async fn delete(&self, id: CatalogItemId) -> Result<(), anyhow::Error> {
+    /// Deletes the secret with the given full name. Deleting a nonexistent secret is not an
+    /// error.
+    async fn delete_by_name(&self, name: String) -> Result<(), anyhow::Error> {
         match self
             .client
             .client
             .delete_secret()
-            .secret_id(self.client.secret_name(id))
+            .secret_id(name)
             .force_delete_without_recovery(true)
             .send()
             .await
@@ -108,10 +108,31 @@ impl SecretsController for AwsSecretsController {
             Ok(_) => Ok(()),
             // Secret is already deleted.
             Err(SdkError::ServiceError(e)) if e.err().is_resource_not_found_exception() => Ok(()),
-            Err(e) => {
-                return Err(e.into());
-            }
+            Err(e) => Err(e.into()),
         }
+    }
+}
+
+#[async_trait]
+impl SecretsController for AwsSecretsController {
+    async fn ensure(&self, id: CatalogItemId, contents: &[u8]) -> Result<(), anyhow::Error> {
+        self.ensure_by_name(self.client.secret_name(id), contents)
+            .await
+    }
+
+    async fn ensure_internal(&self, name: &str, contents: &[u8]) -> Result<(), anyhow::Error> {
+        validate_internal_secret_name(name)?;
+        self.ensure_by_name(self.client.internal_secret_name(name), contents)
+            .await
+    }
+
+    async fn delete(&self, id: CatalogItemId) -> Result<(), anyhow::Error> {
+        self.delete_by_name(self.client.secret_name(id)).await
+    }
+
+    async fn delete_internal(&self, name: &str) -> Result<(), anyhow::Error> {
+        self.delete_by_name(self.client.internal_secret_name(name))
+            .await
     }
 
     async fn list(&self) -> Result<Vec<CatalogItemId>, anyhow::Error> {
@@ -203,23 +224,30 @@ impl AwsSecretsClient {
         format!("{}{}", self.secret_name_prefix, id)
     }
 
+    /// The AWS secret name for an internal secret.
+    ///
+    /// The `internal-` infix keeps internal secrets disjoint from user secrets, whose
+    /// unprefixed names are numeric catalog item IDs, and excludes them from
+    /// [`SecretsController::list`], whose parser only recognizes ID names.
+    fn internal_secret_name(&self, name: &str) -> String {
+        format!("{}internal-{}", self.secret_name_prefix, name)
+    }
+
     fn id_from_secret_name(&self, name: &str) -> Option<CatalogItemId> {
         name.strip_prefix(&self.secret_name_prefix)
             .and_then(|id| id.parse().ok())
     }
-}
 
-#[async_trait]
-impl SecretsReader for AwsSecretsClient {
-    async fn read(&self, id: CatalogItemId) -> Result<Vec<u8>, anyhow::Error> {
+    /// Reads the secret with the given full name.
+    async fn read_by_name(&self, name: String) -> Result<Vec<u8>, anyhow::Error> {
         let op_id = Uuid::new_v4();
-        info!(secret_id = %id, %op_id, "reading secret from AWS");
+        info!(secret_name = %name, %op_id, "reading secret from AWS");
         let start = Instant::now();
         let secret = async {
             Ok(self
                 .client
                 .get_secret_value()
-                .secret_id(self.secret_name(id))
+                .secret_id(name)
                 .send()
                 .await?
                 .secret_binary()
@@ -230,5 +258,16 @@ impl SecretsReader for AwsSecretsClient {
         .await;
         info!(%op_id, success = %secret.is_ok(), "secret read in {:?}", start.elapsed());
         secret
+    }
+}
+
+#[async_trait]
+impl SecretsReader for AwsSecretsClient {
+    async fn read(&self, id: CatalogItemId) -> Result<Vec<u8>, anyhow::Error> {
+        self.read_by_name(self.secret_name(id)).await
+    }
+
+    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
+        self.read_by_name(self.internal_secret_name(name)).await
     }
 }

--- a/src/aws-secrets-controller/src/lib.rs
+++ b/src/aws-secrets-controller/src/lib.rs
@@ -17,6 +17,7 @@ use aws_config::SdkConfig;
 use aws_sdk_secretsmanager::Client;
 use aws_sdk_secretsmanager::config::Builder as SecretsManagerConfigBuilder;
 use aws_sdk_secretsmanager::error::SdkError;
+use aws_sdk_secretsmanager::operation::get_secret_value::GetSecretValueError;
 use aws_sdk_secretsmanager::primitives::Blob;
 use aws_sdk_secretsmanager::types::{Filter, FilterNameStringType, Tag};
 use mz_repr::CatalogItemId;
@@ -267,7 +268,15 @@ impl SecretsReader for AwsSecretsClient {
         self.read_by_name(self.secret_name(id)).await
     }
 
-    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
-        self.read_by_name(self.internal_secret_name(name)).await
+    async fn read_internal(&self, name: &str) -> Result<Option<Vec<u8>>, anyhow::Error> {
+        match self.read_by_name(self.internal_secret_name(name)).await {
+            Ok(contents) => Ok(Some(contents)),
+            Err(e) => match e.downcast_ref::<SdkError<GetSecretValueError>>() {
+                Some(SdkError::ServiceError(e)) if e.err().is_resource_not_found_exception() => {
+                    Ok(None)
+                }
+                _ => Err(e),
+            },
+        }
     }
 }

--- a/src/orchestrator-kubernetes/src/secrets.rs
+++ b/src/orchestrator-kubernetes/src/secrets.rs
@@ -160,12 +160,15 @@ impl SecretsReader for KubernetesSecretsReader {
         read_secret(&self.secret_api, &secret_name(id, &self.name_prefix)).await
     }
 
-    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
-        read_secret(
-            &self.secret_api,
-            &internal_secret_name(name, &self.name_prefix),
-        )
-        .await
+    async fn read_internal(&self, name: &str) -> Result<Option<Vec<u8>>, anyhow::Error> {
+        let name = internal_secret_name(name, &self.name_prefix);
+        match read_secret(&self.secret_api, &name).await {
+            Ok(contents) => Ok(Some(contents)),
+            Err(e) => match e.downcast_ref::<kube::Error>() {
+                Some(kube::Error::Api(e)) if e.code == 404 => Ok(None),
+                _ => Err(e),
+            },
+        }
     }
 }
 

--- a/src/orchestrator-kubernetes/src/secrets.rs
+++ b/src/orchestrator-kubernetes/src/secrets.rs
@@ -19,51 +19,76 @@ use k8s_openapi::api::core::v1::Secret;
 use kube::Api;
 use kube::api::{DeleteParams, ListParams, ObjectMeta, Patch, PatchParams};
 use mz_repr::CatalogItemId;
-use mz_secrets::{SecretsController, SecretsReader};
+use mz_secrets::{SecretsController, SecretsReader, validate_internal_secret_name};
 
 use crate::{FIELD_MANAGER, KubernetesOrchestrator, util};
+
+/// Creates or updates the Kubernetes secret with the given name.
+async fn ensure_secret(
+    secret_api: &Api<Secret>,
+    name: String,
+    contents: &[u8],
+) -> Result<(), anyhow::Error> {
+    let data = iter::once(("contents".into(), ByteString(contents.into())));
+    let secret = Secret {
+        metadata: ObjectMeta {
+            name: Some(name.clone()),
+            ..Default::default()
+        },
+        data: Some(data.collect()),
+        ..Default::default()
+    };
+    secret_api
+        .patch(
+            &name,
+            &PatchParams::apply(FIELD_MANAGER).force(),
+            &Patch::Apply(secret),
+        )
+        .await?;
+    Ok(())
+}
+
+/// Initiates deletion of the Kubernetes secret with the given name.
+///
+/// Does not wait for the secret to be deleted; the obligation is only to initiate the deletion.
+/// Garbage collecting secrets that fail to delete will be the responsibility of a future garbage
+/// collection task.
+async fn delete_secret(secret_api: &Api<Secret>, name: &str) -> Result<(), anyhow::Error> {
+    match secret_api.delete(name, &DeleteParams::default()).await {
+        Ok(_) => Ok(()),
+        // Secret is already deleted.
+        Err(kube::Error::Api(e)) if e.code == 404 => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
 
 #[async_trait]
 impl SecretsController for KubernetesOrchestrator {
     async fn ensure(&self, id: CatalogItemId, contents: &[u8]) -> Result<(), anyhow::Error> {
         let name = secret_name(id, &self.config.name_prefix());
-        let data = iter::once(("contents".into(), ByteString(contents.into())));
-        let secret = Secret {
-            metadata: ObjectMeta {
-                name: Some(name.clone()),
-                ..Default::default()
-            },
-            data: Some(data.collect()),
-            ..Default::default()
-        };
-        self.secret_api
-            .patch(
-                &name,
-                &PatchParams::apply(FIELD_MANAGER).force(),
-                &Patch::Apply(secret),
-            )
-            .await?;
-        Ok(())
+        ensure_secret(&self.secret_api, name, contents).await
+    }
+
+    async fn ensure_internal(&self, name: &str, contents: &[u8]) -> Result<(), anyhow::Error> {
+        validate_internal_secret_name(name)?;
+        let name = internal_secret_name(name, &self.config.name_prefix());
+        ensure_secret(&self.secret_api, name, contents).await
     }
 
     async fn delete(&self, id: CatalogItemId) -> Result<(), anyhow::Error> {
-        // We intentionally don't wait for the secret to be deleted; our
-        // obligation is only to initiate the deletion. Garbage collecting
-        // secrets that fail to delete will be the responsibility of a future
-        // garbage collection task.
-        match self
-            .secret_api
-            .delete(
-                &secret_name(id, &self.config.name_prefix()),
-                &DeleteParams::default(),
-            )
-            .await
-        {
-            Ok(_) => Ok(()),
-            // Secret is already deleted.
-            Err(kube::Error::Api(e)) if e.code == 404 => Ok(()),
-            Err(e) => return Err(e.into()),
-        }
+        delete_secret(
+            &self.secret_api,
+            &secret_name(id, &self.config.name_prefix()),
+        )
+        .await
+    }
+
+    async fn delete_internal(&self, name: &str) -> Result<(), anyhow::Error> {
+        delete_secret(
+            &self.secret_api,
+            &internal_secret_name(name, &self.config.name_prefix()),
+        )
+        .await
     }
 
     async fn list(&self) -> Result<Vec<CatalogItemId>, anyhow::Error> {
@@ -117,24 +142,44 @@ impl KubernetesSecretsReader {
     }
 }
 
+/// Reads the contents of the Kubernetes secret with the given name.
+async fn read_secret(secret_api: &Api<Secret>, name: &str) -> Result<Vec<u8>, anyhow::Error> {
+    let secret = secret_api.get(name).await?;
+    let mut data = secret
+        .data
+        .ok_or_else(|| anyhow!("internal error: secret missing data field"))?;
+    let contents = data
+        .remove("contents")
+        .ok_or_else(|| anyhow!("internal error: secret missing contents field"))?;
+    Ok(contents.0)
+}
+
 #[async_trait]
 impl SecretsReader for KubernetesSecretsReader {
     async fn read(&self, id: CatalogItemId) -> Result<Vec<u8>, anyhow::Error> {
-        let secret = self
-            .secret_api
-            .get(&secret_name(id, &self.name_prefix))
-            .await?;
-        let mut data = secret
-            .data
-            .ok_or_else(|| anyhow!("internal error: secret missing data field"))?;
-        let contents = data
-            .remove("contents")
-            .ok_or_else(|| anyhow!("internal error: secret missing contents field"))?;
-        Ok(contents.0)
+        read_secret(&self.secret_api, &secret_name(id, &self.name_prefix)).await
+    }
+
+    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
+        read_secret(
+            &self.secret_api,
+            &internal_secret_name(name, &self.name_prefix),
+        )
+        .await
     }
 }
 
 const SECRET_NAME_PREFIX: &str = "user-managed-";
+const INTERNAL_SECRET_NAME_PREFIX: &str = "internal-";
+
+/// The Kubernetes object name for an internal secret.
+///
+/// The `internal-` infix keeps internal secrets disjoint from user secrets, which use the
+/// `user-managed-` infix. It also excludes them from [`SecretsController::list`], whose parser
+/// only recognizes `user-managed-` names.
+fn internal_secret_name(name: &str, name_prefix: &str) -> String {
+    format!("{name_prefix}{INTERNAL_SECRET_NAME_PREFIX}{name}")
+}
 
 fn secret_name(id: CatalogItemId, name_prefix: &str) -> String {
     format!("{name_prefix}{SECRET_NAME_PREFIX}{id}")

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -31,5 +31,9 @@ sysinfo.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+mz-ore = { path = "../ore", default-features = false, features = ["test"] }
+tempfile.workspace = true
+
 [features]
 default = []

--- a/src/orchestrator-process/src/secrets.rs
+++ b/src/orchestrator-process/src/secrets.rs
@@ -124,10 +124,11 @@ impl SecretsReader for ProcessSecretsReader {
         Ok(contents)
     }
 
-    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
-        let contents = fs::read(self.secrets_dir.join(internal_secret_file_name(name)))
-            .await
-            .with_context(|| format!("reading secret {name}"))?;
-        Ok(contents)
+    async fn read_internal(&self, name: &str) -> Result<Option<Vec<u8>>, anyhow::Error> {
+        match fs::read(self.secrets_dir.join(internal_secret_file_name(name))).await {
+            Ok(contents) => Ok(Some(contents)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e).with_context(|| format!("reading secret {name}")),
+        }
     }
 }

--- a/src/orchestrator-process/src/secrets.rs
+++ b/src/orchestrator-process/src/secrets.rs
@@ -15,31 +15,54 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_trait::async_trait;
 use mz_repr::CatalogItemId;
-use mz_secrets::{SecretsController, SecretsReader};
+use mz_secrets::{SecretsController, SecretsReader, validate_internal_secret_name};
 use tokio::fs::{self, OpenOptions};
 use tokio::io::AsyncWriteExt;
 
 use crate::ProcessOrchestrator;
 
+/// The file name for an internal secret.
+///
+/// The `internal-` prefix keeps internal secrets disjoint from user secrets, whose file names
+/// are numeric catalog item IDs.
+fn internal_secret_file_name(name: &str) -> String {
+    format!("internal-{name}")
+}
+
+/// Writes a secret file with owner-only permissions.
+async fn write_secret_file(
+    file_path: std::path::PathBuf,
+    contents: &[u8],
+    description: &str,
+) -> Result<(), anyhow::Error> {
+    let mut file = OpenOptions::new()
+        .mode(0o600)
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(file_path)
+        .await
+        .with_context(|| format!("writing secret {description}"))?;
+    file.write_all(contents)
+        .await
+        .with_context(|| format!("writing secret {description}"))?;
+    file.sync_all()
+        .await
+        .with_context(|| format!("writing secret {description}"))?;
+    Ok(())
+}
+
 #[async_trait]
 impl SecretsController for ProcessOrchestrator {
     async fn ensure(&self, id: CatalogItemId, contents: &[u8]) -> Result<(), anyhow::Error> {
         let file_path = self.secrets_dir.join(id.to_string());
-        let mut file = OpenOptions::new()
-            .mode(0o600)
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(file_path)
-            .await
-            .with_context(|| format!("writing secret {id}"))?;
-        file.write_all(contents)
-            .await
-            .with_context(|| format!("writing secret {id}"))?;
-        file.sync_all()
-            .await
-            .with_context(|| format!("writing secret {id}"))?;
-        Ok(())
+        write_secret_file(file_path, contents, &id.to_string()).await
+    }
+
+    async fn ensure_internal(&self, name: &str, contents: &[u8]) -> Result<(), anyhow::Error> {
+        validate_internal_secret_name(name)?;
+        let file_path = self.secrets_dir.join(internal_secret_file_name(name));
+        write_secret_file(file_path, contents, name).await
     }
 
     async fn delete(&self, id: CatalogItemId) -> Result<(), anyhow::Error> {
@@ -49,14 +72,24 @@ impl SecretsController for ProcessOrchestrator {
         Ok(())
     }
 
+    async fn delete_internal(&self, name: &str) -> Result<(), anyhow::Error> {
+        match fs::remove_file(self.secrets_dir.join(internal_secret_file_name(name))).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("deleting secret {name}")),
+        }
+    }
+
     async fn list(&self) -> Result<Vec<CatalogItemId>, anyhow::Error> {
         let mut ids = Vec::new();
         let mut entries = fs::read_dir(&self.secrets_dir)
             .await
             .context("listing secrets")?;
         while let Some(dir) = entries.next_entry().await? {
-            let id: CatalogItemId = dir.file_name().to_string_lossy().parse()?;
-            ids.push(id);
+            // Ignore file names that are not valid user secret IDs, such as internal secrets.
+            if let Ok(id) = dir.file_name().to_string_lossy().parse::<CatalogItemId>() {
+                ids.push(id);
+            }
         }
         Ok(ids)
     }
@@ -88,6 +121,13 @@ impl SecretsReader for ProcessSecretsReader {
         let contents = fs::read(self.secrets_dir.join(id.to_string()))
             .await
             .with_context(|| format!("reading secret {id}"))?;
+        Ok(contents)
+    }
+
+    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
+        let contents = fs::read(self.secrets_dir.join(internal_secret_file_name(name)))
+            .await
+            .with_context(|| format!("reading secret {name}"))?;
         Ok(contents)
     }
 }

--- a/src/orchestrator-process/tests/secrets.rs
+++ b/src/orchestrator-process/tests/secrets.rs
@@ -51,8 +51,8 @@ async fn test_secrets_roundtrip_and_listing() {
     let reader = orchestrator.reader();
     assert_eq!(reader.read(user_id).await.unwrap(), b"user contents");
     assert_eq!(
-        reader.read_internal("ctp-ca").await.unwrap(),
-        b"internal contents"
+        reader.read_internal("ctp-ca").await.unwrap().as_deref(),
+        Some(b"internal contents".as_slice())
     );
 
     // Updates overwrite.
@@ -60,12 +60,15 @@ async fn test_secrets_roundtrip_and_listing() {
         .ensure_internal("ctp-ca", b"rotated")
         .await
         .unwrap();
-    assert_eq!(reader.read_internal("ctp-ca").await.unwrap(), b"rotated");
+    assert_eq!(
+        reader.read_internal("ctp-ca").await.unwrap().as_deref(),
+        Some(b"rotated".as_slice())
+    );
 
     // Deletion is idempotent, and a deleted secret is unreadable.
     orchestrator.delete_internal("ctp-ca").await.unwrap();
     orchestrator.delete_internal("ctp-ca").await.unwrap();
-    assert!(reader.read_internal("ctp-ca").await.is_err());
+    assert_eq!(reader.read_internal("ctp-ca").await.unwrap(), None);
 
     // Invalid internal names are rejected, in particular names that could escape the secrets
     // directory.

--- a/src/orchestrator-process/tests/secrets.rs
+++ b/src/orchestrator-process/tests/secrets.rs
@@ -1,0 +1,78 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Tests for file system backed secrets management.
+
+use mz_orchestrator_process::{ProcessOrchestrator, ProcessOrchestratorConfig};
+use mz_repr::CatalogItemId;
+use mz_secrets::SecretsController;
+
+async fn test_orchestrator(secrets_dir: std::path::PathBuf) -> ProcessOrchestrator {
+    ProcessOrchestrator::new(ProcessOrchestratorConfig {
+        image_dir: secrets_dir.clone(),
+        suppress_output: true,
+        environment_id: "process-secrets-test".into(),
+        scratch_directory: secrets_dir.join("scratch"),
+        secrets_dir,
+        command_wrapper: vec![],
+        propagate_crashes: false,
+        tcp_proxy: None,
+    })
+    .await
+    .expect("creating orchestrator")
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] // uses the file system
+async fn test_secrets_roundtrip_and_listing() {
+    let tempdir = tempfile::tempdir().expect("creating tempdir");
+    let orchestrator = test_orchestrator(tempdir.path().join("secrets")).await;
+
+    let user_id = CatalogItemId::User(1);
+    orchestrator
+        .ensure(user_id, b"user contents")
+        .await
+        .unwrap();
+    orchestrator
+        .ensure_internal("ctp-ca", b"internal contents")
+        .await
+        .unwrap();
+
+    // Internal secrets neither appear in nor break the user secret listing.
+    assert_eq!(orchestrator.list().await.unwrap(), vec![user_id]);
+
+    // Both kinds of secrets are readable through the reader.
+    let reader = orchestrator.reader();
+    assert_eq!(reader.read(user_id).await.unwrap(), b"user contents");
+    assert_eq!(
+        reader.read_internal("ctp-ca").await.unwrap(),
+        b"internal contents"
+    );
+
+    // Updates overwrite.
+    orchestrator
+        .ensure_internal("ctp-ca", b"rotated")
+        .await
+        .unwrap();
+    assert_eq!(reader.read_internal("ctp-ca").await.unwrap(), b"rotated");
+
+    // Deletion is idempotent, and a deleted secret is unreadable.
+    orchestrator.delete_internal("ctp-ca").await.unwrap();
+    orchestrator.delete_internal("ctp-ca").await.unwrap();
+    assert!(reader.read_internal("ctp-ca").await.is_err());
+
+    // Invalid internal names are rejected, in particular names that could escape the secrets
+    // directory.
+    for invalid in ["", "Bad_Name", "../escape", "a/b"] {
+        assert!(
+            orchestrator.ensure_internal(invalid, b"x").await.is_err(),
+            "name {invalid:?} must be rejected"
+        );
+    }
+}

--- a/src/secrets/src/cache.rs
+++ b/src/secrets/src/cache.rs
@@ -182,6 +182,12 @@ impl SecretsReader for CachingSecretsReader {
 
         Ok(value)
     }
+
+    /// Internal secrets are not cached: they are read rarely (typically once, at process
+    /// startup), so caching them would only extend the lifetime of key material in memory.
+    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
+        self.inner.read_internal(name).await
+    }
 }
 
 #[cfg(test)]
@@ -405,6 +411,10 @@ mod test {
             let result = self.reader.read(id).await;
             self.record(id);
             result
+        }
+
+        async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
+            self.reader.read_internal(name).await
         }
     }
 }

--- a/src/secrets/src/cache.rs
+++ b/src/secrets/src/cache.rs
@@ -185,7 +185,7 @@ impl SecretsReader for CachingSecretsReader {
 
     /// Internal secrets are not cached: they are read rarely (typically once, at process
     /// startup), so caching them would only extend the lifetime of key material in memory.
-    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
+    async fn read_internal(&self, name: &str) -> Result<Option<Vec<u8>>, anyhow::Error> {
         self.inner.read_internal(name).await
     }
 }
@@ -413,7 +413,7 @@ mod test {
             result
         }
 
-        async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
+        async fn read_internal(&self, name: &str) -> Result<Option<Vec<u8>>, anyhow::Error> {
             self.reader.read_internal(name).await
         }
     }

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -20,18 +20,55 @@ use mz_repr::CatalogItemId;
 
 pub mod cache;
 
+/// Validates the name of an internal secret.
+///
+/// Internal secret names must be valid across all secrets backends (Kubernetes secret names,
+/// file names, AWS Secrets Manager names), so the accepted alphabet is the conservative
+/// intersection: lowercase alphanumerics and `-`, starting and ending with an alphanumeric,
+/// at most 128 characters.
+pub fn validate_internal_secret_name(name: &str) -> Result<(), anyhow::Error> {
+    let valid = !name.is_empty()
+        && name.len() <= 128
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && !name.starts_with('-')
+        && !name.ends_with('-');
+    if valid {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("invalid internal secret name: {name:?}"))
+    }
+}
+
 /// Securely manages user secrets.
+///
+/// In addition to user secrets, which are keyed by the [`CatalogItemId`] of the corresponding
+/// `CREATE SECRET` item, a controller manages internal secrets, which are keyed by name and hold
+/// system-generated credentials (e.g. transport keys) rather than catalog state. The two
+/// namespaces are disjoint: internal secrets never collide with user secrets and are not
+/// returned by [`list`](SecretsController::list).
 #[async_trait]
 pub trait SecretsController: Debug + Send + Sync {
     /// Creates or updates the specified secret with the specified binary
     /// contents.
     async fn ensure(&self, id: CatalogItemId, contents: &[u8]) -> Result<(), anyhow::Error>;
 
+    /// Creates or updates the specified internal secret with the specified binary contents.
+    ///
+    /// The name must satisfy [`validate_internal_secret_name`].
+    async fn ensure_internal(&self, name: &str, contents: &[u8]) -> Result<(), anyhow::Error>;
+
     /// Deletes the specified secret.
     async fn delete(&self, id: CatalogItemId) -> Result<(), anyhow::Error>;
 
-    /// Lists known secrets. Unrecognized secret objects do not produce an error
-    /// and are ignored.
+    /// Deletes the specified internal secret.
+    ///
+    /// Deleting an internal secret that does not exist is not an error.
+    async fn delete_internal(&self, name: &str) -> Result<(), anyhow::Error>;
+
+    /// Lists known user secrets. Internal secrets are not included.
+    /// Unrecognized secret objects do not produce an error and are ignored.
     async fn list(&self) -> Result<Vec<CatalogItemId>, anyhow::Error>;
 
     /// Returns a reader for the secrets managed by this controller.
@@ -54,6 +91,9 @@ pub trait SecretsReader: Debug + Send + Sync {
     /// Returns the binary contents of the specified secret.
     async fn read(&self, id: CatalogItemId) -> Result<Vec<u8>, anyhow::Error>;
 
+    /// Returns the binary contents of the specified internal secret.
+    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error>;
+
     /// Returns the string contents of the specified secret.
     ///
     /// Returns an error if the secret's contents cannot be decoded as UTF-8.
@@ -66,12 +106,14 @@ pub trait SecretsReader: Debug + Send + Sync {
 #[derive(Debug)]
 pub struct InMemorySecretsController {
     data: Arc<Mutex<BTreeMap<CatalogItemId, Vec<u8>>>>,
+    internal_data: Arc<Mutex<BTreeMap<String, Vec<u8>>>>,
 }
 
 impl InMemorySecretsController {
     pub fn new() -> Self {
         Self {
             data: Arc::new(Mutex::new(BTreeMap::new())),
+            internal_data: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 }
@@ -83,8 +125,22 @@ impl SecretsController for InMemorySecretsController {
         Ok(())
     }
 
+    async fn ensure_internal(&self, name: &str, contents: &[u8]) -> Result<(), anyhow::Error> {
+        validate_internal_secret_name(name)?;
+        self.internal_data
+            .lock()
+            .unwrap()
+            .insert(name.to_string(), contents.to_vec());
+        Ok(())
+    }
+
     async fn delete(&self, id: CatalogItemId) -> Result<(), anyhow::Error> {
         self.data.lock().unwrap().remove(&id);
+        Ok(())
+    }
+
+    async fn delete_internal(&self, name: &str) -> Result<(), anyhow::Error> {
+        self.internal_data.lock().unwrap().remove(name);
         Ok(())
     }
 
@@ -95,6 +151,7 @@ impl SecretsController for InMemorySecretsController {
     fn reader(&self) -> Arc<dyn SecretsReader> {
         Arc::new(InMemorySecretsController {
             data: Arc::clone(&self.data),
+            internal_data: Arc::clone(&self.internal_data),
         })
     }
 }
@@ -104,5 +161,56 @@ impl SecretsReader for InMemorySecretsController {
     async fn read(&self, id: CatalogItemId) -> Result<Vec<u8>, anyhow::Error> {
         let contents = self.data.lock().unwrap().get(&id).cloned();
         contents.ok_or_else(|| anyhow::anyhow!("secret does not exist"))
+    }
+
+    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
+        let contents = self.internal_data.lock().unwrap().get(name).cloned();
+        contents.ok_or_else(|| anyhow::anyhow!("secret does not exist"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test(tokio::test)]
+    async fn test_in_memory_internal_secrets_roundtrip() {
+        let controller = InMemorySecretsController::new();
+
+        controller
+            .ensure_internal("ctp-ca", b"key material")
+            .await
+            .unwrap();
+        let reader = controller.reader();
+        assert_eq!(
+            reader.read_internal("ctp-ca").await.unwrap(),
+            b"key material"
+        );
+
+        // Internal secrets do not appear in the user secret listing, and do not collide with
+        // user secrets of a numeric name.
+        let id = CatalogItemId::User(1);
+        controller.ensure(id, b"user").await.unwrap();
+        assert_eq!(controller.list().await.unwrap(), vec![id]);
+        assert_eq!(reader.read(id).await.unwrap(), b"user");
+
+        controller.delete_internal("ctp-ca").await.unwrap();
+        assert!(reader.read_internal("ctp-ca").await.is_err());
+        // Deleting a nonexistent internal secret is not an error.
+        controller.delete_internal("ctp-ca").await.unwrap();
+    }
+
+    #[mz_ore::test]
+    fn test_validate_internal_secret_name() {
+        for valid in ["a", "ctp-ca", "cluster-u1-replica-u3", "0-a-9"] {
+            validate_internal_secret_name(valid).unwrap();
+        }
+        let too_long = "a".repeat(129);
+        for invalid in ["", "-a", "a-", "A", "a_b", "a.b", "a/b", "ä", &too_long] {
+            assert!(
+                validate_internal_secret_name(invalid).is_err(),
+                "name {invalid:?} must be rejected"
+            );
+        }
     }
 }

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -91,8 +91,14 @@ pub trait SecretsReader: Debug + Send + Sync {
     /// Returns the binary contents of the specified secret.
     async fn read(&self, id: CatalogItemId) -> Result<Vec<u8>, anyhow::Error>;
 
-    /// Returns the binary contents of the specified internal secret.
-    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error>;
+    /// Returns the binary contents of the specified internal secret, or `None` if the secret
+    /// does not exist.
+    ///
+    /// Nonexistence is reported in-band (rather than as an error) because callers bootstrapping
+    /// credentials must distinguish "not created yet" from transient read failures. Treating a
+    /// transient failure as nonexistence could cause a caller to regenerate and overwrite live
+    /// key material.
+    async fn read_internal(&self, name: &str) -> Result<Option<Vec<u8>>, anyhow::Error>;
 
     /// Returns the string contents of the specified secret.
     ///
@@ -163,9 +169,8 @@ impl SecretsReader for InMemorySecretsController {
         contents.ok_or_else(|| anyhow::anyhow!("secret does not exist"))
     }
 
-    async fn read_internal(&self, name: &str) -> Result<Vec<u8>, anyhow::Error> {
-        let contents = self.internal_data.lock().unwrap().get(name).cloned();
-        contents.ok_or_else(|| anyhow::anyhow!("secret does not exist"))
+    async fn read_internal(&self, name: &str) -> Result<Option<Vec<u8>>, anyhow::Error> {
+        Ok(self.internal_data.lock().unwrap().get(name).cloned())
     }
 }
 
@@ -183,8 +188,8 @@ mod tests {
             .unwrap();
         let reader = controller.reader();
         assert_eq!(
-            reader.read_internal("ctp-ca").await.unwrap(),
-            b"key material"
+            reader.read_internal("ctp-ca").await.unwrap().as_deref(),
+            Some(b"key material".as_slice())
         );
 
         // Internal secrets do not appear in the user secret listing, and do not collide with
@@ -195,7 +200,7 @@ mod tests {
         assert_eq!(reader.read(id).await.unwrap(), b"user");
 
         controller.delete_internal("ctp-ca").await.unwrap();
-        assert!(reader.read_internal("ctp-ca").await.is_err());
+        assert_eq!(reader.read_internal("ctp-ca").await.unwrap(), None);
         // Deleting a nonexistent internal secret is not an error.
         controller.delete_internal("ctp-ca").await.unwrap();
     }


### PR DESCRIPTION
### Motivation

PR 2 of 3 toward encrypting the cluster transport protocol (see #37995 for the stack overview). The controller needs to distribute system-generated credentials (a per-environment CA, per-replica TLS keys) to clusterd processes. The right channel already exists — environmentd writes secrets through `SecretsController` and every clusterd boots with a `SecretsReader` — but both traits are keyed by `CatalogItemId`, and transport credentials are not catalog items.

This PR adds internal secrets: name-keyed secrets for system-generated credentials, alongside the id-keyed user secrets. It is independent of #37995 and reviewable standalone; the wiring PR depends on both.

### Design

* `ensure_internal(name, contents)` / `delete_internal(name)` on `SecretsController`, `read_internal(name)` on `SecretsReader`.
* **Disjoint namespaces in every backend.** Kubernetes: `{prefix}internal-{name}` next to the existing `{prefix}user-managed-{id}`. Process orchestrator: `internal-{name}` files next to bare `{id}` files. AWS: `{prefix}internal-{name}` next to `{prefix}{id}`. Internal secrets are excluded from `list()`, whose parsers only recognize user secret names.
* **Name validation** (`validate_internal_secret_name`): lowercase alphanumerics and dashes only, so names are valid in all backends and cannot traverse paths. Enforced at every `ensure_internal` entry point.
* **The caching reader does not cache internal secrets.** They are read rarely (typically once at process startup), so caching would only extend the lifetime of key material in memory.

### Behavior changes

* The process orchestrator's `list()` previously **errored** on any file in the secrets directory whose name did not parse as a `CatalogItemId`. It now skips such files, matching the documented behavior (and the Kubernetes backend's behavior) of ignoring unrecognized objects.
* The AWS reader's log line now reports the full secret name rather than the bare id (the read path is shared between user and internal secrets).
* `ensure`/`delete`/`read` bodies in the Kubernetes and AWS backends moved into name-keyed helpers shared with the internal variants; no functional change beyond the above.

### Testing

* `mz-secrets`: unit tests for the in-memory controller round-trip (including namespace disjointness with a user secret and idempotent deletion) and for name validation accept/reject cases.
* `mz-orchestrator-process`: new integration test covering round-trip, overwrite, idempotent delete, `list()` skipping internal files instead of erroring, and rejection of path-traversal names.
* The Kubernetes and AWS backends have no existing test harness; their internal-name mapping is pure string construction exercised end-to-end in the wiring PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)