### PR TITLE
adapter: let the cluster controller own system clusters

### DIFF
--- a/doc/user/content/self-managed-deployments/troubleshooting.md
+++ b/doc/user/content/self-managed-deployments/troubleshooting.md
@@ -113,13 +113,19 @@ To increase the cluster's size, you can follow the following steps:
    show clusters;
    ```
 
+   Resizing a cluster is a graceful reconfiguration: Materialize brings up a
+   replica at the new size, waits for it to hydrate, and only then retires the
+   old one. Until that finishes, `SHOW CLUSTERS` reports the old size, and
+   briefly both. Re-run the statement until it settles. The replacement replica
+   also gets a fresh name, so the resized cluster reports `r2` rather than `r1`.
+
    The output should include the `mz_catalog_server` cluster with a size of `50cc`:
 
    ```none
           name        | replicas  | comment
     -------------------+-----------+---------
     mz_analytics      |           |
-    mz_catalog_server | r1 (50cc) |
+    mz_catalog_server | r2 (50cc) |
     mz_probe          |           |
     mz_support        |           |
     mz_system         |           |

--- a/misc/python/materialize/checks/all_checks/builtin_cluster_replication_factor.py
+++ b/misc/python/materialize/checks/all_checks/builtin_cluster_replication_factor.py
@@ -21,6 +21,10 @@ class BuiltinClusterReplicationFactor(Check):
     the break-glass path a support engineer scales up by hand. A catalog open that
     does not read the cluster's replication factor tears that replica down, leaving
     the cluster reporting a factor it is not honoring.
+
+    The replica arrives asynchronously: the cluster controller materializes it a
+    tick after the ALTER commits. Every assertion below is a retrying testdrive
+    query for that reason.
     """
 
     def _can_run(self, e: Executor) -> bool:

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1155,9 +1155,14 @@ fn add_new_remove_old_builtin_roles_migration(
 /// recorded durably and runs before the cluster controller is spawned, and the
 /// controller does not run at all while a deployment is read-only.
 ///
-/// The controller derives its target from the same cluster config, so it converges
-/// on the same replica set rather than competing for it. It excludes system
-/// clusters today, but nothing here depends on that staying true.
+/// The cluster controller owns these replica sets at runtime and derives its
+/// target from the same cluster config, so the two converge on the same set
+/// rather than competing for it. The controller matches replicas by shape and
+/// count, never by name, so the `r1..rN` this creates satisfy it. This converges
+/// by name, so a boot after the controller reshaped a cluster renames or
+/// re-creates replicas it had materialized under generator names. That is
+/// harmless: every replica is a cold process at boot anyway, so the cost is
+/// replica-id and audit-log noise.
 fn reconcile_builtin_cluster_replicas(
     txn: &mut Transaction<'_>,
     builtin_cluster_config_map: &BuiltinBootstrapClusterConfigMap,

--- a/src/adapter/src/coord/cluster_controller.rs
+++ b/src/adapter/src/coord/cluster_controller.rs
@@ -18,10 +18,11 @@
 //! signals are pulled on demand, so a tick's round-trips scale with the number of
 //! managed clusters that need a live signal, not with a constant.
 //!
-//! The controller owns the *user* managed-cluster replica set. (System/builtin
-//! clusters are excluded here. Their config-implied replicas are materialized
-//! by `reconcile_builtin_cluster_replicas` at catalog open, which derives the
-//! same target from the same config.)
+//! The controller owns the replica set of every managed cluster, user and
+//! system alike. A builtin cluster's config-implied replicas are additionally
+//! materialized by `reconcile_builtin_cluster_replicas` at catalog open, which
+//! derives the same target from the same config, so the two converge rather
+//! than compete.
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -55,9 +56,7 @@ use crate::error::AdapterError;
 /// per-cluster live signal a strategy pulls on demand.
 #[derive(Debug)]
 pub enum ClusterControllerRequest {
-    /// The ids of all *user* managed clusters the controller owns this tick.
-    /// System/builtin clusters are excluded. `reconcile_builtin_cluster_replicas`
-    /// has already materialized their config-implied replicas at catalog open.
+    /// The ids of all managed clusters the controller owns this tick.
     ManagedClusterIds { tx: oneshot::Sender<Vec<ClusterId>> },
     /// A consistent durable view of the given clusters and their replicas, plus
     /// the current time.
@@ -269,15 +268,7 @@ impl Coordinator {
                 let ids = if active {
                     self.catalog()
                         .clusters()
-                        // Only *user* managed clusters. System/builtin clusters
-                        // (mz_system, mz_catalog_server, …) are also managed, and
-                        // `reconcile_builtin_cluster_replicas` materializes their
-                        // config-implied replica set at catalog open, so those
-                        // replicas exist before the controller could ever tick.
-                        // Both derive the target from the cluster's
-                        // `replication_factor`, so extending ownership here would
-                        // converge rather than conflict.
-                        .filter(|c| c.is_managed() && c.id.is_user())
+                        .filter(|c| c.is_managed())
                         .map(|c| c.id)
                         .collect()
                 } else {

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -310,13 +310,6 @@ impl Coordinator {
             Unchanged => {}
         }
 
-        // The controller owns only *user* managed clusters (see `ManagedClusterIds`
-        // in cluster_controller.rs and `controller_owns` in the managed-to-managed
-        // path below). A system/builtin cluster is never converged by the
-        // controller, so it must not be reshaped into a durable reconfiguration
-        // record nobody would cut over. It takes the direct realized-config path
-        // below.
-        let cluster_controller_owns = cluster_id.is_user();
         let reconfiguration_in_flight = matches!(
             &config.variant,
             Managed(managed) if managed
@@ -330,10 +323,7 @@ impl Coordinator {
         // never writes a reconfiguration record for a scheduled cluster (see
         // the routing below). Refuse flipping the schedule under an in-flight
         // record rather than let the two ownership regimes overlap mid-flight.
-        if cluster_controller_owns
-            && reconfiguration_in_flight
-            && !matches!(options.schedule, Unchanged)
-        {
+        if reconfiguration_in_flight && !matches!(options.schedule, Unchanged) {
             return Err(AdapterError::AlterClusterScheduleWhileReconfiguring);
         }
 
@@ -343,10 +333,7 @@ impl Coordinator {
         // flight would be silently clobbered at cut-over. Refused even when the
         // same statement also re-targets the shape, so a record's target
         // replication factor is always the one it started with.
-        if cluster_controller_owns
-            && reconfiguration_in_flight
-            && !matches!(options.replication_factor, Unchanged)
-        {
+        if reconfiguration_in_flight && !matches!(options.replication_factor, Unchanged) {
             return Err(AdapterError::AlterClusterReplicationFactorWhileReconfiguring);
         }
 
@@ -356,69 +343,65 @@ impl Coordinator {
         // the reshape path below to cancel the record.
         let cancels_or_retargets =
             reconfiguration_in_flight && alter_changes_replica_shape(options);
-        if new_config == config && !(cluster_controller_owns && cancels_or_retargets) {
+        if new_config == config && !cancels_or_retargets {
             return Ok(StageResult::Response(ExecuteResponse::AlteredObject(
                 ObjectType::Cluster,
             )));
         }
 
-        // When the controller owns the replica set, a shape-changing `ALTER`
-        // reshapes into a durable `reconfiguration` record (starting,
-        // retargeting, or cancelling one) instead of going through the legacy
-        // 3-stage machine. Everything else falls through to the realized-config
-        // update below without touching the record, in flight or not.
+        // A shape-changing `ALTER` reshapes into a durable `reconfiguration`
+        // record (starting, retargeting, or cancelling one) instead of going
+        // through the legacy 3-stage machine. Everything else falls through to
+        // the realized-config update below without touching the record, in
+        // flight or not.
         //
         // With a record in flight the statement decides: an `ALTER` back to the
         // realized shape is value-identical yet must reach the reshape path to
         // cancel. With nothing in flight the values decide: a shape option set
         // to its current value reconfigures nothing, and reshaping it anyway
         // would write a spurious pre-cancelled record.
-        if cluster_controller_owns {
-            if let (Managed(old_managed), Managed(new_managed)) =
-                (&config.variant, &new_config.variant)
-            {
-                let needs_record = if reconfiguration_in_flight {
-                    alter_changes_replica_shape(options)
-                } else {
-                    new_managed.replica_config_shape() != old_managed.replica_config_shape()
-                };
-                // A scheduled (non-MANUAL) cluster holds its replication factor
-                // at 0 and the on-refresh strategy owns its replica set, so a
-                // graceful hydrate-overlap has nothing meaningful to wait for.
-                // A config-shape `ALTER` on such a cluster takes the direct
-                // path below instead of writing a record: with the controller
-                // owning the cluster the direct path only updates the realized
-                // config, and the controller reconciles any in-window replica
-                // to the new shape on its next tick. The schedule guard above
-                // keeps a schedule change from reaching here mid-record, so a
-                // record on a scheduled cluster can only pre-date the schedule
-                // (written on an older version). For that case the reshape
-                // path stays reachable, so the record can still be retargeted
-                // or cancelled until it settles.
-                let scheduled_direct =
-                    !matches!(new_managed.schedule, mz_sql::plan::ClusterSchedule::Manual)
-                        && !reconfiguration_in_flight;
-                // A `WAIT` option would be silently vacuous on the direct
-                // path: there may be no replica at all (window closed), and
-                // an in-window replica is bounced to the new shape without a
-                // hydrate-overlap to wait on. Reject it rather than return an
-                // instant success that waited for nothing, mirroring the
-                // planner's rejection of a `WAIT` without a shape change.
-                if scheduled_direct && !matches!(strategy, AlterClusterPlanStrategy::None) {
-                    return Err(AdapterError::AlterClusterWaitOnScheduledCluster);
-                }
-                if needs_record && !scheduled_direct {
-                    return self
-                        .reshape_alter_cluster_managed(
-                            session,
-                            cluster_id,
-                            new_config.clone(),
-                            options,
-                            strategy,
-                            validity,
-                        )
-                        .await;
-                }
+        if let (Managed(old_managed), Managed(new_managed)) = (&config.variant, &new_config.variant)
+        {
+            let needs_record = if reconfiguration_in_flight {
+                alter_changes_replica_shape(options)
+            } else {
+                new_managed.replica_config_shape() != old_managed.replica_config_shape()
+            };
+            // A scheduled (non-MANUAL) cluster holds its replication factor
+            // at 0 and the on-refresh strategy owns its replica set, so a
+            // graceful hydrate-overlap has nothing meaningful to wait for.
+            // A config-shape `ALTER` on such a cluster takes the direct
+            // path below instead of writing a record: that path only updates
+            // the realized config, and the controller reconciles any in-window
+            // replica to the new shape on its next tick. The schedule guard
+            // above keeps a schedule change from reaching here mid-record, so a
+            // record on a scheduled cluster can only pre-date the schedule
+            // (written on an older version). For that case the reshape
+            // path stays reachable, so the record can still be retargeted
+            // or cancelled until it settles.
+            let scheduled_direct =
+                !matches!(new_managed.schedule, mz_sql::plan::ClusterSchedule::Manual)
+                    && !reconfiguration_in_flight;
+            // A `WAIT` option would be silently vacuous on the direct
+            // path: there may be no replica at all (window closed), and
+            // an in-window replica is bounced to the new shape without a
+            // hydrate-overlap to wait on. Reject it rather than return an
+            // instant success that waited for nothing, mirroring the
+            // planner's rejection of a `WAIT` without a shape change.
+            if scheduled_direct && !matches!(strategy, AlterClusterPlanStrategy::None) {
+                return Err(AdapterError::AlterClusterWaitOnScheduledCluster);
+            }
+            if needs_record && !scheduled_direct {
+                return self
+                    .reshape_alter_cluster_managed(
+                        session,
+                        cluster_id,
+                        new_config.clone(),
+                        options,
+                        strategy,
+                        validity,
+                    )
+                    .await;
             }
         }
 
@@ -530,8 +513,10 @@ impl Coordinator {
         cluster_id: ClusterId,
         target: &ReconfigurationTarget,
     ) -> Result<(), AdapterError> {
-        // Only user clusters are converged by the controller and counted against
-        // these limits. A system cluster never reshapes into a record.
+        // System clusters are exempt from `max_replicas_per_cluster` and from
+        // credit accounting everywhere else (see the `is_user` guards in
+        // `catalog_transact`'s validation), so a reconfiguration of one has no
+        // budget to fit either.
         if !cluster_id.is_user() {
             return Ok(());
         }
@@ -2004,7 +1989,7 @@ impl Coordinator {
             }
         }
 
-        // When the controller owns the managed replica set (a user cluster), a
+        // The controller owns the replica set of every managed cluster, so a
         // non-record change reaching this path is replication-factor only.
         // Config-shape changes (size/logging/AZ) are reshaped into a durable
         // reconfiguration record before they get here. The controller reconciles
@@ -2013,9 +1998,11 @@ impl Coordinator {
         // both fights the controller. It derives replica names from the observed
         // set, so an adapter create by canonical `rN` can collide with a
         // controller-chosen name, and an adapter drop by canonical `rN` can miss a
-        // churned one. For a system cluster, which the controller never owns, the
-        // direct path below still does the create/drop itself.
-        let controller_owns = cluster_id.is_user();
+        // churned one.
+        //
+        // The direct create/drop branches below are unreachable while this holds.
+        // They go together with the staged reconfiguration machine.
+        let controller_owns = true;
 
         // Count exactly as many replica ids as the branches below consume. The
         // config-changed branches recreate all replicas. A pure scale-up creates
@@ -2235,12 +2222,9 @@ impl Coordinator {
         }
 
         // If finalization is needed, finalization should update the cluster
-        // config. Otherwise the config write happens here. With the controller
-        // owning the cluster, a record still in progress belongs to a live,
-        // converging reconfiguration this write didn't touch: carry it through
-        // untouched. On a system cluster, which the controller never owns, such
-        // a record is orphaned, so retain it as cancelled with the matching
-        // audit intent rather than leave it behind for nothing to settle.
+        // config. Otherwise the config write happens here. A record still in
+        // progress belongs to a live, converging reconfiguration this write
+        // didn't touch, so carry it through untouched.
         match finalization_needed {
             NeedsFinalization::No => {
                 let mut new_config = new_config;
@@ -2600,10 +2584,9 @@ struct ReconfigurationDimensionsUnchanged {
 /// config write as cancelled, returning the audit intent to declare with the
 /// write.
 ///
-/// The direct write paths change the realized config themselves and settle no
-/// record. Carrying an in-progress one forward would leave it for a controller
-/// that does not own this cluster, so nothing would ever drive it to a terminal
-/// status.
+/// A direct write reshapes the replica set itself, superseding whatever target
+/// the record carries. Leaving the record in progress would have the controller
+/// keep converging on that stale target.
 fn cancel_carried_reconfiguration(config: &mut ClusterConfig) -> Option<ReconfigurationAudit> {
     let ClusterVariant::Managed(managed) = &mut config.variant else {
         return None;

--- a/src/environmentd/tests/bootstrap_builtin_clusters.rs
+++ b/src/environmentd/tests/bootstrap_builtin_clusters.rs
@@ -13,8 +13,17 @@
 //! single source of truth for its replica set. These tests pin that down from
 //! both directions: the factor a deployment bootstraps with is realized, and a
 //! factor an operator sets with `ALTER CLUSTER` survives a restart.
+//!
+//! Two writers realize that factor, at different times. At catalog open the
+//! builtin-replica migration converges the set synchronously, so a bootstrap or
+//! post-restart assertion can be exact. At runtime the cluster controller owns
+//! it and converges a tick after the `ALTER` commits, so an assertion right
+//! after an `ALTER` has to poll.
+
+use std::time::Duration;
 
 use mz_environmentd::test_util::{self, TestHarness, TestServerWithRuntime};
+use mz_ore::retry::Retry;
 
 /// A builtin cluster's declared replication factor and how many replicas it
 /// actually has.
@@ -33,6 +42,24 @@ fn declared_and_actual(server: &TestServerWithRuntime, cluster: &str) -> (i32, i
         )
         .unwrap();
     (row.get(0), row.get(1))
+}
+
+/// Polls [`declared_and_actual`] until it reads `expected`.
+///
+/// For assertions that follow a runtime `ALTER CLUSTER`, whose replica
+/// create/drop the cluster controller applies on a later tick.
+fn await_declared_and_actual(server: &TestServerWithRuntime, cluster: &str, expected: (i32, i32)) {
+    Retry::default()
+        .max_duration(Duration::from_secs(60))
+        .retry(|_| {
+            let actual = declared_and_actual(server, cluster);
+            if actual == expected {
+                Ok(())
+            } else {
+                Err(format!("{cluster}: got {actual:?}, want {expected:?}"))
+            }
+        })
+        .unwrap();
 }
 
 /// Runs `stmt` as `user` over the internal port, which is where the system roles
@@ -104,7 +131,7 @@ fn test_alter_to_zero_replicas_survives_restart() {
             "mz_system",
             "ALTER CLUSTER mz_system SET (REPLICATION FACTOR 0)",
         );
-        assert_eq!(declared_and_actual(&server, "mz_system"), (0, 0));
+        await_declared_and_actual(&server, "mz_system", (0, 0));
     }
 
     let server = harness.start_blocking();
@@ -124,7 +151,7 @@ fn test_alter_above_one_replica_survives_restart() {
             "mz_system",
             "ALTER CLUSTER mz_system SET (REPLICATION FACTOR 2)",
         );
-        assert_eq!(declared_and_actual(&server, "mz_system"), (2, 2));
+        await_declared_and_actual(&server, "mz_system", (2, 2));
     }
 
     let server = harness.start_blocking();
@@ -182,7 +209,7 @@ fn test_support_cluster_replica_survives_restart() {
             "mz_support",
             "ALTER CLUSTER mz_support SET (REPLICATION FACTOR 1)",
         );
-        assert_eq!(declared_and_actual(&server, "mz_support"), (1, 1));
+        await_declared_and_actual(&server, "mz_support", (1, 1));
     }
 
     let server = harness.start_blocking();

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -626,21 +626,26 @@ ALTER CLUSTER mz_system SET (REPLICATION FACTOR 1)
 ----
 COMPLETE 0
 
-# Replicas in system clusters should system IDs.
-
-simple conn=mz_system,user=mz_system
-ALTER CLUSTER mz_system SET (SIZE = 'scale=1,workers=2')
-----
-COMPLETE 0
+# The declared factor is written synchronously. The replica set itself is the
+# cluster controller's, converged on a later tick, so slt (which does not retry)
+# must not assert on it. `test/testdrive/system-cluster.td` covers convergence.
 
 query I
-SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'mz_system') AND id LIKE 's%';
+SELECT replication_factor FROM mz_clusters WHERE name = 'mz_system'
 ----
 1
 
-query I
-SELECT COUNT(*) FROM mz_cluster_replicas WHERE cluster_id = (SELECT id FROM mz_clusters WHERE name = 'mz_system') AND id LIKE 'u%';
+# Replicas of system clusters carry system ids. Asserted over mz_catalog_server,
+# whose replica this file never touches, so the row is there to check: a count
+# over mz_system alone would pass vacuously while its replica is being
+# reconciled. `test/testdrive/system-cluster.td` covers the id of a replica the
+# controller creates at runtime.
+
+query II
+SELECT COUNT(*), COUNT(*) FILTER (WHERE r.id LIKE 's%') FROM mz_cluster_replicas r
+JOIN mz_clusters c ON c.id = r.cluster_id
+WHERE c.name = 'mz_catalog_server';
 ----
-0
+1  1
 
 reset-server

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -113,6 +113,11 @@ mz_system r1 bootstrap <TRUE_OR_FALSE> ""
 ! ALTER CLUSTER mz_support SET (replication factor 1, size 'scale=1,workers=2');
 contains: must be owner of CLUSTER mz_support
 
+# The cluster controller owns a system cluster's replica set, so every ALTER
+# below lands its config synchronously and the replica set (and, for a
+# config-shape change, the realized config itself) converges on a later tick.
+# Every readback is a retrying `>` for that reason.
+
 $ postgres-execute connection=postgres://mz_support@${testdrive.materialize-internal-sql-addr}/materializeI
 ALTER CLUSTER mz_support SET (replication factor 0, SIZE 'scale=1,workers=1');
 
@@ -148,3 +153,62 @@ ALTER CLUSTER mz_support SET (introspection interval = '0s');
 
 > select name, introspection_debugging, introspection_interval from mz_catalog.mz_clusters where name = 'mz_support';
 mz_support true <null>
+
+# Convergence: the controller materializes and retires a system cluster's
+# replicas from its replication factor, and a config-shape change cuts the
+# realized config over once the target is up. The replicas it creates carry
+# system ids, like the ones the catalog-open migration creates.
+#
+# Every readback below is a retrying `>`, with room for a replica boot plus a
+# controller tick on a loaded CI host. `>` returns as soon as it matches, so the
+# budget is never actually slept.
+$ set-sql-timeout duration=120s
+
+$ postgres-execute connection=postgres://mz_support@${testdrive.materialize-internal-sql-addr}/materializeI
+ALTER CLUSTER mz_support SET (REPLICATION FACTOR 1);
+
+> SELECT count(*), bool_and(r.id LIKE 's%')
+  FROM mz_cluster_replicas r
+  JOIN mz_clusters c ON c.id = r.cluster_id
+  WHERE c.name = 'mz_support'
+1 true
+
+$ postgres-execute connection=postgres://mz_support@${testdrive.materialize-internal-sql-addr}/materializeI
+ALTER CLUSTER mz_support SET (SIZE 'scale=1,workers=2');
+
+> SELECT size FROM mz_clusters WHERE name = 'mz_support'
+scale=1,workers=2
+
+> SELECT r.size, count(*)
+  FROM mz_cluster_replicas r
+  JOIN mz_clusters c ON c.id = r.cluster_id
+  WHERE c.name = 'mz_support'
+  GROUP BY r.size
+scale=1,workers=2 1
+
+# The shape change really went through the graceful path: it left a settled
+# reconfiguration record behind, which is the capability system clusters did not
+# have before the controller owned them.
+
+> SELECT recon.status
+  FROM mz_internal.mz_cluster_reconfigurations recon
+  JOIN mz_clusters c ON c.id = recon.cluster_id
+  WHERE c.name = 'mz_support'
+finalized
+
+# Back to the default: no replica, and the cluster reports no activity, so the
+# reconfiguration above really did settle rather than park in progress.
+
+$ postgres-execute connection=postgres://mz_support@${testdrive.materialize-internal-sql-addr}/materializeI
+ALTER CLUSTER mz_support SET (REPLICATION FACTOR 0, SIZE 'scale=1,workers=1');
+
+> SELECT count(*)
+  FROM mz_cluster_replicas r
+  JOIN mz_clusters c ON c.id = r.cluster_id
+  WHERE c.name = 'mz_support'
+0
+
+> SELECT activity FROM (SHOW CLUSTERS) WHERE name = 'mz_support'
+<null>
+
+$ set-sql-timeout duration=default


### PR DESCRIPTION
Part 2 of 3 of the [design][design] for removing the legacy cluster paths.
Stacked on #38101. Part 3 stacks on this one.

[design]: https://github.com/MaterializeInc/materialize/blob/aljoscha/cluster-legacy-05-design/doc/developer/design/20260724_cluster_controller_legacy_removal.md

## Why

System/builtin clusters were excluded from the controller's ownership
(`ManagedClusterIds` and the sequencer's two ownership tests all required
`is_user()`), so the sequencer had to keep a second, complete
replica-materialization implementation alive just for them.

The exception was originally load-bearing: the boot-time builtin replica
migration and the controller would have been two conflicting writers of one
replica set. #37929 removed that conflict. `reconcile_builtin_cluster_replicas`
now converges a builtin cluster's replica set on the cluster's own managed
config, the same config the controller derives its targets from, so the two
converge on the same set by construction.

## What lands

Drop the three `is_user()` conjuncts. Runtime ALTERs of system clusters now
flow through the controller like any other managed cluster: a config-shape
change reshapes into a durable reconfiguration record, a factor change updates
the config and the controller converges the replica set within a tick.

Ownership and the boot migration compose in both directions. The controller
matches replicas by shape and count, never by name, so the migration-created
`r1..rN` satisfy its baseline and a steady system cluster reconciles to no
decisions. The migration converges by canonical name, so a boot after a reshape
(or with a reconfiguration in flight) renames or re-creates replicas the
controller materialized under generator names. That is harmless churn: every
replica is a cold process at boot anyway, so the cost is replica-id and
audit-log noise, and an in-flight record is durable, so the controller picks the
reconfiguration back up on its first tick.

Boot ordering and 0dt read-only behavior are unchanged.
`reconcile_builtin_cluster_replicas` still runs at catalog open, which is what
gets system clusters up and hydrated before the serve loop starts and before a
0dt cutover. The controller cannot cover either window: `Coordinator::bootstrap`
runs before the controller task is spawned, and the controller is inactive while
read-only.

Also rewrites the comment in `validate_reconfiguration_resource_limits`. The
early return for non-user clusters stays, since system clusters are exempt from
`max_replicas_per_cluster` and credit accounting everywhere else, but the reason
it gave ("a system cluster never reshapes into a record") is now false.

## Behavior changes

- `ALTER CLUSTER mz_system SET (SIZE ...)` goes from a synchronous whole-set
  recreation to a background graceful reconfiguration (default deadline 24h,
  `ROLLBACK` on timeout). Strictly more capable: the graceful path did not exist
  for system clusters before, and part 3 adds `WITH (WAIT FOR '0s')` for
  operators who cannot afford the overlap set.
- `ALTER CLUSTER mz_support SET (REPLICATION FACTOR 1)` updates the config and
  returns; the controller materializes the replica within a tick. Same as user
  clusters today.

## Tests

- `test/sqllogictest/system-cluster.slt`: the block asserting a replica count
  right after a factor flip is reworked. slt does not retry, so it now asserts
  the declared factor (synchronous) and phrases the system-id property as "no
  replica that isn't system-id'd", which holds regardless of convergence.
- `test/testdrive/system-cluster.td` (which does retry) picks up the
  convergence coverage: factor up materializes exactly one system-id replica,
  a `SIZE` reshape cuts the realized config over and leaves exactly one replica
  at the new size, and factor back to 0 retires it with no activity left behind.
- `src/environmentd/tests/bootstrap_builtin_clusters.rs`: the three assertions
  that immediately follow a runtime `ALTER CLUSTER` now poll
  (`await_declared_and_actual`). The bootstrap and post-restart assertions stay
  exact, since the catalog-open migration converges synchronously.
- `test/cluster/resources/resource-limits.td` already uses retrying queries for
  its `mz_analytics` factor flips, so it survives unchanged and pins the
  system-cluster limit exemption end to end.
- Docs: the self-managed troubleshooting guide's `mz_catalog_server` resize
  walkthrough gets a note that the resize is a graceful reconfiguration and
  `SHOW CLUSTERS` settles rather than flips.
