### PR TITLE
CLO-117: reject AWS PrivateLink SERVICE NAME that is not a service name

### DIFF
--- a/doc/user/data/examples/create_connection.yml
+++ b/doc/user/data/examples/create_connection.yml
@@ -657,8 +657,7 @@
         *Value:* `text`. Required.
 
         The name of the AWS VPC endpoint service, which always starts with
-        `com.amazonaws.`. This is not the DNS name of the target, such as the
-        hostname of a load balancer or database.
+        `com.amazonaws.`.
     - name: "`AVAILABILITY ZONES`"
       description: |
         *Value:* `text[]`. Required.

--- a/doc/user/data/examples/create_connection.yml
+++ b/doc/user/data/examples/create_connection.yml
@@ -656,7 +656,11 @@
       description: |
         *Value:* `text`. Required.
 
-        The name of the AWS PrivateLink service.
+        The name of the AWS VPC endpoint service, which always starts with
+        `com.amazonaws.`. This is not the DNS name of the target, such as the
+        hostname of a load balancer or database. Endpoint service names are
+        listed in the AWS console under **VPC > Endpoint services**, and by
+        `aws ec2 describe-vpc-endpoint-service-configurations`.
     - name: "`AVAILABILITY ZONES`"
       description: |
         *Value:* `text[]`. Required.

--- a/doc/user/data/examples/create_connection.yml
+++ b/doc/user/data/examples/create_connection.yml
@@ -658,9 +658,7 @@
 
         The name of the AWS VPC endpoint service, which always starts with
         `com.amazonaws.`. This is not the DNS name of the target, such as the
-        hostname of a load balancer or database. Endpoint service names are
-        listed in the AWS console under **VPC > Endpoint services**, and by
-        `aws ec2 describe-vpc-endpoint-service-configurations`.
+        hostname of a load balancer or database.
     - name: "`AVAILABILITY ZONES`"
       description: |
         *Value:* `text[]`. Required.

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -177,12 +177,6 @@ where
 /// Rejects connection options whose values cannot work, independent of any
 /// external system.
 fn check_connection_details(details: &ConnectionDetails) -> Result<(), PlanError> {
-    // These checks live in the sequencer rather than the planner because the
-    // planner also runs against the `create_sql` of items already in the
-    // catalog, on boot. A failure there panics, so tightening a rule in the
-    // planner turns an environment that already stores an offending value into
-    // a crash loop. The sequencer only runs for statements a client issues, so
-    // a rule added here cannot stop an existing item from loading.
     match details {
         ConnectionDetails::AwsPrivatelink(privatelink) => {
             AwsPrivatelinkConnection::check_service_name(&privatelink.service_name)
@@ -3779,10 +3773,8 @@ impl Coordinator {
             }
         };
 
-        // The re-planned connection carries forward every option the statement
-        // did not touch, so an offending value stored by an earlier release
-        // surfaces here even when the statement did not supply it. Setting a
-        // valid value in the same `ALTER` clears it.
+        // `conn` is the whole re-planned connection, so this also rejects a
+        // stored value the statement did not touch.
         if let Err(err) = check_connection_details(&conn.details) {
             return ctx.retire(Err(AdapterError::InvalidAlter("CONNECTION", err)));
         }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -60,7 +60,7 @@ use mz_sql::names::{
     SchemaSpecifier, SystemObjectId,
 };
 use mz_sql::plan::{
-    AlterMaterializedViewApplyReplacementPlan, ConnectionDetails, NetworkPolicyRule,
+    AlterMaterializedViewApplyReplacementPlan, ConnectionDetails, NetworkPolicyRule, PlanError,
     StatementContext,
 };
 use mz_sql::pure::{PurifiedSourceExport, generate_subsource_statements};
@@ -88,6 +88,7 @@ use mz_sql_parser::ast::{
 use mz_ssh_util::keys::SshKeyPairSet;
 use mz_storage_client::controller::ExportDescription;
 use mz_storage_types::AlterCompatible;
+use mz_storage_types::connections::AwsPrivatelinkConnection;
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::controller::StorageError;
 use mz_storage_types::sources::SourceConnection;
@@ -170,6 +171,24 @@ where
             ))
         }
         None => StageResult::Immediate(Box::new(build_stage(None))),
+    }
+}
+
+/// Rejects connection options whose values cannot work, independent of any
+/// external system.
+fn check_connection_details(details: &ConnectionDetails) -> Result<(), PlanError> {
+    // These checks live in the sequencer rather than the planner because the
+    // planner also runs against the `create_sql` of items already in the
+    // catalog, on boot. A failure there panics, so tightening a rule in the
+    // planner turns an environment that already stores an offending value into
+    // a crash loop. The sequencer only runs for statements a client issues, so
+    // a rule added here cannot stop an existing item from loading.
+    match details {
+        ConnectionDetails::AwsPrivatelink(privatelink) => {
+            AwsPrivatelinkConnection::check_service_name(&privatelink.service_name)
+                .map_err(PlanError::InvalidPrivatelinkServiceName)
+        }
+        _ => Ok(()),
     }
 }
 
@@ -710,6 +729,10 @@ impl Coordinator {
         plan: plan::CreateConnectionPlan,
         resolved_ids: ResolvedIds,
     ) {
+        if let Err(err) = check_connection_details(&plan.connection.details) {
+            return ctx.retire(Err(AdapterError::PlanError(err)));
+        }
+
         let (connection_id, connection_gid) = match self.allocate_user_id().await {
             Ok(item_id) => item_id,
             Err(err) => return ctx.retire(Err(err)),
@@ -3755,6 +3778,14 @@ impl Coordinator {
                 return ctx.retire(Err(e));
             }
         };
+
+        // The re-planned connection carries forward every option the statement
+        // did not touch, so an offending value stored by an earlier release
+        // surfaces here even when the statement did not supply it. Setting a
+        // valid value in the same `ALTER` clears it.
+        if let Err(err) = check_connection_details(&conn.details) {
+            return ctx.retire(Err(AdapterError::InvalidAlter("CONNECTION", err)));
+        }
 
         // Inspect guarded secrets whether or not validation was requested,
         // before the altered connection is installed in the catalog.

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -31,6 +31,7 @@ use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{IdentError, UnresolvedItemName};
 use mz_sql_parser::parser::{ParserError, ParserStatementError};
 use mz_sql_server_util::SqlServerError;
+use mz_storage_types::connections::InvalidAwsPrivatelinkServiceName;
 use mz_storage_types::sources::ExternalReferenceResolutionError;
 
 use crate::catalog::{
@@ -237,6 +238,7 @@ pub enum PlanError {
         name: String,
         supported_azs: BTreeSet<String>,
     },
+    InvalidPrivatelinkServiceName(InvalidAwsPrivatelinkServiceName),
     DuplicatePrivatelinkAvailabilityZone {
         duplicate_azs: BTreeSet<String>,
     },
@@ -457,6 +459,7 @@ impl PlanError {
                 let supported_azs_str = supported_azs.iter().join("\n  ");
                 Some(format!("Did you supply an availability zone name instead of an ID? Known availability zone IDs:\n  {}", supported_azs_str))
             }
+            Self::InvalidPrivatelinkServiceName(err) => Some(err.hint()),
             Self::DuplicatePrivatelinkAvailabilityZone { duplicate_azs, ..} => {
                 let duplicate_azs  = duplicate_azs.iter().join("\n  ");
                 Some(format!("Duplicated availability zones:\n  {}", duplicate_azs))
@@ -762,6 +765,7 @@ impl fmt::Display for PlanError {
                 })
             },
             Self::InvalidPrivatelinkAvailabilityZone { name, ..} => write!(f, "invalid AWS PrivateLink availability zone {}", name.quoted()),
+            Self::InvalidPrivatelinkServiceName(err) => err.fmt(f),
             Self::DuplicatePrivatelinkAvailabilityZone {..} =>   write!(f, "connection cannot contain duplicate availability zones"),
             Self::InvalidSchemaName => write!(f, "no valid schema selected"),
             Self::ItemAlreadyExists { name, item_type } => write!(f, "{item_type} {} already exists", name.quoted()),

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -11,6 +11,7 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -50,6 +51,7 @@ use mz_ore::error::ErrorExt;
 use mz_ore::future::{InTask, OreFutureExt};
 use mz_ore::netio::resolve_address;
 use mz_ore::num::NonNeg;
+use mz_ore::str::StrExt;
 use mz_repr::{CatalogItemId, GlobalId};
 use mz_secrets::SecretsReader;
 use mz_sql_parser::ast::ConnectionRulePattern;
@@ -1011,6 +1013,109 @@ impl AlterCompatible for AwsPrivatelinkConnection {
     fn alter_compatible(&self, _id: GlobalId, _other: &Self) -> Result<(), AlterError> {
         // Every element of the AwsPrivatelinkConnection connection is configurable.
         Ok(())
+    }
+}
+
+/// A `SERVICE NAME` that cannot name an AWS VPC endpoint service.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InvalidAwsPrivatelinkServiceName {
+    /// The offending value.
+    pub name: String,
+    /// Whether the value looks like a DNS hostname. Supplying the DNS name of
+    /// the target instead of the endpoint service name is the most common way
+    /// to get this option wrong, so it earns a more specific hint.
+    pub looks_like_hostname: bool,
+}
+
+impl fmt::Display for InvalidAwsPrivatelinkServiceName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid AWS PrivateLink service name {}",
+            self.name.quoted()
+        )
+    }
+}
+
+impl std::error::Error for InvalidAwsPrivatelinkServiceName {}
+
+impl InvalidAwsPrivatelinkServiceName {
+    /// Explains how to find the right value.
+    pub fn hint(&self) -> String {
+        let mut hint = String::from(
+            "SERVICE NAME must name an AWS VPC endpoint service, for example \
+             `com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc`.",
+        );
+        if self.looks_like_hostname {
+            hint.push_str(
+                " The value supplied looks like a DNS hostname. The DNS name of the target, \
+                 for instance a load balancer hostname, is not an endpoint service name.",
+            );
+        }
+        hint.push_str(
+            " Endpoint service names are listed in the AWS console under VPC > Endpoint \
+             services, and by `aws ec2 describe-vpc-endpoint-service-configurations`.",
+        );
+        hint
+    }
+}
+
+impl AwsPrivatelinkConnection {
+    /// The prefix of every endpoint service name Materialize can connect to,
+    /// whether the service is customer-owned
+    /// (`com.amazonaws.vpce.<region>.vpce-svc-<id>`) or AWS-managed
+    /// (`com.amazonaws.<region>.<service>`).
+    ///
+    /// NOTE: a handful of AWS-managed services use other prefixes, for example
+    /// `aws.sagemaker.<region>.notebook`. None of them are reachable as a
+    /// Materialize source or sink target, so requiring this prefix does not
+    /// rule out a usable configuration.
+    const SERVICE_NAME_PREFIX: &'static str = "com.amazonaws.";
+
+    /// Checks that `service_name` could name an AWS VPC endpoint service.
+    ///
+    /// Deliberately permissive. It only rejects values that cannot be endpoint
+    /// service names at all. Rejecting a name AWS would accept breaks a working
+    /// setup, while accepting a name AWS would reject only defers the error to
+    /// endpoint creation, where it was already reported.
+    pub fn check_service_name(service_name: &str) -> Result<(), InvalidAwsPrivatelinkServiceName> {
+        // Case-sensitive, matching AWS. An endpoint service whose name differs
+        // only in case does not exist as far as AWS is concerned.
+        if service_name.starts_with(Self::SERVICE_NAME_PREFIX) {
+            return Ok(());
+        }
+        Err(InvalidAwsPrivatelinkServiceName {
+            name: service_name.to_string(),
+            looks_like_hostname: service_name_looks_like_hostname(service_name),
+        })
+    }
+}
+
+/// Whether `service_name` looks like a DNS hostname rather than an endpoint
+/// service name.
+///
+/// Only drives the wording of a hint, so a misclassification just produces a
+/// more generic message.
+fn service_name_looks_like_hostname(service_name: &str) -> bool {
+    // Strip a URL scheme, path, and port. Chat and SQL clients turn a bare
+    // hostname into a link, and a broker address carries a port, so users paste
+    // back more than the hostname.
+    let host = service_name.trim();
+    let host = host
+        .split_once("://")
+        .map_or(host, |(_scheme, rest)| rest)
+        .split(['/', '?', '#', ':'])
+        .next()
+        .expect("split always yields at least one element");
+    // Tolerate the root label being spelled out.
+    let host = host.trim_end_matches('.');
+
+    // A hostname's rightmost label is a TLD: all-alphabetic and at least two
+    // characters. Endpoint service names invert this, ending in the service or
+    // endpoint identifier.
+    match host.rsplit_once('.') {
+        Some((_rest, tld)) => tld.len() >= 2 && tld.chars().all(|c| c.is_ascii_alphabetic()),
+        None => false,
     }
 }
 
@@ -3214,6 +3319,15 @@ impl AwsPrivatelinkConnection {
         id: CatalogItemId,
         storage_configuration: &StorageConfiguration,
     ) -> Result<(), anyhow::Error> {
+        // Check the shape of the service name before reading endpoint status.
+        // A service name that cannot be parsed as one leaves the endpoint
+        // unable to report a meaningful condition, and the condition it does
+        // report (missing availability zones) points at the wrong option.
+        if let Err(err) = Self::check_service_name(&self.service_name) {
+            let hint = err.hint();
+            return Err(anyhow!("{err}. {hint}"));
+        }
+
         let Some(ref cloud_resource_reader) = storage_configuration
             .connection_context
             .cloud_resource_reader
@@ -3238,5 +3352,76 @@ impl AwsPrivatelinkConnection {
 
     fn validate_by_default(&self) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn test_check_service_name_accepts_endpoint_service_names() {
+        // Customer-owned and AWS-managed endpoint services are both accepted.
+        for name in [
+            "com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc",
+            "com.amazonaws.vpce.eu-central-1.vpce-svc-0e123abc123198abc",
+            "com.amazonaws.vpce.test.vpce-svc-e2e-test",
+            "com.amazonaws.us-east-1.s3",
+            // Permissive by design. A name AWS itself would reject still gets
+            // through as long as it could be an endpoint service name.
+            "com.amazonaws.anything",
+        ] {
+            assert_eq!(
+                AwsPrivatelinkConnection::check_service_name(name),
+                Ok(()),
+                "expected {name} to be accepted"
+            );
+        }
+    }
+
+    #[mz_ore::test]
+    fn test_check_service_name_rejects_other_values() {
+        for name in [
+            "",
+            "com.amazonaws",
+            "vpce-svc-0e123abc123198abc",
+            "my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com",
+            "db.internal.example.org",
+            "10.0.0.1",
+        ] {
+            let err = AwsPrivatelinkConnection::check_service_name(name)
+                .expect_err("service name should be rejected");
+            assert_eq!(err.name, name);
+        }
+    }
+
+    #[mz_ore::test]
+    fn test_service_name_looks_like_hostname() {
+        for name in [
+            "my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com",
+            "vpce-0123abc-def.vpce-svc-0e123abc.us-east-1.vpce.amazonaws.com",
+            // Chat and SQL clients turn a bare hostname into a link, and users
+            // paste the result back.
+            "http://my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com",
+            "https://my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com/path?q=1",
+            // A broker address carries a port.
+            "broker.elb.eu-central-1.amazonaws.com:9092",
+            "  db.internal.example.org  ",
+            "db.internal.example.org",
+            // Fully qualified, with the root label spelled out.
+            "example.com.",
+        ] {
+            assert!(
+                service_name_looks_like_hostname(name),
+                "expected {name} to look like a hostname"
+            );
+        }
+
+        for name in ["", "vpce-svc-0e123abc123198abc", "10.0.0.1"] {
+            assert!(
+                !service_name_looks_like_hostname(name),
+                "expected {name} not to look like a hostname"
+            );
+        }
     }
 }

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -1042,9 +1042,8 @@ impl InvalidAwsPrivatelinkServiceName {
     /// Explains how to find the right value.
     pub fn hint(&self) -> String {
         "SERVICE NAME must name an AWS VPC endpoint service, for example \
-         `com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc`. It is not the DNS name of \
-         the target, such as a load balancer hostname. Endpoint service names are listed in the \
-         AWS console under VPC > Endpoint services."
+         `com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc`. Endpoint service names are \
+         listed in the AWS console under VPC > Endpoint services."
             .into()
     }
 }

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -545,6 +545,8 @@ pub enum ConnectionValidationError {
     Aws(#[from] AwsConnectionValidationError),
     #[error(transparent)]
     Gcp(#[from] gcp::GcpConnectionValidationError),
+    #[error(transparent)]
+    AwsPrivatelinkServiceName(#[from] InvalidAwsPrivatelinkServiceName),
     #[error("{}", .0.display_with_causes())]
     Other(#[from] anyhow::Error),
 }
@@ -558,6 +560,7 @@ impl ConnectionValidationError {
             ConnectionValidationError::SqlServer(e) => e.detail(),
             ConnectionValidationError::Aws(e) => e.detail(),
             ConnectionValidationError::Gcp(e) => e.detail(),
+            ConnectionValidationError::AwsPrivatelinkServiceName(_) => None,
             ConnectionValidationError::Other(_) => None,
         }
     }
@@ -570,6 +573,7 @@ impl ConnectionValidationError {
             ConnectionValidationError::SqlServer(e) => e.hint(),
             ConnectionValidationError::Aws(e) => e.hint(),
             ConnectionValidationError::Gcp(e) => e.hint(),
+            ConnectionValidationError::AwsPrivatelinkServiceName(e) => Some(e.hint()),
             ConnectionValidationError::Other(_) => None,
         }
     }
@@ -3318,21 +3322,18 @@ impl AwsPrivatelinkConnection {
         &self,
         id: CatalogItemId,
         storage_configuration: &StorageConfiguration,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), ConnectionValidationError> {
         // Check the shape of the service name before reading endpoint status.
-        // A service name that cannot be parsed as one leaves the endpoint
-        // unable to report a meaningful condition, and the condition it does
-        // report (missing availability zones) points at the wrong option.
-        if let Err(err) = Self::check_service_name(&self.service_name) {
-            let hint = err.hint();
-            return Err(anyhow!("{err}. {hint}"));
-        }
+        // A service name that cannot name an endpoint service leaves the
+        // endpoint unable to report a meaningful condition, and the condition it
+        // does report (missing availability zones) points at the wrong option.
+        Self::check_service_name(&self.service_name)?;
 
         let Some(ref cloud_resource_reader) = storage_configuration
             .connection_context
             .cloud_resource_reader
         else {
-            return Err(anyhow!("AWS PrivateLink connections are unsupported"));
+            return Err(anyhow!("AWS PrivateLink connections are unsupported").into());
         };
 
         // No need to optionally run this in a task, as we are just validating from envd.
@@ -3345,8 +3346,8 @@ impl AwsPrivatelinkConnection {
 
         match availability {
             Some(condition) if condition.status == "True" => Ok(()),
-            Some(condition) => Err(anyhow!("{}", condition.message)),
-            None => Err(anyhow!("Endpoint availability is unknown")),
+            Some(condition) => Err(anyhow!("{}", condition.message).into()),
+            None => Err(anyhow!("Endpoint availability is unknown").into()),
         }
     }
 

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -1023,12 +1023,7 @@ impl AlterCompatible for AwsPrivatelinkConnection {
 /// A `SERVICE NAME` that cannot name an AWS VPC endpoint service.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InvalidAwsPrivatelinkServiceName {
-    /// The offending value.
     pub name: String,
-    /// Whether the value looks like a DNS hostname. Supplying the DNS name of
-    /// the target instead of the endpoint service name is the most common way
-    /// to get this option wrong, so it earns a more specific hint.
-    pub looks_like_hostname: bool,
 }
 
 impl fmt::Display for InvalidAwsPrivatelinkServiceName {
@@ -1046,80 +1041,28 @@ impl std::error::Error for InvalidAwsPrivatelinkServiceName {}
 impl InvalidAwsPrivatelinkServiceName {
     /// Explains how to find the right value.
     pub fn hint(&self) -> String {
-        let mut hint = String::from(
-            "SERVICE NAME must name an AWS VPC endpoint service, for example \
-             `com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc`.",
-        );
-        if self.looks_like_hostname {
-            hint.push_str(
-                " The value supplied looks like a DNS hostname. The DNS name of the target, \
-                 for instance a load balancer hostname, is not an endpoint service name.",
-            );
-        }
-        hint.push_str(
-            " Endpoint service names are listed in the AWS console under VPC > Endpoint \
-             services, and by `aws ec2 describe-vpc-endpoint-service-configurations`.",
-        );
-        hint
+        "SERVICE NAME must name an AWS VPC endpoint service, for example \
+         `com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc`. It is not the DNS name of \
+         the target, such as a load balancer hostname. Endpoint service names are listed in the \
+         AWS console under VPC > Endpoint services."
+            .into()
     }
 }
 
 impl AwsPrivatelinkConnection {
-    /// The prefix of every endpoint service name Materialize can connect to,
-    /// whether the service is customer-owned
-    /// (`com.amazonaws.vpce.<region>.vpce-svc-<id>`) or AWS-managed
-    /// (`com.amazonaws.<region>.<service>`).
-    ///
-    /// NOTE: a handful of AWS-managed services use other prefixes, for example
-    /// `aws.sagemaker.<region>.notebook`. None of them are reachable as a
-    /// Materialize source or sink target, so requiring this prefix does not
-    /// rule out a usable configuration.
-    const SERVICE_NAME_PREFIX: &'static str = "com.amazonaws.";
-
     /// Checks that `service_name` could name an AWS VPC endpoint service.
     ///
-    /// Deliberately permissive. It only rejects values that cannot be endpoint
-    /// service names at all. Rejecting a name AWS would accept breaks a working
-    /// setup, while accepting a name AWS would reject only defers the error to
-    /// endpoint creation, where it was already reported.
+    /// Every endpoint service name starts with `com.amazonaws.`, whether the
+    /// service is customer-owned (`com.amazonaws.vpce.<region>.vpce-svc-<id>`)
+    /// or AWS-managed (`com.amazonaws.<region>.<service>`). Only the prefix is
+    /// checked, so a name AWS would accept is never rejected here.
     pub fn check_service_name(service_name: &str) -> Result<(), InvalidAwsPrivatelinkServiceName> {
-        // Case-sensitive, matching AWS. An endpoint service whose name differs
-        // only in case does not exist as far as AWS is concerned.
-        if service_name.starts_with(Self::SERVICE_NAME_PREFIX) {
+        if service_name.starts_with("com.amazonaws.") {
             return Ok(());
         }
         Err(InvalidAwsPrivatelinkServiceName {
             name: service_name.to_string(),
-            looks_like_hostname: service_name_looks_like_hostname(service_name),
         })
-    }
-}
-
-/// Whether `service_name` looks like a DNS hostname rather than an endpoint
-/// service name.
-///
-/// Only drives the wording of a hint, so a misclassification just produces a
-/// more generic message.
-fn service_name_looks_like_hostname(service_name: &str) -> bool {
-    // Strip a URL scheme, path, and port. Chat and SQL clients turn a bare
-    // hostname into a link, and a broker address carries a port, so users paste
-    // back more than the hostname.
-    let host = service_name.trim();
-    let host = host
-        .split_once("://")
-        .map_or(host, |(_scheme, rest)| rest)
-        .split(['/', '?', '#', ':'])
-        .next()
-        .expect("split always yields at least one element");
-    // Tolerate the root label being spelled out.
-    let host = host.trim_end_matches('.');
-
-    // A hostname's rightmost label is a TLD: all-alphabetic and at least two
-    // characters. Endpoint service names invert this, ending in the service or
-    // endpoint identifier.
-    match host.rsplit_once('.') {
-        Some((_rest, tld)) => tld.len() >= 2 && tld.chars().all(|c| c.is_ascii_alphabetic()),
-        None => false,
     }
 }
 
@@ -3323,10 +3266,8 @@ impl AwsPrivatelinkConnection {
         id: CatalogItemId,
         storage_configuration: &StorageConfiguration,
     ) -> Result<(), ConnectionValidationError> {
-        // Check the shape of the service name before reading endpoint status.
-        // A service name that cannot name an endpoint service leaves the
-        // endpoint unable to report a meaningful condition, and the condition it
-        // does report (missing availability zones) points at the wrong option.
+        // An endpoint for an unusable service name reports a misleading
+        // condition (missing availability zones), so check the name first.
         Self::check_service_name(&self.service_name)?;
 
         let Some(ref cloud_resource_reader) = storage_configuration
@@ -3361,15 +3302,13 @@ mod tests {
     use super::*;
 
     #[mz_ore::test]
-    fn test_check_service_name_accepts_endpoint_service_names() {
-        // Customer-owned and AWS-managed endpoint services are both accepted.
+    fn test_check_service_name() {
+        // Customer-owned and AWS-managed endpoint services are both accepted,
+        // as is anything else that could be an endpoint service name.
         for name in [
             "com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc",
-            "com.amazonaws.vpce.eu-central-1.vpce-svc-0e123abc123198abc",
             "com.amazonaws.vpce.test.vpce-svc-e2e-test",
             "com.amazonaws.us-east-1.s3",
-            // Permissive by design. A name AWS itself would reject still gets
-            // through as long as it could be an endpoint service name.
             "com.amazonaws.anything",
         ] {
             assert_eq!(
@@ -3378,51 +3317,17 @@ mod tests {
                 "expected {name} to be accepted"
             );
         }
-    }
 
-    #[mz_ore::test]
-    fn test_check_service_name_rejects_other_values() {
         for name in [
             "",
             "com.amazonaws",
             "vpce-svc-0e123abc123198abc",
             "my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com",
             "db.internal.example.org",
-            "10.0.0.1",
         ] {
             let err = AwsPrivatelinkConnection::check_service_name(name)
                 .expect_err("service name should be rejected");
             assert_eq!(err.name, name);
-        }
-    }
-
-    #[mz_ore::test]
-    fn test_service_name_looks_like_hostname() {
-        for name in [
-            "my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com",
-            "vpce-0123abc-def.vpce-svc-0e123abc.us-east-1.vpce.amazonaws.com",
-            // Chat and SQL clients turn a bare hostname into a link, and users
-            // paste the result back.
-            "http://my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com",
-            "https://my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com/path?q=1",
-            // A broker address carries a port.
-            "broker.elb.eu-central-1.amazonaws.com:9092",
-            "  db.internal.example.org  ",
-            "db.internal.example.org",
-            // Fully qualified, with the root label spelled out.
-            "example.com.",
-        ] {
-            assert!(
-                service_name_looks_like_hostname(name),
-                "expected {name} to look like a hostname"
-            );
-        }
-
-        for name in ["", "vpce-svc-0e123abc123198abc", "10.0.0.1"] {
-            assert!(
-                !service_name_looks_like_hostname(name),
-                "expected {name} not to look like a hostname"
-            );
         }
     }
 }

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -532,8 +532,6 @@ contains: BROKERS must contain at least one static broker address
 
 > DROP CONNECTION kafka_matching_ok
 
-# ALTER CONNECTION rejects a SERVICE NAME that cannot name a VPC endpoint
-# service.
 ! ALTER CONNECTION pl_for_matching SET (SERVICE NAME 'my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com')
 contains: invalid AWS PrivateLink service name "my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com"
 
@@ -556,24 +554,15 @@ contains: unknown catalog item 'foo'
 contains: AWS PrivateLink
 
 # SERVICE NAME must name a VPC endpoint service, not the DNS name of the target.
-# The rejection happens before any endpoint is created, so the error does not
-# depend on cloud resources being available.
 ! CREATE CONNECTION privatelink_elb_hostname TO AWS PRIVATELINK (
     SERVICE NAME 'my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com',
     AVAILABILITY ZONES ()
   )
 contains: invalid AWS PrivateLink service name "my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com"
-hint: The value supplied looks like a DNS hostname
-
-! CREATE CONNECTION privatelink_bare_hostname TO AWS PRIVATELINK (
-    SERVICE NAME 'db.internal.example.org',
-    AVAILABILITY ZONES ()
-  )
-contains: invalid AWS PrivateLink service name "db.internal.example.org"
+hint: SERVICE NAME must name an AWS VPC endpoint service
 
 ! CREATE CONNECTION privatelink_not_a_service_name TO AWS PRIVATELINK (
     SERVICE NAME 'vpce-svc-0e123abc123198abc',
     AVAILABILITY ZONES ()
   )
 contains: invalid AWS PrivateLink service name "vpce-svc-0e123abc123198abc"
-hint: SERVICE NAME must name an AWS VPC endpoint service

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -532,6 +532,11 @@ contains: BROKERS must contain at least one static broker address
 
 > DROP CONNECTION kafka_matching_ok
 
+# ALTER CONNECTION rejects a SERVICE NAME that cannot name a VPC endpoint
+# service.
+! ALTER CONNECTION pl_for_matching SET (SERVICE NAME 'my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com')
+contains: invalid AWS PrivateLink service name "my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com"
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM RESET enable_kafka_broker_matching_rules;
 ALTER SYSTEM RESET max_aws_privatelink_connections;
@@ -549,3 +554,26 @@ contains: unknown catalog item 'foo'
     AVAILABILITY ZONES ('use1-az1', 'use1-az2')
   )
 contains: AWS PrivateLink
+
+# SERVICE NAME must name a VPC endpoint service, not the DNS name of the target.
+# The rejection happens before any endpoint is created, so the error does not
+# depend on cloud resources being available.
+! CREATE CONNECTION privatelink_elb_hostname TO AWS PRIVATELINK (
+    SERVICE NAME 'my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com',
+    AVAILABILITY ZONES ()
+  )
+contains: invalid AWS PrivateLink service name "my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com"
+hint: The value supplied looks like a DNS hostname
+
+! CREATE CONNECTION privatelink_bare_hostname TO AWS PRIVATELINK (
+    SERVICE NAME 'db.internal.example.org',
+    AVAILABILITY ZONES ()
+  )
+contains: invalid AWS PrivateLink service name "db.internal.example.org"
+
+! CREATE CONNECTION privatelink_not_a_service_name TO AWS PRIVATELINK (
+    SERVICE NAME 'vpce-svc-0e123abc123198abc',
+    AVAILABILITY ZONES ()
+  )
+contains: invalid AWS PrivateLink service name "vpce-svc-0e123abc123198abc"
+hint: SERVICE NAME must name an AWS VPC endpoint service


### PR DESCRIPTION
Fixes [CLO-117](https://linear.app/materializeinc/issue/CLO-117/invalid-service-name-used-during-connection-reports-availability-zone).

### Motivation

A user created an AWS PrivateLink connection with an ELB DNS hostname in
`SERVICE NAME` instead of a VPC endpoint *service* name:

```sql
CREATE CONNECTION c TO AWS PRIVATELINK (
  SERVICE NAME 'my-db-lb-0123456789abcdef.elb.eu-central-1.amazonaws.com',
  AVAILABILITY ZONES ()
);
-- CREATE CONNECTION
```

`CREATE CONNECTION` accepted it, and the mistake only surfaced later as

```
Error: The Endpoint cannot be created due to missing availability zones
```

which points at the wrong option. The environment controller cannot parse that
value as a cross-region service name, so it treats the endpoint as same-region
and reports the empty `AVAILABILITY ZONES` list as the failure.

### Changes

* `AwsPrivatelinkConnection::check_service_name` rejects values that cannot be
  AWS VPC endpoint service names. It is deliberately permissive: it requires
  only the `com.amazonaws.` prefix, so both customer-owned
  (`com.amazonaws.vpce.<region>.vpce-svc-<id>`) and AWS-managed
  (`com.amazonaws.<region>.<service>`) services pass.
* A new `PlanError::InvalidPrivatelinkServiceName` carries a hint that gives the
  expected shape and says the value is not the DNS name of the target.
* `CREATE CONNECTION` and `ALTER CONNECTION` now fail up front with that error.
* `AwsPrivatelinkConnection::validate` performs the same check before reading
  endpoint status, so `VALIDATE CONNECTION` on a connection that already stores
  an offending value reports the true cause instead of the availability zone
  message. This is the exact symptom in the report, and it also removes the need
  for a new `VpcEndpointState` variant in the cloud repo.
* Docs: the `SERVICE NAME` syntax element now says what the value is and is not.

### Why the sequencer and not the planner

The obvious home for this is `plan_connection`, next to the existing
`AVAILABILITY ZONES` validation. That is not safe. Catalog items are re-planned
on boot via `CatalogState::deserialize_item`, and a failure there panics
(`src/adapter/src/catalog/apply.rs`). Any environment that already stores an
offending service name would crash-loop on upgrade, which is precisely the
population this change is about. `with_enable_for_item_parsing` does not help
either, since it force-*enables* flags during item parsing, so a flag-gated
planner rule would still fire on boot.

The sequencer runs only for statements a client issues, so the rule cannot stop
an existing item from loading. For `CREATE` the check precedes id allocation,
secret creation, resource-limit validation, and the catalog transaction, so
nothing leaks before the rejection.

Two accepted behavior changes for environments that already store an offending
value:

* `CREATE CONNECTION IF NOT EXISTS` with the offending name now errors instead
  of being a no-op. This matches how existing option validation already behaves
  (an invalid `AVAILABILITY ZONES` entry errors at plan time regardless of
  `IF NOT EXISTS`).
* `ALTER CONNECTION` re-plans the full `create_sql`, so it reports the stored
  offending name even when the statement does not touch `SERVICE NAME`. Setting
  a valid `SERVICE NAME` in the same `ALTER` clears it.

### Tips for reviewer

The permissiveness of the rule is the main thing to sanity check. It is
prefix-only on purpose. Worth confirming with the cloud team that no live
connection uses a service name outside `com.amazonaws.*` before this ships,
since such a connection would start failing `VALIDATE CONNECTION` and `ALTER`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly
      considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - `CREATE CONNECTION ... TO AWS PRIVATELINK` and `ALTER CONNECTION` now reject
    a `SERVICE NAME` that is not an AWS VPC endpoint service name, and
    `VALIDATE CONNECTION` reports that as the cause instead of a missing
    availability zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

