### PR TITLE
Attempt at a subsource freshness fix

### DIFF
--- a/doc/developer/design/20260721_subsource_snapshot_freshness_research.md
+++ b/doc/developer/design/20260721_subsource_snapshot_freshness_research.md
@@ -1,0 +1,507 @@
+# Subsource Snapshot Freshness: Options Summary
+
+This document summarizes options for allowing a newly added subsource or
+source-fed table to snapshot without degrading the freshness of the other
+subsources of the same source.
+
+## The Problem
+
+Adding a table to a running source (`CREATE TABLE ... FROM SOURCE`, or the
+legacy `ALTER SOURCE ... ADD SUBSOURCE`) restarts the ingestion dataflow. On
+the new incarnation, the added table has an empty resume upper and is
+snapshotted. Until that snapshot completes, no subsource of the source makes
+visible progress. CDC events for already hydrated tables are not processed,
+and their persist uppers do not advance. A snapshot of one large table can
+stall every other subsource for hours.
+
+In a similar vein, if multiple tables are added together, snapshotting may complete for the smaller
+tables, but they cannot make any progress until the largest table is also done. Any error during
+this time causes snapshotting to restart for all tables.
+
+## Background: current implementation (PostgreSQL)
+
+The mechanism below is implemented in
+`src/storage/src/source/postgres/snapshot.rs` and
+`src/storage/src/source/postgres/replication.rs`. MySQL
+(`src/storage/src/source/mysql/replication.rs`) and SQL Server
+(`src/storage/src/source/sql_server/replication.rs`) use the same structure,
+adapted to their offset types.
+
+**Dataflow restart.** The export set is fixed when the dataflow is rendered.
+There is no path to add an export to a running dataflow, so adding a table
+tears down and re-renders the ingestion dataflow. Tables whose resume upper
+is above the minimum are skipped by the snapshot operator, tables at the
+minimum are selected for snapshot.
+
+**Snapshot consistency.** The snapshot leader creates a temporary logical
+replication slot with `USE_SNAPSHOT` inside a `REPEATABLE READ` read-only
+transaction. The slot's consistent point determines the snapshot LSN. The
+transaction snapshot is exported with `pg_export_snapshot()` and imported by
+the other workers with `SET TRANSACTION SNAPSHOT`, so all workers `COPY` at
+the same visibility. The leader's transaction stays open until all workers
+finish.
+
+**Rewind protocol.** Snapshot data is emitted at the minimum offset. For each
+snapshotted table, after `COPY` completes, the snapshot operator sends a
+`RewindRequest { output_index, snapshot_lsn }` to the replication operator.
+The replication operator re-emits every replication event with
+`commit_lsn <= snapshot_lsn` a second time, negated, at the minimum offset.
+The snapshot state at `snapshot_lsn` minus the negated events between the
+slot's consistent point and `snapshot_lsn` equals the state at the slot's
+consistent point, so replaying the slot from there yields exact
+multiplicities.
+
+**Why other subsources stall.** The replication operator has two gates:
+
+1. The replication operator drains its rewind input to completion before it
+   opens the replication stream. The rewind input only closes after the
+   snapshot operator finishes `COPY` and drops its rewind capability. This
+   serialization is deliberate, to avoid staging replication data in memory
+   while the snapshot runs. During the snapshot the replication stream is not
+   read at all.
+2. All exports share a single data capability. While any rewind request is
+   pending, the capability cannot be downgraded past the minimum offset,
+   because the operator must still be able to emit negated data at the
+   minimum. One hydrating export therefore pins the frontier of every export
+   of the source.
+
+**Resume LSN regression.** The replication resume point is the minimum
+across all exports. A newly added export resumes from the minimum, so the
+stream restarts from the slot's `confirmed_flush_lsn` and replays the gap
+below the existing exports' committed uppers before any new data flows.
+
+## Constraints
+
+**Definiteness.** The contents of a collection at each readable timestamp
+must be a deterministic function of durable shared facts, namely the remap
+shard contents and the upstream history. Replicas and restarts must produce
+identical readable state. The per-incarnation snapshot LSN differs across
+replicas and restarts, so it must not be observable in the output. The
+negation-based rewind satisfies this. Filtering events against a
+replica-local snapshot LSN does not. A snapshot LSN that is durably recorded
+before any output depends on it is a shared fact, and filtering against such
+a durably committed LSN is deterministic.
+
+**Persist immutability.** Once a timestamp is readable in a shard, its
+contents are immutable. No design may reveal partial hydration state and
+amend it later.
+
+**Upstream privileges.** The PostgreSQL source requires only `SELECT` on the
+replicated tables and the `REPLICATION` attribute. No design may require
+write access to the upstream database without changing this contract.
+
+**Exact multiplicities.** Storage collections are differential. Every update
+is a `(row, time, diff)` triple, and the collection at each time is the sum
+of diffs. Correct retraction of a row requires knowing the row's prior value.
+
+## Options
+
+### A. Per-export capabilities with an early snapshot bound
+
+Replace the single shared data capability with per-export capabilities, and
+split the rewind protocol in two: the snapshot operator announces
+`SnapshotStarted { export, snapshot_lsn }` when the snapshot transaction
+opens (the LSN is known at that point), and completion separately after
+`COPY`. The replication operator starts streaming immediately. For a
+hydrating export it emits events both at their commit LSN and negated at the
+minimum (for events at or below the snapshot LSN), holding back only that
+export's capability. Other exports' capabilities advance freely.
+
+Properties:
+
+- Preserves the existing negation-based definiteness argument. No new
+  durable state.
+- Requires capability and rewind bookkeeping changes in each connector
+  (PostgreSQL, MySQL, SQL Server).
+- The hydrating export's concurrent CDC accumulates in the persist sink at
+  fine-grained reclocked times while its frontier is pinned. Batches cannot
+  be appended until the frontier advances. See "Sink staging to blob
+  storage" below for the accumulation mechanism and mitigations.
+- A restart during hydration discards the accumulated work and the snapshot
+  restarts from the beginning.
+- The resume LSN regression remains, since the hydrating export still needs
+  the stream from the slot's consistent point.
+
+### B. Out-of-band snapshot committed directly to persist
+
+Run the snapshot outside the ingestion dataflow as a one-shot job: open the
+temporary slot, obtain snapshot LSN `S`, `COPY`, and `compare_and_append`
+the result into the new export's shard from the empty upper at the reclocked
+time of `S`. The main dataflow then includes the export with a per-export
+start point, ignoring events at or below `S` for that export. The SQL Server
+source already implements per-export event filtering against a per-export
+initial LSN.
+
+Properties:
+
+- The running replication stream and the other exports' frontiers are not
+  involved in the snapshot.
+- No rewind machinery for the added table, and no sink-side accumulation
+  during hydration.
+- `compare_and_append` from the empty upper is atomic, so exactly one
+  snapshot attempt wins and `S` becomes a durable shared fact at commit
+  time. Filtering against it is then deterministic (see Constraints).
+- Requires a handoff protocol: recording `S`, verifying the main slot has
+  not compacted past `S` before commit, and communicating the per-export
+  start point to the dataflow.
+- Requires a remap binding covering the reclocked time of `S`, so the main
+  dataflow must keep minting bindings while the job runs.
+- The dataflow still restarts once to pick up the export, but without
+  stalling and without the resume LSN regression.
+
+### C. Shadow pipeline with catch-up and handoff
+
+Run a second, temporary pipeline for the new table only, with its own
+temporary slot: snapshot, then follow CDC until it reaches an agreed LSN
+`H`, commit through `H`, and hand off to the main pipeline for events after
+`H`.
+
+Properties:
+
+- The main pipeline is unaffected until a restart at handoff time.
+- Requires a second replication slot for the duration, with the associated
+  WAL retention and connection cost on the upstream database.
+- Requires a handoff protocol that guarantees exactly-once around `H`.
+
+### D. Early rewind request emission only
+
+Emit rewind requests when the snapshot transaction opens instead of after
+`COPY`, so the replication operator starts streaming immediately. This
+removes hold 1 but not hold 2: the shared capability remains pinned until
+the snapshot completes, so other subsources still make no visible progress.
+It bounds upstream slot lag during the snapshot but does not address
+freshness.
+
+### Sink staging to blob storage
+
+This addresses the accumulation cost of option A. It is not a standalone
+solution to the freshness problem.
+
+**Where memory grows today.** The storage persist sink
+(`src/storage/src/render/persist_sink.rs`) keeps one `BatchBuilder` per
+distinct timestamp in its `write_batches` operator. `BatchBuilder::add`
+(`src/persist-client/src/batch.rs`) uploads a part to blob storage whenever
+its in-memory columnar buffer reaches `blob_target_size`, so large builders
+already stage data to S3 incrementally. During hydration under option A,
+reclocked CDC arrives at a large number of distinct fine-grained timestamps.
+Each timestamp gets its own builder holding a small buffer that never
+reaches the flush threshold. Resident memory therefore grows with the number
+of distinct timestamps, plus fixed per-builder overhead, rather than with
+data volume.
+
+**Relevant existing behavior.**
+
+- `mint_batch_descriptions` mints one batch description per frontier
+  advancement. A frontier that jumps from the minimum to `T` when the
+  rewind resolves yields a single description covering `[minimum, T)`.
+- Every builder is finished with the full description bounds, and multiple
+  batches for the same description are appended together in one
+  `compare_and_append_batch`. Many batches under one description is the
+  existing pattern.
+- `BatchBuilder` takes its lower bound at creation and its upper bound only
+  at `finish`. `finish(T)` fails if the builder contains any update at or
+  beyond `T`.
+- Eagerly uploaded parts of a builder that is dropped before finishing are
+  leaked on restart. This is current behavior, unchanged by the options
+  below.
+- All cluster replicas are swap-only. No local disk is available to
+  dataflow operators, so spilling operator state to local disk is not an
+  option. Swap does not substitute: cold per-timestamp builders can page
+  out while idle, but finishing all builders when the description arrives
+  pages the entire set back in at once.
+
+**Coalesced builders (sink-only change).** During hydration, route updates
+into a small number of long-lived builders for the pinned region instead of
+one builder per timestamp. Updates are added at their exact per-update
+timestamps, parts flush to S3 at `blob_target_size` increments, and the
+builders are finished with `[minimum, T)` when the description arrives.
+Resident memory is bounded by `blob_target_size` per builder instead of by
+distinct-timestamp count. Because `T` is not known in advance and a builder
+containing updates at or beyond `T` cannot be finished at `T`, a two-tier
+stash is required: coalesced builders hold times older than a trailing
+horizon, and per-timestamp builders hold recent times. `T` is determined
+when the snapshot resolves and corresponds to near-current reclocked time,
+so it falls in the recent tier. No persist API changes are required, and
+the crash leak behavior is unchanged from today.
+
+### Persist extensions
+
+With some changes to persist, we can avoid leaking the data written to blob storage for Option A:
+
+1. **Shard-attached staged batches.** Today a batch only becomes durable when it's linked into shard
+   state via `compare_and_append_batch`. Before that, it's an unlinked `ProtoBatch`: parts arr in S3
+   (uploaded at blob_target_size increments), but nothing references them. A a crash leaks the
+   parts and loses the work. During a long snapshot the coalesced builders can hold hours of
+   concurrent CDC events in this unlinked state.
+
+   To solve the leak, MZ could track these staged batches in a per-shard registry of named staged
+   batches. Shard state would record it: the sink periodically finishes a builder and registers the
+   batch without linking it into the readable trace. That makes the parts GC-tracked (no leak).
+   Linking into the trace happens later, atomically, when the export's frontier can finally advance.
+
+   This doesn't allow us to recover on a dataflow restart without extra bookkeeping.  On a restart,
+   the snapshot LSN changes, which will affect the rewinds.
+
+2. **Two-frontier shards.** Today a shard has one upper, appends must be contiguous, 
+   and everything below the upper is immutable and readable. This change allows the shard to carry
+   two frontiers: a write frontier (how far appends have gone) and a readable upper (the highest
+   frontier that doesn't include a sparse batch). The hydrating export's shard would have a sparse
+   batch where the snapshot belongs, while regular CDC appends normally beyond it. This allows 
+   updates to be durable immediately, resumable from the written frontier after a restart. When the
+   snapshot completes it fills the hole, and the readable upper jumps to the written frontier.
+
+   There is special handling needed in the event the snapshot has to restart. The snapshot cannot
+   be reproduced at the same offset, which means that data written to the shard needs to be
+   retracted. An astute observer may realize that the readable upper is still and T::mininmum, 
+   so they shared has never been read. It may be reasonable to append a truncation marker to the
+   shard to indicate "updates before this point are logically absent as of the marker's write,
+   physically reclaimed at compaction", allowing the shard to restart from T::minimum.
+
+
+For Option B:
+1. **Multi-shard atomic commit.** txn-wal provides atomic writes across
+   shards. Option B's handoff record (the snapshot data and the durable
+   record of `S`) can be committed in one atomic operation using the
+   existing mechanism.
+   No persist change can make the new export itself readable before its 
+   snapshot completes, because contents at a readable timestamp are immutable 
+   and the pre-snapshot contents would be wrong.
+
+## Work required for option A, by connector
+
+### Pipeline facts
+
+The dataflow downstream of the raw connector operators is already built per
+export:
+
+- One statistics operator and one reclock operator instance per export
+  (`src/storage/src/source/source_reader_pipeline.rs`, the loops at the
+  reclock and statistics stages).
+- One decode and envelope fragment per export
+  (`src/storage/src/render/sources.rs`).
+- One persist sink per export, each writing its own data shard
+  (`src/storage/src/render.rs`).
+- The reclock operator derives its output frontier from its own captured
+  input stream combined with the shared remap upper
+  (`src/timely-util/src/reclock.rs`), so per-export input frontiers
+  translate to per-export reclocked frontiers without changes.
+- Remap bindings are minted from the probe channel, independent of data
+  capabilities (`source_reader_pipeline.rs`, `remap_operator`), so bindings
+  advance during a snapshot regardless of data capability holds.
+
+The frontier coupling is confined to the connectors: each raw reader emits
+one multiplexed `(output_index, data)` stream on a single timely output
+port, demuxed with `partition()`, which routes data but propagates the
+single upstream frontier to every output (`postgres.rs`, `kafka.rs`, and
+the MySQL and SQL Server equivalents). `SourceRender::render` already
+returns per-export collections (`src/storage/src/source/types.rs`), so the
+changes below are internal to each connector and require no trait or
+pipeline changes.
+
+### PostgreSQL
+
+1. Replace the `partition()` demux with one output port per export on the
+   snapshot and replication operators. Exports are known at render time and
+   ports can be created in a loop. Each port gets its own capability set.
+2. Snapshot operator: close the ports of already hydrated exports
+   immediately. Emit rewind requests when the snapshot transaction opens
+   (the snapshot LSN is known as soon as the temporary slot is created)
+   instead of after `COPY`. Hold a hydrating export's port at the minimum
+   until its `COPY` completes.
+3. Replication operator: remove the loop that drains the rewind input
+   before opening the replication stream. Make the capability hold
+   per port: hydrated exports downgrade with the data upper freely, a
+   hydrating export's port holds at the minimum until the data upper passes
+   its snapshot LSN. The inline dual emission of rewind negations is
+   unchanged. The `resume_lsn <= snapshot_lsn + 1` validation moves to the
+   earlier rewind arrival point.
+
+Consequences to account for:
+
+- The hydrating export's persist sink accumulates its concurrent CDC for
+  the duration of the snapshot. The sink staging work above is a
+  prerequisite for large or high-churn tables.
+- Restart during a snapshot can now observe states that today's
+  serialization makes impossible by construction. Each restart interleaving
+  needs re-verification.
+- WAL retention is unchanged. Slot acknowledgment follows the minimum
+  committed upper across exports, which the hydrating export holds at the
+  minimum until it completes.
+- A source with hundreds of tables produces that many output ports on the
+  reader operator. The downstream pipeline already has one operator chain
+  per export, but the port-per-export reader shape needs validation at that
+  scale.
+
+### Kafka (upsert envelope)
+
+The Kafka path has no rewind machinery. Retractions are derived by the
+per-export upsert operator from its own state
+(`src/storage/src/render/sources.rs`), and a new export's operator starts
+from an empty shard. The "snapshot" of a new export is a re-read of the
+topic from the export's start offsets. The reader currently resumes every
+partition from the minimum resume upper across all exports
+(`src/storage/src/source/kafka.rs`), so adding an export makes the single
+consumer re-read the topic from the start offsets and no export commits new
+data until the re-read reaches the tip.
+
+1. Per-export output ports, as for PostgreSQL. Message duplication per
+   export moves from the multiplexed stream into per-port emission.
+2. A second, backfill consumer reads from the hydrating exports' start
+   offsets while the steady consumer continues from the hydrated exports'
+   committed positions. Handoff is a per-partition offset `H`: the
+   hydrating export takes offsets below `H` from the backfill consumer and
+   offsets at or above `H` from the steady feed. Kafka offsets are dense
+   per partition, so the split is exact and requires no deduplication and
+   no negation.
+3. Per-export capabilities: hydrated exports' ports track the steady
+   consumer's progress, a hydrating export's port tracks the backfill
+   consumer and holds below the handoff point until the backfill reaches
+   it.
+4. The upsert operator needs no structural change. A hydrating export
+   builds a second full copy of upsert state on the replica while its
+   backfill runs, which is a memory cost on swap-only replicas. Per-export
+   rehydration completion reporting already exists.
+5. Backfilled old offsets reclock through existing remap bindings, and
+   reclocked times not beyond the as-of are advanced to the as-of, which is
+   existing reclock behavior.
+6. The topic must retain data back to the export's start offsets. This
+   holds for any design, since the data has no other source.
+
+For append-only envelopes (none, Debezium), the backfill emits the same
+insert-only records the steady path would, so the consumer split above is
+sufficient and no per-key state is involved.
+
+### MySQL and SQL Server
+
+Both use the PostgreSQL rewind pattern. MySQL reuses the `RewindRequest`
+type keyed by a GTID snapshot upper
+(`src/storage/src/source/mysql/replication.rs`), SQL Server implements the
+same structure with a per-export `initial_lsn` and `snapshot_lsn` pair
+(`src/storage/src/source/sql_server/replication.rs`). The same three
+changes apply: per-export output ports, rewind requests emitted when the
+snapshot transaction is established (the snapshot upper is available at
+that point in both systems, and SQL Server already tracks the per-export
+pair), and per-port capability holds until the replication stream passes
+each hydrating export's snapshot upper. The PostgreSQL consequences apply
+equally: sink staging as a prerequisite, restart interleavings to
+re-verify, and upstream log retention pinned by the minimum committed
+upper for the duration of a snapshot.
+
+In general, a connector supports independent export frontiers when it can
+(a) emit each export on its own output port with its own capabilities,
+(b) determine the snapshot consistency bound when the snapshot starts
+rather than when it completes, (c) reconcile snapshot and stream either by
+compensating negated emission at the minimum time (the rewind pattern) or
+through an envelope that derives retractions from state (upsert), and
+(d) derive per-export progress from its own read process.
+
+## DBLog and derived approaches
+
+### The DBLog algorithm
+
+DBLog ([Andreakis and Papapanagiotou, Netflix, arXiv:2010.12597][dblog])
+captures full table state without a consistent snapshot by interleaving
+chunked selects with the live log stream:
+
+1. Pause log event processing.
+2. Write a low watermark: update a UUID in a dedicated single-row watermark
+   table in the source database. The write appears in the transaction log.
+3. Select the next chunk: rows in ascending primary key order, above the
+   previous chunk's maximum key, at read-committed isolation.
+4. Write a high watermark. Resume log processing.
+5. Between the low and high watermark events in the log, drop any buffered
+   chunk row whose primary key appears in a log event (the log wins, because
+   the select's exact log position is unknown but is bracketed by the
+   window). At the high watermark, emit the surviving chunk rows, then
+   continue with the log.
+
+Log processing stalls only during steps 2 through 4. Chunk progress is
+checkpointed, so capture can pause and resume at chunk granularity and can
+be triggered at any time for all tables, one table, or specific primary
+keys. No locks and no long-running transaction are used.
+
+The output contract is correspondingly weak. Chunk rows are full-row states
+with no before-image. The stream preserves per-key history order but at no
+point during capture corresponds to a consistent database state. Consumers
+must apply per-key upsert semantics (the paper's canonical output is
+log-compacted Kafka).
+
+### Debezium's adaptations
+
+Debezium implemented the algorithm as incremental snapshots
+([DDD-3][ddd3], [blog][dbz-blog]), with a writable signaling table providing
+the watermark events. Two read-only variants replace log-embedded watermarks
+with query-only boundary captures, classifying each streamed event by
+transaction ID instead of watching for watermark events:
+
+- MySQL: compare each binlog event's GTID against `executed_gtid_set`
+  captured before and after the chunk select
+  ([blog][dbz-ro-blog]).
+- PostgreSQL: compare each WAL event's transaction ID against
+  `pg_current_snapshot()` captured before and after the chunk
+  ([DDD-8][ddd8]). This requires PostgreSQL 13, requires a preceding
+  `pg_current_xact_id()` call to force transaction ID assignment (which
+  fails during recovery, so it cannot run on a hot standby), and cannot
+  recognize duplicates written through subtransactions.
+
+Debezium's incremental snapshot delivery model is explicitly weaker than the
+paper's: consumers may receive an update before the corresponding snapshot
+read of the same key, duplicate row states, and deletes for keys never
+delivered ([DDD-3][ddd3]). Correct consumption requires per-key idempotent
+upsert handling.
+
+### Why this family does not fit Materialize
+
+1. **Upsert output vs. differential collections.** Chunk rows carry no
+   before-image, and log events for keys whose chunk has not yet been
+   selected cannot be turned into correct retraction/insertion pairs
+   without per-key prior state. Streaming DBLog output into a persist shard
+   as diffs produces incorrect multiplicities. Converting it requires
+   maintaining upsert state (key to current value) for the entire table for
+   the duration of the capture.
+2. **No consistent state during capture.** Materialize exposes readable
+   collection contents at every timestamp between the since and the upper,
+   and those contents must be a consistent state of the upstream table.
+   Mid-capture DBLog output corresponds to no upstream state at any LSN.
+3. **Nondeterministic interleaving violates definiteness.** Where chunks
+   land relative to log events depends on process scheduling, so the
+   interleaved stream differs across replicas and restarts. Readable
+   contents derived from it are not a deterministic function of durable
+   shared facts.
+4. **Weakened ordering in the practical implementations.** Debezium's
+   delivery model (duplicates, per-key reordering, deletes for undelivered
+   keys) is designed for idempotent upsert consumers and is incompatible
+   with exact-multiplicity ingestion.
+5. **Primary key requirement.** Chunking and window deduplication are keyed
+   on primary keys. Materialize's PostgreSQL source supports tables without
+   primary keys (via `REPLICA IDENTITY FULL`), which have no chunkable key.
+6. **Upstream write access.** The paper's watermark table requires write
+   access to the source database, which the Materialize source contract does
+   not include. The read-only variants remove table writes but the
+   PostgreSQL variant still requires transaction ID assignment on a
+   primary, requires PostgreSQL 13, and has a subtransaction deduplication
+   gap. The MySQL variant requires GTID mode.
+
+## References
+
+- [DBLog: A Watermark Based Change-Data-Capture Framework (arXiv:2010.12597)][dblog]
+- [Debezium DDD-3: Incremental snapshotting][ddd3]
+- [Debezium DDD-8: Read-only incremental snapshots for PostgreSQL][ddd8]
+- [Debezium blog: Incremental Snapshots in Debezium][dbz-blog]
+- [Debezium blog: Read-only Incremental Snapshots for MySQL][dbz-ro-blog]
+- Code: `src/storage/src/source/postgres/snapshot.rs`,
+  `src/storage/src/source/postgres/replication.rs`,
+  `src/storage/src/source/mysql/replication.rs`,
+  `src/storage/src/source/sql_server/replication.rs`,
+  `src/storage/src/source/kafka.rs`,
+  `src/storage/src/source/source_reader_pipeline.rs`,
+  `src/storage/src/render/sources.rs`,
+  `src/storage/src/render/persist_sink.rs`,
+  `src/timely-util/src/reclock.rs`,
+  `src/persist-client/src/batch.rs`
+
+[dblog]: https://arxiv.org/abs/2010.12597
+[ddd3]: https://github.com/debezium/debezium-design-documents/blob/main/DDD-3.md
+[ddd8]: https://github.com/debezium/debezium-design-documents/blob/main/DDD-8.md
+[dbz-blog]: https://debezium.io/blog/2021/10/07/incremental-snapshots/
+[dbz-ro-blog]: https://debezium.io/blog/2022/04/07/read-only-incremental-snapshots/

--- a/doc/developer/design/20260729_per_export_snapshot_frontiers.md
+++ b/doc/developer/design/20260729_per_export_snapshot_frontiers.md
@@ -173,6 +173,17 @@ disables it and keeps today's per-timestamp builders):
   data, so boundaries can land among these near-maximum times. A builder
   cannot be split at a boundary, which is why fresh uncovered updates must
   not enter a shared builder yet.
+- Updates below the lower of the first received description are dropped.
+  The sink's ingress gate uses the shard upper cached when its write
+  handle was opened, while the description minter starts at a freshly
+  fetched upper, so updates in that gap can pass the gate even though they
+  are already durable and no description will ever cover them. Staging
+  them would finish a batch whose parts carry data below the registered
+  append bounds. Persist truncates such data when the parts are read back,
+  and compaction then produces fewer updates than the spine recorded for
+  the batch, which fails a persist-internal invariant. Until the first
+  description arrives the sink cannot tell these updates apart from
+  stageable ones, so aged updates wait in the raw stash until it does.
 - Updates covered by a received description, updates that age past `H`,
   and raw-stashed rows whose time ages past `H` all move into coalesced
   builders: one per received batch description, plus one open builder for
@@ -211,11 +222,15 @@ only progress.
 
 A retained subtlety on the append side: `append_batches` trims batches
 when another writer advanced the shard upper past a batch description's
-lower. A batch carries its largest update timestamp, is deleted when that
-falls below the new lower, and is otherwise kept whole:
-`compare_and_append_batch` truncates updates outside the append bounds,
-and the truncated data is already in the shard, written by whoever
-advanced the upper.
+lower. Each batch carries inclusive bounds on its update timestamps. A
+batch entirely below the new lower is deleted, since that data is already
+in the shard, written by whoever advanced the upper. A batch entirely at
+or beyond the new lower is kept whole. A batch that straddles the new
+lower can be neither appended nor split: appending it would register parts
+with data below the append bounds, which persist truncates at read,
+desyncing the spine's recorded update counts from what compaction
+reproduces. The sink deletes its batches and restarts the dataflow
+instead.
 
 Resident memory is then bounded on both tiers. Each coalesced builder
 holds at most `blob_target_size` plus one part upload in flight, and there

--- a/doc/developer/design/20260729_per_export_snapshot_frontiers.md
+++ b/doc/developer/design/20260729_per_export_snapshot_frontiers.md
@@ -161,52 +161,74 @@ only when a single builder reaches `blob_target_size`. Reclocked CDC
 arrives at many distinct fine-grained timestamps, so resident memory grows
 with the number of distinct timestamps rather than with data volume.
 
-The sink change is a two-tier stash in `write_batches`. The tier is chosen
-per update when the update is added:
+The sink change is a two-tier stash in `write_batches`, gated by the
+`storage_persist_sink_stash_coalesce_lag` configuration (a zero lag
+disables it and keeps today's per-timestamp builders):
 
-- Each worker keeps one long-lived coalesced `BatchBuilder`, created with
-  the minimum lower bound. `BatchBuilder::add` accepts each update at its
-  exact timestamp and the upper bound is supplied only at `finish`, so one
-  builder absorbs updates at any number of distinct timestamps and uploads
-  a part to blob storage every time its buffer reaches `blob_target_size`.
-  This capability exists today, the current code just never uses it across
-  timestamps.
 - The operator maintains a horizon `H`, defined as the maximum timestamp
-  observed on its data input minus a configured lag `L`. `H` never
-  retreats. An arriving update at time `t` is added to the coalesced
-  builder when `t < H` and to today's per-timestamp builder for `t`
-  otherwise.
-- When the batch description `[minimum, T)` arrives after the rewind
-  resolves, the coalesced builder is finished at `T`. `finish(T)` requires
-  that the builder contain no update at or beyond `T`, which holds exactly
-  when `H <= T`. Per-timestamp builders with times below `T` are finished
-  with the description bounds as today. Builders at or beyond `T` are
-  retained for the next description, which is also existing behavior.
+  observed on its data input minus the configured lag `L`. `H` never
+  retreats. An arriving update at time `t` is stashed as a raw row when
+  `t >= H` and no received batch description covers `t`. Batch description
+  boundaries are frontier values, and frontier values trail the newest
+  data, so boundaries can land among these near-maximum times. A builder
+  cannot be split at a boundary, which is why fresh uncovered updates must
+  not enter a shared builder yet.
+- Updates covered by a received description, updates that age past `H`,
+  and raw-stashed rows whose time ages past `H` all move into coalesced
+  builders: one per received batch description, plus one open builder for
+  aged updates beyond every received description. `BatchBuilder::add`
+  accepts each update at its exact timestamp and the upper bound is
+  supplied only at `finish`, so one builder absorbs updates at any number
+  of distinct timestamps and uploads a part to blob storage every time its
+  buffer reaches `blob_target_size`. The open builder is the one that
+  fills during hydration, when the frontier is pinned and no description
+  is minted, absorbing the snapshot rows, the rewind negations, and the
+  concurrently staged CDC alike.
+- When a description `[l, u)` arrives, the open builder rotates: if its
+  contents all fall below `u` it becomes that description's builder, if
+  they all fall at or beyond `u` it stays open for a later description.
+  During hydration the description is `[minimum, T)` minted when the
+  rewind resolves, and the open builder's contents fall below `T` exactly
+  when `H <= T`.
+- When a description is finished (today's logic, once the data frontier
+  passes its upper), the raw-stashed rows it covers are drained into its
+  coalesced builder, and the builder is finished with the description
+  bounds. Each worker therefore contributes at most one batch per
+  description.
 
 `H <= T` is not structurally guaranteed. Timely gives no ordering between
 data delivery and frontier propagation, so updates at or beyond `T` can
 arrive before the description does and, with too small a lag, age into the
-coalesced builder. Such an update is emitted by the reader only after it
+open builder. Such an update is emitted by the reader only after it
 downgrades its capability past `T`, so its timestamp exceeds `T` by at
-most the reclocked time that elapses while the description is in flight.
-`H` therefore exceeds `T` only if that propagation delay exceeds `L`, and
-`L` is chosen orders of magnitude larger (minutes of reclocked time
-against in-flight delays of at most seconds). The failure is detected when
-the description arrives. The builder cannot be split, so the sink raises
-an error and the dataflow restarts, discarding the unlinked batch.
-Correctness is never at risk, only progress, and the same restart path
-already exists for snapshot errors.
+most the time that elapses while the description is in flight. `H`
+therefore exceeds `T` only if that propagation delay exceeds `L`. The
+failure is detected at rotation: the open builder's contents straddle `u`,
+the builder cannot be split, so the sink panics with a message naming the
+lag. The panic halts the cluster process, restarting every dataflow on the
+replica and discarding the unlinked batches. Correctness is never at risk,
+only progress.
 
-Resident memory is then bounded on both tiers. The coalesced builder holds
-at most `blob_target_size` plus one part upload in flight. The
-per-timestamp tier only ever spans the trailing window `L`, so its builder
-count is bounded by `L` divided by the reclock interval rather than by
-snapshot duration. With descriptions arriving regularly (the steady state)
-builders are finished before their times age past `H`, the coalesced
-builder stays empty, and behavior is unchanged. The coalesced tier fills
-only when the frontier stalls for longer than `L`, which is the hydration
-case. No persist API changes are required, and the crash leak behavior of
-eagerly uploaded parts is unchanged from today.
+A retained subtlety on the append side: `append_batches` trims batches
+when another writer advanced the shard upper past a batch description's
+lower. A batch carries its largest update timestamp, is deleted when that
+falls below the new lower, and is otherwise kept whole:
+`compare_and_append_batch` truncates updates outside the append bounds,
+and the truncated data is already in the shard, written by whoever
+advanced the upper.
+
+Resident memory is then bounded on both tiers. Each coalesced builder
+holds at most `blob_target_size` plus one part upload in flight, and there
+are at most as many as there are in-flight descriptions plus one. The raw
+tier only ever spans the trailing window `L`, since rows leave it as soon
+as they age past `H`, so its size is bounded by `L` times the ingest rate
+rather than by snapshot duration. With descriptions arriving regularly
+(the steady state) updates enter their description's builder on arrival or
+drain into it when the description finishes, and the open builder stays
+empty. The open builder fills only when the frontier stalls for longer
+than `L`, which is the hydration case. No persist API changes are
+required, and the crash leak behavior of eagerly uploaded parts is
+unchanged from today.
 
 ### Kafka: backfill consumer with offset handoff
 

--- a/doc/developer/design/20260729_per_export_snapshot_frontiers.md
+++ b/doc/developer/design/20260729_per_export_snapshot_frontiers.md
@@ -1,0 +1,352 @@
+# Per-Export Frontiers for Source Snapshots
+
+- Associated:
+  [Subsource Snapshot Freshness: Options Summary](20260721_subsource_snapshot_freshness_research.md)
+
+## The Problem
+
+Adding a table to a running source (`CREATE TABLE ... FROM SOURCE`, or the
+legacy `ALTER SOURCE ... ADD SUBSOURCE`) restarts the ingestion dataflow. On
+the new incarnation, the added table has an empty resume upper and is
+snapshotted. Until that snapshot completes, no subsource of the source makes
+visible progress. CDC events for already hydrated tables are not processed,
+and their persist uppers do not advance. A snapshot of one large table can
+stall every other subsource for hours.
+
+If multiple tables are added together, snapshotting may complete for the
+smaller tables, but they cannot make progress until the largest table is
+also done. Any error during this time restarts snapshotting for all tables.
+
+For the rewind-pattern connectors (PostgreSQL, MySQL, SQL Server) the stall
+has two causes, both in the upstream reader operators:
+
+1. The replication operator drains its rewind input to completion before processing any CDC events.
+   Rewind requests are only sent after `COPY` (for OLTP) completes, so the CDC stream is not read
+   while a snapshot runs.
+2. All exports share a single data capability. While any rewind request is pending, the capability
+   cannot be downgraded past the minimum offset, because the operator must still be able to emit
+   negated data at the minimum. One hydrating export pins the frontier of every export.
+
+Kafka stalls for a different reason. Multiple tables can be created from one
+Kafka source, for example to accommodate schema changes in the topic. The
+reader resumes every partition from the minimum resume upper across all
+exports, so adding a table makes the single consumer re-read the topic from
+the new table's start offsets, and the shared output port means no export
+commits new data until the re-read reaches the tip.
+
+Everything downstream of the reader operators is already per export: statistics operator, reclock,
+decode and envelope, and persist sink.
+
+## Success Criteria
+
+- While a newly added table snapshots, the already hydrated exports of the
+  same source continue to process CDC events and their persist uppers
+  continue to advance.
+- When multiple tables are added together, each commits its snapshot and
+  begins advancing as soon as its own snapshot completes.
+- Definiteness is preserved. The contents of every collection at each
+  readable timestamp remain a deterministic function of durable shared
+  facts. The output must not depend on any value known only to a single replica or dataflow
+  incarnation, such as the snapshot LSN of the temporary slot.
+- Exact multiplicities are preserved. No design element requires primary
+  keys or upsert semantics from a connector that does not already have
+  them.
+- The upstream privilege contract is unchanged. For example, the PostgreSQL source
+  continues to require only `SELECT` on the replicated tables and the
+  `REPLICATION` attribute.
+- Memory on the replica during hydration is bounded by a configurable
+  target independent of snapshot duration and of the number of distinct
+  reclocked timestamps. Replicas are swap-only, so unbounded operator state
+  is not acceptable.
+- A restart during a snapshot remains correct. The snapshot restarts from
+  the beginning, as today.
+
+## Out of Scope
+
+The following are follow-on work. The design does not depend on them, and
+they can land independently later.
+
+- **Recovering accumulated work across restarts.** A restart during
+  hydration discards the hydrating export's snapshot progress and its
+  accumulated concurrent CDC, both are redone. Crash-safe accumulation
+  needs persist extensions (a staged batch registry, or placeholder batches
+  filled after the fact with a truncate marker for discarded attempts) plus
+  a connector-side watermark protocol. The research document describes
+  these. Nothing in this design forecloses them.
+- **Avoiding the dataflow restart.** The export set is fixed when the
+  dataflow is rendered, so adding a table still tears down and re-renders
+  the ingestion dataflow. This design removes the stall that follows the
+  restart, not the restart itself.
+- **The resume LSN regression.** The replication resume point remains the
+  minimum across all exports, so the stream still replays the gap between
+  the slot's consistent point and the existing exports' committed uppers
+  after a restart. Existing exports now make progress during that replay,
+  but the replay itself remains.
+- **Upstream log retention.** Slot acknowledgment continues to follow the
+  minimum committed upper across exports, so WAL is retained upstream for
+  the duration of a snapshot, as today.
+- **Reading the new export before its snapshot completes.** Contents at a
+  readable timestamp are immutable in persist, and pre-snapshot contents
+  would be wrong. No design can offer this.
+
+## Solution Proposal
+
+Give each export its own output port and capability on the connector reader
+operators, and hold back only the hydrating exports. For the rewind-pattern
+connectors the negation-based rewind protocol is unchanged, so the existing
+definiteness argument carries over without new durable state. For Kafka the
+reconciliation already comes from the upsert operator's state, and the
+change is a second consumer that backfills the hydrating exports.
+
+The work is confined to the connectors. `SourceRender::render` already
+returns per-export collections, reclock derives per-export output frontiers
+from per-export input frontiers without changes, and remap bindings are
+minted from the probe channel independent of data capabilities.
+
+Steps 1 and 4 apply to all connectors. Steps 2 and 3 are the rewind-pattern
+changes, the Kafka section below is their Kafka equivalent.
+
+### 1. One output port per export
+
+Replace the multiplexed `(output_index, data)` output and its `partition()`
+demux with one output port per export on the snapshot and replication
+operators. Exports are known at render time, ports are created in a loop,
+and each port gets its own capability set.
+
+This step is behavior preserving on its own: with all port capabilities
+downgraded in lockstep, every export observes the same frontier as today.
+It has landed for PostgreSQL and is the stepping stone for the steps below.
+
+Because `give_fueled`'s yield accounting is per output handle, operators
+that emit across many ports enforce the aggregate outstanding-byte bound
+with a shared counter against `MAX_OUTSTANDING_BYTES`.
+
+### 2. Early snapshot bound
+
+The snapshot operator emits `RewindRequest { output_index, snapshot_lsn }`
+when the snapshot transaction opens instead of after `COPY` completes. The
+snapshot LSN is the temporary slot's consistent point and is known as soon
+as the slot is created, before any data is copied. The
+`resume_lsn <= snapshot_lsn + 1` validation moves to this earlier point.
+
+The replication operator no longer drains the rewind input before opening
+the replication stream. It starts streaming immediately, knowing from the
+early rewind requests which exports need dual emission.
+
+### 3. Per-export capability policy
+
+Snapshot operator: ports of exports whose resume upper is past the minimum
+are closed immediately. A hydrating export's port holds at the minimum
+until its snapshot (e.g. `COPY`) completes, then closes.
+
+Replication operator: ports of hydrated exports downgrade freely with the
+data upper. A hydrating export's port holds at the minimum until the data
+upper passes its snapshot LSN, because events at or below the snapshot LSN
+must still be emitted negated at the minimum for that export. Once the
+upper passes the snapshot LSN, the port downgrades with the data upper like
+the rest. The inline dual emission of rewind negations is unchanged.
+
+The slot is acknowledged at the minimum committed upper across exports, so
+a hydrating export continues to pin WAL retention, but no longer pins any
+other export's frontier.
+
+### 4. Bounded sink accumulation
+
+While a hydrating export's frontier is pinned, its concurrent CDC
+accumulates in the storage persist sink. The sink keeps one `BatchBuilder`
+per distinct timestamp, and `BatchBuilder` flushes parts to blob storage
+only when a single builder reaches `blob_target_size`. Reclocked CDC
+arrives at many distinct fine-grained timestamps, so resident memory grows
+with the number of distinct timestamps rather than with data volume.
+
+The sink change is a two-tier stash in `write_batches`. The tier is chosen
+per update when the update is added:
+
+- Each worker keeps one long-lived coalesced `BatchBuilder`, created with
+  the minimum lower bound. `BatchBuilder::add` accepts each update at its
+  exact timestamp and the upper bound is supplied only at `finish`, so one
+  builder absorbs updates at any number of distinct timestamps and uploads
+  a part to blob storage every time its buffer reaches `blob_target_size`.
+  This capability exists today, the current code just never uses it across
+  timestamps.
+- The operator maintains a horizon `H`, defined as the maximum timestamp
+  observed on its data input minus a configured lag `L`. `H` never
+  retreats. An arriving update at time `t` is added to the coalesced
+  builder when `t < H` and to today's per-timestamp builder for `t`
+  otherwise.
+- When the batch description `[minimum, T)` arrives after the rewind
+  resolves, the coalesced builder is finished at `T`. `finish(T)` requires
+  that the builder contain no update at or beyond `T`, which holds exactly
+  when `H <= T`. Per-timestamp builders with times below `T` are finished
+  with the description bounds as today. Builders at or beyond `T` are
+  retained for the next description, which is also existing behavior.
+
+`H <= T` is not structurally guaranteed. Timely gives no ordering between
+data delivery and frontier propagation, so updates at or beyond `T` can
+arrive before the description does and, with too small a lag, age into the
+coalesced builder. Such an update is emitted by the reader only after it
+downgrades its capability past `T`, so its timestamp exceeds `T` by at
+most the reclocked time that elapses while the description is in flight.
+`H` therefore exceeds `T` only if that propagation delay exceeds `L`, and
+`L` is chosen orders of magnitude larger (minutes of reclocked time
+against in-flight delays of at most seconds). The failure is detected when
+the description arrives. The builder cannot be split, so the sink raises
+an error and the dataflow restarts, discarding the unlinked batch.
+Correctness is never at risk, only progress, and the same restart path
+already exists for snapshot errors.
+
+Resident memory is then bounded on both tiers. The coalesced builder holds
+at most `blob_target_size` plus one part upload in flight. The
+per-timestamp tier only ever spans the trailing window `L`, so its builder
+count is bounded by `L` divided by the reclock interval rather than by
+snapshot duration. With descriptions arriving regularly (the steady state)
+builders are finished before their times age past `H`, the coalesced
+builder stays empty, and behavior is unchanged. The coalesced tier fills
+only when the frontier stalls for longer than `L`, which is the hydration
+case. No persist API changes are required, and the crash leak behavior of
+eagerly uploaded parts is unchanged from today.
+
+### Kafka: backfill consumer with offset handoff
+
+Kafka has no rewind machinery. Retractions are derived by the per-export
+upsert operator from its own state, so the "snapshot" of a new export is a
+re-read of the topic from the export's start offsets, and a new export's
+upsert operator starts from an empty shard.
+
+- A second, backfill consumer reads from the hydrating exports' start
+  offsets while the steady consumer continues from the hydrated exports'
+  committed positions. The handoff is a per-partition offset `H`: the
+  hydrating export takes offsets below `H` from the backfill consumer and
+  offsets at or above `H` from the steady feed. Kafka offsets are dense per
+  partition, so the split is exact and needs no deduplication and no
+  negation.
+- The backfill consumer is a second rdkafka client. A client has one fetch
+  position per topic-partition, and the backfill reads the same partitions
+  at older offsets than the steady consumer, so one client cannot serve
+  both positions concurrently. Clients do not share connections, so the
+  backfill adds one connection per broker per worker for the duration of
+  the hydration, matching the steady consumer's footprint, and is torn
+  down at handoff. One backfill client per worker serves all hydrating
+  exports, reading once from the minimum of their start offsets, so the
+  cost does not grow with the number of exports added together. Because no
+  other export waits on the backfill, it can be paced to limit broker
+  load.
+- Per-export capabilities: hydrated exports' ports track the steady
+  consumer's progress. A hydrating export's port tracks the backfill
+  consumer and holds below the handoff point until the backfill reaches it.
+- The upsert operator needs no structural change. A hydrating export builds
+  a second full copy of upsert state on the replica while its backfill
+  runs, which is a memory cost on swap-only replicas.
+- Backfilled old offsets reclock through existing remap bindings, and
+  reclocked times not beyond the as-of are advanced to the as-of, which is
+  existing reclock behavior.
+- The topic must retain data back to the export's start offsets. This holds
+  for any design, since the data has no other source.
+
+For append-only envelopes (none, Debezium), the backfill emits the same
+insert-only records the steady path would, so the consumer split is
+sufficient and no per-key state is involved.
+
+### Restart semantics
+
+A restart during hydration discards the accumulated updates, they were
+never linked into the shard, and the snapshot restarts from the beginning,
+for the rewind connectors with a new temporary slot and a new snapshot LSN,
+for Kafka with a new backfill from the export's start offsets. This matches
+today's semantics. The serialization that today makes some restart
+interleavings impossible by construction is removed, so
+restart-during-snapshot paths need explicit re-verification (see Open
+questions).
+
+### Rollout
+
+PostgreSQL first, then MySQL and SQL Server, which use the same rewind
+structure adapted to their offset types. MySQL keys `RewindRequest` by a
+GTID snapshot upper, SQL Server already tracks a per-export `initial_lsn`
+and `snapshot_lsn` pair. In both, the snapshot upper is available when the
+snapshot transaction is established, so the same three operator changes
+apply. Kafka follows, since its backfill consumer is new machinery rather
+than an adaptation of the rewind changes.
+
+The capability policy change is gated by a feature flag, default off in
+production and default on in CI so the new path is exercised by the test
+suites before it is enabled.
+
+In general, a connector supports independent export frontiers when it can
+(a) emit each export on its own output port with its own capabilities,
+(b) determine the snapshot consistency bound when the snapshot starts
+rather than when it completes, (c) reconcile snapshot and stream either by
+compensating negated emission at the minimum time or through an envelope
+that derives retractions from state, and (d) derive per-export progress
+from its own read process.
+
+## Minimal Viable Prototype
+
+Step 1 is implemented for PostgreSQL: the snapshot and replication
+operators emit one output stream per export with capabilities managed in
+lockstep, and the `partition()` demux is replaced by pairwise
+concatenation. The pg-cdc test suite passes unchanged, validating the
+operator shape and the aggregate emission accounting before any behavior
+changes.
+
+## Considered but Rejected
+
+The research document records the full option space. Summary of the
+rejected options and why:
+
+- **Out-of-band snapshot committed directly to persist.** Run the snapshot
+  as a one-shot job and `compare_and_append` the result from the empty
+  upper at the reclocked snapshot LSN, then filter the stream against that
+  durably recorded LSN. Definiteness-sound and free of sink accumulation,
+  but it requires new infrastructure that option A does not: a one-shot job
+  outside the ingestion dataflow, a durable handoff record, verification
+  that the slot has not compacted past the recorded LSN, and per-export
+  start points threaded into the dataflow. Option A reuses the existing
+  rewind argument with connector-local changes only.
+- **Shadow pipeline with catch-up and handoff.** A second temporary
+  pipeline with its own replication slot snapshots the new table, follows
+  CDC to an agreed LSN, and hands off. Rejected for the second slot's WAL
+  retention and connection cost on the upstream database and for the
+  exactly-once handoff protocol it requires.
+- **Early rewind emission alone.** Emitting rewind requests at snapshot
+  start without per-export capabilities removes the stream-draining gate
+  but not the shared capability hold, so other exports still make no
+  visible progress. It is subsumed by this design as step 2.
+- **DBLog-style watermark snapshots.** Interleaving chunked snapshot reads
+  with the stream, deduplicating by primary key between watermarks,
+  produces a per-key upsert stream with no consistent point-in-time state.
+  Rejected because storage collections require exact multiplicities, the
+  nondeterministic interleaving violates definiteness, primary keys are not
+  guaranteed, and the write-access variants violate the upstream privilege
+  contract.
+- **Persist extensions as the primary mechanism.** Gap appends or
+  placeholder batches would make concurrent CDC durable immediately and
+  remove the sink accumulation problem entirely, and a staged batch
+  registry would make the coalesced builders crash-safe. Rejected for the
+  initial delivery because they change persist shard state, compaction, and
+  read paths, while the sink-only two-tier stash meets the memory bound
+  with no persist changes. They remain candidate follow-ons for restart
+  work recovery (see Out of Scope).
+
+## Open Questions
+
+- **Port count at scale.** A source with hundreds of tables produces that
+  many output ports on the reader operators. The downstream pipeline
+  already has one operator chain per export, but the port-per-export reader
+  shape and its progress-tracking overhead need validation at that scale.
+- **Restart interleavings.** Which restart-during-snapshot interleavings
+  become newly possible once the snapshot and replication phases overlap,
+  and what test coverage (platform checks, testdrive) demonstrates each is
+  handled.
+- **Two-tier horizon.** How the lag `L` is chosen and validated (a fixed
+  configurable value, or adaptive to observed description propagation
+  delay), and whether the restart-on-`H > T` fallback needs a metric and
+  alert since it silently costs a rehydration.
+- **Multiple concurrent hydrations.** Whether the sink change needs
+  per-export tuning when several large tables hydrate at once on one
+  replica.
+- **Upsert state during backfill.** A hydrating Kafka export builds a full
+  copy of its upsert state while its backfill runs. Whether that transient
+  cost needs mitigation on swap-only replicas, for example by pacing the
+  backfill consumer, and how it interacts with several exports backfilling
+  at once.

--- a/doc/developer/design/20260729_per_export_snapshot_frontiers.md
+++ b/doc/developer/design/20260729_per_export_snapshot_frontiers.md
@@ -135,8 +135,10 @@ early rewind requests which exports need dual emission.
 
 ### 3. Per-export capability policy
 
-Snapshot operator: ports of exports whose resume upper is past the minimum
-are closed immediately. A hydrating export's port holds at the minimum
+Snapshot operator: ports of exports the operator will not emit snapshot
+data on are closed immediately. That covers exports whose resume upper is
+past the minimum and exports that carry no snapshot data at all, such as a
+source's primary relation. A hydrating export's port holds at the minimum
 until its snapshot (e.g. `COPY`) completes, then closes.
 
 Replication operator: ports of hydrated exports downgrade freely with the

--- a/doc/developer/design/20260729_per_export_snapshot_frontiers.md
+++ b/doc/developer/design/20260729_per_export_snapshot_frontiers.md
@@ -268,8 +268,9 @@ snapshot transaction is established, so the same three operator changes
 apply. Kafka follows, since its backfill consumer is new machinery rather
 than an adaptation of the rewind changes.
 
-The capability policy change is gated by a feature flag, default off in
-production and default on in CI so the new path is exercised by the test
+The behavior change (steps 2 and 3) is gated by the
+`storage_source_snapshot_concurrent_replication` feature flag, default off
+in production and default on in CI so the new path is exercised by the test
 suites before it is enabled.
 
 In general, a connector supports independent export frontiers when it can

--- a/doc/developer/design/20260729_per_export_snapshot_frontiers.md
+++ b/doc/developer/design/20260729_per_export_snapshot_frontiers.md
@@ -1,0 +1,676 @@
+# Per-Export Frontiers for Source Snapshots
+
+## The Problem
+
+Adding a table to a running source (`CREATE TABLE ... FROM SOURCE`, or the legacy
+`ALTER SOURCE ... ADD SUBSOURCE`) restarts the ingestion dataflow. On the new incarnation, the
+added table has an empty resume upper and is snapshotted. Until that snapshot completes, no
+subsource of the source makes visible progress. CDC events for already hydrated tables are not
+processed, and their persist uppers do not advance. A snapshot of one large table can block every
+other subsource for hours.
+
+If multiple tables are added together, snapshotting may complete for the smaller tables, but they
+cannot make progress until the largest table is also done. Any error during this time restarts
+snapshotting for all tables.
+
+For the rewind-pattern sources (PostgreSQL, MySQL, SQL Server) the lost progress has two
+causes, both in the upstream reader operators:
+
+1. The replication operator drains its rewind input to completion before processing any CDC
+   events. Rewind requests are only sent after `COPY` (for OLTP) completes, so the CDC stream is
+   not read while a snapshot runs.
+2. All exports share a single data capability. While any rewind request is pending, the capability
+   cannot be downgraded past the minimum offset, because the operator must still be able to emit
+   retractions at the minimum timestamp.
+
+Kafka blocks for a different reason. Multiple tables can also be created from one Kafka source, for
+example to accommodate schema changes in the topic. The reader resumes every partition from the
+minimum resume upper across all exports, so adding a table makes the single consumer re-read the
+topic from the new table's start offsets, and the shared output port means no export commits new
+data until the re-read reaches the tip.
+
+Everything downstream of the snapshot and replication operators is already per export.
+- the statistics operator
+- reclock
+- decode and envelope
+- the persist sink
+
+One thing was not. The shard upper coming back from each persist sink was concatenated into a
+single feedback edge, so its frontier was the meet across exports and every export reported the
+slowest one's `offset_committed`. See Statistics semantics.
+
+## Success Criteria
+
+- While a newly added table snapshots, the already hydrated exports of the same source continue to
+  process CDC events and their persist uppers continue to advance.
+- When multiple tables are added together, each commits its snapshot and begins advancing as soon
+  as its own snapshot completes.
+- Definiteness is preserved. The contents of every collection at each readable timestamp remain a
+  deterministic function of durable shared facts. The output must not depend on any value known
+  only to a single replica or dataflow incarnation, such as the snapshot LSN of the temporary
+  slot.
+- Exact multiplicities are preserved. No design element requires primary keys or upsert semantics
+  from a source that does not already have them.
+- Memory on the replica during hydration is bounded by the unflushed tail of each open builder,
+  independent of snapshot duration, as long as the minter keeps committing windows. A minter that
+  sees none of an export's data breaks that bound, see Open Questions.
+- The number of batches the sink appends follows the number of committed windows plus the boundary
+  trailblazers, so it grows with the logarithm of the snapshot's duration and then linearly, one
+  per capped window, not with the timestamps the snapshot accumulated.
+- A restart during a snapshot remains correct. The snapshot restarts from the beginning, as today.
+
+
+## Solution Proposal
+
+Give each export its own output port and capability on the snapshot/replication operators, and
+hold back only the hydrating exports. Sources that use the rewind pattern keep their protocol
+unchanged. Kafka would need no reconciliation at all, a backfill feed and a steady feed read
+disjoint offset ranges, but its second consumer is deferred, see the Kafka section and Rollout.
+
+The work is confined to each source. `SourceRender::render` already returns per-export
+collections, reclock derives per-export output frontiers from per-export input frontiers without
+changes, and remap bindings are minted from the probe channel independent of data capabilities.
+
+Steps 1 and 4 apply to all sources. Steps 2 and 3 are the rewind-pattern changes. The Kafka
+section sketches their Kafka equivalent for the deferred work.
+
+### 1. One output port per export
+
+Replace the multiplexed `(output_index, data)` output and its `partition()` demux with one output
+port per export on the snapshot and replication operators. Exports are known at render time, ports
+are created in a loop, and each port gets its own capability set.
+
+This step preserves existing behavior. All port capabilities downgraded in lockstep, every export
+observes the same frontier as today.
+
+For existing operators using a single output handle, `handle.give_fueled()` provided a means of
+yielding at `MAX_OUTSTANDING_BYTES` to prevent the CDC stream from overwhelming downstream
+operators. With the change to multiple output handles, operators must aggregate bytes emitted for
+comparison against `MAX_OUTSTANDING_BYTES`.
+
+There aren't any known issues with the number of input or output ports in timely.
+
+### 2. Early snapshot bound
+
+Modify the snapshot operator to emit rewind requests at the start of the snapshot instead of at
+completion. For Postgres, the snapshot LSN is the temporary slot's consistent point and is known
+as soon as the slot is created, before any data is copied. The `resume_lsn <= snapshot_lsn + 1`
+validation moves to this earlier point.
+
+The replication operator no longer drains the rewind input before opening the replication stream.
+It starts streaming immediately, knowing from the early rewind requests which exports are
+hydrating.
+
+### 3. Per-export capability policy
+
+**Snapshot operator:** ports of exports the operator will not emit snapshot data on are closed
+immediately. That covers exports whose resume upper is past the minimum and exports that carry no
+snapshot data at all, such as a source's primary relation. A hydrating export's port holds at the
+minimum until its snapshot completes, the `COPY` for PostgreSQL, then closes.
+
+**Replication operator:** each port of hydrated exports downgrades with the data upper. A
+hydrating export's port holds at the minimum until the data upper passes its snapshot offset,
+because events at or below the snapshot offset must still be emitted negated at the minimum for
+that export. Once the upper passes the snapshot offset, the port downgrades with the data upper
+like the rest. The emission of rewind negations remains unchanged.
+
+Sources still acknowledge at the minimum shard upper across exports. For PG, a hydrating
+export continues to pin WAL retention, but no longer pins any other export's frontier.
+
+### 4. Bounded sink accumulation
+
+A batch's bounds come from a batch description, which `mint_batch_descriptions` emits when the
+collection's frontier advances. While an export snapshots its frontier is pinned, so no
+description is minted for the duration. The sink still receives snapshot rows at the pinned time
+and CDC events at later times, and has to group them into batches without knowing which
+description will cover them.
+
+Sources have the time domains `F` and `T`, `FromTime` and `MzTime`, respectively. The generic type
+names are `FromTime` and `IntoTime`, and in practice `IntoTime` is MZ time.
+- The snapshot operator emits data at `F:min`, which is reclocked to `T:c`, where `T:c` is the
+  captured current time. The snapshot operator pins its capability to `F:min`, and by extension,
+  `T:c`.
+- The replication operator emits data at from-times `f >= F:min`, that are mapped to MZ times
+  `t >= T:c`. The rewinds are currently the only data emitted by this operator at `F:min`. The
+  replication operator downgrades caps as today.
+
+Because snapshot has pinned its capability at `F:min`, the downgrades of the replication operator
+do not move the frontier forward, so all downstream operators see events reclocked to the correct
+`T` times. Once the snapshot is done, the operator drops its capability, and timely propagates some
+time `T:n`. Left to the frontier alone, the minter emits a single description `[T:c, T:n)`
+covering everything that accumulated during the snapshot. That one description is the root of the
+problem the rest of this step solves. It is the only thing that tells the sink how to group, and it
+arrives only after the snapshot it has to cover.
+
+#### Grouping
+
+The sink writes one batch per description, taking every timestamp that description covers into a
+single `BatchBuilder`. This keeps the batch count proportional to the number of descriptions rather
+than to the number of distinct reclocked timestamps the snapshot accumulated. It needs the bounds
+first. The grouping cannot be chosen before they are known, and a `BatchBuilder` cannot be split
+once a description boundary lands inside it.
+
+An update whose description has not arrived writes a batch of its own timestamp. A single timestamp
+is safe to write without knowing the descriptions, because a description covers a timestamp
+entirely or not at all, and it is exactly what the sink does for every update today. It declares
+the operator's lower, the only lower guaranteed to be at or below every description that could come
+to cover it, and is finished the moment a description covers it.
+
+The data that arrives before the description covering it is the leading edge. The descriptions
+below the leading edge are committed to by the minter ahead of the data, so the leading edge is the
+rows that reach a writer at a window boundary before the broadcast description does, and everything
+else is grouped. A row in the leading edge is a trailblazer, ahead of its description.
+
+An update goes into a `BatchBuilder` as it arrives. The builder is the buffer. It writes a part to
+blob every `persist_blob_target_size` and keeps at most
+`persist_batch_builder_max_outstanding_parts` uploads in flight. What sits in memory while the
+frontier is pinned is the unflushed tail of each open builder. A batch stays unlinked in blob until
+its description is appended, so the sink trades memory for blob writes it may throw away on a
+restart.
+
+Two kinds of builder are open at once.
+- A builder per in-flight description, taking data at timestamps in its range.
+- A builder per trailblazer timestamp, for data in the leading edge that no description covers
+  yet.
+
+A description's builder closes as soon as data moves past it. This keeps their number from following
+how long the frontier stays pinned, with one exception. The builder whose description covers the
+frontier's own time stays open until that description is ready. The frontier's time is incomplete by
+definition, and during a snapshot it is where the snapshot's rows land for the snapshot's whole
+duration, interleaved with replication rows that have moved on to later windows. Closing that
+builder whenever a later window's row arrives reopens it on the next snapshot row, one batch per
+flip.
+
+Arrival order is an efficiency assumption, not a correctness one. Readiness and the
+`operator_batch_lower` declared by trailblazer data are both gated on the frontier, so a straggler,
+a row arriving for a window whose builder has already closed, reopens that builder and costs one
+extra batch.
+
+#### Committed descriptions
+
+The sink can group without waiting for the frontier if it knows where the next description boundary
+falls. The minter will "commit" to boundaries instead of deriving them. I'm not sure if there's a
+better word for this, but this is the upper that the minter "commits" to uphold. It emits `[a, b)`
+for a `b` of its own choosing and then honors it. So a frontier arriving inside `[a, b)` is ignored,
+and the next description still starts at `b`. We choose a `b` that is larger than the frontier
+time step, so eventually this collapses when the snapshot completes and the next frontier arrives.
+The minter emits `[b, frontier_upper)`, and from that point forward, the persist sink operates
+as it does today.
+
+Committing to a boundary for a description before the frontier advances is safe because the
+description doesn't dictate completeness. The sink appends to persist only once `desired_frontier`
+reaches its upper, so a "committed" description waits in `in_flight_batches` until then.
+
+To ensure we can start grouping immediately, the minter commits to a boundary ahead of the data. A
+description has to reach the writers before the rows it covers, since a builder only takes rows at
+times it was opened for. So the first window `[T:c, T:c + w)` is committed the moment the export's
+frontier pins, before any row has arrived, on the knowledge that the snapshot's rows are about to
+land at `T:c` itself. The minter passes data for the desired collection through, so it sees the
+largest timestamp the data has reached. It uses this to determine the boundary for the next window,
+once that timestamp comes within a margin of the committed upper. The margin is equal to the
+initial width, the dyncfg value, so the description still has a head start over the rows. Each
+commitment doubles the width of the next, up to `storage_persist_sink_description_window_max`, so a
+short snapshot commits little past its end and a long one costs few descriptions.
+
+The minter has two rules for emitting a description.
+- Emit `[current_upper, desired_frontier)` whenever the frontier is ahead of the committed upper,
+  which is steady state and commits to nothing.
+- Emit `[current_upper, current_upper + width)` once `max_seen + margin > current_upper`, while the
+  export's snapshot is in progress.
+
+Only a commitment ending past the frontier widens the window, so the doubling is driven by the
+pinned frontier during snapshot, not by steady state. Committing costs the minter the coupling
+between the upper it emits and the frontier it observes. The minter downgrades to that upper
+rather than to the frontier, so `current_upper > desired_frontier` becomes a state it has to expect.
+
+The two rules interleave in three phases. `F` is the frontier and `C` the committed upper, with the
+snapshot pinned at `c` and an initial width of `w`.
+
+While the snapshot runs, `F` does not move and `C` steps ahead of the data, each step on the second
+rule:
+
+```
+frontier     F                                      C        F pinned at c for the whole snapshot
+MZ time  ----c------c+w---------c+3w----------------c+7w-->
+             [c,c+w)[c+w,  c+3w)[c+3w,        c+7w)          C steps ahead of the data
+             on the when data   when data
+             pin    nears c+w   nears c+3w
+```
+
+When the snapshot ends, `F` jumps to wherever the source has reached. Every window below it appends
+in one pass. The window it lands in binds, and the distance from `F` to `C` is the tail:
+
+```
+frontier                                    F       C        F jumps to where the source is
+MZ time  ----c------------------c+3w----------------c+7w-->
+             [c, c+3w) appended [c+3w, c+7w) binds           shard upper waits at c+3w
+                                            |-tail->|        until F reaches c+7w
+```
+
+Once `F` passes `C`, the first rule takes over and every description is derived from the frontier,
+so `C` and `F` coincide from then on:
+
+```
+frontier                FC        FC        FC               C rides on F
+MZ time  ----c+7w-------F1--------F2--------F3------------>
+             [c+7w, F1) [F1, F2)  [F2, F3)                   each derived from the frontier
+```
+
+An export snapshots when its resume upper is the minimum from-time, and this is passed into the
+persist sink. Exports with the CDCv2 envelope are excluded. Their MZ times come from the data rather
+than from reclocking, so a wall-clock width has no meaning there and a committed upper the data
+never reaches would hold the shard upper forever. The test has to be made in the from-time domain.
+Reclocking a resume upper maps any MZ time at or below the as_of back to the minimum, which is what
+keeps a restart during a snapshot reading as snapshotting even though its shard upper has moved past
+`T:min`. The frontier alone doesn't carry enough information to determine if a snapshot is
+happening, as any dataflow restart would appear to be snapshot.
+
+The frontier is used to determine when the snapshot ends. This relies on the invariant that a
+snapshot occupies a single MZ time. Sources that rewind emit theirs at `F:min`, so it reclocks to
+`T:c`, which the frontier holds until the snapshot port closes and the replication port downgrades
+past the snapshot offset. Kafka reads real offsets rather than `F:min` and reaches the same place,
+see the Kafka section. The minter keeps the first non-minimum frontier a snapshotting export takes
+and permits the second rule only while `desired_frontier` equals it, and never before that frontier
+has arrived. Timely does not order progress ahead of data, and a row can reach the minter under a
+frontier still at the minimum. Committing on it would anchor the window at the shard upper rather
+than at `T:c` and mint windows across the whole gap between them, which on a fresh shard is every
+window between zero and the wall clock. Once a snapshot is committed and the shard upper advances,
+this path is not reachable for the export.
+
+Catching up costs one append. Every committed description becomes ready in the same pass when the
+frontier advances, and `append_batches` combines every description ready in a pass into a single
+`compare_and_append` over the whole range. Setting `persist_validate_part_bounds_on_write` or
+`persist_validate_part_bounds_on_read` gives each description an append of its own instead.
+
+The commitment's cost is a tail. A commitment is binding, so while `current_upper` sits ahead of the
+frontier the first rule mints nothing, and when the snapshot ends the shard upper waits for the
+frontier to reach the last committed upper rather than advancing to where the frontier actually
+reached. The last window was committed when the data came within the margin of the previous upper,
+so the tail is at most the margin plus the last width, which with doubling is up to the snapshot's
+own duration, capped by `storage_persist_sink_description_window_max`. The snapshot gate confines
+the exposure to exports that are snapshotting, where the frontier is not advancing anywhere in the
+first place. A collection keeping up lags the data by about one `timestamp_interval` and has nothing
+to group, so committing there would pay the tail for nothing. An export whose stream is quiet during
+its snapshot and then receives a burst commits every window between the last upper and the burst in
+one pass, each an empty description that still has to be minted, broadcast, and carried to the
+append.
+
+Leaving the window at zero mints descriptions from the frontier alone, so the sink writes one batch
+per timestamp exactly as it does today.
+
+#### Commit timing across workers
+
+Only the active worker mints, and its input is `Pipeline` connected, so the timestamp it times the
+next commitment against is the largest one reaching its own sink instance. Descriptions travel to
+the writers by broadcast while data reaches each writer directly, so another worker can take in a
+row at a window boundary before the description covering it arrives. The margin is the head start
+that closes that gap, and a row that beats its description anyway is a trailblazer. It writes a
+batch of its own timestamp, finished under the description's bounds when it lands.
+
+How much of an export the minting worker sees varies by source. PostgreSQL round robins
+replication rows across all workers, so every worker's largest timestamp tracks the stream and the
+margin is enough. MySQL reads its binlog on one worker. A minter that is not that worker sees none
+of the CDC, so its largest timestamp never moves past `T:c`, no window after the first is
+committed, and everything the binlog worker takes in during the snapshot degrades to one batch per
+timestamp. That shape needs either each worker exchanging its largest timestamp to the minter on a
+disconnected input, or a trigger that does not depend on data at all, see Open Questions.
+
+Replicas commit independently, so two of them land on different boundaries. That costs at most one
+straddling batch per transition, which the append path already trims against a raised shard upper.
+
+#### Concurrent ingestion
+
+A concurrent writer, another replica of the same ingestion, can raise the shard upper into the
+middle of a description. The sink advances that description's lower and re-appends. Persist
+registers the batch under the narrowed bounds, as a truncated batch, and filters the out-of-bounds
+updates on read. Batches carry their largest timestamp, so ones lying entirely below the new lower
+are deleted entirely rather than appended as truncated.
+
+#### Statistics semantics
+
+`offset_committed` is reported per export. Each export gets its own feedback edge carrying its
+shard upper back from its persist sink, and one operator in the pipeline inverts each of those
+uppers through the remap bindings and reports the result for that export alone.
+`SourceTimestamp::to_offset_stat` does the frontier to offset conversion, which every timestamp
+type already had in some form on the source side. What the source acknowledges upstream is still
+the meet across exports, that has to respect the slowest one, and `mz_source_statistics` reports the
+parent source as `MIN(offset_committed)` over its exports, so the source-level number keeps its old
+meaning while the per-export rows tell the truth about each
+table.
+
+Two things fall out of that. Every worker has to initialize the gauge, because the controller only
+aggregates a gauge once every worker has reported a value for it and renders a failed aggregate as
+zero, which single-worker tests will not catch. And PostgreSQL no longer pre-fills
+`offset_committed` with the slot's resume LSN at startup, which existed to keep the lag calculation
+from looking enormous during an initial snapshot. An export reads zero until its first commit now.
+That is the honest per-export lag, but anything subtracting it from `offset_known` will show the
+whole LSN as lag while an export snapshots.
+
+#### Handling for large xacts
+
+If an upstream transaction contains a large number of rows they all land at a single timestamp. The
+builder holding them spills its parts to blob once it passes `persist_blob_target_size`, so memory
+is bounded by that rather than by the transaction. A description covering that timestamp puts the
+transaction in the same batch, and the same append, as everything else the description covers.
+
+### Kafka backfill consumer with offset handoff, deferred
+
+This section is the sketch for the Kafka side, which Rollout defers. Kafka has no rewind machinery.
+The "snapshot" of a new export is a re-read of the topic from the export's start offsets, and "CDC"
+events are the data after the snapshot, split by Kafka offset. If there are two exports for the same
+topic, the hydrated export stops progressing because the shared Kafka consumer has to read from the
+other export's start offsets.
+
+The Kafka source would have up to two consumers, one backfilling every export that needs hydration
+and one for steady state. If no hydration is necessary, or all exports need hydration, only a single
+consumer is created. This limits the two consumer case to the situation that motivates it, adding a
+new export where one already exists.
+
+For the mixed export case, a frontier `B` is determined on startup. The backfill consumer will
+capture rows below `B`, and the steady state consumer captures rows at or above `B`. The two
+consumers emit concurrently for hydrating exports. As today with transition from hydration to
+steady state, the handoff at frontier `B` requires no dedup or negation. This is possible because
+the set of records for the snapshot and the set of records for steady state are disjoint. The
+logical choice for `B` is the minimum `resume_upper` for all non-hydrating exports in the mixed
+export case. For the case where all exports are hydrating, `B` keeps its existing definition,
+which is the maximum frontier (maximum offsets of each partition).
+
+The backfill occupies a single MZ time, which is what the sink's snapshot gate reads. Reclocking
+maps an offset to the earliest binding whose source upper exceeds it, and the controller holds the
+remap shard's since one step behind the exports' uppers, so the trace a restart reads is compacted
+to `T:c` and every offset below the source upper there lands on it. `B` sits within a step of that
+bound, so the hydrating export's frontier stays at `T:c` for the backfill's duration and advances
+once when the backfill port closes. A source where every export is hydrating gets there by a
+different route. The first binding minted into an empty remap shard maps the probed tip to the
+minimum MZ time.
+
+The existing Kafka behavior for reporting snapshot progress is to capture the maximum offsets for
+each partition in the topic, sum them, and treat them as `snapshot_records_known`. In the mixed
+export case, snapshot and steady state records are being processed concurrently. To accurately
+record statistics, metrics definitions are updated.
+
+1. `snapshot_records_known` would be `sum(B - start_offsets)`
+2. `snapshot_records_staged` counts backfill progress only
+3. `updates_staged` counts steady state records (doesn't include backfill)
+
+This fixes an issue in the existing implementation, which ignores `start_offsets` in the
+calculation of `snapshot_records_known`. This doesn't change the issue that `B - start_offsets`
+overcounts on compacted topics.
+
+Upsert v2 is rolling out and is expected to become the default. Correctness holds there, since
+snapshot and steady state records land in the merge batcher and are only emitted on frontier
+progression. Unfortunately, updates will accumulate in the upsert merge batcher because the frontier
+is pinned, increasing memory utilization. The increase is the replication updates (e.g. messages 
+at offsets post-snapshot). The batcher pages cold data out of resident memory, but the staged
+volume itself grows with the snapshot duration. Additionally, the merge batcher drain is sequential
+per timestamp. For a long hydration period, this drain would cover thousands of timestamps, each
+making a round-trip through persist. Upsert needs rework to cover the concurrent streams behind
+a pinned frontier. This is deferred as it needs more thought and adds a lot more risk around
+correctness, so is best handled as a separate effort.
+
+### Restart semantics
+
+A restart during hydration discards the accumulated updates. That now includes the CDC staged
+during the snapshot, where before there was only snapshot progress to lose. Multiple tables
+snapshotting together come out ahead. Today none of them can complete until all do, so a restart
+sends every table back to the start. With independent frontiers a table that finished keeps its
+snapshot and only the unfinished ones start over.
+
+The upstream position the source acknowledges is the meet over exports of their shard uppers,
+inverted through the remap bindings. A snapshotting export's shard upper never passes `T:c`, so the
+meet stays at the position the source resumed from when the export was added, `P`, and the upstream
+retains everything from `P` for the whole snapshot. For PostgreSQL that position is the replication
+slot's confirmed flush LSN. And the dataflow `as_of` on restart is the remap since, which the
+snapshotting export's read hold keeps at `T:c`, so the new incarnation reclocks that export's shard
+upper back to the minimum and snapshots it again even though the empty first description moved the
+upper to `T:c`.
+
+These are notes on the newly possible states and how to test them. The cases below use a hydrated
+export `A`, a new table `B` with snapshot offset `s`, and `B`'s appended windows written as
+`[c, c+kw)`. Offsets are the source's from-time, LSNs for PostgreSQL.
+
+1. **Restart during the copy.** `B` snapshots again at a new snapshot offset `s' > s`, stamped
+   at the same `T:c`. The resume offset is the minimum over exports and `B` contributes `P`, so
+   the stream restarts at `P` and re-decodes everything `A` appended during the snapshot. Those
+   rows are dropped below `A`'s shard upper, but `A`'s frontier and its `offset_committed` hold
+   until the re-read passes `A`'s resume offset. The restart also reads the
+   remap trace retained since `T:c`, one binding per probe for the snapshot's duration, in both
+   `reclock_resume_uppers` and `reclock_committed_upper`. Correctness rests on the filtering of
+   re-read rows below an export's upper in the persist sink and in upsert.
+2. **Restart in the tail.** The copy is complete, `B`'s frontier sits inside the last committed
+   window, and the windows below it are appended, so `B`'s shard upper is a window boundary such as
+   `c+3w`. When `s` reclocks to a time above that boundary, `B`'s resume offset is below its own
+   snapshot offset, yet `B` counts as hydrated, so no copy and no rewind request. `B`'s events
+   between the resume offset and `s` are emitted forward at times at or above `c+3w`, while their
+   negations at `T:c` are already in the appended batch. The appended prefix is `B`'s state at the
+   resume offset, so the result is correct. Correctness rests on appends being frontier gated,
+   which makes any `B` upper past `T:c` imply a complete snapshot.
+3. **Two tables added together, one completes first.** `B1` is hydrated and advancing while `B2`
+   still copies. Only `B2` snapshots again. `B1` resumes from its own upper and keeps its data, as
+   does `A`. The stream still restarts at `P` because `B2` contributes it, so `B1`'s events between
+   `P` and its resume offset arrive again and are dropped, and `B2`'s rewind negates `(P, s2']`.
+4. **Restart after `B`'s replication port releases but before the copy ends.** The stream has
+   passed `s`, the rewind entry is gone, and `B`'s forward events already flow into windows.
+   Nothing is appended past `T:c`, so the restart is case 1, but the negations emitted for `(P, s]`
+   are discarded with the batches and the new incarnation negates the wider `(P, s']`. The leaked
+   batches hold that CDC volume as well as the snapshot, see Out of Scope.
+5. **Drop of the snapshotting table.** Dropping `B` restarts the dataflow without it. Its read
+   hold goes, the remap since moves up to `A`'s upper, the resume offset becomes `A`'s, and the
+   acknowledged position advances from `P`. Dropping `B1` while `B2` still copies must leave it at
+   `P`, since `B2` still contributes it.
+
+Cases 1 and 2 are the newly possible states. A stream restarting at `P` while siblings are far
+ahead, and a hydrated resume point below the export's own snapshot offset. Cases 3 to 5 are
+existing behavior over wider intervals. Each needs a test that restarts the replica in that state
+and compares every export against upstream, see Open Questions.
+
+### Rollout
+
+PostgreSQL first, then MySQL and SQL Server, which use the same rewind structure adapted to their
+offset types. MySQL keys `RewindRequest` by a GTID snapshot upper, SQL Server already tracks a
+per-export `initial_lsn` and `snapshot_lsn` pair. In both, the snapshot upper is available when
+the snapshot transaction is established, so the same three operator changes apply. Kafka is
+deferred, since its backfill consumer is new machinery and upsert needs a rethink.
+
+The behavior change is gated by the
+`storage_source_snapshot_concurrent_replication` feature flag, default off in production and
+default on in CI so the new path is exercised by the test suites before it is enabled.
+
+`storage_persist_sink_description_window` is separate and defaults to zero, which leaves the sink
+writing one batch per timestamp. The test configuration sets it to one second with
+`storage_persist_sink_description_window_max` at five minutes. Concurrent replication is what makes
+a snapshot accumulate many timestamps, so the window has to carry a value before that flag is turned
+on.
+
+In general, a source supports independent export frontiers when it can do four things.
+1. emit each export on its own output port with its own capabilities
+2. determine the snapshot consistency bound when the snapshot starts rather than when it completes
+3. reconcile snapshot and stream either by compensating negated emission at the minimum time or
+   through an envelope that derives retractions from state
+4. derive per-export progress from its own read process
+
+
+## Open Questions
+
+- **Restart interleavings.**
+  - Which of the five cases under Restart semantics get a test, and in which framework (platform
+    checks, testdrive). Case 2 needs a window small enough that the first appended window closes
+    before the snapshot offset's time. Cases 1 and 4 need a replica killed while a copy runs against
+    a busy sibling.
+- **Trailblazer visibility.**
+  - Whether the leading edge needs a metric for the batches it produces, so a snapshot whose
+    trailblazers, or whose blind minter, degrade it toward one batch per timestamp is visible rather
+    than inferred from persist shard shape.
+- **Reader distribution versus pipelining.**
+  - Whether source readers should round robin rows to all workers, as PostgreSQL does, or whether
+    an export should stay on the worker that read it. The source implementations already disagree.
+    PostgreSQL exchanges and casts rows downstream of the reader, MySQL reads, decodes and emits on
+    one worker. Neither shape is known to be the faster one, there is no data.
+  - Pipelining is less complex, and part of what would bound it is persist part uploads. Uploads
+    already run as spawned tasks, but `persist_batch_builder_max_outstanding_parts` defaults to 2,
+    so the builder blocks on blob storage long before the append that actually commits, and
+    `write_stalls` counts it when that happens. Measuring a single export at high volume on one
+    worker, with `write_stalls` and CPU separated, would show where the bottlenecks are.
+  - The one-worker shape is also where the minter goes blind, so the answer decides whether each
+    worker exchanges its largest timestamp to the minter, one timestamp rather than a byte count,
+    or whether the trigger moves to the wall clock, which MZ time is in milliseconds.
+- **Multiple concurrent hydrations.**
+  - Builders spill to blob at `persist_blob_target_size`, so the resident exposure per export is one
+    unflushed part for the builder covering the frontier's time, one for the current window, and one
+    per trailblazer timestamp, summed over every export snapshotting at once. Whether that stays
+    inside a replica's memory when several large tables hydrate together.
+- **Tail after long snapshots.**
+  - A snapshot longer than the window cap ends with a tail of up to the cap plus the margin before
+    its export is readable. Whether that is acceptable, and what a policy that shortens the last
+    window as the snapshot nears its end would cost in descriptions, given the sink cannot see the
+    end coming.
+
+
+## Cross-component impact (Claude discovered)
+
+- **Console assumes exports move in lockstep.**
+  - Ingestion lag tracks the freshest export, `max(offset_committed)` over the source and its
+    tables, in `console/src/api/materialize/source/sourceStatistics.ts` for both the current query
+    and the pre-0.148 variant. Fine when every export reported the same offset, but exports can
+    diverge now, so a table that is still snapshotting doesn't show up.
+  - Combined sources may be overcounting. The console unions the source with its tables in
+    `sourceStatistics.ts`, and `mz_source_statistics` in `src/catalog/src/builtin/mz_internal.rs`
+    already rolls the tables up into the source.
+  - The snapshotting badge is all-or-nothing. `console/src/api/materialize/source/sourceList.ts`
+    reads the source-level `snapshot_committed`, which is `bool_and` over the exports, so
+    `console/src/platform/connectors/utils.ts` shows a source as snapshotting while the rest of its
+    exports are streaming.
+  - The per-table tab and the queries behind it only know about source status, in
+    `console/src/api/materialize/source/sourceTables.ts` and
+    `console/src/platform/sources/SourceTables.tsx`. They should be expanded to show per-export
+    info, which is where the divergence is most worth seeing.
+  - `console/src/platform/maintained-objects/SourceDiagnostics.tsx` decides the snapshot is done
+    from record counts instead of the `snapshot_committed` flag. Possibly a bug, though it may have
+    been a workaround, in which case we should fix whatever made the flag unusable.
+  - The maintained objects list in `console/src/platform/maintained-objects/queries.ts` drops
+    anything with `sourceType == "subsource"` and shows only the top-level source. That is no
+    longer accurate, the parent says nothing about the subsources under it.
+
+
+## Out of Scope
+
+The following are follow-on work. The design does not depend on them, and they can land
+independently later.
+
+- **Recovering accumulated work across restarts.**
+  - A restart during hydration discards the hydrating export's snapshot and CDC data. On restart,
+    both must be redone. Ensuring correctness on a restart would require substantial effort, and
+    it isn't clear that it's needed.
+- **Cleanup of leaked batches.**
+  - Batches that were written to persist, but not linked in the shard are leaked. This is existing
+    behavior, but was bound by snapshot size, and is now bound by snapshot + CDC during snapshot
+    size.
+- **Upsert storage increase due to concurrent streams.**
+  - The deferred Kafka design relies on two consumers, a backfill and a steady state one. In a
+    mixed-export scenario, some exports hydrating and some in steady state, the hydrating
+    exports' frontier is pinned due to hydration. Records from both the snapshot and steady state
+    will collect in the upsert's merge batcher, where before it was only snapshot records.
+    Addressing this requires additional design around upsert.
+
+
+## Considered but Rejected
+
+Summary of the rejected options and why.
+
+- **DBLog-style watermark snapshots.**
+  - Interleaving chunked snapshot reads with the stream, deduplicating by primary key between
+  watermarks, produces a per-key upsert stream with no consistent point-in-time state. Rejected
+  because storage collections require exact multiplicities, the nondeterministic interleaving
+  violates definiteness, and all sources would now require upsert.
+- **Persist extensions as the primary mechanism.**
+  - Gap appends or placeholder batches would make concurrent CDC durable immediately and remove the
+  sink accumulation problem entirely, and a staged batch registry would make the grouped builders
+  crash-safe. Rejected for the initial delivery because they change persist shard state, compaction,
+  and read paths.
+- **Out-of-band snapshot committed directly to persist.**
+  - Run the snapshot as a one-shot job and `compare_and_append` the result, then restart the main
+  dataflow to pick up the export, which is now past the snapshot, so no other exports are affected.
+  Rejected because it needs infrastructure this design does not.
+    - a one-shot job outside the ingestion dataflow
+    - a durable handoff record
+    - verification that the slot has not compacted past the recorded LSN
+    - per-export start points threaded into the dataflow
+- **Shadow pipeline with catch-up and handoff.**
+  - A second temporary pipeline with its own replication slot snapshots the new table, follows CDC
+  to an agreed LSN, and hands off. Rejected as this does not improve slot's WAL retention, adds
+  connection cost on the upstream database, and requires an exactly-once handoff protocol.
+
+The following were considered for persist sink, and all share a root cause. Each tries to
+choose a batch's grouping before its bounds are known, which is the thing that cannot be done
+safely.
+
+- **Trailing-lag grouping.**
+  - Hold arriving rows and move them into a grouped builder once they fall a fixed lag `L` behind
+  the latest data time, rotating that builder when the frontier advances. Rejected because `L` must
+  exceed the frontier's propagation delay, which is not a quantity the sink can bound, and
+  exceeding it is only detected at rotation, where the recovery is a dataflow restart.
+- **A coalescing horizon published by the minter.**
+  - Have `mint_batch_descriptions` broadcast a promise that no future description will end below
+  some time, so write operators can group updates below it before their description exists.
+  Rejected as stated, because the promise was derived from the minter's frontier, which is pinned
+  for exactly the duration of a snapshot. The committed descriptions in step 4 are the corrected
+  form. The minter commits to boundaries of its own choosing instead of promising something about a
+  frontier it cannot move, and the data it already passes through triggers the commitment.
+- **Source read progress as the coalescing horizon.**
+  - Feed the source's reclocked read progress into the minter so the promise can advance while the
+  collection's frontier is pinned. Rejected because a horizon that certifies completeness has to
+  come from the data path to be sound. Computing it beside the data path lets it announce a time
+  the reclock operator has not released updates for yet, so it needs a progress output on the
+  per-export reclock, ordered behind the data that operator emits, and even then it cannot pass the
+  upsert merge batcher. Allowing several batches under one description drops the requirement from
+  completeness to a boundary trigger, which the bindings satisfy without touching source
+  machinery.
+- **Splitting the pinned traffic onto its own output.**
+  - Give the traffic at the minimum offset, the snapshot rows and the rewind retractions, a
+  separate output so the ongoing replication stream keeps an unpinned frontier. Rejected because
+  the split is not static. The replication operator's schema-validation errors are emitted at
+  whatever the port's capability currently holds, which is the minimum only while a rewind is
+  pending, so routing them has no fixed answer. Envelope processing in `render_source_stream` is
+  also stateful for upsert and cannot carry a split through in general.
+- **Ending descriptions at the data, with a raw stash for the leading edge.**
+  - Commit `[current_upper, max_seen + 1)` every `N` bytes the minter passes through, so a
+  description ends at the data instead of ahead of it, and have each writer hold rows for
+  timestamps no description covers yet as raw rows, draining them into the description's builder
+  when it arrives and evicting the heaviest timestamps into single-timestamp builders when the
+  stash overflows. This has real advantages. No tail, since the shard upper lands exactly where the
+  frontier does when the snapshot ends, boundaries that track volume rather than time, no need to
+  detect the pin, and snapshot rows that cancel against their rewind retractions before anything is
+  written. Rejected because a description minted behind the data can only group rows the writer is
+  still holding, so the stash is load bearing and needs a budget of its own, kept above the
+  description budget so commitments drain it before eviction fires. The eviction backstop reclaims
+  that budget and not memory, because an evicted builder below `persist_blob_target_size` keeps its
+  rows resident, so a stream spread across many timestamps is invisible to it. And the minter sees
+  only its own worker's bytes, so the trigger needs every worker to exchange running byte totals to
+  it. Scaling the budget by the worker count instead assumes a source spreads an export evenly,
+  which holds for PostgreSQL and not for MySQL, and the sink cannot tell the two shapes apart. That
+  is two budgets with an ordering constraint, a consolidation heuristic, an eviction policy, and an
+  exchange, and it still needs the same rule for the builder covering the frontier's time.
+- **Pager-backed spill for the leading edge.**
+  - Spill rows into `mz_ore::pager` chunks rather than into persist batches, keeping the batch count
+  at one per description regardless of budget. Rejected for now because the pager's default backend
+  is swap, which is ordinary heap plus a reclaim hint and so does not change the bound. Only the
+  file backend does, and it depends on a scratch directory and on a process-global setting that
+  compute owns.
+- **Product timestamps to expose stream progress under the pin.**
+  - Give the ingestion an `(outer, inner)` time so the snapshot sits at `(min, min)` and the stream
+  at `(f, min)`, with the inner coordinate gating persist. Rejected because `(min, min)` is the
+  minimum of the product domain and is below every stream time, so the frontier is the single
+  element `{(min, min)}` for the whole snapshot and carries no more than the plain frontier does.
+  Exposing stream progress needs the snapshot to be incomparable with the stream, that is above it
+  in the gate coordinate. That form would give the minter a global trigger and the writer a
+  frontier-backed closing rule, but it leaves the persist upper and the bounds-at-add-time trade
+  untouched, and it is sound only where addition commutes, so not under upsert, where base before
+  delta is exactly the order that pins.
+- **Folding concurrent CDC into the snapshot time.**
+  - Write the stream's rows at `T:c` alongside the snapshot for as long as it runs, so the whole
+  snapshot period is one persist time, one spilling builder, no grouping, and upsert state that
+  collapses per key. Rejected because the export's contents at `T:c` become the state at the offset
+  where the fold ended, so its history over the interval up to that offset's time disagrees with the
+  remap bindings and with the source's other exports. A dataflow installed on the export during the
+  snapshot picks an `as_of` in that interval, observes the disagreement, and holds the since there
+  so it cannot be advanced past.

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -116,6 +116,7 @@ def get_minimal_system_parameters(
         "enable_worker_core_affinity": "true",
         "grpc_client_http2_keep_alive_timeout": "5s",
         "ore_overflowing_behavior": "panic",
+        "storage_source_snapshot_concurrent_replication": "true",
         "unsafe_enable_table_keys": "true",
         # Keep the 0dt stability soak out of the critical path for tests. The
         # production default is much higher. Dedicated workflows override this.

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -116,6 +116,7 @@ def get_minimal_system_parameters(
         "enable_worker_core_affinity": "true",
         "grpc_client_http2_keep_alive_timeout": "5s",
         "ore_overflowing_behavior": "panic",
+        "storage_persist_sink_stash_coalesce_lag": "1s",
         "storage_source_snapshot_concurrent_replication": "true",
         "unsafe_enable_table_keys": "true",
         # Keep the 0dt stability soak out of the critical path for tests. The

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -131,6 +131,9 @@ def get_minimal_system_parameters(
         "enable_worker_core_affinity": "true",
         "grpc_client_http2_keep_alive_timeout": "5s",
         "ore_overflowing_behavior": "panic",
+        # Tiny so the sink's stash eviction path runs in tests. The production
+        # default is large enough that most stalls never reach it.
+        "storage_persist_sink_max_raw_stash_bytes": "4096",
         "storage_source_snapshot_concurrent_replication": "true",
         "unsafe_enable_table_keys": "true",
         # Keep the 0dt stability soak out of the critical path for tests. The

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -131,9 +131,10 @@ def get_minimal_system_parameters(
         "enable_worker_core_affinity": "true",
         "grpc_client_http2_keep_alive_timeout": "5s",
         "ore_overflowing_behavior": "panic",
-        # Tiny so the sink's stash eviction path runs in tests. The production
-        # default is large enough that most stalls never reach it.
-        "storage_persist_sink_max_raw_stash_bytes": "4096",
+        # Narrow enough that a snapshot in these tests commits several
+        # descriptions and pays little at its end. parallel-workload rolls the
+        # widths production is meant to run at.
+        "storage_persist_sink_description_window": "1s",
         "storage_source_snapshot_concurrent_replication": "true",
         "unsafe_enable_table_keys": "true",
         # Keep the 0dt stability soak out of the critical path for tests. The
@@ -248,6 +249,11 @@ def get_variable_system_parameters(
         # variant lets randomized runs pair a full budget with delay=0s.
         VariableSystemParameter(
             "persist_blob_hedged_get_budget_ratio", "0.01", ["1.0", "0.01"]
+        ),
+        # A ceiling near the 1s window keeps the doubling short so a snapshot
+        # in CI commits many descriptions; the larger ones let it widen.
+        VariableSystemParameter(
+            "storage_persist_sink_description_window_max", "5min", ["2s", "30s", "5min"]
         ),
         # -----
         # Others (ordered by name),

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -131,6 +131,7 @@ def get_minimal_system_parameters(
         "enable_worker_core_affinity": "true",
         "grpc_client_http2_keep_alive_timeout": "5s",
         "ore_overflowing_behavior": "panic",
+        "storage_source_snapshot_concurrent_replication": "true",
         "unsafe_enable_table_keys": "true",
         # Keep the 0dt stability soak out of the critical path for tests. The
         # production default is much higher. Dedicated workflows override this.

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2936,6 +2936,10 @@ class FlipFlagsAction(Action):
             "'10ms'",
             "'2s'",
         ]
+        self.flags_with_values["storage_persist_sink_max_raw_stash_bytes"] = (
+            # Always evict, evict under light load, never evict in practice.
+            ["0", "1024", "16777216"]
+        )
         self.flags_with_values["enable_variadic_left_join_lowering"] = (
             BOOLEAN_FLAG_VALUES
         )

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2936,10 +2936,19 @@ class FlipFlagsAction(Action):
             "'10ms'",
             "'2s'",
         ]
-        self.flags_with_values["storage_persist_sink_max_raw_stash_bytes"] = (
-            # Always evict, evict under light load, never evict in practice.
-            ["0", "1024", "16777216"]
-        )
+        self.flags_with_values["storage_persist_sink_description_window"] = [
+            # Never commit a description ahead of the frontier, a window of a
+            # single timestamp, and a production-like width.
+            "'0s'",
+            "'1ms'",
+            "'5s'",
+        ]
+        self.flags_with_values["storage_persist_sink_description_window_max"] = [
+            # Below the initial width, which clamps to it, and two real ceilings.
+            "'1ms'",
+            "'10s'",
+            "'5min'",
+        ]
         self.flags_with_values["enable_variadic_left_join_lowering"] = (
             BOOLEAN_FLAG_VALUES
         )
@@ -3360,6 +3369,12 @@ class FlipFlagsAction(Action):
             "storage_suspend_and_restart_delay",
             "storage_reclock_to_latest",
             "storage_use_continual_feedback_upsert",
+            # The snapshot and replication operators read this independently at
+            # startup. A flip landing between the two reads leaves one in
+            # concurrent mode and the other not, within the same dataflow, which
+            # is a broken state rather than an interesting one. CI covers the
+            # feature by defaulting it on instead.
+            "storage_source_snapshot_concurrent_replication",
             "storage_server_maintenance_interval",
             "storage_sink_progress_search",
             "storage_sink_ensure_topic_config",

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -398,6 +398,24 @@ pub const SINK_ENSURE_TOPIC_CONFIG: Config<&'static str> = Config::new(
     match the expected configs.",
 );
 
+/// Lag behind the largest observed update timestamp after which updates staged in the
+/// storage persist sink move from a raw stash into shared coalesced batch builders, one
+/// per batch description plus one open builder for times no received description covers
+/// yet. Coalesced builders upload their parts to blob storage incrementally, so while a
+/// collection's frontier stalls (for example while another export of the same source
+/// snapshots) stash memory is bounded by the raw stash, which only ever spans this lag,
+/// plus the buffers of the coalesced builders. The lag must exceed the in-flight delay
+/// between the sink's data and batch description inputs, or the sink panics and the
+/// process restarts. A zero value disables coalescing and stages one batch builder per
+/// distinct timestamp instead.
+pub const STORAGE_PERSIST_SINK_STASH_COALESCE_LAG: Config<Duration> = Config::new(
+    "storage_persist_sink_stash_coalesce_lag",
+    Duration::ZERO,
+    "Lag behind the largest observed timestamp after which updates staged in the storage \
+    persist sink move from a raw stash into shared coalesced batch builders. Zero disables \
+    coalescing.",
+);
+
 /// Whether source snapshot operators emit rewind requests as soon as the snapshot bound is
 /// known instead of after the snapshot completes. This lets the replication operator read
 /// the upstream stream while the snapshot runs. Replication data received during the
@@ -459,6 +477,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&SINK_PROGRESS_SEARCH)
         .add(&SQL_SERVER_SOURCE_VALIDATE_RESTORE_HISTORY)
         .add(&STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION)
+        .add(&STORAGE_PERSIST_SINK_STASH_COALESCE_LAG)
         .add(&STORAGE_ROCKSDB_CLEANUP_TRIES)
         .add(&STORAGE_ROCKSDB_USE_MERGE_OPERATOR)
         .add(&STORAGE_SERVER_MAINTENANCE_INTERVAL)

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -398,6 +398,18 @@ pub const SINK_ENSURE_TOPIC_CONFIG: Config<&'static str> = Config::new(
     match the expected configs.",
 );
 
+/// Whether source snapshot operators emit rewind requests as soon as the snapshot bound is
+/// known instead of after the snapshot completes. This lets the replication operator read
+/// the upstream stream while the snapshot runs. Replication data received during the
+/// snapshot is staged in the dataflow until the snapshot completes, so enabling this
+/// trades cluster memory during hydration for concurrent progress on the stream.
+pub const STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION: Config<bool> = Config::new(
+    "storage_source_snapshot_concurrent_replication",
+    false,
+    "Emit source rewind requests when the snapshot bound is known instead of after the \
+    snapshot completes, so the replication stream is read concurrently with the snapshot.",
+);
+
 /// Configure mz-ore overflowing type behavior.
 pub const ORE_OVERFLOWING_BEHAVIOR: Config<&'static str> = Config::new(
     "ore_overflowing_behavior",
@@ -450,6 +462,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_ROCKSDB_CLEANUP_TRIES)
         .add(&STORAGE_ROCKSDB_USE_MERGE_OPERATOR)
         .add(&STORAGE_SERVER_MAINTENANCE_INTERVAL)
+        .add(&STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION)
         .add(&STORAGE_SUSPEND_AND_RESTART_DELAY)
         .add(&STORAGE_UPSERT_MAX_SNAPSHOT_BATCH_BUFFERING)
         .add(&STORAGE_UPSERT_PREVENT_SNAPSHOT_BUFFERING)

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -512,6 +512,49 @@ pub const STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION: Config<bool> = Config:
     false,
     "Emit source rewind requests when the snapshot bound is known instead of after the \
     snapshot completes, so the replication stream is read concurrently with the snapshot.",
+    ParameterScope::Environment,
+);
+
+/// How many bytes of updates the source `persist_sink` may take in past its last batch description
+/// before committing one ahead of the collection's frontier, so that it can group updates while a
+/// hydrating export holds that frontier pinned.
+///
+/// A batch's bounds come from a batch description, and while a collection's frontier is pinned the
+/// minter has nothing to derive one from, so the sink has no bounds to group updates under and
+/// falls back to one batch per timestamp. With a window the minter commits a description this wide
+/// as soon as the frontier pins, and the next one whenever the data comes within one initial width
+/// of the committed upper, so every description is in the writers' hands before the updates it
+/// covers arrive. Each committed description is twice as wide as the last, up to
+/// [`STORAGE_PERSIST_SINK_DESCRIPTION_WINDOW_MAX`]. Committing does not make a description
+/// appendable, that still waits for the frontier to reach its upper, which is what a short
+/// snapshot pays: its shard upper waits at the last committed lower until the frontier passes
+/// that description's upper.
+///
+/// Only applies to an export that is snapshotting in this dataflow incarnation, and only until the
+/// frontier moves off the time its snapshot occupies. A collection that is keeping up lags the data
+/// by about one `timestamp_interval` and so has nothing to group, and committing ahead of a
+/// frontier that is moving would hold the shard upper at the committed boundary instead.
+///
+/// Zero disables committing ahead, leaving descriptions derived from the frontier alone and every
+/// timestamp writing its own batch.
+pub const STORAGE_PERSIST_SINK_DESCRIPTION_WINDOW: Config<Duration> = Config::new(
+    "storage_persist_sink_description_window",
+    Duration::ZERO,
+    "Width of the first batch description the source persist sink commits ahead of a pinned \
+    collection frontier, so updates can be grouped while a snapshot runs. Later ones double up to \
+    storage_persist_sink_description_window_max (zero leaves every timestamp writing its own batch).",
+    ParameterScope::Environment,
+);
+
+/// Ceiling on the width a committed description reaches by doubling. See
+/// [`STORAGE_PERSIST_SINK_DESCRIPTION_WINDOW`]. It bounds both the batches a long snapshot costs and
+/// how long the shard upper can wait for the frontier once the snapshot ends.
+pub const STORAGE_PERSIST_SINK_DESCRIPTION_WINDOW_MAX: Config<Duration> = Config::new(
+    "storage_persist_sink_description_window_max",
+    Duration::from_secs(300),
+    "Ceiling on the width of a batch description the source persist sink commits ahead of a \
+    pinned collection frontier.",
+    ParameterScope::Environment,
 );
 
 /// Configure mz-ore overflowing type behavior.
@@ -569,6 +612,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION)
         .add(&STORAGE_ROCKSDB_CLEANUP_TRIES)
         .add(&STORAGE_ROCKSDB_USE_MERGE_OPERATOR)
+        .add(&STORAGE_PERSIST_SINK_DESCRIPTION_WINDOW)
+        .add(&STORAGE_PERSIST_SINK_DESCRIPTION_WINDOW_MAX)
         .add(&STORAGE_SERVER_MAINTENANCE_INTERVAL)
         .add(&STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION)
         .add(&STORAGE_SUSPEND_AND_RESTART_DELAY)

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -502,6 +502,18 @@ pub const SINK_ENSURE_TOPIC_CONFIG: Config<&'static str> = Config::new(
     ParameterScope::Environment,
 );
 
+/// Whether source snapshot operators emit rewind requests as soon as the snapshot bound is
+/// known instead of after the snapshot completes. This lets the replication operator read
+/// the upstream stream while the snapshot runs. Replication data received during the
+/// snapshot is staged in the dataflow until the snapshot completes, so enabling this
+/// trades cluster memory during hydration for concurrent progress on the stream.
+pub const STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION: Config<bool> = Config::new(
+    "storage_source_snapshot_concurrent_replication",
+    false,
+    "Emit source rewind requests when the snapshot bound is known instead of after the \
+    snapshot completes, so the replication stream is read concurrently with the snapshot.",
+);
+
 /// Configure mz-ore overflowing type behavior.
 pub const ORE_OVERFLOWING_BEHAVIOR: Config<&'static str> = Config::new(
     "ore_overflowing_behavior",
@@ -558,6 +570,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_ROCKSDB_CLEANUP_TRIES)
         .add(&STORAGE_ROCKSDB_USE_MERGE_OPERATOR)
         .add(&STORAGE_SERVER_MAINTENANCE_INTERVAL)
+        .add(&STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION)
         .add(&STORAGE_SUSPEND_AND_RESTART_DELAY)
         .add(&STORAGE_UPSERT_MAX_SNAPSHOT_BATCH_BUFFERING)
         .add(&STORAGE_UPSERT_PREVENT_SNAPSHOT_BUFFERING)

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -48,6 +48,7 @@ use proptest::strategy::Strategy;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use timely::order::{PartialOrder, TotalOrder};
+use timely::progress::frontier::AntichainRef;
 use timely::progress::timestamp::Refines;
 use timely::progress::{PathSummary, Timestamp};
 
@@ -259,6 +260,13 @@ pub trait SourceTimestamp:
 {
     fn encode_row(&self) -> Row;
     fn decode_row(row: &Row) -> Self;
+
+    /// A scalar summary of a frontier of this timestamp type, as reported by the
+    /// `offset_known` and `offset_committed` source statistics.
+    ///
+    /// Returns `None` when the frontier has no scalar summary, in which case the statistic
+    /// is left unchanged.
+    fn to_offset_stat(frontier: AntichainRef<'_, Self>) -> Option<u64>;
 }
 
 impl SourceTimestamp for MzOffset {
@@ -272,6 +280,10 @@ impl SourceTimestamp for MzOffset {
             (Some(Datum::UInt64(offset)), None) => MzOffset::from(offset),
             _ => panic!("invalid row {row:?}"),
         }
+    }
+
+    fn to_offset_stat(frontier: AntichainRef<'_, Self>) -> Option<u64> {
+        frontier.as_option().map(|offset| offset.offset)
     }
 }
 

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -25,6 +25,7 @@ use mz_timely_util::order::{Extrema, Partitioned};
 use rdkafka::admin::AdminClient;
 use serde::{Deserialize, Serialize};
 use timely::progress::Antichain;
+use timely::progress::frontier::AntichainRef;
 
 use crate::connections::inline::{
     ConnectionAccess, ConnectionResolver, InlinedConnection, IntoInlineConnection,
@@ -526,6 +527,19 @@ impl SourceTimestamp for KafkaTimestamp {
             }
             invalid_binding => unreachable!("invalid binding {:?}", invalid_binding),
         }
+    }
+
+    fn to_offset_stat(frontier: AntichainRef<'_, Self>) -> Option<u64> {
+        // The sum over partitions of the frontier offsets. Note that the frontier offset is
+        // not adjusted down by one: a frontier of 2 for a partition means offsets 0 and 1
+        // are processed, which is 2 offsets.
+        let mut sum = 0;
+        for ts in frontier.iter() {
+            if ts.interval().singleton().is_some() {
+                sum += ts.timestamp().offset;
+            }
+        }
+        Some(sum)
     }
 }
 

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -23,6 +23,7 @@ use mz_timely_util::order::Step;
 use serde::{Deserialize, Serialize};
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::Antichain;
+use timely::progress::frontier::AntichainRef;
 use timely::progress::timestamp::{PathSummary, Refines, Timestamp};
 use uuid::Uuid;
 
@@ -370,6 +371,24 @@ impl SourceTimestamp for GtidPartition {
             }
             _ => panic!("invalid row {row:?}"),
         }
+    }
+
+    fn to_offset_stat(frontier: AntichainRef<'_, Self>) -> Option<u64> {
+        // The sum over sources of the _number of transactions_ each frontier entry
+        // represents.
+        let mut sum = 0;
+        for ts in frontier.iter() {
+            // We assume source ids don't disappear once they appear.
+            if ts.interval().singleton().is_some() {
+                sum += match ts.timestamp() {
+                    GtidState::Absent => 0,
+                    // Txids in mysql start at 1, so we subtract 1 from the _frontier_
+                    // to get the _number of transactions_.
+                    GtidState::Active(id) => id.get().saturating_sub(1),
+                };
+            }
+        }
+        Some(sum)
     }
 }
 

--- a/src/storage-types/src/sources/sql_server.rs
+++ b/src/storage-types/src/sources/sql_server.rs
@@ -19,6 +19,7 @@ use mz_repr::{CatalogItemId, Datum, GlobalId, RelationDesc, Row, SqlScalarType};
 use mz_sql_server_util::cdc::Lsn;
 use serde::{Deserialize, Serialize};
 use timely::progress::Antichain;
+use timely::progress::frontier::AntichainRef;
 
 use crate::AlterCompatible;
 use crate::connections::inline::{
@@ -292,5 +293,9 @@ impl SourceTimestamp for Lsn {
             }
             _ => panic!("invalid row {row:?}"),
         }
+    }
+
+    fn to_offset_stat(frontier: AntichainRef<'_, Self>) -> Option<u64> {
+        frontier.as_option().map(Lsn::abbreviate)
     }
 }

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -197,7 +197,7 @@
 //!
 //! Not yet documented
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -207,22 +207,46 @@ use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::dyncfgs;
 use mz_storage_types::oneshot_sources::{OneshotIngestionDescription, OneshotIngestionRequest};
 use mz_storage_types::sinks::StorageSinkDesc;
-use mz_storage_types::sources::{GenericSourceConnection, IngestionDescription, SourceConnection};
+use mz_storage_types::sources::{
+    GenericSourceConnection, IngestionDescription, SourceConnection, SourceEnvelope,
+    SourceTimestamp,
+};
 use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::scope_label::ScopeExt;
 use timely::dataflow::operators::vec::Map;
 use timely::dataflow::operators::{Concatenate, ConnectLoop, Feedback, Leave};
 use timely::progress::Antichain;
+use timely::progress::Timestamp as _;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::Semaphore;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
 use crate::source::RawSourceCreationConfig;
+use crate::source::types::SourceRender;
 use crate::storage_state::StorageState;
 
 mod persist_sink;
 pub mod sinks;
 pub mod sources;
+
+/// The exports this dataflow incarnation will snapshot.
+///
+/// An export snapshots when its resume upper is the minimum from-time, which is the test each
+/// connector's snapshot operator makes once it decodes the rows back. It has to be made in the
+/// from-time domain: the reclocking of a resume upper maps any into-time upper at or below the
+/// as_of back to the minimum, which is what keeps a restart during a snapshot reading as
+/// snapshotting even though the shard upper has moved past its own minimum by then.
+fn snapshotting_exports<C: SourceRender>(
+    _connection: &C,
+    source_resume_uppers: &BTreeMap<GlobalId, Vec<Row>>,
+) -> BTreeSet<GlobalId> {
+    let minimum = Antichain::from_elem(C::Time::minimum());
+    source_resume_uppers
+        .iter()
+        .filter(|(_, rows)| Antichain::from_iter(rows.iter().map(C::Time::decode_row)) == minimum)
+        .map(|(id, _)| *id)
+        .collect()
+}
 
 /// Assemble the "ingestion" side of a dataflow, i.e. the sources.
 ///
@@ -271,6 +295,32 @@ pub fn build_ingestion_dataflow(
             } else {
                 Arc::new(Semaphore::new(Semaphore::MAX_PERMITS))
             };
+
+            // Which exports snapshot is fixed for this incarnation, so it is decided once here
+            // rather than inferred downstream. See `snapshotting_exports`.
+            let mut snapshotting = match &connection {
+                GenericSourceConnection::Kafka(c) => snapshotting_exports(c, &source_resume_uppers),
+                GenericSourceConnection::Postgres(c) => {
+                    snapshotting_exports(c, &source_resume_uppers)
+                }
+                GenericSourceConnection::MySql(c) => snapshotting_exports(c, &source_resume_uppers),
+                GenericSourceConnection::SqlServer(c) => {
+                    snapshotting_exports(c, &source_resume_uppers)
+                }
+                GenericSourceConnection::LoadGenerator(c) => {
+                    snapshotting_exports(c, &source_resume_uppers)
+                }
+            };
+            // The persist sink commits batch descriptions a wall-clock width ahead of a
+            // snapshotting export's frontier. A CDCv2 export takes its MZ times from the data
+            // rather than from reclocking, so no width relates to the clock and a committed
+            // upper the data never reaches would hold the shard upper forever.
+            snapshotting.retain(|export_id| {
+                !matches!(
+                    description.source_exports[export_id].data_config.envelope,
+                    SourceEnvelope::CdcV2
+                )
+            });
 
             let base_source_config = RawSourceCreationConfig {
                 name: format!("{}-{}", connection.name(), primary_source_id),
@@ -380,6 +430,7 @@ pub fn build_ingestion_dataflow(
                     storage_state,
                     metrics,
                     Arc::clone(&busy_signal),
+                    snapshotting.contains(&export_id),
                 );
                 upper_streams.push(upper_stream);
                 tokens.extend(sink_tokens);

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -277,7 +277,16 @@ pub fn build_ingestion_dataflow(
 
             let mut tokens = vec![];
 
-            let (feedback_handle, feedback) = mz_scope.feedback(Default::default());
+            // One feedback edge per export, so the source pipeline can observe each
+            // export's committed upper individually. The source-wide committed upper is
+            // derived from these in `create_raw_source`.
+            let mut export_upper_handles = BTreeMap::new();
+            let mut export_upper_streams = BTreeMap::new();
+            for export_id in description.source_exports.keys() {
+                let (handle, stream) = mz_scope.feedback(Default::default());
+                export_upper_handles.insert(*export_id, handle);
+                export_upper_streams.insert(*export_id, stream);
+            }
 
             let connection = description.desc.connection.clone();
             tracing::info!(
@@ -355,7 +364,7 @@ pub fn build_ingestion_dataflow(
                     &debug_name,
                     c,
                     description.clone(),
-                    feedback,
+                    export_upper_streams.clone(),
                     storage_state,
                     base_source_config,
                 ),
@@ -365,7 +374,7 @@ pub fn build_ingestion_dataflow(
                     &debug_name,
                     c,
                     description.clone(),
-                    feedback,
+                    export_upper_streams.clone(),
                     storage_state,
                     base_source_config,
                 ),
@@ -375,7 +384,7 @@ pub fn build_ingestion_dataflow(
                     &debug_name,
                     c,
                     description.clone(),
-                    feedback,
+                    export_upper_streams.clone(),
                     storage_state,
                     base_source_config,
                 ),
@@ -385,7 +394,7 @@ pub fn build_ingestion_dataflow(
                     &debug_name,
                     c,
                     description.clone(),
-                    feedback,
+                    export_upper_streams.clone(),
                     storage_state,
                     base_source_config,
                 ),
@@ -395,14 +404,13 @@ pub fn build_ingestion_dataflow(
                     &debug_name,
                     c,
                     description.clone(),
-                    feedback,
+                    export_upper_streams.clone(),
                     storage_state,
                     base_source_config,
                 ),
             };
             tokens.extend(source_tokens);
 
-            let mut upper_streams = vec![];
             let mut health_streams = Vec::with_capacity(source_health.len() + outputs.len());
             health_streams.extend(source_health);
             for (export_id, (ok, err)) in outputs {
@@ -432,7 +440,10 @@ pub fn build_ingestion_dataflow(
                     Arc::clone(&busy_signal),
                     snapshotting.contains(&export_id),
                 );
-                upper_streams.push(upper_stream);
+                let feedback_handle = export_upper_handles
+                    .remove(&export_id)
+                    .expect("each output corresponds to a source export");
+                upper_stream.connect_loop(feedback_handle);
                 tokens.extend(sink_tokens);
 
                 let sink_health = errors.map(move |err: Rc<anyhow::Error>| {
@@ -447,9 +458,13 @@ pub fn build_ingestion_dataflow(
                 health_streams.push(sink_health.leave(root_scope));
             }
 
-            mz_scope
-                .concatenate(upper_streams)
-                .connect_loop(feedback_handle);
+            // Close the feedback edge of any export the source did not render an output
+            // for. An empty stream advances the edge to the empty frontier, so it places no
+            // constraint on the source-wide committed upper.
+            for (_export_id, handle) in export_upper_handles {
+                timely::dataflow::operators::generic::operator::empty(mz_scope)
+                    .connect_loop(handle);
+            }
 
             let health_stream = root_scope.concatenate(health_streams);
             let health_token = crate::healthcheck::health_operator(

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -161,6 +161,8 @@ impl AddAssign<&BatchMetrics> for BatchMetrics {
 }
 
 /// Manages batches and metrics.
+///
+/// `Debug` is implemented manually because [`BatchBuilder`] is not `Debug`.
 struct BatchBuilderAndMetadata<K, V, T, D>
 where
     K: Codec,
@@ -168,7 +170,9 @@ where
     T: Timestamp + Lattice + Codec64,
 {
     builder: BatchBuilder<K, V, T, D>,
-    data_ts: T,
+    /// Inclusive bounds on the timestamps of the updates in the batch.
+    data_min_ts: T,
+    data_max_ts: T,
     metrics: BatchMetrics,
 }
 
@@ -179,29 +183,20 @@ where
     T: Timestamp + Lattice + Codec64,
     D: Monoid + Codec64,
 {
-    /// Creates a new batch.
-    ///
-    /// NOTE(benesch): temporary restriction: all updates added to the batch
-    /// must be at the specified timestamp `data_ts`.
+    /// Creates a new batch whose first update is at `data_ts`.
     fn new(builder: BatchBuilder<K, V, T, D>, data_ts: T) -> Self {
         BatchBuilderAndMetadata {
             builder,
-            data_ts,
+            data_min_ts: data_ts.clone(),
+            data_max_ts: data_ts,
             metrics: Default::default(),
         }
     }
 
     /// Adds an update to the batch.
-    ///
-    /// NOTE(benesch): temporary restriction: all updates added to the batch
-    /// must be at the timestamp specified during creation.
     async fn add(&mut self, k: &K, v: &V, t: &T, d: &D) {
-        assert_eq!(
-            self.data_ts, *t,
-            "BatchBuilderAndMetadata::add called with a timestamp {t:?} that does not match creation timestamp {:?}",
-            self.data_ts
-        );
-
+        self.data_min_ts.meet_assign(t);
+        self.data_max_ts.join_assign(t);
         self.builder.add(k, v, t, d).await.expect("invalid usage");
     }
 
@@ -214,10 +209,50 @@ where
         HollowBatchAndMetadata {
             lower,
             upper,
-            data_ts: self.data_ts,
+            data_max_ts: self.data_max_ts,
             batch: batch.into_transmittable_batch(),
             metrics: self.metrics,
         }
+    }
+}
+
+impl<K, V, T, D> Debug for BatchBuilderAndMetadata<K, V, T, D>
+where
+    K: Codec,
+    V: Codec,
+    T: Timestamp + Lattice + Codec64 + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BatchBuilderAndMetadata")
+            .field("data_min_ts", &self.data_min_ts)
+            .field("data_max_ts", &self.data_max_ts)
+            .field("metrics", &self.metrics)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The concrete builder type staged by the storage `persist_sink`.
+type SourceBatchBuilder = BatchBuilderAndMetadata<SourceData, (), mz_repr::Timestamp, StorageDiff>;
+
+/// Stages one source update into `builder` and records it in the builder's metrics.
+///
+/// Assumes `diff` is +1 or -1, anything else is a logic bug that the metrics layer cannot
+/// represent. Also assumes the metrics additions do not overflow.
+async fn stage_update(
+    builder: &mut SourceBatchBuilder,
+    row: Result<Row, DataflowError>,
+    ts: mz_repr::Timestamp,
+    diff: Diff,
+) {
+    let is_value = row.is_ok();
+    builder
+        .add(&SourceData(row), &(), &ts, &diff.into_inner())
+        .await;
+    match (is_value, diff.is_positive()) {
+        (true, true) => builder.metrics.inserts += diff.unsigned_abs(),
+        (true, false) => builder.metrics.retractions += diff.unsigned_abs(),
+        (false, true) => builder.metrics.error_inserts += diff.unsigned_abs(),
+        (false, false) => builder.metrics.error_retractions += diff.unsigned_abs(),
     }
 }
 
@@ -230,7 +265,9 @@ where
 struct HollowBatchAndMetadata<T> {
     lower: Antichain<T>,
     upper: Antichain<T>,
-    data_ts: T,
+    /// The largest update timestamp in the batch, used to decide whether the batch still
+    /// holds relevant data when an append's lower advances past the batch description's.
+    data_max_ts: T,
     batch: ProtoBatch,
     metrics: BatchMetrics,
 }
@@ -245,7 +282,7 @@ struct BatchSet {
 #[derive(Debug)]
 struct FinishedBatch {
     batch: Batch<SourceData, (), mz_repr::Timestamp, StorageDiff>,
-    data_ts: mz_repr::Timestamp,
+    data_max_ts: mz_repr::Timestamp,
 }
 
 /// Continuously writes the `desired_stream` into persist
@@ -554,6 +591,18 @@ fn write_batches<'scope>(
         .expect("statistics initialized")
         .clone();
 
+    // Milliseconds of lag behind the largest observed update timestamp after which updates
+    // are routed into shared coalesced builders instead of per-timestamp builders. `None`
+    // disables coalescing.
+    let stash_coalesce_lag = dyncfgs::STORAGE_PERSIST_SINK_STASH_COALESCE_LAG
+        .get(storage_state.storage_configuration.config_set());
+    let stash_coalesce_lag: Option<u64> = (!stash_coalesce_lag.is_zero()).then(|| {
+        stash_coalesce_lag
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX)
+    });
+
     let mut write_op =
         AsyncOperatorBuilder::new(format!("{} write_batches", operator_name), scope.clone());
 
@@ -569,19 +618,40 @@ fn write_batches<'scope>(
     // upper_.
 
     let shutdown_button = write_op.build(move |_capabilities| async move {
-        // In-progress batches of data, keyed by timestamp.
+        // In-progress batches of data, keyed by timestamp, used only when stash coalescing
+        // is disabled.
         let mut stashed_batches = BTreeMap::new();
 
+        // Updates within the coalesce lag of the largest observed update timestamp, staged
+        // as raw rows and keyed by timestamp. Future batch description boundaries can land
+        // among these times, and a builder cannot be split, so these updates must not enter
+        // a shared builder yet. They move into a coalesced builder once they age past the
+        // horizon or once a batch description covering them becomes ready.
+        let mut raw_stash: BTreeMap<mz_repr::Timestamp, Vec<(Result<Row, DataflowError>, Diff)>> =
+            BTreeMap::new();
+
+        // A shared builder for updates that aged past the coalesce horizon but fall beyond
+        // every received batch description. It is moved into a description's slot in
+        // `in_flight_batches` once a description covering its contents arrives. While a
+        // collection's frontier stalls, for example while another export of the same source
+        // snapshots, no descriptions are minted and this builder absorbs all aging updates,
+        // uploading its parts to blob storage incrementally.
+        let mut open_coalesced: Option<SourceBatchBuilder> = None;
+        // Updates with timestamps below this horizon are coalesced. Maintained as the largest
+        // observed update timestamp minus the configured lag, and never retreats.
+        let mut coalesce_horizon: Option<mz_repr::Timestamp> = None;
+
         // Contains descriptions of batches for which we know that we can
-        // write data. We got these from the "centralized" operator that
-        // determines batch descriptions for all writers.
+        // write data, along with an optional coalesced builder holding updates that fall
+        // within the description's bounds. We got the descriptions from the "centralized"
+        // operator that determines batch descriptions for all writers.
         //
         // `Antichain` does not implement `Ord`, so we cannot use a `BTreeMap`. We need to search
         // through the map, so we cannot use the `mz_ore` wrapper either.
         #[allow(clippy::disallowed_types)]
         let mut in_flight_batches = std::collections::HashMap::<
             (Antichain<mz_repr::Timestamp>, Antichain<mz_repr::Timestamp>),
-            Capability<mz_repr::Timestamp>,
+            (Capability<mz_repr::Timestamp>, Option<SourceBatchBuilder>),
         >::new();
 
         // TODO(aljoscha): We need to figure out what to do with error results from these calls.
@@ -640,13 +710,47 @@ fn write_batches<'scope>(
                                     description, desired_frontier, batch_descriptions_frontier,
                                 );
                             }
+                            // If the open coalesced builder's contents fall within this
+                            // description, move it into the description's slot so it is
+                            // finished with the description's bounds. Contents entirely
+                            // beyond the description keep accumulating for a later one.
+                            let rotated = match open_coalesced.take() {
+                                Some(builder)
+                                    if !description.1.less_equal(&builder.data_max_ts) =>
+                                {
+                                    Some(builder)
+                                }
+                                Some(builder) if description.1.less_equal(&builder.data_min_ts) => {
+                                    open_coalesced = Some(builder);
+                                    None
+                                }
+                                Some(builder) => {
+                                    // Updates this description covers share a builder with
+                                    // updates beyond it, so the builder can be finished with
+                                    // neither this description's bounds nor a later one's.
+                                    // This can only happen when updates beyond the
+                                    // description outran it by more than the coalesce lag.
+                                    panic!(
+                                        "write_batches: sink {}: the open coalesced stash \
+                                            (times [{:?}, {:?}]) straddles batch description \
+                                            {:?}. storage_persist_sink_stash_coalesce_lag is \
+                                            not large enough to cover the in-flight delay \
+                                            between this operator's inputs.",
+                                        collection_id,
+                                        builder.data_min_ts,
+                                        builder.data_max_ts,
+                                        description,
+                                    );
+                                }
+                                None => None,
+                            };
                             match in_flight_batches.entry(description) {
                                 std::collections::hash_map::Entry::Vacant(v) => {
                                     // This _should_ be `.retain`, but rust
                                     // currently thinks we can't use `cap`
                                     // as an owned value when using the
                                     // match guard `Some(event)`
-                                    v.insert(cap.delayed(cap.time()));
+                                    v.insert((cap.delayed(cap.time()), rotated));
                                 }
                                 std::collections::hash_map::Entry::Occupied(o) => {
                                     let (description, _) = o.remove_entry();
@@ -691,34 +795,57 @@ fn write_batches<'scope>(
 
                         for (row, ts, diff) in data {
                             if write.upper().less_equal(&ts) {
-                                let builder = stashed_batches.entry(ts).or_insert_with(|| {
-                                    BatchBuilderAndMetadata::new(
-                                        write.builder(operator_batch_lower.clone()),
-                                        ts,
-                                    )
-                                });
-
-                                let is_value = row.is_ok();
-
-                                builder
-                                    .add(&SourceData(row), &(), &ts, &diff.into_inner())
-                                    .await;
-
                                 source_statistics.inc_updates_staged_by(1);
 
-                                // Note that we assume `diff` is either +1 or -1 here, being anything
-                                // else is a logic bug we can't handle at the metric layer. We also
-                                // assume this addition doesn't overflow.
-                                match (is_value, diff.is_positive()) {
-                                    (true, true) => builder.metrics.inserts += diff.unsigned_abs(),
-                                    (true, false) => {
-                                        builder.metrics.retractions += diff.unsigned_abs()
+                                let Some(lag) = stash_coalesce_lag else {
+                                    let builder = stashed_batches.entry(ts).or_insert_with(|| {
+                                        BatchBuilderAndMetadata::new(
+                                            write.builder(operator_batch_lower.clone()),
+                                            ts,
+                                        )
+                                    });
+                                    stage_update(builder, row, ts, diff).await;
+                                    continue;
+                                };
+
+                                let candidate =
+                                    mz_repr::Timestamp::from(u64::from(ts).saturating_sub(lag));
+                                if coalesce_horizon.is_none_or(|h| h < candidate) {
+                                    coalesce_horizon = Some(candidate);
+                                }
+
+                                // An update covered by a received batch description joins
+                                // that description's coalesced builder. An uncovered update
+                                // that aged past the horizon joins the open builder. Any
+                                // other update is stashed raw until it ages past the
+                                // horizon or a description covering it becomes ready.
+                                let covering = in_flight_batches
+                                    .iter_mut()
+                                    .find(|((lower, upper), _)| {
+                                        lower.less_equal(&ts) && !upper.less_equal(&ts)
+                                    })
+                                    .map(|(_, (_, slot))| slot);
+                                match covering {
+                                    Some(slot) => {
+                                        let builder = slot.get_or_insert_with(|| {
+                                            BatchBuilderAndMetadata::new(
+                                                write.builder(operator_batch_lower.clone()),
+                                                ts,
+                                            )
+                                        });
+                                        stage_update(builder, row, ts, diff).await;
                                     }
-                                    (false, true) => {
-                                        builder.metrics.error_inserts += diff.unsigned_abs()
+                                    None if coalesce_horizon.is_some_and(|h| ts < h) => {
+                                        let builder = open_coalesced.get_or_insert_with(|| {
+                                            BatchBuilderAndMetadata::new(
+                                                write.builder(operator_batch_lower.clone()),
+                                                ts,
+                                            )
+                                        });
+                                        stage_update(builder, row, ts, diff).await;
                                     }
-                                    (false, false) => {
-                                        builder.metrics.error_retractions += diff.unsigned_abs()
+                                    None => {
+                                        raw_stash.entry(ts).or_default().push((row, diff));
                                     }
                                 }
                             }
@@ -729,6 +856,34 @@ fn write_batches<'scope>(
                     }
                 }
             }
+
+            // Move raw-stashed updates that aged past the horizon into the coalesced tier,
+            // so the raw stash only ever spans the trailing lag window.
+            if let Some(horizon) = coalesce_horizon {
+                let aged: Vec<_> = raw_stash
+                    .keys()
+                    .take_while(|ts| **ts < horizon)
+                    .copied()
+                    .collect();
+                for ts in aged {
+                    let updates = raw_stash.remove(&ts).unwrap();
+                    let covering = in_flight_batches
+                        .iter_mut()
+                        .find(|((lower, upper), _)| lower.less_equal(&ts) && !upper.less_equal(&ts))
+                        .map(|(_, (_, slot))| slot);
+                    let slot = covering.unwrap_or(&mut open_coalesced);
+                    let builder = slot.get_or_insert_with(|| {
+                        BatchBuilderAndMetadata::new(
+                            write.builder(operator_batch_lower.clone()),
+                            ts,
+                        )
+                    });
+                    for (row, diff) in updates {
+                        stage_update(builder, row, ts, diff).await;
+                    }
+                }
+            }
+
             // We may have the opportunity to commit updates, if either frontier
             // has moved
             if PartialOrder::less_equal(&processed_desired_frontier, &desired_frontier)
@@ -778,7 +933,8 @@ fn write_batches<'scope>(
                 );
 
                 for batch_description in ready_batches {
-                    let cap = in_flight_batches.remove(&batch_description).unwrap();
+                    let (cap, mut coalesced_builder) =
+                        in_flight_batches.remove(&batch_description).unwrap();
 
                     if collection_id.is_user() {
                         trace!(
@@ -825,6 +981,46 @@ fn write_batches<'scope>(
                         // It is impossible to emit a batch description that is
                         // beyond a not-yet emitted description in `in_flight_batches`, as
                         // a that description would also have been chosen as ready above.
+                        operator_batch_lower = operator_batch_lower.join(&batch_upper);
+                        batch_tokens.push(batch);
+                    }
+
+                    // Move raw-stashed updates the description covers into its coalesced
+                    // builder. These are the updates that are still within the lag of the
+                    // largest observed timestamp, which the now-ready description proves
+                    // fall within its bounds.
+                    let raw_timestamps: Vec<_> = raw_stash
+                        .keys()
+                        .filter(|time| {
+                            batch_lower.less_equal(time) && !batch_upper.less_equal(time)
+                        })
+                        .copied()
+                        .collect();
+                    for ts in raw_timestamps {
+                        let updates = raw_stash.remove(&ts).unwrap();
+                        let builder = coalesced_builder.get_or_insert_with(|| {
+                            BatchBuilderAndMetadata::new(
+                                write.builder(operator_batch_lower.clone()),
+                                ts,
+                            )
+                        });
+                        for (row, diff) in updates {
+                            stage_update(builder, row, ts, diff).await;
+                        }
+                    }
+
+                    if let Some(builder) = coalesced_builder {
+                        if collection_id.is_user() {
+                            trace!(
+                                "persist_sink {collection_id}/{shard_id}: \
+                                    wrote coalesced batch from worker {}: ({:?}, {:?}),
+                                    containing {:?}",
+                                worker_index, batch_lower, batch_upper, builder.metrics
+                            );
+                        }
+                        let batch = builder
+                            .finish(batch_lower.clone(), batch_upper.clone())
+                            .await;
                         operator_batch_lower = operator_batch_lower.join(&batch_upper);
                         batch_tokens.push(batch);
                     }
@@ -1070,7 +1266,7 @@ fn append_batches<'scope>(
 
                                 batches.finished.push(FinishedBatch {
                                     batch: write.batch_from_transmittable_batch(batch.batch),
-                                    data_ts: batch.data_ts,
+                                    data_max_ts: batch.data_max_ts,
                                 });
                                 batches.batch_metrics += &batch.metrics;
                             }
@@ -1370,13 +1566,16 @@ fn append_batches<'scope>(
                             let new_done_batch_metadata =
                                 (new_batch_lower.clone(), batch_upper.clone());
 
-                            // Retain any batches that are still in advance of
-                            // the new lower, and delete any batches that are
-                            // not.
+                            // Retain any batches that still hold data at or beyond the new
+                            // lower, and delete any batches that do not. A retained batch may
+                            // also hold data below the new lower, which is fine:
+                            // `compare_and_append_batch` truncates updates outside the append
+                            // bounds, and that data is already in the shard, appended by
+                            // whoever advanced the upper past our batch description's lower.
                             let mut batch_delete_futures = vec![];
                             let mut new_batch_set = BatchSet::default();
                             for batch in batches {
-                                if new_batch_lower.less_equal(&batch.data_ts) {
+                                if new_batch_lower.less_equal(&batch.data_max_ts) {
                                     new_batch_set.finished.push(batch);
                                 } else {
                                     batch_delete_futures.push(batch.batch.delete());

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -209,6 +209,7 @@ where
         HollowBatchAndMetadata {
             lower,
             upper,
+            data_min_ts: self.data_min_ts,
             data_max_ts: self.data_max_ts,
             batch: batch.into_transmittable_batch(),
             metrics: self.metrics,
@@ -265,8 +266,9 @@ async fn stage_update(
 struct HollowBatchAndMetadata<T> {
     lower: Antichain<T>,
     upper: Antichain<T>,
-    /// The largest update timestamp in the batch, used to decide whether the batch still
-    /// holds relevant data when an append's lower advances past the batch description's.
+    /// Inclusive bounds on the timestamps of the updates in the batch, used to decide how
+    /// to handle the batch when an append's lower advances past the batch description's.
+    data_min_ts: T,
     data_max_ts: T,
     batch: ProtoBatch,
     metrics: BatchMetrics,
@@ -282,6 +284,7 @@ struct BatchSet {
 #[derive(Debug)]
 struct FinishedBatch {
     batch: Batch<SourceData, (), mz_repr::Timestamp, StorageDiff>,
+    data_min_ts: mz_repr::Timestamp,
     data_max_ts: mz_repr::Timestamp,
 }
 
@@ -641,6 +644,15 @@ fn write_batches<'scope>(
         // observed update timestamp minus the configured lag, and never retreats.
         let mut coalesce_horizon: Option<mz_repr::Timestamp> = None;
 
+        // The lower of the first received batch description. Descriptions arrive in
+        // ascending order, so this is the least time this sink will ever append at. Updates
+        // below it are already durable in the shard and must be dropped rather than staged
+        // into a coalesced builder: no description will ever cover them, and a finished
+        // batch whose parts carry data below the registered append bounds has that data
+        // truncated when the parts are read back, which desyncs persist's spine bookkeeping
+        // from the actual update counts and panics compaction.
+        let mut first_description_lower: Option<Antichain<mz_repr::Timestamp>> = None;
+
         // Contains descriptions of batches for which we know that we can
         // write data, along with an optional coalesced builder holding updates that fall
         // within the description's bounds. We got the descriptions from the "centralized"
@@ -710,6 +722,11 @@ fn write_batches<'scope>(
                                     description, desired_frontier, batch_descriptions_frontier,
                                 );
                             }
+                            // Descriptions arrive in ascending order, so the first one
+                            // carries the least lower this sink will ever append at.
+                            if first_description_lower.is_none() {
+                                first_description_lower = Some(description.0.clone());
+                            }
                             // If the open coalesced builder's contents fall within this
                             // description, move it into the description's slot so it is
                             // finished with the description's bounds. Contents entirely
@@ -718,6 +735,17 @@ fn write_batches<'scope>(
                                 Some(builder)
                                     if !description.1.less_equal(&builder.data_max_ts) =>
                                 {
+                                    assert!(
+                                        description.0.less_equal(&builder.data_min_ts),
+                                        "write_batches: sink {}: the open coalesced stash \
+                                            (times [{:?}, {:?}]) starts below batch \
+                                            description {:?}, which would append data below \
+                                            the registered batch bounds",
+                                        collection_id,
+                                        builder.data_min_ts,
+                                        builder.data_max_ts,
+                                        description,
+                                    );
                                     Some(builder)
                                 }
                                 Some(builder) if description.1.less_equal(&builder.data_min_ts) => {
@@ -808,6 +836,19 @@ fn write_batches<'scope>(
                                     continue;
                                 };
 
+                                // The upper gate above uses the shard upper cached when the
+                                // write handle was opened, while the description minter
+                                // starts at a freshly fetched upper. Updates in that gap are
+                                // already durable in the shard and no description will ever
+                                // cover them, so they are dropped (see
+                                // `first_description_lower`).
+                                if first_description_lower
+                                    .as_ref()
+                                    .is_some_and(|lower| !lower.less_equal(&ts))
+                                {
+                                    continue;
+                                }
+
                                 let candidate =
                                     mz_repr::Timestamp::from(u64::from(ts).saturating_sub(lag));
                                 if coalesce_horizon.is_none_or(|h| h < candidate) {
@@ -835,7 +876,13 @@ fn write_batches<'scope>(
                                         });
                                         stage_update(builder, row, ts, diff).await;
                                     }
-                                    None if coalesce_horizon.is_some_and(|h| ts < h) => {
+                                    // Until the first description arrives we cannot tell
+                                    // already-durable updates from stageable ones, so aged
+                                    // updates wait in the raw stash rather than entering
+                                    // the open builder.
+                                    None if first_description_lower.is_some()
+                                        && coalesce_horizon.is_some_and(|h| ts < h) =>
+                                    {
                                         let builder = open_coalesced.get_or_insert_with(|| {
                                             BatchBuilderAndMetadata::new(
                                                 write.builder(operator_batch_lower.clone()),
@@ -858,8 +905,12 @@ fn write_batches<'scope>(
             }
 
             // Move raw-stashed updates that aged past the horizon into the coalesced tier,
-            // so the raw stash only ever spans the trailing lag window.
-            if let Some(horizon) = coalesce_horizon {
+            // so the raw stash only ever spans the trailing lag window. This waits for the
+            // first description because rows stashed before it arrived may lie below its
+            // lower and must not enter a builder.
+            if let (Some(horizon), Some(first_lower)) =
+                (coalesce_horizon, first_description_lower.as_ref())
+            {
                 let aged: Vec<_> = raw_stash
                     .keys()
                     .take_while(|ts| **ts < horizon)
@@ -867,6 +918,11 @@ fn write_batches<'scope>(
                     .collect();
                 for ts in aged {
                     let updates = raw_stash.remove(&ts).unwrap();
+                    // Rows below the first description's lower are already durable in the
+                    // shard, they are dropped rather than poured.
+                    if !first_lower.less_equal(&ts) {
+                        continue;
+                    }
                     let covering = in_flight_batches
                         .iter_mut()
                         .find(|((lower, upper), _)| lower.less_equal(&ts) && !upper.less_equal(&ts))
@@ -917,7 +973,7 @@ fn write_batches<'scope>(
                 // a) the batch is not beyond `batch_descriptions_frontier`,
                 // and b) we know that we have seen all updates that would
                 // fall into the batch, from `desired_frontier`.
-                let ready_batches = in_flight_batches
+                let mut ready_batches = in_flight_batches
                     .keys()
                     .filter(|(lower, upper)| {
                         !PartialOrder::less_equal(&batch_descriptions_frontier, lower)
@@ -925,6 +981,20 @@ fn write_batches<'scope>(
                     })
                     .cloned()
                     .collect::<Vec<_>>();
+
+                // Process ready descriptions in ascending order. Draining a description
+                // advances `operator_batch_lower` to its upper, and a builder created while
+                // draining a later description must not receive a lower above the rows of
+                // an earlier one.
+                ready_batches.sort_by(|a, b| {
+                    if PartialOrder::less_than(a, b) {
+                        Ordering::Less
+                    } else if PartialOrder::less_than(b, a) {
+                        Ordering::Greater
+                    } else {
+                        Ordering::Equal
+                    }
+                });
 
                 trace!(
                     "persist_sink {collection_id}/{shard_id}: \
@@ -1266,6 +1336,7 @@ fn append_batches<'scope>(
 
                                 batches.finished.push(FinishedBatch {
                                     batch: write.batch_from_transmittable_batch(batch.batch),
+                                    data_min_ts: batch.data_min_ts,
                                     data_max_ts: batch.data_max_ts,
                                 });
                                 batches.batch_metrics += &batch.metrics;
@@ -1566,16 +1637,43 @@ fn append_batches<'scope>(
                             let new_done_batch_metadata =
                                 (new_batch_lower.clone(), batch_upper.clone());
 
-                            // Retain any batches that still hold data at or beyond the new
-                            // lower, and delete any batches that do not. A retained batch may
-                            // also hold data below the new lower, which is fine:
-                            // `compare_and_append_batch` truncates updates outside the append
-                            // bounds, and that data is already in the shard, appended by
-                            // whoever advanced the upper past our batch description's lower.
+                            // A batch that straddles the new lower cannot be appended: its
+                            // parts would carry data below the registered append bounds.
+                            // Persist truncates such data when the parts are read back, and
+                            // compaction then reproduces fewer updates than the spine
+                            // recorded for the batch, which fails a persist-internal
+                            // invariant. The batch cannot be split either, so restart the
+                            // dataflow and rebuild the batches from scratch.
+                            let straddles_new_lower = batches.iter().any(|batch| {
+                                !new_batch_lower.less_equal(&batch.data_min_ts)
+                                    && new_batch_lower.less_equal(&batch.data_max_ts)
+                            });
+                            if straddles_new_lower {
+                                future::join_all(batches.into_iter().map(|b| b.batch.delete()))
+                                    .await;
+                                tracing::warn!(
+                                    "persist_sink({}): invalid upper! \
+                                        Tried to append batch ({:?} -> {:?}) but upper \
+                                        is {:?}, and a staged batch straddles that upper. \
+                                        Someone else was faster than us, and we cannot cut \
+                                        our batches down to the remaining time range, so \
+                                        we'll restart the dataflow.",
+                                    collection_id, batch_lower, batch_upper, mismatch.current,
+                                );
+                                anyhow::bail!(
+                                    "collection concurrently modified. Ingestion dataflow will be restarted"
+                                );
+                            }
+
+                            // Retain any batches whose data lies entirely at or beyond the
+                            // new lower, and delete any batches whose data lies entirely
+                            // below it, since that data is already in the shard, appended
+                            // by whoever advanced the upper past our batch description's
+                            // lower.
                             let mut batch_delete_futures = vec![];
                             let mut new_batch_set = BatchSet::default();
                             for batch in batches {
-                                if new_batch_lower.less_equal(&batch.data_max_ts) {
+                                if new_batch_lower.less_equal(&batch.data_min_ts) {
                                     new_batch_set.finished.push(batch);
                                 } else {
                                     batch_delete_futures.push(batch.batch.delete());

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -106,6 +106,7 @@ use mz_persist_client::Diagnostics;
 use mz_persist_client::batch::{Batch, BatchBuilder, ProtoBatch};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::error::UpperMismatch;
+use mz_persist_client::write::WriteHandle;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::{Codec, Codec64};
 use mz_repr::{Diff, GlobalId, Row};
@@ -128,6 +129,7 @@ use tokio::sync::Semaphore;
 use tracing::trace;
 
 use crate::metrics::source::SourcePersistSinkMetrics;
+use crate::statistics::SourceStatistics;
 use crate::storage_state::StorageState;
 
 /// Metrics about batches.
@@ -168,7 +170,13 @@ where
     T: Timestamp + Lattice + Codec64,
 {
     builder: BatchBuilder<K, V, T, D>,
-    data_ts: T,
+    /// Largest update timestamp staged so far, `None` while empty.
+    ///
+    /// `append_batches` needs this to decide, after an `UpperMismatch`, whether a batch lies
+    /// entirely below a raised append lower and so holds nothing this sink still owes. Such a
+    /// batch is deleted rather than appended, which keeps parts that would be truncated away in
+    /// their entirety out of shard state.
+    data_max_ts: Option<T>,
     metrics: BatchMetrics,
 }
 
@@ -179,33 +187,35 @@ where
     T: Timestamp + Lattice + Codec64,
     D: Monoid + Codec64,
 {
-    /// Creates a new batch.
-    ///
-    /// NOTE(benesch): temporary restriction: all updates added to the batch
-    /// must be at the specified timestamp `data_ts`.
-    fn new(builder: BatchBuilder<K, V, T, D>, data_ts: T) -> Self {
+    /// Creates a new batch. Updates at any timestamp at or beyond the builder's lower may be
+    /// added, in any order.
+    fn new(builder: BatchBuilder<K, V, T, D>) -> Self {
         BatchBuilderAndMetadata {
             builder,
-            data_ts,
+            data_max_ts: None,
             metrics: Default::default(),
         }
     }
 
     /// Adds an update to the batch.
-    ///
-    /// NOTE(benesch): temporary restriction: all updates added to the batch
-    /// must be at the timestamp specified during creation.
     async fn add(&mut self, k: &K, v: &V, t: &T, d: &D) {
-        assert_eq!(
-            self.data_ts, *t,
-            "BatchBuilderAndMetadata::add called with a timestamp {t:?} that does not match creation timestamp {:?}",
-            self.data_ts
-        );
+        self.data_max_ts = Some(match self.data_max_ts.take() {
+            Some(max) => max.join(t),
+            None => t.clone(),
+        });
 
         self.builder.add(k, v, t, d).await.expect("invalid usage");
     }
 
+    /// Finishes the batch, registering it under `lower` and `upper`.
+    ///
+    /// Panics if no update was ever added, since an empty batch has no largest timestamp. Callers
+    /// open a builder on the first update rather than up front, so reaching this is a bug.
     async fn finish(self, lower: Antichain<T>, upper: Antichain<T>) -> HollowBatchAndMetadata<T> {
+        let data_max_ts = self.data_max_ts.expect("finishing an empty builder");
+        // `BatchBuilder::finish` rejects an update at or beyond `upper`, so a builder that was
+        // handed updates outside the description it is being finished under fails here rather
+        // than producing a batch whose parts reach past their registered bounds.
         let batch = self
             .builder
             .finish(upper.clone())
@@ -214,7 +224,7 @@ where
         HollowBatchAndMetadata {
             lower,
             upper,
-            data_ts: self.data_ts,
+            data_max_ts,
             batch: batch.into_transmittable_batch(),
             metrics: self.metrics,
         }
@@ -230,7 +240,7 @@ where
 struct HollowBatchAndMetadata<T> {
     lower: Antichain<T>,
     upper: Antichain<T>,
-    data_ts: T,
+    data_max_ts: T,
     batch: ProtoBatch,
     metrics: BatchMetrics,
 }
@@ -245,7 +255,65 @@ struct BatchSet {
 #[derive(Debug)]
 struct FinishedBatch {
     batch: Batch<SourceData, (), mz_repr::Timestamp, StorageDiff>,
-    data_ts: mz_repr::Timestamp,
+    data_max_ts: mz_repr::Timestamp,
+}
+
+/// The batch builder the source sink writes with.
+type SourceBatchBuilder = BatchBuilderAndMetadata<SourceData, (), mz_repr::Timestamp, StorageDiff>;
+
+/// How far ahead of the data the minter commits batch descriptions while a snapshot pins the
+/// frontier. Widths are in milliseconds, the unit of `mz_repr::Timestamp`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DescriptionWindow {
+    /// Width of the next committed description.
+    width: u64,
+    /// How close the data must come to the committed upper before the next description is
+    /// committed, so it reaches the writers ahead of the updates it covers.
+    margin: u64,
+    /// Ceiling `width` doubles toward with each commitment.
+    max: u64,
+}
+
+impl DescriptionWindow {
+    /// A window starting at `initial`, which is also the margin. `None` when `initial` is zero,
+    /// which disables committing ahead. `max` is raised to at least `initial`.
+    fn new(initial: Duration, max: Duration) -> Option<Self> {
+        let millis = |d: Duration| u64::try_from(d.as_millis()).unwrap_or(u64::MAX);
+        let initial = millis(initial);
+        (initial > 0).then(|| Self {
+            width: initial,
+            margin: initial,
+            max: millis(max).max(initial),
+        })
+    }
+
+    /// Doubles the width of the next committed description, up to `max`.
+    fn widen(&mut self) {
+        self.width = self.width.saturating_mul(2).min(self.max);
+    }
+}
+
+/// Adds one update to `builder`, keeping the batch metrics in step.
+async fn stage_update(
+    builder: &mut SourceBatchBuilder,
+    row: Result<Row, DataflowError>,
+    ts: mz_repr::Timestamp,
+    diff: Diff,
+) {
+    let is_value = row.is_ok();
+
+    builder
+        .add(&SourceData(row), &(), &ts, &diff.into_inner())
+        .await;
+
+    // Note that we assume `diff` is either +1 or -1 here, being anything else is a logic bug we
+    // can't handle at the metric layer. We also assume this addition doesn't overflow.
+    match (is_value, diff.is_positive()) {
+        (true, true) => builder.metrics.inserts += diff.unsigned_abs(),
+        (true, false) => builder.metrics.retractions += diff.unsigned_abs(),
+        (false, true) => builder.metrics.error_inserts += diff.unsigned_abs(),
+        (false, false) => builder.metrics.error_retractions += diff.unsigned_abs(),
+    }
 }
 
 /// Continuously writes the `desired_stream` into persist
@@ -274,6 +342,10 @@ struct FinishedBatch {
 /// `desired_collection`, and passes the data through to `write_batches`.
 /// This is done to avoid a clone of the underlying data so that both
 /// operators can have the collection as input.
+///
+/// `snapshotting` says whether this incarnation will snapshot the collection, which is what lets
+/// the sink group updates behind the pinned frontier a snapshot holds. See
+/// [`next_description_upper`].
 pub(crate) fn render<'scope>(
     scope: Scope<'scope, mz_repr::Timestamp>,
     collection_id: GlobalId,
@@ -282,6 +354,7 @@ pub(crate) fn render<'scope>(
     storage_state: &StorageState,
     metrics: SourcePersistSinkMetrics,
     busy_signal: Arc<Semaphore>,
+    snapshotting: bool,
 ) -> (
     StreamVec<'scope, mz_repr::Timestamp, ()>,
     StreamVec<'scope, mz_repr::Timestamp, Rc<anyhow::Error>>,
@@ -291,6 +364,12 @@ pub(crate) fn render<'scope>(
 
     let operator_name = format!("persist_sink({})", collection_id);
 
+    let config_set = storage_state.storage_configuration.config_set();
+    let description_window = DescriptionWindow::new(
+        dyncfgs::STORAGE_PERSIST_SINK_DESCRIPTION_WINDOW.get(config_set),
+        dyncfgs::STORAGE_PERSIST_SINK_DESCRIPTION_WINDOW_MAX.get(config_set),
+    );
+
     let (batch_descriptions, passthrough_desired_stream, mint_token) = mint_batch_descriptions(
         scope,
         collection_id,
@@ -298,7 +377,15 @@ pub(crate) fn render<'scope>(
         &target,
         desired_collection,
         Arc::clone(&persist_clients),
+        description_window,
+        snapshotting,
     );
+
+    let source_statistics = storage_state
+        .aggregated_statistics
+        .get_source(&collection_id)
+        .expect("statistics initialized")
+        .clone();
 
     let (written_batches, write_token) = write_batches(
         scope,
@@ -308,7 +395,7 @@ pub(crate) fn render<'scope>(
         batch_descriptions.clone(),
         passthrough_desired_stream.as_collection(),
         Arc::clone(&persist_clients),
-        storage_state,
+        source_statistics,
         Arc::clone(&busy_signal),
     );
 
@@ -336,6 +423,11 @@ pub(crate) fn render<'scope>(
 /// and upper) that writers should use for writing the next set of batches to
 /// persist.
 ///
+/// With a `window`, descriptions are also committed ahead of the frontier while a `snapshotting`
+/// export holds it pinned, each before the updates it covers arrive. Such a description is a
+/// commitment: no later description will end inside it, so the write operator can group updates
+/// into bounds the frontier has not certified yet. See [`next_description_upper`].
+///
 /// Only one of the workers does this, meaning there will only be one
 /// description in the stream, even in case of multiple timely workers. Use
 /// `broadcast()` to, ahem, broadcast, the one description to all downstream
@@ -347,6 +439,8 @@ fn mint_batch_descriptions<'scope>(
     target: &CollectionMetadata,
     desired_collection: VecCollection<'scope, mz_repr::Timestamp, Result<Row, DataflowError>, Diff>,
     persist_clients: Arc<PersistClientCache>,
+    window: Option<DescriptionWindow>,
+    snapshotting: bool,
 ) -> (
     StreamVec<
         'scope,
@@ -445,30 +539,63 @@ fn mint_batch_descriptions<'scope>(
             upper
         };
 
-        // The current input frontiers.
-        let mut desired_frontier;
+        // The current input frontier.
+        let mut desired_frontier = Antichain::from_elem(mz_repr::Timestamp::minimum());
+
+        // The largest timestamp seen in the data, which is what the next commitment is timed
+        // against.
+        let mut max_seen_ts: Option<mz_repr::Timestamp> = None;
+
+        // The first non-minimum frontier the collection takes, tracked only while `snapshotting`.
+        // A source emits its snapshot at the minimum from-time, so the whole snapshot occupies the
+        // single time that reclocks to, and the frontier moving off that value is the snapshot
+        // ending. Frontiers only advance, so this can never re-arm. Nothing is committed before it
+        // arms: timely does not order progress ahead of data, and a row seen under the minimum
+        // frontier would otherwise anchor the first window at the shard upper and mint windows
+        // across the whole gap from there to the data.
+        let mut first_frontier: Option<Antichain<mz_repr::Timestamp>> = None;
+
+        // Widens with each commitment, so a short snapshot commits little past its end and a long
+        // one costs few descriptions.
+        let mut window = window;
 
         loop {
-            if let Some(event) = desired_input.next().await {
-                match event {
-                    Event::Data([_output_cap, data_output_cap], mut data) => {
-                        // Just passthrough the data.
-                        data_output.give_container(&data_output_cap, &mut data);
-                        continue;
+            match desired_input.next().await {
+                Some(Event::Data([_output_cap, data_output_cap], mut data)) => {
+                    for (_, ts, _) in data.iter() {
+                        max_seen_ts = Some(match max_seen_ts {
+                            Some(max) => std::cmp::max(max, *ts),
+                            None => *ts,
+                        });
                     }
-                    Event::Progress(frontier) => {
-                        desired_frontier = frontier;
-                    }
+                    // Just passthrough the data.
+                    data_output.give_container(&data_output_cap, &mut data);
                 }
-            } else {
+                Some(Event::Progress(frontier)) => {
+                    if snapshotting
+                        && first_frontier.is_none()
+                        && frontier != Antichain::from_elem(mz_repr::Timestamp::minimum())
+                    {
+                        first_frontier = Some(frontier.clone());
+                    }
+                    desired_frontier = frontier;
+                }
                 // Input is exhausted, so we can shut down.
-                return;
-            };
+                None => return,
+            }
 
-            // If the new frontier for the data input has progressed, produce a batch description.
-            if PartialOrder::less_than(&current_upper, &desired_frontier) {
-                // The maximal description range we can produce.
-                let batch_description = (current_upper.to_owned(), desired_frontier.to_owned());
+            let snapshot_in_progress = snapshotting
+                && first_frontier
+                    .as_ref()
+                    .is_some_and(|first| *first == desired_frontier);
+
+            while let Some(upper) = next_description_upper(
+                &current_upper,
+                &desired_frontier,
+                max_seen_ts,
+                window.filter(|_| snapshot_in_progress),
+            ) {
+                let batch_description = (current_upper.to_owned(), upper.to_owned());
 
                 let lower = batch_description.0.as_option().copied().unwrap();
 
@@ -498,13 +625,20 @@ fn mint_batch_descriptions<'scope>(
                 trace!(
                     "persist_sink {collection_id}/{shard_id}: \
                         downgrading to {:?}",
-                    desired_frontier
+                    upper
                 );
-                cap_set.downgrade(desired_frontier.iter());
+                cap_set.downgrade(upper.iter());
 
-                // After successfully emitting a new description, we can update the upper for the
-                // operator.
-                current_upper.clone_from(&desired_frontier);
+                // A description derived from the frontier ends exactly at it, so one ending past
+                // it was committed ahead. That leaves `current_upper` beyond `desired_frontier`,
+                // which is the state that makes the commitment binding: a frontier arriving inside
+                // it produces no description of its own.
+                if PartialOrder::less_than(&desired_frontier, &upper) {
+                    if let Some(window) = window.as_mut() {
+                        window.widen();
+                    }
+                }
+                current_upper = upper;
             }
         }
     });
@@ -516,10 +650,118 @@ fn mint_batch_descriptions<'scope>(
     )
 }
 
+/// The lower of the in-flight description covering `ts`, if one covers it.
+///
+/// Descriptions are contiguous and disjoint, so the only candidate is the greatest lower at or
+/// below `ts`.
+fn covering_description(
+    description_uppers: &BTreeMap<mz_repr::Timestamp, Antichain<mz_repr::Timestamp>>,
+    ts: mz_repr::Timestamp,
+) -> Option<mz_repr::Timestamp> {
+    let (lower, upper) = description_uppers.range(..=ts).next_back()?;
+    (!upper.less_equal(&ts)).then_some(*lower)
+}
+
+/// The open builder for the in-flight description at `lower`, opening one if there is none.
+///
+/// Finishes the builders of any earlier description first, moving their batches to
+/// `description_batches`, except the one covering the `frontier` time. Closing them is what keeps
+/// the number of open builders independent of how many descriptions a pinned frontier accumulates.
+/// A description accepts any number of batches, so a row arriving for a closed one reopens it at
+/// the cost of one more batch. Arrival order is an efficiency assumption, not a correctness one.
+async fn description_builder<'a>(
+    write: &WriteHandle<SourceData, (), mz_repr::Timestamp, StorageDiff>,
+    description_uppers: &BTreeMap<mz_repr::Timestamp, Antichain<mz_repr::Timestamp>>,
+    description_builders: &'a mut BTreeMap<mz_repr::Timestamp, SourceBatchBuilder>,
+    description_batches: &mut BTreeMap<
+        mz_repr::Timestamp,
+        Vec<HollowBatchAndMetadata<mz_repr::Timestamp>>,
+    >,
+    lower: mz_repr::Timestamp,
+    frontier: Option<mz_repr::Timestamp>,
+) -> &'a mut SourceBatchBuilder {
+    // The frontier's own time is incomplete by definition, so the description covering it keeps
+    // taking updates for as long as the frontier sits there. A pinned snapshot lands its rows
+    // there for its whole duration, interleaved with replication rows in later descriptions, and
+    // closing it on every such flip would write a batch per flip.
+    let incomplete = frontier.and_then(|ts| covering_description(description_uppers, ts));
+    while let Some(stale_lower) = description_builders
+        .keys()
+        .copied()
+        .find(|stale_lower| *stale_lower < lower && Some(*stale_lower) != incomplete)
+    {
+        let builder = description_builders
+            .remove(&stale_lower)
+            .expect("just looked up");
+        let upper = description_uppers
+            .get(&stale_lower)
+            .expect("a builder only exists while its description is in flight")
+            .clone();
+        let batch = builder
+            .finish(Antichain::from_elem(stale_lower), upper)
+            .await;
+        description_batches
+            .entry(stale_lower)
+            .or_default()
+            .push(batch);
+    }
+
+    description_builders
+        .entry(lower)
+        .or_insert_with(|| BatchBuilderAndMetadata::new(write.builder(Antichain::from_elem(lower))))
+}
+
+/// The upper of the next batch description to emit, or `None` if there is none.
+///
+/// A description is either derived from the frontier, which certifies that everything below it has
+/// arrived, or committed ahead of it when a `window` is given, which the caller does only while a
+/// snapshot pins the frontier. The committed form exists because a pinned frontier yields no
+/// descriptions at all, which leaves the write operator no bounds to group updates into. It does
+/// not make the description appendable, that still waits for the frontier to reach its upper.
+///
+/// A commitment has to reach the writers before the updates it covers, since a builder only takes
+/// updates at times it was opened for. So the first one is committed as soon as the frontier pins,
+/// ahead of the snapshot's rows landing at that time, and each later one once `max_seen_ts` comes
+/// within the window's margin of the committed upper.
+///
+/// Committing is confined to a snapshot because a commitment is binding. While `current_upper` sits
+/// ahead of the frontier no description is derived from the frontier either, so the shard upper
+/// waits for the frontier to reach the committed boundary rather than advancing to where the
+/// frontier actually reached. A collection that is keeping up lags the data by about one timestamp
+/// and so has nothing to group, and would pay that for nothing.
+fn next_description_upper(
+    current_upper: &Antichain<mz_repr::Timestamp>,
+    desired_frontier: &Antichain<mz_repr::Timestamp>,
+    max_seen_ts: Option<mz_repr::Timestamp>,
+    window: Option<DescriptionWindow>,
+) -> Option<Antichain<mz_repr::Timestamp>> {
+    if PartialOrder::less_than(current_upper, desired_frontier) {
+        return Some(desired_frontier.clone());
+    }
+    let window = window?;
+    let lower = *current_upper.as_option()?;
+
+    // Before any data, the snapshot's rows are about to land at the pinned time itself.
+    let reach = max_seen_ts
+        .or_else(|| desired_frontier.as_option().copied())?
+        .checked_add(window.margin);
+    if reach.is_some_and(|reach| reach <= lower) {
+        return None;
+    }
+
+    Some(Antichain::from_elem(lower.checked_add(window.width)?))
+}
+
 /// Writes `desired_collection` to persist, but only for updates
 /// that fall into batch a description that we get via `batch_descriptions`.
 /// This forwards a `HollowBatch` (with additional metadata)
 /// for any batch of updates that was written.
+///
+/// Batches are keyed by description, spanning however many timestamps that description covers, so
+/// the batch count follows the number of descriptions rather than the number of timestamps a
+/// pinned frontier accumulates. An update whose description has not arrived yet has no bounds to
+/// be grouped under, so it writes a batch of its own timestamp, which is what the sink does for
+/// every update when no description is ever committed ahead of the frontier.
 ///
 /// This operator assumes that the `desired_collection` comes pre-sharded.
 ///
@@ -536,7 +778,7 @@ fn write_batches<'scope>(
     >,
     desired_collection: VecCollection<'scope, mz_repr::Timestamp, Result<Row, DataflowError>, Diff>,
     persist_clients: Arc<PersistClientCache>,
-    storage_state: &StorageState,
+    source_statistics: SourceStatistics,
     busy_signal: Arc<Semaphore>,
 ) -> (
     StreamVec<'scope, mz_repr::Timestamp, HollowBatchAndMetadata<mz_repr::Timestamp>>,
@@ -547,12 +789,6 @@ fn write_batches<'scope>(
     let persist_location = target.persist_location.clone();
     let shard_id = target.data_shard;
     let target_relation_desc = target.relation_desc.clone();
-
-    let source_statistics = storage_state
-        .aggregated_statistics
-        .get_source(&collection_id)
-        .expect("statistics initialized")
-        .clone();
 
     let mut write_op =
         AsyncOperatorBuilder::new(format!("{} write_batches", operator_name), scope.clone());
@@ -569,8 +805,39 @@ fn write_batches<'scope>(
     // upper_.
 
     let shutdown_button = write_op.build(move |_capabilities| async move {
-        // In-progress batches of data, keyed by timestamp.
-        let mut stashed_batches = BTreeMap::new();
+        // Builders for timestamps no in-flight description covers yet, keyed by timestamp.
+        //
+        // A batch builder cannot be split, so an update may only join updates at other timestamps
+        // once the description that will cover them all is known. Until then a timestamp gets a
+        // builder to itself, which is safe without knowing the descriptions because a description
+        // covers a timestamp entirely or not at all. Such a builder stays below
+        // `persist_blob_target_size` and so holds its rows in memory, so it is finished as soon as
+        // a description covers it rather than held until that description is ready.
+        let mut uncovered_builders: BTreeMap<mz_repr::Timestamp, SourceBatchBuilder> =
+            BTreeMap::new();
+
+        // Uppers of the in-flight descriptions, keyed by lower, so that an arriving timestamp can
+        // be matched to the description covering it.
+        let mut description_uppers: BTreeMap<mz_repr::Timestamp, Antichain<mz_repr::Timestamp>> =
+            BTreeMap::new();
+
+        // The open builder for each in-flight description, keyed by the description's lower.
+        //
+        // It takes every timestamp in the description's range, so it reaches
+        // `persist_blob_target_size` and spills its parts to blob. `description_builder` closes the
+        // builders of earlier descriptions as data moves past them, all but the one covering the
+        // frontier's time, so the number of open builders does not grow with how long the frontier
+        // stays pinned.
+        let mut description_builders: BTreeMap<mz_repr::Timestamp, SourceBatchBuilder> =
+            BTreeMap::new();
+
+        // Batches finished before their description became ready, keyed by the description's
+        // lower. A description can take any number of batches, so a builder is closed once the
+        // data moves past it rather than held open.
+        let mut description_batches: BTreeMap<
+            mz_repr::Timestamp,
+            Vec<HollowBatchAndMetadata<mz_repr::Timestamp>>,
+        > = BTreeMap::new();
 
         // Contains descriptions of batches for which we know that we can
         // write data. We got these from the "centralized" operator that
@@ -624,8 +891,18 @@ fn write_batches<'scope>(
                 _ = desired_input.ready() => {},
             }
 
-            // Collect ready work from both inputs
-            while let Some(event) = descriptions_input.next_sync() {
+            // Collect ready work from both inputs. Descriptions are processed before the data of
+            // the same round so that an update whose description arrived alongside it can go
+            // straight into that description's builder instead of writing a batch of its own.
+            let ready_descriptions =
+                std::iter::from_fn(|| descriptions_input.next_sync()).collect_vec();
+            let ready_events = std::iter::from_fn(|| desired_input.next_sync()).collect_vec();
+
+            // We know start the async work for the input we received. Until we finish the dataflow
+            // should be marked as busy.
+            let permit = busy_signal.acquire().await;
+
+            for event in ready_descriptions {
                 match event {
                     Event::Data(cap, data) => {
                         // Ingest new batch descriptions.
@@ -640,6 +917,29 @@ fn write_batches<'scope>(
                                     description, desired_frontier, batch_descriptions_frontier,
                                 );
                             }
+
+                            let (lower, upper) = (&description.0, &description.1);
+                            let lower_ts = *lower
+                                .as_option()
+                                .expect("minted descriptions have a single-element lower");
+                            let covered = |ts: &mz_repr::Timestamp| {
+                                lower.less_equal(ts) && !upper.less_equal(ts)
+                            };
+                            description_uppers.insert(lower_ts, upper.clone());
+
+                            // These builders have bounds now, so they are finished here rather
+                            // than at readiness. While the frontier is pinned readiness is
+                            // precisely what is not happening, and a builder left open holds its
+                            // rows in memory until it does.
+                            let uncovered_timestamps: Vec<_> =
+                                uncovered_builders.keys().copied().filter(covered).collect();
+                            for ts in uncovered_timestamps {
+                                let builder =
+                                    uncovered_builders.remove(&ts).expect("just looked up");
+                                let batch = builder.finish(lower.clone(), upper.clone()).await;
+                                description_batches.entry(lower_ts).or_default().push(batch);
+                            }
+
                             match in_flight_batches.entry(description) {
                                 std::collections::hash_map::Entry::Vacant(v) => {
                                     // This _should_ be `.retain`, but rust
@@ -665,12 +965,6 @@ fn write_batches<'scope>(
                 }
             }
 
-            let ready_events = std::iter::from_fn(|| desired_input.next_sync()).collect_vec();
-
-            // We know start the async work for the input we received. Until we finish the dataflow
-            // should be marked as busy.
-            let permit = busy_signal.acquire().await;
-
             for event in ready_events {
                 match event {
                     Event::Data(_cap, data) => {
@@ -691,36 +985,48 @@ fn write_batches<'scope>(
 
                         for (row, ts, diff) in data {
                             if write.upper().less_equal(&ts) {
-                                let builder = stashed_batches.entry(ts).or_insert_with(|| {
-                                    BatchBuilderAndMetadata::new(
-                                        write.builder(operator_batch_lower.clone()),
-                                        ts,
-                                    )
-                                });
+                                // Every description this operator has emitted was covered by the
+                                // desired frontier at the time, so no update below
+                                // `operator_batch_lower` can still be in flight. An update that
+                                // arrives anyway belongs to a description that is already gone: it
+                                // matches no later description, so its batch would never be
+                                // appended and the update would be lost unnoticed. Not a
+                                // `debug_assert!`, which compiles out of the optimized and release
+                                // profiles and would leave the loss silent everywhere it matters.
+                                assert!(
+                                    operator_batch_lower.less_equal(&ts),
+                                    "persist_sink {collection_id}/{shard_id}: update at {ts:?} \
+                                    arrived below the emitted batch lower {operator_batch_lower:?}",
+                                );
 
-                                let is_value = row.is_ok();
-
-                                builder
-                                    .add(&SourceData(row), &(), &ts, &diff.into_inner())
-                                    .await;
-
+                                // Once a description covers this timestamp its bounds are known,
+                                // so the update goes straight into that description's builder and
+                                // joins every other timestamp that description covers. Otherwise
+                                // there are no bounds to group under, and the only lower this
+                                // builder can declare is the operator's own, the one lower at or
+                                // below every description that could come to cover it. That
+                                // declaration is what registers the batch truncated once it is
+                                // appended under a description's narrower bounds.
+                                let builder = match covering_description(&description_uppers, ts) {
+                                    Some(lower) => {
+                                        description_builder(
+                                            &write,
+                                            &description_uppers,
+                                            &mut description_builders,
+                                            &mut description_batches,
+                                            lower,
+                                            desired_frontier.as_option().copied(),
+                                        )
+                                        .await
+                                    }
+                                    None => uncovered_builders.entry(ts).or_insert_with(|| {
+                                        BatchBuilderAndMetadata::new(
+                                            write.builder(operator_batch_lower.clone()),
+                                        )
+                                    }),
+                                };
+                                stage_update(builder, row, ts, diff).await;
                                 source_statistics.inc_updates_staged_by(1);
-
-                                // Note that we assume `diff` is either +1 or -1 here, being anything
-                                // else is a logic bug we can't handle at the metric layer. We also
-                                // assume this addition doesn't overflow.
-                                match (is_value, diff.is_positive()) {
-                                    (true, true) => builder.metrics.inserts += diff.unsigned_abs(),
-                                    (true, false) => {
-                                        builder.metrics.retractions += diff.unsigned_abs()
-                                    }
-                                    (false, true) => {
-                                        builder.metrics.error_inserts += diff.unsigned_abs()
-                                    }
-                                    (false, false) => {
-                                        builder.metrics.error_retractions += diff.unsigned_abs()
-                                    }
-                                }
                             }
                         }
                     }
@@ -729,6 +1035,7 @@ fn write_batches<'scope>(
                     }
                 }
             }
+
             // We may have the opportunity to commit updates, if either frontier
             // has moved
             if PartialOrder::less_equal(&processed_desired_frontier, &desired_frontier)
@@ -789,45 +1096,52 @@ fn write_batches<'scope>(
                     }
 
                     let (batch_lower, batch_upper) = batch_description;
+                    let lower = *batch_lower
+                        .as_option()
+                        .expect("minted descriptions have a single-element lower");
 
-                    let finalized_timestamps: Vec<_> = stashed_batches
-                        .keys()
-                        .filter(|time| {
-                            batch_lower.less_equal(time) && !batch_upper.less_equal(time)
-                        })
-                        .copied()
-                        .collect();
+                    // Every update this description covers went into its builder on arrival, or
+                    // into a builder of its own that was finished under these bounds when this
+                    // description arrived.
+                    debug_assert!(
+                        !uncovered_builders
+                            .keys()
+                            .any(|ts| batch_lower.less_equal(ts) && !batch_upper.less_equal(ts)),
+                        "persist_sink {collection_id}/{shard_id}: description {:?} is ready with \
+                        updates it covers still unwritten",
+                        (&batch_lower, &batch_upper),
+                    );
 
-                    let mut batch_tokens = vec![];
-                    for ts in finalized_timestamps {
-                        let batch_builder = stashed_batches.remove(&ts).unwrap();
+                    let mut batch_tokens = description_batches.remove(&lower).unwrap_or_default();
 
+                    description_uppers.remove(&lower);
+                    if let Some(builder) = description_builders.remove(&lower) {
                         if collection_id.is_user() {
                             trace!(
                                 "persist_sink {collection_id}/{shard_id}: \
-                                    wrote batch from worker {}: ({:?}, {:?}),
-                                    containing {:?}",
-                                worker_index, batch_lower, batch_upper, batch_builder.metrics
+                                    wrote batch from worker {}: ({:?}, {:?}), containing {:?}",
+                                worker_index, batch_lower, batch_upper, builder.metrics
                             );
                         }
 
-                        let batch = batch_builder
-                            .finish(batch_lower.clone(), batch_upper.clone())
-                            .await;
-
-                        // The next "safe" lower for batches is the meet (max) of all the emitted
-                        // batches. These uppers all are not beyond the `desired_frontier`, which
-                        // means all updates received by this operator will be beyond this lower.
-                        // Additionally, the `mint_batch_descriptions` operator ensures that
-                        // later-received batch descriptions will start beyond these uppers as
-                        // well.
-                        //
-                        // It is impossible to emit a batch description that is
-                        // beyond a not-yet emitted description in `in_flight_batches`, as
-                        // a that description would also have been chosen as ready above.
-                        operator_batch_lower = operator_batch_lower.join(&batch_upper);
-                        batch_tokens.push(batch);
+                        batch_tokens.push(
+                            builder
+                                .finish(batch_lower.clone(), batch_upper.clone())
+                                .await,
+                        );
                     }
+
+                    // The next "safe" lower for batches is the meet (max) of all the emitted
+                    // batches. These uppers all are not beyond the `desired_frontier`, which
+                    // means all updates received by this operator will be beyond this lower.
+                    // Additionally, the `mint_batch_descriptions` operator ensures that
+                    // later-received batch descriptions will start beyond these uppers as
+                    // well.
+                    //
+                    // It is impossible to emit a batch description that is
+                    // beyond a not-yet emitted description in `in_flight_batches`, as
+                    // a that description would also have been chosen as ready above.
+                    operator_batch_lower = operator_batch_lower.join(&batch_upper);
 
                     output.give_container(&cap, &mut batch_tokens);
 
@@ -1070,7 +1384,7 @@ fn append_batches<'scope>(
 
                                 batches.finished.push(FinishedBatch {
                                     batch: write.batch_from_transmittable_batch(batch.batch),
-                                    data_ts: batch.data_ts,
+                                    data_max_ts: batch.data_max_ts,
                                 });
                                 batches.batch_metrics += &batch.metrics;
                             }
@@ -1370,13 +1684,17 @@ fn append_batches<'scope>(
                             let new_done_batch_metadata =
                                 (new_batch_lower.clone(), batch_upper.clone());
 
-                            // Retain any batches that are still in advance of
-                            // the new lower, and delete any batches that are
-                            // not.
+                            // Re-append every batch that still holds something we owe, under the
+                            // narrowed description. A batch may hold data on both sides of the new
+                            // lower: persist registers it truncated and filters the updates
+                            // outside the registered bounds on read, so the ones the concurrent
+                            // writer already committed do not come back. A batch entirely below
+                            // the new lower owes nothing and is deleted instead, to keep parts
+                            // that would be truncated away in full out of shard state.
                             let mut batch_delete_futures = vec![];
                             let mut new_batch_set = BatchSet::default();
                             for batch in batches {
-                                if new_batch_lower.less_equal(&batch.data_ts) {
+                                if new_batch_lower.less_equal(&batch.data_max_ts) {
                                     new_batch_set.finished.push(batch);
                                 } else {
                                     batch_delete_futures.push(batch.batch.delete());
@@ -1411,4 +1729,1358 @@ fn append_batches<'scope>(
     }));
 
     (upper_stream, errors, shutdown_button.press_on_drop())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::str::FromStr;
+
+    use mz_build_info::DUMMY_BUILD_INFO;
+    use mz_dyncfg::{ConfigUpdates, ConfigVal};
+    use mz_ore::metrics::MetricsRegistry;
+    use mz_ore::now::SYSTEM_TIME;
+    use mz_ore::url::SensitiveUrl;
+    use mz_persist_client::PersistLocation;
+    use mz_persist_client::cfg::PersistConfig;
+    use mz_persist_client::rpc::PubSubClientConnection;
+    use mz_persist_types::ShardId;
+    use mz_repr::{Datum, RelationDesc, SqlScalarType};
+    use mz_storage_types::sources::SourceEnvelope;
+    use mz_storage_types::sources::envelope::{KeyEnvelope, NoneEnvelope};
+    use timely::dataflow::operators::Input;
+
+    use crate::statistics::SourceStatisticsMetricDefs;
+
+    use super::*;
+
+    fn ts(t: u64) -> mz_repr::Timestamp {
+        t.into()
+    }
+
+    fn frontier(t: u64) -> Antichain<mz_repr::Timestamp> {
+        Antichain::from_elem(ts(t))
+    }
+
+    /// One step of a `write_batches` script.
+    #[derive(Clone)]
+    enum Step {
+        /// Deliver a batch description, as `mint_batch_descriptions` would.
+        Description(u64, u64),
+        /// Deliver `count` updates at time `at`.
+        Updates(u64, usize),
+        /// Deliver `count` updates at time `at` with negated diffs, as the rewind of a snapshot
+        /// does for rows the replication stream redelivers at their true offset.
+        Retractions(u64, usize),
+        /// Advance both input frontiers.
+        AdvanceTo(u64),
+    }
+
+    /// What a batch emitted by `write_batches` carries, flattened for assertions.
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    struct EmittedBatch {
+        lower: u64,
+        upper: u64,
+        data_max_ts: u64,
+        inserts: u64,
+    }
+
+    /// Runs a timely worker to completion on a blocking thread.
+    ///
+    /// The test body is a single poll of the runtime's `block_on` future, so it runs under one
+    /// tokio cooperative budget. A worker driven inline spends that budget on the operators'
+    /// `select!` and semaphore polls, and once it is gone every such poll returns `Pending` and
+    /// re-wakes itself, parking the operator for good with no error. Blocking threads have no
+    /// budget.
+    async fn run_worker<T: Send + 'static>(
+        worker: impl FnOnce(&mut timely::worker::Worker) -> T + Send + Sync + 'static,
+    ) -> T {
+        mz_ore::task::spawn_blocking(
+            || "persist_sink_test_worker",
+            move || timely::execute_directly(worker),
+        )
+        .await
+    }
+
+    /// Drives `write_batches` through `script` and returns the batches it emitted, along with a
+    /// handle to the shard so callers can append them and read the result back.
+    async fn run_write_batches(
+        target: CollectionMetadata,
+        persist_clients: Arc<PersistClientCache>,
+        script: Vec<Step>,
+    ) -> Vec<(EmittedBatch, ProtoBatch)> {
+        run_worker(move |worker| {
+            // `ProtoBatch` is not `Ord`, so the captured stream is summarized on the way out
+            // rather than going through `Capture`.
+            let emitted = Rc::new(RefCell::new(Vec::new()));
+
+            let (mut descs_input, mut data_input, button) = worker
+                .dataflow::<mz_repr::Timestamp, _, _>(|scope| {
+                    let (descs_input, descs) = scope.new_input();
+                    let (data_input, data) = scope.new_input();
+
+                    let source_id = GlobalId::User(0);
+                    let stats_defs =
+                        SourceStatisticsMetricDefs::register_with(&MetricsRegistry::new());
+                    let source_statistics = SourceStatistics::new(
+                        source_id,
+                        0,
+                        &stats_defs,
+                        source_id,
+                        &target.data_shard,
+                        SourceEnvelope::None(NoneEnvelope {
+                            key_envelope: KeyEnvelope::None,
+                            key_arity: 0,
+                        }),
+                        Antichain::from_elem(Timestamp::minimum()),
+                    );
+
+                    let (batches, button) = write_batches(
+                        scope,
+                        source_id,
+                        "test",
+                        &target,
+                        descs,
+                        data.as_collection(),
+                        persist_clients,
+                        source_statistics,
+                        Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
+                    );
+                    let sink = Rc::clone(&emitted);
+                    InspectCore::inspect_container(batches, move |event| {
+                        if let Ok((_, data)) = event {
+                            for b in data {
+                                sink.borrow_mut().push((
+                                    EmittedBatch {
+                                        lower: b.lower.as_option().expect("single lower").into(),
+                                        upper: b.upper.as_option().expect("single upper").into(),
+                                        data_max_ts: b.data_max_ts.into(),
+                                        inserts: b.metrics.inserts,
+                                    },
+                                    b.batch.clone(),
+                                ));
+                            }
+                        }
+                    });
+
+                    (descs_input, data_input, button)
+                });
+
+            // The operator waits on persist off the timely scheduler, so a plain `step` can find
+            // the worker idle while the operator is still starting up. Parking hands the thread
+            // over until its waker fires, which is what lets the operator keep up with the script.
+            fn pump(worker: &mut timely::worker::Worker) {
+                for _ in 0..32 {
+                    worker.step_or_park(Some(Duration::from_millis(1)));
+                }
+            }
+
+            // Twice, so the operator is past opening its persist handles before the script runs.
+            pump(worker);
+            pump(worker);
+
+            for step in script {
+                match step {
+                    Step::Description(lower, upper) => {
+                        descs_input.send((frontier(lower), frontier(upper)));
+                    }
+                    Step::Updates(at, count) => {
+                        for i in 0..i64::try_from(count).expect("small count") {
+                            let row = Row::pack_slice(&[Datum::Int64(i)]);
+                            data_input.send((Ok(row), ts(at), Diff::ONE));
+                        }
+                    }
+                    Step::Retractions(at, count) => {
+                        for i in 0..i64::try_from(count).expect("small count") {
+                            let row = Row::pack_slice(&[Datum::Int64(i)]);
+                            data_input.send((Ok(row), ts(at), -Diff::ONE));
+                        }
+                    }
+                    Step::AdvanceTo(t) => {
+                        descs_input.advance_to(ts(t));
+                        data_input.advance_to(ts(t));
+                    }
+                }
+                pump(worker);
+            }
+
+            descs_input.close();
+            data_input.close();
+            for _ in 0..1_000 {
+                if !worker.step_or_park(Some(Duration::from_millis(1))) {
+                    break;
+                }
+            }
+
+            drop(button);
+            while worker.step() {}
+
+            let mut emitted = emitted.borrow().clone();
+            emitted.sort_by(|a, b| a.0.cmp(&b.0));
+            emitted
+        })
+        .await
+    }
+
+    /// Drives `mint_batch_descriptions` through `script` and returns the descriptions it emitted.
+    ///
+    /// Closing the input mints a final description with an empty upper, which is dropped here so a
+    /// script only sees what it drove.
+    async fn run_mint_batch_descriptions(
+        target: CollectionMetadata,
+        persist_clients: Arc<PersistClientCache>,
+        window: Option<DescriptionWindow>,
+        snapshotting: bool,
+        script: Vec<Step>,
+    ) -> Vec<(u64, u64)> {
+        run_worker(move |worker| {
+            let emitted = Rc::new(RefCell::new(Vec::new()));
+
+            let (mut data_input, button) = worker.dataflow::<mz_repr::Timestamp, _, _>(|scope| {
+                let (data_input, data) = scope.new_input();
+
+                let (descriptions, _passthrough, button) = mint_batch_descriptions(
+                    scope,
+                    GlobalId::User(0),
+                    "test",
+                    &target,
+                    data.as_collection(),
+                    persist_clients,
+                    window,
+                    snapshotting,
+                );
+
+                let sink = Rc::clone(&emitted);
+                InspectCore::inspect_container(descriptions, move |event| {
+                    if let Ok((_, data)) = event {
+                        for (lower, upper) in data {
+                            let (Some(lower), Some(upper)) = (lower.as_option(), upper.as_option())
+                            else {
+                                continue;
+                            };
+                            sink.borrow_mut().push((lower.into(), upper.into()));
+                        }
+                    }
+                });
+
+                (data_input, button)
+            });
+
+            // The operator waits on persist off the timely scheduler, so a plain `step` can find
+            // the worker idle while the operator is still starting up.
+            fn pump(worker: &mut timely::worker::Worker) {
+                for _ in 0..32 {
+                    worker.step_or_park(Some(Duration::from_millis(1)));
+                }
+            }
+
+            // Twice, so the operator has fetched the shard upper before the script runs.
+            pump(worker);
+            pump(worker);
+
+            for step in script {
+                match step {
+                    Step::Description(..) => {
+                        panic!("the minter emits descriptions rather than taking them")
+                    }
+                    Step::Updates(at, count) => {
+                        for i in 0..i64::try_from(count).expect("small count") {
+                            let row = Row::pack_slice(&[Datum::Int64(i)]);
+                            data_input.send((Ok(row), ts(at), Diff::ONE));
+                        }
+                    }
+                    Step::Retractions(at, count) => {
+                        for i in 0..i64::try_from(count).expect("small count") {
+                            let row = Row::pack_slice(&[Datum::Int64(i)]);
+                            data_input.send((Ok(row), ts(at), -Diff::ONE));
+                        }
+                    }
+                    Step::AdvanceTo(t) => data_input.advance_to(ts(t)),
+                }
+                // Sends are buffered until the handle is flushed or its time advances, and these
+                // scripts deliver data at times a pinned frontier never reaches.
+                data_input.flush();
+                pump(worker);
+            }
+
+            data_input.close();
+            for _ in 0..1_000 {
+                if !worker.step_or_park(Some(Duration::from_millis(1))) {
+                    break;
+                }
+            }
+
+            drop(button);
+            while worker.step() {}
+
+            let emitted = emitted.borrow().clone();
+            emitted
+        })
+        .await
+    }
+
+    /// Drives the real `mint_batch_descriptions` into the real `write_batches`, so the ordering
+    /// between a committed description and the data it covers is the operators' own rather than
+    /// the script's.
+    async fn run_sink_pipeline(
+        target: CollectionMetadata,
+        persist_clients: Arc<PersistClientCache>,
+        window: Option<DescriptionWindow>,
+        snapshotting: bool,
+        script: Vec<Step>,
+    ) -> Vec<EmittedBatch> {
+        run_worker(move |worker| {
+            let emitted = Rc::new(RefCell::new(Vec::new()));
+
+            let (mut data_input, buttons) = worker.dataflow::<mz_repr::Timestamp, _, _>(|scope| {
+                let (data_input, data) = scope.new_input();
+
+                let source_id = GlobalId::User(0);
+                let (descriptions, passthrough, mint_button) = mint_batch_descriptions(
+                    scope,
+                    source_id,
+                    "test",
+                    &target,
+                    data.as_collection(),
+                    Arc::clone(&persist_clients),
+                    window,
+                    snapshotting,
+                );
+
+                let stats_defs = SourceStatisticsMetricDefs::register_with(&MetricsRegistry::new());
+                let source_statistics = SourceStatistics::new(
+                    source_id,
+                    0,
+                    &stats_defs,
+                    source_id,
+                    &target.data_shard,
+                    SourceEnvelope::None(NoneEnvelope {
+                        key_envelope: KeyEnvelope::None,
+                        key_arity: 0,
+                    }),
+                    Antichain::from_elem(Timestamp::minimum()),
+                );
+
+                let (batches, write_button) = write_batches(
+                    scope,
+                    source_id,
+                    "test",
+                    &target,
+                    descriptions,
+                    passthrough.as_collection(),
+                    persist_clients,
+                    source_statistics,
+                    Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
+                );
+
+                let sink = Rc::clone(&emitted);
+                InspectCore::inspect_container(batches, move |event| {
+                    if let Ok((_, data)) = event {
+                        for b in data {
+                            sink.borrow_mut().push(EmittedBatch {
+                                lower: b.lower.as_option().expect("single lower").into(),
+                                upper: b.upper.as_option().expect("single upper").into(),
+                                data_max_ts: b.data_max_ts.into(),
+                                inserts: b.metrics.inserts,
+                            });
+                        }
+                    }
+                });
+
+                (data_input, [mint_button, write_button])
+            });
+
+            fn pump(worker: &mut timely::worker::Worker) {
+                for _ in 0..32 {
+                    worker.step_or_park(Some(Duration::from_millis(1)));
+                }
+            }
+
+            // Twice, so both operators are past opening their persist handles before the script.
+            pump(worker);
+            pump(worker);
+
+            for step in script {
+                match step {
+                    Step::Description(..) => panic!("the minter emits descriptions"),
+                    Step::Updates(at, count) => {
+                        for i in 0..i64::try_from(count).expect("small count") {
+                            let row = Row::pack_slice(&[Datum::Int64(i)]);
+                            data_input.send((Ok(row), ts(at), Diff::ONE));
+                        }
+                    }
+                    Step::Retractions(at, count) => {
+                        for i in 0..i64::try_from(count).expect("small count") {
+                            let row = Row::pack_slice(&[Datum::Int64(i)]);
+                            data_input.send((Ok(row), ts(at), -Diff::ONE));
+                        }
+                    }
+                    Step::AdvanceTo(t) => data_input.advance_to(ts(t)),
+                }
+                data_input.flush();
+                pump(worker);
+            }
+
+            // Closing makes every outstanding description ready, and finishing their builders is
+            // persist work off the timely scheduler, so wait until the worker has sat idle for a
+            // while rather than until it first reports idle.
+            data_input.close();
+            let mut idle = 0;
+            for _ in 0..20_000 {
+                if worker.step_or_park(Some(Duration::from_millis(1))) {
+                    idle = 0;
+                } else {
+                    idle += 1;
+                    if idle > 1_000 {
+                        break;
+                    }
+                }
+            }
+
+            drop(buttons);
+            while worker.step() {}
+
+            let mut emitted = emitted.borrow().clone();
+            emitted.sort();
+            emitted
+        })
+        .await
+    }
+
+    const PIPELINE_SNAPSHOT_ROWS: u64 = 200;
+    const PIPELINE_PER_TIME: u64 = 3;
+    const PIPELINE_PINNED_TIMES: u64 = 40;
+    const PIPELINE_DONE: u64 = PIPELINE_PINNED_TIMES + 2;
+
+    /// A snapshot at the pinned time, then thin replication data at each later time, then the
+    /// frontier advance that ends the snapshot.
+    fn pinned_snapshot_script() -> Vec<Step> {
+        let mut script = vec![
+            Step::AdvanceTo(1),
+            Step::Updates(1, usize::cast_from(PIPELINE_SNAPSHOT_ROWS)),
+        ];
+        for t in 2..=PIPELINE_PINNED_TIMES + 1 {
+            script.push(Step::Updates(t, usize::cast_from(PIPELINE_PER_TIME)));
+        }
+        script.push(Step::AdvanceTo(PIPELINE_DONE));
+        script
+    }
+
+    /// The same rows as `pinned_snapshot_script`, but the snapshot's rows keep landing at the
+    /// pinned time for as long as the snapshot runs, interleaved with the replication rows that
+    /// move on through later windows.
+    fn interleaved_snapshot_script() -> Vec<Step> {
+        let per_round = usize::cast_from(PIPELINE_SNAPSHOT_ROWS / PIPELINE_PINNED_TIMES);
+        let mut script = vec![Step::AdvanceTo(1)];
+        for t in 2..=PIPELINE_PINNED_TIMES + 1 {
+            script.push(Step::Updates(1, per_round));
+            script.push(Step::Updates(t, usize::cast_from(PIPELINE_PER_TIME)));
+        }
+        script.push(Step::AdvanceTo(PIPELINE_DONE));
+        script
+    }
+
+    /// What `window(8, 16)` makes of either pinned script: windows [1,9), [9,25), [25,41),
+    /// [41,57), the first on the pin and each next one as the data came within 8 of the
+    /// committed upper, at widths 8, 16, 16, 16, with one batch each.
+    fn one_batch_per_window() -> Vec<EmittedBatch> {
+        let batch = |lower: u64, upper: u64, data_max_ts: u64, times: u64| EmittedBatch {
+            lower,
+            upper,
+            data_max_ts,
+            inserts: times * PIPELINE_PER_TIME,
+        };
+        vec![
+            EmittedBatch {
+                inserts: PIPELINE_SNAPSHOT_ROWS + 7 * PIPELINE_PER_TIME,
+                ..batch(1, 9, 8, 0)
+            },
+            batch(9, 25, 24, 16),
+            batch(25, 41, 40, 16),
+            batch(41, 57, 41, 1),
+        ]
+    }
+
+    /// With a window each description reaches the writer ahead of the updates it covers, so a
+    /// pinned frontier writes one batch per description.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn sink_pipeline_groups_a_pinned_frontier_into_one_batch_per_window() {
+        let emitted = run_sink_pipeline(
+            test_target(),
+            test_persist_clients(),
+            window(8, 16),
+            true,
+            pinned_snapshot_script(),
+        )
+        .await;
+        assert_eq!(emitted, one_batch_per_window());
+    }
+
+    /// The pinned time is the one time that stays incomplete for the whole snapshot, so rows at
+    /// it arrive after rows in every later window. Grouping must not depend on data leaving a
+    /// window for good.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn sink_pipeline_keeps_one_batch_per_window_while_snapshot_rows_interleave() {
+        let emitted = run_sink_pipeline(
+            test_target(),
+            test_persist_clients(),
+            window(8, 16),
+            true,
+            interleaved_snapshot_script(),
+        )
+        .await;
+        assert_eq!(
+            emitted.len(),
+            4,
+            "{} batches for 4 windows, per window: {:?}",
+            emitted.len(),
+            emitted
+                .iter()
+                .fold(BTreeMap::<u64, u64>::new(), |mut m, b| {
+                    *m.entry(b.lower).or_default() += 1;
+                    m
+                }),
+        );
+        assert_eq!(emitted, one_batch_per_window());
+    }
+
+    /// Without a window the only description a pinned frontier gets is the one its release
+    /// derives, which arrives behind every update, so each timestamp writes its own batch.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn sink_pipeline_writes_one_batch_per_timestamp_without_a_window() {
+        let emitted = run_sink_pipeline(
+            test_target(),
+            test_persist_clients(),
+            None,
+            true,
+            pinned_snapshot_script(),
+        )
+        .await;
+
+        assert_eq!(
+            emitted.len(),
+            usize::cast_from(PIPELINE_PINNED_TIMES + 1),
+            "{emitted:?}"
+        );
+        assert!(
+            emitted
+                .iter()
+                .all(|b| (b.lower, b.upper) == (1, PIPELINE_DONE)),
+            "all finished under the one description the frontier's advance derives: {emitted:?}"
+        );
+        assert_eq!(
+            emitted.iter().map(|b| b.inserts).sum::<u64>(),
+            PIPELINE_SNAPSHOT_ROWS + PIPELINE_PINNED_TIMES * PIPELINE_PER_TIME,
+        );
+    }
+
+    fn test_target() -> CollectionMetadata {
+        CollectionMetadata {
+            persist_location: PersistLocation {
+                blob_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+                consensus_uri: SensitiveUrl::from_str("mem://").expect("invalid URL"),
+            },
+            data_shard: ShardId::new(),
+            relation_desc: RelationDesc::builder()
+                .with_column("a", SqlScalarType::Int64.nullable(false))
+                .finish(),
+            txns_shard: None,
+        }
+    }
+
+    /// Persist clients with part bounds validation on. Both settings default off in code but are
+    /// turned on in production, so an append has to run under them to say anything about the
+    /// bounds the sink writes.
+    fn test_persist_clients() -> Arc<PersistClientCache> {
+        let persist_cfg =
+            PersistConfig::new_default_configs(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+        let mut updates = ConfigUpdates::default();
+        updates.add_dynamic(
+            "persist_validate_part_bounds_on_write",
+            ConfigVal::Bool(true),
+        );
+        updates.add_dynamic(
+            "persist_validate_part_bounds_on_read",
+            ConfigVal::Bool(true),
+        );
+        updates.apply(&persist_cfg.configs);
+        Arc::new(PersistClientCache::new(
+            persist_cfg,
+            &MetricsRegistry::new(),
+            |_, _| PubSubClientConnection::noop(),
+        ))
+    }
+
+    /// Appends every emitted batch in one `compare_and_append` over `[lower, upper)`, then reads
+    /// the shard back as of `as_of` and returns the summed diffs.
+    ///
+    /// Each entry in `appends` is one `compare_and_append` over `[lower, upper)`, applied in order.
+    /// Batches written for different descriptions need separate calls, because persist rejects a
+    /// batch whose upper is below the append upper. A `lower` above a batch's own lower registers
+    /// it truncated, which is what the sink relies on when a concurrent writer has already claimed
+    /// part of the range.
+    ///
+    /// This is where a batch whose parts reach outside their registered bounds is caught, so the
+    /// tests append for real rather than stopping at what `write_batches` emitted.
+    /// A single `compare_and_append` over `[lower, upper)` carrying every emitted batch.
+    fn one_append(
+        emitted: Vec<(EmittedBatch, ProtoBatch)>,
+        lower: u64,
+        upper: u64,
+    ) -> Vec<(u64, u64, Vec<ProtoBatch>)> {
+        vec![(lower, upper, emitted.into_iter().map(|(_, p)| p).collect())]
+    }
+
+    /// One `compare_and_append` per description the batches were written for, ascending by lower.
+    fn append_per_description(
+        emitted: Vec<(EmittedBatch, ProtoBatch)>,
+    ) -> Vec<(u64, u64, Vec<ProtoBatch>)> {
+        let mut by_desc: BTreeMap<(u64, u64), Vec<ProtoBatch>> = BTreeMap::new();
+        for (batch, proto) in emitted {
+            by_desc
+                .entry((batch.lower, batch.upper))
+                .or_default()
+                .push(proto);
+        }
+        by_desc
+            .into_iter()
+            .map(|((lower, upper), protos)| (lower, upper, protos))
+            .collect()
+    }
+
+    async fn append_and_read_back(
+        target: &CollectionMetadata,
+        persist_clients: &PersistClientCache,
+        appends: Vec<(u64, u64, Vec<ProtoBatch>)>,
+        as_of: u64,
+    ) -> i64 {
+        let persist_client = persist_clients
+            .open(target.persist_location.clone())
+            .await
+            .expect("could not open persist client");
+        let mut write = persist_client
+            .open_writer::<SourceData, (), mz_repr::Timestamp, StorageDiff>(
+                target.data_shard,
+                Arc::new(target.relation_desc.clone()),
+                Arc::new(UnitSchema),
+                Diagnostics::for_tests(),
+            )
+            .await
+            .expect("could not open persist shard");
+
+        assert!(
+            write.validate_part_bounds_on_write(),
+            "part bounds validation is off, so this append proves nothing about batch bounds"
+        );
+
+        for (lower, upper, protos) in appends {
+            let mut batches: Vec<_> = protos
+                .into_iter()
+                .map(|proto| write.batch_from_transmittable_batch(proto))
+                .collect();
+            let mut to_append: Vec<_> = batches.iter_mut().collect();
+            write
+                .compare_and_append_batch(
+                    &mut to_append[..],
+                    frontier(lower),
+                    frontier(upper),
+                    true,
+                )
+                .await
+                .expect("invalid usage")
+                .expect("upper mismatch");
+
+            assert_eq!(write.fetch_recent_upper().await, &frontier(upper));
+        }
+
+        let mut read = persist_client
+            .open_leased_reader::<SourceData, (), mz_repr::Timestamp, StorageDiff>(
+                target.data_shard,
+                Arc::new(target.relation_desc.clone()),
+                Arc::new(UnitSchema),
+                Diagnostics::for_tests(),
+                true,
+            )
+            .await
+            .expect("invalid usage");
+        let contents = read
+            .snapshot_and_fetch(frontier(as_of))
+            .await
+            .expect("since <= as_of");
+
+        contents.iter().map(|(_, _, d)| *d).sum()
+    }
+
+    /// Several descriptions can become ready in the same pass. Each is written under its own
+    /// bounds, so every batch holds exactly the updates its description covers however that ready
+    /// set happens to be ordered.
+    ///
+    /// NOTE: `in_flight_batches` is a `HashMap`, so the ready set comes out in no particular order.
+    /// Enough descriptions are used here that an all-ascending pass is unlikely.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn write_batches_handles_descriptions_ready_in_one_pass() {
+        const DESCRIPTIONS: u64 = 6;
+        const DONE: u64 = DESCRIPTIONS * 2;
+
+        let persist_clients = test_persist_clients();
+        let target = test_target();
+
+        // One update inside each of the tiling descriptions [0,2), [2,4), ... None of them is ready
+        // until the frontier passes every upper, so they all come due together.
+        let mut script = vec![];
+        for i in 0..DESCRIPTIONS {
+            script.push(Step::Updates(i * 2 + 1, 1));
+        }
+        for i in 0..DESCRIPTIONS {
+            script.push(Step::Description(i * 2, i * 2 + 2));
+        }
+        script.push(Step::AdvanceTo(DONE));
+
+        let emitted = run_write_batches(target.clone(), Arc::clone(&persist_clients), script).await;
+
+        assert_eq!(
+            emitted.len(),
+            usize::cast_from(DESCRIPTIONS),
+            "one batch per description, got {:?}",
+            emitted.iter().map(|(b, _)| b).collect::<Vec<_>>()
+        );
+        for (batch, _) in &emitted {
+            assert!(
+                batch.lower <= batch.data_max_ts && batch.data_max_ts < batch.upper,
+                "batch {batch:?} holds data outside the description it was written for"
+            );
+        }
+
+        let total = append_and_read_back(
+            &target,
+            &persist_clients,
+            append_per_description(emitted),
+            DONE - 1,
+        )
+        .await;
+        assert_eq!(
+            total,
+            i64::try_from(DESCRIPTIONS).expect("small"),
+            "every update should be readable exactly once"
+        );
+    }
+
+    /// Advances the shard upper to `upper` without writing data, standing in for a concurrent
+    /// writer that reached part of the range first.
+    async fn advance_shard_upper(
+        target: &CollectionMetadata,
+        persist_clients: &PersistClientCache,
+        upper: u64,
+    ) {
+        let persist_client = persist_clients
+            .open(target.persist_location.clone())
+            .await
+            .expect("could not open persist client");
+        let mut write = persist_client
+            .open_writer::<SourceData, (), mz_repr::Timestamp, StorageDiff>(
+                target.data_shard,
+                Arc::new(target.relation_desc.clone()),
+                Arc::new(UnitSchema),
+                Diagnostics::for_tests(),
+            )
+            .await
+            .expect("could not open persist shard");
+
+        let empty: Vec<((SourceData, ()), mz_repr::Timestamp, StorageDiff)> = Vec::new();
+        write
+            .compare_and_append(
+                &empty,
+                Antichain::from_elem(Timestamp::minimum()),
+                frontier(upper),
+            )
+            .await
+            .expect("invalid usage")
+            .expect("upper mismatch");
+
+        // Otherwise the handle's heartbeat task outlives the test and nextest reports a leak.
+        write.expire().await;
+    }
+
+    /// A batch spanning many timestamps stays usable when a concurrent writer has raised the shard
+    /// upper into the middle of it. Persist registers the batch under the narrowed description and
+    /// filters the updates outside those bounds on read, so the sink can hand a straddling batch
+    /// over as is rather than discarding it and rebuilding from the new upper.
+    ///
+    /// This is the property that lets `write_batches` coalesce a pinned frontier into one batch
+    /// without giving up the ability to recover from a concurrent append.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn a_straddling_batch_is_usable_under_a_raised_lower() {
+        const TIMES: u64 = 10;
+        const DONE: u64 = TIMES + 1;
+        // Inside the batch's data range, so the batch holds updates on both sides of it.
+        const RAISED_LOWER: u64 = 5;
+
+        let persist_clients = test_persist_clients();
+        let target = test_target();
+
+        // One update at each of times 1..=TIMES, all going into the builder of a description
+        // already in hand, so they coalesce into one batch whose data spans the whole range.
+        let emitted = run_write_batches(
+            target.clone(),
+            Arc::clone(&persist_clients),
+            committed_description_script(1, TIMES - 1, DONE),
+        )
+        .await;
+        assert_eq!(
+            emitted.len(),
+            1,
+            "expected one coalesced batch, got {:?}",
+            emitted.iter().map(|(b, _)| b).collect::<Vec<_>>()
+        );
+
+        advance_shard_upper(&target, &persist_clients, RAISED_LOWER).await;
+
+        // Append the straddling batch under the raised lower, as the sink does after an
+        // `UpperMismatch` cuts the description down.
+        let total = append_and_read_back(
+            &target,
+            &persist_clients,
+            one_append(emitted, RAISED_LOWER, DONE),
+            DONE - 1,
+        )
+        .await;
+
+        assert_eq!(
+            total,
+            i64::try_from(TIMES - RAISED_LOWER + 1).expect("small"),
+            "only the updates at or above the raised lower should be readable, and all of them"
+        );
+    }
+
+    /// The rewind mechanism retracts the snapshot's copy of every row the replication stream
+    /// redelivers at its true offset, and both land at the pinned timestamp. They share the
+    /// covering description's builder, so the batch carries both signs and they net out on read.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn write_batches_carries_rewind_retractions_into_the_covering_batch() {
+        const ROWS: usize = 512;
+        const DONE: u64 = 4;
+
+        let persist_clients = test_persist_clients();
+        let target = test_target();
+
+        let emitted = run_write_batches(
+            target.clone(),
+            Arc::clone(&persist_clients),
+            vec![
+                Step::Description(0, DONE),
+                Step::AdvanceTo(1),
+                Step::Updates(1, ROWS),
+                Step::Retractions(1, ROWS - 1),
+                Step::AdvanceTo(DONE),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            emitted.len(),
+            1,
+            "both signs belong to the one description, got {:?}",
+            emitted.iter().map(|(b, _)| b).collect::<Vec<_>>()
+        );
+
+        let total = append_and_read_back(
+            &target,
+            &persist_clients,
+            one_append(emitted, 0, DONE),
+            DONE - 1,
+        )
+        .await;
+        assert_eq!(total, 1, "the shard should hold exactly the surviving row");
+    }
+
+    /// A description that covers no updates must emit no batch, rather than open a builder that
+    /// has no data bounds to register.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn write_batches_emits_nothing_for_a_description_with_no_updates() {
+        const SPLIT: u64 = 4;
+        const DONE: u64 = 8;
+
+        // Two descriptions in hand, with data only in the second.
+        let emitted = run_write_batches(
+            test_target(),
+            test_persist_clients(),
+            vec![
+                Step::Description(0, SPLIT),
+                Step::Description(SPLIT, DONE),
+                Step::AdvanceTo(SPLIT),
+                Step::Updates(SPLIT, 8),
+                Step::AdvanceTo(DONE),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            emitted
+                .iter()
+                .map(|(b, _)| (b.lower, b.upper))
+                .collect::<Vec<_>>(),
+            vec![(SPLIT, DONE)],
+            "only the description holding data should produce a batch",
+        );
+    }
+
+    /// A snapshot at time 1 pinning the frontier while replication delivers one update at each of
+    /// times 2..=`pinned_times`+1, with the description that covers the whole snapshot arriving
+    /// only at the end. This is the sink without a budget: nothing is committed ahead of the
+    /// frontier, so no update ever has bounds to be grouped under while it is staged.
+    fn pinned_frontier_script(snapshot_rows: usize, pinned_times: u64, done: u64) -> Vec<Step> {
+        let mut script = vec![Step::Updates(1, snapshot_rows)];
+        for t in 2..=pinned_times + 1 {
+            script.push(Step::Updates(t, 1));
+        }
+        // The minter holds a capability at the shard upper for the whole snapshot, so its one
+        // description is emitted there, and the frontier then jumps past everything staged.
+        script.push(Step::Description(0, done));
+        script.push(Step::AdvanceTo(done));
+        script
+    }
+
+    /// The same snapshot with the description arriving first, which is what the minter does once its
+    /// budget is spent behind a frontier that is not moving. The frontier advance is what delivers
+    /// the description, so it stops short of the description's upper to leave it in flight while
+    /// the data arrives.
+    fn committed_description_script(
+        snapshot_rows: usize,
+        pinned_times: u64,
+        done: u64,
+    ) -> Vec<Step> {
+        let mut script = vec![
+            Step::Description(0, done),
+            Step::AdvanceTo(1),
+            Step::Updates(1, snapshot_rows),
+        ];
+        for t in 2..=pinned_times + 1 {
+            script.push(Step::Updates(t, 1));
+        }
+        script.push(Step::AdvanceTo(done));
+        script
+    }
+
+    /// A snapshot pins the export's frontier at its as_of while concurrent replication keeps
+    /// delivering updates at later times. Without a description in hand there are no bounds to
+    /// group under, so each timestamp writes a batch of its own, all finished under the one
+    /// description that arrives when the snapshot finishes.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn write_batches_writes_one_batch_per_timestamp_before_a_description_covers_them() {
+        const SNAPSHOT_ROWS: usize = 4;
+        const PINNED_TIMES: u64 = 16;
+        const DONE: u64 = PINNED_TIMES + 2;
+
+        let persist_clients = test_persist_clients();
+        let target = test_target();
+
+        let emitted = run_write_batches(
+            target.clone(),
+            Arc::clone(&persist_clients),
+            pinned_frontier_script(SNAPSHOT_ROWS, PINNED_TIMES, DONE),
+        )
+        .await;
+
+        // Every batch carries the description's bounds, since that is what they are finished
+        // under, and holds a single timestamp's updates. One timestamp per batch is what makes
+        // writing before the covering description is known safe, since a single-timestamp batch
+        // cannot span a description boundary.
+        let expected: Vec<_> = std::iter::once(EmittedBatch {
+            lower: 0,
+            upper: DONE,
+            data_max_ts: 1,
+            inserts: u64::cast_from(SNAPSHOT_ROWS),
+        })
+        .chain((2..=PINNED_TIMES + 1).map(|ts| EmittedBatch {
+            lower: 0,
+            upper: DONE,
+            data_max_ts: ts,
+            inserts: 1,
+        }))
+        .collect();
+        assert_eq!(
+            emitted.iter().map(|(b, _)| b.clone()).collect::<Vec<_>>(),
+            expected,
+        );
+
+        let total = append_and_read_back(
+            &target,
+            &persist_clients,
+            one_append(emitted, 0, DONE),
+            DONE - 1,
+        )
+        .await;
+        assert_eq!(
+            total,
+            i64::try_from(SNAPSHOT_ROWS).expect("small")
+                + i64::try_from(PINNED_TIMES).expect("small"),
+            "the same updates should be readable however they were batched"
+        );
+    }
+
+    /// A window whose widths are in the unit timestamps of these scripts.
+    fn window(initial: u64, max: u64) -> Option<DescriptionWindow> {
+        DescriptionWindow::new(Duration::from_millis(initial), Duration::from_millis(max))
+    }
+
+    /// The first description is committed the moment the frontier pins, before any data, and each
+    /// later one once the data comes within the margin of the committed upper, doubling in width
+    /// up to the ceiling. Without a window a pinned frontier mints nothing.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn mint_batch_descriptions_commits_a_window_ahead_of_the_data() {
+        let script = vec![
+            // Data arrives at times the frontier never reaches, which is a pinned frontier.
+            Step::AdvanceTo(1),
+            Step::Updates(5, 4),
+            // Within the margin of nothing, so this commits nothing.
+            Step::Updates(9, 4),
+            Step::Updates(11, 2),
+        ];
+
+        assert_eq!(
+            run_mint_batch_descriptions(
+                test_target(),
+                test_persist_clients(),
+                window(4, 16),
+                true,
+                script.clone(),
+            )
+            .await,
+            // Derived from the frontier, then committed on the pin, then as the data approached
+            // each committed upper, at widths 4, 8, 16.
+            vec![(0, 1), (1, 5), (5, 13), (13, 29)],
+        );
+
+        assert_eq!(
+            run_mint_batch_descriptions(test_target(), test_persist_clients(), None, true, script)
+                .await,
+            vec![(0, 1)],
+            "without a window a pinned frontier mints nothing",
+        );
+    }
+
+    /// Committing is gated on hydration, which the minter reads off the frontier holding the first
+    /// non-minimum value it took. A second advance ends it for the life of the dataflow, and the
+    /// outstanding commitment is honored until the frontier passes it.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn mint_batch_descriptions_honors_its_commitment_once_the_frontier_moves_again() {
+        let emitted = run_mint_batch_descriptions(
+            test_target(),
+            test_persist_clients(),
+            window(4, 16),
+            true,
+            vec![
+                Step::AdvanceTo(1),
+                // Inside the window committed on the pin, so this mints nothing.
+                Step::AdvanceTo(2),
+                // Past that window, and well within the margin, but the snapshot is over.
+                Step::Updates(9, 8),
+                Step::AdvanceTo(6),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            emitted,
+            vec![(0, 1), (1, 5), (5, 6)],
+            "past hydration the minter should wait for the frontier to pass its commitment and \
+            derive from the frontier alone after that",
+        );
+    }
+
+    /// An export that is not snapshotting in this incarnation never commits ahead of its frontier,
+    /// so a restart of a caught up source has no window where it might.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn mint_batch_descriptions_does_not_commit_for_an_export_that_is_not_snapshotting() {
+        // The shape of a restart: the frontier leaves the minimum once, and data runs past it
+        // before it moves again.
+        let script = vec![Step::AdvanceTo(1), Step::Updates(9, 8)];
+
+        assert_eq!(
+            run_mint_batch_descriptions(
+                test_target(),
+                test_persist_clients(),
+                window(4, 16),
+                false,
+                script.clone(),
+            )
+            .await,
+            vec![(0, 1)],
+        );
+
+        assert_eq!(
+            run_mint_batch_descriptions(
+                test_target(),
+                test_persist_clients(),
+                window(4, 16),
+                true,
+                script,
+            )
+            .await,
+            vec![(0, 1), (1, 5), (5, 13)],
+            "the same script commits when the export is snapshotting",
+        );
+    }
+
+    /// A source may send rows at the snapshot time under a delayed capability before it has
+    /// downgraded its own, so rows can reach the minter while the frontier still sits at the
+    /// minimum. The window is anchored at the frontier the snapshot pins, not at the shard upper.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn mint_batch_descriptions_waits_for_the_frontier_to_arm_before_committing() {
+        let emitted = run_mint_batch_descriptions(
+            test_target(),
+            test_persist_clients(),
+            window(4, 16),
+            true,
+            vec![
+                Step::Updates(1, 1),
+                Step::AdvanceTo(1),
+                Step::Updates(2, 3),
+                Step::AdvanceTo(6),
+            ],
+        )
+        .await;
+        assert_eq!(emitted, vec![(0, 1), (1, 5), (5, 13)]);
+    }
+
+    #[mz_ore::test]
+    fn next_description_upper_derives_from_the_frontier_or_commits_a_window_ahead() {
+        let w = |width: u64| {
+            Some(DescriptionWindow {
+                width,
+                margin: 2,
+                max: 64,
+            })
+        };
+
+        // Everything below the frontier has arrived, so that is the description, window or not.
+        assert_eq!(
+            next_description_upper(&frontier(5), &frontier(7), Some(ts(100)), w(8)),
+            Some(frontier(7))
+        );
+        assert_eq!(
+            next_description_upper(&frontier(5), &frontier(7), None, None),
+            Some(frontier(7))
+        );
+
+        // A pinned frontier with no window has nothing to commit.
+        assert_eq!(
+            next_description_upper(&frontier(5), &frontier(5), Some(ts(14)), None),
+            None
+        );
+        // Pinned with nothing committed yet: the first window goes out ahead of any data.
+        assert_eq!(
+            next_description_upper(&frontier(5), &frontier(5), None, w(8)),
+            Some(frontier(13))
+        );
+        // Data exactly the margin short of the committed upper leaves it alone. Strict, so that
+        // the window committed on the pin does not immediately commit another.
+        assert_eq!(
+            next_description_upper(&frontier(13), &frontier(5), Some(ts(11)), w(8)),
+            None
+        );
+        // Data closer than that commits the next window from the committed upper.
+        assert_eq!(
+            next_description_upper(&frontier(13), &frontier(5), Some(ts(12)), w(16)),
+            Some(frontier(29))
+        );
+        // As does data that already ran past it. The caller loops until it is covered.
+        assert_eq!(
+            next_description_upper(&frontier(13), &frontier(5), Some(ts(40)), w(16)),
+            Some(frontier(29))
+        );
+
+        // A fresh shard's minimum upper pins like any other time, which is what gives a snapshot's
+        // rows bounds before they land.
+        assert_eq!(
+            next_description_upper(&frontier(0), &frontier(0), None, w(8)),
+            Some(frontier(8))
+        );
+        // A collection that is done has no next description.
+        assert_eq!(
+            next_description_upper(&Antichain::new(), &frontier(7), Some(ts(100)), w(8)),
+            None
+        );
+    }
+
+    /// A description committed ahead of the frontier gives arriving updates their bounds, so a
+    /// pinned frontier writes one batch for the description rather than one per timestamp, and the
+    /// rows sit in a builder that fills to the blob target instead of many single-timestamp
+    /// builders that each stay under it and hold their rows in memory.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn write_batches_routes_updates_into_the_description_covering_them() {
+        const SNAPSHOT_ROWS: usize = 4;
+        const PINNED_TIMES: u64 = 16;
+        const DONE: u64 = PINNED_TIMES + 2;
+
+        let persist_clients = test_persist_clients();
+        let target = test_target();
+
+        let emitted = run_write_batches(
+            target.clone(),
+            Arc::clone(&persist_clients),
+            committed_description_script(SNAPSHOT_ROWS, PINNED_TIMES, DONE),
+        )
+        .await;
+
+        assert_eq!(
+            emitted.len(),
+            1,
+            "the whole snapshot should share the committed description's builder, got {:?}",
+            emitted.iter().map(|(b, _)| b).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            emitted[0].0,
+            EmittedBatch {
+                lower: 0,
+                upper: DONE,
+                data_max_ts: PINNED_TIMES + 1,
+                inserts: u64::cast_from(SNAPSHOT_ROWS) + PINNED_TIMES,
+            }
+        );
+
+        let total = append_and_read_back(
+            &target,
+            &persist_clients,
+            one_append(emitted, 0, DONE),
+            DONE - 1,
+        )
+        .await;
+        assert_eq!(
+            total,
+            i64::try_from(SNAPSHOT_ROWS).expect("small")
+                + i64::try_from(PINNED_TIMES).expect("small"),
+            "grouping must not change what the shard ends up holding"
+        );
+    }
+
+    /// A builder for an uncovered timestamp is finished as soon as a description covers it,
+    /// rather than kept open for later updates at that timestamp. It holds its rows in memory
+    /// until it is finished, and while the frontier is pinned the readiness that would finish it is
+    /// exactly what is not happening. Updates arriving at that timestamp afterwards go to the
+    /// description's own builder, which spills its parts to blob.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn write_batches_finishes_an_uncovered_batch_when_its_description_arrives() {
+        const PINNED: u64 = 2;
+        const BEFORE: usize = 4;
+        const AFTER: usize = 6;
+        const DONE: u64 = 8;
+
+        let persist_clients = test_persist_clients();
+        let target = test_target();
+
+        // The advances are what flush each input, so they order the description against the data
+        // around it. Both stop short of `PINNED` + 1, which keeps the pinned timestamp writable.
+        let script = vec![
+            Step::Updates(PINNED, BEFORE),
+            Step::AdvanceTo(1),
+            Step::Description(0, DONE),
+            Step::AdvanceTo(PINNED),
+            Step::Updates(PINNED, AFTER),
+            Step::AdvanceTo(DONE),
+        ];
+
+        let emitted = run_write_batches(target.clone(), Arc::clone(&persist_clients), script).await;
+
+        assert_eq!(
+            emitted.iter().map(|(b, _)| b.clone()).collect::<Vec<_>>(),
+            vec![
+                EmittedBatch {
+                    lower: 0,
+                    upper: DONE,
+                    data_max_ts: PINNED,
+                    inserts: u64::cast_from(BEFORE),
+                },
+                EmittedBatch {
+                    lower: 0,
+                    upper: DONE,
+                    data_max_ts: PINNED,
+                    inserts: u64::cast_from(AFTER),
+                },
+            ],
+            "the uncovered batch should be closed at the description, leaving the later updates \
+            to the description's builder"
+        );
+
+        let total = append_and_read_back(
+            &target,
+            &persist_clients,
+            one_append(emitted, 0, DONE),
+            DONE - 1,
+        )
+        .await;
+        assert_eq!(
+            total,
+            i64::try_from(BEFORE + AFTER).expect("small"),
+            "closing early must not change what the shard ends up holding"
+        );
+    }
+
+    /// Data crossing from one committed description into the next closes the first one's builder,
+    /// so each description gets its own batch under its own bounds rather than a builder spanning
+    /// the boundary between them.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait
+    async fn write_batches_closes_a_description_when_data_moves_past_it() {
+        const SPLIT: u64 = 9;
+        const PINNED_TIMES: u64 = 16;
+        const DONE: u64 = PINNED_TIMES + 2;
+
+        let persist_clients = test_persist_clients();
+        let target = test_target();
+
+        let mut script = vec![
+            Step::Description(0, SPLIT),
+            Step::Description(SPLIT, DONE),
+            Step::AdvanceTo(1),
+        ];
+        for t in 1..=PINNED_TIMES {
+            script.push(Step::Updates(t, 1));
+        }
+        script.push(Step::AdvanceTo(DONE));
+
+        let emitted = run_write_batches(target.clone(), Arc::clone(&persist_clients), script).await;
+
+        let bounds: Vec<_> = emitted.iter().map(|(b, _)| (b.lower, b.upper)).collect();
+        assert_eq!(
+            bounds,
+            vec![(0, SPLIT), (SPLIT, DONE)],
+            "one batch per description, got {:?}",
+            emitted.iter().map(|(b, _)| b).collect::<Vec<_>>()
+        );
+        assert_eq!(emitted[0].0.data_max_ts, SPLIT - 1);
+        assert_eq!(emitted[1].0.data_max_ts, PINNED_TIMES);
+        assert_eq!(
+            emitted[0].0.inserts + emitted[1].0.inserts,
+            PINNED_TIMES,
+            "every update lands in exactly one of the two batches"
+        );
+
+        let total = append_and_read_back(
+            &target,
+            &persist_clients,
+            append_per_description(emitted),
+            DONE - 1,
+        )
+        .await;
+        assert_eq!(
+            total,
+            i64::try_from(PINNED_TIMES).expect("small"),
+            "splitting across descriptions must not change what the shard holds"
+        );
+    }
 }

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -63,7 +63,7 @@ pub fn render_source<'scope, 'root, C>(
     dataflow_debug_name: &String,
     connection: C,
     description: IngestionDescription<CollectionMetadata>,
-    resume_stream: StreamVec<'scope, mz_repr::Timestamp, ()>,
+    committed_uppers: BTreeMap<GlobalId, StreamVec<'scope, mz_repr::Timestamp, ()>>,
     storage_state: &crate::storage_state::StorageState,
     base_source_config: RawSourceCreationConfig,
 ) -> (
@@ -107,7 +107,7 @@ where
         scope,
         root_scope,
         storage_state,
-        resume_stream,
+        committed_uppers,
         &base_source_config,
         connection,
         start_signal,

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -303,7 +303,6 @@ fn render_simple_generator<'scope>(
                 // Emit 0, to mark this worker as having started up correctly.
                 for stats in source_statistics.values() {
                     stats.set_offset_known(0);
-                    stats.set_offset_committed(0);
                 }
                 return;
             }
@@ -451,7 +450,6 @@ fn render_simple_generator<'scope>(
                             // right now, but will come back to it.
                             if let Some(offset_committed) = offset_committed {
                                 for stats in source_statistics.values() {
-                                    stats.set_offset_committed(offset_committed);
                                     // technically we could have _known_ a larger offset
                                     // than the one that has been committed, but we can
                                     // never recover that known amount on restart, so we

--- a/src/storage/src/source/generator/key_value.rs
+++ b/src/storage/src/source/generator/key_value.rs
@@ -568,7 +568,6 @@ pub fn render_statistics_operator<'scope>(
         if !offset_worker {
             // Emit 0, to mark this worker as having started up correctly.
             for stat in source_statistics.values() {
-                stat.set_offset_committed(0);
                 stat.set_offset_known(0);
             }
             return;
@@ -579,7 +578,6 @@ pub fn render_statistics_operator<'scope>(
                 Some(frontier) => {
                     if let Some(offset) = frontier.as_option() {
                         for stat in source_statistics.values() {
-                            stat.set_offset_committed(offset.offset);
                             stat.set_offset_known(offset.offset);
                         }
                     }

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -68,7 +68,6 @@ use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespac
 use crate::metrics::source::kafka::KafkaSourceMetrics;
 use crate::source::types::{FuelSize, Probe, SignaledFuture, SourceRender, StackedCollection};
 use crate::source::{RawSourceCreationConfig, SourceMessage, probe};
-use crate::statistics::SourceStatistics;
 
 #[derive(
     Clone,
@@ -143,13 +142,11 @@ struct PartitionCapability {
 ///  available for consumption + 1.
 type PartitionWatermark = u64;
 
-/// Processes `resume_uppers` stream updates, committing them upstream and
-/// storing them in the `progress_statistics` to be emitted later.
+/// Processes `resume_uppers` stream updates, committing them upstream.
 pub struct KafkaResumeUpperProcessor {
     config: RawSourceCreationConfig,
     topic_name: String,
     consumer: Arc<BaseConsumer<TunnelingClientContext<GlueConsumerContext>>>,
-    statistics: Vec<SourceStatistics>,
 }
 
 /// Computes whether this worker is responsible for consuming a partition. It assigns partitions to
@@ -664,10 +661,9 @@ fn render_reader<'scope>(
                 config: config.clone(),
                 topic_name: topic.clone(),
                 consumer,
-                statistics: all_export_stats.clone(),
             };
 
-            // Seed the progress metrics with `0` if we are snapshotting.
+            // Commit the resume upper upstream if we are snapshotting.
             if !snapshot_export_stats.is_empty() {
                 if let Err(e) = offset_committer
                     .process_frontier(resume_upper.clone())
@@ -1132,24 +1128,13 @@ impl KafkaResumeUpperProcessor {
 
         // Generate a list of partitions that this worker is responsible for
         let mut offsets = vec![];
-        let mut offset_committed = 0;
         for ts in frontier.iter() {
             if let Some(pid) = ts.interval().singleton() {
                 let pid = pid.unwrap_exact();
                 if responsible_for_pid(&self.config, *pid) {
                     offsets.push((pid.clone(), *ts.timestamp()));
-
-                    // Note that we do not subtract 1 from the frontier. Imagine
-                    // that frontier is 2 for this pid. That means we have
-                    // full processed offset 0 and offset 1, which means we have
-                    // processed _2_ offsets.
-                    offset_committed += ts.timestamp().offset;
                 }
             }
-        }
-
-        for export_stat in self.statistics.iter() {
-            export_stat.set_offset_committed(offset_committed);
         }
 
         if !offsets.is_empty() {

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -105,7 +105,7 @@ impl SourceRender for MySqlSourceConnection {
         self,
         scope: Scope<'scope, GtidPartition>,
         config: &RawSourceCreationConfig,
-        resume_uppers: impl futures::Stream<Item = Antichain<GtidPartition>> + 'static,
+        _resume_uppers: impl futures::Stream<Item = Antichain<GtidPartition>> + 'static,
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         BTreeMap<
@@ -178,7 +178,6 @@ impl SourceRender for MySqlSourceConnection {
             scope.clone(),
             config.clone(),
             self,
-            resume_uppers,
             snapshot_err.clone().concat(repl_err.clone()),
         );
 

--- a/src/storage/src/source/mysql/statistics.rs
+++ b/src/storage/src/source/mysql/statistics.rs
@@ -14,12 +14,11 @@ use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::vec::Map;
 use timely::dataflow::{Scope, StreamVec};
-use timely::progress::Antichain;
 
 use mz_mysql_util::query_sys_var;
 use mz_ore::future::InTask;
-use mz_storage_types::sources::MySqlSourceConnection;
-use mz_storage_types::sources::mysql::{GtidPartition, GtidState, gtid_set_frontier};
+use mz_storage_types::sources::mysql::{GtidPartition, gtid_set_frontier};
+use mz_storage_types::sources::{MySqlSourceConnection, SourceTimestamp};
 use mz_timely_util::builder_async::{
     Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
@@ -36,7 +35,6 @@ pub(crate) fn render<'scope>(
     scope: Scope<'scope, GtidPartition>,
     config: RawSourceCreationConfig,
     connection: MySqlSourceConnection,
-    resume_uppers: impl futures::Stream<Item = Antichain<GtidPartition>> + 'static,
     replication_errors: StreamVec<'scope, GtidPartition, ReplicationError>,
 ) -> (
     StreamVec<'scope, GtidPartition, ReplicationError>,
@@ -61,7 +59,6 @@ pub(crate) fn render<'scope>(
                 // Emit 0, to mark this worker as having started up correctly.
                 for stat in config.statistics.values() {
                     stat.set_offset_known(0);
-                    stat.set_offset_committed(0);
                 }
                 return Ok(());
             }
@@ -82,7 +79,6 @@ pub(crate) fn render<'scope>(
                 )
                 .await?;
 
-            tokio::pin!(resume_uppers);
             let timestamp_interval = config.timestamp_interval;
             let mut probe_ticker = probe::Ticker::new(move || timestamp_interval, config.now_fn);
 
@@ -97,7 +93,8 @@ pub(crate) fn render<'scope>(
                     let upstream_frontier =
                         gtid_set_frontier(&gtid_executed).map_err(TransientError::from)?;
 
-                    let offset_known = aggregate_mysql_frontier(&upstream_frontier);
+                    let offset_known = GtidPartition::to_offset_stat(upstream_frontier.borrow())
+                        .expect("gtid frontiers always have an offset stat");
                     for stat in config.statistics.values() {
                         stat.set_offset_known(offset_known);
                     }
@@ -108,14 +105,6 @@ pub(crate) fn render<'scope>(
                             upstream_frontier,
                         },
                     );
-                }
-            };
-            let commit_loop = async {
-                while let Some(committed_frontier) = resume_uppers.next().await {
-                    let offset_committed = aggregate_mysql_frontier(&committed_frontier);
-                    for stat in config.statistics.values() {
-                        stat.set_offset_committed(offset_committed);
-                    }
                 }
             };
             let error_loop = async {
@@ -136,7 +125,6 @@ pub(crate) fn render<'scope>(
             };
             let res = tokio::select! {
                 res = probe_loop => res,
-                res = commit_loop => Ok(res),
                 res = error_loop => res,
             };
             tracing::info!("Statistics loop exited, shutting down");
@@ -149,23 +137,4 @@ pub(crate) fn render<'scope>(
         probe_stream,
         button.press_on_drop(),
     )
-}
-
-/// Aggregate a mysql frontier into single number representing the
-/// _number of transactions_ it represents.
-fn aggregate_mysql_frontier(frontier: &Antichain<GtidPartition>) -> u64 {
-    let mut progress_stat = 0;
-    for ts in frontier.iter() {
-        if let Some(_uuid) = ts.interval().singleton() {
-            // We assume source id's don't disappear once they appear.
-            let ts = match ts.timestamp() {
-                GtidState::Absent => 0,
-                // Txid's in mysql start at 1, so we subtract 1 from the _frontier_
-                // to get the _number of transactions_.
-                GtidState::Active(id) => id.get().saturating_sub(1),
-            };
-            progress_stat += ts;
-        }
-    }
-    progress_stat
 }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -76,22 +76,24 @@
 //!          │concat│              │
 //!          ╰──┬───╯              │
 //!             │ data             │progress
-//!             │ output           │output
+//!             │ outputs          │output
+//!             │ (one per export) │
 //!             v                  v
 //! ```
+//!
+//! Both the snapshot and the replication operators emit one output stream per source export, and
+//! the streams of each export are concatenated pairwise.
 
 use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::time::Duration;
 
-use differential_dataflow::AsCollection;
 use itertools::Itertools as _;
 use mz_expr::EvalError;
-use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
 use mz_postgres_util::desc::PostgresTableDesc;
 use mz_postgres_util::{Client, PostgresError, Sql, query_opt, simple_query_opt, sql};
-use mz_repr::{Datum, Diff, GlobalId, Row};
+use mz_repr::{Datum, GlobalId, Row};
 use mz_storage_types::errors::{DataflowError, SourceError, SourceErrorDetails};
 use mz_storage_types::sources::casts::StorageScalarExpr;
 use mz_storage_types::sources::postgres::CastType;
@@ -100,9 +102,7 @@ use mz_storage_types::sources::{
 };
 use mz_timely_util::builder_async::PressOnDropButton;
 use serde::{Deserialize, Serialize};
-use timely::container::CapacityContainerBuilder;
 use timely::dataflow::operators::Concat;
-use timely::dataflow::operators::core::Partition;
 use timely::dataflow::operators::vec::{Map, ToStream};
 use timely::dataflow::{Scope, StreamVec};
 use timely::progress::Antichain;
@@ -197,24 +197,16 @@ impl SourceRender for PostgresSourceConnection {
             metrics,
         );
 
-        let updates = snapshot_updates.concat(repl_updates);
-        let partition_count = u64::cast_from(config.source_exports.len());
-        let data_streams: Vec<_> = updates
-            .inner
-            .partition::<CapacityContainerBuilder<_>, _, _>(
-                partition_count,
-                |((output, data), time, diff): (
-                    (usize, Result<SourceMessage, DataflowError>),
-                    MzOffset,
-                    Diff,
-                )| {
-                    let output = u64::cast_from(output);
-                    (output, (data, time, diff))
-                },
-            );
+        // Both operators produce one stream per export, in output index order, which matches the
+        // iteration order of `source_exports`.
         let mut data_collections = BTreeMap::new();
-        for (id, data_stream) in config.source_exports.keys().zip_eq(data_streams) {
-            data_collections.insert(*id, data_stream.as_collection());
+        for ((id, snapshot_updates), repl_updates) in config
+            .source_exports
+            .keys()
+            .zip_eq(snapshot_updates)
+            .zip_eq(repl_updates)
+        {
+            data_collections.insert(*id, snapshot_updates.concat(repl_updates));
         }
 
         let export_ids = config.source_exports.keys().copied();

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -201,7 +201,6 @@ pub(crate) fn render<'scope>(
                 // Emit 0, to mark this worker as having started up correctly.
                 for stat in config.statistics.values() {
                     stat.set_offset_known(0);
-                    stat.set_offset_committed(0);
                 }
                 return Ok(());
             }
@@ -322,12 +321,6 @@ pub(crate) fn render<'scope>(
                 std::future::pending::<()>().await;
                 return Ok(());
             };
-            // If we don't set "offset_committed" now, it'll be stuck at 0 (the default value)
-            // until we finish processing the table snapshot. If the snapshot is large, that could be a long time.
-            // This confuses the ingestion lag calculation in the UI, causing it to yield erroneously high values.
-            for stat in config.statistics.values() {
-                stat.set_offset_committed(resume_lsn.offset);
-            }
             trace!(%id, "timely-{worker_id} replication reader started lsn={resume_lsn}");
 
             // Emitting an initial probe before we start waiting for rewinds ensures that we will
@@ -900,11 +893,10 @@ async fn raw_stream<'a>(
                 },
                 Some(upper) = uppers.next() => match upper.into_option() {
                     Some(lsn) => {
+                        // `offset_committed` is reported per export by the source pipeline,
+                        // this only drives the slot feedback.
                         if last_committed_upper < lsn {
                             last_committed_upper = lsn;
-                            for stat in config.statistics.values() {
-                                stat.set_offset_committed(last_committed_upper.offset);
-                            }
                         }
                         Ok(())
                     }

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -89,6 +89,7 @@ use mz_postgres_util::{Client, Sql, execute, query_opt, simple_query_opt, sql};
 use mz_repr::{Datum, DatumVec, Diff, Row};
 use mz_storage_types::dyncfgs::PG_SCHEMA_VALIDATION_INTERVAL;
 use mz_storage_types::dyncfgs::PG_SOURCE_VALIDATE_TIMELINE;
+use mz_storage_types::dyncfgs::STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
@@ -159,8 +160,11 @@ pub(crate) fn render<'scope>(
     let mut builder = AsyncOperatorBuilder::new(op_name, scope.clone());
 
     let slot_reader = u64::cast_from(config.responsible_worker("slot"));
-    // One data output port per source export, in output index order. All data port capabilities
-    // are managed in lockstep, so every export observes the same frontier.
+    // One data output port per source export, in output index order. With concurrent
+    // replication enabled a port holds the minimum capability only while its export has a
+    // pending rewind and advances with the stream otherwise. When disabled all ports are
+    // managed in lockstep and hold the minimum until every rewind resolves, so every export
+    // observes the same frontier.
     let export_count = config.source_exports.len();
     let mut data_outputs = Vec::with_capacity(export_count);
     let mut data_streams = Vec::with_capacity(export_count);
@@ -190,6 +194,8 @@ pub(crate) fn render<'scope>(
             let (id, worker_id) = (config.id, config.worker_id);
             let (data_cap_sets, caps) = caps.split_at_mut(export_count);
             let [definite_error_cap_set, probe_cap]: &mut [_; 2] = caps.try_into().unwrap();
+            let concurrent_replication =
+                STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION.get(config.config.config_set());
 
             if !config.responsible_for("slot") {
                 // Emit 0, to mark this worker as having started up correctly.
@@ -610,9 +616,17 @@ pub(crate) fn render<'scope>(
                 if will_yield {
                     trace!(%id, "timely-{worker_id} yielding at lsn={data_upper}");
                     rewinds.retain(|_, req| data_upper <= req.snapshot_lsn);
-                    // As long as there are pending rewinds we can't downgrade our data
-                    // capabilities since we must be able to produce data at offset 0.
-                    if rewinds.is_empty() {
+                    // A port with a pending rewind must stay at the minimum capability since
+                    // negated rewind data for its export is emitted at offset 0.
+                    if concurrent_replication {
+                        // Every other port advances with the stream, so exports that need no
+                        // rewind make progress while a snapshot runs.
+                        for (output_index, cap_set) in data_cap_sets.iter_mut().enumerate() {
+                            if !rewinds.contains_key(&output_index) {
+                                cap_set.downgrade([&data_upper]);
+                            }
+                        }
+                    } else if rewinds.is_empty() {
                         for cap_set in data_cap_sets.iter_mut() {
                             cap_set.downgrade([&data_upper]);
                         }

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -92,8 +92,8 @@ use mz_storage_types::dyncfgs::PG_SOURCE_VALIDATE_TIMELINE;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
-    AsyncOutputHandle, Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder,
-    PressOnDropButton,
+    AsyncOutputHandle, Event as AsyncEvent, MAX_OUTSTANDING_BYTES,
+    OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
 use postgres_replication::LogicalReplicationStream;
 use postgres_replication::protocol::{LogicalReplicationMessage, ReplicationMessage, TupleData};
@@ -150,7 +150,7 @@ pub(crate) fn render<'scope>(
     committed_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
     metrics: PgSourceMetrics,
 ) -> (
-    StackedCollection<'scope, MzOffset, (usize, Result<SourceMessage, DataflowError>)>,
+    Vec<StackedCollection<'scope, MzOffset, Result<SourceMessage, DataflowError>>>,
     StreamVec<'scope, MzOffset, Probe<MzOffset>>,
     StreamVec<'scope, MzOffset, ReplicationError>,
     PressOnDropButton,
@@ -159,7 +159,16 @@ pub(crate) fn render<'scope>(
     let mut builder = AsyncOperatorBuilder::new(op_name, scope.clone());
 
     let slot_reader = u64::cast_from(config.responsible_worker("slot"));
-    let (data_output, data_stream) = builder.new_output();
+    // One data output port per source export, in output index order. All data port capabilities
+    // are managed in lockstep, so every export observes the same frontier.
+    let export_count = config.source_exports.len();
+    let mut data_outputs = Vec::with_capacity(export_count);
+    let mut data_streams = Vec::with_capacity(export_count);
+    for _ in 0..export_count {
+        let (output, stream) = builder.new_output();
+        data_outputs.push(output);
+        data_streams.push(stream);
+    }
     let (definite_error_handle, definite_errors) =
         builder.new_output::<CapacityContainerBuilder<_>>();
     let (probe_output, probe_stream) = builder.new_output::<CapacityContainerBuilder<_>>();
@@ -179,8 +188,8 @@ pub(crate) fn render<'scope>(
         let busy_signal = Arc::clone(&config.busy_signal);
         Box::pin(SignaledFuture::new(busy_signal, async move {
             let (id, worker_id) = (config.id, config.worker_id);
-            let [data_cap_set, definite_error_cap_set, probe_cap]: &mut [_; 3] =
-                caps.try_into().unwrap();
+            let (data_cap_sets, caps) = caps.split_at_mut(export_count);
+            let [definite_error_cap_set, probe_cap]: &mut [_; 2] = caps.try_into().unwrap();
 
             if !config.responsible_for("slot") {
                 // Emit 0, to mark this worker as having started up correctly.
@@ -345,22 +354,18 @@ pub(crate) fn render<'scope>(
                             );
                             // If the replication stream cannot be obtained from the resume point there is nothing
                             // else to do. These errors are not retractable.
-                            for (oid, outputs) in table_info.iter() {
+                            for outputs in table_info.values() {
                                 for output_index in outputs.keys() {
                                     // We pick `u64::MAX` as the LSN which will (in practice) never conflict
                                     // any previously revealed portions of the TVC.
                                     let update = (
-                                        (
-                                            *oid,
-                                            *output_index,
-                                            Err(DataflowError::from(err.clone())),
-                                        ),
+                                        Err(DataflowError::from(err.clone())),
                                         MzOffset::from(u64::MAX),
                                         Diff::ONE,
                                     );
                                     let size = update.fuel_size();
-                                    data_output
-                                        .give_fueled(&data_cap_set[0], update, size)
+                                    data_outputs[*output_index]
+                                        .give_fueled(&data_cap_sets[*output_index][0], update, size)
                                         .await;
                                 }
                             }
@@ -398,18 +403,18 @@ pub(crate) fn render<'scope>(
                 Err(err) => {
                     // If the replication stream cannot be obtained in a definite way there is
                     // nothing else to do. These errors are not retractable.
-                    for (oid, outputs) in table_info.iter() {
+                    for outputs in table_info.values() {
                         for output_index in outputs.keys() {
                             // We pick `u64::MAX` as the LSN which will (in practice) never conflict
                             // any previously revealed portions of the TVC.
                             let update = (
-                                (*oid, *output_index, Err(DataflowError::from(err.clone()))),
+                                Err(DataflowError::from(err.clone())),
                                 MzOffset::from(u64::MAX),
                                 Diff::ONE,
                             );
                             let size = update.fuel_size();
-                            data_output
-                                .give_fueled(&data_cap_set[0], update, size)
+                            data_outputs[*output_index]
+                                .give_fueled(&data_cap_sets[*output_index][0], update, size)
                                 .await;
                         }
                     }
@@ -442,6 +447,10 @@ pub(crate) fn render<'scope>(
             // creating excessive progress tracking traffic when there are multiple small
             // transactions ready to go.
             let mut data_upper = resume_lsn;
+            // `give_fueled` bounds outstanding bytes per output handle. With one handle per
+            // export that bound no longer limits the aggregate buffered data, so we track the
+            // total across all handles and yield at the threshold a single handle would.
+            let mut outstanding_bytes = 0;
             while let Some(event) = stream.as_mut().next().await {
                 use LogicalReplicationMessage::*;
                 use ReplicationMessage::*;
@@ -469,24 +478,34 @@ pub(crate) fn render<'scope>(
                                 "new_upper={data_upper} tx_lsn={commit_lsn}",
                             );
                             data_upper = commit_lsn + 1;
-                            while let Some((oid, output_index, event, diff)) = tx.try_next().await?
+                            while let Some((_oid, output_index, event, diff)) =
+                                tx.try_next().await?
                             {
-                                let event = event.map_err(Into::into);
-                                let data = (oid, output_index, event);
+                                let event: Result<_, DataflowError> = event.map_err(Into::into);
                                 if let Some(req) = rewinds.get(&output_index) {
                                     if commit_lsn <= req.snapshot_lsn {
-                                        let update = (data.clone(), MzOffset::from(0), -diff);
+                                        let update = (event.clone(), MzOffset::from(0), -diff);
                                         let size = update.fuel_size();
-                                        data_output
-                                            .give_fueled(&data_cap_set[0], update, size)
+                                        outstanding_bytes += size;
+                                        data_outputs[output_index]
+                                            .give_fueled(
+                                                &data_cap_sets[output_index][0],
+                                                update,
+                                                size,
+                                            )
                                             .await;
                                     }
                                 }
-                                let update = (data, commit_lsn, diff);
+                                let update = (event, commit_lsn, diff);
                                 let size = update.fuel_size();
-                                data_output
-                                    .give_fueled(&data_cap_set[0], update, size)
+                                outstanding_bytes += size;
+                                data_outputs[output_index]
+                                    .give_fueled(&data_cap_sets[output_index][0], update, size)
                                     .await;
+                                if outstanding_bytes > MAX_OUTSTANDING_BYTES {
+                                    outstanding_bytes = 0;
+                                    tokio::task::yield_now().await;
+                                }
                             }
                         }
                         _ => return Err(TransientError::BareTransactionEvent),
@@ -503,20 +522,20 @@ pub(crate) fn render<'scope>(
                             match error {
                                 Postgres(PostgresError::PublicationMissing(publication)) => {
                                     let err = DefiniteError::PublicationDropped(publication);
-                                    for (oid, outputs) in table_info.iter() {
+                                    for outputs in table_info.values() {
                                         for output_index in outputs.keys() {
                                             let update = (
-                                                (
-                                                    *oid,
-                                                    *output_index,
-                                                    Err(DataflowError::from(err.clone())),
-                                                ),
-                                                data_cap_set[0].time().clone(),
+                                                Err(DataflowError::from(err.clone())),
+                                                data_cap_sets[*output_index][0].time().clone(),
                                                 Diff::ONE,
                                             );
                                             let size = update.fuel_size();
-                                            data_output
-                                                .give_fueled(&data_cap_set[0], update, size)
+                                            data_outputs[*output_index]
+                                                .give_fueled(
+                                                    &data_cap_sets[*output_index][0],
+                                                    update,
+                                                    size,
+                                                )
                                                 .await;
                                         }
                                     }
@@ -535,21 +554,21 @@ pub(crate) fn render<'scope>(
                                     // definite, non-retryable error.
                                     let err =
                                         DefiniteError::InvalidPhysicalReplica { expected, actual };
-                                    for (oid, outputs) in table_info.iter() {
+                                    for outputs in table_info.values() {
                                         for output_index in outputs.keys() {
                                             let update = (
-                                                (
-                                                    *oid,
-                                                    *output_index,
-                                                    Err(DataflowError::from(err.clone())),
-                                                ),
+                                                Err(DataflowError::from(err.clone())),
                                                 // We don't have a clean way to align on when the replica changed so jump straight to u64::MAX to avoid conflicts.
                                                 MzOffset::from(u64::MAX),
                                                 Diff::ONE,
                                             );
                                             let size = update.fuel_size();
-                                            data_output
-                                                .give_fueled(&data_cap_set[0], update, size)
+                                            data_outputs[*output_index]
+                                                .give_fueled(
+                                                    &data_cap_sets[*output_index][0],
+                                                    update,
+                                                    size,
+                                                )
                                                 .await;
                                         }
                                     }
@@ -570,13 +589,13 @@ pub(crate) fn render<'scope>(
                                     }
 
                                     let update = (
-                                        (oid, output_index, Err(error.into())),
-                                        data_cap_set[0].time().clone(),
+                                        Err(error.into()),
+                                        data_cap_sets[output_index][0].time().clone(),
                                         Diff::ONE,
                                     );
                                     let size = update.fuel_size();
-                                    data_output
-                                        .give_fueled(&data_cap_set[0], update, size)
+                                    data_outputs[output_index]
+                                        .give_fueled(&data_cap_sets[output_index][0], update, size)
                                         .await;
                                 }
                             }
@@ -591,10 +610,12 @@ pub(crate) fn render<'scope>(
                 if will_yield {
                     trace!(%id, "timely-{worker_id} yielding at lsn={data_upper}");
                     rewinds.retain(|_, req| data_upper <= req.snapshot_lsn);
-                    // As long as there are pending rewinds we can't downgrade our data capability
-                    // since we must be able to produce data at offset 0.
+                    // As long as there are pending rewinds we can't downgrade our data
+                    // capabilities since we must be able to produce data at offset 0.
                     if rewinds.is_empty() {
-                        data_cap_set.downgrade([&data_upper]);
+                        for cap_set in data_cap_sets.iter_mut() {
+                            cap_set.downgrade([&data_upper]);
+                        }
                     }
                 }
             }
@@ -603,43 +624,55 @@ pub(crate) fn render<'scope>(
         }))
     });
 
-    // We now process the slot updates and apply the cast expressions
-    let mut final_row = Row::default();
-    let mut datum_vec = DatumVec::new();
-    let mut next_worker = (0..u64::cast_from(scope.peers()))
-        // Round robin on 1000-records basis to avoid creating tiny containers when there are a
-        // small number of updates and a large number of workers.
-        .flat_map(|w| std::iter::repeat_n(w, 1000))
-        .cycle();
-    let round_robin = Exchange::new(move |_| next_worker.next().unwrap());
-    let replication_updates = data_stream
-        .unary(round_robin, "PgCastReplicationRows", |_, _| {
-            move |input, output| {
-                input.for_each_time(|time, data| {
-                    let mut session = output.session(&time);
-                    for ((oid, output_index, event), time, diff) in
-                        data.flat_map(|data| data.drain(..))
-                    {
-                        let output = &table_info
-                            .get(&oid)
-                            .and_then(|outputs| outputs.get(&output_index))
-                            .expect("table_info contains all outputs");
-                        let event = event.and_then(|row| {
-                            let datums = datum_vec.borrow_with(&row);
-                            super::cast_row(&output.casts, &datums, &mut final_row)?;
-                            Ok(SourceMessage {
-                                key: Row::default(),
-                                value: final_row.clone(),
-                                metadata: Row::default(),
-                            })
+    // We now process the slot updates and apply the cast expressions, with one decode operator
+    // per export.
+    let mut output_info = BTreeMap::new();
+    for outputs in table_info.into_values() {
+        for (output_index, info) in outputs {
+            output_info.insert(output_index, info);
+        }
+    }
+    let mut replication_updates = Vec::with_capacity(data_streams.len());
+    for (output_index, data_stream) in data_streams.into_iter().enumerate() {
+        let info = output_info.get(&output_index).cloned();
+        let mut final_row = Row::default();
+        let mut datum_vec = DatumVec::new();
+        let mut next_worker = (0..u64::cast_from(scope.peers()))
+            // Round robin on 1000-records basis to avoid creating tiny containers when there are a
+            // small number of updates and a large number of workers.
+            .flat_map(|w| std::iter::repeat_n(w, 1000))
+            .cycle();
+        let round_robin = Exchange::new(move |_| next_worker.next().unwrap());
+        let updates = data_stream
+            .unary(
+                round_robin,
+                &format!("PgCastReplicationRows({output_index})"),
+                |_, _| {
+                    move |input, output| {
+                        input.for_each_time(|time, data| {
+                            let mut session = output.session(&time);
+                            for (event, time, diff) in data.flat_map(|data| data.drain(..)) {
+                                let info = info
+                                    .as_ref()
+                                    .expect("only exports with output info receive data");
+                                let event = event.and_then(|row| {
+                                    let datums = datum_vec.borrow_with(&row);
+                                    super::cast_row(&info.casts, &datums, &mut final_row)?;
+                                    Ok(SourceMessage {
+                                        key: Row::default(),
+                                        value: final_row.clone(),
+                                        metadata: Row::default(),
+                                    })
+                                });
+                                session.give((event, time, diff));
+                            }
                         });
-
-                        session.give(((output_index, event), time, diff));
                     }
-                });
-            }
-        })
-        .as_collection();
+                },
+            )
+            .as_collection();
+        replication_updates.push(updates);
+    }
 
     let errors = definite_errors.concat(transient_errors.map(ReplicationError::from));
 

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -681,6 +681,23 @@ pub(crate) fn render<'scope>(
             let mut outstanding_bytes = 0;
             for (&oid, outputs) in tables_to_snapshot.iter() {
                 for (&output_index, info) in outputs.iter() {
+                    // Test-only pause point. Configuring the failpoint as
+                    // `pg_snapshot_pause=return(<table name>)` holds the snapshot of that
+                    // table here, before any of its data is emitted, until the failpoint is
+                    // deactivated. Tables are snapshotted in table OID order, so tables
+                    // ordered before the paused one complete their snapshots.
+                    loop {
+                        let paused = fail::eval("pg_snapshot_pause", |payload| {
+                            payload.is_some_and(|table| table == info.desc.name)
+                        });
+                        match paused {
+                            Some(true) => {
+                                tokio::time::sleep(std::time::Duration::from_millis(100)).await
+                            }
+                            _ => break,
+                        }
+                    }
+
                     if let Err(err) = verify_schema(oid, info, &upstream_info) {
                         let update = (Err(err.into()), MzOffset::minimum(), Diff::ONE);
                         let size = update.fuel_size();

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -175,6 +175,7 @@ use mz_postgres_util::schemas::get_pg_major_version;
 use mz_postgres_util::{Client, Config, PostgresError, Sql, simple_query, simple_query_opt, sql};
 use mz_repr::{Datum, DatumVec, Diff, Row};
 use mz_storage_types::connections::ConnectionContext;
+use mz_storage_types::dyncfgs::STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::parameters::PgSourceSnapshotConfig;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
@@ -630,6 +631,35 @@ pub(crate) fn render<'scope>(
                 use_snapshot(&client, &snapshot_id).await?;
             }
 
+            // Since all workers snapshot all tables (each with different ctid ranges), we only
+            // emit rewind requests from the worker responsible for each output to avoid
+            // duplicates.
+            let emit_rewinds = |rewind_cap_set: &mut CapabilitySet<MzOffset>| {
+                for (&oid, outputs) in tables_to_snapshot.iter() {
+                    for (output_index, info) in outputs {
+                        if !config.responsible_for((oid, *output_index)) {
+                            continue;
+                        }
+                        trace!(%id, "timely-{worker_id} producing rewind request for table {} output {output_index}", info.desc.name);
+                        let req = RewindRequest { output_index: *output_index, snapshot_lsn };
+                        rewinds_handle.give(&rewind_cap_set[0], req);
+                    }
+                }
+                *rewind_cap_set = CapabilitySet::new();
+            };
+
+            // The rewind requests are what unblock the replication operator. With concurrent
+            // replication they are emitted now, before any data is copied, since the snapshot
+            // LSN is already known. The replication operator then reads the replication stream
+            // while the snapshot runs, staging its data in the dataflow until the snapshot
+            // completes. Otherwise they are emitted after the snapshot, which keeps the two
+            // phases serial and avoids that staging cost.
+            let concurrent_replication =
+                STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION.get(config.config.config_set());
+            if concurrent_replication {
+                emit_rewinds(rewind_cap_set);
+            }
+
             // `give_fueled` bounds outstanding bytes per output handle. With one handle per
             // export that bound no longer limits the aggregate buffered data, so we track the
             // total across all handles and yield at the threshold a single handle would.
@@ -719,27 +749,9 @@ pub(crate) fn render<'scope>(
                 }
             }
 
-            // We are done with the snapshot so now we will emit rewind requests. It is important
-            // that this happens after the snapshot has finished because this is what unblocks the
-            // replication operator and we want this to happen serially. It might seem like a good
-            // idea to read the replication stream concurrently with the snapshot but it actually
-            // leads to a lot of data being staged for the future, which needlessly consumed memory
-            // in the cluster.
-            //
-            // Since all workers now snapshot all tables (each with different ctid ranges), we only
-            // emit rewind requests from the worker responsible for each output to avoid duplicates.
-            for (&oid, output) in tables_to_snapshot.iter() {
-                for (output_index, info) in output {
-                    // Only emit rewind request from one worker per output
-                    if !config.responsible_for((oid, *output_index)) {
-                        continue;
-                    }
-                    trace!(%id, "timely-{worker_id} producing rewind request for table {} output {output_index}", info.desc.name);
-                    let req = RewindRequest { output_index: *output_index, snapshot_lsn };
-                    rewinds_handle.give(&rewind_cap_set[0], req);
-                }
+            if !concurrent_replication {
+                emit_rewinds(rewind_cap_set);
             }
-            *rewind_cap_set = CapabilitySet::new();
 
             // Failure scenario after we have produced the snapshot, but before a successful COMMIT
             fail::fail_point!("pg_snapshot_failure", |_| Err(

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -179,7 +179,8 @@ use mz_storage_types::errors::DataflowError;
 use mz_storage_types::parameters::PgSourceSnapshotConfig;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
-    Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+    Event as AsyncEvent, MAX_OUTSTANDING_BYTES, OperatorBuilder as AsyncOperatorBuilder,
+    PressOnDropButton,
 };
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
@@ -338,7 +339,7 @@ pub(crate) fn render<'scope>(
     table_info: BTreeMap<u32, BTreeMap<usize, SourceOutputInfo>>,
     metrics: PgSnapshotMetrics,
 ) -> (
-    StackedCollection<'scope, MzOffset, (usize, Result<SourceMessage, DataflowError>)>,
+    Vec<StackedCollection<'scope, MzOffset, Result<SourceMessage, DataflowError>>>,
     StreamVec<'scope, MzOffset, RewindRequest>,
     StreamVec<'scope, MzOffset, Infallible>,
     StreamVec<'scope, MzOffset, ReplicationError>,
@@ -349,7 +350,16 @@ pub(crate) fn render<'scope>(
 
     let (feedback_handle, feedback_data) = scope.feedback(Default::default());
 
-    let (raw_handle, raw_data) = builder.new_output();
+    // One data output port per source export, in output index order. All data port capabilities
+    // are managed in lockstep, so every export observes the same frontier.
+    let export_count = config.source_exports.len();
+    let mut raw_handles = Vec::with_capacity(export_count);
+    let mut raw_streams = Vec::with_capacity(export_count);
+    for _ in 0..export_count {
+        let (handle, stream) = builder.new_output();
+        raw_handles.push(handle);
+        raw_streams.push(stream);
+    }
     let (rewinds_handle, rewinds) = builder.new_output::<CapacityContainerBuilder<_>>();
     // This output is used to signal to the replication operator that the replication slot has been
     // created. With the current state of execution serialization there isn't a lot of benefit
@@ -404,13 +414,13 @@ pub(crate) fn render<'scope>(
         Box::pin(SignaledFuture::new(busy_signal, async move {
             let id = config.id;
             let worker_id = config.worker_id;
+            let (data_cap_sets, caps) = caps.split_at_mut(export_count);
             let [
-                data_cap_set,
                 rewind_cap_set,
                 slot_ready_cap_set,
                 snapshot_cap_set,
                 definite_error_cap_set,
-            ]: &mut [_; 5] = caps.try_into().unwrap();
+            ]: &mut [_; 4] = caps.try_into().unwrap();
 
             trace!(
                 %id,
@@ -522,7 +532,7 @@ pub(crate) fn render<'scope>(
                             // nothing else to do. These errors are not retractable.
                             Err(PostgresError::PublicationMissing(publication)) => {
                                 let err = DefiniteError::PublicationDropped(publication);
-                                for (oid, outputs) in tables_to_snapshot.iter() {
+                                for outputs in tables_to_snapshot.values() {
                                     // Produce a definite error here and then exit to ensure
                                     // a missing publication doesn't generate a transient
                                     // error and restart this dataflow indefinitely.
@@ -532,13 +542,17 @@ pub(crate) fn render<'scope>(
                                     // portions of the TVC.
                                     for output_index in outputs.keys() {
                                         let update = (
-                                            (*oid, *output_index, Err(err.clone().into())),
+                                            Err(err.clone().into()),
                                             MzOffset::from(u64::MAX),
                                             Diff::ONE,
                                         );
                                         let size = update.fuel_size();
-                                        raw_handle
-                                            .give_fueled(&data_cap_set[0], update, size)
+                                        raw_handles[*output_index]
+                                            .give_fueled(
+                                                &data_cap_sets[*output_index][0],
+                                                update,
+                                                size,
+                                            )
                                             .await;
                                     }
                                 }
@@ -616,17 +630,17 @@ pub(crate) fn render<'scope>(
                 use_snapshot(&client, &snapshot_id).await?;
             }
 
+            // `give_fueled` bounds outstanding bytes per output handle. With one handle per
+            // export that bound no longer limits the aggregate buffered data, so we track the
+            // total across all handles and yield at the threshold a single handle would.
+            let mut outstanding_bytes = 0;
             for (&oid, outputs) in tables_to_snapshot.iter() {
                 for (&output_index, info) in outputs.iter() {
                     if let Err(err) = verify_schema(oid, info, &upstream_info) {
-                        let update = (
-                            (oid, output_index, Err(err.into())),
-                            MzOffset::minimum(),
-                            Diff::ONE,
-                        );
+                        let update = (Err(err.into()), MzOffset::minimum(), Diff::ONE);
                         let size = update.fuel_size();
-                        raw_handle
-                            .give_fueled(&data_cap_set[0], update, size)
+                        raw_handles[output_index]
+                            .give_fueled(&data_cap_sets[output_index][0], update, size)
                             .await;
                         continue;
                     }
@@ -682,15 +696,16 @@ pub(crate) fn render<'scope>(
 
                     let mut snapshot_staged = 0;
                     while let Some(bytes) = stream.try_next().await? {
-                        let update = (
-                            (oid, output_index, Ok(bytes)),
-                            MzOffset::minimum(),
-                            Diff::ONE,
-                        );
+                        let update = (Ok(bytes), MzOffset::minimum(), Diff::ONE);
                         let size = update.fuel_size();
-                        raw_handle
-                            .give_fueled(&data_cap_set[0], update, size)
+                        outstanding_bytes += size;
+                        raw_handles[output_index]
+                            .give_fueled(&data_cap_sets[output_index][0], update, size)
                             .await;
+                        if outstanding_bytes > MAX_OUTSTANDING_BYTES {
+                            outstanding_bytes = 0;
+                            tokio::task::yield_now().await;
+                        }
                         snapshot_staged += 1;
                         if snapshot_staged % 1000 == 0 {
                             let stat = &export_statistics[&(oid, output_index)];
@@ -749,43 +764,54 @@ pub(crate) fn render<'scope>(
         }))
     });
 
-    // We now decode the COPY protocol and apply the cast expressions
-    let mut text_row = Row::default();
-    let mut final_row = Row::default();
-    let mut datum_vec = DatumVec::new();
-    let snapshot_updates = raw_data
-        .unary(Pipeline, "PgCastSnapshotRows", |_, _| {
-            move |input, output| {
-                input.for_each_time(|time, data| {
-                    let mut session = output.session(&time);
-                    for ((oid, output_index, event), time, diff) in
-                        data.flat_map(|data| data.drain(..))
-                    {
-                        let output = &table_info
-                            .get(&oid)
-                            .and_then(|outputs| outputs.get(&output_index))
-                            .expect("table_info contains all outputs");
-
-                        let event = event
-                            .as_ref()
-                            .map_err(|e: &DataflowError| e.clone())
-                            .and_then(|bytes| {
-                                decode_copy_row(bytes, output.casts.len(), &mut text_row)?;
-                                let datums = datum_vec.borrow_with(&text_row);
-                                super::cast_row(&output.casts, &datums, &mut final_row)?;
-                                Ok(SourceMessage {
-                                    key: Row::default(),
-                                    value: final_row.clone(),
-                                    metadata: Row::default(),
-                                })
-                            });
-
-                        session.give(((output_index, event), time, diff));
+    // We now decode the COPY protocol and apply the cast expressions, with one decode operator
+    // per export.
+    let mut output_info = BTreeMap::new();
+    for outputs in table_info.into_values() {
+        for (output_index, info) in outputs {
+            output_info.insert(output_index, info);
+        }
+    }
+    let mut snapshot_updates = Vec::with_capacity(raw_streams.len());
+    for (output_index, raw_stream) in raw_streams.into_iter().enumerate() {
+        let info = output_info.get(&output_index).cloned();
+        let mut text_row = Row::default();
+        let mut final_row = Row::default();
+        let mut datum_vec = DatumVec::new();
+        let updates = raw_stream
+            .unary(
+                Pipeline,
+                &format!("PgCastSnapshotRows({output_index})"),
+                |_, _| {
+                    move |input, output| {
+                        input.for_each_time(|time, data| {
+                            let mut session = output.session(&time);
+                            for (event, time, diff) in data.flat_map(|data| data.drain(..)) {
+                                let info = info
+                                    .as_ref()
+                                    .expect("only exports with output info receive data");
+                                let event = event
+                                    .as_ref()
+                                    .map_err(|e: &DataflowError| e.clone())
+                                    .and_then(|bytes| {
+                                        decode_copy_row(bytes, info.casts.len(), &mut text_row)?;
+                                        let datums = datum_vec.borrow_with(&text_row);
+                                        super::cast_row(&info.casts, &datums, &mut final_row)?;
+                                        Ok(SourceMessage {
+                                            key: Row::default(),
+                                            value: final_row.clone(),
+                                            metadata: Row::default(),
+                                        })
+                                    });
+                                session.give((event, time, diff));
+                            }
+                        });
                     }
-                });
-            }
-        })
-        .as_collection();
+                },
+            )
+            .as_collection();
+        snapshot_updates.push(updates);
+    }
 
     let errors = definite_errors.concat(transient_errors.map(ReplicationError::from));
 

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -351,8 +351,10 @@ pub(crate) fn render<'scope>(
 
     let (feedback_handle, feedback_data) = scope.feedback(Default::default());
 
-    // One data output port per source export, in output index order. All data port capabilities
-    // are managed in lockstep, so every export observes the same frontier.
+    // One data output port per source export, in output index order. With concurrent
+    // replication enabled each port is held at the minimum only while this operator still has
+    // snapshot data to emit for that export. When disabled all ports are held until the
+    // entire snapshot completes, so every export observes the same frontier.
     let export_count = config.source_exports.len();
     let mut raw_handles = Vec::with_capacity(export_count);
     let mut raw_streams = Vec::with_capacity(export_count);
@@ -422,6 +424,21 @@ pub(crate) fn render<'scope>(
                 snapshot_cap_set,
                 definite_error_cap_set,
             ]: &mut [_; 4] = caps.try_into().unwrap();
+            let concurrent_replication =
+                STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION.get(config.config.config_set());
+
+            // This operator only ever emits snapshot data for the exports it snapshots. With
+            // concurrent replication the ports of all other exports are closed up front, so
+            // their frontiers are determined by the replication operator alone and they make
+            // progress while the snapshot runs. Ports of snapshotted exports close one by one
+            // as each export's copy finishes on this worker.
+            if concurrent_replication {
+                for (output_index, cap_set) in data_cap_sets.iter_mut().enumerate() {
+                    if !all_outputs.contains(&output_index) {
+                        *cap_set = CapabilitySet::new();
+                    }
+                }
+            }
 
             trace!(
                 %id,
@@ -654,8 +671,6 @@ pub(crate) fn render<'scope>(
             // while the snapshot runs, staging its data in the dataflow until the snapshot
             // completes. Otherwise they are emitted after the snapshot, which keeps the two
             // phases serial and avoids that staging cost.
-            let concurrent_replication =
-                STORAGE_SOURCE_SNAPSHOT_CONCURRENT_REPLICATION.get(config.config.config_set());
             if concurrent_replication {
                 emit_rewinds(rewind_cap_set);
             }
@@ -672,6 +687,9 @@ pub(crate) fn render<'scope>(
                         raw_handles[output_index]
                             .give_fueled(&data_cap_sets[output_index][0], update, size)
                             .await;
+                        if concurrent_replication {
+                            data_cap_sets[output_index] = CapabilitySet::new();
+                        }
                         continue;
                     }
 
@@ -688,6 +706,9 @@ pub(crate) fn render<'scope>(
                             "timely-{worker_id} no ctid range assigned for table {:?}({oid})",
                             info.desc.name
                         );
+                        if concurrent_replication {
+                            data_cap_sets[output_index] = CapabilitySet::new();
+                        }
                         continue;
                     };
 
@@ -746,6 +767,9 @@ pub(crate) fn render<'scope>(
                     // values as the total is an estimate
                     let stat = &export_statistics[&(oid, output_index)];
                     stat.set_snapshot_records_staged(snapshot_staged);
+                    if concurrent_replication {
+                        data_cap_sets[output_index] = CapabilitySet::new();
+                    }
                 }
             }
 

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -681,6 +681,33 @@ pub(crate) fn render<'scope>(
             let mut outstanding_bytes = 0;
             for (&oid, outputs) in tables_to_snapshot.iter() {
                 for (&output_index, info) in outputs.iter() {
+                    // Test-only pause point. Configuring the failpoint as
+                    // `pg_snapshot_pause=return(<table name>)` holds the snapshot of that table
+                    // here, before any of its data is emitted, until the failpoint is
+                    // deactivated. `return(<table name>:<millis>)` holds it for that long
+                    // instead, so the snapshot completes in the same dataflow incarnation.
+                    // Tables are snapshotted in OID order, so tables ordered before the paused
+                    // one complete their snapshots.
+                    let held_since = std::time::Instant::now();
+                    loop {
+                        let held = fail::eval("pg_snapshot_pause", |payload| {
+                            let (table, millis) = payload
+                                .as_deref()
+                                .map(|p| p.split_once(':').unwrap_or((p, "")))
+                                .unwrap_or_default();
+                            table == info.desc.name
+                                && millis.parse::<u64>().map_or(true, |millis| {
+                                    held_since.elapsed() < std::time::Duration::from_millis(millis)
+                                })
+                        });
+                        match held {
+                            Some(true) => {
+                                tokio::time::sleep(std::time::Duration::from_millis(100)).await
+                            }
+                            _ => break,
+                        }
+                    }
+
                     if let Err(err) = verify_schema(oid, info, &upstream_info) {
                         let update = (Err(err.into()), MzOffset::minimum(), Diff::ONE);
                         let size = update.fuel_size();

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -55,7 +55,7 @@ use timely::dataflow::operators::core::Map as _;
 use timely::dataflow::operators::generic::OutputBuilder;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
 use timely::dataflow::operators::vec::Broadcast;
-use timely::dataflow::operators::{CapabilitySet, InspectCore, Leave};
+use timely::dataflow::operators::{CapabilitySet, Concatenate, InspectCore, Leave};
 use timely::dataflow::{Scope, StreamVec};
 use timely::order::TotalOrder;
 use timely::progress::frontier::MutableAntichain;
@@ -160,13 +160,15 @@ impl RawSourceCreationConfig {
 /// See the [`source` module docs](crate::source) for more details about how raw
 /// sources are used.
 ///
-/// The `resume_stream` parameter will contain frontier updates whenever times are durably
-/// recorded which allows the ingestion to release upstream resources.
+/// The `committed_uppers` parameter contains one stream per export whose frontier advances
+/// whenever times are durably recorded for that export. Their meet is what allows the
+/// ingestion to release upstream resources, and each individual stream drives that export's
+/// `offset_committed` statistic.
 pub fn create_raw_source<'scope, 'root, C>(
     scope: Scope<'scope, mz_repr::Timestamp>,
     root_scope: Scope<'root, ()>,
     storage_state: &crate::storage_state::StorageState,
-    committed_upper: StreamVec<'scope, mz_repr::Timestamp, ()>,
+    committed_uppers: BTreeMap<GlobalId, StreamVec<'scope, mz_repr::Timestamp, ()>>,
     config: &RawSourceCreationConfig,
     source_connection: C,
     start_signal: impl std::future::Future<Output = ()> + 'static,
@@ -198,7 +200,7 @@ where
     let timestamp_desc = source_connection.timestamp_desc();
 
     let (remap_collection, remap_token) = remap_operator(
-        scope,
+        scope.clone(),
         storage_state,
         config.clone(),
         probed_upper_rx,
@@ -208,6 +210,12 @@ where
     let remap_collection = remap_collection.inner.broadcast().as_collection();
     tokens.push(remap_token);
 
+    export_committed_offset_stats(&remap_collection, config, &committed_uppers);
+
+    // The source-wide committed upper is the meet of the per-export committed uppers. It
+    // determines what the source can release upstream, which must respect the slowest
+    // export.
+    let committed_upper = scope.concatenate(committed_uppers.into_values().collect::<Vec<_>>());
     let committed_upper = reclock_committed_upper(
         remap_collection.clone(),
         config.as_of.clone(),
@@ -551,6 +559,140 @@ where
     });
 
     (remap_stream.as_collection(), button.press_on_drop())
+}
+
+/// Reports the per-export `offset_committed` statistic by inverting each export's committed
+/// upper through the remap bindings, in the same way [`reclock_committed_upper`] inverts the
+/// source-wide committed upper.
+///
+/// The statistic must be derived per export rather than from the source-wide committed upper:
+/// that one is the meet across all exports, so a single hydrating export would hold back the
+/// reported offset of every other export.
+///
+/// The controller sums the per-worker values of the statistic, so each export is reported by
+/// exactly one worker.
+fn export_committed_offset_stats<'scope, FromTime>(
+    bindings: &VecCollection<'scope, mz_repr::Timestamp, FromTime, Diff>,
+    config: &RawSourceCreationConfig,
+    committed_uppers: &BTreeMap<GlobalId, StreamVec<'scope, mz_repr::Timestamp, ()>>,
+) where
+    FromTime: SourceTimestamp,
+{
+    let scope = bindings.scope().clone();
+    let name = format!("ExportOffsetCommittedStats({})", config.id);
+    let mut builder = OperatorBuilderRc::new(name, scope);
+
+    let mut bindings_input = builder.new_input(bindings.inner.clone(), Pipeline);
+    // One frontier-only input per export. An export's input index is offset by one for the
+    // bindings input. Only the entries for exports this worker reports carry state.
+    let mut exports = Vec::with_capacity(committed_uppers.len());
+    for (export_id, upper_stream) in committed_uppers {
+        let _ = builder.new_input(upper_stream.clone(), Pipeline);
+        let stats = config.statistics.get(export_id).cloned();
+        // The controller only aggregates this gauge once every worker has reported a value
+        // for it, so every worker initializes it to zero. Only the worker responsible for
+        // the export ever reports more, so the sum across workers is that worker's value.
+        if let Some(stats) = &stats {
+            stats.set_offset_committed(0);
+        }
+        let responsible = config.responsible_for(*export_id);
+        exports.push(
+            stats
+                .filter(|_| responsible)
+                .map(|stats| (stats, MutableAntichain::new(), 0usize)),
+        );
+    }
+    let as_of = config.as_of.clone();
+
+    builder.build(move |_| {
+        use timely::progress::ChangeBatch;
+        // Remap bindings beyond the bindings upper.
+        let mut accepted_times: ChangeBatch<(mz_repr::Timestamp, FromTime)> = ChangeBatch::new();
+        // The upper frontier of the bindings.
+        let mut upper = Antichain::from_elem(mz_repr::Timestamp::minimum());
+        // Remap bindings not beyond the bindings upper, in `into` time order. Unlike
+        // `reclock_committed_upper`, entries cannot be dropped as they are applied: the
+        // exports' committed uppers advance independently, so an entry is retained until
+        // every reported export has passed it.
+        let mut ready_times: VecDeque<(FromTime, mz_repr::Timestamp, i64)> = VecDeque::new();
+        // The number of entries popped off the front of `ready_times`, which makes the
+        // per-export `applied` counts absolute rather than deque indices.
+        let mut trimmed: usize = 0;
+
+        move |frontiers| {
+            bindings_input.for_each(|_, data| {
+                accepted_times.extend(data.drain(..).map(|(from, mut into, diff)| {
+                    into.advance_by(as_of.borrow());
+                    ((into, from), diff.into_inner())
+                }));
+            });
+            // Extract ready bindings.
+            let new_upper = frontiers[0].frontier();
+            if PartialOrder::less_than(&upper.borrow(), &new_upper) {
+                upper = new_upper.to_owned();
+                let mut pending_times = std::mem::take(&mut accepted_times).into_inner();
+                // These should already be sorted, as part of `.into_inner()`, but sort
+                // defensively in case.
+                pending_times.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+                for ((into, from), diff) in pending_times.drain(..) {
+                    if !upper.less_equal(&into) {
+                        ready_times.push_back((from, into, diff));
+                    } else {
+                        accepted_times.update((into, from), diff);
+                    }
+                }
+            }
+
+            // The received times only accumulate correctly for times beyond the as_of.
+            if !as_of.iter().all(|t| !upper.less_equal(t)) {
+                return;
+            }
+
+            // When this worker reports no exports this stays at the deque's end, so the
+            // trim below keeps `ready_times` empty rather than accumulating forever.
+            let mut min_applied = trimmed + ready_times.len();
+            for (i, export) in exports.iter_mut().enumerate() {
+                let Some((stats, source_upper, applied)) = export else {
+                    continue;
+                };
+                let committed_upper = frontiers[1 + i].frontier();
+                if !as_of.iter().all(|t| !committed_upper.less_equal(t)) {
+                    min_applied = std::cmp::min(min_applied, *applied);
+                    continue;
+                }
+                match committed_upper.as_option() {
+                    Some(t_next) => {
+                        // Apply the bindings between this export's last position and its
+                        // committed upper. See [`reclock_committed_upper`] for why applying
+                        // all bindings with time less than `t_next` inverts the frontier to
+                        // remap[t_prev].
+                        let start = *applied - trimmed;
+                        let end = ready_times.partition_point(|(_, t, _)| t < t_next);
+                        if start < end {
+                            let updates = ready_times
+                                .range(start..end)
+                                .map(|(from, _, diff)| (from.clone(), *diff));
+                            source_upper.update_iter(updates);
+                            *applied = trimmed + end;
+                        }
+                        if let Some(offset) = FromTime::to_offset_stat(source_upper.frontier()) {
+                            stats.set_offset_committed(offset);
+                        }
+                    }
+                    // An empty committed upper means the export will never commit anything
+                    // again. Leave the statistic at its last value and stop holding back
+                    // binding cleanup.
+                    None => *applied = trimmed + ready_times.len(),
+                }
+                min_applied = std::cmp::min(min_applied, *applied);
+            }
+            // Drop the bindings every reported export has applied.
+            while trimmed < min_applied {
+                ready_times.pop_front();
+                trimmed += 1;
+            }
+        }
+    });
 }
 
 /// Reclocks an `IntoTime` frontier stream into a `FromTime` frontier stream. This is used for the

--- a/src/storage/src/source/sql_server/progress.rs
+++ b/src/storage/src/source/sql_server/progress.rs
@@ -81,7 +81,6 @@ pub(crate) fn render<'scope>(
                 // Emit 0 to mark this worker as having started up correctly.
                 for stat in config.statistics.values() {
                     stat.set_offset_known(0);
-                    stat.set_offset_committed(0);
                 }
                 return Ok(());
             }

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -313,12 +313,17 @@ where
     }
 }
 
+/// Maximum bytes [`AsyncOutputHandle::give_fueled`] emits before yielding back to timely.
+/// Operators that spread emission over multiple output handles can use this to enforce the same
+/// bound over their aggregate emission, since the built-in counter is per handle.
+pub const MAX_OUTSTANDING_BYTES: usize = 128 * 1024 * 1024;
+
 impl<T, D> AsyncOutputHandle<T, FueledBuilder<CapacityContainerBuilder<Vec<D>>>>
 where
     D: Clone + 'static,
     T: Timestamp,
 {
-    pub const MAX_OUTSTANDING_BYTES: usize = 128 * 1024 * 1024;
+    pub const MAX_OUTSTANDING_BYTES: usize = MAX_OUTSTANDING_BYTES;
 
     /// Provides one record at the time specified by the capability and
     /// charges `size_bytes` against the builder's fuel counter. Once at least

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1404,6 +1404,33 @@ def workflow_pg_snapshot_resumption(c: Composition) -> None:
             c.run_testdrive_files("pg-snapshot-resumption/05-verify-data.td")
 
 
+def workflow_pg_snapshot_freshness(c: Composition) -> None:
+    """Test that already hydrated tables of a PostgreSQL source keep ingesting
+    CDC while a newly added table's snapshot runs, and that a table added
+    alongside completes its own snapshot without waiting. The new table's
+    snapshot is held with the pg_snapshot_pause failpoint."""
+
+    with c.override(
+        Testdrive(no_reset=True),
+        Clusterd(
+            name="clusterd1",
+            environment_extra=["FAILPOINTS=pg_snapshot_pause=return(t_paused)"],
+            workers=4,
+        ),
+    ):
+        c.up("materialized", "postgres", "clusterd1")
+
+        c.run_testdrive_files("pg-snapshot-freshness/01-setup.td")
+        c.run_testdrive_files("pg-snapshot-freshness/02-add-tables.td")
+
+        with c.override(
+            # turn off the failpoint
+            Clusterd(name="clusterd1", workers=4)
+        ):
+            c.up("clusterd1")
+            c.run_testdrive_files("pg-snapshot-freshness/03-verify.td")
+
+
 def workflow_sink_failure(c: Composition) -> None:
     """Test specific sink failure scenarios"""
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1484,6 +1484,59 @@ def workflow_pg_snapshot_resumption(c: Composition) -> None:
             c.run_testdrive_files("pg-snapshot-resumption/05-verify-data.td")
 
 
+def workflow_pg_snapshot_freshness(c: Composition) -> None:
+    """Test that already hydrated tables of a PostgreSQL source keep ingesting
+    CDC while a newly added table's snapshot runs, and that a table added
+    alongside completes its own snapshot without waiting. The new table's
+    snapshot is held with the pg_snapshot_pause failpoint."""
+
+    with c.override(
+        Testdrive(no_reset=True),
+        Clusterd(
+            name="clusterd1",
+            environment_extra=["FAILPOINTS=pg_snapshot_pause=return(t_paused)"],
+            workers=4,
+        ),
+    ):
+        c.up("materialized", "postgres", "clusterd1")
+
+        c.run_testdrive_files("pg-snapshot-freshness/01-setup.td")
+        c.run_testdrive_files("pg-snapshot-freshness/02-add-tables.td")
+
+        with c.override(
+            # turn off the failpoint
+            Clusterd(name="clusterd1", workers=4)
+        ):
+            c.up("clusterd1")
+            c.run_testdrive_files("pg-snapshot-freshness/03-verify.td")
+
+
+def workflow_pg_snapshot_freshness_release(c: Composition) -> None:
+    """Test that a table whose snapshot is held while CDC streams into it
+    converges once the hold lifts within the same dataflow incarnation. What
+    commits is the snapshot plus the updates the persist sink staged behind
+    the held frontier, not a re-run snapshot. The hold is timed with the
+    pg_snapshot_pause failpoint, long enough for the staging assertions of the
+    shared add-tables phase to run against a frontier that is still held."""
+
+    with c.override(
+        # The release waits out the hold, and after it the shard upper waits
+        # for the frontier to pass the last description the sink committed
+        # ahead of it.
+        Testdrive(no_reset=True, default_timeout="120s"),
+        Clusterd(
+            name="clusterd1",
+            environment_extra=["FAILPOINTS=pg_snapshot_pause=return(t_paused:30000)"],
+            workers=4,
+        ),
+    ):
+        c.up("materialized", "postgres", "clusterd1")
+
+        c.run_testdrive_files("pg-snapshot-freshness/01-setup.td")
+        c.run_testdrive_files("pg-snapshot-freshness/02-add-tables.td")
+        c.run_testdrive_files("pg-snapshot-freshness/04-release.td")
+
+
 def workflow_sink_failure(c: Composition) -> None:
     """Test specific sink failure scenarios"""
 

--- a/test/cluster/pg-snapshot-freshness/01-setup.td
+++ b/test/cluster/pg-snapshot-freshness/01-setup.td
@@ -1,0 +1,71 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Set up a postgres source with one hydrated table. The upstream tables that
+# are added to the source later already exist and have data. `t_alongside` is
+# created upstream before `t_paused` so it has the smaller OID: the snapshot
+# operator copies tables in OID order, so `t_alongside` finishes its copy
+# before the `pg_snapshot_pause` failpoint holds `t_paused`.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET unsafe_enable_unorchestrated_cluster_replicas = true
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE SCHEMA public;
+
+CREATE TABLE t_before (f1 INTEGER);
+ALTER TABLE t_before REPLICA IDENTITY FULL;
+INSERT INTO t_before VALUES (1);
+
+CREATE TABLE t_alongside (f1 INTEGER);
+ALTER TABLE t_alongside REPLICA IDENTITY FULL;
+INSERT INTO t_alongside VALUES (10), (20);
+
+CREATE TABLE t_paused (f1 INTEGER);
+ALTER TABLE t_paused REPLICA IDENTITY FULL;
+INSERT INTO t_paused VALUES (100), (200);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> DROP SOURCE IF EXISTS mz_source CASCADE;
+> DROP SECRET IF EXISTS pgpass CASCADE;
+> DROP CONNECTION IF EXISTS pg CASCADE;
+> DROP CLUSTER IF EXISTS storage CASCADE;
+
+> CREATE CLUSTER storage REPLICAS (
+    r1 (
+      STORAGECTL ADDRESSES ['clusterd1:2100'],
+      STORAGE ADDRESSES ['clusterd1:2103'],
+      COMPUTECTL ADDRESSES ['clusterd1:2101'],
+      COMPUTE ADDRESSES ['clusterd1:2102'],
+      WORKERS 4
+    )
+  )
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+> CREATE SOURCE mz_source
+  IN CLUSTER storage
+  FROM POSTGRES
+  CONNECTION pg
+  (PUBLICATION 'mz_source');
+
+> CREATE TABLE t_before FROM SOURCE mz_source (REFERENCE t_before);
+
+> SELECT * FROM t_before
+1

--- a/test/cluster/pg-snapshot-freshness/02-add-tables.td
+++ b/test/cluster/pg-snapshot-freshness/02-add-tables.td
@@ -1,0 +1,62 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# The `pg_snapshot_pause=return(t_paused)` failpoint is active on the storage
+# cluster, so `t_paused`'s snapshot copy hangs after the tables below are
+# added. This phase asserts the properties that hold while a snapshot runs:
+# the hydrated table keeps ingesting CDC, and a table added together with the
+# paused one completes its own snapshot without waiting.
+#
+# This relies on `storage_source_snapshot_concurrent_replication`, which is
+# enabled by default in the test configuration.
+
+# Adding both tables in one transaction restarts the ingestion dataflow once,
+# so both snapshot in the same incarnation.
+> BEGIN
+> CREATE TABLE t_alongside FROM SOURCE mz_source (REFERENCE t_alongside);
+> CREATE TABLE t_paused FROM SOURCE mz_source (REFERENCE t_paused);
+> COMMIT
+
+# A table added alongside the paused one completes its snapshot.
+> SELECT * FROM t_alongside
+10
+20
+
+# The hydrated table continues to ingest CDC while the snapshot is paused.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t_before VALUES (2);
+
+> SELECT * FROM t_before
+1
+2
+
+# And the alongside table ingests CDC once its own snapshot is done.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t_alongside VALUES (30);
+
+> SELECT * FROM t_alongside
+10
+20
+30
+
+# CDC for the paused table streams concurrently with its held snapshot. The
+# updates are staged in the persist sink but cannot commit, since the table's
+# frontier is held until its snapshot completes.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t_paused VALUES (300);
+
+# The paused table has staged updates but its snapshot has not committed.
+# snapshot_committed stays false while the failpoint holds the copy, so the
+# assertion is stable once the row exists.
+> SELECT s.name, bool_and(u.snapshot_committed), sum(u.updates_staged) > 0
+  FROM mz_internal.mz_source_statuses s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name = 't_paused'
+  GROUP BY s.name
+t_paused false true

--- a/test/cluster/pg-snapshot-freshness/03-verify.td
+++ b/test/cluster/pg-snapshot-freshness/03-verify.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# The storage cluster has restarted without the failpoint, so `t_paused`'s
+# snapshot re-runs to completion and every table converges. The row inserted
+# while the snapshot was held appears exactly once, whether it was staged
+# before the restart or picked up by the re-run snapshot.
+
+> SELECT * FROM t_paused
+100
+200
+300
+
+> SELECT * FROM t_before
+1
+2
+
+> SELECT * FROM t_alongside
+10
+20
+30
+
+> SELECT s.name, bool_and(u.snapshot_committed)
+  FROM mz_internal.mz_source_statuses s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name = 't_paused'
+  GROUP BY s.name
+t_paused true

--- a/test/cluster/pg-snapshot-freshness/04-release.td
+++ b/test/cluster/pg-snapshot-freshness/04-release.td
@@ -1,0 +1,89 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# The `pg_snapshot_pause=return(t_paused:<millis>)` failpoint holds `t_paused`'s
+# snapshot for a fixed time, so it completes in this dataflow incarnation and
+# what commits is the snapshot plus the CDC the persist sink staged behind the
+# held frontier. A restart would discard that staging and re-run the snapshot,
+# which is what the verify phase of the sibling workflow covers.
+
+# More CDC for the held table, spread over several timestamps. Each round waits
+# for the hydrated table's row to commit, which takes at least one timestamp
+# interval, so the held table's rows land at distinct times rather than in one.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t_paused VALUES (301);
+INSERT INTO t_before VALUES (3);
+
+> SELECT * FROM t_before
+1
+2
+3
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t_paused VALUES (302);
+INSERT INTO t_before VALUES (4);
+
+> SELECT * FROM t_before
+1
+2
+3
+4
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t_paused VALUES (303);
+INSERT INTO t_before VALUES (5);
+
+> SELECT * FROM t_before
+1
+2
+3
+4
+5
+
+# Still held.
+> SELECT s.name, bool_and(u.snapshot_committed)
+  FROM mz_internal.mz_source_statuses s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name = 't_paused'
+  GROUP BY s.name
+t_paused false
+
+# The hold lifts. The snapshot rows and every staged CDC row appear exactly once.
+> SELECT * FROM t_paused
+100
+200
+300
+301
+302
+303
+
+> SELECT s.name, bool_and(u.snapshot_committed)
+  FROM mz_internal.mz_source_statuses s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name = 't_paused'
+  GROUP BY s.name
+t_paused true
+
+# And CDC after the release lands as for any hydrated table.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t_paused VALUES (400);
+
+> SELECT * FROM t_paused
+100
+200
+300
+301
+302
+303
+400
+
+> SELECT * FROM t_alongside
+10
+20
+30

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -410,6 +410,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     statement_logging_use_reproducible_rng
     storage_cluster_shutdown_grace_period
     storage_downgrade_since_during_finalization
+    storage_persist_sink_max_raw_stash_bytes
     storage_record_source_sink_namespaced_errors
     storage_rocksdb_cleanup_tries
     storage_server_maintenance_interval

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -410,7 +410,8 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     statement_logging_use_reproducible_rng
     storage_cluster_shutdown_grace_period
     storage_downgrade_since_during_finalization
-    storage_persist_sink_max_raw_stash_bytes
+    storage_persist_sink_description_window
+    storage_persist_sink_description_window_max
     storage_record_source_sink_namespaced_errors
     storage_rocksdb_cleanup_tries
     storage_server_maintenance_interval


### PR DESCRIPTION
Design and POC (against Postgres) of a solution to allow a new export to be added to an existing source with hydrated exports, without stalling progress of already hydrated exports. I'm specifically avoiding making any massive changes in persist to accomplish this to avoid risk and minimize implementation time.

For the source side, there are small-to-medium changes:
- Snapshot / replication operators now have an output per export (instead of multiplexed), each with their own caps.
- Rewind requests are emitted before the snapshot starts to allow snapshot and replication operators to run concurrently.
- Hydrating exports hold their caps at the minimum, other exports are free to downgrade.


The bigger change is to the persist sink:
The main issue with today's approach is that the sink keeps one `BatchBuilder` per distinct timestamp.  If we made no changes to the persist sink, there are pathological cases where the sink accumulates batch builders for thousands of timestamps, but no one timestamp ever reaches the spill threshold, so memory grows unbounded.
