### PR TITLE
storage: realize replica-scoped dyncfg overrides in storage workers

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2361,26 +2361,32 @@ impl Coordinator {
             }
         }
 
-        // Only the compute controller's per-replica dyncfg layer is pushed, but on
-        // `clusterd` that also reaches storage. Compute and storage share one
-        // process, and the compute worker's `handle_update_configuration` applies
-        // the pushed dyncfg updates both to compute's own worker `ConfigSet` and to
-        // the shared persist client `ConfigSet` (`persist_clients.cfg()`) that the
-        // co-located storage server reads from the same `Arc`. So persist-backed and
-        // process-global replica-local configs such as the persist pager, LZ4,
-        // persist client tuning, and `lgalloc` take effect on storage too. The only
-        // gap would be a future `Replica`-scoped config realized solely in the
-        // storage worker's own `ConfigSet`, of which none exists today.
+        // Both controllers carry a per-replica dyncfg layer, because the two
+        // protocols realize configs in different worker `ConfigSet`s on
+        // `clusterd`. The compute worker's `handle_update_configuration`
+        // applies the pushed dyncfg updates to compute's own worker
+        // `ConfigSet` and to the shared persist client `ConfigSet`
+        // (`persist_clients.cfg()`) that the co-located storage server reads
+        // from the same `Arc`, which covers persist-backed and process-global
+        // configs such as persist client tuning and `lgalloc`. Configs
+        // realized from the storage worker's own `ConfigSet` (read in its
+        // `UpdateConfiguration` handler) are reached only by the storage
+        // controller's layer.
         self.controller
             .compute
+            .update_replica_dyncfg_overrides(instance_overrides.clone());
+        self.controller
+            .storage
             .update_replica_dyncfg_overrides(instance_overrides);
-        // Re-push the env-wide compute config so existing replicas pick up their
-        // (possibly changed) overrides. This also reverts a removed override: the
-        // per-replica layer no longer carries the key, so the replica falls back
-        // to the env-wide value, which `compute_config` always includes because it
-        // renders the full dyncfg set.
+        // Re-push the env-wide configs so existing replicas pick up their
+        // (possibly changed) overrides. This also reverts a removed override:
+        // the per-replica layer no longer carries the key, so the replica
+        // falls back to the env-wide value, which both configs always include
+        // because they render the full dyncfg set.
         let compute_config = crate::flags::compute_config(self.catalog().system_config());
         self.controller.compute.update_configuration(compute_config);
+        let storage_config = crate::flags::storage_config(self.catalog().system_config());
+        self.controller.storage.update_parameters(storage_config);
     }
 
     /// Returns the cluster-coherent scoped optimizer-feature overrides for

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -32,7 +32,7 @@ use differential_dataflow::lattice::Lattice;
 use mz_cluster_client::ReplicaId;
 use mz_cluster_client::client::ClusterReplicaLocation;
 use mz_controller_types::dyncfgs::WALLCLOCK_LAG_HISTOGRAM_PERIOD_INTERVAL;
-use mz_dyncfg::ConfigSet;
+use mz_dyncfg::{ConfigSet, ConfigUpdates};
 use mz_ore::soft_panic_or_log;
 use mz_persist_client::batch::ProtoBatch;
 use mz_persist_types::{Codec64, ShardId};
@@ -351,6 +351,19 @@ pub trait StorageController: Debug {
 
     /// Update storage configuration with new parameters.
     fn update_parameters(&mut self, config_params: StorageParameters);
+
+    /// Replaces the per-replica dyncfg overrides for the given instances.
+    ///
+    /// This only stores the overrides; callers should follow with a
+    /// configuration push (e.g. [`Self::update_parameters`]) so existing
+    /// replicas observe the new values. Instances absent from `overrides` have
+    /// their overrides cleared, so a replica that no longer has an override
+    /// reverts to the environment-wide configuration. Used by the scoped
+    /// feature flags (replica-local) layer.
+    fn update_replica_dyncfg_overrides(
+        &mut self,
+        overrides: BTreeMap<StorageInstanceId, BTreeMap<ReplicaId, ConfigUpdates>>,
+    );
 
     /// Get the current configuration, including parameters updated with `update_parameters`.
     fn config(&self) -> &StorageConfiguration;

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -20,6 +20,7 @@ use itertools::Itertools;
 use mz_build_info::BuildInfo;
 use mz_cluster_client::ReplicaId;
 use mz_cluster_client::client::ClusterReplicaLocation;
+use mz_dyncfg::ConfigUpdates;
 use mz_ore::cast::CastFrom;
 use mz_ore::now::NowFn;
 use mz_ore::retry::{Retry, RetryState};
@@ -76,6 +77,11 @@ pub(crate) struct Instance {
     /// The command history, used to replay past commands when introducing new replicas or
     /// reconnecting to existing replicas.
     history: CommandHistory,
+    /// Per-replica dyncfg overrides, merged into `UpdateConfiguration` commands
+    /// when they are sent or replayed to the overridden replica. The history
+    /// records the base (un-specialized) commands, so overrides are re-applied
+    /// at replay time rather than baked into the shared history.
+    replica_dyncfg_overrides: BTreeMap<ReplicaId, ConfigUpdates>,
     /// Metrics tracked for this storage instance.
     metrics: InstanceMetrics,
     /// A function that returns the current time.
@@ -128,6 +134,7 @@ impl Instance {
             ingestion_exports: Default::default(),
             active_exports: BTreeMap::new(),
             history,
+            replica_dyncfg_overrides: Default::default(),
             metrics,
             now,
             response_tx: instance_response_tx,
@@ -199,8 +206,14 @@ impl Instance {
             .get_mut(&replica_id)
             .expect("replica must exist");
 
-        // Replay the commands at the new replica.
+        // Replay the commands at the new replica, re-applying its dyncfg
+        // override to configuration commands.
         for command in filtered_commands {
+            let command = Self::specialize_command_for_replica(
+                command,
+                replica_id,
+                &self.replica_dyncfg_overrides,
+            );
             replica.send(command);
         }
     }
@@ -333,6 +346,34 @@ impl Instance {
         }
     }
 
+    /// Replaces the per-replica dyncfg overrides. Callers should follow this
+    /// with a configuration push (e.g. an `UpdateConfiguration` command) so
+    /// that existing replicas observe the new overrides.
+    pub fn update_replica_dyncfg_overrides(
+        &mut self,
+        overrides: BTreeMap<ReplicaId, ConfigUpdates>,
+    ) {
+        self.replica_dyncfg_overrides = overrides;
+    }
+
+    /// Specializes a command for a specific replica by merging that replica's
+    /// dyncfg override into its configuration. For `UpdateConfiguration` the
+    /// override is merged into the update. All other commands are returned
+    /// unchanged.
+    fn specialize_command_for_replica(
+        mut command: StorageCommand,
+        replica_id: ReplicaId,
+        overrides: &BTreeMap<ReplicaId, ConfigUpdates>,
+    ) -> StorageCommand {
+        if let StorageCommand::UpdateConfiguration(params) = &mut command
+            && let Some(over) = overrides.get(&replica_id)
+            && !over.updates.is_empty()
+        {
+            params.dyncfg_updates.extend(over.clone());
+        }
+        command
+    }
+
     /// Sends a command to this storage instance.
     pub fn send(&mut self, command: StorageCommand) {
         // Record the command so that new replicas can be brought up to speed.
@@ -372,8 +413,14 @@ impl Instance {
                 self.absorb_compaction(id, frontier);
             }
             command => {
-                for replica in self.replicas.values_mut() {
-                    replica.send(command.clone());
+                let overrides = &self.replica_dyncfg_overrides;
+                for (replica_id, replica) in self.replicas.iter_mut() {
+                    let command = Self::specialize_command_for_replica(
+                        command.clone(),
+                        *replica_id,
+                        overrides,
+                    );
+                    replica.send(command);
                 }
             }
         }
@@ -947,5 +994,61 @@ impl ReplicaTask {
         if let StorageCommand::Hello { nonce } = command {
             *nonce = Uuid::new_v4();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use mz_dyncfg::{ConfigUpdates, ConfigVal};
+    use mz_storage_types::dyncfgs::ENABLE_UPSERT_PAGED_SPILL;
+    use mz_storage_types::parameters::StorageParameters;
+
+    use super::{Instance, ReplicaId, StorageCommand};
+
+    fn update_configuration_command() -> StorageCommand {
+        StorageCommand::UpdateConfiguration(Box::new(StorageParameters::default()))
+    }
+
+    fn dyncfg_updates(command: &StorageCommand) -> &ConfigUpdates {
+        match command {
+            StorageCommand::UpdateConfiguration(params) => &params.dyncfg_updates,
+            other => panic!("expected UpdateConfiguration, got {other:?}"),
+        }
+    }
+
+    /// An overridden replica's `UpdateConfiguration` carries its override on
+    /// top of the environment-wide updates, while replicas without an
+    /// override receive the base command unchanged.
+    #[mz_ore::test]
+    fn update_configuration_applies_replica_override() {
+        let mut over = ConfigUpdates::default();
+        over.add(&ENABLE_UPSERT_PAGED_SPILL, true);
+        let overrides = BTreeMap::from([(ReplicaId::User(1), over)]);
+
+        let command = Instance::specialize_command_for_replica(
+            update_configuration_command(),
+            ReplicaId::User(1),
+            &overrides,
+        );
+        assert_eq!(
+            dyncfg_updates(&command)
+                .updates
+                .get(ENABLE_UPSERT_PAGED_SPILL.name()),
+            Some(&ConfigVal::Bool(true)),
+        );
+
+        let command = Instance::specialize_command_for_replica(
+            update_configuration_command(),
+            ReplicaId::User(2),
+            &overrides,
+        );
+        assert_eq!(
+            dyncfg_updates(&command)
+                .updates
+                .get(ENABLE_UPSERT_PAGED_SPILL.name()),
+            None,
+        );
     }
 }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -35,6 +35,7 @@ use mz_cluster_client::{ReplicaId, WallclockLagFn};
 use mz_controller_types::dyncfgs::{
     ENABLE_0DT_DEPLOYMENT_SOURCES, WALLCLOCK_LAG_RECORDING_INTERVAL,
 };
+use mz_dyncfg::ConfigUpdates;
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
@@ -331,6 +332,16 @@ impl StorageController for Controller {
                 .parameters
                 .user_storage_managed_collections_batch_duration,
         );
+    }
+
+    fn update_replica_dyncfg_overrides(
+        &mut self,
+        mut overrides: BTreeMap<StorageInstanceId, BTreeMap<ReplicaId, ConfigUpdates>>,
+    ) {
+        for (id, instance) in self.instances.iter_mut() {
+            let instance_overrides = overrides.remove(id).unwrap_or_default();
+            instance.update_replica_dyncfg_overrides(instance_overrides);
+        }
     }
 
     /// Get the current configuration


### PR DESCRIPTION
### Motivation

Replica-scoped system parameters are realized as per-replica dyncfg overrides, but only the compute controller carries a per-replica dyncfg layer. On `clusterd` the compute worker applies pushed updates to its own worker `ConfigSet` and to the shared persist-client `ConfigSet`, which covers persist-backed and process-global configs. A dyncfg that the storage worker reads from its own `ConfigSet` (in its `UpdateConfiguration` handler) never sees a replica-scoped override: the storage protocol delivers only environment-wide values, so scoping such a flag to a replica is silently inert.

### Description

Mirror the compute controller's per-replica dyncfg layer in the storage controller:

* The storage `Instance` stores per-replica `ConfigUpdates` overrides and specializes `UpdateConfiguration` commands per replica, both at send time and when replaying history to new or reconnecting replicas. The history records base commands, so overrides are re-applied at replay rather than baked into the shared history.
* New `StorageController::update_replica_dyncfg_overrides`, with the same replace-and-clear semantics as the compute controller's: instances absent from the pushed map have their overrides cleared.
* The coordinator's `push_replica_dyncfg_overrides` now pushes the same override map to both controllers and re-pushes the environment-wide storage config afterward, so existing replicas observe changed overrides and removed overrides revert to environment-wide values (`storage_config` renders the full dyncfg set).

This unblocks scoping storage-realized flags (for example the upsert-v2 spill gate) to individual replicas.

### Verification

Adds a unit test for the storage command specialization: an overridden replica's `UpdateConfiguration` carries the merged override, while replicas without an override receive the base command. This mirrors the existing compute-side specialization tests.