### PR TITLE
expr: bound the memory a webhook CHECK may allocate (SQL-431)

### DIFF
--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -316,11 +316,15 @@ SELECT COUNT(body) FROM webhook_source_ndjson;
 
 Webhook sources apply the following limits to received requests:
 
-* The maximum size of the request body is **`2MB`**. Requests larger than this
+* The maximum size of the request body is **`5MB`**. Requests larger than this
   will fail with `413 Payload Too Large`.
 * The maximum number of concurrent requests across **all** webhook sources
   is **500**. Trying to connect when the server is at capacity will fail with
   `429 Too Many Requests`.
+* A `CHECK` expression may use at most **`20MB`** of temporary memory while
+  validating a single request. A `CHECK` that needs more, for example one that
+  builds a large string out of the request body, will fail with
+  `400 Bad Request`.
 * Requests that contain a header name specified more than once will be rejected
   with `401 Unauthorized`.
 

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -767,6 +767,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "mcp_request_timeout",
     "user_id_pool_batch_size",
     "webhook_max_request_size_bytes",
+    "webhook_validation_memory_budget_bytes",
     "cluster_controller_tick_interval",
     "default_cluster_reconfiguration_timeout",
     "read_then_write_max_dependencies",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3057,6 +3057,15 @@ class FlipFlagsAction(Action):
             "5242880",
             "10485760",
         ]
+        # The CHECK expressions this workload generates allocate at most a few
+        # bytes of temporary storage, well under the 1 MiB floor here, so none of
+        # these values can make one fail.
+        self.flags_with_values["webhook_validation_memory_budget_bytes"] = [
+            # 1 MiB, 20 MiB (default), 100 MiB
+            "1048576",
+            "20971520",
+            "104857600",
+        ]
         self.flags_with_values["aws_prefetch_sts_connect_timeout"] = [
             "'3100ms'",
             "'30s'",

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -280,13 +280,16 @@ pub const WEBHOOK_MAX_REQUEST_SIZE_BYTES: Config<usize> = Config::new(
 /// validating one request. A `CHECK` that exceeds it fails the request with HTTP
 /// 400 rather than holding the memory.
 ///
-/// This exists because a `CHECK` can allocate a multiple of the request body,
-/// and `environmentd` evaluates one per in-flight request: without a bound
-/// proportionate to the request, a bounded amount of network input becomes an
-/// unbounded amount of heap on a process shared by every connection. The default
-/// is 4x `WEBHOOK_MAX_REQUEST_SIZE_BYTES`, far above what a realistic `CHECK`
-/// (an HMAC, a `decode`, a `concat` with a secret) needs, and well below the
-/// 100 MiB per-call ceiling that applies in a cluster.
+/// A `CHECK` can allocate a multiple of the request body, and `environmentd`
+/// evaluates one per in-flight request. Without a bound proportionate to the
+/// request, bounded network input becomes unbounded heap on a process shared by
+/// every connection. The default is 4x `WEBHOOK_MAX_REQUEST_SIZE_BYTES`, well
+/// above what a realistic `CHECK` (an HMAC, a `decode`, a `concat` with a
+/// secret) needs and well below the 100 MiB per-call ceiling used in a cluster.
+///
+/// NOTE: this is runtime-reconfigurable, so it must only bound a single webhook
+/// validation. Do not feed it (or any mutable budget) to a `RowArena` used in a
+/// compute dataflow (see `mz_repr::RowArena::with_budget`).
 pub const WEBHOOK_VALIDATION_MEMORY_BUDGET_BYTES: Config<usize> = Config::new(
     "webhook_validation_memory_budget_bytes",
     20 * 1024 * 1024,

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -276,6 +276,23 @@ pub const WEBHOOK_MAX_REQUEST_SIZE_BYTES: Config<usize> = Config::new(
     "The maximum size in bytes of a webhook request body, measured after decompression.",
 );
 
+/// Maximum temporary storage a webhook `CHECK` expression may allocate while
+/// validating one request. A `CHECK` that exceeds it fails the request with HTTP
+/// 400 rather than holding the memory.
+///
+/// This exists because a `CHECK` can allocate a multiple of the request body,
+/// and `environmentd` evaluates one per in-flight request: without a bound
+/// proportionate to the request, a bounded amount of network input becomes an
+/// unbounded amount of heap on a process shared by every connection. The default
+/// is 4x `WEBHOOK_MAX_REQUEST_SIZE_BYTES`, far above what a realistic `CHECK`
+/// (an HMAC, a `decode`, a `concat` with a secret) needs, and well below the
+/// 100 MiB per-call ceiling that applies in a cluster.
+pub const WEBHOOK_VALIDATION_MEMORY_BUDGET_BYTES: Config<usize> = Config::new(
+    "webhook_validation_memory_budget_bytes",
+    20 * 1024 * 1024,
+    "The maximum bytes of temporary storage a webhook CHECK expression may allocate while validating one request.",
+);
+
 /// Number of user IDs to pre-allocate in a batch. Pre-allocating IDs avoids
 /// a persist write + oracle call per DDL statement.
 pub const USER_ID_POOL_BATCH_SIZE: Config<u32> = Config::new(
@@ -445,6 +462,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&MCP_MAX_RESPONSE_SIZE)
         .add(&MCP_REQUEST_TIMEOUT)
         .add(&WEBHOOK_MAX_REQUEST_SIZE_BYTES)
+        .add(&WEBHOOK_VALIDATION_MEMORY_BUDGET_BYTES)
         .add(&USER_ID_POOL_BATCH_SIZE)
         .add(&GROUP_COMMIT_MAX_ATTEMPTS)
         .add(&CONSOLE_OIDC_CLIENT_ID)

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -474,6 +474,7 @@ fn eval_error_code(err: &EvalError) -> SqlState {
         EvalError::StringValueTooLong { .. } => SqlState::STRING_DATA_RIGHT_TRUNCATION,
         EvalError::LikePatternTooLong
         | EvalError::LengthTooLarge
+        | EvalError::TempStorageBudgetExceeded
         | EvalError::NullCharacterNotPermitted
         | EvalError::MaxArraySizeExceeded(_)
         | EvalError::LetRecLimitExceeded(_) => SqlState::PROGRAM_LIMIT_EXCEEDED,

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -76,11 +76,17 @@ impl AppendWebhookValidator {
         }
     }
 
+    /// Runs the validation expression against one request.
+    ///
+    /// `memory_budget` caps the temporary storage the expression may allocate. The expression is
+    /// user-authored and runs in `environmentd`, so without a cap proportionate to the request one
+    /// `CHECK` can turn a bounded body into an unbounded amount of heap on a shared process.
     pub async fn eval(
         self,
         body: bytes::Bytes,
         headers: Arc<BTreeMap<String, String>>,
         received_at: DateTime<Utc>,
+        memory_budget: usize,
     ) -> Result<bool, AppendWebhookError> {
         let AppendWebhookValidator {
             validation,
@@ -125,9 +131,7 @@ impl AppendWebhookValidator {
         // work.
         let validate = move || {
             // Gather our Datums for evaluation
-            //
-            // TODO(parkmycar): Re-use the RowArena when we implement rate limiting.
-            let temp_storage = RowArena::default();
+            let temp_storage = RowArena::with_budget(memory_budget);
             let mut datums = Vec::with_capacity(
                 body_columns.len() + header_columns.len() + secret_contents.len(),
             );

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -26,7 +26,9 @@ use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use bytes::Bytes;
 use http::StatusCode;
-use mz_adapter_types::dyncfgs::WEBHOOK_MAX_REQUEST_SIZE_BYTES;
+use mz_adapter_types::dyncfgs::{
+    WEBHOOK_MAX_REQUEST_SIZE_BYTES, WEBHOOK_VALIDATION_MEMORY_BUDGET_BYTES,
+};
 use thiserror::Error;
 
 use crate::http::WebhookState;
@@ -42,6 +44,7 @@ pub async fn handle_webhook(
     body: Body,
 ) -> impl IntoResponse {
     let max_request_size = WEBHOOK_MAX_REQUEST_SIZE_BYTES.get(&dyncfgs);
+    let validation_memory_budget = WEBHOOK_VALIDATION_MEMORY_BUDGET_BYTES.get(&dyncfgs);
     let body = axum::body::to_bytes(body, max_request_size)
         .await
         .map_err(|err| {
@@ -88,6 +91,7 @@ pub async fn handle_webhook(
                 &name,
                 &body,
                 &headers,
+                validation_memory_budget,
             )
             .await;
 
@@ -114,6 +118,7 @@ async fn append_webhook(
     name: &str,
     body: &Bytes,
     headers: &Arc<BTreeMap<String, String>>,
+    validation_memory_budget: usize,
 ) -> Result<(), AppendWebhookError> {
     // Shenanigans to get the types working for the async retry.
     let (database, schema, name) = (database.to_string(), schema.to_string(), name.to_string());
@@ -164,7 +169,12 @@ async fn append_webhook(
     // If this source requires validation, then validate!
     if let Some(validator) = validator {
         let valid = validator
-            .eval(Bytes::clone(body), Arc::clone(headers), received_at)
+            .eval(
+                Bytes::clone(body),
+                Arc::clone(headers),
+                received_at,
+                validation_memory_budget,
+            )
             .await?;
         if !valid {
             return Err(AppendWebhookError::ValidationFailed);

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -3193,6 +3193,108 @@ fn webhook_max_request_size() {
         .expect("2 KiB body rejected after lowering the limit to 1 KiB");
 }
 
+/// A `CHECK` expression that allocates a multiple of the request body must be refused rather than
+/// allowed to hold the memory (SQL-431).
+///
+/// `environmentd` evaluates one `CHECK` per in-flight request, so before the budget existed 150
+/// concurrent 5 MB posts to a source checking `length(repeat(body, 20)) >= 0` took the process from
+/// 355 MiB to 8.7 GiB, growing with the number of clients. Every request returned 200. Nothing
+/// refused the work, so the memory was just held.
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // too slow
+#[allow(clippy::disallowed_methods)]
+fn webhook_validation_memory_budget() {
+    let server = test_util::TestHarness::default()
+        .unsafe_mode()
+        .start_blocking();
+
+    let mut mz_client = server
+        .pg_config_internal()
+        .user(&SYSTEM_USER.name)
+        .connect(postgres::NoTls)
+        .unwrap();
+
+    let mut client = server.connect(postgres::NoTls).unwrap();
+
+    client
+        .execute(
+            "CREATE CLUSTER webhook_cluster (SIZE 'scale=1,workers=1');",
+            &[],
+        )
+        .expect("failed to create cluster");
+    client
+        .execute(
+            "CREATE SOURCE webhook_amplify IN CLUSTER webhook_cluster \
+             FROM WEBHOOK BODY FORMAT TEXT \
+             CHECK (WITH (BODY) length(repeat(body, 20)) >= 0)",
+            &[],
+        )
+        .expect("failed to create source");
+
+    let http_client = reqwest::Client::new();
+    let webhook_url = format!(
+        "http://{}/api/webhook/materialize/public/webhook_amplify",
+        server.http_local_addr(),
+    );
+
+    let post = |len: usize| {
+        let body = vec![b'a'; len];
+        server.runtime().block_on(async {
+            http_client
+                .post(&webhook_url)
+                .body(body)
+                .send()
+                .await
+                .expect("request failed")
+                .status()
+        })
+    };
+
+    // The default budget is 20 MiB. A 2 MiB body amplifies to 40 MiB, so the `CHECK` is refused
+    // with 400 rather than allocating. Note that nothing else rejects this: 40 MiB is comfortably
+    // under the 100 MiB per-call ceiling that applies in a cluster, and 2 MiB is under the 5 MiB
+    // request-size limit.
+    assert_eq!(post(2 * 1024 * 1024).as_u16(), 400);
+
+    // A body whose amplified size fits the budget still succeeds through the same source, so the
+    // rejection above is the budget and not the `CHECK` or the source being broken.
+    assert!(post(512 * 1024).is_success());
+
+    // Raising the budget above the amplified size accepts the body that was just rejected. This is
+    // what pins the test to the budget: with enforcement removed the 2 MiB case would already have
+    // succeeded and the first assertion would fail.
+    mz_client
+        .batch_execute("ALTER SYSTEM SET webhook_validation_memory_budget_bytes = 67108864")
+        .unwrap();
+    // The dyncfg propagates to the shared persist ConfigSet asynchronously, so retry briefly.
+    Retry::default()
+        .max_duration(std::time::Duration::from_secs(30))
+        .retry(|_| {
+            if post(2 * 1024 * 1024).is_success() {
+                Ok(())
+            } else {
+                Err(())
+            }
+        })
+        .expect("2 MiB body accepted after raising the budget to 64 MiB");
+
+    // And lowering it below what the smaller body needs rejects that too, confirming the knob is
+    // live in both directions rather than the first result being a fixed threshold.
+    mz_client
+        .batch_execute("ALTER SYSTEM SET webhook_validation_memory_budget_bytes = 1024")
+        .unwrap();
+    Retry::default()
+        .max_duration(std::time::Duration::from_secs(30))
+        .retry(|_| {
+            if post(512 * 1024).as_u16() == 400 {
+                Ok(())
+            } else {
+                Err(())
+            }
+        })
+        .expect("512 KiB body rejected after lowering the budget to 1 KiB");
+}
+
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // too slow
 #[allow(clippy::disallowed_methods)]

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -165,5 +165,6 @@ message ProtoEvalError {
     string invalid_catalog_json = 81;
     string redact_error = 82;
     google.protobuf.Empty negative_rows_from_subquery = 83;
+    google.protobuf.Empty temp_storage_budget_exceeded = 84;
   }
 }

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -2551,12 +2551,13 @@ mod tests {
         assert_eq!(datum.unwrap_str().len(), 20 * 1024 * 1024);
     }
 
-    /// The budget also has to catch a function with no size pre-check of its own, which allocates
-    /// straight into the arena. Enforcement for those is the evaluator's post-call check.
+    /// The budget also has to bound both dimensions of an arena-building function: the packed
+    /// result, and the transient it collects on its own stack first. The arena never sees the
+    /// transient, so the post-call check can't catch it.
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // multi-MB allocations; the small-size UB coverage is in `row.rs`
     fn test_arena_built_result_respects_budget() {
-        use crate::scalar::func::variadic::StringToArray;
+        use crate::scalar::func::variadic::{RegexpSplitToArray, StringToArray};
 
         let body = "a".repeat(256 * 1024);
         let expr = MirScalarExpr::call_variadic(
@@ -2579,6 +2580,40 @@ mod tests {
             Err(EvalError::TempStorageBudgetExceeded),
             "an over-budget arena-built result must be refused"
         );
+
+        // A split collects every chunk into a `Vec<&str>` first, 16 bytes per fat pointer against
+        // the 2 an empty chunk packs to. A budget the packed array fits under still refuses it.
+        let intermediate = (body.len() + 1) * std::mem::size_of::<&str>();
+        let budget = 4 * unbudgeted;
+        assert!(
+            unbudgeted < budget && budget < intermediate,
+            "budget sits between"
+        );
+        let arena = RowArena::with_budget(budget);
+        assert!(
+            expr.eval(&datums, &arena).is_err(),
+            "a split costing {intermediate} bytes to build must be refused by a {budget} byte budget"
+        );
+        assert_eq!(
+            arena.allocated_bytes(),
+            0,
+            "refused before the transient was built"
+        );
+
+        // The regexp sibling builds the same transient and takes the same bound.
+        let regexp_expr = MirScalarExpr::call_variadic(
+            RegexpSplitToArray,
+            vec![
+                MirScalarExpr::column(0),
+                MirScalarExpr::literal_ok(Datum::String("a"), ReprScalarType::String),
+            ],
+        );
+        let arena = RowArena::with_budget(budget);
+        assert!(
+            regexp_expr.eval(&datums, &arena).is_err(),
+            "a regexp split costing {intermediate} bytes to build must be refused too"
+        );
+        assert_eq!(arena.allocated_bytes(), 0);
     }
 
     /// `array_fill` sizes its result from a parameter rather than its input, so a budgeted arena
@@ -2631,6 +2666,55 @@ mod tests {
 
         // Budgeted well above both the packed result and the intermediate: unaffected.
         let arena = RowArena::with_budget(256 * 1024 * 1024);
+        expr.eval(&datums, &arena).expect("within budget");
+    }
+
+    /// `array_remove` cannot grow its result, so no packed-size check would ever fire for it. The
+    /// transient `Vec<Datum>` it filters into is a fresh input-scaled allocation on top of the input
+    /// array's own bytes, and only a pre-check bounds that (SQL-431).
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // multi-MB allocations; the small-size UB coverage is in `row.rs`
+    fn test_array_remove_respects_arena_budget() {
+        use crate::scalar::func::ArrayRemove;
+        use mz_repr::adt::array::ArrayDimension;
+
+        const ELEMS: usize = 256 * 1024;
+        let input_storage = RowArena::new();
+        let array = input_storage
+            .try_make_datum(|packer| {
+                packer.try_push_array(
+                    &[ArrayDimension {
+                        lower_bound: 1,
+                        length: ELEMS,
+                    }],
+                    (0..ELEMS).map(|i| Datum::Int32(i32::try_from(i).unwrap())),
+                )
+            })
+            .unwrap();
+        let expr = MirScalarExpr::column(0).call_binary(MirScalarExpr::column(1), ArrayRemove);
+        let datums = [array, Datum::Int32(0)];
+
+        // Unbudgeted: allowed, and the arena holds the packed result.
+        let arena = RowArena::new();
+        expr.eval(&datums, &arena).expect("no ceiling applies");
+        let unbudgeted = arena.allocated_bytes();
+        assert!(unbudgeted > 0);
+
+        // A `Datum` is several times what an `Int32` packs to, so a budget with room for the packed
+        // result twice over still has to refuse the transient.
+        let transient = ELEMS * std::mem::size_of::<Datum<'_>>();
+        let budget = 2 * unbudgeted;
+        assert!(budget < transient, "budget sits between");
+        let arena = RowArena::with_budget(budget);
+        assert_eq!(
+            expr.eval(&datums, &arena),
+            Err(EvalError::TempStorageBudgetExceeded),
+            "an over-budget transient must be refused"
+        );
+        assert_eq!(arena.allocated_bytes(), 0);
+
+        // Budgeted above both: unaffected.
+        let arena = RowArena::with_budget(64 * 1024 * 1024);
         expr.eval(&datums, &arena).expect("within budget");
     }
 

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -2634,6 +2634,84 @@ mod tests {
         expr.eval(&datums, &arena).expect("within budget");
     }
 
+    /// A budget has to bound what a single call allocates, not just what is observable between
+    /// calls (SQL-431).
+    ///
+    /// The evaluator only polls the budget after `func.eval` has built its result and moved it into
+    /// the arena, and erroring then does not give the bytes back. They stay resident until the arena
+    /// drops, which for a webhook `CHECK` is the end of the request. So we assert on arena residency,
+    /// not the returned `Result`. The overshoot is not a constant either. It scales with the body and
+    /// with a multiplier the `CHECK` author picks at DDL time.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // multi-MB allocations; the small-size UB coverage is in `row.rs`
+    fn test_single_call_respects_arena_budget() {
+        use mz_ore::cast::CastLossy;
+
+        use crate::scalar::func::variadic::{ArrayCreate, PadLeading, Translate};
+
+        // Scaled down from the shipped 5 MiB body and 20 MiB budget. Every amplifier here is linear
+        // in the body, so the ratios hold at any scale.
+        const BODY_BYTES: usize = 1024 * 1024;
+        const BUDGET: usize = 2 * 1024 * 1024;
+        const WIDE: &str = "\u{1F4A5}"; // one character, four bytes
+
+        let str_lit = |s| MirScalarExpr::literal_ok(Datum::String(s), ReprScalarType::String);
+        // `ARRAY[body, ...]` is not a string function, so no ceiling of its own applies. The
+        // multiplier is just how many times the author wrote `body`.
+        let array_of = |n| {
+            let elem_type = mz_repr::SqlScalarType::String;
+            let refs = vec![MirScalarExpr::column(0); n];
+            MirScalarExpr::call_variadic(ArrayCreate { elem_type }, refs)
+        };
+        let cases = [
+            ("ARRAY[body x4]", array_of(4)),
+            ("ARRAY[body x16]", array_of(16)),
+            // `lpad`'s pre-check is budget-aware but compares `len`, a character count, against a
+            // budget in bytes, so a 4-byte pad passes a check for exactly the budget then writes 4x.
+            (
+                "lpad(body, BUDGET, wide)",
+                MirScalarExpr::call_variadic(
+                    PadLeading,
+                    vec![
+                        MirScalarExpr::column(0),
+                        MirScalarExpr::literal_ok(
+                            Datum::Int32(i32::try_from(BUDGET).unwrap()),
+                            ReprScalarType::Int32,
+                        ),
+                        str_lit(WIDE),
+                    ],
+                ),
+            ),
+            // `translate` has no pre-check at all, and widening each body byte is a 4x amplifier
+            // that needs no length argument to drive it.
+            (
+                "translate(body, 'a', wide)",
+                MirScalarExpr::call_variadic(
+                    Translate,
+                    vec![MirScalarExpr::column(0), str_lit("a"), str_lit(WIDE)],
+                ),
+            ),
+        ];
+
+        let body = "a".repeat(BODY_BYTES);
+        let datums = [Datum::String(&body)];
+        let mut over = Vec::new();
+        for (name, expr) in cases {
+            let arena = RowArena::with_budget(BUDGET);
+            let _ = expr.eval(&datums, &arena); // refused or not, we only care what's left resident
+            let held = arena.allocated_bytes();
+            if held > BUDGET {
+                let ratio = f64::cast_lossy(held) / f64::cast_lossy(BUDGET);
+                over.push(format!("  {name}: held {held} bytes, {ratio:.1}x"));
+            }
+        }
+        assert!(
+            over.is_empty(),
+            "a single call left a {BUDGET} byte arena holding more:\n{}",
+            over.join("\n"),
+        );
+    }
+
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
     fn test_reduce() {

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -1157,6 +1157,22 @@ impl MirScalarExpr {
     }
 }
 
+/// Fails once `temp_storage` holds more than the budget it was built with.
+///
+/// Checked after each function call rather than inside the arena, because `RowArena`'s pushes are
+/// infallible: refusing one would hand back a truncated value. Between calls is the innermost point
+/// that can return an error, so a budgeted arena reaches at most its budget plus whatever the call
+/// that crossed it allocated. Functions that can predict their own size cut that overshoot by
+/// consulting [`crate::func::max_string_func_result_bytes`] first.
+///
+/// An unbudgeted arena, which is every arena in a dataflow, costs one branch on a `None`.
+fn check_temp_storage_budget(temp_storage: &RowArena) -> Result<(), EvalError> {
+    if temp_storage.over_budget() {
+        return Err(EvalError::TempStorageBudgetExceeded);
+    }
+    Ok(())
+}
+
 impl Eval for MirScalarExpr {
     fn eval<'a>(
         &'a self,
@@ -1176,13 +1192,19 @@ impl Eval for MirScalarExpr {
                 format!("cannot evaluate unmaterializable function: {:?}", x).into(),
             )),
             MirScalarExpr::CallUnary { func, expr } => {
-                func.eval(datums, temp_storage, expr.as_ref())
+                let datum = func.eval(datums, temp_storage, expr.as_ref())?;
+                check_temp_storage_budget(temp_storage)?;
+                Ok(datum)
             }
             MirScalarExpr::CallBinary { func, expr1, expr2 } => {
-                func.eval(datums, temp_storage, &[expr1.as_ref(), expr2.as_ref()])
+                let datum = func.eval(datums, temp_storage, &[expr1.as_ref(), expr2.as_ref()])?;
+                check_temp_storage_budget(temp_storage)?;
+                Ok(datum)
             }
             MirScalarExpr::CallVariadic { func, exprs } => {
-                func.eval(datums, temp_storage, exprs.as_slice())
+                let datum = func.eval(datums, temp_storage, exprs.as_slice())?;
+                check_temp_storage_budget(temp_storage)?;
+                Ok(datum)
             }
             MirScalarExpr::If { cond, then, els } => match cond.eval(datums, temp_storage)? {
                 Datum::True => then.eval(datums, temp_storage),
@@ -1827,6 +1849,10 @@ pub enum EvalError {
     // printer.
     IfNullError(Box<str>),
     LengthTooLarge,
+    // A budgeted `RowArena` (`mz_repr::RowArena::with_budget`) exceeded its budget while an
+    // expression was being evaluated. Only a budgeted arena raises this, so it never arises in a
+    // dataflow, only on the webhook `CHECK` path that runs user expressions in `environmentd`.
+    TempStorageBudgetExceeded,
     AclArrayNullElement,
     MzAclArrayNullElement,
     PrettyError(Box<str>),
@@ -2048,6 +2074,9 @@ impl fmt::Display for EvalError {
             }
             EvalError::IfNullError(s) => f.write_str(s),
             EvalError::LengthTooLarge => write!(f, "requested length too large"),
+            EvalError::TempStorageBudgetExceeded => {
+                write!(f, "expression exceeded its temporary storage limit")
+            }
             EvalError::AclArrayNullElement => write!(f, "ACL arrays must not contain null values"),
             EvalError::MzAclArrayNullElement => {
                 write!(f, "MZ_ACL arrays must not contain null values")
@@ -2310,6 +2339,7 @@ impl RustType<ProtoEvalError> for EvalError {
             }),
             EvalError::IfNullError(s) => IfNullError(s.into_proto()),
             EvalError::LengthTooLarge => LengthTooLarge(()),
+            EvalError::TempStorageBudgetExceeded => TempStorageBudgetExceeded(()),
             EvalError::AclArrayNullElement => AclArrayNullElement(()),
             EvalError::MzAclArrayNullElement => MzAclArrayNullElement(()),
             EvalError::InvalidIanaTimezoneId(s) => InvalidIanaTimezoneId(s.into_proto()),
@@ -2438,6 +2468,7 @@ impl RustType<ProtoEvalError> for EvalError {
                 }),
                 IfNullError(v) => Ok(EvalError::IfNullError(v.into())),
                 LengthTooLarge(()) => Ok(EvalError::LengthTooLarge),
+                TempStorageBudgetExceeded(()) => Ok(EvalError::TempStorageBudgetExceeded),
                 AclArrayNullElement(()) => Ok(EvalError::AclArrayNullElement),
                 MzAclArrayNullElement(()) => Ok(EvalError::MzAclArrayNullElement),
                 InvalidIanaTimezoneId(s) => Ok(EvalError::InvalidIanaTimezoneId(s.into())),
@@ -2478,6 +2509,129 @@ mod tests {
             err.to_string(),
             "function f is defined for numbers in an unspecified range"
         );
+    }
+
+    /// A budgeted arena must stop an amplifying expression that the per-call constant allows
+    /// (SQL-431). `repeat(body, 20)` on a 1 MiB body is 20 MiB: far under
+    /// `MAX_STRING_FUNC_RESULT_BYTES`, so nothing rejects it without a budget, and it is exactly
+    /// the shape that made a webhook `CHECK` turn a bounded request into unbounded heap.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // multi-MB allocations; the small-size UB coverage is in `row.rs`
+    fn test_repeat_respects_arena_budget() {
+        use crate::scalar::func::RepeatString;
+
+        let body = "a".repeat(1024 * 1024);
+        let expr = MirScalarExpr::column(0).call_binary(
+            MirScalarExpr::literal_ok(Datum::Int32(20), ReprScalarType::Int32),
+            RepeatString,
+        );
+        let datums = [Datum::String(&body)];
+
+        // Unbudgeted: allowed, and the arena really does hold the 20 MiB.
+        let arena = RowArena::new();
+        let datum = expr
+            .eval(&datums, &arena)
+            .expect("under the 100 MiB ceiling");
+        assert_eq!(datum.unwrap_str().len(), 20 * 1024 * 1024);
+        assert!(arena.allocated_bytes() >= 20 * 1024 * 1024);
+
+        // Budgeted below the result: rejected, and the pre-check means the arena never grew, i.e.
+        // the bytes were never allocated rather than allocated and then complained about.
+        let arena = RowArena::with_budget(4 * 1024 * 1024);
+        assert_eq!(
+            expr.eval(&datums, &arena),
+            Err(EvalError::LengthTooLarge),
+            "an over-budget result must be refused"
+        );
+        assert_eq!(arena.allocated_bytes(), 0);
+
+        // Budgeted above the result: unaffected.
+        let arena = RowArena::with_budget(64 * 1024 * 1024);
+        let datum = expr.eval(&datums, &arena).expect("within budget");
+        assert_eq!(datum.unwrap_str().len(), 20 * 1024 * 1024);
+    }
+
+    /// The budget also has to catch a function with no size pre-check of its own, which allocates
+    /// straight into the arena. Enforcement for those is the evaluator's post-call check.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // multi-MB allocations; the small-size UB coverage is in `row.rs`
+    fn test_arena_built_result_respects_budget() {
+        use crate::scalar::func::variadic::StringToArray;
+
+        let body = "a".repeat(256 * 1024);
+        let expr = MirScalarExpr::call_variadic(
+            StringToArray,
+            vec![
+                MirScalarExpr::column(0),
+                MirScalarExpr::literal_ok(Datum::String("a"), ReprScalarType::String),
+            ],
+        );
+        let datums = [Datum::String(&body)];
+
+        let arena = RowArena::new();
+        expr.eval(&datums, &arena).expect("no ceiling applies");
+        let unbudgeted = arena.allocated_bytes();
+        assert!(unbudgeted > 0);
+
+        let arena = RowArena::with_budget(unbudgeted / 2);
+        assert_eq!(
+            expr.eval(&datums, &arena),
+            Err(EvalError::TempStorageBudgetExceeded),
+            "an over-budget arena-built result must be refused"
+        );
+    }
+
+    /// `array_fill` sizes its result from a parameter rather than its input, so a budgeted arena
+    /// has to refuse it in its own pre-check the way the string amplifiers do (SQL-431). Its result
+    /// stays under the `array_fill` size ceiling, so without the budget-aware pre-check the only
+    /// thing that would catch it is the evaluator's post-call check, after the spike has happened.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // multi-MB allocations; the small-size UB coverage is in `row.rs`
+    fn test_array_fill_respects_arena_budget() {
+        use crate::scalar::func::variadic::ArrayFill;
+        use mz_repr::adt::array::ArrayDimension;
+
+        // array_fill(1, ARRAY[fill_count]) builds a one-dimensional int array of `fill_count` ones.
+        let fill_count: usize = 512 * 1024;
+        let dims_storage = RowArena::new();
+        let dims = dims_storage
+            .try_make_datum(|packer| {
+                packer.try_push_array(
+                    &[ArrayDimension {
+                        lower_bound: 1,
+                        length: 1,
+                    }],
+                    [Datum::Int32(i32::try_from(fill_count).unwrap())],
+                )
+            })
+            .unwrap();
+        let expr = MirScalarExpr::call_variadic(
+            ArrayFill {
+                elem_type: mz_repr::SqlScalarType::Int32,
+            },
+            vec![MirScalarExpr::column(0), MirScalarExpr::column(1)],
+        );
+        let datums = [Datum::Int32(1), dims];
+
+        // Unbudgeted: allowed, and the arena really holds the packed array.
+        let arena = RowArena::new();
+        expr.eval(&datums, &arena)
+            .expect("under the array-size ceiling");
+        assert!(arena.allocated_bytes() > 0);
+
+        // Budgeted below what the call needs: refused by the pre-check, so nothing was allocated.
+        // The intermediate `Vec<Datum>` alone is 512 Ki elements, well over this 1 MiB budget.
+        let arena = RowArena::with_budget(1024 * 1024);
+        assert_eq!(
+            expr.eval(&datums, &arena),
+            Err(EvalError::TempStorageBudgetExceeded),
+            "an over-budget array_fill must be refused before it allocates"
+        );
+        assert_eq!(arena.allocated_bytes(), 0);
+
+        // Budgeted well above both the packed result and the intermediate: unaffected.
+        let arena = RowArena::with_budget(256 * 1024 * 1024);
+        expr.eval(&datums, &arena).expect("within budget");
     }
 
     #[mz_ore::test]

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -212,6 +212,38 @@ pub fn check_datums_fit_budget<'a>(
     Ok(())
 }
 
+/// Refuses an input-scaled transient the arena's budget cannot afford, before it is built.
+///
+/// A function that gathers `n_elems` of `elem_size` bytes into its own `Vec` before packing them
+/// holds that allocation on the stack, where the arena never sees it. The evaluator's post-call
+/// check counts arena bytes only, so a transient wider than the result it becomes can slip past a
+/// budget the packed result fits under. A `Vec<&str>` of split chunks is one: a 16-byte fat pointer
+/// per chunk against the ~2 bytes an empty chunk packs to. Pair this with
+/// [`check_datums_fit_budget`], which bounds the packed result.
+///
+/// `n_elems` is a closure so an unbudgeted arena, which is every arena in a dataflow, never pays for
+/// a count that can cost a pass over the input.
+///
+/// NOTE: the reformatters (`jsonb_pretty`, `pretty_sql`, `redact_sql`) are the known exception.
+/// Sizing their output needs the same walk that produces it, so only the post-call check bounds
+/// them.
+pub fn check_build_fits_budget(
+    n_elems: impl FnOnce() -> usize,
+    elem_size: usize,
+    temp_storage: &RowArena,
+) -> Result<(), EvalError> {
+    let budget_remaining = temp_storage.budget_remaining();
+    // `usize::MAX` is the unbudgeted sentinel. Return before the count so an unbudgeted arena never
+    // pays for it.
+    if budget_remaining == usize::MAX {
+        return Ok(());
+    }
+    if n_elems().saturating_mul(elem_size) > budget_remaining {
+        return Err(EvalError::TempStorageBudgetExceeded);
+    }
+    Ok(())
+}
+
 pub fn jsonb_stringify<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Option<&'a str> {
     match a {
         Datum::JsonNull => None,
@@ -2504,6 +2536,13 @@ fn regexp_split_to_array_re<'a>(
     regexp: &Regex,
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
+    // Bound the transient `Vec<&str>` before the split builds it. The count follows the split's own
+    // zero-length-match rule, so it refuses exactly the calls the split would build.
+    check_build_fits_budget(
+        || mz_regexp::regexp_split_to_array_count(text, regexp),
+        std::mem::size_of::<&str>(),
+        temp_storage,
+    )?;
     let found = mz_regexp::regexp_split_to_array(text, regexp);
     // Splitting amplifies: each chunk is packed with its own tag and length, so a pattern that
     // splits per character costs several times the input.
@@ -2520,6 +2559,7 @@ fn regexp_split_to_array_re<'a>(
     Ok(temp_storage.push_unary_row(row))
 }
 
+// NOTE: no budget pre-check, see the exception on `check_build_fits_budget`.
 #[sqlfunc(propagates_nulls = true)]
 fn pretty_sql<'a>(sql: &str, width: i32, temp_storage: &'a RowArena) -> Result<&'a str, EvalError> {
     let width =
@@ -2536,6 +2576,7 @@ fn pretty_sql<'a>(sql: &str, width: i32, temp_storage: &'a RowArena) -> Result<&
     Ok(pretty)
 }
 
+// NOTE: no budget pre-check, see the exception on `check_build_fits_budget`.
 #[sqlfunc]
 fn redact_sql(sql: &str) -> Result<String, EvalError> {
     let stmts = mz_sql_parser::parser::parse_statements(sql)
@@ -2960,8 +3001,16 @@ fn array_remove<'a>(
         return Err(EvalError::MultidimensionalArrayRemovalNotSupported);
     }
 
-    let elems: Vec<_> = arr.elements().iter().filter(|v| v != &b).collect();
     let mut dims = arr.dims().into_iter().collect::<Vec<_>>();
+    // Removal can't grow the result, but the transient `Vec<Datum>` it filters into is a fresh
+    // input-scaled allocation. One-dimensional by the check above, so dim 0's length is the count.
+    check_build_fits_budget(
+        || dims[0].length,
+        std::mem::size_of::<Datum<'a>>(),
+        temp_storage,
+    )?;
+
+    let elems: Vec<_> = arr.elements().iter().filter(|v| v != &b).collect();
     // This access is safe because `dims` is guaranteed to be non-empty
     dims[0] = ArrayDimension {
         lower_bound: 1,

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -187,6 +187,31 @@ pub fn max_string_func_result_bytes(temp_storage: &RowArena) -> usize {
     )
 }
 
+/// Refuses a collection `temp_storage`'s budget cannot afford, before it is packed.
+///
+/// The collection builders (`ARRAY[..]`, `LIST[..]`, `ROW(..)`, `MAP[..]`, `jsonb_build_*`) pack the
+/// datums they are handed straight into `temp_storage`, so the result is as large as those datums
+/// times however many times the expression names each one. Unlike the string functions bounded by
+/// [`max_string_func_result_bytes`], `ARRAY[body, body, ..]` has no ceiling of its own.
+///
+/// Like that ceiling, this must be consulted *before* the result is built, since the arena's budget
+/// is only observable once the bytes exist. [`mz_repr::datum_size`] is the size a datum occupies
+/// once packed, so summing it bounds the result without allocating anything. Without a budget
+/// `budget_remaining` is `usize::MAX` and nothing is refused.
+pub fn check_datums_fit_budget<'a>(
+    datums: impl IntoIterator<Item = Datum<'a>>,
+    temp_storage: &RowArena,
+) -> Result<(), EvalError> {
+    let need: usize = datums
+        .into_iter()
+        .map(|d| mz_repr::datum_size(&d))
+        .fold(0, usize::saturating_add);
+    if need > temp_storage.budget_remaining() {
+        return Err(EvalError::TempStorageBudgetExceeded);
+    }
+    Ok(())
+}
+
 pub fn jsonb_stringify<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Option<&'a str> {
     match a {
         Datum::JsonNull => None,
@@ -2480,6 +2505,9 @@ fn regexp_split_to_array_re<'a>(
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
     let found = mz_regexp::regexp_split_to_array(text, regexp);
+    // Splitting amplifies: each chunk is packed with its own tag and length, so a pattern that
+    // splits per character costs several times the input.
+    check_datums_fit_budget(found.iter().copied().map(Datum::String), temp_storage)?;
     let mut row = Row::default();
     let mut packer = row.packer();
     packer.try_push_array(
@@ -2683,6 +2711,7 @@ fn array_create_scalar<'a>(
         // strangely to satisfy the borrow checker while avoiding an allocation.
         dims = &[];
     }
+    check_datums_fit_budget(datums.iter().copied(), temp_storage)?;
     let datum = temp_storage.try_make_datum(|packer| packer.try_push_array(dims, datums))?;
     Ok(datum)
 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -171,6 +171,22 @@ func_name! {
 /// function where it applies.
 pub const MAX_STRING_FUNC_RESULT_BYTES: usize = 1024 * 1024 * 100;
 
+/// The largest result a string function may build into `temp_storage`.
+///
+/// [`MAX_STRING_FUNC_RESULT_BYTES`] unless the arena carries a tighter budget, which is how an
+/// expression evaluated in `environmentd` on behalf of a request (a webhook `CHECK`) is held to a
+/// size proportionate to that request rather than to the constant, which is sized for a cluster.
+///
+/// A function that can predict its result size must consult this *before* building the result: the
+/// arena's own budget is only observable after the bytes exist, which for an amplifying function is
+/// exactly too late.
+pub fn max_string_func_result_bytes(temp_storage: &RowArena) -> usize {
+    std::cmp::min(
+        MAX_STRING_FUNC_RESULT_BYTES,
+        temp_storage.budget_remaining(),
+    )
+}
+
 pub fn jsonb_stringify<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Option<&'a str> {
     match a {
         Datum::JsonNull => None,
@@ -469,10 +485,10 @@ fn encode(bytes: &[u8], format: &str) -> Result<String, EvalError> {
 }
 
 #[sqlfunc]
-fn decode(string: &str, format: &str) -> Result<Vec<u8>, EvalError> {
+fn decode(string: &str, format: &str, temp_storage: &RowArena) -> Result<Vec<u8>, EvalError> {
     let format = encoding::lookup_format(format)?;
     let out = format.decode(string)?;
-    if out.len() > MAX_STRING_FUNC_RESULT_BYTES {
+    if out.len() > max_string_func_result_bytes(temp_storage) {
         Err(EvalError::LengthTooLarge)
     } else {
         Ok(out)
@@ -2521,8 +2537,8 @@ fn starts_with(a: &str, b: &str) -> bool {
     // 'A' < 'AA' but 'AZ' > 'AAZ'.)
     is_monotone = (false, true),
 )]
-fn text_concat_binary(a: &str, b: &str) -> Result<String, EvalError> {
-    if a.len() + b.len() > MAX_STRING_FUNC_RESULT_BYTES {
+fn text_concat_binary(a: &str, b: &str, temp_storage: &RowArena) -> Result<String, EvalError> {
+    if a.len() + b.len() > max_string_func_result_bytes(temp_storage) {
         return Err(EvalError::LengthTooLarge);
     }
     let mut buf = String::with_capacity(a.len() + b.len());
@@ -2639,9 +2655,9 @@ pub fn build_regex(needle: &str, flags: &str) -> Result<Regex, EvalError> {
 }
 
 #[sqlfunc(sqlname = "repeat")]
-fn repeat_string(string: &str, count: i32) -> Result<String, EvalError> {
+fn repeat_string(string: &str, count: i32, temp_storage: &RowArena) -> Result<String, EvalError> {
     let len = usize::try_from(count).unwrap_or(0);
-    if (len * string.len()) > MAX_STRING_FUNC_RESULT_BYTES {
+    if len.saturating_mul(string.len()) > max_string_func_result_bytes(temp_storage) {
         return Err(EvalError::LengthTooLarge);
     }
     Ok(string.repeat(len))

--- a/src/expr/src/scalar/func/impls/jsonb.rs
+++ b/src/expr/src/scalar/func/impls/jsonb.rs
@@ -234,6 +234,7 @@ fn jsonb_strip_nulls<'a>(a: JsonbRef<'a>) -> Jsonb {
     Jsonb::from_row(row)
 }
 
+// NOTE: no budget pre-check, see the exception on `crate::func::check_build_fits_budget`.
 #[sqlfunc]
 fn jsonb_pretty<'a>(a: JsonbRef<'a>) -> String {
     let mut buf = String::new();

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -40,9 +40,10 @@ use mz_repr::{
 use serde::{Deserialize, Serialize};
 
 use crate::func::{
-    CaseLiteral, array_create_scalar, build_regex, check_datums_fit_budget, date_bin,
-    max_string_func_result_bytes, parse_timezone, regexp_match_static, regexp_replace_parse_flags,
-    regexp_split_to_array_re, stringify_datum, timezone_time,
+    CaseLiteral, array_create_scalar, build_regex, check_build_fits_budget,
+    check_datums_fit_budget, date_bin, max_string_func_result_bytes, parse_timezone,
+    regexp_match_static, regexp_replace_parse_flags, regexp_split_to_array_re, stringify_datum,
+    timezone_time,
 };
 use crate::{Eval, EvalError, MirScalarExpr};
 use mz_repr::adt::date::Date;
@@ -1154,7 +1155,9 @@ fn map_build<'a>(
         .filter_map(|(k, v)| k.map(|k| (k, v)))
         .collect();
 
-    // Checked after the collect, so duplicate keys are counted once, as they are packed.
+    // Checked after the collect, so duplicate keys are counted once, as they are packed. The
+    // `BTreeMap` transient needs no pre-check: it holds one entry per argument, a count the query
+    // text fixes, not the input.
     check_datums_fit_budget(
         map.iter().flat_map(|(k, v)| [Datum::String(k), *v]),
         temp_storage,
@@ -1444,6 +1447,20 @@ fn string_to_array_impl<'a>(
     null_string: Option<&'a str>,
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
+    // Bound the transient `Vec<&str>` before it is collected. The count walks the same iterator the
+    // collect does, so the two agree.
+    check_build_fits_budget(
+        || {
+            if delimiter.is_empty() {
+                string.split(delimiter).filter(|s| !s.is_empty()).count()
+            } else {
+                string.split(delimiter).count()
+            }
+        },
+        std::mem::size_of::<&str>(),
+        temp_storage,
+    )?;
+
     let mut row = Row::default();
     let mut packer = row.packer();
 

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -40,9 +40,9 @@ use mz_repr::{
 use serde::{Deserialize, Serialize};
 
 use crate::func::{
-    CaseLiteral, array_create_scalar, build_regex, date_bin, max_string_func_result_bytes,
-    parse_timezone, regexp_match_static, regexp_replace_parse_flags, regexp_split_to_array_re,
-    stringify_datum, timezone_time,
+    CaseLiteral, array_create_scalar, build_regex, check_datums_fit_budget, date_bin,
+    max_string_func_result_bytes, parse_timezone, regexp_match_static, regexp_replace_parse_flags,
+    regexp_split_to_array_re, stringify_datum, timezone_time,
 };
 use crate::{Eval, EvalError, MirScalarExpr};
 use mz_repr::adt::date::Date;
@@ -213,6 +213,7 @@ fn array_create_multidim<'a>(
     if let Some(d) = datums.first() {
         dims.extend(d.unwrap_array().dims());
     };
+    check_datums_fit_budget(datums.iter().copied(), temp_storage)?;
     let elements = datums
         .iter()
         .flat_map(|d| d.unwrap_array().elements().iter());
@@ -465,10 +466,15 @@ fn array_to_string<'a>(
     array: Array<'a>,
     delimiter: &str,
     null_str_arg: OptionalArg<Option<&str>>,
+    temp_storage: &RowArena,
 ) -> Result<String, EvalError> {
     // `flatten` treats absent arguments (`None`) the same as explicit NULL
     // (`Some(None)`), both becoming `None`.
     let null_str = null_str_arg.flatten();
+    // A delimiter is repeated once per element, so the array size doesn't bound the result. We
+    // check as it grows rather than up front, since an element's stringified length isn't known
+    // without stringifying it. That bounds the peak at the ceiling plus one element.
+    let max_result_bytes = max_string_func_result_bytes(temp_storage);
     let mut out = String::new();
     for elem in array.elements().iter() {
         if elem.is_null() {
@@ -479,6 +485,9 @@ fn array_to_string<'a>(
         } else {
             stringify_datum(&mut out, elem, &self.elem_type)?;
             out.push_str(delimiter);
+        }
+        if out.len() > max_result_bytes {
+            return Err(EvalError::LengthTooLarge);
         }
     }
     if out.len() > 0 {
@@ -839,14 +848,18 @@ pub fn hmac_inner(to_digest: &[u8], key: &[u8], typ: &str) -> Result<Vec<u8>, Ev
 }
 
 #[sqlfunc]
-fn jsonb_build_array<'a>(datums: Variadic<Datum<'a>>, temp_storage: &'a RowArena) -> JsonbRef<'a> {
+fn jsonb_build_array<'a>(
+    datums: Variadic<Datum<'a>>,
+    temp_storage: &'a RowArena,
+) -> Result<JsonbRef<'a>, EvalError> {
+    check_datums_fit_budget(datums.iter().copied(), temp_storage)?;
     let datum = temp_storage.make_datum(|packer| {
         packer.push_list(datums.into_iter().map(|d| match d {
             Datum::Null => Datum::JsonNull,
             d => d,
         }))
     });
-    JsonbRef::from_datum(datum)
+    Ok(JsonbRef::from_datum(datum))
 }
 
 #[sqlfunc]
@@ -856,6 +869,8 @@ fn jsonb_build_object<'a>(
 ) -> Result<JsonbRef<'a>, EvalError> {
     kvs.0.sort_by(|kv1, kv2| kv1.0.cmp(&kv2.0));
     kvs.0.dedup_by(|kv1, kv2| kv1.0 == kv2.0);
+    // Checked after the dedup, so duplicate keys are counted once, as they are packed.
+    check_datums_fit_budget(kvs.0.iter().flat_map(|(k, v)| [*k, *v]), temp_storage)?;
     let datum = temp_storage.try_make_datum(|packer| {
         packer.push_dict_with(|packer| {
             for (k, v) in kvs {
@@ -952,8 +967,13 @@ pub struct ListCreate {
     output_type_expr = "SqlScalarType::List { element_type: Box::new(self.elem_type.clone()), custom_id: None }.nullable(false)",
     introduces_nulls = false
 )]
-fn list_create<'a>(&self, datums: Variadic<Datum<'a>>, temp_storage: &'a RowArena) -> Datum<'a> {
-    temp_storage.make_datum(|packer| packer.push_list(datums))
+fn list_create<'a>(
+    &self,
+    datums: Variadic<Datum<'a>>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    check_datums_fit_budget(datums.iter().copied(), temp_storage)?;
+    Ok(temp_storage.make_datum(|packer| packer.push_list(datums)))
 }
 
 #[derive(
@@ -975,8 +995,13 @@ pub struct RecordCreate {
     output_type_expr = "SqlScalarType::Record { fields: self.field_names.clone().into_iter().zip_eq(input_types.iter().cloned()).collect(), custom_id: None }.nullable(false)",
     introduces_nulls = false
 )]
-fn record_create<'a>(&self, datums: Variadic<Datum<'a>>, temp_storage: &'a RowArena) -> Datum<'a> {
-    temp_storage.make_datum(|packer| packer.push_list(datums.iter().copied()))
+fn record_create<'a>(
+    &self,
+    datums: Variadic<Datum<'a>>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    check_datums_fit_budget(datums.iter().copied(), temp_storage)?;
+    Ok(temp_storage.make_datum(|packer| packer.push_list(datums.iter().copied())))
 }
 
 #[sqlfunc(
@@ -1122,14 +1147,19 @@ fn map_build<'a>(
     &self,
     datums: Variadic<(Option<&str>, Datum<'a>)>,
     temp_storage: &'a RowArena,
-) -> Datum<'a> {
+) -> Result<Datum<'a>, EvalError> {
     // Collect into a `BTreeMap` to provide the same semantics as it.
     let map: std::collections::BTreeMap<&str, _> = datums
         .into_iter()
         .filter_map(|(k, v)| k.map(|k| (k, v)))
         .collect();
 
-    temp_storage.make_datum(|packer| packer.push_dict(map))
+    // Checked after the collect, so duplicate keys are counted once, as they are packed.
+    check_datums_fit_budget(
+        map.iter().flat_map(|(k, v)| [Datum::String(k), *v]),
+        temp_storage,
+    )?;
+    Ok(temp_storage.make_datum(|packer| packer.push_dict(map)))
 }
 
 #[derive(
@@ -1223,19 +1253,37 @@ fn pad_leading(
             ));
         }
     };
-    if len > max_string_func_result_bytes(temp_storage) {
+    let pad_string = pad.unwrap_or(" ");
+
+    // `len` is a character count but the ceiling is in bytes, so a multi-byte pad character writes
+    // several bytes per character the check allowed. Bound the bytes instead. The result is the kept
+    // prefix of `string` plus `len - string_chars` padding characters, each at most as wide as the
+    // widest character in `pad_string`. Truncation (`len <= string_chars`) writes at most
+    // `string.len()`, which the same expression covers.
+    let widest_pad = pad_string.chars().map(char::len_utf8).max().unwrap_or(0);
+    let pad_chars = len.saturating_sub(string.chars().count());
+    let max_result_bytes = string
+        .len()
+        .saturating_add(pad_chars.saturating_mul(widest_pad));
+    if max_result_bytes > max_string_func_result_bytes(temp_storage) {
         return Err(EvalError::LengthTooLarge);
     }
-
-    let pad_string = pad.unwrap_or(" ");
 
     let (end_char, end_char_byte_offset) = string
         .chars()
         .take(len)
         .fold((0, 0), |acc, char| (acc.0 + 1, acc.1 + char.len_utf8()));
 
-    let mut buf = String::with_capacity(len);
-    if len == end_char {
+    // NOTE: reserve from the bytes actually written, not from `len`, which is a character count.
+    // Reserving `len` is too little for a multi-byte pad, and unbounded for an empty one, which
+    // writes nothing and so has no result size for the ceiling above to refuse.
+    let truncating = len == end_char;
+    let mut buf = String::with_capacity(if truncating {
+        end_char_byte_offset
+    } else {
+        max_result_bytes
+    });
+    if truncating {
         buf.push_str(&string[0..end_char_byte_offset]);
     } else {
         buf.extend(pad_string.chars().cycle().take(len - end_char));
@@ -1281,10 +1329,41 @@ fn regexp_replace<'a>(
     pattern: &str,
     replacement: &str,
     flags_opt: OptionalArg<&str>,
+    temp_storage: &RowArena,
 ) -> Result<Cow<'a, str>, EvalError> {
     let flags = flags_opt.0.unwrap_or("");
     let (limit, flags) = regexp_replace_parse_flags(flags);
     let regexp = build_regex(pattern, &flags)?;
+
+    // The result is the unreplaced parts of `source` plus one replacement per match. A `$ref` in the
+    // replacement expands to captured text, which is at most the match, and matches are disjoint, so
+    // all the expansions together cost at most one `source` per `$`.
+    let dollars = replacement.matches('$').count();
+    let max_result_bytes = |matches: usize| {
+        let expansions = match matches {
+            0 => 0,
+            _ => dollars.saturating_mul(source.len()),
+        };
+        source
+            .len()
+            .saturating_add(matches.saturating_mul(replacement.len()))
+            .saturating_add(expansions)
+    };
+    // A `limit` of 0 means replace every match, and a pattern that matches the empty string matches
+    // at every position. Assume that first, and only pay for counting the real matches when the
+    // assumption is over the ceiling. Same compromise as `replace`.
+    let most_matches = match limit {
+        0 => source.len().saturating_add(1),
+        limit => limit,
+    };
+    let ceiling = max_string_func_result_bytes(temp_storage);
+    if max_result_bytes(most_matches) > ceiling {
+        let matches = regexp.find_iter(source).take(most_matches).count();
+        if max_result_bytes(matches) > ceiling {
+            return Err(EvalError::LengthTooLarge);
+        }
+    }
+
     Ok(regexp.replacen(source, limit, replacement))
 }
 
@@ -1378,6 +1457,11 @@ fn string_to_array_impl<'a>(
         lower_bound: 1,
         length: found.len(),
     }];
+
+    // Splitting amplifies: each chunk is packed with its own tag and length, so a delimiter that
+    // splits per character costs several times the input. `Datum::Null` packs smaller than the
+    // chunk it replaces, so treating every chunk as a string is an upper bound.
+    check_datums_fit_budget(found.iter().copied().map(Datum::String), temp_storage)?;
 
     if let Some(null_string) = null_string {
         let found_datums = found.into_iter().map(|chunk| {
@@ -1519,17 +1603,41 @@ fn concat_ws(
 }
 
 #[sqlfunc]
-fn translate(string: &str, from_str: &str, to_str: &str) -> String {
+fn translate(
+    string: &str,
+    from_str: &str,
+    to_str: &str,
+    temp_storage: &RowArena,
+) -> Result<String, EvalError> {
+    // Translating to a wider character amplifies: each byte of an ASCII input can become four.
+    // Every output character is either the input character or a `to` character, so it costs at most
+    // `max(len_utf8(c), widest)` bytes, and at most `len_utf8(c) + widest - 1` since a character is
+    // at least one byte. Summed, that's the input's byte length plus one `widest - 1` per character.
+    // Tight when every character widens, exactly the input length when `to` is ASCII, so we refuse
+    // only calls that really would exceed the ceiling.
+    let widest = to_str.chars().map(char::len_utf8).max().unwrap_or(0);
+    let max_result_bytes = match widest.saturating_sub(1) {
+        // An ASCII `to` widens nothing, so the result fits the input and counting characters isn't
+        // worth a second pass.
+        0 => string.len(),
+        widening => string
+            .len()
+            .saturating_add(string.chars().count().saturating_mul(widening)),
+    };
+    if max_result_bytes > max_string_func_result_bytes(temp_storage) {
+        return Err(EvalError::LengthTooLarge);
+    }
+
     let from = from_str.chars().collect::<Vec<_>>();
     let to = to_str.chars().collect::<Vec<_>>();
 
-    string
+    Ok(string
         .chars()
         .filter_map(|c| match from.iter().position(|f| f == &c) {
             Some(idx) => to.get(idx).copied(),
             None => Some(c),
         })
-        .collect()
+        .collect())
 }
 
 #[sqlfunc(

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -40,7 +40,7 @@ use mz_repr::{
 use serde::{Deserialize, Serialize};
 
 use crate::func::{
-    CaseLiteral, MAX_STRING_FUNC_RESULT_BYTES, array_create_scalar, build_regex, date_bin,
+    CaseLiteral, array_create_scalar, build_regex, date_bin, max_string_func_result_bytes,
     parse_timezone, regexp_match_static, regexp_replace_parse_flags, regexp_split_to_array_re,
     stringify_datum, timezone_time,
 };
@@ -321,6 +321,19 @@ fn array_fill<'a>(
         None | Some(MAX_SIZE..)
     ) {
         return Err(EvalError::MaxArraySizeExceeded(MAX_SIZE));
+    }
+
+    // The packed array lands in `temp_storage`, and building it first allocates a transient
+    // `Vec<Datum>` of `fill_count` elements. Unlike the string amplifiers, `array_fill` sizes its
+    // result from a parameter rather than its input, so without this check a single call could
+    // spike far past a budgeted arena before the evaluator's post-call check ever runs. Refuse both
+    // allocations up front instead. Without a budget `budget_remaining` is `usize::MAX` and both
+    // comparisons fold away, so this is free in a dataflow.
+    let budget_remaining = temp_storage.budget_remaining();
+    let packed_size = mz_repr::datum_size(&fill).saturating_mul(fill_count);
+    let build_size = fill_count.saturating_mul(std::mem::size_of::<Datum<'a>>());
+    if packed_size > budget_remaining || build_size > budget_remaining {
+        return Err(EvalError::TempStorageBudgetExceeded);
     }
 
     let array_dimensions = if fill_count == 0 {
@@ -1196,7 +1209,12 @@ impl LazyVariadicFunc for Or {
 }
 
 #[sqlfunc(sqlname = "lpad")]
-fn pad_leading(string: &str, raw_len: i32, pad: OptionalArg<&str>) -> Result<String, EvalError> {
+fn pad_leading(
+    string: &str,
+    raw_len: i32,
+    pad: OptionalArg<&str>,
+    temp_storage: &RowArena,
+) -> Result<String, EvalError> {
     let len = match usize::try_from(raw_len) {
         Ok(len) => len,
         Err(_) => {
@@ -1205,7 +1223,7 @@ fn pad_leading(string: &str, raw_len: i32, pad: OptionalArg<&str>) -> Result<Str
             ));
         }
     };
-    if len > MAX_STRING_FUNC_RESULT_BYTES {
+    if len > max_string_func_result_bytes(temp_storage) {
         return Err(EvalError::LengthTooLarge);
     }
 
@@ -1271,18 +1289,19 @@ fn regexp_replace<'a>(
 }
 
 #[sqlfunc]
-fn replace(text: &str, from: &str, to: &str) -> Result<String, EvalError> {
+fn replace(text: &str, from: &str, to: &str, temp_storage: &RowArena) -> Result<String, EvalError> {
     // As a compromise to avoid always nearly duplicating the work of replace by doing size estimation,
     // we first check if it's possible for the fully replaced string to exceed the limit by assuming that
     // every possible substring is replaced.
     //
     // If that estimate exceeds the limit, we then do a more precise (and expensive) estimate by counting
     // the actual number of replacements that would occur, and using that to calculate the final size.
+    let max_result_bytes = max_string_func_result_bytes(temp_storage);
     let possible_size = text.len() * to.len();
-    if possible_size > MAX_STRING_FUNC_RESULT_BYTES {
+    if possible_size > max_result_bytes {
         let replacement_count = text.matches(from).count();
         let estimated_size = text.len() + replacement_count * (to.len().saturating_sub(from.len()));
-        if estimated_size > MAX_STRING_FUNC_RESULT_BYTES {
+        if estimated_size > max_result_bytes {
             return Err(EvalError::LengthTooLarge);
         }
     }
@@ -1456,12 +1475,13 @@ fn split_part<'a>(string: &'a str, delimiter: &str, field: i32) -> Result<&'a st
 }
 
 #[sqlfunc(is_associative = true)]
-fn concat(strs: Variadic<Option<&str>>) -> Result<String, EvalError> {
+fn concat(strs: Variadic<Option<&str>>, temp_storage: &RowArena) -> Result<String, EvalError> {
+    let max_result_bytes = max_string_func_result_bytes(temp_storage);
     let mut total_size = 0;
     for s in &strs {
         if let Some(s) = s {
             total_size += s.len();
-            if total_size > MAX_STRING_FUNC_RESULT_BYTES {
+            if total_size > max_result_bytes {
                 return Err(EvalError::LengthTooLarge);
             }
         }
@@ -1476,13 +1496,18 @@ fn concat(strs: Variadic<Option<&str>>) -> Result<String, EvalError> {
 }
 
 #[sqlfunc]
-fn concat_ws(ws: &str, rest: Variadic<Option<&str>>) -> Result<String, EvalError> {
+fn concat_ws(
+    ws: &str,
+    rest: Variadic<Option<&str>>,
+    temp_storage: &RowArena,
+) -> Result<String, EvalError> {
+    let max_result_bytes = max_string_func_result_bytes(temp_storage);
     let mut total_size = 0;
     for s in &rest {
         if let Some(s) = s {
             total_size += s.len();
             total_size += ws.len();
-            if total_size > MAX_STRING_FUNC_RESULT_BYTES {
+            if total_size > max_result_bytes {
                 return Err(EvalError::LengthTooLarge);
             }
         }

--- a/src/regexp/src/lib.rs
+++ b/src/regexp/src/lib.rs
@@ -40,11 +40,24 @@ pub fn regexp_split_to_array<'a>(text: &'a str, regexp: &Regex) -> Vec<&'a str> 
     found
 }
 
+/// How many chunks [`regexp_split_to_array`] would return, without building them.
+///
+/// One chunk per kept match plus the trailing remainder, keeping a match exactly when it is not
+/// zero-length at the start or end of the string. This must mirror the split's rule so a caller
+/// sizing an allocation refuses only what the split itself would refuse.
+/// `tests::test_regexp_split_array_count` pins the two together.
+pub fn regexp_split_to_array_count(text: &str, regexp: &Regex) -> usize {
+    1 + regexp
+        .find_iter(text)
+        .filter(|m| m.end() > 0 && m.start() < text.len())
+        .count()
+}
+
 #[cfg(test)]
 mod tests {
     use mz_repr::adt::regex::Regex;
 
-    use crate::regexp_split_to_array;
+    use crate::{regexp_split_to_array, regexp_split_to_array_count};
 
     fn build_regex(needle: &str, flags: &str) -> Result<Regex, anyhow::Error> {
         let mut case_insensitive = false;
@@ -236,6 +249,26 @@ mod tests {
                 println!(
                     "input: `{}`, regex: `{}`, got: {:?}, expect: {:?}",
                     tc.text, tc.regexp, result, tc.expect
+                );
+            }
+        }
+    }
+
+    /// The count must agree with the split for every input, so a caller sizing an allocation from
+    /// it refuses exactly what the split would have built. Covers no match, matches at each
+    /// boundary, and empty-string matches, where the naive "matches + 1" is wrong.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // too slow
+    fn test_regexp_split_array_count() {
+        let texts = ["", " ", "  ", "abc", "aaa", "12 34", " 12 34 "];
+        let regexps = ["", "\\s", "\\s+", "\\s*", "a", "a*", "b*", "x"];
+        for text in texts {
+            for re in regexps {
+                let regex = build_regex(re, "").unwrap();
+                assert_eq!(
+                    regexp_split_to_array_count(text, &regex),
+                    regexp_split_to_array(text, &regex).len(),
+                    "text: `{text}`, regexp: `{re}`",
                 );
             }
         }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -838,9 +838,10 @@ pub struct RowArena {
     // finds the slot empty and allocates its own buffer instead of double-borrowing.
     scratch: RefCell<Option<Vec<u8>>>,
     // Optional ceiling on the bytes this arena will hold, and a running total of what it holds.
-    // `None` is unbounded, which is what every arena in a dataflow uses. A budget is for evaluating
-    // a user-authored expression in a shared process, where that expression's memory use has to be
-    // bounded (see `mz_adapter::webhook`).
+    // `None` is unbounded, which is what every arena in a dataflow must keep using: a budget that
+    // can change mid-run would make dataflow evaluation non-deterministic (see
+    // [`RowArena::with_budget`]). A budget is for evaluating a user-authored expression in a shared
+    // process, where that expression's memory use must be bounded (see `mz_adapter::webhook`).
     //
     // NOTE: exceeding the budget does not make a push fail. The pushes are infallible, and a
     // refused push would hand back a truncated value, i.e. a corrupt datum. The budget is instead a
@@ -3101,6 +3102,15 @@ impl RowArena {
     /// truncated value would corrupt the datum. It is the caller's job to poll `over_budget` at a
     /// point where it can fail, so the bytes an arena actually reaches is `budget` plus whatever the
     /// operation in flight at the time added.
+    ///
+    /// NOTE: a budget bounds a single ad-hoc evaluation in a shared process (see
+    /// `mz_adapter::webhook`). It must not be given to an arena that feeds a compute dataflow. A
+    /// dataflow re-evaluates the same expression against the same input and must return the same
+    /// result every time. Whether an evaluation is over budget depends on what else the arena has
+    /// accumulated, and the webhook budget is a runtime dyncfg, so a budgeted dataflow arena would
+    /// make the result depend on when it ran. Differential then turns a changed-but-not-retracted
+    /// result into non-accumulating diffs that corrupt the collection. A dataflow that ever needs a
+    /// budget must fix it for the lifetime of a cluster replica.
     pub fn with_budget(budget: usize) -> Self {
         RowArena {
             budget: Some(budget),
@@ -3216,23 +3226,31 @@ impl RowArena {
 
     /// Moves `bytes` into the arena and returns a reference valid for its lifetime.
     ///
-    /// Prefer this to [`RowArena::push_bytes`] whenever the bytes are already owned: when they do
-    /// not fit the active region, their allocation is adopted as a region instead of a fresh region
-    /// being allocated and copied into, which for a large value halves the peak.
+    /// Prefer this to [`RowArena::push_bytes`] whenever the bytes are already owned: a value large
+    /// enough that it would get a region to itself has its allocation adopted as that region, rather
+    /// than a fresh region being allocated and copied into, which for a large value halves the peak.
+    /// Smaller values are copied, so the arena keeps bump allocating.
     pub fn push_owned_bytes<'a>(&'a self, bytes: Vec<u8>) -> &'a [u8] {
+        /// Never adopt below this, however empty the arena. `last_cap` alone would let every value
+        /// on a fresh or small arena look big enough, and then each gets an exactly-sized region
+        /// with no headroom: one region and one `Vec<u8>` header per value.
+        const MIN_ADOPT_BYTES: usize = 4 * 1024;
+
         let need = bytes.len();
         if need == 0 {
             return &[];
         }
 
         let mut inner = self.inner.borrow_mut();
-        let has_room = inner
-            .last()
-            .map_or(false, |region| region.capacity() - region.len() >= need);
-        if has_room {
-            // Copying into a region that is already paid for beats giving these bytes one of their
-            // own. Adopting unconditionally would turn every small string into its own allocation
-            // and defeat the bump allocator.
+        // Adopt only when `push_bytes` would have given these bytes a dedicated, `need`-sized region
+        // anyway, i.e. when `need` exceeds the `last_cap * 2` it would otherwise allocate. There's
+        // no headroom to lose, so adoption saves a copy for free. Below that we copy, because
+        // `push_bytes` grows a region *with* headroom that later values reuse. Adopting there would
+        // defeat the bump allocator: adoption leaves an empty region (capacity 0) on top, so nothing
+        // would ever grow a region with headroom again.
+        let last_cap = inner.last().map_or(0, |region| region.capacity());
+        let adopt = need > std::cmp::max(MIN_ADOPT_BYTES, last_cap.saturating_mul(2));
+        if !adopt {
             drop(inner);
             return self.push_bytes(&bytes[..]);
         }
@@ -3713,6 +3731,53 @@ mod tests {
     }
 
     #[mz_ore::test]
+    fn test_arena_owned_pushes_keep_bump_allocating() {
+        // Adoption never *creates* a region with headroom: it inserts the caller's buffer, whose
+        // capacity equals its length, below whatever is on top. Only `push_bytes` grows the arena
+        // geometrically (`new_cap = max(need, last_cap * 2)`), so once the active region cannot fit
+        // an incoming value it never can again and every later owned push adopts: one retained
+        // allocation and one `Vec<u8>` header per value, rather than `O(log n)` regions. That is the
+        // default path for every `String`- and `Vec<u8>`-returning scalar function, and the arenas
+        // in the MFP and join paths outlive a single row, so the region list grows with the number
+        // of string values in a batch. `RowArena::clear` scans every region, so it degrades too.
+        const VALUES: usize = 500;
+        const VALUE: &str = "0123456789";
+
+        let regions = |arena: &RowArena| arena.inner.borrow().len();
+        let push_all = |arena: &RowArena, owned: bool| {
+            for _ in 0..VALUES {
+                match owned {
+                    true => _ = arena.push_string(VALUE.to_string()),
+                    false => _ = arena.push_bytes(VALUE.as_bytes()),
+                }
+            }
+        };
+
+        // The bump allocator working as intended, as the baseline to hold the owned path to.
+        let copied = RowArena::new();
+        push_all(&copied, false);
+
+        let owned = RowArena::new();
+        push_all(&owned, true);
+
+        // Seeding with ordinary copies first must not change the answer. The arena never recovers,
+        // so this is not just the empty-arena case where the placeholder on top has capacity 0.
+        let seeded = RowArena::new();
+        let _ = seeded.push_bytes(VALUE.as_bytes());
+        push_all(&seeded, true);
+
+        // Compare against the copy path rather than an absolute count, so this pins the property (a
+        // run of small owned pushes still ends with a region that has headroom) and leaves the
+        // adoption predicate to the fix.
+        let (copied, owned, seeded) = (regions(&copied), regions(&owned), regions(&seeded));
+        assert!(
+            owned <= copied * 2 && seeded <= copied * 2,
+            "{VALUES} owned pushes left {owned} regions on an empty arena and {seeded} on a seeded \
+             one, against {copied} for the same bytes copied",
+        );
+    }
+
+    #[mz_ore::test]
     fn miri_test_arena_budget() {
         // Without a budget nothing is ever over it, however much is pushed.
         let arena = RowArena::new();
@@ -3739,8 +3804,9 @@ mod tests {
         assert_eq!(arena.budget_remaining(), 0);
 
         // An adopted buffer counts against the budget too, or adoption would be a way around it.
+        // Large enough to actually be adopted rather than copied.
         let mut arena = RowArena::with_budget(100);
-        let _ = arena.push_owned_bytes(vec![0u8; 101]);
+        let _ = arena.push_owned_bytes(vec![0u8; 8 * 1024]);
         assert!(arena.over_budget());
 
         arena.clear();

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -837,6 +837,17 @@ pub struct RowArena {
     // writer's lifetime. That keeps nested writers sound: a writer obtained while another is live
     // finds the slot empty and allocates its own buffer instead of double-borrowing.
     scratch: RefCell<Option<Vec<u8>>>,
+    // Optional ceiling on the bytes this arena will hold, and a running total of what it holds.
+    // `None` is unbounded, which is what every arena in a dataflow uses. A budget is for evaluating
+    // a user-authored expression in a shared process, where that expression's memory use has to be
+    // bounded (see `mz_adapter::webhook`).
+    //
+    // NOTE: exceeding the budget does not make a push fail. The pushes are infallible, and a
+    // refused push would hand back a truncated value, i.e. a corrupt datum. The budget is instead a
+    // *reported* condition: `over_budget` is polled by whoever is able to return an error, which
+    // for scalar expressions is the evaluator between calls.
+    budget: Option<usize>,
+    allocated: Cell<usize>,
 }
 
 // DatumList and DatumDict defined here rather than near Datum because we need private access to the unsafe data field
@@ -3078,6 +3089,45 @@ impl RowArena {
         RowArena {
             inner: RefCell::new(vec![]),
             scratch: RefCell::new(None),
+            budget: None,
+            allocated: Cell::new(0),
+        }
+    }
+
+    /// Creates a `RowArena` that reports itself [`RowArena::over_budget`] once it holds more than
+    /// `budget` bytes.
+    ///
+    /// The budget is advisory to the arena itself: pushes still succeed, because handing back a
+    /// truncated value would corrupt the datum. It is the caller's job to poll `over_budget` at a
+    /// point where it can fail, so the bytes an arena actually reaches is `budget` plus whatever the
+    /// operation in flight at the time added.
+    pub fn with_budget(budget: usize) -> Self {
+        RowArena {
+            budget: Some(budget),
+            ..RowArena::new()
+        }
+    }
+
+    /// Bytes this arena currently holds.
+    pub fn allocated_bytes(&self) -> usize {
+        self.allocated.get()
+    }
+
+    /// Whether this arena holds more than its budget. Always false without one.
+    pub fn over_budget(&self) -> bool {
+        self.budget
+            .is_some_and(|budget| self.allocated.get() > budget)
+    }
+
+    /// Bytes this arena can still take before it is [`RowArena::over_budget`], or `usize::MAX`
+    /// without a budget.
+    ///
+    /// Intended for an operation that can predict its own size and would rather fail than build a
+    /// value it is about to be told is too big.
+    pub fn budget_remaining(&self) -> usize {
+        match self.budget {
+            None => usize::MAX,
+            Some(budget) => budget.saturating_sub(self.allocated.get()),
         }
     }
 
@@ -3090,7 +3140,7 @@ impl RowArena {
         }
         RowArena {
             inner: RefCell::new(inner),
-            scratch: RefCell::new(None),
+            ..RowArena::new()
         }
     }
 
@@ -3148,6 +3198,7 @@ impl RowArena {
         let region = inner.last_mut().expect("region present");
         let start = region.len();
         region.extend_from_slice(bytes);
+        self.allocated.set(self.allocated.get() + need);
         let copied = &region[start..];
         unsafe {
             // This is safe because:
@@ -3163,11 +3214,54 @@ impl RowArena {
         }
     }
 
-    /// Copies `string` into the arena and returns a reference valid for its lifetime.
+    /// Moves `bytes` into the arena and returns a reference valid for its lifetime.
+    ///
+    /// Prefer this to [`RowArena::push_bytes`] whenever the bytes are already owned: when they do
+    /// not fit the active region, their allocation is adopted as a region instead of a fresh region
+    /// being allocated and copied into, which for a large value halves the peak.
+    pub fn push_owned_bytes<'a>(&'a self, bytes: Vec<u8>) -> &'a [u8] {
+        let need = bytes.len();
+        if need == 0 {
+            return &[];
+        }
+
+        let mut inner = self.inner.borrow_mut();
+        let has_room = inner
+            .last()
+            .map_or(false, |region| region.capacity() - region.len() >= need);
+        if has_room {
+            // Copying into a region that is already paid for beats giving these bytes one of their
+            // own. Adopting unconditionally would turn every small string into its own allocation
+            // and defeat the bump allocator.
+            drop(inner);
+            return self.push_bytes(&bytes[..]);
+        }
+
+        // `push_bytes` would allocate a fresh region here and copy into it, so adopt the caller's
+        // allocation as that region. Sound for the same reasons as `push_bytes`: the reference
+        // points into a heap buffer the arena now owns for `'a`, and the buffer is never resized
+        // while it holds data.
+        //
+        // Inserted *below* the active region rather than appended, because `push_bytes` sizes a new
+        // region as twice the last one's capacity: leaving a large adopted buffer on top would make
+        // the next push allocate twice its size.
+        self.allocated.set(self.allocated.get() + need);
+        let idx = inner.len().saturating_sub(1);
+        inner.insert(idx, bytes);
+        if inner.len() == 1 {
+            // There was no active region to insert below, so keep an empty one on top for the same
+            // reason. `Vec::new` does not allocate.
+            inner.push(Vec::new());
+        }
+        let adopted = &inner[idx][..];
+        unsafe { transmute::<&[u8], &'a [u8]>(adopted) }
+    }
+
+    /// Moves `string` into the arena and returns a reference valid for its lifetime.
     pub fn push_string<'a>(&'a self, string: String) -> &'a str {
-        let copied = self.push_bytes(string.as_bytes());
+        let copied = self.push_owned_bytes(string.into_bytes());
         unsafe {
-            // This is safe because we just copied the bytes of a valid `String`.
+            // This is safe because we just moved in the bytes of a valid `String`.
             std::str::from_utf8_unchecked(copied)
         }
     }
@@ -3294,6 +3388,7 @@ impl RowArena {
             inner.truncate(1);
             inner[0].clear();
         }
+        self.allocated.set(0);
     }
 }
 
@@ -3594,6 +3689,63 @@ mod tests {
         arena.clear();
         let empty: &[u8] = &[];
         assert_eq!(arena.push_bytes(Vec::<u8>::new()), empty);
+    }
+
+    #[mz_ore::test]
+    fn miri_test_arena_adopts_owned_bytes_and_keeps_references() {
+        // `push_owned_bytes` adopts a buffer too large for the active region instead of copying it,
+        // which puts a region the arena never wrote into in the middle of the stack. References
+        // handed out before and after that must all stay valid.
+        let arena = RowArena::new();
+        let before = arena.push_bytes(vec![1u8; 8]);
+        let adopted = arena.push_owned_bytes(vec![2u8; 64 * 1024]);
+        let after = arena.push_bytes(vec![3u8; 8]);
+        // A small buffer fits the active region, so it is copied rather than given a region.
+        let small = arena.push_owned_bytes(vec![4u8; 4]);
+
+        assert_eq!(before, &[1u8; 8]);
+        assert_eq!(adopted, &vec![2u8; 64 * 1024][..]);
+        assert_eq!(after, &[3u8; 8]);
+        assert_eq!(small, &[4u8; 4]);
+
+        let empty: &[u8] = &[];
+        assert_eq!(arena.push_owned_bytes(vec![]), empty);
+    }
+
+    #[mz_ore::test]
+    fn miri_test_arena_budget() {
+        // Without a budget nothing is ever over it, however much is pushed.
+        let arena = RowArena::new();
+        let _ = arena.push_bytes(vec![0u8; 1024]);
+        assert!(!arena.over_budget());
+        assert_eq!(arena.budget_remaining(), usize::MAX);
+
+        let arena = RowArena::with_budget(100);
+        assert!(!arena.over_budget());
+        assert_eq!(arena.budget_remaining(), 100);
+
+        // Staying within the budget leaves it satisfied, and the remaining count tracks what a
+        // caller that predicts its own size would consult.
+        let _ = arena.push_bytes(vec![0u8; 60]);
+        assert!(!arena.over_budget());
+        assert_eq!(arena.budget_remaining(), 40);
+        assert_eq!(arena.allocated_bytes(), 60);
+
+        // Crossing it reports, rather than refusing the push: a truncated push would corrupt the
+        // datum, so the value is intact and it is the caller's job to fail.
+        let pushed = arena.push_bytes(vec![7u8; 80]);
+        assert_eq!(pushed, &[7u8; 80]);
+        assert!(arena.over_budget());
+        assert_eq!(arena.budget_remaining(), 0);
+
+        // An adopted buffer counts against the budget too, or adoption would be a way around it.
+        let mut arena = RowArena::with_budget(100);
+        let _ = arena.push_owned_bytes(vec![0u8; 101]);
+        assert!(arena.over_budget());
+
+        arena.clear();
+        assert!(!arena.over_budget());
+        assert_eq!(arena.allocated_bytes(), 0);
     }
 
     #[mz_ore::test]

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -2775,7 +2775,7 @@ impl<'a, E> OutputDatumType<'a, E> for Vec<u8> {
     }
 
     fn into_result(self, temp_storage: &'a RowArena) -> Result<Datum<'a>, E> {
-        Ok(Datum::Bytes(temp_storage.push_bytes(self)))
+        Ok(Datum::Bytes(temp_storage.push_owned_bytes(self)))
     }
 }
 

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -668,6 +668,7 @@ mod columnation {
                         | e @ EvalError::InvalidTimezoneInterval
                         | e @ EvalError::InvalidTimezoneConversion
                         | e @ EvalError::LengthTooLarge
+                        | e @ EvalError::TempStorageBudgetExceeded
                         | e @ EvalError::AclArrayNullElement
                         | e @ EvalError::MzAclArrayNullElement => e.clone(),
                         EvalError::Unsupported {


### PR DESCRIPTION
Problem:
A webhook CHECK is a user defined expression that environmentd evaluates once per in-flight request, and nothing bounds what it could allocate.

The webhook path caps request count (500) and body size (5 MiB), but the evaluation's footprint is per-request and was bounded only by MAX_STRING_FUNC_RESULT_BYTES, a 100 MiB per-call ceiling sized for a cluster.

That ceiling multiplies by request concurrency, so a CHECK doing length(repeat(body, 20)) >= 0 turned 150 concurrent 5 MB posts into 8.7 GiB of RSS, growing with the number of clients.

Solution:
- Give RowArena an optional budget and build the validation arena with one, defaulting to 20 MiB via a new dyncfg, webhook_validation_memory_budget_bytes.
- Functions that can predict their result size consult max_string_func_result_bytes, which narrows the constant to the arena's remaining budget, so an over-budget result is never allocated at all.
- Everything else is caught by a post-call check in the evaluator, which covers functions with no ceiling of their own.
- Stop copying an owned result into the arena. String and Vec<u8> outputs went through push_string/push_bytes, which copied and dropped the original.

An unbudgeted arena, which is every arena in a dataflow, is unaffected

Testing:
- New integration test webhook_validation_memory_budget: a 2 MiB body that amplifies past the 20 MiB default is refused with 400, a smaller body through the same source succeeds, and raising then lowering the dyncfg flips the result both ways
- New expr unit tests cover the pre-check and post-call paths
- New unit tests cover the arena bookkeeping and buffer adoption

