### PR TITLE
adapter: delete the staged cluster reconfiguration and direct replica paths

### DIFF
--- a/doc/developer/design/20260522_cluster_autoscaling.md
+++ b/doc/developer/design/20260522_cluster_autoscaling.md
@@ -19,6 +19,10 @@
 > - Resource exhaustion can terminate an active graceful reconfiguration as
 >   `ResourceExhausted`. A foreground `ALTER` reports insufficient resources.
 >   The baseline and hydration burst are not shed.
+> - The controller-owned implementation does not use `pending` as active
+>   replica lifecycle state. The durable field and catalog-open cleanup remain
+>   temporarily so an upgrade can reap a replica stranded by an older supported
+>   binary.
 
 ## The Problem
 

--- a/doc/user/content/reference/system-catalog/mz_internal.md
+++ b/doc/user/content/reference/system-catalog/mz_internal.md
@@ -354,7 +354,7 @@ The `mz_internal_cluster_replicas` table lists the replicas that are created and
 
 ## `mz_pending_cluster_replicas`
 
-The `mz_pending_cluster_replicas` table lists the replicas that were created during managed cluster alter statement that has not yet finished. The configurations of these replica may differ from the cluster's configuration.
+The `mz_pending_cluster_replicas` table is retained for upgrade compatibility with older versions that could create pending replicas during `ALTER CLUSTER`. Materialize removes inherited pending replicas during startup before serving queries, and current versions do not create them, so this table is empty during normal operation. Active reconfiguration targets appear as ordinary rows in [`mz_cluster_replicas`](../mz_catalog/#mz_cluster_replicas).
 
 <!-- RELATION_SPEC mz_internal.mz_pending_cluster_replicas -->
 | Field      | Type     | Meaning                                                                                                     |

--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -219,7 +219,7 @@ You can monitor a resize through the following:
 
 ##### Cancel a resize
 To **cancel** an in-flight resize, reissue `ALTER CLUSTER` with the cluster's
-current size. Materialize drops the pending replicas and keeps the current
+current size. Materialize drops the target replicas and keeps the current
 configuration.
 
 #### Downtime considerations for v26.34 or before

--- a/doc/user/data/examples/alter_cluster.yml
+++ b/doc/user/data/examples/alter_cluster.yml
@@ -197,4 +197,4 @@
     | Option | Description |
     |--------|-------------|
     | `TIMEOUT` | The maximum duration to wait for the new replicas to be ready. |
-    | `ON TIMEOUT` | The action to take on timeout. <br><ul><li><code>COMMIT</code> retires the old replicas and proceeds with the new ones regardless of their hydration status, which may lead to downtime.</li><li><code>ROLLBACK</code> removes the pending replicas and keeps the current configuration.</li></ul>Default: <code>ROLLBACK</code>. |
+    | `ON TIMEOUT` | The action to take on timeout. <br><ul><li><code>COMMIT</code> retires the old replicas and proceeds with the new ones regardless of their hydration status, which may lead to downtime.</li><li><code>ROLLBACK</code> removes the target replicas and keeps the current configuration.</li></ul>Default: <code>ROLLBACK</code>. |

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1447,8 +1447,14 @@ fn remove_invalid_config_param_role_defaults_migration(
     Ok(())
 }
 
-/// Cluster Replicas may be created ephemerally during an alter statement, these replicas
-/// are marked as pending and should be cleaned up on catalog open.
+/// Drops replicas left durably marked `pending`.
+///
+/// No runtime path creates one anymore. An upgrade can still come from a version
+/// whose staged reconfiguration machine crashed between the pending-create commit
+/// and the finalize, and those replicas are excluded from the cluster
+/// controller's ownership test, so this catalog-open sweep is their only
+/// remaining cleaner. It goes away together with the durable `pending` field,
+/// once no supported upgrade source can still write one.
 fn remove_pending_cluster_replicas_migration(
     tx: &mut Transaction,
     boot_ts: mz_repr::Timestamp,

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -242,11 +242,6 @@ pub enum Op {
         /// this write, alongside the record carried in `config`.
         burst_audit: Option<BurstAudit>,
     },
-    UpdateClusterReplicaConfig {
-        cluster_id: ClusterId,
-        replica_id: ReplicaId,
-        config: ReplicaConfig,
-    },
     UpdateItem {
         id: CatalogItemId,
         name: QualifiedItemName,
@@ -2927,24 +2922,6 @@ impl Catalog {
                         EventDetails::ClusterHydrationBurstV1(details),
                     )?;
                 }
-            }
-            Op::UpdateClusterReplicaConfig {
-                replica_id,
-                cluster_id,
-                config,
-            } => {
-                let replica = state.get_cluster_replica(cluster_id, replica_id).to_owned();
-                info!("update replica {}", replica.name);
-                tx.update_cluster_replica(
-                    replica_id,
-                    mz_catalog::durable::ClusterReplica {
-                        cluster_id,
-                        replica_id,
-                        name: replica.name.clone(),
-                        config: config.clone().into(),
-                        owner_id: replica.owner_id,
-                    },
-                )?;
             }
             Op::UpdateItem { id, name, to_item } => {
                 // A non-temporary item must not depend on a temporary one.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -106,8 +106,8 @@ use mz_catalog::config::{AwsPrincipalContext, BuiltinItemMigrationConfig, Cluste
 use mz_catalog::durable::OpenableDurableCatalogState;
 use mz_catalog::expr_cache::{GlobalExpressions, LocalExpressions};
 use mz_catalog::memory::objects::{
-    CatalogEntry, CatalogItem, ClusterReplicaProcessStatus, ClusterVariantManaged, Connection,
-    DataSourceDesc, ReconfigurationTarget, Table, TableDataSource,
+    CatalogEntry, CatalogItem, ClusterReplicaProcessStatus, Connection, DataSourceDesc,
+    ReconfigurationTarget, Table, TableDataSource,
 };
 use mz_cloud_resources::{CloudResourceController, VpcEndpointConfig, VpcEndpointEvent};
 use mz_compute_client::as_of_selection;
@@ -155,7 +155,7 @@ use mz_sql::names::{QualifiedItemName, ResolvedIds};
 use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::{
     self, AlterSinkPlan, ConnectionDetails, CreateConnectionPlan, HirRelationExpr,
-    NetworkPolicyRule, OnTimeoutAction, Params, QueryWhen,
+    NetworkPolicyRule, Params, QueryWhen,
 };
 use mz_sql::session::user::User;
 use mz_sql::session::vars::{MAX_CREDIT_CONSUMPTION_RATE, SystemVars, Var};
@@ -937,8 +937,6 @@ pub struct ExplainTimestampFinish {
 #[derive(Debug)]
 pub enum ClusterStage {
     Alter(AlterCluster),
-    WaitForHydrated(AlterClusterWaitForHydrated),
-    Finalize(AlterClusterFinalize),
     /// The foreground wait-shim over a controller-driven background
     /// reconfiguration: poll the durable `reconfiguration` record until it
     /// clears, then report success or timeout depending on whether the realized
@@ -950,24 +948,6 @@ pub enum ClusterStage {
 pub struct AlterCluster {
     validity: PlanValidity,
     plan: plan::AlterClusterPlan,
-}
-
-#[derive(Debug)]
-pub struct AlterClusterWaitForHydrated {
-    validity: PlanValidity,
-    plan: plan::AlterClusterPlan,
-    new_config: ClusterVariantManaged,
-    workload_class: Option<String>,
-    timeout_time: Instant,
-    on_timeout: OnTimeoutAction,
-}
-
-#[derive(Debug)]
-pub struct AlterClusterFinalize {
-    validity: PlanValidity,
-    plan: plan::AlterClusterPlan,
-    new_config: ClusterVariantManaged,
-    workload_class: Option<String>,
 }
 
 #[derive(Debug)]
@@ -1403,10 +1383,6 @@ pub struct ConnMeta {
     /// Lock for the Coordinator's deferred statements that is dropped on transaction clear.
     #[serde(skip)]
     deferred_lock: Option<OwnedMutexGuard<()>>,
-
-    /// Cluster reconfigurations that will need to be
-    /// cleaned up when the current transaction is cleared
-    pending_cluster_alters: BTreeSet<ClusterId>,
 
     /// Channel on which to send notices to a session.
     #[serde(skip)]

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -883,7 +883,6 @@ impl Coordinator {
                     secret_key,
                     notice_tx,
                     drop_sinks: BTreeSet::new(),
-                    pending_cluster_alters: BTreeSet::new(),
                     connected_at: self.now(),
                     user,
                     application_name,
@@ -2054,8 +2053,6 @@ impl Coordinator {
         // SQL cancellation has no success response to delay. Each subscribe
         // still waits for its own retraction before it observes retirement.
         drop(retire_notify);
-        self.cancel_cluster_reconfigurations_for_conn(&conn_id)
-            .await;
         self.cancel_pending_copy(&conn_id);
         if let Some((tx, _rx)) = self.connection_cancel_watches.get_mut(&conn_id) {
             let _ = tx.send(true);

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -51,7 +51,7 @@ use serde_json::json;
 use tracing::{Instrument, Level, event, info_span, warn};
 
 use crate::active_compute_sink::{ActiveComputeSink, ActiveComputeSinkRetireReason};
-use crate::catalog::{DropObjectInfo, Op, ReplicaCreateDropReason, TransactionResult};
+use crate::catalog::{DropObjectInfo, Op, TransactionResult};
 use crate::coord::Coordinator;
 use crate::coord::appends::{BuiltinTableAppendCompletion, BuiltinTableAppendNotify};
 use crate::coord::catalog_implications::parsed_state_updates::ParsedStateUpdate;
@@ -890,43 +890,6 @@ impl Coordinator {
         }))
     }
 
-    /// Drops all pending replicas for a set of clusters
-    /// that are undergoing reconfiguration.
-    pub async fn drop_reconfiguration_replicas(
-        &mut self,
-        cluster_ids: BTreeSet<ClusterId>,
-    ) -> Result<(), AdapterError> {
-        let pending_cluster_ops: Vec<Op> = cluster_ids
-            .iter()
-            .map(|c| {
-                self.catalog()
-                    .get_cluster(c.clone())
-                    .replicas()
-                    .filter_map(|r| match r.config.location {
-                        ReplicaLocation::Managed(ref l) if l.pending => {
-                            Some(DropObjectInfo::ClusterReplica((
-                                c.clone(),
-                                r.replica_id,
-                                ReplicaCreateDropReason::Manual,
-                            )))
-                        }
-                        _ => None,
-                    })
-                    .collect::<Vec<DropObjectInfo>>()
-            })
-            .filter_map(|pending_replica_drop_ops_by_cluster| {
-                match pending_replica_drop_ops_by_cluster.len() {
-                    0 => None,
-                    _ => Some(Op::DropObjects(pending_replica_drop_ops_by_cluster)),
-                }
-            })
-            .collect();
-        if !pending_cluster_ops.is_empty() {
-            self.catalog_transact(None, pending_cluster_ops).await?;
-        }
-        Ok(())
-    }
-
     /// Cancels all active compute sinks for the identified connection.
     #[mz_ore::instrument(level = "debug")]
     pub(crate) async fn cancel_compute_sinks_for_conn(
@@ -935,15 +898,6 @@ impl Coordinator {
     ) -> BuiltinTableAppendCompletion {
         self.retire_compute_sinks_for_conn(conn_id, ActiveComputeSinkRetireReason::Canceled)
             .await
-    }
-
-    /// Cancels all active cluster reconfigurations sinks for the identified connection.
-    #[mz_ore::instrument(level = "debug")]
-    pub(crate) async fn cancel_cluster_reconfigurations_for_conn(
-        &mut self,
-        conn_id: &ConnectionId,
-    ) {
-        self.retire_cluster_reconfigurations_for_conn(conn_id).await
     }
 
     /// Retires all active compute sinks for the identified connection with the
@@ -963,30 +917,6 @@ impl Coordinator {
             .map(|sink_id| (*sink_id, reason.clone()))
             .collect();
         self.retire_compute_sinks(drop_sinks).await
-    }
-
-    /// Cleans pending cluster reconfiguraiotns for the identified connection
-    #[mz_ore::instrument(level = "debug")]
-    pub(crate) async fn retire_cluster_reconfigurations_for_conn(
-        &mut self,
-        conn_id: &ConnectionId,
-    ) {
-        let reconfiguring_clusters = self
-            .active_conns
-            .get(conn_id)
-            .expect("must exist for active session")
-            .pending_cluster_alters
-            .clone();
-        // try to drop reconfig replicas
-        self.drop_reconfiguration_replicas(reconfiguring_clusters)
-            .await
-            .unwrap_or_terminate("cannot fail to drop reconfiguration replicas");
-
-        self.active_conns
-            .get_mut(conn_id)
-            .expect("must exist for active session")
-            .pending_cluster_alters
-            .clear();
     }
 
     pub(crate) fn drop_storage_sinks(&mut self, sink_gids: Vec<GlobalId>) {
@@ -1462,7 +1392,6 @@ impl Coordinator {
                 | Op::UpdateOwner { .. }
                 | Op::RevokeRole { .. }
                 | Op::UpdateClusterConfig { .. }
-                | Op::UpdateClusterReplicaConfig { .. }
                 | Op::UpdateSourceReferences { .. }
                 | Op::UpdateSystemConfiguration { .. }
                 | Op::ResetSystemConfiguration { .. }

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -7,22 +7,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::time::{Duration, Instant};
+use std::collections::BTreeSet;
+use std::time::Duration;
 
 use itertools::Itertools;
-use maplit::btreeset;
 use mz_adapter_types::cluster_state::ReconfigurationAudit;
 use mz_catalog::builtin::BUILTINS;
 use mz_catalog::durable::managed_cluster_replica_name;
 use mz_catalog::memory::error::ErrorKind;
 use mz_catalog::memory::objects::{
-    Cluster, ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged, DataSourceDesc,
+    Cluster, ClusterConfig, ClusterVariant, ClusterVariantManaged, DataSourceDesc,
     ManagedReplicaConfigShape, ReconfigurationState, ReconfigurationStatus, ReconfigurationTarget,
 };
 use mz_compute_types::config::ComputeReplicaConfig;
 use mz_controller::clusters::{
-    ClusterStatus, ManagedReplicaLocation, ReplicaConfig, ReplicaLocation, ReplicaLogging,
+    ManagedReplicaLocation, ReplicaConfig, ReplicaLocation, ReplicaLogging,
 };
 use mz_controller_types::{ClusterId, DEFAULT_REPLICA_LOGGING_INTERVAL, ReplicaId};
 use mz_ore::cast::CastFrom;
@@ -31,14 +30,13 @@ use mz_ore::instrument;
 use mz_repr::Timestamp;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::role_id::RoleId;
-use mz_sql::ast::{Ident, QualifiedReplica};
 use mz_sql::catalog::{CatalogCluster, CatalogError, ObjectType};
 use mz_sql::names::QualifiedItemName;
 use mz_sql::plan::{
     self, AlterClusterPlanStrategy, AlterClusterRenamePlan, AlterClusterReplicaRenamePlan,
-    AlterClusterSwapPlan, AlterOptionParameter, AlterSetClusterPlan,
-    ComputeReplicaIntrospectionConfig, CreateClusterManagedPlan, CreateClusterPlan,
-    CreateClusterReplicaPlan, CreateClusterUnmanagedPlan, CreateClusterVariant, PlanClusterOption,
+    AlterClusterSwapPlan, AlterOptionParameter, AlterSetClusterPlan, CreateClusterManagedPlan,
+    CreateClusterPlan, CreateClusterReplicaPlan, CreateClusterUnmanagedPlan, CreateClusterVariant,
+    PlanClusterOption,
 };
 use mz_sql::plan::{AlterClusterPlan, OnTimeoutAction};
 use mz_sql::session::metadata::SessionMetadata;
@@ -46,23 +44,19 @@ use mz_sql::session::vars::{
     MAX_CREDIT_CONSUMPTION_RATE, MAX_REPLICAS_PER_CLUSTER, SystemVars, Var,
 };
 use mz_storage_types::sources::SourceConnection;
-use tracing::{Instrument, Span, debug};
+use tracing::{Instrument, Span};
 
 use mz_adapter_types::dyncfgs::{
     DEFAULT_CLUSTER_RECONFIGURATION_TIMEOUT, ENABLE_BACKGROUND_ALTER_CLUSTER,
 };
 
 use super::return_if_err;
-use crate::AdapterError::AlterClusterWhilePendingReplicas;
 use crate::catalog::{self, Op, ReplicaCreateDropReason};
 use crate::coord::{
-    AlterCluster, AlterClusterAwaitReconfiguration, AlterClusterFinalize,
-    AlterClusterWaitForHydrated, ClusterReplicaStatuses, ClusterStage, Coordinator, Message,
+    AlterCluster, AlterClusterAwaitReconfiguration, ClusterStage, Coordinator, Message,
     PlanValidity, StageResult, Staged,
 };
 use crate::{AdapterError, AdapterNotice, ExecuteContext, ExecuteResponse, session::Session};
-
-const PENDING_REPLICA_SUFFIX: &str = "-pending";
 
 impl Staged for ClusterStage {
     type Ctx = ExecuteContext;
@@ -70,8 +64,6 @@ impl Staged for ClusterStage {
     fn validity(&mut self) -> &mut PlanValidity {
         match self {
             Self::Alter(stage) => &mut stage.validity,
-            Self::WaitForHydrated(stage) => &mut stage.validity,
-            Self::Finalize(stage) => &mut stage.validity,
             Self::AwaitReconfiguration(stage) => &mut stage.validity,
         }
     }
@@ -85,37 +77,6 @@ impl Staged for ClusterStage {
             Self::Alter(stage) => {
                 coord
                     .sequence_alter_cluster_stage(ctx.session(), stage.plan.clone(), stage.validity)
-                    .await
-            }
-            Self::WaitForHydrated(stage) => {
-                let AlterClusterWaitForHydrated {
-                    validity,
-                    plan,
-                    new_config,
-                    workload_class,
-                    timeout_time,
-                    on_timeout,
-                } = stage;
-                coord
-                    .check_if_pending_replicas_hydrated_stage(
-                        ctx.session(),
-                        plan,
-                        new_config,
-                        workload_class,
-                        timeout_time,
-                        on_timeout,
-                        validity,
-                    )
-                    .await
-            }
-            Self::Finalize(stage) => {
-                coord
-                    .finalize_alter_cluster_stage(
-                        ctx.session(),
-                        stage.plan.clone(),
-                        stage.new_config.clone(),
-                        stage.workload_class.clone(),
-                    )
                     .await
             }
             Self::AwaitReconfiguration(stage) => {
@@ -433,70 +394,15 @@ impl Coordinator {
         }
 
         match (&config.variant, &new_config.variant) {
-            (Managed(_), Managed(new_config_managed)) => {
-                let alter_followup = self
-                    .sequence_alter_cluster_managed_to_managed(
-                        Some(session),
-                        cluster_id,
-                        new_config.clone(),
-                        ReplicaCreateDropReason::Manual,
-                        strategy.clone(),
-                    )
-                    .await?;
+            (Managed(_), Managed(_)) => {
+                self.sequence_alter_cluster_managed_to_managed(
+                    session,
+                    cluster_id,
+                    new_config.clone(),
+                )
+                .await?;
                 if let Some(notice) = single_replica_sources_notice {
                     session.add_notice(notice);
-                }
-                if alter_followup == NeedsFinalization::Yes {
-                    // For non backgrounded zero-downtime alters, store the
-                    // cluster_id in the ConnMeta to allow for cancellation.
-                    self.active_conns
-                        .get_mut(session.conn_id())
-                        .expect("There must be an active connection")
-                        .pending_cluster_alters
-                        .insert(cluster_id.clone());
-                    let new_config_managed = new_config_managed.clone();
-                    return match &strategy {
-                        AlterClusterPlanStrategy::None => Err(AdapterError::Internal(
-                            "AlterClusterPlanStrategy must not be None if NeedsFinalization is Yes"
-                                .into(),
-                        )),
-                        AlterClusterPlanStrategy::For(duration) => {
-                            let span = Span::current();
-                            let plan = plan.clone();
-                            let duration = duration.clone().to_owned();
-                            let workload_class = new_config.workload_class.clone();
-                            Ok(StageResult::Handle(mz_ore::task::spawn(
-                                || "Finalize Alter Cluster",
-                                async move {
-                                    tokio::time::sleep(duration).await;
-                                    let stage = ClusterStage::Finalize(AlterClusterFinalize {
-                                        validity,
-                                        plan,
-                                        new_config: new_config_managed,
-                                        workload_class,
-                                    });
-                                    Ok(Box::new(stage))
-                                }
-                                .instrument(span),
-                            )))
-                        }
-                        AlterClusterPlanStrategy::UntilReady {
-                            timeout,
-                            on_timeout,
-                        } => Ok(StageResult::Immediate(Box::new(
-                            ClusterStage::WaitForHydrated(AlterClusterWaitForHydrated {
-                                validity,
-                                plan: plan.clone(),
-                                new_config: new_config_managed.clone(),
-                                workload_class: new_config.workload_class.clone(),
-                                timeout_time: Instant::now() + timeout.to_owned(),
-                                // The legacy foreground wait uses COMMIT as
-                                // its implicit default. The controller-owned
-                                // paths default to ROLLBACK.
-                                on_timeout: on_timeout.unwrap_or(OnTimeoutAction::Commit),
-                            }),
-                        ))),
-                    };
                 }
             }
             (Unmanaged, Managed(new_managed)) => {
@@ -681,7 +587,7 @@ impl Coordinator {
         // its target may already have. `ROLLBACK` (the default) reverts an
         // un-hydrated reconfiguration to its pre-reconfiguration shape rather
         // than cutting over to a not-yet-hydrated target, which could induce
-        // downtime. The legacy foreground path uses implicit `COMMIT`.
+        // downtime.
         let now = self.now();
         let deadline_from = |timeout: Duration| -> Timestamp {
             now.saturating_add(u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX))
@@ -856,259 +762,6 @@ impl Coordinator {
         }
     }
 
-    async fn finalize_alter_cluster_stage(
-        &mut self,
-        session: &Session,
-        AlterClusterPlan {
-            id: cluster_id,
-            name: cluster_name,
-            ..
-        }: AlterClusterPlan,
-        new_config: ClusterVariantManaged,
-        workload_class: Option<String>,
-    ) -> Result<StageResult<Box<ClusterStage>>, AdapterError> {
-        let cluster = self.catalog.get_cluster(cluster_id);
-        let mut ops = vec![];
-
-        // Gather the ops to remove the non pending replicas
-        // Also skip any billed_as free replicas
-        let remove_replicas = cluster
-            .replicas()
-            .filter_map(|r| {
-                if !r.config.location.pending() && !r.config.location.internal() {
-                    Some(catalog::DropObjectInfo::ClusterReplica((
-                        cluster_id.clone(),
-                        r.replica_id,
-                        ReplicaCreateDropReason::Manual,
-                    )))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        ops.push(catalog::Op::DropObjects(remove_replicas));
-
-        // Gather the Ops to remove the "-pending" suffix from the name and set
-        // pending to false
-        let finalize_replicas: Vec<catalog::Op> = cluster
-            .replicas()
-            .filter_map(|r| {
-                if r.config.location.pending() {
-                    let cluster_ident = match Ident::new(cluster.name.clone()) {
-                        Ok(id) => id,
-                        Err(err) => {
-                            return Some(Err(AdapterError::internal(
-                                "Unexpected error parsing cluster name",
-                                err,
-                            )));
-                        }
-                    };
-                    let replica_ident = match Ident::new(r.name.clone()) {
-                        Ok(id) => id,
-                        Err(err) => {
-                            return Some(Err(AdapterError::internal(
-                                "Unexpected error parsing replica name",
-                                err,
-                            )));
-                        }
-                    };
-                    Some(Ok((cluster_ident, replica_ident, r)))
-                } else {
-                    None
-                }
-            })
-            // Early collection is to handle errors from generating of the
-            // Idents
-            .collect::<Result<Vec<(Ident, Ident, &ClusterReplica)>, _>>()?
-            .into_iter()
-            .map(|(cluster_ident, replica_ident, replica)| {
-                let mut new_replica_config = replica.config.clone();
-                debug!("Promoting replica: {}", replica.name);
-                match new_replica_config.location {
-                    mz_controller::clusters::ReplicaLocation::Managed(ManagedReplicaLocation {
-                        ref mut pending,
-                        ..
-                    }) => {
-                        *pending = false;
-                    }
-                    mz_controller::clusters::ReplicaLocation::Unmanaged(_) => {}
-                }
-
-                let mut replica_ops = vec![];
-                let to_name = replica.name.strip_suffix(PENDING_REPLICA_SUFFIX);
-                if let Some(to_name) = to_name {
-                    replica_ops.push(catalog::Op::RenameClusterReplica {
-                        cluster_id: cluster_id.clone(),
-                        replica_id: replica.replica_id.to_owned(),
-                        name: QualifiedReplica {
-                            cluster: cluster_ident,
-                            replica: replica_ident,
-                        },
-                        to_name: to_name.to_owned(),
-                    });
-                }
-                replica_ops.push(catalog::Op::UpdateClusterReplicaConfig {
-                    cluster_id,
-                    replica_id: replica.replica_id.to_owned(),
-                    config: new_replica_config,
-                });
-                replica_ops
-            })
-            .flatten()
-            .collect();
-
-        ops.extend(finalize_replicas);
-
-        // Add the Op to update the cluster state. A stale in-progress
-        // reconfiguration record carried by this legacy write is retained as
-        // cancelled, with the matching audit intent declared.
-        let mut final_config = ClusterConfig {
-            variant: ClusterVariant::Managed(new_config),
-            workload_class: workload_class.clone(),
-        };
-        let reconfiguration_audit = cancel_carried_reconfiguration(&mut final_config);
-        ops.push(Op::UpdateClusterConfig {
-            id: cluster_id,
-            name: cluster_name,
-            config: final_config,
-            reconfiguration_audit,
-            burst_audit: None,
-        });
-        self.catalog_transact(Some(session), ops).await?;
-        // Remove the cluster being altered from the ConnMeta
-        // pending_cluster_alters BTreeSet
-        self.active_conns
-            .get_mut(session.conn_id())
-            .expect("There must be an active connection")
-            .pending_cluster_alters
-            .remove(&cluster_id);
-
-        Ok(StageResult::Response(ExecuteResponse::AlteredObject(
-            ObjectType::Cluster,
-        )))
-    }
-
-    async fn check_if_pending_replicas_hydrated_stage(
-        &mut self,
-        session: &Session,
-        plan: AlterClusterPlan,
-        new_config: ClusterVariantManaged,
-        workload_class: Option<String>,
-        timeout_time: Instant,
-        on_timeout: OnTimeoutAction,
-        validity: PlanValidity,
-    ) -> Result<StageResult<Box<ClusterStage>>, AdapterError> {
-        // wait and re-signal wait for hydrated if not hydrated
-        let cluster = self.catalog.get_cluster(plan.id);
-        let pending_replicas = cluster
-            .replicas()
-            .filter_map(|r| {
-                if r.config.location.pending() {
-                    Some(r.replica_id.clone())
-                } else {
-                    None
-                }
-            })
-            .collect_vec();
-        // Check For timeout
-        if Instant::now() > timeout_time {
-            // Timed out handle timeout action
-            match on_timeout {
-                OnTimeoutAction::Rollback => {
-                    self.active_conns
-                        .get_mut(session.conn_id())
-                        .expect("There must be an active connection")
-                        .pending_cluster_alters
-                        .remove(&cluster.id);
-                    self.drop_reconfiguration_replicas(btreeset!(cluster.id))
-                        .await?;
-                    return Err(AdapterError::AlterClusterTimeout);
-                }
-                OnTimeoutAction::Commit => {
-                    let span = Span::current();
-                    let poll_duration = self
-                        .catalog
-                        .system_config()
-                        .cluster_alter_check_ready_interval()
-                        .clone();
-                    return Ok(StageResult::Handle(mz_ore::task::spawn(
-                        || "Finalize Alter Cluster",
-                        async move {
-                            tokio::time::sleep(poll_duration).await;
-                            let stage = ClusterStage::Finalize(AlterClusterFinalize {
-                                validity,
-                                plan,
-                                new_config,
-                                workload_class,
-                            });
-                            Ok(Box::new(stage))
-                        }
-                        .instrument(span),
-                    )));
-                }
-            }
-        }
-        let compute_hydrated_fut = self
-            .controller
-            .compute
-            .collections_hydrated_for_replicas(cluster.id, pending_replicas.clone(), [].into())
-            .map_err(|e| AdapterError::internal("Failed to check hydration", e))?;
-
-        let storage_hydrated = self
-            .controller
-            .storage
-            .collections_hydrated_on_replicas(
-                Some(pending_replicas.clone()),
-                &cluster.id,
-                &[].into(),
-            )
-            .map_err(|e| AdapterError::internal("Failed to check hydration", e))?;
-
-        // Also require every pending replica to be online, in case it has no
-        // objects that need hydration on it (e.g. a single-replica source).
-        let replicas_online = pending_replicas.iter().all(|replica_id| {
-            let status = self
-                .cluster_replica_statuses
-                .try_get_cluster_replica_statuses(cluster.id, *replica_id)
-                .map(ClusterReplicaStatuses::cluster_replica_status);
-            matches!(status, Some(ClusterStatus::Online))
-        });
-
-        let span = Span::current();
-        Ok(StageResult::Handle(mz_ore::task::spawn(
-            || "Alter Cluster: wait for hydrated",
-            async move {
-                let compute_hydrated = compute_hydrated_fut
-                    .await
-                    .map_err(|e| AdapterError::internal("Failed to check hydration", e))?;
-
-                if compute_hydrated && storage_hydrated && replicas_online {
-                    // We're done
-                    Ok(Box::new(ClusterStage::Finalize(AlterClusterFinalize {
-                        validity,
-                        plan,
-                        new_config: new_config.clone(),
-                        workload_class: workload_class.clone(),
-                    })))
-                } else {
-                    // Check later
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                    let stage = ClusterStage::WaitForHydrated(AlterClusterWaitForHydrated {
-                        validity,
-                        plan,
-                        new_config,
-                        workload_class,
-                        timeout_time,
-                        on_timeout,
-                    });
-                    Ok(Box::new(stage))
-                }
-            }
-            .instrument(span),
-        )))
-    }
-
-    #[mz_ore::instrument(level = "debug")]
     pub(crate) async fn sequence_create_cluster(
         &mut self,
         session: &Session,
@@ -1533,10 +1186,8 @@ impl Coordinator {
     /// replication-factor domain. Replicas belonging to a reconfiguration's
     /// hydrate-overlap are deliberately not counted: they replace the serving
     /// set at cut-over rather than adding to it. Counting the replication
-    /// factor instead of replicas excludes them under both reconfiguration
-    /// mechanisms, the legacy graceful alter (which marks them pending) and
-    /// the cluster controller (which creates them as ordinary replicas of the
-    /// target shape).
+    /// factor instead of replicas excludes the ordinary replicas the cluster
+    /// controller creates for the target shape.
     fn notice_relevant_replica_count(&self, cluster: &Cluster) -> usize {
         match &cluster.config.variant {
             ClusterVariant::Managed(managed) => {
@@ -1763,9 +1414,14 @@ impl Coordinator {
         }
     }
 
-    /// When this is called by the automated cluster scheduling, `scheduling_decision_reason` should
-    /// contain information on why is a cluster being turned On/Off. It will be forwarded to the
-    /// `details` field of the audit log event that records creating or dropping replicas.
+    /// Applies a managed→managed `ALTER CLUSTER`.
+    ///
+    /// This is a config-only write: the cluster controller owns the replica set
+    /// and reconciles it to the new realized config on its next tick. Emitting
+    /// creates and drops here as well would fight it, since it derives replica
+    /// names from the observed set, so an adapter create by canonical `rN` can
+    /// collide with a controller-chosen name and an adapter drop by canonical
+    /// `rN` can miss a churned one.
     ///
     /// # Panics
     ///
@@ -1773,18 +1429,12 @@ impl Coordinator {
     /// Panics if `new_config` is not a configuration for a managed cluster.
     pub(crate) async fn sequence_alter_cluster_managed_to_managed(
         &mut self,
-        session: Option<&Session>,
+        session: &Session,
         cluster_id: ClusterId,
         new_config: ClusterConfig,
-        reason: ReplicaCreateDropReason,
-        strategy: AlterClusterPlanStrategy,
-    ) -> Result<NeedsFinalization, AdapterError> {
+    ) -> Result<(), AdapterError> {
         let cluster = self.catalog.get_cluster(cluster_id);
         let name = cluster.name().to_string();
-        let owner_id = cluster.owner_id();
-
-        let mut ops = vec![];
-        let mut finalization_needed = NeedsFinalization::No;
 
         let ClusterVariant::Managed(ClusterVariantManaged {
             size,
@@ -1801,14 +1451,6 @@ impl Coordinator {
         else {
             panic!("expected existing managed cluster config");
         };
-        // Clone the existing managed config out of the cluster so the immutable
-        // catalog borrow can be released before the out-of-band replica id
-        // allocation below, which needs mutable access to self.
-        let size = size.clone();
-        let availability_zones = availability_zones.clone();
-        let logging = logging.clone();
-        let arrangement_compression = *arrangement_compression;
-        let replication_factor = *replication_factor;
         let ClusterVariant::Managed(new_managed) = &new_config.variant else {
             panic!("expected new managed cluster config");
         };
@@ -1816,8 +1458,8 @@ impl Coordinator {
             size: new_size,
             replication_factor: new_replication_factor,
             availability_zones: new_availability_zones,
-            logging: new_logging,
-            arrangement_compression: new_arrangement_compression,
+            logging: _,
+            arrangement_compression: _,
             optimizer_feature_overrides: _,
             schedule: _,
             auto_scaling_strategy: new_auto_scaling_strategy,
@@ -1825,7 +1467,7 @@ impl Coordinator {
             burst: _,
         } = new_managed;
 
-        let role_id = session.map(|s| s.role_metadata().current_role);
+        let role_id = Some(session.role_metadata().current_role);
         self.catalog.ensure_valid_replica_size(
             &self.catalog().get_role_allowed_cluster_sizes(&role_id),
             new_size,
@@ -1864,49 +1506,18 @@ impl Coordinator {
             }
         }
 
-        // check for active updates
-        if cluster.replicas().any(|r| r.config.location.pending()) {
-            return Err(AlterClusterWhilePendingReplicas);
-        }
-
-        // Resolve existing replica ids by name before releasing the catalog
-        // borrow, so the drop branches below can build their ops without it.
-        let replica_id_by_name: BTreeMap<String, ReplicaId> = cluster
-            .replicas()
-            .map(|r| (r.name.clone(), r.replica_id))
-            .collect();
-        // The cluster's observed owned replica set, with the same exclusions
-        // as the controller's ownership test: internal and billed-as replicas
-        // are manually managed, pending ones belong to an in-flight
-        // reconfiguration (rejected above, so none exist here).
-        let owned_replica_ids: Vec<ReplicaId> = cluster
-            .replicas()
-            .filter(|r| {
-                !r.config.location.internal()
-                    && r.config.location.billed_as().is_none()
-                    && !r.config.location.pending()
-            })
-            .map(|r| r.replica_id)
-            .collect();
-
-        let compute = mz_sql::plan::ComputeReplicaConfig {
-            introspection: new_logging
-                .interval
-                .map(|interval| ComputeReplicaIntrospectionConfig {
-                    debugging: new_logging.log_logging,
-                    interval,
-                }),
-            arrangement_compression: *new_arrangement_compression,
-        };
-
-        // A replication-factor-only increase changes the committed baseline,
-        // which the controller cannot shed. Validate that floor without trying
-        // to predict the controller's transient strategy union. Concrete create
-        // transactions still validate the complete physical replica set.
-        if *new_replication_factor > replication_factor && cluster_id.is_user() {
+        // The committed baseline is an exact count, not a prediction of the
+        // controller's transient strategy union, and no strategy can shed it.
+        // Validate it here: `Op::UpdateClusterConfig` contributes nothing to
+        // `catalog_transact`'s replica accounting, because the controller
+        // materializes the replicas on a later tick rather than this transaction
+        // emitting creates. Without the check the ALTER would succeed and the
+        // controller would then fail its own create transaction on every tick.
+        // See database-issues#6046.
+        if new_replication_factor > replication_factor && cluster_id.is_user() {
             self.validate_resource_limit(
-                usize::cast_from(replication_factor),
-                i64::from(*new_replication_factor) - i64::from(replication_factor),
+                usize::cast_from(*replication_factor),
+                i64::from(*new_replication_factor) - i64::from(*replication_factor),
                 SystemVars::max_replicas_per_cluster,
                 "cluster replica",
                 MAX_REPLICAS_PER_CLUSTER.name(),
@@ -1933,206 +1544,32 @@ impl Coordinator {
             )?;
         }
 
-        // The controller owns the replica set of every managed cluster, so a
-        // non-record change reaching this path is replication-factor only.
-        // Config-shape changes (size, logging, AZ, and EXPERIMENTAL ARRANGEMENT
-        // COMPRESSION) are reshaped into a durable reconfiguration record before
-        // they get here. The controller reconciles the replica set to the realized
-        // config's new count on its next tick. We update only the realized config
-        // and emit no create/drop here because doing both fights the controller.
-        // It derives replica names from the observed set, so an adapter create by
-        // canonical `rN` can collide with a controller-chosen name. An adapter drop
-        // by canonical `rN` can miss a churned one.
-        //
-        // The direct create/drop branches below are unreachable while this holds.
-        // They go together with the staged reconfiguration machine.
-        let controller_owns = true;
-
-        // Count exactly as many replica ids as the branches below consume. The
-        // config-changed branches recreate all replicas. A pure scale-up creates
-        // only the delta. Scale-down and no-op create none. A controller-owned
-        // alter emits no create/drop at all, so it must not allocate. Allocating
-        // there burns those ids durably and throws them away. The controller
-        // allocates its own when it materializes the change.
         let config_changed = new_managed.replica_config_shape()
             != ManagedReplicaConfigShape::new(
-                &size,
-                &availability_zones,
-                &logging,
-                arrangement_compression,
+                size,
+                availability_zones,
+                logging,
+                *arrangement_compression,
             );
-        let needed_replica_ids = if controller_owns {
-            0
-        } else if config_changed {
-            *new_replication_factor
-        } else if *new_replication_factor > replication_factor {
-            *new_replication_factor - replication_factor
-        } else {
-            0
-        };
-        // Allocate the replica ids out-of-band via the durable allocator. Pick
-        // the id type from the target cluster, which may be a system cluster.
-        // This mirrors how cluster and item ids are allocated, so nothing
-        // allocates a replica id in-apply. Fetch the catalog write timestamp
-        // lazily here, since it needs mutable access to self (the cluster borrow
-        // above is already released) and scale-down, no-op, and automated
-        // scheduling turn-off alters must not pay an oracle round-trip just to
-        // allocate nothing.
-        let mut new_replica_ids = if needed_replica_ids > 0 {
-            let id_ts = self.get_catalog_write_ts().await;
-            let ids = self
-                .catalog()
-                .allocate_replica_ids(cluster_id, u64::from(needed_replica_ids), id_ts)
-                .await?;
-            ids.into_iter()
-        } else {
-            Vec::<ReplicaId>::new().into_iter()
-        };
-
-        if controller_owns {
-            // Defer all replica create/drop to the controller. Only the realized
-            // config update below is applied here. The target must still be
-            // valid: the controller creates replicas from the realized config
-            // without re-validating availability zones, so an invalid pool
-            // written here would produce an unplaceable replica.
-            if config_changed {
-                self.ensure_valid_azs(new_availability_zones.iter())?;
-            }
-        } else if config_changed {
+        // The controller creates replicas from the realized config without
+        // re-validating availability zones, so an invalid pool written here
+        // would produce an unplaceable replica.
+        if config_changed {
             self.ensure_valid_azs(new_availability_zones.iter())?;
-            // If we're not doing a zero-downtime reconfig tear down all
-            // replicas, create new ones else create the pending replicas and
-            // return early asking for finalization
-            match strategy {
-                AlterClusterPlanStrategy::None => {
-                    // Names can drift from the canonical `r1..rN` while the
-                    // controller owns the set (its name generator avoids
-                    // observed names), so a factor-derived name list can miss
-                    // replicas after a break-glass handoff. This branch
-                    // recreates the entire replica set anyway, so dropping the
-                    // observed owned set by id closes that. In the pure
-                    // canonical world the two sets are identical.
-                    let replica_ids_and_reasons = owned_replica_ids
-                        .iter()
-                        .map(|replica_id| {
-                            catalog::DropObjectInfo::ClusterReplica((
-                                cluster_id,
-                                *replica_id,
-                                reason.clone(),
-                            ))
-                        })
-                        .collect();
-                    ops.push(catalog::Op::DropObjects(replica_ids_and_reasons));
-                    for replica_name in
-                        (0..*new_replication_factor).map(managed_cluster_replica_name)
-                    {
-                        // The replica id is pre-allocated above like the create
-                        // paths so its scoped overrides can be folded below.
-                        let replica_id = new_replica_ids
-                            .next()
-                            .expect("pre-allocated enough replica ids");
-                        self.create_managed_cluster_replica_op(
-                            cluster_id,
-                            replica_id,
-                            replica_name.clone(),
-                            &compute,
-                            new_size,
-                            &mut ops,
-                            Some(new_availability_zones.as_ref()),
-                            false,
-                            owner_id,
-                            reason.clone(),
-                        )?;
-                    }
-                }
-                AlterClusterPlanStrategy::For(_) | AlterClusterPlanStrategy::UntilReady { .. } => {
-                    for replica_name in
-                        (0..*new_replication_factor).map(managed_cluster_replica_name)
-                    {
-                        let replica_name = format!("{replica_name}{PENDING_REPLICA_SUFFIX}");
-                        let replica_id = new_replica_ids
-                            .next()
-                            .expect("pre-allocated enough replica ids");
-                        self.create_managed_cluster_replica_op(
-                            cluster_id,
-                            replica_id,
-                            replica_name.clone(),
-                            &compute,
-                            new_size,
-                            &mut ops,
-                            Some(new_availability_zones.as_ref()),
-                            true,
-                            owner_id,
-                            reason.clone(),
-                        )?;
-                    }
-                    finalization_needed = NeedsFinalization::Yes;
-                }
-            }
-        } else if *new_replication_factor < replication_factor {
-            // Adjust replica count down
-            let replica_ids = (*new_replication_factor..replication_factor)
-                .map(managed_cluster_replica_name)
-                .filter_map(|name| replica_id_by_name.get(&name).copied())
-                .map(|replica_id| {
-                    catalog::DropObjectInfo::ClusterReplica((
-                        cluster_id,
-                        replica_id,
-                        reason.clone(),
-                    ))
-                })
-                .collect();
-            ops.push(catalog::Op::DropObjects(replica_ids));
-        } else if *new_replication_factor > replication_factor {
-            // Adjust replica count up
-            for replica_name in
-                (replication_factor..*new_replication_factor).map(managed_cluster_replica_name)
-            {
-                let replica_id = new_replica_ids
-                    .next()
-                    .expect("pre-allocated enough replica ids");
-                self.create_managed_cluster_replica_op(
-                    cluster_id,
-                    replica_id,
-                    replica_name.clone(),
-                    &compute,
-                    new_size,
-                    &mut ops,
-                    // AVAILABILITY ZONES hasn't changed, so existing replicas don't need to be
-                    // rescheduled.
-                    Some(new_availability_zones.as_ref()),
-                    false,
-                    owner_id,
-                    reason.clone(),
-                )?;
-            }
         }
 
-        // If finalization is needed, finalization should update the cluster
-        // config. Otherwise the config write happens here. A record still in
-        // progress belongs to a live, converging reconfiguration this write
-        // didn't touch, so carry it through untouched.
-        match finalization_needed {
-            NeedsFinalization::No => {
-                let mut new_config = new_config;
-                let reconfiguration_audit = if controller_owns {
-                    None
-                } else {
-                    cancel_carried_reconfiguration(&mut new_config)
-                };
-                ops.push(catalog::Op::UpdateClusterConfig {
-                    id: cluster_id,
-                    name: name.clone(),
-                    config: new_config,
-                    reconfiguration_audit,
-                    burst_audit: None,
-                });
-            }
-            NeedsFinalization::Yes => {}
-        }
+        // A record still in progress belongs to a live reconfiguration this
+        // cluster-level write did not touch, so carry it through unchanged.
+        let ops = vec![catalog::Op::UpdateClusterConfig {
+            id: cluster_id,
+            name,
+            config: new_config,
+            reconfiguration_audit: None,
+            burst_audit: None,
+        }];
 
-        self.catalog_transact(session, ops).await?;
-        Ok(finalization_needed)
+        self.catalog_transact(Some(session), ops).await?;
+        Ok(())
     }
 
     /// # Panics
@@ -2485,25 +1922,6 @@ fn reconfiguration_wait_result(
     }
 }
 
-/// Retains a stale in-progress reconfiguration record carried by a direct
-/// config write as cancelled, returning the audit intent to declare with the
-/// write.
-///
-/// A direct write reshapes the replica set itself, superseding whatever target
-/// the record carries. Leaving the record in progress would have the controller
-/// keep converging on that stale target.
-fn cancel_carried_reconfiguration(config: &mut ClusterConfig) -> Option<ReconfigurationAudit> {
-    let ClusterVariant::Managed(managed) = &mut config.variant else {
-        return None;
-    };
-    let record = managed.reconfiguration.as_mut()?;
-    if !record.is_in_progress() {
-        return None;
-    }
-    record.status = ReconfigurationStatus::Cancelled;
-    Some(ReconfigurationAudit::Cancelled)
-}
-
 /// Whether an `ALTER` statement sets a replica config shape dimension (`SIZE`,
 /// `AVAILABILITY ZONES`, either `INTROSPECTION` option, or `EXPERIMENTAL
 /// ARRANGEMENT COMPRESSION`). These dimensions use a durable reconfiguration
@@ -2596,15 +2014,6 @@ fn fold_reconfiguration_target(
             new_target.arrangement_compression
         },
     }
-}
-
-/// The type of finalization needed after an
-/// operation such as alter_cluster_managed_to_managed.
-#[derive(PartialEq)]
-pub(crate) enum NeedsFinalization {
-    /// Wait for the provided duration before finalizing
-    Yes,
-    No,
 }
 
 #[cfg(test)]

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -233,7 +233,6 @@ impl Coordinator {
         let retire_notify = self
             .retire_compute_sinks_for_conn(conn_id, ActiveComputeSinkRetireReason::Finished)
             .await;
-        self.retire_cluster_reconfigurations_for_conn(conn_id).await;
 
         // Release this transaction's compaction hold on collections.
         if let Some(txn_reads) = self.txn_read_holds.remove(conn_id) {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -317,7 +317,6 @@ pub enum AdapterError {
     /// The cluster controller could not provision a reconfiguration target
     /// within the environment's resource limits.
     AlterClusterResourceExhausted,
-    AlterClusterWhilePendingReplicas,
     /// Attempt to convert a cluster to unmanaged while a graceful
     /// reconfiguration is in progress.
     AlterClusterUnmanagedWhileReconfiguring,
@@ -1101,7 +1100,6 @@ impl AdapterError {
             AdapterError::AlterClusterTimeout => SqlState::QUERY_CANCELED,
             AdapterError::AlterClusterSuperseded => SqlState::QUERY_CANCELED,
             AdapterError::AlterClusterResourceExhausted => SqlState::INSUFFICIENT_RESOURCES,
-            AdapterError::AlterClusterWhilePendingReplicas => SqlState::OBJECT_IN_USE,
             AdapterError::AlterClusterUnmanagedWhileReconfiguring => SqlState::OBJECT_IN_USE,
             AdapterError::AlterClusterUnmanagedWhileBursting => SqlState::OBJECT_IN_USE,
             AdapterError::AlterClusterReplicationFactorWhileReconfiguring => {
@@ -1592,9 +1590,6 @@ impl fmt::Display for AdapterError {
                     )?;
                 }
                 Ok(())
-            }
-            AdapterError::AlterClusterWhilePendingReplicas => {
-                write!(f, "cannot alter clusters with pending updates")
             }
             AdapterError::AlterClusterUnmanagedWhileReconfiguring => {
                 write!(

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -377,12 +377,12 @@ pub struct ClusterVariantManaged {
 /// A managed cluster's replicas are derived from its `replication_factor`: for a
 /// factor of N they are named `r1` through `rN`.
 ///
-/// `ALTER CLUSTER` computes the replicas it creates and drops by this rule, and
-/// so does the catalog-open reconciler that materializes builtin replicas. The
-/// two have to share it, or `ALTER` cannot find the replicas it means to change.
-/// The cluster controller deliberately does not: its `ReplicaNameGen` picks names
-/// that avoid the observed set, which is why `ALTER` against a controller-owned
-/// cluster drops by observed id rather than by derived name.
+/// The catalog-open reconciler that materializes builtin replicas converges on
+/// this rule, `CREATE CLUSTER` names its replicas by it, and the
+/// unmanaged-to-managed conversion validates the existing names against it. The
+/// cluster controller deliberately does not: its `ReplicaNameGen` picks names
+/// that avoid the observed set, which is why it drops by observed id rather
+/// than by derived name.
 pub fn managed_cluster_replica_name(index: u32) -> String {
     format!("r{}", index + 1)
 }

--- a/src/cluster-controller/src/ctx.rs
+++ b/src/cluster-controller/src/ctx.rs
@@ -58,7 +58,8 @@ pub struct ObservedReplica {
     pub internal: bool,
     /// Carries a `BILLED AS` override.
     pub billed_as: bool,
-    /// The `-pending` target of an in-flight graceful reconfiguration.
+    /// Durably marked `pending`. Vestigial: no path creates one anymore, but a
+    /// crash on an older version could have left one behind.
     pub pending: bool,
 }
 
@@ -67,11 +68,11 @@ impl ObservedReplica {
     ///
     /// INTERNAL / BILLED AS replicas are manually managed: a user can attach
     /// one to any managed cluster, outside the replication-factor domain. A
-    /// pending replica is owned by the reconfiguration sequencer path until
-    /// finalize (retiring it would defeat the zero-downtime resize creating
-    /// it). The controller must neither count such a replica toward a desired
-    /// shape nor drop it as excess, but their names still block the name
-    /// generator, since every replica observed here occupies a name.
+    /// durably `pending` replica is stranded state from an older version, reaped
+    /// by the catalog-open migration rather than here. The controller must
+    /// neither count such a replica toward a desired shape nor drop it as
+    /// excess, but their names still block the name generator, since every
+    /// replica observed here occupies a name.
     pub fn owned_shape(&self) -> Option<&ReplicaShape> {
         if self.internal || self.billed_as || self.pending {
             return None;

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -312,10 +312,11 @@ impl ReplicaLocation {
         }
     }
 
-    /// A pending replica is created as part of an alter cluster of an managed
-    /// cluster. the configuration of a pending replica will not match that of
-    /// the clusters until the alter has been finalized promoting the pending
-    /// replicas and setting this value to false.
+    /// Whether the replica is durably marked `pending`.
+    ///
+    /// Vestigial: no path creates one anymore. A crash on a version that still
+    /// staged reconfigurations through overlap replicas could have left one
+    /// behind, and the catalog-open migration reaps those.
     pub fn pending(&self) -> bool {
         match self {
             ReplicaLocation::Managed(ManagedReplicaLocation { pending, .. }) => *pending,
@@ -374,7 +375,7 @@ pub struct ManagedReplicaLocation {
     /// concretization, not read back from a durable record.
     #[serde(skip)]
     pub availability_zones: Vec<String>,
-    /// Whether the replica is pending reconfiguration
+    /// See [`ReplicaLocation::pending`].
     pub pending: bool,
 }
 


### PR DESCRIPTION
## Motivation

The staged cluster-reconfiguration machine is unreachable. Managed cluster
shape changes return through the durable reconfiguration-record path, and
`sequence_alter_cluster_managed_to_managed` has `controller_owns = true`, so its
staged/direct branches have no live producer.

Controller-path correctness fixes are split into #38580, the preceding PR. This PR is
dead-code removal.

## Description

Deletes:

- `ClusterStage::WaitForHydrated` and `ClusterStage::Finalize`
- `NeedsFinalization` and `PENDING_REPLICA_SUFFIX`
- pending overlap-replica creation, promotion, and drop logic
- per-connection pending ALTER state and cleanup paths
- the sequencer's managed-replica create/drop reconciliation branches
- dead `Op::UpdateClusterReplicaConfig` and error plumbing

The surviving managed-to-managed path is a config-only write. The controller
reconciles replication-factor changes and scheduled-cluster shape changes on its
next tick.

The durable `pending` field and catalog-open cleanup stay. An older binary may
have crashed after creating a pending replica, and an upgraded binary must still
reap that stranded state.

Net diff: +100/-806. Most additions are the small config-only
replacement for the deleted reconciliation function and comments documenting
upgrade cleanup.

## Verification

- `cargo clippy -p mz-adapter -p mz-cluster-controller --all-targets -- -D warnings`
- `cargo check -p mz-adapter -p mz-cluster-controller`
- `cargo fmt --all -- --check`
- controller and ALTER coverage lives in the preceding fix PR because it tests
  the production path, not the deleted implementation

Integration suites are left to PR CI.

