### PR TITLE
storage: don't halt bootstrap on a sealed collection

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -989,7 +989,14 @@ impl StorageController for Controller {
                 // environmentd/controller deletes a collection. We exit
                 // gracefully, which means we'll get restarted and get to try
                 // again.
-                if dependency_since.is_empty() {
+                //
+                // We only do this when our own upper is not empty. An empty
+                // upper means the collection is sealed and no-one can write to
+                // it anymore, so an empty dependency since cannot hurt us. And
+                // a sealed collection is durable state rather than a race, so
+                // halting on it would wedge bootstrap forever instead of
+                // resolving on the next attempt.
+                if dependency_since.is_empty() && !write_frontier.is_empty() {
                     halt!(
                         "dependency since frontier is empty while dependent upper \
                         is not empty (dependent id={id}, write_frontier={:?}, dependency_read_holds={:?}), \


### PR DESCRIPTION
### Motivation

An environment can crash-loop on bootstrap, never coming up, because of a
check whose condition does not match what its own message claims.

`StorageController::create_collections` halts when a collection's dependency
has an empty since frontier. The message reads "dependency since frontier is
empty while dependent upper is not empty", but nothing ever checked the
dependent's upper. Halting is the right response to the case the check was
written for, a read-write environmentd deleting a collection while we come up
in read-only mode, because the next bootstrap attempt sees the deletion and
proceeds. It is the wrong response when the state is durable, because then
every attempt halts and the environment never boots.

This was seen in the [nightly Invariants
test](https://buildkite.com/materialize/nightly/builds/17732#019fd1fc-8e5f-47a0-b86e-af9fdbeeeca6),
where an environment restarted every ten seconds for eleven minutes with:

```
halting process: dependency since frontier is empty while dependent upper is
not empty (dependent id=u35, write_frontier=Antichain { elements: [] },
dependency_read_holds=[ReadHold { id: User(4), since: Antichain { elements: [] }, .. }])
```

Note that `write_frontier` is in fact empty.

Fixes SQL-603.

### Description

Gate the halt on the dependent's upper being non-empty.

A collection whose upper is the empty antichain is sealed. No-one can write to
it again, so its dependency's since cannot affect it, empty or otherwise. This
is exactly the reasoning already spelled out for the soft assertion twenty
lines below the halt:

> We don't care about the dependency since when the write frontier is empty.
> In that case, no-one can write down any more updates.

The halt remains in place for the non-empty-upper case, which is the genuine
concurrent-deletion race it was written for.

### Context on the nightly failure

The corruption that triggered the crash loop is separate and already fixed on
main by #37705 (SQL-536). Recorded here because it explains how a durably
sealed collection with an empty dependency since arises in the first place.

A replacement materialized view shares its target's persist shard, and the
storage controller distinguishes the shard owner from the collections that
merely reference it via an in-memory `primary` link. Before #37705, coordinator
bootstrap did not reconstruct that link for materialized views, so after a
restart a pending replacement looked like the shard owner. Dropping it then
advanced the shared shard's critical since to the empty antichain and recorded
the shard for finalization, tombstoning the live target.

The nightly upgrades from a base version that predates #37705, so the old
environmentd produced exactly that state: the shard of a live materialized view
with since `[]` and upper `[]`. The new environmentd's finalization-WAL guard
from #37705 correctly rescued the shard from deletion on boot, and then this
halt refused to let it come up at all.

With this change the environment boots. The materialized view remains sealed
and empty, which is the outcome the tombstone already determined, but the
environment is reachable and an operator can drop and recreate it.

### Verification

No new test. The condition is wrong on its own terms, independent of the
corruption that exposed it, so a regression test built around reproducing that
corruption would be testing the wrong thing. Reproducing it would also mean
pinning a specific pre-#37705 release image into a test, and the state it
produces is not reachable from current code.
