### PR TITLE
storage: Fast approximate snapshot partitioning

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -2012,12 +2012,12 @@ class MySqlInitialLoad(MySqlCdc):
 
     FIXED_SCALE = True  # TODO: Remove when database-issues#7556 is fixed
 
-    # The parallel snapshot path has a wider memory envelope during the initial
-    # load, so allow a bit more headroom than the base default before flagging a
-    # regression.
+    # The initial load has a wider memory envelope, so allow a bit more
+    # headroom than the base default before flagging a regression.
     RELATIVE_THRESHOLD: dict[MeasurementType, float] = {
-        # Integer primary keys are no longer handled for primary key splitting.
-        # Bumping to account for this.
+        # Primary key splitting supports only string primary keys, so this
+        # BIGINT-keyed snapshot reads serially where older versions split it across
+        # workers. The increased wallclock tolerance covers that lost parallelism.
         MeasurementType.WALLCLOCK: 0.25,
         MeasurementType.MEMORY_MZ: 0.30,
         MeasurementType.MEMORY_CLUSTERD: 0.50,
@@ -2170,10 +2170,10 @@ class MySqlInitialLoadMultiWorkerSingleTable(MySqlCdc):
     single-table companion to MySqlInitialLoadMultiWorkerSampled."""
 
     RELATIVE_THRESHOLD: dict[MeasurementType, float] = {
-        # Bumping to account for small performance regression for approximate
-        # primary key probing: measured locally at 2-14% wallclock versus the
-        # exact OFFSET-sampler baseline. Grabbing the offset was quite fast
-        # for small datasets in MySQL.
+        # In MySQL, probing primary keys (for approximately even partitions) is
+        # slower on small datasets than using OFFSET (for exactly even
+        # partitions). Measured locally at 2-14% slower by wallclock at
+        # SCALE=6 (1M rows).
         MeasurementType.WALLCLOCK: 0.25,
         MeasurementType.MEMORY_MZ: 0.60,
         MeasurementType.MEMORY_CLUSTERD: 0.60,

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -2016,7 +2016,9 @@ class MySqlInitialLoad(MySqlCdc):
     # load, so allow a bit more headroom than the base default before flagging a
     # regression.
     RELATIVE_THRESHOLD: dict[MeasurementType, float] = {
-        MeasurementType.WALLCLOCK: 0.10,
+        # Integer primary keys are no longer handled for primary key splitting.
+        # Bumping to account for this.
+        MeasurementType.WALLCLOCK: 0.25,
         MeasurementType.MEMORY_MZ: 0.30,
         MeasurementType.MEMORY_CLUSTERD: 0.50,
     }
@@ -2168,7 +2170,11 @@ class MySqlInitialLoadMultiWorkerSingleTable(MySqlCdc):
     single-table companion to MySqlInitialLoadMultiWorkerSampled."""
 
     RELATIVE_THRESHOLD: dict[MeasurementType, float] = {
-        MeasurementType.WALLCLOCK: 0.10,
+        # Bumping to account for small performance regression for approximate
+        # primary key probing: measured locally at 2-14% wallclock versus the
+        # exact OFFSET-sampler baseline. Grabbing the offset was quite fast
+        # for small datasets in MySQL.
+        MeasurementType.WALLCLOCK: 0.25,
         MeasurementType.MEMORY_MZ: 0.60,
         MeasurementType.MEMORY_CLUSTERD: 0.60,
     }

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -2097,7 +2097,7 @@ class MySqlInitialLoadMultiWorkerSampled(MySqlCdc):
         for i in range(self.TABLES):
             table = f"pk_table{i + 1}"
             table_blocks.append(
-                f"CREATE TABLE {table} (pk CHAR(26) PRIMARY KEY, f2 BIGINT);\n"
+                f"CREATE TABLE {table} (pk CHAR(26) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin PRIMARY KEY, f2 BIGINT);\n"
                 f"SET @i := 0;\n"
                 f"INSERT INTO {table} SELECT {row_values} "
                 f"FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT {row_counts[i]};"
@@ -2188,7 +2188,7 @@ DROP DATABASE IF EXISTS public;
 CREATE DATABASE public;
 USE public;
 
-CREATE TABLE pk_table (pk CHAR(26) PRIMARY KEY, f2 BIGINT);
+CREATE TABLE pk_table (pk CHAR(26) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin PRIMARY KEY, f2 BIGINT);
 SET @i := 0;
 INSERT INTO pk_table SELECT LPAD(CONV(@i := @i + 1, 10, 36), 26, '0'), @i FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT {self.n()};
 """)

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -2012,8 +2012,9 @@ class MySqlInitialLoad(MySqlCdc):
 
     FIXED_SCALE = True  # TODO: Remove when database-issues#7556 is fixed
 
-    # The initial load has a wider memory envelope, so allow a bit more
-    # headroom than the base default before flagging a regression.
+    # The parallel snapshot path has a wider memory envelope during the initial
+    # load, so allow a bit more headroom than the base default before flagging a
+    # regression.
     RELATIVE_THRESHOLD: dict[MeasurementType, float] = {
         # Primary key splitting supports only string primary keys, so this
         # BIGINT-keyed snapshot reads serially where older versions split it across

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -717,8 +717,6 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     # The estimated path is covered explicitly in mysql-cdc/statistics.td and
     # by parallel-workload.
     "mysql_source_snapshot_exact_count_max_rows",
-    # Not varied here because the 256-prefix floor dominates for test-sized
-    # tables. parallel-workload flips it.
     "mysql_source_snapshot_partition_probed_prefixes_per_billion_rows",
     "postgres_fetch_slot_resume_lsn_interval",
     "pg_schema_validation_interval",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -314,6 +314,10 @@ def get_variable_system_parameters(
         VariableSystemParameter(
             "mysql_source_snapshot_parallelism", "true", ["true", "false"]
         ),
+        # Low default so small tables exercise partitioning.
+        VariableSystemParameter(
+            "mysql_source_snapshot_partition_min_rows", "2", ["2", "50000"]
+        ),
         VariableSystemParameter(
             "persist_batch_delete_enabled", "true", ["true", "false"]
         ),
@@ -713,6 +717,9 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     # The estimated path is covered explicitly in mysql-cdc/statistics.td and
     # by parallel-workload.
     "mysql_source_snapshot_exact_count_max_rows",
+    # Not varied here because the 256-prefix floor dominates for test-sized
+    # tables. parallel-workload flips it.
+    "mysql_source_snapshot_partition_probed_prefixes_per_billion_rows",
     "postgres_fetch_slot_resume_lsn_interval",
     "pg_schema_validation_interval",
     "pg_source_validate_timeline",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3093,7 +3093,7 @@ class FlipFlagsAction(Action):
             "2",
             "50000",
         ]
-        # 0 will end up as 256 probes internally because that's the floor.
+        # 0 will end up as 64 probes internally because that's the floor.
         self.flags_with_values[
             "mysql_source_snapshot_partition_probed_prefixes_per_billion_rows"
         ] = [

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3088,6 +3088,18 @@ class FlipFlagsAction(Action):
         self.flags_with_values["mysql_source_snapshot_parallelism"] = (
             BOOLEAN_FLAG_VALUES
         )
+        # 2 exercises PK-prefix splitting on parallel-workload sized tables.
+        self.flags_with_values["mysql_source_snapshot_partition_min_rows"] = [
+            "2",
+            "50000",
+        ]
+        # 0 will end up as 256 probes internally because that's the floor.
+        self.flags_with_values[
+            "mysql_source_snapshot_partition_probed_prefixes_per_billion_rows"
+        ] = [
+            "0",
+            "1000",
+        ]
 
         # If you are adding a new config flag in Materialize, consider using it
         # here instead of just marking it as uninteresting to silence the

--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -46,7 +46,7 @@ pub mod probe;
 pub use probe::{KeyProber, MAX_KEY_LENGTH};
 
 pub mod partition;
-pub use partition::partition_table;
+pub use partition::{PartitionParams, partition_table};
 
 mod aws_rds;
 

--- a/src/mysql-util/src/partition.rs
+++ b/src/mysql-util/src/partition.rs
@@ -7,10 +7,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use mysql_async::prelude::Queryable;
 use mz_ore::cast::CastFrom;
 use mz_ore::str::redact;
 
 use crate::{KeyProber, MySqlError, QualifiedTableRef};
+
+/// Settings for [`partition_table`], bundled so call sites can't transpose the bare `u64`s.
+pub struct PartitionParams {
+    pub num_workers: usize,
+    pub estimated_row_count: u64,
+    pub min_split_threshold: u64,
+    pub max_probed_prefixes: u64,
+}
 
 /// Computes up to `num_workers - 1` partition boundaries that divide the primary key space
 /// into `num_workers` roughly even partitions. At most `max_probed_prefixes` prefixes are
@@ -31,23 +40,20 @@ use crate::{KeyProber, MySqlError, QualifiedTableRef};
 /// target, which means if the algorithm processes a prefix estimated to cover less
 /// than min_split_threshold rows it won't bother splitting it up further. This is useful to
 /// avoid unnecessary work for smaller tables limiting the overhead of partitioning.
-pub async fn partition_table(
-    conn: &mut mysql_async::Conn,
+pub async fn partition_table<Q: Queryable>(
+    conn: &mut Q,
     table: QualifiedTableRef<'_>,
     pk_col: &str,
-    num_workers: usize,
-    estimated_row_count: u64,
-    min_split_threshold: u64,
-    max_probed_prefixes: u64,
+    params: PartitionParams,
 ) -> Result<Vec<String>, MySqlError> {
     let (schema_name, table_name) = (table.schema_name, table.table_name);
     let mut db = KeyProber::new(conn, table, pk_col);
     let boundaries = partition(
         &mut db,
-        num_workers,
-        estimated_row_count,
-        min_split_threshold,
-        max_probed_prefixes,
+        params.num_workers,
+        params.estimated_row_count,
+        params.min_split_threshold,
+        params.max_probed_prefixes,
     )
     .await?;
     tracing::trace!(
@@ -249,7 +255,7 @@ trait PrimaryKeyProber {
     ) -> Result<Option<String>, MySqlError>;
 }
 
-impl<'a> PrimaryKeyProber for KeyProber<'a> {
+impl<'a, Q: Queryable> PrimaryKeyProber for KeyProber<'a, Q> {
     async fn estimate_range_rows(
         &mut self,
         start: &str,
@@ -284,6 +290,19 @@ mod tests {
 
     use super::*;
     use crate::probe::tests::{connect, drop_db, setup_table};
+
+    fn params(
+        num_workers: usize,
+        estimated_row_count: u64,
+        min_split_threshold: u64,
+    ) -> PartitionParams {
+        PartitionParams {
+            num_workers,
+            estimated_row_count,
+            min_split_threshold,
+            max_probed_prefixes: u64::MAX,
+        }
+    }
 
     /// In-memory [`PrimaryKeyProber`] over a sorted key list with exact
     /// "estimates". Byte order stands in for the collation, so the PAD SPACE
@@ -545,8 +564,7 @@ mod tests {
         let table = setup_table(&mut conn, DB, "utf8mb4_bin", &all_keys).await?;
         let total = u64::cast_from(all_keys.len());
 
-        let bounds =
-            partition_table(&mut conn, table.clone(), "id", 4, total, 100, u64::MAX).await?;
+        let bounds = partition_table(&mut conn, table.clone(), "id", params(4, total, 100)).await?;
         assert_eq!(bounds.len(), 3, "{bounds:?}");
         assert_bounds_increasing(&mut conn, &bounds, "utf8mb4_bin").await?;
         let counts = partition_counts(&mut conn, DB, &bounds, total).await?;
@@ -585,12 +603,12 @@ mod tests {
 
         // A minimum above the table size yields no boundaries at all.
         let bounds =
-            partition_table(&mut conn, table.clone(), "id", 4, total, 50_000, u64::MAX).await?;
+            partition_table(&mut conn, table.clone(), "id", params(4, total, 50_000)).await?;
         assert!(bounds.is_empty(), "{bounds:?}");
 
         // A low minimum splits inside the 'a' extensions rather than stopping
         // at the exact key.
-        let bounds = partition_table(&mut conn, table, "id", 4, total, 10, u64::MAX).await?;
+        let bounds = partition_table(&mut conn, table, "id", params(4, total, 10)).await?;
         assert_eq!(bounds.len(), 3, "{bounds:?}");
 
         assert_bounds_increasing(&mut conn, &bounds, "utf8mb4_bin").await?;
@@ -630,7 +648,7 @@ mod tests {
         let total = u64::cast_from(all_keys.len());
 
         // Partition for 4 workers with a minimum split size around 250.
-        let bounds = partition_table(&mut conn, table, "id", 4, total, 250, u64::MAX).await?;
+        let bounds = partition_table(&mut conn, table, "id", params(4, total, 250)).await?;
         assert_eq!(bounds.len(), 3);
         let counts = partition_counts(&mut conn, DB, &bounds, total).await?;
         // ~8k keys are visible, so each count gets at least 2k under perfect

--- a/src/mysql-util/src/partition.rs
+++ b/src/mysql-util/src/partition.rs
@@ -7,13 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mysql_async::prelude::Queryable;
+use mysql_async::Transaction;
 use mz_ore::cast::CastFrom;
 use mz_ore::str::redact;
 
 use crate::{KeyProber, MySqlError, QualifiedTableRef};
 
-/// Settings for [`partition_table`], bundled so call sites can't transpose the bare `u64`s.
+/// Settings for [`partition_table`], bundled to make it harder to accidentally put arguments
+/// in the wrong order.
 pub struct PartitionParams {
     pub num_workers: usize,
     pub estimated_row_count: u64,
@@ -33,21 +34,21 @@ pub struct PartitionParams {
 /// * The column type is CHAR or VARCHAR with a declared length of at most
 ///   [`crate::probe::MAX_KEY_LENGTH`] characters.
 /// * The column collation is `utf8mb4_bin`.
-/// * The connection is inside a REPEATABLE READ transaction, so the probes
-///   (several queries each) all see one snapshot of the table.
+/// * The transaction is `REPEATABLE READ`, so the probes (several queries
+///   each) all see one snapshot of the table.
 ///
 /// `min_split_threshold` is the smallest estimated row count granularity partitioning will
 /// target, which means if the algorithm processes a prefix estimated to cover less
 /// than min_split_threshold rows it won't bother splitting it up further. This is useful to
 /// avoid unnecessary work for smaller tables limiting the overhead of partitioning.
-pub async fn partition_table<Q: Queryable>(
-    conn: &mut Q,
+pub async fn partition_table(
+    tx: &mut Transaction<'_>,
     table: QualifiedTableRef<'_>,
     pk_col: &str,
     params: PartitionParams,
 ) -> Result<Vec<String>, MySqlError> {
     let (schema_name, table_name) = (table.schema_name, table.table_name);
-    let mut db = KeyProber::new(conn, table, pk_col);
+    let mut db = KeyProber::new(tx, table, pk_col);
     let boundaries = partition(
         &mut db,
         params.num_workers,
@@ -255,7 +256,7 @@ trait PrimaryKeyProber {
     ) -> Result<Option<String>, MySqlError>;
 }
 
-impl<'a, Q: Queryable> PrimaryKeyProber for KeyProber<'a, Q> {
+impl<'a, 't> PrimaryKeyProber for KeyProber<'a, 't> {
     async fn estimate_range_rows(
         &mut self,
         start: &str,
@@ -289,7 +290,7 @@ mod tests {
     use mz_ore::cast::CastFrom;
 
     use super::*;
-    use crate::probe::tests::{connect, drop_db, setup_table};
+    use crate::probe::tests::{connect, drop_db, setup_table, start_tx};
 
     fn params(
         num_workers: usize,
@@ -564,7 +565,9 @@ mod tests {
         let table = setup_table(&mut conn, DB, "utf8mb4_bin", &all_keys).await?;
         let total = u64::cast_from(all_keys.len());
 
-        let bounds = partition_table(&mut conn, table.clone(), "id", params(4, total, 100)).await?;
+        let mut tx = start_tx(&mut conn).await?;
+        let bounds = partition_table(&mut tx, table.clone(), "id", params(4, total, 100)).await?;
+        tx.rollback().await?;
         assert_eq!(bounds.len(), 3, "{bounds:?}");
         assert_bounds_increasing(&mut conn, &bounds, "utf8mb4_bin").await?;
         let counts = partition_counts(&mut conn, DB, &bounds, total).await?;
@@ -601,14 +604,17 @@ mod tests {
         let table = setup_table(&mut conn, DB, "utf8mb4_bin", &all_keys).await?;
         let total = u64::cast_from(all_keys.len());
 
+        let mut tx = start_tx(&mut conn).await?;
+
         // A minimum above the table size yields no boundaries at all.
         let bounds =
-            partition_table(&mut conn, table.clone(), "id", params(4, total, 50_000)).await?;
+            partition_table(&mut tx, table.clone(), "id", params(4, total, 50_000)).await?;
         assert!(bounds.is_empty(), "{bounds:?}");
 
         // A low minimum splits inside the 'a' extensions rather than stopping
         // at the exact key.
-        let bounds = partition_table(&mut conn, table, "id", params(4, total, 10)).await?;
+        let bounds = partition_table(&mut tx, table, "id", params(4, total, 10)).await?;
+        tx.rollback().await?;
         assert_eq!(bounds.len(), 3, "{bounds:?}");
 
         assert_bounds_increasing(&mut conn, &bounds, "utf8mb4_bin").await?;
@@ -648,7 +654,9 @@ mod tests {
         let total = u64::cast_from(all_keys.len());
 
         // Partition for 4 workers with a minimum split size around 250.
-        let bounds = partition_table(&mut conn, table, "id", params(4, total, 250)).await?;
+        let mut tx = start_tx(&mut conn).await?;
+        let bounds = partition_table(&mut tx, table, "id", params(4, total, 250)).await?;
+        tx.rollback().await?;
         assert_eq!(bounds.len(), 3);
         let counts = partition_counts(&mut conn, DB, &bounds, total).await?;
         // ~8k keys are visible, so each count gets at least 2k under perfect

--- a/src/mysql-util/src/probe.rs
+++ b/src/mysql-util/src/probe.rs
@@ -38,10 +38,10 @@ pub struct KeyProber<'a, 't> {
 }
 
 impl<'a, 't> KeyProber<'a, 't> {
-    /// NOTE: `tx` should be `REPEATABLE READ` so sequential probes see one
-    /// snapshot of the table, and its connection is assumed to use a utf8mb4
-    /// connection character set (the driver's handshake default), so key
-    /// values arrive converted to UTF-8.
+    /// NOTE: `tx` is assumed to use a utf8mb4 connection character set (the
+    /// driver's handshake default), so key values arrive converted to UTF-8.
+    /// `tx` should be `REPEATABLE READ` so sequential probes see one
+    /// snapshot of the table.
     pub fn new(tx: &'a mut Transaction<'t>, table: QualifiedTableRef<'_>, key_col: &str) -> Self {
         Self {
             tx,
@@ -862,22 +862,27 @@ pub(crate) mod tests {
         let ids: Vec<String> = (0..1000).map(|i| format!("a{i:05}")).collect();
         let table = setup_table(&mut conn, DB, "utf8mb4_bin", &ids).await?;
 
+        // One transaction serves every measurement below. The handler
+        // counters are session-level, so they read fine through it, and a
+        // throwaway prober per probe keeps the transaction usable in between
+        // (a prober holds the exclusive borrow for its whole lifetime).
+        let mut tx = start_tx(&mut conn).await?;
+
         // Prove the methodology first: a deliberately non-sargable predicate
         // reads every row, and the session handler counters see it.
-        let before = handler_reads(&mut conn).await?;
-        let _: Option<u64> = conn
+        let before = handler_reads(&mut tx).await?;
+        let _: Option<u64> = tx
             .exec_first(
                 format!("SELECT COUNT(*) FROM {DB}.t WHERE LEFT(id, 2) = 'a0'"),
                 (),
             )
             .await?;
-        let scan_reads = handler_reads(&mut conn).await? - before;
+        let scan_reads = handler_reads(&mut tx).await? - before;
         assert!(scan_reads >= 1000, "scan_reads={scan_reads}");
 
         // Every probe must stay a handful of index operations. A regression
         // to a scan costs >= 1000 reads, far past the generous bound.
-        let before = handler_reads(&mut conn).await?;
-        let mut tx = start_tx(&mut conn).await?;
+        let before = handler_reads(&mut tx).await?;
         let got = prefix_of_first_key_in_range(
             &mut KeyProber::new(&mut tx, table.clone(), "id"),
             "a00500",
@@ -885,14 +890,12 @@ pub(crate) mod tests {
             6,
         )
         .await;
-        tx.rollback().await?;
-        let reads = handler_reads(&mut conn).await? - before;
+        let reads = handler_reads(&mut tx).await? - before;
         // The exclusive bound skips the exact key a00500.
         assert_eq!(got, some("a00501"));
         assert!(reads < 50, "prefix_of_first_key_in_range reads={reads}");
 
-        let before = handler_reads(&mut conn).await?;
-        let mut tx = start_tx(&mut conn).await?;
+        let before = handler_reads(&mut tx).await?;
         let got = prefix_of_first_row_not_matching_prefix(
             &mut KeyProber::new(&mut tx, table.clone(), "id"),
             "a00500",
@@ -900,13 +903,11 @@ pub(crate) mod tests {
             6,
         )
         .await;
-        tx.rollback().await?;
-        let reads = handler_reads(&mut conn).await? - before;
+        let reads = handler_reads(&mut tx).await? - before;
         assert_eq!(got, some("a00501"));
         assert!(reads < 50, "max_key probe reads={reads}");
 
-        let before = handler_reads(&mut conn).await?;
-        let mut tx = start_tx(&mut conn).await?;
+        let before = handler_reads(&mut tx).await?;
         let got = prefix_of_first_row_not_matching_prefix(
             &mut KeyProber::new(&mut tx, table.clone(), "id"),
             "a0",
@@ -914,31 +915,31 @@ pub(crate) mod tests {
             6,
         )
         .await;
-        tx.rollback().await?;
-        let reads = handler_reads(&mut conn).await? - before;
+        let reads = handler_reads(&mut tx).await? - before;
         // Every key matches 'a0%', so the prefix match covers the whole table and
         // there is no next prefix, at the cost of two dives rather than a
         // scan.
         assert_eq!(got, None);
         assert!(reads < 50, "whole-table match reads={reads}");
 
-        let before = handler_reads(&mut conn).await?;
+        let before = handler_reads(&mut tx).await?;
         let got = prefix_of_first_key_in_range(
-            &mut KeyProber::new(&mut conn, table.clone(), "id"),
+            &mut KeyProber::new(&mut tx, table.clone(), "id"),
             "a00500",
             Some("a00501"),
             6,
         )
         .await;
-        let reads = handler_reads(&mut conn).await? - before;
+        let reads = handler_reads(&mut tx).await? - before;
         assert_eq!(got, None);
         assert!(reads < 50, "empty bounded range reads={reads}");
 
-        let bounded = KeyProber::new(&mut conn, table.clone(), "id")
+        let bounded = KeyProber::new(&mut tx, table.clone(), "id")
             .estimate_range_rows("a00100", Some("a00200"))
             .await?;
         assert!((50..=300).contains(&bounded), "bounded estimate={bounded}");
 
+        tx.rollback().await?;
         drop_db(&mut conn, DB).await?;
         conn.disconnect().await?;
         Ok(())
@@ -1145,7 +1146,7 @@ pub(crate) mod tests {
 
     /// Sum of this session's `Handler_read_*` counters: how many index or row
     /// read operations the connection has performed so far.
-    async fn handler_reads(conn: &mut mysql_async::Conn) -> Result<u64, anyhow::Error> {
+    async fn handler_reads<Q: Queryable>(conn: &mut Q) -> Result<u64, anyhow::Error> {
         let rows: Vec<(String, String)> = conn
             .exec("SHOW SESSION STATUS LIKE 'Handler_read%'", ())
             .await?;

--- a/src/mysql-util/src/probe.rs
+++ b/src/mysql-util/src/probe.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use mysql_async::prelude::Queryable;
-use mysql_async::{Params, Value};
+use mysql_async::{Params, Transaction, Value};
 use mz_ore::str::redact;
 
 use crate::{MySqlError, QualifiedTableRef, quote_identifier};
@@ -25,8 +25,8 @@ pub const MAX_KEY_LENGTH: u32 = 768;
 /// Probes a string primary key column. Only supports `utf8mb4_bin` against CHAR/VARCHAR
 /// columns up to 768 characters. Enforcement is deferred to the caller. There may be
 /// other collations we can support, but we should do more validation.
-pub struct KeyProber<'a, Q> {
-    conn: &'a mut Q,
+pub struct KeyProber<'a, 't> {
+    tx: &'a mut Transaction<'t>,
     /// Quoted `` `schema`.`table` `` for SQL interpolation.
     table: String,
     /// Quoted key column for SQL interpolation.
@@ -37,12 +37,14 @@ pub struct KeyProber<'a, Q> {
     col_name: String,
 }
 
-impl<'a, Q: Queryable> KeyProber<'a, Q> {
-    /// NOTE: `conn` is assumed to use a utf8mb4 connection character set (the
-    /// driver's handshake default), so key values arrive converted to UTF-8.
-    pub fn new(conn: &'a mut Q, table: QualifiedTableRef<'_>, key_col: &str) -> Self {
+impl<'a, 't> KeyProber<'a, 't> {
+    /// NOTE: `tx` should be `REPEATABLE READ` so sequential probes see one
+    /// snapshot of the table, and its connection is assumed to use a utf8mb4
+    /// connection character set (the driver's handshake default), so key
+    /// values arrive converted to UTF-8.
+    pub fn new(tx: &'a mut Transaction<'t>, table: QualifiedTableRef<'_>, key_col: &str) -> Self {
         Self {
-            conn,
+            tx,
             table: format!(
                 "{}.{}",
                 quote_identifier(table.schema_name),
@@ -75,7 +77,7 @@ impl<'a, Q: Queryable> KeyProber<'a, Q> {
             col = self.col,
             table = self.table,
         );
-        explain_row_estimate(&mut *self.conn, &select, Params::Positional(params))
+        explain_row_estimate(&mut *self.tx, &select, Params::Positional(params))
             .await?
             .ok_or_else(|| MySqlError::MissingRowEstimate {
                 qualified_table_name: self.table_name.clone(),
@@ -204,10 +206,8 @@ impl<'a, Q: Queryable> KeyProber<'a, Q> {
         sql: String,
         params: Vec<Value>,
     ) -> Result<Option<String>, MySqlError> {
-        let row: Option<mysql_async::Row> = self
-            .conn
-            .exec_first(sql, Params::Positional(params))
-            .await?;
+        let row: Option<mysql_async::Row> =
+            self.tx.exec_first(sql, Params::Positional(params)).await?;
         match row.and_then(|mut row| row.take_opt::<String, _>(0)) {
             None => Ok(None),
             Some(Ok(value)) => Ok(Some(value)),
@@ -236,16 +236,15 @@ fn like_prefix_pattern(prefix: &str) -> String {
     pattern
 }
 
-async fn explain_row_estimate<Q, P>(
-    conn: &mut Q,
+async fn explain_row_estimate<P>(
+    tx: &mut Transaction<'_>,
     select: &str,
     params: P,
 ) -> Result<Option<u64>, MySqlError>
 where
-    Q: Queryable,
     P: Into<Params> + Send,
 {
-    let plan: Option<mysql_async::Row> = conn
+    let plan: Option<mysql_async::Row> = tx
         .exec_first(format!("EXPLAIN FORMAT=TRADITIONAL {select}"), params)
         .await?;
     let estimate = plan.and_then(|row| {
@@ -287,7 +286,8 @@ pub(crate) mod tests {
         let keys = ["aa", "ab", "b", "bb", "bbb", "c"];
         let table = setup_table(&mut conn, DB, "utf8mb4_bin", &keys).await?;
 
-        let p = &mut KeyProber::new(&mut conn, table, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let p = &mut KeyProber::new(&mut tx, table, "id");
         assert_eq!(
             prefix_of_first_key_in_range(p, "", None, 1).await,
             some("a")
@@ -330,6 +330,7 @@ pub(crate) mod tests {
         );
         assert_eq!(prefix_of_first_key_in_range(p, "c", None, 2).await, None);
 
+        tx.rollback().await?;
         drop_db(&mut conn, DB).await?;
         conn.disconnect().await?;
         Ok(())
@@ -344,7 +345,8 @@ pub(crate) mod tests {
         const DB: &str = "mz_probe_explain_test";
         let ids: Vec<String> = (0..1000).map(|i| format!("a{i:05}")).collect();
         let table = setup_table(&mut conn, DB, "utf8mb4_bin", &ids).await?;
-        let mut p = KeyProber::new(&mut conn, table, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let mut p = KeyProber::new(&mut tx, table, "id");
 
         // Estimates are index dives, near reality but never exact by
         // contract, so the bounds are deliberately loose.
@@ -355,6 +357,7 @@ pub(crate) mod tests {
         let none = p.estimate_range_rows("zzz", None).await?;
         assert!(none <= 5, "none={none}");
 
+        tx.rollback().await?;
         drop_db(&mut conn, DB).await?;
         conn.disconnect().await?;
         Ok(())
@@ -370,7 +373,8 @@ pub(crate) mod tests {
         let keys = ["Aa", "ab", "b", "Bb", "bbb", "C"];
         let table = setup_table(&mut conn, DB, "utf8mb4_general_ci", &keys).await?;
 
-        let p = &mut KeyProber::new(&mut conn, table, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let p = &mut KeyProber::new(&mut tx, table, "id");
         // Sorting is case-insensitive but returned prefixes are the stored
         // bytes: "A", "b", "C".
         // Grab the initial prefix.
@@ -425,6 +429,7 @@ pub(crate) mod tests {
 
         assert_eq!(prefix_of_first_key_in_range(p, "C", None, 2).await, None);
 
+        tx.rollback().await?;
         drop_db(&mut conn, DB).await?;
         conn.disconnect().await?;
         Ok(())
@@ -443,7 +448,8 @@ pub(crate) mod tests {
         let keys = ["a_1", "a\\2", "a\\3", "a%4", "a|5"];
         let table = setup_table(&mut conn, DB, "utf8mb4_bin", &keys).await?;
 
-        let p = &mut KeyProber::new(&mut conn, table, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let p = &mut KeyProber::new(&mut tx, table, "id");
         assert_eq!(
             prefix_of_first_key_in_range(p, "", None, 1).await,
             some("a")
@@ -511,6 +517,7 @@ pub(crate) mod tests {
             None
         );
 
+        tx.rollback().await?;
         drop_db(&mut conn, DB).await?;
         conn.disconnect().await?;
         Ok(())
@@ -528,7 +535,8 @@ pub(crate) mod tests {
         let keys = ["a", "a😀", "日本", "日本語", "😀", "😀a", "😀😀"];
         let table = setup_table(&mut conn, DB, "utf8mb4_general_ci", &keys).await?;
 
-        let p = &mut KeyProber::new(&mut conn, table, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let p = &mut KeyProber::new(&mut tx, table, "id");
         // Prefix lengths count characters, not bytes: a one-char prefix of a
         // four-byte emoji is the whole emoji, never a broken fragment.
         assert_eq!(
@@ -578,6 +586,7 @@ pub(crate) mod tests {
             None
         );
 
+        tx.rollback().await?;
         drop_db(&mut conn, DB).await?;
         conn.disconnect().await?;
         Ok(())
@@ -599,7 +608,8 @@ pub(crate) mod tests {
             })
             .collect();
         let table = setup_table(&mut conn, DB, "utf8mb4_bin", &ids).await?;
-        let mut p = KeyProber::new(&mut conn, table, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let mut p = KeyProber::new(&mut tx, table, "id");
 
         // Lowercase hex order matches byte order under this collation.
         assert_eq!(
@@ -616,6 +626,7 @@ pub(crate) mod tests {
             .collect();
         assert_eq!(walked, expected);
 
+        tx.rollback().await?;
         drop_db(&mut conn, DB).await?;
         conn.disconnect().await?;
         Ok(())
@@ -659,8 +670,10 @@ pub(crate) mod tests {
         // Assert that walking the prefixes gives range boundaries that
         // partition the table and every key falls into exactly one range.
         for len in [1, 2] {
+            let mut tx = start_tx(&mut conn).await?;
             let walked =
-                walk_prefixes(&mut KeyProber::new(&mut conn, table.clone(), "id"), len).await?;
+                walk_prefixes(&mut KeyProber::new(&mut tx, table.clone(), "id"), len).await?;
+            tx.rollback().await?;
             let mut total = 0;
             for (i, lo) in walked.iter().enumerate() {
                 let (n, prefixed) = count_range(&mut conn, DB, lo, walked.get(i + 1)).await?;
@@ -699,19 +712,23 @@ pub(crate) mod tests {
         // keys differ by letter, in mixed case.
         let ci_keys = ["Apple", "apricot", "banana", "Cherry"];
         let t_ci = setup_table(&mut conn, CI_DB, "utf8mb4_general_ci", &ci_keys).await?;
-        let mut prober = KeyProber::new(&mut conn, t_ci, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let mut prober = KeyProber::new(&mut tx, t_ci, "id");
         // 'A' covers 'apricot' too: LIKE is case-insensitive here, so a
         // returned prefix covers every case variant of it.
         assert_eq!(walk_prefixes(&mut prober, 1).await?, ["A", "b", "C"]);
+        tx.rollback().await?;
 
         // Binary collation: case variants coexist and order by byte value.
         let bin_keys = ["ABC", "ABD", "abc", "abd"];
         let t_bin = setup_table(&mut conn, BIN_DB, "utf8mb4_bin", &bin_keys).await?;
-        let mut prober = KeyProber::new(&mut conn, t_bin, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let mut prober = KeyProber::new(&mut tx, t_bin, "id");
         // Uppercase sorts before lowercase in byte order, and case variants
         // are distinct prefixes.
         assert_eq!(walk_prefixes(&mut prober, 1).await?, ["A", "a"]);
         assert_eq!(walk_prefixes(&mut prober, 3).await?, bin_keys);
+        tx.rollback().await?;
 
         drop_db(&mut conn, CI_DB).await?;
         drop_db(&mut conn, BIN_DB).await?;
@@ -748,7 +765,8 @@ pub(crate) mod tests {
             schema_name: DB,
             table_name: "t",
         };
-        let mut p = KeyProber::new(&mut conn, table, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let mut p = KeyProber::new(&mut tx, table, "id");
 
         // Estimates never decode key values, they keep working.
         assert!(p.estimate_range_rows("", None).await.is_ok());
@@ -770,6 +788,7 @@ pub(crate) mod tests {
             .unwrap_err();
         assert!(matches!(err, MySqlError::NonUtf8KeyValue { .. }), "{err:?}");
 
+        tx.rollback().await?;
         drop_db(&mut conn, DB).await?;
         conn.disconnect().await?;
         Ok(())
@@ -817,7 +836,8 @@ pub(crate) mod tests {
             schema_name: DB,
             table_name: "t",
         };
-        let mut prober = KeyProber::new(&mut conn, table, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let mut prober = KeyProber::new(&mut tx, table, "id");
 
         // Range estimates come from index dives on the real B-tree, not the
         // stale table statistics, so they still reflect the actual data.
@@ -826,6 +846,7 @@ pub(crate) mod tests {
         let range = prober.estimate_range_rows("a00100", Some("a00200")).await?;
         assert!((50..=200).contains(&range), "range={range}");
 
+        tx.rollback().await?;
         drop_db(&mut conn, DB).await?;
         conn.disconnect().await?;
         Ok(())
@@ -856,38 +877,44 @@ pub(crate) mod tests {
         // Every probe must stay a handful of index operations. A regression
         // to a scan costs >= 1000 reads, far past the generous bound.
         let before = handler_reads(&mut conn).await?;
+        let mut tx = start_tx(&mut conn).await?;
         let got = prefix_of_first_key_in_range(
-            &mut KeyProber::new(&mut conn, table.clone(), "id"),
+            &mut KeyProber::new(&mut tx, table.clone(), "id"),
             "a00500",
             None,
             6,
         )
         .await;
+        tx.rollback().await?;
         let reads = handler_reads(&mut conn).await? - before;
         // The exclusive bound skips the exact key a00500.
         assert_eq!(got, some("a00501"));
         assert!(reads < 50, "prefix_of_first_key_in_range reads={reads}");
 
         let before = handler_reads(&mut conn).await?;
+        let mut tx = start_tx(&mut conn).await?;
         let got = prefix_of_first_row_not_matching_prefix(
-            &mut KeyProber::new(&mut conn, table.clone(), "id"),
+            &mut KeyProber::new(&mut tx, table.clone(), "id"),
             "a00500",
             None,
             6,
         )
         .await;
+        tx.rollback().await?;
         let reads = handler_reads(&mut conn).await? - before;
         assert_eq!(got, some("a00501"));
         assert!(reads < 50, "max_key probe reads={reads}");
 
         let before = handler_reads(&mut conn).await?;
+        let mut tx = start_tx(&mut conn).await?;
         let got = prefix_of_first_row_not_matching_prefix(
-            &mut KeyProber::new(&mut conn, table.clone(), "id"),
+            &mut KeyProber::new(&mut tx, table.clone(), "id"),
             "a0",
             None,
             6,
         )
         .await;
+        tx.rollback().await?;
         let reads = handler_reads(&mut conn).await? - before;
         // Every key matches 'a0%', so the prefix match covers the whole table and
         // there is no next prefix, at the cost of two dives rather than a
@@ -932,13 +959,15 @@ pub(crate) mod tests {
         ];
         let table = setup_table(&mut conn, DB, "utf8mb4_bin", &keys).await?;
 
-        let p = &mut KeyProber::new(&mut conn, table, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let p = &mut KeyProber::new(&mut tx, table, "id");
         assert_eq!(walk_prefixes(p, 1).await?, ["a", "c", "d", "h", "i"]);
         assert_eq!(
             walk_prefixes(p, 2).await?,
             ["aa", "as", "aß", "ce", "ch", "du", "ho", "ib"]
         );
 
+        tx.rollback().await?;
         drop_db(&mut conn, DB).await?;
         conn.disconnect().await?;
         Ok(())
@@ -960,7 +989,8 @@ pub(crate) mod tests {
         let keys = ["\0a", "\u{1}a", "\u{9}b", "a1", "a1\u{1}x", "b1"];
         let table = setup_table(&mut conn, DB, "utf8mb4_bin", &keys).await?;
 
-        let p = &mut KeyProber::new(&mut conn, table, "id");
+        let mut tx = start_tx(&mut conn).await?;
+        let p = &mut KeyProber::new(&mut tx, table, "id");
         assert_eq!(
             prefix_of_first_key_in_range(p, "", None, 2).await,
             some("a1")
@@ -987,6 +1017,7 @@ pub(crate) mod tests {
             some("a1")
         );
 
+        tx.rollback().await?;
         drop_db(&mut conn, DB).await?;
         conn.disconnect().await?;
         Ok(())
@@ -1008,6 +1039,18 @@ pub(crate) mod tests {
         Ok(Some(
             mysql_async::Conn::new(mysql_async::Opts::from_url(&url)?).await?,
         ))
+    }
+
+    /// Opens the transaction shape [`KeyProber`]'s contract expects:
+    /// `REPEATABLE READ` and read-only.
+    pub(crate) async fn start_tx(
+        conn: &mut mysql_async::Conn,
+    ) -> Result<Transaction<'_>, anyhow::Error> {
+        let mut tx_opts = mysql_async::TxOpts::default();
+        tx_opts
+            .with_isolation_level(mysql_async::IsolationLevel::RepeatableRead)
+            .with_readonly(true);
+        Ok(conn.start_transaction(tx_opts).await?)
     }
 
     /// Drops and recreates the scratch database `db`. Each test must use its
@@ -1111,7 +1154,7 @@ pub(crate) mod tests {
 
     // Wrapped to limit boilerplate
     async fn prefix_of_first_key_in_range(
-        prober: &mut KeyProber<'_, mysql_async::Conn>,
+        prober: &mut KeyProber<'_, '_>,
         lower_bound_exclusive: &str,
         upper_bound_exclusive: Option<&str>,
         max_prefix_length: usize,
@@ -1128,7 +1171,7 @@ pub(crate) mod tests {
 
     // Wrapped to limit boilerplate
     async fn prefix_of_first_row_not_matching_prefix(
-        prober: &mut KeyProber<'_, mysql_async::Conn>,
+        prober: &mut KeyProber<'_, '_>,
         prefix: &str,
         upper_bound_exclusive: Option<&str>,
         max_prefix_length: usize,
@@ -1153,7 +1196,7 @@ pub(crate) mod tests {
     /// Test helper to walk prefixes at a consistent depth. Only works when
     /// all keys have length >= len.
     async fn walk_prefixes(
-        prober: &mut KeyProber<'_, mysql_async::Conn>,
+        prober: &mut KeyProber<'_, '_>,
         len: usize,
     ) -> Result<Vec<String>, anyhow::Error> {
         let mut walked = Vec::new();

--- a/src/mysql-util/src/probe.rs
+++ b/src/mysql-util/src/probe.rs
@@ -1146,8 +1146,8 @@ pub(crate) mod tests {
 
     /// Sum of this session's `Handler_read_*` counters: how many index or row
     /// read operations the connection has performed so far.
-    async fn handler_reads<Q: Queryable>(conn: &mut Q) -> Result<u64, anyhow::Error> {
-        let rows: Vec<(String, String)> = conn
+    async fn handler_reads(tx: &mut Transaction<'_>) -> Result<u64, anyhow::Error> {
+        let rows: Vec<(String, String)> = tx
             .exec("SHOW SESSION STATUS LIKE 'Handler_read%'", ())
             .await?;
         Ok(rows.into_iter().map(|(_, v)| v.parse().unwrap_or(0)).sum())

--- a/src/mysql-util/src/probe.rs
+++ b/src/mysql-util/src/probe.rs
@@ -25,8 +25,8 @@ pub const MAX_KEY_LENGTH: u32 = 768;
 /// Probes a string primary key column. Only supports `utf8mb4_bin` against CHAR/VARCHAR
 /// columns up to 768 characters. Enforcement is deferred to the caller. There may be
 /// other collations we can support, but we should do more validation.
-pub struct KeyProber<'a> {
-    conn: &'a mut mysql_async::Conn,
+pub struct KeyProber<'a, Q> {
+    conn: &'a mut Q,
     /// Quoted `` `schema`.`table` `` for SQL interpolation.
     table: String,
     /// Quoted key column for SQL interpolation.
@@ -37,14 +37,10 @@ pub struct KeyProber<'a> {
     col_name: String,
 }
 
-impl<'a> KeyProber<'a> {
+impl<'a, Q: Queryable> KeyProber<'a, Q> {
     /// NOTE: `conn` is assumed to use a utf8mb4 connection character set (the
     /// driver's handshake default), so key values arrive converted to UTF-8.
-    pub fn new(
-        conn: &'a mut mysql_async::Conn,
-        table: QualifiedTableRef<'_>,
-        key_col: &str,
-    ) -> Self {
+    pub fn new(conn: &'a mut Q, table: QualifiedTableRef<'_>, key_col: &str) -> Self {
         Self {
             conn,
             table: format!(
@@ -240,12 +236,13 @@ fn like_prefix_pattern(prefix: &str) -> String {
     pattern
 }
 
-async fn explain_row_estimate<P>(
-    conn: &mut mysql_async::Conn,
+async fn explain_row_estimate<Q, P>(
+    conn: &mut Q,
     select: &str,
     params: P,
 ) -> Result<Option<u64>, MySqlError>
 where
+    Q: Queryable,
     P: Into<Params> + Send,
 {
     let plan: Option<mysql_async::Row> = conn
@@ -1114,7 +1111,7 @@ pub(crate) mod tests {
 
     // Wrapped to limit boilerplate
     async fn prefix_of_first_key_in_range(
-        prober: &mut KeyProber<'_>,
+        prober: &mut KeyProber<'_, mysql_async::Conn>,
         lower_bound_exclusive: &str,
         upper_bound_exclusive: Option<&str>,
         max_prefix_length: usize,
@@ -1131,7 +1128,7 @@ pub(crate) mod tests {
 
     // Wrapped to limit boilerplate
     async fn prefix_of_first_row_not_matching_prefix(
-        prober: &mut KeyProber<'_>,
+        prober: &mut KeyProber<'_, mysql_async::Conn>,
         prefix: &str,
         upper_bound_exclusive: Option<&str>,
         max_prefix_length: usize,
@@ -1156,7 +1153,7 @@ pub(crate) mod tests {
     /// Test helper to walk prefixes at a consistent depth. Only works when
     /// all keys have length >= len.
     async fn walk_prefixes(
-        prober: &mut KeyProber<'_>,
+        prober: &mut KeyProber<'_, mysql_async::Conn>,
         len: usize,
     ) -> Result<Vec<String>, anyhow::Error> {
         let mut walked = Vec::new();

--- a/src/mysql-util/src/probe.rs
+++ b/src/mysql-util/src/probe.rs
@@ -862,10 +862,6 @@ pub(crate) mod tests {
         let ids: Vec<String> = (0..1000).map(|i| format!("a{i:05}")).collect();
         let table = setup_table(&mut conn, DB, "utf8mb4_bin", &ids).await?;
 
-        // One transaction serves every measurement below. The handler
-        // counters are session-level, so they read fine through it, and a
-        // throwaway prober per probe keeps the transaction usable in between
-        // (a prober holds the exclusive borrow for its whole lifetime).
         let mut tx = start_tx(&mut conn).await?;
 
         // Prove the methodology first: a deliberately non-sargable predicate

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -215,8 +215,7 @@ pub static MYSQL_SOURCE_SNAPSHOT_PARALLELISM: Config<bool> = Config::new(
     "Whether to split MySQL snapshot reads across workers by primary-key ranges.",
 );
 
-/// Smallest estimated row count the MySQL snapshot partitioner attempts to subdivide
-/// for partitioning.
+/// Smallest estimated row count the MySQL snapshot partitioner attempts to subdivide.
 pub static MYSQL_SOURCE_SNAPSHOT_PARTITION_MIN_ROWS: Config<usize> = Config::new(
     "mysql_source_snapshot_partition_min_rows",
     50_000,

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -215,6 +215,25 @@ pub static MYSQL_SOURCE_SNAPSHOT_PARALLELISM: Config<bool> = Config::new(
     "Whether to split MySQL snapshot reads across workers by primary-key ranges.",
 );
 
+/// Smallest estimated row count the MySQL snapshot partitioner attempts to subdivide
+/// for partitioning.
+pub static MYSQL_SOURCE_SNAPSHOT_PARTITION_MIN_ROWS: Config<usize> = Config::new(
+    "mysql_source_snapshot_partition_min_rows",
+    50_000,
+    "Minimum estimated rows the MySQL snapshot partitioner attempts to split.",
+);
+
+/// Cap on string primary key prefixes visited when attempting to partition a table for
+/// parallel snapshotting in MySQL. This limits runtime on high-cardinality prefixes,
+/// and will return correct but likely more skewed boundaries on budget exhaustion.
+pub static MYSQL_SOURCE_SNAPSHOT_PARTITION_PROBED_PREFIXES_PER_BILLION_ROWS: Config<usize> =
+    Config::new(
+        "mysql_source_snapshot_partition_probed_prefixes_per_billion_rows",
+        1_000,
+        "Cap on MySQL snapshot PK-prefix partitioning probed prefixes per table, per billion \
+     estimated rows; when exhausted, splitting stops early with coarser partition boundaries.",
+    );
+
 /// If the optimizer estimates the table has fewer rows than this, compute the exact row count
 /// with `COUNT(*)`. Otherwise, report the `information_schema` estimate directly.
 pub static MYSQL_SOURCE_SNAPSHOT_EXACT_COUNT_MAX_ROWS: Config<usize> = Config::new(
@@ -438,6 +457,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&MYSQL_REPLICATION_HEARTBEAT_INTERVAL)
         .add(&MYSQL_SOURCE_SNAPSHOT_EXACT_COUNT_MAX_ROWS)
         .add(&MYSQL_SOURCE_SNAPSHOT_PARALLELISM)
+        .add(&MYSQL_SOURCE_SNAPSHOT_PARTITION_MIN_ROWS)
+        .add(&MYSQL_SOURCE_SNAPSHOT_PARTITION_PROBED_PREFIXES_PER_BILLION_ROWS)
         .add(&ORE_OVERFLOWING_BEHAVIOR)
         .add(&PG_FETCH_SLOT_RESUME_LSN_INTERVAL)
         .add(&PG_SCHEMA_VALIDATION_INTERVAL)

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -413,9 +413,8 @@ async fn sample_pk_bounds(
                     }
                     None => None,
                 };
-                // Ends the borrow of `conn`; the transaction itself is rolled
-                // back when the pooled connection is next used or disconnected.
-                drop(tx);
+                // Ends the borrow of `conn`.
+                tx.rollback().await?;
                 pool.borrow_mut().push(conn);
                 Ok::<_, TransientError>((table.clone(), count, splits))
             }

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -236,7 +236,6 @@ fn worker_pk_range(
 const SUPPORTED_PK_COLLATION: &str = "utf8mb4_bin";
 const SUPPORTED_PK_CHARSET: &str = "utf8mb4";
 const MIN_PROBED_PREFIXES: u64 = 64;
-const BILLION_ROWS: u64 = 1_000_000_000;
 
 /// Partitioning configuration settings bundled to avoid accidental mixing.
 struct PartitionSettings {
@@ -277,7 +276,7 @@ async fn compute_sampled_splits(
     // network requests to search through prefixes can take minutes, but is worth it for billions of rows
     // that can take hours to snapshot.
     let max_probed_prefixes = (row_count.saturating_mul(settings.probed_prefixes_per_billion_rows)
-        / BILLION_ROWS)
+        / 1_000_000_000)
         .max(MIN_PROBED_PREFIXES);
     let params = mz_mysql_util::PartitionParams {
         num_workers: worker_count,
@@ -617,7 +616,7 @@ where
         // lookup failing means `plan_worker_reads` and this check disagree.
         let Some(Some(splits)) = pk_bounds.get(table) else {
             return Err(TransientError::Generic(anyhow::anyhow!(
-                "PK range planned for {table} without verifiable bounds"
+                "PK range planned for {table} without any PK bounds, which is unexpected"
             )));
         };
         let Some((raw_col, _)) = tables
@@ -625,7 +624,7 @@ where
             .and_then(|outputs| try_extract_single_column_pk(&outputs[0].desc))
         else {
             return Err(TransientError::Generic(anyhow::anyhow!(
-                "PK range planned for {table} without verifiable bounds"
+                "PK range planned for {table} without a single-column PK, which is unexpected"
             )));
         };
         let ok = match fetch_column_collation(tx, table, &raw_col).await? {

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -238,27 +238,27 @@ const SUPPORTED_PK_CHARSET: &str = "utf8mb4";
 const MIN_PROBED_PREFIXES: u64 = 256;
 const BILLION_ROWS: u64 = 1_000_000_000;
 
-/// Partitioning knobs read from dyncfgs, bundled so call sites can't transpose
-/// the bare `u64`s.
+/// Partitioning knobs read from the same-named `mysql_source_snapshot_partition_*` dyncfgs.
 struct PartitionSettings {
-    /// [`mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_MIN_ROWS`].
     min_rows: u64,
-    /// [`mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_PROBED_PREFIXES_PER_BILLION_ROWS`].
     probed_prefixes_per_billion_rows: u64,
 }
 
 /// Attempts to compute roughly even boundaries for primary keys. Returns None if the column type
 /// is unsupported or boundaries couldn't be estimated for some reason. Currently only supports
 /// CHAR/VARCHAR columns with up to 768 characters with utf8mb4_bin collation.
-async fn compute_sampled_splits(
-    conn: &mut mysql_async::Conn,
+async fn compute_sampled_splits<Q>(
+    conn: &mut Q,
     table: &MySqlTableName,
     raw_col: &str,
     scalar_type: &SqlScalarType,
     worker_count: usize,
     row_count: u64,
     settings: &PartitionSettings,
-) -> Result<Option<PkBoundaries>, TransientError> {
+) -> Result<Option<PkBoundaries>, TransientError>
+where
+    Q: Queryable,
+{
     match scalar_type {
         SqlScalarType::Char { length }
             if length.is_some_and(|l| l.into_u32() <= mz_mysql_util::MAX_KEY_LENGTH) => {}
@@ -282,17 +282,13 @@ async fn compute_sampled_splits(
     let max_probed_prefixes = (row_count.saturating_mul(settings.probed_prefixes_per_billion_rows)
         / BILLION_ROWS)
         .max(MIN_PROBED_PREFIXES);
-    let prefixes = match mz_mysql_util::partition_table(
-        conn,
-        table_ref,
-        raw_col,
-        worker_count,
-        row_count,
-        settings.min_rows,
+    let params = mz_mysql_util::PartitionParams {
+        num_workers: worker_count,
+        estimated_row_count: row_count,
+        min_split_threshold: settings.min_rows,
         max_probed_prefixes,
-    )
-    .await
-    {
+    };
+    let prefixes = match mz_mysql_util::partition_table(conn, table_ref, raw_col, params).await {
         Ok(prefixes) => prefixes,
         Err(err @ (MySqlError::NonUtf8KeyValue { .. } | MySqlError::MissingRowEstimate { .. })) => {
             tracing::warn!(%err, "partitioning failed, falling back to a single partition");
@@ -380,27 +376,21 @@ async fn sample_pk_bounds(
                             ))
                             .await?;
                         }
-                        // `partition_table` requires the probes to run inside a
-                        // REPEATABLE READ transaction so they all see one snapshot
-                        // of the table. The session default isolation level is
-                        // server-configurable, so set it explicitly. It applies to
-                        // every transaction started on this session, i.e. it
-                        // survives the connection being pooled and reused.
-                        #[allow(clippy::disallowed_methods)]
-                        conn.query_drop("SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ")
-                            .await?;
-                        #[allow(clippy::disallowed_methods)]
-                        conn.query_drop("START TRANSACTION READ ONLY").await?;
                         conn
                     }
                 };
+                // Repeatable read required by the partitioner.
+                let mut tx_opts = TxOpts::default();
+                tx_opts
+                    .with_isolation_level(IsolationLevel::RepeatableRead)
+                    .with_readonly(true);
+                let mut tx = conn.start_transaction(tx_opts).await?;
                 // Row count, reused for boundary discovery and the size gauge. When it
-                // is counted exactly it runs on the same `READ ONLY` transaction as the
-                // boundary walk in `compute_sampled_splits`, so both see one consistent
+                // is counted exactly it runs on the same transaction as the boundary
+                // walk in `compute_sampled_splits`, so both see one consistent
                 // snapshot. For large tables it is an optimizer estimate instead, which
                 // `compute_sampled_splits` tolerates.
-                let stats =
-                    collect_table_statistics(&mut *conn, table, exact_count_max_rows).await?;
+                let stats = collect_table_statistics(&mut tx, table, exact_count_max_rows).await?;
                 metrics.record_table_count_latency(
                     table.1.clone(),
                     table.0.clone(),
@@ -414,7 +404,7 @@ async fn sample_pk_bounds(
                 {
                     Some((raw_col, scalar_type)) => {
                         compute_sampled_splits(
-                            &mut *conn,
+                            &mut tx,
                             table,
                             &raw_col,
                             &scalar_type,
@@ -426,6 +416,7 @@ async fn sample_pk_bounds(
                     }
                     None => None,
                 };
+                tx.commit().await?;
                 pool.borrow_mut().push(conn);
                 Ok::<_, TransientError>((table.clone(), count, splits))
             }
@@ -444,8 +435,7 @@ async fn sample_pk_bounds(
     }
 
     // Every future has completed and dropped its `Rc` clone, so `pool` is the sole
-    // owner. Release the probe connections now, ending their `READ ONLY` transactions
-    // and the shared metadata locks they hold, before the caller takes `LOCK TABLES`.
+    // owner. Release the probe connections before the caller takes `LOCK TABLES`.
     let probe_conns = Rc::into_inner(pooled_conns)
         .expect("all sampling futures completed, so no Rc clones remain")
         .into_inner();
@@ -965,6 +955,7 @@ pub(crate) fn render<'scope>(
                     .with_consistent_snapshot(true)
                     .with_readonly(true);
                 let mut tx = conn.start_transaction(tx_opts).await?;
+
                 // Set the session time zone to UTC so that we can read TIMESTAMP columns as UTC
                 // From https://dev.mysql.com/doc/refman/8.0/en/datetime.html: "MySQL converts TIMESTAMP values
                 // from the current time zone to UTC for storage, and back from UTC to the current time zone

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -177,8 +177,8 @@ struct PkBoundaries {
     boundaries: Vec<String>,
 }
 
-// Manual impl so no `{:?}` site can print the boundaries, which are key
-// values and therefore user data. Redacted outside of CI.
+// Ensure that boundaries are not printed because they contain data from the
+// primary key column.
 impl std::fmt::Debug for PkBoundaries {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PkBoundaries")
@@ -238,12 +238,9 @@ const SUPPORTED_PK_CHARSET: &str = "utf8mb4";
 const MIN_PROBED_PREFIXES: u64 = 256;
 const BILLION_ROWS: u64 = 1_000_000_000;
 
-/// Partitioning knobs read from dyncfgs, bundled so call sites can't transpose
-/// the bare `u64`s.
+/// Partitioning configuration settings bundled to avoid accidental mixing.
 struct PartitionSettings {
-    /// [`mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_MIN_ROWS`].
     min_rows: u64,
-    /// [`mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_PROBED_PREFIXES_PER_BILLION_ROWS`].
     probed_prefixes_per_billion_rows: u64,
 }
 

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -170,11 +170,22 @@ fn try_extract_single_column_pk(
     Some((name.clone(), scalar_type))
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 struct PkBoundaries {
     pk_col: String,
     // Ordered primary key values that partition the table space.
     boundaries: Vec<String>,
+}
+
+// Manual impl so no `{:?}` site can print the boundaries, which are key
+// values and therefore user data. Redacted outside of CI.
+impl std::fmt::Debug for PkBoundaries {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PkBoundaries")
+            .field("pk_col", &self.pk_col)
+            .field("boundaries", &mz_ore::str::redact(&self.boundaries))
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -223,6 +234,7 @@ fn worker_pk_range(
 }
 
 const SUPPORTED_PK_COLLATION: &str = "utf8mb4_bin";
+const SUPPORTED_PK_CHARSET: &str = "utf8mb4";
 const MIN_PROBED_PREFIXES: u64 = 256;
 const BILLION_ROWS: u64 = 1_000_000_000;
 
@@ -592,17 +604,28 @@ where
         if !matches!(plan, ReadPlan::Range(_)) {
             continue;
         }
+        // A `Range` plan is only ever derived from populated bounds over a
+        // single-column PK recorded in the static source desc, so either
+        // lookup failing means `plan_worker_reads` and this check disagree.
         let Some(Some(splits)) = pk_bounds.get(table) else {
-            continue;
+            return Err(TransientError::Generic(anyhow::anyhow!(
+                "PK range planned for {table} without verifiable bounds"
+            )));
         };
         let Some((raw_col, _)) = tables
             .get(table)
             .and_then(|outputs| try_extract_single_column_pk(&outputs[0].desc))
         else {
-            continue;
+            return Err(TransientError::Generic(anyhow::anyhow!(
+                "PK range planned for {table} without verifiable bounds"
+            )));
         };
         let ok = match fetch_column_collation(tx, table, &raw_col).await? {
-            Some((charset, collation)) if collation == SUPPORTED_PK_COLLATION => {
+            // The character set is always utf8mb4 for the utf8mb4_bin
+            // collation, so this is a sanity assertion.
+            Some((charset, collation))
+                if collation == SUPPORTED_PK_COLLATION && charset == SUPPORTED_PK_CHARSET =>
+            {
                 boundaries_strictly_monotonic(tx, &splits.boundaries, &charset, &collation).await?
             }
             // Populated PK bounds imply the split column was a supported string PK.

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -115,8 +115,10 @@ use differential_dataflow::AsCollection;
 use futures::{StreamExt as _, TryStreamExt};
 use itertools::Itertools;
 use mysql_async::prelude::Queryable;
-use mysql_async::{IsolationLevel, Row as MySqlRow, TxOpts};
-use mz_mysql_util::{MySqlConn, MySqlError, pack_mysql_row, query_sys_var, quote_identifier};
+use mysql_async::{IsolationLevel, Row as MySqlRow, TxOpts, Value};
+use mz_mysql_util::{
+    MySqlConn, MySqlError, QualifiedTableRef, pack_mysql_row, query_sys_var, quote_identifier,
+};
 use mz_ore::cast::CastFrom;
 use mz_ore::future::InTask;
 use mz_ore::iter::IteratorExt;
@@ -186,9 +188,9 @@ struct SnapshotInfo {
 struct PkRange {
     /// Quoted PK column, e.g. `` `id` ``.
     pk_col: String,
-    /// Inclusive lower bound literal, or `None` for the first partition (open start).
+    /// Inclusive lower bound key value, or `None` for the first partition (open start).
     lower: Option<String>,
-    /// Exclusive upper bound literal, or `None` for the last partition (open end).
+    /// Exclusive upper bound key value, or `None` for the last partition (open end).
     upper: Option<String>,
 }
 
@@ -220,80 +222,70 @@ fn worker_pk_range(
     })
 }
 
-/// Walks the primary key index in steps of about `row_count / worker_count`, taking the key
-/// at each step's `OFFSET`. The per-step OFFSET scans sum to a full index pass, so this
-/// function has a time complexity of O(row_count). Worker count is small, so the OFFSET
-/// scans dominate the runtime. `row_count` can be an optimizer estimate for large tables,
-/// so the partitions are approximate. An overestimate walks off the end of the index and stops
-/// with fewer boundaries, resulting in some workers receiving less or no work. An underestimate
-/// leaves a larger final partition for the last worker, however both still correctly partition
-/// the table. Returns None if the primary key column type is not supported or the table is too
-/// small to split.
-async fn compute_sampled_splits<Q>(
-    conn: &mut Q,
+const SUPPORTED_PK_COLLATION: &str = "utf8mb4_bin";
+const MIN_PROBED_PREFIXES: u64 = 256;
+const BILLION_ROWS: u64 = 1_000_000_000;
+
+/// Attempts to compute roughly even boundaries for primary keys. Returns None if the column type
+/// is unsupported or boundaries couldn't be estimated for some reason. Currently only supports
+/// CHAR/VARCHAR columns with up to 768 characters with utf8mb4_bin collation.
+async fn compute_sampled_splits(
+    conn: &mut mysql_async::Conn,
     table: &MySqlTableName,
-    pk_col: &(String, SqlScalarType),
+    raw_col: &str,
+    scalar_type: &SqlScalarType,
     worker_count: usize,
-    total: u64,
-) -> Result<Option<PkBoundaries>, TransientError>
-where
-    Q: Queryable,
-{
-    let (col, scalar_type) = pk_col;
-    // Render the PK column as text that sorts and compares the same way the range
-    // predicates do: `QUOTE()` under the column's collation for character types,
-    // `CAST(.. AS CHAR)` for integers. Any other type can't be split safely.
-    let (col_literal, integer_path) = match scalar_type {
-        SqlScalarType::Int16
-        | SqlScalarType::Int32
-        | SqlScalarType::Int64
-        | SqlScalarType::UInt16
-        | SqlScalarType::UInt32
-        | SqlScalarType::UInt64 => (format!("CAST({col} AS CHAR)"), true),
-        SqlScalarType::Char { .. } | SqlScalarType::VarChar { .. } | SqlScalarType::String => {
-            (format!("QUOTE({col})"), false)
-        }
+    row_count: u64,
+    partition_min_rows: u64,
+    partition_probed_prefixes_per_billion_rows: u64,
+) -> Result<Option<PkBoundaries>, TransientError> {
+    match scalar_type {
+        SqlScalarType::Char { length }
+            if length.is_some_and(|l| l.into_u32() <= mz_mysql_util::MAX_KEY_LENGTH) => {}
+        SqlScalarType::VarChar { max_length }
+            if max_length.is_some_and(|l| l.into_u32() <= mz_mysql_util::MAX_KEY_LENGTH) => {}
         _ => return Ok(None),
+    }
+    let collation = fetch_column_collation(conn, table, raw_col).await?;
+    let supported = matches!(&collation, Some(c) if c.1 == SUPPORTED_PK_COLLATION);
+    if !supported {
+        tracing::debug!(?collation, "PK splitting skipped: unsupported collation");
+        return Ok(None);
+    }
+    let table_ref = QualifiedTableRef {
+        schema_name: &table.0,
+        table_name: &table.1,
     };
-
-    let partitions = std::cmp::min(u64::cast_from(worker_count), total);
-    if partitions < 2 {
-        return Ok(None);
-    }
-    let chunk = total / partitions;
-
-    let mut boundaries: Vec<String> = Vec::with_capacity(usize::cast_from(partitions) - 1);
-    for _ in 1..partitions {
-        let (predicate, offset) = match boundaries.last() {
-            Some(prev) => (format!(" WHERE {col} > {prev}"), chunk - 1),
-            None => (String::new(), chunk),
-        };
-        // The identifier is quoted via `quote_identifier`, the previous boundary is
-        // itself a value MySQL rendered as a literal, `table` via Display, and the
-        // offset is an integer, so this interpolation is safe; not parameterizable.
-        #[allow(clippy::disallowed_methods)]
-        let row: Option<MySqlRow> = conn
-            .query_first(format!(
-                "SELECT {col_literal} FROM {table}{predicate} \
-                 ORDER BY {col} LIMIT 1 OFFSET {offset}"
-            ))
-            .await?;
-        // Defensive: if a concurrent write shrank the range out from under us, stop and
-        // use the boundaries found so far. Fewer partitions is still correct.
-        let Some(mut row) = row else { break };
-        // The column is CAST/QUOTE-ed to text, so it decodes as a String that is
-        // already a valid SQL literal. A decode failure (e.g. a non-UTF-8
-        // collation) means we can't safely partition: fall back.
-        match row.take_opt::<String, usize>(0) {
-            Some(Ok(lit)) if !integer_path || is_decimal_literal(&lit) => boundaries.push(lit),
-            _ => return Ok(None),
+    // For larger table sizes we can afford to spend more time computing partitions. Making thousands of
+    // network requests to search through prefixes can take minutes, but is worth it for billions of rows
+    // that can take hours to snapshot.
+    let max_probed_prefixes =
+        (row_count.saturating_mul(partition_probed_prefixes_per_billion_rows) / BILLION_ROWS)
+            .max(MIN_PROBED_PREFIXES);
+    let prefixes = match mz_mysql_util::partition_table(
+        conn,
+        table_ref,
+        raw_col,
+        worker_count,
+        row_count,
+        partition_min_rows,
+        max_probed_prefixes,
+    )
+    .await
+    {
+        Ok(prefixes) => prefixes,
+        Err(err @ (MySqlError::NonUtf8KeyValue { .. } | MySqlError::MissingRowEstimate { .. })) => {
+            tracing::warn!(%err, "Unexpected error during partitioning, falling back to a single partition");
+            return Ok(None);
         }
-    }
-    if boundaries.is_empty() {
+        Err(err) => return Err(err.into()),
+    };
+    if prefixes.is_empty() {
         return Ok(None);
     }
+    let boundaries = prefixes;
     Ok(Some(PkBoundaries {
-        pk_col: col.clone(),
+        pk_col: quote_identifier(raw_col),
         boundaries,
     }))
 }
@@ -301,11 +293,9 @@ where
 /// For every table, read the row count (exact only for small tables) and, for a
 /// supported single-column primary key, compute the PK-range split boundaries,
 /// concurrently over at most `worker_count` connections. `None` bounds means
-/// single-worker fallback for that table. The counts are reused for both the sampling
-/// stride and the snapshot size gauge. Snapshot size gauge is a metric for the snapshot
-/// size used to report how many rows we need to process. "Sampling stride" refers to
-/// the number of rows we use to page through the table to find roughly evenly spaced
-/// primary keys to use as partition boundaries.
+/// single-worker fallback for that table. The counts are reused for both boundary
+/// discovery and the snapshot size gauge. The snapshot size gauge is a metric
+/// reporting how many rows the snapshot needs to process.
 async fn sample_pk_bounds(
     config: &RawSourceCreationConfig,
     connection_config: &mz_mysql_util::Config,
@@ -335,11 +325,17 @@ async fn sample_pk_bounds(
         mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_EXACT_COUNT_MAX_ROWS
             .get(config.config.config_set()),
     );
+    let partition_min_rows = u64::cast_from(
+        mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_MIN_ROWS
+            .get(config.config.config_set()),
+    );
+    let partition_probed_prefixes_per_billion_rows = u64::cast_from(
+        mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_PROBED_PREFIXES_PER_BILLION_ROWS
+            .get(config.config.config_set()),
+    );
 
     let pooled_conns: Rc<RefCell<Vec<MySqlConn>>> = Rc::new(RefCell::new(Vec::new()));
-    // Counting and boundary-sampling each walk a table's index (O(rows)), so run tables
-    // concurrently, capped at worker_count, to keep the leader's setup from scaling with
-    // table count.
+    // Get row count and boundary estimates with worker-count concurrency.
     let per_table: Vec<(MySqlTableName, u64, Option<PkBoundaries>)> = futures::stream::iter(tables)
         .map(|(table, outputs)| {
             let pool = Rc::clone(&pooled_conns);
@@ -366,7 +362,7 @@ async fn sample_pk_bounds(
                         conn
                     }
                 };
-                // Row count, reused for the sampling stride and the size gauge. When it
+                // Row count, reused for boundary discovery and the size gauge. When it
                 // is counted exactly it runs on the same `READ ONLY` transaction as the
                 // boundary walk in `compute_sampled_splits`, so both see one consistent
                 // snapshot. For large tables it is an optimizer estimate instead, which
@@ -385,9 +381,17 @@ async fn sample_pk_bounds(
                     .flatten()
                 {
                     Some((raw_col, scalar_type)) => {
-                        let pk_col = (quote_identifier(&raw_col), scalar_type);
-                        compute_sampled_splits(&mut *conn, table, &pk_col, worker_count, count)
-                            .await?
+                        compute_sampled_splits(
+                            &mut *conn,
+                            table,
+                            &raw_col,
+                            &scalar_type,
+                            worker_count,
+                            count,
+                            partition_min_rows,
+                            partition_probed_prefixes_per_billion_rows,
+                        )
+                        .await?
                     }
                     None => None,
                 };
@@ -542,10 +546,10 @@ where
 }
 
 /// Whether `boundaries` are strictly increasing under `collation`. The half-open PK
-/// ranges only partition the table without gaps or overlaps when this holds. The
-/// boundaries are already SQL literals (from `QUOTE()`); each is coerced to
-/// `charset`/`collation` so the comparison uses the same collation as the column,
-/// matching the read predicates. Fewer than two boundaries are trivially monotonic.
+/// ranges only partition the table without gaps or overlaps when this holds. Each
+/// boundary is coerced to `charset`/`collation` so the comparison uses the same
+/// collation as the column, matching the read predicates. Fewer than two boundaries
+/// are trivially monotonic.
 async fn boundaries_strictly_monotonic<Q>(
     conn: &mut Q,
     boundaries: &[String],
@@ -563,19 +567,15 @@ where
     if !is_plain_ident(charset) || !is_plain_ident(collation) {
         return Ok(false);
     }
-    let terms = boundaries
-        .iter()
-        .map(|b| format!("CONVERT({b} USING {charset}) COLLATE {collation}"))
-        .collect::<Vec<_>>();
-    let predicate = terms
+    let term = format!("CONVERT(? USING {charset}) COLLATE {collation}");
+    let predicate = vec![format!("{term} < {term}"); boundaries.len() - 1].join(" AND ");
+    let params: Vec<Value> = boundaries
         .windows(2)
-        .map(|w| format!("{} < {}", w[0], w[1]))
-        .collect::<Vec<_>>()
-        .join(" AND ");
-    // Boundaries are MySQL-rendered literals and the identifiers are validated above,
-    // so this interpolation is safe; not parameterizable.
-    #[allow(clippy::disallowed_methods)]
-    let ok: Option<i64> = conn.query_first(format!("SELECT {predicate}")).await?;
+        .flat_map(|w| [w[0].as_str().into(), w[1].as_str().into()])
+        .collect();
+    let ok: Option<i64> = conn
+        .exec_first(format!("SELECT {predicate}"), params)
+        .await?;
     Ok(ok == Some(1))
 }
 
@@ -601,10 +601,14 @@ where
         else {
             continue;
         };
-        let Some((charset, collation)) = fetch_column_collation(tx, table, &raw_col).await? else {
-            continue;
+        let ok = match fetch_column_collation(tx, table, &raw_col).await? {
+            Some((charset, collation)) if collation == SUPPORTED_PK_COLLATION => {
+                boundaries_strictly_monotonic(tx, &splits.boundaries, &charset, &collation).await?
+            }
+            // Populated PK bounds imply the split column was a supported string PK.
+            _ => false,
         };
-        if !boundaries_strictly_monotonic(tx, &splits.boundaries, &charset, &collation).await? {
+        if !ok {
             return Err(TransientError::Generic(anyhow::anyhow!(
                 "collation of {table} changed during snapshot setup"
             )));
@@ -617,11 +621,6 @@ where
 /// gate charset/collation names before interpolating them (they can't be parameters).
 fn is_plain_ident(s: &str) -> bool {
     !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-}
-
-fn is_decimal_literal(s: &str) -> bool {
-    let digits = s.strip_prefix('-').unwrap_or(s);
-    !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
 }
 
 /// Returns the set of full tables/sections of tables to read.
@@ -1017,9 +1016,9 @@ pub(crate) fn render<'scope>(
                     };
 
                     let mut snapshot_staged = 0;
-                    let query = build_snapshot_query(outputs, pk_range);
+                    let (query, params) = build_snapshot_query(outputs, pk_range);
                     trace!(%id, "timely-{worker_id} reading snapshot query='{}'", query);
-                    let mut results = tx.exec_stream(query, ()).await?;
+                    let mut results = tx.exec_stream(query, params).await?;
                     while let Some(row) = results.try_next().await? {
                         let row: MySqlRow = row;
                         snapshot_staged += 1;
@@ -1178,7 +1177,10 @@ async fn lock_tables_and_read_gtid_set(
 ///
 /// When `pk_range` is provided, a WHERE clause is appended to filter rows by PK range.
 #[must_use]
-fn build_snapshot_query(outputs: &[SourceOutputInfo], pk_range: Option<&PkRange>) -> String {
+fn build_snapshot_query(
+    outputs: &[SourceOutputInfo],
+    pk_range: Option<&PkRange>,
+) -> (String, Vec<Value>) {
     let info = outputs.first().expect("MySQL table info");
     for output in &outputs[1..] {
         // the columns may be decoded based on position, and different outputs may replicate
@@ -1196,12 +1198,14 @@ fn build_snapshot_query(outputs: &[SourceOutputInfo], pk_range: Option<&PkRange>
         .map(|col| quote_identifier(&col.name))
         .join(", ");
     let mut query = format!("SELECT {} FROM {}", columns, info.table_name);
+    let mut params: Vec<Value> = vec![];
     if let Some(range) = pk_range {
         // Half-open range on the PK column. The first/last partition omits its
         // open bound.
         let col = &range.pk_col;
         if let Some(lower) = &range.lower {
-            query.push_str(&format!(" WHERE {col} >= {lower}"));
+            query.push_str(&format!(" WHERE {col} >= ?"));
+            params.push(lower.as_str().into());
         }
         if let Some(upper) = &range.upper {
             let kw = if range.lower.is_some() {
@@ -1209,10 +1213,11 @@ fn build_snapshot_query(outputs: &[SourceOutputInfo], pk_range: Option<&PkRange>
             } else {
                 "WHERE"
             };
-            query.push_str(&format!(" {kw} {col} < {upper}"));
+            query.push_str(&format!(" {kw} {col} < ?"));
+            params.push(upper.as_str().into());
         }
     }
-    query
+    (query, params)
 }
 
 #[derive(Default)]
@@ -1307,7 +1312,7 @@ mod tests {
             export_id: mz_repr::GlobalId::User(1),
             binlog_full_metadata: false,
         };
-        let query = build_snapshot_query(&[info.clone(), info], None);
+        let (query, _) = build_snapshot_query(&[info.clone(), info], None);
         assert_eq!(
             format!(
                 "SELECT `c1`, `c2`, `c3` FROM `{}`.`{}`",
@@ -1354,14 +1359,15 @@ mod tests {
             lower: Some("100".to_string()),
             upper: Some("200".to_string()),
         };
-        let query = build_snapshot_query(std::slice::from_ref(&info), Some(&range));
+        let (query, params) = build_snapshot_query(std::slice::from_ref(&info), Some(&range));
         assert_eq!(
             format!(
-                "SELECT `id`, `name` FROM `{}`.`{}` WHERE `id` >= 100 AND `id` < 200",
+                "SELECT `id`, `name` FROM `{}`.`{}` WHERE `id` >= ? AND `id` < ?",
                 schema_name, table_name
             ),
             query
         );
+        assert_eq!(params, vec![Value::from("100"), Value::from("200")]);
 
         // First worker: open start.
         let range = PkRange {
@@ -1369,14 +1375,15 @@ mod tests {
             lower: None,
             upper: Some("200".to_string()),
         };
-        let query = build_snapshot_query(std::slice::from_ref(&info), Some(&range));
+        let (query, params) = build_snapshot_query(std::slice::from_ref(&info), Some(&range));
         assert_eq!(
             format!(
-                "SELECT `id`, `name` FROM `{}`.`{}` WHERE `id` < 200",
+                "SELECT `id`, `name` FROM `{}`.`{}` WHERE `id` < ?",
                 schema_name, table_name
             ),
             query
         );
+        assert_eq!(params, vec![Value::from("200")]);
 
         // Last worker: open end.
         let range = PkRange {
@@ -1384,14 +1391,15 @@ mod tests {
             lower: Some("200".to_string()),
             upper: None,
         };
-        let query = build_snapshot_query(std::slice::from_ref(&info), Some(&range));
+        let (query, params) = build_snapshot_query(std::slice::from_ref(&info), Some(&range));
         assert_eq!(
             format!(
-                "SELECT `id`, `name` FROM `{}`.`{}` WHERE `id` >= 200",
+                "SELECT `id`, `name` FROM `{}`.`{}` WHERE `id` >= ?",
                 schema_name, table_name
             ),
             query
         );
+        assert_eq!(params, vec![Value::from("200")]);
     }
 
     #[mz_ore::test]

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -235,7 +235,7 @@ fn worker_pk_range(
 
 const SUPPORTED_PK_COLLATION: &str = "utf8mb4_bin";
 const SUPPORTED_PK_CHARSET: &str = "utf8mb4";
-const MIN_PROBED_PREFIXES: u64 = 256;
+const MIN_PROBED_PREFIXES: u64 = 64;
 const BILLION_ROWS: u64 = 1_000_000_000;
 
 /// Partitioning configuration settings bundled to avoid accidental mixing.

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -238,6 +238,15 @@ const SUPPORTED_PK_CHARSET: &str = "utf8mb4";
 const MIN_PROBED_PREFIXES: u64 = 256;
 const BILLION_ROWS: u64 = 1_000_000_000;
 
+/// Partitioning knobs read from dyncfgs, bundled so call sites can't transpose
+/// the bare `u64`s.
+struct PartitionSettings {
+    /// [`mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_MIN_ROWS`].
+    min_rows: u64,
+    /// [`mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_PROBED_PREFIXES_PER_BILLION_ROWS`].
+    probed_prefixes_per_billion_rows: u64,
+}
+
 /// Attempts to compute roughly even boundaries for primary keys. Returns None if the column type
 /// is unsupported or boundaries couldn't be estimated for some reason. Currently only supports
 /// CHAR/VARCHAR columns with up to 768 characters with utf8mb4_bin collation.
@@ -248,8 +257,7 @@ async fn compute_sampled_splits(
     scalar_type: &SqlScalarType,
     worker_count: usize,
     row_count: u64,
-    partition_min_rows: u64,
-    partition_probed_prefixes_per_billion_rows: u64,
+    settings: &PartitionSettings,
 ) -> Result<Option<PkBoundaries>, TransientError> {
     match scalar_type {
         SqlScalarType::Char { length }
@@ -271,23 +279,23 @@ async fn compute_sampled_splits(
     // For larger table sizes we can afford to spend more time computing partitions. Making thousands of
     // network requests to search through prefixes can take minutes, but is worth it for billions of rows
     // that can take hours to snapshot.
-    let max_probed_prefixes =
-        (row_count.saturating_mul(partition_probed_prefixes_per_billion_rows) / BILLION_ROWS)
-            .max(MIN_PROBED_PREFIXES);
+    let max_probed_prefixes = (row_count.saturating_mul(settings.probed_prefixes_per_billion_rows)
+        / BILLION_ROWS)
+        .max(MIN_PROBED_PREFIXES);
     let prefixes = match mz_mysql_util::partition_table(
         conn,
         table_ref,
         raw_col,
         worker_count,
         row_count,
-        partition_min_rows,
+        settings.min_rows,
         max_probed_prefixes,
     )
     .await
     {
         Ok(prefixes) => prefixes,
         Err(err @ (MySqlError::NonUtf8KeyValue { .. } | MySqlError::MissingRowEstimate { .. })) => {
-            tracing::warn!(%err, "Unexpected error during partitioning, falling back to a single partition");
+            tracing::warn!(%err, "partitioning failed, falling back to a single partition");
             return Ok(None);
         }
         Err(err) => return Err(err.into()),
@@ -295,10 +303,9 @@ async fn compute_sampled_splits(
     if prefixes.is_empty() {
         return Ok(None);
     }
-    let boundaries = prefixes;
     Ok(Some(PkBoundaries {
         pk_col: quote_identifier(raw_col),
-        boundaries,
+        boundaries: prefixes,
     }))
 }
 
@@ -337,14 +344,18 @@ async fn sample_pk_bounds(
         mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_EXACT_COUNT_MAX_ROWS
             .get(config.config.config_set()),
     );
-    let partition_min_rows = u64::cast_from(
+    let min_rows = u64::cast_from(
         mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_MIN_ROWS
             .get(config.config.config_set()),
     );
-    let partition_probed_prefixes_per_billion_rows = u64::cast_from(
+    let probed_prefixes_per_billion_rows = u64::cast_from(
         mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_PROBED_PREFIXES_PER_BILLION_ROWS
             .get(config.config.config_set()),
     );
+    let partition_settings = &PartitionSettings {
+        min_rows,
+        probed_prefixes_per_billion_rows,
+    };
 
     let pooled_conns: Rc<RefCell<Vec<MySqlConn>>> = Rc::new(RefCell::new(Vec::new()));
     // Get row count and boundary estimates with worker-count concurrency.
@@ -369,6 +380,15 @@ async fn sample_pk_bounds(
                             ))
                             .await?;
                         }
+                        // `partition_table` requires the probes to run inside a
+                        // REPEATABLE READ transaction so they all see one snapshot
+                        // of the table. The session default isolation level is
+                        // server-configurable, so set it explicitly. It applies to
+                        // every transaction started on this session, i.e. it
+                        // survives the connection being pooled and reused.
+                        #[allow(clippy::disallowed_methods)]
+                        conn.query_drop("SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+                            .await?;
                         #[allow(clippy::disallowed_methods)]
                         conn.query_drop("START TRANSACTION READ ONLY").await?;
                         conn
@@ -400,8 +420,7 @@ async fn sample_pk_bounds(
                             &scalar_type,
                             worker_count,
                             count,
-                            partition_min_rows,
-                            partition_probed_prefixes_per_billion_rows,
+                            partition_settings,
                         )
                         .await?
                     }

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -115,7 +115,7 @@ use differential_dataflow::AsCollection;
 use futures::{StreamExt as _, TryStreamExt};
 use itertools::Itertools;
 use mysql_async::prelude::Queryable;
-use mysql_async::{IsolationLevel, Row as MySqlRow, TxOpts, Value};
+use mysql_async::{IsolationLevel, Row as MySqlRow, Transaction, TxOpts, Value};
 use mz_mysql_util::{
     MySqlConn, MySqlError, QualifiedTableRef, pack_mysql_row, query_sys_var, quote_identifier,
 };
@@ -238,27 +238,27 @@ const SUPPORTED_PK_CHARSET: &str = "utf8mb4";
 const MIN_PROBED_PREFIXES: u64 = 256;
 const BILLION_ROWS: u64 = 1_000_000_000;
 
-/// Partitioning knobs read from the same-named `mysql_source_snapshot_partition_*` dyncfgs.
+/// Partitioning knobs read from dyncfgs, bundled so call sites can't transpose
+/// the bare `u64`s.
 struct PartitionSettings {
+    /// [`mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_MIN_ROWS`].
     min_rows: u64,
+    /// [`mz_storage_types::dyncfgs::MYSQL_SOURCE_SNAPSHOT_PARTITION_PROBED_PREFIXES_PER_BILLION_ROWS`].
     probed_prefixes_per_billion_rows: u64,
 }
 
 /// Attempts to compute roughly even boundaries for primary keys. Returns None if the column type
 /// is unsupported or boundaries couldn't be estimated for some reason. Currently only supports
 /// CHAR/VARCHAR columns with up to 768 characters with utf8mb4_bin collation.
-async fn compute_sampled_splits<Q>(
-    conn: &mut Q,
+async fn compute_sampled_splits(
+    tx: &mut Transaction<'_>,
     table: &MySqlTableName,
     raw_col: &str,
     scalar_type: &SqlScalarType,
     worker_count: usize,
     row_count: u64,
     settings: &PartitionSettings,
-) -> Result<Option<PkBoundaries>, TransientError>
-where
-    Q: Queryable,
-{
+) -> Result<Option<PkBoundaries>, TransientError> {
     match scalar_type {
         SqlScalarType::Char { length }
             if length.is_some_and(|l| l.into_u32() <= mz_mysql_util::MAX_KEY_LENGTH) => {}
@@ -266,7 +266,7 @@ where
             if max_length.is_some_and(|l| l.into_u32() <= mz_mysql_util::MAX_KEY_LENGTH) => {}
         _ => return Ok(None),
     }
-    let collation = fetch_column_collation(conn, table, raw_col).await?;
+    let collation = fetch_column_collation(&mut *tx, table, raw_col).await?;
     let supported = matches!(&collation, Some(c) if c.1 == SUPPORTED_PK_COLLATION);
     if !supported {
         tracing::debug!(?collation, "PK splitting skipped: unsupported collation");
@@ -288,7 +288,7 @@ where
         min_split_threshold: settings.min_rows,
         max_probed_prefixes,
     };
-    let prefixes = match mz_mysql_util::partition_table(conn, table_ref, raw_col, params).await {
+    let prefixes = match mz_mysql_util::partition_table(tx, table_ref, raw_col, params).await {
         Ok(prefixes) => prefixes,
         Err(err @ (MySqlError::NonUtf8KeyValue { .. } | MySqlError::MissingRowEstimate { .. })) => {
             tracing::warn!(%err, "partitioning failed, falling back to a single partition");
@@ -386,8 +386,8 @@ async fn sample_pk_bounds(
                     .with_readonly(true);
                 let mut tx = conn.start_transaction(tx_opts).await?;
                 // Row count, reused for boundary discovery and the size gauge. When it
-                // is counted exactly it runs on the same transaction as the boundary
-                // walk in `compute_sampled_splits`, so both see one consistent
+                // is counted exactly it runs on the same `READ ONLY` transaction as the
+                // boundary walk in `compute_sampled_splits`, so both see one consistent
                 // snapshot. For large tables it is an optimizer estimate instead, which
                 // `compute_sampled_splits` tolerates.
                 let stats = collect_table_statistics(&mut tx, table, exact_count_max_rows).await?;
@@ -416,7 +416,9 @@ async fn sample_pk_bounds(
                     }
                     None => None,
                 };
-                tx.commit().await?;
+                // Ends the borrow of `conn`; the transaction itself is rolled
+                // back when the pooled connection is next used or disconnected.
+                drop(tx);
                 pool.borrow_mut().push(conn);
                 Ok::<_, TransientError>((table.clone(), count, splits))
             }
@@ -435,7 +437,8 @@ async fn sample_pk_bounds(
     }
 
     // Every future has completed and dropped its `Rc` clone, so `pool` is the sole
-    // owner. Release the probe connections before the caller takes `LOCK TABLES`.
+    // owner. Release the probe connections now, ending their `READ ONLY` transactions
+    // and the shared metadata locks they hold, before the caller takes `LOCK TABLES`.
     let probe_conns = Rc::into_inner(pooled_conns)
         .expect("all sampling futures completed, so no Rc clones remain")
         .into_inner();
@@ -955,7 +958,6 @@ pub(crate) fn render<'scope>(
                     .with_consistent_snapshot(true)
                     .with_readonly(true);
                 let mut tx = conn.start_transaction(tx_opts).await?;
-
                 // Set the session time zone to UTC so that we can read TIMESTAMP columns as UTC
                 // From https://dev.mysql.com/doc/refman/8.0/en/datetime.html: "MySQL converts TIMESTAMP values
                 // from the current time zone to UTC for storage, and back from UTC to the current time zone

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -572,6 +572,11 @@ true
 
 > DROP SOURCE large_cluster_source CASCADE;
 
+#
+# Integer PK. Integer keys are not split into PK ranges, so on a multi-worker
+# cluster this covers the single-worker whole-table fallback.
+#
+
 $ mysql-execute name=mysql
 DROP TABLE IF EXISTS pk_range_test;
 CREATE TABLE pk_range_test (id BIGINT PRIMARY KEY, val BIGINT);
@@ -608,12 +613,14 @@ $ mysql-execute name=mysql
 DROP TABLE pk_range_test;
 
 #
-# Same, but for a single-column non-integer (char) PK.
+# Single-column char PK with the utf8mb4_bin collation, the supported type for
+# PK-range splitting. The explicit collation matters: the database default is
+# utf8mb4_general_ci, which is not split.
 #
 
 $ mysql-execute name=mysql
 DROP TABLE IF EXISTS pk_char_test;
-CREATE TABLE pk_char_test (id CHAR(26) PRIMARY KEY, val BIGINT);
+CREATE TABLE pk_char_test (id CHAR(26) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin PRIMARY KEY, val BIGINT);
 SET @i := 0;
 INSERT INTO pk_char_test SELECT LPAD(CONV(@i := @i + 1, 10, 36), 26, '0'), @i FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000;
 
@@ -637,6 +644,40 @@ INSERT INTO pk_char_test SELECT LPAD(CONV(@i := @i + 1, 10, 36), 26, '0'), @i FR
 
 $ mysql-execute name=mysql
 DROP TABLE pk_char_test;
+
+#
+# Same shape, but with the database-default utf8mb4_general_ci collation.
+# Only utf8mb4_bin PKs are split, so this pins the collation fallback: the
+# table is read whole by a single worker and must still be complete and
+# duplicate-free.
+#
+
+$ mysql-execute name=mysql
+DROP TABLE IF EXISTS pk_general_ci_test;
+CREATE TABLE pk_general_ci_test (id CHAR(26) PRIMARY KEY, val BIGINT);
+SET @i := 0;
+INSERT INTO pk_general_ci_test SELECT LPAD(CONV(@i := @i + 1, 10, 36), 26, '0'), @i FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000;
+
+> CREATE CLUSTER pk_general_ci_cluster SIZE 'scale=1,workers=4'
+
+> CREATE SOURCE pk_general_ci_source
+  IN CLUSTER pk_general_ci_cluster
+  FROM MYSQL CONNECTION mysql_conn;
+> CREATE TABLE pk_general_ci_table FROM SOURCE pk_general_ci_source (REFERENCE public.pk_general_ci_test);
+
+# Exact count and no duplicate/missing keys
+> SELECT COUNT(*), COUNT(DISTINCT id) FROM pk_general_ci_table;
+1000 1000
+
+# Checksum: val = row number, so SUM(val) = SUM(1..1000) = 500500
+> SELECT SUM(val) FROM pk_general_ci_table;
+500500
+
+> DROP SOURCE pk_general_ci_source CASCADE;
+> DROP CLUSTER pk_general_ci_cluster CASCADE;
+
+$ mysql-execute name=mysql
+DROP TABLE pk_general_ci_test;
 
 #
 # Same, but for a composite (char, int) primary key.
@@ -677,9 +718,14 @@ ee 200
 $ mysql-execute name=mysql
 DROP TABLE pk_comp_test;
 
+#
+# Splittable PK with far more workers than rows: any splitting must not
+# duplicate or drop the few rows.
+#
+
 $ mysql-execute name=mysql
 DROP TABLE IF EXISTS pk_surplus_test;
-CREATE TABLE pk_surplus_test (id CHAR(26) PRIMARY KEY, val BIGINT);
+CREATE TABLE pk_surplus_test (id CHAR(26) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin PRIMARY KEY, val BIGINT);
 SET @i := 0;
 INSERT INTO pk_surplus_test SELECT LPAD(CONV(@i := @i + 1, 10, 36), 26, '0'), @i FROM mysql.time_zone t1 LIMIT 3;
 
@@ -705,12 +751,12 @@ $ mysql-execute name=mysql
 DROP TABLE pk_surplus_test;
 
 #
-# Empty table.
+# Empty table with a splittable PK.
 #
 
 $ mysql-execute name=mysql
 DROP TABLE IF EXISTS pk_empty_test;
-CREATE TABLE pk_empty_test (id CHAR(26) PRIMARY KEY, val BIGINT);
+CREATE TABLE pk_empty_test (id CHAR(26) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin PRIMARY KEY, val BIGINT);
 
 > CREATE CLUSTER pk_empty_cluster SIZE 'scale=1,workers=4'
 
@@ -817,7 +863,7 @@ ALTER SYSTEM SET mysql_source_snapshot_parallelism = false
 
 $ mysql-execute name=mysql
 DROP TABLE IF EXISTS pk_serial_test;
-CREATE TABLE pk_serial_test (id CHAR(26) PRIMARY KEY, val BIGINT);
+CREATE TABLE pk_serial_test (id CHAR(26) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin PRIMARY KEY, val BIGINT);
 SET @i := 0;
 INSERT INTO pk_serial_test SELECT LPAD(CONV(@i := @i + 1, 10, 36), 26, '0'), @i * 7 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000;
 

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -573,46 +573,6 @@ true
 > DROP SOURCE large_cluster_source CASCADE;
 
 #
-# Integer PK. Integer keys are not split into PK ranges, so on a multi-worker
-# cluster this covers the single-worker whole-table fallback.
-#
-
-$ mysql-execute name=mysql
-DROP TABLE IF EXISTS pk_range_test;
-CREATE TABLE pk_range_test (id BIGINT PRIMARY KEY, val BIGINT);
-SET @i := 0;
-INSERT INTO pk_range_test SELECT @i := @i + 1, @i * 7 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000;
-
-> CREATE CLUSTER pk_range_cluster SIZE 'scale=1,workers=4'
-
-> CREATE SOURCE pk_range_source
-  IN CLUSTER pk_range_cluster
-  FROM MYSQL CONNECTION mysql_conn;
-> CREATE TABLE pk_range_table FROM SOURCE pk_range_source (REFERENCE public.pk_range_test);
-
-# Exact row count
-> SELECT COUNT(*) FROM pk_range_table;
-1000
-
-# No duplicates: distinct count must equal total count
-> SELECT COUNT(DISTINCT id) = COUNT(*) FROM pk_range_table;
-true
-
-# Full key range present (ids 1..1000)
-> SELECT MIN(id), MAX(id) FROM pk_range_table;
-1 1000
-
-# Checksum: val = id * 7, so SUM(val) = 7 * SUM(1..1000) = 7 * 500500
-> SELECT SUM(val) FROM pk_range_table;
-3503500
-
-> DROP SOURCE pk_range_source CASCADE;
-> DROP CLUSTER pk_range_cluster CASCADE;
-
-$ mysql-execute name=mysql
-DROP TABLE pk_range_test;
-
-#
 # Single-column char PK with the utf8mb4_bin collation, the supported type for
 # PK-range splitting. The explicit collation matters: the database default is
 # utf8mb4_general_ci, which is not split.

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -767,16 +767,12 @@ $ mysql-execute name=mysql
 DROP TABLE pk_uint_test;
 
 #
-# BIT primary key. A BIT column maps to a Materialize uint64, but carries the
-# MySqlColumnMeta::Bit marker. The PK-range sampler renders a boundary from the
-# Materialize scalar type alone (uint64 takes the integer path, CAST(id AS CHAR)),
-# discarding that marker. For a BIT column CAST(.. AS CHAR) returns the value's
-# raw bytes, not a decimal literal, and that text is spliced verbatim into the
-# worker range predicates. The BIT(64) value X'30204F5220313D31' is the eight
-# ASCII bytes "0 OR 1=1", so the sampled boundary turns the two worker reads into
-#   WHERE id <  0 OR 1=1
-#   WHERE id >= 0 OR 1=1
-# both of which match every row. Every key must still be emitted exactly once.
+# BIT primary key. A BIT column maps to a Materialize uint64, so it is not a
+# string key and must not be split into PK ranges. The BIT(64) value
+# X'30204F5220313D31' is the eight ASCII bytes "0 OR 1=1": a splitter that
+# rendered the raw key bytes into a range predicate would turn a worker read
+# into WHERE id >= 0 OR 1=1, matching every row on every worker. Every key
+# must still be emitted exactly once.
 #
 
 $ mysql-execute name=mysql
@@ -791,8 +787,9 @@ INSERT INTO pk_bit_test VALUES (1, 100), (0x30204F5220313D31, 200);
   FROM MYSQL CONNECTION mysql_conn;
 > CREATE TABLE pk_bit_table FROM SOURCE pk_bit_source (REFERENCE public.pk_bit_test);
 
-# Exact count and no duplicate keys. Under the bug both workers read the whole
-# table, so COUNT(*) is 4 while COUNT(DISTINCT id) stays 2.
+# Exact count and no duplicate keys. If the table were wrongly split and both
+# workers read the whole table, COUNT(*) would be 4 while COUNT(DISTINCT id)
+# stays 2.
 > SELECT COUNT(*), COUNT(DISTINCT id) FROM pk_bit_table;
 2 2
 
@@ -810,9 +807,9 @@ DROP TABLE pk_bit_test;
 
 #
 # PK-range splitting disabled via the mysql_source_snapshot_parallelism dyncfg.
-# The same shape as the pk_range_test above, but every table must fall back to a
-# single-worker whole-table read and still produce a complete, duplicate-free
-# snapshot.
+# The same shape as the pk_char_test above, a string PK that would otherwise be
+# split, but every table must fall back to a single-worker whole-table read and
+# still produce a complete, duplicate-free snapshot.
 #
 
 $ postgres-execute connection=mz_system
@@ -820,9 +817,9 @@ ALTER SYSTEM SET mysql_source_snapshot_parallelism = false
 
 $ mysql-execute name=mysql
 DROP TABLE IF EXISTS pk_serial_test;
-CREATE TABLE pk_serial_test (id BIGINT PRIMARY KEY, val BIGINT);
+CREATE TABLE pk_serial_test (id CHAR(26) PRIMARY KEY, val BIGINT);
 SET @i := 0;
-INSERT INTO pk_serial_test SELECT @i := @i + 1, @i * 7 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000;
+INSERT INTO pk_serial_test SELECT LPAD(CONV(@i := @i + 1, 10, 36), 26, '0'), @i * 7 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000;
 
 > CREATE CLUSTER pk_serial_cluster SIZE 'scale=1,workers=4'
 
@@ -835,11 +832,7 @@ INSERT INTO pk_serial_test SELECT @i := @i + 1, @i * 7 FROM mysql.time_zone t1, 
 > SELECT COUNT(*), COUNT(DISTINCT id) FROM pk_serial_table;
 1000 1000
 
-# Full key range present (ids 1..1000)
-> SELECT MIN(id), MAX(id) FROM pk_serial_table;
-1 1000
-
-# Checksum: val = id * 7, so SUM(val) = 7 * SUM(1..1000) = 7 * 500500
+# Checksum: val = row number * 7, so SUM(val) = 7 * SUM(1..1000) = 7 * 500500
 > SELECT SUM(val) FROM pk_serial_table;
 3503500
 

--- a/test/mysql-cdc/mzcompose.py
+++ b/test/mysql-cdc/mzcompose.py
@@ -321,7 +321,7 @@ def workflow_large_scale(c: Composition, parser: WorkflowArgumentParser) -> None
                 CREATE DATABASE public;
                 USE public;
                 DROP TABLE IF EXISTS products;
-                CREATE TABLE products (id int NOT NULL, name varchar(255) DEFAULT NULL, merchant_id int NOT NULL, price int DEFAULT NULL, status int DEFAULT NULL, created_at timestamp NULL DEFAULT CURRENT_TIMESTAMP(), recordSizePayload longtext, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+                CREATE TABLE products (id char(26) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL, name varchar(255) DEFAULT NULL, merchant_id int NOT NULL, price int DEFAULT NULL, status int DEFAULT NULL, created_at timestamp NULL DEFAULT CURRENT_TIMESTAMP(), recordSizePayload longtext, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
                 ALTER TABLE products DISABLE KEYS;
 
                 > DROP SOURCE IF EXISTS s1 CASCADE;
@@ -336,7 +336,7 @@ def workflow_large_scale(c: Composition, parser: WorkflowArgumentParser) -> None
             SET foreign_key_checks = 0;
             USE public;
             SET @i:={start};
-            INSERT INTO products (id, name, merchant_id, price, status, created_at, recordSizePayload) SELECT @i:=@i+1, CONCAT("name", @i), @i % 1000, @i % 1000, @i % 10, '2024-12-12', repeat('x', 1000000) FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT {batch_num};
+            INSERT INTO products (id, name, merchant_id, price, status, created_at, recordSizePayload) SELECT REVERSE(LPAD(@i:=@i+1, 26, '0')), CONCAT("name", @i), @i % 1000, @i % 1000, @i % 10, '2024-12-12', repeat('x', 1000000) FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT {batch_num};
             """),
         )
 


### PR DESCRIPTION
### Motivation
The boundary computation for parallel snapshotting was about as slow as the single-threaded snapshot in many cases, i.e.
Parallelized (~2h runtime):
<img width="30%" height="516" alt="Screenshot 2026-08-03 at 10 42 14 AM" src="https://github.com/user-attachments/assets/dfa6b2ac-9e03-4ccb-9372-efc3f82066ac" /> <img width="30%" height="525" alt="Screenshot 2026-08-03 at 10 42 49 AM" src="https://github.com/user-attachments/assets/c35d0eb4-93be-4f86-b9b5-7a236043c540" />

Single-threaded (~1h50m runtime):
<img width="30%" height="518" alt="Screenshot 2026-08-03 at 10 44 07 AM" src="https://github.com/user-attachments/assets/f80e77f3-d018-4c54-94d6-3944998e67a2" /> <img width="30%" height="510" alt="Screenshot 2026-08-03 at 10 44 27 AM" src="https://github.com/user-attachments/assets/23b2c132-b2c0-435e-abb1-e10e00ea0d75" />

With this change we got rid of the table scan for boundary computation and were able to snapshot 1B rows in ~16m:
<img width="30%" height="668" alt="image" src="https://github.com/user-attachments/assets/42bf2043-14ac-42c5-9700-ef21385e3542" /> <img width="30%" height="648" alt="image" src="https://github.com/user-attachments/assets/bedaad69-d66a-40d2-aa6e-2201f58458e1" />

Follow this anchor link for full details on the specs/data: https://app.notion.com/p/materialize/MySQL-Parallel-Snapshot-Smoke-Test-3a613f48d37b806fa311d1bfe9d4ec4c?source=copy_link#3a913f48d37b80a3bbb2dd05f6bc94c2


### Description
Probes the values of a single-column string primary key using `EXPLAIN` and `SELECT LIKE` queries to compute approximate partitioning.

In slightly more detail we:
1. Grab all of the unique first characters of the primary key strings and use `EXPLAIN` to estimate their row count
2. For any character with a high row count we will redo the process one character deeper
3. We continue stepping down into longer prefixes until we run out of a configured number of calls to make or we've resolved granular enough buckets to build partition boundaries
4. Finally, we pick partition boundaries based on the total estimated row count (which could diverge from the real row count or the regular estimated row count by a good bit), and just walk the partitions in order computing boundary keys, which are just prefixes.

This replaces the previous OFFSET-walk boundary sampler and narrows which tables are split: MySQL snapshots are now read in parallel PK ranges only for tables whose primary key is a single CHAR/VARCHAR column of at most 768 characters with the `utf8mb4_bin` collation. Tables with integer primary keys or other string collations, which the OFFSET-walk sampler previously split, now snapshot as a single whole-table read per table (correct, just not parallelized within the table).

### Downsides/Known Unhandled Cases
1. Complexity
2. Won't work well in cases with extremely high cardinality of initial characters
3. Won't work well in cases with "jagged" (word I made up for this) rows, like "a", "aa", "aaa", "aaaa", "aaaaa"...
4. Won't work for collations with contractions, expansions or skips -- relies on character prefixes sorting reliably relative to suffixes.
5. For "PAD SPACE" collations like utf8mb4_bin (which we're starting with) we won't support characters below space. So if customers append leading nulls or carriage returns to all PKs we'll effectively fall back to a full table snapshot. 
6. Estimations are quite approximate so partitioning could be quite unbalanced
7. Not resilient to skew in the size of individual rows, i.e. the PK has some time-sorted prefix and a bunch of the more recent rows have a lot of data, there can still be skew in processing.

### Verification
1. Deployed [777e7e8](https://github.com/MaterializeInc/materialize/commit/777e7e8acd9c0f8e0f375d9511391e279b5162dc) to staging and snapshot 1B row table (August 3, around noon-3pm EDT)




---
Recreated from #37994 with an in-repo head branch so this PR can join the GitHub stack.

