### PR TITLE
docs: Create a separate AI & agents section

### DIFF
--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -25,20 +25,8 @@ menu:
 
 ## Agent skills and MCP servers
 
-### Agent skills
-
-Materialize provides the following open-source [agent
-skills](https://github.com/MaterializeInc/agent-skills) to help developers build
-with Materialize.
-
-{{% include-headless "/headless/agent-skills-table" %}}
-
-### MCP servers
-
-Materialize providesthe following built-in Model Context Protocol (MCP) servers
-that AI agents can use.
-
-{{% include-headless "/headless/mcp-servers-table" %}}
+For Materialize's open-source agent skills and built-in Model Context Protocol
+(MCP) servers, see [AI & agents](/integrations/mcp-server/).
 
 ## SQL clients/client libraries
 

--- a/doc/user/content/integrations/coding-agent-skills.md
+++ b/doc/user/content/integrations/coding-agent-skills.md
@@ -7,7 +7,16 @@ menu:
     weight: 7
 ---
 
-Coding agents like [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://openai.com/index/codex/), [Cursor](https://www.cursor.com/), and others can work with Materialize using our open-source [agent skills](https://github.com/MaterializeInc/agent-skills). Once installed, these skills give your coding agent access to Materialize documentation and reference material so it can provide more accurate assistance when writing queries, setting up sources, creating materialized views, and more.
+Coding agents like [Claude
+Code](https://docs.anthropic.com/en/docs/claude-code),
+[Codex](https://openai.com/index/codex/), [Cursor](https://www.cursor.com/), and
+others can work with Materialize using the open-source [Materialize agent
+skills](https://github.com/MaterializeInc/agent-skills). These skills follow the
+[Agent Skills Open Standard](https://agentskills.io/home) and work with any
+coding agent that supports the standard. Once installed, these skills give your
+coding agent access to Materialize documentation and reference material so it
+can provide more accurate assistance when writing queries, setting up sources,
+creating materialized views, and more.
 
 ## Skills
 
@@ -26,8 +35,6 @@ npx skills add MaterializeInc/agent-skills
 ```
 
 Once installed, you can update installed skills by running `npx skills update`.
-
-The skills follow the [Agent Skills Open Standard](https://agentskills.io/home) and work with any coding agent that supports the standard.
 
 ## Reduce permission prompts (Claude Code)
 

--- a/doc/user/content/integrations/mcp-server/_index.md
+++ b/doc/user/content/integrations/mcp-server/_index.md
@@ -4,10 +4,9 @@ description: "This section contains guides for installing Materialize Agent skil
 disable_list: true
 menu:
   main:
-    parent: integrations
-    name: "MCP Server and skills"
+    name: "AI & agents"
     identifier: mcp-server
-    weight: 6
+    weight: 65
 aliases:
   - /integrations/mcp-server/llm/
   - /integrations/llm/


### PR DESCRIPTION
Promotes "MCP Server and skills" out of **Tools and integrations** into its own top-level nav section, **AI & agents**, so the MCP servers and coding-agent skills docs are discoverable as a first-class area rather than nested under integrations.

This is a nav-only promotion: all URLs stay under `/integrations/mcp-server/...`, so no aliases or inbound-link updates are needed.

- `mcp-server/_index.md`: drop `parent: integrations`, rename the menu entry to "AI & agents", move to weight 65 (directly above Tools and integrations at 70). The `mcp-server` identifier is unchanged, so all child pages (Agent Skills, MCP Server for Agents/Developers with their tools and config pages, Troubleshooting) stay attached.
- Tools and integrations landing page: replace the duplicated agent-skills and MCP-servers tables with a one-line pointer to the new section (people will still look for MCP there out of habit). Incidentally fixes a "providesthe" typo that lived in the replaced text.
- Agent Skills page: move the Agent Skills Open Standard compatibility sentence from the Installation section into the intro, where it answers "does my agent work with this?" up front, and tighten the intro wording.

Verified with a local Hugo build: "AI & agents" renders as a top-level section with the full subtree intact, and the landing-page pointer resolves.

### Motivation

Documentation improvement: surfaces the AI/agents documentation as a top-level section.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)