### PR TITLE
ci: Miri test is expected to have an empty services.log

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -404,6 +404,7 @@ cleanup() {
     && [ "$BUILDKITE_LABEL" != "QA Canary Environment Base Load" ] \
     && [ "$BUILDKITE_LABEL" != "Parallel Benchmark against QA Canary Environment" ] \
     && [ "$BUILDKITE_LABEL" != "Parallel Benchmark against QA Benchmarking Staging Environment" ] \
+    && [ "$BUILDKITE_LABEL" != "Miri test (full)" } \
     && [[ ! "$BUILDKITE_LABEL" =~ Terraform\ .* ]] \
     && [[ ! "$BUILDKITE_LABEL" =~ Orchestratord\ .* ]] \
     && [[ ! "$BUILDKITE_LABEL" =~ Cluster\ spec\ sheet.* ]]; then

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -404,7 +404,7 @@ cleanup() {
     && [ "$BUILDKITE_LABEL" != "QA Canary Environment Base Load" ] \
     && [ "$BUILDKITE_LABEL" != "Parallel Benchmark against QA Canary Environment" ] \
     && [ "$BUILDKITE_LABEL" != "Parallel Benchmark against QA Benchmarking Staging Environment" ] \
-    && [ "$BUILDKITE_LABEL" != "Miri test (full)" } \
+    && [ "$BUILDKITE_LABEL" != "Miri test (full)" ] \
     && [[ ! "$BUILDKITE_LABEL" =~ Terraform\ .* ]] \
     && [[ ! "$BUILDKITE_LABEL" =~ Orchestratord\ .* ]] \
     && [[ ! "$BUILDKITE_LABEL" =~ Cluster\ spec\ sheet.* ]]; then


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/18065#019ff6d1-7bbb-4b40-81b4-f9f03004f2a0

Caused by https://github.com/MaterializeInc/materialize/pull/38173

Test run: https://buildkite.com/materialize/nightly/builds/18066