### PR TITLE
sql: support IF NOT EXISTS for CREATE CLUSTER and CREATE CLUSTER REPLICA

### DIFF
--- a/doc/user/data/examples/create_cluster.yml
+++ b/doc/user/data/examples/create_cluster.yml
@@ -1,6 +1,6 @@
 - name: "syntax"
   code: |
-    CREATE CLUSTER <cluster_name> (
+    CREATE CLUSTER [IF NOT EXISTS] <cluster_name> (
         SIZE = <text>
         [, REPLICATION FACTOR = <int>]
         [, MANAGED = <bool>]
@@ -12,6 +12,12 @@
         )]
     );
   syntax_elements:
+    - name: "**IF NOT EXISTS**"
+      description: |
+        *Optional.* If specified, do not throw an error if a cluster with the
+        same name already exists. Instead, issue a notice and skip the cluster
+        creation. Note that the existing cluster is left untouched, its
+        configuration is not updated to match the statement.
     - name: "`<cluster_name>`"
       description: |
         A name for the cluster.

--- a/doc/user/data/examples/create_cluster_replica.yml
+++ b/doc/user/data/examples/create_cluster_replica.yml
@@ -1,9 +1,15 @@
 - name: "syntax"
   code: |
-    CREATE CLUSTER REPLICA <cluster_name>.<replica_name> (
+    CREATE CLUSTER REPLICA [IF NOT EXISTS] <cluster_name>.<replica_name> (
         SIZE = <text>
     );
   syntax_elements:
+    - name: "**IF NOT EXISTS**"
+      description: |
+        *Optional.* If specified, do not throw an error if a replica with the
+        same name already exists on the cluster. Instead, issue a notice and
+        skip the replica creation. Note that the existing replica is left
+        untouched, its configuration is not updated to match the statement.
     - name: "`<cluster_name>`"
       description: |
         The cluster you want to attach a replica to.

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -15,6 +15,7 @@ use maplit::btreeset;
 use mz_adapter_types::cluster_state::ReconfigurationAudit;
 use mz_catalog::builtin::BUILTINS;
 use mz_catalog::durable::managed_cluster_replica_name;
+use mz_catalog::memory::error::ErrorKind;
 use mz_catalog::memory::objects::{
     ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged,
     ManagedReplicaConfigShape, ReconfigurationState, ReconfigurationStatus, ReconfigurationTarget,
@@ -31,7 +32,7 @@ use mz_repr::Timestamp;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::role_id::RoleId;
 use mz_sql::ast::{Ident, QualifiedReplica};
-use mz_sql::catalog::{CatalogCluster, ObjectType};
+use mz_sql::catalog::{CatalogCluster, CatalogError, ObjectType};
 use mz_sql::plan::{
     self, AlterClusterPlanStrategy, AlterClusterRenamePlan, AlterClusterReplicaRenamePlan,
     AlterClusterSwapPlan, AlterOptionParameter, AlterSetClusterPlan,
@@ -61,7 +62,7 @@ use crate::coord::{
     AlterClusterWaitForHydrated, ClusterReplicaStatuses, ClusterStage, Coordinator, Message,
     PlanValidity, StageResult, Staged,
 };
-use crate::{AdapterError, ExecuteContext, ExecuteResponse, session::Session};
+use crate::{AdapterError, AdapterNotice, ExecuteContext, ExecuteResponse, session::Session};
 
 const PENDING_REPLICA_SUFFIX: &str = "-pending";
 
@@ -1210,6 +1211,7 @@ impl Coordinator {
             name,
             variant,
             workload_class,
+            if_not_exists,
         }: CreateClusterPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         tracing::debug!("sequence_create_cluster");
@@ -1260,14 +1262,26 @@ impl Coordinator {
 
         match variant {
             CreateClusterVariant::Managed(plan) => {
-                self.sequence_create_managed_cluster(session, plan, id, name, ops)
+                self.sequence_create_managed_cluster(session, plan, id, name.clone(), ops)
                     .await
             }
             CreateClusterVariant::Unmanaged(plan) => {
-                self.sequence_create_unmanaged_cluster(session, plan, id, name, ops)
+                self.sequence_create_unmanaged_cluster(session, plan, id, name.clone(), ops)
                     .await
             }
         }
+        .or_else(|err| match err {
+            AdapterError::Catalog(mz_catalog::memory::error::Error {
+                kind: ErrorKind::Sql(CatalogError::ClusterAlreadyExists(_)),
+            }) if if_not_exists => {
+                session.add_notice(AdapterNotice::ObjectAlreadyExists {
+                    name,
+                    ty: "cluster",
+                });
+                Ok(ExecuteResponse::CreatedCluster)
+            }
+            err => Err(err),
+        })
     }
 
     #[mz_ore::instrument(level = "debug")]
@@ -1668,6 +1682,7 @@ impl Coordinator {
             name,
             cluster_id,
             config,
+            if_not_exists,
         }: CreateClusterReplicaPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         // Choose default AZ if necessary
@@ -1765,6 +1780,9 @@ impl Coordinator {
 
         let cluster_name = cluster.name.clone();
         let is_builtin = cluster_id.is_system();
+        // A replica name is only unique within its cluster, so the notice on the
+        // `IF NOT EXISTS` path below has to name both.
+        let qualified_name = format!("{cluster_name}.{name}");
 
         // Pre-allocate the replica id out-of-band via the durable allocator,
         // picking the id type from the target cluster, which may be a system
@@ -1822,9 +1840,19 @@ impl Coordinator {
             }
         }
 
-        self.catalog_transact(Some(session), ops).await?;
-
-        Ok(ExecuteResponse::CreatedClusterReplica)
+        match self.catalog_transact(Some(session), ops).await {
+            Ok(()) => Ok(ExecuteResponse::CreatedClusterReplica),
+            Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
+                kind: ErrorKind::Sql(CatalogError::DuplicateReplica(_, _)),
+            })) if if_not_exists => {
+                session.add_notice(AdapterNotice::ObjectAlreadyExists {
+                    name: qualified_name,
+                    ty: "cluster replica",
+                });
+                Ok(ExecuteResponse::CreatedClusterReplica)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// When this is called by the automated cluster scheduling, `scheduling_decision_reason` should

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -404,6 +404,13 @@ impl Cluster {
         }
     }
 
+    /// Builds the plan that a `CREATE CLUSTER` statement for this cluster would
+    /// have produced.
+    ///
+    /// Clusters are stored as a structured config, not as SQL text, so `SHOW
+    /// CREATE CLUSTER` cannot just print a stored statement. It rebuilds one,
+    /// and this is the first half of that: config to plan. `unplan_create_cluster`
+    /// then turns the plan back into a statement.
     pub fn try_to_plan(&self) -> Result<CreateClusterPlan, PlanError> {
         let name = self.name.clone();
         let variant = match &self.config.variant {
@@ -462,6 +469,10 @@ impl Cluster {
             name,
             variant,
             workload_class,
+            // Nothing about `IF NOT EXISTS` is stored. It only ever affected how
+            // the original statement handled a name collision, so the rebuilt
+            // statement never shows it.
+            if_not_exists: false,
         })
     }
 }

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -19,7 +19,9 @@
 // limitations under the License.
 
 use mz_ore::str::StrExt;
-use mz_sql_lexer::keywords::{ALL, ANY, AS, DISTINCT, INTO, Keyword, LIST, PREPARE, SOME, WHEN};
+use mz_sql_lexer::keywords::{
+    ALL, ANY, AS, DISTINCT, IF, INTO, Keyword, LIST, PREPARE, SOME, WHEN,
+};
 use mz_sql_lexer::lexer::{IdentString, MAX_IDENTIFIER_LENGTH};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -359,6 +361,12 @@ impl Ident {
                         // (`COPY into FROM x` -> `COPY INTO <name=from> …`, which
                         // then fails expecting the FROM/TO direction).
                         || kw == INTO
+                        // The `IF [NOT] EXISTS` clauses of CREATE/DROP/ALTER sit
+                        // exactly where the object name goes, so a bare `if` name
+                        // is consumed as the start of such a clause on reparse
+                        // (`CREATE CLUSTER if (SIZE …)` -> "expected NOT, found
+                        // left parenthesis").
+                        || kw == IF
                 })
                 .unwrap_or(false)
     }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2467,11 +2467,15 @@ pub struct CreateClusterStatement<T: AstInfo> {
     pub options: Vec<ClusterOption<T>>,
     /// The comma-separated features enabled on the cluster.
     pub features: Vec<ClusterFeature<T>>,
+    pub if_not_exists: bool,
 }
 
 impl<T: AstInfo> AstDisplay for CreateClusterStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE CLUSTER ");
+        if self.if_not_exists {
+            f.write_str("IF NOT EXISTS ");
+        }
         f.write_node(&self.name);
         if !self.options.is_empty() {
             f.write_str(" (");
@@ -2566,11 +2570,15 @@ pub struct CreateClusterReplicaStatement<T: AstInfo> {
     pub of_cluster: Ident,
     /// The replica's definition.
     pub definition: ReplicaDefinition<T>,
+    pub if_not_exists: bool,
 }
 
 impl<T: AstInfo> AstDisplay for CreateClusterReplicaStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE CLUSTER REPLICA ");
+        if self.if_not_exists {
+            f.write_str("IF NOT EXISTS ");
+        }
         f.write_node(&self.of_cluster);
         f.write_str(".");
         f.write_node(&self.definition.name);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4564,6 +4564,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_create_cluster(&mut self) -> Result<Statement<Raw>, ParserError> {
+        let if_not_exists = self.parse_if_not_exists()?;
         let name = self.parse_identifier()?;
         // For historical reasons, the parentheses around the options can be
         // omitted.
@@ -4586,6 +4587,7 @@ impl<'a> Parser<'a> {
             name,
             options,
             features,
+            if_not_exists,
         }))
     }
 
@@ -4871,6 +4873,7 @@ impl<'a> Parser<'a> {
 
     fn parse_create_cluster_replica(&mut self) -> Result<Statement<Raw>, ParserError> {
         self.next_token();
+        let if_not_exists = self.parse_if_not_exists()?;
         let of_cluster = self.parse_identifier()?;
         self.expect_token(&Token::Dot)?;
         let name = self.parse_identifier()?;
@@ -4885,6 +4888,7 @@ impl<'a> Parser<'a> {
             CreateClusterReplicaStatement {
                 of_cluster,
                 definition: ReplicaDefinition { name, options },
+                if_not_exists,
             },
         ))
     }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1973,7 +1973,7 @@ CREATE CLUSTER cluster REPLICAS ()
 ----
 CREATE CLUSTER cluster (REPLICAS = ())
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([])) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([])) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster WITH REPLICAS ()
@@ -1994,91 +1994,112 @@ CREATE CLUSTER cluster REPLICAS (a (STORAGECTL ADDRESSES ['host1']))
 ----
 CREATE CLUSTER cluster (REPLICAS = (a (STORAGECTL ADDRESSES = ('host1'))))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: StoragectlAddresses, value: Some(Sequence([Value(String("host1"))])) }] }])) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: StoragectlAddresses, value: Some(Sequence([Value(String("host1"))])) }] }])) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (COMPUTECTL ADDRESSES ['host1']), b (SIZE 'scale=1,workers=1'))
 ----
 CREATE CLUSTER cluster (REPLICAS = (a (COMPUTECTL ADDRESSES = ('host1')), b (SIZE = 'scale=1,workers=1')))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: ComputectlAddresses, value: Some(Sequence([Value(String("host1"))])) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }] }])) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: ComputectlAddresses, value: Some(Sequence([Value(String("host1"))])) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }] }])) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (COMPUTE ADDRESSES ['host1'], INTROSPECTION INTERVAL '1s', INTROSPECTION DEBUGGING true), b (SIZE 'scale=1,workers=1', INTROSPECTION INTERVAL 0))
 ----
 CREATE CLUSTER cluster (REPLICAS = (a (COMPUTE ADDRESSES = ('host1'), INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = true), b (SIZE = 'scale=1,workers=1', INTROSPECTION INTERVAL = 0)))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: ComputeAddresses, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }] }])) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: ComputeAddresses, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }] }])) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (SIZE 'scale=1,workers=1'))
 ----
 CREATE CLUSTER cluster (REPLICAS = (a (SIZE = 'scale=1,workers=1')))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }] }])) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }] }])) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (STORAGECTL ADDRESSES ['123'], STORAGE ADDRESSES ['124'], COMPUTECTL ADDRESSES ['host1:2400', 'host2:2400'], COMPUTE ADDRESSES ['host1:2401', 'host2:2401'], WORKERS '1'))
 ----
 CREATE CLUSTER cluster (REPLICAS = (a (STORAGECTL ADDRESSES = ('123'), STORAGE ADDRESSES = ('124'), COMPUTECTL ADDRESSES = ('host1:2400', 'host2:2400'), COMPUTE ADDRESSES = ('host1:2401', 'host2:2401'), WORKERS = '1')))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: StoragectlAddresses, value: Some(Sequence([Value(String("123"))])) }, ReplicaOption { name: StorageAddresses, value: Some(Sequence([Value(String("124"))])) }, ReplicaOption { name: ComputectlAddresses, value: Some(Sequence([Value(String("host1:2400")), Value(String("host2:2400"))])) }, ReplicaOption { name: ComputeAddresses, value: Some(Sequence([Value(String("host1:2401")), Value(String("host2:2401"))])) }, ReplicaOption { name: Workers, value: Some(Value(String("1"))) }] }])) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: StoragectlAddresses, value: Some(Sequence([Value(String("123"))])) }, ReplicaOption { name: StorageAddresses, value: Some(Sequence([Value(String("124"))])) }, ReplicaOption { name: ComputectlAddresses, value: Some(Sequence([Value(String("host1:2400")), Value(String("host2:2400"))])) }, ReplicaOption { name: ComputeAddresses, value: Some(Sequence([Value(String("host1:2401")), Value(String("host2:2401"))])) }, ReplicaOption { name: Workers, value: Some(Value(String("1"))) }] }])) }], features: [], if_not_exists: false })
+
+parse-statement
+CREATE CLUSTER IF NOT EXISTS cluster SIZE 'scale=1,workers=1'
+----
+CREATE CLUSTER IF NOT EXISTS cluster (SIZE = 'scale=1,workers=1')
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }], features: [], if_not_exists: true })
+
+parse-statement
+CREATE CLUSTER IF EXISTS cluster SIZE 'scale=1,workers=1'
+----
+error: Expected NOT, found EXISTS
+CREATE CLUSTER IF EXISTS cluster SIZE 'scale=1,workers=1'
+                  ^
+
+parse-statement
+CREATE CLUSTER "if" SIZE 'scale=1,workers=1'
+----
+CREATE CLUSTER "if" (SIZE = 'scale=1,workers=1')
+=>
+CreateCluster(CreateClusterStatement { name: Ident("if"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster SIZE 'scale=1,workers=1'
 ----
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1')
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (SIZE 'scale=1,workers=1') FEATURES (enable eager delta joins = true)
 ----
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1') FEATURES (ENABLE EAGER DELTA JOINS = true)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }], features: [ClusterFeature { name: EnableEagerDeltaJoins, value: Some(Value(Boolean(true))) }] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }], features: [ClusterFeature { name: EnableEagerDeltaJoins, value: Some(Value(Boolean(true))) }], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster REPLICATION FACTOR 1
 ----
 CREATE CLUSTER cluster (REPLICATION FACTOR = 1)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: ReplicationFactor, value: Some(Value(Number("1"))) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: ReplicationFactor, value: Some(Value(Number("1"))) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster AVAILABILITY ZONES ('1')
 ----
 CREATE CLUSTER cluster (AVAILABILITY ZONES = ('1'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: AvailabilityZones, value: Some(Sequence([Value(String("1"))])) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: AvailabilityZones, value: Some(Sequence([Value(String("1"))])) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster MANAGED true
 ----
 CREATE CLUSTER cluster (MANAGED = true)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: Some(Value(Boolean(true))) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: Some(Value(Boolean(true))) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster MANAGED
 ----
 CREATE CLUSTER cluster (MANAGED)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: None }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: None }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster MANAGED, DISK = true
 ----
 CREATE CLUSTER cluster (MANAGED, DISK = true)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: None }, ClusterOption { name: Disk, value: Some(Value(Boolean(true))) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: None }, ClusterOption { name: Disk, value: Some(Value(Boolean(true))) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (MANAGED, DISK = true)
 ----
 CREATE CLUSTER cluster (MANAGED, DISK = true)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: None }, ClusterOption { name: Disk, value: Some(Value(Boolean(true))) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Managed, value: None }, ClusterOption { name: Disk, value: Some(Value(Boolean(true))) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (MANAGED, DISK = true
@@ -2099,56 +2120,56 @@ CREATE CLUSTER cluster INTROSPECTION INTERVAL '1'
 ----
 CREATE CLUSTER cluster (INTROSPECTION INTERVAL = '1')
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: IntrospectionInterval, value: Some(Value(String("1"))) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: IntrospectionInterval, value: Some(Value(String("1"))) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster INTROSPECTION DEBUGGING true
 ----
 CREATE CLUSTER cluster (INTROSPECTION DEBUGGING = true)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (SIZE = '1', EXPERIMENTAL ARRANGEMENT COMPRESSION = true)
 ----
 CREATE CLUSTER cluster (SIZE = '1', EXPERIMENTAL ARRANGEMENT COMPRESSION = true)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: ExperimentalArrangementCompression, value: Some(Value(Boolean(true))) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: ExperimentalArrangementCompression, value: Some(Value(Boolean(true))) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA cluster.r1 (SIZE = '1', EXPERIMENTAL ARRANGEMENT COMPRESSION = true)
 ----
 CREATE CLUSTER REPLICA cluster.r1 (SIZE = '1', EXPERIMENTAL ARRANGEMENT COMPRESSION = true)
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("cluster"), definition: ReplicaDefinition { name: Ident("r1"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: ExperimentalArrangementCompression, value: Some(Value(Boolean(true))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("cluster"), definition: ReplicaDefinition { name: Ident("r1"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: ExperimentalArrangementCompression, value: Some(Value(Boolean(true))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', SCHEDULE = MANUAL)
 ----
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', SCHEDULE = MANUAL)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Manual)) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Manual)) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', SCHEDULE = ON REFRESH)
 ----
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', SCHEDULE = ON REFRESH)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: None })) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: None })) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour'))
 ----
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: Some(IntervalValue { value: "1 hour", precision_high: Year, precision_low: Second, fsec_max_precision: None }) })) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: Some(IntervalValue { value: "1 hour", precision_high: Year, precision_low: Second, fsec_max_precision: None }) })) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE '1 hour'))
 ----
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: Some(IntervalValue { value: "1 hour", precision_high: Year, precision_low: Second, fsec_max_precision: None }) })) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: Some(IntervalValue { value: "1 hour", precision_high: Year, precision_low: Second, fsec_max_precision: None }) })) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE))
@@ -2183,21 +2204,21 @@ CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', AUTO SCALING STRATEGY = (ON 
 ----
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', AUTO SCALING STRATEGY = (ON HYDRATION (HYDRATION SIZE = '400cc', LINGER DURATION = '600s')))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: AutoScalingStrategy, value: Some(ClusterAutoScalingStrategyOptionValue(ClusterAutoScalingStrategyOptionValue { on_hydration: Some(OnHydrationOptionValue { hydration_size: String("400cc"), linger_duration: Some(String("600s")) }) })) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: AutoScalingStrategy, value: Some(ClusterAutoScalingStrategyOptionValue(ClusterAutoScalingStrategyOptionValue { on_hydration: Some(OnHydrationOptionValue { hydration_size: String("400cc"), linger_duration: Some(String("600s")) }) })) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', AUTO SCALING STRATEGY = (ON HYDRATION (HYDRATION SIZE = '400cc')))
 ----
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', AUTO SCALING STRATEGY = (ON HYDRATION (HYDRATION SIZE = '400cc')))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: AutoScalingStrategy, value: Some(ClusterAutoScalingStrategyOptionValue(ClusterAutoScalingStrategyOptionValue { on_hydration: Some(OnHydrationOptionValue { hydration_size: String("400cc"), linger_duration: None }) })) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: AutoScalingStrategy, value: Some(ClusterAutoScalingStrategyOptionValue(ClusterAutoScalingStrategyOptionValue { on_hydration: Some(OnHydrationOptionValue { hydration_size: String("400cc"), linger_duration: None }) })) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', AUTO SCALING STRATEGY = ())
 ----
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', AUTO SCALING STRATEGY = ())
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: AutoScalingStrategy, value: Some(ClusterAutoScalingStrategyOptionValue(ClusterAutoScalingStrategyOptionValue { on_hydration: None })) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: AutoScalingStrategy, value: Some(ClusterAutoScalingStrategyOptionValue(ClusterAutoScalingStrategyOptionValue { on_hydration: None })) }], features: [], if_not_exists: false })
 
 parse-statement
 ALTER CLUSTER cluster SET (AUTO SCALING STRATEGY = (ON HYDRATION (HYDRATION SIZE = '400cc')))
@@ -2232,14 +2253,14 @@ CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', WORKLOAD CLASS NULL)
 ----
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', WORKLOAD CLASS = NULL)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: WorkloadClass, value: Some(Value(Null)) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: WorkloadClass, value: Some(Value(Null)) }], features: [], if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', WORKLOAD CLASS 'production')
 ----
 CREATE CLUSTER cluster (SIZE = 'scale=1,workers=1', WORKLOAD CLASS = 'production')
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: WorkloadClass, value: Some(Value(String("production"))) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("scale=1,workers=1"))) }, ClusterOption { name: WorkloadClass, value: Some(Value(String("production"))) }], features: [], if_not_exists: false })
 
 parse-statement
 ALTER CLUSTER cluster SET (SIZE 'scale=1,workers=1')
@@ -2397,102 +2418,116 @@ CREATE CLUSTER REPLICA replica
                               ^
 
 parse-statement
+CREATE CLUSTER REPLICA IF NOT EXISTS default.replica SIZE 'small'
+----
+CREATE CLUSTER REPLICA IF NOT EXISTS default.replica (SIZE = 'small')
+=>
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }] }, if_not_exists: true })
+
+parse-statement
+CREATE CLUSTER REPLICA IF EXISTS default.replica SIZE 'small'
+----
+error: Expected NOT, found EXISTS
+CREATE CLUSTER REPLICA IF EXISTS default.replica SIZE 'small'
+                          ^
+
+parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small'
 ----
 CREATE CLUSTER REPLICA default.replica (SIZE = 'small')
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', INTERNAL, BILLED AS 'free'
 ----
 CREATE CLUSTER REPLICA default.replica (SIZE = 'small', INTERNAL, BILLED AS = 'free')
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: Internal, value: None }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: Internal, value: None }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica (SIZE 'small', INTERNAL, BILLED AS 'free')
 ----
 CREATE CLUSTER REPLICA default.replica (SIZE = 'small', INTERNAL, BILLED AS = 'free')
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: Internal, value: None }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: Internal, value: None }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', INTERNAL = true, BILLED AS 'free'
 ----
 CREATE CLUSTER REPLICA default.replica (SIZE = 'small', INTERNAL = true, BILLED AS = 'free')
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: Internal, value: Some(Value(Boolean(true))) }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: Internal, value: Some(Value(Boolean(true))) }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', INTERNAL = false, BILLED AS 'free'
 ----
 CREATE CLUSTER REPLICA default.replica (SIZE = 'small', INTERNAL = false, BILLED AS = 'free')
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: Internal, value: Some(Value(Boolean(false))) }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: Internal, value: Some(Value(Boolean(false))) }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', BILLED AS 'free'
 ----
 CREATE CLUSTER REPLICA default.replica (SIZE = 'small', BILLED AS = 'free')
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', AVAILABILITY ZONE 'a'
 ----
 CREATE CLUSTER REPLICA default.replica (SIZE = 'small', AVAILABILITY ZONE = 'a')
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', AVAILABILITY ZONE 'a', DISK = false
 ----
 CREATE CLUSTER REPLICA default.replica (SIZE = 'small', AVAILABILITY ZONE = 'a', DISK = false)
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }, ReplicaOption { name: Disk, value: Some(Value(Boolean(false))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }, ReplicaOption { name: Disk, value: Some(Value(Boolean(false))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 'b'
 ----
 CREATE CLUSTER REPLICA default.replica (AVAILABILITY ZONE = 'a', AVAILABILITY ZONE = 'b')
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("b"))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("b"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', AVAILABILITY ZONE 'a'
 ----
 CREATE CLUSTER REPLICA default.replica (SIZE = 'small', AVAILABILITY ZONE = 'a')
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', INTROSPECTION INTERVAL '1s', INTROSPECTION DEBUGGING = false
 ----
 CREATE CLUSTER REPLICA default.replica (SIZE = 'small', INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = false)
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(false))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(false))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica INTROSPECTION INTERVAL = 0, SIZE 'small'
 ----
 CREATE CLUSTER REPLICA default.replica (INTROSPECTION INTERVAL = 0, SIZE = 'small')
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }, ReplicaOption { name: Size, value: Some(Value(String("small"))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }, ReplicaOption { name: Size, value: Some(Value(String("small"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica INTROSPECTION INTERVAL NULL
 ----
 CREATE CLUSTER REPLICA default.replica (INTROSPECTION INTERVAL = NULL)
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: IntrospectionInterval, value: Some(Value(Null)) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: IntrospectionInterval, value: Some(Value(Null)) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica STORAGECTL ADDRESSES ('1', '2'), COMPUTECTL ADDRESSES ('1', '2'), COMPUTE ADDRESSES ('3', '4'), WORKERS 2, INTROSPECTION INTERVAL = NULL
 ----
 CREATE CLUSTER REPLICA default.replica (STORAGECTL ADDRESSES = ('1', '2'), COMPUTECTL ADDRESSES = ('1', '2'), COMPUTE ADDRESSES = ('3', '4'), WORKERS = 2, INTROSPECTION INTERVAL = NULL)
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: StoragectlAddresses, value: Some(Sequence([Value(String("1")), Value(String("2"))])) }, ReplicaOption { name: ComputectlAddresses, value: Some(Sequence([Value(String("1")), Value(String("2"))])) }, ReplicaOption { name: ComputeAddresses, value: Some(Sequence([Value(String("3")), Value(String("4"))])) }, ReplicaOption { name: Workers, value: Some(Value(Number("2"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Null)) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: StoragectlAddresses, value: Some(Sequence([Value(String("1")), Value(String("2"))])) }, ReplicaOption { name: ComputectlAddresses, value: Some(Sequence([Value(String("1")), Value(String("2"))])) }, ReplicaOption { name: ComputeAddresses, value: Some(Sequence([Value(String("3")), Value(String("4"))])) }, ReplicaOption { name: Workers, value: Some(Value(Number("2"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Null)) }] }, if_not_exists: false })
 
 
 parse-statement

--- a/src/sql-pretty/src/doc.rs
+++ b/src/sql-pretty/src/doc.rs
@@ -438,8 +438,12 @@ impl Pretty {
     ) -> RcDoc<'a> {
         let mut docs = Vec::new();
 
-        // CREATE CLUSTER name
-        docs.push(nest_title("CREATE CLUSTER", self.doc_display_pass(&v.name)));
+        // CREATE CLUSTER [IF NOT EXISTS] name
+        let mut title = "CREATE CLUSTER".to_string();
+        if v.if_not_exists {
+            title.push_str(" IF NOT EXISTS");
+        }
+        docs.push(nest_title(&title, self.doc_display_pass(&v.name)));
 
         // OPTIONS (...)
         if !v.options.is_empty() {
@@ -468,13 +472,17 @@ impl Pretty {
     ) -> RcDoc<'a> {
         let mut docs = Vec::new();
 
-        // CREATE CLUSTER REPLICA cluster.replica
+        // CREATE CLUSTER REPLICA [IF NOT EXISTS] cluster.replica
+        let mut title = "CREATE CLUSTER REPLICA".to_string();
+        if v.if_not_exists {
+            title.push_str(" IF NOT EXISTS");
+        }
         let replica_name = RcDoc::concat([
             self.doc_display_pass(&v.of_cluster),
             RcDoc::text("."),
             self.doc_display_pass(&v.definition.name),
         ]);
-        docs.push(nest_title("CREATE CLUSTER REPLICA", replica_name));
+        docs.push(nest_title(&title, replica_name));
 
         // OPTIONS (...)
         docs.push(bracket(

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -566,6 +566,7 @@ pub struct CreateClusterPlan {
     pub name: String,
     pub variant: CreateClusterVariant,
     pub workload_class: Option<String>,
+    pub if_not_exists: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -597,6 +598,7 @@ pub struct CreateClusterReplicaPlan {
     pub cluster_id: ClusterId,
     pub name: String,
     pub config: ReplicaConfig,
+    pub if_not_exists: bool,
 }
 
 /// Configuration of introspection for a cluster replica.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4936,6 +4936,7 @@ pub fn plan_create_cluster_inner(
         name,
         options,
         features,
+        if_not_exists,
     }: CreateClusterStatement<Aug>,
 ) -> Result<CreateClusterPlan, PlanError> {
     let ClusterOptionExtracted {
@@ -5072,6 +5073,7 @@ pub fn plan_create_cluster_inner(
                 auto_scaling_strategy,
             }),
             workload_class,
+            if_not_exists,
         })
     } else {
         let Some(replica_defs) = replicas else {
@@ -5119,19 +5121,24 @@ pub fn plan_create_cluster_inner(
             name: normalize::ident(name),
             variant: CreateClusterVariant::Unmanaged(CreateClusterUnmanagedPlan { replicas }),
             workload_class,
+            if_not_exists,
         })
     }
 }
 
 /// Convert a [`CreateClusterPlan`] into a [`CreateClusterStatement`].
 ///
-/// The reverse of [`plan_create_cluster`].
+/// The reverse of [`plan_create_cluster`], so this renders `IF NOT EXISTS`
+/// when the plan carries it. A caller that wants the cluster's canonical
+/// definition rather than a faithful reverse must pass `if_not_exists: false`,
+/// which is what `Cluster::try_to_plan` produces for `SHOW CREATE CLUSTER`.
 pub fn unplan_create_cluster(
     scx: &StatementContext,
     CreateClusterPlan {
         name,
         variant,
         workload_class,
+        if_not_exists,
     }: CreateClusterPlan,
 ) -> Result<CreateClusterStatement<Aug>, PlanError> {
     match variant {
@@ -5232,6 +5239,7 @@ pub fn unplan_create_cluster(
                 name,
                 options,
                 features,
+                if_not_exists,
             })
         }
         CreateClusterVariant::Unmanaged(_) => {
@@ -5561,6 +5569,7 @@ pub fn plan_create_cluster_replica(
     CreateClusterReplicaStatement {
         definition: ReplicaDefinition { name, options },
         of_cluster,
+        if_not_exists,
     }: CreateClusterReplicaStatement<Aug>,
 ) -> Result<Plan, PlanError> {
     let cluster = scx
@@ -5581,6 +5590,7 @@ pub fn plan_create_cluster_replica(
         name: normalize::ident(name),
         cluster_id: cluster.id(),
         config,
+        if_not_exists,
     }))
 }
 

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -532,6 +532,7 @@ fn generate_rbac_requirements(
             name: _,
             variant: _,
             workload_class: _,
+            if_not_exists: _,
         }) => RbacRequirements {
             privileges: vec![(SystemObjectId::System, AclMode::CREATE_CLUSTER, role_id)],
             item_usage: &CREATE_ITEM_USAGE,
@@ -541,6 +542,7 @@ fn generate_rbac_requirements(
             cluster_id,
             name: _,
             config: _,
+            if_not_exists: _,
         }) => RbacRequirements {
             ownership: vec![ObjectId::Cluster(*cluster_id)],
             item_usage: &CREATE_ITEM_USAGE,

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -505,3 +505,36 @@ ReadyForQuery {"status":"I"}
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"00000"},{"typ":"M","value":"drop cascades to 2 other objects"}]}
 CommandComplete {"tag":"DROP TABLE"}
 ReadyForQuery {"status":"I"}
+
+# Cluster case: `CREATE CLUSTER IF NOT EXISTS` for a name that is already taken
+# skips creation and reports success with an "already exists, skipping" notice.
+# `CREATE CLUSTER REPLICA IF NOT EXISTS` behaves the same for a replica name
+# already used on the target cluster.
+send
+Query {"query": "CREATE CLUSTER nc REPLICAS (r1 (SIZE = 'scale=1,workers=1'))"}
+Query {"query": "CREATE CLUSTER IF NOT EXISTS nc REPLICAS ()"}
+Query {"query": "CREATE CLUSTER REPLICA IF NOT EXISTS nc.r1 SIZE = 'scale=1,workers=1'"}
+Query {"query": "CREATE CLUSTER REPLICA IF NOT EXISTS nc.r2 SIZE = 'scale=1,workers=1'"}
+Query {"query": "DROP CLUSTER nc"}
+----
+
+until err_field_typs=SCM
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE CLUSTER"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"42710"},{"typ":"M","value":"cluster \"nc\" already exists, skipping"}]}
+CommandComplete {"tag":"CREATE CLUSTER"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"42710"},{"typ":"M","value":"cluster replica \"nc.r1\" already exists, skipping"}]}
+CommandComplete {"tag":"CREATE CLUSTER REPLICA"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE CLUSTER REPLICA"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"00000"},{"typ":"M","value":"drop cascades to 2 other objects"}]}
+CommandComplete {"tag":"DROP CLUSTER"}
+ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -1041,3 +1041,153 @@ u3  NULL
 
 statement ok
 DROP CLUSTER c1
+
+# `IF NOT EXISTS`
+
+statement ok
+CREATE CLUSTER ine1 (SIZE 'scale=1,workers=1')
+
+# Skipping leaves the existing cluster untouched: the configuration in the
+# statement is not applied.
+statement ok
+CREATE CLUSTER IF NOT EXISTS ine1 (SIZE 'scale=1,workers=2', REPLICATION FACTOR 2)
+
+query TIT
+SELECT name, replication_factor, size FROM mz_clusters WHERE name = 'ine1'
+----
+ine1  1  scale=1,workers=1
+
+# The statement is validated in full before the collision is reported, exactly
+# as it is without `IF NOT EXISTS`. A typo must not hide behind the clause.
+statement error unknown cluster replica size
+CREATE CLUSTER IF NOT EXISTS ine1 (SIZE 'lol')
+
+statement error cluster 'ine1' already exists
+CREATE CLUSTER ine1 (SIZE 'scale=1,workers=2')
+
+# The unmanaged variant takes the clause too.
+statement ok
+CREATE CLUSTER ineu REPLICAS (r1 (SIZE 'scale=1,workers=1'))
+
+statement ok
+CREATE CLUSTER IF NOT EXISTS ineu REPLICAS (r2 (SIZE 'scale=1,workers=1'))
+
+query T rowsort
+SELECT r.name
+FROM mz_cluster_replicas r JOIN mz_clusters c ON c.id = r.cluster_id
+WHERE c.name = 'ineu'
+----
+r1
+
+statement ok
+DROP CLUSTER ineu
+
+# `IF NOT EXISTS` still creates the cluster when the name is free.
+statement ok
+CREATE CLUSTER IF NOT EXISTS ine3 (SIZE 'scale=1,workers=1')
+
+query T
+SELECT name FROM mz_clusters WHERE name = 'ine3'
+----
+ine3
+
+# Cluster names are case sensitive, so an unquoted `INE3` is `ine3` but a
+# quoted `INE3` is a distinct, free name.
+statement ok
+CREATE CLUSTER IF NOT EXISTS INE3 (SIZE 'scale=1,workers=1')
+
+statement ok
+CREATE CLUSTER IF NOT EXISTS "INE3" (SIZE 'scale=1,workers=1')
+
+query T rowsort
+SELECT name FROM mz_clusters WHERE name ILIKE 'ine3'
+----
+INE3
+ine3
+
+# `FEATURES` is system-user only, and it is the shape with the most plan/unplan
+# roundtrip surface, so cover it with the clause too.
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER IF NOT EXISTS inef (SIZE 'scale=1,workers=1') FEATURES (ENABLE EAGER DELTA JOINS = true)
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER IF NOT EXISTS inef (SIZE 'scale=1,workers=2') FEATURES (ENABLE EAGER DELTA JOINS = false)
+----
+COMPLETE 0
+
+query TT
+SHOW CREATE CLUSTER inef
+----
+inef  CREATE␠CLUSTER␠"inef"␠(EXPERIMENTAL␠ARRANGEMENT␠COMPRESSION␠=␠false,␠INTROSPECTION␠DEBUGGING␠=␠false,␠INTROSPECTION␠INTERVAL␠=␠INTERVAL␠'00:00:01',␠MANAGED␠=␠true,␠REPLICATION␠FACTOR␠=␠1,␠SIZE␠=␠'scale=1,workers=1',␠SCHEDULE␠=␠MANUAL)␠FEATURES␠(ENABLE␠EAGER␠DELTA␠JOINS␠=␠true)
+
+simple conn=mz_system,user=mz_system
+DROP CLUSTER inef
+----
+COMPLETE 0
+
+# `IF NOT EXISTS` is not part of the cluster's definition, so it does not show
+# up here.
+query TT
+SHOW CREATE CLUSTER ine3
+----
+ine3  CREATE␠CLUSTER␠"ine3"␠(EXPERIMENTAL␠ARRANGEMENT␠COMPRESSION␠=␠false,␠INTROSPECTION␠DEBUGGING␠=␠false,␠INTROSPECTION␠INTERVAL␠=␠INTERVAL␠'00:00:01',␠MANAGED␠=␠true,␠REPLICATION␠FACTOR␠=␠1,␠SIZE␠=␠'scale=1,workers=1',␠SCHEDULE␠=␠MANUAL)
+
+# A reserved name is rejected before the name is ever checked for a collision,
+# so `IF NOT EXISTS` must report the reserved name rather than a skip.
+statement error cluster name "mz_system" is reserved
+CREATE CLUSTER IF NOT EXISTS mz_system (SIZE 'scale=1,workers=1')
+
+statement error cluster name "mz_nope" is reserved
+CREATE CLUSTER IF NOT EXISTS mz_nope (SIZE 'scale=1,workers=1')
+
+statement ok
+DROP CLUSTER ine1
+
+statement ok
+DROP CLUSTER ine3
+
+statement ok
+DROP CLUSTER "INE3"
+
+# `IF NOT EXISTS` for cluster replicas.
+
+statement ok
+CREATE CLUSTER iner REPLICAS (r1 (SIZE 'scale=1,workers=1'))
+
+statement error cannot create multiple replicas named 'r1' on cluster 'iner'
+CREATE CLUSTER REPLICA iner.r1 SIZE 'scale=1,workers=2'
+
+statement ok
+CREATE CLUSTER REPLICA IF NOT EXISTS iner.r1 SIZE 'scale=1,workers=2'
+
+statement ok
+CREATE CLUSTER REPLICA IF NOT EXISTS iner.r2 SIZE 'scale=1,workers=1'
+
+query TT rowsort
+SELECT r.name, r.size
+FROM mz_cluster_replicas r JOIN mz_clusters c ON c.id = r.cluster_id
+WHERE c.name = 'iner'
+----
+r1  scale=1,workers=1
+r2  scale=1,workers=1
+
+# `IF NOT EXISTS` covers the replica name only, the cluster must exist.
+statement error unknown cluster 'nope'
+CREATE CLUSTER REPLICA IF NOT EXISTS nope.r1 SIZE 'scale=1,workers=1'
+
+# Replicas cannot be added to a managed cluster at all, and `IF NOT EXISTS`
+# does not soften that: the rejection happens at plan time, before the replica
+# name is ever considered.
+statement ok
+CREATE CLUSTER inem (SIZE 'scale=1,workers=1')
+
+statement error cannot modify managed cluster inem
+CREATE CLUSTER REPLICA IF NOT EXISTS inem.r1 SIZE 'scale=1,workers=1'
+
+statement ok
+DROP CLUSTER inem
+
+statement ok
+DROP CLUSTER iner


### PR DESCRIPTION
`CREATE CLUSTER` and `CREATE CLUSTER REPLICA` now accept an `IF NOT EXISTS`
clause, matching the 13 other `CREATE` statements that already support it.
With it, creating a cluster or replica whose name is already taken succeeds and
emits a `cluster "c" already exists, skipping` notice (SQLSTATE 42710) instead
of failing, so idempotent provisioning scripts no longer need a pre-flight
existence check.

Skipping leaves the existing object completely untouched. The configuration in
the statement is not applied, so this is not an upsert.

Previously these two statements produced a misleading parse error, because `IF`
was consumed as the object name and the failure surfaced one token later:

```
CREATE CLUSTER IF NOT EXISTS c (SIZE '25cc')
ERROR: Expected one of AUTO or AVAILABILITY or DISK or ..., found NOT
```

## Implementation

The machinery already exists end to end, so this is mostly threading a flag:
`if_not_exists` on the two AST nodes and the two plans, a `parse_if_not_exists()`
call in each parse function, and the established "turn the catalog's
already-exists error into a notice" arm in the sequencer.

Two things worth calling out:

* The skip happens at the catalog transaction, where every sibling path puts
  it, rather than short-circuiting early on the in-memory catalog. That means
  the statement is validated in full first, so `CREATE CLUSTER IF NOT EXISTS c
  (SIZE 'typo')` still reports the bad size rather than silently succeeding
  because `c` happens to exist. The cost is that a skipped statement still
  allocates (and discards) a cluster id, which is a durable catalog write. That
  is the same cost every other `CREATE ... IF NOT EXISTS` already pays, and
  silently accepting a typo'd config in a provisioning script is the worse
  failure mode.

* A bare `if` identifier now renders quoted, joining the existing list of
  keywords quoted for exactly this reason (`PREPARE`, `INTO`, `WHEN`, …). The
  `IF [NOT] EXISTS` clause sits exactly where the object name goes, so
  `CREATE CLUSTER if (SIZE …)` rendered in Simple mode no longer reparses. That
  affects the parser's own display roundtrip test, the user-facing `pretty_sql()`
  function, and `mz-deploy`, which renders a project file's statement with
  `to_string()` and executes it. `SHOW CREATE CLUSTER` and the plan/unplan
  roundtrip assertion in `plan_create_cluster` both use Stable mode, which
  already quoted everything, so neither was ever affected.

  The flip side is a grammar break: `CREATE CLUSTER if …` and
  `CREATE CLUSTER REPLICA if.r …` used to parse, since the parser accepts
  keywords as identifiers, and now do not. Quoting still works, and
  `DROP CLUSTER if` was already broken the same way.

  I smoke tested the upgrade: created a cluster named `if` (unquoted) on `main`
  along with a table, index and materialized view in it, then restarted on this
  branch against the same catalog. Bootstrap is clean, the cluster and its
  objects survive and serve queries, and `ALTER`/`DROP` by quoted name work.
  The only observable change is that renderings which used to emit a bare `if`
  now quote it, for example `SHOW CREATE INDEX` goes from `IN CLUSTER if` to
  `IN CLUSTER "if"`.

`SHOW CREATE CLUSTER` does not render `IF NOT EXISTS`. It is a property of the
statement, not of the cluster.

## Tests

* `src/sql-parser/tests/testdata/ddl`: syntax for both statements, the
  `IF EXISTS` typo, and a cluster literally named `if`.
* `test/sqllogictest/cluster.slt`: idempotence, that the existing object is left
  untouched, that a bad `SIZE` is still reported, the managed and unmanaged
  cluster variants, `FEATURES`, reserved names, case sensitivity, full
  `SHOW CREATE CLUSTER` output, that the replica form still requires the cluster
  to exist, and that it does not soften the managed-cluster rejection.
* `test/pgtest-mz/notice.pt`: the wire-level notice for both statements.

Fixes [SQL-601](https://linear.app/materializeinc/issue/SQL-601)
