### PR TITLE
docker: pin the debian-base base image by digest

### DIFF
--- a/misc/images/debian-base/Dockerfile
+++ b/misc/images/debian-base/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM debian:13-slim
+FROM debian:13-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
 
 # Ensure any Rust binaries that crash print a backtrace.
 ENV RUST_BACKTRACE=1


### PR DESCRIPTION
We should track the hash for dependabot updates.