### PR TITLE
Bump k8s-openapi feature to Kubernetes 1.34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -399,7 +399,7 @@ jemalloc_pprof = "0.8.2"
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 junit-report = "0.8.3"
 k8s-controller = "0.12.0"
-k8s-openapi = { version = "0.27.0", features = ["schemars", "v1_32"] }
+k8s-openapi = { version = "0.27.0", features = ["schemars", "v1_34"] }
 kube = { version = "3.1.0", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
 launchdarkly-server-sdk = { version = "3.1.1", default-features = false, features = ["hyper-rustls-native-roots", "crypto-aws-lc-rs"] }
 launchdarkly-sdk-transport = "0.1.4"

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -325,16 +325,15 @@ RUN if [ $ARCH_GCC = x86_64 ]; then \
 
 # Install KinD, kubectl, helm & helm-docs
 
-# TODO(def-) Upgrading kind/kubectl seems to cause Cloudtest failures
-RUN curl -fsSL https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-$ARCH_GO > /usr/local/bin/kind \
+RUN curl -fsSL https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-$ARCH_GO > /usr/local/bin/kind \
     && chmod +x /usr/local/bin/kind \
-    && if [ $ARCH_GO = amd64 ]; then echo 'c72eda46430f065fb45c5f70e7c957cc9209402ef309294821978677c8fb3284 /usr/local/bin/kind' | sha256sum --check; fi \
-    && if [ $ARCH_GO = arm64 ]; then echo '03d45095dbd9cc1689f179a3e5e5da24b77c2d1b257d7645abf1b4174bebcf2a /usr/local/bin/kind' | sha256sum --check; fi
+    && if [ $ARCH_GO = amd64 ]; then echo '50030de23cf40a18505f20426f6a8506bedf13c6e509244bd1fa9463721b0f54 /usr/local/bin/kind' | sha256sum --check; fi \
+    && if [ $ARCH_GO = arm64 ]; then echo 'b92cd615e97585de8ddade28ed5cd7feb4248d717c233eea5b03c37298900f5d /usr/local/bin/kind' | sha256sum --check; fi
 
-RUN curl -fsSL https://dl.k8s.io/release/v1.24.3/bin/linux/$ARCH_GO/kubectl > /usr/local/bin/kubectl \
+RUN curl -fsSL https://dl.k8s.io/release/v1.34.10/bin/linux/$ARCH_GO/kubectl > /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
-    && if [ $ARCH_GO = amd64 ]; then echo '8a45348bdaf81d46caf1706c8bf95b3f431150554f47d444ffde89e8cdd712c1 /usr/local/bin/kubectl' | sha256sum --check; fi \
-    && if [ $ARCH_GO = arm64 ]; then echo 'bdad4d3063ddb7bfa5ecf17fb8b029d5d81d7d4ea1650e4369aafa13ed97149a /usr/local/bin/kubectl' | sha256sum --check; fi
+    && if [ $ARCH_GO = amd64 ]; then echo '95bd70842bd11a524d24acd5b68726899e3488e153e45e2b4ae846545beda050 /usr/local/bin/kubectl' | sha256sum --check; fi \
+    && if [ $ARCH_GO = arm64 ]; then echo '52d3aeefea32fdfa3671ccd636be5da463ddfd0a2fc09d7bcbaedcff4c76cad5 /usr/local/bin/kubectl' | sha256sum --check; fi
 
 RUN curl -fsSL https://get.helm.sh/helm-v4.0.0-linux-$ARCH_GO.tar.gz > helm.tar.gz \
     && if [ $ARCH_GO = amd64 ]; then echo 'c77e9e7c1cc96e066bd240d190d1beed9a6b08060b2043ef0862c4f865eca08f helm.tar.gz' | sha256sum --check; fi \
@@ -517,16 +516,15 @@ RUN ln -s ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack 
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
     && corepack enable
 
-# TODO(def-) Upgrading kind/kubectl seems to cause Cloudtest failures
-RUN curl -fsSL https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-$ARCH_GO > /usr/local/bin/kind \
+RUN curl -fsSL https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-$ARCH_GO > /usr/local/bin/kind \
     && chmod +x /usr/local/bin/kind \
-    && if [ $ARCH_GO = amd64 ]; then echo 'c72eda46430f065fb45c5f70e7c957cc9209402ef309294821978677c8fb3284 /usr/local/bin/kind' | sha256sum --check; fi \
-    && if [ $ARCH_GO = arm64 ]; then echo '03d45095dbd9cc1689f179a3e5e5da24b77c2d1b257d7645abf1b4174bebcf2a /usr/local/bin/kind' | sha256sum --check; fi
+    && if [ $ARCH_GO = amd64 ]; then echo '50030de23cf40a18505f20426f6a8506bedf13c6e509244bd1fa9463721b0f54 /usr/local/bin/kind' | sha256sum --check; fi \
+    && if [ $ARCH_GO = arm64 ]; then echo 'b92cd615e97585de8ddade28ed5cd7feb4248d717c233eea5b03c37298900f5d /usr/local/bin/kind' | sha256sum --check; fi
 
-RUN curl -fsSL https://dl.k8s.io/release/v1.24.3/bin/linux/$ARCH_GO/kubectl > /usr/local/bin/kubectl \
+RUN curl -fsSL https://dl.k8s.io/release/v1.34.10/bin/linux/$ARCH_GO/kubectl > /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
-    && if [ $ARCH_GO = amd64 ]; then echo '8a45348bdaf81d46caf1706c8bf95b3f431150554f47d444ffde89e8cdd712c1 /usr/local/bin/kubectl' | sha256sum --check; fi \
-    && if [ $ARCH_GO = arm64 ]; then echo 'bdad4d3063ddb7bfa5ecf17fb8b029d5d81d7d4ea1650e4369aafa13ed97149a /usr/local/bin/kubectl' | sha256sum --check; fi
+    && if [ $ARCH_GO = amd64 ]; then echo '95bd70842bd11a524d24acd5b68726899e3488e153e45e2b4ae846545beda050 /usr/local/bin/kubectl' | sha256sum --check; fi \
+    && if [ $ARCH_GO = arm64 ]; then echo '52d3aeefea32fdfa3671ccd636be5da463ddfd0a2fc09d7bcbaedcff4c76cad5 /usr/local/bin/kubectl' | sha256sum --check; fi
 
 # Use Helm 3 (not 4) because the cloud repo's bin/kind-create uses relative
 # file paths for vendored charts, which Helm 4 rejects as invalid URLs.

--- a/console/README.md
+++ b/console/README.md
@@ -67,7 +67,7 @@ Install the [aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/getting-s
 Install some k8s utils:
 
 ```shell
-brew install kubectl@1.24 k9s kind
+brew install kubernetes-cli@1.34 k9s kind
 ```
 
 Run the commands below to configure your aws account and k8s contexts

--- a/doc/developer/cloudtest.md
+++ b/doc/developer/cloudtest.md
@@ -29,7 +29,7 @@ official [`kubernetes`] Python library to control the Kubernetes cluster.
     On Linux, use:
 
     ```
-    curl -fL https://dl.k8s.io/release/v1.34.5/bin/linux/amd64/kubectl > kubectl
+    curl -fL https://dl.k8s.io/release/v1.34.10/bin/linux/amd64/kubectl > kubectl
     chmod +x kubectl
     sudo mv kubectl /usr/local/bin
     ```
@@ -48,7 +48,7 @@ official [`kubernetes`] Python library to control the Kubernetes cluster.
     On Linux, use:
 
     ```
-    curl -fL https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64 > kind
+    curl -fL https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64 > kind
     chmod +x kind
     sudo mv kind /usr/local/bin
     ```

--- a/misc/kind/cluster-node-recovery-test.yaml
+++ b/misc/kind/cluster-node-recovery-test.yaml
@@ -22,7 +22,7 @@ kubeadmConfigPatches:
         "service-node-port-range": "32000-32063"
 nodes:
   - role: control-plane
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.34.8
     extraPortMappings:
       - containerPort: 32000
         hostPort: 32000
@@ -154,37 +154,37 @@ nodes:
         hostPort: 32063
 
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "1"
       topology.kubernetes.io/zone: "1"
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "1"
       topology.kubernetes.io/zone: "1"
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "2"
       topology.kubernetes.io/zone: "2"
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "2"
       topology.kubernetes.io/zone: "2"
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "3"
       topology.kubernetes.io/zone: "3"
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "3"
@@ -192,7 +192,7 @@ nodes:
 
   # node for the `quickstart` cluster replica
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "quickstart"
@@ -200,14 +200,14 @@ nodes:
 
   # only envd (nodes will be tainted in the setup)
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       environmentd: true
       materialize.cloud/availability-zone: "3"
       topology.kubernetes.io/zone: "3"
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       environmentd: true
@@ -216,7 +216,7 @@ nodes:
 
   # for supporting services
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.34.8
     labels:
       supporting-services: true
       materialize.cloud/availability-zone: "3"

--- a/misc/kind/cluster.yaml
+++ b/misc/kind/cluster.yaml
@@ -22,7 +22,7 @@ kubeadmConfigPatches:
         "service-node-port-range": "32000-32063"
 nodes:
   - role: control-plane
-    image: kindest/node:v1.31.6
+    image: kindest/node:v1.34.8
     extraPortMappings:
       - containerPort: 32000
         hostPort: 32000
@@ -154,21 +154,21 @@ nodes:
         hostPort: 32063
 
   - role: worker
-    image: kindest/node:v1.31.6
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/swap: true
       materialize.cloud/availability-zone: "1"
       topology.kubernetes.io/zone: "1"
   - role: worker
-    image: kindest/node:v1.31.6
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/swap: true
       materialize.cloud/availability-zone: "2"
       topology.kubernetes.io/zone: "2"
   - role: worker
-    image: kindest/node:v1.31.6
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/swap: true
@@ -177,7 +177,7 @@ nodes:
 
   # no-disk
   - role: worker
-    image: kindest/node:v1.31.6
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: false
       materialize.cloud/swap: false
@@ -186,14 +186,14 @@ nodes:
 
   # others
   - role: worker
-    image: kindest/node:v1.31.6
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/swap: true
       materialize.cloud/availability-zone: "3"
       topology.kubernetes.io/zone: "3"
   - role: worker
-    image: kindest/node:v1.31.6
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/disk: true
       materialize.cloud/swap: true

--- a/misc/python/materialize/cloudtest/app/materialize_application.py
+++ b/misc/python/materialize/cloudtest/app/materialize_application.py
@@ -152,12 +152,20 @@ class MaterializeApplication(CloudtestApplicationBase):
         wait(condition="condition=Ready", resource="pod/environmentd-0")
 
         start = datetime.now()
-        while datetime.now() - start < timedelta(seconds=300):
+        while True:
             try:
                 self.environmentd.sql("SELECT 1")
                 break
             except (InterfaceError, OSError) as e:
-                # Since we crash environmentd, we expect some errors that we swallow.
+                if datetime.now() - start > timedelta(seconds=300):
+                    raise
+                # Since we crash environmentd, we expect some errors that we
+                # swallow. pg8000 wraps most connection failures in
+                # InterfaceError, but raw socket errors from its SSL
+                # negotiation (e.g. ConnectionResetError when the connection
+                # is accepted by the port-forwarding proxy and then reset
+                # because environmentd is not listening yet) leak through
+                # unwrapped.
                 LOGGER.info(f"SQL interface not ready, {e} while SELECT 1. Waiting...")
                 time.sleep(2)
 

--- a/misc/python/materialize/cloudtest/app/materialize_application.py
+++ b/misc/python/materialize/cloudtest/app/materialize_application.py
@@ -156,7 +156,7 @@ class MaterializeApplication(CloudtestApplicationBase):
             try:
                 self.environmentd.sql("SELECT 1")
                 break
-            except InterfaceError as e:
+            except (InterfaceError, OSError) as e:
                 # Since we crash environmentd, we expect some errors that we swallow.
                 LOGGER.info(f"SQL interface not ready, {e} while SELECT 1. Waiting...")
                 time.sleep(2)

--- a/misc/python/materialize/cloudtest/k8s/minio.py
+++ b/misc/python/materialize/cloudtest/k8s/minio.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import yaml
+
 from materialize import MZ_ROOT
 from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
 from materialize.cloudtest.k8s.api.k8s_resource import K8sResource
@@ -35,9 +37,8 @@ class Minio(K8sResource):
             "true",
         )
 
-        # the PVC will be created afterwards
         for yaml_file in [
-            "minio-standalone-deployment",
+            "minio-standalone-pvc",
             "minio-standalone-service",
         ]:
             self.kubectl(
@@ -46,22 +47,20 @@ class Minio(K8sResource):
                 str(MINIO_YAML_DIRECTORY / f"{yaml_file}.yaml"),
             )
 
-        if self.apply_node_selectors:
-            self.kubectl(
-                "patch",
-                "deployment",
-                "minio-deployment",
-                "--type",
-                "json",
-                "-p",
-                '[{"op": "add", "path": "/spec/template/spec/nodeSelector", "value": {"supporting-services": "true"} }]',
-            )
-
-        # the PVC needs to be created after patching the deployment
+        # NOTE: The deployment must carry its final nodeSelector before it is
+        # created, so it is injected here rather than patched in afterwards.
+        # The claim's storage class binds with WaitForFirstConsumer, so the
+        # provisioner pins the volume to whichever node the scheduler picks for
+        # the first pod that consumes the claim. A pod created without the
+        # nodeSelector can drive that decision even if it is replaced moments
+        # later, pinning the volume to a node the final pod may not run on. The
+        # pod then stays Pending forever, because nothing can satisfy both the
+        # volume's node affinity and the pod's node selector.
         self.kubectl(
             "create",
             "-f",
-            str(MINIO_YAML_DIRECTORY / "minio-standalone-pvc.yaml"),
+            "-",
+            input=self.deployment_manifest(),
         )
 
         self.wait(
@@ -71,6 +70,17 @@ class Minio(K8sResource):
         )
 
         self.create_buckets(["persist", "copytos3", "copyfroms3"])
+
+    def deployment_manifest(self) -> str:
+        with open(MINIO_YAML_DIRECTORY / "minio-standalone-deployment.yaml") as f:
+            deployment = yaml.safe_load(f)
+
+        if self.apply_node_selectors:
+            deployment["spec"]["template"]["spec"]["nodeSelector"] = {
+                "supporting-services": "true"
+            }
+
+        return yaml.dump(deployment)
 
     def create_buckets(self, buckets: list[str]) -> None:
         cmds = [

--- a/misc/scratch/provision.bash
+++ b/misc/scratch/provision.bash
@@ -79,12 +79,10 @@ rm -rf /tmp/awscli.zip /tmp/aws) &
 # uv
 (curl -fsSL https://astral.sh/uv/install.sh | sudo -u ubuntu sh >/dev/null 2>&1) &
 
-# kubectl + kind + k9s. kind and kubectl mirror ci/builder/Dockerfile, which
-# deliberately holds them back: newer versions break Cloudtest (minio fails to
-# come up on the kind cluster).
-(curl -fsSL "https://dl.k8s.io/release/v1.24.3/bin/linux/$ARCH_GO/kubectl" -o /usr/local/bin/kubectl
+# kubectl + kind + k9s. kind and kubectl mirror ci/builder/Dockerfile.
+(curl -fsSL "https://dl.k8s.io/release/v1.34.10/bin/linux/$ARCH_GO/kubectl" -o /usr/local/bin/kubectl
 chmod +x /usr/local/bin/kubectl) &
-(curl -fsSL "https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-$ARCH_GO" -o /usr/local/bin/kind
+(curl -fsSL "https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-$ARCH_GO" -o /usr/local/bin/kind
 chmod +x /usr/local/bin/kind) &
 (curl -fsSL "https://github.com/derailed/k9s/releases/download/v0.50.18/k9s_Linux_$ARCH_GO.tar.gz" \
     | tar xzf - -C /usr/local/bin k9s

--- a/test/orchestratord/cluster.yaml.tmpl
+++ b/test/orchestratord/cluster.yaml.tmpl
@@ -30,7 +30,7 @@ kubeadmConfigPatches:
         "service-node-port-range": "32000-32063"
 nodes:
   - role: control-plane
-    image: kindest/node:v1.32.5
+    image: kindest/node:v1.34.8
     extraMounts:
       - containerPath: /var/lib/kubelet/config.json
         hostPath: "$DOCKER_CONFIG/config.json"
@@ -165,7 +165,7 @@ nodes:
         hostPort: 32063
 
   - role: worker
-    image: kindest/node:v1.32.5
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/swap: "true"
       materialize.cloud/availability-zone: "1"
@@ -175,7 +175,7 @@ nodes:
       - containerPath: /var/lib/kubelet/config.json
         hostPath: "$DOCKER_CONFIG/config.json"
   - role: worker
-    image: kindest/node:v1.32.5
+    image: kindest/node:v1.34.8
     labels:
       materialize.cloud/scratch-fs: "true"
       materialize.cloud/disk: "true"

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -293,8 +293,8 @@ def get_console_app_config(namespace="materialize-environment") -> dict[str, Any
 def ensure_kind_version() -> None:
     kind_version = Version.parse(spawn.capture(["kind", "version"]).split(" ")[1][1:])
     assert kind_version >= Version.parse(
-        "0.29.0"
-    ), f"kind >= v0.29.0 required, while you are on {kind_version}"
+        "0.32.0"
+    ), f"kind >= v0.32.0 required, while you are on {kind_version}"
 
 
 def stop_and_remove_container(container_name: str) -> None:


### PR DESCRIPTION
Bump k8s-openapi feature to Kubernetes 1.34.
Bump kind to v0.32.0 and kubectl to v1.34.10 in the CI builder image and dev tooling.
Bump all kind cluster configs to `kindest/node:v1.34.8` nodes (the pre-built 1.34 image for kind v0.32.0).
Fix a race in our minio setup, which shows up more consistently in Kubernetes 1.34, where the PVC could end up on a different node and minio pods would never become ready. [DB-143](https://linear.app/materializeinc/issue/DB-143)

Kubernetes 1.34 is the oldest currently supported version. Newer Kubernetes versions may not support legacy APIs over time, so better to stay current.

This will require a similar bump in the cloud repo when bumping the submodule.

### Motivation

Keep up to date, on supported platforms.

### Verification

Nightly pipelines that exercise the bumped kind/kubectl/node images and should be run on this PR:

- `cloudtest`, `cloudtest-slow`, `cloudtest-upgrade`: run kind via the rebuilt ci-builder image.
- `orchestratord-*`: run in the `test/orchestratord` kind cluster, now on 1.34.8 nodes.
- `k8s-node-recovery-*`: use `misc/kind/cluster-node-recovery-test.yaml`, now on 1.34.8 nodes. These are the steps the minio fix targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
