### PR TITLE
ci: Reduce parallelism a bit & don't start CI agents too early

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -546,7 +546,7 @@ def increase_agents_timeouts(
                 step["name"] = "Build aarch64 with coverage"
             if step.get("id") == "cargo-test":
                 step["agents"]["queue"] = "hetzner-x86-64-dedi-32cpu-128gb"
-                del step["parallelism"]
+                step.pop("parallelism", None)
     else:
         for step in steps(pipeline):
             if step.get("coverage") == "only":

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -376,15 +376,7 @@ so it is executed.""",
     move_build_to_lto(pipeline, lto)
     trim_builds_prep_thread.join()
     trim_builds(pipeline, hash_check)
-    add_cargo_test_dependency(
-        pipeline,
-        args.pipeline,
-        args.coverage,
-        args.sanitizer,
-        lto,
-    )
     add_nightly_deploy_dependency(pipeline, args.pipeline)
-    remove_dependencies_on_prs(pipeline, args.pipeline, hash_check)
     remove_mz_specific_keys(pipeline)
 
     print("--- Uploading new pipeline:")
@@ -1188,90 +1180,6 @@ def add_nightly_deploy_dependency(pipeline: Any, pipeline_name: str) -> None:
             step["depends_on"] = "deploy"
 
         previous_step = step
-
-
-def add_cargo_test_dependency(
-    pipeline: Any,
-    pipeline_name: str,
-    coverage: bool,
-    sanitizer: Sanitizer,
-    lto: bool,
-) -> None:
-    """Cargo Test normally doesn't have to wait for the build to complete, but it requires a few images (debian-base, postgres), which are rarely changed. So only add a dependency when those images are not on Dockerhub yet."""
-    if pipeline_name not in ("test", "nightly"):
-        return
-    if ui.env_is_truthy("BUILDKITE_PULL_REQUEST") and pipeline_name == "test":
-        for step in steps(pipeline):
-            if step.get("id") == "cargo-test":
-                step["depends_on"] = "build-x86_64"
-        return
-
-    repo = mzbuild.Repository(
-        Path("."),
-        arch=Arch.X86_64,
-        profile=mzbuild.Profile.RELEASE if lto else mzbuild.Profile.OPTIMIZED,
-        coverage=coverage,
-        sanitizer=sanitizer,
-    )
-    composition = Composition(repo, name="cargo-test")
-    deps = composition.dependencies
-    if deps.check():
-        # We already have the dependencies available, no need to add a build dependency
-        return
-
-    for step in steps(pipeline):
-        if step.get("id") in ("cargo-test", "miri-test"):
-            step["depends_on"] = (
-                "build-x86_64" if "x86" in step["agents"]["queue"] else "build-aarch64"
-            )
-
-
-def remove_dependencies_on_prs(
-    pipeline: Any,
-    pipeline_name: str,
-    hash_check: dict[Arch, tuple[str, bool]],
-) -> None:
-    """On test-pipeline PRs, let single-architecture consumers retry for their image instead of waiting for its build."""
-    if pipeline_name != "test":
-        return
-    if (
-        not ui.env_is_truthy("BUILDKITE_PULL_REQUEST")
-        or os.environ["BUILDKITE_TAG"]
-        or ui.env_is_truthy("CI_RELEASE_LTO_BUILD")
-        or os.environ["BUILDKITE_BRANCH"].startswith("dependabot/")
-    ):
-        return
-    build_image_exists = {
-        "build-x86_64": hash_check[Arch.X86_64][1],
-        "build-aarch64": hash_check[Arch.AARCH64][1],
-    }
-    for step in steps(pipeline):
-        if step.get("id") in (
-            "upload-debug-symbols-x86_64",
-            "upload-debug-symbols-aarch64",
-        ):
-            continue
-        d = step.get("depends_on")
-        if d is None:
-            continue
-        deps = [d] if isinstance(d, str) else list(d)
-        build_deps = [dep for dep in deps if dep in build_image_exists]
-        # CI_WAITING_FOR_BUILD tracks one build's status. A multi-architecture
-        # consumer needs every build, so it cannot safely use that contract.
-        if len(build_deps) > 1:
-            continue
-        # Drop the build dependency whose image isn't published yet, so the
-        # consumer starts immediately and keeps retrying for the Docker image.
-        missing_build_deps = [dep for dep in build_deps if not build_image_exists[dep]]
-        if not missing_build_deps:
-            continue
-        waiting_for_build = missing_build_deps[0]
-        step.setdefault("env", {})["CI_WAITING_FOR_BUILD"] = waiting_for_build
-        remaining = [dep for dep in deps if dep != waiting_for_build]
-        if remaining:
-            step["depends_on"] = remaining
-        else:
-            del step["depends_on"]
 
 
 def move_build_to_lto(pipeline: Any, lto: bool) -> None:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -163,7 +163,7 @@ steps:
   - id: miri-test
     topics: [kafka, postgres]
     label: ":rust: Miri test (full)"
-    depends_on: []
+    depends_on: build-aarch64
     timeout_in_minutes: 60
     plugins:
       - ./ci/plugins/mzcompose:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -129,7 +129,7 @@ steps:
           - "**/*.rs"
         depends_on: []
         timeout_in_minutes: 60
-        parallelism: 8
+        parallelism: 4
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         sanitizer: skip
@@ -181,7 +181,7 @@ steps:
         label: "Feature benchmark against merge base or 'latest'"
         depends_on: build-x86_64
         timeout_in_minutes: 120
-        parallelism: 12
+        parallelism: 6
         agents:
           queue: hetzner-x86-64-dedi-16cpu-64gb
         plugins:
@@ -202,7 +202,7 @@ steps:
         agents:
           # Larger instance is more stable in performance
           queue: hetzner-x86-64-dedi-16cpu-64gb
-        parallelism: 4
+        parallelism: 2
         plugins:
           - ./ci/plugins/mzcompose:
               composition: scalability
@@ -222,7 +222,6 @@ steps:
         label: "Scalability benchmark (DDL) against merge base or 'latest'"
         depends_on: build-x86_64
         timeout_in_minutes: 120
-        parallelism: 2
         env:
           # Runs against Dockerhub directly
           MZ_GHCR: 0
@@ -252,7 +251,6 @@ steps:
         label: "Scalability benchmark (connection) against merge base or 'latest'"
         depends_on: build-x86_64
         timeout_in_minutes: 120
-        parallelism: 2
         env:
           # Runs against Dockerhub directly
           MZ_GHCR: 0
@@ -299,7 +297,7 @@ steps:
         label: "Workload Replay (1% initial data)"
         depends_on: build-x86_64
         timeout_in_minutes: 120
-        parallelism: 5
+        parallelism: 3
         plugins:
           - ./ci/plugins/mzcompose:
               composition: workload-replay
@@ -494,7 +492,7 @@ steps:
               composition: limits
               run: main
         timeout_in_minutes: 60
-        parallelism: 3
+        parallelism: 2
 
       - id: limits-instance-size
         topics: [cockroach, iceberg, kafka, kafka-sink, mysql, postgres, sql-server]
@@ -513,7 +511,7 @@ steps:
         label: "Bounded Memory"
         depends_on: build-aarch64
         timeout_in_minutes: 60
-        parallelism: 3
+        parallelism: 2
         agents:
           queue: hetzner-aarch64-4cpu-8gb
         plugins:
@@ -524,7 +522,7 @@ steps:
         label: "Bounded Memory Search (materialized only)"
         depends_on: build-aarch64
         timeout_in_minutes: 60
-        parallelism: 8
+        parallelism: 4
         skip: "disabled by default"
         agents:
           queue: hetzner-aarch64-8cpu-16gb
@@ -804,7 +802,6 @@ steps:
       - id: mysql-cdc-resumption
         topics: [mysql]
         label: MySQL CDC resumption
-        parallelism: 2
         depends_on: build-aarch64
         timeout_in_minutes: 60
         inputs: [test/mysql-cdc-resumption]
@@ -817,7 +814,6 @@ steps:
       - id: pg-cdc-resumption
         topics: [postgres]
         label: Postgres CDC resumption
-        parallelism: 2
         depends_on: build-aarch64
         timeout_in_minutes: 60
         inputs: [test/pg-cdc-resumption]
@@ -874,7 +870,6 @@ steps:
         label: MySQL CDC resumption (before source versioning)
         depends_on: build-aarch64
         timeout_in_minutes: 60
-        parallelism: 2
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc-resumption-old-syntax
@@ -909,7 +904,6 @@ steps:
         label: Postgres CDC source-versioning migration
         depends_on: build-aarch64
         timeout_in_minutes: 60
-        parallelism: 2
         plugins:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc-old-syntax
@@ -990,7 +984,7 @@ steps:
               run: migration
         agents:
           queue: hetzner-aarch64-16cpu-32gb
-        parallelism: 4
+        parallelism: 2
 
       - id: sql-server-cdc-old-syntax
         topics: [sql-server]
@@ -1208,7 +1202,7 @@ steps:
         label: "Checks Self-Managed upgrade, whole-Mz restart"
         depends_on: build-x86_64
         timeout_in_minutes: 60
-        parallelism: 4
+        parallelism: 2
         agents:
           queue: hetzner-x86-64-12cpu-24gb
         plugins:
@@ -1221,7 +1215,7 @@ steps:
         label: "Checks Self-Managed upgrade from previous, whole-Mz restart"
         depends_on: build-x86_64
         timeout_in_minutes: 60
-        parallelism: 4
+        parallelism: 2
         agents:
           queue: hetzner-x86-64-12cpu-24gb
         plugins:
@@ -1234,7 +1228,7 @@ steps:
         label: "Checks upgrade v80 migration"
         depends_on: build-x86_64
         timeout_in_minutes: 60
-        parallelism: 4
+        parallelism: 2
         agents:
           queue: hetzner-x86-64-12cpu-24gb
         plugins:
@@ -1261,7 +1255,7 @@ steps:
         label: "Checks 0dt restart of the entire Mz with forced migrations"
         depends_on: build-x86_64
         timeout_in_minutes: 60
-        parallelism: 4
+        parallelism: 2
         agents:
           queue: hetzner-x86-64-12cpu-24gb
         plugins:
@@ -1313,9 +1307,9 @@ steps:
         label: "Platform checks upgrade in Cloudtest/K8s"
         depends_on: build-x86_64
         timeout_in_minutes: 60
+        parallelism: 2
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
-        parallelism: 2
         agents:
           # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
           queue: linux-x86_64-large
@@ -2075,7 +2069,6 @@ steps:
       label: "Data Ingest (1 replica)"
       depends_on: build-x86_64
       timeout_in_minutes: 90
-      parallelism: 2
       agents:
         queue: hetzner-x86-64-4cpu-8gb
       plugins:
@@ -2089,7 +2082,6 @@ steps:
       label: "Data Ingest (2 replicas)"
       depends_on: build-x86_64
       timeout_in_minutes: 90
-      parallelism: 2
       agents:
         queue: hetzner-x86-64-4cpu-8gb
       plugins:
@@ -2103,7 +2095,6 @@ steps:
       label: "Data Ingest (8 replicas)"
       depends_on: build-x86_64
       timeout_in_minutes: 90
-      parallelism: 2
       agents:
         queue: hetzner-x86-64-8cpu-16gb
       plugins:
@@ -2387,7 +2378,6 @@ steps:
     label: "Txn-wal fencing with :azure: blob store"
     depends_on: build-aarch64
     timeout_in_minutes: 60
-    parallelism: 2
     plugins:
       - ./ci/plugins/mzcompose:
           composition: txn-wal-fencing
@@ -2461,7 +2451,7 @@ steps:
     label: Zero downtime
     depends_on: build-x86_64
     timeout_in_minutes: 60
-    parallelism: 4
+    parallelism: 2
     plugins:
       - ./ci/plugins/mzcompose:
           composition: 0dt
@@ -2745,7 +2735,7 @@ steps:
     label: ":bulb: SLT (2 replicas)"
     depends_on: build-aarch64
     timeout_in_minutes: 60
-    parallelism: 10
+    parallelism: 5
     agents:
       queue: hetzner-aarch64-16cpu-32gb
     plugins:

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -37,7 +37,6 @@ class ImagesNotPublicError(Exception):
 
 def main() -> None:
     try:
-        set_build_status("pending")
         coverage = ui.env_is_truthy("CI_COVERAGE_ENABLED")
         sanitizer = Sanitizer[os.getenv("CI_SANITIZER", "none")]
 
@@ -68,10 +67,8 @@ def main() -> None:
             deps.ensure(pre_build=lambda images: upload_debuginfo(repo, images))
             if public_check is not None:
                 public_check.result()
-        set_build_status("success")
         annotate_buildkite_with_tags(repo.rd.arch, deps)
     except RustIncrementalBuildFailure:
-        mark_failed_after_last_retry()
         print(
             "--- Detected incremental build failure, clearing cargo target directories"
         )
@@ -80,34 +77,8 @@ def main() -> None:
                 shutil.rmtree(dir, ignore_errors=True)
         sys.exit(199)
     except CargoRegistryFetchFailure:
-        mark_failed_after_last_retry()
         print("--- Detected transient cargo registry failure, retrying")
         sys.exit(199)
-    except:
-        set_build_status("failed")
-        raise
-
-
-def mark_failed_after_last_retry() -> None:
-    """Report the build as failed only once its automatic retries are used up.
-
-    Exit code 199 gets two automatic retries, see mkpipeline.py.
-    """
-    if int(os.getenv("BUILDKITE_RETRY_COUNT", "0")) >= 2:
-        set_build_status("failed")
-
-
-def set_build_status(status: str) -> None:
-    if step_key := os.getenv("BUILDKITE_STEP_KEY"):
-        spawn.runv(
-            [
-                "buildkite-agent",
-                "meta-data",
-                "set",
-                step_key,
-                status,
-            ]
-        )
 
 
 def check_images_public(deps: mzbuild.DependencySet) -> None:

--- a/ci/test/lint-main/checks/check-pipeline.sh
+++ b/ci/test/lint-main/checks/check-pipeline.sh
@@ -28,7 +28,6 @@ unset CI_TEST_IDS
 unset CI_TEST_SELECTION
 unset CI_SANITIZER
 unset CI_COVERAGE_ENABLED
-unset CI_WAITING_FOR_BUILD
 
 pids=()
 for pipeline in $(find ci -name "pipeline.template.yml" -not -path "ci/test/pipeline.template.yml" -exec dirname {} \; | cut -d/ -f2); do

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -277,7 +277,7 @@ steps:
       - "**/*.pt"
       - "**/*.proto"
       - "**/testdata/**"
-    depends_on: []
+    depends_on: build-x86_64
     env:
       AWS_DEFAULT_REGION: "us-east-1"
       # cargo-test's coverage is handled separately by cargo-llvm-cov

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -278,7 +278,6 @@ steps:
       - "**/*.proto"
       - "**/testdata/**"
     depends_on: []
-    parallelism: 2
     env:
       AWS_DEFAULT_REGION: "us-east-1"
       # cargo-test's coverage is handled separately by cargo-llvm-cov
@@ -298,7 +297,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 40
     inputs: [test/testdrive]
-    parallelism: 20
+    parallelism: 8
     plugins:
       - ./ci/plugins/mzcompose:
           composition: testdrive
@@ -311,7 +310,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 30
     inputs: [test/cluster]
-    parallelism: 16
+    parallelism: 5
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cluster
@@ -323,7 +322,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 30
     inputs: [test/sqllogictest]
-    parallelism: 5
+    parallelism: 2
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
@@ -337,7 +336,6 @@ steps:
     label: Restart
     depends_on: build-aarch64
     timeout_in_minutes: 30
-    parallelism: 2
     plugins:
       - ./ci/plugins/mzcompose:
           composition: restart
@@ -350,7 +348,7 @@ steps:
       - id: mysql-cdc
         topics: [mysql]
         label: MySQL CDC
-        parallelism: 5
+        parallelism: 2
         depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/mysql-cdc]
@@ -378,7 +376,6 @@ steps:
       - id: pg-cdc
         topics: [postgres]
         label: Postgres CDC
-        parallelism: 6
         depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/pg-cdc]
@@ -422,7 +419,6 @@ steps:
         depends_on: build-x86_64
         timeout_in_minutes: 40
         inputs: [test/ssh-connection]
-        parallelism: 3
         plugins:
           - ./ci/plugins/mzcompose:
               composition: ssh-connection
@@ -449,7 +445,6 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 30
         inputs: [test/kafka-auth]
-        parallelism: 3
         plugins:
           - ./ci/plugins/mzcompose:
               composition: kafka-auth
@@ -522,7 +517,7 @@ steps:
     depends_on: build-x86_64
     inputs: [misc/python/materialize/checks]
     timeout_in_minutes: 45
-    parallelism: 8
+    parallelism: 2
     agents:
       # Uses SQL Server, which is not yet available for ARM
       queue: hetzner-x86-64-8cpu-16gb
@@ -558,7 +553,6 @@ steps:
     topics: [kafka, kafka-sink, postgres]
     label: "S&S error reporting"
     depends_on: build-aarch64
-    parallelism: 3
     timeout_in_minutes: 30
     agents:
       queue: hetzner-aarch64-4cpu-8gb
@@ -607,7 +601,6 @@ steps:
     label: dbt-materialize
     depends_on: build-aarch64
     timeout_in_minutes: 30
-    parallelism: 2
     plugins:
       - ./ci/plugins/mzcompose:
           composition: dbt-materialize

--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -10,7 +10,6 @@
 """Buildkite utilities."""
 
 import os
-import subprocess
 from collections.abc import Callable
 from enum import Enum, auto
 from pathlib import Path
@@ -326,10 +325,3 @@ def get_job_url_from_pipeline_and_build(
 ) -> str:
     build_url = f"https://buildkite.com/materialize/{pipeline}/builds/{build_number}"
     return get_job_url_from_build_url(build_url, build_job_id)
-
-
-def get_build_status(build: str) -> str:
-    return spawn.capture(
-        ["buildkite-agent", "meta-data", "get", build],
-        stderr=subprocess.DEVNULL,
-    )

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -46,7 +46,7 @@ import requests
 import yaml
 from requests.auth import HTTPBasicAuth
 
-from materialize import MZ_ROOT, buildkite, cargo, git, rustc_flags, spawn, ui, xcompile
+from materialize import MZ_ROOT, cargo, git, rustc_flags, spawn, ui, xcompile
 from materialize.docker import image_registry
 from materialize.rustc_flags import Sanitizer
 from materialize.xcompile import Arch, target
@@ -1199,30 +1199,9 @@ class ResolvedImage:
                         # happened based on error code
                         # (https://github.com/docker/cli/issues/538) and we
                         # want to print output directly to terminal.
-                        if build := os.getenv("CI_WAITING_FOR_BUILD"):
-                            for retry in range(max_retries):
-                                try:
-                                    build_status = buildkite.get_build_status(build)
-                                except subprocess.CalledProcessError:
-                                    time.sleep(sleep_time)
-                                    sleep_time = min(sleep_time * 2, 10)
-                                    break
-                                print(f"Build {build} status: {build_status}")
-                                if build_status == "failed":
-                                    print(
-                                        f"Build {build} has been marked as failed, exiting hard"
-                                    )
-                                    sys.exit(1)
-                                elif build_status == "success":
-                                    break
-                                assert (
-                                    build_status == "pending"
-                                ), f"Unknown build status {build_status}"
-                                time.sleep(1)
-                        else:
-                            print(f"Retrying in {sleep_time}s ...")
-                            time.sleep(sleep_time)
-                            sleep_time = min(sleep_time * 2, 10)
+                        print(f"Retrying in {sleep_time}s ...")
+                        time.sleep(sleep_time)
+                        sleep_time = min(sleep_time * 2, 10)
                         continue
                     else:
                         break
@@ -1427,14 +1406,10 @@ class DependencySet:
         # Only retry in CI runs since we struggle with flaky docker pulls there
         if not max_retries:
             max_retries = (
-                90
-                if os.getenv("CI_WAITING_FOR_BUILD")
-                else (
-                    5
-                    if ui.env_is_truthy("CI")
-                    and not ui.env_is_truthy("CI_ALLOW_LOCAL_BUILD")
-                    else 1
-                )
+                5
+                if ui.env_is_truthy("CI")
+                and not ui.env_is_truthy("CI_ALLOW_LOCAL_BUILD")
+                else 1
             )
         assert max_retries > 0
 

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -369,7 +369,6 @@ class Composition:
         max_tries: int = 1,
         silent: bool = False,
         environment: dict[str, str] | None = None,
-        build: str | None = None,
         print_prefix: str | None = None,
     ) -> subprocess.CompletedProcess:
         """Invoke `docker compose` on the rendered composition.
@@ -547,35 +546,16 @@ class Composition:
 
                 if retry < max_tries:
                     print("Retrying ...")
-                    if build:
-                        for retry in range(max_tries):
-                            try:
-                                build_status = buildkite.get_build_status(build)
-                            except subprocess.CalledProcessError:
-                                time.sleep(3)
-                                break
-                            if build_status == "failed":
-                                print(
-                                    f"Build {build} has been marked as failed, exiting hard"
-                                )
-                                sys.exit(1)
-                            elif build_status == "success":
-                                break
-                            assert (
-                                build_status == "pending"
-                            ), f"Unknown build status {build_status}"
-                            time.sleep(1)
-                    else:
-                        # Back off exponentially rather than sleeping a flat
-                        # 3s each time. The only `invoke` callers that retry
-                        # (max_tries > 1) are image pulls (`up`, `pull`), and a
-                        # freshly-built mzbuild image can briefly fail to
-                        # resolve in the registry ("failed to resolve reference
-                        # ... not found") before it has propagated. With a flat
-                        # 3s sleep, `up`'s tries exhausted in seconds, which was
-                        # too short to ride out the propagation delay; the cap
-                        # plus `up`'s try count govern the total wait (see there).
-                        time.sleep(min(3 * 2 ** (retry - 1), 30))
+                    # Back off exponentially rather than sleeping a flat
+                    # 3s each time. The only `invoke` callers that retry
+                    # (max_tries > 1) are image pulls (`up`, `pull`), and a
+                    # freshly-built mzbuild image can briefly fail to
+                    # resolve in the registry ("failed to resolve reference
+                    # ... not found") before it has propagated. With a flat
+                    # 3s sleep, `up`'s tries exhausted in seconds, which was
+                    # too short to ride out the propagation delay; the cap
+                    # plus `up`'s try count govern the total wait (see there).
+                    time.sleep(min(3 * 2 ** (retry - 1), 30))
                     continue
                 else:
                     raise CommandFailureCausedUIError(
@@ -1270,8 +1250,7 @@ class Composition:
                 *(["--wait"] if wait else []),
                 *(["--quiet-pull"] if ui.env_is_truthy("CI") else []),
                 *service_names,
-                max_tries=300 if os.getenv("CI_WAITING_FOR_BUILD") else max_tries,
-                build=os.getenv("CI_WAITING_FOR_BUILD"),
+                max_tries=max_tries,
             )
         finally:
             # Restore even on failure: otherwise the next test in the same

--- a/test/mz-deploy/mzcompose.py
+++ b/test/mz-deploy/mzcompose.py
@@ -191,18 +191,6 @@ def setup_base(c: Composition) -> None:
     c.down(destroy_volumes=True)
     c.up("postgres", "materialized")
 
-    # On PRs, mkpipeline drops this job's dependency on the image build so it
-    # starts immediately while the build runs concurrently, signalled by
-    # CI_WAITING_FOR_BUILD (see remove_dependencies_on_prs). `c.run` issues a
-    # plain pull with no retry, so the first mz-deploy invocation would fail if
-    # the image hasn't been pushed yet. Pull it up front, polling the build the
-    # same way `c.up` does for the other services. Only needed in that CI
-    # window; locally the image is loaded directly and never pulled.
-    if build := os.getenv("CI_WAITING_FOR_BUILD"):
-        c.invoke(
-            "pull", "mz-deploy", max_tries=300, build=build, stdin=subprocess.DEVNULL
-        )
-
     # Ensure profiles exist before first run_mz_deploy call
     create_profiles()
 

--- a/test/testdrive/copy-from-s3-minio-parquet.td
+++ b/test/testdrive/copy-from-s3-minio-parquet.td
@@ -23,7 +23,7 @@ $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.mater
     REGION = 'us-east-1'
   );
 
-$ s3-upload-parquet-types bucket=copyfroms3 key-prefix=parquet/types.parquet
+$ s3-upload-parquet-types bucket=copyfroms3 key-prefix=parquet-types/types.parquet
 
 # Create a custom type for a composite type
 > CREATE TYPE record_type AS (name text, age int, avg double precision);
@@ -59,7 +59,7 @@ $ s3-upload-parquet-types bucket=copyfroms3 key-prefix=parquet/types.parquet
   map_col map[text => text]
   );
 
-$ s3-set-presigned-url bucket=copyfroms3 key=parquet/types.parquet var-name=types_url
+$ s3-set-presigned-url bucket=copyfroms3 key=parquet-types/types.parquet var-name=types_url
 
 > COPY INTO types FROM '${types_url}' (FORMAT PARQUET);
 
@@ -94,7 +94,7 @@ Taco
 
 
 # gzip Compression.
-$ s3-set-presigned-url bucket=copyfroms3 key=parquet/types.parquet.gzip var-name=gzip_types_url
+$ s3-set-presigned-url bucket=copyfroms3 key=parquet-types/types.parquet.gzip var-name=gzip_types_url
 
 > COPY INTO types FROM '${gzip_types_url}' (FORMAT PARQUET);
 
@@ -128,7 +128,7 @@ Taco
 0
 
 # snappy Compression.
-$ s3-set-presigned-url bucket=copyfroms3 key=parquet/types.parquet.snappy var-name=snappy_types_url
+$ s3-set-presigned-url bucket=copyfroms3 key=parquet-types/types.parquet.snappy var-name=snappy_types_url
 
 > COPY INTO types FROM '${snappy_types_url}' (FORMAT PARQUET);
 
@@ -162,7 +162,7 @@ Taco
 0
 
 # brotli Compression.
-$ s3-set-presigned-url bucket=copyfroms3 key=parquet/types.parquet.brotli var-name=brotli_types_url
+$ s3-set-presigned-url bucket=copyfroms3 key=parquet-types/types.parquet.brotli var-name=brotli_types_url
 
 > COPY INTO types FROM '${brotli_types_url}' (FORMAT PARQUET);
 
@@ -196,7 +196,7 @@ Taco
 0
 
 # zstd Compression.
-$ s3-set-presigned-url bucket=copyfroms3 key=parquet/types.parquet.zstd var-name=zstd_types_url
+$ s3-set-presigned-url bucket=copyfroms3 key=parquet-types/types.parquet.zstd var-name=zstd_types_url
 
 > COPY INTO types FROM '${zstd_types_url}' (FORMAT PARQUET);
 
@@ -230,7 +230,7 @@ Taco
 0
 
 # lz4 Compression.
-$ s3-set-presigned-url bucket=copyfroms3 key=parquet/types.parquet.lz4 var-name=lz4_types_url
+$ s3-set-presigned-url bucket=copyfroms3 key=parquet-types/types.parquet.lz4 var-name=lz4_types_url
 
 > COPY INTO types FROM '${lz4_types_url}' (FORMAT PARQUET);
 
@@ -268,8 +268,12 @@ Taco
 # Test the AWS Source.
 
 
-# Test glob patterns.
-> COPY INTO types FROM 's3://copyfroms3/parquet' (FORMAT PARQUET, AWS CONNECTION = aws_conn);
+# Test glob patterns. This matches every key under the `parquet-types/` prefix,
+# so that prefix must stay exclusive to this file. The `copyfroms3` bucket is
+# shared by every testdrive file in the run, and an unrelated file's parquet
+# object landing under this prefix would be copied into `types` too and fail on
+# the column count.
+> COPY INTO types FROM 's3://copyfroms3/parquet-types' (FORMAT PARQUET, AWS CONNECTION = aws_conn);
 
 > SELECT COUNT(*) FROM types;
 18


### PR DESCRIPTION
New target times for tests:

Test pipeline: 5 min -> 10 min
Nightly pipeline: 30 min -> 60 min

This reduces CI cost by a bit.