### PR TITLE
storage: fix double-counted messages_staged in Iceberg sinks

### DIFF
--- a/console/src/platform/sinks/SinkOverview/SinkStatistics.tsx
+++ b/console/src/platform/sinks/SinkOverview/SinkStatistics.tsx
@@ -16,6 +16,7 @@ import {
   SinkStatisticsDataPoint,
 } from "~/api/materialize/sink/sinkStatistics";
 import { SubscribeRow } from "~/api/materialize/SubscribeManager";
+import Alert from "~/components/Alert";
 import { AppErrorBoundary } from "~/components/AppErrorBoundary";
 import { ConnectorStatisticsGraph } from "~/platform/connectors/ConnectorStatisticsGraph";
 import {
@@ -62,6 +63,7 @@ export const SinkStatisticsInner = (props: SinkStatisticsProps) => {
   const { colors } = useTheme<MaterializeTheme>();
   const {
     data: rawData,
+    isError,
     currentStartTime,
     currentEndTime,
     paddedStartTime,
@@ -137,6 +139,18 @@ export const SinkStatisticsInner = (props: SinkStatisticsProps) => {
     ],
     [colors.accent.purple, colors.foreground.tertiary],
   );
+
+  // A failed subscribe would otherwise render as an empty graph, which is
+  // indistinguishable from a healthy sink with no traffic.
+  if (isError) {
+    return (
+      <Alert
+        variant="error"
+        width="100%"
+        message="Sink statistics are currently unavailable."
+      />
+    );
+  }
 
   return (
     <VStack alignItems="flex-start" width="100%" spacing="64px" mb="64px">

--- a/src/storage/src/sink/iceberg.rs
+++ b/src/storage/src/sink/iceberg.rs
@@ -1718,11 +1718,12 @@ fn write_data_files<'scope, H: EnvelopeHandler + 'static>(
                                 let record_batch = handler
                                     .row_to_batch(diff_pair, time)
                                     .context("failed to convert row to recordbatch")?;
+                                staged_messages_since_flush +=
+                                    u64::cast_from(record_batch.num_rows());
                                 batch_writer
                                     .write(record_batch)
                                     .await
                                     .context("failed to write recordbatch")?;
-                                staged_messages_since_flush += 1;
                                 if staged_messages_since_flush >= 10_000 {
                                     statistics.inc_messages_staged_by(staged_messages_since_flush);
                                     staged_messages_since_flush = 0;
@@ -1767,7 +1768,6 @@ fn write_data_files<'scope, H: EnvelopeHandler + 'static>(
                                     metrics.delete_files_written.inc();
                                 }
                             }
-                            statistics.inc_messages_staged_by(data_file.record_count());
                             statistics.inc_bytes_staged_by(data_file.file_size_in_bytes());
                             let file = BoundedDataFile::new(
                                 data_file,

--- a/test/iceberg/mode-append.td
+++ b/test/iceberg/mode-append.td
@@ -102,6 +102,15 @@ SELECT a, b, _mz_diff FROM polaris.default_namespace.append_demo_table ORDER BY 
 1 ONE 1
 1 one -1
 
+# Once the sink has committed everything, staged and committed counts must
+# agree. Staged is counted once per input row, so a mismatch here means rows
+# are being double-counted somewhere in the write path.
+> SELECT ss.messages_staged, ss.messages_committed
+  FROM mz_internal.mz_sink_statistics ss
+  JOIN mz_catalog.mz_sinks s ON s.id = ss.id
+  WHERE s.name = 'append_demo'
+6 6
+
 # Test: table with columns named "_mz_diff" and "_mz_timestamp" — these clash with
 # the columns that MODE APPEND automatically appends to the Iceberg schema.
 


### PR DESCRIPTION

The Iceberg sink counted every row twice in messages_staged: once as
rows are written, and again at file close via the file's record count.
As a result, staged always reported exactly twice the committed count,
and the Console's sink charts drew a Staged line at double the true
rate.

Keep the per-row accounting, which provides live progress during long
batch writes, and drop the file-close increment. Bytes are still
counted at file close, the only point where file sizes are known.

Also surface subscribe errors in the Console's sink statistics charts.
A failed subscribe previously rendered as an empty chart pinned at 0,
indistinguishable from a healthy sink with no traffic.

### Motivation

Fixes [CNS-119](https://linear.app/materializeinc/issue/CNS-119/iceberg-sink-metrics-stay-at-0-in-console-on-gcp)



### Verification
Verification, against the test/iceberg mzcompose stack (Polaris REST
catalog + MinIO):

* Baseline on the unpatched binary: while feeding a MODE APPEND sink
  one row every 2s, mz_internal.mz_sink_statistics reported staged at
  exactly 2x committed at every sample (4/2, 184/92, 443/221). A
  MODE UPSERT sink over a 2M-row table showed the same after its
  initial snapshot: 4,000,000 staged / 2,000,000 committed.
* With the fix, the same append workload converged to 307 staged /
  307 committed with equal byte counts, and the counters survived an
  environmentd restart. A fresh 500-row MODE UPSERT sink reported
  500/500 after its initial snapshot.
* DuckDB iceberg_scan on the sink's table counted exactly 307 records,
  confirming the committed counter matches what actually landed.
* A local Console pointed at the stack showed the Staged and Committed
  chart lines overlapping at the expected rate on the sink Overview
  page. Before the fix, Staged drew at exactly double Committed.
* mode-append.td now asserts staged == committed once the sink
  quiesces. Without the fix that assertion reads 12/6 and fails.

<img width="2048" height="1092" alt="image" src="https://github.com/user-attachments/assets/e771ec08-14e6-44b5-9407-d37afcb7b68e" />

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
