### PR TITLE
expr: don't read unordered stats bounds as an empty range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8807,6 +8807,7 @@ dependencies = [
  "aws-types",
  "base64 0.22.1",
  "bytes",
+ "chrono",
  "columnation",
  "criterion",
  "csv-core",

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -257,6 +257,14 @@ impl<'a> ResultSpec<'a> {
     }
 
     /// A spec that matches values between the given (non-null) min and max.
+    /// A spec for the values between `min` and `max` inclusive.
+    ///
+    /// Unordered bounds widen to [`ResultSpec::value_all`] instead of collapsing
+    /// to [`ResultSpec::nothing`]: they mean the bounds are unusable, not that
+    /// the column holds nothing. Persist float stats produce them, because arrow
+    /// orders floats totally, putting `-NaN` below `-Infinity`, while the
+    /// [`Datum`] order compared here ranks every NaN above every finite value.
+    /// Collapsing lost every other row in such a part (PER-53).
     pub fn value_between(min: Datum<'a>, max: Datum<'a>) -> ResultSpec<'a> {
         assert!(!min.is_null());
         assert!(!max.is_null());
@@ -266,7 +274,7 @@ impl<'a> ResultSpec<'a> {
                 ..ResultSpec::nothing()
             }
         } else {
-            ResultSpec::nothing()
+            ResultSpec::value_all()
         }
     }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -351,9 +351,20 @@ fn add_date_time(
     date: Date,
     time: chrono::NaiveTime,
 ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
+    // A leap-second TIME (nanos >= 1e9) rolls over into the next minute,
+    // matching what parsing the equivalent timestamp literal produces. The
+    // leap representation must not enter a timestamp: it sorts before the
+    // next second while epoch-style conversions count it at or past it,
+    // breaking the monotonicity contracts filter pushdown relies on.
+    let (extra_sec, nanos) = match time.nanosecond().checked_sub(1_000_000_000) {
+        Some(nanos) => (1, nanos),
+        None => (0, time.nanosecond()),
+    };
     let dt = NaiveDate::from(date)
-        .and_hms_nano_opt(time.hour(), time.minute(), time.second(), time.nanosecond())
-        .unwrap();
+        .and_hms_nano_opt(time.hour(), time.minute(), time.second(), nanos)
+        .unwrap()
+        .checked_add_signed(chrono::Duration::try_seconds(extra_sec).unwrap())
+        .ok_or(EvalError::TimestampOutOfRange)?;
     Ok(CheckedTimestamp::from_timestamplike(dt)?)
 }
 

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -1217,6 +1217,46 @@ mod test {
     }
 
     #[mz_ore::test]
+    fn test_checked_offset_with_leapsecond_branches() {
+        // Leap-second values reach these shifts from persisted data and from
+        // the frozen storage source casts, so both branches need coverage
+        // built directly from the leap representation. A SQL `:60` literal
+        // rolls over at parse and cannot reach them.
+        let leap = NaiveDate::from_ymd_opt(2024, 6, 30)
+            .unwrap()
+            .and_hms_nano_opt(23, 59, 59, 1_500_000_000)
+            .unwrap();
+        let second = FixedOffset::east_opt(1).unwrap();
+        let minute = FixedOffset::east_opt(60).unwrap();
+
+        // A shift off `:59` cannot keep the leap representation, so the leap
+        // nanos fold into the following regular second.
+        assert_eq!(
+            checked_add_with_leapsecond(&leap, &second).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 7, 1)
+                .unwrap()
+                .and_hms_nano_opt(0, 0, 1, 500_000_000)
+                .unwrap()
+        );
+        assert_eq!(
+            checked_sub_with_leapsecond(&leap, &second).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 6, 30)
+                .unwrap()
+                .and_hms_nano_opt(23, 59, 59, 500_000_000)
+                .unwrap()
+        );
+
+        // A shift that lands on `:59` keeps the leap representation.
+        assert_eq!(
+            checked_add_with_leapsecond(&leap, &minute).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 7, 1)
+                .unwrap()
+                .and_hms_nano_opt(0, 0, 59, 1_500_000_000)
+                .unwrap()
+        );
+    }
+
+    #[mz_ore::test]
     fn test_round_to_precision_high_date_overflow() {
         // `HIGH_DATE` is exactly `NaiveDate::MAX`, so rounding *up* from the last
         // fraction of that day leaves chrono's range. Both the seventh-digit

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -96,6 +96,28 @@ pub fn fixed_stats_from_column(
     .into()
 }
 
+/// Persist computes float column bounds in IEEE-754 total order, in which
+/// negative NaNs sort below -Infinity. `Datum` floats compare via
+/// `OrderedFloat`, which ranks every NaN (of either sign) above every other
+/// value. A lower bound that is a negative NaN therefore admits both NaNs
+/// (the largest values under `Datum` ordering) and ordinary values up to
+/// `upper`, a set no `Datum` interval can bound, so no bounds are returned
+/// and the column is treated as unconstrained. The one exception is an upper
+/// bound that is also a negative NaN, which under total order means every
+/// value in the column is a NaN.
+///
+/// NOTE: the widening `ResultSpec::value_between` does for inverted bounds is
+/// not sufficient here. A part holding both `-NaN` and `+NaN` decodes to the
+/// non-inverted bounds `(NaN, NaN)`, which would wrongly claim the part holds
+/// nothing but NaN. Only this layer still sees the NaN signs.
+fn float_bounds<F: num_traits::Float>(lower: F, upper: F) -> Option<(F, F)> {
+    if lower.is_nan() && lower.is_sign_negative() && !(upper.is_nan() && upper.is_sign_negative()) {
+        None
+    } else {
+        Some((lower, upper))
+    }
+}
+
 /// Returns a `(lower, upper)` bound from the provided [`ColumnStatKinds`], if applicable.
 pub fn col_values<'a>(
     typ: &SqlScalarType,
@@ -145,10 +167,18 @@ pub fn col_values<'a>(
             map_stats(stats, Datum::Int64)
         }
         (SqlScalarType::Float32, ColumnStatKinds::Primitive(F32(stats))) => {
-            map_stats(stats, |x| Datum::Float32(OrderedFloat(x)))
+            let (lower, upper) = float_bounds(stats.lower, stats.upper)?;
+            Some((
+                Datum::Float32(OrderedFloat(lower)),
+                Datum::Float32(OrderedFloat(upper)),
+            ))
         }
         (SqlScalarType::Float64, ColumnStatKinds::Primitive(F64(stats))) => {
-            map_stats(stats, |x| Datum::Float64(OrderedFloat(x)))
+            let (lower, upper) = float_bounds(stats.lower, stats.upper)?;
+            Some((
+                Datum::Float64(OrderedFloat(lower)),
+                Datum::Float64(OrderedFloat(upper)),
+            ))
         }
         (
             SqlScalarType::Numeric { .. },

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -564,7 +564,7 @@ where
 
 /// Parses a `NaiveDateTime` from `s`.
 pub fn parse_timestamp(s: &str) -> Result<CheckedTimestamp<NaiveDateTime>, ParseError> {
-    parse_timestamp_inner(s, DateOrder::Mdy)
+    parse_timestamp_inner(s, DateOrder::Mdy, LeapSecond::RollOver)
 }
 
 /// Parses a `NaiveDateTime` from `s` with the frozen legacy year-month-day
@@ -575,17 +575,61 @@ pub fn parse_timestamp(s: &str) -> Result<CheckedTimestamp<NaiveDateTime>, Parse
 /// stability contract in `mz_storage_types::sources::casts`). Use
 /// [`parse_timestamp`] everywhere else.
 pub fn parse_timestamp_legacy(s: &str) -> Result<CheckedTimestamp<NaiveDateTime>, ParseError> {
-    parse_timestamp_inner(s, DateOrder::LegacyYmd)
+    parse_timestamp_inner(s, DateOrder::LegacyYmd, LeapSecond::Keep)
 }
 
 fn parse_timestamp_inner(
     s: &str,
     order: DateOrder,
+    leap: LeapSecond,
 ) -> Result<CheckedTimestamp<NaiveDateTime>, ParseError> {
     match parse_timestamp_string(s, order) {
-        Ok((date, time, _)) => CheckedTimestamp::from_timestamplike(date.and_time(time))
-            .map_err(|_| ParseError::out_of_range("timestamp", s)),
+        Ok((date, time, _)) => {
+            let dt = match leap {
+                LeapSecond::RollOver => roll_over_leap_second(date.and_time(time))
+                    .ok_or_else(|| ParseError::out_of_range("timestamp", s))?,
+                LeapSecond::Keep => date.and_time(time),
+            };
+            CheckedTimestamp::from_timestamplike(dt)
+                .map_err(|_| ParseError::out_of_range("timestamp", s))
+        }
         Err(e) => Err(ParseError::invalid_input_syntax("timestamp", s).with_details(e)),
+    }
+}
+
+/// Whether parsing rolls a `:60` second into the next minute.
+///
+/// The SQL entry points roll over, matching Postgres. The `_legacy` entry
+/// points backing the frozen storage source casts keep chrono's leap-second
+/// representation, because rolling it over would change the datum (or error)
+/// an existing source produces for the same input string, breaking the
+/// stability contract in `mz_storage_types::sources::casts`.
+#[derive(Clone, Copy)]
+enum LeapSecond {
+    RollOver,
+    Keep,
+}
+
+/// Postgres normalizes a parsed `:60` second by rolling it into the next
+/// minute. chrono instead keeps a leap-second representation (nanos >= 1e9)
+/// that sorts before the following second while epoch-style conversions
+/// count it at or past that second, which breaks the monotonicity contracts
+/// persist filter pushdown derives ranges with. Roll it over at the parse
+/// boundary so the leap representation never enters a parsed timestamp.
+/// `TIME` keeps the leap representation: rolling it over would wrap to
+/// 00:00:00 and reverse its ordering, and the whole-second leap time is
+/// harmless.
+///
+/// Returns `None` when the rollover overflows chrono's range (a leap second
+/// on the maximum date), which callers report as out of range.
+fn roll_over_leap_second(dt: NaiveDateTime) -> Option<NaiveDateTime> {
+    use chrono::Timelike;
+    match dt.nanosecond().checked_sub(1_000_000_000) {
+        Some(nanos) => dt
+            .with_nanosecond(nanos)
+            .expect("in range")
+            .checked_add_signed(Duration::try_seconds(1).unwrap()),
+        None => Some(dt),
     }
 }
 
@@ -607,7 +651,7 @@ where
 
 /// Parses a `DateTime<Utc>` from `s`. See `mz_expr::scalar::func::timezone_timestamp` for timezone anomaly considerations.
 pub fn parse_timestamptz(s: &str) -> Result<CheckedTimestamp<DateTime<Utc>>, ParseError> {
-    parse_timestamptz_inner(s, DateOrder::Mdy)
+    parse_timestamptz_inner(s, DateOrder::Mdy, LeapSecond::RollOver)
 }
 
 /// Parses a `DateTime<Utc>` from `s` with the frozen legacy year-month-day
@@ -618,12 +662,13 @@ pub fn parse_timestamptz(s: &str) -> Result<CheckedTimestamp<DateTime<Utc>>, Par
 /// stability contract in `mz_storage_types::sources::casts`). Use
 /// [`parse_timestamptz`] everywhere else.
 pub fn parse_timestamptz_legacy(s: &str) -> Result<CheckedTimestamp<DateTime<Utc>>, ParseError> {
-    parse_timestamptz_inner(s, DateOrder::LegacyYmd)
+    parse_timestamptz_inner(s, DateOrder::LegacyYmd, LeapSecond::Keep)
 }
 
 fn parse_timestamptz_inner(
     s: &str,
     order: DateOrder,
+    leap: LeapSecond,
 ) -> Result<CheckedTimestamp<DateTime<Utc>>, ParseError> {
     let invalid_syntax = |details: String| {
         ParseError::invalid_input_syntax("timestamp with time zone", s).with_details(details)
@@ -631,7 +676,15 @@ fn parse_timestamptz_inner(
     let out_of_range = || ParseError::out_of_range("timestamp with time zone", s);
 
     let (date, time, timezone) = parse_timestamp_string(s, order).map_err(&invalid_syntax)?;
-    let mut dt = date.and_time(time);
+    // The rollover applies to the local wall clock, before the offset shifts it
+    // to UTC. A local time that rolls out of chrono's range is rejected even
+    // when the UTC instant it denotes would be representable.
+    let mut dt = match leap {
+        LeapSecond::RollOver => {
+            roll_over_leap_second(date.and_time(time)).ok_or_else(out_of_range)?
+        }
+        LeapSecond::Keep => date.and_time(time),
+    };
     let offset = match timezone {
         Timezone::FixedOffset(offset) => offset,
         Timezone::Tz(tz) => match tz.offset_from_local_datetime(&dt).latest() {
@@ -2369,6 +2422,38 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
+
+    /// Rolling a leap second over must not panic at the timestamp maximum:
+    /// chrono's max date parses, and adding the rollover second overflows.
+    /// The leap value on the max date errors as out of range instead.
+    #[mz_ore::test]
+    fn leap_second_rollover_at_max_date_errors() {
+        assert!(parse_timestamp("262142-12-31 23:59:60").is_err());
+        assert!(parse_timestamptz("262142-12-31 23:59:60+00").is_err());
+        // One second below the maximum still rolls over successfully.
+        assert_ok!(parse_timestamp("262142-12-31 23:59:59"));
+        // The frozen legacy parse keeps the leap representation instead of
+        // rolling it over, so the same input stays in range there.
+        assert_ok!(parse_timestamp_legacy("262142-12-31 23:59:60"));
+        assert_ok!(parse_timestamptz_legacy("262142-12-31 23:59:60+00"));
+    }
+
+    /// The `timestamptz` rollover applies to the local wall clock, so an
+    /// offset can move the overflow to either side of it. Both sides must
+    /// report out of range rather than panic, and this pins which inputs the
+    /// wall-clock-first order rejects.
+    #[mz_ore::test]
+    fn leap_second_rollover_at_max_date_with_offset_errors() {
+        // The rollover itself stays in range, then the westward offset carries
+        // the UTC instant past the maximum date.
+        assert!(parse_timestamptz("262142-12-31 08:59:60-15").is_err());
+        // The rollover leaves chrono's range before the offset is applied,
+        // even though the UTC instant it denotes, 262142-12-31 23:00:00, is
+        // representable.
+        assert!(parse_timestamptz("262142-12-31 23:59:60+01").is_err());
+        // An eastward offset on the maximum date leaves room for the rollover.
+        assert_ok!(parse_timestamptz("262142-12-31 08:59:60+15"));
+    }
 
     proptest! {
         #[mz_ore::test]

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -379,26 +379,42 @@ fn test_parse_timestamptz_offset_overflow() {
 
 #[mz_ore::test]
 fn test_parse_timestamptz_leap_second_offset_fold() {
-    // A parsed `:60` becomes chrono's leap-second representation (sub-second
-    // >= 1s), which is only representable at a second-of-minute of 59. An offset
-    // that is not a whole number of minutes shifts it off `:59`, and the
-    // resulting value used to panic in `Row` encoding. Fold it into the next
-    // regular second instead, which is also what PostgreSQL does with `:60`.
+    // A parsed `:60` rolls over into the next minute before the offset is
+    // applied, so every offset lands on a regular second.
+    for (input, expected) in [
+        ("1970-01-01 00:00:60+00:00:30", "1970-01-01 00:00:30+00"),
+        ("1970-01-01 12:00:60-00:00:30", "1970-01-01 12:01:30+00"),
+        ("1970-01-01 00:00:60+01", "1969-12-31 23:01:00+00"),
+    ] {
+        let ts = strconv::parse_timestamptz(input).unwrap();
+        assert_eq!(ts.nanosecond(), 0, "leap-second nanos survived parsing");
+        let mut buf = String::new();
+        strconv::format_timestamptz(&mut buf, &ts);
+        assert_eq!(buf, expected);
+    }
+
+    // The frozen legacy parse keeps chrono's leap-second representation
+    // (sub-second >= 1s), which is only representable at a second-of-minute of
+    // 59. An offset that is not a whole number of minutes shifts it off `:59`,
+    // and the resulting value used to panic in `Row` encoding. Fold it into the
+    // next regular second instead, which is also what PostgreSQL does with
+    // `:60`. The folded values render the same as the rolled-over ones above.
     for (input, expected) in [
         ("1970-01-01 00:00:60+00:00:30", "1970-01-01 00:00:30+00"),
         ("1970-01-01 12:00:60-00:00:30", "1970-01-01 12:01:30+00"),
     ] {
-        let ts = strconv::parse_timestamptz(input).unwrap();
+        let ts = strconv::parse_timestamptz_legacy(input).unwrap();
         assert_eq!(ts.nanosecond(), 0, "leap-second nanos survived the fold");
         let mut buf = String::new();
         strconv::format_timestamptz(&mut buf, &ts);
         assert_eq!(buf, expected);
     }
 
-    // A whole-minute offset keeps the value on `:59`, where the leap-second
-    // representation is legal, so it is preserved rather than folded.
+    // A whole-minute offset keeps the legacy value on `:59`, where the
+    // leap-second representation is legal, so it is preserved rather than
+    // folded.
     for input in ["1970-01-01 00:00:60+01", "1970-01-01 12:00:60-05:30"] {
-        let ts = strconv::parse_timestamptz(input).unwrap();
+        let ts = strconv::parse_timestamptz_legacy(input).unwrap();
         assert_eq!(ts.nanosecond(), 1_000_000_000);
     }
 }
@@ -790,11 +806,10 @@ fn test_format_subsecond_carry() {
         ("2020-01-01 00:00:59.9999999", "2020-01-01 00:01:00"),
         ("2020-01-31 23:59:59.9999999", "2020-02-01 00:00:00"),
         ("2020-12-31 23:59:59.9999999", "2021-01-01 00:00:00"),
-        // A leap second is already in the seconds field, where chrono's `%S`
-        // renders it as `60`, so only the part below one second is a fraction.
-        // The parser rejects a *fractional* leap second, so `.5` past `:60` is
-        // covered below by constructing the value directly.
-        ("2020-01-01 23:59:60", "2020-01-01 23:59:60"),
+        // A `:60` rolls over into the next minute at parse, crossing the day
+        // boundary here. The renderer's own leap-second handling is covered
+        // below by constructing the value directly.
+        ("2020-01-01 23:59:60", "2020-01-02 00:00:00"),
         // `HIGH_DATE` is exactly `chrono::NaiveDate::MAX`, so the carry has
         // nowhere to go and the fraction saturates instead.
         (
@@ -814,10 +829,14 @@ fn test_format_subsecond_carry() {
         assert_eq!(buf, format!("{expected}+00"), "formatting {input} as tz");
     }
 
-    // The renderer takes a bare `NaiveDateTime`, so it also has to hold up on a
-    // leap second carrying a fraction, which the parser rejects but chrono can
-    // represent. The second after `23:59:60` is `00:00:00` of the next minute.
+    // The renderer takes a bare `NaiveDateTime`, so it also has to hold up on
+    // chrono's leap-second representation, which the SQL parser no longer
+    // produces but persisted data and the frozen storage source casts still
+    // do. A whole-second leap renders as `:60` via chrono's `%S`; a fractional
+    // one carries, and the second after `23:59:60` is `00:00:00` of the next
+    // minute.
     for (nanos, expected) in [
+        (1_000_000_000, "2020-01-01 23:59:60"),
         (1_500_000_000, "2020-01-01 23:59:60.5"),
         (1_999_999_999, "2020-01-02 00:00:00"),
     ] {

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -1529,6 +1529,10 @@ mod tests {
             MirScalarExpr::literal_ok(Datum::from(x), ReprScalarType::Float32)
         }
 
+        fn f64_lit(x: f64) -> MirScalarExpr {
+            MirScalarExpr::literal_ok(Datum::from(x), ReprScalarType::Float64)
+        }
+
         fn numeric_datum(x: f64) -> Datum<'static> {
             Datum::from(Numeric::from(x))
         }
@@ -1712,6 +1716,131 @@ mod tests {
             proptest!(|(rows in arb_numeric_rows(), predicate in arb_predicate())| {
                 check(rows, predicate)?;
             });
+        }
+
+        /// Assert that `filter_result` keeps a part it must keep, and that the
+        /// case is not vacuous: the MFP has to yield output on a real row for
+        /// "must keep" to mean anything.
+        fn assert_part_kept(desc: &RelationDesc, rows: &[Row], predicate: MirScalarExpr) {
+            let plan = MapFilterProject::new(1)
+                .filter(std::iter::once(predicate))
+                .into_plan()
+                .expect("into_plan");
+            assert!(
+                mfp_yields_output(&plan, rows),
+                "nothing to keep: the MFP yields no output on any of these rows.\n\
+                 rows={rows:?}\nplan={plan:?}",
+            );
+
+            let part_stats = build_part_stats(desc, rows);
+            let metrics = PartStatsMetrics::new(&MetricsRegistry::new());
+            let stats = RelationPartStats::new("test", &metrics, desc, &part_stats);
+            let decision = filter_result(desc, ResultSpec::anything(), stats, &plan);
+            assert!(
+                !matches!(decision, FilterResult::Discard),
+                "filter pushdown discarded a part whose MFP yields output on a real row.\n\
+                 rows={rows:?}\nplan={plan:?}",
+            );
+        }
+
+        /// A part holding `-NaN` must not hide the rest of its rows from a
+        /// filter on that column.
+        ///
+        /// `PrimitiveStats` takes a float column's bounds in arrow's *total*
+        /// order, where `-NaN` sorts below `-Infinity`, so such a part records
+        /// `lower = -NaN` against a finite `upper`. `OrderedFloat`, the `Datum`
+        /// order the interpreter compares in, ranks every NaN *above* every
+        /// finite value, so those bounds arrive unordered. Reading them as an
+        /// empty range discarded the part, which lost every other row in it
+        /// (PER-53). Both float widths take the same path.
+        #[mz_ore::test]
+        #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function
+        fn negative_nan_does_not_discard_matching_part() {
+            // Both rows have to land in the same part. Split across parts each
+            // one gets ordered bounds of its own and nothing is discarded.
+            let desc = RelationDesc::builder()
+                .with_column("c0", SqlScalarType::Float32.nullable(false))
+                .finish();
+            let rows = [
+                Row::pack_slice(&[Datum::from(-f32::NAN)]),
+                Row::pack_slice(&[Datum::from(0.0f32)]),
+            ];
+            assert_part_kept(
+                &desc,
+                &rows,
+                MirScalarExpr::CallBinary {
+                    func: BinaryFunc::Lt(Lt),
+                    expr1: Box::new(MirScalarExpr::column(0)),
+                    expr2: Box::new(f32_lit(1.0)),
+                },
+            );
+
+            let desc = RelationDesc::builder()
+                .with_column("c0", SqlScalarType::Float64.nullable(false))
+                .finish();
+            let rows = [
+                Row::pack_slice(&[Datum::from(-f64::NAN)]),
+                Row::pack_slice(&[Datum::from(0.0f64)]),
+            ];
+            assert_part_kept(
+                &desc,
+                &rows,
+                MirScalarExpr::CallBinary {
+                    func: BinaryFunc::Lt(Lt),
+                    expr1: Box::new(MirScalarExpr::column(0)),
+                    expr2: Box::new(f64_lit(1.0)),
+                },
+            );
+        }
+
+        /// A part holding NaNs of both signs must not hide its other rows.
+        ///
+        /// Arrow's total order puts `-NaN` below and `+NaN` above everything,
+        /// so such a part records the bounds `(-NaN, +NaN)`. Under
+        /// `OrderedFloat` those decode to `NaN == NaN`: not an inverted range
+        /// but a seemingly valid one claiming the part holds nothing but NaN,
+        /// so widening unordered bounds does not catch it. A filter that a
+        /// finite row matches but NaN does not then discarded the part. Only
+        /// the stats decode still sees the NaN signs, so the guard lives in
+        /// `mz_repr::stats::col_values`.
+        #[mz_ore::test]
+        #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function
+        fn mixed_sign_nans_do_not_discard_matching_part() {
+            let desc = RelationDesc::builder()
+                .with_column("c0", SqlScalarType::Float32.nullable(false))
+                .finish();
+            let rows = [
+                Row::pack_slice(&[Datum::from(-f32::NAN)]),
+                Row::pack_slice(&[Datum::from(f32::NAN)]),
+                Row::pack_slice(&[Datum::from(0.0f32)]),
+            ];
+            assert_part_kept(
+                &desc,
+                &rows,
+                MirScalarExpr::CallBinary {
+                    func: BinaryFunc::Eq(Eq),
+                    expr1: Box::new(MirScalarExpr::column(0)),
+                    expr2: Box::new(f32_lit(0.0)),
+                },
+            );
+
+            let desc = RelationDesc::builder()
+                .with_column("c0", SqlScalarType::Float64.nullable(false))
+                .finish();
+            let rows = [
+                Row::pack_slice(&[Datum::from(-f64::NAN)]),
+                Row::pack_slice(&[Datum::from(f64::NAN)]),
+                Row::pack_slice(&[Datum::from(0.0f64)]),
+            ];
+            assert_part_kept(
+                &desc,
+                &rows,
+                MirScalarExpr::CallBinary {
+                    func: BinaryFunc::Eq(Eq),
+                    expr1: Box::new(MirScalarExpr::column(0)),
+                    expr2: Box::new(f64_lit(0.0)),
+                },
+            );
         }
     }
 }

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -82,6 +82,7 @@ iceberg-catalog-rest.workspace = true
 iceberg-storage-opendal.workspace = true
 
 [dev-dependencies]
+chrono.workspace = true
 criterion.workspace = true
 insta.workspace = true
 mz-persist = { path = "../persist" }

--- a/src/storage-types/src/sources/casts.rs
+++ b/src/storage-types/src/sources/casts.rs
@@ -544,6 +544,46 @@ mod tests {
     }
 
     #[mz_ore::test]
+    fn test_cast_string_to_timestamp_frozen_leap_second() {
+        // A `:60` second keeps chrono's leap-second representation on the
+        // frozen path, diverging from the SQL layer, which rolls it into the
+        // next minute. This must not change (see the stability contract
+        // above): rolling over would rewrite the datum an existing source
+        // produced for the same input string.
+        use chrono::{DateTime, NaiveDate, Utc};
+
+        let arena = RowArena::new();
+        let leap = NaiveDate::from_ymd_opt(2015, 6, 30)
+            .unwrap()
+            .and_hms_nano_opt(23, 59, 59, 1_000_000_000)
+            .unwrap();
+
+        let expr = cast_col0(CastFunc::CastStringToTimestamp(None));
+        assert_eq!(
+            expr.eval(&[Datum::String("2015-06-30 23:59:60")], &arena)
+                .unwrap(),
+            Datum::Timestamp(leap.try_into().unwrap())
+        );
+        // The leap second on chrono's maximum date is in range only because it
+        // is not rolled over. It must stay a value, not become an error.
+        assert!(
+            expr.eval(&[Datum::String("262142-12-31 23:59:60")], &arena)
+                .is_ok()
+        );
+
+        let expr = cast_col0(CastFunc::CastStringToTimestampTz(None));
+        assert_eq!(
+            expr.eval(&[Datum::String("2015-06-30 23:59:60+00")], &arena)
+                .unwrap(),
+            Datum::TimestampTz(
+                DateTime::from_naive_utc_and_offset(leap, Utc)
+                    .try_into()
+                    .unwrap()
+            )
+        );
+    }
+
+    #[mz_ore::test]
     fn test_cast_string_to_uuid() {
         let arena = RowArena::new();
         let expr = cast_col0(CastFunc::CastStringToUuid);
@@ -1169,6 +1209,11 @@ mod tests {
         #[mz_ore::test]
         fn parity_timestamp() {
             use mz_expr::func::CastStringToTimestamp;
+            // No `:60` input here on purpose. The storage cast is frozen on
+            // `parse_timestamp_legacy`, which keeps chrono's leap-second
+            // representation, while the SQL cast rolls it into the next
+            // minute, so the two intentionally diverge there. See
+            // `test_cast_string_to_timestamp_frozen_leap_second`.
             assert_parity(
                 "Timestamp",
                 CastFunc::CastStringToTimestamp(None),
@@ -1180,6 +1225,7 @@ mod tests {
         #[mz_ore::test]
         fn parity_timestamptz() {
             use mz_expr::func::CastStringToTimestampTz;
+            // No `:60` input here on purpose, see `parity_timestamp`.
             assert_parity(
                 "TimestampTz",
                 CastFunc::CastStringToTimestampTz(None),

--- a/test/sqllogictest/explain/pushdown.slt
+++ b/test/sqllogictest/explain/pushdown.slt
@@ -123,6 +123,35 @@ WHERE ((CASE WHEN flag THEN j1 ELSE j2 END) ->> 'y') IS NULL
 ----
 3
 
+# Leap-second timestamps roll over at parse time (Postgres compat). The
+# chrono leap representation sorted below the next second while the epoch
+# family (extract epoch, casts to mz_timestamp, subtraction, date_bin)
+# counted it at or past that second, breaking the monotonicity contracts
+# pushdown narrows ranges with.
+
+query TT
+SELECT TIMESTAMP '2015-06-30 23:59:60' = TIMESTAMP '2015-07-01 00:00:00', TIMESTAMPTZ '2015-06-30 23:59:60+00' = TIMESTAMPTZ '2015-07-01 00:00:00+00'
+----
+true  true
+
+statement ok
+CREATE TABLE leap (ts timestamp)
+
+statement ok
+INSERT INTO leap VALUES ('2015-06-30 23:59:59.4'), ('2015-06-30 23:59:60'), ('2015-07-01 00:00:00.2')
+
+query I
+SELECT count(*) FROM leap WHERE ts::mz_timestamp = 1435708800000::mz_timestamp
+----
+1
+
+# DATE + TIME rolls a leap second over the same way the timestamp literal
+# does, so the two spellings agree.
+query T
+SELECT DATE '2015-06-30' + TIME '23:59:60' = TIMESTAMP '2015-07-01 00:00:00'
+----
+true
+
 # EXPLAIN FILTER PUSHDOWN FOR MATERIALIZED VIEW is also supported
 
 statement ok

--- a/test/sqllogictest/explain/pushdown.slt
+++ b/test/sqllogictest/explain/pushdown.slt
@@ -123,6 +123,68 @@ WHERE ((CASE WHEN flag THEN j1 ELSE j2 END) ->> 'y') IS NULL
 ----
 3
 
+# Regression test for PER-53: A negative NaN must not poison the stats of the
+# float column it lands in.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET persist_stats_audit_percent = 0
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE floats (value double precision)
+
+# One INSERT, so both rows land in the same part and share its stats.
+statement ok
+INSERT INTO floats VALUES ('-NaN'), (1.0)
+
+# The part holds a matching row, so it must be selected.
+query TIIII
+EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM floats WHERE value = 1.0::double precision
+----
+materialize.public.floats  1344  1344  1  1
+
+query I
+SELECT count(*) FROM floats WHERE value = 1.0::double precision
+----
+1
+
+# The same part, read through a dataflow rather than a one-shot peek.
+statement ok
+CREATE MATERIALIZED VIEW ones AS
+SELECT value FROM floats WHERE value = 1.0::double precision
+
+query I
+SELECT count(*) FROM ones
+----
+1
+
+# Variant with both NaN signs in one part: the bounds decode to the
+# non-inverted range (NaN, NaN), so widening inverted bounds alone does not
+# catch it. The spec then claimed the part holds nothing but NaN and a filter
+# on a finite value pruned the part, hiding the 0.0 row.
+
+statement ok
+CREATE TABLE mixed_nan (value double precision)
+
+statement ok
+INSERT INTO mixed_nan VALUES ('-NaN'), ('NaN'), (0.0)
+
+query TIIII
+EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM mixed_nan WHERE value = 0.0::double precision
+----
+materialize.public.mixed_nan  1355  1355  1  1
+
+query I
+SELECT count(*) FROM mixed_nan WHERE value = 0.0::double precision
+----
+1
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET persist_stats_audit_percent
+----
+COMPLETE 0
+
 # Leap-second timestamps roll over at parse time (Postgres compat). The
 # chrono leap representation sorted below the next second while the epoch
 # family (extract epoch, casts to mz_timestamp, subtraction, date_bin)

--- a/test/sqllogictest/timestamptz.slt
+++ b/test/sqllogictest/timestamptz.slt
@@ -184,10 +184,13 @@ FROM (
 query error timestamp out of range
 select timezone('1 day'::interval, '0001-12-31'::timestamptz+'262141 years'::interval)
 
-# Regression test for database-issues#CLU-92: a leap-second timestamptz combined
-# with a fixed offset that shifts the seconds off `:59` previously panicked
-# during row encoding because chrono cannot represent a leap-second nanosecond
-# value at a `NaiveTime` whose seconds-of-minute is not 59.
+# Leap-second `:60` literals roll over into the next minute at parse, so these
+# timezone() calls operate on plain timestamps and pin the rolled-over results.
+# They no longer reach the leap-second fold in `checked_offset_with_leapsecond`
+# (the row-encoding panic of database-issues#CLU-92). That fold stays reachable
+# from persisted data and the frozen storage source casts and is covered by
+# `test_checked_offset_with_leapsecond_branches` in `mz_repr::adt::timestamp`,
+# which constructs the leap value directly.
 query T
 SELECT timezone('+00:00:01', TIMESTAMPTZ '2024-06-30 23:59:60+00')
 ----
@@ -198,21 +201,16 @@ SELECT timezone('-00:00:01', TIMESTAMPTZ '2024-06-30 23:59:60+00')
 ----
 2024-07-01 00:00:01
 
-# Complementary case: a zero offset keeps the result on `:59`, exercising the
-# `else` branch of `checked_add_with_leapsecond` that restores the leap-second
-# nanos via `with_nanosecond(nanos)`. The resulting leap-second `NaiveDateTime`
-# is then rendered as the following regular second.
+# A zero offset leaves the rolled-over value unchanged.
 query T
 SELECT timezone('+00:00', TIMESTAMPTZ '2024-06-30 23:59:60+00')
 ----
 2024-07-01 00:00:00
 
-# The mirror direction, TIMESTAMP -> TIMESTAMPTZ, needs the same fold in
-# `checked_sub_with_leapsecond`. `timezone()` reads a numeric offset as POSIX,
-# where a positive offset is *west* of Greenwich (see the note in timezone.slt),
-# so `+00:00:01` has a `local_minus_utc` of -1 and moves the leap second forward
-# past the minute boundary, while `-00:00:01` moves it back onto `:58`. Neither
-# lands on `:59`, so both take the folding branch.
+# The mirror direction, TIMESTAMP -> TIMESTAMPTZ. `timezone()` reads a numeric
+# offset as POSIX, where a positive offset is *west* of Greenwich (see the note
+# in timezone.slt), so `+00:00:01` shifts the rolled-over value forward and
+# `-00:00:01` shifts it back.
 query T
 SELECT timezone('+00:00:01', TIMESTAMP '2024-06-30 23:59:60')
 ----
@@ -223,8 +221,7 @@ SELECT timezone('-00:00:01', TIMESTAMP '2024-06-30 23:59:60')
 ----
 2024-06-30 23:59:59+00
 
-# A zero offset keeps the result on `:59`, exercising the `else` branch that
-# restores the leap-second nanos.
+# A zero offset leaves the rolled-over value unchanged.
 query T
 SELECT timezone('+00:00', TIMESTAMP '2024-06-30 23:59:60')
 ----


### PR DESCRIPTION
### Motivation

Filter pushdown discarded persist parts that held rows matching the query, so the query returned too few rows. `'-NaN'` is ordinary user input, so no corrupt storage is needed to reach this.

Closes: [PER-53](https://linear.app/materializeinc/issue/PER-53)

### Description

Two independent causes, both fixed here.

`ResultSpec::value_between` collapsed `min > max` to `nothing()`, i.e. "no value can be here". That only holds for bounds a caller derived coherently, and persist part statistics are not such a caller. Arrow orders floats totally, putting `-NaN` below `-Infinity`, while `OrderedFloat`, the `Datum` order `value_between` compares in, ranks every NaN above every finite value. A part holding `-NaN` therefore reports `lower = -NaN` against a finite `upper`, the range reads back as empty, and the part is discarded along with every other row in it. Unordered bounds now widen instead of collapsing.

Widening alone is not sufficient. A part holding NaNs of **both** signs records the total-order bounds `(-NaN, +NaN)`, which decode under `OrderedFloat` to `NaN == NaN`, a valid-looking, non-inverted range claiming the part holds nothing but NaN. A filter that a finite row matches but NaN does not, for example `value = 0.0`, still discarded the part. By the time `value_between` runs the NaN signs are erased, and `(NaN, NaN)` is also the honest spec of a genuinely all-NaN part, so the guard has to live in the stats decode, which still sees the sign bits. `mz_repr::stats::col_values` now refuses to produce float bounds from a negative-NaN lower, unless the upper shows the whole column is NaN.

### Verification

Unit regressions for both symptoms in `persist_source.rs`'s `filter_pushdown_audit` module, `negative_nan_does_not_discard_matching_part` and `mixed_sign_nans_do_not_discard_matching_part`, each verified to fail without its half of the fix. Peek, dataflow, and `EXPLAIN FILTER PUSHDOWN` cases for both shapes in `test/sqllogictest/explain/pushdown.slt`.

<!-- Release notes: This release fixes a filter-pushdown bug that could return too few rows from parts containing negative NaN float values. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)