### PR TITLE
properly retry when LD client initialization fails

### DIFF
--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -23,9 +23,9 @@ use mz_cluster_client::ReplicaId;
 use mz_controller_types::ClusterId;
 use mz_ore::metrics::UIntGauge;
 use mz_ore::now::NowFn;
+use mz_ore::retry::Retry;
 use mz_sql::catalog::EnvironmentId;
 use serde_json::Value as JsonValue;
-use tokio::time;
 use tracing::warn;
 
 use crate::config::{
@@ -72,9 +72,9 @@ impl SystemParameterFrontendClient {}
 impl SystemParameterFrontend {
     /// Create a new [SystemParameterFrontend] initialize.
     ///
-    /// This will create and initialize an [ld::Client] instance. The
-    /// [ld::Client::wait_for_initialization] call will be attempted in a loop with an
-    /// exponential backoff with power `2s` and max duration `60s`.
+    /// This will create and initialize an [ld::Client] instance. The client
+    /// initialization will be attempted in a loop with an exponential backoff
+    /// with factor 2 and max duration `60s`.
     pub async fn from(sync_config: &SystemParameterSyncConfig) -> Result<Self, anyhow::Error> {
         match &sync_config.backend_config {
             super::SystemParameterSyncClientConfig::File { path } => Ok(Self {
@@ -465,25 +465,35 @@ async fn ld_client(
 ) -> Result<ld::Client, anyhow::Error> {
     let ld_client = ld::Client::build(ld_config(api_key, base_uri, metrics, now_fn))?;
     tracing::info!("waiting for SystemParameterFrontend to initialize");
-    ld_client.start_with_default_executor();
 
-    let max_backoff = Duration::from_secs(60);
-    let mut backoff = Duration::from_secs(5);
-    let timeout = Duration::from_secs(10);
+    let try_init = |_| async {
+        ld_client.start_with_default_executor();
 
-    // TODO(materialize#32030): fix retry logic
-    loop {
-        match ld_client.wait_for_initialization(timeout).await {
-            Some(true) => break,
-            Some(false) => tracing::warn!("SystemParameterFrontend failed to initialize"),
-            None => tracing::warn!("SystemParameterFrontend initialization timed out"),
+        match ld_client
+            .wait_for_initialization(Duration::from_secs(10))
+            .await
+        {
+            Some(true) => {
+                tracing::info!("successfully initialized SystemParameterFrontend");
+                Ok(())
+            }
+            Some(false) => {
+                tracing::warn!("SystemParameterFrontend failed to initialize");
+                Err(())
+            }
+            None => {
+                tracing::warn!("SystemParameterFrontend initialization timed out");
+                Err(())
+            }
         }
+    };
 
-        time::sleep(backoff).await;
-        backoff = (backoff * 2).min(max_backoff);
-    }
-
-    tracing::info!("successfully initialized SystemParameterFrontend");
+    Retry::default()
+        .initial_backoff(Duration::from_secs(5))
+        .clamp_backoff(Duration::from_secs(60))
+        .retry_async(try_init)
+        .await
+        .expect("retries forever");
 
     Ok(ld_client)
 }

--- a/src/dyncfg-launchdarkly/src/lib.rs
+++ b/src/dyncfg-launchdarkly/src/lib.rs
@@ -15,6 +15,7 @@ use launchdarkly_server_sdk as ld;
 use mz_build_info::BuildInfo;
 use mz_dyncfg::{ConfigSet, ConfigUpdates, ConfigVal};
 use mz_ore::cast::CastLossy;
+use mz_ore::retry::Retry;
 use mz_ore::task;
 use tokio::time;
 
@@ -48,6 +49,7 @@ where
     for entry in set.entries() {
         let _ = dyn_into_flag(entry.val())?;
     }
+
     let ld_client = if let Some(key) = launchdarkly_sdk_key {
         // The 300s streaming read timeout must stay above LaunchDarkly's
         // streaming heartbeat interval (roughly 3 minutes per LD's
@@ -77,23 +79,27 @@ where
             .build()
             .expect("valid config");
         let client = ld::Client::build(config)?;
-        client.start_with_default_executor();
+
         let init = async {
-            let max_backoff = Duration::from_secs(60);
-            let mut backoff = Duration::from_secs(5);
+            Retry::default()
+                .initial_backoff(Duration::from_secs(5))
+                .clamp_backoff(Duration::from_secs(60))
+                .retry_async(|_| async {
+                    client.start_with_default_executor();
 
-            // TODO(materialize#32030): fix retry logic
-            loop {
-                match client.wait_for_initialization(config_sync_timeout).await {
-                    Some(true) => break,
-                    Some(false) => tracing::warn!("SyncedConfigSet failed to initialize"),
-                    None => {}
-                }
-
-                tokio::time::sleep(backoff).await;
-                backoff = (backoff * 2).min(max_backoff);
-            }
+                    match client.wait_for_initialization(config_sync_timeout).await {
+                        Some(true) => Ok(()),
+                        Some(false) => {
+                            tracing::warn!("SyncedConfigSet failed to initialize");
+                            Err(())
+                        }
+                        None => Err(()),
+                    }
+                })
+                .await
+                .expect("retries forever")
         };
+
         if tokio::time::timeout(config_sync_timeout, init)
             .await
             .is_err()


### PR DESCRIPTION
Reopened from https://github.com/MaterializeInc/materialize/pull/32030, does anyone know why we didn't merge this? There are 2 TODOs in the code referencing it.

Claude claims this might not work:

> 3. The fix doesn't work. The PR's whole mechanism is calling start_with_default_executor again to force a new initialization. That call early-returns:
```rust
  pub fn start_with_default_executor(&self) {
      if self.started.load(Ordering::SeqCst) { return; }   // ← no-op on every retry
```

Original description:

Previously the code initializing the LD client would correctly await `initialized_async` to see if the initialization succeeded. However, if it didn't succeed it would simply wait a bit and then call `initialized_async` again. Reading the LD server sdk code, there is no reason to assume that the call would return something different if repeated.

This commit changes the logic to call `start_with_default_executor` again when `initialized_async` reports failure, to attempt a new initialization. It also moves to the mz-ore `Retry` type, instead of implementing manual retry logic.