### PR TITLE
docs: point users to agent skills and MCP servers

### DIFF
--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -663,8 +663,9 @@ creating indexes, see [Index Best Practices](/concepts/indexes/#best-practices).
   - [MCP Server for agents](/integrations/mcp-server/mcp-agent/) to discover and
     query your data products.
 
-  - [MCP Server for developers](/integrations/mcp-server/mcp-developer/) to read
-    the `mz_*` system catalog tables for troubleshooting and observability.
+  - [MCP Server for developers](/integrations/mcp-server/mcp-developer/) to
+    troubleshoot and observe your deployment through the `mz_*` system catalog
+    tables, and to run queries on your objects.
 
 - For help getting started with your data or other questions about Materialize,
   you can schedule a [free guided

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -643,11 +643,29 @@ creating indexes, see [Index Best Practices](/concepts/indexes/#best-practices).
 
 [//]: # "TODO(morsapaes) Extend to suggest third party tools. dbt, Census and Metabase could all fit here to do interesting things as a follow-up."
 
-To get started ingesting your own data from an external system like Kafka, MySQL
-or PostgreSQL, check the documentation for [sources](/sql/create-source/), and
-navigate to **Data** > **Sources** > **New source** in the [Materialize Console](/console/)
-to create your first source.
+- To get started ingesting your own data from an external system like Kafka,
+  MySQL or PostgreSQL, check the documentation for
+  [sources](/sql/create-source/), and navigate to **Data** > **Sources** > **New
+  source** in the [Materialize Console](/console/) to create your first source.
 
-For help getting started with your data or other questions about Materialize,
-you can schedule a [free guided
-trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+- To have your coding agent (such as Claude Code, Codex, or Cursor) write more
+  accurate Materialize SQL, install the [Materialize agent
+  skills](/integrations/coding-agent-skills/). The skills give your agent access
+  to Materialize documentation and reference material:
+
+  ```bash
+  npx skills add MaterializeInc/agent-skills
+  ```
+
+- To let your agent query your data and inspect your deployment, connect it to
+  Materialize's built-in [MCP servers](/integrations/mcp-server/):
+
+  - [MCP Server for agents](/integrations/mcp-server/mcp-agent/) to discover and
+    query your data products.
+
+  - [MCP Server for developers](/integrations/mcp-server/mcp-developer/) to read
+    the `mz_*` system catalog tables for troubleshooting and observability.
+
+- For help getting started with your data or other questions about Materialize,
+  you can schedule a [free guided
+  trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).

--- a/doc/user/content/headless/mcp-servers-table.md
+++ b/doc/user/content/headless/mcp-servers-table.md
@@ -4,4 +4,4 @@ headless: true
 | Endpoint | Path | Description |
 |----------|------|-------------|
 | **Agent** | `/api/mcp/agent` | Discover and query your real-time data products over HTTP. <br>For details, see [MCP Server for agents](/integrations/mcp-server/mcp-agent/).<br>*Available starting in v26.24*|
-| **Developer** | `/api/mcp/developer` | Read `mz_*` system catalog tables for troubleshooting and observability. <br>For details, see [MCP Server for developer](/integrations/mcp-server/mcp-developer/).|
+| **Developer** | `/api/mcp/developer` | Read `mz_*` system catalog tables for troubleshooting and observability, and run queries on your objects. <br>For details, see [MCP Server for developer](/integrations/mcp-server/mcp-developer/).<br>*Running queries on your objects available starting in v26.30*|

--- a/doc/user/content/headless/mcp-servers-table.md
+++ b/doc/user/content/headless/mcp-servers-table.md
@@ -4,4 +4,4 @@ headless: true
 | Endpoint | Path | Description |
 |----------|------|-------------|
 | **Agent** | `/api/mcp/agent` | Discover and query your real-time data products over HTTP. <br>For details, see [MCP Server for agents](/integrations/mcp-server/mcp-agent/).<br>*Available starting in v26.24*|
-| **Developer** | `/api/mcp/developer` | Read `mz_*` system catalog tables for troubleshooting and observability, and run queries on your objects. <br>For details, see [MCP Server for developer](/integrations/mcp-server/mcp-developer/).<br>*Running queries on your objects available starting in v26.30*|
+| **Developer** | `/api/mcp/developer` | Read `mz_*` system catalog tables for troubleshooting and observability, and run queries on your objects. <br>For details, see [MCP Server for developer](/integrations/mcp-server/mcp-developer/). <br>*Available starting in v26.20*|

--- a/doc/user/content/integrations/mcp-server/_index.md
+++ b/doc/user/content/integrations/mcp-server/_index.md
@@ -15,11 +15,11 @@ aliases:
 
 ## Agent skills
 
-Materialize provides the following open-source [agent
-skills](https://github.com/MaterializeInc/agent-skills) to help developers build
-with Materialize.
-
-{{% include-headless "/headless/agent-skills-table" %}}
+Materialize provides open-source [agent
+skills](https://github.com/MaterializeInc/agent-skills) that give coding agents
+like Claude Code, Codex, and Cursor access to Materialize documentation and
+reference material. For the list of available skills and installation
+instructions, see [Agent Skills](/integrations/coding-agent-skills/).
 
 ## MCP servers
 


### PR DESCRIPTION
### Motivation

The quickstart's "Next steps" didn't mention our AI/agent surfaces, so a user
who just finished the tutorial had no pointer to the agent skills or the
built-in MCP servers. Separately, the "AI & agents" landing page duplicated the
skills table that already lives on the Agent Skills page, so the list had to be
kept in sync in two places.

### Description

`get-started/quickstart.md`: converted the "Next steps" prose into a list and
added two items, one for installing the Materialize agent skills (including the
`npx skills add` command) and one for connecting an agent to the built-in MCP
servers, linking both the agent and developer server pages. The existing
sources and guided-trial content stayed, now as list items.

`integrations/mcp-server/_index.md`: replaced the
`include-headless "/headless/agent-skills-table"` shortcode in the "Agent
skills" section with a short description and a link to
[Agent Skills](/integrations/coding-agent-skills/), which carries the same table
plus installation instructions. The headless partial is still used by the Agent
Skills page, so nothing was removed.

### Verification

Docs-only change. Ran `bin/format-docs` (no further changes) and checked that
every link target exists in the repo:
`integrations/coding-agent-skills.md`, `integrations/mcp-server/mcp-agent.md`,
and `integrations/mcp-server/mcp-developer.md`. The
`/integrations/coding-agent-skills/` path matches how other pages already link
to that page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVVzJwod8MvecAD65Ak1P4)_