### PR TITLE
docker: build the jobs image on distroless-prod-base

### DIFF
--- a/misc/images/jobs/Dockerfile
+++ b/misc/images/jobs/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM prod-base
+MZFROM distroless-prod-base
 
 COPY persistcli mz-catalog-debug /usr/local/bin/
 


### PR DESCRIPTION
### Motivation

`jobs` is one of the last two images (with `mz`) still built on the full-Debian `prod-base`. `environmentd`, `clusterd`, `balancerd`, `orchestratord`, and `fivetran-destination` are already on `distroless-prod-base`.

The OS package findings on this image come from the inherited Debian layers, not from `persistcli` or `mz-catalog-debug`. Many have no upstream fix available, so a fresher Debian only goes so far — not shipping the packages is what removes them.

Complementary to #38200 but independent; either can merge alone. Note they don't overlap: `distroless-prod-base` does not derive from `debian-base`, so once `jobs` moves here it leaves that chain entirely. #38200 still covers `mz`, `cli`, `psql`, `mysql-client`, `frontegg-mock`, and `materialized-base`.

### Description

One line: `MZFROM prod-base` → `MZFROM distroless-prod-base`.

`ENTRYPOINT ["persistcli"]` stays bare — the distroless base has `/usr/local/bin` on `PATH`, the same shape `balancerd` and `fivetran-destination` use. The base keeps what this image needs: `/mzdata` and `/scratch` at uid 999, `tini`, a CA bundle plus `SSL_CERT_FILE`, and the `debug-nonroot` variant's busybox at `/busybox` for interactive `mz-catalog-debug` use.

Three differences to weigh:

1. **Runtime user goes root → `materialize` (999).** `prod-base` creates the user but never sets `USER`, so this image runs as root today. The cloud Job specs set no `securityContext`, so they inherit the image's user.
2. **No llvm for sanitizer builds** — `prod-base` installs it when `CI_SANITIZER != none`; `distroless-prod-base` has no such path, the same tradeoff the other production images made.
3. **`curl` and `ssh` go away.** Neither binary looks to need them; if ssh is required, `COPY --from=openssh /output/ssh /usr/bin/ssh` is the established pattern.

### Blocked on a cloud change

The cloud upgrade-check job runs its script with `command: ["bash", "-c", ...]` inside this image, and distroless carries no `bash` (and no `/bin/sh` — `/bin` is empty; the only shell is `/busybox/sh`). That job would fail to exec.

The script itself is already POSIX, so the fix is just the interpreter: **MaterializeInc/cloud#13199**. That has to ship first, since `jobs_image_ref` is `materialize/jobs:{to_version}` — the first upgrade-check against a version built after this merges would break.

### Verification

`bin/mzimage fingerprint jobs` confirms the image actually rebuilds: `OZ7INSFC6U25URF6PD3G4GGEK5IPFB7T` on `main` → `KMAFZ6XEFDBKFFRE2LMRLDPWHRG63UKF` here.

Runtime assumptions checked directly against the base `distroless-prod-base` pins, using a dynamically-linked glibc binary in `/usr/local/bin` as a `persistcli` stand-in: bare-name `ENTRYPOINT` resolves via `PATH`; container args append correctly (`argc=3`, matching how the cloud Job passes them); the binary loads against distroless/cc's libc; it runs as a non-root uid; `/busybox/sh` and the CA bundle are present.

Test paths were audited too. Every one goes through `mzbuild: jobs` via the `Persistcli` service — `backup-restore`, `backup-restore-postgres`, `platform-checks`, `zippy`, `parallel-workload`, all in the nightly pipeline. They pass argv rather than shelling out, and there's no `CMD-SHELL` healthcheck on this service, so they're unaffected. One thing to know: `idle=True` rewrites the entrypoint to `["sleep", "infinity"]`, which survives here only because the debug variant supplies busybox (`sleep` → `/busybox/sleep`, and BusyBox 1.37 does accept `infinity`). On a non-debug distroless base all five suites would break. `jobs` would also be the first distroless image used with `idle=True` — the `pull_images()` docstring warning about distroless images lacking a shell or `sleep` was added by 80e6413302 (#35595, distroless orchestratord), so this has bitten before.

**Not verified locally:** an actual build of the image, which needs both binaries cargo-built in the CI builder. Draft until cloud#13199 lands and someone who owns persist tooling weighs in on the root → 999 change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
