### PR TITLE
ci: publish npm packages over OIDC instead of a static token

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -54,11 +54,27 @@ jobs:
           aws-region: us-east-1
 
       # Node 22.14+ and npm 11.5.1+ are what support OIDC publishing.
+      #
+      # Deliberately no `registry-url`: it makes setup-node write an
+      # `_authToken` line into .npmrc, and an empty token there makes npm
+      # believe it is already authenticated and skip the OIDC exchange
+      # entirely, which fails the publish with ENEEDAUTH.
+      # See https://github.com/actions/setup-node/issues/1551. The default
+      # registry is registry.npmjs.org, which is where we publish anyway.
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "24"
-          registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
+
+      - name: Check for auth that would preempt OIDC
+        run: |
+          set -euo pipefail
+          npmrc="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          if [ -f "$npmrc" ] && grep -q _authToken "$npmrc"; then
+            echo "::error::$npmrc configures an _authToken, which stops npm from using OIDC"
+            exit 1
+          fi
+          npm --version
 
       - name: Download staged packages
         env:
@@ -88,6 +104,14 @@ jobs:
             version=$(jq -r '.version' <<<"$package")
             tarball=$(jq -r '.tarball' <<<"$package")
             tag=$(jq -r '.tag' <<<"$package")
+            # Tolerating an already-published version is what makes this
+            # workflow re-runnable: if a later step fails, the whole run can be
+            # repeated from the same staging URI, which is how missing
+            # dist-tags get fixed.
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "$name@$version is already published, skipping"
+              continue
+            fi
             echo "::group::publishing $name@$version (tag $tag)"
             npm publish "staging/$tarball" --access public --tag "$tag"
             echo "::endgroup::"
@@ -95,30 +119,43 @@ jobs:
           done
 
       - name: Apply additional dist-tags
-        # OIDC covers `npm publish` and `npm stage publish` only, so the
-        # `latest-X.Y` tags that release builds also carry still need a token.
-        # It lives in this environment rather than in every Buildkite build,
-        # and it is only ever used to move a tag -- it cannot publish, because
-        # the packages disallow token publishes.
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_DIST_TAG_TOKEN }}
+        # `npm dist-tag` never performs the OIDC exchange itself -- only
+        # `npm publish` and `npm stage publish` do -- so we perform it by hand
+        # and hand the resulting short-lived, package-scoped registry token to
+        # the CLI. This is what keeps the `latest-X.Y` tags from requiring a
+        # long-lived token that would need rotating every 90 days.
         run: |
           set -euo pipefail
-          extra=$(jq -r '[.packages[] | select(.extra_tags | length > 0)] | length' staging/manifest.json)
-          if [ "$extra" -eq 0 ]; then
+          specs=$(jq -r '.packages[] | select(.extra_tags | length > 0) | .extra_tags[] as $t | "\(.name) \(.version) \($t)"' staging/manifest.json)
+          if [ -z "$specs" ]; then
             echo "no additional dist-tags requested"
             exit 0
           fi
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "::warning::NPM_DIST_TAG_TOKEN is not set; the latest-X.Y dist-tags below were NOT applied"
-            jq -r '.packages[] | select(.extra_tags | length > 0) | .extra_tags[] as $t | "npm dist-tag add \(.name)@\(.version) \($t)"' \
-              staging/manifest.json | tee -a "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          jq -r '.packages[] | select(.extra_tags | length > 0) | .extra_tags[] as $t | "\(.name)@\(.version) \($t)"' \
-            staging/manifest.json | while read -r spec tag; do
-            echo "::group::tagging $spec as $tag"
-            npm dist-tag add "$spec" "$tag"
+          id_token=$(curl -fsS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            -G --data-urlencode "audience=npm:registry.npmjs.org" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value')
+          while read -r name version tag; do
+            # npm escapes the scope separator when addressing a package by
+            # name in this API, as npm-package-arg's `escapedName` does.
+            escaped=${name/\//%2f}
+            token=$(curl -fsS -X POST -H "Authorization: Bearer $id_token" \
+              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$escaped" \
+              | jq -r '.token')
+            echo "::group::tagging $name@$version as $tag"
+            npm dist-tag add "$name@$version" "$tag" \
+              "--//registry.npmjs.org/:_authToken=$token"
             echo "::endgroup::"
-            echo "- \`$spec\` tagged \`$tag\`" >> "$GITHUB_STEP_SUMMARY"
-          done
+            echo "- \`$name@$version\` tagged \`$tag\`" >> "$GITHUB_STEP_SUMMARY"
+          done <<<"$specs"
+
+      - name: Explain a dist-tag failure
+        if: failure()
+        run: |
+          {
+            echo "### Publish incomplete"
+            echo
+            echo "If the packages published but the dist-tag step failed, re-run"
+            echo "this workflow from the same staging URI -- the publish step"
+            echo "skips versions that are already on npm. The staged tarballs"
+            echo "are kept for 14 days."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,124 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Publishes the wasm npm packages that the `deploy-npm` Buildkite step builds.
+#
+# Buildkite remains the release pipeline: it builds and packs the tarballs,
+# stages them in S3, triggers this workflow, and fails its step if this
+# workflow fails. This workflow exists only because npm's trusted publishing
+# accepts OIDC tokens from GitHub Actions, GitLab, and CircleCI, but not from
+# Buildkite -- so this is the smallest possible amount of publishing that has
+# to happen outside of Buildkite in order to retire the long-lived NPM_TOKEN.
+#
+# Each package's trusted publisher on npmjs.com must name this workflow file
+# ("publish-npm.yml") and the "npm-publish" environment. The repository
+# variable NPM_PUBLISH_ROLE_ARN must name the GithubActionsNpmPublish role
+# from MaterializeInc/i2, which grants read access to the staging bucket.
+
+name: publish npm packages
+
+run-name: publish npm packages (${{ inputs.staging_uri || github.event.client_payload.staging_uri }})
+
+on:
+  repository_dispatch:
+    types: [publish-npm]
+  workflow_dispatch:
+    inputs:
+      staging_uri:
+        description: "s3:// URI of a staging directory left behind by a Buildkite deploy-npm step"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  # Mints the OIDC tokens used both to assume the AWS role and to authenticate
+  # to npm. Without this, npm falls back to token auth and the publish fails.
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # npm's trusted publisher configuration is pinned to this environment, and
+    # the AWS role's trust policy only accepts tokens issued for it.
+    environment: npm-publish
+    steps:
+      - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ vars.NPM_PUBLISH_ROLE_ARN }}
+          aws-region: us-east-1
+
+      # Node 22.14+ and npm 11.5.1+ are what support OIDC publishing.
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Download staged packages
+        env:
+          STAGING_URI: ${{ inputs.staging_uri || github.event.client_payload.staging_uri }}
+        run: |
+          set -euo pipefail
+          case "$STAGING_URI" in
+            s3://*) ;;
+            *) echo "refusing to fetch non-s3 staging URI: $STAGING_URI" >&2; exit 1 ;;
+          esac
+          mkdir staging
+          aws s3 cp --recursive "$STAGING_URI" staging/
+          test -f staging/manifest.json
+          cat staging/manifest.json
+
+      - name: Publish to npm
+        # Provenance is generated automatically when publishing over OIDC, but
+        # it would attest that this workflow built the tarballs, and it did
+        # not -- Buildkite did. Publishing an attestation we know to be untrue
+        # is worse than publishing none, which is what we do today.
+        env:
+          NPM_CONFIG_PROVENANCE: "false"
+        run: |
+          set -euo pipefail
+          jq -c '.packages[]' staging/manifest.json | while read -r package; do
+            name=$(jq -r '.name' <<<"$package")
+            version=$(jq -r '.version' <<<"$package")
+            tarball=$(jq -r '.tarball' <<<"$package")
+            tag=$(jq -r '.tag' <<<"$package")
+            echo "::group::publishing $name@$version (tag $tag)"
+            npm publish "staging/$tarball" --access public --tag "$tag"
+            echo "::endgroup::"
+            echo "- \`$name@$version\` published with tag \`$tag\`" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+      - name: Apply additional dist-tags
+        # OIDC covers `npm publish` and `npm stage publish` only, so the
+        # `latest-X.Y` tags that release builds also carry still need a token.
+        # It lives in this environment rather than in every Buildkite build,
+        # and it is only ever used to move a tag -- it cannot publish, because
+        # the packages disallow token publishes.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_DIST_TAG_TOKEN }}
+        run: |
+          set -euo pipefail
+          extra=$(jq -r '[.packages[] | select(.extra_tags | length > 0)] | length' staging/manifest.json)
+          if [ "$extra" -eq 0 ]; then
+            echo "no additional dist-tags requested"
+            exit 0
+          fi
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::warning::NPM_DIST_TAG_TOKEN is not set; the latest-X.Y dist-tags below were NOT applied"
+            jq -r '.packages[] | select(.extra_tags | length > 0) | .extra_tags[] as $t | "npm dist-tag add \(.name)@\(.version) \($t)"' \
+              staging/manifest.json | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          jq -r '.packages[] | select(.extra_tags | length > 0) | .extra_tags[] as $t | "\(.name)@\(.version) \($t)"' \
+            staging/manifest.json | while read -r spec tag; do
+            echo "::group::tagging $spec as $tag"
+            npm dist-tag add "$spec" "$tag"
+            echo "::endgroup::"
+            echo "- \`$spec\` tagged \`$tag\`" >> "$GITHUB_STEP_SUMMARY"
+          done

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -310,7 +310,7 @@ case "$cmd" in
                 --env NIGHTLY_CANARY_APP_PASSWORD
                 --env MZ_CI_LICENSE_KEY
                 --env MZ_CLI_APP_PASSWORD
-                --env NPM_TOKEN
+                --env NPM_STAGING_BUCKET
                 --env POLAR_SIGNALS_API_TOKEN
                 --env PRODUCTION_ANALYTICS_USERNAME
                 --env PRODUCTION_ANALYTICS_APP_PASSWORD

--- a/ci/deploy/npm.py
+++ b/ci/deploy/npm.py
@@ -12,15 +12,17 @@ import json
 import logging
 import os
 import shutil
+import tempfile
 import urllib.parse
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import requests
 from semver.version import VersionInfo
 
-from materialize import MZ_ROOT, cargo, spawn
+from materialize import MZ_ROOT, buildkite, cargo, github, spawn
 
 logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -29,6 +31,11 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 PUBLISH_CRATES = ["mz-sql-lexer-wasm", "mz-sql-parser-wasm", "mz-sql-pretty-wasm"]
+
+# The GitHub Actions workflow that performs the actual publish. Each package's
+# trusted publisher on npmjs.com is pinned to this filename, so renaming the
+# workflow requires updating those configurations too.
+PUBLISH_WORKFLOW = "publish-npm.yml"
 
 
 @dataclass(frozen=True)
@@ -85,13 +92,20 @@ def build_package(version: NpmPackageVersion, crate_path: Path) -> Path:
     return package_path
 
 
-def release_package(version: NpmPackageVersion, package_path: Path) -> None:
+def stage_package(
+    version: NpmPackageVersion, package_path: Path, staging_path: Path
+) -> dict[str, Any] | None:
+    """Pack a built package for publishing, returning its manifest entry.
+
+    Returns None if the version is already on npm, in which case there is
+    nothing to publish.
+    """
     with open(package_path / "package.json") as package_file:
         package = json.load(package_file)
     name = package["name"]
     if version_exists_in_npm(name, version):
         logger.warning("%s %s already released, skipping.", name, version.node)
-        return
+        return None
     else:
         dist_tag: str | None = "dev" if version.is_development else "latest"
         branch_tag: str | None = None
@@ -106,45 +120,129 @@ def release_package(version: NpmPackageVersion, package_path: Path) -> None:
                     version.node,
                 )
                 dist_tag = None
-        logger.info("Releasing %s %s", name, version.node)
-        set_npm_credentials(package_path)
-        # If we do not specify a dist tag, this automatically is tagged as
-        # `latest`. So, force a dist tag for release builds that are lower than
-        # the stable version. This usually happens when we cut a hotfix release
-        # for the in-production version after a release has been cut for the
-        # next version.
+        logger.info("Packing %s %s", name, version.node)
+        before = set(staging_path.glob("*.tgz"))
         spawn.runv(
-            [
-                "npm",
-                "publish",
-                "--access",
-                "public",
-                "--tag",
-                cast(str, dist_tag or branch_tag),
-            ],
+            ["npm", "pack", "--pack-destination", str(staging_path)],
             cwd=package_path,
         )
-        # If we didn't tag the release with the branch tag, add it now.
-        if dist_tag == "latest" and branch_tag:
-            spawn.runv(
-                ["npm", "dist-tag", "add", f"{name}@{version.node}", branch_tag],
-                cwd=package_path,
+        packed = set(staging_path.glob("*.tgz")) - before
+        if len(packed) != 1:
+            raise RuntimeError(
+                f"expected npm pack to produce one tarball for {name}, "
+                f"got {sorted(p.name for p in packed)}"
             )
+        tarball = packed.pop().name
+        # If we do not specify a dist tag, npm automatically tags the publish
+        # as `latest`. So, force a dist tag for release builds that are lower
+        # than the stable version. This usually happens when we cut a hotfix
+        # release for the in-production version after a release has been cut
+        # for the next version.
+        return {
+            "name": name,
+            "version": version.node,
+            "tarball": tarball,
+            "tag": cast(str, dist_tag or branch_tag),
+            # The branch tag has to be applied after the publish, because a
+            # publish can only set one tag.
+            "extra_tags": [branch_tag] if dist_tag == "latest" and branch_tag else [],
+        }
+
+
+def publish_via_github(packages: list[dict[str, Any]], staging_path: Path) -> None:
+    """Hand the packed tarballs off to GitHub Actions to publish.
+
+    npm's trusted publishing does not accept OIDC tokens from Buildkite, so
+    the actual `npm publish` runs in the publish-npm workflow, which
+    authenticates to npm with an OIDC token instead of a long-lived one. This
+    uploads the tarballs to a staging bucket that the workflow's AWS role can
+    read, triggers the workflow, and fails this step if the workflow fails, so
+    that a broken publish still turns the Buildkite pipeline red.
+    """
+    bucket = os.environ["NPM_STAGING_BUCKET"]
+    # Unique per job, and reused as the handle for finding the run that this
+    # dispatch creates.
+    dispatch_id = os.environ.get("BUILDKITE_JOB_ID") or str(uuid.uuid4())
+    staging_uri = f"s3://{bucket}/npm/{dispatch_id}/"
+    sha = os.environ.get("BUILDKITE_COMMIT", "")
+    build_url = os.environ.get("BUILDKITE_BUILD_URL", "")
+
+    with open(staging_path / "manifest.json", "w") as manifest_file:
+        json.dump(
+            {
+                "dispatch_id": dispatch_id,
+                "sha": sha,
+                "build_url": build_url,
+                "packages": packages,
+            },
+            manifest_file,
+            indent=2,
+        )
+
+    spawn.runv(
+        [
+            "aws",
+            "s3",
+            "cp",
+            "--recursive",
+            "--only-show-errors",
+            str(staging_path),
+            staging_uri,
+        ],
+    )
+    logger.info("Staged %d package(s) at %s", len(packages), staging_uri)
+
+    github.repository_dispatch(
+        "publish-npm",
+        {
+            "staging_uri": staging_uri,
+            "dispatch_id": dispatch_id,
+            "sha": sha,
+            "build_url": build_url,
+        },
+    )
+    logger.info("Dispatched publish-npm, waiting for the workflow run")
+    # Comfortably inside the Buildkite step's timeout, so that a workflow that
+    # hangs surfaces as an annotated failure here rather than as a killed step.
+    run = github.wait_for_workflow_run(PUBLISH_WORKFLOW, staging_uri, timeout_secs=1200)
+
+    summary = "\n".join(
+        f"- `{p['name']}@{p['version']}` ({p['tag']})" for p in packages
+    )
+    if buildkite.is_in_buildkite():
+        buildkite.add_annotation(
+            "info" if run["conclusion"] == "success" else "error",
+            f"npm publish {run['conclusion']}: {run['html_url']}",
+            summary,
+        )
+    if run["conclusion"] != "success":
+        raise RuntimeError(
+            f"publish-npm workflow {run['conclusion']}: {run['html_url']}"
+        )
+    logger.info("Published %d package(s): %s", len(packages), run["html_url"])
 
 
 def build_all(
     workspace: cargo.Workspace, version: NpmPackageVersion, *, do_release: bool = True
 ) -> None:
-    for crate_name in PUBLISH_CRATES:
-        crate_path = workspace.all_crates[crate_name].path
-        logger.info("Building %s @ %s", crate_path, version.node)
-        package_path = build_package(version, crate_path)
-        logger.info("Built %s", crate_path)
-        if do_release:
-            release_package(version, package_path)
-            logger.info("Released %s", package_path)
-        else:
-            logger.info("Skipping release for %s", package_path)
+    with tempfile.TemporaryDirectory() as staging_dir:
+        staging_path = Path(staging_dir)
+        packages: list[dict[str, Any]] = []
+        for crate_name in PUBLISH_CRATES:
+            crate_path = workspace.all_crates[crate_name].path
+            logger.info("Building %s @ %s", crate_path, version.node)
+            package_path = build_package(version, crate_path)
+            logger.info("Built %s", crate_path)
+            if not do_release:
+                logger.info("Skipping release for %s", package_path)
+                continue
+            package = stage_package(version, package_path, staging_path)
+            if package is not None:
+                packages.append(package)
+        if packages:
+            publish_via_github(packages, staging_path)
+        elif do_release:
+            logger.info("Nothing to publish; all versions already exist on npm")
 
 
 def _query_npm_version(name: str, version: str) -> requests.Response:
@@ -171,12 +269,6 @@ def version_exists_in_npm(name: str, version: NpmPackageVersion) -> bool:
         return False
     res.raise_for_status()
     return True
-
-
-def set_npm_credentials(package_path: Path) -> None:
-    (package_path / ".npmrc").write_text(
-        "//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n"
-    )
 
 
 def parse_args() -> argparse.Namespace:
@@ -216,8 +308,10 @@ if __name__ == "__main__":
             )
         else:
             build_id = int(os.environ["BUILDKITE_BUILD_NUMBER"])
-    if args.do_release and "NPM_TOKEN" not in os.environ:
-        raise ValueError("'NPM_TOKEN' must be set")
+    if args.do_release:
+        for var in ["GITHUB_TOKEN", "NPM_STAGING_BUCKET"]:
+            if var not in os.environ:
+                raise ValueError(f"{var!r} must be set")
     root_workspace = cargo.Workspace(MZ_ROOT)
     wasm_workspace = cargo.Workspace(MZ_ROOT / "misc" / "wasm")
     crate_version = VersionInfo.parse(

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -286,6 +286,15 @@ WASM builds can then be initiated through
 WASM crates reside in `misc/wasm/` Cargo workspace, and should be kept out of
 the main Cargo workspace to avoid cache invalidation issues.
 
+Publishing happens in two hops. The `deploy-npm` Buildkite step builds and
+packs the packages ([`ci/deploy/npm.py`](/ci/deploy/npm.py)), stages the
+tarballs in S3, and triggers the
+[`publish-npm`](/.github/workflows/publish-npm.yml) GitHub Actions workflow,
+which runs the actual `npm publish` and reports back -- the Buildkite step
+fails if the workflow does. The hop exists because npm's trusted publishing
+issues credentials to GitHub Actions, GitLab, and CircleCI but not to
+Buildkite, so this is what lets us publish without a long-lived npm token.
+
 ## Running Confluent Platform
 
 As mentioned above, **Confluent Platform is only required need to test Kafka

--- a/misc/python/materialize/github.py
+++ b/misc/python/materialize/github.py
@@ -11,6 +11,7 @@
 
 import os
 import re
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -312,6 +313,79 @@ def create_release(
             f"{response.status_code}, response={response.text[:500]}"
         )
     print(f"Created GitHub release: {response.json()['html_url']}")
+
+
+def repository_dispatch(
+    event_type: str,
+    client_payload: dict[str, Any],
+    repo: str = "MaterializeInc/materialize",
+    token: str | None = None,
+) -> None:
+    """Trigger the repository_dispatch workflows listening for `event_type`.
+
+    Dispatched workflows always run the definition on the default branch, so
+    the payload cannot be used to run workflow code from another ref.
+    """
+    response = requests.post(
+        f"https://api.github.com/repos/{repo}/dispatches",
+        headers=_auth_headers(token),
+        json={"event_type": event_type, "client_payload": client_payload},
+        timeout=60,
+    )
+    if response.status_code != 204:
+        raise ValueError(
+            f"Failed to dispatch {event_type} to {repo}: "
+            f"{response.status_code}, response={response.text[:500]}"
+        )
+
+
+def wait_for_workflow_run(
+    workflow: str,
+    match: str,
+    repo: str = "MaterializeInc/materialize",
+    token: str | None = None,
+    timeout_secs: int = 1800,
+    poll_secs: int = 15,
+) -> dict[str, Any]:
+    """Wait for a run of `workflow` whose name contains `match` to finish.
+
+    The dispatch API does not report which run it created, so the caller is
+    expected to put a unique identifier in the payload and the workflow is
+    expected to surface it in its `run-name`. Returns the completed run, whose
+    `conclusion` the caller must still check.
+    """
+    headers = _auth_headers(token)
+    deadline = time.monotonic() + timeout_secs
+    run: dict[str, Any] | None = None
+    while True:
+        response = requests.get(
+            f"https://api.github.com/repos/{repo}/actions/workflows/{workflow}/runs",
+            headers=headers,
+            params={"per_page": 50},
+            timeout=60,
+        )
+        if response.status_code != 200:
+            raise ValueError(
+                f"Failed to list runs of {workflow} in {repo}: "
+                f"{response.status_code}, response={response.text[:500]}"
+            )
+        for candidate in response.json()["workflow_runs"]:
+            if match in (candidate["display_title"] or ""):
+                run = candidate
+                break
+        if run is not None and run["status"] == "completed":
+            return run
+        if time.monotonic() >= deadline:
+            if run is None:
+                raise ValueError(
+                    f"No run of {workflow} matching {match!r} appeared within "
+                    f"{timeout_secs}s"
+                )
+            raise ValueError(
+                f"Run of {workflow} matching {match!r} did not complete within "
+                f"{timeout_secs}s: {run['html_url']}"
+            )
+        time.sleep(poll_secs)
 
 
 def for_github_re(text: bytes) -> bytes:


### PR DESCRIPTION
### Motivation

`NPM_TOKEN` is a long-lived npm write token injected into the environment of *every* build on the high-risk Buildkite agent queues. Since npm capped granular access tokens at 90 days, it also has to be rotated on a timer, which is the cost we actually want to eliminate.

npm's [trusted publishing](https://docs.npmjs.com/trusted-publishers/) replaces tokens with short-lived OIDC credentials, but it accepts them from GitHub Actions, GitLab, and CircleCI only — not from Buildkite.

Companion PR in MaterializeInc/i2 provisions the staging bucket and the IAM role.

### Description

Rather than move the release off Buildkite, this keeps Buildkite as the pipeline and moves only the `npm publish` call:

1. `deploy-npm` builds the wasm packages as before, then `npm pack`s them and writes a `manifest.json` describing what to publish and with which dist-tags.
2. It uploads that staging directory to S3 (agent instance role) and fires a `repository_dispatch`.
3. `.github/workflows/publish-npm.yml` assumes an AWS role via GitHub OIDC, downloads the tarballs, and publishes each one with an npm OIDC credential.
4. The Buildkite step polls the run, annotates the build with a link to it, and exits nonzero if the workflow failed, so a broken publish still turns the pipeline red where people are looking.

**No npm token anywhere in the path** — including for the `latest-X.Y` dist-tags, which is the part that took some doing. The npm CLI only performs the OIDC exchange from `npm publish` and `npm stage publish`; `npm dist-tag` never does, so it would ordinarily need a token. The workflow therefore performs the exchange by hand — `POST /-/npm/v1/oidc/token/exchange/package/<pkg>` with the Actions ID token, exactly as [the CLI does internally](https://github.com/npm/cli/blob/latest/lib/utils/oidc.js) — and passes the resulting short-lived, package-scoped registry token to `npm dist-tag add`.

**This is the one thing that needs an empirical check.** npm documents the exchanged token as covering publish, and the trusted-publisher UI's "allowed actions" list offers only `npm publish` and `npm stage publish`, so the registry may reject a dist-tag write with it. The CLI does use the same token for a non-publish endpoint (`libaccess.getVisibility`), which is why this is worth trying. One `workflow_dispatch` run against a `dev` version settles it. If the registry says no, the fallback that still gets us to zero tokens is to retire the `latest-X.Y` tags in favor of `~X.Y.0` ranges in consumers — `~26.37.0` resolves to the newest `26.37.x`, which is what the tag means.

Other non-obvious decisions:

- **Provenance is explicitly disabled.** Trusted publishing generates attestations automatically, but they would claim the Actions run built tarballs that Buildkite actually built. A knowingly false signed attestation is worse than the none we publish today.
- **No `registry-url` on `setup-node`.** It writes an `_authToken` line into `.npmrc`, and an empty token there convinces npm it is already authenticated so it never attempts OIDC, failing with `ENEEDAUTH` ([actions/setup-node#1551](https://github.com/actions/setup-node/issues/1551)). A guard step fails the job if anything else configures one.
- **`repository_dispatch`, not a tag trigger**, because the `dev` channel publishes a prerelease on every main build. Dispatched workflows always run the definition from the default branch, so the payload can't run workflow code from another ref.
- **The publish step skips versions already on npm**, which makes the workflow re-runnable from the same staging URI. That is the remedy if the dist-tag step fails; staged tarballs are kept for 14 days.

Worth being explicit about the security boundary: this retires the long-lived token, but the published bytes still come off a Buildkite agent, and S3-write plus dispatch from that environment are jointly equivalent to publish rights. The hardening win of building where you publish is not part of this change.

### Required setup before merging

- Configure a trusted publisher for `@materializeinc/sql-lexer`, `sql-parser`, and `sql-pretty`: this repository, workflow filename `publish-npm.yml`, environment `npm-publish`. npm does not validate any of this at save time — mistakes surface as `ENEEDAUTH` at publish.
- Create the `npm-publish` environment and set the `NPM_PUBLISH_ROLE_ARN` repository variable to the `GithubActionsNpmPublish` role ARN from the i2 PR.
- Deploy the i2 PR first, so `NPM_STAGING_BUCKET` reaches the agents.

Once a release has gone out through this path: set each package's publishing access to "require 2FA and disallow tokens", revoke the automation token, and drop `npm_token` from i2. At that point there is no npm credential left to rotate.

### Verification

Not yet verified end to end — the handoff can't run until the trusted publishers and the AWS role exist, which is why this is a draft. Locally: `bin/pyactivate -m ci.deploy.npm --no-release` still exercises the build path unchanged, and the publish path is guarded by `version_exists_in_npm`, so a retried step re-publishes nothing.

The first real test should be a `workflow_dispatch` run against a `dev` build, which exercises the publish path but not the dist-tag path (dev versions carry no `latest-X.Y`). A release build is what settles the dist-tag question above.