### PR TITLE
docs: draft MySQL snapshot parallelism page

### DIFF
--- a/doc/user/content/concepts/snapshotting.md
+++ b/doc/user/content/concepts/snapshotting.md
@@ -18,6 +18,10 @@ menu:
 
 {{% include-headless "/headless/ingestion/snapshotting-duration" %}}
 
+### Parallelism
+
+{{% include-headless "/headless/ingestion/snapshotting-parallelism" %}}
+
 ## Queries during snapshotting
 
 {{% include-headless "/headless/ingestion/snapshotting-queries" %}}
@@ -27,7 +31,8 @@ menu:
 Snapshotting has the following upstream impacts:
 
 - **Read load.** Snapshotting puts read, CPU, and network load on the upstream
-  system, proportional to the data volume.
+  system, proportional to the data volume and concentrated in proportion to
+  the source cluster's [parallelism](#parallelism).
 
 - **Change-log retention for CDC database sources.** When ingesting data from
   CDC database sources (PostgreSQL, MySQL, SQL Server), the upstream system must
@@ -41,3 +46,4 @@ Snapshotting has the following upstream impacts:
 
 - [Ingest data](/ingest-data/)
 - [Sources](/concepts/sources/)
+- [Troubleshooting data ingestion](/ingest-data/troubleshooting/)

--- a/doc/user/content/concepts/snapshotting.md
+++ b/doc/user/content/concepts/snapshotting.md
@@ -31,8 +31,9 @@ menu:
 Snapshotting has the following upstream impacts:
 
 - **Read load.** Snapshotting puts read, CPU, and network load on the upstream
-  system, proportional to the data volume and concentrated in proportion to
-  the source cluster's [parallelism](#parallelism).
+  system. The total load is proportional to the volume of data being
+  snapshotted, while the source cluster's [parallelism](#parallelism) affects
+  the peak load: more workers compress the reads into a shorter window.
 
 - **Change-log retention for CDC database sources.** When ingesting data from
   CDC database sources (PostgreSQL, MySQL, SQL Server), the upstream system must

--- a/doc/user/content/headless/ingestion/snapshotting-parallelism.md
+++ b/doc/user/content/headless/ingestion/snapshotting-parallelism.md
@@ -2,21 +2,33 @@
 headless: true
 ---
 
-Materialize parallelizes snapshotting across the workers of the cluster
-hosting the source. For PostgreSQL and MySQL sources, work is distributed by
-table, with different tables read concurrently by different workers.
-PostgreSQL sources additionally partition every table, splitting its read
-across workers (on PostgreSQL 14 and later). MySQL sources partition tables
-that meet certain requirements. See [MySQL snapshot
-parallelism](/ingest-data/mysql/snapshot-parallelism/). Kafka sources are
-parallelized by topic partition, with partitions distributed across workers,
-so parallelism is bounded by the topic's partition count. SQL Server sources
-are not parallelized: a single worker reads all tables.
+Materialize can parallelize snapshotting across the workers of the cluster
+hosting the source.
 
-A cluster's [size](/sql/create-cluster/#available-sizes) determines its
-number of workers, so a larger cluster shortens the snapshot. The volume
-read from the upstream database is unchanged, it is compressed into a
-shorter window of more concurrent queries and connections. To tell whether
-the upstream database is struggling under this load, and for options if it
-is, see [Is the upstream database
+- **PostgreSQL sources** are parallelized by table, i.e., different tables
+  are read concurrently by different workers. On PostgreSQL 14 and later,
+  Materialize additionally attempts to partition each table's read across
+  workers. Tables that cannot be partitioned fall back to a single worker.
+
+- **MySQL sources** are parallelized by table, i.e., different tables are
+  read concurrently by different workers. For tables that meet certain
+  requirements, Materialize can additionally partition the table's read
+  across workers {{< private-preview-inline />}}. See [MySQL snapshot
+  parallelism](/ingest-data/mysql/snapshot-parallelism/).
+
+- **Kafka sources** are parallelized by topic partition, with partitions
+  distributed across workers, so parallelism is bounded by the topic's
+  partition count.
+
+- **SQL Server sources** are not parallelized: a single worker reads all
+  tables.
+
+The degree of snapshot parallelism depends on the number of workers. A
+cluster's [size](/sql/create-cluster/#available-sizes) determines its number
+of workers, so a larger cluster can shorten the snapshot, to the extent the
+work parallelizes and the upstream database keeps up. The volume read from
+the upstream database is unchanged, it is compressed into a shorter window
+of more concurrent queries and connections. To determine whether
+snapshotting is overloading the upstream database, and for ways to mitigate
+the load, see [Is the upstream database
 overloaded?](/ingest-data/troubleshooting/#is-the-upstream-database-overloaded)

--- a/doc/user/content/headless/ingestion/snapshotting-parallelism.md
+++ b/doc/user/content/headless/ingestion/snapshotting-parallelism.md
@@ -1,0 +1,22 @@
+---
+headless: true
+---
+
+Materialize parallelizes snapshotting across the workers of the cluster
+hosting the source. For PostgreSQL and MySQL sources, work is distributed by
+table, with different tables read concurrently by different workers.
+PostgreSQL sources additionally partition every table, splitting its read
+across workers (on PostgreSQL 14 and later). MySQL sources partition tables
+that meet certain requirements. See [MySQL snapshot
+parallelism](/ingest-data/mysql/snapshot-parallelism/). Kafka sources are
+parallelized by topic partition, with partitions distributed across workers,
+so parallelism is bounded by the topic's partition count. SQL Server sources
+are not parallelized: a single worker reads all tables.
+
+A cluster's [size](/sql/create-cluster/#available-sizes) determines its
+number of workers, so a larger cluster shortens the snapshot. The volume
+read from the upstream database is unchanged, it is compressed into a
+shorter window of more concurrent queries and connections. To tell whether
+the upstream database is struggling under this load, and for options if it
+is, see [Is the upstream database
+overloaded?](/ingest-data/troubleshooting/#is-the-upstream-database-overloaded)

--- a/doc/user/content/ingest-data/_index.md
+++ b/doc/user/content/ingest-data/_index.md
@@ -60,6 +60,10 @@ we recommend:
   the steady-state resource needs of your upsert source(s). See [Best practices:
   Upsert sources](#upsert-sources).
 
+### Parallelism
+
+{{% include-headless "/headless/ingestion/snapshotting-parallelism" %}}
+
 ### Monitoring progress
 
 While snapshotting is taking place, you can monitor the progress of the

--- a/doc/user/content/ingest-data/mysql/_index.md
+++ b/doc/user/content/ingest-data/mysql/_index.md
@@ -33,6 +33,11 @@ gives you the following benefits:
   read-replica to build views on top of your MySQL data that are efficiently
   maintained and always up-to-date.
 
+When a source is created, Materialize parallelizes the initial snapshot
+across the cluster's workers and can split the read of large tables that meet
+certain requirements {{< private-preview-inline />}}. See [Snapshot
+parallelism](/ingest-data/mysql/snapshot-parallelism/).
+
 ## Supported versions and services
 
 {{< note >}}

--- a/doc/user/content/ingest-data/mysql/snapshot-parallelism.md
+++ b/doc/user/content/ingest-data/mysql/snapshot-parallelism.md
@@ -1,0 +1,78 @@
+---
+title: "Snapshot parallelism"
+description: "How Materialize parallelizes the initial snapshot of MySQL tables, and how to get the most out of it."
+menu:
+  main:
+    parent: "mysql"
+    name: "Snapshot parallelism"
+    identifier: "mysql-snapshot-parallelism"
+    weight: 70
+---
+
+{{< private-preview />}}
+
+When you create a [MySQL source](/sql/create-source/mysql-v2/), Materialize
+performs an initial, snapshot-based sync of the selected tables before it
+starts ingesting change events from the binlog. For large tables, this
+snapshot dominates the time until the source becomes healthy and your queries
+return up-to-date results.
+
+To speed this up, Materialize can split the snapshot of a single table across
+all the workers of the cluster hosting the source. Each worker reads a
+disjoint range of the table's primary key space in parallel, instead of one
+worker reading the whole table on its own.
+
+## How it works
+
+Before reading a table, Materialize samples the table's primary key to find
+boundary keys that divide it into ranges of roughly equal size, using
+inexpensive index probes and optimizer row estimates. Each worker then reads
+only its assigned key range, within the same consistent snapshot of the
+upstream database. The results are identical to a single-worker snapshot,
+including transactional consistency: parallelism changes only how fast the
+snapshot completes.
+
+Sampling adds a small number of point queries per table before the snapshot
+starts. These queries use the primary key index and do not scan the table.
+Their number is capped in proportion to the table's estimated size, so
+sampling stays negligible next to the snapshot itself.
+
+## Requirements
+
+A table's snapshot is parallelized when all of the following hold:
+
+- The table has a **single-column primary key** of a **string type**
+  (`CHAR`, `VARCHAR`, or `TEXT`). Composite and numeric primary keys are not
+  yet supported.
+- The table is large enough to be worth splitting. Small tables are read by a
+  single worker, where parallelism would add overhead without benefit.
+
+Tables that don't meet these requirements are still snapshot correctly, each
+by a single worker. Different tables are always processed concurrently,
+independent of this feature.
+
+## Upstream considerations
+
+- **Connection count.** During snapshotting, Materialize opens one connection
+  per worker reading a key range, plus a small number of coordination
+  connections. If your MySQL server or connection pooler enforces a low
+  [`max_connections`](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_connections)
+  limit, account for this burst when sizing it. After the snapshot completes,
+  the source drops back to a single replication connection.
+
+- **Statistics freshness.** Range boundaries are placed using the MySQL
+  optimizer's row estimates. Stale statistics don't affect correctness, but
+  can skew how evenly work divides across workers. Running
+  [`ANALYZE TABLE`](https://dev.mysql.com/doc/refman/8.0/en/analyze-table.html)
+  on very large tables before creating the source can improve balance.
+
+- **Read load.** A parallel snapshot reads the same total data as a serial
+  one, but over a shorter window, so expect proportionally higher read
+  throughput on the upstream database (or read replica) while it runs.
+
+## Observability
+
+The progress of an ongoing snapshot is visible in the
+[`mz_internal.mz_source_statistics`](/reference/system-catalog/mz_internal/#mz_source_statistics)
+system catalog view, including the number of rows read so far relative to the
+estimated total.

--- a/doc/user/content/ingest-data/mysql/snapshot-parallelism.md
+++ b/doc/user/content/ingest-data/mysql/snapshot-parallelism.md
@@ -1,6 +1,6 @@
 ---
 title: "Snapshot parallelism"
-description: "How Materialize parallelizes the initial snapshot of MySQL tables, and how to get the most out of it."
+description: "How Materialize splits the snapshot of a single MySQL table across the workers of a cluster."
 menu:
   main:
     parent: "mysql"
@@ -9,56 +9,81 @@ menu:
     weight: 70
 ---
 
-{{< private-preview />}}
-
 When you create a [MySQL source](/sql/create-source/mysql-v2/), Materialize
 performs an initial, snapshot-based sync of the selected tables before it
 starts ingesting change events from the binlog. For large tables, this
-snapshot dominates the time until the source becomes healthy and your queries
-return up-to-date results.
+snapshot dominates the time until the source becomes healthy.
 
-To speed this up, Materialize can split the snapshot of a single table across
-all the workers of the cluster hosting the source. Each worker reads a
-disjoint range of the table's primary key space in parallel, instead of one
-worker reading the whole table on its own.
+How snapshot work is spread across the workers of a cluster, and what that
+means for the upstream database, is covered in
+[Snapshotting](/concepts/snapshotting/#parallelism). This page covers what is
+specific to MySQL: Materialize can split the read of a **single table**
+across all the workers of the cluster, so that even a source dominated by one
+very large table benefits from a larger cluster.
 
-## How it works
+## Which tables are split
 
-Before reading a table, Materialize samples the table's primary key to find
-boundary keys that divide it into ranges of roughly equal size, using
-inexpensive index probes and optimizer row estimates. Each worker then reads
-only its assigned key range, within the same consistent snapshot of the
-upstream database. The results are identical to a single-worker snapshot,
-including transactional consistency: parallelism changes only how fast the
-snapshot completes.
+The snapshot of an individual table is split across workers when all of the
+following hold:
 
-Sampling adds a small number of point queries per table before the snapshot
-starts. These queries use the primary key index and do not scan the table.
-Their number is capped in proportion to the table's estimated size, so
-sampling stays negligible next to the snapshot itself.
+- The table has a **single-column primary key**. Composite primary keys are
+  not supported.
+- The primary key column is of type **`CHAR` or `VARCHAR`**, with a declared
+  length of **at most 768 characters**. Other types, including numeric keys,
+  are not supported.
+- The primary key column uses the **`utf8mb4` character set** with the
+  **`utf8mb4_bin` collation**.
+- The table is **large enough to be worth splitting**. Small tables are read
+  by a single worker, where splitting would add overhead without benefit.
 
-## Requirements
+How evenly the split lands also depends on the distribution of the key
+values. See [How a table is partitioned](#how-a-table-is-partitioned).
 
-A table's snapshot is parallelized when all of the following hold:
+Tables that don't meet these requirements, or whose boundary sampling fails
+for any reason, still snapshot correctly: each is read in full by a single
+worker, and different tables are still read concurrently.
 
-- The table has a **single-column primary key** of a **string type**
-  (`CHAR`, `VARCHAR`, or `TEXT`). Composite and numeric primary keys are not
-  yet supported.
-- The table is large enough to be worth splitting. Small tables are read by a
-  single worker, where parallelism would add overhead without benefit.
+## How a table is partitioned
 
-Tables that don't meet these requirements are still snapshot correctly, each
-by a single worker. Different tables are always processed concurrently,
-independent of this feature.
+Materialize partitions a table by the unique leading characters of its
+primary keys. Before reading the table, it probes the primary key index to
+discover key prefixes and uses the MySQL optimizer's row estimates to gauge
+how many rows fall under each one, extending prefixes until it finds
+boundaries that divide the table into roughly even ranges. The probes are
+inexpensive point lookups, capped in proportion to the table's estimated
+size, so this sampling phase stays negligible next to the snapshot itself.
+Each worker then reads only its assigned range, within the same consistent
+snapshot of the upstream database, so the result is identical to a
+single-worker snapshot, only faster.
 
-## Upstream considerations
+Because partitioning is based on key prefixes and optimizer estimates, how
+evenly the work divides depends on the shape of your keys:
 
-- **Connection count.** During snapshotting, Materialize opens one connection
-  per worker reading a key range, plus a small number of coordination
-  connections. If your MySQL server or connection pooler enforces a low
+- **Evenly distributed keys partition well.** Keys whose leading characters
+  spread rows uniformly, such as UUIDs, hashes, or other randomized
+  identifiers, produce well-balanced ranges.
+
+- **Skewed keys partition less evenly.** If a large share of the table's rows
+  sort under a few common prefixes, some ranges end up with more rows than
+  others, and the workers assigned to them finish later.
+
+- **The probe budget can run out.** If finding even boundaries would require
+  examining very many distinct prefixes, Materialize stops probing and uses
+  the coarser boundaries found so far, which can also leave ranges uneven.
+
+Uneven partitioning is never incorrect. It only reduces the speedup, since
+the snapshot finishes when the busiest worker finishes.
+
+## MySQL-specific upstream considerations
+
+- **Connection count.** While the snapshot is being set up, Materialize
+  briefly holds up to two connections per worker, plus one. Once reading is
+  underway, this settles to one connection per worker reading a range, plus
+  one coordination connection. After the snapshot completes, the source drops
+  back to a single replication connection. If your MySQL server or connection
+  pooler enforces a low
   [`max_connections`](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_connections)
-  limit, account for this burst when sizing it. After the snapshot completes,
-  the source drops back to a single replication connection.
+  limit, account for this burst when sizing it.
 
 - **Statistics freshness.** Range boundaries are placed using the MySQL
   optimizer's row estimates. Stale statistics don't affect correctness, but
@@ -66,13 +91,14 @@ independent of this feature.
   [`ANALYZE TABLE`](https://dev.mysql.com/doc/refman/8.0/en/analyze-table.html)
   on very large tables before creating the source can improve balance.
 
-- **Read load.** A parallel snapshot reads the same total data as a serial
-  one, but over a shorter window, so expect proportionally higher read
-  throughput on the upstream database (or read replica) while it runs.
+For general guidance on read load, IOPS, and other upstream impact, which is
+not specific to MySQL, see [Is the upstream database
+overloaded?](/ingest-data/troubleshooting/#is-the-upstream-database-overloaded)
 
 ## Observability
 
 The progress of an ongoing snapshot is visible in the
 [`mz_internal.mz_source_statistics`](/reference/system-catalog/mz_internal/#mz_source_statistics)
-system catalog view, including the number of rows read so far relative to the
-estimated total.
+system catalog view: `snapshot_records_known` is the estimated total size of
+the snapshot and `snapshot_records_staged` is how much of it has been read so
+far.

--- a/doc/user/content/ingest-data/mysql/snapshot-parallelism.md
+++ b/doc/user/content/ingest-data/mysql/snapshot-parallelism.md
@@ -9,6 +9,8 @@ menu:
     weight: 70
 ---
 
+{{< private-preview />}}
+
 When you create a [MySQL source](/sql/create-source/mysql-v2/), Materialize
 performs an initial, snapshot-based sync of the selected tables before it
 starts ingesting change events from the binlog. For large tables, this
@@ -16,15 +18,16 @@ snapshot dominates the time until the source becomes healthy.
 
 How snapshot work is spread across the workers of a cluster, and what that
 means for the upstream database, is covered in
-[Snapshotting](/concepts/snapshotting/#parallelism). This page covers what is
-specific to MySQL: Materialize can split the read of a **single table**
-across all the workers of the cluster, so that even a source dominated by one
-very large table benefits from a larger cluster.
+[Snapshotting](/concepts/snapshotting/#parallelism). Materialize can split
+the read of a **single table** across all the workers of the cluster, so
+that even a source dominated by one very large table benefits from a larger
+cluster. This page covers what is specific to MySQL: which tables are
+eligible for splitting, and how their reads are partitioned.
 
 ## Which tables are split
 
-The snapshot of an individual table is split across workers when all of the
-following hold:
+Materialize splits the snapshot of an individual table across workers when
+all of the following conditions are met:
 
 - The table has a **single-column primary key**. Composite primary keys are
   not supported.
@@ -39,19 +42,22 @@ following hold:
 How evenly the split lands also depends on the distribution of the key
 values. See [How a table is partitioned](#how-a-table-is-partitioned).
 
-Tables that don't meet these requirements, or whose boundary sampling fails
-for any reason, still snapshot correctly: each is read in full by a single
-worker, and different tables are still read concurrently.
+If a table does not meet these requirements, or if the [boundary
+sampling](#how-a-table-is-partitioned) fails, its snapshot is not split: a
+single worker reads the table in full. Different tables are still read
+concurrently by different workers.
 
 ## How a table is partitioned
 
-Materialize partitions a table by the unique leading characters of its
-primary keys. Before reading the table, it probes the primary key index to
-discover key prefixes and uses the MySQL optimizer's row estimates to gauge
-how many rows fall under each one, extending prefixes until it finds
-boundaries that divide the table into roughly even ranges. The probes are
-inexpensive point lookups, capped in proportion to the table's estimated
-size, so this sampling phase stays negligible next to the snapshot itself.
+Materialize partitions an [eligible](#which-tables-are-split) table using the
+leading characters of its primary key values. Before reading the table,
+Materialize probes the primary key index to discover key prefixes and uses
+the MySQL optimizer's row estimates to gauge how many rows fall under each
+prefix. It extends the prefixes as needed to find boundaries that divide the
+table into roughly even ranges. The probes are inexpensive point lookups,
+capped in proportion to the table's estimated size, so the sampling phase
+stays negligible next to the snapshot itself.
+
 Each worker then reads only its assigned range, within the same consistent
 snapshot of the upstream database, so the result is identical to a
 single-worker snapshot, only faster.
@@ -97,8 +103,6 @@ overloaded?](/ingest-data/troubleshooting/#is-the-upstream-database-overloaded)
 
 ## Observability
 
-The progress of an ongoing snapshot is visible in the
-[`mz_internal.mz_source_statistics`](/reference/system-catalog/mz_internal/#mz_source_statistics)
-system catalog view: `snapshot_records_known` is the estimated total size of
-the snapshot and `snapshot_records_staged` is how much of it has been read so
-far.
+To observe the progress of an ongoing snapshot, see [Monitoring the
+snapshotting
+progress](/ingest-data/monitoring-data-ingestion/#monitoring-the-snapshotting-progress).

--- a/doc/user/content/ingest-data/postgres/_index.md
+++ b/doc/user/content/ingest-data/postgres/_index.md
@@ -37,6 +37,11 @@ Materialize gives you the following benefits:
     Materialize as a read-replica to build views on top of your PostgreSQL data
     that are efficiently maintained and always up-to-date.
 
+When a source is created, Materialize parallelizes the initial snapshot
+across the cluster's workers and, on PostgreSQL 14 and later, splits each
+table's read across workers. See [Snapshot
+parallelism](/concepts/snapshotting/#parallelism).
+
 ## Supported versions and services
 
 The PostgreSQL source requires **PostgreSQL 11+** and is compatible with most

--- a/doc/user/content/ingest-data/troubleshooting.md
+++ b/doc/user/content/ingest-data/troubleshooting.md
@@ -101,29 +101,38 @@ snapshotting](/ingest-data/#use-a-larger-cluster-for-upsert-source-snapshotting)
 
 ## Is the upstream database overloaded?
 
-Snapshotting puts significant load on the upstream database (see [Impact on
-upstream system](/concepts/snapshotting/#impact-on-upstream-system)).
+Snapshotting can put significant load on the upstream database (see [Impact
+on upstream system](/concepts/snapshotting/#impact-on-upstream-system)).
 
-Check the upstream database when a snapshot progresses more slowly than the
-data volume suggests, when applications sharing the database slow down while
+Check the upstream database when a snapshot progresses more slowly than
+expected, when applications sharing the database slow down while
 it runs, or when the source reports upstream connection errors or timeouts.
 The relevant metrics are in your cloud provider's monitoring console, or in
 OS tools like `iostat` and the database's activity views for self-hosted
 databases. Look for:
 
+- **Read IOPS or throughput** flat at a provisioned cap.
 - **CPU** pinned at the instance's limit for the duration of the snapshot.
-- **Read IOPS or throughput** flat at a provisioned cap while disk queue
-  depth and read latency climb.
 - **Network throughput** at the instance type's cap.
-- **Memory** pressure, or a falling cache hit rate as large scans evict the
-  normal workload's working set.
-- **Connections** near the database's limit. Snapshotting opens connections
-  in proportion to the source cluster's workers.
+- **Connections** near the database's limit. For PostgreSQL and MySQL
+  sources, snapshotting opens connections in proportion to the source
+  cluster's workers.
 
-If the database is overloaded, snapshot during off-peak hours, ingest from a
-read replica, use a smaller source cluster to spread the load over a longer
-window, [limit the volume of data](/ingest-data/#limit-the-volume-of-data)
-you sync, or provision more IOPS, throughput, or instance capacity.
+Also watch disk usage on the upstream database during a long-running
+snapshot: CDC database sources must retain their change log until Materialize
+consumes it (see [Impact on upstream
+system](/concepts/snapshotting/#impact-on-upstream-system)).
+
+If the database is overloaded, you can upsize the source database or cancel
+the snapshot by dropping the source, and retry:
+
+- on a smaller source cluster to spread the load over a longer window.
+- with more IOPS, throughput, or instance capacity provisioned for the
+  database.
+- during off-peak hours when the database is less busy, as recommended in the
+  [ingestion best practices](/ingest-data/#scheduling).
+- with a smaller [volume of data to
+  sync](/ingest-data/#limit-the-volume-of-data).
 
 ## Adding a new subsource to an existing source blocks replication. Should I just create a new source instead?
 

--- a/doc/user/content/ingest-data/troubleshooting.md
+++ b/doc/user/content/ingest-data/troubleshooting.md
@@ -99,6 +99,32 @@ also be necessary to support increased memory usage during the process. For more
 information, see [Use a larger cluster for upsert source
 snapshotting](/ingest-data/#use-a-larger-cluster-for-upsert-source-snapshotting).
 
+## Is the upstream database overloaded?
+
+Snapshotting puts significant load on the upstream database (see [Impact on
+upstream system](/concepts/snapshotting/#impact-on-upstream-system)).
+
+Check the upstream database when a snapshot progresses more slowly than the
+data volume suggests, when applications sharing the database slow down while
+it runs, or when the source reports upstream connection errors or timeouts.
+The relevant metrics are in your cloud provider's monitoring console, or in
+OS tools like `iostat` and the database's activity views for self-hosted
+databases. Look for:
+
+- **CPU** pinned at the instance's limit for the duration of the snapshot.
+- **Read IOPS or throughput** flat at a provisioned cap while disk queue
+  depth and read latency climb.
+- **Network throughput** at the instance type's cap.
+- **Memory** pressure, or a falling cache hit rate as large scans evict the
+  normal workload's working set.
+- **Connections** near the database's limit. Snapshotting opens connections
+  in proportion to the source cluster's workers.
+
+If the database is overloaded, snapshot during off-peak hours, ingest from a
+read replica, use a smaller source cluster to spread the load over a longer
+window, [limit the volume of data](/ingest-data/#limit-the-volume-of-data)
+you sync, or provision more IOPS, throughput, or instance capacity.
+
 ## Adding a new subsource to an existing source blocks replication. Should I just create a new source instead?
 
 It depends. Materialize provides transactional guarantees for subsource of the


### PR DESCRIPTION
Part of [SS-358](https://linear.app/materializeinc/issue/SS-358).

Adding docs for the new MySQL parallel snapshotting feature, some more context on the load we place on upstream databases, and some high-level debugging tips for triaging obvious database issues.

The table-splitting feature ships with `mysql_source_snapshot_parallelism` off by default, so it is documented as private preview: a banner on the MySQL snapshot parallelism page and inline preview markers where the splitting is mentioned elsewhere.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AgSuGEvoVT9TFHAgq6FCi