### PR TITLE
mcp: report data product hydration for the cluster the read actually uses (DEX-71)

### DIFF
--- a/src/catalog/src/builtin/mz_internal.rs
+++ b/src/catalog/src/builtin/mz_internal.rs
@@ -6135,6 +6135,10 @@ WITH details_raw AS (
     SELECT
         '"' || op.database || '"."' || op.schema || '"."' || op.name || '"' AS object_name,
         COALESCE(c_idx.name, c_obj.name) AS cluster,
+        -- The object's own cluster, kept so hydration can follow the persist
+        -- fallback when `cluster` above is hidden (DEX-71). Not projected by
+        -- the view.
+        c_obj.name AS object_cluster,
         COALESCE(cts_idx.comment, cts_obj.comment) AS description,
         COALESCE(jsonb_build_object(
         'type', 'object',
@@ -6209,7 +6213,7 @@ WHERE op.privilege_type = 'SELECT'
   AND (o.type = 'materialized-view'
        OR (o.type = 'view' AND i.id IS NOT NULL AND cp.name IS NOT NULL))
   AND s.name NOT IN ('mz_catalog', 'mz_internal', 'pg_catalog', 'information_schema', 'mz_introspection')
-GROUP BY 1, 2, 3
+GROUP BY 1, 2, 3, 4
 ),
 -- Pick the right (object_id, cluster_id) for hydration: the index's id +
 -- cluster when an index exists (its arrangement is what the data product
@@ -6227,6 +6231,24 @@ hydration_meta AS (
     LEFT JOIN mz_clusters c_idx ON c_idx.id = i.cluster_id
     LEFT JOIN mz_clusters c_obj ON c_obj.id = o.cluster_id
     WHERE (o.type = 'materialized-view' OR (o.type = 'view' AND i.id IS NOT NULL))
+      AND s.name NOT IN ('mz_catalog', 'mz_internal', 'pg_catalog', 'information_schema', 'mz_introspection')
+    UNION
+    -- The persist fallback path for a materialized view: when the advertised
+    -- index cluster is hidden the read runs on the session's cluster and is
+    -- served from persist, so readiness is governed by the view's own cluster
+    -- rather than the index's (DEX-71). For an index on the view's own cluster
+    -- this row merges with the branch above, which is harmless: an index
+    -- cannot hydrate before the collection it arranges.
+    SELECT DISTINCT
+        '"' || db.name || '"."' || s.name || '"."' || o.name || '"' AS object_name,
+        c_obj.name AS cluster,
+        o.id AS hydration_object_id,
+        o.cluster_id AS cluster_id
+    FROM mz_objects o
+    JOIN mz_schemas s ON s.id = o.schema_id
+    JOIN mz_databases db ON db.id = s.database_id
+    JOIN mz_clusters c_obj ON c_obj.id = o.cluster_id
+    WHERE o.type = 'materialized-view'
       AND s.name NOT IN ('mz_catalog', 'mz_internal', 'pg_catalog', 'information_schema', 'mz_introspection')
 ),
 -- Dedupe by replica before counting: an MV with multiple indexes on the
@@ -6254,17 +6276,21 @@ hydration AS (
         COUNT(replica_id) FILTER (WHERE replica_hydrated)::int AS hydrated_replica_count
     FROM hydration_per_replica
     GROUP BY object_name, cluster
+),
+details AS (
+    SELECT
+        d.*,
+        EXISTS (
+            SELECT 1 FROM mz_internal.mz_show_my_cluster_privileges cp
+            WHERE cp.name = d.cluster AND cp.privilege_type = 'USAGE'
+        ) AS cluster_visible
+    FROM details_raw d
 )
 SELECT
     d.object_name,
     -- Null the advertised cluster unless the role has USAGE on it (DEX-66),
-    -- matching mz_mcp_data_products. Hydration below still joins on the real
-    -- d.cluster, so readiness is reported accurately even when the name is
-    -- hidden.
-    CASE WHEN EXISTS (
-        SELECT 1 FROM mz_internal.mz_show_my_cluster_privileges cp
-        WHERE cp.name = d.cluster AND cp.privilege_type = 'USAGE'
-    ) THEN d.cluster END AS cluster,
+    -- matching mz_mcp_data_products.
+    CASE WHEN d.cluster_visible THEN d.cluster END AS cluster,
     d.description,
     d.schema,
     jsonb_build_object(
@@ -6273,10 +6299,14 @@ SELECT
         'replica_count', COALESCE(h.replica_count, 0),
         'hydrated_replica_count', COALESCE(h.hydrated_replica_count, 0)
     ) AS hydration
-FROM details_raw d
+FROM details d
+-- Report readiness for the cluster the read will actually use: the advertised
+-- one when the role can use it, otherwise the view's own cluster, which governs
+-- the freshness of the persist shard the fallback read serves from (DEX-71).
 LEFT JOIN hydration h
     ON h.object_name = d.object_name
-   AND h.cluster IS NOT DISTINCT FROM d.cluster
+   AND h.cluster IS NOT DISTINCT FROM
+       CASE WHEN d.cluster_visible THEN d.cluster ELSE d.object_cluster END
 "#,
     access: vec![PUBLIC_SELECT],
     ontology: None,

--- a/test/sqllogictest/catalog_server_explain.slt
+++ b/test/sqllogictest/catalog_server_explain.slt
@@ -9073,14 +9073,14 @@ Explained Query:
           Filter: (#1{schema} != "mz_catalog") AND (#1{schema} != "pg_catalog") AND (#1{schema} != "mz_internal") AND (#1{schema} != "mz_introspection") AND (#1{schema} != "information_schema") AND (#4{privilege_type} = "SELECT") AND ((#3{object_type} = "materialized-view") OR ((#10{id}) IS NOT NULL AND (#14{name}) IS NOT NULL AND (#3{object_type} = "view")))
             →Read l28
     cte l31 =
-      →Differential Join %0[#0..=#2] » %1[#0..=#2]
+      →Differential Join %0[#0..=#3] » %1[#0..=#3]
         after %1:
-          Project: #0..=#2, #5
-          Map: jsonb_build_object("type", "object", "indexedColumns", jsonbable_to_jsonb(#3), "properties", jsonbable_to_jsonb(jsonb_strip_nulls(#4)))
+          Project: #0..=#3, #6
+          Map: jsonb_build_object("type", "object", "indexedColumns", jsonbable_to_jsonb(#4), "properties", jsonbable_to_jsonb(jsonb_strip_nulls(#5)))
         →Non-incremental GroupAggregate
           Aggregation: jsonb_agg[order_by=[]](distinct row(case when (#4{position} = #5{on_position}) then jsonbable_to_jsonb(#3{name}) else null end))
           Key:
-            Project: #10..=#12
+            Project: #10, #11, #7, #12
             Map: (((((("\"" || #0{database}) || "\".\"") || #1{schema}) || "\".\"") || #2{name}) || "\""), coalesce(#6{name}, #7{name}), coalesce(#8{comment}, #9{comment})
           →Fused with Child Map/Filter/Project
             Project: #0..=#4, #6..=#10
@@ -9088,7 +9088,7 @@ Explained Query:
         →Non-incremental GroupAggregate
           Aggregation: jsonb_object_agg[order_by=[]](row(row(#3{name}, coalesce(jsonbable_to_jsonb(case when ((#4{type} = "int") OR (#4{type} = "real") OR (#4{type} = "float") OR (#4{type} = "uint2") OR (#4{type} = "uint4") OR (#4{type} = "uint8") OR (#4{type} = "bigint") OR (#4{type} = "double") OR (#4{type} = "integer") OR (#4{type} = "numeric") OR (#4{type} = "smallint") OR (#4{type} = "double precision")) then jsonb_build_object("type", "number", "description", jsonbable_to_jsonb(#9{comment})) else case when (#4{type} = "boolean") then jsonb_build_object("type", "boolean", "description", jsonbable_to_jsonb(#9{comment})) else case when (#4{type} = "bytea") then jsonb_build_object("type", "string", "description", jsonbable_to_jsonb(#9{comment}), "contentEncoding", "base64", "contentMediaType", "application/octet-stream") else case when (#4{type} = "date") then jsonb_build_object("type", "string", "format", "date", "description", jsonbable_to_jsonb(#9{comment})) else case when (#4{type} = "time") then jsonb_build_object("type", "string", "format", "time", "description", jsonbable_to_jsonb(#9{comment})) else case when ilike["timestamp%%"](#4{type}) then jsonb_build_object("type", "string", "format", "date-time", "description", jsonbable_to_jsonb(#9{comment})) else case when (#4{type} = "jsonb") then jsonb_build_object("type", "object", "description", jsonbable_to_jsonb(#9{comment})) else case when (#4{type} = "uuid") then jsonb_build_object("type", "string", "format", "uuid", "description", jsonbable_to_jsonb(#9{comment})) else jsonb_build_object("type", "string", "description", jsonbable_to_jsonb(#9{comment})) end end end end end end end end), json_null))))
           Key:
-            Project: #10..=#12
+            Project: #10, #11, #6, #12
             Map: (((((("\"" || #0{database}) || "\".\"") || #1{schema}) || "\".\"") || #2{name}) || "\""), coalesce(#5{name}, #6{name}), coalesce(#7{comment}, #8{comment})
           →Fused with Child Map/Filter/Project
             Project: #0..=#3, #5, #7..=#11
@@ -9105,51 +9105,72 @@ Explained Query:
         →Arranged l8
     cte l33 =
       →Distinct GroupAggregate
-        Key:
-          Project: #12, #13, #15, #16
-          Map: (((((("\"" || #4{name}) || "\".\"") || #3{name}) || "\".\"") || #1{name}) || "\""), case when (#9) IS NULL then case when (#11) IS NULL then null else #10 end else coalesce(#8, case when (#11) IS NULL then null else #10 end) end, (#7) IS NULL, case when #14 then #0{id} else coalesce(#5, #0{id}) end, case when #14 then #2{cluster_id} else coalesce(#6, #2{cluster_id}) end
-        →One-Shot Delta Join [%0:l32 » %1[#1] » %2:l16[#0] » %3[#0]]
-          path %0:
-            after %1:
-              Project: #0, #1, #3..=#8
-              Filter: ((#2{type} = "materialized-view") OR ((case when (#8) IS NULL then null else #6 end) IS NOT NULL AND (#2{type} = "view")))
-          →Unarranged Raw Stream
-            →Fused with Child Map/Filter/Project
-              Filter: ((#2{type} = "view") OR (#2{type} = "materialized-view")) AND (#4{name} != "mz_catalog") AND (#4{name} != "pg_catalog") AND (#4{name} != "mz_internal") AND (#4{name} != "mz_introspection") AND (#4{name} != "information_schema")
-                →Read l32
-          →Arrange (#1) (case when (#3) IS NULL then null else #2 end)
-            →Union
-              →Stream l15
-              →Map/Filter/Project
-                Project: #1, #0, #2, #3
-                Map: null, null, null
-                  →Threshold Diffs #0
-                    →Arrange (#0)
-                      →Union
-                        →Stream l14
-                        →Unarranged Raw Stream
-                          →Distinct GroupAggregate
-                            →Fused with Child Map/Filter/Project
-                              Project: #0
-                                →Read l32
-          →Arranged l16
-          →Arrange (#0)
-            →Union
-              →Stream l13
-              →Map/Filter/Project
-                Project: #0..=#2
-                Map: null, null
-                  →Threshold Diffs #0
-                    →Arrange (#0)
-                      →Union
-                        →Stream l12
-                        →Unarranged Raw Stream
-                          →Distinct GroupAggregate
-                            →Union
+        →Union
+          →One-Shot Delta Join [%0:l32 » %1[#1] » %2:l16[#0] » %3[#0]]
+            path %0:
+              after %1:
+                Project: #2, #5, #6, #3, #9, #10
+                Filter: ((#1{type} = "materialized-view") OR ((#8) IS NOT NULL AND (#1{type} = "view")))
+                Map: (#6) IS NULL, case when #7 then null else #4 end, coalesce(#8{id}, #0{id}), case when #7 then #2{cluster_id} else coalesce(#5, #2{cluster_id}) end
+              after %3:
+                Project: #3, #8, #4, #5
+                Map: case when (#2) IS NULL then case when (#7) IS NULL then null else #6 end else coalesce(#1, case when (#7) IS NULL then null else #6 end) end
+            →Unarranged Raw Stream
+              →Fused with Child Map/Filter/Project
+                Filter: ((#2{type} = "view") OR (#2{type} = "materialized-view")) AND (#4{name} != "mz_catalog") AND (#4{name} != "pg_catalog") AND (#4{name} != "mz_internal") AND (#4{name} != "mz_introspection") AND (#4{name} != "information_schema")
+                  →Read l32
+            →Arrange (#1) (case when (#3) IS NULL then null else #2 end)
+              →Union
+                →Stream l15
+                →Map/Filter/Project
+                  Project: #1, #0, #2, #3
+                  Map: null, null, null
+                    →Threshold Diffs #0
+                      →Arrange (#0)
+                        →Union
+                          →Stream l14
+                          →Unarranged Raw Stream
+                            →Distinct GroupAggregate
                               →Fused with Child Map/Filter/Project
-                                Project: #3
+                                Project: #0
                                   →Read l32
-                              →Constant (1 row)
+            →Arranged l16
+            →Arrange (#0)
+              →Union
+                →Stream l13
+                →Map/Filter/Project
+                  Project: #0..=#2
+                  Map: null, null
+                    →Threshold Diffs #0
+                      →Arrange (#0)
+                        →Union
+                          →Stream l12
+                          →Unarranged Raw Stream
+                            →Distinct GroupAggregate
+                              →Union
+                                →Fused with Child Map/Filter/Project
+                                  Project: #3
+                                    →Read l32
+                                →Constant (1 row)
+          →One-Shot Delta Join [%0:mz_objects » %3:mz_clusters[#0{id}] » %1:mz_schemas[#0{id}] » %2:l8[#0{id}]]
+            path %0:
+              after %2:
+                Project: #7, #5, #1, #3
+                Map: (((((("\"" || #6{name}) || "\".\"") || #4{name}) || "\".\"") || #2{name}) || "\"")
+            →Unarranged Raw Stream
+              →Fused with Child Map/Filter/Project
+                Project: #1, #0, #3, #6
+                Filter: (#4{type} = "materialized-view") AND (#6{cluster_id}) IS NOT NULL
+                  →Arranged mz_catalog.mz_objects
+                    Key: (#2{schema_id})
+            →Arrange (#0{id}) (#1{database_id})
+              →Fused with Child Map/Filter/Project
+                Project: #1, #0, #3
+                Filter: (#0{database_id}) IS NOT NULL AND (#3{name} != "mz_catalog") AND (#3{name} != "pg_catalog") AND (#3{name} != "mz_internal") AND (#3{name} != "mz_introspection") AND (#3{name} != "information_schema")
+                  →Arranged mz_catalog.mz_schemas
+                    Key: (#2{database_id})
+            →Arranged l8
+            →Arranged mz_catalog.mz_clusters
     cte l34 =
       →Arrange (#3{cluster_id})
         →Fused with Child Map/Filter/Project
@@ -9192,21 +9213,49 @@ Explained Query:
               →Read l36
         →Arranged mz_internal.mz_hydration_statuses
     cte l38 =
+      →Distinct GroupAggregate
+        →Fused with Child Map/Filter/Project
+          Project: #1
+            →Read l31
+    cte l39 =
+      →Differential Join %0:l38[#0] » %1[#0]
+        →Arranged l38
+        →Distinct GroupAggregate
+          →Stream l18
+    cte l40 =
+      →Differential Join %0:l31[#1] » %1[#0]
+        →Arrange (#1)
+          →Stream l31
+        →Arrange (#0)
+          →Union
+            →Fused with Child Map/Filter/Project
+              Project: #0, #1
+              Map: true
+                →Read l39
+            →Map/Filter/Project
+              Project: #0, #1
+              Map: false
+                →Consolidating Union
+                  →Negate Diffs
+                    →Stream l39
+                  →Unarranged Raw Stream
+                    →Arranged l38
+    cte l41 =
       →Fused with Child Map/Filter/Project
         Project: #0..=#4
         Map: (#1) IS NULL
           →Read l36
-    cte l39 =
-      →Differential Join %0:l31[#0{object_name}] » %1[#0{object_name}]
+    cte l42 =
+      →Differential Join %0:l40[#0{object_name}] » %1[#0{object_name}]
         after %1:
-          Project: #0..=#3, #5, #6
-          Filter: ((#7 AND #8) OR (NOT(#7) AND NOT(#8) AND (#1{cluster} = #4{cluster})))
-          Map: (#1{cluster}) IS NULL, (#4{cluster}) IS NULL
+          Project: #0..=#5, #7, #8
+          Filter: ((#9 AND #11) OR (NOT(#9) AND NOT(#11) AND (#6{cluster} = #10)))
+          Map: (#6{cluster}) IS NULL, case when #5{cluster_visible} then #1{cluster} else #2{object_cluster} end, (#10) IS NULL
         →Arrange (#0{object_name})
           →Fused with Child Map/Filter/Project
-            Filter: (#4 OR NOT(#4))
-            Map: (#1{cluster}) IS NULL
-              →Read l31
+            Filter: (#6 OR NOT(#6))
+            Map: (case when #5{cluster_visible} then #1{cluster} else #2{object_cluster} end) IS NULL
+              →Read l40
         →Arrange (#0{object_name})
           →Map/Filter/Project
             Project: #0, #1, #4, #5
@@ -9225,12 +9274,12 @@ Explained Query:
                       Map: null
                         →Consolidating Union
                           →Negate Diffs
-                            →Differential Join %1[#0, #1] » %0:l38[#2{hydration_object_id}, #3{id}]
+                            →Differential Join %1[#0, #1] » %0:l41[#2{hydration_object_id}, #3{id}]
                               →Arrange (#2{hydration_object_id}, #3{id})
                                 →Fused with Child Map/Filter/Project
                                   Project: #0..=#3
                                   Filter: (#3{id}) IS NOT NULL AND (#4 OR NOT(#4))
-                                    →Read l38
+                                    →Read l41
                               →Distinct GroupAggregate
                                 →Fused with Child Map/Filter/Project
                                   Project: #2, #3
@@ -9238,64 +9287,44 @@ Explained Query:
                           →Fused with Child Map/Filter/Project
                             Project: #0, #1, #3
                             Filter: (#4 OR NOT(#4))
-                              →Read l38
+                              →Read l41
                     →Fused with Child Map/Filter/Project
                       Project: #0, #1, #3, #4
                       Filter: (#5 OR NOT(#5))
                       Map: (#1) IS NULL
                         →Read l37
-    cte l40 =
-      →Union
-        →Stream l39
-        →Map/Filter/Project
-          Project: #0..=#5
-          Map: null, null
-            →Consolidating Union
-              →Negate Diffs
-                →Unarranged Raw Stream
-                  →Distinct GroupAggregate
-                    →Fused with Child Map/Filter/Project
-                      Project: #0..=#3
-                        →Read l39
-              →Stream l31
-    cte l41 =
-      →Distinct GroupAggregate
-        →Fused with Child Map/Filter/Project
-          Project: #1
-            →Read l40
-    cte l42 =
-      →Differential Join %0:l41[#0] » %1[#0]
-        →Arranged l41
-        →Distinct GroupAggregate
-          →Stream l18
   →Return
-    →Differential Join %0:l40[#1] » %1[#0]
-      after %1:
-        Project: #1, #7, #2, #3, #8
-        Map: case when #6 then #0{cluster} else null end, jsonb_build_object("hydrated", jsonbable_to_jsonb(coalesce(((#4{replica_count} = #5{hydrated_replica_count}) AND (#4{replica_count} > 0)), false)), "replica_count", jsonbable_to_jsonb(integer_to_numeric(coalesce(#4{replica_count}, 0))), "hydrated_replica_count", jsonbable_to_jsonb(integer_to_numeric(coalesce(#5{hydrated_replica_count}, 0))))
-      →Arrange (#1)
-        →Stream l40
-      →Arrange (#0)
+    →Map/Filter/Project
+      Project: #0, #7, #2, #3, #8
+      Map: case when #4{cluster_visible} then #1{cluster} else null end, jsonb_build_object("hydrated", jsonbable_to_jsonb(coalesce(((#5{replica_count} = #6{hydrated_replica_count}) AND (#5{replica_count} > 0)), false)), "replica_count", jsonbable_to_jsonb(integer_to_numeric(coalesce(#5{replica_count}, 0))), "hydrated_replica_count", jsonbable_to_jsonb(integer_to_numeric(coalesce(#6{hydrated_replica_count}, 0))))
         →Union
           →Fused with Child Map/Filter/Project
-            Project: #0, #1
-            Map: true
+            Project: #0, #1, #3..=#7
               →Read l42
-          →Map/Filter/Project
-            Project: #0, #1
-            Map: false
+          →Differential Join %0[#0..=#5] » %1:l40[#0..=#5]
+            Final closure:
+              Project: #0..=#6
+              Map: null, null
+            →Arrange (#0..=#5)
               →Consolidating Union
                 →Negate Diffs
-                  →Stream l42
+                  →Unarranged Raw Stream
+                    →Distinct GroupAggregate
+                      →Fused with Child Map/Filter/Project
+                        Project: #0..=#5
+                          →Read l42
                 →Unarranged Raw Stream
-                  →Arranged l41
+                  →Distinct GroupAggregate
+                    →Stream l40
+            →Arrange (#0..=#5)
+              →Stream l40
 
 Source mz_catalog.mz_index_columns
   project=(#0, #2)
 
 Used Indexes:
   - mz_internal.mz_hydration_statuses_ind (differential join)
-  - mz_catalog.mz_clusters_ind (*** full scan ***)
+  - mz_catalog.mz_clusters_ind (*** full scan ***, delta join lookup)
   - mz_catalog.mz_indexes_ind (*** full scan ***)
   - mz_catalog.mz_roles_ind (*** full scan ***)
   - mz_catalog.mz_cluster_replicas_ind (*** full scan ***)

--- a/test/sqllogictest/rbac_mcp_agent.slt
+++ b/test/sqllogictest/rbac_mcp_agent.slt
@@ -598,6 +598,79 @@ SELECT c.name FROM mz_indexes i JOIN mz_clusters c ON c.id = i.cluster_id WHERE 
 agent_compute
 COMPLETE 1
 
+# =============================================================================
+# DEX-71: hydration must describe the cluster the read will actually use. A
+# materialized view whose only index sits on a zero-replica cluster the agent
+# cannot use is advertised with a null cluster and read from persist on the
+# session's cluster, so readiness has to come from the view's own cluster.
+# Reporting the hidden index's cluster instead surfaced replica_count 0, which
+# the agent contract reads as "unreadable", hiding a working product.
+# =============================================================================
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER agent_dead_idx REPLICAS ();
+----
+COMPLETE 0
+
+# The view lives on agent_serving (1 replica); its only index is on the
+# zero-replica cluster the agent has no USAGE on.
+simple conn=mz_system,user=mz_system
+CREATE MATERIALIZED VIEW agent_objects.fallback_mv IN CLUSTER agent_serving AS SELECT 1 AS id;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE INDEX fallback_mv_idx IN CLUSTER agent_dead_idx ON agent_objects.fallback_mv (id);
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON agent_objects.fallback_mv TO agent;
+----
+COMPLETE 0
+
+# Sanity check: the index really is on the zero-replica cluster, so the
+# assertion below cannot pass vacuously.
+simple conn=mz_system,user=mz_system
+SELECT c.name, (SELECT count(*) FROM mz_cluster_replicas r WHERE r.cluster_id = c.id) FROM mz_indexes i JOIN mz_clusters c ON c.id = i.cluster_id WHERE i.name = 'fallback_mv_idx';
+----
+agent_dead_idx,0
+COMPLETE 1
+
+# Discovery hides the index cluster, as in DEX-66.
+simple conn=agent_restricted,user=agent
+SELECT object_name, cluster FROM mz_internal.mz_mcp_data_product_details WHERE object_name = '"materialize"."agent_objects"."fallback_mv"';
+----
+"materialize"."agent_objects"."fallback_mv",NULL
+COMPLETE 1
+
+# Hydration follows the fallback read path (agent_serving, 1 replica) rather
+# than the hidden zero-replica index cluster. `hydrated` is timing-dependent so
+# only the replica count is asserted here.
+simple conn=agent_restricted,user=agent
+SELECT (hydration->>'replica_count')::int FROM mz_internal.mz_mcp_data_product_details WHERE object_name = '"materialize"."agent_objects"."fallback_mv"';
+----
+1
+COMPLETE 1
+
+# A product whose advertised cluster IS usable keeps reporting that cluster's
+# readiness, unchanged by the fallback logic.
+simple conn=agent_restricted,user=agent
+SELECT (hydration->>'replica_count')::int FROM mz_internal.mz_mcp_data_product_details WHERE object_name = '"materialize"."agent_objects"."transfer_windows"';
+----
+1
+COMPLETE 1
+
+simple conn=mz_system,user=mz_system
+DROP MATERIALIZED VIEW agent_objects.fallback_mv CASCADE;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP CLUSTER agent_dead_idx CASCADE;
+----
+COMPLETE 0
+
 # mz_session_role_memberships() is callable in a restricted session (it only
 # exposes the current session's role chain, not the full system graph).
 # Verify it walks the full transitive chain: grant agent membership in a parent


### PR DESCRIPTION
When a materialized view's index cluster is hidden because the role lacks USAGE, the read falls back to persist on the session's cluster, but hydration still followed the hidden index and could report `replica_count: 0` for a product that reads fine. Since the agent contract treats that as unreadable, a working product looked broken. Hydration now follows the view's own cluster in that case, which is what governs the persist shard's freshness.