### PR TITLE
persist: proactively recycle connections on draining CRDB nodes [POC]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,27 +2906,28 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.9.5"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
+ "lazy_static",
  "num_cpus",
- "retain_mut",
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-postgres"
-version = "0.10.3"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e866e414e9e12fc988f0bfb89a0b86228e7ed196ca509fbc4dcbc738c56e753c"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
 dependencies = [
+ "async-trait",
  "deadpool",
- "log",
+ "getrandom 0.2.16",
  "tokio",
  "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]
@@ -5501,11 +5502,11 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -8079,7 +8080,6 @@ name = "mz-postgres-client"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "deadpool",
  "deadpool-postgres",
  "mz-ore",
@@ -11417,12 +11417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
-
-[[package]]
 name = "retry-policies"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12447,9 +12441,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,8 +340,8 @@ ctor = "1.0.10"
 custom-labels = "0.4.6"
 darling = "0.23.0"
 datadriven = "0.9.0"
-deadpool = { version = "0.9.5", default-features = false, features = ["managed"] }
-deadpool-postgres = "0.10.3"
+deadpool = { version = "0.12.3", default-features = false, features = ["managed"] }
+deadpool-postgres = "0.14.1"
 dec = "0.4.9"
 derivative = "2.2.0"
 differential-dataflow = "0.25.0"

--- a/deny.toml
+++ b/deny.toml
@@ -141,8 +141,8 @@ skip = [
     { name = "quick-xml", version = "0.37.5" },
     # aws-lc-rs (via jsonwebtoken 10) and ring pull different `untrusted`.
     { name = "untrusted", version = "0.7.1" },
-    # Held back by lazy_static 1.4.0 (used by num-bigint-dig).
-    { name = "spin", version = "0.5.2" },
+    # Held back by lazy_static 1.5.0 (used by num-bigint-dig, deadpool).
+    { name = "spin", version = "0.9.9" },
     # held back by tower-lsp 0.20 (mz-deploy LSP server)
     { name = "dashmap", version = "5.5.3" },
     { name = "tower", version = "0.4.13" },
@@ -242,6 +242,7 @@ wrappers = [
 [[bans.deny]]
 name = "lazy_static"
 wrappers = [
+    "deadpool",
     "dynfmt",
     "findshlibs",
     "launchdarkly-server-sdk",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -160,6 +160,17 @@ def get_variable_system_parameters(
         ["true", "false"] if read_committed_safe else ["false"],
     )
 
+    # Drain-aware recycling stamps connections and polls gossip via
+    # crdb_internal, which only exists on CockroachDB. Default it on there for
+    # coverage; on other metadata stores the queries would fail (tolerated,
+    # but noisy), so keep it off.
+    drain_aware_safe = metadata_store == "cockroach"
+    persist_drain_aware_recycling = VariableSystemParameter(
+        "persist_consensus_connection_pool_drain_aware_recycling",
+        "true" if drain_aware_safe else "false",
+        ["true", "false"] if drain_aware_safe else ["false"],
+    )
+
     return [
         # -----
         # To reduce CRDB load as we are struggling with it in CI (values based on load test environment):
@@ -455,6 +466,7 @@ def get_variable_system_parameters(
             "persist_blob_cache_scale_with_threads", "true", ["true", "false"]
         ),
         persist_pg_consensus_read_committed,
+        persist_drain_aware_recycling,
         VariableSystemParameter(
             "persist_state_update_lease_timeout", "1s", ["0s", "1s", "10s"]
         ),
@@ -623,6 +635,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "persist_consensus_connection_pool_max_wait",
     "persist_consensus_connection_pool_ttl",
     "persist_consensus_connection_pool_ttl_stagger",
+    "persist_consensus_connection_pool_drain_culls_per_tick",
     "persist_use_postgres_tuned_queries",
     "crdb_connect_timeout",
     "crdb_tcp_user_timeout",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1840,6 +1840,9 @@ class FlipFlagsAction(Action):
         self.flags_with_values["persist_claim_unclaimed_compactions"] = (
             BOOLEAN_FLAG_VALUES
         )
+        self.flags_with_values[
+            "persist_consensus_connection_pool_drain_aware_recycling"
+        ] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_optimize_ignored_data_fetch"] = (
             BOOLEAN_FLAG_VALUES
         )
@@ -2109,6 +2112,7 @@ class FlipFlagsAction(Action):
             "persist_consensus_connection_pool_max_wait",
             "persist_consensus_connection_pool_ttl",
             "persist_consensus_connection_pool_ttl_stagger",
+            "persist_consensus_connection_pool_drain_culls_per_tick",
             "persist_use_postgres_tuned_queries",
             "crdb_connect_timeout",
             "crdb_tcp_user_timeout",

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -387,7 +387,8 @@ impl PersistConfig {
 
 /// Sets the maximum size of the connection pool that is used by consensus.
 ///
-/// Requires a restart of the process to take effect.
+/// Applies to existing pools without a restart. Each pool picks up a changed
+/// value the next time a connection is requested from it.
 pub const CONSENSUS_CONNECTION_POOL_MAX_SIZE: Config<usize> = Config::new(
     "persist_consensus_connection_pool_max_size",
     50,

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -299,6 +299,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&BLOB_OPERATION_ATTEMPT_TIMEOUT)
         .add(&BLOB_CONNECT_TIMEOUT)
         .add(&BLOB_READ_TIMEOUT)
+        .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_DRAIN_AWARE_RECYCLING)
+        .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_DRAIN_CULLS_PER_TICK)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_MAX_SIZE)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_MAX_WAIT)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
@@ -427,6 +429,31 @@ const CONSENSUS_CONNECTION_POOL_TTL_STAGGER: Config<Duration> = Config::new(
     "persist_consensus_connection_pool_ttl_stagger",
     Duration::from_secs(6),
     "The minimum time between TTLing Consensus connections to Postgres/CRDB.",
+);
+
+/// Whether consensus connections whose CockroachDB node is draining are
+/// proactively recycled, ahead of the server hard-closing them at the end of
+/// its drain. Only effective on CockroachDB backends, and only where the
+/// consensus role can read `crdb_internal.gossip_liveness` (see
+/// [`mz_postgres_client::PostgresClientKnobs::drain_aware_recycling`]). Leave
+/// off for vanilla Postgres.
+pub const CONSENSUS_CONNECTION_POOL_DRAIN_AWARE_RECYCLING: Config<bool> = Config::new(
+    "persist_consensus_connection_pool_drain_aware_recycling",
+    false,
+    "\
+    Proactively recycle consensus connections whose CockroachDB node is \
+    draining. Requires a role that can read crdb_internal.gossip_liveness.",
+);
+
+/// How many idle consensus connections on draining CockroachDB nodes are
+/// discarded per sweep, bounding how fast the pool sheds them. See
+/// [`CONSENSUS_CONNECTION_POOL_DRAIN_AWARE_RECYCLING`].
+const CONSENSUS_CONNECTION_POOL_DRAIN_CULLS_PER_TICK: Config<usize> = Config::new(
+    "persist_consensus_connection_pool_drain_culls_per_tick",
+    2,
+    "\
+    How many idle consensus connections on draining CockroachDB nodes are \
+    discarded per sweep.",
 );
 
 /// The duration to wait for a Consensus Postgres/CRDB connection to be made
@@ -599,6 +626,14 @@ pub const USAGE_STATE_FETCH_CONCURRENCY_LIMIT: Config<usize> = Config::new(
 impl PostgresClientKnobs for PersistConfig {
     fn connection_pool_max_size(&self) -> usize {
         CONSENSUS_CONNECTION_POOL_MAX_SIZE.get(self)
+    }
+
+    fn drain_aware_recycling(&self) -> bool {
+        CONSENSUS_CONNECTION_POOL_DRAIN_AWARE_RECYCLING.get(self)
+    }
+
+    fn connection_pool_drain_culls_per_tick(&self) -> usize {
+        CONSENSUS_CONNECTION_POOL_DRAIN_CULLS_PER_TICK.get(self)
     }
 
     fn connection_pool_max_wait(&self) -> Option<Duration> {

--- a/src/postgres-client/Cargo.toml
+++ b/src/postgres-client/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 deadpool.workspace = true
 deadpool-postgres.workspace = true
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes"] }
@@ -19,6 +18,9 @@ mz-tls-util = { path = "../tls-util" }
 prometheus.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 
 [features]
 default = []

--- a/src/postgres-client/src/lib.rs
+++ b/src/postgres-client/src/lib.rs
@@ -21,13 +21,14 @@
 pub mod error;
 pub mod metrics;
 
+use std::collections::BTreeSet;
 use std::fmt::Write;
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use deadpool::managed::{self, Hook, HookError, Metrics, Object, Pool, RecycleResult};
+use deadpool::managed::{self, Hook, HookError, Metrics, Object, Pool, RecycleResult, Timeouts};
 use deadpool_postgres::tokio_postgres::{self, Config};
 use deadpool_postgres::{
     ClientWrapper as DeadpoolClient, Manager as PgManager, ManagerConfig, PoolError,
@@ -36,8 +37,9 @@ use deadpool_postgres::{
 use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::metrics::Counter;
 use mz_ore::now::SYSTEM_TIME;
+use mz_ore::task::AbortOnDropHandle;
 use mz_ore::url::SensitiveUrl;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::error::PostgresError;
 use crate::metrics::PostgresClientMetrics;
@@ -67,6 +69,36 @@ pub trait PostgresClientKnobs: std::fmt::Debug + Send + Sync {
     /// Server-side `statement_timeout` to set on each connection. A value of
     /// zero is a sentinel that means "do not set a statement timeout".
     fn statement_timeout(&self) -> Duration;
+    /// Whether to proactively recycle connections whose backend node is
+    /// draining. Each connection is stamped with `crdb_internal.node_id()` at
+    /// creation, and a background task polls `crdb_internal.gossip_liveness`
+    /// for draining nodes and sweeps idle connections on them out of the pool,
+    /// ahead of the server's hard close at the end of its drain. Sweeping on a
+    /// timer rather than at acquire time means a pool with little traffic
+    /// migrates too. Connections checked out by a caller are never swept
+    /// mid-use; they are considered once returned.
+    ///
+    /// Requires a CockroachDB backend whose role can read
+    /// `crdb_internal.gossip_liveness`. That is not implied by ordinary
+    /// database privileges: it needs `GRANT SYSTEM VIEWCLUSTERMETADATA TO
+    /// <role>` (CockroachDB v23.2 and later) or membership in `admin` (older
+    /// versions, which do not honor the system privilege for this table).
+    /// Stamping needs no special grant.
+    ///
+    /// Enabling this where it cannot work is safe but pointless: the pool
+    /// disables the feature for its remaining lifetime the first time either
+    /// query fails permanently, so it costs one failed query rather than one
+    /// per connection.
+    fn drain_aware_recycling(&self) -> bool {
+        false
+    }
+    /// Maximum number of idle connections on draining nodes discarded per
+    /// sweep, bounding how fast the pool sheds them so their replacement cost
+    /// stays amortized. Should be large enough that a node's share of the pool
+    /// migrates well within a drain grace window. Zero disables culling.
+    fn connection_pool_drain_culls_per_tick(&self) -> usize {
+        2
+    }
 }
 
 /// The transaction isolation level applied to new connections.
@@ -108,12 +140,21 @@ pub type Connection = Object<Manager>;
 pub struct Client {
     inner: DeadpoolClient,
     isolation: IsolationLevel,
+    /// The CockroachDB node this connection landed on, if
+    /// [`PostgresClientKnobs::drain_aware_recycling`] is enabled and the
+    /// backend is CockroachDB. `None` otherwise.
+    node_id: Option<i64>,
 }
 
 impl Client {
     /// The [`IsolationLevel`] this connection was configured with when it was created.
     pub fn isolation_level(&self) -> IsolationLevel {
         self.isolation
+    }
+
+    /// The CockroachDB node this connection landed on, if known.
+    pub fn node_id(&self) -> Option<i64> {
+        self.node_id
     }
 }
 
@@ -141,6 +182,35 @@ pub struct Manager {
     isolation: IsolationLevelFn,
     knobs: Arc<dyn PostgresClientKnobs>,
     connections_created: Counter,
+    /// Whether this pool can use the `crdb_internal` introspection that
+    /// drain-aware recycling needs. Starts `true` and latches to `false` the
+    /// first time either the node-id stamp or the liveness poll fails
+    /// permanently (see [`is_crdb_unsupported_err`]). It never latches back
+    /// on, so a mistakenly enabled flag against an unsupported backend costs
+    /// one failed query rather than one per connection and one per poll.
+    ///
+    /// NOTE: the two queries do not necessarily fail together. A role without
+    /// `VIEWCLUSTERMETADATA` on a real CockroachDB can stamp connections but
+    /// not read `crdb_internal.gossip_liveness`, so the poll is what latches
+    /// the feature off in that case.
+    drain_recycling_supported: Arc<AtomicBool>,
+}
+
+/// Whether an error means this pool will never be able to use `crdb_internal`,
+/// as opposed to a transient failure worth retrying. Either the backend is not
+/// CockroachDB at all (the schema, table, or function does not exist) or the
+/// role lacks the privileges `gossip_liveness` requires (see
+/// [`PostgresClientKnobs::drain_aware_recycling`]). Neither changes within the
+/// life of a pool, so both latch the feature off instead of retrying forever.
+fn is_crdb_unsupported_err(e: &tokio_postgres::Error) -> bool {
+    use deadpool_postgres::tokio_postgres::error::SqlState;
+    matches!(
+        e.code(),
+        Some(&SqlState::UNDEFINED_FUNCTION)
+            | Some(&SqlState::UNDEFINED_TABLE)
+            | Some(&SqlState::INVALID_SCHEMA_NAME)
+            | Some(&SqlState::INSUFFICIENT_PRIVILEGE)
+    )
 }
 
 impl std::fmt::Debug for Manager {
@@ -181,7 +251,37 @@ impl managed::Manager for Manager {
         #[allow(clippy::disallowed_methods)]
         inner.batch_execute(&setup).await?;
 
-        Ok(Client { inner, isolation })
+        // Stamp the connection with the CockroachDB node it landed on, so a
+        // draining node's connections can be recycled proactively.
+        let node_id = if self.knobs.drain_aware_recycling()
+            && self.drain_recycling_supported.load(Ordering::SeqCst)
+        {
+            #[allow(clippy::disallowed_methods)]
+            match inner
+                .query_one("SELECT crdb_internal.node_id()::INT8", &[])
+                .await
+            {
+                Ok(row) => Some(row.get::<_, i64>(0)),
+                Err(e) => {
+                    if is_crdb_unsupported_err(&e) {
+                        self.drain_recycling_supported
+                            .store(false, Ordering::SeqCst);
+                        info!("disabling drain-aware recycling, cannot stamp node ids: {e}");
+                    } else {
+                        debug!("unable to stamp connection with a node id: {e}");
+                    }
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        Ok(Client {
+            inner,
+            isolation,
+            node_id,
+        })
     }
 
     async fn recycle(
@@ -242,6 +342,18 @@ pub struct PostgresClient {
     pool: Pool<Manager>,
     knobs: Arc<dyn PostgresClientKnobs>,
     metrics: PostgresClientMetrics,
+    /// CockroachDB nodes currently draining, maintained by the drain watchdog
+    /// task and consulted by the pool's `pre_recycle` hook. Empty unless
+    /// [`PostgresClientKnobs::drain_aware_recycling`] is enabled.
+    draining_nodes: Arc<Mutex<BTreeSet<i64>>>,
+    /// Background task that polls for draining nodes. Spawned lazily on the
+    /// first acquire (opening a client does not require a Tokio runtime,
+    /// acquiring does). Aborted when the client is dropped.
+    drain_watchdog: std::sync::OnceLock<AbortOnDropHandle<()>>,
+    /// See [`Manager::drain_recycling_supported`]. Shared with the manager so
+    /// that a permanent failure from either the stamp or the poll disables
+    /// both.
+    drain_recycling_supported: Arc<AtomicBool>,
 }
 
 impl std::fmt::Debug for PostgresClient {
@@ -279,16 +391,19 @@ impl PostgresClient {
         );
         // The isolation level and `statement_timeout` are applied inside `Manager::create` so the
         // resolved level can be recorded on each connection it hands out.
+        let drain_recycling_supported = Arc::new(AtomicBool::new(true));
         let manager = Manager {
             inner: pg_manager,
             isolation: Arc::clone(&config.isolation),
             knobs: Arc::clone(&config.knobs),
             connections_created: config.metrics.connpool_connections_created.clone(),
+            drain_recycling_supported: Arc::clone(&drain_recycling_supported),
         };
 
         let last_ttl_connection = AtomicU64::new(0);
         let ttl_reconnections = config.metrics.connpool_ttl_reconnections.clone();
         let knobs = Arc::clone(&config.knobs);
+        let draining_nodes = Arc::new(Mutex::new(BTreeSet::new()));
         let builder = Pool::builder(manager);
         let builder = match config.knobs.connection_pool_max_wait() {
             None => builder,
@@ -296,7 +411,7 @@ impl PostgresClient {
         };
         let pool = builder
             .max_size(config.knobs.connection_pool_max_size())
-            .pre_recycle(Hook::sync_fn(move |_client, conn_metrics| {
+            .pre_recycle(Hook::sync_fn(move |_client: &mut Client, conn_metrics| {
                 // proactively TTL connections to rebalance load to Postgres/CRDB. this helps
                 // fix skew when downstream DB operations (e.g. CRDB rolling restart) result
                 // in uneven load to each node, and works to reduce the # of connections
@@ -332,7 +447,152 @@ impl PostgresClient {
             pool,
             knobs,
             metrics: config.metrics,
+            draining_nodes,
+            drain_watchdog: std::sync::OnceLock::new(),
+            drain_recycling_supported,
         })
+    }
+
+    /// How often the drain watchdog polls for draining nodes. Chosen to be
+    /// well under typical drain grace windows so the pool can move off a
+    /// draining node before the server hard-closes its connections.
+    const DRAIN_POLL_INTERVAL: Duration = Duration::from_secs(5);
+    /// How long a watchdog acquire may wait for a pool connection. Kept short
+    /// so the watchdog never meaningfully competes with real acquires.
+    const DRAIN_POLL_ACQUIRE_TIMEOUT: Duration = Duration::from_millis(100);
+
+    fn ensure_drain_watchdog(&self) {
+        self.drain_watchdog.get_or_init(|| {
+            let pool = self.pool.clone();
+            let knobs = Arc::clone(&self.knobs);
+            let draining_nodes = Arc::clone(&self.draining_nodes);
+            let drain_recycling_supported = Arc::clone(&self.drain_recycling_supported);
+            mz_ore::task::spawn(|| "postgres_client_drain_watchdog", async move {
+                let mut interval = tokio::time::interval(Self::DRAIN_POLL_INTERVAL);
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                loop {
+                    interval.tick().await;
+                    if !knobs.drain_aware_recycling()
+                        || !drain_recycling_supported.load(Ordering::SeqCst)
+                    {
+                        continue;
+                    }
+                    Self::drain_poll_tick(&pool, &draining_nodes, &drain_recycling_supported).await;
+                    Self::drain_cull_tick(&pool, &draining_nodes, knobs.as_ref());
+                }
+            })
+            .abort_on_drop()
+        });
+    }
+
+    /// Discards idle connections whose node is draining, so the pool migrates
+    /// off the node during its drain rather than discovering closed
+    /// connections afterwards.
+    ///
+    /// Culling from here rather than from the pool's `pre_recycle` hook means
+    /// it happens on a timer instead of only when a connection is checked out,
+    /// so a pool with little or no traffic still migrates. Only a bounded
+    /// number of connections are removed per tick, so replacing them stays
+    /// amortized instead of ejecting a node's entire share at once.
+    ///
+    /// NOTE: [`Pool::retain`] only ever sees connections sitting in the idle
+    /// queue. A connection checked out by a caller has been removed from that
+    /// queue and cannot be culled mid-use; it is considered on a later tick,
+    /// once it has been returned.
+    fn drain_cull_tick(
+        pool: &Pool<Manager>,
+        draining_nodes: &Arc<Mutex<BTreeSet<i64>>>,
+        knobs: &dyn PostgresClientKnobs,
+    ) {
+        {
+            let draining = draining_nodes.lock().expect("draining_nodes lock poisoned");
+            if draining.is_empty() {
+                return;
+            }
+        }
+        let mut budget = knobs.connection_pool_drain_culls_per_tick();
+        if budget == 0 {
+            return;
+        }
+        let draining = Arc::clone(draining_nodes);
+        let result = pool.retain(|client: &Client, _metrics| {
+            let Some(node_id) = client.node_id else {
+                return true;
+            };
+            if budget == 0 {
+                return true;
+            }
+            let draining = draining.lock().expect("draining_nodes lock poisoned");
+            if draining.contains(&node_id) {
+                budget -= 1;
+                false
+            } else {
+                true
+            }
+        });
+        if !result.removed.is_empty() {
+            debug!(
+                "culled {} idle connections on draining nodes",
+                result.removed.len()
+            );
+        }
+    }
+
+    /// Polls CockroachDB's gossiped liveness for draining nodes and replaces
+    /// the draining set with the result.
+    async fn drain_poll_tick(
+        pool: &Pool<Manager>,
+        draining_nodes: &Arc<Mutex<BTreeSet<i64>>>,
+        drain_recycling_supported: &Arc<AtomicBool>,
+    ) {
+        let timeouts = Timeouts {
+            wait: Some(Self::DRAIN_POLL_ACQUIRE_TIMEOUT),
+            ..Timeouts::default()
+        };
+        let Ok(conn) = pool.timeout_get(&timeouts).await else {
+            return;
+        };
+        // `draining` and `membership` are deliberate operator states (rolling
+        // restart, decommission), so connections to matching nodes are doomed
+        // and safe to cull. The join against `gossip_nodes` restricts the
+        // result to current cluster members: liveness records for
+        // long-decommissioned nodes linger indefinitely (frequently with
+        // `draining` still set from their final drain) and would otherwise
+        // pollute the set forever. Liveness `expiration` is deliberately NOT
+        // consulted: an expired record is a symptom (crash, partition, clock
+        // skew) that TCP keepalives already handle, and acting on it could
+        // mass-cull a healthy pool when gossip itself is stale.
+        #[allow(clippy::disallowed_methods)]
+        let rows = conn
+            .query(
+                "SELECT l.node_id::INT8 \
+                 FROM crdb_internal.gossip_liveness l \
+                 JOIN crdb_internal.gossip_nodes n ON l.node_id = n.node_id \
+                 WHERE l.draining OR l.membership != 'active'",
+                &[],
+            )
+            .await;
+        match rows {
+            Ok(rows) => {
+                let nodes: BTreeSet<i64> = rows.iter().map(|row| row.get(0)).collect();
+                let mut set = draining_nodes.lock().expect("draining_nodes lock poisoned");
+                if nodes != *set {
+                    info!("draining CockroachDB nodes changed: {nodes:?}");
+                    *set = nodes;
+                }
+            }
+            Err(e) => {
+                if is_crdb_unsupported_err(&e) {
+                    // Vanilla Postgres: latch the feature off for the
+                    // lifetime of this pool.
+                    drain_recycling_supported.store(false, Ordering::SeqCst);
+                    info!("disabling drain-aware recycling, cannot poll liveness: {e}");
+                } else {
+                    // Transient failure. Leave the set unchanged.
+                    debug!("unable to poll for draining nodes: {e}");
+                }
+            }
+        }
     }
 
     fn status_metrics(&self, status: Status) {
@@ -350,8 +610,26 @@ impl PostgresClient {
         self.pool.status()
     }
 
+    /// Marks a node as draining, as the watchdog's liveness poll would.
+    #[cfg(test)]
+    fn mark_node_draining(&self, node_id: i64) {
+        self.draining_nodes
+            .lock()
+            .expect("draining_nodes lock poisoned")
+            .insert(node_id);
+    }
+
+    /// Runs one sweep of the drain cull, as the watchdog would on its timer.
+    #[cfg(test)]
+    fn cull_draining_now(&self) {
+        Self::drain_cull_tick(&self.pool, &self.draining_nodes, self.knobs.as_ref());
+    }
+
     /// Gets connection from the pool or waits for one to become available.
     pub async fn get_connection(&self) -> Result<Connection, PoolError> {
+        if self.knobs.drain_aware_recycling() {
+            self.ensure_drain_watchdog();
+        }
         let start = Instant::now();
         // note that getting the pool status here requires briefly locking the pool
         let status = self.pool.status();
@@ -390,11 +668,15 @@ mod tests {
     #[derive(Debug)]
     struct TestKnobs {
         max_size: AtomicUsize,
+        drain_aware: bool,
     }
 
     impl PostgresClientKnobs for TestKnobs {
         fn connection_pool_max_size(&self) -> usize {
             self.max_size.load(Ordering::SeqCst)
+        }
+        fn drain_aware_recycling(&self) -> bool {
+            self.drain_aware
         }
         fn connection_pool_max_wait(&self) -> Option<Duration> {
             Some(Duration::from_secs(1))
@@ -439,6 +721,7 @@ mod tests {
         };
         let knobs = Arc::new(TestKnobs {
             max_size: AtomicUsize::new(2),
+            drain_aware: false,
         });
         let dyn_knobs: Arc<dyn PostgresClientKnobs> = Arc::<TestKnobs>::clone(&knobs);
         let config = PostgresClientConfig::new(
@@ -463,5 +746,122 @@ mod tests {
         drop(conn2);
         let _conn3 = client.get_connection().await.expect("connection");
         assert_eq!(client.status().max_size, 1);
+    }
+
+    /// Verifies that connections are stamped with their CockroachDB node and
+    /// that marking the node as draining causes the pooled connection to be
+    /// discarded and replaced on the next acquire. Opt-in like the other
+    /// tests in this module; requires a CockroachDB backend.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    async fn drain_aware_recycling_culls_stamped_connections() {
+        let url = match std::env::var("MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL") {
+            Ok(url) => SensitiveUrl::from_str(&url).expect("valid url"),
+            Err(_) => return,
+        };
+        // A pool of exactly one connection keeps the assertions below
+        // deterministic even though the drain watchdog concurrently acquires
+        // from (and could otherwise grow) the pool.
+        let knobs = Arc::new(TestKnobs {
+            max_size: AtomicUsize::new(1),
+            drain_aware: true,
+        });
+        let dyn_knobs: Arc<dyn PostgresClientKnobs> = Arc::<TestKnobs>::clone(&knobs);
+        let config = PostgresClientConfig::new(
+            url,
+            dyn_knobs,
+            PostgresClientMetrics::new(&MetricsRegistry::new(), "mz_postgres_client_test"),
+        );
+        let client = PostgresClient::open(config).expect("open client");
+
+        let conn = client.get_connection().await.expect("connection");
+        let Some(node_id) = conn.node_id() else {
+            // Not a CockroachDB backend. CI runs these tests against vanilla
+            // Postgres, so this is the path exercised there: verify the
+            // feature detects the unsupported backend and latches itself off
+            // rather than retrying `crdb_internal` on every connection.
+            drop(conn);
+            assert!(!client.drain_recycling_supported.load(Ordering::SeqCst));
+            let created_before = client.metrics.connpool_connections_created.get();
+            for _ in 0..3 {
+                let conn = client.get_connection().await.expect("connection");
+                assert_eq!(conn.node_id(), None);
+            }
+            assert_eq!(
+                client.metrics.connpool_connections_created.get(),
+                created_before,
+                "connections should be reused once the feature latches off",
+            );
+            return;
+        };
+        drop(conn);
+
+        // The single connection is reused while its node is healthy: no
+        // matter how the watchdog's acquires interleave, nothing is created.
+        let created_before = client.metrics.connpool_connections_created.get();
+        drop(client.get_connection().await.expect("connection"));
+        assert_eq!(
+            client.metrics.connpool_connections_created.get(),
+            created_before,
+        );
+
+        // A sweep with the node healthy leaves the idle connection alone.
+        client.cull_draining_now();
+        assert_eq!(client.status().size, 1);
+
+        // Once the node is draining, a sweep discards the idle connection
+        // even though nothing is acquiring from the pool.
+        client.mark_node_draining(node_id);
+        client.cull_draining_now();
+        assert_eq!(
+            client.status().size,
+            0,
+            "idle connection on a draining node should be culled by the sweep",
+        );
+
+        // The next acquire is served by a freshly created connection.
+        let conn = client.get_connection().await.expect("connection");
+        assert!(client.metrics.connpool_connections_created.get() > created_before);
+        drop(conn);
+    }
+
+    /// A connection checked out by a caller must never be culled mid-use: it
+    /// is not in the pool's idle queue, so [`Pool::retain`] cannot see it. It
+    /// is considered on a later sweep, once returned.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    async fn drain_cull_leaves_checked_out_connections_alone() {
+        let url = match std::env::var("MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL") {
+            Ok(url) => SensitiveUrl::from_str(&url).expect("valid url"),
+            Err(_) => return,
+        };
+        let knobs = Arc::new(TestKnobs {
+            max_size: AtomicUsize::new(1),
+            drain_aware: true,
+        });
+        let dyn_knobs: Arc<dyn PostgresClientKnobs> = Arc::<TestKnobs>::clone(&knobs);
+        let config = PostgresClientConfig::new(
+            url,
+            dyn_knobs,
+            PostgresClientMetrics::new(&MetricsRegistry::new(), "mz_postgres_client_test"),
+        );
+        let client = PostgresClient::open(config).expect("open client");
+
+        let conn = client.get_connection().await.expect("connection");
+        let Some(node_id) = conn.node_id() else {
+            return; // Not CockroachDB; covered by the test above.
+        };
+
+        // Hold the connection checked out across a sweep of its own node.
+        client.mark_node_draining(node_id);
+        client.cull_draining_now();
+
+        // It survived and is still usable.
+        #[allow(clippy::disallowed_methods)]
+        let row = conn.query_one("SELECT 1::INT8", &[]).await.expect("query");
+        assert_eq!(row.get::<_, i64>(0), 1);
+
+        // Once returned, the next sweep discards it.
+        drop(conn);
+        client.cull_draining_now();
+        assert_eq!(client.status().size, 0);
     }
 }

--- a/src/postgres-client/src/lib.rs
+++ b/src/postgres-client/src/lib.rs
@@ -27,8 +27,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use async_trait::async_trait;
-use deadpool::managed::{self, Hook, HookError, HookErrorCause, Object, Pool, RecycleResult};
+use deadpool::managed::{self, Hook, HookError, Metrics, Object, Pool, RecycleResult};
 use deadpool_postgres::tokio_postgres::{self, Config};
 use deadpool_postgres::{
     ClientWrapper as DeadpoolClient, Manager as PgManager, ManagerConfig, PoolError,
@@ -152,7 +151,6 @@ impl std::fmt::Debug for Manager {
     }
 }
 
-#[async_trait]
 impl managed::Manager for Manager {
     type Type = Client;
     type Error = tokio_postgres::Error;
@@ -186,8 +184,12 @@ impl managed::Manager for Manager {
         Ok(Client { inner, isolation })
     }
 
-    async fn recycle(&self, client: &mut Client) -> RecycleResult<tokio_postgres::Error> {
-        self.inner.recycle(&mut client.inner).await
+    async fn recycle(
+        &self,
+        client: &mut Client,
+        metrics: &Metrics,
+    ) -> RecycleResult<tokio_postgres::Error> {
+        self.inner.recycle(&mut client.inner, metrics).await
     }
 
     fn detach(&self, client: &mut Client) {
@@ -238,6 +240,7 @@ impl PostgresClientConfig {
 /// A Postgres client wrapper that uses deadpool as a connection pool.
 pub struct PostgresClient {
     pool: Pool<Manager>,
+    knobs: Arc<dyn PostgresClientKnobs>,
     metrics: PostgresClientMetrics,
 }
 
@@ -285,6 +288,7 @@ impl PostgresClient {
 
         let last_ttl_connection = AtomicU64::new(0);
         let ttl_reconnections = config.metrics.connpool_ttl_reconnections.clone();
+        let knobs = Arc::clone(&config.knobs);
         let builder = Pool::builder(manager);
         let builder = match config.knobs.connection_pool_max_wait() {
             None => builder,
@@ -314,9 +318,9 @@ impl PostgresClient {
                         .is_ok()
                 {
                     ttl_reconnections.inc();
-                    return Err(HookError::Continue(Some(HookErrorCause::Message(
-                        "connection has been TTLed".to_string(),
-                    ))));
+                    // A pre_recycle error discards this connection and the
+                    // acquire proceeds with another (or a fresh) one.
+                    return Err(HookError::message("connection has been TTLed"));
                 }
 
                 Ok(())
@@ -326,6 +330,7 @@ impl PostgresClient {
 
         Ok(PostgresClient {
             pool,
+            knobs,
             metrics: config.metrics,
         })
     }
@@ -338,11 +343,27 @@ impl PostgresClient {
         // Don't bother reporting the maximum size of the pool... we know that from config.
     }
 
+    /// The current [`Status`] of the connection pool.
+    ///
+    /// NOTE: this briefly locks the pool.
+    pub fn status(&self) -> Status {
+        self.pool.status()
+    }
+
     /// Gets connection from the pool or waits for one to become available.
     pub async fn get_connection(&self) -> Result<Connection, PoolError> {
         let start = Instant::now();
-        // note that getting the pool size here requires briefly locking the pool
-        self.status_metrics(self.pool.status());
+        // note that getting the pool status here requires briefly locking the pool
+        let status = self.pool.status();
+        // Apply knob changes to the pool cap without a restart, so an operator
+        // can grow (or shrink) the pool during an incident or ahead of planned
+        // CRDB maintenance. Shrinking is graceful: deadpool drops surplus
+        // connections as they are returned.
+        let max_size = self.knobs.connection_pool_max_size();
+        if status.max_size != max_size {
+            self.pool.resize(max_size);
+        }
+        self.status_metrics(status);
         let res = self.pool.get().await;
         if let Err(PoolError::Backend(err)) = &res {
             debug!("error establishing connection: {}", err);
@@ -354,5 +375,93 @@ impl PostgresClient {
         self.metrics.connpool_acquires.inc();
         self.status_metrics(self.pool.status());
         res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::atomic::AtomicUsize;
+
+    use mz_ore::metrics::MetricsRegistry;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestKnobs {
+        max_size: AtomicUsize,
+    }
+
+    impl PostgresClientKnobs for TestKnobs {
+        fn connection_pool_max_size(&self) -> usize {
+            self.max_size.load(Ordering::SeqCst)
+        }
+        fn connection_pool_max_wait(&self) -> Option<Duration> {
+            Some(Duration::from_secs(1))
+        }
+        fn connection_pool_ttl(&self) -> Duration {
+            Duration::MAX
+        }
+        fn connection_pool_ttl_stagger(&self) -> Duration {
+            Duration::MAX
+        }
+        fn connect_timeout(&self) -> Duration {
+            Duration::from_secs(5)
+        }
+        fn tcp_user_timeout(&self) -> Duration {
+            Duration::ZERO
+        }
+        fn keepalives_idle(&self) -> Duration {
+            Duration::from_secs(10)
+        }
+        fn keepalives_interval(&self) -> Duration {
+            Duration::from_secs(5)
+        }
+        fn keepalives_retries(&self) -> u32 {
+            5
+        }
+        fn statement_timeout(&self) -> Duration {
+            Duration::ZERO
+        }
+    }
+
+    /// Verifies that a changed `connection_pool_max_size` knob is applied to a
+    /// live pool on the next acquire, without reopening the client.
+    ///
+    /// Requires a running Postgres/CRDB, opted into via the same environment
+    /// variable as the persist external-storage tests. No-op otherwise so
+    /// `cargo test` works on unconfigured environments.
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    async fn pool_resize_applies_on_acquire() {
+        let url = match std::env::var("MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL") {
+            Ok(url) => SensitiveUrl::from_str(&url).expect("valid url"),
+            Err(_) => return,
+        };
+        let knobs = Arc::new(TestKnobs {
+            max_size: AtomicUsize::new(2),
+        });
+        let dyn_knobs: Arc<dyn PostgresClientKnobs> = Arc::<TestKnobs>::clone(&knobs);
+        let config = PostgresClientConfig::new(
+            url,
+            dyn_knobs,
+            PostgresClientMetrics::new(&MetricsRegistry::new(), "mz_postgres_client_test"),
+        );
+        let client = PostgresClient::open(config).expect("open client");
+
+        let conn = client.get_connection().await.expect("connection");
+        assert_eq!(client.status().max_size, 2);
+
+        // Growing applies on the next acquire.
+        knobs.max_size.store(5, Ordering::SeqCst);
+        let conn2 = client.get_connection().await.expect("connection");
+        assert_eq!(client.status().max_size, 5);
+
+        // Shrinking applies too. Surplus connections are dropped as they are
+        // returned to the pool.
+        knobs.max_size.store(1, Ordering::SeqCst);
+        drop(conn);
+        drop(conn2);
+        let _conn3 = client.get_connection().await.expect("connection");
+        assert_eq!(client.status().max_size, 1);
     }
 }


### PR DESCRIPTION
### Motivation

Stacked on #38050 (deadpool upgrade + live pool resize) — review that first; this diff includes it until it merges.

During a CRDB node drain, the server gives clients no protocol-level advance notice: new connections are refused with `AdminShutdown` (57P01), idle connections are closed with a bare TCP FIN, and anything still open at the end of the drain is force-closed (see `pkg/sql/pgwire/server.go`, `ErrDrainingNewConn` / `ErrDrainingExistingConn`). Deadpool only discovers a dead connection at its next checkout, so during a rolling upgrade the pool sits on dead-connections-walking until first use.

This PR gives the pool the earliest signal CRDB exposes — the gossiped `draining` flag — and recycles connections off a draining node during the drain grace window instead of after the close.

### Changes

* Each pooled connection is stamped with `crdb_internal.node_id()` at creation (one extra round trip per create, gated).
* A background watchdog (spawned lazily on first acquire, aborted on client drop) polls `crdb_internal.gossip_liveness` every 5s for current cluster members that are draining or decommissioning (`draining OR membership != 'active'`, joined against `gossip_nodes` to exclude liveness tombstones of long-decommissioned nodes, which linger forever with `draining` still set). Liveness `expiration` is deliberately not consulted: an expired record is a symptom (crash, partition, clock skew) that TCP keepalives already handle, and acting on it could mass-cull a healthy pool when gossip itself is stale.
* Each watchdog tick then **sweeps** idle connections on those nodes out of the pool via `Pool::retain`, bounded to `persist_consensus_connection_pool_drain_culls_per_tick` (default 2) so replacement stays amortized rather than ejecting a node's whole share at once.

Sweeping from the watchdog's timer rather than from the pool's `pre_recycle` hook is deliberate. `pre_recycle` fires only when an acquire pops an existing idle connection (`deadpool` `pool.rs`: `try_recycle` is reached only when the idle queue is non-empty), so a pool with little or no traffic would sit on doomed connections until traffic returned — precisely when it has spare capacity to replace them gracefully. The timer-driven sweep has no such dependency, and it keeps the drain check off the hot acquire path.

**Connections in use are never affected.** `Pool::retain` locks the pool's slots and walks only the idle queue; a checked-out connection was removed from that queue by `get()` and is not returned until its `Object` drops, so it cannot be swept mid-use. It is considered on a later tick, once returned. There is a test for exactly this.
* Gated behind new dyncfg `persist_consensus_connection_pool_drain_aware_recycling`, default off in production, CI default on for CockroachDB-backed metadata stores and off otherwise.

### :warning: Required grant before enabling

Reading `crdb_internal.gossip_liveness` is **not** implied by ordinary database privileges. Before turning this flag on for a deployment, the consensus role needs:

```sql
GRANT SYSTEM VIEWCLUSTERMETADATA TO <role>;   -- CockroachDB v23.2+
```

On CockroachDB versions before v23.2 the system privilege is not honored for this table and membership in `admin` is required instead (verified: on v23.1.4 the grant succeeds but the read still fails with "only users with the admin role are allowed to read crdb_internal.gossip_liveness"; on v25.4.10 the grant works). Stamping connections via `crdb_internal.node_id()` needs no special grant.

**No deployment can enable this flag today without a privilege change first.** Environments connect as an unprivileged per-environment role that owns only its own database, so the liveness poll will fail and the feature will disable itself. Granting the privilege is a deliberate decision with real tradeoffs (it is cluster-wide, and on a shared metadata cluster it exposes cross-tenant metadata such as other databases' names and cluster topology), so the flag should stay off until that is worked through. A missing grant degrades rather than breaks.

### Known limitation: poll amplification

Every pool polls independently. One production region currently runs ~500 processes with consensus pools, so enabling this fleet-wide at the default 5s interval would add ~100 queries/sec of permanent load to the very metadata cluster the feature is meant to protect, in order to detect drains that happen a handful of times a year. Before this is enabled broadly, the draining-node set is probably better discovered once per cluster by a privileged component and distributed to environments, rather than polled per pool. Filing that as follow-up rather than blocking this PR, which is still useful for single-pool and self-hosted cases.

### Graceful degradation on non-CockroachDB backends

This pool is shared with vanilla-Postgres deployments, so enabling the feature where it cannot work must be harmless rather than pathological. Each pool holds a `drain_recycling_supported` flag that starts true and latches false the first time either query fails with a permanent SQLSTATE — `3F000` / `42P01` / `42883` (no `crdb_internal`) or `42501` (role lacks the grant above). After that the pool stops stamping and stops polling, so a misconfigured flag costs one failed query for the life of the pool instead of one per connection plus one every 5s.

The two queries do not necessarily fail together, which is why the flag is a latch rather than a "detected backend" value: a read-only role on a real CockroachDB **can** call `crdb_internal.node_id()` but **cannot** read `gossip_liveness`, so stamping succeeds and only the poll fails. Verified against all four configurations (vanilla Postgres 16, CockroachDB as admin, CockroachDB as a role without cluster-metadata access, and no backend configured).

### Design notes

* Polling gossip beats probing for the drain error string: probes through a load balancer can't target a node (and health-checked LBs remove draining nodes from rotation, so probes miss them), the refused startup doesn't identify which node is draining, and pgcode is stable while error text isn't.
* Node IDs are never reused (monotonic allocator; in-place restarts keep their ID), so a tombstone or stale set entry can never match a live connection's stamp.
* Effectiveness depends on the drain actually having a grace window: with `server.shutdown.connections.timeout` at its 0s default there is little time between the gossip flag flipping and the hard close. Pairs with the operational recommendation to raise that timeout.

### Tests

* `drain_aware_recycling_culls_stamped_connections` in `mz-postgres-client`: verifies node stamping, that healthy-node connections are reused, and that marking a connection's node as draining causes it to be discarded and replaced on the next acquire. Deterministic under the concurrent watchdog (single-connection pool, inequality assertions). Opt-in via `MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL`.
* End-to-end validation against a real rolling drain can use the `pool-exhaustion` workflow in `test/crdb-restarts` (from #38053): with this flag on, `connections_created` should rise *during* each drain window rather than after node restart.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
