### PR TITLE
compute: fix replica crash on a peek with a huge LIMIT

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1768,7 +1768,19 @@ impl IndexPeek {
                 // We use a threshold twice what we intend, to amortize the work
                 // across all of the insertions. We could tighten this, but it
                 // works for the moment.
-                if results.len() >= 2 * max_results {
+                //
+                // `max_results` is `limit + offset`, so a `LIMIT` near
+                // `i64::MAX` makes the doubling overflow. We then hold fewer
+                // rows than the threshold no matter what, and never thin. That
+                // is the right answer: such a peek cannot accumulate that many
+                // rows anyway, the result size limit stops it long before.
+                // Wrapping instead would make the threshold tiny, and we would
+                // thin while holding almost nothing, dropping rows past the end
+                // of the buffer.
+                if max_results
+                    .checked_mul(2)
+                    .is_some_and(|threshold| results.len() >= threshold)
+                {
                     if peek.finishing.order_by.is_empty() {
                         results.truncate(max_results);
                         metrics

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -667,6 +667,11 @@ def compileFastSltConfig() -> SltRunConfig:
         "test/sqllogictest/operator.slt",
         "test/sqllogictest/outer_join.slt",
         "test/sqllogictest/outer_join_simplification.slt",
+        # The huge `LIMIT`s here overflow `limit + offset` inside the
+        # maintained TopK that --auto-index-selects wraps the query in, which
+        # then returns no rows at all. That is a separate bug in a different
+        # operator from the peek result thinning this file covers.
+        "test/sqllogictest/peek_result_thinning.slt",
         "test/sqllogictest/parse_ident.slt",
         "test/sqllogictest/pg_catalog_attribute.slt",
         "test/sqllogictest/pg_catalog_class.slt",
@@ -1092,6 +1097,11 @@ def compileSlowSltConfig() -> SltRunConfig:
         # which no longer holds once --auto-index-selects wraps the SELECT in a
         # view, where a non-constant LIMIT is allowed.
         "test/sqllogictest/limit_expr.slt",
+        # The huge `LIMIT`s here overflow `limit + offset` inside the
+        # maintained TopK that --auto-index-selects wraps the query in, which
+        # then returns no rows at all. That is a separate bug in a different
+        # operator from the peek result thinning this file covers.
+        "test/sqllogictest/peek_result_thinning.slt",
         # The extra statements make it more flaky from timing issues, when expecting a refresh to not yet have happened.
         "test/sqllogictest/materialized_views.slt",
         # Asserts on exact allocated ids to force a replica/item id collision,

--- a/test/sqllogictest/peek_result_thinning.slt
+++ b/test/sqllogictest/peek_result_thinning.slt
@@ -1,0 +1,72 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# ---------------------------------------------------------
+# Thinning of index peek results.
+#
+# While scanning an arrangement, a peek whose finishing bounds how many rows it
+# can need keeps twice that bound and periodically drops the excess. The bound
+# is `limit + offset`, which a `LIMIT` near `i64::MAX` pushes to `2^63`, and
+# doubling that wraps around a `usize`. The doubled value has to be computed
+# without wrapping, or the peek thins when it holds almost nothing: with an
+# `ORDER BY` it drops rows past the end of its buffer and kills the worker,
+# without one it returns a truncated answer.
+#
+# The offsets below are chosen so the wrapped threshold lands within reach of
+# the row count. With `limit = i64::MAX`, doubling `limit + offset` wraps to
+# `2 * offset - 2`, so `OFFSET 1` thins from the very first row and `OFFSET 3`
+# from the fourth.
+# ---------------------------------------------------------
+
+statement ok
+CREATE TABLE t (a int)
+
+statement ok
+INSERT INTO t VALUES (1), (2), (3), (4), (5)
+
+# The peek has to be served from an arrangement to reach the scan at all.
+statement ok
+CREATE DEFAULT INDEX ON t
+
+# Wrapped threshold of 0, so every row looks like an excess row.
+query I
+SELECT a FROM t ORDER BY a LIMIT 9223372036854775807 OFFSET 1
+----
+2
+3
+4
+5
+
+# Same bound with no `ORDER BY`, which takes the other branch of the thinning.
+query I rowsort
+SELECT a FROM t LIMIT 9223372036854775807 OFFSET 1
+----
+2
+3
+4
+5
+
+# Wrapped threshold of 4, so the thinning starts partway through the scan.
+query I
+SELECT a FROM t ORDER BY a LIMIT 9223372036854775807 OFFSET 3
+----
+4
+5
+
+# A bound small enough that thinning genuinely fires, to show it still keeps the
+# right rows: 5 rows held against a bound of 2.
+query I
+SELECT a FROM t ORDER BY a LIMIT 1 OFFSET 1
+----
+2
+
+# The largest offset that is still representable, with no limit to pair it with.
+query I
+SELECT a FROM t ORDER BY a OFFSET 9223372036854775807
+----


### PR DESCRIPTION
### Motivation

Any user who can query an indexed relation can crash a replica, repeatedly, with
one statement:

```sql
SELECT a FROM t ORDER BY a LIMIT 9223372036854775807 OFFSET 1
```

```
thread 'timely:work-0' panicked at library/core/src/slice/index.rs:
range start index 9223372036854775808 out of range for slice of length 1
   9: <Vec<(Row, NonZero<usize>)>>::drain::<RangeFrom<usize>>
  10: <IndexPeek>::collect_ok_finished_data::<...>
```

The coordinator re-issues the peek against the restarted replica, so this is a
crash loop rather than one failed query.

Base of a 3-PR stack, but it stands alone and is worth backporting on its own.
The rest of the stack rewrites these same lines, which is how this surfaced.

Part of [CPU-195](https://linear.app/materializeinc/issue/CPU-195).

### Description

While scanning an arrangement, a peek whose finishing bounds how many rows it
can need keeps twice that bound in hand and periodically drops the excess. The
bound is `limit + offset`. `LIMIT` is a `NonNeg<i64>` and `OFFSET` is validated
as an `i64`, so the sum reaches `2^63`, and doubling it wraps a `usize`:

```
max_results      = 2^63        (i64::MAX limit + offset 1)
2 * max_results  = 0           (wraps)
len >= 0         = true        → thin after the very first row
```

Both branches of the thinning then misbehave:

* With an `ORDER BY`, `results.drain(max_results..)` drains from index `2^63` of
  a one-element buffer. The worker panics and the replica goes down.
* Without one, `results.truncate(max_results)` is a no-op, so there is no panic.
  The peek just returns a wrong, truncated answer. Silent.

Compute the threshold with `checked_mul` and skip thinning when it overflows.
Never thinning is the right answer rather than a fallback: a peek whose bound is
that large cannot accumulate anywhere near that many rows, because the result
size limit stops it long before. So the rows we decline to drop are bounded by
the same limit that already bounds the peek.

Only builds without debug assertions are affected, which is what we ship. Under
`[profile.ci]` the multiplication panics on overflow instead.

The bug dates to #4649 (2020-10-29), so every released version has it.

### Verification

`test/sqllogictest/peek_result_thinning.slt` is new, and reproduces the crash
before the fix. Confirmed both directions against this branch: the replica
panics and `propagate_crashes` aborts the run without the fix, 8/8 pass with it.

The offsets in it are chosen to land the wrapped threshold within reach of the
row count, which is what makes the cases actually reach the thinning. With
`limit = i64::MAX`, doubling `limit + offset` wraps to `2 * offset - 2`, so
`OFFSET 1` thins from the first row and `OFFSET 3` from the fourth. It covers
both branches, a bound small enough that thinning legitimately fires (to show
the right rows still survive), and a bare `OFFSET i64::MAX`.

The file is exempted from `--auto-index-selects` in both SLT configs, which is
where the interesting part is. That mode re-runs each `SELECT` as an indexed view
and compares, and three of these queries disagree when wrapped: the view returns
no rows at all.

That is **a second bug, not this one**. `render/top_k.rs` computes the TopK's
limit as `limit.checked_add(offset)`, and when that overflows it falls back to
building a runtime `AddInt64` of the same two values, which overflows again. So
a maintained `TopK` with a huge `LIMIT` silently yields nothing. Different
operator, different failure mode, and picking the right semantics (saturate
versus error) is a decision worth making on its own rather than inside this fix.
Filed separately.

Worth noting which cases disagree, because it localizes that bug: only the three
with both a huge `LIMIT` and an `OFFSET`. `LIMIT 1 OFFSET 1` and a bare
`OFFSET i64::MAX` both pass wrapped.

