### PR TITLE
adapter: notice when single-replica sources meet multiple replicas

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -90,6 +90,7 @@ use mz_storage_client::controller::ExportDescription;
 use mz_storage_types::AlterCompatible;
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::controller::StorageError;
+use mz_storage_types::sources::SourceConnection;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::notice::{OptimizerNotice, RawOptimizerNotice};
 use smallvec::SmallVec;
@@ -634,7 +635,22 @@ impl Coordinator {
         }
 
         match transact_result {
-            Ok(()) => Ok(ExecuteResponse::CreatedSource),
+            Ok(()) => {
+                // Warn about any new source that runs on only one replica but
+                // landed on a cluster that has more than one.
+                for (_item_id, source) in &sources {
+                    let cluster_id = match &source.data_source {
+                        DataSourceDesc::Ingestion { desc, cluster_id }
+                        | DataSourceDesc::OldSyntaxIngestion {
+                            desc, cluster_id, ..
+                        } if desc.connection.prefers_single_replica() => cluster_id,
+                        _ => continue,
+                    };
+                    let cluster = self.catalog().get_cluster(*cluster_id);
+                    self.notify_single_replica_sources(ctx.session(), cluster);
+                }
+                Ok(ExecuteResponse::CreatedSource)
+            }
             Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
                 kind: ErrorKind::Sql(CatalogError::ItemAlreadyExists(id, _)),
             })) if if_not_exists_ids.contains_key(&id) => {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -183,7 +183,7 @@ struct DropOps {
 // A bundle of values returned from create_source_inner
 struct CreateSourceInner {
     ops: Vec<catalog::Op>,
-    sources: Vec<(CatalogItemId, Source)>,
+    sources: Vec<(CatalogItemId, QualifiedItemName, Source)>,
     if_not_exists_ids: BTreeMap<CatalogItemId, QualifiedItemName>,
 }
 
@@ -362,11 +362,11 @@ impl Coordinator {
             let source = Source::new(plan, global_id, resolved_ids, None, false);
             ops.push(catalog::Op::CreateItem {
                 id: item_id,
-                name,
+                name: name.clone(),
                 item: CatalogItem::Source(source.clone()),
                 owner_id: *session.current_role_id(),
             });
-            sources.push((item_id, source));
+            sources.push((item_id, name, source));
             // These operations must be executed after the source is added to the catalog.
             ops.extend(reference_ops);
         }
@@ -625,7 +625,7 @@ impl Coordinator {
             .await;
 
         // Check if any sources are webhook sources and report them as created.
-        for (item_id, source) in &sources {
+        for (item_id, _name, source) in &sources {
             if matches!(source.data_source, DataSourceDesc::Webhook { .. }) {
                 if let Some(url) = self.catalog().state().try_get_webhook_url(item_id) {
                     ctx.session()
@@ -637,8 +637,11 @@ impl Coordinator {
         match transact_result {
             Ok(()) => {
                 // Warn about any new source that runs on only one replica but
-                // landed on a cluster that has more than one.
-                for (_item_id, source) in &sources {
+                // landed on a cluster that has more than one. The source's
+                // name is passed along explicitly: in a DDL transaction the
+                // creation is only staged at this point, so the source is not
+                // yet visible in the catalog.
+                for (_item_id, name, source) in &sources {
                     let cluster_id = match &source.data_source {
                         DataSourceDesc::Ingestion { desc, cluster_id }
                         | DataSourceDesc::OldSyntaxIngestion {
@@ -647,7 +650,7 @@ impl Coordinator {
                         _ => continue,
                     };
                     let cluster = self.catalog().get_cluster(*cluster_id);
-                    self.notify_single_replica_sources(ctx.session(), cluster);
+                    self.notify_single_replica_sources(ctx.session(), cluster, Some(name));
                 }
                 Ok(ExecuteResponse::CreatedSource)
             }

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -33,6 +33,7 @@ use mz_repr::adt::numeric::Numeric;
 use mz_repr::role_id::RoleId;
 use mz_sql::ast::{Ident, QualifiedReplica};
 use mz_sql::catalog::{CatalogCluster, CatalogError, ObjectType};
+use mz_sql::names::QualifiedItemName;
 use mz_sql::plan::{
     self, AlterClusterPlanStrategy, AlterClusterRenamePlan, AlterClusterReplicaRenamePlan,
     AlterClusterSwapPlan, AlterOptionParameter, AlterSetClusterPlan,
@@ -1695,32 +1696,86 @@ impl Coordinator {
         cluster
             .bound_objects
             .iter()
-            .filter(|id| {
-                self.catalog().get_entry(id).source().is_some_and(|source| {
-                    match &source.data_source {
-                        DataSourceDesc::Ingestion { desc, .. }
-                        | DataSourceDesc::OldSyntaxIngestion { desc, .. } => {
-                            desc.connection.prefers_single_replica()
-                        }
-                        _ => false,
-                    }
+            .filter_map(|id| {
+                let entry = self.catalog().get_entry(id);
+                let single_replica =
+                    entry
+                        .source()
+                        .is_some_and(|source| match &source.data_source {
+                            DataSourceDesc::Ingestion { desc, .. }
+                            | DataSourceDesc::OldSyntaxIngestion { desc, .. } => {
+                                desc.connection.prefers_single_replica()
+                            }
+                            _ => false,
+                        });
+                single_replica.then(|| {
+                    self.catalog()
+                        .resolve_full_name(entry.name(), None)
+                        .to_string()
                 })
-            })
-            .map(|id| {
-                let name = self.catalog().get_entry(id).name();
-                self.catalog().resolve_full_name(name, None).to_string()
             })
             .collect()
     }
 
-    /// Emits a notice if `cluster` has more than one replica while containing
-    /// sources that run on only one replica. Call after a command that added a
-    /// replica or such a source.
-    pub(crate) fn notify_single_replica_sources(&self, session: &Session, cluster: &Cluster) {
-        if cluster.replicas().count() <= 1 {
+    /// The number of replicas `cluster` aims to run, for deciding whether to
+    /// emit the single-replica-sources notice.
+    ///
+    /// For a managed cluster this is the replication factor, taking the target
+    /// of an in-progress reconfiguration over the realized one, plus any
+    /// INTERNAL or BILLED AS replicas, which are manually managed outside the
+    /// replication-factor domain. Replicas belonging to a reconfiguration's
+    /// hydrate-overlap are deliberately not counted: they replace the serving
+    /// set at cut-over rather than adding to it. Counting the replication
+    /// factor instead of replicas excludes them under both reconfiguration
+    /// mechanisms, the legacy graceful alter (which marks them pending) and
+    /// the cluster controller (which creates them as ordinary replicas of the
+    /// target shape).
+    fn notice_relevant_replica_count(&self, cluster: &Cluster) -> usize {
+        match &cluster.config.variant {
+            ClusterVariant::Managed(managed) => {
+                let replication_factor = managed
+                    .reconfiguration
+                    .as_ref()
+                    .filter(|record| record.is_in_progress())
+                    .map_or(managed.replication_factor, |record| {
+                        record.target.replication_factor
+                    });
+                let manual_replicas = cluster
+                    .replicas()
+                    .filter(|r| {
+                        r.config.location.internal() || r.config.location.billed_as().is_some()
+                    })
+                    .count();
+                usize::cast_from(replication_factor) + manual_replicas
+            }
+            ClusterVariant::Unmanaged => cluster.replicas().count(),
+        }
+    }
+
+    /// Emits a notice if `cluster` aims to run more than one replica while
+    /// containing sources that run on only one replica. Call after a command
+    /// that added a replica or such a source.
+    ///
+    /// `creating_source` names a source the current command is creating in
+    /// `cluster`. It is included in the notice even when it is not yet visible
+    /// in the catalog, which happens when the creation is staged in a DDL
+    /// transaction that commits later.
+    pub(crate) fn notify_single_replica_sources(
+        &self,
+        session: &Session,
+        cluster: &Cluster,
+        creating_source: Option<&QualifiedItemName>,
+    ) {
+        if self.notice_relevant_replica_count(cluster) <= 1 {
             return;
         }
-        let sources = self.single_replica_source_names(cluster);
+        let mut sources = self.single_replica_source_names(cluster);
+        if let Some(name) = creating_source {
+            let full_name = self.catalog().resolve_full_name(name, None).to_string();
+            if !sources.contains(&full_name) {
+                sources.push(full_name);
+            }
+        }
         if !sources.is_empty() {
             session.add_notice(AdapterNotice::SingleReplicaSourcesOnMultiReplicaCluster {
                 cluster: cluster.name.clone(),
@@ -1899,7 +1954,11 @@ impl Coordinator {
             Ok(()) => {
                 // The commit made the new replica visible in the catalog, so
                 // the check sees the updated replica count.
-                self.notify_single_replica_sources(session, self.catalog().get_cluster(cluster_id));
+                self.notify_single_replica_sources(
+                    session,
+                    self.catalog().get_cluster(cluster_id),
+                    None,
+                );
                 Ok(ExecuteResponse::CreatedClusterReplica)
             }
             Err(AdapterError::Catalog(mz_catalog::memory::error::Error {

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -17,7 +17,7 @@ use mz_catalog::builtin::BUILTINS;
 use mz_catalog::durable::managed_cluster_replica_name;
 use mz_catalog::memory::error::ErrorKind;
 use mz_catalog::memory::objects::{
-    ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged,
+    Cluster, ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged, DataSourceDesc,
     ManagedReplicaConfigShape, ReconfigurationState, ReconfigurationStatus, ReconfigurationTarget,
 };
 use mz_compute_types::config::ComputeReplicaConfig;
@@ -44,6 +44,7 @@ use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::{
     MAX_CREDIT_CONSUMPTION_RATE, MAX_REPLICAS_PER_CLUSTER, SystemVars, Var,
 };
+use mz_storage_types::sources::SourceConnection;
 use tracing::{Instrument, Span, debug};
 
 use mz_adapter_types::dyncfgs::{
@@ -349,6 +350,28 @@ impl Coordinator {
             )));
         }
 
+        // An `ALTER` that raises a managed cluster's replication factor above
+        // one deserves a notice when the cluster contains sources that run on
+        // only one replica, since the additional replicas do not benefit those
+        // sources. Computed here, emitted only after the alter succeeds. The
+        // unmanaged conversion paths never change the replica count, so only
+        // the managed-to-managed transition is of interest.
+        let single_replica_sources_notice = match (&config.variant, &new_config.variant) {
+            (Managed(old_managed), Managed(new_managed))
+                if new_managed.replication_factor > old_managed.replication_factor
+                    && new_managed.replication_factor > 1 =>
+            {
+                let sources = self.single_replica_source_names(cluster);
+                (!sources.is_empty()).then(|| {
+                    AdapterNotice::SingleReplicaSourcesOnMultiReplicaCluster {
+                        cluster: cluster.name.clone(),
+                        sources,
+                    }
+                })
+            }
+            _ => None,
+        };
+
         // A shape-changing `ALTER` reshapes into a durable `reconfiguration`
         // record (starting, retargeting, or cancelling one) instead of going
         // through the legacy 3-stage machine. Everything else falls through to
@@ -392,7 +415,7 @@ impl Coordinator {
                 return Err(AdapterError::AlterClusterWaitOnScheduledCluster);
             }
             if needs_record && !scheduled_direct {
-                return self
+                let result = self
                     .reshape_alter_cluster_managed(
                         session,
                         cluster_id,
@@ -402,6 +425,12 @@ impl Coordinator {
                         validity,
                     )
                     .await;
+                if result.is_ok() {
+                    if let Some(notice) = single_replica_sources_notice {
+                        session.add_notice(notice);
+                    }
+                }
+                return result;
             }
         }
 
@@ -416,6 +445,9 @@ impl Coordinator {
                         strategy.clone(),
                     )
                     .await?;
+                if let Some(notice) = single_replica_sources_notice {
+                    session.add_notice(notice);
+                }
                 if alter_followup == NeedsFinalization::Yes {
                     // For non backgrounded zero-downtime alters, store the
                     // cluster_id in the ConnMeta to allow for cancellation.
@@ -1656,6 +1688,47 @@ impl Coordinator {
         Ok(ExecuteResponse::CreatedCluster)
     }
 
+    /// Returns the full names of all sources bound to `cluster` whose
+    /// connections prefer to run on a single replica, so additional replicas
+    /// do not make them more fault tolerant or increase their throughput.
+    fn single_replica_source_names(&self, cluster: &Cluster) -> Vec<String> {
+        cluster
+            .bound_objects
+            .iter()
+            .filter(|id| {
+                self.catalog().get_entry(id).source().is_some_and(|source| {
+                    match &source.data_source {
+                        DataSourceDesc::Ingestion { desc, .. }
+                        | DataSourceDesc::OldSyntaxIngestion { desc, .. } => {
+                            desc.connection.prefers_single_replica()
+                        }
+                        _ => false,
+                    }
+                })
+            })
+            .map(|id| {
+                let name = self.catalog().get_entry(id).name();
+                self.catalog().resolve_full_name(name, None).to_string()
+            })
+            .collect()
+    }
+
+    /// Emits a notice if `cluster` has more than one replica while containing
+    /// sources that run on only one replica. Call after a command that added a
+    /// replica or such a source.
+    pub(crate) fn notify_single_replica_sources(&self, session: &Session, cluster: &Cluster) {
+        if cluster.replicas().count() <= 1 {
+            return;
+        }
+        let sources = self.single_replica_source_names(cluster);
+        if !sources.is_empty() {
+            session.add_notice(AdapterNotice::SingleReplicaSourcesOnMultiReplicaCluster {
+                cluster: cluster.name.clone(),
+                sources,
+            });
+        }
+    }
+
     #[mz_ore::instrument(level = "debug")]
     pub(crate) async fn sequence_create_cluster_replica(
         &mut self,
@@ -1823,7 +1896,12 @@ impl Coordinator {
         }
 
         match self.catalog_transact(Some(session), ops).await {
-            Ok(()) => Ok(ExecuteResponse::CreatedClusterReplica),
+            Ok(()) => {
+                // The commit made the new replica visible in the catalog, so
+                // the check sees the updated replica count.
+                self.notify_single_replica_sources(session, self.catalog().get_cluster(cluster_id));
+                Ok(ExecuteResponse::CreatedClusterReplica)
+            }
             Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
                 kind: ErrorKind::Sql(CatalogError::DuplicateReplica(_, _)),
             })) if if_not_exists => {

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -136,6 +136,12 @@ pub enum AdapterNotice {
     PlanInsights(String),
     IntrospectionClusterUsage,
     AutoRouteIntrospectionQueriesUsage,
+    /// A cluster contains sources that run on only one replica, yet the
+    /// cluster has (or is about to have) more than one replica.
+    SingleReplicaSourcesOnMultiReplicaCluster {
+        cluster: String,
+        sources: Vec<String>,
+    },
     /// An OIDC group has no matching Materialize role.
     OidcGroupSyncUnmatchedGroup {
         group: String,
@@ -215,6 +221,7 @@ impl AdapterNotice {
             AdapterNotice::PlanInsights(_) => Severity::Notice,
             AdapterNotice::IntrospectionClusterUsage => Severity::Warning,
             AdapterNotice::AutoRouteIntrospectionQueriesUsage => Severity::Warning,
+            AdapterNotice::SingleReplicaSourcesOnMultiReplicaCluster { .. } => Severity::Warning,
             AdapterNotice::OidcGroupSyncUnmatchedGroup { .. } => Severity::Notice,
             AdapterNotice::OidcGroupSyncReservedRole { .. } => Severity::Warning,
             AdapterNotice::OidcGroupSyncError { .. } => Severity::Warning,
@@ -225,6 +232,11 @@ impl AdapterNotice {
     pub fn detail(&self) -> Option<String> {
         match self {
             AdapterNotice::PlanNotice(notice) => notice.detail(),
+            AdapterNotice::SingleReplicaSourcesOnMultiReplicaCluster { .. } => Some(
+                "Adding replicas to the cluster does not make these sources more fault tolerant \
+                 and does not increase their ingestion throughput."
+                    .into(),
+            ),
             AdapterNotice::QueryTimestamp { explanation } => Some(format!("\n{explanation}")),
             AdapterNotice::CascadeDroppedObject { objects } => Some(
                 objects
@@ -269,6 +281,11 @@ impl AdapterNotice {
             AdapterNotice::DroppedInUseIndex(..) => Some("To free up the resources used by the index, recreate all the above-mentioned objects.".into()),
             AdapterNotice::IntrospectionClusterUsage => Some("Use the new name instead.".into()),
             AdapterNotice::AutoRouteIntrospectionQueriesUsage => Some("Use the new name instead.".into()),
+            AdapterNotice::SingleReplicaSourcesOnMultiReplicaCluster { .. } => Some(
+                "To achieve fault tolerance for other objects in the cluster, consider moving \
+                 these sources to a separate cluster with a single replica."
+                    .into(),
+            ),
             _ => None
         }
     }
@@ -327,6 +344,7 @@ impl AdapterNotice {
             AdapterNotice::PlanInsights(_) => SqlState::from_code("MZ001"),
             AdapterNotice::IntrospectionClusterUsage => SqlState::WARNING,
             AdapterNotice::AutoRouteIntrospectionQueriesUsage => SqlState::WARNING,
+            AdapterNotice::SingleReplicaSourcesOnMultiReplicaCluster { .. } => SqlState::WARNING,
             AdapterNotice::OidcGroupSyncUnmatchedGroup { .. } => SqlState::SUCCESSFUL_COMPLETION,
             AdapterNotice::OidcGroupSyncReservedRole { .. } => SqlState::WARNING,
             AdapterNotice::OidcGroupSyncError { .. } => SqlState::WARNING,
@@ -518,6 +536,15 @@ impl fmt::Display for AdapterNotice {
                 f,
                 "The auto_route_introspection_queries variable has been renamed to auto_route_catalog_queries."
             ),
+            AdapterNotice::SingleReplicaSourcesOnMultiReplicaCluster { cluster, sources } => {
+                write!(
+                    f,
+                    "cluster {} has more than one replica, but the following sources in it always \
+                     run on only the first replica: {}",
+                    cluster.quoted(),
+                    separated(", ", sources.iter().map(|name| name.quoted())),
+                )
+            }
             AdapterNotice::OidcGroupSyncUnmatchedGroup { group } => {
                 write!(
                     f,

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -537,13 +537,22 @@ impl fmt::Display for AdapterNotice {
                 "The auto_route_introspection_queries variable has been renamed to auto_route_catalog_queries."
             ),
             AdapterNotice::SingleReplicaSourcesOnMultiReplicaCluster { cluster, sources } => {
+                // Keep the notice readable on clusters with many sources.
+                const MAX_LISTED_SOURCES: usize = 3;
                 write!(
                     f,
                     "cluster {} has more than one replica, but the following sources in it always \
                      run on only the first replica: {}",
                     cluster.quoted(),
-                    separated(", ", sources.iter().map(|name| name.quoted())),
-                )
+                    separated(
+                        ", ",
+                        sources.iter().take(MAX_LISTED_SOURCES).map(|n| n.quoted())
+                    ),
+                )?;
+                if sources.len() > MAX_LISTED_SOURCES {
+                    write!(f, ", and {} more", sources.len() - MAX_LISTED_SOURCES)?;
+                }
+                Ok(())
             }
             AdapterNotice::OidcGroupSyncUnmatchedGroup { group } => {
                 write!(

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -302,7 +302,8 @@ def workflow_single_replica_source_notice(
     (OLTP) sources ends up with more than one replica: raising the replication
     factor of a cluster with such a source, adding a replica (billed or
     unbilled) to a cluster with such a source, and creating such a source on a
-    cluster that already has more than one replica.
+    cluster that already has more than one replica. Also checks that graceful
+    resizes and their overlap replicas emit no spurious notice.
     """
 
     pg_version = get_targeted_pg_version(parser)
@@ -404,6 +405,45 @@ def workflow_single_replica_source_notice(
             expect_no_notice(notices)
             with mz_system_conn.cursor() as system_cur:
                 system_cur.execute("DROP CLUSTER REPLICA c1.free")
+
+            # A graceful resize (a shape change writes a reconfiguration
+            # record and runs an overlap replica until cut-over) does not
+            # change how many replicas the cluster aims for, so it emits no
+            # notice.
+            other_size = f"scale={Materialized.Size.DEFAULT_SIZE},workers=1"
+            cur.execute(f"ALTER CLUSTER c1 SET (SIZE '{other_size}')".encode())
+            expect_no_notice(notices)
+
+            # Nor does creating such a source while the reconfiguration may
+            # still be in flight: the overlap replica is not counted.
+            cur.execute(
+                "CREATE SOURCE src5 IN CLUSTER c1 "
+                "FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')"
+            )
+            expect_no_notice(notices)
+
+            # Raising the replication factor together with a shape change
+            # routes through the reconfiguration path and emits the notice.
+            # Changing the replication factor is refused while the previous
+            # reconfiguration is still in flight, so retry until it settles.
+            for _ in range(60):
+                try:
+                    cur.execute(
+                        f"ALTER CLUSTER c1 SET (SIZE '{size}', REPLICATION FACTOR 2)".encode()
+                    )
+                    break
+                except psycopg.Error as e:
+                    assert "reconfiguration is in progress" in str(
+                        e
+                    ), f"unexpected error: {e}"
+                    time.sleep(1)
+            else:
+                raise RuntimeError("reconfiguration did not settle")
+            expect_notice(
+                notices,
+                "c1",
+                '"materialize.public.src1", "materialize.public.src5"',
+            )
 
             # Creating such a source on a cluster that already has two replicas
             # emits the notice.

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -364,6 +364,7 @@ def workflow_single_replica_source_notice(
             cur.execute("DROP CLUSTER IF EXISTS c1 CASCADE")
             cur.execute("DROP CLUSTER IF EXISTS c2 CASCADE")
             cur.execute("DROP CLUSTER IF EXISTS c3 CASCADE")
+            cur.execute("DROP CLUSTER IF EXISTS c4 CASCADE")
             notices.clear()
 
             cur.execute("CREATE SECRET pgpass AS 'postgres'")
@@ -415,6 +416,21 @@ def workflow_single_replica_source_notice(
                 "FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')"
             )
             expect_notice(notices, "c2", '"materialize.public.src2"')
+
+            # Creating such a source in a DDL transaction includes the source
+            # in the notice even though its creation is only staged when the
+            # notice is emitted.
+            cur.execute(
+                f"CREATE CLUSTER c4 (SIZE '{size}', REPLICATION FACTOR 2)".encode()
+            )
+            expect_no_notice(notices)
+            cur.execute("BEGIN")
+            cur.execute(
+                "CREATE SOURCE src4 IN CLUSTER c4 "
+                "FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')"
+            )
+            cur.execute("COMMIT")
+            expect_notice(notices, "c4", '"materialize.public.src4"')
 
             # Adding a replica to an unmanaged cluster with such a source emits
             # the notice.

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -294,6 +294,151 @@ def _verify_exactly_n_replication_slots_exist(pg_conn: Connection, n: int) -> No
     ), f"Expected {n} replication slot(s) but found {count_slots} slot(s)"
 
 
+def workflow_single_replica_source_notice(
+    c: Composition, parser: WorkflowArgumentParser
+) -> None:
+    """
+    Test the notice that is emitted when a cluster containing single-replica
+    (OLTP) sources ends up with more than one replica: raising the replication
+    factor of a cluster with such a source, adding a replica (billed or
+    unbilled) to a cluster with such a source, and creating such a source on a
+    cluster that already has more than one replica.
+    """
+
+    pg_version = get_targeted_pg_version(parser)
+    with c.override(create_postgres(pg_version=pg_version)):
+        c.up("materialized", "postgres")
+
+        pg_conn = psycopg.connect(
+            host="localhost",
+            user="postgres",
+            password="postgres",
+            port=c.default_port("postgres"),
+        )
+        pg_conn.autocommit = True
+        with pg_conn.cursor() as cur:
+            cur.execute("ALTER USER postgres WITH replication;")
+            cur.execute("DROP SCHEMA IF EXISTS public CASCADE;")
+            cur.execute("CREATE SCHEMA public;")
+            cur.execute("CREATE TABLE t (a int);")
+            cur.execute("ALTER TABLE t REPLICA IDENTITY FULL;")
+            cur.execute("DROP PUBLICATION IF EXISTS mz_source;")
+            cur.execute("CREATE PUBLICATION mz_source FOR ALL TABLES;")
+
+        conn = c.sql_connection()
+        mz_system_conn = c.sql_connection(user="mz_system", port=6877)
+
+        def collect_notices(conn: Connection) -> list[str]:
+            collected: list[str] = []
+            conn.add_notice_handler(
+                lambda diag: collected.append(diag.message_primary or "")
+            )
+            return collected
+
+        notices = collect_notices(conn)
+        mz_system_notices = collect_notices(mz_system_conn)
+
+        def expect_notice(collected: list[str], cluster: str, sources: str) -> None:
+            expected = (
+                f'cluster "{cluster}" has more than one replica, but the following '
+                f"sources in it always run on only the first replica: {sources}"
+            )
+            assert (
+                expected in collected
+            ), f"expected notice {expected!r} in {collected!r}"
+            collected.clear()
+
+        def expect_no_notice(collected: list[str]) -> None:
+            unexpected = [n for n in collected if "run on only the first replica" in n]
+            assert not unexpected, f"unexpected notice(s): {unexpected!r}"
+            collected.clear()
+
+        size = f"scale={Materialized.Size.DEFAULT_SIZE},workers={Materialized.Size.DEFAULT_SIZE}"
+        with conn.cursor() as cur:
+            # Workflows in a CI shard share the Materialize catalog (the
+            # containers are recreated between workflows, but the mzdata volume
+            # survives), so drop any leftovers from earlier workflows or a
+            # previous run of this one.
+            cur.execute("DROP CONNECTION IF EXISTS pg CASCADE")
+            cur.execute("DROP SECRET IF EXISTS pgpass CASCADE")
+            cur.execute("DROP CLUSTER IF EXISTS c1 CASCADE")
+            cur.execute("DROP CLUSTER IF EXISTS c2 CASCADE")
+            cur.execute("DROP CLUSTER IF EXISTS c3 CASCADE")
+            notices.clear()
+
+            cur.execute("CREATE SECRET pgpass AS 'postgres'")
+            cur.execute(
+                "CREATE CONNECTION pg TO POSTGRES "
+                "(HOST postgres, DATABASE postgres, USER postgres, PASSWORD SECRET pgpass)"
+            )
+
+            # A source on a single-replica cluster emits no notice.
+            cur.execute(
+                f"CREATE CLUSTER c1 (SIZE '{size}', REPLICATION FACTOR 1)".encode()
+            )
+            cur.execute(
+                "CREATE SOURCE src1 IN CLUSTER c1 "
+                "FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')"
+            )
+            expect_no_notice(notices)
+
+            # Raising the replication factor of a cluster with such a source
+            # emits the notice.
+            cur.execute("ALTER CLUSTER c1 SET (REPLICATION FACTOR 2)")
+            expect_notice(notices, "c1", '"materialize.public.src1"')
+
+            # Lowering it again does not.
+            cur.execute("ALTER CLUSTER c1 SET (REPLICATION FACTOR 1)")
+            expect_no_notice(notices)
+
+            # Adding an unbilled replica to a managed cluster with such a
+            # source also emits the notice, to the internal session that
+            # created the replica.
+            with mz_system_conn.cursor() as system_cur:
+                system_cur.execute(
+                    f"CREATE CLUSTER REPLICA c1.free "
+                    f"(SIZE '{size}', BILLED AS 'free', INTERNAL)".encode()
+                )
+            expect_notice(mz_system_notices, "c1", '"materialize.public.src1"')
+            expect_no_notice(notices)
+            with mz_system_conn.cursor() as system_cur:
+                system_cur.execute("DROP CLUSTER REPLICA c1.free")
+
+            # Creating such a source on a cluster that already has two replicas
+            # emits the notice.
+            cur.execute(
+                f"CREATE CLUSTER c2 (SIZE '{size}', REPLICATION FACTOR 2)".encode()
+            )
+            expect_no_notice(notices)
+            cur.execute(
+                "CREATE SOURCE src2 IN CLUSTER c2 "
+                "FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')"
+            )
+            expect_notice(notices, "c2", '"materialize.public.src2"')
+
+            # Adding a replica to an unmanaged cluster with such a source emits
+            # the notice.
+            cur.execute(f"CREATE CLUSTER c3 REPLICAS (r1 (SIZE '{size}'))".encode())
+            cur.execute(
+                "CREATE SOURCE src3 IN CLUSTER c3 "
+                "FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')"
+            )
+            expect_no_notice(notices)
+            cur.execute(f"CREATE CLUSTER REPLICA c3.r2 (SIZE '{size}')".encode())
+            expect_notice(notices, "c3", '"materialize.public.src3"')
+
+            # The same for an unbilled replica taking an unmanaged cluster from
+            # one replica to two.
+            cur.execute("DROP CLUSTER REPLICA c3.r2")
+            expect_no_notice(notices)
+            with mz_system_conn.cursor() as system_cur:
+                system_cur.execute(
+                    f"CREATE CLUSTER REPLICA c3.free "
+                    f"(SIZE '{size}', BILLED AS 'free', INTERNAL)".encode()
+                )
+            expect_notice(mz_system_notices, "c3", '"materialize.public.src3"')
+
+
 def workflow_cdc(c: Composition, parser: WorkflowArgumentParser) -> None:
     pg_version = get_targeted_pg_version(parser)
 


### PR DESCRIPTION
Emit a pgwire notice whenever a command puts a cluster in a state where it has more than one replica while containing sources that run on only one replica (PostgreSQL, MySQL, SQL Server): raising the replication factor of a cluster with such a source, adding a replica to it, or creating such a source on a cluster that already has multiple replicas. The extra replicas do not make these sources more fault tolerant and do not increase their ingestion throughput, so call that out.

Tested by a new pg-cdc mzcompose workflow that captures notices over pgwire and checks all three directions plus negative cases.

Motivation: [incident-1223](https://materializeinc.slack.com/archives/C0BNF861537/p1786086542285139)

### Example

```
materialize=> ALTER CLUSTER oltp_cluster SET (REPLICATION FACTOR 2);
WARNING:  cluster "oltp_cluster" has more than one replica, but the following sources in it always run on only the first replica: "materialize.public.pg_orders"
DETAIL:  Adding replicas to the cluster does not make these sources more fault tolerant and does not increase their ingestion throughput.
HINT:  To achieve fault tolerance for other objects in the cluster, consider moving these sources to a separate cluster with a single replica.
ALTER CLUSTER
```