### PR TITLE
sql: accept WITH (WAIT ...) on ALTER CLUSTER unconditionally

### DIFF
--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -177,10 +177,6 @@ by default), Materialize rolls back the resize and the cluster keeps its current
 size. To customize the timeout behavior, use the `WAIT UNTIL READY` or `WAIT FOR` options.
 The resize still proceeds in the background.
 
-{{< private-preview >}}
-Customizing the resize timeout with `WAIT UNTIL READY` or `WAIT FOR`
-{{< /private-preview >}}
-
 - `WAIT UNTIL READY (TIMEOUT = ..., ON TIMEOUT = ...)` sets the timeout for the
   resize. On timeout, `ON TIMEOUT` selects whether to `COMMIT` (retire the old
   replicas and proceed with the not-yet-hydrated new ones, which can cause
@@ -225,7 +221,6 @@ current size. Materialize drops the pending replicas and keeps the current
 configuration.
 
 #### Downtime considerations for v26.34 or before
-{{< private-preview />}}
 
 You can use the `WAIT UNTIL READY` option to perform a zero-downtime resizing,
 which incurs **no downtime**. Instead of restarting the cluster, this approach

--- a/misc/python/materialize/checks/all_checks/cluster.py
+++ b/misc/python/materialize/checks/all_checks/cluster.py
@@ -152,9 +152,6 @@ class AlterClusterGracefulReconfiguration(Check):
 
     def initialize(self) -> Testdrive:
         return Testdrive(dedent("""
-            $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
-            ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true
-
             $ postgres-execute connection=postgres://postgres:postgres@postgres
             CREATE USER graceful_reconfig WITH SUPERUSER PASSWORD 'postgres';
             ALTER USER graceful_reconfig WITH replication;

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -131,6 +131,14 @@ def get_minimal_system_parameters(
             "true" if version >= MzVersion.parse_mz("v26.29.0-dev") else "false"
         )
 
+    # The `WITH (WAIT ...)` graceful-reconfiguration surface. Always accepted
+    # from v26.38 on. Older binaries still gate it behind this feature flag, so
+    # pin it on for them: the tests that use the surface no longer enable it
+    # themselves, and in a mixed-version run some of their phases execute
+    # against the old binary.
+    if version < MzVersion.parse_mz("v26.38.0-dev"):
+        config["enable_zero_downtime_cluster_reconfiguration"] = "true"
+
     return config
 
 

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -168,10 +168,6 @@ def run(
         system_exe.execute("ALTER SYSTEM SET max_sql_server_connections = 1000000")
         system_exe.execute("ALTER SYSTEM SET max_kafka_connections = 1000000")
         system_exe.execute("ALTER SYSTEM SET idle_in_transaction_session_timeout = 0")
-        # Gates the WITH (WAIT ...) clause used by ReconfigureClusterAction.
-        system_exe.execute(
-            "ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true"
-        )
         # Most queries should not fail because of privileges
         for object_type in [
             "TABLES",

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -6557,15 +6557,6 @@ pub fn plan_alter_cluster(
                         );
                     }
 
-                    match alter_strategy {
-                        AlterClusterPlanStrategy::None => {}
-                        _ => {
-                            scx.require_feature_flag(
-                                &crate::session::vars::ENABLE_ZERO_DOWNTIME_CLUSTER_RECONFIGURATION,
-                            )?;
-                        }
-                    }
-
                     if replica_defs.is_some() {
                         sql_bail!("REPLICAS not supported for managed clusters");
                     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2228,12 +2228,6 @@ feature_flags!(
         enable_for_item_parsing: false,
     },
     {
-        name: enable_zero_downtime_cluster_reconfiguration,
-        desc: "Enable zero-downtime reconfiguration for alter cluster",
-        default: false,
-        enable_for_item_parsing: false,
-    },
-    {
         name: enable_network_policies,
         desc: "ENABLE NETWORK POLICIES",
         default: true,

--- a/test/cloudtest/test_managed_cluster.py
+++ b/test/cloudtest/test_managed_cluster.py
@@ -146,7 +146,6 @@ def test_zero_downtime_reconfiguration(mz: MaterializeApplication) -> None:
     # within the short poll loops below.
     mz.environmentd.sql(
         """
-        ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
         ALTER SYSTEM SET cluster_controller_tick_interval = '5ms';
         """,
         port="internal",

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -5829,7 +5829,6 @@ def workflow_test_zero_downtime_reconfigure(
             key${kafka-ingest.iteration}:value${kafka-ingest.iteration}
 
             $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-            ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
             CREATE CLUSTER cluster1 ( SIZE = 'scale=1,workers=1');
             GRANT ALL ON CLUSTER cluster1 TO materialize;
 
@@ -5946,13 +5945,6 @@ def workflow_test_zero_downtime_reconfigure(
             > SELECT count(*) FROM kafka_tbl
             1000
             """))
-        c.sql(
-            """
-            ALTER SYSTEM RESET enable_zero_downtime_cluster_reconfiguration;
-            """,
-            port=6877,
-            user="mz_system",
-        )
 
 
 def workflow_test_pending_replica_audit_events(
@@ -5968,11 +5960,10 @@ def workflow_test_pending_replica_audit_events(
     """
     c.up("materialized")
 
-    # Enable the WAIT surface and drive the controller tick down so the (empty)
-    # cluster's reconfiguration converges quickly.
+    # Drive the controller tick down so the (empty) cluster's reconfiguration
+    # converges quickly.
     c.sql(
         """
-        ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
         ALTER SYSTEM SET cluster_controller_tick_interval = '5ms';
         CREATE CLUSTER test_audit (SIZE = 'scale=1,workers=1');
         GRANT ALL ON CLUSTER test_audit TO materialize;
@@ -6067,7 +6058,6 @@ def workflow_test_pending_replica_audit_events(
     c.sql(
         """
         DROP CLUSTER test_audit CASCADE;
-        ALTER SYSTEM RESET enable_zero_downtime_cluster_reconfiguration;
         """,
         port=6877,
         user="mz_system",

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -465,6 +465,7 @@ KNOWN_STALE_LD_FLAGS: set[str] = set("""
     enable_repr_typecheck
     enable_unified_cluster_arrangment
     enable_yugabyte_connection
+    enable_zero_downtime_cluster_reconfiguration
     kafka_default_metadata_fetch_interval
     mysql_offset_known_interval
     persist_enable_arrow_lgalloc_noncc_sizes
@@ -502,7 +503,6 @@ INTENTIONAL_LD_OVERRIDES: set[str] = {
     "enable_scoped_system_parameters",
     "enable_timely_zero_copy_lgalloc",
     "enable_upsert_paged_spill",
-    "enable_zero_downtime_cluster_reconfiguration",
     "kafka_client_id_enrichment_rules",
     "kafka_progress_record_fetch_timeout",
     "kafka_socket_timeout",

--- a/test/pg-cdc/cluster-graceful-reconfiguration.td
+++ b/test/pg-cdc/cluster-graceful-reconfiguration.td
@@ -16,12 +16,6 @@
 # new replica until cut-over drops the old one. Readiness must therefore not
 # wait for the source to hydrate on the target, but must still wait for the
 # target's processes to come online before cutting over.
-#
-# The background flag is pinned explicitly so the test does not depend on the
-# harness defaults.
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true
 
 > CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -309,11 +309,6 @@ CREATE CLUSTER foo SIZE invalid_size, REPLICATION FACTOR 0
 statement error creating cluster replica would violate max_replicas_per_cluster limit \(desired: 9999999, limit: 5, current: 0\)
 CREATE CLUSTER foo SIZE 'scale=1,workers=1', replication factor 9999999;
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
-----
-COMPLETE 0
-
 statement ok
 CREATE CLUSTER foo (SIZE 'scale=1,workers=1')
 

--- a/test/testdrive/cluster-controller.td
+++ b/test/testdrive/cluster-controller.td
@@ -24,11 +24,9 @@ $ set-sql-timeout duration=120s
 
 # Drive the tick interval down so the controller ticks ~hundreds of times across
 # the waits below. It is re-read each tick, so the flip takes effect without a
-# restart. The graceful cases use the WITH (WAIT ...) surface, whose planner
-# acceptance is gated on enable_zero_downtime.
+# restart.
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET cluster_controller_tick_interval = '5ms'
-ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true
 
 # ----- Baseline reconcile is a no-op -----
 #
@@ -1455,7 +1453,6 @@ ALTER SYSTEM SET unsafe_enable_unstable_dependencies = false
 # Restore pristine server state (including the tick-interval override).
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM RESET cluster_controller_tick_interval
-ALTER SYSTEM RESET enable_zero_downtime_cluster_reconfiguration
 ALTER SYSTEM RESET enable_background_alter_cluster
 ALTER SYSTEM RESET enable_auto_scaling_strategy
 ALTER SYSTEM RESET enable_hydration_burst


### PR DESCRIPTION
Part 4 of the [design][design] stack. Stacked on #38081.

[design]: https://github.com/MaterializeInc/materialize/blob/aljoscha/cluster-legacy-00-design/doc/developer/design/20260724_cluster_controller_legacy_removal.md

## Why

Graceful cluster reconfiguration has lived behind
`enable_zero_downtime_cluster_reconfiguration`, default off, so the planner
rejected any `WITH (WAIT ...)` clause unless a deployment turned the flag on.

That flag is now the only thing standing between an operator and the synchronous
cut-over (#38081), which is the escape hatch for reshaping a cluster when the
cluster controller itself is the problem. On any deployment running the compiled
default there would be no way to reshape a cluster at all in that situation. A
break-glass path behind a default-off flag is not a break-glass path.

## What lands

- The `feature_flags!` entry and the `require_feature_flag` call in
  `plan_alter_cluster`. Everything else about the flag is macro-derived, so
  there is no second registry to update.
- Every test that used the surface enabled the flag itself, so those
  `ALTER SYSTEM SET`/`RESET` statements go (testdrive, sqllogictest, pg-cdc,
  `test/cluster/mzcompose.py`, cloudtest, parallel-workload, and the
  graceful-reconfiguration platform check).
- `get_minimal_system_parameters` pins the flag on below v26.38 instead. This is
  load-bearing, not tidiness: `AlterClusterGracefulReconfiguration` issues
  `WITH (WAIT UNTIL READY ...)` in its first manipulate phase, which under
  `UpgradeEntireMz` runs against the last released binary, and that binary still
  enforces the gate.
- The launchdarkly-flag-consistency allowlist entry moves from
  `INTENTIONAL_LD_OVERRIDES` to `KNOWN_STALE_LD_FLAGS`. The flag is a real LD
  flag, so once the last release carrying it ages out the consistency check
  would report it stale and fail. **The flag should be archived in
  LaunchDarkly**, after which this entry can go too.

The two rejections that share the removed code path are untouched: a `WAIT`
without a replica-shape change (`WAIT can only be used together with a SIZE,
AVAILABILITY ZONES, or INTROSPECTION change`) and a `WAIT` on an unmanaged
cluster (`ALTER... WITH not supported for unmanaged clusters`). No test asserted
the gate's own error text, so nothing there changes.

`enable_cluster_schedule_refresh` is deliberately left alone at its current
default, even though it is the near-identical sibling gate a dozen lines below.

## Reviewer attention, please

Two judgment calls worth a second opinion:

1. **The private-preview badges in `doc/user/content/sql/alter-cluster.md` are
   removed.** Nothing gates the surface after this, so describing it as private
   preview is no longer accurate. If the preview status is a product decision
   that has not been made yet, revert just that file and the rest still stands.
2. **No release-note entry.** `doc/user/content/releases/_index.md` is organized
   by released version with release dates, and v26.38 has no section yet, so
   there is nowhere to put one without inventing a date. Whoever writes the
   v26.38 notes should announce that `WITH (WAIT ...)` is generally available.
