### PR TITLE
docs: address review on the dictionary compression page

### DIFF
--- a/doc/user/content/transform-data/dictionary-compression.md
+++ b/doc/user/content/transform-data/dictionary-compression.md
@@ -13,8 +13,9 @@ menu:
 Arrangement dictionary compression
 {{< /private-preview >}}
 
-Dictionary compression reduces the memory that [arrangements] use when a column
-holds the same values over and over. Instead of storing a repeated value in full
+Dictionary compression reduces the memory that
+[arrangements](/get-started/arrangements/#arrangements) use when a column holds
+the same values over and over. Instead of storing a repeated value in full
 once per row, Materialize stores that value once and has each row reference it.
 The values that repeat most often within a column are stored this way, and
 everything else is stored as-is, exactly as it would be without compression.
@@ -22,73 +23,11 @@ Compression is applied per column, so a wide row can have one column compressed
 and the rest untouched.
 
 Dictionary compression is **alpha** and is off by default. You opt in per
-cluster with the `EXPERIMENTAL ARRANGEMENT COMPRESSION` option. See [Enable
-dictionary compression](#enable-dictionary-compression).
-
-## The tradeoff
-
-Dictionary compression trades CPU for memory, and it does **not** reduce memory
-on every workload. Read this section before you turn it on, and [contact our
-team](/support/) if you have questions about whether it suits your workload.
-
-### What it helps
-
-- Columns that hold a small set of longer values that repeat often. Status
-  strings, enum-like labels, country codes, and tenant IDs are typical examples.
-  Essentially all of the savings come from columns like these. See [How distinct
-  values affect the benefit](#how-distinct-values-affect-the-benefit) for how the
-  benefit changes as that set grows.
-- Large arrangements. The larger the arrangement, the more occurrences of each
-  repeated value there are to collapse.
-
-Only data held in an arrangement is affected. That means [indexes] and the
-arrangements a dataflow builds internally for joins and aggregations (`GROUP BY`,
-`DISTINCT`). Data that is not arranged is untouched.
-
-### What it does not help
-
-- **High-cardinality or near-unique columns.** A value that never repeats is
-  never worth storing in a dictionary, so such a column sees no memory savings.
-  Materialize has no heuristic that detects this and skips the column. It
-  inspects every column of every row regardless, so a near-unique column pays
-  the full CPU cost for zero memory benefit. Large arrangements dominated by
-  unique identifiers, timestamps, or free-form text carry the cost without the
-  benefit.
-- **Columns of short values.** Booleans, `NULL`s, and small integers are already
-  stored compactly enough that a dictionary reference cannot beat storing the
-  value itself. They are never compressed.
-- **Small arrangements.** An arrangement built from scratch does not install a
-  dictionary until it has seen on the order of 65,000 rows. Small arrangements
-  are effectively unaffected.
-
-### The CPU cost
-
-The cost falls mainly on the write path. As updates arrive, Materialize has to
-track which values in each column repeat and maintain the dictionary. The most
-visible symptom is slower arrangement hydration. A replica in a cluster with
-compression enabled takes longer to build its arrangements after it is created,
-restarted, or resized.
-
-Reads pay a smaller but ongoing cost. Resolving a compressed value requires an
-extra indirection, and comparing compressed rows cannot use the fast path that
-uncompressed rows use.
-
-## How distinct values affect the benefit
-
-The memory benefit is largest when a column repeats a small set of values across
-many rows. It tapers off as the number of distinct values in a column grows past
-roughly 64, and with enough distinct values the bookkeeping becomes overhead that
-buys no memory saving at all.
-
-This is not a limit. Nothing breaks when a column holds more distinct values
-than that. Values that are not worth storing in a dictionary, including values
-that appear only once, are stored as-is. The result is less memory saved, and
-nothing else changes.
+cluster with the `EXPERIMENTAL ARRANGEMENT COMPRESSION` option.
 
 ## Enable dictionary compression
 
-Dictionary compression is controlled by the cluster option `EXPERIMENTAL
-ARRANGEMENT COMPRESSION`, which defaults to off. Set it on each cluster whose
+Set the `EXPERIMENTAL ARRANGEMENT COMPRESSION` option on each cluster whose
 arrangements you want compressed. No other setting is involved.
 
 ### Set the option on a cluster
@@ -128,6 +67,66 @@ The option is configured on the cluster, but the arrangements it applies to live
 in the cluster's replicas, in each replica's memory. A replica picks up the
 configured value when it is created and holds it for its lifetime.
 
+## The tradeoff
+
+Dictionary compression trades CPU for memory, and it does **not** reduce memory
+on every workload. Use this section to judge whether it suits your workload, and
+[contact our team](/support/) if you have questions.
+
+### When it helps
+
+- Columns that hold a small set of longer values that repeat often. Status
+  strings, enum-like labels, country codes, and tenant IDs are typical examples.
+  Essentially all of the savings come from columns like these. See [How distinct
+  values affect the benefit](#how-distinct-values-affect-the-benefit) for how the
+  benefit changes as that set grows.
+- Large arrangements. The larger the arrangement, the more occurrences of each
+  repeated value there are to collapse.
+
+Only data held in an arrangement is affected. That means [indexes] and the
+arrangements a dataflow builds internally for joins and aggregations (`GROUP BY`,
+`DISTINCT`). Data that is not arranged is untouched.
+
+### When it does not help
+
+- **High-cardinality or near-unique columns.** A value that never repeats is
+  never worth storing in a dictionary, so such a column sees no memory savings.
+  Materialize has no heuristic that detects this and skips the column. It
+  inspects every column of every row regardless, so a near-unique column pays
+  the full CPU cost for zero memory benefit. Large arrangements dominated by
+  unique identifiers, timestamps, or free-form text carry the cost without the
+  benefit.
+- **Columns of short values.** Booleans, `NULL`s, and small integers are already
+  stored compactly enough that a dictionary reference cannot beat storing the
+  value itself. They are never compressed.
+- **Small arrangements.** An arrangement built from scratch does not install a
+  dictionary until it has seen on the order of 65,000 rows. Small arrangements
+  are effectively unaffected.
+
+### The CPU cost
+
+The cost falls mainly on the write path. As updates arrive, Materialize has to
+track which values in each column repeat and maintain the dictionary. The most
+visible symptom is slower arrangement hydration. A replica in a cluster with
+compression enabled takes longer to build its arrangements after it is created,
+restarted, or resized.
+
+Reads pay a smaller but ongoing cost. Resolving a compressed value requires an
+extra indirection, and comparing compressed rows cannot use the fast path that
+uncompressed rows use.
+
+## How distinct values affect the benefit
+
+The memory benefit is largest when a column repeats a small set of values across
+many rows. It tapers off as the number of distinct values in a column grows past
+roughly 64, and with enough distinct values the bookkeeping becomes overhead that
+buys no memory saving at all.
+
+This is not a limit. Nothing breaks when a column holds more distinct values
+than that. Values that are not worth storing in a dictionary, including values
+that appear only once, are stored as-is. The result is less memory saved, and
+nothing else changes.
+
 ## Observe the effect
 
 There is no metric or system catalog relation specific to dictionary
@@ -158,7 +157,6 @@ re-hydrates the cluster, wait until hydration has completed before you measure.
 - [`ALTER CLUSTER`](/sql/alter-cluster/)
 - [`SHOW CREATE CLUSTER`]
 
-[arrangements]: /get-started/arrangements/#arrangements
 [Arrangements]: /get-started/arrangements/
 [indexes]: /concepts/indexes/
 [`SHOW CREATE CLUSTER`]: /sql/show-create-cluster/


### PR DESCRIPTION
### Motivation

Addresses the four open review comments from @maheshwarip on
https://github.com/MaterializeInc/materialize/pull/38024. This PR targets that
PR's branch so the fixes land in it rather than as a competing page.

### Description

Four review comments, one file (`doc/user/content/transform-data/dictionary-compression.md`):

- **"Rephrase as: When it helps"** — `### What it helps` is now `### When it helps`.
- **"Rephrase as: When it does not help"** — `### What it does not help` is now
  `### When it does not help`.
- **"Link to the arrangements page"** — the first mention of arrangements in the
  opening paragraph was a reference-style link, which is invisible in a raw diff.
  It is now an explicit inline link to `/get-started/arrangements/#arrangements`,
  and the now-unused reference definition is dropped.
- **"Move this section above the section for 'The Tradeoff'"** —
  `## Enable dictionary compression`, with its `### Set the option on a cluster`
  subsection, the re-hydration warning, and the cluster-versus-replica paragraph,
  now sits directly after the intro and ahead of `## The tradeoff`. The page reads
  intro → how to turn it on → when it helps and what it costs → how distinct values
  affect the benefit → how to observe the effect.

Two wording follow-ons the move forced, both minimal:

- The intro's forward pointer to `#enable-dictionary-compression` is gone, since
  that section is now the very next thing on the page, as is the enablement
  section's opening line that restated "controlled by the cluster option ...
  defaults to off" (the sentence immediately above it already says that).
- "The tradeoff" opened with "Read this section before you turn it on", which
  no longer holds once enablement precedes it. It now reads "Use this section to
  judge whether it suits your workload."

No other prose changed, and no claim on the page was altered. The open
fact-check questions in the original PR description are untouched.

### Verification

- Read through the reordered page for broken cross-references. The in-page anchor
  `#how-distinct-values-affect-the-benefit` still resolves, `#arrangements` is a real
  heading on `/get-started/arrangements/`, and every remaining reference-style link
  definition is still used (`[Arrangements]`, `[indexes]`, `` [`SHOW CREATE CLUSTER`] ``,
  and the two `mz_introspection` ones).
- Confirmed nothing outside this file links to the page or to the two renamed
  anchors, so the heading renames break no inbound links.
- **`hugo` was not re-run**: it is not installed in this environment. The change is
  prose and section ordering only, with no new or edited shortcodes, so the build
  surface is unchanged from the clean `hugo --quiet` run reported on #38024.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x1x9sYXTsYAdbN8Hftqe5

---
_Generated by [Claude Code](https://claude.ai/code/session_016x1x9sYXTsYAdbN8Hftqe5)_