### PR TITLE
dbt-materialize: make strict_mode schema isolation fire for views, materialized views and tables

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Fix `strict_mode` schema isolation for `view`, `materialized_view` and
+  `table` models. The check that blocks these materializations from schemas
+  holding sources, source tables or sinks never fired, because the flags it
+  set inside a loop did not survive the loop. Building one of these models on
+  its own in a reserved schema now raises an error, as documented.
+
 ## 1.9.11 - 2026-07-26
 
 * Add support for the [`AUTO SCALING STRATEGY`](https://materialize.com/docs/sql/create-cluster/#autoscaling)

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/validate_schema_isolation.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/validate_schema_isolation.sql
@@ -208,10 +208,10 @@
   {# Step 1: Only run validation when strict_mode is enabled #}
   {% if var('strict_mode', False) %}
 
-    {# Step 2: Initialize flags to track if we find isolated types #}
-    {% set has_source = false %}
-    {% set has_sink = false %}
-    {% set has_source_table = false %}
+    {# Step 2: Initialize flags to track if we find isolated types. These live
+       in a namespace because assignments made inside a for loop do not survive
+       the loop otherwise. #}
+    {% set found = namespace(source=false, sink=false, source_table=false) %}
 
     {# Step 3: Iterate through all nodes in the dbt manifest #}
     {% for node in graph.nodes.values() %}
@@ -221,18 +221,18 @@
 
         {# Step 5: Check if this node is a source, sink, or source_table #}
         {% if node.config.materialized == 'source' %}
-          {% set has_source = true %}
+          {% set found.source = true %}
         {% elif node.config.materialized == 'sink' %}
-          {% set has_sink = true %}
+          {% set found.sink = true %}
         {% elif node.config.materialized == 'source_table' %}
-          {% set has_source_table = true %}
+          {% set found.source_table = true %}
         {% endif %}
 
       {% endif %}
     {% endfor %}
 
     {# Step 6: If schema contains sources, block creation of this object #}
-    {% if has_source %}
+    {% if found.source %}
       {{ exceptions.raise_compiler_error(
         "Cannot create object in schema '" ~ target_schema ~ "'. " ~
         "Schema contains source objects. " ~
@@ -241,7 +241,7 @@
     {% endif %}
 
     {# Step 7: If schema contains sinks, block creation of this object #}
-    {% if has_sink %}
+    {% if found.sink %}
       {{ exceptions.raise_compiler_error(
         "Cannot create object in schema '" ~ target_schema ~ "'. " ~
         "Schema contains sink objects. " ~
@@ -250,7 +250,7 @@
     {% endif %}
 
     {# Step 8: If schema contains source_tables, block creation of this object #}
-    {% if has_source_table %}
+    {% if found.source_table %}
       {{ exceptions.raise_compiler_error(
         "Cannot create object in schema '" ~ target_schema ~ "'. " ~
         "Schema contains source_table objects. " ~

--- a/misc/dbt-materialize/tests/adapter/test_strict_mode.py
+++ b/misc/dbt-materialize/tests/adapter/test_strict_mode.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import pytest
-from dbt.tests.util import run_dbt
+from dbt.tests.util import run_dbt, run_dbt_and_capture
 
 # Source materialization in dedicated schema (for non-strict tests)
 load_gen_source = """
@@ -282,6 +282,14 @@ class TestStrictModeViewBlocked:
         """With strict_mode, mixing view and source_table in same schema fails at compile time."""
         run_dbt(["run"], expect_pass=False)
 
+    def test_view_alone_blocked_by_source_table_in_schema(self, project):
+        """Building only the view must still fail, since the source_table's own
+        validation does not run. This pins the view side of the check."""
+        _, output = run_dbt_and_capture(
+            ["run", "--select", "test_view"], expect_pass=False
+        )
+        assert "Schema contains source_table objects" in output
+
 
 class TestStrictModeSourceTablesCanCoexist:
     """Test that multiple source_tables can coexist in the same schema (strict_mode enabled)."""
@@ -353,6 +361,14 @@ class TestStrictModeViewBlockedBySink:
         """With strict_mode, mixing view and sink in same schema fails at compile time."""
         run_dbt(["run"], expect_pass=False)
 
+    def test_view_alone_blocked_by_sink_in_schema(self, project):
+        """Building only the view must still fail, since the sink's own
+        validation does not run. This pins the view side of the check."""
+        _, output = run_dbt_and_capture(
+            ["run", "--select", "test_view"], expect_pass=False
+        )
+        assert "Schema contains sink objects" in output
+
 
 class TestStrictModeSinksCanCoexist:
     """Test that multiple sinks can coexist in the same schema (strict_mode enabled)."""
@@ -422,6 +438,14 @@ class TestStrictModeViewBlockedBySource:
     def test_view_blocked_in_schema_with_source(self, project):
         """With strict_mode, mixing view and source in same schema fails at compile time."""
         run_dbt(["run"], expect_pass=False)
+
+    def test_view_alone_blocked_by_source_in_schema(self, project):
+        """Building only the view must still fail, since the source's own
+        validation does not run. This pins the view side of the check."""
+        _, output = run_dbt_and_capture(
+            ["run", "--select", "test_view"], expect_pass=False
+        )
+        assert "Schema contains source objects" in output
 
 
 class TestStrictModeSourcesCanCoexist:


### PR DESCRIPTION
The strict_mode check that keeps views, materialized views and tables out of schemas reserved for sources, source tables and sinks never actually ran, because the flags it set inside a Jinja loop were dropped when the loop ended. This moves the flags into a namespace so the check works, and adds tests that build only the blocked model so each direction of the rule is covered on its own.

Test plan: added three cases to `test_strict_mode.py` that select just the view and assert the error message.