### PR TITLE
PGO build for releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6671,6 +6671,7 @@ dependencies = [
  "futures",
  "hyper 1.9.0",
  "hyper-util",
+ "libc",
  "mz-alloc",
  "mz-alloc-default",
  "mz-build-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -685,7 +685,7 @@ trivial_numeric_casts = "warn"
 unused_lifetimes = "warn"
 unused_macro_rules = "warn"
 unused_import_braces = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(stamped, coverage, nightly_doc_features, release, tokio_unstable, kani)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(stamped, coverage, nightly_doc_features, release, tokio_unstable, kani, pgo_instrument)'] }
 
 [workspace.lints.rustdoc]
 

--- a/bin/pgo-build
+++ b/bin/pgo-build
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# pgo-build - build PGO-optimized Materialize binaries.
+
+exec "$(dirname "$0")"/pyactivate -m materialize.cli.pgo_build "$@"

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -173,6 +173,7 @@ RUN gpg --dearmor < apt-llvm.asc > /etc/apt/keyrings/apt-llvm.gpg \
     && apt-get update \
     && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     clang-22 \
+    libclang-rt-22-dev \
     lld-22 \
     llvm-22 \
     && apt-get clean \

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -1256,6 +1256,12 @@ def move_build_to_lto(pipeline: Any, lto: bool) -> None:
             step["agents"]["queue"] = "builder-linux-x86_64"
         elif step.get("id") == "build-aarch64":
             step["agents"]["queue"] = "builder-linux-aarch64-mem"
+        else:
+            continue
+
+        # PGO takes a while
+        if "timeout_in_minutes" in step:
+            step["timeout_in_minutes"] *= 3
 
 
 def trim_builds(

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -15,6 +15,7 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+from ci.test import pgo
 from materialize import mzbuild, spawn, ui
 from materialize.ci_util.upload_debug_symbols_to_s3 import (
     DEBUGINFO_BINS,
@@ -27,7 +28,7 @@ from materialize.mzbuild import (
     ResolvedImage,
     RustIncrementalBuildFailure,
 )
-from materialize.rustc_flags import Sanitizer
+from materialize.rustc_flags import Pgo, Sanitizer
 from materialize.xcompile import Arch
 
 
@@ -46,6 +47,11 @@ def main() -> None:
             sanitizer=sanitizer,
             image_registry="materialize",
         )
+
+        # An LTO build is profile-guided, so it collects a profile of this
+        # exact source before building anything shippable.
+        if repo.rd.pgo == Pgo.optimize:
+            repo.rd.pgo_profile = pgo.train(repo.rd.profile)
 
         # Build and push any images that are not already available on Docker Hub,
         # so they are accessible to other build agents.

--- a/ci/test/pgo.py
+++ b/ci/test/pgo.py
@@ -1,0 +1,170 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Collect the profile that the LTO build optimizes against.
+
+An LTO build is profile-guided, so it has to produce its own profile first:
+this builds instrumented binaries, runs a workload against them, and merges
+what they leave behind. Nothing is carried between builds, so a profile can
+never go stale against the source it is applied to. Both builds share
+`target-xcompile` and their rustflags differ, so an LTO build ends up
+compiling the workspace twice.
+"""
+
+import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from materialize import MZ_ROOT, mzbuild, rustc_flags, spawn, ui
+from materialize.mzcompose.composition import Composition, Service
+from materialize.rustc_flags import Pgo
+from materialize.ui import UIError
+
+# The sqllogictest image is the only one that has to be built instrumented,
+# and it covers both halves of the profile: sqllogictest embeds environmentd,
+# so the adapter and optimizer code the environmentd binary is built from runs
+# in-process, and it spawns real clusterd replicas for the compute code. A
+# profile is keyed on function names, so counts from the embedded copy apply
+# to the same functions in the environmentd binary.
+IMAGE = "sqllogictest"
+
+# The mzbuild image behind the composition's default `postgres-metadata`
+# service, which serves persist consensus for the run.
+METADATA_IMAGE = "postgres"
+
+# Only the top level of the sqllogictest tree. The sqlite/ and cockroach/
+# trees below it are ports of other engines' suites, large enough to dominate
+# the run and skewed towards SQL parsing rather than the code we care about.
+TRAINING_FILES = "test/sqllogictest/*.slt"
+
+# Each worker takes one shard, so a run covers WORKERS/SHARDS of the files.
+# Training on all of them takes far longer than a build can spare, and PGO
+# needs to learn which code is hot, not to reach every branch. Every worker
+# is a full instrumented Materialize, so the worker count is bounded by
+# memory, not cores.
+WORKERS = 4
+SHARDS = 16
+
+# The two binaries a run profiles, sqllogictest and clusterd. Fewer means one
+# of them ran without leaving anything behind.
+EXPECTED_PROFILED_BINARIES = 2
+
+PROFDATA = MZ_ROOT / "target-xcompile" / "pgo.profdata"
+
+
+def train(profile: mzbuild.Profile) -> Path:
+    """Run the training workload and return the merged profile.
+
+    Instruments with the cargo profile the result will be applied to, so that
+    the binaries the counts come from are compiled like the ones that consume
+    them.
+    """
+    # An absolute root, as the mzcompose CLI uses. Services that bind-mount a
+    # generated file build the mount from the composition's path, and docker
+    # reads a relative source as a named volume rather than a bind mount.
+    repo = mzbuild.Repository(
+        MZ_ROOT,
+        profile=profile,
+        pgo=Pgo.instrument,
+        image_registry="materialize",
+    )
+
+    ui.section("Building instrumented images for PGO training")
+    # Only the images the training run actually starts. Nothing is published:
+    # an instrumented image is useful to nothing but the run it was built for,
+    # and it is far slower than the image whose name it shares. The metadata
+    # store holds no Rust, so it resolves to its ordinary tag and is pulled
+    # rather than built.
+    images = [repo.images[IMAGE], repo.images[METADATA_IMAGE]]
+    repo.resolve_dependencies(images).ensure(push=False)
+
+    composition = Composition(repo, IMAGE)
+    profile_dir = composition.path / rustc_flags.PGO_HOST_DIR
+    shutil.rmtree(profile_dir, ignore_errors=True)
+    profile_dir.mkdir(parents=True)
+    # The profile runtime creates the files itself, from whatever user the
+    # image runs as.
+    profile_dir.chmod(0o777)
+
+    files = sorted(str(path) for path in Path(".").glob(TRAINING_FILES))
+    if not files:
+        raise UIError(f"PGO training workload {TRAINING_FILES} matched no files")
+
+    ui.section(f"Training on {len(files)} sqllogictest files, {WORKERS} at a time")
+    try:
+        composition.up(
+            composition.metadata_store(),
+            *[Service(f"slt_{i + 1}", idle=True) for i in range(WORKERS)],
+        )
+        with ThreadPoolExecutor(max_workers=WORKERS) as executor:
+            futures = [
+                executor.submit(_train_worker, composition, shard, files)
+                for shard in range(WORKERS)
+            ]
+            for future in as_completed(futures):
+                # A worker that dies still leaves behind whatever it had
+                # written, and one crashing shard is not worth failing every
+                # release build over. The profile pool check below is what
+                # decides whether the run was usable.
+                try:
+                    future.result()
+                except Exception as e:
+                    print(f"PGO training worker failed, continuing: {e}")
+    finally:
+        try:
+            composition.down()
+        except Exception as e:
+            # Not worth failing a build over once the profiles are on disk.
+            # Log capture in particular fails outright against a container
+            # that was killed mid-run.
+            print(f"PGO training cleanup failed, continuing: {e}")
+
+    # `%m` expands to <binary signature>_<pool index>, behind the name of the
+    # service that wrote it, so distinct signatures are distinct binaries.
+    profraws = sorted(profile_dir.glob("*.profraw"))
+    binaries = {p.stem.rsplit("-", 1)[-1].split("_")[0] for p in profraws}
+    print(f"Collected {len(profraws)} profile(s) from {len(binaries)} binaries")
+    if len(binaries) < EXPECTED_PROFILED_BINARIES:
+        raise UIError(
+            f"PGO training profiled {len(binaries)} binaries, expected "
+            f"{EXPECTED_PROFILED_BINARIES}",
+            hint="A binary that leaves no profile is compiled as if all of it "
+            "were cold, which is worse than not applying PGO to it at all.",
+        )
+
+    ui.section("Merging profiles")
+    # Discards profiles truncated by a process that died mid-write, which a
+    # plain `llvm-profdata merge` would fail the whole merge over.
+    spawn.runv(["bin/ci-validate-profraws", PROFDATA], cwd=MZ_ROOT)
+    return PROFDATA
+
+
+def _train_worker(composition: Composition, shard: int, files: list[str]) -> None:
+    service = f"slt_{shard + 1}"
+    composition.exec(
+        service,
+        "sqllogictest",
+        # Training cares about which code runs, not about whether the
+        # assertions hold. Failing here would make every LTO build hostage to
+        # an unrelated SLT regression.
+        "--no-fail",
+        # Without a command wrapper the process orchestrator sends replicas
+        # SIGKILL, which no handler can catch, and the clusterd half of the
+        # profile is lost. `env` execs its argument in the same process, so it
+        # changes nothing but making the signal arrive.
+        "--orchestrator-process-wrapper=env",
+        f"--postgres-url=postgres://root@{composition.metadata_store()}:26257",
+        f"--prefix={service}",
+        f"--shard={shard}",
+        f"--shard-count={SHARDS}",
+        *files,
+        capture=True,
+        capture_stderr=True,
+    )
+    print(f"PGO training worker {service} finished")

--- a/misc/python/materialize/cli/gen-lints.py
+++ b/misc/python/materialize/cli/gen-lints.py
@@ -225,7 +225,7 @@ MESSAGE_LINT_INHERIT = "The lint section in {} does not inherit from the workspa
 
 EXCLUDE_CRATES: list[str] = []
 
-CHECK_CFGS = "stamped, coverage, nightly_doc_features, release, tokio_unstable, kani"
+CHECK_CFGS = "stamped, coverage, nightly_doc_features, release, tokio_unstable, kani, pgo_instrument"
 
 
 def main() -> None:

--- a/misc/python/materialize/cli/pgo_build.py
+++ b/misc/python/materialize/cli/pgo_build.py
@@ -1,0 +1,196 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Build profile-guided-optimization binaries.
+
+Two steps, with a training workload run between them:
+
+    bin/pgo-build instrument
+    <run a representative workload against the instrumented binaries>
+    bin/pgo-build optimize
+
+Only a process that exits through its exit handlers writes a usable profile,
+which is what `TRAINING_RUN_ARGS` below is about. A training run that skips it
+collects nothing from the cluster replicas, where most of the work happens.
+"""
+
+import argparse
+import os
+import shlex
+import shutil
+from pathlib import Path
+
+import toml
+
+from materialize import MZ_ROOT, rustc_flags, spawn
+
+TARGET_DIR = MZ_ROOT / "target"
+PGO_PROFILE_DIR = TARGET_DIR / "pgo"
+MERGED_PROFDATA = PGO_PROFILE_DIR / "merged.profdata"
+
+DEFAULT_BINS = ["environmentd", "clusterd"]
+
+# Training runs must reach the binaries through a command wrapper, because the
+# process orchestrator only sends SIGTERM to replicas when one is configured
+# and otherwise goes straight to SIGKILL. `env` execs its argument in the same
+# process, so it changes nothing except making the signal arrive.
+TRAINING_RUN_ARGS = "--orchestrator-process-wrapper=env"
+
+
+def host_triple() -> str:
+    for line in spawn.capture(["rustc", "-vV"]).splitlines():
+        if line.startswith("host: "):
+            return line.removeprefix("host: ")
+    raise RuntimeError("could not determine host triple from `rustc -vV`")
+
+
+def base_rustflags(triple: str) -> list[str]:
+    """Compute the rustflags that would apply to a normal build.
+
+    Setting the RUSTFLAGS environment variable makes cargo ignore every
+    rustflags entry in .cargo/config.toml, so to append flags we must
+    replicate the flags that would otherwise apply. Cargo uses the first
+    match of: the RUSTFLAGS environment variable, target.<triple>.rustflags,
+    build.rustflags.
+    """
+    env_flags = os.environ.get("RUSTFLAGS")
+    if env_flags is not None:
+        return shlex.split(env_flags)
+    config = toml.load(MZ_ROOT / ".cargo" / "config.toml")
+    target_flags = config.get("target", {}).get(triple, {}).get("rustflags")
+    if target_flags is not None:
+        return list(target_flags)
+    return list(config.get("build", {}).get("rustflags", []))
+
+
+def cargo_build(
+    args: argparse.Namespace, extra_rustflags: list[str], triple: str
+) -> list[Path]:
+    env = dict(
+        os.environ,
+        RUSTFLAGS=" ".join(base_rustflags(triple) + extra_rustflags),
+    )
+    # Pass --target explicitly even though we only build for the host. With an
+    # explicit target, cargo applies RUSTFLAGS only to target artifacts,
+    # keeping build scripts and proc macros out of the instrumented build, and
+    # puts those artifacts under target/<triple>/, where they do not displace
+    # an ordinary `cargo build`.
+    cmd = ["cargo", "build", "--profile", args.cargo_profile, "--target", triple]
+    for bin in args.bins:
+        cmd += ["--bin", bin]
+    spawn.runv(cmd, cwd=MZ_ROOT, env=env)
+    out_profile = "debug" if args.cargo_profile == "dev" else args.cargo_profile
+    return [TARGET_DIR / triple / out_profile / bin for bin in args.bins]
+
+
+def find_profdata(triple: str) -> Path | str:
+    """Find an llvm-profdata that matches rustc's LLVM version.
+
+    The profraw format is not stable across LLVM versions, so prefer the
+    tools shipped with the toolchain over whatever is on the PATH.
+    """
+    sysroot = Path(spawn.capture(["rustc", "--print", "sysroot"]).strip())
+    tool = sysroot / "lib" / "rustlib" / triple / "bin" / "llvm-profdata"
+    if tool.exists():
+        return tool
+    for name in ["rust-profdata", "llvm-profdata"]:
+        if shutil.which(name):
+            return name
+    raise SystemExit(
+        "error: llvm-profdata not found\n"
+        "hint: run `rustup component add llvm-tools` to install it"
+    )
+
+
+def do_instrument(args: argparse.Namespace) -> None:
+    triple = host_triple()
+    PGO_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+    for stale in PGO_PROFILE_DIR.glob("*.profraw"):
+        stale.unlink()
+    bins = cargo_build(args, rustc_flags.pgo_generate(str(PGO_PROFILE_DIR)), triple)
+    print("\nInstrumented binaries:")
+    for bin in bins:
+        print(f"  {bin}")
+    print(
+        "\nRun a representative workload against them. Profiles are written to\n"
+        f"  {PGO_PROFILE_DIR}\n"
+        "automatically, one merge pool per binary. Then run\n"
+        "`bin/pgo-build optimize`.\n"
+        "\n"
+        "IMPORTANT: pass\n"
+        f"  {TRAINING_RUN_ARGS}\n"
+        "to the workload, or cluster replicas contribute no profile. Check\n"
+        "that the pool count matches the number of instrumented binaries\n"
+        "before trusting a training run: a missing pool means that binary\n"
+        "gets built as if every function in it were cold, which is worse\n"
+        "than not applying PGO to it at all."
+    )
+
+
+def do_optimize(args: argparse.Namespace) -> None:
+    triple = host_triple()
+    profraws = sorted(PGO_PROFILE_DIR.glob("*.profraw"))
+    if not profraws:
+        raise SystemExit(
+            f"error: no .profraw files in {PGO_PROFILE_DIR}\n"
+            "hint: run `bin/pgo-build instrument` and exercise the "
+            "instrumented binaries first"
+        )
+    if len(profraws) < len(args.bins):
+        print(
+            f"warning: {len(profraws)} profile pool(s) for {len(args.bins)} "
+            "binaries. A binary with no profile is built as if all of it were "
+            "cold, which is worse than not applying PGO to it at all.\nfound: "
+            + ", ".join(p.name for p in profraws)
+        )
+    spawn.runv(
+        [find_profdata(triple), "merge", "-o", MERGED_PROFDATA, *profraws],
+        cwd=MZ_ROOT,
+    )
+    bins = cargo_build(args, rustc_flags.pgo_use(MERGED_PROFDATA), triple)
+    print("\nPGO-optimized binaries:")
+    for bin in bins:
+        print(f"  {bin}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="pgo-build",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__,
+    )
+    parser.add_argument(
+        "--bin",
+        dest="bins",
+        action="append",
+        metavar="NAME",
+        help=f"binary to build (default: {', '.join(DEFAULT_BINS)})",
+    )
+    parser.add_argument(
+        "--cargo-profile",
+        default="release",
+        help="cargo profile to build with (default: %(default)s)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    p = subparsers.add_parser(
+        "instrument", help="build binaries instrumented for PGO profile collection"
+    )
+    p.set_defaults(func=do_instrument)
+    p = subparsers.add_parser(
+        "optimize", help="merge collected profiles and rebuild with PGO"
+    )
+    p.set_defaults(func=do_optimize)
+    args = parser.parse_args()
+    if args.bins is None:
+        args.bins = DEFAULT_BINS
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -48,7 +48,7 @@ from requests.auth import HTTPBasicAuth
 
 from materialize import MZ_ROOT, cargo, git, rustc_flags, spawn, ui, xcompile
 from materialize.docker import image_registry
-from materialize.rustc_flags import Sanitizer
+from materialize.rustc_flags import Pgo, Sanitizer
 from materialize.xcompile import Arch, target
 
 GHCR_PREFIX = "ghcr.io/materializeinc/"
@@ -185,6 +185,12 @@ class RepositoryDetails:
         coverage: Whether the repository has code coverage instrumentation
             enabled.
         sanitizer: Whether to use a sanitizer (address, hwaddress, cfi, thread, leak, memory, none)
+        pgo: What role this build plays in the profile-guided-optimization
+            cycle. Derived from the other settings when not given.
+        pgo_profile: The profile a `Pgo.optimize` build compiles against, set
+            once the training run that produces it has finished. The one
+            mutable field: it cannot be known at construction time, since
+            training needs a `Pgo.instrument` repository of its own.
         cargo_workspace: The `cargo.Workspace` associated with the repository.
         image_registry: The Docker image registry to pull images from and push
             images to.
@@ -200,12 +206,24 @@ class RepositoryDetails:
         sanitizer: Sanitizer,
         image_registry: str,
         image_prefix: str,
+        pgo: Pgo | None = None,
+        pgo_profile: Path | None = None,
     ):
         self.root = root
         self.arch = arch
         self.profile = profile
         self.coverage = coverage
         self.sanitizer = sanitizer
+        if pgo is None:
+            pgo = (
+                Pgo.optimize
+                if profile == Profile.RELEASE
+                and not coverage
+                and sanitizer == Sanitizer.none
+                else Pgo.none
+            )
+        self.pgo = pgo
+        self.pgo_profile = pgo_profile
         self.cargo_workspace = cargo.Workspace(root)
         self.image_registry = image_registry
         self.image_prefix = image_prefix
@@ -630,6 +648,13 @@ class CargoPreImage(PreImage):
             flags += "coverage"
         if self.rd.sanitizer != Sanitizer.none:
             flags += self.rd.sanitizer.value
+        # The PGO mode, and not the profile it was built against: the
+        # fingerprint has to be known before the build that produces the
+        # profile has run. Two training runs of one commit therefore produce
+        # different binaries under the same tag, as any other nondeterminism
+        # in the build would.
+        if self.rd.pgo != Pgo.none:
+            flags += [str(self.rd.pgo)]
         flags.sort()
         return ",".join(flags)
 
@@ -723,6 +748,14 @@ class CargoBuild(CargoPreImage):
                 "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER": "/usr/local/bin/clang-lld-22",
                 "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER": "/usr/local/bin/clang-lld-22",
             }
+
+        # PGO rides on the LTO configuration above rather than replacing any of
+        # it, so that the binaries a profile is collected from are compiled the
+        # same way as the binaries it is applied to.
+        if rd.pgo == Pgo.instrument:
+            rustflags += rustc_flags.pgo_generate()
+        elif rd.pgo == Pgo.optimize and rd.pgo_profile is not None:
+            rustflags += rustc_flags.pgo_use(rd.pgo_profile)
 
         cargo_build = rd.build(
             "build", channel=None, rustflags=rustflags, extra_env=extra_env
@@ -1440,7 +1473,11 @@ class DependencySet:
         for dep in deps_to_build:
             dep.build(prep)
 
-    def ensure(self, pre_build: Callable[[list[ResolvedImage]], None] | None = None):
+    def ensure(
+        self,
+        pre_build: Callable[[list[ResolvedImage]], None] | None = None,
+        push: bool = True,
+    ):
         """Ensure all publishable images in this dependency set exist on Docker
         Hub.
 
@@ -1451,6 +1488,9 @@ class DependencySet:
                        to be built locally, invoked after their cargo build is
                        done, but before the Docker images are build and
                        uploaded to DockerHub.
+            push: Whether to publish what was built. Pass `False` for images
+                  that exist only to serve this build, such as the
+                  instrumented images a PGO training run is collected from.
         """
         num_deps = len(list(self))
         if not num_deps:
@@ -1486,7 +1526,7 @@ class DependencySet:
                 time.sleep(0.01)
             for attempts_remaining in reversed(range(3)):
                 try:
-                    dep.build(prep, push=dep.publish)
+                    dep.build(prep, push=dep.publish and push)
                     with lock:
                         built_deps.add(dep.name)
                     break
@@ -1537,6 +1577,8 @@ class Repository:
         image_registry: The Docker image registry to pull images from and push
             images to.
         image_prefix: A prefix to apply to all Docker image names.
+        pgo: What role this build plays in the profile-guided-optimization
+            cycle. Derived from the other settings when not given.
 
     Attributes:
         images: A mapping from image name to `Image` for all contained images.
@@ -1554,6 +1596,7 @@ class Repository:
         sanitizer: Sanitizer = Sanitizer.none,
         image_registry: str = image_registry(),
         image_prefix: str = "",
+        pgo: Pgo | None = None,
     ):
         self.rd = RepositoryDetails(
             root,
@@ -1563,6 +1606,7 @@ class Repository:
             sanitizer,
             image_registry,
             image_prefix,
+            pgo,
         )
         self.images: dict[str, Image] = {}
         self.compositions: dict[str, Path] = {}

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -49,7 +49,7 @@ import yaml
 from psycopg import Connection, Cursor
 from psycopg.sql import Composed
 
-from materialize import MZ_ROOT, buildkite, mzbuild, spawn, ui
+from materialize import MZ_ROOT, buildkite, mzbuild, rustc_flags, spawn, ui
 from materialize.docker import image_registry
 from materialize.mzcompose import cluster_replica_size_map, loader
 from materialize.mzcompose.service import Service as MzComposeService
@@ -65,6 +65,7 @@ from materialize.mzcompose.test_result import (
     try_determine_errors_from_cmd_execution,
 )
 from materialize.parallel_workload.worker_exception import WorkerFailedException
+from materialize.rustc_flags import Pgo
 from materialize.ui import (
     CommandFailureCausedUIError,
     UIError,
@@ -341,6 +342,29 @@ class Composition:
                         break
                 else:
                     config.setdefault("environment", []).append(llvm_profile_file)
+
+            if self.repo.rd.pgo == Pgo.instrument:
+                # Keep the profiles that instrumented binaries write to the
+                # compiled-in `PGO_PROFILE_DIR`.
+                pgo_volume = (
+                    f"./{rustc_flags.PGO_HOST_DIR}:{rustc_flags.PGO_PROFILE_DIR}"
+                )
+                if pgo_volume not in config.get("volumes", []):
+                    config.setdefault("volumes", []).append(pgo_volume)
+
+                # `%m` is one merge pool per binary, which is what lets a
+                # service's many clusterd replicas accumulate into a single
+                # profile. Naming the service as well keeps concurrent
+                # services out of each other's pool: they share the bind
+                # mount, and a merge that loses the race is dropped with
+                # "Invalid profile data to merge", not retried.
+                config["environment"] = [
+                    env
+                    for env in config.get("environment", [])
+                    if not env.startswith("LLVM_PROFILE_FILE=")
+                ] + [
+                    f"LLVM_PROFILE_FILE={rustc_flags.PGO_PROFILE_DIR}/{name}-%m.profraw"
+                ]
 
         if self.resolve_image_specs:
             deps = self.repo.resolve_dependencies(images)

--- a/misc/python/materialize/rustc_flags.py
+++ b/misc/python/materialize/rustc_flags.py
@@ -8,8 +8,41 @@
 # by the Apache License, Version 2.0.
 
 from enum import Enum
+from pathlib import Path
 
 """rustc flags."""
+
+
+class Pgo(Enum):
+    """What role a build plays in the profile-guided-optimization cycle."""
+
+    instrument = "instrument"
+    optimize = "optimize"
+    none = "none"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+# Host directory the profiles land in, relative to the composition running the
+# training workload, and the path it is bind-mounted to. `-Cprofile-generate`
+# bakes the latter into the binary, so it is a path inside whatever container
+# the binary later runs in, not one on the build host.
+PGO_HOST_DIR = "pgo"
+PGO_PROFILE_DIR = f"/{PGO_HOST_DIR}"
+
+
+def pgo_generate(profile_dir: str = PGO_PROFILE_DIR) -> list[str]:
+    # `--cfg=pgo_instrument` compiles the shutdown hook that lets a
+    # signal-terminated clusterd flush its profile. Cluster replicas run the
+    # large majority of the CPU work, so without the hook the profile covers
+    # only a small share of it.
+    return [f"-Cprofile-generate={profile_dir}", "--cfg=pgo_instrument"]
+
+
+def pgo_use(profdata: Path) -> list[str]:
+    return [f"-Cprofile-use={profdata}"]
+
 
 # Flags to enable code coverage.
 #

--- a/misc/wasm/Cargo.toml
+++ b/misc/wasm/Cargo.toml
@@ -19,7 +19,7 @@ trivial_numeric_casts = "warn"
 unused_lifetimes = "warn"
 unused_macro_rules = "warn"
 unused_import_braces = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(stamped, coverage, nightly_doc_features, release, tokio_unstable, kani)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(stamped, coverage, nightly_doc_features, release, tokio_unstable, kani, pgo_instrument)'] }
 
 [workspace.lints.rustdoc]
 

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -17,6 +17,7 @@ fail.workspace = true
 futures.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
+libc.workspace = true
 mz-alloc = { path = "../alloc" }
 mz-alloc-default = { path = "../alloc-default", optional = true }
 mz-build-info = { path = "../build-info" }

--- a/src/clusterd/src/lib.rs
+++ b/src/clusterd/src/lib.rs
@@ -190,6 +190,38 @@ fn process_ordinal_from_hostname(hostname: &str) -> Option<&str> {
 pub fn main() {
     mz_ore::panic::install_enhanced_handler();
 
+    // Exit normally on SIGTERM so that a PGO-instrumented build flushes its
+    // profile. The profile runtime writes counters from an exit handler, and
+    // the process orchestrator terminates replicas by signal, whose default
+    // action skips those handlers. Without this a profiled replica
+    // contributes no profile at all, which matters because the replicas, not
+    // the parent process, run the large majority of the CPU work.
+    //
+    // Compiled only into instrumented builds, so production shutdown
+    // behavior is unchanged. This is one half of the requirement. The other
+    // is that the orchestrator has to send SIGTERM at all, which it only does
+    // when a command wrapper is configured (`send_sigterm` in
+    // `mz_orchestrator_process` is `!command_wrapper.is_empty()`). With no
+    // wrapper it goes straight to SIGKILL, which cannot be caught.
+    #[cfg(pgo_instrument)]
+    {
+        extern "C" fn exit_for_profile(_: std::ffi::c_int) {
+            // Not async-signal-safe, since it runs the exit handlers that
+            // write the profile. That is the entire point, and this build
+            // exists only to collect profiles.
+            std::process::exit(0);
+        }
+        // SAFETY: called before any threads are spawned. The panic hook
+        // installed above only spawns a thread on panic, which cannot have
+        // happened yet.
+        unsafe {
+            libc::signal(
+                libc::SIGTERM,
+                exit_for_profile as *const () as libc::sighandler_t,
+            );
+        }
+    }
+
     // Pin the rustls crypto provider to aws-lc-rs. The LaunchDarkly SDK uses
     // hyper-rustls, so building its client resolves the process-default rustls
     // provider. The workspace also links rustls' `ring` feature (pulled by

--- a/src/ore/src/stack.rs
+++ b/src/ore/src/stack.rs
@@ -63,7 +63,7 @@ pub const STACK_RED_ZONE: usize = {
     }
     #[cfg(not(debug_assertions))]
     {
-        64 << 10 // 64KiB
+        128 << 10 // 128KiB
     }
 };
 


### PR DESCRIPTION
Adds a driver for building PGO-optimized `environmentd` and `clusterd`, plus the
one product change PGO needs before it can collect a usable profile.

```
bin/pgo-build instrument
<run a representative workload against the instrumented binaries>
bin/pgo-build optimize
```

Not enough effect for my taste, so I'll close this again:
```
  ┌─────────────────────────────┬────────────┬─────┬─────────┬──────────────┬────────────┬───────────┐
  │      Benchmark family       │   Metric   │  n  │  Wins   │   Geomean    │   95% CI   │ Wilcoxon  │
  │                             │            │     │         │    effect    │            │     p     │
  ├─────────────────────────────┼────────────┼─────┼─────────┼──────────────┼────────────┼───────────┤
  │ Scalability — SQL workloads │ TPS        │ 90  │ 73      │ +3.16%       │ +1.7% …    │ 6.6e-07   │
  │                             │            │     │ (81%)   │              │ +4.8%      │           │
  ├─────────────────────────────┼────────────┼─────┼─────────┼──────────────┼────────────┼───────────┤
  │ Scalability — all points    │ TPS        │ 123 │ 87      │ +2.21%       │ +1.0% …    │ 2.0e-06   │
  │                             │            │     │ (71%)   │              │ +3.5%      │           │
  ├─────────────────────────────┼────────────┼─────┼─────────┼──────────────┼────────────┼───────────┤
  │ Scalability — per-workload  │ TPS        │ 15  │ 13      │ +2.37%       │ +1.2% …    │ 4.1e-03   │
  │ rollup                      │            │     │ (87%)   │              │ +3.8%      │           │
  ├─────────────────────────────┼────────────┼─────┼─────────┼──────────────┼────────────┼───────────┤
  │ Scalability — connection    │ TPS        │ 33  │ 14      │ −0.34%       │ −2.1% …    │ 0.54      │
  │ setup                       │            │     │ (42%)   │              │ +1.3%      │           │
  ├─────────────────────────────┼────────────┼─────┼─────────┼──────────────┼────────────┼───────────┤
  │ Feature benchmark           │ wallclock  │ 86  │ 35      │ median       │ −1.0% …    │ 0.21      │
  │                             │            │     │ (41%)   │ −0.95%       │ +5.8%      │           │
  ├─────────────────────────────┼────────────┼─────┼─────────┼──────────────┼────────────┼───────────┤
  │ Feature benchmark           │ envd       │ 91  │ 43      │ −0.14%       │ −0.8% …    │ 0.64      │
  │                             │ memory     │     │ (47%)   │              │ +0.5%      │           │
  ├─────────────────────────────┼────────────┼─────┼─────────┼──────────────┼────────────┼───────────┤
  │ Parallel benchmark          │ p50        │ 31  │ 17      │ −1.19%       │ −4.1% …    │ 0.78      │
  │                             │ latency    │     │ (55%)   │              │ +1.6%      │           │
  └─────────────────────────────┴────────────┴─────┴─────────┴──────────────┴────────────┴───────────┘
```
based on https://buildkite.com/materialize/nightly/builds/18059