### PR TITLE
dbt-materialize: fix the missing deployment timestamp in deploy_promote schema tags

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Fix the deployment timestamp in the schema comment `deploy_promote` leaves
+  behind. It read the second row of the first column instead of the second
+  column of the only row, so every tag said `Deployment by <user> on ` with
+  nothing after it.
+
 ## 1.9.11 - 2026-07-26
 
 * Add support for the [`AUTO SCALING STRATEGY`](https://materialize.com/docs/sql/create-cluster/#autoscaling)

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -242,8 +242,8 @@
 
     {% set result = run_query("SELECT current_user, now();") %}
     {% if result is not none and result.rows|length > 0 %}
-        {% set db_user = result.columns[0][0] %}
-        {% set deploy_time = result.columns[0][1] %}
+        {% set db_user = result.rows[0][0] %}
+        {% set deploy_time = result.rows[0][1] %}
     {% else %}
         {% set db_user = "unknown" %}
         {% set deploy_time = "unknown" %}

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import re
 import threading
 import time
 
@@ -540,9 +541,12 @@ class TestTargetDeploy:
             assert (
                 "Deployment by" in tagged_schema_comment[0]
             ), f"Missing deployment info in {schema_name} comment"
-            assert (
-                "on" in tagged_schema_comment[0]
-            ), f"Missing timestamp in {schema_name} comment"
+            # The user and timestamp are read out of a single-row result, so
+            # match on their values rather than on the surrounding words.
+            assert re.search(
+                r"Deployment by \S+ on \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}",
+                tagged_schema_comment[0],
+            ), f"Missing user or timestamp in {schema_name} comment: {tagged_schema_comment[0]}"
 
     def test_dbt_deploy_with_force(self, project):
         project.run_sql("CREATE CLUSTER prod SIZE = 'scale=1,workers=1'")


### PR DESCRIPTION
The comment that `deploy_promote` puts on each promoted schema was reading the second row of the first column of a one row result, which Jinja turns into an empty value, so every tag ended with "on " and no timestamp. It now reads the second column of the first row.

