### PR TITLE
compute: make index peek processing cooperative

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -345,6 +345,19 @@ def get_variable_system_parameters(
         VariableSystemParameter(
             "persist_encoding_enable_dictionary", "true", ["true", "false"]
         ),
+        # A small work budget makes nearly every index peek yield at least once,
+        # so CI exercises the resumable scan path rather than just the
+        # scan-completes-in-one-slice path.
+        VariableSystemParameter(
+            "peek_yielding",
+            "work:64,time:10",
+            ["work:16,time:10", "work:64,time:10", "work:100000,time:10"],
+        ),
+        VariableSystemParameter(
+            "peek_yielding_total",
+            "work:1024,time:100",
+            ["work:128,time:100", "work:1024,time:100", "work:1000000,time:100"],
+        ),
         VariableSystemParameter(
             "persist_fast_path_limit",
             "1000",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1850,6 +1850,18 @@ class FlipFlagsAction(Action):
             BOOLEAN_FLAG_VALUES
         )
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
+        # Small work budgets force index peeks to yield and resume, which is
+        # where the interesting state lives.
+        self.flags_with_values["peek_yielding"] = [
+            "work:16,time:10",
+            "work:64,time:10",
+            "work:100000,time:10",
+        ]
+        self.flags_with_values["peek_yielding_total"] = [
+            "work:128,time:100",
+            "work:1024,time:100",
+            "work:1000000,time:100",
+        ]
         self.flags_with_values["enable_public_metrics_endpoint"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_scoped_system_parameters"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -236,6 +236,27 @@ pub const LINEAR_JOIN_YIELDING: Config<&str> = Config::new(
      work, respectively, rather than falling back to some default.",
 );
 
+/// The yielding behavior with which a single index peek should be processed.
+pub const PEEK_YIELDING: Config<&str> = Config::new(
+    "peek_yielding",
+    "work:100000,time:10",
+    "How much work a compute worker may spend on one index peek before moving on to the \
+     next pending peek. Either 'work:<cursor steps>' or 'time:<milliseconds>' or \
+     'work:<cursor steps>,time:<milliseconds>'. Note that omitting one of 'work' or 'time' \
+     will entirely disable peek yielding by time or work, respectively, rather than falling \
+     back to some default.",
+);
+
+/// The yielding behavior with which index peeks as a whole should be processed.
+pub const PEEK_YIELDING_TOTAL: Config<&str> = Config::new(
+    "peek_yielding_total",
+    "work:1000000,time:100",
+    "How much work a compute worker may spend on all index peeks together in one worker \
+     activation, before it goes back to scheduling dataflows and handling commands. Same \
+     format as 'peek_yielding'. Should be larger than 'peek_yielding', which bounds a single \
+     peek's turn within this allowance.",
+);
+
 /// Enable lgalloc.
 pub const ENABLE_LGALLOC: Config<bool> =
     Config::new("enable_lgalloc", true, "Enable lgalloc.").scoped(ParameterScope::Replica);
@@ -556,6 +577,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_COMPUTE_TEMPORAL_BUCKETING)
         .add(&TEMPORAL_BUCKETING_SUMMARY)
         .add(&LINEAR_JOIN_YIELDING)
+        .add(&PEEK_YIELDING)
+        .add(&PEEK_YIELDING_TOTAL)
         .add(&ENABLE_LGALLOC)
         .add(&LGALLOC_BACKGROUND_INTERVAL)
         .add(&LGALLOC_FILE_GROWTH_DAMPENER)

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -17,9 +17,7 @@ use std::time::{Duration, Instant};
 use bytesize::ByteSize;
 use differential_dataflow::Hashable;
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::trace::cursor::BatchCursor;
-use differential_dataflow::trace::implementations::BatchContainer;
-use differential_dataflow::trace::{Cursor, Navigable, TraceReader};
+use differential_dataflow::trace::{Cursor, TraceReader};
 use mz_compute_client::logging::LoggingConfig;
 use mz_compute_client::protocol::command::{
     ComputeCommand, ComputeParameters, InstanceConfig, Peek, PeekTarget,
@@ -35,8 +33,8 @@ use mz_compute_types::dyncfgs::{
 };
 use mz_compute_types::plan::render_plan::RenderPlan;
 use mz_dyncfg::ConfigSet;
+use mz_expr::SafeMfpPlan;
 use mz_expr::row::RowCollection;
-use mz_expr::{RowComparator, SafeMfpPlan};
 use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::{MetricsRegistry, UIntGauge};
@@ -50,7 +48,6 @@ use mz_persist_client::cfg::USE_CRITICAL_SINCE_SNAPSHOT;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_types::PersistLocation;
 use mz_persist_types::codec_impls::UnitSchema;
-use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena, Timestamp};
 use mz_storage_operators::stats::StatsCursor;
 use mz_storage_types::StorageDiff;
@@ -69,14 +66,17 @@ use tracing::{Level, debug, error, info, span, trace, warn};
 use uuid::Uuid;
 
 use crate::arrangement::manager::{TraceBundle, TraceManager};
+use crate::compute_state::peek_scan::{PeekScan, ScanOutcome};
 use crate::logging;
 use crate::logging::compute::{CollectionLogging, ComputeEvent, PeekEvent};
 use crate::logging::initialize::LoggingTraces;
 use crate::metrics::{CollectionMetrics, WorkerMetrics};
 use crate::render::{LinearJoinSpec, StartSignal};
 use crate::server::{ComputeInstanceContext, ResponseSender};
+use crate::yielding::{Budget, NestedBudget, YieldSpec};
 
 mod peek_result_iterator;
+mod peek_scan;
 mod peek_stash;
 
 /// Worker-local state that is maintained across dataflows.
@@ -122,6 +122,18 @@ pub struct ComputeState {
     max_result_size: u64,
     /// Specification for rendering linear joins.
     pub linear_join_spec: LinearJoinSpec,
+    /// How much scanning work one index peek may do before we move on to the
+    /// next pending peek.
+    pub peek_yielding: YieldSpec,
+    /// How much scanning work all index peeks together may do in one worker
+    /// activation.
+    pub peek_yielding_total: YieldSpec,
+    /// Peek to resume the round robin from in the next `process_peeks`.
+    ///
+    /// The activation budget usually runs out before every pending peek has
+    /// had a turn, so we remember where we stopped. Without this, peeks with
+    /// low uuids would starve the rest.
+    peek_resume_at: Uuid,
     /// Metrics for this worker.
     pub metrics: WorkerMetrics,
     /// A process-global handle to tracing configuration.
@@ -202,6 +214,9 @@ impl ComputeState {
             command_history,
             max_result_size: u64::MAX,
             linear_join_spec: Default::default(),
+            peek_yielding: Default::default(),
+            peek_yielding_total: Default::default(),
+            peek_resume_at: Uuid::nil(),
             metrics,
             tracing_handle,
             context,
@@ -251,6 +266,18 @@ impl ComputeState {
         let config = &self.worker_config;
 
         self.linear_join_spec = LinearJoinSpec::from_config(config);
+
+        let peek_yielding_raw = PEEK_YIELDING.get(config);
+        self.peek_yielding = YieldSpec::try_from_str(&peek_yielding_raw).unwrap_or_else(|| {
+            error!("invalid PEEK_YIELDING config: {peek_yielding_raw}");
+            YieldSpec::default()
+        });
+        let peek_yielding_total_raw = PEEK_YIELDING_TOTAL.get(config);
+        self.peek_yielding_total = YieldSpec::try_from_str(&peek_yielding_total_raw)
+            .unwrap_or_else(|| {
+                error!("invalid PEEK_YIELDING_TOTAL config: {peek_yielding_total_raw}");
+                YieldSpec::default()
+            });
 
         if ENABLE_LGALLOC.get(config) {
             if let Some(path) = &self.context.scratch_directory {
@@ -765,7 +792,13 @@ impl<'a> ActiveComputeState<'a> {
             logger.log(&pending.as_log_event(true));
         }
 
-        self.process_peek(&mut Antichain::new(), pending);
+        // We don't serve the peek here. `process_peeks` runs later in the same
+        // worker iteration, so the peek is served without extra latency, and
+        // going through there means a burst of peeks shares one work budget
+        // rather than each getting its own.
+        self.compute_state
+            .pending_peeks
+            .insert(pending.peek().uuid, pending);
     }
 
     fn handle_cancel_peek(&mut self, uuid: Uuid) {
@@ -1000,8 +1033,19 @@ impl<'a> ActiveComputeState<'a> {
         }
     }
 
-    /// Either complete the peek (and send the response) or put it in the pending set.
-    fn process_peek(&mut self, upper: &mut Antichain<Timestamp>, mut peek: PendingPeek) {
+    /// Either completes the peek (and sends the response) or puts it back in
+    /// the pending set.
+    ///
+    /// Scanning work is charged against `budget`, this peek's turn within the
+    /// worker's activation. Returns `true` if the peek has work left that only
+    /// this worker will pick up, meaning the worker must not park.
+    fn process_peek(
+        &mut self,
+        upper: &mut Antichain<Timestamp>,
+        budget: &mut NestedBudget<'_>,
+        mut peek: PendingPeek,
+    ) -> bool {
+        let mut work_pending = false;
         let response = match &mut peek {
             PendingPeek::Index(peek) => {
                 let start = Instant::now();
@@ -1052,19 +1096,30 @@ impl<'a> ActiveComputeState<'a> {
                 let status = peek.seek_fulfillment(
                     upper,
                     self.compute_state.max_result_size,
-                    peek_stash_enabled && peek_stash_eligible,
-                    peek_stash_threshold_bytes,
+                    (peek_stash_enabled && peek_stash_eligible)
+                        .then_some(peek_stash_threshold_bytes),
+                    budget,
                     &metrics,
                 );
 
-                self.compute_state
-                    .metrics
-                    .index_peek_total_seconds
-                    .observe(start.elapsed().as_secs_f64());
+                // A peek can span many activations, so we only report the total
+                // once it is done. Otherwise a slow peek would show up as a
+                // string of fast ones.
+                peek.elapsed += start.elapsed();
+                if !matches!(status, PeekStatus::NotReady | PeekStatus::Yielded) {
+                    self.compute_state
+                        .metrics
+                        .index_peek_total_seconds
+                        .observe(peek.elapsed.as_secs_f64());
+                }
 
                 match status {
                     PeekStatus::Ready(result) => Some(result),
                     PeekStatus::NotReady => None,
+                    PeekStatus::Yielded => {
+                        work_pending = true;
+                        None
+                    }
                     PeekStatus::UsePeekStash => {
                         let _span =
                             span!(parent: &peek.span, Level::DEBUG, "process_stash_peek").entered();
@@ -1086,7 +1141,7 @@ impl<'a> ActiveComputeState<'a> {
                         self.compute_state
                             .pending_peeks
                             .insert(peek.peek.uuid, PendingPeek::Stash(stash_task));
-                        return;
+                        return false;
                     }
                 }
             }
@@ -1118,20 +1173,50 @@ impl<'a> ActiveComputeState<'a> {
 
         if let Some(response) = response {
             let _span = span!(parent: peek.span(), Level::DEBUG, "process_peek_response").entered();
-            self.send_peek_response(peek, response)
+            self.send_peek_response(peek, response);
         } else {
             let uuid = peek.peek().uuid;
             self.compute_state.pending_peeks.insert(uuid, peek);
         }
+
+        work_pending
     }
 
-    /// Scan pending peeks and attempt to retire each.
-    pub fn process_peeks(&mut self) {
+    /// Scans pending peeks and attempts to retire each.
+    ///
+    /// Returns `true` if any peek yielded with work remaining, in which case
+    /// the worker must not park before calling this again.
+    ///
+    /// Peeks take turns: each gets a slice of the activation's budget, and we
+    /// stop once that budget is spent. Peeks that did not get a turn are
+    /// served first on the next activation.
+    pub fn process_peeks(&mut self) -> bool {
+        let per_peek = self.compute_state.peek_yielding;
+        let mut activation = Budget::new(&self.compute_state.peek_yielding_total);
         let mut upper = Antichain::new();
-        let pending_peeks = std::mem::take(&mut self.compute_state.pending_peeks);
-        for (_uuid, peek) in pending_peeks {
-            self.process_peek(&mut upper, peek);
+        let mut work_pending = false;
+
+        // Rotate the pending peeks so we resume where the last activation ran
+        // out of budget, rather than always starting from the lowest uuid.
+        let mut wrapped = std::mem::take(&mut self.compute_state.pending_peeks);
+        let rest = wrapped.split_off(&self.compute_state.peek_resume_at);
+
+        let mut resume_at = None;
+        for (uuid, peek) in rest.into_iter().chain(wrapped) {
+            // Peeks reached after the budget is spent still get their frontiers
+            // checked, they just don't get to scan. Remember the first of them
+            // so the next activation starts there.
+            if resume_at.is_none() && activation.is_spent() {
+                resume_at = Some(uuid);
+            }
+
+            let mut budget = activation.nest(&per_peek);
+            work_pending |= self.process_peek(&mut upper, &mut budget, peek);
         }
+
+        self.compute_state.peek_resume_at = resume_at.unwrap_or(Uuid::nil());
+
+        work_pending
     }
 
     /// Sends a response for this peek's resolution to the coordinator.
@@ -1318,6 +1403,9 @@ impl PendingPeek {
             peek,
             trace_bundle,
             span: tracing::Span::current(),
+            scan: None,
+            elapsed: Duration::ZERO,
+            seek_fulfillment_time: Duration::ZERO,
         })
     }
 
@@ -1555,6 +1643,13 @@ pub struct IndexPeek {
     trace_bundle: TraceBundle,
     /// The `tracing::Span` tracking this peek's operation
     span: tracing::Span,
+    /// The result scan, created once the trace frontiers allow the read. It
+    /// persists across activations because the scan yields before it is done.
+    scan: Option<PeekScan>,
+    /// Worker time spent on this peek, summed over all activations.
+    elapsed: Duration,
+    /// Time spent inside `seek_fulfillment`, summed over all activations.
+    seek_fulfillment_time: Duration,
 }
 
 /// Histogram metrics for index peek phases.
@@ -1588,11 +1683,52 @@ impl IndexPeek {
         &mut self,
         upper: &mut Antichain<Timestamp>,
         max_result_size: u64,
-        peek_stash_eligible: bool,
-        peek_stash_threshold_bytes: usize,
+        peek_stash_threshold_bytes: Option<usize>,
+        budget: &mut NestedBudget<'_>,
         metrics: &IndexPeekMetrics<'_>,
     ) -> PeekStatus {
         let method_start = Instant::now();
+        let status = self.fulfill(
+            upper,
+            max_result_size,
+            peek_stash_threshold_bytes,
+            budget,
+            metrics,
+        );
+        self.seek_fulfillment_time += method_start.elapsed();
+
+        // The peek can span many activations, so the accumulated time is only
+        // meaningful once it has reached a terminal state.
+        if !matches!(status, PeekStatus::NotReady | PeekStatus::Yielded) {
+            metrics
+                .seek_fulfillment_seconds
+                .observe(self.seek_fulfillment_time.as_secs_f64());
+        }
+
+        status
+    }
+
+    /// Checks the peek's preconditions and advances its scan by one slice.
+    ///
+    /// `max_result_size` and `peek_stash_threshold_bytes` only take effect on
+    /// the activation that creates the scan. The scan captures them, so a
+    /// config change mid-peek does not apply retroactively.
+    fn fulfill(
+        &mut self,
+        upper: &mut Antichain<Timestamp>,
+        max_result_size: u64,
+        peek_stash_threshold_bytes: Option<usize>,
+        budget: &mut NestedBudget<'_>,
+        metrics: &IndexPeekMetrics<'_>,
+    ) -> PeekStatus {
+        // Once the scan exists the frontier requirements have been checked and
+        // the cursor holds the batches it reads, so we go straight back to
+        // scanning.
+        if self.scan.is_some() {
+            return self.step_scan(budget, metrics);
+        }
+
+        let frontier_check_start = Instant::now();
 
         self.trace_bundle.oks_mut().read_upper(upper);
         if upper.less_equal(&self.peek.timestamp) {
@@ -1615,34 +1751,45 @@ impl IndexPeek {
 
         metrics
             .frontier_check_seconds
-            .observe(method_start.elapsed().as_secs_f64());
+            .observe(frontier_check_start.elapsed().as_secs_f64());
 
-        let result = self.collect_finished_data(
-            max_result_size,
-            peek_stash_eligible,
+        if let Some(status) = self.scan_error_trace(metrics) {
+            return status;
+        }
+
+        self.scan = Some(PeekScan::new(
+            &self.peek,
+            self.trace_bundle.oks_mut(),
+            usize::cast_from(max_result_size),
             peek_stash_threshold_bytes,
             metrics,
-        );
+        ));
 
-        metrics
-            .seek_fulfillment_seconds
-            .observe(method_start.elapsed().as_secs_f64());
-
-        result
+        self.step_scan(budget, metrics)
     }
 
-    /// Collects data for a known-complete peek from the ok stream.
-    fn collect_finished_data(
+    /// Advances the result scan by one budgeted slice.
+    fn step_scan(
         &mut self,
-        max_result_size: u64,
-        peek_stash_eligible: bool,
-        peek_stash_threshold_bytes: usize,
+        budget: &mut NestedBudget<'_>,
         metrics: &IndexPeekMetrics<'_>,
     ) -> PeekStatus {
-        let error_scan_start = Instant::now();
+        let scan = self.scan.as_mut().expect("scan exists");
+        match scan.step(budget, metrics) {
+            ScanOutcome::Yielded => PeekStatus::Yielded,
+            ScanOutcome::Complete(response) => PeekStatus::Ready(response),
+            ScanOutcome::UsePeekStash => PeekStatus::UsePeekStash,
+        }
+    }
 
-        // Check if there exist any errors and, if so, return whatever one we
-        // find first.
+    /// Scans the error trace and returns a response if it holds any errors.
+    ///
+    /// NOTE: This scan is not budgeted. It walks every key of the errs trace,
+    /// which in practice holds at most a handful of rows, but a dataflow that
+    /// errors on a large fraction of its input could make it run long.
+    fn scan_error_trace(&mut self, metrics: &IndexPeekMetrics<'_>) -> Option<PeekStatus> {
+        let scan_start = Instant::now();
+
         let (mut cursor, storage) = self.trace_bundle.errs_mut().cursor();
         while cursor.key_valid(&storage) {
             let mut copies = Diff::ZERO;
@@ -1657,174 +1804,25 @@ impl IndexPeek {
                     target = %self.peek.target.id(), diff = %copies, %error,
                     "index peek encountered negative multiplicities in error trace",
                 );
-                return PeekStatus::Ready(PeekResponse::Error(format!(
+                return Some(PeekStatus::Ready(PeekResponse::Error(format!(
                     "Invalid data in source errors, \
                     saw retractions ({}) for row that does not exist: {}",
                     -copies, error,
-                )));
+                ))));
             }
             if copies.is_positive() {
-                return PeekStatus::Ready(PeekResponse::Error(cursor.key(&storage).to_string()));
+                return Some(PeekStatus::Ready(PeekResponse::Error(
+                    cursor.key(&storage).to_string(),
+                )));
             }
             cursor.step_key(&storage);
         }
 
         metrics
             .error_scan_seconds
-            .observe(error_scan_start.elapsed().as_secs_f64());
+            .observe(scan_start.elapsed().as_secs_f64());
 
-        Self::collect_ok_finished_data(
-            &self.peek,
-            self.trace_bundle.oks_mut(),
-            max_result_size,
-            peek_stash_eligible,
-            peek_stash_threshold_bytes,
-            metrics,
-        )
-    }
-
-    /// Collects data for a known-complete peek from the ok stream.
-    fn collect_ok_finished_data<Tr>(
-        peek: &Peek,
-        oks_handle: &mut Tr,
-        max_result_size: u64,
-        peek_stash_eligible: bool,
-        peek_stash_threshold_bytes: usize,
-        metrics: &IndexPeekMetrics<'_>,
-    ) -> PeekStatus
-    where
-        Tr: TraceReader<Batch: Navigable>,
-        for<'a> BatchCursor<Tr>: Cursor<
-                Key<'a>: ExtendDatums + Eq,
-                KeyContainer: BatchContainer<Owned = Row>,
-                Val<'a>: ExtendDatums,
-                TimeGat<'a>: PartialOrder<Timestamp>,
-                DiffGat<'a> = &'a Diff,
-            >,
-    {
-        let max_result_size = usize::cast_from(max_result_size);
-        let count_byte_size = size_of::<NonZeroUsize>();
-
-        // Cursor setup timing
-        let cursor_setup_start = Instant::now();
-
-        // We clone `literal_constraints` here because we don't want to move the constraints
-        // out of the peek struct, and don't want to modify in-place.
-        let mut peek_iterator = peek_result_iterator::PeekResultIterator::new(
-            peek.target.id().clone(),
-            peek.map_filter_project.clone(),
-            peek.timestamp,
-            peek.literal_constraints.clone().as_deref_mut(),
-            oks_handle,
-        );
-
-        metrics
-            .cursor_setup_seconds
-            .observe(cursor_setup_start.elapsed().as_secs_f64());
-
-        // Accumulated `Vec<(row, count)>` results that we are likely to return.
-        let mut results = Vec::new();
-        let mut total_size: usize = 0;
-
-        // When set, a bound on the number of records we need to return.
-        // The requirements on the records are driven by the finishing's
-        // `order_by` field. Further limiting will happen when the results
-        // are collected, so we don't need to have exactly this many results,
-        // just at least those results that would have been returned.
-        let max_results = peek.finishing.num_rows_needed();
-
-        let comparator = RowComparator::new(peek.finishing.order_by.as_slice());
-
-        // Row iteration timing
-        let row_iteration_start = Instant::now();
-        let mut sort_time_accum = Duration::ZERO;
-
-        while let Some(row) = peek_iterator.next() {
-            let row: (Row, _) = match row {
-                Ok(row) => row,
-                Err(err) => return PeekStatus::Ready(PeekResponse::Error(err)),
-            };
-            let (row, copies) = row;
-            let copies: NonZeroUsize = NonZeroUsize::try_from(copies).expect("fits into usize");
-
-            total_size = total_size
-                .saturating_add(row.byte_len())
-                .saturating_add(count_byte_size);
-            if peek_stash_eligible && total_size > peek_stash_threshold_bytes {
-                return PeekStatus::UsePeekStash;
-            }
-            if total_size > max_result_size {
-                return PeekStatus::Ready(PeekResponse::Error(format!(
-                    "result exceeds max size of {}",
-                    ByteSize::b(u64::cast_from(max_result_size))
-                )));
-            }
-
-            results.push((row, copies));
-
-            // If we hold many more than `max_results` records, we can thin down
-            // `results` using `self.finishing.ordering`.
-            if let Some(max_results) = max_results {
-                // We use a threshold twice what we intend, to amortize the work
-                // across all of the insertions. We could tighten this, but it
-                // works for the moment.
-                if results.len() >= 2 * max_results {
-                    if peek.finishing.order_by.is_empty() {
-                        results.truncate(max_results);
-                        metrics
-                            .row_iteration_seconds
-                            .observe(row_iteration_start.elapsed().as_secs_f64());
-                        metrics
-                            .result_sort_seconds
-                            .observe(sort_time_accum.as_secs_f64());
-                        let row_collection_start = Instant::now();
-                        let collection = RowCollection::new(results, &peek.finishing.order_by);
-                        metrics
-                            .row_collection_seconds
-                            .observe(row_collection_start.elapsed().as_secs_f64());
-                        return PeekStatus::Ready(PeekResponse::Rows(vec![collection]));
-                    } else {
-                        // We can sort `results` and then truncate to `max_results`.
-                        // This has an effect similar to a priority queue, without
-                        // its interactive dequeueing properties.
-                        // TODO: Had we left these as `Vec<Datum>` we would avoid
-                        // the unpacking; we should consider doing that, although
-                        // it will require a re-pivot of the code to branch on this
-                        // inner test (as we prefer not to maintain `Vec<Datum>`
-                        // in the other case).
-                        let sort_start = Instant::now();
-                        results.sort_by(|left, right| {
-                            comparator.compare_rows(&left.0, &right.0, || left.0.cmp(&right.0))
-                        });
-                        sort_time_accum += sort_start.elapsed();
-                        let dropped = results.drain(max_results..);
-                        let dropped_size =
-                            dropped
-                                .into_iter()
-                                .fold(0, |acc: usize, (row, _count): (Row, _)| {
-                                    acc.saturating_add(
-                                        row.byte_len().saturating_add(count_byte_size),
-                                    )
-                                });
-                        total_size = total_size.saturating_sub(dropped_size);
-                    }
-                }
-            }
-        }
-
-        metrics
-            .row_iteration_seconds
-            .observe(row_iteration_start.elapsed().as_secs_f64());
-        metrics
-            .result_sort_seconds
-            .observe(sort_time_accum.as_secs_f64());
-
-        let row_collection_start = Instant::now();
-        let collection = RowCollection::new(results, &peek.finishing.order_by);
-        metrics
-            .row_collection_seconds
-            .observe(row_collection_start.elapsed().as_secs_f64());
-        PeekStatus::Ready(PeekResponse::Rows(vec![collection]))
+        None
     }
 }
 
@@ -1834,6 +1832,9 @@ enum PeekStatus {
     /// The frontiers of objects are not yet advanced enough, peek is still
     /// pending.
     NotReady,
+    /// The peek is being served but ran out of budget for this activation. It
+    /// has to be stepped again, and nothing else will wake the worker for it.
+    Yielded,
     /// The result size is above the configured threshold and the peek is
     /// eligible for using the peek result stash.
     UsePeekStash,

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -176,19 +176,63 @@ where
     type Item = Result<(Row, NonZeroI64), String>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let mut fuel = usize::MAX;
+        match self.step(&mut fuel) {
+            Step::Row(row) => Some(row),
+            Step::Done => None,
+            Step::OutOfFuel => unreachable!("stepped with unbounded fuel"),
+        }
+    }
+}
+
+/// The outcome of a single fueled [`PeekResultIterator::step`].
+pub enum Step {
+    /// A result row, or the error that ended the scan.
+    Row(Result<(Row, NonZeroI64), String>),
+    /// The cursor is exhausted. Further steps also return `Done`.
+    Done,
+    /// The fuel ran out before a row was found. The iterator is unchanged
+    /// apart from the cursor positions it consumed, and can be resumed.
+    OutOfFuel,
+}
+
+impl<Tr> PeekResultIterator<Tr>
+where
+    Tr: TraceReader<Batch: Navigable>,
+    for<'a> BatchCursor<Tr>: Cursor<
+            Key<'a>: ExtendDatums + Eq,
+            KeyContainer: BatchContainer<Owned = Row>,
+            Val<'a>: ExtendDatums,
+            TimeGat<'a>: PartialOrder<mz_repr::Timestamp>,
+            DiffGat<'a> = &'a Diff,
+        >,
+{
+    /// Advances the cursor until it produces a row, the cursor is exhausted,
+    /// or `fuel` runs out, whichever comes first. Decrements `fuel` by the
+    /// number of cursor positions visited.
+    ///
+    /// Fuel is charged per cursor position, not per row returned, so a
+    /// selective `map_filter_project` cannot starve the caller of yield
+    /// points. Returning with fuel left over means the cursor is exhausted.
+    pub fn step(&mut self, fuel: &mut usize) -> Step {
         let result = loop {
+            if *fuel == 0 {
+                return Step::OutOfFuel;
+            }
+            *fuel -= 1;
+
             if self.literals_exhausted() {
-                return None;
+                return Step::Done;
             }
 
             if !self.cursor.key_valid(&self.storage) {
-                return None;
+                return Step::Done;
             }
 
             if !self.cursor.val_valid(&self.storage) {
                 let exhausted = self.step_key();
                 if exhausted {
-                    return None;
+                    return Step::Done;
                 }
             }
 
@@ -204,21 +248,9 @@ where
 
         self.cursor.step_val(&self.storage);
 
-        Some(result)
+        Step::Row(result)
     }
-}
 
-impl<Tr> PeekResultIterator<Tr>
-where
-    Tr: TraceReader<Batch: Navigable>,
-    for<'a> BatchCursor<Tr>: Cursor<
-            Key<'a>: ExtendDatums + Eq,
-            KeyContainer: BatchContainer<Owned = Row>,
-            Val<'a>: ExtendDatums,
-            TimeGat<'a>: PartialOrder<mz_repr::Timestamp>,
-            DiffGat<'a> = &'a Diff,
-        >,
-{
     /// Extracts and returns the row currently pointed at by our cursor. Returns
     /// `Ok(None)` if our MapFilterProject evaluates to `None`. Also returns any
     /// errors that arise from evaluating the MapFilterProject.

--- a/src/compute/src/compute_state/peek_scan.rs
+++ b/src/compute/src/compute_state/peek_scan.rs
@@ -1,0 +1,260 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Cooperative accumulation of an index peek's result.
+//!
+//! Walking an arrangement can take arbitrarily long, and the compute worker is
+//! a single thread that also has to schedule dataflows and handle commands. A
+//! [`PeekScan`] therefore does its work in bounded slices: each
+//! [`step`](PeekScan::step) spends at most one [`NestedBudget`] and then hands
+//! the worker back, keeping enough state to resume where it left off.
+//!
+//! The scan owns its cursor, and the cursor owns the batches it reads rather
+//! than borrowing them from the trace. So a scan is self-contained and parking
+//! one between activations is safe.
+
+use std::num::{NonZeroI64, NonZeroUsize};
+use std::time::{Duration, Instant};
+
+use bytesize::ByteSize;
+use mz_compute_client::protocol::command::Peek;
+use mz_compute_client::protocol::response::PeekResponse;
+use mz_expr::row::RowCollection;
+use mz_expr::{ColumnOrder, RowComparator};
+use mz_ore::cast::CastFrom;
+use mz_repr::{Diff, Row, Timestamp};
+
+use crate::arrangement::manager::PaddedTrace;
+use crate::compute_state::IndexPeekMetrics;
+use crate::compute_state::peek_result_iterator::{PeekResultIterator, Step};
+use crate::typedefs::RowRowAgent;
+use crate::yielding::NestedBudget;
+
+/// Per-entry overhead we charge on top of the row itself, matching how the
+/// result is laid out in a [`RowCollection`].
+const COUNT_BYTE_SIZE: usize = size_of::<NonZeroUsize>();
+
+/// The result of one slice of scanning work.
+pub(super) enum ScanOutcome {
+    /// The budget ran out with work remaining. Call [`PeekScan::step`] again.
+    Yielded,
+    /// The scan is finished and this is the peek's response.
+    Complete(PeekResponse),
+    /// The result outgrew what we are willing to send inline. The caller
+    /// should abandon this scan and stash the response instead.
+    UsePeekStash,
+}
+
+/// Why the scan loop stopped.
+enum Stop {
+    /// No further rows are needed. The accumulated results are the answer.
+    Complete,
+    /// The scan ended early with this response.
+    Response(PeekResponse),
+    /// The result outgrew the inline threshold.
+    UsePeekStash,
+}
+
+/// An index peek's result scan, resumable across worker activations.
+pub(super) struct PeekScan {
+    iter: PeekResultIterator<PaddedTrace<RowRowAgent<Timestamp, Diff>>>,
+    /// Rows accumulated so far, periodically thinned down to `max_results`.
+    results: Vec<(Row, NonZeroUsize)>,
+    /// Byte size of `results`, kept in sync as rows are added and thinned out.
+    total_size: usize,
+    /// A bound on the number of records the finishing can need, if it has one.
+    ///
+    /// Further limiting happens once the results are collected, so we don't
+    /// need exactly this many, just at least those that would be returned.
+    max_results: Option<usize>,
+    order_by: Vec<ColumnOrder>,
+    comparator: RowComparator,
+    max_result_size: usize,
+    /// When set, a result that grows past this many bytes goes to the peek
+    /// stash rather than being sent inline.
+    peek_stash_threshold_bytes: Option<usize>,
+    /// Wall time spent scanning, summed over all slices.
+    row_iteration_time: Duration,
+    /// Wall time spent sorting during thinning, summed over all slices.
+    thinning_time: Duration,
+}
+
+impl PeekScan {
+    /// Sets up a scan of `oks` at the peek's timestamp.
+    ///
+    /// The caller must have established that the trace's frontiers permit a
+    /// read at `peek.timestamp`. Taking the cursor fixes what the scan will
+    /// read, so that check has no meaning once the scan exists.
+    pub fn new(
+        peek: &Peek,
+        oks: &mut PaddedTrace<RowRowAgent<Timestamp, Diff>>,
+        max_result_size: usize,
+        peek_stash_threshold_bytes: Option<usize>,
+        metrics: &IndexPeekMetrics<'_>,
+    ) -> Self {
+        let cursor_setup_start = Instant::now();
+
+        // We clone `literal_constraints` here because we don't want to move the
+        // constraints out of the peek struct, and don't want to modify in-place.
+        let iter = PeekResultIterator::new(
+            peek.target.id(),
+            peek.map_filter_project.clone(),
+            peek.timestamp,
+            peek.literal_constraints.clone().as_deref_mut(),
+            oks,
+        );
+
+        metrics
+            .cursor_setup_seconds
+            .observe(cursor_setup_start.elapsed().as_secs_f64());
+
+        Self {
+            iter,
+            results: Vec::new(),
+            total_size: 0,
+            max_results: peek.finishing.num_rows_needed(),
+            order_by: peek.finishing.order_by.clone(),
+            comparator: RowComparator::new(peek.finishing.order_by.clone()),
+            max_result_size,
+            peek_stash_threshold_bytes,
+            row_iteration_time: Duration::ZERO,
+            thinning_time: Duration::ZERO,
+        }
+    }
+
+    /// Performs one slice of scanning work, bounded by `budget`.
+    pub fn step(
+        &mut self,
+        budget: &mut NestedBudget<'_>,
+        metrics: &IndexPeekMetrics<'_>,
+    ) -> ScanOutcome {
+        let slice_start = Instant::now();
+        let stop = self.scan(budget);
+        self.row_iteration_time += slice_start.elapsed();
+
+        let Some(stop) = stop else {
+            return ScanOutcome::Yielded;
+        };
+
+        // The scan is over, so the accumulated timings are final.
+        metrics
+            .row_iteration_seconds
+            .observe(self.row_iteration_time.as_secs_f64());
+        metrics
+            .result_sort_seconds
+            .observe(self.thinning_time.as_secs_f64());
+
+        match stop {
+            Stop::Complete => {
+                let collection_start = Instant::now();
+                let results = std::mem::take(&mut self.results);
+                let collection = RowCollection::new(results, &self.order_by);
+                metrics
+                    .row_collection_seconds
+                    .observe(collection_start.elapsed().as_secs_f64());
+                ScanOutcome::Complete(PeekResponse::Rows(vec![collection]))
+            }
+            Stop::Response(response) => ScanOutcome::Complete(response),
+            Stop::UsePeekStash => ScanOutcome::UsePeekStash,
+        }
+    }
+
+    /// Runs the cursor until the budget is spent, returning `None` in that
+    /// case, or until the scan reaches a terminal state.
+    fn scan(&mut self, budget: &mut NestedBudget<'_>) -> Option<Stop> {
+        loop {
+            if budget.is_spent() {
+                return None;
+            }
+
+            // The iterator charges fuel per cursor position, including
+            // positions its `map_filter_project` rejects, so a selective filter
+            // over a large arrangement still reaches this budget check.
+            let allowance = budget.allowance();
+            let mut fuel = allowance;
+            let step = self.iter.step(&mut fuel);
+            budget.charge(allowance - fuel);
+
+            match step {
+                Step::OutOfFuel => continue,
+                Step::Done => return Some(Stop::Complete),
+                Step::Row(Err(err)) => return Some(Stop::Response(PeekResponse::Error(err))),
+                Step::Row(Ok((row, copies))) => {
+                    if let Some(stop) = self.absorb(row, copies) {
+                        return Some(stop);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Folds one result row into the accumulated results, thinning them down
+    /// if they have outgrown what the finishing can need.
+    fn absorb(&mut self, row: Row, copies: NonZeroI64) -> Option<Stop> {
+        let copies: NonZeroUsize = NonZeroUsize::try_from(copies).expect("fits into usize");
+
+        self.total_size = self
+            .total_size
+            .saturating_add(row.byte_len())
+            .saturating_add(COUNT_BYTE_SIZE);
+
+        if let Some(threshold) = self.peek_stash_threshold_bytes
+            && self.total_size > threshold
+        {
+            return Some(Stop::UsePeekStash);
+        }
+        if self.total_size > self.max_result_size {
+            return Some(Stop::Response(PeekResponse::Error(format!(
+                "result exceeds max size of {}",
+                ByteSize::b(u64::cast_from(self.max_result_size))
+            ))));
+        }
+
+        self.results.push((row, copies));
+
+        let Some(max_results) = self.max_results else {
+            return None;
+        };
+        // We use a threshold twice what we intend, to amortize the work across
+        // all of the insertions. We could tighten this, but it works for the
+        // moment.
+        if self.results.len() < 2 * max_results {
+            return None;
+        }
+
+        if self.order_by.is_empty() {
+            // Any `max_results` rows are as good as any others, so we're done.
+            self.results.truncate(max_results);
+            return Some(Stop::Complete);
+        }
+
+        // Sorting and truncating has an effect similar to a priority queue,
+        // without its interactive dequeueing properties.
+        // TODO: Had we left these as `Vec<Datum>` we would avoid the unpacking.
+        // We should consider doing that, although it will require a re-pivot of
+        // the code to branch on this inner test (as we prefer not to maintain
+        // `Vec<Datum>` in the other case).
+        let sort_start = Instant::now();
+        let comparator = &self.comparator;
+        self.results.sort_by(|left, right| {
+            comparator.compare_rows(&left.0, &right.0, || left.0.cmp(&right.0))
+        });
+        self.thinning_time += sort_start.elapsed();
+
+        let dropped_size = self
+            .results
+            .drain(max_results..)
+            .fold(0usize, |acc, (row, _count)| {
+                acc.saturating_add(row.byte_len().saturating_add(COUNT_BYTE_SIZE))
+            });
+        self.total_size = self.total_size.saturating_sub(dropped_size);
+
+        None
+    }
+}

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -27,3 +27,4 @@ pub mod sink;
 #[cfg(not(feature = "bench"))]
 mod sink;
 mod typedefs;
+mod yielding;

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -11,7 +11,7 @@
 //!
 //! Consult [LinearJoinPlan] documentation for details.
 
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use differential_dataflow::lattice::Lattice;
@@ -42,6 +42,7 @@ use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::render::join::mz_join_core::mz_join_core;
 use crate::typedefs::{RowRowAgent, RowRowEnter};
+use crate::yielding::YieldSpec;
 use mz_row_spine::{RowRowBuilder, RowRowColPagedBuilder, RowRowSpine};
 
 /// Available linear join implementations.
@@ -137,53 +138,6 @@ impl LinearJoinSpec {
                 mz_join_core(arranged1, arranged2, result, yield_fn).as_collection()
             }
         }
-    }
-}
-
-/// Specification of a dataflow operator's yielding behavior.
-#[derive(Clone, Copy)]
-struct YieldSpec {
-    /// Yield after the given amount of work was performed.
-    after_work: Option<usize>,
-    /// Yield after the given amount of time has elapsed.
-    after_time: Option<Duration>,
-}
-
-impl Default for YieldSpec {
-    fn default() -> Self {
-        Self {
-            after_work: Some(1_000_000),
-            after_time: Some(Duration::from_millis(100)),
-        }
-    }
-}
-
-impl YieldSpec {
-    fn try_from_str(s: &str) -> Option<Self> {
-        let mut after_work = None;
-        let mut after_time = None;
-
-        let options = s.split(',').map(|o| o.trim());
-        for option in options {
-            let mut iter = option.split(':').map(|p| p.trim());
-            match std::array::from_fn(|_| iter.next()) {
-                [Some("work"), Some(amount), None] => {
-                    let amount = amount.parse().ok()?;
-                    after_work = Some(amount);
-                }
-                [Some("time"), Some(millis), None] => {
-                    let millis = millis.parse().ok()?;
-                    let duration = Duration::from_millis(millis);
-                    after_time = Some(duration);
-                }
-                _ => return None,
-            }
-        }
-
-        Some(Self {
-            after_work,
-            after_time,
-        })
     }
 }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -376,6 +376,9 @@ impl<'w> Worker<'w> {
         // The last time we did periodic maintenance.
         let mut last_maintenance = Instant::now();
 
+        // Whether a peek yielded with scanning work left to do.
+        let mut peek_work_pending = false;
+
         // Commence normal operation.
         loop {
             // Get the maintenance interval, default to zero if we don't have a compute state.
@@ -407,6 +410,16 @@ impl<'w> Worker<'w> {
                 sleep_duration = Some(next_maintenance.saturating_duration_since(now))
             };
 
+            // A yielded peek is work we owe ourselves, and nothing outside this
+            // loop will activate the worker on its behalf. Parking would stall
+            // it until some unrelated event happens to wake us, so we step
+            // without parking instead.
+            let sleep_duration = if peek_work_pending {
+                Some(Duration::ZERO)
+            } else {
+                sleep_duration
+            };
+
             // Step the timely worker, recording the time taken.
             let timer = self.metrics.timely_step_duration_seconds.start_timer();
             self.timely_worker.step_or_park(sleep_duration);
@@ -414,8 +427,9 @@ impl<'w> Worker<'w> {
 
             self.handle_pending_commands()?;
 
+            peek_work_pending = false;
             if let Some(mut compute_state) = self.activate_compute() {
-                compute_state.process_peeks();
+                peek_work_pending = compute_state.process_peeks();
                 compute_state.process_subscribes();
                 compute_state.process_copy_tos();
             }

--- a/src/compute/src/yielding.rs
+++ b/src/compute/src/yielding.rs
@@ -1,0 +1,274 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Cooperative scheduling of long-running work on a compute worker.
+//!
+//! A compute worker is a single thread that multiplexes dataflow scheduling,
+//! command handling, and peek processing. Any one of those refusing to return
+//! for seconds at a time costs the whole worker its interactivity. Work that
+//! can run long is therefore expected to run in bounded slices: perform a
+//! slice, return, and get called again on the next activation.
+//!
+//! [`YieldSpec`] says how large a slice may be, and [`Budget`] tracks the
+//! remaining allowance within one slice. When several items share an
+//! activation, [`Budget::nest`] gives each one its own allowance inside the
+//! shared one, so that no single item can hog the activation or keep the
+//! others from being reached.
+
+use std::time::{Duration, Instant};
+
+/// Specification of how large a slice of cooperative work may be.
+///
+/// Both bounds are optional and independent. Omitting one disables that
+/// dimension entirely rather than falling back to a default, and omitting both
+/// disables yielding.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct YieldSpec {
+    /// Yield after the given amount of work was performed.
+    pub after_work: Option<usize>,
+    /// Yield after the given amount of time has elapsed.
+    pub after_time: Option<Duration>,
+}
+
+impl Default for YieldSpec {
+    fn default() -> Self {
+        Self {
+            after_work: Some(1_000_000),
+            after_time: Some(Duration::from_millis(100)),
+        }
+    }
+}
+
+impl YieldSpec {
+    /// Parses the dyncfg representation: `work:<amount>`, `time:<millis>`, or
+    /// both separated by a comma. Returns `None` if the string does not parse.
+    pub fn try_from_str(s: &str) -> Option<Self> {
+        let mut after_work = None;
+        let mut after_time = None;
+
+        let options = s.split(',').map(|o| o.trim());
+        for option in options {
+            let mut iter = option.split(':').map(|p| p.trim());
+            match std::array::from_fn(|_| iter.next()) {
+                [Some("work"), Some(amount), None] => {
+                    let amount = amount.parse().ok()?;
+                    after_work = Some(amount);
+                }
+                [Some("time"), Some(millis), None] => {
+                    let millis = millis.parse().ok()?;
+                    let duration = Duration::from_millis(millis);
+                    after_time = Some(duration);
+                }
+                _ => return None,
+            }
+        }
+
+        Some(Self {
+            after_work,
+            after_time,
+        })
+    }
+}
+
+/// The remaining allowance for one slice of cooperative work.
+///
+/// Work is measured in caller-defined units. The caller asks for an
+/// [`allowance`](Budget::allowance), spends up to that much, reports what it
+/// spent with [`charge`](Budget::charge), and yields once the budget
+/// [`is_spent`](Budget::is_spent).
+pub(crate) struct Budget {
+    /// Work units left, `None` when the spec imposes no work bound.
+    work: Option<usize>,
+    deadline: Option<Instant>,
+    /// Work units left until we read the clock again. Reading the clock is
+    /// cheap but not free, and a slice can be tens of millions of units, so we
+    /// only consult the deadline every `CLOCK_INTERVAL` units.
+    until_clock_check: usize,
+    /// Latched once the deadline has passed.
+    expired: bool,
+}
+
+impl Budget {
+    /// Work units charged between clock reads. Small enough that any unit cost
+    /// short of pathological keeps deadline overshoot in the sub-millisecond
+    /// range, large enough that the clock read does not show up in a profile.
+    const CLOCK_INTERVAL: usize = 1024;
+
+    pub fn new(spec: &YieldSpec) -> Self {
+        Self {
+            work: spec.after_work,
+            deadline: spec.after_time.map(|d| Instant::now() + d),
+            until_clock_check: Self::CLOCK_INTERVAL,
+            expired: false,
+        }
+    }
+
+    /// How much work the caller may perform before it must call
+    /// [`charge`](Budget::charge) again.
+    ///
+    /// Guaranteed to be non-zero while the budget is not spent, so a caller
+    /// that loops on `!is_spent()` always makes progress.
+    pub fn allowance(&self) -> usize {
+        match self.work {
+            Some(work) => work.min(self.until_clock_check),
+            None => self.until_clock_check,
+        }
+    }
+
+    /// Charges `units` of performed work against the budget.
+    pub fn charge(&mut self, units: usize) {
+        if let Some(work) = &mut self.work {
+            *work = work.saturating_sub(units);
+        }
+        self.until_clock_check = self.until_clock_check.saturating_sub(units);
+
+        if self.until_clock_check == 0 {
+            self.until_clock_check = Self::CLOCK_INTERVAL;
+            if let Some(deadline) = self.deadline {
+                self.expired = Instant::now() >= deadline;
+            }
+        }
+    }
+
+    /// Whether the allowance is used up and the caller should yield.
+    pub fn is_spent(&self) -> bool {
+        self.work == Some(0) || self.expired
+    }
+
+    /// Carves a per-item allowance out of this budget.
+    pub fn nest(&mut self, spec: &YieldSpec) -> NestedBudget<'_> {
+        NestedBudget {
+            own: Budget::new(spec),
+            shared: self,
+        }
+    }
+}
+
+/// A per-item allowance nested inside one shared by all items.
+///
+/// Work charged here is charged against both, and the pair is spent as soon as
+/// either bound is reached. So an item yields once it has had its turn, and
+/// the shared bound still caps what all items together may spend.
+pub(crate) struct NestedBudget<'a> {
+    own: Budget,
+    shared: &'a mut Budget,
+}
+
+impl NestedBudget<'_> {
+    /// See [`Budget::allowance`].
+    pub fn allowance(&self) -> usize {
+        self.own.allowance().min(self.shared.allowance())
+    }
+
+    /// See [`Budget::charge`].
+    pub fn charge(&mut self, units: usize) {
+        self.own.charge(units);
+        self.shared.charge(units);
+    }
+
+    /// See [`Budget::is_spent`].
+    pub fn is_spent(&self) -> bool {
+        self.own.is_spent() || self.shared.is_spent()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn parses_yield_spec() {
+        let spec = YieldSpec::try_from_str("work:100,time:5").unwrap();
+        assert_eq!(spec.after_work, Some(100));
+        assert_eq!(spec.after_time, Some(Duration::from_millis(5)));
+
+        let spec = YieldSpec::try_from_str("work:100").unwrap();
+        assert_eq!(spec.after_work, Some(100));
+        assert_eq!(spec.after_time, None);
+
+        let spec = YieldSpec::try_from_str("time:5").unwrap();
+        assert_eq!(spec.after_work, None);
+        assert_eq!(spec.after_time, Some(Duration::from_millis(5)));
+
+        assert!(YieldSpec::try_from_str("work:banana").is_none());
+        assert!(YieldSpec::try_from_str("fuel:100").is_none());
+    }
+
+    #[mz_ore::test]
+    fn budget_allowance_is_never_zero_before_spent() {
+        let spec = YieldSpec {
+            after_work: Some(3 * Budget::CLOCK_INTERVAL),
+            after_time: None,
+        };
+        let mut budget = Budget::new(&spec);
+
+        let mut spent = 0;
+        while !budget.is_spent() {
+            let allowance = budget.allowance();
+            assert!(allowance > 0);
+            budget.charge(allowance);
+            spent += allowance;
+        }
+        assert_eq!(spent, 3 * Budget::CLOCK_INTERVAL);
+    }
+
+    #[mz_ore::test]
+    fn nested_budget_is_bounded_by_both() {
+        let own = YieldSpec {
+            after_work: Some(Budget::CLOCK_INTERVAL),
+            after_time: None,
+        };
+        let shared_spec = YieldSpec {
+            after_work: Some(3 * Budget::CLOCK_INTERVAL),
+            after_time: None,
+        };
+
+        // The shared budget covers three turns of the per-item budget.
+        let mut shared = Budget::new(&shared_spec);
+        for _ in 0..3 {
+            let mut nested = shared.nest(&own);
+            let mut spent = 0;
+            while !nested.is_spent() {
+                let allowance = nested.allowance();
+                assert!(allowance > 0);
+                nested.charge(allowance);
+                spent += allowance;
+            }
+            assert_eq!(spent, Budget::CLOCK_INTERVAL);
+        }
+
+        assert!(shared.is_spent());
+        assert!(shared.nest(&own).is_spent());
+    }
+
+    #[mz_ore::test]
+    fn budget_expires_on_deadline() {
+        let spec = YieldSpec {
+            after_work: None,
+            after_time: Some(Duration::ZERO),
+        };
+        let mut budget = Budget::new(&spec);
+
+        // The deadline is only consulted once a full clock interval is charged.
+        assert!(!budget.is_spent());
+        budget.charge(Budget::CLOCK_INTERVAL);
+        assert!(budget.is_spent());
+    }
+
+    #[mz_ore::test]
+    fn unbounded_budget_never_spends() {
+        let spec = YieldSpec {
+            after_work: None,
+            after_time: None,
+        };
+        let mut budget = Budget::new(&spec);
+        budget.charge(usize::MAX);
+        assert!(!budget.is_spent());
+    }
+}


### PR DESCRIPTION
### Motivation

Part 1 of 2 in a stack that makes index peeks stop monopolizing the compute
worker.

Serving a ready index peek walked the whole arrangement cursor in one call.
The compute worker is a single thread, so for a large arrangement that pins it
for the full duration of the scan: dataflows aren't scheduled, commands aren't
handled, and the peek can't even observe its own cancellation.

Part of [CPU-195](https://linear.app/materializeinc/issue/CPU-195).

### Description

A peek now scans in bounded slices. `PeekScan` owns the cursor, the rows
collected so far, and the size accounting, and its `step` spends one budget
before handing the worker back. The cursor owns the batches it reads rather
than borrowing them from the trace, so a scan is self-contained and parking one
between activations is safe. This is the same shape the peek stash path already
uses to pump rows across ticks.

Fuel is charged per cursor position, not per row returned. Counting rows would
let a selective `map_filter_project` over a large arrangement run arbitrarily
long without ever reaching a yield point, which is exactly the case we care
about.

Budgets nest. Each peek gets its own turn (`peek_yielding`), bounded by what
all peeks together may spend in one activation (`peek_yielding_total`). Peeks
that don't get a turn are served first on the next activation, so a long peek
can't starve the ones behind it.

A yielded peek is work the worker owes itself, so `run_client` doesn't park
while any peek has work left. That is also why `handle_peek` no longer serves
the peek inline: `process_peeks` runs later in the same loop iteration, so
latency is unchanged, and routing everything through there means a burst of
peeks shares one budget instead of each getting a full one.

Cancellation of a long scan now actually works. Previously the worker could not
observe a `CancelPeek` while it was inside the scan.

`YieldSpec` moves out of the linear join into `crate::yielding` so both callers
share one policy type and config format. That move is pure, the linear join
behaves the same.

Peek timings now accumulate across activations and are reported once the peek
is done. Reporting per activation would turn one slow peek into a string of
fast ones.

The error-trace scan stays unbudgeted. It walks every key of the errs trace,
which in practice holds a handful of rows. There is a `NOTE:` on it.

### Verification

New unit tests in `src/compute/src/yielding.rs` cover the yield-spec parser and
the budget arithmetic: that a nested budget is bounded by both its own and the
shared allowance, that an unbounded budget never spends, and that a budget that
is not yet spent never hands out a zero allowance. That last one would spin the
scan loop, and it caught a real bug while I was writing it.

The coverage that matters is the whole existing suite run with a small budget,
so that nearly every index peek yields and resumes rather than completing in
one slice. `peek_yielding` and `peek_yielding_total` are wired into
`get_variable_system_parameters` with deliberately small CI defaults for that
reason, and into parallel-workload's flag flipping.

Draft: iterating on CI.