### PR TITLE
sql: accept WITH (WAIT ...) on ALTER CLUSTER unconditionally

### DIFF
--- a/doc/developer/design/20260522_cluster_autoscaling.md
+++ b/doc/developer/design/20260522_cluster_autoscaling.md
@@ -2,6 +2,24 @@
 
 - Associated: (TBD — link epics/issues)
 
+> [!NOTE]
+> This document preserves the design context in which it was written. The
+> implementation has several refinements that matter when interpreting the
+> proposal:
+>
+> - Durable graceful-reconfiguration records apply to MANUAL clusters. Shape
+>   changes on non-MANUAL scheduled clusters update the realized config
+>   directly because there is no baseline set for hydration overlap.
+>   `WITH (WAIT ...)` is rejected on that path.
+> - `EXPERIMENTAL ARRANGEMENT COMPRESSION` is part of a replica's config shape.
+> - A forced `ON TIMEOUT COMMIT` replaces the realized replicas with the
+>   complete target in one transaction. The baseline yields during this
+>   transaction. A later reconciliation advances the realized config and
+>   finalizes without requiring hydration.
+> - Resource exhaustion can terminate an active graceful reconfiguration as
+>   `ResourceExhausted`. A foreground `ALTER` reports insufficient resources.
+>   The baseline and hydration burst are not shed.
+
 ## The Problem
 
 Two user-facing capabilities motivate this work:

--- a/doc/developer/design/20260522_cluster_autoscaling.md
+++ b/doc/developer/design/20260522_cluster_autoscaling.md
@@ -19,6 +19,10 @@
 > - Resource exhaustion can terminate an active graceful reconfiguration as
 >   `ResourceExhausted`. A foreground `ALTER` reports insufficient resources.
 >   The baseline and hydration burst are not shed.
+> - The controller-owned implementation does not use `pending` as active
+>   replica lifecycle state. The durable field and catalog-open cleanup remain
+>   temporarily so an upgrade can reap a replica stranded by an older supported
+>   binary.
 
 ## The Problem
 

--- a/doc/developer/design/20260609_scoped_feature_flags.md
+++ b/doc/developer/design/20260609_scoped_feature_flags.md
@@ -417,9 +417,9 @@ paths read as symmetric ("resolution at existing boundaries") but are not.
 
 A cluster or replica created between sync ticks must resolve its scoped overrides synchronously at creation, not on the next tick.
 This is a correctness requirement, not a latency nicety: render-frozen flags — optimizer features baked into immutable dataflows, and any replica-local flag consumed only at dataflow-render time — turn the tick-latency window into a window in which the object renders permanently under the wrong values.
-It is feasible at no cost on the DDL path because `launchdarkly_server_sdk::Client::variation` is a synchronous, local evaluation against the SDK's streamed flag cache, with no network call, so an arbitrary new-object context evaluates correctly inline.
+It is feasible at no cost on the DDL path because the targeting client evaluates synchronously against its streamed flag cache, with no network call, so an arbitrary new-object context evaluates correctly inline.
 The frontend is shared with the coordinator.
-Both the new cluster's cluster-coherent and the new replicas' replica-local overrides are evaluated from the pre-allocated ids and *folded into the create transaction itself* (`scoped_overrides_create_op` appends an `Op::UpdateScopedSystemParameters` to the create ops in `src/adapter/src/coord/sequencer/inner/cluster.rs`).
+Both the new cluster's cluster-coherent and the new replicas' replica-local overrides are evaluated from the pre-allocated ids and *folded into the create transaction itself*. The coordinator transaction boundaries in `src/adapter/src/coord/ddl.rs` call `scoped_overrides_create_op`, which derives evaluation contexts from concrete `CreateCluster` and `CreateClusterReplica` ops and appends an `Op::UpdateScopedSystemParameters`.
 Folding into the create transaction, rather than resolving after it, means the committed diff drives both boundaries:
 
 * The replica-local overrides reach the compute controller's per-replica dyncfg layer through the catalog implication derived from that diff, *before* `create_replica`, so the replica's first configuration already carries them.
@@ -427,7 +427,7 @@ Folding into the create transaction, rather than resolving after it, means the c
 
 Because the overrides are committed in the create transaction, they are persisted synchronously: a just-created object's overrides survive an `environmentd` restart with no re-hydration gap.
 The periodic sync loop remains the authoritative full-state writer (`reconcile_scoped_system_parameters`), and the create-time fold and the loop are the only writers, both serialized on the coordinator loop and both persisting through the same `Op::UpdateScopedSystemParameters`.
-Both paths no-op when the gate is off or before the frontend is installed (the cold-cache environment-wide fallback).
+The create path no-ops when no scoped object is created or before the frontend is installed. With an installed frontend it writes an empty scoped update when no override applies, so the final evaluation in a DDL transaction can clear a value staged by an earlier statement.
 
 Precedence for replica-local flags, lowest to highest:
 `Global < ReplicaSizeFamily < Replica(id)` (a specific replica pin beats a size

--- a/doc/developer/guide-adapter.md
+++ b/doc/developer/guide-adapter.md
@@ -66,6 +66,26 @@ logic to them. Extend the implications framework instead.
   Representing a new kind may require extending `ParsedStateUpdate` /
   `ParsedStateUpdateKind` first.
 
+### Background reconcilers own convergence resource failures
+
+When a catalog mutation writes desired state that a background reconciler
+materializes, the sequencer must not predict the reconciler's transient resource
+footprint. The prediction would have to reproduce every strategy that contributes
+to desired state, along with their sharing and shedding rules. It will diverge as
+those strategies evolve.
+
+The sequencer should validate properties intrinsic to the requested state, such
+as valid replica sizes, availability zones, and role permissions. The catalog
+transaction enforces resource limits against concrete creates. If a reconciler
+cannot apply those creates, it owns the response and the durable or logged
+observability for that outcome.
+
+Catalog accounting and downstream side-effect ordering must agree. If one
+transaction nets replacement drops against creates, its implications must queue
+those drops before the creates. An orchestrator can retry a failed create
+indefinitely. Queuing the drop behind it would deadlock a replacement against
+the same physical quota that catalog accounting correctly considered available.
+
 ## Correctness Invariants
 
 ### Timestamp selection must respect real-time bounds

--- a/doc/user/content/reference/system-catalog/mz_internal.md
+++ b/doc/user/content/reference/system-catalog/mz_internal.md
@@ -354,7 +354,7 @@ The `mz_internal_cluster_replicas` table lists the replicas that are created and
 
 ## `mz_pending_cluster_replicas`
 
-The `mz_pending_cluster_replicas` table lists the replicas that were created during managed cluster alter statement that has not yet finished. The configurations of these replica may differ from the cluster's configuration.
+The `mz_pending_cluster_replicas` table is retained for upgrade compatibility with older versions that could create pending replicas during `ALTER CLUSTER`. Materialize removes inherited pending replicas during startup before serving queries, and current versions do not create them, so this table is empty during normal operation. Active reconfiguration targets appear as ordinary rows in [`mz_cluster_replicas`](../mz_catalog/#mz_cluster_replicas).
 
 <!-- RELATION_SPEC mz_internal.mz_pending_cluster_replicas -->
 | Field      | Type     | Meaning                                                                                                     |

--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -221,7 +221,7 @@ You can monitor a resize through the following:
 
 ##### Cancel a resize
 To **cancel** an in-flight resize, reissue `ALTER CLUSTER` with the cluster's
-current size. Materialize drops the pending replicas and keeps the current
+current size. Materialize drops the target replicas and keeps the current
 configuration.
 
 #### Downtime considerations for v26.34 or before

--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -177,10 +177,6 @@ by default), Materialize rolls back the resize and the cluster keeps its current
 size. To customize the timeout behavior, use the `WAIT UNTIL READY` or `WAIT FOR` options.
 The resize still proceeds in the background.
 
-{{< private-preview >}}
-Customizing the resize timeout with `WAIT UNTIL READY` or `WAIT FOR`
-{{< /private-preview >}}
-
 - `WAIT UNTIL READY (TIMEOUT = ..., ON TIMEOUT = ...)` sets the timeout for the
   resize. On timeout, `ON TIMEOUT` selects whether to `COMMIT` (retire the old
   replicas and proceed with the not-yet-hydrated new ones, which can cause
@@ -225,7 +221,6 @@ current size. Materialize drops the target replicas and keeps the current
 configuration.
 
 #### Downtime considerations for v26.34 or before
-{{< private-preview />}}
 
 You can use the `WAIT UNTIL READY` option to perform a zero-downtime resizing,
 which incurs **no downtime**. Instead of restarting the cluster, this approach

--- a/doc/user/data/examples/alter_cluster.yml
+++ b/doc/user/data/examples/alter_cluster.yml
@@ -197,4 +197,4 @@
     | Option | Description |
     |--------|-------------|
     | `TIMEOUT` | The maximum duration to wait for the new replicas to be ready. |
-    | `ON TIMEOUT` | The action to take on timeout. <br><ul><li><code>COMMIT</code> retires the old replicas and proceeds with the new ones regardless of their hydration status, which may lead to downtime.</li><li><code>ROLLBACK</code> removes the pending replicas and keeps the current configuration.</li></ul>Default: <code>ROLLBACK</code>. |
+    | `ON TIMEOUT` | The action to take on timeout. <br><ul><li><code>COMMIT</code> retires the old replicas and proceeds with the new ones regardless of their hydration status, which may lead to downtime.</li><li><code>ROLLBACK</code> removes the target replicas and keeps the current configuration.</li></ul>Default: <code>ROLLBACK</code>. |

--- a/doc/user/data/examples/alter_cluster.yml
+++ b/doc/user/data/examples/alter_cluster.yml
@@ -96,8 +96,8 @@
         The following `<with_option>`s are supported:
         | Option  | Description |
         |--------|-------------|
-        | `WAIT UNTIL READY(...)`    | ***Private preview.** This option has known performance or stability issues and is under active development.* {{< include-from-yaml data="examples/alter_cluster" name="wait-until-ready-cmd-option" >}} |
-        | `WAIT FOR` |  ***Private preview.** This option has known performance or stability issues and is under active development.* A fixed duration to wait for the new replicas to be ready. This option can lead to downtime. As such, we recommend using the `WAIT UNTIL READY` option instead.|
+        | `WAIT UNTIL READY(...)`    | {{< include-from-yaml data="examples/alter_cluster" name="wait-until-ready-cmd-option" >}} |
+        | `WAIT FOR` | A fixed duration to wait for the new replicas to be ready. This option can lead to downtime. As such, we recommend using the `WAIT UNTIL READY` option instead.|
 
 - name: "syntax-reset-to-default"
   code: |

--- a/misc/python/materialize/checks/all_checks/cluster.py
+++ b/misc/python/materialize/checks/all_checks/cluster.py
@@ -152,9 +152,6 @@ class AlterClusterGracefulReconfiguration(Check):
 
     def initialize(self) -> Testdrive:
         return Testdrive(dedent("""
-            $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
-            ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true
-
             $ postgres-execute connection=postgres://postgres:postgres@postgres
             CREATE USER graceful_reconfig WITH SUPERUSER PASSWORD 'postgres';
             ALTER USER graceful_reconfig WITH replication;

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -167,6 +167,14 @@ def get_minimal_system_parameters(
             "true" if version >= MzVersion.parse_mz("v26.29.0-dev") else "false"
         )
 
+    # The `WITH (WAIT ...)` graceful-reconfiguration surface. Always accepted
+    # from v26.39 on. Older binaries still gate it behind this feature flag, so
+    # pin it on for them: the tests that use the surface no longer enable it
+    # themselves, and in a mixed-version run some of their phases execute
+    # against the old binary.
+    if version < MzVersion.parse_mz("v26.39.0-dev"):
+        config["enable_zero_downtime_cluster_reconfiguration"] = "true"
+
     return config
 
 

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -168,11 +168,11 @@ def get_minimal_system_parameters(
         )
 
     # The `WITH (WAIT ...)` graceful-reconfiguration surface. Always accepted
-    # from v26.39 on. Older binaries still gate it behind this feature flag, so
+    # from v26.41 on. Older binaries still gate it behind this feature flag, so
     # pin it on for them: the tests that use the surface no longer enable it
     # themselves, and in a mixed-version run some of their phases execute
     # against the old binary.
-    if version < MzVersion.parse_mz("v26.39.0-dev"):
+    if version < MzVersion.parse_mz("v26.41.0-dev"):
         config["enable_zero_downtime_cluster_reconfiguration"] = "true"
 
     return config

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -168,10 +168,6 @@ def run(
         system_exe.execute("ALTER SYSTEM SET max_sql_server_connections = 1000000")
         system_exe.execute("ALTER SYSTEM SET max_kafka_connections = 1000000")
         system_exe.execute("ALTER SYSTEM SET idle_in_transaction_session_timeout = 0")
-        # Gates the WITH (WAIT ...) clause used by ReconfigureClusterAction.
-        system_exe.execute(
-            "ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true"
-        )
         # Most queries should not fail because of privileges
         for object_type in [
             "TABLES",

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1447,8 +1447,14 @@ fn remove_invalid_config_param_role_defaults_migration(
     Ok(())
 }
 
-/// Cluster Replicas may be created ephemerally during an alter statement, these replicas
-/// are marked as pending and should be cleaned up on catalog open.
+/// Drops replicas left durably marked `pending`.
+///
+/// No runtime path creates one anymore. An upgrade can still come from a version
+/// whose staged reconfiguration machine crashed between the pending-create commit
+/// and the finalize, and those replicas are excluded from the cluster
+/// controller's ownership test, so this catalog-open sweep is their only
+/// remaining cleaner. It goes away together with the durable `pending` field,
+/// once no supported upgrade source can still write one.
 fn remove_pending_cluster_replicas_migration(
     tx: &mut Transaction,
     boot_ts: mz_repr::Timestamp,

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -242,11 +242,6 @@ pub enum Op {
         /// this write, alongside the record carried in `config`.
         burst_audit: Option<BurstAudit>,
     },
-    UpdateClusterReplicaConfig {
-        cluster_id: ClusterId,
-        replica_id: ReplicaId,
-        config: ReplicaConfig,
-    },
     UpdateItem {
         id: CatalogItemId,
         name: QualifiedItemName,
@@ -2927,24 +2922,6 @@ impl Catalog {
                         EventDetails::ClusterHydrationBurstV1(details),
                     )?;
                 }
-            }
-            Op::UpdateClusterReplicaConfig {
-                replica_id,
-                cluster_id,
-                config,
-            } => {
-                let replica = state.get_cluster_replica(cluster_id, replica_id).to_owned();
-                info!("update replica {}", replica.name);
-                tx.update_cluster_replica(
-                    replica_id,
-                    mz_catalog::durable::ClusterReplica {
-                        cluster_id,
-                        replica_id,
-                        name: replica.name.clone(),
-                        config: config.clone().into(),
-                        owner_id: replica.owner_id,
-                    },
-                )?;
             }
             Op::UpdateItem { id, name, to_item } => {
                 // A non-temporary item must not depend on a temporary one.

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -190,11 +190,11 @@ pub enum Command {
     },
 
     /// Install (or replace) the shared system-parameter frontend on the
-    /// coordinator, so the create-cluster / create-replica paths can resolve a
-    /// new object's scoped overrides synchronously, before the controller
-    /// installs it or its first dataflow is planned, rather than waiting for
-    /// the next sync tick. Sent by the sync loop whenever it (re)initializes the
-    /// frontend. See the scoped feature flags design.
+    /// coordinator, so catalog transactions can resolve a new object's scoped
+    /// overrides before its replica is provisioned or its first dataflow is
+    /// planned, rather than waiting for the next sync tick. Sent by the sync loop
+    /// whenever it (re)initializes the frontend. See the scoped feature flags
+    /// design.
     InstallScopedSystemParameterFrontend {
         frontend: Arc<SystemParameterFrontend>,
     },

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -190,8 +190,9 @@ use crate::catalog::{BuiltinTableUpdate, Catalog, OpenCatalogResult};
 use crate::client::{Client, Handle};
 use crate::command::{Command, ExecuteResponse};
 use crate::config::{
-    ClusterEvalContext, ReplicaEvalContext, ScopedParameters, ScopedParametersScope,
-    SynchronizedParameters, SystemParameterFrontend, SystemParameterSyncConfig,
+    ClusterEvalContext, ClusterScopeContext, ReplicaEvalContext, ReplicaScopeContext,
+    ScopedParameters, ScopedParametersScope, SynchronizedParameters, SystemParameterFrontend,
+    SystemParameterSyncConfig,
 };
 use crate::coord::appends::{
     BuiltinTableAppendCompletion, BuiltinTableAppendNotify, DeferredOp, GroupCommitPermit,
@@ -2304,30 +2305,85 @@ impl Coordinator {
         }
     }
 
-    /// Evaluates the scoped overrides for freshly-created objects from explicit
-    /// eval contexts and returns an [`Op::UpdateScopedSystemParameters`] to fold
-    /// into the same transaction that creates them.
+    /// Evaluates scoped overrides for objects created by `ops` and returns an
+    /// [`Op::UpdateScopedSystemParameters`] to fold into the same transaction.
     ///
-    /// The objects are not yet in the catalog, so the contexts are built from
-    /// plan data and pre-allocated ids. Folding the op into the create
-    /// transaction makes its committed diff drive the replica-scoped controller
-    /// push, as a catalog implication, before `create_replica`. A new replica's
-    /// first configuration then carries its overrides rather than the env-wide
-    /// values. Render-frozen flags (e.g. the column-paged batcher, chosen at
-    /// arrangement-build time) make a later push too late, which is why this
-    /// happens in the create transaction rather than the next sync tick.
+    /// The objects are not yet in the catalog, so this derives their contexts
+    /// from concrete create ops and pre-allocated ids. Centralizing the fold
+    /// here makes create-time configuration an invariant of coordinator-applied
+    /// catalog ops, independent of which component produced them. The committed
+    /// diff drives the replica-scoped controller push before `create_replica`.
+    /// Render-frozen flags make a later push too late.
     ///
-    /// Returns `None` when the shared frontend is not yet installed (e.g. before
-    /// LaunchDarkly connects), or when no override applies. The new objects then
-    /// resolve to the environment-wide value, and the periodic sync loop remains
-    /// the authoritative full-state reconciler.
+    /// Returns `None` when no scoped object is created or the shared frontend is
+    /// not yet installed. An installed frontend produces an op even when no
+    /// override applies, so a final DDL-transaction evaluation can clear a value
+    /// staged by an earlier statement. The periodic sync loop remains the
+    /// authoritative full-state reconciler.
     ///
     /// [`Op::UpdateScopedSystemParameters`]: crate::catalog::Op::UpdateScopedSystemParameters
-    fn scoped_overrides_create_op(
-        &self,
-        clusters: &[ClusterEvalContext],
-        replicas: &[ReplicaEvalContext],
-    ) -> Option<crate::catalog::Op> {
+    fn scoped_overrides_create_op(&self, ops: &[crate::catalog::Op]) -> Option<crate::catalog::Op> {
+        let mut created_clusters = BTreeMap::new();
+        let mut clusters = Vec::new();
+        for op in ops {
+            let crate::catalog::Op::CreateCluster { id, name, .. } = op else {
+                continue;
+            };
+            let cluster = ClusterScopeContext {
+                id: id.to_string(),
+                name: name.clone(),
+                is_builtin: id.is_system(),
+            };
+            created_clusters.insert(*id, cluster.clone());
+            clusters.push(ClusterEvalContext {
+                cluster_id: *id,
+                cluster,
+            });
+        }
+
+        let mut replicas = Vec::new();
+        for op in ops {
+            let crate::catalog::Op::CreateClusterReplica {
+                cluster_id,
+                replica_id,
+                name,
+                config,
+                ..
+            } = op
+            else {
+                continue;
+            };
+            let ReplicaLocation::Managed(location) = &config.location else {
+                continue;
+            };
+            let cluster = created_clusters.get(cluster_id).cloned().or_else(|| {
+                self.catalog()
+                    .try_get_cluster(*cluster_id)
+                    .map(|cluster| ClusterScopeContext {
+                        id: cluster_id.to_string(),
+                        name: cluster.name.clone(),
+                        is_builtin: cluster_id.is_system(),
+                    })
+            })?;
+            replicas.push(ReplicaEvalContext {
+                cluster_id: *cluster_id,
+                replica_id: *replica_id,
+                replica: ReplicaScopeContext {
+                    id: replica_id.to_string(),
+                    name: name.clone(),
+                    is_builtin: cluster_id.is_system(),
+                    size: location.size.clone(),
+                    size_family: location.allocation.family().to_string(),
+                    cluster_id: cluster_id.to_string(),
+                    cluster_name: cluster.name.clone(),
+                },
+                cluster,
+            });
+        }
+
+        if clusters.is_empty() && replicas.is_empty() {
+            return None;
+        }
         let frontend = self.scoped_frontend.clone()?;
         let catalog = self.catalog();
         let system_config = catalog.system_config();
@@ -2349,19 +2405,15 @@ impl Coordinator {
         let mut evaluated = ScopedParameters::default();
         if !cluster_param_names.is_empty() && !clusters.is_empty() {
             evaluated.cluster =
-                frontend.pull_cluster_overrides(&params, &cluster_param_names, clusters);
+                frontend.pull_cluster_overrides(&params, &cluster_param_names, &clusters);
         }
         if !replica_param_names.is_empty() && !replicas.is_empty() {
             evaluated.replica =
-                frontend.pull_replica_overrides(&params, &replica_param_names, replicas);
+                frontend.pull_replica_overrides(&params, &replica_param_names, &replicas);
         }
-        if evaluated.is_empty() {
-            return None;
-        }
-
-        // Prune only within the objects being created. They have no prior rows,
-        // so nothing is removed, and this op never touches another object whose
-        // override a concurrent reconcile may be writing.
+        // Prune only within the objects this transaction creates. A later
+        // statement in a DDL transaction can replace an earlier folded value,
+        // but this never touches an unrelated object's override.
         let prune_scope = ScopedParametersScope {
             clusters: clusters.iter().map(|cluster| cluster.cluster_id).collect(),
             replicas: replicas.iter().map(|replica| replica.replica_id).collect(),

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -106,8 +106,8 @@ use mz_catalog::config::{AwsPrincipalContext, BuiltinItemMigrationConfig, Cluste
 use mz_catalog::durable::OpenableDurableCatalogState;
 use mz_catalog::expr_cache::{GlobalExpressions, LocalExpressions};
 use mz_catalog::memory::objects::{
-    CatalogEntry, CatalogItem, ClusterReplicaProcessStatus, ClusterVariantManaged, Connection,
-    DataSourceDesc, ReconfigurationTarget, Table, TableDataSource,
+    CatalogEntry, CatalogItem, ClusterReplicaProcessStatus, Connection, DataSourceDesc,
+    ReconfigurationTarget, Table, TableDataSource,
 };
 use mz_cloud_resources::{CloudResourceController, VpcEndpointConfig, VpcEndpointEvent};
 use mz_compute_client::as_of_selection;
@@ -155,7 +155,7 @@ use mz_sql::names::{QualifiedItemName, ResolvedIds};
 use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::{
     self, AlterSinkPlan, ConnectionDetails, CreateConnectionPlan, HirRelationExpr,
-    NetworkPolicyRule, OnTimeoutAction, Params, QueryWhen,
+    NetworkPolicyRule, Params, QueryWhen,
 };
 use mz_sql::session::user::User;
 use mz_sql::session::vars::{MAX_CREDIT_CONSUMPTION_RATE, SystemVars, Var};
@@ -930,8 +930,6 @@ pub struct ExplainTimestampFinish {
 #[derive(Debug)]
 pub enum ClusterStage {
     Alter(AlterCluster),
-    WaitForHydrated(AlterClusterWaitForHydrated),
-    Finalize(AlterClusterFinalize),
     /// The foreground wait-shim over a controller-driven background
     /// reconfiguration: poll the durable `reconfiguration` record until it
     /// clears, then report success or timeout depending on whether the realized
@@ -943,24 +941,6 @@ pub enum ClusterStage {
 pub struct AlterCluster {
     validity: PlanValidity,
     plan: plan::AlterClusterPlan,
-}
-
-#[derive(Debug)]
-pub struct AlterClusterWaitForHydrated {
-    validity: PlanValidity,
-    plan: plan::AlterClusterPlan,
-    new_config: ClusterVariantManaged,
-    workload_class: Option<String>,
-    timeout_time: Instant,
-    on_timeout: OnTimeoutAction,
-}
-
-#[derive(Debug)]
-pub struct AlterClusterFinalize {
-    validity: PlanValidity,
-    plan: plan::AlterClusterPlan,
-    new_config: ClusterVariantManaged,
-    workload_class: Option<String>,
 }
 
 #[derive(Debug)]
@@ -1366,10 +1346,6 @@ pub struct ConnMeta {
     /// Lock for the Coordinator's deferred statements that is dropped on transaction clear.
     #[serde(skip)]
     deferred_lock: Option<OwnedMutexGuard<()>>,
-
-    /// Cluster reconfigurations that will need to be
-    /// cleaned up when the current transaction is cleared
-    pending_cluster_alters: BTreeSet<ClusterId>,
 
     /// Channel on which to send notices to a session.
     #[serde(skip)]

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -254,6 +254,7 @@ impl Coordinator {
         let mut vpc_endpoints_to_drop = vec![];
         let mut clusters_to_drop = vec![];
         let mut cluster_replicas_to_drop = vec![];
+        let mut cluster_replicas_to_create = vec![];
         let mut active_compute_sinks_to_drop = BTreeMap::new();
         let mut peeks_to_drop = vec![];
         let mut copies_to_drop = vec![];
@@ -721,15 +722,14 @@ impl Coordinator {
                     let cluster = self.catalog().get_cluster(cluster_id);
                     let cluster_name = cluster.name.clone();
                     let cluster_role = cluster.role();
-                    self.handle_create_cluster_replica(
+                    cluster_replicas_to_create.push((
                         cluster_id,
                         replica_id,
                         cluster_role,
                         cluster_name,
                         replica.name.clone(),
                         replica.config.clone(),
-                    )
-                    .await;
+                    ));
                 }
                 CatalogImplication::ClusterReplica(CatalogImplicationKind::Altered {
                     prev: _prev_replica,
@@ -755,6 +755,42 @@ impl Coordinator {
                     );
                 }
             }
+        }
+
+        let clusters_with_replica_creates = cluster_replicas_to_create
+            .iter()
+            .map(|(cluster_id, ..)| *cluster_id)
+            .collect();
+        let (replacement_drops, deferred_drops) = partition_cluster_replica_drops(
+            &clusters_with_replica_creates,
+            cluster_replicas_to_drop,
+        );
+        cluster_replicas_to_drop = deferred_drops;
+
+        // A same-cluster mixed drop/create batch replaces the replica set, as a
+        // forced cut-over does. Catalog resource accounting charges its net, so
+        // controller side effects must preserve the same contract. Queue the
+        // old replicas' drops before creates. If orchestration needs time to
+        // release a physical quota, a later ensure can retry without blocking
+        // the drop behind it.
+        if !replacement_drops.is_empty() {
+            fail::fail_point!("after_catalog_drop_replica");
+            for (cluster_id, replica_id) in replacement_drops {
+                self.drop_replica(cluster_id, replica_id);
+            }
+        }
+        for (cluster_id, replica_id, role, cluster_name, replica_name, config) in
+            cluster_replicas_to_create
+        {
+            self.handle_create_cluster_replica(
+                cluster_id,
+                replica_id,
+                role,
+                cluster_name,
+                replica_name,
+                config,
+            )
+            .await;
         }
 
         if !source_collections_to_create.is_empty() {
@@ -1926,6 +1962,15 @@ impl CatalogImplication {
     impl_absorb_method!(absorb_cluster_replica, ClusterReplica, ClusterReplica);
 }
 
+fn partition_cluster_replica_drops(
+    clusters_with_creates: &BTreeSet<ClusterId>,
+    drops: Vec<(ClusterId, ReplicaId)>,
+) -> (Vec<(ClusterId, ReplicaId)>, Vec<(ClusterId, ReplicaId)>) {
+    drops
+        .into_iter()
+        .partition(|(cluster_id, _)| clusters_with_creates.contains(cluster_id))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1948,6 +1993,21 @@ mod tests {
             is_retained_metrics_object: false,
             data_source: TableDataSource::TableWrites { defaults: vec![] },
         }
+    }
+
+    #[mz_ore::test]
+    fn mixed_replica_drops_are_applied_before_creates() {
+        let c1 = ClusterId::user(1).expect("valid id");
+        let c2 = ClusterId::user(2).expect("valid id");
+        let r1 = ReplicaId::User(1);
+        let r2 = ReplicaId::User(2);
+        let creates = BTreeSet::from([c1]);
+
+        let (before_creates, deferred) =
+            partition_cluster_replica_drops(&creates, vec![(c1, r1), (c2, r2)]);
+
+        assert_eq!(before_creates, vec![(c1, r1)]);
+        assert_eq!(deferred, vec![(c2, r2)]);
     }
 
     #[mz_ore::test]

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -883,7 +883,6 @@ impl Coordinator {
                     secret_key,
                     notice_tx,
                     drop_sinks: BTreeSet::new(),
-                    pending_cluster_alters: BTreeSet::new(),
                     connected_at: self.now(),
                     user,
                     application_name,
@@ -2054,8 +2053,6 @@ impl Coordinator {
         // SQL cancellation has no success response to delay. Each subscribe
         // still waits for its own retraction before it observes retirement.
         drop(retire_notify);
-        self.cancel_cluster_reconfigurations_for_conn(&conn_id)
-            .await;
         self.cancel_pending_copy(&conn_id);
         if let Some((tx, _rx)) = self.connection_cancel_watches.get_mut(&conn_id) {
             let _ = tx.send(true);

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -254,7 +254,7 @@ impl Coordinator {
     pub(crate) async fn catalog_transact_with_ddl_transaction<F>(
         &mut self,
         ctx: &mut ExecuteContext,
-        ops: Vec<catalog::Op>,
+        mut ops: Vec<catalog::Op>,
         side_effect: F,
     ) -> Result<(), AdapterError>
     where
@@ -321,6 +321,21 @@ impl Coordinator {
         let prep_start = Instant::now();
         let mut combined_ops = txn_ops_clone;
         combined_ops.extend(ops.iter().cloned());
+        let creates_scoped_object = ops.iter().any(|op| {
+            matches!(
+                op,
+                catalog::Op::CreateCluster { .. } | catalog::Op::CreateClusterReplica { .. }
+            )
+        });
+        if creates_scoped_object {
+            // Include accumulated creates when deriving contexts. A replica can
+            // be created in a later DDL statement than its still-uncommitted
+            // cluster, which is absent from the coordinator's live catalog.
+            if let Some(scoped_op) = self.scoped_overrides_create_op(&combined_ops) {
+                ops.push(scoped_op.clone());
+                combined_ops.push(scoped_op);
+            }
+        }
         let conn_id = ctx.session().conn_id().clone();
         let validate_res = self.validate_resource_limits(&combined_ops, &conn_id);
         phase_seconds
@@ -384,10 +399,14 @@ impl Coordinator {
     pub(crate) async fn catalog_transact_inner(
         &mut self,
         conn_id: Option<&ConnectionId>,
-        ops: Vec<catalog::Op>,
+        mut ops: Vec<catalog::Op>,
     ) -> Result<(BuiltinTableAppendNotify, Vec<ParsedStateUpdate>), AdapterError> {
         if self.controller.read_only() {
             return Err(AdapterError::ReadOnly);
+        }
+
+        if let Some(scoped_op) = self.scoped_overrides_create_op(&ops) {
+            ops.push(scoped_op);
         }
 
         event!(Level::TRACE, ops = format!("{:?}", ops));

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -51,7 +51,7 @@ use serde_json::json;
 use tracing::{Instrument, Level, event, info_span, warn};
 
 use crate::active_compute_sink::{ActiveComputeSink, ActiveComputeSinkRetireReason};
-use crate::catalog::{DropObjectInfo, Op, ReplicaCreateDropReason, TransactionResult};
+use crate::catalog::{DropObjectInfo, Op, TransactionResult};
 use crate::coord::Coordinator;
 use crate::coord::appends::{BuiltinTableAppendCompletion, BuiltinTableAppendNotify};
 use crate::coord::catalog_implications::parsed_state_updates::ParsedStateUpdate;
@@ -889,43 +889,6 @@ impl Coordinator {
         }))
     }
 
-    /// Drops all pending replicas for a set of clusters
-    /// that are undergoing reconfiguration.
-    pub async fn drop_reconfiguration_replicas(
-        &mut self,
-        cluster_ids: BTreeSet<ClusterId>,
-    ) -> Result<(), AdapterError> {
-        let pending_cluster_ops: Vec<Op> = cluster_ids
-            .iter()
-            .map(|c| {
-                self.catalog()
-                    .get_cluster(c.clone())
-                    .replicas()
-                    .filter_map(|r| match r.config.location {
-                        ReplicaLocation::Managed(ref l) if l.pending => {
-                            Some(DropObjectInfo::ClusterReplica((
-                                c.clone(),
-                                r.replica_id,
-                                ReplicaCreateDropReason::Manual,
-                            )))
-                        }
-                        _ => None,
-                    })
-                    .collect::<Vec<DropObjectInfo>>()
-            })
-            .filter_map(|pending_replica_drop_ops_by_cluster| {
-                match pending_replica_drop_ops_by_cluster.len() {
-                    0 => None,
-                    _ => Some(Op::DropObjects(pending_replica_drop_ops_by_cluster)),
-                }
-            })
-            .collect();
-        if !pending_cluster_ops.is_empty() {
-            self.catalog_transact(None, pending_cluster_ops).await?;
-        }
-        Ok(())
-    }
-
     /// Cancels all active compute sinks for the identified connection.
     #[mz_ore::instrument(level = "debug")]
     pub(crate) async fn cancel_compute_sinks_for_conn(
@@ -934,15 +897,6 @@ impl Coordinator {
     ) -> BuiltinTableAppendCompletion {
         self.retire_compute_sinks_for_conn(conn_id, ActiveComputeSinkRetireReason::Canceled)
             .await
-    }
-
-    /// Cancels all active cluster reconfigurations sinks for the identified connection.
-    #[mz_ore::instrument(level = "debug")]
-    pub(crate) async fn cancel_cluster_reconfigurations_for_conn(
-        &mut self,
-        conn_id: &ConnectionId,
-    ) {
-        self.retire_cluster_reconfigurations_for_conn(conn_id).await
     }
 
     /// Retires all active compute sinks for the identified connection with the
@@ -962,30 +916,6 @@ impl Coordinator {
             .map(|sink_id| (*sink_id, reason.clone()))
             .collect();
         self.retire_compute_sinks(drop_sinks).await
-    }
-
-    /// Cleans pending cluster reconfiguraiotns for the identified connection
-    #[mz_ore::instrument(level = "debug")]
-    pub(crate) async fn retire_cluster_reconfigurations_for_conn(
-        &mut self,
-        conn_id: &ConnectionId,
-    ) {
-        let reconfiguring_clusters = self
-            .active_conns
-            .get(conn_id)
-            .expect("must exist for active session")
-            .pending_cluster_alters
-            .clone();
-        // try to drop reconfig replicas
-        self.drop_reconfiguration_replicas(reconfiguring_clusters)
-            .await
-            .unwrap_or_terminate("cannot fail to drop reconfiguration replicas");
-
-        self.active_conns
-            .get_mut(conn_id)
-            .expect("must exist for active session")
-            .pending_cluster_alters
-            .clear();
     }
 
     pub(crate) fn drop_storage_sinks(&mut self, sink_gids: Vec<GlobalId>) {
@@ -1477,7 +1407,6 @@ impl Coordinator {
                 | Op::UpdateOwner { .. }
                 | Op::RevokeRole { .. }
                 | Op::UpdateClusterConfig { .. }
-                | Op::UpdateClusterReplicaConfig { .. }
                 | Op::UpdateSourceReferences { .. }
                 | Op::UpdateSystemConfiguration { .. }
                 | Op::ResetSystemConfiguration { .. }

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -29,7 +29,6 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::instrument;
 use mz_repr::Timestamp;
-use mz_repr::adt::numeric::Numeric;
 use mz_repr::role_id::RoleId;
 use mz_sql::ast::{Ident, QualifiedReplica};
 use mz_sql::catalog::{CatalogCluster, CatalogError, ObjectType};
@@ -42,9 +41,7 @@ use mz_sql::plan::{
 };
 use mz_sql::plan::{AlterClusterPlan, OnTimeoutAction};
 use mz_sql::session::metadata::SessionMetadata;
-use mz_sql::session::vars::{
-    MAX_CREDIT_CONSUMPTION_RATE, MAX_REPLICAS_PER_CLUSTER, SystemVars, Var,
-};
+use mz_sql::session::vars::{MAX_REPLICAS_PER_CLUSTER, SystemVars, Var};
 use mz_storage_types::sources::SourceConnection;
 use tracing::{Instrument, Span, debug};
 
@@ -55,9 +52,6 @@ use mz_adapter_types::dyncfgs::{
 use super::return_if_err;
 use crate::AdapterError::AlterClusterWhilePendingReplicas;
 use crate::catalog::{self, Op, ReplicaCreateDropReason};
-use crate::config::{
-    ClusterEvalContext, ClusterScopeContext, ReplicaEvalContext, ReplicaScopeContext,
-};
 use crate::coord::{
     AlterCluster, AlterClusterAwaitReconfiguration, AlterClusterFinalize,
     AlterClusterWaitForHydrated, ClusterReplicaStatuses, ClusterStage, Coordinator, Message,
@@ -540,103 +534,6 @@ impl Coordinator {
         )))
     }
 
-    /// Validates that a reconfiguration to `target` fits the resource budget.
-    fn validate_reconfiguration_resource_limits(
-        &self,
-        cluster_id: ClusterId,
-        target: &ReconfigurationTarget,
-    ) -> Result<(), AdapterError> {
-        // System clusters are exempt from `max_replicas_per_cluster` and from
-        // credit accounting everywhere else (see the `is_user` guards in
-        // `catalog_transact`'s validation), so a reconfiguration of one has no
-        // budget to fit either.
-        if !cluster_id.is_user() {
-            return Ok(());
-        }
-        let cluster = self.catalog().get_cluster(cluster_id);
-        let ClusterVariant::Managed(realized) = &cluster.config.variant else {
-            return Ok(());
-        };
-
-        // An `ALTER` back to the realized shape cancels the reconfiguration and
-        // materializes nothing new, so there is nothing to validate. The peak
-        // model below would double count the realized set and spuriously reject
-        // the cancel, exactly when the environment is at its limits and the
-        // escape hatch matters most.
-        if target.matches_realized_config(realized) {
-            return Ok(());
-        }
-
-        // Both checks below model the transient peak: the controller runs the
-        // realized and target sets side by side until cut-over, so this cluster's
-        // peak contribution is both shapes at once, computed from config as
-        // realized plus target. That slightly over-counts a same-shape overlap,
-        // where existing replicas double as target replicas, but it matches the
-        // legacy wait path, which creates the full target set as pending replicas
-        // at `ALTER` time and therefore enforces both limits on the overlap.
-        // Rejecting here is also strictly better than the asynchronous abort the
-        // controller falls back to when a limit shrinks or the environment grows
-        // after the record is written.
-
-        // Per-cluster replica count: the peak is `realized_rf + target_rf`,
-        // deterministic from the cluster's own config. `validate_resource_limit`
-        // returns early on an rf-0 target.
-        self.validate_resource_limit(
-            usize::cast_from(realized.replication_factor),
-            i64::from(target.replication_factor),
-            SystemVars::max_replicas_per_cluster,
-            "cluster replica",
-            MAX_REPLICAS_PER_CLUSTER.name(),
-        )?;
-
-        // Global credit rate: the peak is `credit(realized) + credit(target)`.
-        self.validate_reconfiguration_credit_peak(cluster_id, realized, target)?;
-
-        Ok(())
-    }
-
-    /// Validates that the transient credit-rate peak of a reconfiguration, the
-    /// realized plus the target shape, fits the environment-wide budget.
-    ///
-    /// The base is the live consumption of every other cluster. It excludes
-    /// this cluster's own replicas so a re-target of an in-flight record does
-    /// not additionally count an already-materialized overlap on top of the
-    /// modeled peak.
-    fn validate_reconfiguration_credit_peak(
-        &self,
-        cluster_id: ClusterId,
-        realized: &ClusterVariantManaged,
-        target: &ReconfigurationTarget,
-    ) -> Result<(), AdapterError> {
-        let shape_credit = |size: &str, replication_factor: u32| -> Numeric {
-            let per_replica = self
-                .catalog()
-                .cluster_replica_sizes()
-                .0
-                .get(size)
-                .map(|allocation| allocation.credits_per_hour)
-                // Sizes are validated by `ensure_valid_replica_size` before we get
-                // here, so an unknown size contributes nothing rather than panics.
-                .unwrap_or_else(Numeric::zero);
-            per_replica * Numeric::from(replication_factor)
-        };
-        let mut peak_credit = shape_credit(&target.size, target.replication_factor);
-        peak_credit += shape_credit(&realized.size, realized.replication_factor);
-        self.validate_resource_limit_numeric(
-            self.current_credit_consumption_rate(Some(cluster_id)),
-            peak_credit,
-            |system_vars| {
-                self.license_key
-                    .max_credit_consumption_rate()
-                    .map_or_else(|| system_vars.max_credit_consumption_rate(), Numeric::from)
-            },
-            "cluster replica",
-            MAX_CREDIT_CONSUMPTION_RATE.name(),
-        )?;
-
-        Ok(())
-    }
-
     /// Reshape a managed→managed `ALTER` into a durable `reconfiguration` record.
     ///
     /// Writes (or folds into) the `reconfiguration` record carrying the full target
@@ -737,10 +634,25 @@ impl Coordinator {
             false,
         )?;
         self.ensure_valid_azs(target.availability_zones.iter())?;
-        // Validate the reconfiguration's resource footprint up front, so a
-        // reshape that cannot fit errors at `ALTER` time rather than writing a
-        // record the controller aborts asynchronously.
-        self.validate_reconfiguration_resource_limits(cluster_id, &target)?;
+
+        let cancels = match &cluster.config.variant {
+            ClusterVariant::Managed(managed) => target.matches_realized_config(managed),
+            ClusterVariant::Unmanaged => false,
+        };
+        // Bound the target's steady baseline before the controller expands it
+        // into desired replica slots. This deliberately ignores overlap and
+        // other strategies. Concrete create transactions validate the complete
+        // strategy union. Cancellation remains available if the limit has
+        // fallen below the realized replication factor.
+        if cluster_id.is_user() && !cancels {
+            self.validate_resource_limit(
+                0,
+                i64::from(target.replication_factor),
+                SystemVars::max_replicas_per_cluster,
+                "cluster replica",
+                MAX_REPLICAS_PER_CLUSTER.name(),
+            )?;
+        }
 
         // Resolve the deadline and the on-timeout action, both written relative
         // to the current time so they survive session disconnect and restart.
@@ -815,7 +727,7 @@ impl Coordinator {
         // The status and the audit intent are two views of the same decision,
         // made together here: an ALTER back to the realized shape is a cancel,
         // anything else starts (or re-targets) a reconfiguration.
-        let (status, audit) = if target.matches_realized_config(realized_now) {
+        let (status, audit) = if cancels {
             (
                 ReconfigurationStatus::Cancelled,
                 ReconfigurationAudit::Cancelled,
@@ -915,17 +827,10 @@ impl Coordinator {
                 }
             }
             Some(record) if !record.is_in_progress() => {
-                if matches!(
-                    record.status,
-                    ReconfigurationStatus::Finalized | ReconfigurationStatus::Cancelled
-                ) && realized_matches_target
-                {
-                    Ok(StageResult::Response(ExecuteResponse::AlteredObject(
-                        ObjectType::Cluster,
-                    )))
-                } else {
-                    Err(AdapterError::AlterClusterTimeout)
-                }
+                terminal_reconfiguration_result(&record, &target, realized_matches_target)?;
+                Ok(StageResult::Response(ExecuteResponse::AlteredObject(
+                    ObjectType::Cluster,
+                )))
             }
             Some(_) => {
                 // Still in progress. Re-poll after the configured interval and
@@ -1271,11 +1176,11 @@ impl Coordinator {
 
         match variant {
             CreateClusterVariant::Managed(plan) => {
-                self.sequence_create_managed_cluster(session, plan, id, name.clone(), ops)
+                self.sequence_create_managed_cluster(session, plan, id, ops)
                     .await
             }
             CreateClusterVariant::Unmanaged(plan) => {
-                self.sequence_create_unmanaged_cluster(session, plan, id, name.clone(), ops)
+                self.sequence_create_unmanaged_cluster(session, plan, id, ops)
                     .await
             }
         }
@@ -1307,7 +1212,6 @@ impl Coordinator {
             auto_scaling_strategy,
         }: CreateClusterManagedPlan,
         cluster_id: ClusterId,
-        cluster_name: String,
         mut ops: Vec<catalog::Op>,
     ) -> Result<ExecuteResponse, AdapterError> {
         tracing::debug!("sequence_create_managed_cluster");
@@ -1355,28 +1259,19 @@ impl Coordinator {
         }
 
         // Pre-allocate replica ids out-of-band via the durable allocator,
-        // picking the id type from the owning cluster, so each replica's scoped
-        // overrides can be folded into the create transaction below (the
-        // overrides are keyed by the replica id). This mirrors how cluster and
-        // item ids are allocated, so nothing allocates a replica id in-apply.
+        // picking the id type from the owning cluster. This mirrors how cluster
+        // and item ids are allocated, so nothing allocates a replica id in-apply.
         let id_ts = self.get_catalog_write_ts().await;
         let replica_ids = self
             .catalog()
             .allocate_replica_ids(cluster_id, u64::from(replication_factor), id_ts)
             .await?;
 
-        let cluster_ctx = ClusterScopeContext {
-            id: cluster_id.to_string(),
-            name: cluster_name.clone(),
-            is_builtin: cluster_id.is_system(),
-        };
-
-        let mut replica_ctxs = Vec::new();
         for (replica_id, replica_name) in replica_ids
             .into_iter()
             .zip_eq((0..replication_factor).map(managed_cluster_replica_name))
         {
-            let size_family = self.create_managed_cluster_replica_op(
+            self.create_managed_cluster_replica_op(
                 cluster_id,
                 replica_id,
                 replica_name.clone(),
@@ -1392,34 +1287,6 @@ impl Coordinator {
                 *session.current_role_id(),
                 ReplicaCreateDropReason::Manual,
             )?;
-            replica_ctxs.push(ReplicaEvalContext {
-                cluster_id,
-                replica_id,
-                cluster: cluster_ctx.clone(),
-                replica: ReplicaScopeContext {
-                    id: replica_id.to_string(),
-                    name: replica_name,
-                    is_builtin: cluster_id.is_system(),
-                    size: size.clone(),
-                    size_family,
-                    cluster_id: cluster_id.to_string(),
-                    cluster_name: cluster_name.clone(),
-                },
-            });
-        }
-
-        // Fold the new cluster's cluster-coherent and the replicas' replica-local
-        // scoped overrides into the create transaction. Folding (rather than a
-        // post-transact resolve) makes the committed diff drive the
-        // replica-scoped controller push before create_replica, which
-        // render-frozen flags require, and gives the new cluster its optimizer
-        // overrides for its first plan.
-        let cluster_eval = ClusterEvalContext {
-            cluster_id,
-            cluster: cluster_ctx,
-        };
-        if let Some(scoped_op) = self.scoped_overrides_create_op(&[cluster_eval], &replica_ctxs) {
-            ops.push(scoped_op);
         }
 
         self.catalog_transact(Some(session), ops).await?;
@@ -1439,7 +1306,7 @@ impl Coordinator {
         pending: bool,
         owner_id: RoleId,
         reason: ReplicaCreateDropReason,
-    ) -> Result<String, AdapterError> {
+    ) -> Result<(), AdapterError> {
         let location = mz_catalog::durable::ReplicaLocation::Managed {
             // Concretized below from the cluster config; this intermediate value
             // is discarded, so the list is left empty here.
@@ -1476,17 +1343,6 @@ impl Coordinator {
 
         // The caller pre-allocates `replica_id` out-of-band via the durable
         // allocator, so nothing allocates a replica id in-apply.
-        //
-        // Extract the size family before `config` moves into the op, for the
-        // replica's scoped eval context.
-        let size_family = match &config.location {
-            ReplicaLocation::Managed(location) => location.allocation.family().to_string(),
-            // A managed replica always concretizes to a managed location.
-            ReplicaLocation::Unmanaged(_) => {
-                unreachable!("managed cluster replica has a managed location")
-            }
-        };
-
         ops.push(catalog::Op::CreateClusterReplica {
             cluster_id,
             replica_id,
@@ -1495,7 +1351,7 @@ impl Coordinator {
             owner_id,
             reason,
         });
-        Ok(size_family)
+        Ok(())
     }
 
     fn ensure_valid_azs<'a, I: IntoIterator<Item = &'a String>>(
@@ -1520,7 +1376,6 @@ impl Coordinator {
         session: &Session,
         CreateClusterUnmanagedPlan { replicas }: CreateClusterUnmanagedPlan,
         id: ClusterId,
-        cluster_name: String,
         mut ops: Vec<catalog::Op>,
     ) -> Result<ExecuteResponse, AdapterError> {
         tracing::debug!("sequence_create_unmanaged_cluster");
@@ -1552,22 +1407,13 @@ impl Coordinator {
         }
 
         // Pre-allocate replica ids out-of-band via the durable allocator,
-        // picking the id type from the owning cluster, so each replica's scoped
-        // overrides can be folded into the create transaction below. This
-        // mirrors how cluster and item ids are allocated, so nothing allocates
-        // a replica id in-apply.
+        // picking the id type from the owning cluster. This mirrors how cluster
+        // and item ids are allocated, so nothing allocates a replica id in-apply.
         let id_ts = self.get_catalog_write_ts().await;
         let replica_ids = self
             .catalog()
             .allocate_replica_ids(id, u64::cast_from(replicas.len()), id_ts)
             .await?;
-
-        let cluster_ctx = ClusterScopeContext {
-            id: id.to_string(),
-            name: cluster_name.clone(),
-            is_builtin: id.is_system(),
-        };
-        let mut replica_ctxs = Vec::new();
 
         for (replica_id, (replica_name, replica_config)) in replica_ids.into_iter().zip_eq(replicas)
         {
@@ -1639,25 +1485,6 @@ impl Coordinator {
                 },
             };
 
-            // Only orchestrated (managed-location) replicas have a size and size
-            // family, so only they carry replica-local overrides.
-            if let ReplicaLocation::Managed(location) = &config.location {
-                replica_ctxs.push(ReplicaEvalContext {
-                    cluster_id: id,
-                    replica_id,
-                    cluster: cluster_ctx.clone(),
-                    replica: ReplicaScopeContext {
-                        id: replica_id.to_string(),
-                        name: replica_name.clone(),
-                        is_builtin: id.is_system(),
-                        size: location.size.clone(),
-                        size_family: location.allocation.family().to_string(),
-                        cluster_id: id.to_string(),
-                        cluster_name: cluster_name.clone(),
-                    },
-                });
-            }
-
             ops.push(catalog::Op::CreateClusterReplica {
                 cluster_id: id,
                 replica_id,
@@ -1666,16 +1493,6 @@ impl Coordinator {
                 owner_id: *session.current_role_id(),
                 reason: ReplicaCreateDropReason::Manual,
             });
-        }
-
-        // Fold the new cluster's and replicas' scoped overrides into the create
-        // transaction (see the managed path for rationale).
-        let cluster_eval = ClusterEvalContext {
-            cluster_id: id,
-            cluster: cluster_ctx,
-        };
-        if let Some(scoped_op) = self.scoped_overrides_create_op(&[cluster_eval], &replica_ctxs) {
-            ops.push(scoped_op);
         }
 
         self.catalog_transact(Some(session), ops).await?;
@@ -1883,18 +1700,14 @@ impl Coordinator {
         let owner_id = cluster.owner_id();
 
         let cluster_name = cluster.name.clone();
-        let is_builtin = cluster_id.is_system();
         // A replica name is only unique within its cluster, so the notice on the
         // `IF NOT EXISTS` path below has to name both.
         let qualified_name = format!("{cluster_name}.{name}");
 
         // Pre-allocate the replica id out-of-band via the durable allocator,
         // picking the id type from the target cluster, which may be a system
-        // cluster, so the replica's scoped overrides can be folded into the same
-        // transaction. The overrides are keyed by replica id, and the
-        // replica-scoped controller push must run before `create_replica`. This
-        // mirrors how cluster and item ids are allocated, so nothing allocates a
-        // replica id in-apply.
+        // cluster. This mirrors how cluster and item ids are allocated, so
+        // nothing allocates a replica id in-apply.
         let id_ts = self.get_catalog_write_ts().await;
         let replica_id = self
             .catalog()
@@ -1902,31 +1715,7 @@ impl Coordinator {
             .await?
             .into_element();
 
-        // Build the replica's eval context from the plan before `config` moves
-        // into the op. Only managed replicas have a size (and size family).
-        let replica_ctx = match &config.location {
-            ReplicaLocation::Managed(location) => Some(ReplicaEvalContext {
-                cluster_id,
-                replica_id,
-                cluster: ClusterScopeContext {
-                    id: cluster_id.to_string(),
-                    name: cluster_name.clone(),
-                    is_builtin,
-                },
-                replica: ReplicaScopeContext {
-                    id: replica_id.to_string(),
-                    name: name.to_string(),
-                    is_builtin,
-                    size: location.size.clone(),
-                    size_family: location.allocation.family().to_string(),
-                    cluster_id: cluster_id.to_string(),
-                    cluster_name,
-                },
-            }),
-            ReplicaLocation::Unmanaged(_) => None,
-        };
-
-        let mut ops = vec![catalog::Op::CreateClusterReplica {
+        let ops = vec![catalog::Op::CreateClusterReplica {
             cluster_id,
             replica_id,
             name: name.clone(),
@@ -1934,15 +1723,6 @@ impl Coordinator {
             owner_id,
             reason: ReplicaCreateDropReason::Manual,
         }];
-
-        // The cluster already exists, so only this replica's local overrides
-        // need resolving. Fold them into the create transaction so the
-        // replica-scoped push runs before `create_replica`.
-        if let Some(replica_ctx) = replica_ctx {
-            if let Some(scoped_op) = self.scoped_overrides_create_op(&[], &[replica_ctx]) {
-                ops.push(scoped_op);
-            }
-        }
 
         match self.catalog_transact(Some(session), ops).await {
             Ok(()) => {
@@ -2104,20 +1884,17 @@ impl Coordinator {
             arrangement_compression: *new_arrangement_compression,
         };
 
-        // Eagerly validate the `max_replicas_per_cluster` limit.
-        // `catalog_transact` will do this validation too, but allocating
-        // replica IDs is expensive enough that we need to do this validation
-        // before allocating replica IDs. See database-issues#6046.
-        if *new_replication_factor > replication_factor {
-            if cluster_id.is_user() {
-                self.validate_resource_limit(
-                    usize::cast_from(replication_factor),
-                    i64::from(*new_replication_factor) - i64::from(replication_factor),
-                    SystemVars::max_replicas_per_cluster,
-                    "cluster replica",
-                    MAX_REPLICAS_PER_CLUSTER.name(),
-                )?;
-            }
+        // A replication-factor-only increase changes the committed baseline,
+        // which the controller cannot shed. Unlike a reshape's transient
+        // strategy union, the resulting replica count is exact here.
+        if *new_replication_factor > replication_factor && cluster_id.is_user() {
+            self.validate_resource_limit(
+                usize::cast_from(replication_factor),
+                i64::from(*new_replication_factor) - i64::from(replication_factor),
+                SystemVars::max_replicas_per_cluster,
+                "cluster replica",
+                MAX_REPLICAS_PER_CLUSTER.name(),
+            )?;
         }
 
         // The controller owns the replica set of every managed cluster, so a
@@ -2157,15 +1934,14 @@ impl Coordinator {
         } else {
             0
         };
-        // Allocate the replica ids out-of-band via the durable allocator, only
-        // after the eager limit validation above so a rejected alter allocates
-        // nothing. Pick the id type from the target cluster, which may be a
-        // system cluster. This mirrors how cluster and item ids are allocated,
-        // so nothing allocates a replica id in-apply. Fetch the catalog write
-        // timestamp lazily here, since it needs mutable access to self (the
-        // cluster borrow above is already released) and scale-down, no-op, and
-        // automated scheduling turn-off alters must not pay an oracle
-        // round-trip just to allocate nothing.
+        // Allocate the replica ids out-of-band via the durable allocator. Pick
+        // the id type from the target cluster, which may be a system cluster.
+        // This mirrors how cluster and item ids are allocated, so nothing
+        // allocates a replica id in-apply. Fetch the catalog write timestamp
+        // lazily here, since it needs mutable access to self (the cluster borrow
+        // above is already released) and scale-down, no-op, and automated
+        // scheduling turn-off alters must not pay an oracle round-trip just to
+        // allocate nothing.
         let mut new_replica_ids = if needed_replica_ids > 0 {
             let id_ts = self.get_catalog_write_ts().await;
             let ids = self
@@ -2176,20 +1952,6 @@ impl Coordinator {
         } else {
             Vec::<ReplicaId>::new().into_iter()
         };
-
-        // Collect an eval context for each replica recreated below, so the alter
-        // transaction folds the replicas' replica-scoped overrides the same way
-        // the create paths do. ALTER CLUSTER SET (SIZE ...) to a different size
-        // family flips size-family-keyed render-frozen flags, so the override
-        // must reach the controller before the recreated replica renders. Only
-        // the replica scope is folded. The cluster already exists and its
-        // cluster-scoped overrides are unaffected by this alter.
-        let cluster_ctx = ClusterScopeContext {
-            id: cluster_id.to_string(),
-            name: name.clone(),
-            is_builtin: cluster_id.is_system(),
-        };
-        let mut replica_ctxs = Vec::new();
 
         if controller_owns {
             // Defer all replica create/drop to the controller. Only the realized
@@ -2233,7 +1995,7 @@ impl Coordinator {
                         let replica_id = new_replica_ids
                             .next()
                             .expect("pre-allocated enough replica ids");
-                        let size_family = self.create_managed_cluster_replica_op(
+                        self.create_managed_cluster_replica_op(
                             cluster_id,
                             replica_id,
                             replica_name.clone(),
@@ -2245,20 +2007,6 @@ impl Coordinator {
                             owner_id,
                             reason.clone(),
                         )?;
-                        replica_ctxs.push(ReplicaEvalContext {
-                            cluster_id,
-                            replica_id,
-                            cluster: cluster_ctx.clone(),
-                            replica: ReplicaScopeContext {
-                                id: replica_id.to_string(),
-                                name: replica_name,
-                                is_builtin: cluster_id.is_system(),
-                                size: new_size.clone(),
-                                size_family,
-                                cluster_id: cluster_id.to_string(),
-                                cluster_name: cluster_ctx.name.clone(),
-                            },
-                        });
                     }
                 }
                 AlterClusterPlanStrategy::For(_) | AlterClusterPlanStrategy::UntilReady { .. } => {
@@ -2269,7 +2017,7 @@ impl Coordinator {
                         let replica_id = new_replica_ids
                             .next()
                             .expect("pre-allocated enough replica ids");
-                        let size_family = self.create_managed_cluster_replica_op(
+                        self.create_managed_cluster_replica_op(
                             cluster_id,
                             replica_id,
                             replica_name.clone(),
@@ -2281,20 +2029,6 @@ impl Coordinator {
                             owner_id,
                             reason.clone(),
                         )?;
-                        replica_ctxs.push(ReplicaEvalContext {
-                            cluster_id,
-                            replica_id,
-                            cluster: cluster_ctx.clone(),
-                            replica: ReplicaScopeContext {
-                                id: replica_id.to_string(),
-                                name: replica_name,
-                                is_builtin: cluster_id.is_system(),
-                                size: new_size.clone(),
-                                size_family,
-                                cluster_id: cluster_id.to_string(),
-                                cluster_name: cluster_ctx.name.clone(),
-                            },
-                        });
                     }
                     finalization_needed = NeedsFinalization::Yes;
                 }
@@ -2321,7 +2055,7 @@ impl Coordinator {
                 let replica_id = new_replica_ids
                     .next()
                     .expect("pre-allocated enough replica ids");
-                let size_family = self.create_managed_cluster_replica_op(
+                self.create_managed_cluster_replica_op(
                     cluster_id,
                     replica_id,
                     replica_name.clone(),
@@ -2335,20 +2069,6 @@ impl Coordinator {
                     owner_id,
                     reason.clone(),
                 )?;
-                replica_ctxs.push(ReplicaEvalContext {
-                    cluster_id,
-                    replica_id,
-                    cluster: cluster_ctx.clone(),
-                    replica: ReplicaScopeContext {
-                        id: replica_id.to_string(),
-                        name: replica_name,
-                        is_builtin: cluster_id.is_system(),
-                        size: new_size.clone(),
-                        size_family,
-                        cluster_id: cluster_id.to_string(),
-                        cluster_name: cluster_ctx.name.clone(),
-                    },
-                });
             }
         }
 
@@ -2373,16 +2093,6 @@ impl Coordinator {
                 });
             }
             NeedsFinalization::Yes => {}
-        }
-
-        // Fold the recreated replicas' replica-scoped overrides into the same
-        // transaction, so the committed diff drives the replica-scoped controller
-        // push before create_replica. Render-frozen flags (chosen at
-        // arrangement-build time) require the override to land before the replica
-        // renders. Scale-down and no-op alters recreate no replicas, so this is
-        // empty and folds nothing.
-        if let Some(scoped_op) = self.scoped_overrides_create_op(&[], &replica_ctxs) {
-            ops.push(scoped_op);
         }
 
         self.catalog_transact(session, ops).await?;
@@ -2711,6 +2421,30 @@ struct ReconfigurationDimensionsUnchanged {
     arrangement_compression: bool,
 }
 
+/// Returns the foreground result for a terminal reconfiguration record.
+///
+/// Records are overwritten by later ALTERs. A terminal outcome belongs to this
+/// waiter only when it resolved the target the waiter wrote. A superseding
+/// target therefore reports the generic timeout/cancellation result rather than
+/// attributing its resource failure to the earlier statement.
+fn terminal_reconfiguration_result(
+    record: &ReconfigurationState,
+    awaited_target: &ReconfigurationTarget,
+    realized_matches_target: bool,
+) -> Result<(), AdapterError> {
+    match record.status {
+        ReconfigurationStatus::ResourceExhausted if record.target == *awaited_target => {
+            Err(AdapterError::AlterClusterResourceExhausted)
+        }
+        ReconfigurationStatus::Finalized | ReconfigurationStatus::Cancelled
+            if realized_matches_target =>
+        {
+            Ok(())
+        }
+        _ => Err(AdapterError::AlterClusterTimeout),
+    }
+}
+
 /// Retains a stale in-progress reconfiguration record carried by a direct
 /// config write as cancelled, returning the audit intent to declare with the
 /// write.
@@ -2872,6 +2606,28 @@ mod tests {
             interval: true,
             arrangement_compression: true,
         }
+    }
+
+    #[mz_ore::test]
+    fn resource_exhaustion_is_attributed_to_the_matching_waiter() {
+        let awaited = target("200cc", 1, &[], false);
+        let mut record = ReconfigurationState {
+            target: awaited.clone(),
+            deadline: Timestamp::from(0),
+            on_timeout: OnTimeoutAction::Rollback,
+            status: ReconfigurationStatus::ResourceExhausted,
+        };
+
+        assert!(matches!(
+            terminal_reconfiguration_result(&record, &awaited, false),
+            Err(AdapterError::AlterClusterResourceExhausted)
+        ));
+
+        record.target = target("300cc", 1, &[], false);
+        assert!(matches!(
+            terminal_reconfiguration_result(&record, &awaited, false),
+            Err(AdapterError::AlterClusterTimeout)
+        ));
     }
 
     #[mz_ore::test]

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -7,22 +7,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::time::{Duration, Instant};
+use std::collections::BTreeSet;
+use std::time::Duration;
 
 use itertools::Itertools;
-use maplit::btreeset;
 use mz_adapter_types::cluster_state::ReconfigurationAudit;
 use mz_catalog::builtin::BUILTINS;
 use mz_catalog::durable::managed_cluster_replica_name;
 use mz_catalog::memory::error::ErrorKind;
 use mz_catalog::memory::objects::{
-    Cluster, ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged, DataSourceDesc,
+    Cluster, ClusterConfig, ClusterVariant, ClusterVariantManaged, DataSourceDesc,
     ManagedReplicaConfigShape, ReconfigurationState, ReconfigurationStatus, ReconfigurationTarget,
 };
 use mz_compute_types::config::ComputeReplicaConfig;
 use mz_controller::clusters::{
-    ClusterStatus, ManagedReplicaLocation, ReplicaConfig, ReplicaLocation, ReplicaLogging,
+    ManagedReplicaLocation, ReplicaConfig, ReplicaLocation, ReplicaLogging,
 };
 use mz_controller_types::{ClusterId, DEFAULT_REPLICA_LOGGING_INTERVAL, ReplicaId};
 use mz_ore::cast::CastFrom;
@@ -31,14 +30,13 @@ use mz_ore::instrument;
 use mz_repr::Timestamp;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::role_id::RoleId;
-use mz_sql::ast::{Ident, QualifiedReplica};
 use mz_sql::catalog::{CatalogCluster, CatalogError, ObjectType};
 use mz_sql::names::QualifiedItemName;
 use mz_sql::plan::{
     self, AlterClusterPlanStrategy, AlterClusterRenamePlan, AlterClusterReplicaRenamePlan,
-    AlterClusterSwapPlan, AlterOptionParameter, AlterSetClusterPlan,
-    ComputeReplicaIntrospectionConfig, CreateClusterManagedPlan, CreateClusterPlan,
-    CreateClusterReplicaPlan, CreateClusterUnmanagedPlan, CreateClusterVariant, PlanClusterOption,
+    AlterClusterSwapPlan, AlterOptionParameter, AlterSetClusterPlan, CreateClusterManagedPlan,
+    CreateClusterPlan, CreateClusterReplicaPlan, CreateClusterUnmanagedPlan, CreateClusterVariant,
+    PlanClusterOption,
 };
 use mz_sql::plan::{AlterClusterPlan, OnTimeoutAction};
 use mz_sql::session::metadata::SessionMetadata;
@@ -46,23 +44,19 @@ use mz_sql::session::vars::{
     MAX_CREDIT_CONSUMPTION_RATE, MAX_REPLICAS_PER_CLUSTER, SystemVars, Var,
 };
 use mz_storage_types::sources::SourceConnection;
-use tracing::{Instrument, Span, debug};
+use tracing::{Instrument, Span};
 
 use mz_adapter_types::dyncfgs::{
     DEFAULT_CLUSTER_RECONFIGURATION_TIMEOUT, ENABLE_BACKGROUND_ALTER_CLUSTER,
 };
 
 use super::return_if_err;
-use crate::AdapterError::AlterClusterWhilePendingReplicas;
 use crate::catalog::{self, Op, ReplicaCreateDropReason};
 use crate::coord::{
-    AlterCluster, AlterClusterAwaitReconfiguration, AlterClusterFinalize,
-    AlterClusterWaitForHydrated, ClusterReplicaStatuses, ClusterStage, Coordinator, Message,
+    AlterCluster, AlterClusterAwaitReconfiguration, ClusterStage, Coordinator, Message,
     PlanValidity, StageResult, Staged,
 };
 use crate::{AdapterError, AdapterNotice, ExecuteContext, ExecuteResponse, session::Session};
-
-const PENDING_REPLICA_SUFFIX: &str = "-pending";
 
 impl Staged for ClusterStage {
     type Ctx = ExecuteContext;
@@ -70,8 +64,6 @@ impl Staged for ClusterStage {
     fn validity(&mut self) -> &mut PlanValidity {
         match self {
             Self::Alter(stage) => &mut stage.validity,
-            Self::WaitForHydrated(stage) => &mut stage.validity,
-            Self::Finalize(stage) => &mut stage.validity,
             Self::AwaitReconfiguration(stage) => &mut stage.validity,
         }
     }
@@ -85,37 +77,6 @@ impl Staged for ClusterStage {
             Self::Alter(stage) => {
                 coord
                     .sequence_alter_cluster_stage(ctx.session(), stage.plan.clone(), stage.validity)
-                    .await
-            }
-            Self::WaitForHydrated(stage) => {
-                let AlterClusterWaitForHydrated {
-                    validity,
-                    plan,
-                    new_config,
-                    workload_class,
-                    timeout_time,
-                    on_timeout,
-                } = stage;
-                coord
-                    .check_if_pending_replicas_hydrated_stage(
-                        ctx.session(),
-                        plan,
-                        new_config,
-                        workload_class,
-                        timeout_time,
-                        on_timeout,
-                        validity,
-                    )
-                    .await
-            }
-            Self::Finalize(stage) => {
-                coord
-                    .finalize_alter_cluster_stage(
-                        ctx.session(),
-                        stage.plan.clone(),
-                        stage.new_config.clone(),
-                        stage.workload_class.clone(),
-                    )
                     .await
             }
             Self::AwaitReconfiguration(stage) => {
@@ -433,70 +394,15 @@ impl Coordinator {
         }
 
         match (&config.variant, &new_config.variant) {
-            (Managed(_), Managed(new_config_managed)) => {
-                let alter_followup = self
-                    .sequence_alter_cluster_managed_to_managed(
-                        Some(session),
-                        cluster_id,
-                        new_config.clone(),
-                        ReplicaCreateDropReason::Manual,
-                        strategy.clone(),
-                    )
-                    .await?;
+            (Managed(_), Managed(_)) => {
+                self.sequence_alter_cluster_managed_to_managed(
+                    session,
+                    cluster_id,
+                    new_config.clone(),
+                )
+                .await?;
                 if let Some(notice) = single_replica_sources_notice {
                     session.add_notice(notice);
-                }
-                if alter_followup == NeedsFinalization::Yes {
-                    // For non backgrounded zero-downtime alters, store the
-                    // cluster_id in the ConnMeta to allow for cancellation.
-                    self.active_conns
-                        .get_mut(session.conn_id())
-                        .expect("There must be an active connection")
-                        .pending_cluster_alters
-                        .insert(cluster_id.clone());
-                    let new_config_managed = new_config_managed.clone();
-                    return match &strategy {
-                        AlterClusterPlanStrategy::None => Err(AdapterError::Internal(
-                            "AlterClusterPlanStrategy must not be None if NeedsFinalization is Yes"
-                                .into(),
-                        )),
-                        AlterClusterPlanStrategy::For(duration) => {
-                            let span = Span::current();
-                            let plan = plan.clone();
-                            let duration = duration.clone().to_owned();
-                            let workload_class = new_config.workload_class.clone();
-                            Ok(StageResult::Handle(mz_ore::task::spawn(
-                                || "Finalize Alter Cluster",
-                                async move {
-                                    tokio::time::sleep(duration).await;
-                                    let stage = ClusterStage::Finalize(AlterClusterFinalize {
-                                        validity,
-                                        plan,
-                                        new_config: new_config_managed,
-                                        workload_class,
-                                    });
-                                    Ok(Box::new(stage))
-                                }
-                                .instrument(span),
-                            )))
-                        }
-                        AlterClusterPlanStrategy::UntilReady {
-                            timeout,
-                            on_timeout,
-                        } => Ok(StageResult::Immediate(Box::new(
-                            ClusterStage::WaitForHydrated(AlterClusterWaitForHydrated {
-                                validity,
-                                plan: plan.clone(),
-                                new_config: new_config_managed.clone(),
-                                workload_class: new_config.workload_class.clone(),
-                                timeout_time: Instant::now() + timeout.to_owned(),
-                                // The legacy foreground wait uses COMMIT as
-                                // its implicit default. The controller-owned
-                                // paths default to ROLLBACK.
-                                on_timeout: on_timeout.unwrap_or(OnTimeoutAction::Commit),
-                            }),
-                        ))),
-                    };
                 }
             }
             (Unmanaged, Managed(new_managed)) => {
@@ -682,7 +588,7 @@ impl Coordinator {
         // its target may already have. `ROLLBACK` (the default) reverts an
         // un-hydrated reconfiguration to its pre-reconfiguration shape rather
         // than cutting over to a not-yet-hydrated target, which could induce
-        // downtime. The legacy foreground path uses implicit `COMMIT`.
+        // downtime.
         let now = self.now();
         let deadline_from = |timeout: Duration| -> Timestamp {
             now.saturating_add(u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX))
@@ -868,259 +774,6 @@ impl Coordinator {
         }
     }
 
-    async fn finalize_alter_cluster_stage(
-        &mut self,
-        session: &Session,
-        AlterClusterPlan {
-            id: cluster_id,
-            name: cluster_name,
-            ..
-        }: AlterClusterPlan,
-        new_config: ClusterVariantManaged,
-        workload_class: Option<String>,
-    ) -> Result<StageResult<Box<ClusterStage>>, AdapterError> {
-        let cluster = self.catalog.get_cluster(cluster_id);
-        let mut ops = vec![];
-
-        // Gather the ops to remove the non pending replicas
-        // Also skip any billed_as free replicas
-        let remove_replicas = cluster
-            .replicas()
-            .filter_map(|r| {
-                if !r.config.location.pending() && !r.config.location.internal() {
-                    Some(catalog::DropObjectInfo::ClusterReplica((
-                        cluster_id.clone(),
-                        r.replica_id,
-                        ReplicaCreateDropReason::Manual,
-                    )))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        ops.push(catalog::Op::DropObjects(remove_replicas));
-
-        // Gather the Ops to remove the "-pending" suffix from the name and set
-        // pending to false
-        let finalize_replicas: Vec<catalog::Op> = cluster
-            .replicas()
-            .filter_map(|r| {
-                if r.config.location.pending() {
-                    let cluster_ident = match Ident::new(cluster.name.clone()) {
-                        Ok(id) => id,
-                        Err(err) => {
-                            return Some(Err(AdapterError::internal(
-                                "Unexpected error parsing cluster name",
-                                err,
-                            )));
-                        }
-                    };
-                    let replica_ident = match Ident::new(r.name.clone()) {
-                        Ok(id) => id,
-                        Err(err) => {
-                            return Some(Err(AdapterError::internal(
-                                "Unexpected error parsing replica name",
-                                err,
-                            )));
-                        }
-                    };
-                    Some(Ok((cluster_ident, replica_ident, r)))
-                } else {
-                    None
-                }
-            })
-            // Early collection is to handle errors from generating of the
-            // Idents
-            .collect::<Result<Vec<(Ident, Ident, &ClusterReplica)>, _>>()?
-            .into_iter()
-            .map(|(cluster_ident, replica_ident, replica)| {
-                let mut new_replica_config = replica.config.clone();
-                debug!("Promoting replica: {}", replica.name);
-                match new_replica_config.location {
-                    mz_controller::clusters::ReplicaLocation::Managed(ManagedReplicaLocation {
-                        ref mut pending,
-                        ..
-                    }) => {
-                        *pending = false;
-                    }
-                    mz_controller::clusters::ReplicaLocation::Unmanaged(_) => {}
-                }
-
-                let mut replica_ops = vec![];
-                let to_name = replica.name.strip_suffix(PENDING_REPLICA_SUFFIX);
-                if let Some(to_name) = to_name {
-                    replica_ops.push(catalog::Op::RenameClusterReplica {
-                        cluster_id: cluster_id.clone(),
-                        replica_id: replica.replica_id.to_owned(),
-                        name: QualifiedReplica {
-                            cluster: cluster_ident,
-                            replica: replica_ident,
-                        },
-                        to_name: to_name.to_owned(),
-                    });
-                }
-                replica_ops.push(catalog::Op::UpdateClusterReplicaConfig {
-                    cluster_id,
-                    replica_id: replica.replica_id.to_owned(),
-                    config: new_replica_config,
-                });
-                replica_ops
-            })
-            .flatten()
-            .collect();
-
-        ops.extend(finalize_replicas);
-
-        // Add the Op to update the cluster state. A stale in-progress
-        // reconfiguration record carried by this legacy write is retained as
-        // cancelled, with the matching audit intent declared.
-        let mut final_config = ClusterConfig {
-            variant: ClusterVariant::Managed(new_config),
-            workload_class: workload_class.clone(),
-        };
-        let reconfiguration_audit = cancel_carried_reconfiguration(&mut final_config);
-        ops.push(Op::UpdateClusterConfig {
-            id: cluster_id,
-            name: cluster_name,
-            config: final_config,
-            reconfiguration_audit,
-            burst_audit: None,
-        });
-        self.catalog_transact(Some(session), ops).await?;
-        // Remove the cluster being altered from the ConnMeta
-        // pending_cluster_alters BTreeSet
-        self.active_conns
-            .get_mut(session.conn_id())
-            .expect("There must be an active connection")
-            .pending_cluster_alters
-            .remove(&cluster_id);
-
-        Ok(StageResult::Response(ExecuteResponse::AlteredObject(
-            ObjectType::Cluster,
-        )))
-    }
-
-    async fn check_if_pending_replicas_hydrated_stage(
-        &mut self,
-        session: &Session,
-        plan: AlterClusterPlan,
-        new_config: ClusterVariantManaged,
-        workload_class: Option<String>,
-        timeout_time: Instant,
-        on_timeout: OnTimeoutAction,
-        validity: PlanValidity,
-    ) -> Result<StageResult<Box<ClusterStage>>, AdapterError> {
-        // wait and re-signal wait for hydrated if not hydrated
-        let cluster = self.catalog.get_cluster(plan.id);
-        let pending_replicas = cluster
-            .replicas()
-            .filter_map(|r| {
-                if r.config.location.pending() {
-                    Some(r.replica_id.clone())
-                } else {
-                    None
-                }
-            })
-            .collect_vec();
-        // Check For timeout
-        if Instant::now() > timeout_time {
-            // Timed out handle timeout action
-            match on_timeout {
-                OnTimeoutAction::Rollback => {
-                    self.active_conns
-                        .get_mut(session.conn_id())
-                        .expect("There must be an active connection")
-                        .pending_cluster_alters
-                        .remove(&cluster.id);
-                    self.drop_reconfiguration_replicas(btreeset!(cluster.id))
-                        .await?;
-                    return Err(AdapterError::AlterClusterTimeout);
-                }
-                OnTimeoutAction::Commit => {
-                    let span = Span::current();
-                    let poll_duration = self
-                        .catalog
-                        .system_config()
-                        .cluster_alter_check_ready_interval()
-                        .clone();
-                    return Ok(StageResult::Handle(mz_ore::task::spawn(
-                        || "Finalize Alter Cluster",
-                        async move {
-                            tokio::time::sleep(poll_duration).await;
-                            let stage = ClusterStage::Finalize(AlterClusterFinalize {
-                                validity,
-                                plan,
-                                new_config,
-                                workload_class,
-                            });
-                            Ok(Box::new(stage))
-                        }
-                        .instrument(span),
-                    )));
-                }
-            }
-        }
-        let compute_hydrated_fut = self
-            .controller
-            .compute
-            .collections_hydrated_for_replicas(cluster.id, pending_replicas.clone(), [].into())
-            .map_err(|e| AdapterError::internal("Failed to check hydration", e))?;
-
-        let storage_hydrated = self
-            .controller
-            .storage
-            .collections_hydrated_on_replicas(
-                Some(pending_replicas.clone()),
-                &cluster.id,
-                &[].into(),
-            )
-            .map_err(|e| AdapterError::internal("Failed to check hydration", e))?;
-
-        // Also require every pending replica to be online, in case it has no
-        // objects that need hydration on it (e.g. a single-replica source).
-        let replicas_online = pending_replicas.iter().all(|replica_id| {
-            let status = self
-                .cluster_replica_statuses
-                .try_get_cluster_replica_statuses(cluster.id, *replica_id)
-                .map(ClusterReplicaStatuses::cluster_replica_status);
-            matches!(status, Some(ClusterStatus::Online))
-        });
-
-        let span = Span::current();
-        Ok(StageResult::Handle(mz_ore::task::spawn(
-            || "Alter Cluster: wait for hydrated",
-            async move {
-                let compute_hydrated = compute_hydrated_fut
-                    .await
-                    .map_err(|e| AdapterError::internal("Failed to check hydration", e))?;
-
-                if compute_hydrated && storage_hydrated && replicas_online {
-                    // We're done
-                    Ok(Box::new(ClusterStage::Finalize(AlterClusterFinalize {
-                        validity,
-                        plan,
-                        new_config: new_config.clone(),
-                        workload_class: workload_class.clone(),
-                    })))
-                } else {
-                    // Check later
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                    let stage = ClusterStage::WaitForHydrated(AlterClusterWaitForHydrated {
-                        validity,
-                        plan,
-                        new_config,
-                        workload_class,
-                        timeout_time,
-                        on_timeout,
-                    });
-                    Ok(Box::new(stage))
-                }
-            }
-            .instrument(span),
-        )))
-    }
-
-    #[mz_ore::instrument(level = "debug")]
     pub(crate) async fn sequence_create_cluster(
         &mut self,
         session: &Session,
@@ -1540,10 +1193,8 @@ impl Coordinator {
     /// replication-factor domain. Replicas belonging to a reconfiguration's
     /// hydrate-overlap are deliberately not counted: they replace the serving
     /// set at cut-over rather than adding to it. Counting the replication
-    /// factor instead of replicas excludes them under both reconfiguration
-    /// mechanisms, the legacy graceful alter (which marks them pending) and
-    /// the cluster controller (which creates them as ordinary replicas of the
-    /// target shape).
+    /// factor instead of replicas excludes the ordinary replicas the cluster
+    /// controller creates for the target shape.
     fn notice_relevant_replica_count(&self, cluster: &Cluster) -> usize {
         match &cluster.config.variant {
             ClusterVariant::Managed(managed) => {
@@ -1751,9 +1402,14 @@ impl Coordinator {
         }
     }
 
-    /// When this is called by the automated cluster scheduling, `scheduling_decision_reason` should
-    /// contain information on why is a cluster being turned On/Off. It will be forwarded to the
-    /// `details` field of the audit log event that records creating or dropping replicas.
+    /// Applies a managed→managed `ALTER CLUSTER`.
+    ///
+    /// This is a config-only write: the cluster controller owns the replica set
+    /// and reconciles it to the new realized config on its next tick. Emitting
+    /// creates and drops here as well would fight it, since it derives replica
+    /// names from the observed set, so an adapter create by canonical `rN` can
+    /// collide with a controller-chosen name and an adapter drop by canonical
+    /// `rN` can miss a churned one.
     ///
     /// # Panics
     ///
@@ -1761,18 +1417,12 @@ impl Coordinator {
     /// Panics if `new_config` is not a configuration for a managed cluster.
     pub(crate) async fn sequence_alter_cluster_managed_to_managed(
         &mut self,
-        session: Option<&Session>,
+        session: &Session,
         cluster_id: ClusterId,
         new_config: ClusterConfig,
-        reason: ReplicaCreateDropReason,
-        strategy: AlterClusterPlanStrategy,
-    ) -> Result<NeedsFinalization, AdapterError> {
+    ) -> Result<(), AdapterError> {
         let cluster = self.catalog.get_cluster(cluster_id);
         let name = cluster.name().to_string();
-        let owner_id = cluster.owner_id();
-
-        let mut ops = vec![];
-        let mut finalization_needed = NeedsFinalization::No;
 
         let ClusterVariant::Managed(ClusterVariantManaged {
             size,
@@ -1789,14 +1439,6 @@ impl Coordinator {
         else {
             panic!("expected existing managed cluster config");
         };
-        // Clone the existing managed config out of the cluster so the immutable
-        // catalog borrow can be released before the out-of-band replica id
-        // allocation below, which needs mutable access to self.
-        let size = size.clone();
-        let availability_zones = availability_zones.clone();
-        let logging = logging.clone();
-        let arrangement_compression = *arrangement_compression;
-        let replication_factor = *replication_factor;
         let ClusterVariant::Managed(new_managed) = &new_config.variant else {
             panic!("expected new managed cluster config");
         };
@@ -1804,8 +1446,8 @@ impl Coordinator {
             size: new_size,
             replication_factor: new_replication_factor,
             availability_zones: new_availability_zones,
-            logging: new_logging,
-            arrangement_compression: new_arrangement_compression,
+            logging: _,
+            arrangement_compression: _,
             optimizer_feature_overrides: _,
             schedule: _,
             auto_scaling_strategy: new_auto_scaling_strategy,
@@ -1813,7 +1455,7 @@ impl Coordinator {
             burst: _,
         } = new_managed;
 
-        let role_id = session.map(|s| s.role_metadata().current_role);
+        let role_id = Some(session.role_metadata().current_role);
         self.catalog.ensure_valid_replica_size(
             &self.catalog().get_role_allowed_cluster_sizes(&role_id),
             new_size,
@@ -1852,49 +1494,18 @@ impl Coordinator {
             }
         }
 
-        // check for active updates
-        if cluster.replicas().any(|r| r.config.location.pending()) {
-            return Err(AlterClusterWhilePendingReplicas);
-        }
-
-        // Resolve existing replica ids by name before releasing the catalog
-        // borrow, so the drop branches below can build their ops without it.
-        let replica_id_by_name: BTreeMap<String, ReplicaId> = cluster
-            .replicas()
-            .map(|r| (r.name.clone(), r.replica_id))
-            .collect();
-        // The cluster's observed owned replica set, with the same exclusions
-        // as the controller's ownership test: internal and billed-as replicas
-        // are manually managed, pending ones belong to an in-flight
-        // reconfiguration (rejected above, so none exist here).
-        let owned_replica_ids: Vec<ReplicaId> = cluster
-            .replicas()
-            .filter(|r| {
-                !r.config.location.internal()
-                    && r.config.location.billed_as().is_none()
-                    && !r.config.location.pending()
-            })
-            .map(|r| r.replica_id)
-            .collect();
-
-        let compute = mz_sql::plan::ComputeReplicaConfig {
-            introspection: new_logging
-                .interval
-                .map(|interval| ComputeReplicaIntrospectionConfig {
-                    debugging: new_logging.log_logging,
-                    interval,
-                }),
-            arrangement_compression: *new_arrangement_compression,
-        };
-
-        // A replication-factor-only increase changes the committed baseline,
-        // which the controller cannot shed. Validate that floor without trying
-        // to predict the controller's transient strategy union. Concrete create
-        // transactions still validate the complete physical replica set.
-        if *new_replication_factor > replication_factor && cluster_id.is_user() {
+        // The committed baseline is an exact count, not a prediction of the
+        // controller's transient strategy union, and no strategy can shed it.
+        // Validate it here: `Op::UpdateClusterConfig` contributes nothing to
+        // `catalog_transact`'s replica accounting, because the controller
+        // materializes the replicas on a later tick rather than this transaction
+        // emitting creates. Without the check the ALTER would succeed and the
+        // controller would then fail its own create transaction on every tick.
+        // See database-issues#6046.
+        if new_replication_factor > replication_factor && cluster_id.is_user() {
             self.validate_resource_limit(
-                usize::cast_from(replication_factor),
-                i64::from(*new_replication_factor) - i64::from(replication_factor),
+                usize::cast_from(*replication_factor),
+                i64::from(*new_replication_factor) - i64::from(*replication_factor),
                 SystemVars::max_replicas_per_cluster,
                 "cluster replica",
                 MAX_REPLICAS_PER_CLUSTER.name(),
@@ -1921,206 +1532,32 @@ impl Coordinator {
             )?;
         }
 
-        // The controller owns the replica set of every managed cluster, so a
-        // non-record change reaching this path is replication-factor only.
-        // Config-shape changes (size, logging, AZ, and EXPERIMENTAL ARRANGEMENT
-        // COMPRESSION) are reshaped into a durable reconfiguration record before
-        // they get here. The controller reconciles the replica set to the realized
-        // config's new count on its next tick. We update only the realized config
-        // and emit no create/drop here because doing both fights the controller.
-        // It derives replica names from the observed set, so an adapter create by
-        // canonical `rN` can collide with a controller-chosen name. An adapter drop
-        // by canonical `rN` can miss a churned one.
-        //
-        // The direct create/drop branches below are unreachable while this holds.
-        // They go together with the staged reconfiguration machine.
-        let controller_owns = true;
-
-        // Count exactly as many replica ids as the branches below consume. The
-        // config-changed branches recreate all replicas. A pure scale-up creates
-        // only the delta. Scale-down and no-op create none. A controller-owned
-        // alter emits no create/drop at all, so it must not allocate. Allocating
-        // there burns those ids durably and throws them away. The controller
-        // allocates its own when it materializes the change.
         let config_changed = new_managed.replica_config_shape()
             != ManagedReplicaConfigShape::new(
-                &size,
-                &availability_zones,
-                &logging,
-                arrangement_compression,
+                size,
+                availability_zones,
+                logging,
+                *arrangement_compression,
             );
-        let needed_replica_ids = if controller_owns {
-            0
-        } else if config_changed {
-            *new_replication_factor
-        } else if *new_replication_factor > replication_factor {
-            *new_replication_factor - replication_factor
-        } else {
-            0
-        };
-        // Allocate the replica ids out-of-band via the durable allocator. Pick
-        // the id type from the target cluster, which may be a system cluster.
-        // This mirrors how cluster and item ids are allocated, so nothing
-        // allocates a replica id in-apply. Fetch the catalog write timestamp
-        // lazily here, since it needs mutable access to self (the cluster borrow
-        // above is already released) and scale-down, no-op, and automated
-        // scheduling turn-off alters must not pay an oracle round-trip just to
-        // allocate nothing.
-        let mut new_replica_ids = if needed_replica_ids > 0 {
-            let id_ts = self.get_catalog_write_ts().await;
-            let ids = self
-                .catalog()
-                .allocate_replica_ids(cluster_id, u64::from(needed_replica_ids), id_ts)
-                .await?;
-            ids.into_iter()
-        } else {
-            Vec::<ReplicaId>::new().into_iter()
-        };
-
-        if controller_owns {
-            // Defer all replica create/drop to the controller. Only the realized
-            // config update below is applied here. The target must still be
-            // valid: the controller creates replicas from the realized config
-            // without re-validating availability zones, so an invalid pool
-            // written here would produce an unplaceable replica.
-            if config_changed {
-                self.ensure_valid_azs(new_availability_zones.iter())?;
-            }
-        } else if config_changed {
+        // The controller creates replicas from the realized config without
+        // re-validating availability zones, so an invalid pool written here
+        // would produce an unplaceable replica.
+        if config_changed {
             self.ensure_valid_azs(new_availability_zones.iter())?;
-            // If we're not doing a zero-downtime reconfig tear down all
-            // replicas, create new ones else create the pending replicas and
-            // return early asking for finalization
-            match strategy {
-                AlterClusterPlanStrategy::None => {
-                    // Names can drift from the canonical `r1..rN` while the
-                    // controller owns the set (its name generator avoids
-                    // observed names), so a factor-derived name list can miss
-                    // replicas after a break-glass handoff. This branch
-                    // recreates the entire replica set anyway, so dropping the
-                    // observed owned set by id closes that. In the pure
-                    // canonical world the two sets are identical.
-                    let replica_ids_and_reasons = owned_replica_ids
-                        .iter()
-                        .map(|replica_id| {
-                            catalog::DropObjectInfo::ClusterReplica((
-                                cluster_id,
-                                *replica_id,
-                                reason.clone(),
-                            ))
-                        })
-                        .collect();
-                    ops.push(catalog::Op::DropObjects(replica_ids_and_reasons));
-                    for replica_name in
-                        (0..*new_replication_factor).map(managed_cluster_replica_name)
-                    {
-                        // The replica id is pre-allocated above like the create
-                        // paths so its scoped overrides can be folded below.
-                        let replica_id = new_replica_ids
-                            .next()
-                            .expect("pre-allocated enough replica ids");
-                        self.create_managed_cluster_replica_op(
-                            cluster_id,
-                            replica_id,
-                            replica_name.clone(),
-                            &compute,
-                            new_size,
-                            &mut ops,
-                            Some(new_availability_zones.as_ref()),
-                            false,
-                            owner_id,
-                            reason.clone(),
-                        )?;
-                    }
-                }
-                AlterClusterPlanStrategy::For(_) | AlterClusterPlanStrategy::UntilReady { .. } => {
-                    for replica_name in
-                        (0..*new_replication_factor).map(managed_cluster_replica_name)
-                    {
-                        let replica_name = format!("{replica_name}{PENDING_REPLICA_SUFFIX}");
-                        let replica_id = new_replica_ids
-                            .next()
-                            .expect("pre-allocated enough replica ids");
-                        self.create_managed_cluster_replica_op(
-                            cluster_id,
-                            replica_id,
-                            replica_name.clone(),
-                            &compute,
-                            new_size,
-                            &mut ops,
-                            Some(new_availability_zones.as_ref()),
-                            true,
-                            owner_id,
-                            reason.clone(),
-                        )?;
-                    }
-                    finalization_needed = NeedsFinalization::Yes;
-                }
-            }
-        } else if *new_replication_factor < replication_factor {
-            // Adjust replica count down
-            let replica_ids = (*new_replication_factor..replication_factor)
-                .map(managed_cluster_replica_name)
-                .filter_map(|name| replica_id_by_name.get(&name).copied())
-                .map(|replica_id| {
-                    catalog::DropObjectInfo::ClusterReplica((
-                        cluster_id,
-                        replica_id,
-                        reason.clone(),
-                    ))
-                })
-                .collect();
-            ops.push(catalog::Op::DropObjects(replica_ids));
-        } else if *new_replication_factor > replication_factor {
-            // Adjust replica count up
-            for replica_name in
-                (replication_factor..*new_replication_factor).map(managed_cluster_replica_name)
-            {
-                let replica_id = new_replica_ids
-                    .next()
-                    .expect("pre-allocated enough replica ids");
-                self.create_managed_cluster_replica_op(
-                    cluster_id,
-                    replica_id,
-                    replica_name.clone(),
-                    &compute,
-                    new_size,
-                    &mut ops,
-                    // AVAILABILITY ZONES hasn't changed, so existing replicas don't need to be
-                    // rescheduled.
-                    Some(new_availability_zones.as_ref()),
-                    false,
-                    owner_id,
-                    reason.clone(),
-                )?;
-            }
         }
 
-        // If finalization is needed, finalization should update the cluster
-        // config. Otherwise the config write happens here. A record still in
-        // progress belongs to a live, converging reconfiguration this write
-        // didn't touch, so carry it through untouched.
-        match finalization_needed {
-            NeedsFinalization::No => {
-                let mut new_config = new_config;
-                let reconfiguration_audit = if controller_owns {
-                    None
-                } else {
-                    cancel_carried_reconfiguration(&mut new_config)
-                };
-                ops.push(catalog::Op::UpdateClusterConfig {
-                    id: cluster_id,
-                    name: name.clone(),
-                    config: new_config,
-                    reconfiguration_audit,
-                    burst_audit: None,
-                });
-            }
-            NeedsFinalization::Yes => {}
-        }
+        // A record still in progress belongs to a live reconfiguration this
+        // cluster-level write did not touch, so carry it through unchanged.
+        let ops = vec![catalog::Op::UpdateClusterConfig {
+            id: cluster_id,
+            name,
+            config: new_config,
+            reconfiguration_audit: None,
+            burst_audit: None,
+        }];
 
-        self.catalog_transact(session, ops).await?;
-        Ok(finalization_needed)
+        self.catalog_transact(Some(session), ops).await?;
+        Ok(())
     }
 
     /// # Panics
@@ -2469,25 +1906,6 @@ fn terminal_reconfiguration_result(
     }
 }
 
-/// Retains a stale in-progress reconfiguration record carried by a direct
-/// config write as cancelled, returning the audit intent to declare with the
-/// write.
-///
-/// A direct write reshapes the replica set itself, superseding whatever target
-/// the record carries. Leaving the record in progress would have the controller
-/// keep converging on that stale target.
-fn cancel_carried_reconfiguration(config: &mut ClusterConfig) -> Option<ReconfigurationAudit> {
-    let ClusterVariant::Managed(managed) = &mut config.variant else {
-        return None;
-    };
-    let record = managed.reconfiguration.as_mut()?;
-    if !record.is_in_progress() {
-        return None;
-    }
-    record.status = ReconfigurationStatus::Cancelled;
-    Some(ReconfigurationAudit::Cancelled)
-}
-
 /// Whether an `ALTER` statement sets a replica config shape dimension (`SIZE`,
 /// `AVAILABILITY ZONES`, either `INTROSPECTION` option, or `EXPERIMENTAL
 /// ARRANGEMENT COMPRESSION`). These dimensions use a durable reconfiguration
@@ -2580,15 +1998,6 @@ fn fold_reconfiguration_target(
             new_target.arrangement_compression
         },
     }
-}
-
-/// The type of finalization needed after an
-/// operation such as alter_cluster_managed_to_managed.
-#[derive(PartialEq)]
-pub(crate) enum NeedsFinalization {
-    /// Wait for the provided duration before finalizing
-    Yes,
-    No,
 }
 
 #[cfg(test)]

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -29,6 +29,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::instrument;
 use mz_repr::Timestamp;
+use mz_repr::adt::numeric::Numeric;
 use mz_repr::role_id::RoleId;
 use mz_sql::ast::{Ident, QualifiedReplica};
 use mz_sql::catalog::{CatalogCluster, CatalogError, ObjectType};
@@ -41,7 +42,9 @@ use mz_sql::plan::{
 };
 use mz_sql::plan::{AlterClusterPlan, OnTimeoutAction};
 use mz_sql::session::metadata::SessionMetadata;
-use mz_sql::session::vars::{MAX_REPLICAS_PER_CLUSTER, SystemVars, Var};
+use mz_sql::session::vars::{
+    MAX_CREDIT_CONSUMPTION_RATE, MAX_REPLICAS_PER_CLUSTER, SystemVars, Var,
+};
 use mz_storage_types::sources::SourceConnection;
 use tracing::{Instrument, Span, debug};
 
@@ -1885,8 +1888,9 @@ impl Coordinator {
         };
 
         // A replication-factor-only increase changes the committed baseline,
-        // which the controller cannot shed. Unlike a reshape's transient
-        // strategy union, the resulting replica count is exact here.
+        // which the controller cannot shed. Validate that floor without trying
+        // to predict the controller's transient strategy union. Concrete create
+        // transactions still validate the complete physical replica set.
         if *new_replication_factor > replication_factor && cluster_id.is_user() {
             self.validate_resource_limit(
                 usize::cast_from(replication_factor),
@@ -1894,6 +1898,26 @@ impl Coordinator {
                 SystemVars::max_replicas_per_cluster,
                 "cluster replica",
                 MAX_REPLICAS_PER_CLUSTER.name(),
+            )?;
+
+            let credits_per_replica = self
+                .catalog()
+                .cluster_replica_sizes()
+                .0
+                .get(new_size)
+                .expect("new replica size was validated")
+                .credits_per_hour;
+            let baseline_credits = credits_per_replica * Numeric::from(*new_replication_factor);
+            self.validate_resource_limit_numeric(
+                self.current_credit_consumption_rate(Some(cluster_id)),
+                baseline_credits,
+                |system_vars| {
+                    self.license_key
+                        .max_credit_consumption_rate()
+                        .map_or_else(|| system_vars.max_credit_consumption_rate(), Numeric::from)
+                },
+                "cluster replica",
+                MAX_CREDIT_CONSUMPTION_RATE.name(),
             )?;
         }
 

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -370,11 +370,11 @@ impl Coordinator {
             _ => None,
         };
 
-        // A shape-changing `ALTER` reshapes into a durable `reconfiguration`
-        // record (starting, retargeting, or cancelling one) instead of going
-        // through the legacy 3-stage machine. Everything else falls through to
-        // the realized-config update below without touching the record, in
-        // flight or not.
+        // A shape-changing `ALTER` on a MANUAL cluster reshapes into a durable
+        // `reconfiguration` record that the controller converges on. A scheduled
+        // cluster without an in-flight record takes the direct path below because
+        // it has no baseline replica set to overlap. Everything else falls through
+        // to the realized-config update without touching the record.
         //
         // With a record in flight the statement decides: an `ALTER` back to the
         // realized shape is value-identical yet must reach the reshape path to
@@ -556,15 +556,15 @@ impl Coordinator {
     /// dimension this `ALTER` did not mention. With no record in flight there is
     /// nothing to fold and the target is exactly `new_config`'s shape.
     ///
-    /// **Timeout action.** The record carries an `on_timeout` action (resolved
-    /// from `WITH (WAIT ...)`, defaulting to `ROLLBACK`), which the controller
-    /// applies at the deadline only if the target has not hydrated: `ROLLBACK`
-    /// marks the record timed out and drops the in-flight target set, leaving the
-    /// realized config untouched, so the cluster reverts to its
-    /// pre-reconfiguration shape and the strategy disengages. `COMMIT` cuts the
-    /// realized config over to the not-fully-hydrated target and marks the record
-    /// finalized. Success always takes precedence. A target that hydrates before the deadline cuts over regardless
-    /// of the action.
+    /// **Timeout action.** The record carries an `on_timeout` action resolved
+    /// from `WITH (WAIT ...)`, defaulting to `ROLLBACK`. At the deadline,
+    /// `ROLLBACK` marks the record timed out and drops the in-flight target set.
+    /// The realized config stays unchanged and the strategy disengages. For
+    /// `COMMIT`, the baseline yields while the complete target materializes in a
+    /// replacement transaction. A later reconciliation observes that target,
+    /// advances the realized config, and finalizes without requiring hydration.
+    /// Success always takes precedence. A target that hydrates before the
+    /// deadline cuts over regardless of the action.
     ///
     /// With `enable_background_alter_cluster` on, the statement returns
     /// immediately. With it off, the session blocks on a wait-shim
@@ -1923,14 +1923,14 @@ impl Coordinator {
 
         // The controller owns the replica set of every managed cluster, so a
         // non-record change reaching this path is replication-factor only.
-        // Config-shape changes (size/logging/AZ) are reshaped into a durable
-        // reconfiguration record before they get here. The controller reconciles
-        // the replica set to the realized config's new count on its next tick, so
-        // we update only the realized config and emit no create/drop here. Doing
-        // both fights the controller. It derives replica names from the observed
-        // set, so an adapter create by canonical `rN` can collide with a
-        // controller-chosen name, and an adapter drop by canonical `rN` can miss a
-        // churned one.
+        // Config-shape changes (size, logging, AZ, and EXPERIMENTAL ARRANGEMENT
+        // COMPRESSION) are reshaped into a durable reconfiguration record before
+        // they get here. The controller reconciles the replica set to the realized
+        // config's new count on its next tick. We update only the realized config
+        // and emit no create/drop here because doing both fights the controller.
+        // It derives replica names from the observed set, so an adapter create by
+        // canonical `rN` can collide with a controller-chosen name. An adapter drop
+        // by canonical `rN` can miss a churned one.
         //
         // The direct create/drop branches below are unreachable while this holds.
         // They go together with the staged reconfiguration machine.
@@ -2490,8 +2490,9 @@ fn cancel_carried_reconfiguration(config: &mut ClusterConfig) -> Option<Reconfig
 
 /// Whether an `ALTER` statement sets a replica config shape dimension (`SIZE`,
 /// `AVAILABILITY ZONES`, either `INTROSPECTION` option, or `EXPERIMENTAL
-/// ARRANGEMENT COMPRESSION`), the changes that need a durable
-/// `reconfiguration` record and a hydrate-overlap.
+/// ARRANGEMENT COMPRESSION`). These dimensions use a durable reconfiguration
+/// record for MANUAL clusters. Scheduled clusters without an in-flight record
+/// take the direct realized-config path instead.
 ///
 /// A statement-level check, used while a reconfiguration is in flight: an
 /// `ALTER` back to the realized shape sets a shape option without changing its

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -233,7 +233,6 @@ impl Coordinator {
         let retire_notify = self
             .retire_compute_sinks_for_conn(conn_id, ActiveComputeSinkRetireReason::Finished)
             .await;
-        self.retire_cluster_reconfigurations_for_conn(conn_id).await;
 
         // Release this transaction's compaction hold on collections.
         if let Some(txn_reads) = self.txn_read_holds.remove(conn_id) {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -314,7 +314,6 @@ pub enum AdapterError {
     /// The cluster controller could not provision a reconfiguration target
     /// within the environment's resource limits.
     AlterClusterResourceExhausted,
-    AlterClusterWhilePendingReplicas,
     /// Attempt to convert a cluster to unmanaged while a graceful
     /// reconfiguration is in progress.
     AlterClusterUnmanagedWhileReconfiguring,
@@ -1094,7 +1093,6 @@ impl AdapterError {
             AdapterError::ReadOnly => SqlState::READ_ONLY_SQL_TRANSACTION,
             AdapterError::AlterClusterTimeout => SqlState::QUERY_CANCELED,
             AdapterError::AlterClusterResourceExhausted => SqlState::INSUFFICIENT_RESOURCES,
-            AdapterError::AlterClusterWhilePendingReplicas => SqlState::OBJECT_IN_USE,
             AdapterError::AlterClusterUnmanagedWhileReconfiguring => SqlState::OBJECT_IN_USE,
             AdapterError::AlterClusterUnmanagedWhileBursting => SqlState::OBJECT_IN_USE,
             AdapterError::AlterClusterReplicationFactorWhileReconfiguring => {
@@ -1579,9 +1577,6 @@ impl fmt::Display for AdapterError {
                     )?;
                 }
                 Ok(())
-            }
-            AdapterError::AlterClusterWhilePendingReplicas => {
-                write!(f, "cannot alter clusters with pending updates")
             }
             AdapterError::AlterClusterUnmanagedWhileReconfiguring => {
                 write!(

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -311,6 +311,9 @@ pub enum AdapterError {
     /// read-only mode.
     ReadOnly,
     AlterClusterTimeout,
+    /// The cluster controller could not provision a reconfiguration target
+    /// within the environment's resource limits.
+    AlterClusterResourceExhausted,
     AlterClusterWhilePendingReplicas,
     /// Attempt to convert a cluster to unmanaged while a graceful
     /// reconfiguration is in progress.
@@ -885,6 +888,11 @@ impl AdapterError {
             AdapterError::AlterClusterTimeout => Some(
                 "Consider increasing the timeout duration in the alter cluster statement.".into(),
             ),
+            AdapterError::AlterClusterResourceExhausted => Some(
+                "Reduce the target resource use, or inspect \
+                 mz_internal.mz_cluster_reconfigurations for the retained outcome."
+                    .into(),
+            ),
             AdapterError::DDLTransactionRace => Some(
                 "Currently, DDL transactions fail when any other DDL happens concurrently, \
                  even on unrelated schemas/clusters.".into()
@@ -1085,6 +1093,7 @@ impl AdapterError {
             // transactions.
             AdapterError::ReadOnly => SqlState::READ_ONLY_SQL_TRANSACTION,
             AdapterError::AlterClusterTimeout => SqlState::QUERY_CANCELED,
+            AdapterError::AlterClusterResourceExhausted => SqlState::INSUFFICIENT_RESOURCES,
             AdapterError::AlterClusterWhilePendingReplicas => SqlState::OBJECT_IN_USE,
             AdapterError::AlterClusterUnmanagedWhileReconfiguring => SqlState::OBJECT_IN_USE,
             AdapterError::AlterClusterUnmanagedWhileBursting => SqlState::OBJECT_IN_USE,
@@ -1552,6 +1561,12 @@ impl fmt::Display for AdapterError {
             AdapterError::AlterClusterTimeout => {
                 write!(f, "canceling statement, provided timeout lapsed")
             }
+            AdapterError::AlterClusterResourceExhausted => {
+                write!(
+                    f,
+                    "cluster reconfiguration could not provision its target within the available resource limits"
+                )
+            }
             AdapterError::AuthenticationError(e) => {
                 write!(f, "authentication error {e}")
             }
@@ -1824,6 +1839,23 @@ impl Error for AdapterError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[mz_ore::test]
+    fn alter_cluster_resource_exhausted_is_specific() {
+        let error = AdapterError::AlterClusterResourceExhausted;
+        assert_eq!(error.code(), SqlState::INSUFFICIENT_RESOURCES);
+        assert_eq!(
+            error.hint().as_deref(),
+            Some(
+                "Reduce the target resource use, or inspect \
+                 mz_internal.mz_cluster_reconfigurations for the retained outcome."
+            )
+        );
+        assert_eq!(
+            error.to_string(),
+            "cluster reconfiguration could not provision its target within the available resource limits"
+        );
+    }
 
     #[mz_ore::test]
     fn peek_row_iteration_limit_error_is_user_facing() {

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -377,12 +377,12 @@ pub struct ClusterVariantManaged {
 /// A managed cluster's replicas are derived from its `replication_factor`: for a
 /// factor of N they are named `r1` through `rN`.
 ///
-/// `ALTER CLUSTER` computes the replicas it creates and drops by this rule, and
-/// so does the catalog-open reconciler that materializes builtin replicas. The
-/// two have to share it, or `ALTER` cannot find the replicas it means to change.
-/// The cluster controller deliberately does not: its `ReplicaNameGen` picks names
-/// that avoid the observed set, which is why `ALTER` against a controller-owned
-/// cluster drops by observed id rather than by derived name.
+/// The catalog-open reconciler that materializes builtin replicas converges on
+/// this rule, `CREATE CLUSTER` names its replicas by it, and the
+/// unmanaged-to-managed conversion validates the existing names against it. The
+/// cluster controller deliberately does not: its `ReplicaNameGen` picks names
+/// that avoid the observed set, which is why it drops by observed id rather
+/// than by derived name.
 pub fn managed_cluster_replica_name(index: u32) -> String {
     format!("r{}", index + 1)
 }

--- a/src/cluster-controller/src/ctx.rs
+++ b/src/cluster-controller/src/ctx.rs
@@ -58,7 +58,8 @@ pub struct ObservedReplica {
     pub internal: bool,
     /// Carries a `BILLED AS` override.
     pub billed_as: bool,
-    /// The `-pending` target of an in-flight graceful reconfiguration.
+    /// Durably marked `pending`. Vestigial: no path creates one anymore, but a
+    /// crash on an older version could have left one behind.
     pub pending: bool,
 }
 
@@ -67,11 +68,11 @@ impl ObservedReplica {
     ///
     /// INTERNAL / BILLED AS replicas are manually managed: a user can attach
     /// one to any managed cluster, outside the replication-factor domain. A
-    /// pending replica is owned by the reconfiguration sequencer path until
-    /// finalize (retiring it would defeat the zero-downtime resize creating
-    /// it). The controller must neither count such a replica toward a desired
-    /// shape nor drop it as excess, but their names still block the name
-    /// generator, since every replica observed here occupies a name.
+    /// durably `pending` replica is stranded state from an older version, reaped
+    /// by the catalog-open migration rather than here. The controller must
+    /// neither count such a replica toward a desired shape nor drop it as
+    /// excess, but their names still block the name generator, since every
+    /// replica observed here occupies a name.
     pub fn owned_shape(&self) -> Option<&ReplicaShape> {
         if self.internal || self.billed_as || self.pending {
             return None;

--- a/src/cluster-controller/src/ctx.rs
+++ b/src/cluster-controller/src/ctx.rs
@@ -389,9 +389,9 @@ pub enum ApplyOutcome {
     /// batch is rejected; the controller recomputes next tick.
     Rejected,
     /// The batch was rejected because it exceeded the environment's resource
-    /// budget. Nothing was transacted. Unlike a guard rejection, retrying the
-    /// same batch cannot succeed on its own: the controller decides what to
-    /// shed to make room.
+    /// budget. No requested cluster mutation was transacted. Unlike a guard
+    /// rejection, retrying the same batch cannot succeed on its own: the
+    /// controller decides what to shed to make room.
     ResourceExhausted,
 }
 

--- a/src/cluster-controller/src/lib.rs
+++ b/src/cluster-controller/src/lib.rs
@@ -206,14 +206,15 @@ impl ClusterController {
     /// The strategy to shed is chosen by presence, ranked by expendability, not
     /// by which create failed: validation is aggregate, and the strategy worth
     /// giving up may be one whose replicas already materialized rather than one
-    /// in the failed batch. The graceful reconfiguration is the most expendable:
-    /// a discretionary user change that fails cleanly (audited, and the wait-shim
-    /// reports a timeout) and can be retried, while aborting it leaves the
-    /// cluster running at its realized shape. The baseline is never shed, it is
-    /// the committed floor.
+    /// in the failed batch. A graceful reconfiguration is a discretionary user
+    /// change that fails cleanly. The failure is audited, the wait-shim reports
+    /// insufficient resources, and the cluster keeps running at its realized
+    /// shape. The baseline is never shed because it is the committed floor. A
+    /// hydration burst remains armed because no durable state records that the
+    /// unchanged policy should suppress it.
     ///
-    /// We shed one strategy per exhausted apply. If that was not enough, the
-    /// next tick recomputes and sheds the next one.
+    /// Without an active graceful reconfiguration there is nothing to shed. The
+    /// next tick retries the desired replica set.
     fn shed_decision(state: &ClusterState) -> Option<Decision> {
         let record = state.reconfiguration.as_ref()?;
         if !record.is_in_progress() {

--- a/src/cluster-controller/src/strategy.rs
+++ b/src/cluster-controller/src/strategy.rs
@@ -167,10 +167,10 @@ pub struct LiveSignals {
 /// The implicit baseline strategy, always present.
 ///
 /// Desires `replication_factor` replicas at the cluster's realized shape
-/// (`cluster.size` plus its AZ pool and logging). It holds the steady-state set
-/// so that the policy strategies can be purely additive. They only ever add to
-/// the baseline. With only the baseline engaged, the desired set equals the
-/// realized set, so a steady-state managed cluster reconciles to no decisions.
+/// (`cluster.size` plus its AZ pool, logging, and arrangement compression). It
+/// holds the steady-state set so that policy strategies normally only add to
+/// it. With only the baseline engaged, the desired set equals the realized set,
+/// so a steady-state managed cluster reconciles to no decisions.
 ///
 /// The baseline holds the set only for MANUAL clusters. On a scheduled cluster
 /// the controller (not the user's `replication_factor`) owns the replica set,
@@ -584,8 +584,9 @@ impl Strategy for OnRefreshStrategy {
             return Vec::new();
         }
         // One replica at the realized shape (`cluster.size` plus the cluster's AZ
-        // pool and logging). The window decision rides inside the reason so the
-        // create it may produce can carry the audit detail.
+        // pool, logging, and arrangement compression). The window decision rides
+        // inside the reason so the create it may produce can carry the audit
+        // detail.
         vec![DesiredReplica {
             shape: state.realized_shape(),
             reason: CreateReason::OnRefresh(decision),

--- a/src/cluster-controller/src/strategy.rs
+++ b/src/cluster-controller/src/strategy.rs
@@ -178,8 +178,34 @@ pub struct LiveSignals {
 /// contributor. (The on-refresh strategy also normalizes a scheduled cluster's
 /// `replication_factor` to `0` via `update_state`, so the two views agree after
 /// the first tick regardless.)
+///
+/// The one case where the baseline steps aside is a forced cut-over, see
+/// `forced_cutover_pending`.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct BaselineStrategy;
+
+/// Whether a forced cut-over is imminent: an in-progress reconfiguration is
+/// past its deadline under `ON TIMEOUT COMMIT`, so the next cut-over commits
+/// the target whether or not it hydrated.
+///
+/// In that window the baseline yields its realized-shape replicas. Overlapping
+/// the two sets only buys availability while the target hydrates, and a forced
+/// cut-over has given up on hydration. Yielding turns the reshape into one
+/// transaction that retires the realized replicas and creates the target's, so
+/// it has to fit the larger of the two shapes rather than their sum. That is
+/// what lets a resize succeed on a budget that has no room for overlap, and it
+/// is the only way to shrink a cluster that is already near its limit.
+///
+/// If that single transaction still does not fit, it is rejected whole and the
+/// record is left in progress for `ClusterController::shed_decision` to shed,
+/// so an unaffordable target stays observable rather than half-applied.
+fn forced_cutover_pending(state: &ClusterState, now: Timestamp) -> bool {
+    state.reconfiguration.as_ref().is_some_and(|record| {
+        record.is_in_progress()
+            && now >= record.deadline
+            && matches!(record.on_timeout, OnTimeout::Commit)
+    })
+}
 
 impl Strategy for BaselineStrategy {
     fn desired_replicas(
@@ -187,9 +213,12 @@ impl Strategy for BaselineStrategy {
         state: &ClusterState,
         _signals: &LiveSignals,
         _config: &ConfigSignals,
-        _now: Timestamp,
+        now: Timestamp,
     ) -> Vec<DesiredReplica> {
         if !matches!(state.schedule, ClusterSchedule::Manual) {
+            return Vec::new();
+        }
+        if forced_cutover_pending(state, now) {
             return Vec::new();
         }
         let shape = state.realized_shape();
@@ -211,9 +240,12 @@ impl Strategy for BaselineStrategy {
 /// `update_state` cuts over: the realized config advances to the target, the
 /// record is marked finalized, and the old replicas fall out of the union and
 /// are dropped. Success takes precedence over the deadline. On a timeout,
-/// `Commit` cuts over to the un-hydrated target anyway while `Rollback` (the
-/// default) marks the record timed out without touching the realized config and
-/// stops desiring the target replicas, reverting to the pre-reconfiguration set.
+/// `Commit` cuts over once the complete target set exists without waiting for
+/// hydration, and the baseline stops contributing in that window so the two
+/// sets swap in one transaction rather than overlapping (see
+/// `forced_cutover_pending`). `Rollback` (the default) marks the record timed
+/// out without touching the realized config and stops desiring the target
+/// replicas, reverting to the pre-reconfiguration set.
 ///
 /// Both functions are pure over the observed [`ClusterState`] and the fetched
 /// [`LiveSignals`]. Hydration is requested via [`Strategy::signal_request`]
@@ -247,6 +279,18 @@ impl GracefulReconfigurationStrategy {
         let target_rf = usize::try_from(record.target.replication_factor).unwrap_or(usize::MAX);
         hydrated_target_replicas >= target_rf
     }
+
+    /// Whether the complete target set exists, without requiring hydration.
+    fn target_materialized(&self, state: &ClusterState, record: &ReconfigurationRecord) -> bool {
+        let target_shape = record.target.shape();
+        let target_replicas = state
+            .replicas
+            .iter()
+            .filter(|r| r.owned_shape().is_some_and(|s| s.matches(&target_shape)))
+            .count();
+        let target_rf = usize::try_from(record.target.replication_factor).unwrap_or(usize::MAX);
+        target_replicas >= target_rf
+    }
 }
 
 impl Strategy for GracefulReconfigurationStrategy {
@@ -278,20 +322,21 @@ impl Strategy for GracefulReconfigurationStrategy {
         // the record finalized on either of two conditions:
         //   1. rf-many target replicas are present and hydrated (success, which
         //      takes precedence over the deadline regardless of `on_timeout`), or
-        //   2. the deadline has been reached un-hydrated and `on_timeout` is
-        //      `Commit` (cut over to the not-yet-hydrated target anyway).
+        //   2. the deadline has been reached, `on_timeout` is `Commit`, and the
+        //      complete target set exists (cut over without waiting for hydration).
         //
-        // NOTE: the deadline is reached at `now >= deadline`, not `now > deadline`.
-        // A `WAIT FOR '0s'` writes `deadline = now` to request an immediate
-        // cut-over. With a strict `>`, a first tick landing at exactly that
-        // timestamp would miss the deadline, so phase 2 would provision the overlap
-        // target replicas and only a later tick would cut over. `>=` fires the
-        // deadline the instant it is reached, so the zero-timeout cut-over happens
-        // on the first tick, before any overlap replica is desired.
+        // We require the target set to exist before a forced cut-over so its
+        // concrete create transaction can enforce resource limits. Otherwise a
+        // zero-timeout commit could finalize first, fail to create the new
+        // baseline, and leave no in-progress strategy for the controller to shed.
+        // The baseline yields while we wait (see `forced_cutover_pending`), so
+        // that create arrives in the same transaction that retires the realized
+        // replicas and does not have to fit alongside them.
         let hydrated = self.target_hydrated(state, signals, record);
         let deadline_reached = now >= record.deadline;
         let commit_on_timeout = deadline_reached && matches!(record.on_timeout, OnTimeout::Commit);
-        if hydrated || commit_on_timeout {
+        let target_materialized = self.target_materialized(state, record);
+        if hydrated || (commit_on_timeout && target_materialized) {
             return StateWrite {
                 new_size: Some(record.target.size.clone()),
                 new_replication_factor: Some(record.target.replication_factor),

--- a/src/cluster-controller/src/tests.rs
+++ b/src/cluster-controller/src/tests.rs
@@ -1617,7 +1617,10 @@ fn graceful_deadline_fires_at_exact_timestamp() {
             c,
             "100cc",
             1,
-            vec![observed(replica(1), "r0", "100cc")],
+            vec![
+                observed(replica(1), "r0", "100cc"),
+                observed(replica(2), "r1", "200cc"),
+            ],
             record_on_timeout("200cc", 1, deadline, on_timeout),
             BTreeSet::new(),
         )
@@ -2040,21 +2043,17 @@ async fn graceful_commit_at_timeout_cuts_over_through_seam() {
 }
 
 #[mz_ore::test(tokio::test)]
-async fn resource_exhaustion_sheds_the_reconfiguration() {
-    // A reconfiguration is in flight and the target replica does not exist yet,
-    // so phase 2 emits a create. The apply reports resource exhaustion, and the
-    // controller must shed the reconfiguration: a follow-up state write under
-    // the same expected witness, which marks the record resource-exhausted without
-    // touching the realized config or the existing replica.
+async fn resource_exhaustion_sheds_a_zero_timeout_reconfiguration() {
+    // The elapsed commit deadline does not finalize before the target replica
+    // exists. Phase 2 attempts the swap, which reports resource exhaustion,
+    // then the controller sheds the still-in-progress reconfiguration.
     let c = cluster(1);
     let (state, _signals) = reconfiguring_state(
         c,
         "100cc",
         1,
         vec![observed(replica(1), "r0", "100cc")],
-        // A deadline far past the fake's `now`, so the deadline machinery stays
-        // out of the picture and phase 1 writes nothing.
-        record("200cc", 1, 9999),
+        record_on_timeout("200cc", 1, 0, OnTimeout::Commit),
         BTreeSet::new(),
     );
     let expected = state.expected();
@@ -2064,11 +2063,13 @@ async fn resource_exhaustion_sheds_the_reconfiguration() {
 
     controller.reconcile(&mut ctx).await;
 
-    // Two applies: the exhausted create batch, then the shed.
+    // Two applies: the exhausted swap batch, then the shed.
     assert_eq!(ctx.applied.len(), 2);
     assert!(
-        matches!(ctx.applied[0][0], Decision::CreateReplica { .. }),
-        "the exhausted batch was the target create"
+        ctx.applied[0]
+            .iter()
+            .any(|d| matches!(d, Decision::CreateReplica { .. })),
+        "the exhausted batch carries the target create"
     );
     let [shed] = &ctx.applied[1][..] else {
         panic!("the shed is a single decision, got {:?}", ctx.applied[1]);
@@ -2112,6 +2113,243 @@ async fn resource_exhaustion_sheds_the_reconfiguration() {
     let before = ctx.applied.len();
     controller.reconcile(&mut ctx).await;
     assert_eq!(ctx.applied.len(), before, "stable after the shed");
+}
+
+#[mz_ore::test(tokio::test)]
+async fn forced_cutover_swaps_the_replica_set_in_one_transaction() {
+    // A forced cut-over never overlaps the two replica sets: the baseline
+    // yields, so the tick that provisions the target also retires the realized
+    // replicas, in one transaction. That is what lets a reshape land on a
+    // budget with no room for both sets at once.
+    let c = cluster(1);
+    let (state, _signals) = reconfiguring_state(
+        c,
+        "100cc",
+        1,
+        vec![observed(replica(1), "r0", "100cc")],
+        record_on_timeout("200cc", 1, 0, OnTimeout::Commit),
+        BTreeSet::new(),
+    );
+    let mut ctx = FakeCtx::new(vec![state]);
+    let controller = controller();
+
+    controller.reconcile(&mut ctx).await;
+
+    assert_eq!(ctx.applied.len(), 1, "the swap is a single apply");
+    let swap = &ctx.applied[0];
+    assert_eq!(
+        swap.iter()
+            .filter(|d| matches!(d, Decision::CreateReplica { .. }))
+            .count(),
+        1,
+        "the target replica is created"
+    );
+    assert_eq!(
+        swap.iter()
+            .filter(|d| matches!(d, Decision::DropReplica { .. }))
+            .count(),
+        1,
+        "the realized replica is retired in the same batch"
+    );
+    let sizes: Vec<_> = ctx.states[&c]
+        .replicas
+        .iter()
+        .filter_map(|r| r.owned_shape().map(|shape| shape.size.as_str()))
+        .collect();
+    assert_eq!(sizes, vec!["200cc"], "no overlap was ever materialized");
+    assert_eq!(
+        ctx.states[&c].size, "100cc",
+        "the cut-over itself waits for the next tick's first phase"
+    );
+
+    // With the target now present, the deadline commits it.
+    controller.reconcile(&mut ctx).await;
+    assert_eq!(ctx.states[&c].size, "200cc", "the forced cut-over lands");
+    assert_eq!(
+        reconfiguration_status(&ctx.states[&c]),
+        Some(ReconfigurationStatus::Finalized)
+    );
+
+    // The retired record hands the set back to the baseline, which desires the
+    // same replicas the swap created. Nothing is suppressed and nothing churns.
+    let before = ctx.applied.len();
+    controller.reconcile(&mut ctx).await;
+    assert_eq!(ctx.applied.len(), before, "steady after the cut-over");
+    assert_eq!(ctx.states[&c].replicas.len(), 1);
+}
+
+#[mz_ore::test]
+fn forced_cutover_yield_is_covered_by_the_target_contribution() {
+    // The baseline yields on the same `is_in_progress` predicate that makes the
+    // graceful strategy contribute the target set, so the yield can never leave
+    // the union short. Asserted over the states that reach the yield window,
+    // because the two conditions live in different strategies and could drift.
+    use crate::strategy::BaselineStrategy;
+
+    let c = cluster(1);
+    let deadline = 1000u64;
+    let baseline = BaselineStrategy;
+    let graceful = GracefulReconfigurationStrategy;
+    let mut yields = 0;
+
+    for on_timeout in [OnTimeout::Commit, OnTimeout::Rollback] {
+        for now in [deadline - 1, deadline, deadline + 1] {
+            for status in [
+                ReconfigurationStatus::InProgress,
+                ReconfigurationStatus::Finalized,
+                ReconfigurationStatus::TimedOut,
+                ReconfigurationStatus::Cancelled,
+                ReconfigurationStatus::ResourceExhausted,
+            ] {
+                let rec = ReconfigurationRecord {
+                    status,
+                    ..record_on_timeout("200cc", 2, deadline, on_timeout)
+                };
+                let (state, signals) = reconfiguring_state(
+                    c,
+                    "100cc",
+                    2,
+                    vec![observed(replica(1), "r0", "100cc")],
+                    rec,
+                    BTreeSet::new(),
+                );
+                let now = Timestamp::from(now);
+                let from_baseline = baseline.desired_replicas(&state, &signals, &config(), now);
+                if !from_baseline.is_empty() {
+                    continue;
+                }
+                yields += 1;
+                let from_graceful = graceful.desired_replicas(&state, &signals, &config(), now);
+                assert_eq!(
+                    from_graceful.len(),
+                    2,
+                    "baseline yielded at {status:?}/{on_timeout:?}/{now} with no target set to \
+                     take its place"
+                );
+                assert!(
+                    from_graceful
+                        .iter()
+                        .all(|desired| desired.shape.size == "200cc")
+                );
+            }
+        }
+    }
+    assert_eq!(yields, 2, "the matrix must actually reach the yield window");
+}
+
+#[mz_ore::test(tokio::test)]
+async fn forced_cutover_swap_preserves_the_burst_replica() {
+    // The baseline yields, the other strategies do not. A hydration burst in
+    // flight keeps its replica (and with it the hydration work it has done)
+    // across the swap, exactly as it does across a graceful cut-over.
+    use crate::ctx::{BurstRecord, OnHydrationPolicy};
+
+    let c = cluster(1);
+    let (mut state, _signals) = reconfiguring_state(
+        c,
+        "100cc",
+        1,
+        vec![
+            observed(replica(1), "r0", "100cc"),
+            observed(replica(2), "r0-burst", "400cc"),
+        ],
+        record_on_timeout("200cc", 1, 0, OnTimeout::Commit),
+        BTreeSet::new(),
+    );
+    state.auto_scaling_policy = Some(AutoScalingPolicy {
+        on_hydration: Some(OnHydrationPolicy {
+            hydration_size: "400cc".to_string(),
+            linger_duration: Some(Duration::from_secs(60)),
+        }),
+    });
+    state.burst = Some(BurstRecord {
+        burst_size: "400cc".to_string(),
+        linger_duration: Duration::from_secs(60),
+        steady_hydrated_at: None,
+    });
+
+    let mut ctx = FakeCtx::new(vec![state]);
+    ctx.has_hydratable_objects.insert(c, true);
+    let controller = controller();
+
+    controller.reconcile(&mut ctx).await;
+
+    let mut sizes: Vec<_> = ctx.states[&c]
+        .replicas
+        .iter()
+        .filter_map(|r| r.owned_shape().map(|shape| shape.size.as_str()))
+        .collect();
+    sizes.sort();
+    assert_eq!(
+        sizes,
+        vec!["200cc", "400cc"],
+        "the realized replica was swapped out and the burst replica kept"
+    );
+    let burst_id = ctx.states[&c]
+        .replicas
+        .iter()
+        .find(|r| r.name == "r0-burst")
+        .map(|r| r.replica_id);
+    assert_eq!(burst_id, Some(replica(2)), "the burst keeps its identity");
+}
+
+#[mz_ore::test(tokio::test)]
+async fn resource_exhaustion_leaves_an_unaffordable_burst_armed() {
+    // A hydration burst is not shed on exhaustion. Nothing durable would record
+    // that it was unaffordable, so the unchanged policy would arm it again on
+    // the next tick and every cycle would write a start and a finish. The burst
+    // stays armed and its create is simply retried.
+    use crate::ctx::{BurstRecord, OnHydrationPolicy};
+
+    let c = cluster(1);
+    let (mut state, _signals) = reconfiguring_state(
+        c,
+        "100cc",
+        1,
+        vec![observed(replica(1), "r0", "100cc")],
+        record("200cc", 1, 5000),
+        BTreeSet::new(),
+    );
+    state.auto_scaling_policy = Some(AutoScalingPolicy {
+        on_hydration: Some(OnHydrationPolicy {
+            hydration_size: "400cc".to_string(),
+            linger_duration: Some(Duration::from_secs(60)),
+        }),
+    });
+    state.burst = Some(BurstRecord {
+        burst_size: "400cc".to_string(),
+        linger_duration: Duration::from_secs(60),
+        steady_hydrated_at: None,
+    });
+
+    let mut ctx = FakeCtx::new(vec![state]);
+    ctx.has_hydratable_objects.insert(c, true);
+    let controller = controller();
+
+    ctx.exhaust_next = 1;
+    controller.reconcile(&mut ctx).await;
+    assert_eq!(
+        reconfiguration_status(&ctx.states[&c]),
+        Some(ReconfigurationStatus::ResourceExhausted),
+        "the graceful reconfiguration is shed"
+    );
+    assert!(
+        ctx.states[&c].burst.is_some(),
+        "the burst survives the shed"
+    );
+
+    ctx.exhaust_next = 1;
+    let before = ctx.applied.len();
+    controller.reconcile(&mut ctx).await;
+    assert!(
+        ctx.states[&c].burst.is_some(),
+        "a later exhausted apply still leaves the burst alone"
+    );
+    assert_eq!(
+        ctx.applied.len(),
+        before + 1,
+        "the exhausted create is the only apply: no shed follows it"
+    );
 }
 
 #[mz_ore::test(tokio::test)]
@@ -2762,12 +3000,12 @@ async fn on_refresh_graceful_record_settles_then_normalizes() {
     // graceful strategy owns the record to settlement: its cut-over writes the
     // target (including rf 2) alone, without contending with the on-refresh
     // normalization (a dual write of `new_replication_factor` would trip the
-    // merge tripwire's soft panic and fail this test). The next tick sees the
+    // merge tripwire's soft panic and fail this test). A following tick sees the
     // record settled and normalizes rf back to 0.
     let c = cluster(1);
     let (mut state, _signals) = scheduled_state(c, "100cc", 1, 0, Vec::new(), None);
-    // The deadline (500) already passed at the fake's now (1000) under COMMIT,
-    // so the first tick cuts over without waiting for hydration.
+    // The deadline (500) already passed at the fake's now (1000) under COMMIT.
+    // The first tick provisions the target set without finalizing early.
     state.reconfiguration = Some(record_on_timeout("200cc", 2, 500, OnTimeout::Commit));
     let mut ctx = FakeCtx::new(vec![state]);
     ctx.set_refresh_window(c, window_inputs(100, 0, Some(200), refresh_at(50)));
@@ -2775,8 +3013,17 @@ async fn on_refresh_graceful_record_settles_then_normalizes() {
     let controller = controller();
     controller.reconcile(&mut ctx).await;
 
-    // The cut-over landed alone: the realized config advanced to the target and
-    // the record settled, with rf briefly at the target's value.
+    assert_eq!(ctx.states[&c].size, "100cc");
+    assert_eq!(ctx.states[&c].replicas.len(), 2);
+    assert_eq!(
+        reconfiguration_status(&ctx.states[&c]),
+        Some(ReconfigurationStatus::InProgress)
+    );
+
+    // With the target materialized, the next tick cuts over without requiring
+    // hydration. The on-refresh normalization deferred at the phase-1 read, so
+    // the realized factor briefly carries the target value.
+    controller.reconcile(&mut ctx).await;
     assert_eq!(ctx.states[&c].size, "200cc");
     assert_eq!(ctx.states[&c].replication_factor, 2);
     assert_eq!(
@@ -2784,7 +3031,7 @@ async fn on_refresh_graceful_record_settles_then_normalizes() {
         Some(ReconfigurationStatus::Finalized)
     );
 
-    // The next tick normalizes the scheduled cluster's rf back to 0.
+    // The following tick sees the settled record and normalizes rf back to 0.
     controller.reconcile(&mut ctx).await;
     assert_eq!(ctx.states[&c].replication_factor, 0);
 }

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -312,10 +312,11 @@ impl ReplicaLocation {
         }
     }
 
-    /// A pending replica is created as part of an alter cluster of an managed
-    /// cluster. the configuration of a pending replica will not match that of
-    /// the clusters until the alter has been finalized promoting the pending
-    /// replicas and setting this value to false.
+    /// Whether the replica is durably marked `pending`.
+    ///
+    /// Vestigial: no path creates one anymore. A crash on a version that still
+    /// staged reconfigurations through overlap replicas could have left one
+    /// behind, and the catalog-open migration reaps those.
     pub fn pending(&self) -> bool {
         match self {
             ReplicaLocation::Managed(ManagedReplicaLocation { pending, .. }) => *pending,
@@ -374,7 +375,7 @@ pub struct ManagedReplicaLocation {
     /// concretization, not read back from a durable record.
     #[serde(skip)]
     pub availability_zones: Vec<String>,
-    /// Whether the replica is pending reconfiguration
+    /// See [`ReplicaLocation::pending`].
     pub pending: bool,
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -6727,15 +6727,6 @@ pub fn plan_alter_cluster(
                         );
                     }
 
-                    match alter_strategy {
-                        AlterClusterPlanStrategy::None => {}
-                        _ => {
-                            scx.require_feature_flag(
-                                &crate::session::vars::ENABLE_ZERO_DOWNTIME_CLUSTER_RECONFIGURATION,
-                            )?;
-                        }
-                    }
-
                     if replica_defs.is_some() {
                         sql_bail!("REPLICAS not supported for managed clusters");
                     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2254,12 +2254,6 @@ feature_flags!(
         enable_for_item_parsing: false,
     },
     {
-        name: enable_zero_downtime_cluster_reconfiguration,
-        desc: "Enable zero-downtime reconfiguration for alter cluster",
-        default: false,
-        enable_for_item_parsing: false,
-    },
-    {
         name: enable_network_policies,
         desc: "ENABLE NETWORK POLICIES",
         default: true,

--- a/test/cloudtest/test_managed_cluster.py
+++ b/test/cloudtest/test_managed_cluster.py
@@ -146,7 +146,6 @@ def test_zero_downtime_reconfiguration(mz: MaterializeApplication) -> None:
     # within the short poll loops below.
     mz.environmentd.sql(
         """
-        ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
         ALTER SYSTEM SET cluster_controller_tick_interval = '5ms';
         """,
         port="internal",

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -6318,7 +6318,6 @@ def workflow_test_zero_downtime_reconfigure(
             key${kafka-ingest.iteration}:value${kafka-ingest.iteration}
 
             $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-            ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
             CREATE CLUSTER cluster1 ( SIZE = 'scale=1,workers=1');
             GRANT ALL ON CLUSTER cluster1 TO materialize;
 
@@ -6435,13 +6434,6 @@ def workflow_test_zero_downtime_reconfigure(
             > SELECT count(*) FROM kafka_tbl
             1000
             """))
-        c.sql(
-            """
-            ALTER SYSTEM RESET enable_zero_downtime_cluster_reconfiguration;
-            """,
-            port=6877,
-            user="mz_system",
-        )
 
 
 def workflow_test_pending_replica_audit_events(
@@ -6457,11 +6449,10 @@ def workflow_test_pending_replica_audit_events(
     """
     c.up("materialized")
 
-    # Enable the WAIT surface and drive the controller tick down so the (empty)
-    # cluster's reconfiguration converges quickly.
+    # Drive the controller tick down so the (empty) cluster's reconfiguration
+    # converges quickly.
     c.sql(
         """
-        ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
         ALTER SYSTEM SET cluster_controller_tick_interval = '5ms';
         CREATE CLUSTER test_audit (SIZE = 'scale=1,workers=1');
         GRANT ALL ON CLUSTER test_audit TO materialize;
@@ -6556,7 +6547,6 @@ def workflow_test_pending_replica_audit_events(
     c.sql(
         """
         DROP CLUSTER test_audit CASCADE;
-        ALTER SYSTEM RESET enable_zero_downtime_cluster_reconfiguration;
         """,
         port=6877,
         user="mz_system",

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -480,6 +480,7 @@ KNOWN_STALE_LD_FLAGS: set[str] = set("""
     enable_repr_typecheck
     enable_unified_cluster_arrangment
     enable_yugabyte_connection
+    enable_zero_downtime_cluster_reconfiguration
     kafka_default_metadata_fetch_interval
     mysql_offset_known_interval
     persist_enable_arrow_lgalloc_noncc_sizes
@@ -516,7 +517,6 @@ INTENTIONAL_LD_OVERRIDES: set[str] = {
     "enable_lgalloc",
     "enable_timely_zero_copy_lgalloc",
     "enable_upsert_paged_spill",
-    "enable_zero_downtime_cluster_reconfiguration",
     "kafka_client_id_enrichment_rules",
     "kafka_progress_record_fetch_timeout",
     "kafka_socket_timeout",

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -533,6 +533,21 @@ def run_scoped_feature_flag_cases(
                     ]
                 )
             )
+
+            # Controller-created replicas use the same create-time fold. Record
+            # the initial replica, force a shape change, then require the new
+            # replica's row before the periodic sync can run.
+            c.testdrive(
+                "\n".join(
+                    [
+                        "$ set-from-sql var=ld_sync_replica_id",
+                        "SELECT cr.id::text FROM mz_cluster_replicas cr JOIN mz_clusters c ON c.id = cr.cluster_id WHERE c.name = 'ld_sync'",
+                        "> ALTER CLUSTER ld_sync SET (INTROSPECTION DEBUGGING = TRUE)",
+                        f"> SELECT cr.id::text <> '${{ld_sync_replica_id}}', p.value FROM mz_internal.mz_replica_system_parameters p JOIN mz_cluster_replicas cr ON cr.id = p.replica_id JOIN mz_clusters c ON c.id = cr.cluster_id WHERE p.name = '{LGALLOC_PARAM}' AND c.name = 'ld_sync' AND cr.id::text <> '${{ld_sync_replica_id}}'",
+                        "true false",
+                    ]
+                )
+            )
             c.stop("materialized")
     finally:
         for flag in (

--- a/test/pg-cdc/cluster-graceful-reconfiguration.td
+++ b/test/pg-cdc/cluster-graceful-reconfiguration.td
@@ -16,12 +16,6 @@
 # new replica until cut-over drops the old one. Readiness must therefore not
 # wait for the source to hydrate on the target, but must still wait for the
 # target's processes to come online before cutting over.
-#
-# The background flag is pinned explicitly so the test does not depend on the
-# harness defaults.
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true
 
 > CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -309,11 +309,6 @@ CREATE CLUSTER foo SIZE invalid_size, REPLICATION FACTOR 0
 statement error creating cluster replica would violate max_replicas_per_cluster limit \(desired: 9999999, limit: 5, current: 0\)
 CREATE CLUSTER foo SIZE 'scale=1,workers=1', replication factor 9999999;
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
-----
-COMPLETE 0
-
 statement ok
 CREATE CLUSTER foo (SIZE 'scale=1,workers=1')
 

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -317,6 +317,13 @@ COMPLETE 0
 statement ok
 CREATE CLUSTER foo (SIZE 'scale=1,workers=1')
 
+# Every WAIT spelling, zero timeout included, writes a reconfiguration record
+# the controller converges on. The realized config advances only at the
+# controller's cut-over, and this suite pins background ALTER CLUSTER on, so the
+# statements below return before that and there is nothing deterministic to read
+# back here. Exercised for acceptance; the realized-config transition and the
+# record's lifecycle are covered in test/testdrive/cluster-controller.td.
+
 statement ok
 ALTER CLUSTER foo set (SIZE 'scale=1,workers=2') WITH (WAIT FOR '0s')
 
@@ -324,7 +331,7 @@ statement ok
 ALTER CLUSTER foo set (SIZE 'scale=1,workers=4') WITH (WAIT UNTIL READY (TIMEOUT '0s', ON TIMEOUT 'COMMIT') )
 
 statement ok
-ALTER CLUSTER foo set (SIZE 'scale=1,workers=4') WITH (WAIT UNTIL READY (TIMEOUT '10ms', ON TIMEOUT 'ROLLBACK') )
+ALTER CLUSTER foo set (SIZE 'scale=1,workers=2') WITH (WAIT UNTIL READY (TIMEOUT '10ms', ON TIMEOUT 'ROLLBACK') )
 
 statement ok
 DROP CLUSTER foo
@@ -362,7 +369,9 @@ statement error WAIT can only be used together with a SIZE, AVAILABILITY ZONES, 
 ALTER CLUSTER foo SET (REPLICATION FACTOR 2) WITH (WAIT UNTIL READY (TIMEOUT '0s', ON TIMEOUT 'COMMIT'))
 
 # A `WAIT` clause paired with a real shape change is still accepted, including
-# alongside a non-shape option in the same statement.
+# alongside a non-shape option in the same statement. Nothing is in flight for
+# this cluster, so the replication factor is free to ride along into the
+# record's target.
 statement ok
 ALTER CLUSTER foo SET (SIZE 'scale=1,workers=2', REPLICATION FACTOR 2) WITH (WAIT FOR '0s')
 
@@ -381,8 +390,11 @@ ALTER CLUSTER foo SET (MANAGED = false) WITH (WAIT UNTIL READY (TIMEOUT '0s', ON
 statement ok
 DROP CLUSTER foo
 
-# Regression: zero-downtime finalization (PR #28836) reads workload_class from
-# the catalog instead of the planned config, silently dropping the change.
+# A `WORKLOAD CLASS` change riding along with a shape change reaches the durable
+# config rather than being silently dropped by the reshape. The reshape defers
+# only the replica config shape to the reconfiguration record and applies
+# non-shape fields to the realized config in the same transaction, so the
+# readback needs no retry even though the size transition lands later.
 
 simple conn=mz_system,user=mz_system
 CREATE CLUSTER wc_test SIZE 'scale=1,workers=1'

--- a/test/testdrive/cluster-controller.td
+++ b/test/testdrive/cluster-controller.td
@@ -24,11 +24,9 @@ $ set-sql-timeout duration=120s
 
 # Drive the tick interval down so the controller ticks ~hundreds of times across
 # the waits below. It is re-read each tick, so the flip takes effect without a
-# restart. The graceful cases use the WITH (WAIT ...) surface, whose planner
-# acceptance is gated on enable_zero_downtime.
+# restart.
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET cluster_controller_tick_interval = '5ms'
-ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true
 
 # ----- Baseline reconcile is a no-op -----
 #
@@ -1797,7 +1795,6 @@ ALTER SYSTEM SET unsafe_enable_unstable_dependencies = false
 # Restore pristine server state (including the tick-interval override).
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM RESET cluster_controller_tick_interval
-ALTER SYSTEM RESET enable_zero_downtime_cluster_reconfiguration
 ALTER SYSTEM RESET enable_background_alter_cluster
 ALTER SYSTEM RESET enable_auto_scaling_strategy
 ALTER SYSTEM RESET enable_hydration_burst

--- a/test/testdrive/cluster-controller.td
+++ b/test/testdrive/cluster-controller.td
@@ -755,6 +755,30 @@ scale=1,workers=1 2
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM RESET max_credit_consumption_rate
 
+# ----- Replication-factor increases validate their committed credit floor -----
+
+> CREATE CLUSTER cc_rf_credit (SIZE 'scale=2,workers=2', REPLICATION FACTOR 1)
+
+# The additional replica costs 4 credits. Leave only 3 credits of headroom, so
+# the ALTER must fail synchronously rather than commit an RF the controller
+# cannot materialize.
+$ set-from-sql var=rf_credit_limit
+SELECT (sum(s.credits_per_hour) + 3)::text FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id JOIN mz_catalog.mz_cluster_replica_sizes s ON r.size = s.size WHERE c.id LIKE 'u%'
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET max_credit_consumption_rate = ${rf_credit_limit}
+
+! ALTER CLUSTER cc_rf_credit SET (REPLICATION FACTOR 2)
+contains: creating cluster replica would violate max_credit_consumption_rate limit
+
+> SELECT replication_factor FROM mz_clusters WHERE name = 'cc_rf_credit'
+1
+
+> DROP CLUSTER cc_rf_credit
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM RESET max_credit_consumption_rate
+
 # ----- A forced cut-over swaps instead of overlapping -----
 #
 # Same budget shape as above (the settled target fits, the two sets at once do

--- a/test/testdrive/cluster-controller.td
+++ b/test/testdrive/cluster-controller.td
@@ -12,11 +12,11 @@
 # Convergence is asynchronous (a config-shape ALTER returns before the realized
 # config settles), so every readback below is a retrying testdrive query (`>`
 # re-runs until it matches or the SQL timeout elapses), never a fixed-duration
-# sleep. Where a transient in-flight state must be observed, the controller is
-# held off first (by cranking the tick interval back up) so the state cannot
-# move; where the assertion is a negative ("the controller does nothing"), a
-# sibling reconfiguration is used as a liveness synchronizer, proving the
-# reconcile loop ran many ticks without acting on the cluster under test.
+# sleep. Where a transient in-flight state must be observed, a sleeping
+# dataflow prevents the target from hydrating. Where the assertion is a negative
+# ("the controller does nothing"), a sibling reconfiguration is used as a
+# liveness synchronizer, proving the reconcile loop ran many ticks without
+# acting on the cluster under test.
 
 # Give convergence (provision + hydrate + cut-over) ample room on a loaded CI host
 # without ever sleeping the full budget. `>` returns as soon as it matches.
@@ -56,8 +56,7 @@ cc_steady r2 scale=1,workers=1
 # reusing the same name, would leave a dropped replica in the history. The
 # baseline controller never does, so cc_steady has no dropped replica recorded.
 # (Materialize forbids copying these system rows into a user table, so we assert
-# no-drop directly.) This is not satisfied by gate-off legacy behavior, which
-# never runs the reconcile loop at all.
+# no-drop directly.)
 > SELECT count(*) FROM mz_internal.mz_cluster_replica_history WHERE cluster_name = 'cc_steady' AND dropped_at IS NOT NULL
 0
 
@@ -78,11 +77,10 @@ drop retired
 
 # ----- Graceful background reconfiguration -----
 #
-# With the master gate on and background ALTER enabled, a config-shape ALTER (SIZE
-# change) writes a durable reconfiguration record and returns immediately; the
-# controller creates the target replica, and once it hydrates (an empty cluster
-# hydrates promptly) cuts the realized size over to the target and drops the old
-# replica.
+# With background ALTER enabled, a config-shape ALTER (SIZE change) writes a
+# durable reconfiguration record and returns immediately. The controller creates
+# the target replica, and once it hydrates (an empty cluster hydrates promptly)
+# cuts the realized size over to the target and drops the old replica.
 
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_background_alter_cluster = true
@@ -180,15 +178,24 @@ scale=1,workers=1
 #
 # The WAIT-without-shape rejection is planner-level and covered in
 # managed_cluster.slt. Asserted here: the replication factor is refused while
-# a reconfiguration is in flight (it is one of the four dimensions the
-# cut-over sets atomically from the record's target), and a WORKLOAD CLASS
-# change applies immediately without disturbing the reconfiguration.
+# a reconfiguration is in flight because cut-over sets it atomically from the
+# record's target. A WORKLOAD CLASS change applies immediately without
+# disturbing the reconfiguration.
 #
-# The refused ALTER is issued immediately after the SIZE change, so the
-# reconfiguration is still in flight when it lands. If the reconfiguration
-# somehow cut over first, the ALTER would succeed and this fails loudly
-# rather than hangs.
+# A sleeping dataflow keeps the target from hydrating, so controller wakeups
+# cannot settle the reconfiguration before the refusal assertions. `mz_sleep`
+# blocks the worker thread and dropping the view does not interrupt a sleep
+# already in flight, so unlike the rest of this file the duration is bounded:
+# this section asserts the convergence that happens once it expires.
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET unsafe_enable_unstable_dependencies = true
+
 > CREATE CLUSTER cc_nonshape (SIZE 'scale=1,workers=1', REPLICATION FACTOR 1)
+
+> CREATE TABLE cc_nonshape_t (id int)
+> INSERT INTO cc_nonshape_t VALUES (1)
+> CREATE MATERIALIZED VIEW cc_nonshape_slow IN CLUSTER cc_nonshape AS
+  SELECT mz_unsafe.mz_sleep(id * 20) AS s FROM cc_nonshape_t
 
 > ALTER CLUSTER cc_nonshape SET (SIZE 'scale=1,workers=2')
 
@@ -207,6 +214,12 @@ ALTER CLUSTER cc_nonshape SET (WORKLOAD CLASS 'test')
 
 > SELECT workload_class FROM mz_internal.mz_cluster_workload_classes WHERE id = (SELECT id FROM mz_clusters WHERE name = 'cc_nonshape')
 test
+
+# Drop the view and let the in-flight sleep expire, which frees the worker and
+# lets the target hydrate so the remaining steady-state assertions can proceed.
+> DROP MATERIALIZED VIEW cc_nonshape_slow
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET unsafe_enable_unstable_dependencies = false
 
 # The reconfiguration converges normally: the WORKLOAD CLASS change did not
 # disturb the record, and its lifecycle is exactly `started`, `finalized`.
@@ -230,14 +243,15 @@ test2
 2
 
 > DROP CLUSTER cc_nonshape
+> DROP TABLE cc_nonshape_t
 
 # ----- Per-ALTER timeout / ON TIMEOUT -----
 #
 # The deadline and the on-timeout action come from the WITH (WAIT ...) surface and
 # are written into the durable record, so the controller enforces them. These
 # cases use a promptly-hydrating (empty) cluster, so success precedence cuts over
-# before any deadline matters. They assert the three spellings are accepted under
-# the gate and drive the record to a successful cut-over. ROLLBACK-vs-COMMIT
+# before any deadline matters. They assert the three spellings drive the record
+# to a successful cut-over. ROLLBACK-vs-COMMIT
 # behavior *at* a timeout (a target that never hydrates) is pinned in the
 # controller's kernel unit tests and asserted end-to-end in the deadline
 # scenarios below.
@@ -257,7 +271,7 @@ scale=1,workers=2
 scale=1,workers=4
 
 # Explicit ON TIMEOUT COMMIT, and WAIT FOR (which desugars to ON TIMEOUT COMMIT):
-# both accepted under the gate and drive a cut-over.
+# both accepted and drive a cut-over.
 > ALTER CLUSTER cc_timeout SET (SIZE 'scale=1,workers=2') WITH (WAIT UNTIL READY (TIMEOUT '60s', ON TIMEOUT 'COMMIT'))
 > SELECT size FROM mz_clusters WHERE name = 'cc_timeout'
 scale=1,workers=2
@@ -581,6 +595,18 @@ running
 $ kafka-verify-data format=json sink=materialize.public.cc_fg_sink key=false sort-messages=true
 {"before": null, "after": {"id": 2}}
 
+# A zero-timeout commit reaches the same shim. Its record's deadline is already
+# elapsed, so nothing waits for hydration, but the cut-over is still the
+# controller's: the statement blocks for a tick instead of returning
+# synchronously, and the realized size has advanced by the time it returns.
+> ALTER CLUSTER cc_fg SET (SIZE 'scale=1,workers=4') WITH (WAIT FOR '0s')
+
+> SELECT c.size, r.size
+  FROM mz_clusters c
+  JOIN mz_cluster_replicas r ON r.cluster_id = c.id
+  WHERE c.name = 'cc_fg'
+scale=1,workers=4 scale=1,workers=4
+
 # Background mode exercises the same readiness check without the wait shim.
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_background_alter_cluster = true
@@ -606,45 +632,98 @@ $ kafka-verify-data format=json sink=materialize.public.cc_fg_sink key=false sor
 > DROP TABLE cc_fg_t
 > DROP CONNECTION cc_fg_kafka
 
-# ----- A reshape whose transient peak exceeds the replica budget is rejected -----
+# A limit reduction must not prevent cancelling back to the realized config.
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET unsafe_enable_unstable_dependencies = true
+ALTER SYSTEM SET max_replicas_per_cluster = 6
+
+> CREATE CLUSTER cc_limit_cancel (SIZE 'scale=1,workers=1', REPLICATION FACTOR 3)
+> CREATE TABLE cc_limit_cancel_t (id int)
+> INSERT INTO cc_limit_cancel_t VALUES (1)
+> CREATE MATERIALIZED VIEW cc_limit_cancel_slow IN CLUSTER cc_limit_cancel AS
+  SELECT mz_unsafe.mz_sleep(id * 3600) AS s FROM cc_limit_cancel_t
+
+> ALTER CLUSTER cc_limit_cancel SET (SIZE 'scale=1,workers=2')
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters c ON c.id = recon.cluster_id WHERE c.name = 'cc_limit_cancel'
+in-progress
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET max_replicas_per_cluster = 2
+
+> ALTER CLUSTER cc_limit_cancel SET (SIZE 'scale=1,workers=1')
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters c ON c.id = recon.cluster_id WHERE c.name = 'cc_limit_cancel'
+cancelled
+> SELECT size, replication_factor FROM mz_clusters WHERE name = 'cc_limit_cancel'
+scale=1,workers=1 3
+
+> DROP CLUSTER cc_limit_cancel CASCADE
+> DROP TABLE cc_limit_cancel_t
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET unsafe_enable_unstable_dependencies = false
+ALTER SYSTEM RESET max_replicas_per_cluster
+
+# ----- The controller reports a reshape that exceeds the replica budget -----
 #
-# A shape-change reshape runs the realized and target replica sets side by side
-# until cut-over, so the transient peak is realized_rf + target_rf. The ALTER
-# validates that peak, matching the legacy wait path (which creates the full
-# target set as pending replicas at ALTER time), and rejects synchronously: no
-# record is written and nothing has to be aborted. Apply-time exhaustion, and
-# the controller's abort reaction, remains reachable only when a limit shrinks
-# or the environment grows after the record is written, which is covered by
-# kernel unit tests.
+# The sequencer does not reproduce the controller's strategy union to predict a
+# transient peak. The ALTER writes its durable target. If the target set cannot
+# be created alongside the realized set, the controller marks the record and
+# audits the outcome while leaving the realized shape untouched.
 
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET max_replicas_per_cluster = 3
 
 > CREATE CLUSTER cc_budget (SIZE 'scale=1,workers=1', REPLICATION FACTOR 2)
 
+# The target baseline itself is bounded before the controller expands it into
+# desired replica slots.
+! ALTER CLUSTER cc_budget SET (SIZE 'scale=1,workers=2', REPLICATION FACTOR 9999999)
+contains:creating cluster replica would violate max_replicas_per_cluster limit (desired: 9999999, limit: 3, current: 0)
+
+> SELECT count(*) FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters c ON c.id = recon.cluster_id WHERE c.name = 'cc_budget'
+0
+
 # The settled target (2 replicas) fits the limit of 3, but the peak
 # (2 realized + 2 target = 4) does not.
-! ALTER CLUSTER cc_budget SET (SIZE 'scale=1,workers=2')
-contains:would violate max_replicas_per_cluster limit
+> ALTER CLUSTER cc_budget SET (SIZE 'scale=1,workers=2')
 
-# The ALTER was rejected outright: no record was written, no lifecycle
-# transition was audited, and the realized shape is untouched.
-> SELECT count(*) FROM mz_catalog.mz_audit_events WHERE event_type = 'alter' AND object_type = 'cluster' AND details->>'cluster_name' = 'cc_budget' AND details->>'transition' IS NOT NULL
-0
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters ON mz_clusters.id = recon.cluster_id WHERE mz_clusters.name = 'cc_budget'
+resource-exhausted
+
+> SELECT details->>'transition' FROM mz_catalog.mz_audit_events WHERE event_type = 'alter' AND object_type = 'cluster' AND details->>'cluster_name' = 'cc_budget' AND details->>'transition' = 'resource-exhausted'
+resource-exhausted
 
 > SELECT size, replication_factor FROM mz_clusters WHERE name = 'cc_budget'
 scale=1,workers=1 2
 
 > DROP CLUSTER cc_budget
 
+# Foreground mode waits for the same durable outcome and reports resource
+# exhaustion specifically, rather than presenting it as an ALTER timeout.
+> CREATE CLUSTER cc_budget_fg (SIZE 'scale=1,workers=1', REPLICATION FACTOR 2)
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET enable_background_alter_cluster = false
+
+! ALTER CLUSTER cc_budget_fg SET (SIZE 'scale=1,workers=2')
+contains:cluster reconfiguration could not provision its target within the available resource limits
+
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters c ON c.id = recon.cluster_id WHERE c.name = 'cc_budget_fg'
+resource-exhausted
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET enable_background_alter_cluster = true
+
+> DROP CLUSTER cc_budget_fg
+
 # Reset the limit after this section.
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM RESET max_replicas_per_cluster
 
-# ----- The credit budget is validated the same way, against the live environment -----
+# ----- Credit exhaustion has the same durable outcome -----
 #
-# The credit peak is likewise credit(realized) + credit(target), but its budget
-# is environment-wide, so the limit here is computed from the live replica set.
+# The credit budget is environment-wide, so the limit is computed from the live
+# replica set.
 
 > CREATE CLUSTER cc_credit (SIZE 'scale=1,workers=1', REPLICATION FACTOR 2)
 
@@ -659,13 +738,13 @@ SELECT (sum(s.credits_per_hour) + 3)::text FROM mz_cluster_replicas r JOIN mz_cl
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET max_credit_consumption_rate = ${credit_limit}
 
-! ALTER CLUSTER cc_credit SET (SIZE 'scale=1,workers=2')
-contains:would violate max_credit_consumption_rate limit
+> ALTER CLUSTER cc_credit SET (SIZE 'scale=1,workers=2')
 
-# The ALTER was rejected outright: no record was written, no lifecycle
-# transition was audited, and the realized shape is untouched.
-> SELECT count(*) FROM mz_catalog.mz_audit_events WHERE event_type = 'alter' AND object_type = 'cluster' AND details->>'cluster_name' = 'cc_credit' AND details->>'transition' IS NOT NULL
-0
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters ON mz_clusters.id = recon.cluster_id WHERE mz_clusters.name = 'cc_credit'
+resource-exhausted
+
+> SELECT details->>'transition' FROM mz_catalog.mz_audit_events WHERE event_type = 'alter' AND object_type = 'cluster' AND details->>'cluster_name' = 'cc_credit' AND details->>'transition' = 'resource-exhausted'
+resource-exhausted
 
 > SELECT size, replication_factor FROM mz_clusters WHERE name = 'cc_credit'
 scale=1,workers=1 2
@@ -676,44 +755,84 @@ scale=1,workers=1 2
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM RESET max_credit_consumption_rate
 
+# ----- A forced cut-over swaps instead of overlapping -----
+#
+# Same budget shape as above (the settled target fits, the two sets at once do
+# not), but the reshape is forced rather than graceful. A forced cut-over has
+# given up on hydration, so the realized replicas have nothing left to serve
+# and the baseline yields them: one transaction retires them and creates the
+# target's, and only its net has to fit. Resizing a cluster that already sits
+# near the budget therefore works, where waiting for hydration cannot.
+
+> CREATE CLUSTER cc_swap (SIZE 'scale=1,workers=1', REPLICATION FACTOR 2)
+
+$ set-from-sql var=swap_credit_limit
+SELECT (sum(s.credits_per_hour) + 3)::text FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id JOIN mz_catalog.mz_cluster_replica_sizes s ON r.size = s.size WHERE c.id LIKE 'u%'
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET max_credit_consumption_rate = ${swap_credit_limit}
+
+> ALTER CLUSTER cc_swap SET (SIZE 'scale=1,workers=2') WITH (WAIT FOR '0s')
+
+> SELECT size, replication_factor FROM mz_clusters WHERE name = 'cc_swap'
+scale=1,workers=2 2
+
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters ON mz_clusters.id = recon.cluster_id WHERE mz_clusters.name = 'cc_swap'
+finalized
+
+> SELECT details->>'transition', details->>'forced' FROM mz_catalog.mz_audit_events WHERE event_type = 'alter' AND object_type = 'cluster' AND details->>'cluster_name' = 'cc_swap' AND details->>'transition' IS NOT NULL ORDER BY id
+started <null>
+finalized true
+
+# The cluster never held more than its target's worth of replicas.
+> SELECT DISTINCT r.size FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id WHERE c.name = 'cc_swap'
+scale=1,workers=2
+
+> DROP CLUSTER cc_swap
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM RESET max_credit_consumption_rate
+
 # ----- Converting to unmanaged is refused while a reconfiguration is in flight -----
 #
 # The unmanaged variant has no reconfiguration field, so the conversion would
 # silently drop an in-progress record with no terminal status and no audit
 # event, and strand any overlap replicas. The conversion is refused instead.
 #
-# The controller is held off across the assertion by cranking the tick interval
-# up before the reconfiguring ALTER. It still reconciles once right after that
-# ALTER (a cluster write wakes it), which is what brings the overlap replica up,
-# but from then on nothing wakes it: the refused conversion below writes no
-# catalog state, so it cannot race a cut-over.
+# A sleeping dataflow keeps the target from hydrating, so the self-wake after
+# the cluster write cannot settle the record before the refusal assertion.
 
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
-ALTER SYSTEM SET cluster_controller_tick_interval = '10s'
+ALTER SYSTEM SET unsafe_enable_unstable_dependencies = true
 
 > CREATE CLUSTER cc_unmanaged (SIZE 'scale=1,workers=1', REPLICATION FACTOR 1)
+> CREATE TABLE cc_unmanaged_t (id int)
+> INSERT INTO cc_unmanaged_t VALUES (1)
+> CREATE MATERIALIZED VIEW cc_unmanaged_slow IN CLUSTER cc_unmanaged AS
+  SELECT mz_unsafe.mz_sleep(id * 3600) AS s FROM cc_unmanaged_t
 > ALTER CLUSTER cc_unmanaged SET (SIZE 'scale=1,workers=2')
 
 ! ALTER CLUSTER cc_unmanaged SET (MANAGED = false)
 contains:cannot convert cluster to unmanaged while a reconfiguration is in progress
 
-# Restore the cadence and cancel by ALTERing back to the realized size. Once the
-# record settles (the retrying `>` rides out the interim), the conversion goes
-# through.
-$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
-ALTER SYSTEM SET cluster_controller_tick_interval = '5ms'
-
+# Cancel by ALTERing back to the realized size. Once the record settles, the
+# conversion goes through.
 > ALTER CLUSTER cc_unmanaged SET (SIZE 'scale=1,workers=1')
 > ALTER CLUSTER cc_unmanaged SET (MANAGED = false)
 
 > DROP CLUSTER cc_unmanaged CASCADE
+> DROP TABLE cc_unmanaged_t
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET unsafe_enable_unstable_dependencies = false
 
 # ----- Observability: introspection relations + SHOW CLUSTERS -----
 #
 # mz_internal.mz_cluster_reconfigurations retains one row per cluster that has been
 # reconfigured: the target delta (target shape as JSON, deadline, on_timeout) and a
 # `status` that is `in-progress` while the reconfiguration runs, then a terminal
-# `finalized` / `timed-out` / `cancelled`. The row is never cleared by settling,
+# `finalized` / `timed-out` / `cancelled` / `resource-exhausted`. The row is
+# never cleared by settling,
 # only overwritten by the next ALTER. SHOW CLUSTERS folds an in-progress
 # reconfiguration and the auto-scaling state into a single `activity` summary, NULL
 # when steady.
@@ -809,10 +928,9 @@ timed-out
 > SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'cc_rollback'
 cc_rollback r1 scale=1,workers=1
 
-# A forced cut-over: TIMEOUT '0s' with ON TIMEOUT COMMIT advances the realized
-# config to the (necessarily un-hydrated) target on the first tick. The retained
-# record carries status `finalized` with the deadline, so a reader can tell it was a
-# past-deadline (forced) cut-over.
+# A forced cut-over provisions the target set but does not wait for it to
+# hydrate. The retained record carries status `finalized` with the deadline, so
+# a reader can tell it was a past-deadline cut-over.
 > ALTER CLUSTER cc_rollback SET (SIZE 'scale=1,workers=2') WITH (WAIT UNTIL READY (TIMEOUT '0s', ON TIMEOUT 'COMMIT'))
 > SELECT size FROM mz_clusters WHERE name = 'cc_rollback'
 scale=1,workers=2
@@ -881,9 +999,9 @@ ALTER SYSTEM SET unsafe_enable_unstable_dependencies = false
 
 # ----- ON REFRESH scheduling driven by the controller -----
 #
-# With the gate on, the on-refresh strategy (not the legacy scheduling tick) owns
-# a scheduled cluster's replica set: it normalizes the realized replication factor
-# to 0 and brings up a single replica while the cluster is inside a refresh window.
+# The on-refresh strategy owns a scheduled cluster's replica set. It normalizes
+# the realized replication factor to 0 and brings up a single replica while the
+# cluster is inside a refresh window.
 
 # A scheduled cluster with no bound REFRESH MV is outside any refresh window, so it
 # has no replica and its replication factor reads 0. The large HYDRATION TIME
@@ -1427,6 +1545,230 @@ manual
 > SELECT size, replication_factor FROM mz_clusters WHERE name = 'cc_wait_manual'
 scale=1,workers=2 0
 > DROP CLUSTER cc_wait_manual
+
+# ----- Forcing a wedged reconfiguration through with a zero-timeout commit -----
+#
+# A zero timeout with COMMIT writes a reconfiguration record whose deadline has
+# already passed. The controller ensures the target set exists, then advances
+# the realized config without waiting for hydration. That makes it the way out
+# of a wedged reconfiguration, which is the scenario below.
+#
+# Both spellings of an elapsed deadline (`WAIT FOR '0s'` here, `WAIT UNTIL READY
+# (TIMEOUT '0s', ON TIMEOUT 'COMMIT')` in the `cc_force_existing` section) take
+# this one path, so the first block below covers the zero-timeout spelling of
+# what that section covers.
+#
+# A sleeping materialized view pins hydration on every replica of the cluster,
+# baseline and overlap alike, so the target set never hydrates and the
+# controller cannot cut over on hydration. The default deadline is 24h away, so
+# nothing else retires the record either: the reconfiguration is stuck until an
+# operator intervenes.
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET unsafe_enable_unstable_dependencies = true
+
+> CREATE CLUSTER cc_cutover (SIZE 'scale=1,workers=1', REPLICATION FACTOR 1)
+
+> CREATE TABLE cc_cutover_t (id int)
+> INSERT INTO cc_cutover_t VALUES (1)
+
+> CREATE MATERIALIZED VIEW cc_cutover_slow IN CLUSTER cc_cutover AS
+  SELECT mz_unsafe.mz_sleep(id * 3600) AS s FROM cc_cutover_t
+
+> ALTER CLUSTER cc_cutover SET (SIZE 'scale=1,workers=2')
+
+# Wedged: baseline and overlap run side by side, the realized size is unchanged,
+# and the record stays in progress.
+> SELECT r.size, count(*) FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id WHERE c.name = 'cc_cutover' GROUP BY r.size
+scale=1,workers=1 1
+scale=1,workers=2 1
+> SELECT size FROM mz_clusters WHERE name = 'cc_cutover'
+scale=1,workers=1
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters ON mz_clusters.id = recon.cluster_id WHERE mz_clusters.name = 'cc_cutover'
+in-progress
+
+# Re-stating the in-flight target with an elapsed deadline is the "commit this
+# now" case. The overlap replica already has the target shape, so the
+# controller's reconcile keeps it and only retires the baseline: forcing the
+# commit must not cost a cold restart of a replica that was already up. The
+# record reached its own target, so it settles `finalized`, marked forced
+# because nothing waited for hydration. Re-targeting an in-progress record
+# audits a second `started`.
+$ set-from-sql var=cc_cutover_target_id
+SELECT r.id::text
+FROM mz_cluster_replicas r
+JOIN mz_clusters c ON c.id = r.cluster_id
+WHERE c.name = 'cc_cutover' AND r.size = 'scale=1,workers=2'
+
+> ALTER CLUSTER cc_cutover SET (SIZE 'scale=1,workers=2') WITH (WAIT FOR '0s')
+
+> SELECT r.id::text = '${cc_cutover_target_id}', r.size
+  FROM mz_cluster_replicas r
+  JOIN mz_clusters c ON c.id = r.cluster_id
+  WHERE c.name = 'cc_cutover'
+true scale=1,workers=2
+> SELECT size FROM mz_clusters WHERE name = 'cc_cutover'
+scale=1,workers=2
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters ON mz_clusters.id = recon.cluster_id WHERE mz_clusters.name = 'cc_cutover'
+finalized
+
+> SELECT row_number() OVER (ORDER BY id), details->>'transition', details->>'forced'
+  FROM mz_catalog.mz_audit_events
+  WHERE event_type = 'alter' AND object_type = 'cluster'
+    AND details->>'cluster_name' = 'cc_cutover' AND details->>'transition' IS NOT NULL
+1 started <null>
+2 started <null>
+3 finalized true
+
+# Now wedge it again and force through a *different* size. The zero-timeout
+# ALTER re-targets the stuck record rather than abandoning it, so the whole
+# owned set is replaced (nothing matches the new target, including the stranded
+# overlap replica) and the record settles `finalized` on its new target.
+> ALTER CLUSTER cc_cutover SET (SIZE 'scale=1,workers=4')
+
+> SELECT r.size, count(*) FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id WHERE c.name = 'cc_cutover' GROUP BY r.size
+scale=1,workers=2 1
+scale=1,workers=4 1
+
+> ALTER CLUSTER cc_cutover SET (SIZE 'scale=1,workers=8') WITH (WAIT FOR '0s')
+
+> SELECT size FROM mz_clusters WHERE name = 'cc_cutover'
+scale=1,workers=8
+> SELECT r.size, count(*) FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id WHERE c.name = 'cc_cutover' GROUP BY r.size
+scale=1,workers=8 1
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters ON mz_clusters.id = recon.cluster_id WHERE mz_clusters.name = 'cc_cutover'
+finalized
+
+# The other zero-timeout spelling requests the same thing, here with a factor
+# change riding along and no record in flight, so the factor is free to enter
+# the record's target. The realized factor stays 1 until the record's cut-over
+# writes the target's 2, along with the target size.
+> ALTER CLUSTER cc_cutover SET (SIZE 'scale=1,workers=2', REPLICATION FACTOR 2) WITH (WAIT UNTIL READY (TIMEOUT '0s', ON TIMEOUT 'COMMIT'))
+
+> SELECT size, replication_factor FROM mz_clusters WHERE name = 'cc_cutover'
+scale=1,workers=2 2
+> SELECT r.size, count(*) FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id WHERE c.name = 'cc_cutover' GROUP BY r.size
+scale=1,workers=2 2
+
+# A factor change while a record is in flight is refused on every path: the
+# record's cut-over writes its target factor, which would silently clobber the
+# change.
+> ALTER CLUSTER cc_cutover SET (SIZE 'scale=1,workers=4')
+
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters ON mz_clusters.id = recon.cluster_id WHERE mz_clusters.name = 'cc_cutover'
+in-progress
+> SELECT r.size, count(*) FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id WHERE c.name = 'cc_cutover' GROUP BY r.size
+scale=1,workers=2 2
+scale=1,workers=4 2
+
+! ALTER CLUSTER cc_cutover SET (REPLICATION FACTOR 3)
+contains:cannot change replication factor while a reconfiguration is in progress
+
+# No path is exempt, a zero-timeout commit included: it writes a record like any
+# other, and that record's cut-over would restore the target factor a tick
+# later.
+! ALTER CLUSTER cc_cutover SET (SIZE 'scale=1,workers=4', REPLICATION FACTOR 1) WITH (WAIT FOR '0s')
+contains:cannot change replication factor while a reconfiguration is in progress
+
+# Forcing a wedged resize through and scaling down therefore takes two
+# statements: commit the record with a zero-timeout WAIT, then change the factor
+# once nothing is in flight. The factor is untouched by the commit (the record
+# carries the realized 2 as its target), so only the size moves here.
+> ALTER CLUSTER cc_cutover SET (SIZE 'scale=1,workers=4') WITH (WAIT FOR '0s')
+
+> SELECT size FROM mz_clusters WHERE name = 'cc_cutover'
+scale=1,workers=4
+> SELECT r.size, count(*) FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id WHERE c.name = 'cc_cutover' GROUP BY r.size
+scale=1,workers=4 2
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters ON mz_clusters.id = recon.cluster_id WHERE mz_clusters.name = 'cc_cutover'
+finalized
+
+> ALTER CLUSTER cc_cutover SET (REPLICATION FACTOR 1)
+
+> SELECT size, replication_factor FROM mz_clusters WHERE name = 'cc_cutover'
+scale=1,workers=4 1
+> SELECT r.size, count(*) FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id WHERE c.name = 'cc_cutover' GROUP BY r.size
+scale=1,workers=4 1
+
+> DROP CLUSTER cc_cutover CASCADE
+> DROP TABLE cc_cutover_t
+
+# ----- A forced cut-over preserves an active hydration burst -----
+#
+# The controller unions every strategy's desired replica set. A forced cut-over
+# settles the graceful-reconfiguration record but not the warranted burst record,
+# so the burst replica must keep running under the same id rather than lose its
+# hydration progress in a drop-and-recreate cycle.
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET enable_auto_scaling_strategy = true
+ALTER SYSTEM SET enable_hydration_burst = true
+
+> CREATE CLUSTER cc_cutover_burst (SIZE 'scale=1,workers=1', REPLICATION FACTOR 1, AUTO SCALING STRATEGY = (ON HYDRATION (HYDRATION SIZE = 'scale=2,workers=2', LINGER DURATION = '600s')))
+
+> CREATE TABLE cc_cutover_burst_t (id int)
+> INSERT INTO cc_cutover_burst_t VALUES (1)
+
+> CREATE MATERIALIZED VIEW cc_cutover_burst_slow IN CLUSTER cc_cutover_burst AS
+  SELECT mz_unsafe.mz_sleep(id * 3600) AS s FROM cc_cutover_burst_t
+
+> SELECT r.size, count(*) FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id WHERE c.name = 'cc_cutover_burst' GROUP BY r.size ORDER BY r.size
+scale=1,workers=1 1
+scale=2,workers=2 1
+
+$ set-from-sql var=cc_cutover_burst_replica_id
+SELECT r.id::text
+FROM mz_cluster_replicas r
+JOIN mz_clusters c ON c.id = r.cluster_id
+WHERE c.name = 'cc_cutover_burst' AND r.size = 'scale=2,workers=2'
+
+# The live burst fills the replica budget. The ALTER still records its target,
+# then the controller's concrete create transaction exceeds the limit and sheds
+# the reconfiguration. The existing baseline and burst remain untouched.
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET max_replicas_per_cluster = 2
+
+> ALTER CLUSTER cc_cutover_burst SET (SIZE 'scale=1,workers=2')
+
+> SELECT recon.status FROM mz_internal.mz_cluster_reconfigurations recon JOIN mz_clusters c ON c.id = recon.cluster_id WHERE c.name = 'cc_cutover_burst'
+resource-exhausted
+
+> SELECT details->>'transition' FROM mz_catalog.mz_audit_events WHERE event_type = 'alter' AND object_type = 'cluster' AND details->>'cluster_name' = 'cc_cutover_burst' AND details->>'transition' = 'resource-exhausted'
+resource-exhausted
+
+> SELECT r.size, r.id::text = '${cc_cutover_burst_replica_id}' FROM mz_cluster_replicas r JOIN mz_clusters c ON c.id = r.cluster_id WHERE c.name = 'cc_cutover_burst' ORDER BY r.size
+scale=1,workers=1 false
+scale=2,workers=2 true
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM RESET max_replicas_per_cluster
+
+# The ordinary reshape adds its target overlap alongside the burst.
+> ALTER CLUSTER cc_cutover_burst SET (SIZE 'scale=1,workers=2')
+
+> SELECT r.size, r.id::text = '${cc_cutover_burst_replica_id}' FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id WHERE c.name = 'cc_cutover_burst' ORDER BY r.size
+scale=1,workers=1 false
+scale=1,workers=2 false
+scale=2,workers=2 true
+
+# Re-stating the target with an elapsed deadline forces the controller to cut
+# over. The overlap already matches the new baseline, and the independent burst
+# strategy still desires its replica, so both survive under their existing ids.
+> ALTER CLUSTER cc_cutover_burst SET (SIZE 'scale=1,workers=2') WITH (WAIT FOR '0s')
+
+> SELECT r.size, r.id::text = '${cc_cutover_burst_replica_id}' FROM mz_cluster_replicas r JOIN mz_clusters c ON r.cluster_id = c.id WHERE c.name = 'cc_cutover_burst' ORDER BY r.size
+scale=1,workers=2 false
+scale=2,workers=2 true
+
+# Exactly one burst replica was created across both reshapes.
+> SELECT count(*) FROM mz_catalog.mz_audit_events WHERE object_type = 'cluster-replica' AND details->>'cluster_name' = 'cc_cutover_burst' AND details->>'reason' = 'hydration-burst'
+1
+
+> DROP CLUSTER cc_cutover_burst CASCADE
+> DROP TABLE cc_cutover_burst_t
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+ALTER SYSTEM SET unsafe_enable_unstable_dependencies = false
 
 # Restore pristine server state (including the tick-interval override).
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize


### PR DESCRIPTION
## Motivation

`WITH (WAIT ...)` on `ALTER CLUSTER` is gated behind
`enable_zero_downtime_cluster_reconfiguration`, default off. Stacked on #38103,
every graceful reconfiguration already runs through one durable controller path,
so the flag only controls whether users can express a deadline and a timeout
action for it.

## Description

Removes the feature flag and its planner gate, so `WITH (WAIT ...)` is accepted
on every deployment. The two rejections that share that code path stay: a `WAIT`
without a replica-shape change, and a `WAIT` on an unmanaged cluster.

The mixed-version default is bounded at v26.41 so upgrade scenarios running
against an older binary still set the flag, and the private-preview badges come
off the `ALTER CLUSTER` reference page.

`enable_cluster_schedule_refresh`, the near-identical sibling gate, is
deliberately untouched. It gates a separate SQL surface under its own rollout.

## Verification

Existing graceful-reconfiguration coverage in testdrive, sqllogictest, and
platform checks now exercises the surface without setting a flag.

## User-visible behavior

Graceful cluster reconfiguration with `WITH (WAIT UNTIL READY ...)` and
`WITH (WAIT FOR ...)` becomes generally available, no longer private preview and
no longer requiring a feature flag.

