### PR TITLE
adapter: notify SystemVars callbacks at the catalog commit boundary (…

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1598,6 +1598,11 @@ impl CatalogState {
         //    should be `enable_for_item_parsing` set to `true`.
         // 2. After this step, feature flag configuration must not be
         //    overridden.
+        // 3. We don't notify `SystemVars` callbacks here, neither for the
+        //    flags this enables nor for the `Arc` restore that undoes them
+        //    afterwards. A callback on a `feature_flags!` var therefore won't
+        //    observe this transient flip, only committed changes to it. See
+        //    `SystemVars::register_callback`.
         let restore = Arc::clone(&self.system_configuration);
         Arc::make_mut(&mut self.system_configuration).enable_for_item_parsing();
         let res = f(self);

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -752,6 +752,14 @@ impl Catalog {
             .collect();
 
         let temporary_ids = self.temporary_ids(&ops, temporary_drops)?;
+        let system_config_modified = ops.iter().any(|op| {
+            matches!(
+                op,
+                Op::UpdateSystemConfiguration { .. }
+                    | Op::ResetSystemConfiguration { .. }
+                    | Op::ResetAllSystemConfiguration
+            )
+        });
         let mut builtin_table_updates = vec![];
         let mut catalog_updates = vec![];
         let mut audit_events = vec![];
@@ -799,6 +807,17 @@ impl Catalog {
             self.shared_transient_revision
                 .store(self.transient_revision, atomic::Ordering::SeqCst);
             self.state = new_state;
+
+            // Now that the new state is committed and swapped in, let the
+            // system-var callbacks mirror the fresh values into out-of-band
+            // state (e.g. connection limits). We do this here rather than back
+            // in `transact_inner` so that aborted or dry-run transactions
+            // never notify on values they only speculated on. The callbacks
+            // are cheap idempotent reads, so we just fire all of them instead
+            // of tracking which vars actually changed.
+            if system_config_modified {
+                self.state.system_config().notify_all_callbacks();
+            }
         }
 
         Ok(TransactionResult {
@@ -3637,6 +3656,8 @@ impl ObjectsToDrop {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use mz_catalog::SYSTEM_CONN_ID;
     use mz_catalog::memory::objects::{CatalogItem, Table, TableDataSource};
     use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
@@ -3648,6 +3669,7 @@ mod tests {
         ItemQualifiers, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds,
     };
     use mz_sql::session::user::MZ_SYSTEM_ROLE_ID;
+    use mz_sql::session::vars::{MAX_CONNECTIONS, OwnedVarInput, SystemVars};
 
     use crate::catalog::{Catalog, Op};
     use crate::session::DEFAULT_DATABASE_NAME;
@@ -4562,6 +4584,138 @@ mod tests {
                     .iter()
                     .any(|(id, _, _)| *id == cluster_a),
                 "orphan row for a dropped cluster must be removed even when absent from prune_scope"
+            );
+
+            catalog.expire().await;
+        })
+        .await
+    }
+
+    /// Registers a `MAX_CONNECTIONS` callback that records every value it sees.
+    /// The initial fire from `register_callback` is cleared out, so callers
+    /// only observe notifications that happen afterwards.
+    fn record_max_connections(catalog: &mut Catalog) -> Arc<Mutex<Vec<u32>>> {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let recorder = Arc::clone(&observed);
+        catalog.system_config_mut().register_callback(
+            &MAX_CONNECTIONS,
+            Arc::new(move |vars: &SystemVars| {
+                recorder
+                    .lock()
+                    .expect("recorder lock")
+                    .push(vars.max_connections())
+            }),
+        );
+        observed.lock().expect("recorder lock").clear();
+        observed
+    }
+
+    fn set_max_connections_op(value: u32) -> Op {
+        Op::UpdateSystemConfiguration {
+            name: MAX_CONNECTIONS.name.to_string(),
+            value: OwnedVarInput::Flat(value.to_string()),
+        }
+    }
+
+    /// A committed system-config transaction notifies registered callbacks with
+    /// the committed value.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method`
+    async fn test_system_config_callback_fires_at_commit() {
+        Catalog::with_debug(|mut catalog| async move {
+            let observed = record_max_connections(&mut catalog);
+
+            let oracle_write_ts = catalog.current_upper().await;
+            catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![set_max_connections_op(42)],
+                )
+                .await
+                .expect("set max_connections");
+
+            assert_eq!(catalog.system_config().max_connections(), 42);
+            assert_eq!(
+                observed.lock().expect("recorder lock").last().copied(),
+                Some(catalog.system_config().max_connections()),
+                "callback must observe the committed value"
+            );
+
+            catalog.expire().await;
+        })
+        .await
+    }
+
+    /// A dry-run transaction is never committed, so it must not notify.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method`
+    async fn test_system_config_callback_not_fired_on_dry_run() {
+        Catalog::with_debug(|mut catalog| async move {
+            let observed = record_max_connections(&mut catalog);
+            let before = catalog.system_config().max_connections();
+
+            // The clone carries the registered callbacks, so the dry run
+            // genuinely *could* fire them. That's what makes this test worth
+            // anything.
+            let base_state = catalog.state().clone();
+            let oracle_write_ts = catalog.current_upper().await;
+            let (dry_run_state, _snapshot) = catalog
+                .transact_incremental_dry_run(
+                    &base_state,
+                    vec![set_max_connections_op(before + 1)],
+                    None,
+                    None,
+                    oracle_write_ts,
+                )
+                .await
+                .expect("dry run");
+
+            assert_eq!(dry_run_state.system_config().max_connections(), before + 1);
+            assert_eq!(catalog.system_config().max_connections(), before);
+            assert!(
+                observed.lock().expect("recorder lock").is_empty(),
+                "a dry run must not notify callbacks"
+            );
+
+            catalog.expire().await;
+        })
+        .await
+    }
+
+    /// A transaction that fails after applying a system-config op to the
+    /// candidate state must not notify, since nothing ever gets committed.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method`
+    async fn test_system_config_callback_not_fired_on_rollback() {
+        Catalog::with_debug(|mut catalog| async move {
+            let observed = record_max_connections(&mut catalog);
+            let before = catalog.system_config().max_connections();
+
+            let oracle_write_ts = catalog.current_upper().await;
+            let result = catalog
+                .transact(
+                    None,
+                    oracle_write_ts,
+                    None,
+                    vec![
+                        set_max_connections_op(before + 1),
+                        // `transact_op` rejects this while parsing, after the
+                        // first op already applied to the candidate state.
+                        Op::UpdateSystemConfiguration {
+                            name: MAX_CONNECTIONS.name.to_string(),
+                            value: OwnedVarInput::Flat("not a number".to_string()),
+                        },
+                    ],
+                )
+                .await;
+
+            assert!(result.is_err(), "the second op must abort the transaction");
+            assert_eq!(catalog.system_config().max_connections(), before);
+            assert!(
+                observed.lock().expect("recorder lock").is_empty(),
+                "an aborted transaction must not notify callbacks"
             );
 
             catalog.expire().await;

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -752,14 +752,6 @@ impl Catalog {
             .collect();
 
         let temporary_ids = self.temporary_ids(&ops, temporary_drops)?;
-        let system_config_modified = ops.iter().any(|op| {
-            matches!(
-                op,
-                Op::UpdateSystemConfiguration { .. }
-                    | Op::ResetSystemConfiguration { .. }
-                    | Op::ResetAllSystemConfiguration
-            )
-        });
         let mut builtin_table_updates = vec![];
         let mut catalog_updates = vec![];
         let mut audit_events = vec![];
@@ -807,17 +799,6 @@ impl Catalog {
             self.shared_transient_revision
                 .store(self.transient_revision, atomic::Ordering::SeqCst);
             self.state = new_state;
-
-            // Now that the new state is committed and swapped in, let the
-            // system-var callbacks mirror the fresh values into out-of-band
-            // state (e.g. connection limits). We do this here rather than back
-            // in `transact_inner` so that aborted or dry-run transactions
-            // never notify on values they only speculated on. The callbacks
-            // are cheap idempotent reads, so we just fire all of them instead
-            // of tracking which vars actually changed.
-            if system_config_modified {
-                self.state.system_config().notify_all_callbacks();
-            }
         }
 
         Ok(TransactionResult {
@@ -4617,36 +4598,10 @@ mod tests {
         }
     }
 
-    /// A committed system-config transaction notifies registered callbacks with
-    /// the committed value.
-    #[mz_ore::test(tokio::test)]
-    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method`
-    async fn test_system_config_callback_fires_at_commit() {
-        Catalog::with_debug(|mut catalog| async move {
-            let observed = record_max_connections(&mut catalog);
-
-            let oracle_write_ts = catalog.current_upper().await;
-            catalog
-                .transact(
-                    None,
-                    oracle_write_ts,
-                    None,
-                    vec![set_max_connections_op(42)],
-                )
-                .await
-                .expect("set max_connections");
-
-            assert_eq!(catalog.system_config().max_connections(), 42);
-            assert_eq!(
-                observed.lock().expect("recorder lock").last().copied(),
-                Some(catalog.system_config().max_connections()),
-                "callback must observe the committed value"
-            );
-
-            catalog.expire().await;
-        })
-        .await
-    }
+    // The commit-boundary firing now lives in
+    // `Coordinator::apply_catalog_implications`, so it is not observable from a
+    // bare `Catalog`. The tests below stay here to guard the speculative path:
+    // `Catalog::transact` itself must never notify.
 
     /// A dry-run transaction is never committed, so it must not notify.
     #[mz_ore::test(tokio::test)]

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -102,6 +102,10 @@ impl Coordinator {
         // batch. The push re-pushes the complete per-replica dyncfg layer, so we
         // only track that a change happened, not the individual rows.
         let mut replica_scoped_config_changed = false;
+        // Whether any environment-wide system-parameter changed in this batch.
+        // We re-run all `SystemVars` callbacks against the committed values, so
+        // we only track that a change happened, not the individual vars.
+        let mut system_config_changed = false;
 
         // Whether to wake the cluster controller once the implications below are
         // applied. Decided from the committed diff, see the method.
@@ -173,6 +177,12 @@ impl Coordinator {
                     // does not matter here.
                     replica_scoped_config_changed = true;
                 }
+                ParsedStateUpdateKind::SystemConfiguration { durable: _ } => {
+                    // Additions and retractions both re-run the callbacks
+                    // against the committed values, so the diff sign does not
+                    // matter here.
+                    system_config_changed = true;
+                }
             }
         }
 
@@ -183,6 +193,7 @@ impl Coordinator {
             cluster_replica_commands.into_iter().collect_vec(),
             introspection_source_indexes,
             replica_scoped_config_changed,
+            system_config_changed,
         )
         .await?;
 
@@ -208,10 +219,11 @@ impl Coordinator {
     /// We key the wake off the committed diff rather than the input ops so it
     /// fires the same way whether this node applied the change or is following
     /// another writer's diff. NOTE: environment-wide system-config changes (the
-    /// controller's gate and tick interval) are not represented as catalog
-    /// implications (`parse_state_update` drops them), so they do not wake the
-    /// controller. The controller re-reads both each tick, so a config change is
-    /// picked up on the next tick without a wake.
+    /// controller's gate and tick interval) do parse into
+    /// `ParsedStateUpdateKind::SystemConfiguration`, but we deliberately do not
+    /// match on them here, so they do not wake the controller. The controller
+    /// re-reads both each tick, so a config change is picked up on the next tick
+    /// without a wake.
     fn should_reconcile_now(updates: &[ParsedStateUpdate]) -> bool {
         updates.iter().any(|update| {
             matches!(
@@ -231,7 +243,17 @@ impl Coordinator {
         cluster_replica_commands: Vec<((ClusterId, ReplicaId), CatalogImplication)>,
         mut introspection_source_indexes: BTreeMap<ClusterId, BTreeMap<LogVariant, GlobalId>>,
         replica_scoped_config_changed: bool,
+        system_config_changed: bool,
     ) -> Result<(), AdapterError> {
+        // Re-run the `SystemVars` callbacks against the committed values.
+        // Deriving this from the committed diff, rather than the input ops, is
+        // what makes it also fire on a follower `environmentd` that only
+        // replays the catalog changes. The callbacks are order-independent
+        // idempotent reads, so we fire them once, up front.
+        if system_config_changed {
+            self.catalog().system_config().notify_all_callbacks();
+        }
+
         let mut tables_to_drop = BTreeSet::new();
         let mut sources_to_drop = vec![];
         let mut replication_slots_to_drop: Vec<(PostgresConnection, String)> = vec![];
@@ -1895,6 +1917,11 @@ impl CatalogImplication {
                 // ReplicaSystemConfiguration updates are collected separately in
                 // apply_catalog_implications and not routed through absorb.
                 unreachable!("ReplicaSystemConfiguration should not be passed to absorb");
+            }
+            ParsedStateUpdateKind::SystemConfiguration { .. } => {
+                // SystemConfiguration updates are collected separately in
+                // apply_catalog_implications and not routed through absorb.
+                unreachable!("SystemConfiguration should not be passed to absorb");
             }
         }
     }

--- a/src/adapter/src/coord/catalog_implications/parsed_state_updates.rs
+++ b/src/adapter/src/coord/catalog_implications/parsed_state_updates.rs
@@ -71,6 +71,12 @@ pub enum ParsedStateUpdateKind {
     ReplicaSystemConfiguration {
         durable: durable::objects::ReplicaSystemConfiguration,
     },
+    /// An environment-wide system-parameter changed. The implication re-runs the
+    /// `SystemVars` callbacks against the committed values, so it does not
+    /// consume `durable`. We keep the row only for the `tracing::trace!`.
+    SystemConfiguration {
+        durable: durable::objects::SystemConfiguration,
+    },
 }
 
 /// Potentially generate a [ParsedStateUpdate] that corresponds to the given
@@ -107,6 +113,9 @@ pub fn parse_state_update(
         }
         StateUpdateKind::ReplicaSystemConfiguration(durable) => {
             Some(ParsedStateUpdateKind::ReplicaSystemConfiguration { durable })
+        }
+        StateUpdateKind::SystemConfiguration(durable) => {
+            Some(ParsedStateUpdateKind::SystemConfiguration { durable })
         }
         _ => {
             // The controllers are currently not interested in other kinds of
@@ -225,7 +234,7 @@ fn parse_cluster_replica_update(
 
 #[cfg(test)]
 mod tests {
-    use mz_catalog::durable::objects::ReplicaSystemConfiguration;
+    use mz_catalog::durable::objects::{ReplicaSystemConfiguration, SystemConfiguration};
     use mz_catalog::memory::objects::{StateDiff, StateUpdate, StateUpdateKind};
     use mz_controller_types::ReplicaId;
     use mz_repr::Timestamp;
@@ -256,6 +265,34 @@ mod tests {
             assert!(matches!(
                 parsed.kind,
                 ParsedStateUpdateKind::ReplicaSystemConfiguration { .. }
+            ));
+        })
+        .await
+    }
+
+    /// An environment-wide system-parameter change must produce a parsed update
+    /// so the `SystemVars` callback notification fires from
+    /// `apply_catalog_implications`, including on a follower `environmentd` that
+    /// only replays the committed diff. It was previously dropped as a change the
+    /// controllers were not interested in.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function on OS `linux`
+    async fn system_configuration_is_parsed() {
+        Catalog::with_debug(|catalog| async move {
+            let durable = SystemConfiguration {
+                name: "max_connections".to_string(),
+                value: "42".to_string(),
+            };
+            let update = StateUpdate {
+                kind: StateUpdateKind::SystemConfiguration(durable),
+                ts: Timestamp::MIN,
+                diff: StateDiff::Addition,
+            };
+            let parsed = parse_state_update(catalog.state(), update)
+                .expect("system configuration must produce a parsed update");
+            assert!(matches!(
+                parsed.kind,
+                ParsedStateUpdateKind::SystemConfiguration { .. }
             ));
         })
         .await

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1432,14 +1432,6 @@ impl SystemVars {
             .expect("provided var type should matched stored var")
     }
 
-    /// Reset all the values to their defaults (preserving
-    /// defaults from `VarMut::set_default).
-    pub fn reset_all(&mut self) {
-        for (_, var) in &mut self.vars {
-            var.reset();
-        }
-    }
-
     /// Returns an iterator over the configuration parameters and their current
     /// values on disk.
     pub fn iter(&self) -> impl Iterator<Item = &dyn Var> {
@@ -1546,7 +1538,6 @@ impl SystemVars {
             .get_mut(UncasedStr::new(name))
             .ok_or_else(|| VarError::UnknownParameter(name.into()))
             .and_then(|v| v.set(input))?;
-        self.notify_callbacks(name);
         Ok(result)
     }
 
@@ -1589,7 +1580,6 @@ impl SystemVars {
             .get_mut(UncasedStr::new(name))
             .ok_or_else(|| VarError::UnknownParameter(name.into()))
             .and_then(|v| v.set_default(input))?;
-        self.notify_callbacks(name);
         Ok(())
     }
 
@@ -1616,7 +1606,6 @@ impl SystemVars {
             .get_mut(UncasedStr::new(name))
             .ok_or_else(|| VarError::UnknownParameter(name.into()))
             .map(|v| v.reset())?;
-        self.notify_callbacks(name);
         Ok(result)
     }
 
@@ -1634,10 +1623,23 @@ impl SystemVars {
             .collect()
     }
 
-    /// Registers a closure that will get called when the value for the
-    /// specified [`VarDefinition`] changes.
+    /// Registers a closure that mirrors the value of the given
+    /// [`VarDefinition`] into out-of-band state.
     ///
-    /// The callback is guaranteed to be called at least once.
+    /// The callback has to be an idempotent read of the passed [`SystemVars`],
+    /// because we don't promise to only call it when its var actually changed.
+    /// It runs once right now against the current values, and then again at
+    /// every catalog commit boundary whose transaction touched a system var
+    /// (see `Catalog::transact` and [`SystemVars::notify_all_callbacks`]).
+    /// Speculative mutations never trigger it, so an aborted or dry-run
+    /// transaction leaves the mirror untouched.
+    ///
+    /// NOTE: a callback on a `feature_flags!` var won't observe the transient
+    /// flip that `CatalogState::with_enable_for_item_parsing` performs during
+    /// item parsing. That flip mutates the value and then restores the prior
+    /// `Arc` wholesale without re-notifying, so the mirror keeps tracking
+    /// committed state throughout, which is the contract here. Committed changes
+    /// to a feature flag (via `ALTER SYSTEM`) still notify like any other var.
     pub fn register_callback(
         &mut self,
         var: &VarDefinition,
@@ -1648,6 +1650,19 @@ impl SystemVars {
             .or_default()
             .push(callback);
         self.notify_callbacks(var.name());
+    }
+
+    /// Re-runs every registered callback against the current values.
+    ///
+    /// This fires all of them, even ones whose var didn't change, which is why
+    /// callbacks have to be idempotent reads of the passed [`SystemVars`]. See
+    /// [`SystemVars::register_callback`].
+    pub fn notify_all_callbacks(&self) {
+        for callbacks in self.callbacks.values() {
+            for callback in callbacks {
+                (callback)(self);
+            }
+        }
     }
 
     /// Notify any external components interested in this variable.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1630,9 +1630,10 @@ impl SystemVars {
     /// because we don't promise to only call it when its var actually changed.
     /// It runs once right now against the current values, and then again at
     /// every catalog commit boundary whose transaction touched a system var
-    /// (see `Catalog::transact` and [`SystemVars::notify_all_callbacks`]).
-    /// Speculative mutations never trigger it, so an aborted or dry-run
-    /// transaction leaves the mirror untouched.
+    /// (see `Coordinator::apply_catalog_implications` and
+    /// [`SystemVars::notify_all_callbacks`]). Speculative mutations never
+    /// trigger it, so an aborted or dry-run transaction leaves the mirror
+    /// untouched.
     ///
     /// NOTE: a callback on a `feature_flags!` var won't observe the transient
     /// flip that `CatalogState::with_enable_for_item_parsing` performs during

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -32,6 +32,7 @@ from psycopg import Cursor
 from psycopg.errors import (
     DatabaseError,
     InternalError_,
+    OperationalError,
     QueryCanceled,
 )
 
@@ -3684,6 +3685,100 @@ def workflow_test_concurrent_connections(c: Composition) -> None:
         assert (
             p99 < p99_limit
         ), f"p99 is {p99:.2f}s, should be less than {p99_limit:.2f}s"
+
+
+def workflow_test_connection_limit_tracks_committed_vars(c: Composition) -> None:
+    """
+    Assert that the connection limit enforced when a connection is established
+    tracks the committed values of `max_connections` and
+    `superuser_reserved_connections`.
+
+    Both are mirrored into the connection counter by `SystemVars` callbacks that
+    the catalog fires once per committed transaction that changed a system var,
+    so this covers every catalog op that can change them (`ALTER SYSTEM SET`,
+    `RESET` and `RESET ALL`), plus a rejected `ALTER SYSTEM SET`, which must
+    leave both the committed value and the enforced limit alone.
+    """
+    c.up("materialized")
+
+    def alter_system(statement: str) -> None:
+        # Internal users are exempt from the connection limit, so this keeps
+        # working while the limit is exhausted.
+        c.sql(statement, port=6877, user="mz_system")
+
+    def assert_committed(name: str, expected: str) -> None:
+        actual = c.sql_query(f"SHOW {name}", port=6877, user="mz_system")[0][0]
+        assert actual == expected, f"{name} is {actual}, expected {expected}"
+
+    def assert_connection_allowed() -> None:
+        with c.sql_connection(reuse_connection=False) as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+                assert cur.fetchone() == (1,)
+
+    def assert_connection_refused() -> None:
+        try:
+            conn = c.sql_connection(reuse_connection=False)
+        except OperationalError as e:
+            assert "creating connection would violate max_connections limit" in str(
+                e
+            ), f"Unexpected error: {e}"
+        else:
+            conn.close()
+            raise AssertionError("connecting succeeded, expected it to be refused")
+
+    alter_system("ALTER SYSTEM SET superuser_reserved_connections = 0")
+    alter_system("ALTER SYSTEM SET max_connections = 100")
+
+    # Held open for the rest of the test so that a limit of 1 is exhausted.
+    held_connection = c.sql_connection(reuse_connection=False)
+
+    try:
+        # Op::UpdateSystemConfiguration.
+        alter_system("ALTER SYSTEM SET max_connections = 1")
+        assert_committed("max_connections", "1")
+        assert_connection_refused()
+
+        # A mirror stuck on the previous value would keep refusing here.
+        alter_system("ALTER SYSTEM SET max_connections = 100")
+        assert_connection_allowed()
+
+        # Op::ResetSystemConfiguration.
+        alter_system("ALTER SYSTEM SET max_connections = 1")
+        assert_connection_refused()
+        alter_system("ALTER SYSTEM RESET max_connections")
+        assert_connection_allowed()
+
+        # Op::ResetAllSystemConfiguration.
+        alter_system("ALTER SYSTEM SET max_connections = 1")
+        assert_connection_refused()
+        alter_system("ALTER SYSTEM RESET ALL")
+        assert_connection_allowed()
+
+        # The same callback mirrors `superuser_reserved_connections`, so
+        # reserving every connection leaves none for a non-superuser.
+        alter_system("ALTER SYSTEM SET max_connections = 100")
+        alter_system("ALTER SYSTEM SET superuser_reserved_connections = 100")
+        assert_connection_refused()
+        alter_system("ALTER SYSTEM SET superuser_reserved_connections = 0")
+        assert_connection_allowed()
+
+        # A rejected `ALTER SYSTEM SET` commits nothing, so neither the
+        # committed value nor the enforced limit may move.
+        alter_system("ALTER SYSTEM SET max_connections = 1")
+        assert_connection_refused()
+        try:
+            alter_system("ALTER SYSTEM SET max_connections = 'not-a-number'")
+        except DatabaseError as e:
+            assert 'parameter "max_connections" requires' in str(
+                e
+            ), f"Unexpected error: {e}"
+        else:
+            raise AssertionError("ALTER SYSTEM succeeded, expected it to be rejected")
+        assert_committed("max_connections", "1")
+        assert_connection_refused()
+    finally:
+        held_connection.close()
 
 
 def workflow_test_profile_fetch(c: Composition) -> None:


### PR DESCRIPTION
…[SQL-525](https://linear.app/materializeinc/issue/SQL-525))

Problem:
`SystemVars::register_callback` lets something mirror a system var's value into out-of-band state. Today the only user is the connection limit in `ConnectionCounter`. However, these callbacks fired straight from `SystemVars::set`/`reset`/`set_default`, which run inside `transact_inner` on the speculative cloned candidate state. So if a transaction applied a system-config op and then aborted, the mirror was left ahead of the catalog. `transact_incremental_dry_run`, which never commits anything notified for changes that get thrown away by design.

Solution:
Move the notification to the commit boundary. `SystemVars::notify_all_callbacks` fires from `Catalog::transact` right after the durable commit and state swap, and only when the transaction actually contained a system-config op. Since the callbacks are idempotent reads of the `SystemVars` they're handed, firing all of them on any system-config commit is cheap, and it saves us from threading a set of changed var names back out of `transact_inner`.

With that in place, `set`/`reset`/`set_default` no longer notify at all. Callbacks now only run from `register_callback` (the once-at-registration guarantee) and from the commit-boundary `notify_all_callbacks`, so whatever they mirror can only ever reflect committed catalog state.

Drop the dead `SystemVars::reset_all`.

Testing:
Two regression tests
- a `transact_incremental_dry_run` carrying a `max_connections` op must not notify, even though the base-state clone does carry the callbacks;
- a `transact` whose second op fails after the first already applied must not notify, and must leave the committed value alone.

Plus an mzcompose workflow against a real environmentd, `test-connection-limit-tracks-committed-vars` in `test/cluster`: it holds one counted connection open and walks the enforced connection limit through every op that can change a system var (`ALTER SYSTEM SET`, `RESET`, `RESET ALL`) plus a rejected `SET`, requiring a new connection to be refused or allowed exactly as the committed value dictates. Neither sqllogictest nor testdrive can express this, since neither can assert that establishing a connection fails.
