### PR TITLE
adapter: don't append table writes a concurrent ALTER TABLE made stale

### DIFF
--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -901,12 +901,13 @@ READ_THEN_WRITE_COUNTER_NAME = "materialize.public.pw_rtw_counter"
 
 # Error texts that prove an increment did not land.
 #
-# A concurrently modified dependency is what the coordinator reports when it
-# revalidates a plan before sequencing it, which is before any write. The other
-# is a cluster-resolution failure during planning, which the workload provokes
-# on purpose by pointing the default cluster at a nonexistent one, so the
-# statement never reaches a write path at all. The trailing quote keeps it from
-# matching "unknown cluster replica size" errors.
+# A concurrently modified dependency comes from two places: the coordinator
+# revalidating a plan before it sequences it, and group commit rejecting a staged
+# write that a concurrent ALTER TABLE made stale. Neither one appends anything.
+# The other error is a cluster-resolution failure during planning, which the
+# workload provokes on purpose by pointing the default cluster at a nonexistent
+# one, so the statement never reaches a write path at all. The trailing quote
+# keeps it from matching "unknown cluster replica size" errors.
 #
 # Every other failure counts as unknown, a statement timeout and a cancellation
 # included, because either can race a commit that did happen. A wrong entry here

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -901,13 +901,14 @@ READ_THEN_WRITE_COUNTER_NAME = "materialize.public.pw_rtw_counter"
 
 # Error texts that prove an increment did not land.
 #
-# A concurrently modified dependency comes from two places: the coordinator
-# revalidating a plan before it sequences it, and group commit rejecting a staged
-# write that a concurrent ALTER TABLE made stale. Neither one appends anything.
-# The other error is a cluster-resolution failure during planning, which the
-# workload provokes on purpose by pointing the default cluster at a nonexistent
-# one, so the statement never reaches a write path at all. The trailing quote
-# keeps it from matching "unknown cluster replica size" errors.
+# A concurrently modified dependency is reported when the coordinator rejects a
+# statement whose dependency changed underneath it, before anything is appended:
+# a plan it revalidates before sequencing, or a staged write that group commit
+# drops because a concurrent ALTER TABLE left the rows stale against the table's
+# current schema. The other error is a cluster-resolution failure during planning,
+# which the workload provokes on purpose by pointing the default cluster at a
+# nonexistent one, so the statement never reaches a write path at all. The trailing
+# quote keeps it from matching "unknown cluster replica size" errors.
 #
 # Every other failure counts as unknown, a statement timeout and a cancellation
 # included, because either can race a commit that did happen. A wrong entry here

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -760,11 +760,12 @@ impl Coordinator {
                 } => {
                     assert_none!(write_locks, "should have merged together all locks above");
 
-                    // These rows were packed against the table's RelationDesc as of whenever the
-                    // statement ran, but the append below picks up whatever version is latest
-                    // now. If an ALTER TABLE ... ADD COLUMN snuck in, that descriptor is wider
-                    // than the rows are, and the persist encoder panics on the mismatch rather
-                    // than erroring. Fail the transaction and let the client retry.
+                    // Group commit resolves each write to the table's latest GlobalId and encodes
+                    // the staged rows against that collection's RelationDesc. But the rows were
+                    // packed against whatever descriptor was latest when the statement ran. A
+                    // concurrent ALTER TABLE can move the latest descriptor out from under them, so
+                    // the staged rows no longer match what we are about to encode against. Reject
+                    // the transaction and let the client retry against the current schema.
                     if let Some(id) = Self::stale_write_target(self.catalog(), &writes) {
                         let err = AdapterError::ConcurrentDependencyMutation {
                             dependency_id: id.to_string(),

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -66,7 +66,7 @@ use tracing::{Instrument, Span, info, warn};
 use crate::catalog::{BuiltinTableUpdate, Catalog, CatalogUpperHandle};
 use crate::coord::{Coordinator, Message, PendingTxn, PlanValidity};
 use crate::metrics::Metrics;
-use crate::session::{GroupCommitWriteLocks, Session, WriteLocks};
+use crate::session::{EndTransactionAction, GroupCommitWriteLocks, Session, WriteLocks};
 use crate::statement_logging::StatementLoggingId;
 use crate::util::{CompletedClientTransmitter, ResultExt};
 use crate::{AdapterError, ExecuteContext};
@@ -759,6 +759,26 @@ impl Coordinator {
                         }),
                 } => {
                     assert_none!(write_locks, "should have merged together all locks above");
+
+                    // These rows were packed against the table's RelationDesc as of whenever the
+                    // statement ran, but the append below picks up whatever version is latest
+                    // now. If an ALTER TABLE ... ADD COLUMN snuck in, that descriptor is wider
+                    // than the rows are, and the persist encoder panics on the mismatch rather
+                    // than erroring. Fail the transaction and let the client retry.
+                    if let Some(id) = Self::stale_write_target(self.catalog(), &writes) {
+                        let err = AdapterError::ConcurrentDependencyMutation {
+                            dependency_id: id.to_string(),
+                        };
+                        let (ctx, result) = CompletedClientTransmitter::new(
+                            ctx,
+                            Err(err),
+                            EndTransactionAction::Rollback,
+                        )
+                        .finalize();
+                        ctx.retire(result);
+                        continue;
+                    }
+
                     for (id, table_data) in writes {
                         // If the table that some write was targeting has been deleted while the
                         // write was waiting, then the write will be ignored and we respond to the
@@ -834,6 +854,36 @@ impl Coordinator {
             // Dropping the request retires its clients and notifies its waiters.
             warn!("group committer task gone, dropping staged group commit");
         }
+    }
+
+    /// Returns a table whose staged rows no longer match its latest `RelationDesc`, if any.
+    ///
+    /// Only `TableData::Rows` can go stale, because it gets encoded during the commit itself.
+    /// `TableData::Batches` is already encoded and records its own schema with Persist, which
+    /// migrates older parts on read.
+    ///
+    /// NOTE: We only look at the first row of each `TableData::Rows`. All of its rows come from
+    /// one statement and so share an arity, and checking every row would mean decoding every row
+    /// on the coordinator thread, since a `Row` doesn't carry its arity.
+    fn stale_write_target(
+        catalog: &Catalog,
+        writes: &BTreeMap<CatalogItemId, SmallVec<[TableData; 1]>>,
+    ) -> Option<CatalogItemId> {
+        writes.iter().find_map(|(id, table_data)| {
+            // A write to a dropped table isn't stale, it's dropped. The caller deals with it.
+            let entry = catalog.try_get_entry(id)?;
+            let arity = entry
+                .relation_desc_latest()
+                .expect("write target is a table")
+                .arity();
+            let stale = table_data.iter().any(|data| match data {
+                TableData::Rows(rows) => rows
+                    .first()
+                    .is_some_and(|(row, _)| row.iter().count() != arity),
+                TableData::Batches(_) => false,
+            });
+            stale.then_some(*id)
+        })
     }
 
     /// Registers `tables` in FIFO order and returns the applied timestamp.

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2648,6 +2648,14 @@ impl Coordinator {
                 mz_ore::task::spawn(|| "coord::sequence_inner", async move {
                     let result =
                         Self::insert_constant(&catalog, ctx.session_mut(), plan.id, selection);
+
+                    // Test-only synchronization point: parks a blind INSERT once its rows are
+                    // packed against the table's current RelationDesc, but before retiring
+                    // triggers the implicit commit that stages them for group commit. Lets a
+                    // test land a concurrent ALTER TABLE ... ADD COLUMN in that window. Used by
+                    // test_insert_concurrent_alter_table.
+                    fail::fail_point!("insert_after_pack_before_commit");
+
                     ctx.retire(result);
                 });
             }

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -129,7 +129,9 @@ pub enum AdapterError {
     },
     /// A dependency's definition changed while a statement was being sequenced.
     /// Raised by `PlanValidity::check` when a dependency's `create_sql` hash no
-    /// longer matches what we captured at plan time.
+    /// longer matches what we captured at plan time, and by
+    /// `Coordinator::stage_group_commit` when a table's `RelationDesc` no longer
+    /// matches the rows a staged write packed against it.
     ConcurrentDependencyMutation {
         dependency_id: String,
     },

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -18,7 +18,7 @@
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::net::{Ipv4Addr, SocketAddr};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -1726,6 +1726,89 @@ fn test_subscribe_outlive_cluster() {
             .get::<_, i64>(0),
         0
     );
+}
+
+/// Regression test for SQL-267. A blind INSERT packs its rows against the table's RelationDesc as
+/// of when it ran, but group commit resolves the append to whatever version is latest by the time
+/// it commits. An ALTER TABLE ADD COLUMN landing in between used to leave group commit encoding
+/// those rows against a wider descriptor, which panicked the persist table write worker and took
+/// environmentd down with it.
+///
+/// The window is a cross-thread gap, so the test drives it through the
+/// `insert_after_pack_before_commit` failpoint as a rendezvous: the INSERT blocks there and tells
+/// the test it has arrived, the test widens the table, then the test hands it back. No wall-clock
+/// waiting is involved, so there is no window to miss.
+///
+/// The reported repro widened the same window instead, by getting the INSERT deferred behind a
+/// write lock another session held. Both paths stage the write through `stage_group_commit`, which
+/// is where the check lives.
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_insert_concurrent_alter_table() {
+    let server = test_util::TestHarness::default().start_blocking();
+    server.enable_feature_flags(&["enable_alter_table_add_column"]);
+
+    let mut ddl_client = server.connect(postgres::NoTls).unwrap();
+    ddl_client.batch_execute("CREATE TABLE t (a int)").unwrap();
+    ddl_client
+        .batch_execute("INSERT INTO t VALUES (1)")
+        .unwrap();
+
+    // Arm only once setup is done, so it's the INSERT below that parks and not one of these.
+    let packed = Arc::new(Barrier::new(2));
+    let resume = Arc::new(Barrier::new(2));
+    fail::cfg_callback("insert_after_pack_before_commit", {
+        let packed = Arc::clone(&packed);
+        let resume = Arc::clone(&resume);
+        move || {
+            packed.wait();
+            resume.wait();
+        }
+    })
+    .unwrap();
+
+    let mut writer = server.connect(postgres::NoTls).unwrap();
+    let (writer_tx, writer_rx) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        let _ = writer_tx.send(writer.batch_execute("INSERT INTO t VALUES (100)"));
+    });
+
+    // Returns once the INSERT has packed its rows and reached the failpoint, so the ALTER below
+    // cannot land too early.
+    packed.wait();
+
+    // Widen the table while the INSERT's rows sit packed against the old schema.
+    ddl_client
+        .batch_execute("ALTER TABLE t ADD COLUMN b int")
+        .unwrap();
+
+    // Disarm before handing the INSERT back, so the one at the end of this test doesn't park at a
+    // rendezvous nobody is waiting on.
+    fail::remove("insert_after_pack_before_commit");
+    resume.wait();
+
+    let insert_res = writer_rx
+        .recv_timeout(Duration::from_secs(60))
+        .expect("INSERT finished");
+
+    // The rows were packed against the old schema, so this should come back as a serialization
+    // failure instead of getting appended.
+    let err = insert_res
+        .expect_err("stale write must be rejected")
+        .unwrap_db_error();
+    assert_eq!(err.code(), &SqlState::T_R_SERIALIZATION_FAILURE);
+    assert_contains!(err.message(), "was concurrently modified");
+
+    // The table still works at its new schema, and the rejected row didn't land.
+    let rows = ddl_client
+        .query("SELECT a, b FROM t ORDER BY a", &[])
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get::<_, i32>(0), 1);
+    assert_eq!(rows[0].get::<_, Option<i32>>(1), None);
+    ddl_client
+        .batch_execute("INSERT INTO t VALUES (9, 10)")
+        .unwrap();
 }
 
 #[mz_ore::test]


### PR DESCRIPTION
Problem:

A race between ALTER table and table writes can lead to a panic... details follow...

The cause is that group commit resolves each write's target table to its latest collection and encodes the staged rows against that collection's RelationDesc. But the rows were packed earlier, against whatever version was latest when the statement ran. If an ALTER TABLE ... ADD COLUMN commits in between, the descriptor is wider than the rows are, and RowColumnarEncoder::append trips itertools::zip_eq and panics. That panic happens on the persist table write worker, so it aborts environmentd.

There are two windows where this can happen: (1) A blind INSERT that can't get the table's write lock parks in deferred_write_ops until the lock frees up and deferred plans get a PlanValidity check when they retry, deferred writes get nothing. (2) even with no lock contention at all, insert_constant packs its rows on a spawned task from an owned catalog snapshot, and the response then round-trips to the client before the implicit COMMIT stages the write.

Solution:

Check the staged rows against the descriptor group commit is about to resolve, and fail the transaction if they don't line up. This goes in the per-write loop, which still owns each transaction's ExecuteContext, before the writes get merged together across sessions.

The error is ConcurrentDependencyMutation, which carries a hint telling the client to retry.

TableData::Batches is exempt. It's already encoded and records its own schema with Persist, which migrates older parts on read, so COPY FROM racing an ALTER TABLE is fine.

Testing:

New regression test, test_insert_concurrent_alter_table. It checks that the INSERT comes back as 40001, that the table still works at its new schema, and that the rejected row didn't land.

The window is a cross-thread gap, so the test drives it through a new test-only failpoint, insert_after_pack_before_commit, in the same style as the existing peek_after_register_before_issue and subscribe_before_dispatch. The INSERT blocks there once its rows are packed and signals the test, the test widens the table, then the test hands it back. It's a rendezvous rather than a sleep, so there is no window to miss and nothing to tune.

Fixes [SQL-267](https://linear.app/materializeinc/issue/SQL-267)
