### PR TITLE
dbt-materialize: add unit tests that run without a Materialize instance

### DIFF
--- a/misc/dbt-materialize/pytest.ini
+++ b/misc/dbt-materialize/pytest.ini
@@ -18,4 +18,5 @@ filterwarnings =
     ignore:.*'soft_unicode' has been renamed to 'soft_str'*:DeprecationWarning
     ignore:unclosed file .*:ResourceWarning
 testpaths =
+    tests/unit
     tests/adapter

--- a/misc/dbt-materialize/tests/unit/test_configs.py
+++ b/misc/dbt-materialize/tests/unit/test_configs.py
@@ -1,0 +1,92 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from dbt.adapters.materialize.exceptions import (
+    PartitionByConfigError,
+    RefreshIntervalConfigError,
+)
+from dbt.adapters.materialize.impl import (
+    MaterializeAdapter,
+    MaterializeIndexConfig,
+    MaterializeRefreshIntervalConfig,
+)
+
+
+class TestIndexConfig:
+    def test_none(self):
+        assert MaterializeIndexConfig.parse(None) is None
+
+    def test_columns(self):
+        index = MaterializeIndexConfig.parse({"columns": ["a", "b"]})
+
+        assert index.columns == ["a", "b"]
+        assert index.default is False
+        assert index.name is None
+        assert index.cluster is None
+
+    def test_all_fields(self):
+        index = MaterializeIndexConfig.parse(
+            {
+                "columns": ["a"],
+                "default": True,
+                "name": "my_idx",
+                "cluster": "my_cluster",
+            }
+        )
+
+        assert index.default is True
+        assert index.name == "my_idx"
+        assert index.cluster == "my_cluster"
+
+
+class TestRefreshIntervalConfig:
+    def test_none(self):
+        assert MaterializeRefreshIntervalConfig.parse(None) is None
+
+    def test_every(self):
+        refresh_interval = MaterializeRefreshIntervalConfig.parse(
+            {"every": "1 day", "aligned_to": "2024-01-01"}
+        )
+
+        assert refresh_interval.every == "1 day"
+        assert refresh_interval.aligned_to == "2024-01-01"
+        assert refresh_interval.on_commit is False
+
+    def test_invalid_field_type(self):
+        with pytest.raises(RefreshIntervalConfigError):
+            MaterializeRefreshIntervalConfig.parse({"every": 1})
+
+
+class TestPartitionByConfig:
+    @pytest.fixture
+    def adapter(self):
+        # parse_partition_by only validates the shape of the config, so it does
+        # not need a connected adapter.
+        return MaterializeAdapter.__new__(MaterializeAdapter)
+
+    def test_none(self, adapter):
+        assert adapter.parse_partition_by(None) is None
+
+    def test_empty_list(self, adapter):
+        assert adapter.parse_partition_by([]) is None
+
+    def test_columns(self, adapter):
+        assert adapter.parse_partition_by(["a", "b"]) == ["a", "b"]
+
+    @pytest.mark.parametrize("raw", ["a", {"columns": ["a"]}, ["a", 1]])
+    def test_invalid(self, adapter, raw):
+        with pytest.raises(PartitionByConfigError):
+            adapter.parse_partition_by(raw)

--- a/misc/dbt-materialize/tests/unit/test_connections.py
+++ b/misc/dbt-materialize/tests/unit/test_connections.py
@@ -1,0 +1,75 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dbt.adapters.materialize.connections import (
+    DEFAULT_SESSION_PARAMETERS,
+    MaterializeCredentials,
+    _build_options_string,
+)
+
+
+def parse_options(options_string):
+    """Turn a libpq options string back into a dictionary, undoing the escaping
+    of spaces."""
+    parsed = {}
+    for part in options_string.replace("\\ ", "\x00").split(" "):
+        key, _, value = part.partition("=")
+        parsed[key.lstrip("-")] = value.replace("\x00", " ")
+    return parsed
+
+
+def test_defaults_are_applied():
+    options = parse_options(_build_options_string(None, None))
+
+    assert options == DEFAULT_SESSION_PARAMETERS
+
+
+def test_user_options_win_over_defaults():
+    options = parse_options(
+        _build_options_string({"welcome_message": "on", "cluster": "my_cluster"}, None)
+    )
+
+    assert options["welcome_message"] == "on"
+    assert options["cluster"] == "my_cluster"
+    # Defaults the user did not override are still there.
+    assert options["auto_route_catalog_queries"] == "on"
+
+
+def test_search_path_is_appended():
+    options = parse_options(_build_options_string(None, "my_schema"))
+
+    assert options["search_path"] == "my_schema"
+
+
+def test_values_with_spaces_are_escaped():
+    options_string = _build_options_string({"application_name": "my app"}, None)
+
+    assert "--application_name=my\\ app" in options_string
+    assert parse_options(options_string)["application_name"] == "my app"
+
+
+def test_credentials_type():
+    credentials = MaterializeCredentials(
+        host="localhost",
+        port=6875,
+        database="materialize",
+        schema="public",
+        user="materialize",
+        password="",
+    )
+
+    assert credentials.type == "materialize"
+    assert "cluster" in credentials._connection_keys()
+    assert "options" in credentials._connection_keys()

--- a/misc/dbt-materialize/tests/unit/test_relation.py
+++ b/misc/dbt-materialize/tests/unit/test_relation.py
@@ -1,0 +1,60 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from dbt.adapters.materialize.relation import MaterializeRelation
+
+
+def make_relation(relation_type):
+    return MaterializeRelation.create(
+        database="materialize",
+        schema="public",
+        identifier="my_relation",
+        type=relation_type,
+    )
+
+
+@pytest.mark.parametrize(
+    "relation_type,expected",
+    [
+        ("materialized_view", True),
+        # The legacy materialization name is still supported.
+        ("materializedview", True),
+        ("view", False),
+        ("table", False),
+    ],
+)
+def test_is_materialized_view(relation_type, expected):
+    assert make_relation(relation_type).is_materialized_view is expected
+
+
+@pytest.mark.parametrize(
+    "relation_type,attribute",
+    [
+        ("source", "is_source"),
+        ("source_table", "is_source_table"),
+        ("sink", "is_sink"),
+    ],
+)
+def test_materialize_specific_types(relation_type, attribute):
+    relation = make_relation(relation_type)
+
+    assert getattr(relation, attribute) is True
+    assert relation.is_view is False
+
+
+def test_relation_max_name_length():
+    # Materialize does not have PostgreSQL's 63 character limit.
+    assert make_relation("view").relation_max_name_length() == 255


### PR DESCRIPTION
Every test in the adapter today needs a running Materialize, so the plain Python pieces like the config parsers, the connection options string and the relation types have no cheap coverage and small mistakes in them only show up through a full integration run. This adds a `tests/unit` directory for those, which runs in well under a second and needs no server.

Test plan: 25 new tests covering `_build_options_string`, the index, refresh interval and partition by config parsers, and the Materialize relation types.