### PR TITLE
compute: disable by default the alternative persist sink implemenetation

### DIFF
--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -187,7 +187,7 @@ pub const ENABLE_MZ_JOIN_CORE: Config<bool> = Config::new(
 /// Use sync Timely operators with Tokio tasks for the MV sink.
 pub const ENABLE_SYNC_MV_SINK: Config<bool> = Config::new(
     "enable_compute_sync_mv_sink",
-    true,
+    false,
     "Use sync Timely operators with Tokio tasks for the MV sink.",
 );
 


### PR DESCRIPTION
Follow up to incident 1175 where it was observed that the new sink implementation schedules long running blocking work on tokio worker threads causing them to stop scheduling all the other tasks, leading to lost reader leases.

This is only to guard self-managed deployments from the problem. In cloud we have already disabled it for everyone via LD. We should consider re-flipping the default after having rolled it out gradually via LaunchDarkly for some time.


