### PR TITLE
rust: Convert cheap debug_asserts into soft_asserts

### DIFF
--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -1051,7 +1051,7 @@ impl Catalog {
                 }
             }
             TransactInnerMode::DryRun => {
-                debug_assert!(
+                mz_ore::soft_assert_no_log!(
                     storage_collections.is_none(),
                     "dry-run mode must not prepare storage state"
                 );

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -642,7 +642,7 @@ impl Name {
                 _ => out.push('_'),
             }
         }
-        debug_assert!(
+        mz_ore::soft_assert_no_log!(
             Name::is_valid(&out),
             "make_valid({name}) produced invalid name: {out}"
         );

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -322,7 +322,7 @@ impl DemuxHandler<'_, '_, '_> {
         let ts = self.ts();
         let operator_id = event.operator;
         let diff = Diff::cast_from(event.diff);
-        debug_assert_ne!(diff, Diff::ZERO);
+        mz_ore::soft_assert_ne_no_log!(diff, Diff::ZERO);
         self.output.sharing.give(((operator_id, ()), ts, diff));
 
         let sharing = self.state.sharing.entry(operator_id).or_default();

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1661,7 +1661,7 @@ const FLOAT_SCALE: f64 = (1_u64 << FLOAT_SCALE_EXP) as f64;
 /// would saturate to `i128::MAX` and `i128::MIN`, which sum to `-1` rather than
 /// `0` (see database-issues#11265).
 fn float_to_fixed_point(n: f64) -> i128 {
-    debug_assert!(n.is_finite());
+    mz_ore::soft_assert_no_log!(n.is_finite());
 
     // Decompose `n` into integer parts such that `n == sign * mantissa *
     // 2^exponent`. Folding in the `* 2^FLOAT_SCALE_EXP` scaling then amounts to

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -997,7 +997,7 @@ pub mod monoids {
 
     impl Ord for Top1Monoid {
         fn cmp(&self, other: &Self) -> Ordering {
-            debug_assert_eq!(self.order_key, other.order_key);
+            mz_ore::soft_assert_eq_no_log!(self.order_key, other.order_key);
 
             // It might be nice to cache this row decoding like the non-monotonic codepath, but we'd
             // have to store the decoded Datums in the same struct as the Row, which gets tricky.
@@ -1120,7 +1120,7 @@ pub mod monoids {
 
     impl Ord for Top1MonoidLocal {
         fn cmp(&self, other: &Self) -> Ordering {
-            debug_assert!(Rc::ptr_eq(&self.shared, &other.shared));
+            mz_ore::soft_assert_no_log!(Rc::ptr_eq(&self.shared, &other.shared));
             let Top1MonoidShared {
                 left,
                 right,

--- a/src/compute/src/sink/correction.rs
+++ b/src/compute/src/sink/correction.rs
@@ -222,7 +222,7 @@ impl<D: Data> CorrectionV1<D> {
         let mut new_size = self.total_size;
         let mut updates = updates.drain(..).peekable();
         while let Some(&(_, time, _)) = updates.peek() {
-            debug_assert!(
+            mz_ore::soft_assert_no_log!(
                 self.since.less_equal(&time),
                 "update not advanced by `since`"
             );

--- a/src/compute/src/sink/correction_v2.rs
+++ b/src/compute/src/sink/correction_v2.rs
@@ -855,7 +855,7 @@ impl<D: Data> Chain<D> {
     /// All updates in the chunk must sort after all updates already in the chain, in
     /// (time, data)-order, to ensure the chain remains sorted.
     fn push_chunk(&mut self, chunk: Chunk<D>) {
-        debug_assert!(self.can_accept_chunk(&chunk));
+        mz_ore::soft_assert_no_log!(self.can_accept_chunk(&chunk));
 
         self.update_count += chunk.len();
         self.chunks.push(chunk);
@@ -864,9 +864,13 @@ impl<D: Data> Chain<D> {
     /// Return whether the chain can accept the given chunk at its end while preserving
     /// (time, data)-order.
     ///
-    /// Uses the cached boundary times and only materializes the boundary chunks when the times
-    /// tie (a single timestamp straddling the chunk boundary), so the common
-    /// strictly-increasing-time case checks the invariant without paging chunks in.
+    /// NOTE: The cached boundary times settle every case but a tie. On a tie the boundary updates
+    /// themselves are compared, which materializes both chunks and keeps them resident for the
+    /// rest of their lifetime. The only caller is the soft assertion in [`Chain::push_chunk`], and
+    /// soft assertions are live in any build started with `MZ_SOFT_ASSERTIONS` set, so this cost is
+    /// not confined to debug builds. Ties are reached whenever a run of updates at a single
+    /// timestamp spans a chunk boundary, which [`ChunkBuilder`] produces for any such run larger
+    /// than its byte limit.
     fn can_accept_chunk(&self, chunk: &Chunk<D>) -> bool {
         match self.chunks.last() {
             None => true,
@@ -955,8 +959,10 @@ impl<D: Data> Chain<D> {
         };
 
         for chunk in self.chunks.drain(..) {
-            // Route whole chunks by cached boundary times so a chunk that lands entirely on one
-            // side is moved without paging it in; only a straddling chunk is materialized.
+            // Route whole chunks by cached boundary times, so a chunk that lands entirely on one
+            // side is moved without paging it in. Only a straddling chunk is materialized here.
+            // With soft assertions on, `push_chunk` can still page in a chunk whose boundary time
+            // ties the chain's last one, see `Chain::can_accept_chunk`.
             if chunk.last_time() < time {
                 lower.push_chunk(chunk);
             } else if chunk.first_time() >= time {
@@ -1553,7 +1559,7 @@ impl<D: Data> ChunkBuilder<D> {
         std::iter::from_fn(move || {
             loop {
                 let col = std::mem::take(self.inner.finish()?);
-                if col.borrow().len() > 0 {
+                if !col.is_empty() {
                     return Some(Chunk::from_column(col));
                 }
             }

--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -392,7 +392,7 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
                     buf.extend(iv.months.to_le_bytes());
                     buf.extend(iv.days.to_le_bytes());
                     buf.extend(iv.micros.to_le_bytes());
-                    debug_assert_eq!(buf.len(), 16);
+                    mz_ore::soft_assert_eq_no_log!(buf.len(), 16);
                     buf
                 }),
                 SqlScalarType::Bytes => Value::Bytes(Vec::from(datum.unwrap_bytes())),

--- a/src/mz-deploy/src/project/compiler/typecheck/executor.rs
+++ b/src/mz-deploy/src/project/compiler/typecheck/executor.rs
@@ -170,7 +170,7 @@ fn worker_loop<T, F>(
                 .get(dependent_id)
                 .expect("dependent has a bookkeeping entry");
             let prev = dep_bk.remaining_deps.fetch_sub(1, Ordering::AcqRel);
-            debug_assert!(prev >= 1, "remaining_deps underflow for {dependent_id:?}");
+            mz_ore::soft_assert_no_log!(prev >= 1, "remaining_deps underflow for {dependent_id:?}");
             if prev == 1 {
                 tx.send(Some(dependent_id.clone())).expect("channel open");
             }

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -39,6 +39,7 @@
 //!   * [`soft_assert_no_log`](crate::soft_assert_no_log)
 //!   * [`soft_assert_eq_no_log`](crate::soft_assert_eq_no_log)
 //!   * [`soft_assert_ne_no_log`](crate::soft_assert_ne_no_log)
+//!   * [`soft_assert_none_no_log`](crate::soft_assert_none_no_log)
 //!
 //! The `_or_log` variants should be used by default, as they allow us to find
 //! failed condition checks in production. The `_no_log` variants are silent
@@ -147,6 +148,23 @@ macro_rules! soft_assert_ne_no_log {
     ($cond:expr, $($arg:tt)+) => {{
         if $crate::assert::soft_assertions_enabled() {
             assert_ne!($cond, $($arg)+);
+        }
+    }}
+}
+
+/// Asserts that the provided expression, that returns an `Option`, is `None` if
+/// soft assertions are enabled.
+///
+/// Unlike `soft_assert_eq_no_log!(x, None)`, a failure reports the value held by
+/// the `Some(_)` variant. See [`assert_none`](crate::assert_none).
+///
+/// Soft assertions have a small runtime cost even when disabled. See
+/// [`ore::assert`](crate::assert#Soft-assertions) for details.
+#[macro_export]
+macro_rules! soft_assert_none_no_log {
+    ($val:expr $(, $($msg:tt)+)?) => {{
+        if $crate::assert::soft_assertions_enabled() {
+            $crate::assert_none!($val $(, $($msg)+)?);
         }
     }}
 }

--- a/src/ore/src/pool.rs
+++ b/src/ore/src/pool.rs
@@ -2172,7 +2172,7 @@ impl Drop for ChunkHandle {
             }
             Residency::Evicted => {
                 // Eviction already released the slot.
-                debug_assert!(state.slot.is_none(), "evicted chunk holds no slot");
+                crate::soft_assert_no_log!(state.slot.is_none(), "evicted chunk holds no slot");
                 if let Some(extent) = &state.extent {
                     pool.note_extent_released(extent);
                 }

--- a/src/ore/src/pool/extent.rs
+++ b/src/ore/src/pool/extent.rs
@@ -270,7 +270,7 @@ impl SwapExtent {
             let mut buf = cell.borrow_mut();
             codec.encode(bytes, &mut buf);
             let comp_len = buf.len();
-            debug_assert!(
+            crate::soft_assert_no_log!(
                 comp_len <= max_stored_len(bytes.len()),
                 "codec output exceeds the extent-store bound",
             );
@@ -367,7 +367,7 @@ impl SwapExtent {
     /// Callers must not invoke this on a [`SwapExtent::pageout_capped`]
     /// extent.
     pub(crate) fn pageout(&mut self) -> bool {
-        debug_assert!(!self.pageout_capped());
+        crate::soft_assert_no_log!(!self.pageout_capped());
         region::pageout(self.ptr, self.alloc_size);
         if region::nonresident(self.ptr, self.alloc_size) {
             self.resident = false;

--- a/src/ore/src/pool/region.rs
+++ b/src/ore/src/pool/region.rs
@@ -131,7 +131,7 @@ impl SlotAllocator {
 
     /// Returns a previously allocated slot to the warm or cold free list.
     fn free(&mut self, slot: u32, warm: bool) {
-        debug_assert!(slot < self.high_water);
+        crate::soft_assert_no_log!(slot < self.high_water);
         if warm {
             self.free_warm.push(slot);
         } else {
@@ -296,7 +296,7 @@ impl Region {
     /// The base address of a slot, fixed while its owning chunk is resident.
     pub(crate) fn slot_ptr(&self, slot: u32) -> *mut u8 {
         let offset = usize::cast_from(slot) * self.class_size;
-        debug_assert!(offset + self.class_size <= self.capacity);
+        crate::soft_assert_no_log!(offset + self.class_size <= self.capacity);
         // SAFETY: `slot` was handed out by `alloc`, so `offset + class_size`
         // lies within the single `capacity`-byte mapping that `base` points
         // to; the add stays in bounds of one allocated object.
@@ -440,7 +440,7 @@ pub(crate) mod fake_residency {
 /// and both `addr + offset` and `sub_len` are `page`-aligned.
 #[cfg_attr(miri, allow(dead_code))]
 fn aligned_subrange(addr: usize, len: usize, page: usize) -> Option<(usize, usize)> {
-    debug_assert!(page.is_power_of_two());
+    crate::soft_assert_no_log!(page.is_power_of_two());
     let start = addr.checked_add(page - 1)? & !(page - 1);
     let end = addr.checked_add(len)? & !(page - 1);
     (start < end).then(|| (start - addr, end - start))
@@ -457,7 +457,7 @@ fn aligned_subrange(addr: usize, len: usize, page: usize) -> Option<(usize, usiz
 /// unmappable) — proved by the Kani harnesses.
 #[cfg_attr(miri, allow(dead_code))]
 fn align_trim(addr: usize, map_len: usize, len: usize, align: usize) -> Option<(usize, usize)> {
-    debug_assert!(align.is_power_of_two());
+    crate::soft_assert_no_log!(align.is_power_of_two());
     let aligned = addr.checked_next_multiple_of(align)?;
     let head = aligned - addr;
     let tail = map_len.checked_sub(head.checked_add(len)?)?;
@@ -505,7 +505,7 @@ mod sys {
     /// fragmentation).
     pub(super) fn map(len: usize, align: usize) -> io::Result<*mut u8> {
         let page = page_size();
-        debug_assert!(len % page == 0 && align % page == 0);
+        crate::soft_assert_no_log!(len % page == 0 && align % page == 0);
         #[cfg(target_os = "linux")]
         let flags = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_NORESERVE;
         #[cfg(not(target_os = "linux"))]

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -729,7 +729,7 @@ impl<K, V, T, D> LockingTypedState<K, V, T, D> {
         let seqno_before = state.seqno;
         let ret = f(&mut state);
         let seqno_after = state.seqno;
-        debug_assert!(seqno_after >= seqno_before);
+        mz_ore::soft_assert_no_log!(seqno_after >= seqno_before);
         if seqno_after > seqno_before {
             // The notifier only advances the upper waiters' signal on a strict
             // upper advance. The seqno bumps for many non-data reasons (GC,

--- a/src/persist-client/src/internal/cache.rs
+++ b/src/persist-client/src/internal/cache.rs
@@ -224,7 +224,7 @@ mod lru {
 
         /// Returns the total number of entries in the cache.
         pub fn entry_count(&self) -> usize {
-            debug_assert_eq!(self.entries.len(), self.by_time.len());
+            mz_ore::soft_assert_eq_no_log!(self.entries.len(), self.by_time.len());
             self.entries.len()
         }
 

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -886,10 +886,10 @@ where
             // This batch is too large to compact with others, or even in a single go.
             // Process this batch alone, splitting into single-batch chunks as needed.
             let mut run_iter = runs.into_iter().peekable();
-            debug_assert!(current_chunk_ids.is_empty());
-            debug_assert!(current_chunk_descs.is_empty());
-            debug_assert!(current_chunk_runs.is_empty());
-            debug_assert_eq!(current_chunk_max_memory_usage, 0);
+            mz_ore::soft_assert_no_log!(current_chunk_ids.is_empty());
+            mz_ore::soft_assert_no_log!(current_chunk_descs.is_empty());
+            mz_ore::soft_assert_no_log!(current_chunk_runs.is_empty());
+            mz_ore::soft_assert_eq_no_log!(current_chunk_max_memory_usage, 0);
             let mut current_chunk_run_ids = BTreeSet::new();
 
             while let Some((desc, meta, parts)) = run_iter.next() {

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -254,9 +254,10 @@ where
         // seqno hold). The real invariant we want to protect here is that the
         // hold is >= the seqno_since, so validate that instead of anything more
         // specific.
-        debug_assert!(
+        mz_ore::soft_assert_no_log!(
             reader_state.seqno >= seqno_since,
-            "{} vs {}",
+            "leased reader {} registered with seqno hold {} below the shard's seqno_since {}",
+            reader_id,
             reader_state.seqno,
             seqno_since,
         );

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1018,15 +1018,15 @@ impl<T> HollowBatch<T> {
             run_splits.is_strictly_sorted(),
             "run indices should be strictly increasing"
         );
-        debug_assert!(
+        mz_ore::soft_assert_no_log!(
             run_splits.first().map_or(true, |i| *i > 0),
             "run indices should be positive"
         );
-        debug_assert!(
+        mz_ore::soft_assert_no_log!(
             run_splits.last().map_or(true, |i| *i < parts.len()),
             "run indices should be valid indices into parts"
         );
-        debug_assert!(
+        mz_ore::soft_assert_no_log!(
             parts.is_empty() || run_meta.len() == run_splits.len() + 1,
             "all metadata should correspond to a run"
         );
@@ -1467,11 +1467,12 @@ where
         let mut removed = vec![];
         for (seqno, key) in remove_rollups {
             let removed_key = self.rollups.remove(seqno);
-            debug_assert!(
+            mz_ore::soft_assert_no_log!(
                 removed_key.as_ref().map_or(true, |x| &x.key == key),
-                "{} vs {:?}",
-                key,
-                removed_key
+                "rollup at {} to be removed has key {:?} in state, but GC asked to remove {}",
+                seqno,
+                removed_key,
+                key
             );
 
             if removed_key.is_some() {
@@ -1847,7 +1848,7 @@ where
             )
         }
 
-        debug_assert_eq!(self.trace.upper(), batch.desc.upper());
+        mz_ore::soft_assert_eq_no_log!(self.trace.upper(), batch.desc.upper());
         writer_state.most_recent_write_token = idempotency_token.clone();
         // The writer's most recent upper should only go forward.
         assert!(
@@ -2181,7 +2182,7 @@ where
         self.leased_readers.clear();
         self.critical_readers.clear();
 
-        debug_assert!(self.is_tombstone());
+        mz_ore::soft_assert_no_log!(self.is_tombstone());
 
         // Now that we're in a "tombstone" state -- ie. nobody can read the data from a shard or write to
         // it -- the actual contents of our batches no longer matter.

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -708,7 +708,9 @@ where
                         val: Delete(fv.clone()),
                     });
                     let f_next = from.next();
-                    debug_assert!(f_next.as_ref().map_or(true, |(fk_next, _)| fk_next > &fk));
+                    mz_ore::soft_assert_no_log!(
+                        f_next.as_ref().map_or(true, |(fk_next, _)| fk_next > &fk)
+                    );
                     f = f_next;
                 }
                 Ordering::Greater => {
@@ -717,7 +719,9 @@ where
                         val: Insert(tv.clone()),
                     });
                     let t_next = to.next();
-                    debug_assert!(t_next.as_ref().map_or(true, |(tk_next, _)| tk_next > &tk));
+                    mz_ore::soft_assert_no_log!(
+                        t_next.as_ref().map_or(true, |(tk_next, _)| tk_next > &tk)
+                    );
                     t = t_next;
                 }
                 Ordering::Equal => {
@@ -730,10 +734,14 @@ where
                         });
                     }
                     let f_next = from.next();
-                    debug_assert!(f_next.as_ref().map_or(true, |(fk_next, _)| fk_next > &fk));
+                    mz_ore::soft_assert_no_log!(
+                        f_next.as_ref().map_or(true, |(fk_next, _)| fk_next > &fk)
+                    );
                     f = f_next;
                     let t_next = to.next();
-                    debug_assert!(t_next.as_ref().map_or(true, |(tk_next, _)| tk_next > &tk));
+                    mz_ore::soft_assert_no_log!(
+                        t_next.as_ref().map_or(true, |(tk_next, _)| tk_next > &tk)
+                    );
                     t = t_next;
                 }
             },
@@ -743,7 +751,9 @@ where
                     val: Insert(tv.clone()),
                 });
                 let t_next = to.next();
-                debug_assert!(t_next.as_ref().map_or(true, |(tk_next, _)| tk_next > &tk));
+                mz_ore::soft_assert_no_log!(
+                    t_next.as_ref().map_or(true, |(tk_next, _)| tk_next > &tk)
+                );
                 t = t_next;
             }
             (Some((fk, fv)), None) => {
@@ -752,7 +762,9 @@ where
                     val: Delete(fv.clone()),
                 });
                 let f_next = from.next();
-                debug_assert!(f_next.as_ref().map_or(true, |(fk_next, _)| fk_next > &fk));
+                mz_ore::soft_assert_no_log!(
+                    f_next.as_ref().map_or(true, |(fk_next, _)| fk_next > &fk)
+                );
                 f = f_next;
             }
         }

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -920,8 +920,8 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
     }
 
     fn id(&self) -> SpineId {
-        debug_assert_eq!(self.parts.first().map(|x| x.id.0), Some(self.id.0));
-        debug_assert_eq!(self.parts.last().map(|x| x.id.1), Some(self.id.1));
+        mz_ore::soft_assert_eq_no_log!(self.parts.first().map(|x| x.id.0), Some(self.id.0));
+        mz_ore::soft_assert_eq_no_log!(self.parts.last().map(|x| x.id.1), Some(self.id.1));
         self.id
     }
 
@@ -1631,7 +1631,7 @@ impl<T: Timestamp + Lattice> FuelingMerge<T> {
             merged_parts.extend(b.parts)
         }
         // Sanity check the pre-size code.
-        debug_assert_eq!(merged_parts.len(), merged_parts_len);
+        mz_ore::soft_assert_eq_no_log!(merged_parts.len(), merged_parts_len);
 
         if let SpineLog::Enabled { merge_reqs } = log {
             merge_reqs.push(FueledMergeReq {

--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -251,7 +251,7 @@ impl<I: Clone + Ord, S: PartialEq + Debug> SchemaCacheMap<I, S> {
             // same, so just overwrite
             let prev = map.insert(id.clone(), Arc::clone(val));
             match prev {
-                Some(prev) => debug_assert_eq!(*val, prev),
+                Some(prev) => mz_ore::soft_assert_eq_no_log!(*val, prev),
                 None => self.metrics.added_count.inc(),
             }
         } else {

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -652,12 +652,14 @@ impl From<ShardUsageCumulativeMaybeRacy<'_>> for ShardUsageAudit {
         };
 
         // These ones are guaranteed to be equal.
-        debug_assert_eq!(ret.total_bytes(), total_bytes);
-        debug_assert_eq!(ret.not_leaked_bytes(), not_leaked_bytes);
+        mz_ore::soft_assert_eq_no_log!(ret.total_bytes(), total_bytes);
+        mz_ore::soft_assert_eq_no_log!(ret.not_leaked_bytes(), not_leaked_bytes);
         // The rest might have been reduced because of the race condition.
-        debug_assert!(ret.referenced_bytes() <= referenced_bytes);
-        debug_assert!(ret.current_state_bytes() <= x.current_state_bytes);
-        debug_assert!(ret.current_state_batches_bytes <= x.current_state_batches_bytes);
+        mz_ore::soft_assert_no_log!(ret.referenced_bytes() <= referenced_bytes);
+        mz_ore::soft_assert_no_log!(ret.current_state_bytes() <= x.current_state_bytes);
+        mz_ore::soft_assert_no_log!(
+            ret.current_state_batches_bytes <= x.current_state_batches_bytes
+        );
         ret
     }
 }

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -624,7 +624,7 @@ impl<'a> Ord for ArrayIdx<'a> {
         }
         match (&self.array, &other.array) {
             (ArrayOrd::Null(s), ArrayOrd::Null(o)) => {
-                debug_assert!(
+                mz_ore::soft_assert_no_log!(
                     self.idx < s.len() && other.idx < o.len(),
                     "null array indices in bounds"
                 );

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -160,7 +160,7 @@ impl Blob for FileBlob {
         // To implement atomic set, write to a temp file and rename it into
         // place.
         let mut tmp_name = file_path.clone();
-        debug_assert_eq!(tmp_name.extension(), None);
+        mz_ore::soft_assert_none_no_log!(tmp_name.extension());
         tmp_name.set_extension("tmp");
         // NB: Don't use create_new(true) for this so that if we have a partial
         // one from a previous crash, it will just get overwritten (which is

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -974,7 +974,9 @@ impl MultipartConfig {
     }
 
     fn part_iter(&self, blob_len: usize) -> MultipartChunkIter {
-        debug_assert!(self.multipart_chunk_size >= MultipartConfig::MIN_UPLOAD_CHUNK_SIZE);
+        mz_ore::soft_assert_no_log!(
+            self.multipart_chunk_size >= MultipartConfig::MIN_UPLOAD_CHUNK_SIZE
+        );
         MultipartChunkIter::new(self.multipart_chunk_size, blob_len)
     }
 }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -557,7 +557,7 @@ mod columnar {
         const SLICE_COUNT: usize = BC::SLICE_COUNT + VC::SLICE_COUNT;
         #[inline(always)]
         fn get_byte_slice(&self, index: usize) -> (u64, &'a [u8]) {
-            debug_assert!(index < Self::SLICE_COUNT);
+            mz_ore::soft_assert_no_log!(index < Self::SLICE_COUNT);
             if index < BC::SLICE_COUNT {
                 self.bounds.get_byte_slice(index)
             } else {
@@ -3048,10 +3048,11 @@ impl<'a> Iterator for DatumDictIter<'a> {
             let key = unsafe { read_lengthed_datum(&mut self.data, key_tag).unwrap_str() };
             let val = unsafe { read_datum(&mut self.data) };
 
-            // if in debug mode, sanity check keys
-            if cfg!(debug_assertions) {
+            // Gate the `prev_key` bookkeeping on the same flag as the assert it feeds, so builds
+            // with soft assertions off pay nothing for it.
+            if mz_ore::assert::soft_assertions_enabled() {
                 if let Some(prev_key) = self.prev_key {
-                    debug_assert!(
+                    mz_ore::soft_assert_no_log!(
                         prev_key < key,
                         "Dict keys must be unique and given in ascending order: {} came before {}",
                         prev_key,

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -347,7 +347,7 @@ where
         FpCategory::Nan => buf.write_str("NaN"),
         FpCategory::Zero if f.is_sign_negative() => buf.write_str("-0"),
         _ => {
-            debug_assert!(f.is_finite());
+            mz_ore::soft_assert_no_log!(f.is_finite());
             let mut ryu_buf = ryu::Buffer::new();
             let mut s = ryu_buf.format_finite(f);
             if let Some(trimmed) = s.strip_suffix(".0") {

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -169,7 +169,7 @@ mod columnar_timestamp {
         const SLICE_COUNT: usize = 1;
         #[inline(always)]
         fn get_byte_slice(&self, index: usize) -> (u64, &'a [u8]) {
-            debug_assert!(index < Self::SLICE_COUNT);
+            mz_ore::soft_assert_no_log!(index < Self::SLICE_COUNT);
             (
                 u64::cast_from(align_of::<Timestamp>()),
                 bytemuck::cast_slice(self.0),

--- a/src/row-spine/src/lib.rs
+++ b/src/row-spine/src/lib.rs
@@ -625,7 +625,7 @@ mod bytes_container {
         }
         #[inline(always)]
         fn len(&self) -> usize {
-            debug_assert_eq!(self.len, self.offsets.len() - 1);
+            mz_ore::soft_assert_eq_no_log!(self.len, self.offsets.len() - 1);
             self.len
         }
 
@@ -1995,7 +1995,7 @@ mod row_codec {
                 I: IntoIterator<Item = &'a [u8]>,
             {
                 for bytes in iter.into_iter() {
-                    debug_assert!(
+                    mz_ore::soft_assert_no_log!(
                         !bytes.is_empty(),
                         "row encoding never yields empty column slices",
                     );
@@ -2012,7 +2012,7 @@ mod row_codec {
                         // entry instead of reading the datum. This `debug_assert` makes
                         // the load-bearing "no later first-byte outside the observed
                         // union" invariant self-checking.
-                        debug_assert!(
+                        mz_ore::soft_assert_no_log!(
                             self.decode.get(bytes[0].into()).is_none(),
                             "raw datum first-byte {} collides with a dictionary tag; \
                              decode would be ambiguous",
@@ -2111,7 +2111,7 @@ mod row_codec {
             ///    occur, ceasing to compress the ones that do.
             #[inline]
             pub fn observe(&mut self, bytes: &[u8]) {
-                debug_assert!(
+                mz_ore::soft_assert_no_log!(
                     !bytes.is_empty(),
                     "row encoding never yields empty column slices",
                 );

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -924,8 +924,8 @@ mod columnation {
                     DataflowError::EnvelopeError(boxed)
                 }
             };
-            // Debug-only check that we're returning an equal object.
-            debug_assert_eq!(item, &err);
+            // Soft-assert-only check that we're returning an equal object.
+            mz_ore::soft_assert_eq_no_log!(item, &err);
             err
         }
 

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -194,7 +194,7 @@ mod columnar_upsert_key {
         const SLICE_COUNT: usize = 1;
         #[inline(always)]
         fn get_byte_slice(&self, index: usize) -> (u64, &'a [u8]) {
-            debug_assert!(index < Self::SLICE_COUNT);
+            mz_ore::soft_assert_no_log!(index < Self::SLICE_COUNT);
             (
                 u64::cast_from(align_of::<UpsertKey>()),
                 bytemuck::cast_slice(self.0),

--- a/src/timely-util/src/column_pager.rs
+++ b/src/timely-util/src/column_pager.rs
@@ -400,10 +400,10 @@ impl ColumnPager {
                 // bodies are already fitting (or refcounted), so move them
                 // through unchanged.
                 let resident = if matches!(col, Column::Typed(_)) {
-                    debug_assert_eq!(len_bytes % 8, 0);
+                    mz_ore::soft_assert_eq_no_log!(len_bytes % 8, 0);
                     let mut buf = Vec::with_capacity(len_bytes);
                     col.into_bytes(&mut buf);
-                    debug_assert_eq!(buf.len() % 8, 0);
+                    mz_ore::soft_assert_eq_no_log!(buf.len() % 8, 0);
                     col.clear();
                     Column::Align(bytemuck::allocation::pod_collect_to_vec::<u8, u64>(&buf))
                 } else {
@@ -420,7 +420,7 @@ impl ColumnPager {
                 // Raw path: the body must end up as u64-aligned bytes for the
                 // pager. `Column::Align` already is; other variants are
                 // serialized and copied.
-                debug_assert_eq!(len_bytes % 8, 0);
+                mz_ore::soft_assert_eq_no_log!(len_bytes % 8, 0);
                 let body: Vec<u64> = match std::mem::take(col) {
                     // Move the aligned buffer straight into the pager: the
                     // allocation transfers with no copy. `take` already left
@@ -429,7 +429,7 @@ impl ColumnPager {
                     mut other => {
                         let mut buf = Vec::with_capacity(len_bytes);
                         other.into_bytes(&mut buf);
-                        debug_assert_eq!(buf.len() % 8, 0);
+                        mz_ore::soft_assert_eq_no_log!(buf.len() % 8, 0);
                         // `into_bytes` only borrowed `other`; clear it in place
                         // and hand it back so the caller keeps the `Typed`
                         // allocation instead of us dropping a reusable buffer.
@@ -512,7 +512,7 @@ impl ColumnPager {
             PagedColumn::Paged { handle, meta } => {
                 let mut body: Vec<u64> = Vec::with_capacity(handle.len());
                 pager::take(handle, &mut body);
-                debug_assert_eq!(body.len() * 8, meta.len_bytes);
+                mz_ore::soft_assert_eq_no_log!(body.len() * 8, meta.len_bytes);
                 metrics::observe_pagein(meta.len_bytes);
                 self.policy.record(PageEvent::PagedIn {
                     bytes: meta.len_bytes,
@@ -536,7 +536,7 @@ impl ColumnPager {
                             .expect("lz4 decode from pager");
                     }
                 }
-                debug_assert_eq!(decoded.len(), meta.len_bytes);
+                mz_ore::soft_assert_eq_no_log!(decoded.len(), meta.len_bytes);
                 metrics::observe_pagein(decoded.len());
                 self.policy.record(PageEvent::PagedIn {
                     bytes: decoded.len(),
@@ -557,7 +557,7 @@ fn pad_u8_to_u64(mut bytes: Vec<u8>) -> Vec<u64> {
     if pad != 0 {
         bytes.resize(bytes.len() + pad, 0);
     }
-    debug_assert_eq!(bytes.len() % 8, 0);
+    mz_ore::soft_assert_eq_no_log!(bytes.len() % 8, 0);
     // `Vec<u8>` and `Vec<u64>` have different layouts (size + align), so we
     // can't transmute the allocation. Copy into a fresh, properly aligned
     // `Vec<u64>`. The cost is one `len_bytes/8`-word memcpy per pageout.

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -98,6 +98,19 @@ impl<C: Columnar> Column<C> {
         }
     }
 
+    /// True when the column holds no records.
+    ///
+    /// The `Typed` variant answers from the container itself. The serialized
+    /// variants have to reconstruct their borrowed view to reach a length, so
+    /// there this costs as much as [`Column::borrow`].
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Column::Typed(t) => t.is_empty(),
+            Column::Bytes(_) | Column::Align(_) => self.borrow().is_empty(),
+        }
+    }
+
     /// Borrows the container as a reference.
     #[inline]
     pub fn borrow(&self) -> <C::Container as Borrow>::Borrowed<'_> {

--- a/src/timely-util/src/columnar/batcher.rs
+++ b/src/timely-util/src/columnar/batcher.rs
@@ -238,7 +238,7 @@ where
             }
         }
 
-        if self.target.borrow().len() > 0 {
+        if !self.target.is_empty() {
             let chunk = std::mem::replace(&mut self.target, Column::Typed(Default::default()));
             self.ready.push_back(chunk);
         }

--- a/src/timely-util/src/columnar/chunk.rs
+++ b/src/timely-util/src/columnar/chunk.rs
@@ -177,6 +177,7 @@ fn borrow_words<C: Columnar>(words: &[u64]) -> BorrowedOf<'_, C> {
 /// Narrow a columnar ref to a shorter lifetime, so refs from different
 /// borrows, such as a probe column and a chunk's own columns, can be compared
 /// (the refs are lifetime-invariant).
+#[inline(always)]
 fn rr<'b, 'a: 'b, C: Columnar>(item: columnar::Ref<'a, C>) -> columnar::Ref<'b, C> {
     columnar::ContainerOf::<C>::reborrow_ref(item)
 }
@@ -239,7 +240,7 @@ impl<D: Columnar, T: Columnar, R: Columnar> ColumnChunk<D, T, R> {
     /// Wrap a sorted, consolidated, non-empty column as a resident chunk of
     /// the youngest generation.
     pub fn from_column(column: Column<(D, T, R)>) -> Self {
-        debug_assert!(column.borrow().len() > 0, "chunks must be non-empty");
+        mz_ore::soft_assert_no_log!(!column.is_empty(), "chunks must be non-empty");
         ColumnChunk::Resident(Rc::new(column), 0)
     }
 
@@ -297,7 +298,7 @@ impl<D: Columnar, T: Columnar, R: Columnar> ColumnChunk<D, T, R> {
     /// the pool when spilling is on and the body is worth a slot, else keep it
     /// resident.
     fn commit(column: Column<(D, T, R)>, depth: u8) -> Self {
-        debug_assert!(column.borrow().len() > 0, "chunks must be non-empty");
+        mz_ore::soft_assert_no_log!(!column.is_empty(), "chunks must be non-empty");
         if let Some(pool) = spill_pool() {
             if column.length_in_bytes() >= SPILL_MIN_BYTES {
                 return Self::spill_body(column, &pool, depth);
@@ -379,7 +380,7 @@ fn spill_column<C: Columnar>(
     len_bytes: usize,
     hints: ChunkHints,
 ) -> ChunkHandle {
-    debug_assert_eq!(len_bytes % 8, 0);
+    mz_ore::soft_assert_eq_no_log!(len_bytes % 8, 0);
     match column {
         Column::Align(words) => pool.insert_with(words.len(), hints, &LZ4_CODEC, |dst| {
             dst.copy_from_slice(&words)
@@ -479,7 +480,7 @@ where
         loop {
             let mut result: Column<(D, T, R)> = Column::default();
             let yielded = result.merge_from(&mut cols, &mut positions);
-            if result.borrow().len() > 0 {
+            if !result.is_empty() {
                 out.push_back(ColumnChunk::Resident(Rc::new(result), out_depth));
             }
             if !yielded {
@@ -539,7 +540,7 @@ where
         // Move a side's accumulation to its queue, at the ship threshold
         // mid-loop, or any non-empty remainder at the end.
         let cut = |col: &mut Column<(D, T, R)>, queue: &mut VecDeque<Self>, force: bool| {
-            if col.borrow().len() > 0 && (force || at_serialized_capacity(&col.borrow())) {
+            if !col.is_empty() && (force || at_serialized_capacity(&col.borrow())) {
                 queue.push_back(ColumnChunk::Resident(Rc::new(std::mem::take(col)), depth));
             }
         };
@@ -673,7 +674,7 @@ where
                 }
             }
         }
-        if result.borrow().len() > 0 {
+        if !result.is_empty() {
             out.push_back(ColumnChunk::Resident(Rc::new(Column::Typed(result)), depth));
         }
 
@@ -767,7 +768,7 @@ fn extract_view_into<'v, 'p, K, V, T, R>(
     let mut pos = 0;
     while *probe_index < count {
         let probe = probes.get(*probe_index);
-        debug_assert!(
+        mz_ore::soft_assert_no_log!(
             *probe_index == 0 || rr::<K>(probes.get(*probe_index - 1)) < rr::<K>(probe),
             "probe keys must be sorted and deduplicated"
         );

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -859,7 +859,7 @@ mod non_negative {
                             let _negate = children.next().unwrap();
                             let base_id = children.next().unwrap();
                             let extra = children.next();
-                            debug_assert_eq!(extra, None);
+                            mz_ore::soft_assert_none_no_log!(extra);
                             if results[base_id] && is_superset_of(&*base, &*input) {
                                 return true;
                             }
@@ -1724,7 +1724,7 @@ mod cardinality {
             let mut estimate = input;
             for expr in predicates {
                 let selectivity = self.predicate(expr, &unique_columns);
-                debug_assert!(
+                mz_ore::soft_assert_no_log!(
                     OrderedFloat(0.0) <= selectivity && selectivity <= OrderedFloat(1.0),
                     "predicate selectivity {selectivity} should be in the range [0,1]"
                 );

--- a/src/txn-wal/src/txn_cache.rs
+++ b/src/txn-wal/src/txn_cache.rs
@@ -469,12 +469,12 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync> TxnsCac
             match e {
                 TxnsEntry::Register(data_id, ts) => {
                     let ts = T::decode(ts);
-                    debug_assert!(ts <= t);
+                    mz_ore::soft_assert_no_log!(ts <= t);
                     self.push_register(data_id, ts, d, t);
                 }
                 TxnsEntry::Append(data_id, ts, batch) => {
                     let ts = T::decode(ts);
-                    debug_assert!(ts <= t);
+                    mz_ore::soft_assert_no_log!(ts <= t);
                     self.push_append(data_id, batch, ts, d)
                 }
             }
@@ -487,7 +487,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync> TxnsCac
         self.assert_only_data_id(&data_id);
         // Since we keep the original non-advanced timestamp around, retractions
         // necessarily might be for times in the past, so `|| diff < 0`.
-        debug_assert!(ts >= self.progress_exclusive || diff < 0);
+        mz_ore::soft_assert_no_log!(ts >= self.progress_exclusive || diff < 0);
         if let Some(only_data_id) = self.only_data_id.as_ref() {
             if only_data_id != &data_id {
                 return;
@@ -537,7 +537,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync> TxnsCac
         self.assert_only_data_id(&data_id);
         // Since we keep the original non-advanced timestamp around, retractions
         // necessarily might be for times in the past, so `|| diff < 0`.
-        debug_assert!(ts >= self.progress_exclusive || diff < 0);
+        mz_ore::soft_assert_no_log!(ts >= self.progress_exclusive || diff < 0);
         if let Some(only_data_id) = self.only_data_id.as_ref() {
             if only_data_id != &data_id {
                 return;
@@ -584,10 +584,10 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64 + Sync> TxnsCac
                 .unapplied_batches
                 .remove(&idx)
                 .expect("invariant violation: batch index should exist");
-            debug_assert_eq!(data_id, prev.0);
-            debug_assert_eq!(batch, prev.1);
+            mz_ore::soft_assert_eq_no_log!(data_id, prev.0);
+            mz_ore::soft_assert_eq_no_log!(batch, prev.1);
             // Insertion timestamp should be less equal retraction timestamp.
-            debug_assert!(prev.2 <= ts);
+            mz_ore::soft_assert_no_log!(prev.2 <= ts);
         } else {
             unreachable!("only +1/-1 diffs are used");
         }
@@ -866,7 +866,7 @@ where
             |progress_exclusive| progress_exclusive > ts,
         )
         .await;
-        debug_assert!(&self.progress_exclusive > ts);
+        mz_ore::soft_assert_no_log!(&self.progress_exclusive > ts);
         debug_assert_eq!(self.validate(), Ok(()));
         &self.progress_exclusive
     }
@@ -886,7 +886,7 @@ where
             |progress_exclusive| progress_exclusive >= ts,
         )
         .await;
-        debug_assert!(&self.progress_exclusive >= ts);
+        mz_ore::soft_assert_no_log!(&self.progress_exclusive >= ts);
         debug_assert_eq!(self.validate(), Ok(()));
         &self.progress_exclusive
     }


### PR DESCRIPTION
debug asserts are only available in cargo test, soft asserts are also enabled in our e2e tests in CI

Nightly run: https://buildkite.com/materialize/nightly/builds/18058 (failures are unrelated and just fixed on main)