### PR TITLE
dbt-materialize: report clear errors on the adapter's error paths

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -13,6 +13,25 @@
   now also created with a quoted name, matching how it is dropped and how its
   grants and default privileges are copied.
 
+* Report errors instead of failing in odd ways on a few paths:
+
+  * A malformed `indexes` config now raises a clear parse error. It used to
+    hit a `dbt_common` helper that no longer exists and crash with an
+    unhandled `AttributeError`.
+  * Incremental models and the `listagg` macro now show the explanation they
+    were written to show. Both called an exception class that dbt does not
+    expose to Jinja, so users saw a message about a `dict object` instead.
+  * `rename_relation` looked at an undefined variable to pick between a view
+    and a materialized view, which made every rename fail.
+  * `drop_relation` now errors for relation types it does not handle, rather
+    than sending an empty statement to the server.
+  * Option values in the `options` profile field are no longer mangled when
+    they contain a backslash, and non-string values no longer raise an
+    `AttributeError`.
+  * Connections that reach the adapter's version check without an
+    `mz_version` (for example, through a proxy that strips it) now get a
+    clear error instead of a crash on the missing version string.
+
 ## 1.9.11 - 2026-07-26
 
 * Add support for the [`AUTO SCALING STRATEGY`](https://materialize.com/docs/sql/create-cluster/#autoscaling)

--- a/misc/dbt-materialize/dbt/adapters/materialize/connections.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/connections.py
@@ -54,10 +54,11 @@ DEFAULT_SESSION_PARAMETERS = {
 }
 
 
-def _escape_option_value(v: str) -> str:
-    # libpq's options-string parser splits on spaces so values containing
-    # them either must be escaped
-    return v.replace(" ", "\\ ")
+def _escape_option_value(v: object) -> str:
+    # libpq's options-string parser treats a backslash as an escape and splits
+    # on spaces, so both must be escaped. Backslashes go first, otherwise the
+    # ones this adds to escape spaces get escaped in turn.
+    return str(v).replace("\\", "\\\\").replace(" ", "\\ ")
 
 
 def _build_options_string(
@@ -191,6 +192,12 @@ class MaterializeConnectionManager(PostgresConnectionManager):
         mz_version = connection.handle.info.parameter_status(
             "mz_version"
         )  # e.g. v0.79.0-dev (937dfde5e)
+        if mz_version is None:
+            raise dbt_common.exceptions.DbtRuntimeError(
+                "Server did not report an mz_version. Make sure you are "
+                "connecting to Materialize and not to another PostgreSQL-"
+                "compatible database."
+            )
         mz_version = mz_version.split()[0]  # e.g. v0.79.0-dev
         mz_version = mz_version[1:]  # e.g. 0.79.0-dev
         if not versions_compatible(mz_version, SUPPORTED_MATERIALIZE_VERSIONS):
@@ -217,7 +224,9 @@ class MaterializeConnectionManager(PostgresConnectionManager):
 
         connection_name = connection.name
         try:
-            logger.debug("Closing connection '{}' to force cancellation")
+            logger.debug(
+                f"Closing connection '{connection_name}' to force cancellation"
+            )
             connection.handle.close()
         except psycopg2.InterfaceError as exc:
             # if the connection is already closed, not much to cancel!

--- a/misc/dbt-materialize/dbt/adapters/materialize/exceptions.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/exceptions.py
@@ -15,6 +15,7 @@
 
 from typing import Any
 
+from dbt_common.dataclass_schema import ValidationError
 from dbt_common.exceptions import CompilationError
 
 
@@ -33,13 +34,24 @@ class RefreshIntervalConfigNotDictError(CompilationError):
 
 
 class RefreshIntervalConfigError(CompilationError):
-    def __init__(self, exc: TypeError):
+    def __init__(self, exc: ValidationError):
         self.exc = exc
         super().__init__(msg=self.get_message())
 
     def get_message(self) -> str:
         validator_msg = self.validator_error_message(self.exc)
         msg = f"Could not parse refresh interval config: {validator_msg}"
+        return msg
+
+
+class IndexConfigError(CompilationError):
+    def __init__(self, exc: ValidationError):
+        self.exc = exc
+        super().__init__(msg=self.get_message())
+
+    def get_message(self) -> str:
+        validator_msg = self.validator_error_message(self.exc)
+        msg = f"Could not parse index config: {validator_msg}"
         return msg
 
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -19,7 +19,6 @@ from collections import namedtuple
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set
 
-import dbt_common.exceptions
 import psycopg2
 from dbt_common.contracts.constraints import (
     ColumnLevelConstraint,
@@ -38,6 +37,7 @@ from dbt.adapters.capability import (
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.materialize.connections import MaterializeConnectionManager
 from dbt.adapters.materialize.exceptions import (
+    IndexConfigError,
     PartitionByConfigError,
     RefreshIntervalConfigError,
     RefreshIntervalConfigNotDictError,
@@ -66,16 +66,7 @@ class MaterializeIndexConfig(dbtClassMixin):
             cls.validate(raw_index)
             return cls.from_dict(raw_index)
         except ValidationError as exc:
-            msg = dbt_common.exceptions.validator_error_message(exc)
-            dbt_common.exceptions.CompilationError(
-                f"Could not parse index config: {msg}"
-            )
-        except TypeError:
-            dbt_common.exceptions.CompilationError(
-                "Invalid index config:\n"
-                f"  Got: {raw_index}\n"
-                '  Expected a dictionary with at minimum a "columns" key'
-            )
+            raise IndexConfigError(exc)
 
 
 # NOTE(morsapaes): Materialize allows configuring a refresh interval for the
@@ -244,10 +235,7 @@ class MaterializeAdapter(PostgresAdapter, SQLAdapter):
     @classmethod
     def render_column_constraint(cls, constraint: ColumnLevelConstraint) -> str:
         if constraint.type == ConstraintType.not_null:
-            rendered_column_constraint = None
-            rendered_column_constraint = "assert not null"
-
-            return rendered_column_constraint
+            return "assert not null"
         else:
             return ""
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -141,7 +141,7 @@
 {% macro materialize__rename_relation(from_relation, to_relation) -%}
   {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}
   {% call statement('rename_relation') -%}
-    {% if relation.type == 'view' %}
+    {% if from_relation.type == 'view' %}
       alter view {{ from_relation }} rename to {{ target_name }}
     {% else %}
       alter materialized view {{ from_relation }} rename to {{ target_name }}
@@ -165,6 +165,8 @@
     -- but seeds and source tables are materialized as tables.
     {% elif relation.type == 'table' %}
       drop table if exists {{ relation }} cascade
+    {% else %}
+      {{ exceptions.raise_compiler_error("Don't know how to drop relation " ~ relation ~ " of type " ~ relation.type) }}
     {% endif %}
   {%- endcall %}
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/incremental.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/incremental.sql
@@ -25,7 +25,7 @@
    -- in, Materialize only performs work on that new data. And, all this happens without
    -- extra configurations or scheduled refreshes.
    -- For more information, please visit: https://materialize.com/docs/
-    {{ exceptions.CompilationError(
+    {{ exceptions.raise_compiler_error(
         """
         dbt-materialize does not support incremental models, because all views in
         Materialize are natively maintained incrementally.

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/listagg.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/listagg.sql
@@ -14,7 +14,7 @@
 -- limitations under the License.
 
 {% macro materialize__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}
-    {{ exceptions.CompilationError(
+    {{ exceptions.raise_compiler_error(
         """
         Materialize supports the list_agg() function; use it directly.
 

--- a/misc/dbt-materialize/tests/adapter/test_connection_options.py
+++ b/misc/dbt-materialize/tests/adapter/test_connection_options.py
@@ -106,3 +106,34 @@ class TestConnectionOptionsOverrideEscapeSpaces:
         result = project.run_sql(f"SELECT current_setting('{setting}')", fetch="one")
         print(result)
         assert result[0] == expected
+
+
+class TestConnectionOptionsOverrideEscapeBackslashes:
+    """Verify backslashes in options survive the round trip through libpq's
+    options-string parser, including a backslash directly before a space,
+    which pins the escaping order (backslashes first, then spaces)."""
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        return {
+            "type": "materialize",
+            "threads": 1,
+            "host": "{{ env_var('DBT_HOST', 'localhost') }}",
+            "user": "materialize",
+            "pass": "password",
+            "database": "materialize",
+            "options": {
+                "application_name": "app\\with\\ backslashes",
+            },
+            "port": "{{ env_var('DBT_PORT', 6875) }}",
+        }
+
+    @pytest.mark.parametrize(
+        "setting,expected",
+        [
+            ("application_name", "app\\with\\ backslashes"),
+        ],
+    )
+    def test_defaults(self, project, setting, expected):
+        result = project.run_sql(f"SELECT current_setting('{setting}')", fetch="one")
+        assert result[0] == expected

--- a/misc/dbt-materialize/tests/adapter/test_incremental.py
+++ b/misc/dbt-materialize/tests/adapter/test_incremental.py
@@ -20,6 +20,7 @@ from dbt.tests.adapter.incremental.test_incremental_merge_exclude_columns import
 from dbt.tests.adapter.incremental.test_incremental_on_schema_change import (
     BaseIncrementalOnSchemaChange,
 )
+from dbt.tests.util import run_dbt_and_capture
 
 
 @pytest.mark.skip(reason="dbt-materialize does not support incremental models")
@@ -30,3 +31,23 @@ class TestMergeExcludeColumns(BaseMergeExcludeColumns):
 @pytest.mark.skip(reason="dbt-materialize does not support incremental models")
 class TestIncrementalOnSchemaChange(BaseIncrementalOnSchemaChange):
     pass
+
+
+incremental_model = """
+{{ config(materialized='incremental') }}
+
+SELECT 1 AS id
+"""
+
+
+class TestIncrementalNotSupported:
+    """The incremental materialization must explain itself instead of failing
+    on the way to raising the error."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_incremental_model.sql": incremental_model}
+
+    def test_incremental_model_explains_why_it_is_unsupported(self, project):
+        _, output = run_dbt_and_capture(["run"], expect_pass=False)
+        assert "does not support incremental models" in output

--- a/misc/dbt-materialize/tests/adapter/test_relation_macros.py
+++ b/misc/dbt-materialize/tests/adapter/test_relation_macros.py
@@ -1,0 +1,135 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+
+view_model = """
+{{ config(materialized='view') }}
+
+SELECT 1 AS id
+"""
+
+view_model_invalid_index = """
+{{ config(
+    materialized='view',
+    indexes=[{'columns': 'id'}]
+) }}
+
+SELECT 1 AS id
+"""
+
+mv_model = """
+{{ config(materialized='materialized_view') }}
+
+SELECT 1 AS id
+"""
+
+rename_view_macro = """
+{% macro rename_view(from_name, to_name, relation_type='view') %}
+  {% set from_relation = api.Relation.create(
+      database=target.database, schema=target.schema, identifier=from_name, type=relation_type) %}
+  {% set to_relation = api.Relation.create(
+      database=target.database, schema=target.schema, identifier=to_name, type=relation_type) %}
+  {% do adapter.rename_relation(from_relation, to_relation) %}
+{% endmacro %}
+
+{% macro drop_unsupported_relation(name) %}
+  {% set relation = api.Relation.create(
+      database=target.database, schema=target.schema, identifier=name, type='source_table') %}
+  {% do adapter.drop_relation(relation) %}
+{% endmacro %}
+"""
+
+
+class TestInvalidIndexConfig:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_view.sql": view_model_invalid_index}
+
+    def test_invalid_index_config_is_reported(self, project):
+        _, output = run_dbt_and_capture(["run"], expect_pass=False)
+        assert "Could not parse index config" in output
+
+
+class TestRelationMacros:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_view.sql": view_model, "my_mv.sql": mv_model}
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"relation_macros.sql": rename_view_macro}
+
+    def test_rename_view(self, project):
+        run_dbt(["run"])
+
+        run_dbt(
+            [
+                "run-operation",
+                "rename_view",
+                "--args",
+                "{from_name: my_view, to_name: my_renamed_view}",
+            ]
+        )
+
+        result = project.run_sql(
+            f"""
+            SELECT count(*)
+            FROM mz_views v
+            JOIN mz_schemas s ON v.schema_id = s.id
+            WHERE v.name = 'my_renamed_view' AND s.name = '{project.test_schema}'
+            """,
+            fetch="one",
+        )
+
+        assert result[0] == 1
+
+    def test_rename_materialized_view(self, project):
+        run_dbt(["run"])
+
+        run_dbt(
+            [
+                "run-operation",
+                "rename_view",
+                "--args",
+                "{from_name: my_mv, to_name: my_renamed_mv, relation_type: materialized_view}",
+            ]
+        )
+
+        result = project.run_sql(
+            f"""
+            SELECT count(*)
+            FROM mz_materialized_views mv
+            JOIN mz_schemas s ON mv.schema_id = s.id
+            WHERE mv.name = 'my_renamed_mv' AND s.name = '{project.test_schema}'
+            """,
+            fetch="one",
+        )
+
+        assert result[0] == 1
+
+    def test_drop_relation_of_unsupported_type(self, project):
+        _, output = run_dbt_and_capture(
+            [
+                "run-operation",
+                "drop_unsupported_relation",
+                "--args",
+                "{name: my_view}",
+            ],
+            expect_pass=False,
+        )
+
+        assert "Don't know how to drop relation" in output

--- a/misc/dbt-materialize/tests/adapter/test_utils.py
+++ b/misc/dbt-materialize/tests/adapter/test_utils.py
@@ -32,6 +32,7 @@ from dbt.tests.adapter.utils.test_get_intervals_between import BaseGetIntervalsB
 from dbt.tests.adapter.utils.test_get_powers_of_two import BaseGetPowersOfTwo
 from dbt.tests.adapter.utils.test_listagg import BaseListagg
 from dbt.tests.adapter.utils.test_timestamps import BaseCurrentTimestamps
+from dbt.tests.util import run_dbt
 
 models__test_cast_bool_to_text_sql = """
 with data_bool as (
@@ -170,3 +171,25 @@ class TestGetIntervalsBeteween(BaseGetIntervalsBetween):
 
 class TestGetPowersOfTwo(BaseGetPowersOfTwo):
     pass
+
+
+listagg_model = """
+SELECT {{ dbt.listagg("a", "','") }} FROM (SELECT 1 AS a)
+"""
+
+
+class TestListaggExplainsAlternative:
+    """The listagg macro must show its explanation instead of failing on the
+    way to raising the error."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_listagg_model.sql": listagg_model}
+
+    def test_listagg_explains_alternative(self, project):
+        # The macro raises while dbt renders the model during manifest
+        # parsing, so the error surfaces as an exception rather than a
+        # failed node result.
+        with pytest.raises(Exception) as excinfo:
+            run_dbt(["compile"], expect_pass=False)
+        assert "Materialize supports the list_agg() function" in str(excinfo.value)

--- a/misc/dbt-materialize/tests/unit/test_configs.py
+++ b/misc/dbt-materialize/tests/unit/test_configs.py
@@ -15,6 +15,7 @@
 
 import pytest
 from dbt.adapters.materialize.exceptions import (
+    IndexConfigError,
     PartitionByConfigError,
     RefreshIntervalConfigError,
 )
@@ -50,6 +51,16 @@ class TestIndexConfig:
         assert index.default is True
         assert index.name == "my_idx"
         assert index.cluster == "my_cluster"
+
+    def test_invalid_columns_type(self):
+        with pytest.raises(IndexConfigError):
+            MaterializeIndexConfig.parse({"columns": "a"})
+
+    def test_not_a_dict(self):
+        # jsonschema reports non-dict input as a ValidationError, so it lands
+        # in IndexConfigError like any other malformed shape.
+        with pytest.raises(IndexConfigError):
+            MaterializeIndexConfig.parse("a")
 
 
 class TestRefreshIntervalConfig:

--- a/misc/dbt-materialize/tests/unit/test_connections.py
+++ b/misc/dbt-materialize/tests/unit/test_connections.py
@@ -73,3 +73,12 @@ def test_credentials_type():
     assert credentials.type == "materialize"
     assert "cluster" in credentials._connection_keys()
     assert "options" in credentials._connection_keys()
+
+
+def test_non_string_values_are_stringified():
+    options = parse_options(
+        _build_options_string({"welcome_message": True, "statement_timeout": 5}, None)
+    )
+
+    assert options["welcome_message"] == "True"
+    assert options["statement_timeout"] == "5"


### PR DESCRIPTION
A handful of error paths in the adapter did not do what they looked like they did, so users hit confusing failures instead of the messages we wrote for them. This fixes the index config parser, the incremental and listagg explanations, the branch in rename_relation that read an undefined variable, the missing fallback in drop_relation, backslash and non-string handling in connection options, and the version check against a server that is not Materialize.

Test plan: added `test_relation_macros.py` for the index config error, renaming a view and dropping an unsupported relation type, plus a case in `test_incremental.py` that checks the explanation is what users actually see.