### PR TITLE
dbt-materialize: pass the schema name when tagging deployment schemas in deploy_init

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Fix `deploy_init` when the `CI_TAG` environment variable is set. The
+  deployment schema was tagged without passing the schema name, so the
+  operation failed with `COMMENT ON SCHEMA ""`. The deployment schema is
+  now also created with a quoted name, matching how it is dropped.
+
 ## 1.9.11 - 2026-07-26
 
 * Add support for the [`AUTO SCALING STRATEGY`](https://materialize.com/docs/sql/create-cluster/#autoscaling)

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -7,6 +7,11 @@
   column of the only row, so every tag said `Deployment by <user> on ` with
   nothing after it.
 
+* Fix `deploy_init` when the `CI_TAG` environment variable is set. The
+  deployment schema was tagged without passing the schema name, so the
+  operation failed with `COMMENT ON SCHEMA ""`. The deployment schema is
+  now also created with a quoted name, matching how it is dropped.
+
 ## 1.9.11 - 2026-07-26
 
 * Add support for the [`AUTO SCALING STRATEGY`](https://materialize.com/docs/sql/create-cluster/#autoscaling)

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
@@ -98,10 +98,10 @@
     {% else %}
         {{ log("Creating deployment schema " ~ deploy_schema, info=True)}}
         {% set create_schema %}
-        CREATE SCHEMA {{ deploy_schema }};
+        CREATE SCHEMA {{ adapter.quote(deploy_schema) }};
         {% endset %}
         {{ run_query(create_schema) }}
-        {{ set_schema_ci_tag() }}
+        {{ set_schema_ci_tag(deploy_schema) }}
         {{ internal_copy_schema_default_privs(schema, deploy_schema) }}
         {{ internal_copy_schema_grants(schema, deploy_schema) }}
     {% endif %}

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -544,6 +544,28 @@ class TestTargetDeploy:
                 "on" in tagged_schema_comment[0]
             ), f"Missing timestamp in {schema_name} comment"
 
+    def test_dbt_deploy_init_tags_schema_with_ci_tag(self, project, monkeypatch):
+        monkeypatch.setenv("CI_TAG", "gh_ci_123")
+        project.run_sql("CREATE CLUSTER prod SIZE = 'scale=1,workers=1'")
+        project.run_sql("CREATE SCHEMA prod")
+        project.run_sql("CREATE SCHEMA staging")
+
+        run_dbt(["run-operation", "deploy_init"])
+
+        for schema_name in ["prod_dbt_deploy", "staging_dbt_deploy"]:
+            comment = project.run_sql(
+                f"""
+                SELECT c.comment
+                FROM mz_internal.mz_comments c
+                JOIN mz_schemas s USING (id)
+                WHERE s.name = '{schema_name}';
+                """,
+                fetch="one",
+            )
+
+            assert comment is not None, f"No CI tag on schema {schema_name}"
+            assert comment[0] == "gh_ci_123"
+
     def test_dbt_deploy_with_force(self, project):
         project.run_sql("CREATE CLUSTER prod SIZE = 'scale=1,workers=1'")
         project.run_sql("CREATE CLUSTER prod_dbt_deploy SIZE = 'scale=1,workers=1'")

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -548,6 +548,28 @@ class TestTargetDeploy:
                 tagged_schema_comment[0],
             ), f"Missing user or timestamp in {schema_name} comment: {tagged_schema_comment[0]}"
 
+    def test_dbt_deploy_init_tags_schema_with_ci_tag(self, project, monkeypatch):
+        monkeypatch.setenv("CI_TAG", "gh_ci_123")
+        project.run_sql("CREATE CLUSTER prod SIZE = 'scale=1,workers=1'")
+        project.run_sql("CREATE SCHEMA prod")
+        project.run_sql("CREATE SCHEMA staging")
+
+        run_dbt(["run-operation", "deploy_init"])
+
+        for schema_name in ["prod_dbt_deploy", "staging_dbt_deploy"]:
+            comment = project.run_sql(
+                f"""
+                SELECT c.comment
+                FROM mz_internal.mz_comments c
+                JOIN mz_schemas s USING (id)
+                WHERE s.name = '{schema_name}';
+                """,
+                fetch="one",
+            )
+
+            assert comment is not None, f"No CI tag on schema {schema_name}"
+            assert comment[0] == "gh_ci_123"
+
     def test_dbt_deploy_with_force(self, project):
         project.run_sql("CREATE CLUSTER prod SIZE = 'scale=1,workers=1'")
         project.run_sql("CREATE CLUSTER prod_dbt_deploy SIZE = 'scale=1,workers=1'")


### PR DESCRIPTION
When `CI_TAG` is set, `deploy_init` called the schema tagging macro without the schema name, so it ran `COMMENT ON SCHEMA ""` and the whole operation failed. Since `CI_TAG` is the variable our blue/green CI docs tell people to set, this broke deploy_init in the setup it was built for, so this passes the deployment schema through and quotes it on creation the same way it is quoted on drop.

Test plan: added a case to `test_deploy.py` that runs `deploy_init` with `CI_TAG` set and checks the tag lands on both deployment schemas.