### PR TITLE
docs: tweak snapshotting

### DIFF
--- a/doc/user/content/concepts/_index.md
+++ b/doc/user/content/concepts/_index.md
@@ -20,11 +20,12 @@ The pages in this section introduces some of the key concepts in Materialize:
 
 Concept                                  | Description
 -----------------------------------------|-----
-[Reaction Time](/concepts/reaction-time) | Measures how quickly a system can reflect a change in input data and return an up-to-date query result. Defined as the sum of data freshness and query latency.
 [Clusters](/concepts/clusters/)          | Clusters are isolated pools of compute resources for sources, sinks, indexes, materialized views, and ad-hoc queries.
 [Sources](/concepts/sources/)            | Sources describe an external system you want Materialize to read data from.
 [Views](/concepts/views/)    | Views represent a named query that you want to save for repeated execution. You can use **indexed views** and **materialized views** to incrementally maintain the results of views.
 [Indexes](/concepts/indexes/)            | Indexes represent query results stored in memory.
 [Sinks](/concepts/sinks/)                | Sinks describe an external system you want Materialize to write data to.
+[Snapshotting](/concepts/snapshotting/) | The initial sync of a source's data from an upstream system, before the source can serve queries.
+[Reaction Time](/concepts/reaction-time) | Measures how quickly a system can reflect a change in input data and return an up-to-date query result. Defined as the sum of data freshness and query latency.
 
 Refer to the individual pages for more information.

--- a/doc/user/content/concepts/reaction-time.md
+++ b/doc/user/content/concepts/reaction-time.md
@@ -4,7 +4,7 @@ description: "Learn about indexes in Materialize."
 menu:
   main:
     parent: concepts
-    weight: 1
+    weight: 100
     identifier: 'concepts-reaction-time'
 ---
 

--- a/doc/user/content/concepts/snapshotting.md
+++ b/doc/user/content/concepts/snapshotting.md
@@ -1,0 +1,46 @@
+---
+title: Snapshotting
+description: "Learn about snapshotting in Materialize: the initial sync of a source's data from an upstream system."
+menu:
+  main:
+    parent: concepts
+    weight: 30
+    identifier: 'concepts-snapshotting'
+---
+
+{{% include-headless "/headless/ingestion/snapshotting-definition" %}}
+
+## When snapshotting occurs
+
+{{% include-headless "/headless/ingestion/snapshotting-occurrence" %}}
+
+## Snapshot duration
+
+Snapshotting reads from the upstream system, so its duration depends on the
+volume of upstream data and the size of the source's cluster. For **upsert**
+sources, snapshotting can be especially resource-intensive (compared to
+append-only), and large upsert sources can take hours to snapshot.
+
+## Queries during snapshotting
+
+{{% include-headless "/headless/ingestion/snapshotting-queries" %}}
+
+## Impact on upstream system
+
+Snapshotting has the following upstream impacts:
+
+- **Read load.** Snapshotting puts read, CPU, and network load on the upstream
+  system, proportional to the data volume.
+
+- **Change-log retention for CDC database sources.** When ingesting data from
+  CDC database sources (PostgreSQL, MySQL, SQL Server), the upstream system must
+  retain its change-log data until Materialize consumes it. During the initial
+  snapshot, changes accumulate from the source's starting position until the
+  snapshot completes and Materialize has consumed the accumulated changes. A
+  stalled or long-running snapshot can therefore increase disk usage on the
+  upstream database.
+
+## Related pages
+
+- [Ingest data](/ingest-data/)
+- [Sources](/concepts/sources/)

--- a/doc/user/content/concepts/snapshotting.md
+++ b/doc/user/content/concepts/snapshotting.md
@@ -16,10 +16,7 @@ menu:
 
 ## Snapshot duration
 
-Snapshotting reads from the upstream system, so its duration depends on the
-volume of upstream data and the size of the source's cluster. For **upsert**
-sources, snapshotting can be especially resource-intensive (compared to
-append-only), and large upsert sources can take hours to snapshot.
+{{% include-headless "/headless/ingestion/snapshotting-duration" %}}
 
 ## Queries during snapshotting
 

--- a/doc/user/content/concepts/sources.md
+++ b/doc/user/content/concepts/sources.md
@@ -32,3 +32,4 @@ See also [Operational guidelines](/manage/operational-guidelines/).
 ## Related pages
 
 - [`CREATE SOURCE`](/sql/create-source)
+- [Snapshotting](/concepts/snapshotting/)

--- a/doc/user/content/get-started/_index.md
+++ b/doc/user/content/get-started/_index.md
@@ -45,13 +45,15 @@ this exact purpose.
 
 ### Standard SQL support
 
-Like most databases, you interact with Materialize using **SQL**. You can build
-complex analytical
-workloads using **[any type of join](/sql/select/join/)** (including
-non-windowed joins and joins on arbitrary conditions) as well as leverage new
-SQL patterns enabled by streaming like [**Change Data Capture
-(CDC)**](/ingest-data/), [**temporal
-filters**](/sql/patterns/temporal-filters/), and
+With Materialize, you use SQL to transform your fast-changing data into **live
+data products**: the business objects (e.g., a customer, an order, a store) that
+your applications, services, dashboards, and AI agents read.
+
+You can express complex transformations using **[any type of
+join](/sql/select/join/)** (including non-windowed joins and joins on arbitrary
+conditions), as well as SQL patterns
+enabled by streaming like [**Change Data Capture (CDC)**](/ingest-data/),
+[**temporal filters**](/sql/patterns/temporal-filters/), and
 [**subscriptions**](/sql/subscribe/).
 
 {{% include-from-yaml data="materialize_details" name="postgres-compatibility" %}}
@@ -72,19 +74,15 @@ world. Materialize uses the [PostgreSQL wire protocol](https://datastation.multi
 which allows it to integrate out-of-the-box with many SQL clients and other
 tools in the data ecosystem that support PostgreSQL — like [dbt](/integrations/dbt/).
 
-Don't see the a tool that you’d like to use with Materialize listed under
-[Tools and integrations](/integrations/)? Let us know by submitting a
-[feature request](https://github.com/MaterializeInc/materialize/discussions/new?category=feature-requests&labels=A-integration)!
-
 ### Strong consistency guarantees
 
 By default, Materialize provides the highest level of transaction isolation:
-[**strict serializability**](https://jepsen.io/consistency/models/strict-serializable).
-This means that it presents as if it were a single process, despite spanning a
-large number of threads, processes, and machines. Strict serializability avoids
-common pitfalls like eventual consistency and dual writes, which affect the
-correctness of your results. You can [adjust the transaction isolation level](/overview/isolation-level/)
-depending on your consistency and performance requirements.
+**strict serializability**. This means that it presents as if it were a single
+process, despite spanning a large number of threads, processes, and machines.
+Strict serializability avoids common pitfalls like eventual consistency and dual
+writes, which affect the correctness of your results. You can [adjust the
+transaction isolation level](/overview/isolation-level/) depending on your
+consistency and performance requirements.
 
 ## Learn more
 

--- a/doc/user/content/headless/create-table-from-source-snapshotting.md
+++ b/doc/user/content/headless/create-table-from-source-snapshotting.md
@@ -1,10 +1,12 @@
 ---
 headless: true
 ---
-Creating the tables from sources starts the [snapshotting](/ingest-data/#snapshotting) process. Snapshotting syncs the
-currently available data into Materialize. Because the initial snapshot is
-persisted in the storage layer atomically (i.e., at the same ingestion
-timestamp), you are not able to query the table until snapshotting is complete.
+Creating a table from a source starts the
+[snapshotting](/ingest-data/#snapshotting) process.
+
+{{% include-headless "/headless/ingestion/snapshotting-definition" %}}
+
+You cannot query the table until its snapshot completes.
 
 {{< note >}}
 

--- a/doc/user/content/headless/ingestion/snapshotting-definition.md
+++ b/doc/user/content/headless/ingestion/snapshotting-definition.md
@@ -1,0 +1,7 @@
+---
+headless: true
+---
+Snapshotting is the initial sync of a table's data. It reads from the upstream
+system and writes the data into Materialize's storage. The initial snapshot is
+committed to storage atomically, with all records assigned the same ingestion
+timestamp.

--- a/doc/user/content/headless/ingestion/snapshotting-duration.md
+++ b/doc/user/content/headless/ingestion/snapshotting-duration.md
@@ -1,0 +1,18 @@
+---
+headless: true
+---
+
+Snapshot duration depends on:
+
+- Volume of upstream data
+- Size of the source's cluster
+- Upstream capacity to serve the read, on top of its normal workload
+- Network path between the upstream system and Materialize
+
+In cloud environments, an instance's network and disk throughput are typically
+capped by its instance type, so a busy or throughput-limited upstream, or a
+constrained network path, can be the bottleneck regardless of the source
+cluster's size.
+
+For **upsert** sources, snapshotting can be especially resource-intensive
+(compared to append-only), and large upsert sources can take hours to snapshot.

--- a/doc/user/content/headless/ingestion/snapshotting-ingestion.md
+++ b/doc/user/content/headless/ingestion/snapshotting-ingestion.md
@@ -1,0 +1,14 @@
+---
+headless: true
+---
+
+<!--
+Generic (syntax-agnostic) version of the "existing tables blocked" behavior.
+Keep in sync with the syntax-specific version in
+headless/ingestion/snapshotting-queries.md.
+-->
+
+When you create additional tables for a source that already has tables ingesting
+data, ingestion for the existing tables is blocked while the new tables
+snapshot. The existing tables remain queryable, but they stop advancing until
+the new tables' snapshots complete.

--- a/doc/user/content/headless/ingestion/snapshotting-occurrence.md
+++ b/doc/user/content/headless/ingestion/snapshotting-occurrence.md
@@ -1,0 +1,16 @@
+---
+headless: true
+---
+When snapshotting occurs depends on the syntax.
+
+- With the legacy [`CREATE SOURCE ... FOR <ALL
+  TABLES|TABLES|SCHEMAS>`](/sql/create-source/#legacy-syntax), you run a single
+  statement to create both the source and the tables that ingest data.
+  Snapshotting begins when you run the statement. For an existing source, the
+  legacy [`ALTER SOURCE ... ADD SUBSOURCE`](/sql/alter-source/) starts the
+  snapshotting for the added table.
+
+- With the source-versioning syntax, you create the source and its tables
+  separately using [`CREATE SOURCE ...`](/sql/create-source/#new-syntax) and
+  [`CREATE TABLE ... FROM SOURCE`](/sql/create-table/). Snapshotting begins when
+  you run `CREATE TABLE ... FROM SOURCE`.

--- a/doc/user/content/headless/ingestion/snapshotting-queries.md
+++ b/doc/user/content/headless/ingestion/snapshotting-queries.md
@@ -1,0 +1,32 @@
+---
+headless: true
+---
+<!--
+Syntax-specific (legacy and source-versioning) query behavior during
+snapshotting. For the generic (syntax-agnostic) version, see
+headless/ingestion/snapshotting-ingestion.md.
+-->
+
+Queries on a table that is snapshotting are blocked until its snapshot
+completes.
+
+- With the legacy `CREATE` syntax:
+
+  - None of the tables created as part of `CREATE SOURCE ... FOR ...` are
+    queryable until they have all finished snapshotting.
+
+  - When altering a source to add a new table (`ALTER SOURCE ... ADD
+    SUBSOURCE`), only the new table snapshots. The source's other tables
+    remain queryable. However, ingestion for these tables is temporarily
+    blocked, so they stop advancing until the snapshot completes.
+
+- With the source-versioning `CREATE TABLE FROM SOURCE` syntax:
+
+  - None of the tables created within a [transaction
+    block](/sql/begin/#ddl-only-transactions) are queryable until all their
+    snapshots complete.
+
+  - When you create new tables from a source that already has tables, only the
+    new tables snapshot. The source's existing tables remain queryable.
+    However, ingestion for the existing tables is temporarily blocked, so they
+    stop advancing until the snapshots for the new tables complete.

--- a/doc/user/content/ingest-data/_index.md
+++ b/doc/user/content/ingest-data/_index.md
@@ -41,9 +41,7 @@ If possible, dedicate a cluster just for sources.
 
 ### Duration
 
-The duration of the snapshotting operation depends on the volume of data in the
-initial snapshot and the size of the cluster where the source is hosted. Large
-upsert sources, in particular, can take hours to snapshot.
+{{% include-headless "/headless/ingestion/snapshotting-duration" %}}
 
 To reduce the operational burden of snapshotting on the upstream system and
 ensure you are only bringing in the volume of data that you need in Materialize,

--- a/doc/user/content/ingest-data/_index.md
+++ b/doc/user/content/ingest-data/_index.md
@@ -33,19 +33,21 @@ If possible, dedicate a cluster just for sources.
 
 ## Snapshotting
 
-When a new source is created, Materialize performs a sync of all data available
-in the external system before it starts ingesting new data — an operation known
-as _snapshotting_. Because the initial snapshot is persisted in the storage
-layer atomically (i.e., at the same ingestion timestamp), you are **not able to
-query the source until snapshotting is complete**.
+{{% include-headless "/headless/ingestion/snapshotting-definition" %}}
+
+### When snapshotting occurs
+
+{{% include-headless "/headless/ingestion/snapshotting-occurrence" %}}
 
 ### Duration
 
 The duration of the snapshotting operation depends on the volume of data in the
-initial snapshot and the size of the cluster where the source is hosted. To
-reduce the operational burden of snapshotting on the upstream system and ensure
-you are only bringing in the volume of data that you need in Materialize, we
-recommend:
+initial snapshot and the size of the cluster where the source is hosted. Large
+upsert sources, in particular, can take hours to snapshot.
+
+To reduce the operational burden of snapshotting on the upstream system and
+ensure you are only bringing in the volume of data that you need in Materialize,
+we recommend:
 
 - If possible, running source creation operations during **off-peak hours** to
   minimize operational risk in both the upstream system and Materialize.
@@ -76,16 +78,14 @@ exhaustion, you may need to [resize the cluster](#use-a-larger-cluster-for-upser
 
 ### Queries during snapshotting
 
-Because the initial snapshot is persisted atomically, you are **not able to
-query the source until snapshotting is complete**. This means that queries
-issued against (sub)sources undergoing snapshotting will hang until the
-operation completes. Once the initial snapshot has been ingested, you can start
-querying your (sub)sources and Materialize will continue ingesting any new data
-as it arrives, in real time.
+{{% include-headless "/headless/ingestion/snapshotting-queries" %}}
 
 ### Modifying an existing source
 
-{{% include-headless "/headless/alter-source-snapshot-blocking-behavior" %}}
+{{% include-headless "/headless/ingestion/snapshotting-ingestion" %}}
+
+If possible, resize the cluster to speed up the snapshot, then right-size it once
+snapshotting completes.
 
 ## Running/steady-state
 

--- a/doc/user/content/transform-data/troubleshooting.md
+++ b/doc/user/content/transform-data/troubleshooting.md
@@ -232,7 +232,7 @@ on diagnosing a slow snapshot and sizing a cluster appropriately for
 snapshotting, follow the [`Ingest data`
 troubleshooting](/ingest-data/troubleshooting) guide.
 
-For upsert and Debezium sources, see also [Hydrating objects](#hydrating-objects).
+For upsert sources, see also [Hydrating objects](#hydrating-objects).
 
 ### Hydrating objects
 
@@ -245,10 +245,10 @@ to take longer to hydrate.
 
 When a materialized view or index is created, it undergoes hydration. Hydration
 also happens whenever a cluster is restarted or resized: the materialized views
-and indexes on that cluster rebuild their in-memory state, and upsert and
-Debezium sources rebuild their internal index. On Materialize Cloud, this
-includes restarts during the [routine
-maintenance window](/releases/schedule/#cloud-upgrade-schedule).
+and indexes on that cluster rebuild their in-memory state, and upsert sources
+rebuild their internal index. On Materialize Cloud, this includes restarts
+during the [routine maintenance
+window](/releases/schedule/#cloud-upgrade-schedule).
 
 To see whether an object is still hydrating, navigate to the
 [workflow graph](#detect) for the object in the Materialize console.


### PR DESCRIPTION
Continuation of coalescing both legacy and source versioning syntax work from https://github.com/MaterializeInc/materialize/pull/37842, additional cleanup where our text only refers to legacy syntax 
(as a side benefit, some of this cleanup should also help w keeping the Aug hydration work more focused on hydration part).

https://preview.materialize.com/materialize/38116/concepts/snapshotting/