### PR TITLE
CS-697 - apply connection pool size changes without a restart 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,27 +2906,28 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.9.5"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
+ "lazy_static",
  "num_cpus",
- "retain_mut",
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-postgres"
-version = "0.10.3"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e866e414e9e12fc988f0bfb89a0b86228e7ed196ca509fbc4dcbc738c56e753c"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
 dependencies = [
+ "async-trait",
  "deadpool",
- "log",
+ "getrandom 0.2.16",
  "tokio",
  "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]
@@ -5501,11 +5502,11 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -8079,7 +8080,6 @@ name = "mz-postgres-client"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "deadpool",
  "deadpool-postgres",
  "mz-ore",
@@ -11417,12 +11417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
-
-[[package]]
 name = "retry-policies"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12447,9 +12441,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,8 +340,8 @@ ctor = "1.0.10"
 custom-labels = "0.4.6"
 darling = "0.23.0"
 datadriven = "0.9.0"
-deadpool = { version = "0.9.5", default-features = false, features = ["managed"] }
-deadpool-postgres = "0.10.3"
+deadpool = { version = "0.12.3", default-features = false, features = ["managed"] }
+deadpool-postgres = "0.14.1"
 dec = "0.4.9"
 derivative = "2.2.0"
 differential-dataflow = "0.25.0"

--- a/deny.toml
+++ b/deny.toml
@@ -141,8 +141,8 @@ skip = [
     { name = "quick-xml", version = "0.37.5" },
     # aws-lc-rs (via jsonwebtoken 10) and ring pull different `untrusted`.
     { name = "untrusted", version = "0.7.1" },
-    # Held back by lazy_static 1.4.0 (used by num-bigint-dig).
-    { name = "spin", version = "0.5.2" },
+    # Held back by lazy_static 1.5.0 (used by num-bigint-dig, deadpool).
+    { name = "spin", version = "0.9.9" },
     # held back by tower-lsp 0.20 (mz-deploy LSP server)
     { name = "dashmap", version = "5.5.3" },
     { name = "tower", version = "0.4.13" },
@@ -242,6 +242,7 @@ wrappers = [
 [[bans.deny]]
 name = "lazy_static"
 wrappers = [
+    "deadpool",
     "dynfmt",
     "findshlibs",
     "launchdarkly-server-sdk",

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -387,7 +387,8 @@ impl PersistConfig {
 
 /// Sets the maximum size of the connection pool that is used by consensus.
 ///
-/// Requires a restart of the process to take effect.
+/// Applies to existing pools without a restart. Each pool picks up a changed
+/// value the next time a connection is requested from it.
 pub const CONSENSUS_CONNECTION_POOL_MAX_SIZE: Config<usize> = Config::new(
     "persist_consensus_connection_pool_max_size",
     50,

--- a/src/postgres-client/Cargo.toml
+++ b/src/postgres-client/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 deadpool.workspace = true
 deadpool-postgres.workspace = true
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes"] }
@@ -19,6 +18,9 @@ mz-tls-util = { path = "../tls-util" }
 prometheus.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 
 [features]
 default = []

--- a/src/postgres-client/src/lib.rs
+++ b/src/postgres-client/src/lib.rs
@@ -27,8 +27,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use async_trait::async_trait;
-use deadpool::managed::{self, Hook, HookError, HookErrorCause, Object, Pool, RecycleResult};
+use deadpool::managed::{self, Hook, HookError, Metrics, Object, Pool, RecycleResult};
 use deadpool_postgres::tokio_postgres::{self, Config};
 use deadpool_postgres::{
     ClientWrapper as DeadpoolClient, Manager as PgManager, ManagerConfig, PoolError,
@@ -152,7 +151,6 @@ impl std::fmt::Debug for Manager {
     }
 }
 
-#[async_trait]
 impl managed::Manager for Manager {
     type Type = Client;
     type Error = tokio_postgres::Error;
@@ -186,8 +184,12 @@ impl managed::Manager for Manager {
         Ok(Client { inner, isolation })
     }
 
-    async fn recycle(&self, client: &mut Client) -> RecycleResult<tokio_postgres::Error> {
-        self.inner.recycle(&mut client.inner).await
+    async fn recycle(
+        &self,
+        client: &mut Client,
+        metrics: &Metrics,
+    ) -> RecycleResult<tokio_postgres::Error> {
+        self.inner.recycle(&mut client.inner, metrics).await
     }
 
     fn detach(&self, client: &mut Client) {
@@ -238,6 +240,7 @@ impl PostgresClientConfig {
 /// A Postgres client wrapper that uses deadpool as a connection pool.
 pub struct PostgresClient {
     pool: Pool<Manager>,
+    knobs: Arc<dyn PostgresClientKnobs>,
     metrics: PostgresClientMetrics,
 }
 
@@ -285,6 +288,7 @@ impl PostgresClient {
 
         let last_ttl_connection = AtomicU64::new(0);
         let ttl_reconnections = config.metrics.connpool_ttl_reconnections.clone();
+        let knobs = Arc::clone(&config.knobs);
         let builder = Pool::builder(manager);
         let builder = match config.knobs.connection_pool_max_wait() {
             None => builder,
@@ -314,9 +318,9 @@ impl PostgresClient {
                         .is_ok()
                 {
                     ttl_reconnections.inc();
-                    return Err(HookError::Continue(Some(HookErrorCause::Message(
-                        "connection has been TTLed".to_string(),
-                    ))));
+                    // A pre_recycle error discards this connection and the
+                    // acquire proceeds with another (or a fresh) one.
+                    return Err(HookError::message("connection has been TTLed"));
                 }
 
                 Ok(())
@@ -326,6 +330,7 @@ impl PostgresClient {
 
         Ok(PostgresClient {
             pool,
+            knobs,
             metrics: config.metrics,
         })
     }
@@ -338,11 +343,27 @@ impl PostgresClient {
         // Don't bother reporting the maximum size of the pool... we know that from config.
     }
 
+    /// The current [`Status`] of the connection pool.
+    ///
+    /// NOTE: this briefly locks the pool.
+    pub fn status(&self) -> Status {
+        self.pool.status()
+    }
+
     /// Gets connection from the pool or waits for one to become available.
     pub async fn get_connection(&self) -> Result<Connection, PoolError> {
         let start = Instant::now();
-        // note that getting the pool size here requires briefly locking the pool
-        self.status_metrics(self.pool.status());
+        // note that getting the pool status here requires briefly locking the pool
+        let status = self.pool.status();
+        // Apply knob changes to the pool cap without a restart, so an operator
+        // can grow (or shrink) the pool during an incident or ahead of planned
+        // CRDB maintenance. Shrinking is graceful: deadpool drops surplus
+        // connections as they are returned.
+        let max_size = self.knobs.connection_pool_max_size();
+        if status.max_size != max_size {
+            self.pool.resize(max_size);
+        }
+        self.status_metrics(status);
         let res = self.pool.get().await;
         if let Err(PoolError::Backend(err)) = &res {
             debug!("error establishing connection: {}", err);
@@ -354,5 +375,93 @@ impl PostgresClient {
         self.metrics.connpool_acquires.inc();
         self.status_metrics(self.pool.status());
         res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::atomic::AtomicUsize;
+
+    use mz_ore::metrics::MetricsRegistry;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestKnobs {
+        max_size: AtomicUsize,
+    }
+
+    impl PostgresClientKnobs for TestKnobs {
+        fn connection_pool_max_size(&self) -> usize {
+            self.max_size.load(Ordering::SeqCst)
+        }
+        fn connection_pool_max_wait(&self) -> Option<Duration> {
+            Some(Duration::from_secs(1))
+        }
+        fn connection_pool_ttl(&self) -> Duration {
+            Duration::MAX
+        }
+        fn connection_pool_ttl_stagger(&self) -> Duration {
+            Duration::MAX
+        }
+        fn connect_timeout(&self) -> Duration {
+            Duration::from_secs(5)
+        }
+        fn tcp_user_timeout(&self) -> Duration {
+            Duration::ZERO
+        }
+        fn keepalives_idle(&self) -> Duration {
+            Duration::from_secs(10)
+        }
+        fn keepalives_interval(&self) -> Duration {
+            Duration::from_secs(5)
+        }
+        fn keepalives_retries(&self) -> u32 {
+            5
+        }
+        fn statement_timeout(&self) -> Duration {
+            Duration::ZERO
+        }
+    }
+
+    /// Verifies that a changed `connection_pool_max_size` knob is applied to a
+    /// live pool on the next acquire, without reopening the client.
+    ///
+    /// Requires a running Postgres/CRDB, opted into via the same environment
+    /// variable as the persist external-storage tests. No-op otherwise so
+    /// `cargo test` works on unconfigured environments.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    async fn pool_resize_applies_on_acquire() {
+        let url = match std::env::var("MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL") {
+            Ok(url) => SensitiveUrl::from_str(&url).expect("valid url"),
+            Err(_) => return,
+        };
+        let knobs = Arc::new(TestKnobs {
+            max_size: AtomicUsize::new(2),
+        });
+        let dyn_knobs: Arc<dyn PostgresClientKnobs> = Arc::<TestKnobs>::clone(&knobs);
+        let config = PostgresClientConfig::new(
+            url,
+            dyn_knobs,
+            PostgresClientMetrics::new(&MetricsRegistry::new(), "mz_postgres_client_test"),
+        );
+        let client = PostgresClient::open(config).expect("open client");
+
+        let conn = client.get_connection().await.expect("connection");
+        assert_eq!(client.status().max_size, 2);
+
+        // Growing applies on the next acquire.
+        knobs.max_size.store(5, Ordering::SeqCst);
+        let conn2 = client.get_connection().await.expect("connection");
+        assert_eq!(client.status().max_size, 5);
+
+        // Shrinking applies too. Surplus connections are dropped as they are
+        // returned to the pool.
+        knobs.max_size.store(1, Ordering::SeqCst);
+        drop(conn);
+        drop(conn2);
+        let _conn3 = client.get_connection().await.expect("connection");
+        assert_eq!(client.status().max_size, 1);
     }
 }


### PR DESCRIPTION
### Motivation

During a recent CockroachDB rolling upgrade we observed persist consensus connection pools exhausting on every node drain: each drain force-closes its share of pooled connections, deadpool silently discards them on recycle, and acquires queue while the pool re-creates connections on demand. On the busiest environments the acquire queue reached thousands of waiters, stalling every persist operation on that process and degrading freshness.

The pool cap (`persist_consensus_connection_pool_max_size`, `pg_timestamp_oracle_connection_pool_max_size`) is the natural operational lever here, but it was read once at pool construction and required a process restart to change. This PR makes it apply to live pools, so it can be raised (or lowered) fleet-wide via dyncfg ahead of planned CRDB maintenance or during an incident.

### Changes

* Upgrade `deadpool` 0.9.5 → 0.12.3 and `deadpool-postgres` 0.10.3 → 0.14.1 to get `Pool::resize`. API migration: `Manager` is natively async, `recycle` takes a `Metrics` argument, `pre_recycle` hook errors use `HookError::message`. TTL-culling semantics are unchanged.
* `PostgresClient::get_connection` now compares the knob against the pool's current `max_size` and calls `Pool::resize` on mismatch, so both consensus and timestamp oracle pools pick up knob changes on the next acquire. Both knob implementations already read live values (dyncfg / atomics), so no plumbing changes were needed there.
* **Monitoring behavior change**: with deadpool ≥ 0.10, `*_postgres_connpool_available` is a non-negative idle count. Acquires queued on an exhausted pool were previously visible as negative `available`; dashboards/alerts keying on negative `available` will no longer fire.
* `deny.toml`: deadpool 0.12 requires `lazy_static` 1.5, so add it as a wrapper for the `lazy_static` ban and move the duplicate-`spin` skip from 0.5.2 to 0.9.9.

### Tests

* New `pool_resize_applies_on_acquire` test in `mz-postgres-client` verifying grow and shrink both apply on acquire, opted in via `MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL` like the persist external-storage tests.
* Existing `mz-persist` consensus and `mz-timestamp-oracle` tests pass.
* Noticed while validating (pre-existing on main, unrelated to this change): `postgres::tests::postgres_consensus` fails when `MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL` points at a CockroachDB backend, because the read-committed re-run trips the `get_connection` serializable assertion that refuses READ COMMITTED on CRDB. The test comment expects the flag to be a no-op on CRDB, but the isolation resolver follows the flag unconditionally. Will file separately.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
