### PR TITLE
compute: run MV sink correction maintenance on a blocking thread

### DIFF
--- a/src/compute/src/sink/correction.rs
+++ b/src/compute/src/sink/correction.rs
@@ -17,13 +17,12 @@ use std::ops::{AddAssign, Bound, RangeBounds, SubAssign};
 
 use differential_dataflow::consolidation::{consolidate, consolidate_updates};
 use differential_dataflow::logging::{BatchEvent, DropEvent};
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use mz_compute_types::dyncfgs::{
     CONSOLIDATING_VEC_GROWTH_DAMPENER, CORRECTION_V2_CHAIN_PROPORTIONALITY,
     CORRECTION_V2_CHUNK_SIZE, ENABLE_CORRECTION_V2,
 };
 use mz_dyncfg::ConfigSet;
-use mz_ore::iter::IteratorExt;
 use mz_persist_client::metrics::{SinkMetrics, SinkWorkerMetrics, UpdateDelta};
 use mz_repr::{Diff, Timestamp};
 use timely::PartialOrder;
@@ -98,6 +97,33 @@ impl<D: Data> Correction<D> {
         match self {
             Self::V1(c) => Box::new(c.updates_before(upper)),
             Self::V2(c) => Box::new(c.updates_before(upper)),
+        }
+    }
+
+    /// Consolidate the updates before the given `upper`.
+    ///
+    /// This is the expensive half of [`Correction::updates_before`], split out so callers that
+    /// must not run unbounded CPU work inline can perform it elsewhere.
+    pub fn consolidate_before(&mut self, upper: &Antichain<Timestamp>) {
+        match self {
+            Self::V1(c) => c.consolidate_before(upper),
+            Self::V2(c) => c.consolidate_before(upper),
+        }
+    }
+
+    /// Return the updates before the given `upper`, as consolidated by a preceding
+    /// [`Correction::consolidate_before`] call.
+    ///
+    /// The caller must have invoked `consolidate_before` with the same `upper` and must not have
+    /// mutated the buffer since. Otherwise the returned updates are neither consolidated nor
+    /// necessarily complete.
+    pub fn consolidated_updates_before<'a>(
+        &'a self,
+        upper: &Antichain<Timestamp>,
+    ) -> impl Iterator<Item = (D, Timestamp, Diff)> + Send + use<'a, D> {
+        match self {
+            Self::V1(c) => Either::Left(c.consolidated_updates_before(upper)),
+            Self::V2(c) => Either::Right(c.consolidated_updates_before(upper)),
         }
     }
 
@@ -251,42 +277,42 @@ impl<D: Data> CorrectionV1<D> {
         self.update_metrics(new_size);
     }
 
-    /// Consolidate and return updates within the given bounds.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `lower` is not less than or equal to `upper`.
-    pub fn updates_within<'a>(
-        &'a mut self,
-        lower: &Antichain<Timestamp>,
-        upper: &Antichain<Timestamp>,
-    ) -> impl Iterator<Item = (D, Timestamp, Diff)> + ExactSizeIterator + use<'a, D> {
-        assert!(PartialOrder::less_equal(lower, upper));
-
-        let start = match lower.as_option() {
-            Some(ts) => Bound::Included(*ts),
-            None => Bound::Excluded(Timestamp::MAX),
-        };
+    /// The range of stored times before the given `upper`.
+    fn range_before(upper: &Antichain<Timestamp>) -> (Bound<Timestamp>, Bound<Timestamp>) {
+        let start = Bound::Included(Timestamp::MIN);
         let end = match upper.as_option() {
             Some(ts) => Bound::Excluded(*ts),
             None => Bound::Unbounded,
         };
+        (start, end)
+    }
 
-        let update_count = self.consolidate((start, end));
+    /// Consolidate the updates before the given `upper`.
+    pub fn consolidate_before(&mut self, upper: &Antichain<Timestamp>) {
+        let _ = self.consolidate(Self::range_before(upper));
+    }
 
-        let range = self.updates.range((start, end));
-        range
+    /// Return the updates before the given `upper`, as consolidated by a preceding
+    /// [`CorrectionV1::consolidate_before`] call.
+    ///
+    /// The caller must have invoked `consolidate_before` with the same `upper` and must not have
+    /// mutated the buffer since. Otherwise the returned updates are not consolidated.
+    pub fn consolidated_updates_before<'a>(
+        &'a self,
+        upper: &Antichain<Timestamp>,
+    ) -> impl Iterator<Item = (D, Timestamp, Diff)> + Send + use<'a, D> {
+        self.updates
+            .range(Self::range_before(upper))
             .flat_map(|(t, data)| data.iter().map(|(d, r)| (d.clone(), *t, *r)))
-            .exact_size(update_count)
     }
 
     /// Consolidate and return updates before the given `upper`.
     pub fn updates_before<'a>(
         &'a mut self,
         upper: &Antichain<Timestamp>,
-    ) -> impl Iterator<Item = (D, Timestamp, Diff)> + ExactSizeIterator + Send + use<'a, D> {
-        let lower = Antichain::from_elem(Timestamp::MIN);
-        self.updates_within(&lower, upper)
+    ) -> impl Iterator<Item = (D, Timestamp, Diff)> + Send + use<'a, D> {
+        self.consolidate_before(upper);
+        self.consolidated_updates_before(upper)
     }
 
     /// Consolidate the updates at the times in the given range.

--- a/src/compute/src/sink/correction_v2.rs
+++ b/src/compute/src/sink/correction_v2.rs
@@ -358,15 +358,26 @@ impl<D: Data> CorrectionV2<D> {
         &'a mut self,
         upper: &Antichain<Timestamp>,
     ) -> impl Iterator<Item = (D, Timestamp, Diff)> + Send + 'a {
+        self.consolidate_before(upper);
+        self.consolidated_updates_before(upper)
+    }
+
+    /// Return the updates before the given `upper`, as consolidated by a preceding
+    /// [`CorrectionV2::consolidate_before`] call.
+    ///
+    /// The caller must have invoked `consolidate_before` with the same `upper` and must not have
+    /// mutated the buffer since. Otherwise the returned updates are neither consolidated nor
+    /// necessarily complete.
+    pub fn consolidated_updates_before<'a>(
+        &'a self,
+        upper: &Antichain<Timestamp>,
+    ) -> impl Iterator<Item = (D, Timestamp, Diff)> + Send + use<'a, D> {
         // All contained times are advanced to at least the `since`, so a read at an `upper` that
-        // is not beyond the `since` is always empty. Short-circuit to avoid the eager peel, merge,
-        // and `boundary` advancement that `consolidate_before` would otherwise perform. Normal
-        // reads and `consolidate_at_since` always pass an `upper` beyond the `since`.
+        // is not beyond the `since` is always empty. This mirrors the short-circuit in
+        // `consolidate_before`, which leaves `emitted` untouched in that case.
         if !PartialOrder::less_than(&self.since, upper) {
             return None.into_iter().flatten();
         }
-
-        self.consolidate_before(upper);
 
         // After `consolidate_before`, `emitted` holds exactly the updates before `upper`: every
         // path that populates it splits at `upper` (pushing the remainder to `pending_low`), and
@@ -385,9 +396,17 @@ impl<D: Data> CorrectionV2<D> {
     /// Consolidate all updates before the given `upper` into the `emitted` chain.
     ///
     /// Once this method returns, `emitted` contains all updates at times before `upper`,
-    /// consolidated. It can also contain updates at times at or beyond `upper` if `upper` is not
-    /// beyond the `since`.
-    fn consolidate_before(&mut self, upper: &Antichain<Timestamp>) {
+    /// consolidated.
+    ///
+    /// Does nothing if `upper` is not beyond the `since`: all contained times are advanced to at
+    /// least the `since`, so such a read is empty anyway, and skipping avoids an eager peel,
+    /// merge, and `boundary` advancement. Normal reads and `consolidate_at_since` always pass an
+    /// `upper` beyond the `since`.
+    pub fn consolidate_before(&mut self, upper: &Antichain<Timestamp>) {
+        if !PartialOrder::less_than(&self.since, upper) {
+            return;
+        }
+
         if let Some(mut ready) = self.stage.flush() {
             self.route(&mut ready);
         }

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -551,6 +551,9 @@ mod write {
         }
     }
 
+    /// The correction buffers owned by the Tokio write task.
+    type Corrections = OkErr<Correction<Row>, Correction<DataflowErrorSer>>;
+
     /// A response from the Tokio write task back to the Timely operator.
     struct WriteResponse {
         /// The written batch, or `None` if the corrections buffer had no updates.
@@ -628,7 +631,7 @@ mod write {
         // Construct corrections on the Timely thread (reads ConfigSet), then move to the
         // Tokio task. The ChannelLogging sends events back to the Timely thread.
         let worker_metrics = sink_metrics.for_worker(worker_id);
-        let mut corrections: OkErr<Correction<Row>, Correction<DataflowErrorSer>> = OkErr::new(
+        let mut corrections: Corrections = OkErr::new(
             Correction::new(
                 sink_metrics.clone(),
                 worker_metrics.clone(),
@@ -685,7 +688,8 @@ mod write {
                     let mut writer = persist_api.open_writer().await;
 
                     while let Some(cmd) = cmd_rx.recv().await {
-                        apply_command(&mut corrections, &mut writer, cmd, &resp_tx).await;
+                        corrections =
+                            apply_command(sink_id, corrections, &mut writer, cmd, &resp_tx).await;
                         // Activate the operator to drain logging events and process batch responses.
                         // ArcActivator suppresses redundant activations, so this is cheap.
                         activator.activate();
@@ -831,19 +835,99 @@ mod write {
         batches_output_stream
     }
 
-    /// Apply a single command to the task state.
+    /// Apply a single command to the task state, returning the correction buffers.
     ///
     /// `desired` updates enter `corrections` as positive contributions and `persist` updates as
     /// negative contributions, so the buffer contains `desired - persist`, i.e. the updates that
     /// need to be written to bring the shard in line with `desired`.
+    ///
+    /// Correction maintenance is CPU-bound and unbounded in duration: an insert can merge chains
+    /// spanning the whole buffer and a consolidation sorts it, neither with an await point in
+    /// between. Running that inline occupies a Tokio worker thread for the entire time, which
+    /// stops it from polling every other task scheduled on it. It therefore runs on a blocking
+    /// thread, which the OS can preempt. The buffers move into the blocking closure and back out
+    /// again because this task owns them exclusively.
     async fn apply_command(
-        corrections: &mut OkErr<Correction<Row>, Correction<DataflowErrorSer>>,
+        sink_id: GlobalId,
+        mut corrections: Corrections,
         writer: &mut WriteHandle<SourceData, (), Timestamp, StorageDiff>,
         cmd: WriteCommand,
         resp_tx: &mpsc::UnboundedSender<WriteResponse>,
-    ) {
+    ) -> Corrections {
         match cmd {
-            WriteCommand::Batch(mut batch) => {
+            WriteCommand::Batch(batch) => apply_batch(sink_id, corrections, batch).await,
+            WriteCommand::WriteBatch(desc) => {
+                let upper = desc.upper.clone();
+                corrections = mz_ore::task::spawn_blocking(
+                    || operator_name(sink_id, "write::consolidate"),
+                    move || {
+                        corrections.ok.consolidate_before(&upper);
+                        corrections.err.consolidate_before(&upper);
+                        corrections
+                    },
+                )
+                .await;
+
+                // Reading the consolidated updates back only clones them into the batch builder,
+                // which awaits at every part flush, so it stays on the async task. Chain ok and
+                // err correction iterators directly, avoiding an intermediate Vec allocation.
+                let oks = corrections
+                    .ok
+                    .consolidated_updates_before(&desc.upper)
+                    .map(|(d, t, r)| ((SourceData(Ok(d)), ()), t, r.into_inner()));
+                let errs = corrections
+                    .err
+                    .consolidated_updates_before(&desc.upper)
+                    .map(|(d, t, r)| ((SourceData(Err(d.deserialize())), ()), t, r.into_inner()));
+                let mut updates = oks.chain(errs).peekable();
+
+                if updates.peek().is_none() {
+                    // No corrections to write.
+                    let _ = resp_tx.send(WriteResponse { batch: None });
+                    drop(updates);
+                    return corrections;
+                }
+
+                let batch = writer
+                    .batch(updates, desc.lower, desc.upper)
+                    .await
+                    .expect("valid usage");
+                let proto_batch = batch.into_transmittable_batch();
+                if let Err(err) = resp_tx.send(WriteResponse {
+                    batch: Some(proto_batch),
+                }) {
+                    let batch =
+                        writer.batch_from_transmittable_batch(err.0.batch.expect("just sent"));
+                    batch.delete().await;
+                }
+
+                corrections
+            }
+        }
+    }
+
+    /// Apply a coalesced batch of updates to the correction buffers, on a blocking thread.
+    ///
+    /// See [`apply_command`] for why this work must not run on a Tokio worker thread.
+    async fn apply_batch(
+        sink_id: GlobalId,
+        mut corrections: Corrections,
+        mut batch: BatchUpdates,
+    ) -> Corrections {
+        mz_ore::task::spawn_blocking(
+            || operator_name(sink_id, "write::apply_batch"),
+            move || {
+                // Stands in for the page-in storm this code produces when the process is under
+                // memory pressure: the buffer's chunks come back one blocking read at a time, from
+                // inside the sorts and merges below, where no await point can be placed. The
+                // failpoint's `sleep` action blocks its thread the same way, so it has to sit on
+                // the same side of the `spawn_blocking` boundary as the work it stands for.
+                //
+                // NOTE: activate it with the `FAILPOINTS` env var on the clusterd process, e.g.
+                // `FAILPOINTS=mv_sink_correction=sleep(30000)`. The `failpoints` session variable
+                // only reaches environmentd, never a cluster.
+                fail::fail_point!("mv_sink_correction");
+
                 // Apply the same logical sequence of operations that the per-chunk commands
                 // used to: positive desired inserts, negated persist inserts, then optional
                 // frontier advancement and forced consolidation.
@@ -860,8 +944,8 @@ mod write {
                     corrections.err.insert_negated(&mut batch.persist_err);
                 }
                 if let Some(frontier) = batch.persist_frontier {
-                    // We will only emit times at or after the `persist` frontier, so now is a
-                    // good time to advance the times of stashed updates.
+                    // We will only emit times at or after the `persist` frontier, so now is a good
+                    // time to advance the times of stashed updates.
                     corrections.ok.advance_since(frontier.clone());
                     corrections.err.advance_since(frontier);
                 }
@@ -869,40 +953,10 @@ mod write {
                     corrections.ok.consolidate_at_since();
                     corrections.err.consolidate_at_since();
                 }
-            }
-            WriteCommand::WriteBatch(desc) => {
-                // Chain ok and err correction iterators directly, avoiding an
-                // intermediate Vec allocation.
-                let oks = corrections
-                    .ok
-                    .updates_before(&desc.upper)
-                    .map(|(d, t, r)| ((SourceData(Ok(d)), ()), t, r.into_inner()));
-                let errs = corrections
-                    .err
-                    .updates_before(&desc.upper)
-                    .map(|(d, t, r)| ((SourceData(Err(d.deserialize())), ()), t, r.into_inner()));
-                let mut updates = oks.chain(errs).peekable();
-
-                if updates.peek().is_none() {
-                    // No corrections to write.
-                    let _ = resp_tx.send(WriteResponse { batch: None });
-                    return;
-                }
-
-                let batch = writer
-                    .batch(updates, desc.lower, desc.upper)
-                    .await
-                    .expect("valid usage");
-                let proto_batch = batch.into_transmittable_batch();
-                if let Err(err) = resp_tx.send(WriteResponse {
-                    batch: Some(proto_batch),
-                }) {
-                    let batch =
-                        writer.batch_from_transmittable_batch(err.0.batch.expect("just sent"));
-                    batch.delete().await;
-                }
-            }
-        }
+                corrections
+            },
+        )
+        .await
     }
 
     /// State maintained by the `write` operator on the Timely thread.
@@ -1113,6 +1167,104 @@ mod write {
                 .send(WriteCommand::WriteBatch(desc.clone()))
                 .expect("write task unexpectedly gone");
             Some((desc, cap))
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::time::{Duration, Instant};
+
+        use mz_ore::metrics::MetricsRegistry;
+        use mz_persist_client::cfg::PersistConfig;
+        use mz_persist_client::metrics::Metrics;
+
+        use super::*;
+
+        /// One stall per worker thread would leave scheduling to chance, so oversubscribe: with
+        /// more stalls than workers every worker is guaranteed to pick one up.
+        const WORKER_THREADS: usize = 2;
+        const STALLS: usize = WORKER_THREADS * 2;
+        /// How long a stalled `apply_batch` blocks its thread.
+        const STALL: Duration = Duration::from_millis(1_000);
+        /// The largest tick gap the canary may observe. Generous enough to absorb scheduling noise
+        /// on a loaded CI host, while far below the `STALL` an inline correction pass produces.
+        const MAX_GAP: Duration = Duration::from_millis(500);
+        const TICK: Duration = Duration::from_millis(10);
+
+        fn corrections() -> Corrections {
+            let registry = MetricsRegistry::new();
+            let metrics = Metrics::new(&PersistConfig::new_for_tests(), &registry);
+            let sink_metrics = metrics.sink.clone();
+            let worker_metrics = sink_metrics.for_worker(0);
+            let config = mz_dyncfgs::all_dyncfgs();
+            OkErr::new(
+                Correction::new(sink_metrics.clone(), worker_metrics.clone(), None, &config),
+                Correction::new(sink_metrics, worker_metrics, None, &config),
+            )
+        }
+
+        /// Tick every [`TICK`], recording the largest gap between consecutive ticks in millis.
+        ///
+        /// A gap only opens up if no worker thread was available to poll this task.
+        async fn canary(max_gap_millis: Arc<AtomicU64>) {
+            let mut last = Instant::now();
+            loop {
+                tokio::time::sleep(TICK).await;
+                let now = Instant::now();
+                let gap = u64::try_from(now.duration_since(last).as_millis()).unwrap_or(u64::MAX);
+                max_gap_millis.fetch_max(gap, Ordering::Relaxed);
+                last = now;
+            }
+        }
+
+        /// Correction maintenance must not occupy a Tokio worker thread.
+        ///
+        /// Run inline, a pass over a large buffer pins a worker for its whole duration. Under
+        /// memory pressure it is blocked in the kernel paging chunks back in rather than
+        /// computing, which is why yielding cannot fix it.
+        ///
+        /// Stalls every worker thread inside `apply_batch` and asserts an unrelated task keeps
+        /// getting polled throughout.
+        #[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+        #[cfg_attr(miri, ignore)] // depends on real thread scheduling
+        async fn correction_work_does_not_stall_the_runtime() {
+            let max_gap_millis = Arc::new(AtomicU64::new(0));
+            let _canary = mz_ore::task::spawn(|| "canary", canary(Arc::clone(&max_gap_millis)))
+                .abort_on_drop();
+
+            // Let the canary settle, then discard the gaps observed while it did.
+            tokio::time::sleep(TICK * 5).await;
+            max_gap_millis.store(0, Ordering::Relaxed);
+
+            let action = format!("sleep({})", STALL.as_millis());
+            fail::cfg("mv_sink_correction", &action).expect("valid failpoint action");
+
+            let stalls: Vec<_> = (0..STALLS)
+                .map(|i| {
+                    // A forced consolidation is the operation that hurt: it sweeps the whole
+                    // buffer, so its cost is unbounded by the size of the incoming batch.
+                    let batch = BatchUpdates {
+                        force_consolidation: true,
+                        ..BatchUpdates::new()
+                    };
+                    let sink_id = GlobalId::User(u64::cast_from(i));
+                    mz_ore::task::spawn(|| "stall", apply_batch(sink_id, corrections(), batch))
+                })
+                .collect();
+            for stall in stalls {
+                let _ = stall.await;
+            }
+
+            fail::remove("mv_sink_correction");
+
+            let max_gap = Duration::from_millis(max_gap_millis.load(Ordering::Relaxed));
+            assert!(
+                max_gap < MAX_GAP,
+                "runtime went unpolled for {max_gap:?}, so correction work is occupying a \
+                 worker thread",
+            );
         }
     }
 }


### PR DESCRIPTION
Follow-up to #38074, which disabled `ENABLE_SYNC_MV_SINK` by default after incident 1175.

The sync MV sink's `write` Tokio task performed correction-buffer maintenance inline. Inserts merge chains spanning the whole buffer and consolidation sorts it, neither with an await point in between, so a pass over a large buffer occupied a Tokio worker thread for its entire duration and stopped it polling everything else scheduled there. Persist lease heartbeats were among the casualties: readers lost their leases and the process halted with `batch fetcher could not fetch batch part`. The async sink never hit this, because its operators run on the Timely thread.

Under memory pressure the pass is not merely slow. `CorrectionV2` pages its chunks out through the column pager, and consolidation calls `Chunk::column` on every chunk it merges, so the chunks come back one blocking read at a time from inside the sorts and merges. The thread is blocked in the kernel rather than computing. That rules out fixing this by yielding: there is no program point between the faults at which a yield could be placed, and a cooperative fix is only ever as strong as the worst un-yielded path. Running the work on a blocking thread lets the OS preempt it, which holds regardless of what the buffer does.

`Correction::updates_before` is split into `consolidate_before`, which does the expensive part, and `consolidated_updates_before`, which reads the result back. `updates_before` becomes the composition of the two, so the async sink and the benchmarks are unaffected. The `CorrectionV2` `since` guard moves from `updates_before` into `consolidate_before`; `consolidate_at_since` always passes an `upper` beyond the `since`, so it is unaffected.

The write task runs the correction work on a blocking thread and then feeds the updates to the persist batch builder from the async task, where the loop awaits at every part flush and so stays bounded.

The cost is a thread hop per command, one or two per Timely activation. Note that `persist-client`'s `IsolatedRuntime` documents a preference against `spawn_blocking` for CPU-bound work, on thread-count and shutdown grounds. It is used here deliberately: the failure mode is a thread blocked in the kernel, and OS preemption is what addresses that.

This does not re-flip the `ENABLE_SYNC_MV_SINK` default, which stays `false` pending gradual rollout via LaunchDarkly. mzcompose continues to set the parameter to `true`, so CI exercises the path.

Adds `write::tests::correction_work_does_not_stall_the_runtime`, which stalls every worker thread of a two-worker runtime inside the correction path via a new `mv_sink_correction` failpoint and asserts an unrelated task keeps getting polled. Moving the `apply_batch` body back out of `spawn_blocking` fails it. The failpoint also drives the end-to-end lease-expiry scenario when set through the `FAILPOINTS` environment variable on a clusterd process; the `failpoints` session variable only reaches environmentd, never a cluster.

### Release notes

This release will not include user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
