### PR TITLE
dbt-materialize: run unit tests on the configured cluster

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Apply the `cluster` configuration to unit tests. The unit test
+  materialization never passed the cluster on to the macro that sets it, so
+  unit test queries always ran against the session default cluster instead of
+  the one configured for the model or in `profiles.yml`.
+
 ## 1.9.11 - 2026-07-26
 
 * Add support for the [`AUTO SCALING STRATEGY`](https://materialize.com/docs/sql/create-cluster/#autoscaling)

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/unit.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/unit.sql
@@ -40,7 +40,13 @@
     {% set expected_sql = get_expected_sql(expected_rows, column_name_to_data_types, column_name_to_quoted) %}
   {% endif %}
 
-  {% set unit_test_sql = get_unit_test_sql(sql, expected_sql, tested_expected_column_names) %}
+  -- Unit tests compile to ad-hoc queries, which need a cluster to run against.
+  -- If no cluster is configured, use the target cluster from `profiles.yml`. If
+  -- none exists, fall back to the default cluster configured for the connected
+  -- user, matching the data test materialization.
+  {%- set cluster = adapter.generate_final_cluster_name(config.get('cluster', target.cluster)) %}
+
+  {% set unit_test_sql = get_unit_test_sql(sql, expected_sql, tested_expected_column_names, cluster) %}
 
   {% call statement('main', fetch_result=True) -%}
     {{ unit_test_sql }}

--- a/misc/dbt-materialize/tests/adapter/test_unit_testing.py
+++ b/misc/dbt-materialize/tests/adapter/test_unit_testing.py
@@ -18,6 +18,23 @@ from dbt.tests.adapter.unit_testing.test_case_insensitivity import (
 )
 from dbt.tests.adapter.unit_testing.test_invalid_input import BaseUnitTestInvalidInput
 from dbt.tests.adapter.unit_testing.test_types import BaseUnitTestingTypes
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+
+my_model = """
+{{ config(materialized='view') }}
+
+SELECT 1 AS id
+"""
+
+my_model_unit_test_yml = """
+unit_tests:
+  - name: test_my_model
+    model: my_model
+    given: []
+    expect:
+      rows:
+        - {id: 1}
+"""
 
 
 class TestMaterializeUnitTestingTypes(BaseUnitTestingTypes):
@@ -57,3 +74,36 @@ class TestMaterializeUnitTestCaseInsensitivity(BaseUnitTestCaseInsensivity):
 
 class TestMaterializeUnitTestInvalidInput(BaseUnitTestInvalidInput):
     pass
+
+
+class TestMaterializeUnitTestCluster:
+    """The unit test materialization must run its query against the configured
+    cluster, like the data test materialization does. Unit test queries only
+    reference fixtures, so Materialize answers them without a cluster, which is
+    why this checks the statement dbt issues rather than the query result."""
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        return {
+            "type": "materialize",
+            "threads": 1,
+            "host": "{{ env_var('DBT_HOST', 'localhost') }}",
+            "user": "materialize",
+            "pass": "password",
+            "database": "materialize",
+            "port": "{{ env_var('DBT_PORT', 6875) }}",
+            "cluster": "quickstart",
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model,
+            "my_model_unit_test.yml": my_model_unit_test_yml,
+        }
+
+    def test_unit_test_sets_configured_cluster(self, project):
+        run_dbt(["run"])
+
+        _, output = run_dbt_and_capture(["--debug", "test"])
+        assert "set cluster = quickstart" in output


### PR DESCRIPTION
The unit test materialization called the macro that sets the cluster without passing one, so the cluster argument was always empty and unit test queries ran against whatever the session default cluster happened to be. It now resolves the cluster the same way the data test materialization does.

Test plan: added a case to `test_unit_testing.py` that runs a unit test with a cluster in the profile and checks dbt issues the matching `set cluster` statement.