### PR TITLE
dbt-materialize: quote the schema when copying default privileges

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -10,7 +10,8 @@
 * Fix `deploy_init` when the `CI_TAG` environment variable is set. The
   deployment schema was tagged without passing the schema name, so the
   operation failed with `COMMENT ON SCHEMA ""`. The deployment schema is
-  now also created with a quoted name, matching how it is dropped.
+  now also created with a quoted name, matching how it is dropped and how its
+  grants and default privileges are copied.
 
 ## 1.9.11 - 2026-07-26
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
@@ -170,7 +170,7 @@ SELECT
     WHEN object_owner = 'PUBLIC' THEN 'FOR ALL ROLES '
     ELSE 'FOR ROLE ' || quote_ident(object_owner) || ' '
   END ||
-  'IN SCHEMA {{ to }} '         ||
+  'IN SCHEMA ' || quote_ident({{ dbt.string_literal(to) }}) || ' ' ||
   'GRANT '  || privilege_type   || ' ' ||
   'ON '     || object_type      || 's ' ||
   CASE

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -64,14 +64,18 @@ class TestApplyGrantsAndPrivileges:
             project.run_sql("DROP ROLE IF EXISTS my_role")
         project.run_sql("DROP SCHEMA IF EXISTS blue_schema CASCADE")
         project.run_sql("DROP SCHEMA IF EXISTS green_schema CASCADE")
+        project.run_sql('DROP SCHEMA IF EXISTS "Green_Schema" CASCADE')
         project.run_sql("DROP CLUSTER IF EXISTS blue_cluster CASCADE")
         project.run_sql("DROP CLUSTER IF EXISTS green_cluster CASCADE")
 
-    def test_apply_schema_default_privileges(self, project):
+    # `deploy_init` creates the deployment schema with a quoted name, so a
+    # non-lowercase name has to survive into the generated statements too.
+    @pytest.mark.parametrize("to_schema", ["green_schema", "Green_Schema"])
+    def test_apply_schema_default_privileges(self, project, to_schema):
         project.run_sql("CREATE ROLE my_role")
         project.run_sql("GRANT my_role TO materialize")
         project.run_sql("CREATE SCHEMA blue_schema")
-        project.run_sql("CREATE SCHEMA green_schema")
+        project.run_sql(f'CREATE SCHEMA "{to_schema}"')
         project.run_sql(
             "ALTER DEFAULT PRIVILEGES FOR ROLE my_role IN SCHEMA blue_schema GRANT SELECT ON TABLES TO my_role"
         )
@@ -81,15 +85,15 @@ class TestApplyGrantsAndPrivileges:
                 "run-operation",
                 "internal_copy_schema_default_privs",
                 "--args",
-                "{from: blue_schema, to: green_schema}",
+                f"{{from: blue_schema, to: {to_schema}}}",
             ]
         )
 
         result = project.run_sql(
-            """SELECT count(*) = 1
+            f"""SELECT count(*) = 1
              FROM mz_internal.mz_show_default_privileges
              WHERE database = current_database()
-                AND schema = 'green_schema'
+                AND schema = '{to_schema}'
                 AND grantee = 'my_role'
                 AND object_type = 'table'
                 AND privilege_type = 'SELECT'""",


### PR DESCRIPTION
`internal_copy_schema_default_privs` interpolated the target schema name raw into `ALTER DEFAULT PRIVILEGES ... IN SCHEMA`, so the parser folded it to lowercase. #38066 started creating the deployment schema with a quoted name, which made the two disagree for any schema name that is not a bare lowercase identifier: `deploy_init` created `"Prod_dbt_deploy"` and then failed trying to alter default privileges in `prod_dbt_deploy`, after the schema already existed. The retry then took the schema-already-exists branch, which skips both privilege-copying macros, so the operation reported success while silently dropping the grants and default privileges the production schema had.

Test run: https://buildkite.com/materialize/nightly/builds/18074