### PR TITLE
persist: pre-warm the consensus connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,27 +2906,28 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.9.5"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
+ "lazy_static",
  "num_cpus",
- "retain_mut",
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-postgres"
-version = "0.10.3"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e866e414e9e12fc988f0bfb89a0b86228e7ed196ca509fbc4dcbc738c56e753c"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
 dependencies = [
+ "async-trait",
  "deadpool",
- "log",
+ "getrandom 0.2.16",
  "tokio",
  "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]
@@ -5501,11 +5502,11 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -8079,7 +8080,6 @@ name = "mz-postgres-client"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "deadpool",
  "deadpool-postgres",
  "mz-ore",
@@ -11417,12 +11417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
-
-[[package]]
 name = "retry-policies"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12447,9 +12441,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spin"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8082,6 +8082,7 @@ dependencies = [
  "anyhow",
  "deadpool",
  "deadpool-postgres",
+ "futures",
  "mz-ore",
  "mz-tls-util",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,8 +340,8 @@ ctor = "1.0.10"
 custom-labels = "0.4.6"
 darling = "0.23.0"
 datadriven = "0.9.0"
-deadpool = { version = "0.9.5", default-features = false, features = ["managed"] }
-deadpool-postgres = "0.10.3"
+deadpool = { version = "0.12.3", default-features = false, features = ["managed"] }
+deadpool-postgres = "0.14.1"
 dec = "0.4.9"
 derivative = "2.2.0"
 differential-dataflow = "0.25.0"

--- a/deny.toml
+++ b/deny.toml
@@ -141,8 +141,8 @@ skip = [
     { name = "quick-xml", version = "0.37.5" },
     # aws-lc-rs (via jsonwebtoken 10) and ring pull different `untrusted`.
     { name = "untrusted", version = "0.7.1" },
-    # Held back by lazy_static 1.4.0 (used by num-bigint-dig).
-    { name = "spin", version = "0.5.2" },
+    # Held back by lazy_static 1.5.0 (used by num-bigint-dig, deadpool).
+    { name = "spin", version = "0.9.9" },
     # held back by tower-lsp 0.20 (mz-deploy LSP server)
     { name = "dashmap", version = "5.5.3" },
     { name = "tower", version = "0.4.13" },
@@ -242,6 +242,7 @@ wrappers = [
 [[bans.deny]]
 name = "lazy_static"
 wrappers = [
+    "deadpool",
     "dynfmt",
     "findshlibs",
     "launchdarkly-server-sdk",

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -29,6 +29,10 @@ metrics:
   help: times a connection was recycled due to ttl
   source: src/postgres-client/src/metrics.rs
   visibility: internal
+- name: '*_postgres_connpool_waiting'
+  help: acquires currently queued waiting for a connection
+  source: src/postgres-client/src/metrics.rs
+  visibility: internal
 - name: '*_request_duration_seconds_bucket'
   help: How long it takes for a request to complete in seconds.
   labels:

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -620,6 +620,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "persist_write_combine_inline_writes",
     "persist_reader_lease_duration",
     "persist_consensus_connection_pool_max_size",
+    "persist_consensus_connection_pool_min_idle",
     "persist_consensus_connection_pool_max_wait",
     "persist_consensus_connection_pool_ttl",
     "persist_consensus_connection_pool_ttl_stagger",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2106,6 +2106,7 @@ class FlipFlagsAction(Action):
             "storage_source_decode_fuel",
             "persist_reader_lease_duration",
             "persist_consensus_connection_pool_max_size",
+            "persist_consensus_connection_pool_min_idle",
             "persist_consensus_connection_pool_max_wait",
             "persist_consensus_connection_pool_ttl",
             "persist_consensus_connection_pool_ttl_stagger",

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -387,7 +387,8 @@ impl PersistConfig {
 
 /// Sets the maximum size of the connection pool that is used by consensus.
 ///
-/// Requires a restart of the process to take effect.
+/// Applies to existing pools without a restart. Each pool picks up a changed
+/// value the next time a connection is requested from it.
 pub const CONSENSUS_CONNECTION_POOL_MAX_SIZE: Config<usize> = Config::new(
     "persist_consensus_connection_pool_max_size",
     50,

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -300,6 +300,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&BLOB_CONNECT_TIMEOUT)
         .add(&BLOB_READ_TIMEOUT)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_MAX_SIZE)
+        .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_MIN_IDLE)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_MAX_WAIT)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL)
@@ -393,6 +394,18 @@ pub const CONSENSUS_CONNECTION_POOL_MAX_SIZE: Config<usize> = Config::new(
     "persist_consensus_connection_pool_max_size",
     50,
     "The maximum size the connection pool to Postgres/CRDB will grow to.",
+);
+
+/// Sets the number of idle connections the consensus pool proactively keeps
+/// ready, so that a burst of demand after connections are lost (e.g. a CRDB
+/// node drain closing its share of the pool) does not pay connection
+/// establishment on the acquire path. Zero disables pre-warming.
+///
+/// Applies to existing pools without a restart.
+pub const CONSENSUS_CONNECTION_POOL_MIN_IDLE: Config<usize> = Config::new(
+    "persist_consensus_connection_pool_min_idle",
+    0,
+    "The number of idle connections the Postgres/CRDB pool proactively maintains.",
 );
 
 /// Sets the maximum amount of time we'll wait to acquire a connection from
@@ -599,6 +612,10 @@ pub const USAGE_STATE_FETCH_CONCURRENCY_LIMIT: Config<usize> = Config::new(
 impl PostgresClientKnobs for PersistConfig {
     fn connection_pool_max_size(&self) -> usize {
         CONSENSUS_CONNECTION_POOL_MAX_SIZE.get(self)
+    }
+
+    fn connection_pool_min_idle(&self) -> usize {
+        CONSENSUS_CONNECTION_POOL_MIN_IDLE.get(self)
     }
 
     fn connection_pool_max_wait(&self) -> Option<Duration> {

--- a/src/postgres-client/Cargo.toml
+++ b/src/postgres-client/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow.workspace = true
 deadpool.workspace = true
 deadpool-postgres.workspace = true
+futures.workspace = true
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes"] }
 mz-tls-util = { path = "../tls-util" }
 prometheus.workspace = true

--- a/src/postgres-client/Cargo.toml
+++ b/src/postgres-client/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 deadpool.workspace = true
 deadpool-postgres.workspace = true
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes"] }
@@ -19,6 +18,9 @@ mz-tls-util = { path = "../tls-util" }
 prometheus.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 
 [features]
 default = []

--- a/src/postgres-client/src/lib.rs
+++ b/src/postgres-client/src/lib.rs
@@ -27,15 +27,17 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use deadpool::managed::{self, Hook, HookError, Metrics, Object, Pool, RecycleResult};
+use deadpool::managed::{self, Hook, HookError, Metrics, Object, Pool, RecycleResult, Timeouts};
 use deadpool_postgres::tokio_postgres::{self, Config};
 use deadpool_postgres::{
     ClientWrapper as DeadpoolClient, Manager as PgManager, ManagerConfig, PoolError,
     RecyclingMethod, Runtime, Status,
 };
+use futures::future::join_all;
 use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::metrics::Counter;
 use mz_ore::now::SYSTEM_TIME;
+use mz_ore::task::AbortOnDropHandle;
 use mz_ore::url::SensitiveUrl;
 use tracing::debug;
 
@@ -67,6 +69,14 @@ pub trait PostgresClientKnobs: std::fmt::Debug + Send + Sync {
     /// Server-side `statement_timeout` to set on each connection. A value of
     /// zero is a sentinel that means "do not set a statement timeout".
     fn statement_timeout(&self) -> Duration;
+    /// Minimum number of idle connections the pool proactively maintains, up
+    /// to `connection_pool_max_size`. Zero disables pre-warming. Keeping a
+    /// floor of ready connections means a burst of demand after connections
+    /// are lost (e.g. a database node drain closing its share of the pool)
+    /// does not pay connection establishment on the acquire path.
+    fn connection_pool_min_idle(&self) -> usize {
+        0
+    }
 }
 
 /// The transaction isolation level applied to new connections.
@@ -242,6 +252,11 @@ pub struct PostgresClient {
     pool: Pool<Manager>,
     knobs: Arc<dyn PostgresClientKnobs>,
     metrics: PostgresClientMetrics,
+    /// Background task that maintains `connection_pool_min_idle` idle
+    /// connections. Spawned lazily on the first acquire (opening a client
+    /// does not require a Tokio runtime, acquiring does). Aborted when the
+    /// client is dropped.
+    prewarm_task: std::sync::OnceLock<AbortOnDropHandle<()>>,
 }
 
 impl std::fmt::Debug for PostgresClient {
@@ -332,7 +347,58 @@ impl PostgresClient {
             pool,
             knobs,
             metrics: config.metrics,
+            prewarm_task: std::sync::OnceLock::new(),
         })
+    }
+
+    /// How often the pre-warm task checks the pool's idle floor.
+    const PREWARM_INTERVAL: Duration = Duration::from_secs(1);
+    /// How long a pre-warm acquire may wait for the pool. Kept short so that
+    /// pre-warming never meaningfully competes with real acquires when the
+    /// pool is saturated.
+    const PREWARM_ACQUIRE_TIMEOUT: Duration = Duration::from_millis(100);
+
+    fn ensure_prewarm_task(&self) {
+        self.prewarm_task.get_or_init(|| {
+            let pool = self.pool.clone();
+            let knobs = Arc::clone(&self.knobs);
+            mz_ore::task::spawn(|| "postgres_client_prewarm", async move {
+                let mut interval = tokio::time::interval(Self::PREWARM_INTERVAL);
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                loop {
+                    interval.tick().await;
+                    Self::prewarm_tick(&pool, &knobs).await;
+                }
+            })
+            .abort_on_drop()
+        });
+    }
+
+    /// Tops the pool up to `connection_pool_min_idle` idle connections by
+    /// briefly holding that many connections at once (forcing creates for the
+    /// shortfall) and returning them all to the pool.
+    async fn prewarm_tick(pool: &Pool<Manager>, knobs: &Arc<dyn PostgresClientKnobs>) {
+        let min_idle = knobs.connection_pool_min_idle();
+        if min_idle == 0 {
+            return;
+        }
+        let status = pool.status();
+        // If acquires are already queued, demand is driving connection
+        // creation and holding extra connections would only deepen the queue.
+        if status.waiting > 0 || status.available >= min_idle {
+            return;
+        }
+        let target = min_idle.min(status.max_size);
+        let timeouts = Timeouts {
+            wait: Some(Self::PREWARM_ACQUIRE_TIMEOUT),
+            ..Timeouts::default()
+        };
+        // Holding all `target` connections simultaneously is what forces the
+        // pool to create the shortfall rather than handing the same idle
+        // connection out repeatedly. Dropping them returns them as idle.
+        let holds = join_all((0..target).map(|_| pool.timeout_get(&timeouts))).await;
+        let created = holds.iter().filter(|r| r.is_ok()).count();
+        debug!("connection pool pre-warm held {created}/{target} connections");
     }
 
     fn status_metrics(&self, status: Status) {
@@ -355,6 +421,7 @@ impl PostgresClient {
 
     /// Gets connection from the pool or waits for one to become available.
     pub async fn get_connection(&self) -> Result<Connection, PoolError> {
+        self.ensure_prewarm_task();
         let start = Instant::now();
         // note that getting the pool status here requires briefly locking the pool
         let status = self.pool.status();
@@ -393,11 +460,15 @@ mod tests {
     #[derive(Debug)]
     struct TestKnobs {
         max_size: AtomicUsize,
+        min_idle: AtomicUsize,
     }
 
     impl PostgresClientKnobs for TestKnobs {
         fn connection_pool_max_size(&self) -> usize {
             self.max_size.load(Ordering::SeqCst)
+        }
+        fn connection_pool_min_idle(&self) -> usize {
+            self.min_idle.load(Ordering::SeqCst)
         }
         fn connection_pool_max_wait(&self) -> Option<Duration> {
             Some(Duration::from_secs(1))
@@ -442,6 +513,7 @@ mod tests {
         };
         let knobs = Arc::new(TestKnobs {
             max_size: AtomicUsize::new(2),
+            min_idle: AtomicUsize::new(0),
         });
         let dyn_knobs: Arc<dyn PostgresClientKnobs> = Arc::<TestKnobs>::clone(&knobs);
         let config = PostgresClientConfig::new(
@@ -466,5 +538,44 @@ mod tests {
         drop(conn2);
         let _conn3 = client.get_connection().await.expect("connection");
         assert_eq!(client.status().max_size, 1);
+    }
+
+    /// Verifies that the pre-warm task tops the pool up to
+    /// `connection_pool_min_idle` idle connections without any acquire
+    /// traffic. Opt-in like `pool_resize_applies_on_acquire`.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    async fn pool_prewarm_maintains_idle_floor() {
+        let url = match std::env::var("MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL") {
+            Ok(url) => SensitiveUrl::from_str(&url).expect("valid url"),
+            Err(_) => return,
+        };
+        let knobs = Arc::new(TestKnobs {
+            max_size: AtomicUsize::new(5),
+            min_idle: AtomicUsize::new(3),
+        });
+        let dyn_knobs: Arc<dyn PostgresClientKnobs> = Arc::<TestKnobs>::clone(&knobs);
+        let config = PostgresClientConfig::new(
+            url,
+            dyn_knobs,
+            PostgresClientMetrics::new(&MetricsRegistry::new(), "mz_postgres_client_test"),
+        );
+        let client = PostgresClient::open(config).expect("open client");
+
+        // The pre-warm task starts on the first acquire. Drop the connection
+        // immediately, then wait for the task to build the idle floor.
+        drop(client.get_connection().await.expect("connection"));
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let status = client.status();
+            if status.available >= 3 {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "pre-warm never reached min_idle=3, status: {status:?}",
+            );
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
     }
 }

--- a/src/postgres-client/src/lib.rs
+++ b/src/postgres-client/src/lib.rs
@@ -27,8 +27,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use async_trait::async_trait;
-use deadpool::managed::{self, Hook, HookError, HookErrorCause, Object, Pool, RecycleResult};
+use deadpool::managed::{self, Hook, HookError, Metrics, Object, Pool, RecycleResult};
 use deadpool_postgres::tokio_postgres::{self, Config};
 use deadpool_postgres::{
     ClientWrapper as DeadpoolClient, Manager as PgManager, ManagerConfig, PoolError,
@@ -152,7 +151,6 @@ impl std::fmt::Debug for Manager {
     }
 }
 
-#[async_trait]
 impl managed::Manager for Manager {
     type Type = Client;
     type Error = tokio_postgres::Error;
@@ -186,8 +184,12 @@ impl managed::Manager for Manager {
         Ok(Client { inner, isolation })
     }
 
-    async fn recycle(&self, client: &mut Client) -> RecycleResult<tokio_postgres::Error> {
-        self.inner.recycle(&mut client.inner).await
+    async fn recycle(
+        &self,
+        client: &mut Client,
+        metrics: &Metrics,
+    ) -> RecycleResult<tokio_postgres::Error> {
+        self.inner.recycle(&mut client.inner, metrics).await
     }
 
     fn detach(&self, client: &mut Client) {
@@ -238,6 +240,7 @@ impl PostgresClientConfig {
 /// A Postgres client wrapper that uses deadpool as a connection pool.
 pub struct PostgresClient {
     pool: Pool<Manager>,
+    knobs: Arc<dyn PostgresClientKnobs>,
     metrics: PostgresClientMetrics,
 }
 
@@ -285,6 +288,7 @@ impl PostgresClient {
 
         let last_ttl_connection = AtomicU64::new(0);
         let ttl_reconnections = config.metrics.connpool_ttl_reconnections.clone();
+        let knobs = Arc::clone(&config.knobs);
         let builder = Pool::builder(manager);
         let builder = match config.knobs.connection_pool_max_wait() {
             None => builder,
@@ -314,9 +318,9 @@ impl PostgresClient {
                         .is_ok()
                 {
                     ttl_reconnections.inc();
-                    return Err(HookError::Continue(Some(HookErrorCause::Message(
-                        "connection has been TTLed".to_string(),
-                    ))));
+                    // A pre_recycle error discards this connection and the
+                    // acquire proceeds with another (or a fresh) one.
+                    return Err(HookError::message("connection has been TTLed"));
                 }
 
                 Ok(())
@@ -326,6 +330,7 @@ impl PostgresClient {
 
         Ok(PostgresClient {
             pool,
+            knobs,
             metrics: config.metrics,
         })
     }
@@ -334,15 +339,34 @@ impl PostgresClient {
         self.metrics
             .connpool_available
             .set(f64::cast_lossy(status.available));
+        self.metrics
+            .connpool_waiting
+            .set(u64::cast_from(status.waiting));
         self.metrics.connpool_size.set(u64::cast_from(status.size));
         // Don't bother reporting the maximum size of the pool... we know that from config.
+    }
+
+    /// The current [`Status`] of the connection pool.
+    ///
+    /// NOTE: this briefly locks the pool.
+    pub fn status(&self) -> Status {
+        self.pool.status()
     }
 
     /// Gets connection from the pool or waits for one to become available.
     pub async fn get_connection(&self) -> Result<Connection, PoolError> {
         let start = Instant::now();
-        // note that getting the pool size here requires briefly locking the pool
-        self.status_metrics(self.pool.status());
+        // note that getting the pool status here requires briefly locking the pool
+        let status = self.pool.status();
+        // Apply knob changes to the pool cap without a restart, so an operator
+        // can grow (or shrink) the pool during an incident or ahead of planned
+        // CRDB maintenance. Shrinking is graceful: deadpool drops surplus
+        // connections as they are returned.
+        let max_size = self.knobs.connection_pool_max_size();
+        if status.max_size != max_size {
+            self.pool.resize(max_size);
+        }
+        self.status_metrics(status);
         let res = self.pool.get().await;
         if let Err(PoolError::Backend(err)) = &res {
             debug!("error establishing connection: {}", err);
@@ -354,5 +378,93 @@ impl PostgresClient {
         self.metrics.connpool_acquires.inc();
         self.status_metrics(self.pool.status());
         res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::atomic::AtomicUsize;
+
+    use mz_ore::metrics::MetricsRegistry;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestKnobs {
+        max_size: AtomicUsize,
+    }
+
+    impl PostgresClientKnobs for TestKnobs {
+        fn connection_pool_max_size(&self) -> usize {
+            self.max_size.load(Ordering::SeqCst)
+        }
+        fn connection_pool_max_wait(&self) -> Option<Duration> {
+            Some(Duration::from_secs(1))
+        }
+        fn connection_pool_ttl(&self) -> Duration {
+            Duration::MAX
+        }
+        fn connection_pool_ttl_stagger(&self) -> Duration {
+            Duration::MAX
+        }
+        fn connect_timeout(&self) -> Duration {
+            Duration::from_secs(5)
+        }
+        fn tcp_user_timeout(&self) -> Duration {
+            Duration::ZERO
+        }
+        fn keepalives_idle(&self) -> Duration {
+            Duration::from_secs(10)
+        }
+        fn keepalives_interval(&self) -> Duration {
+            Duration::from_secs(5)
+        }
+        fn keepalives_retries(&self) -> u32 {
+            5
+        }
+        fn statement_timeout(&self) -> Duration {
+            Duration::ZERO
+        }
+    }
+
+    /// Verifies that a changed `connection_pool_max_size` knob is applied to a
+    /// live pool on the next acquire, without reopening the client.
+    ///
+    /// Requires a running Postgres/CRDB, opted into via the same environment
+    /// variable as the persist external-storage tests. No-op otherwise so
+    /// `cargo test` works on unconfigured environments.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    async fn pool_resize_applies_on_acquire() {
+        let url = match std::env::var("MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL") {
+            Ok(url) => SensitiveUrl::from_str(&url).expect("valid url"),
+            Err(_) => return,
+        };
+        let knobs = Arc::new(TestKnobs {
+            max_size: AtomicUsize::new(2),
+        });
+        let dyn_knobs: Arc<dyn PostgresClientKnobs> = Arc::<TestKnobs>::clone(&knobs);
+        let config = PostgresClientConfig::new(
+            url,
+            dyn_knobs,
+            PostgresClientMetrics::new(&MetricsRegistry::new(), "mz_postgres_client_test"),
+        );
+        let client = PostgresClient::open(config).expect("open client");
+
+        let conn = client.get_connection().await.expect("connection");
+        assert_eq!(client.status().max_size, 2);
+
+        // Growing applies on the next acquire.
+        knobs.max_size.store(5, Ordering::SeqCst);
+        let conn2 = client.get_connection().await.expect("connection");
+        assert_eq!(client.status().max_size, 5);
+
+        // Shrinking applies too. Surplus connections are dropped as they are
+        // returned to the pool.
+        knobs.max_size.store(1, Ordering::SeqCst);
+        drop(conn);
+        drop(conn2);
+        let _conn3 = client.get_connection().await.expect("connection");
+        assert_eq!(client.status().max_size, 1);
     }
 }

--- a/src/postgres-client/src/metrics.rs
+++ b/src/postgres-client/src/metrics.rs
@@ -20,6 +20,7 @@ pub struct PostgresClientMetrics {
     pub(crate) connpool_acquires: IntCounter,
     pub(crate) connpool_acquire_seconds: Counter,
     pub(crate) connpool_available: prometheus::Gauge,
+    pub(crate) connpool_waiting: UIntGauge,
     pub(crate) connpool_connections_created: Counter,
     pub(crate) connpool_connection_errors: Counter,
     pub(crate) connpool_ttl_reconnections: Counter,
@@ -44,6 +45,10 @@ impl PostgresClientMetrics {
             connpool_available: registry.register(metric!(
                 name: format!("{}_postgres_connpool_available", prefix),
                 help: "available connections in the pool",
+            )),
+            connpool_waiting: registry.register(metric!(
+                name: format!("{}_postgres_connpool_waiting", prefix),
+                help: "acquires currently queued waiting for a connection",
             )),
             connpool_connections_created: registry.register(metric!(
                 name: format!("{}_postgres_connpool_connections_created", prefix),

--- a/test/crdb-restarts/haproxy.cfg
+++ b/test/crdb-restarts/haproxy.cfg
@@ -1,0 +1,16 @@
+defaults
+  mode tcp
+  timeout connect 5s
+  timeout client 300s
+  timeout server 300s
+
+frontend crdb
+  bind *:26257
+  default_backend crdb_nodes
+
+backend crdb_nodes
+  balance roundrobin
+  server cockroach0 cockroach0:26257 check
+  server cockroach1 cockroach1:26257 check
+  server cockroach2 cockroach2:26257 check
+  server cockroach3 cockroach3:26257 check

--- a/test/crdb-restarts/mzcompose.py
+++ b/test/crdb-restarts/mzcompose.py
@@ -11,6 +11,9 @@
 Disrupt Cockroach and verify that Materialize recovers from it.
 """
 
+import threading
+import time
+import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass
 from textwrap import dedent
@@ -20,6 +23,7 @@ from materialize.mzcompose.composition import (
     Service,
     WorkflowArgumentParser,
 )
+from materialize.mzcompose.service import Service as ServiceDef
 from materialize.mzcompose.service import ServiceHealthcheck
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.materialized import Materialized
@@ -78,6 +82,19 @@ ALL_COCKROACH_NODES = ",".join(
 
 SERVICES = [
     Testdrive(default_timeout=TESTDRIVE_TIMEOUT, no_reset=True),
+    # TCP round-robin load balancer over the CRDB nodes, standing in for the
+    # cloud load balancer. Connecting through it is what spreads a connection
+    # pool across nodes; connecting to the shared `cockroach` DNS alias does
+    # not (the client picks one resolved address and sticks with it).
+    ServiceDef(
+        name="crdb-lb",
+        config={
+            "image": "haproxy:2.9",
+            "ports": [26257],
+            "volumes": ["./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro"],
+            "networks": {"default": {"aliases": ["crdb-lb"]}},
+        },
+    ),
     Materialized(
         # Consensus runs against CockroachDB here, so
         # `persist_pg_consensus_read_committed` must stay off (the CRDB_*
@@ -162,10 +179,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         run_disruption(c, d)
 
 
-def run_disruption(c: Composition, d: CrdbDisruption) -> None:
-    print(f"--- Running Disruption {d.name} ...")
-    c.down(destroy_volumes=True, sanity_restart_mz=False)
-
+def bootstrap_crdb_cluster(c: Composition) -> None:
     c.up(*[f"cockroach{id}" for id in range(CRDB_NODE_COUNT)])
 
     c.exec("cockroach0", "cockroach", "init", "--insecure", "--host=localhost:26257")
@@ -178,6 +192,13 @@ def run_disruption(c: Composition, d: CrdbDisruption) -> None:
         "CREATE SCHEMA IF NOT EXISTS tsoracle",
     ]:
         c.exec("cockroach0", "cockroach", "sql", "--insecure", "-e", query)
+
+
+def run_disruption(c: Composition, d: CrdbDisruption) -> None:
+    print(f"--- Running Disruption {d.name} ...")
+    c.down(destroy_volumes=True, sanity_restart_mz=False)
+
+    bootstrap_crdb_cluster(c)
 
     c.up("materialized", Service("testdrive", idle=True))
 
@@ -200,3 +221,245 @@ def run_disruption(c: Composition, d: CrdbDisruption) -> None:
 
         # Confirm things continue to work after CRDB is back to full complement
         c.testdrive(input=VALIDATE_SCRIPT)
+
+
+class MetricsScraper(threading.Thread):
+    """Polls environmentd's internal metrics endpoint and records the persist
+    consensus connection pool gauges/counters as (time, name, value) samples."""
+
+    def __init__(self, port: int):
+        super().__init__(daemon=True)
+        self.port = port
+        self.samples: list[tuple[float, str, float]] = []
+        self.stop_event = threading.Event()
+
+    def run(self) -> None:
+        while not self.stop_event.is_set():
+            try:
+                body = (
+                    urllib.request.urlopen(
+                        f"http://localhost:{self.port}/metrics", timeout=2
+                    )
+                    .read()
+                    .decode()
+                )
+                now = time.time()
+                for line in body.splitlines():
+                    if line.startswith("mz_persist_postgres_connpool_"):
+                        name, _, value = line.rpartition(" ")
+                        try:
+                            self.samples.append((now, name, float(value)))
+                        except ValueError:
+                            pass
+            except Exception:
+                # environmentd may be briefly unreachable; keep polling.
+                pass
+            self.stop_event.wait(0.5)
+
+    def series(self, name: str) -> list[tuple[float, float]]:
+        return [(t, v) for (t, n, v) in self.samples if n == name]
+
+
+class InsertLoad(threading.Thread):
+    """Round-robin single-row inserts across the workload tables, each on its
+    own connection, to keep steady write (and thus consensus) traffic going."""
+
+    def __init__(self, port: int, tables: int, thread_id: int, num_threads: int):
+        super().__init__(daemon=True)
+        self.port = port
+        self.tables = tables
+        self.thread_id = thread_id
+        self.num_threads = num_threads
+        self.stop_event = threading.Event()
+        self.errors = 0
+        self.inserts = 0
+
+    def run(self) -> None:
+        import psycopg
+
+        conn = None
+        i = self.thread_id
+        while not self.stop_event.is_set():
+            try:
+                if conn is None:
+                    conn = psycopg.connect(
+                        host="localhost",
+                        port=self.port,
+                        user="materialize",
+                        dbname="materialize",
+                    )
+                    conn.autocommit = True
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"INSERT INTO pool_t{i % self.tables} VALUES (1)".encode()
+                    )
+                self.inserts += 1
+                i += self.num_threads
+            except Exception:
+                self.errors += 1
+                try:
+                    if conn is not None:
+                        conn.close()
+                except Exception:
+                    pass
+                conn = None
+                self.stop_event.wait(0.5)
+
+
+def summarize_window(
+    scraper: MetricsScraper, label: str, start: float, end: float
+) -> dict[str, float]:
+    def window(name: str) -> list[float]:
+        return [v for (t, v) in scraper.series(name) if start <= t <= end]
+
+    def rate(name: str) -> float:
+        pts = [(t, v) for (t, v) in scraper.series(name) if start <= t <= end]
+        if len(pts) < 2 or pts[-1][0] == pts[0][0]:
+            return 0.0
+        return (pts[-1][1] - pts[0][1]) / (pts[-1][0] - pts[0][0])
+
+    waiting = window("mz_persist_postgres_connpool_waiting")
+    summary = {
+        "max_waiting": max(waiting, default=0.0),
+        "created_per_s": rate("mz_persist_postgres_connpool_connections_created"),
+        "acquire_ms_per_acquire": (
+            1000.0
+            * rate("mz_persist_postgres_connpool_acquire_seconds")
+            / max(rate("mz_persist_postgres_connpool_acquires"), 0.001)
+        ),
+    }
+    print(
+        f"--- [{label}] max_waiting={summary['max_waiting']:.0f} "
+        f"created/s={summary['created_per_s']:.2f} "
+        f"mean_acquire_ms={summary['acquire_ms_per_acquire']:.2f}"
+    )
+    return summary
+
+
+def print_session_distribution(c: Composition) -> None:
+    """Show how SQL sessions are spread across CRDB nodes, to confirm the
+    load balancer is distributing the connection pool."""
+    c.exec(
+        "cockroach0",
+        "cockroach",
+        "sql",
+        "--insecure",
+        "-e",
+        "SELECT node_id, count(*) FROM crdb_internal.cluster_sessions GROUP BY 1 ORDER BY 1",
+        check=False,
+    )
+
+
+def workflow_pool_exhaustion(c: Composition, parser: WorkflowArgumentParser) -> None:
+    """Reproduce persist consensus connection pool exhaustion during a CRDB
+    rolling restart, and measure whether pool pre-warming mitigates it.
+
+    Rolls the CRDB cluster node by node (drain, SIGTERM, restart) under a
+    steady multi-table insert load and reports connection pool queueing from
+    environmentd's metrics for each drain window."""
+    parser.add_argument("--tables", type=int, default=256)
+    parser.add_argument("--insert-threads", type=int, default=16)
+    parser.add_argument(
+        "--pool-max-size",
+        type=int,
+        default=20,
+        help="scaled-down consensus pool cap to make exhaustion reachable locally",
+    )
+    parser.add_argument(
+        "--min-idle",
+        type=int,
+        default=0,
+        help="persist consensus pool pre-warm floor (0 = disabled)",
+    )
+    parser.add_argument("--settle-secs", type=int, default=45)
+    args = parser.parse_args()
+
+    c.down(destroy_volumes=True, sanity_restart_mz=False)
+    bootstrap_crdb_cluster(c)
+
+    sysparams = {
+        "persist_consensus_connection_pool_max_size": str(args.pool_max_size),
+        "max_tables": str(args.tables + 100),
+    }
+    if args.min_idle > 0:
+        sysparams["persist_consensus_connection_pool_min_idle"] = str(args.min_idle)
+
+    with c.override(
+        Materialized(
+            metadata_store="cockroach",
+            depends_on=["crdb-lb"]
+            + [f"cockroach{id}" for id in range(CRDB_NODE_COUNT)],
+            options=[
+                "--persist-consensus-url=postgres://root@crdb-lb:26257?options=--search_path=consensus",
+                "--timestamp-oracle-url=postgres://root@crdb-lb:26257?options=--search_path=tsoracle",
+            ],
+            additional_system_parameter_defaults=sysparams,
+        )
+    ):
+        c.up("crdb-lb", "materialized")
+
+        print(f"--- Creating {args.tables} workload tables ...")
+        for i in range(args.tables):
+            c.sql(f"CREATE TABLE pool_t{i} (a int)")
+
+        sql_port = c.default_port("materialized")
+        metrics_port = c.port("materialized", 6878)
+
+        scraper = MetricsScraper(metrics_port)
+        scraper.start()
+        loaders = [
+            InsertLoad(sql_port, args.tables, i, args.insert_threads)
+            for i in range(args.insert_threads)
+        ]
+        for l in loaders:
+            l.start()
+
+        # Let the workload reach steady state and capture a baseline window.
+        time.sleep(args.settle_secs)
+        baseline_end = time.time()
+        summarize_window(
+            scraper, "baseline", baseline_end - args.settle_secs, baseline_end
+        )
+        print_session_distribution(c)
+
+        drain_summaries = []
+        # Node #0 stays untouched (see run_disruption: disrupting it borks the
+        # cluster), matching the production pattern of rolling a subset of
+        # nodes while the LB address keeps resolving.
+        for id in range(1, CRDB_NODE_COUNT):
+            window_start = time.time()
+            print(f"--- Draining and restarting cockroach{id} ...")
+            c.exec(
+                f"cockroach{(id % 2) + 1}",
+                "cockroach",
+                "node",
+                "drain",
+                str(id + 1),
+                "--insecure",
+                check=False,
+            )
+            try:
+                c.kill(f"cockroach{id}", signal="SIGTERM")
+            except UIError:
+                pass
+            c.up(f"cockroach{id}")
+            time.sleep(args.settle_secs)
+            window_end = time.time()
+            drain_summaries.append(
+                summarize_window(
+                    scraper, f"drain-cockroach{id}", window_start, window_end
+                )
+            )
+
+        for l in loaders:
+            l.stop_event.set()
+        scraper.stop_event.set()
+        for l in loaders:
+            l.join(timeout=5)
+        scraper.join(timeout=5)
+
+        total_inserts = sum(l.inserts for l in loaders)
+        total_errors = sum(l.errors for l in loaders)
+        print(f"--- Load summary: {total_inserts} inserts, {total_errors} errors")
+        max_waiting = max(s["max_waiting"] for s in drain_summaries)
+        print(f"--- RESULT: max waiting across drain windows: {max_waiting:.0f}")


### PR DESCRIPTION
### Motivation

Stacked on #38050 (deadpool upgrade, live pool resize, `waiting` gauge) — review that first; this PR's diff includes it until it merges.

During a CRDB rolling upgrade, each node drain closes its share of the persist consensus pool's connections. Deadpool discards them silently on recycle and recreates on demand, so the first burst of acquires after a drain pays TCP+TLS+auth while demand queues behind the pool cap. We observed multi-second acquire stalls and deep waiter queues during a recent production CRDB upgrade.

### Changes

* `connection_pool_min_idle` on `PostgresClientKnobs` (trait default 0), wired to new dyncfg `persist_consensus_connection_pool_min_idle` (default 0 = disabled, applies live).
* Background top-up task in `PostgresClient`: each second, if idle < floor **and no acquires are queued**, briefly hold `min_idle` connections concurrently (forcing creation of the shortfall) and return them all as idle. The waiting-check guard plus a 100ms acquire timeout guarantee it never deepens a queue on a saturated pool. Task spawns lazily on first acquire, aborts on client drop.
* New `pool-exhaustion` workflow in `test/crdb-restarts`: 4-node CRDB behind an haproxy round-robin TCP balancer (a shared DNS alias does *not* spread a pool's connections — the client sticks to one resolved address; the balancer matches cloud LB behavior), multi-table insert load, scripted drain+restart roll, per-drain-window report of queued waiters / connection creation / mean acquire latency from environmentd's metrics.

### Validation

With `--insert-threads 32 --pool-max-size 10` (cap scaled down to make exhaustion locally reachable), max queued waiters per run across three drain windows, steady-state noise ~20–25:

| arm | run 1 | run 2 |
|---|---|---|
| baseline (`min_idle=0`) | **282** | 51 |
| pre-warm (`min_idle=5`) | 28 | 40 |

The baseline tail event (282, >10x noise) did not occur in either pre-warm run. Sample is small and run-to-run variance is high (the tail event hit 1 of 6 baseline drain windows), so this is directional, not conclusive. The harness makes more runs cheap; happy to accumulate samples before undraft.

### Tests

* `pool_prewarm_maintains_idle_floor` in `mz-postgres-client` (opt-in via `MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL`) verifies the idle floor is rebuilt without acquire traffic.
* Knob added to `UNINTERESTING_SYSTEM_PARAMETERS` and the parallel-workload toggle list.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)