### PR TITLE
CNS-120 In Console, cluster list now pulls data from SUBSCRIBE

### DIFF
--- a/console/src/platform/clusters/ClusterDetail.tsx
+++ b/console/src/platform/clusters/ClusterDetail.tsx
@@ -45,7 +45,7 @@ const ClusterDetailBreadcrumbs = (props: { crumbs: Breadcrumb[] }) => {
   const [showSystemObjects] = useShowSystemObjects();
   const { clusterId, clusterName } = useParams<ClusterParams>();
   const { data: clusters, getClusterById } = useAllClusters();
-  const { data: ownersById, isPending: isOwnersPending } = useOwners();
+  const { isOwner } = useOwners();
   const { pathname, search } = useLocation();
   assert(clusterId);
   assert(clusterName);
@@ -85,13 +85,7 @@ const ClusterDetailBreadcrumbs = (props: { crumbs: Breadcrumb[] }) => {
       rightSideChildren={
         cluster && (
           <OverflowMenuContainer
-            cluster={{
-              ...cluster,
-              // Treat an in-flight owners query as non-owner so owner-only menu
-              // items stay hidden until ownership is known.
-              isOwner:
-                !isOwnersPending && (ownersById?.get(cluster.ownerId) ?? false),
-            }}
+            cluster={{ ...cluster, isOwner: isOwner(cluster.ownerId) }}
           />
         )
       }

--- a/console/src/platform/clusters/ClusterReplicas.tsx
+++ b/console/src/platform/clusters/ClusterReplicas.tsx
@@ -73,13 +73,8 @@ const ClusterReplicasInner = () => {
   assert(clusterId);
   const { getClusterById } = useAllClusters();
   const cluster = getClusterById(clusterId);
-  const { data: ownersById, isPending: isOwnersPending } = useOwners();
-  // Treat an in-flight owners query as non-owner so owner-only controls stay
-  // hidden until ownership is known.
-  const isClusterOwner =
-    !isOwnersPending && cluster
-      ? (ownersById?.get(cluster.ownerId) ?? false)
-      : false;
+  const { isOwner } = useOwners();
+  const isClusterOwner = cluster ? isOwner(cluster.ownerId) : false;
   const { data: replicas, refetch } = useClusterReplicasWithUtilization({
     clusterId,
   });

--- a/console/src/platform/clusters/ClusterRoutes.test.tsx
+++ b/console/src/platform/clusters/ClusterRoutes.test.tsx
@@ -12,24 +12,14 @@ import React from "react";
 
 import { Cluster } from "~/api/materialize/cluster/clusterList";
 import { ErrorCode } from "~/api/materialize/types";
-import {
-  buildSqlQueryHandlerV2,
-  mapKyselyToTabular,
-} from "~/api/mocks/buildSqlQueryHandler";
-import server from "~/api/mocks/server";
 import { getStore } from "~/jotai";
 import { allClusters } from "~/store/allClusters";
-import {
-  clustersFetchColumns,
-  emptyClustersResponse,
-} from "~/test/clusterQueryBuilders";
 import { mockSubscribeState } from "~/test/mockSubscribe";
 import { renderComponent, RenderWithPathname } from "~/test/utils";
 
 import ClusterRoutes from "./ClusterRoutes";
 import { buildClusterServerResponse } from "./clustersTestUtils";
 import { CLUSTERS_FETCH_ERROR_MESSAGE } from "./constants";
-import { clusterQueryKeys } from "./queries";
 
 vi.mock("~/platform/clusters/ClusterDetail", () => ({
   default: function () {
@@ -73,30 +63,6 @@ const validCluster: Cluster = {
   latestStatusUpdate: "2024-01-01T00:00:00.000Z",
 };
 
-export const noSystemObjectClustersResponse = buildSqlQueryHandlerV2({
-  queryKey: clusterQueryKeys.list({
-    includeSystemObjects: false,
-  }),
-  results: mapKyselyToTabular({
-    columns: clustersFetchColumns,
-    rows: [
-      buildClusterServerResponse({ id: "u1", name: "default" }),
-      buildClusterServerResponse({ id: "u2", name: "user_cluster" }),
-    ],
-  }),
-});
-
-export const errorClustersResponse = buildSqlQueryHandlerV2({
-  queryKey: clusterQueryKeys.list({ includeSystemObjects: false }),
-  results: {
-    error: {
-      message: "Something went wrong",
-      code: ErrorCode.INTERNAL_ERROR,
-    },
-    notices: [],
-  },
-});
-
 describe("ClusterRoutes", () => {
   beforeEach(() => {
     const store = getStore();
@@ -104,7 +70,11 @@ describe("ClusterRoutes", () => {
   });
 
   it("shows a spinner initially", async () => {
-    server.use(emptyClustersResponse);
+    const store = getStore();
+    store.set(
+      allClusters,
+      mockSubscribeState<Cluster>({ data: [], snapshotComplete: false }),
+    );
     renderComponent(<ClusterRoutes />);
 
     expect(await screen.findByText("Clusters")).toBeVisible();
@@ -114,22 +84,42 @@ describe("ClusterRoutes", () => {
   });
 
   it("shows the empty state when there are no results", async () => {
-    server.use(emptyClustersResponse);
+    const store = getStore();
+    store.set(allClusters, mockSubscribeState<Cluster>({ data: [] }));
     renderComponent(<ClusterRoutes />);
 
     expect(await screen.findByText("No available clusters")).toBeVisible();
   });
 
-  it("shows an error state when clusters fail to load", async () => {
-    server.use(errorClustersResponse);
+  it("shows an error state when the clusters subscribe fails", async () => {
+    const store = getStore();
+    store.set(
+      allClusters,
+      mockSubscribeState<Cluster>({
+        data: [],
+        snapshotComplete: false,
+        error: {
+          code: ErrorCode.INTERNAL_ERROR,
+          message: "Something went wrong",
+        },
+      }),
+    );
     renderComponent(<ClusterRoutes />);
 
     expect(await screen.findByText(CLUSTERS_FETCH_ERROR_MESSAGE)).toBeVisible();
   });
 
   it("renders the cluster list", async () => {
-    // The cluster routes use the unfiltered response and the list uses the filtered response
-    server.use(noSystemObjectClustersResponse);
+    const store = getStore();
+    store.set(
+      allClusters,
+      mockSubscribeState({
+        data: [
+          buildClusterServerResponse({ id: "u1", name: "default" }),
+          buildClusterServerResponse({ id: "u2", name: "user_cluster" }),
+        ],
+      }),
+    );
     renderComponent(<ClusterRoutes />);
 
     expect(await screen.findByText("Clusters")).toBeVisible();

--- a/console/src/platform/clusters/ClustersList.tsx
+++ b/console/src/platform/clusters/ClustersList.tsx
@@ -27,6 +27,7 @@ import useLatestOfflineReplica, {
 import { AppErrorBoundary } from "~/components/AppErrorBoundary";
 import { CodeBlock } from "~/components/copyableComponents";
 import DeleteObjectMenuItem from "~/components/DeleteObjectMenuItem";
+import ErrorBox from "~/components/ErrorBox";
 import { LoadingContainer } from "~/components/LoadingContainer";
 import OverflowMenu, { OVERFLOW_BUTTON_WIDTH } from "~/components/OverflowMenu";
 import { sortingFunctions } from "~/components/Table/tableColumnBuilders";
@@ -50,6 +51,7 @@ import {
 } from "~/layouts/listPageComponents";
 import docUrls from "~/mz-doc-urls.json";
 import { relativeClusterPath } from "~/platform/routeHelpers";
+import { useAllClusters } from "~/store/allClusters";
 import WarningIcon from "~/svg/WarningIcon";
 import { truncateMaxWidth } from "~/theme/components/Table";
 import {
@@ -59,7 +61,7 @@ import {
 
 import AlterClusterMenuItem from "./AlterClusterMenuItem";
 import { CLUSTERS_FETCH_ERROR_MESSAGE } from "./constants";
-import { useClusters } from "./queries";
+import { useOwners } from "./queries";
 import { useShowSystemObjects } from "./useShowSystemObjects";
 
 const createClusterSuggestion = {
@@ -73,7 +75,6 @@ const createClusterSuggestion = {
  * Read from `info.table.options.meta` and cast to this shape inside cells.
  */
 interface ClusterTableMeta {
-  refetchClusters: () => void;
   offlineReplicaMap: LatestOfflineReplicaMap | undefined;
 }
 
@@ -137,13 +138,7 @@ const LastStatusChangeCell = ({
   );
 };
 
-const ClusterActionsCell = ({
-  cluster,
-  refetchClusters,
-}: {
-  cluster: ClusterWithOwnership;
-  refetchClusters: () => void;
-}) => (
+const ClusterActionsCell = ({ cluster }: { cluster: ClusterWithOwnership }) => (
   <OverflowMenu
     items={[
       {
@@ -154,7 +149,8 @@ const ClusterActionsCell = ({
             <DeleteObjectMenuItem
               key="delete-object"
               selectedObject={cluster}
-              onSuccessAction={refetchClusters}
+              // the subscribe drops the row from our list
+              onSuccessAction={() => undefined}
               objectType="CLUSTER"
             />
           </>
@@ -210,15 +206,7 @@ const columns = [
   columnHelper.display({
     id: "actions",
     header: "",
-    cell: (info) => {
-      const meta = info.table.options.meta as ClusterTableMeta;
-      return (
-        <ClusterActionsCell
-          cluster={info.row.original}
-          refetchClusters={meta.refetchClusters}
-        />
-      );
-    },
+    cell: (info) => <ClusterActionsCell cluster={info.row.original} />,
     enableSorting: false,
     size: OVERFLOW_BUTTON_WIDTH,
   }),
@@ -229,20 +217,42 @@ const ClustersListContent = ({
 }: {
   showSystemObjects: boolean;
 }) => {
-  const { data: clusters, refetch } = useClusters({
-    includeSystemObjects: showSystemObjects,
-  });
+  const { data: clusters, snapshotComplete, isError } = useAllClusters();
+  const { data: ownersById, isPending: isOwnersPending } = useOwners();
 
   const orderedClusters = React.useMemo(() => {
-    if (!clusters) return [];
-    const systemClusters = clusters.filter((c) => isSystemCluster(c.id));
-    const nonSystemClusters = clusters
+    const visibleClusters = clusters
+      .filter((c) => showSystemObjects || !isSystemCluster(c.id))
+      .map((c) => ({
+        ...c,
+        // Treat an in-flight owners query as non-owner so owner-only menu items
+        // stay hidden until ownership is known.
+        isOwner: !isOwnersPending && (ownersById?.get(c.ownerId) ?? false),
+      }));
+    // The subscribe upserts by id, so the atom's order is arbitrary. Sort each
+    // group by name and keep system clusters at the end.
+    const byName = (a: ClusterWithOwnership, b: ClusterWithOwnership) =>
+      a.name.localeCompare(b.name);
+    const systemClusters = visibleClusters
+      .filter((c) => isSystemCluster(c.id))
+      .sort(byName);
+    const nonSystemClusters = visibleClusters
       .filter((c) => !isSystemCluster(c.id))
-      .sort((a, b) => a.name.localeCompare(b.name));
+      .sort(byName);
     return [...nonSystemClusters, ...systemClusters];
-  }, [clusters]);
+  }, [clusters, isOwnersPending, ownersById, showSystemObjects]);
 
-  if (clusters !== null && clusters.length === 0) {
+  if (isError) {
+    return <ErrorBox message={CLUSTERS_FETCH_ERROR_MESSAGE} />;
+  }
+
+  // The atom starts out empty, so the empty state has to wait for the snapshot
+  // or it would flash before the first rows arrive.
+  if (!snapshotComplete) {
+    return <LoadingContainer />;
+  }
+
+  if (orderedClusters.length === 0) {
     return (
       <EmptyListWrapper>
         <EmptyListHeader>
@@ -270,19 +280,18 @@ const ClustersListContent = ({
     );
   }
 
-  return <ClusterTable clusters={orderedClusters} refetchClusters={refetch} />;
+  return <ClusterTable clusters={orderedClusters} />;
 };
 
 interface ClusterTableProps {
   clusters: ClusterWithOwnership[];
-  refetchClusters: () => void;
 }
 
-const ClusterTable = ({ clusters, refetchClusters }: ClusterTableProps) => {
+const ClusterTable = ({ clusters }: ClusterTableProps) => {
   const { data: offlineReplicaMap, error: offlineReplicaError } =
     useLatestOfflineReplica();
 
-  const meta: ClusterTableMeta = { refetchClusters, offlineReplicaMap };
+  const meta: ClusterTableMeta = { offlineReplicaMap };
 
   const table = useUniversalTable({
     data: clusters,

--- a/console/src/platform/clusters/ClustersList.tsx
+++ b/console/src/platform/clusters/ClustersList.tsx
@@ -218,17 +218,12 @@ const ClustersListContent = ({
   showSystemObjects: boolean;
 }) => {
   const { data: clusters, snapshotComplete, isError } = useAllClusters();
-  const { data: ownersById, isPending: isOwnersPending } = useOwners();
+  const { isOwner } = useOwners();
 
   const orderedClusters = React.useMemo(() => {
     const visibleClusters = clusters
       .filter((c) => showSystemObjects || !isSystemCluster(c.id))
-      .map((c) => ({
-        ...c,
-        // Treat an in-flight owners query as non-owner so owner-only menu items
-        // stay hidden until ownership is known.
-        isOwner: !isOwnersPending && (ownersById?.get(c.ownerId) ?? false),
-      }));
+      .map((c) => ({ ...c, isOwner: isOwner(c.ownerId) }));
     // The subscribe upserts by id, so the atom's order is arbitrary. Sort each
     // group by name and keep system clusters at the end.
     const byName = (a: ClusterWithOwnership, b: ClusterWithOwnership) =>
@@ -240,7 +235,7 @@ const ClustersListContent = ({
       .filter((c) => !isSystemCluster(c.id))
       .sort(byName);
     return [...nonSystemClusters, ...systemClusters];
-  }, [clusters, isOwnersPending, ownersById, showSystemObjects]);
+  }, [clusters, isOwner, showSystemObjects]);
 
   if (isError) {
     return <ErrorBox message={CLUSTERS_FETCH_ERROR_MESSAGE} />;

--- a/console/src/platform/clusters/queries.test.ts
+++ b/console/src/platform/clusters/queries.test.ts
@@ -1,0 +1,139 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { ErrorCode, MzDataType } from "~/api/materialize/types";
+import {
+  buildColumns,
+  buildSqlQueryHandlerV2,
+  mapKyselyToTabular,
+} from "~/api/mocks/buildSqlQueryHandler";
+import server from "~/api/mocks/server";
+import { roleQueryKeys } from "~/platform/roles/queries";
+import { getQueryClient } from "~/queryClient";
+import { createProviderWrapper } from "~/test/utils";
+
+import { useOwners } from "./queries";
+
+const ownersColumns = buildColumns([
+  "id",
+  "name",
+  { name: "isOwner", type_oid: MzDataType.bool },
+]);
+
+const OWNED_ROLE_ID = "u1";
+const UNOWNED_ROLE_ID = "u2";
+const UNKNOWN_ROLE_ID = "u404";
+
+function buildOwnersHandler(waitTimeMs?: number) {
+  return buildSqlQueryHandlerV2(
+    {
+      queryKey: roleQueryKeys.owners(),
+      results: mapKyselyToTabular({
+        columns: ownersColumns,
+        rows: [
+          { id: OWNED_ROLE_ID, name: "my_role", isOwner: true },
+          { id: UNOWNED_ROLE_ID, name: "someone_elses_role", isOwner: false },
+        ],
+      }),
+    },
+    { waitTimeMs },
+  );
+}
+
+const errorOwnersHandler = buildSqlQueryHandlerV2({
+  queryKey: roleQueryKeys.owners(),
+  results: {
+    error: {
+      message: "Something went wrong",
+      code: ErrorCode.INTERNAL_ERROR,
+    },
+    notices: [],
+  },
+});
+
+async function renderUseOwners() {
+  const ProviderWrapper = await createProviderWrapper();
+  return renderHook(() => useOwners(), { wrapper: ProviderWrapper });
+}
+
+describe("useOwners", () => {
+  it("returns true for a role the user can act as", async () => {
+    server.use(buildOwnersHandler());
+    const { result } = await renderUseOwners();
+
+    await waitFor(() =>
+      expect(result.current.isOwner(OWNED_ROLE_ID)).toBe(true),
+    );
+  });
+
+  it("returns false for a role the user cannot act as", async () => {
+    server.use(buildOwnersHandler());
+    const { result } = await renderUseOwners();
+
+    // Settle on a known owner first, so this asserts the resolved answer rather
+    // than the in-flight default.
+    await waitFor(() =>
+      expect(result.current.isOwner(OWNED_ROLE_ID)).toBe(true),
+    );
+    expect(result.current.isOwner(UNOWNED_ROLE_ID)).toBe(false);
+  });
+
+  it("returns false for an owner id missing from the result set", async () => {
+    server.use(buildOwnersHandler());
+    const { result } = await renderUseOwners();
+
+    await waitFor(() =>
+      expect(result.current.isOwner(OWNED_ROLE_ID)).toBe(true),
+    );
+    expect(result.current.isOwner(UNKNOWN_ROLE_ID)).toBe(false);
+  });
+
+  it("returns false until the query resolves", async () => {
+    server.use(buildOwnersHandler(50));
+    const { result } = await renderUseOwners();
+
+    // An owner must not read as an owner before the query settles, otherwise
+    // owner-only controls would appear and then disappear.
+    expect(result.current.isOwner(OWNED_ROLE_ID)).toBe(false);
+
+    await waitFor(() =>
+      expect(result.current.isOwner(OWNED_ROLE_ID)).toBe(true),
+    );
+  });
+
+  it("returns false when the query fails", async () => {
+    server.use(errorOwnersHandler);
+    const { result } = await renderUseOwners();
+
+    // A failed query leaves no ownership data, so isOwner has no flip to wait
+    // on. Wait on the query reaching its error state instead.
+    await waitFor(() =>
+      expect(
+        getQueryClient().getQueryState(roleQueryKeys.owners())?.status,
+      ).toEqual("error"),
+    );
+    expect(result.current.isOwner(OWNED_ROLE_ID)).toBe(false);
+  });
+
+  it("keeps a stable isOwner reference across re-renders", async () => {
+    server.use(buildOwnersHandler());
+    const { result, rerender } = await renderUseOwners();
+
+    await waitFor(() =>
+      expect(result.current.isOwner(OWNED_ROLE_ID)).toBe(true),
+    );
+    // Consumers pass isOwner to useMemo dependency arrays, so a new reference on
+    // every render would defeat their memoization.
+    const firstReference = result.current.isOwner;
+    rerender();
+    expect(result.current.isOwner).toBe(firstReference);
+  });
+});

--- a/console/src/platform/clusters/queries.ts
+++ b/console/src/platform/clusters/queries.ts
@@ -227,12 +227,25 @@ export function useClusters(filters?: ClusterListFilters) {
   };
 }
 
+// Declared at module scope so react-query's select memoization holds. An inline
+// select is a new function every render, which makes react-query re-run it and
+// hand back a fresh Map, which in turn breaks `isOwner`'s referential stability.
+const selectOwnersById = (result: Awaited<ReturnType<typeof fetchOwners>>) =>
+  new Map(result.rows.map((row) => [row.id, row.isOwner]));
+
 /**
- * Returns a map from role id to whether the current user can act as that
- * role, for deriving `isOwner` on rows from the allClusters subscribe.
+ * Returns `isOwner`, a predicate on an object's owner id, for deriving
+ * ownership on rows from the allClusters subscribe.
+ *
+ * An unknown owner id and an in-flight query both resolve to false, so
+ * owner-only controls stay hidden until ownership is known rather than
+ * appearing and then disappearing.
+ *
+ * `isOwner` keeps a stable reference while the underlying data is unchanged, so
+ * callers can safely put it in a dependency array.
  */
 export function useOwners() {
-  return useQuery({
+  const { data: ownersById, isPending } = useQuery({
     // Role mutations invalidate this key, so this long interval is only a
     // backstop for external role changes while the page stays open.
     refetchInterval: 300_000,
@@ -240,9 +253,15 @@ export function useOwners() {
     queryFn: ({ queryKey, signal }) => {
       return fetchOwners({ queryKey, requestOptions: { signal } });
     },
-    select: (result) =>
-      new Map(result.rows.map((row) => [row.id, row.isOwner])),
+    select: selectOwnersById,
   });
+
+  const isOwner = useCallback(
+    (ownerId: string) => !isPending && (ownersById?.get(ownerId) ?? false),
+    [isPending, ownersById],
+  );
+
+  return { isOwner };
 }
 
 export type AlterClusterParams = AlterClusterSettingsParams &


### PR DESCRIPTION
In Console, cluster list data is now sourced from SUBSCRIBE via Jotai store. This moves one more consumer away from the deprecated polling model and it's a prerequisite for adding replica usage metrics to the list display. 

### Motivation

Fixes [CNS-120](https://linear.app/materializeinc/issue/CNS-120/move-cluster-list-to-use-cluster-subscribe)

### Verification

- Manually tested UI (add/delete clusters; sort; link to detail views) on integration environment and staging stack.
- Passed automated tests.

<img width="1142" height="539" alt="Screenshot 2026-08-03 at 2 31 53 PM" src="https://github.com/user-attachments/assets/40629c51-84ae-4314-9533-18c6ca9461f6" />
