### PR TITLE
helm-charts: drop unused clusterrolebindings grant from the operator

### DIFF
--- a/misc/helm-charts/operator/templates/clusterrole.yaml
+++ b/misc/helm-charts/operator/templates/clusterrole.yaml
@@ -59,7 +59,6 @@ rules:
   resources:
   - roles
   - rolebindings
-  - clusterrolebindings
   verbs:
   - create
   - update

--- a/misc/helm-charts/operator/tests/clusterrole_test.yaml
+++ b/misc/helm-charts/operator/tests/clusterrole_test.yaml
@@ -23,6 +23,15 @@ tests:
             apiGroups: [""]
             resources: ["configmaps", "persistentvolumeclaims", "pods", "namespaces", "secrets", "serviceaccounts", "services"]
             verbs: ["create", "update", "patch", "delete", "get", "list", "watch"]
+      # The operator only ever creates namespaced RBAC. Granting it
+      # clusterrolebindings would let it hand its own permissions to any
+      # subject in the cluster.
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["rbac.authorization.k8s.io"]
+            resources: ["roles", "rolebindings"]
+            verbs: ["create", "update", "patch", "delete", "get", "list", "watch"]
 
   - it: should not create a clusterrole when RBAC is disabled
     set:


### PR DESCRIPTION
Removes `clusterrolebindings` from the operator's ClusterRole. The rule keeps `roles` and `rolebindings`, which the operator does use.

```diff
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources:
   - roles
   - rolebindings
-  - clusterrolebindings
   verbs:
```

### Motivation

The permission is unused and has been since **e47f05c521** ("Do not create ClusterRoleBinding in orchestratord", 2024-10-17), which removed the code that created them but left the grant behind in the chart.

Nothing has needed it since. `ClusterRoleBinding` does not appear anywhere in `src/` — the operator's RBAC handling is namespaced only, in `src/orchestratord/src/controller/materialize/global.rs`, which creates a `Role` and a `RoleBinding` per environment. The chart's own ClusterRoleBinding (`templates/clusterrolebinding.yaml`) is created by Helm at install time, not by the operator at runtime, so it does not depend on this grant either.

It is worth removing rather than leaving as harmless dead config. With `clusterrolebindings: create`, the operator can bind its own permissions to any subject in the cluster — Kubernetes' privilege-escalation check permits granting permissions the grantor already holds. Since the operator holds cluster-wide write on `secrets`, `pods`, `namespaces`, and `serviceaccounts`, that is a meaningful lateral-movement primitive for anything that compromises the operator's service account, in exchange for functionality that no longer exists.

The neighbouring `clusterroles: bind` rule is already correctly scoped with `resourceNames: [environmentd]` and is untouched here.

Found while auditing operator RBAC for the Materialize Cloud environment isolation model.

### Description

One line removed from `templates/clusterrole.yaml`.

I also added an assertion to `tests/clusterrole_test.yaml` pinning the expected contents of that rule, so a future edit that re-adds `clusterrolebindings` fails the chart's unit tests rather than passing silently. The existing test only asserted the core-resources rule.

I did **not** bump `version` in `Chart.yaml`. `CONTRIBUTING.md` asks for a bump on every change, but the actual history of that file is exclusively `release: bump to version vX.Y.Z-dev.0` commits from release automation, and the current value tracks the Materialize version rather than independent SemVer. Happy to add a bump if that guidance is still live and I have read the convention backwards.

### Verification

* `helm lint .` passes. (It emits a pre-existing warning that `v26.38.0-dev.0` is not valid SemVerV2, unrelated to this change.)
* `helm template . --set rbac.create=true` renders the rule as `roles, rolebindings` with the same verbs, and no other rule changes.
* Confirmed by search that no Rust code references `ClusterRoleBinding`; the only `ClusterRole` symbols in the tree are `mz_controller::clusters::ClusterRole`, an unrelated Materialize concept.

### Rollout note

This is a permission removal, so it takes effect when the chart is upgraded, and there is no cleanup to do — the operator never created any ClusterRoleBindings to leave behind. Existing installs that upgrade will simply lose an unused grant.
