### PR TITLE
v26.38.0 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -20,8 +20,8 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 {{</ note >}}
 
 ## v26.38.0
-*Released to Materialize Cloud: 2026-08-20* <br>
-*Released to Materialize Self-Managed: 2026-08-21* <br>
+*Released to Materialize Cloud: 2026-08-19* <br>
+*Released to Materialize Self-Managed: 2026-08-20* <br>
 
 ### Improvements {#v26.38-improvements}
 - **Notice for single-replica sources on multi-replica clusters**: Materialize now warns when a command leaves a cluster holding more than one replica alongside PostgreSQL, MySQL, or SQL Server sources, which always run on a single replica, since the extra replicas make those sources neither more fault tolerant nor faster to ingest.

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -19,6 +19,26 @@ Starting with the v26.1.0 release, Materialize releases on a weekly schedule for
 both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for details.
 {{</ note >}}
 
+## v26.38.0
+*Released to Materialize Cloud: 2026-08-20* <br>
+*Released to Materialize Self-Managed: 2026-08-21* <br>
+
+### Improvements {#v26.38-improvements}
+- **Notice for single-replica sources on multi-replica clusters**: Materialize now warns when a command leaves a cluster holding more than one replica alongside PostgreSQL, MySQL, or SQL Server sources, which always run on a single replica, since the extra replicas make those sources neither more fault tolerant nor faster to ingest.
+- **Self-Managed: Graceful resizing of system clusters**: `ALTER CLUSTER ... SET (SIZE ...)` on a system cluster such as `mz_catalog_server` or `mz_system` now runs as a background graceful reconfiguration, with a 24-hour default deadline and a rollback on timeout, instead of recreating the whole replica set at once, so `SHOW CLUSTERS` settles on the new configuration rather than flipping to it.
+
+### Bug Fixes {#v26.38-bug-fixes}
+- Fixed an `INSERT` that ran concurrently with an `ALTER TABLE ... ADD COLUMN` crashing the server; the insert now fails with a retryable serialization error instead.
+- Fixed an environment restarting every few seconds and never becoming reachable when it held a sealed collection whose dependency had no readable history left; such a collection no longer blocks startup, so an operator can drop and recreate the affected object.
+- Fixed filter pushdown discarding data that matched the query when a float column contained negative `NaN` values, so the query returned too few rows.
+- Fixed a `TIMESTAMPTZ` literal near the end of the representable range, and rounding such a value to a lower precision, aborting the server.
+- Fixed several date/time and range text-format bugs: a sub-second value that rounded up to a full second rendered about a second early, a `TIME` string naming no time field was accepted instead of erroring, a quoted range bound kept its quotes so a `tsrange` could not survive a `::text::tsrange` round trip, and a BC date was not quoted inside a composite value.
+- Fixed a regular expression exhausting server memory before erroring — a pattern under the documented 1 MiB limit could allocate several gigabytes while being translated — by also rejecting patterns with more than 2000 character classes, counting each Unicode, Perl, or POSIX class such as `\p{L}`, `\d`, or `[[:alpha:]]`, and each range such as `a-z`.
+- Fixed a webhook source's `CHECK` expression having no bound on the memory it may allocate, which let concurrent requests to a source with an amplifying check exhaust server memory; a check that exceeds the budget, 20 MiB per request by default, is now refused with a `400` response.
+- Fixed the enforced connection limit picking up an `ALTER SYSTEM SET max_connections` from a transaction that was then rolled back, so the limit clients were held to could differ from the committed value.
+- Fixed `dbt-materialize`'s `deploy_init` failing when `CI_TAG` is set, the setup the blue/green deployment documentation prescribes, and made it quote the deployment schema consistently so a schema name that is not a bare lowercase identifier is handled correctly throughout the operation.
+- Fixed the comment `dbt-materialize`'s `deploy_promote` puts on each promoted schema ending without a timestamp.
+
 ## v26.37.0
 *Released to Materialize Cloud: 2026-08-12* <br>
 *Released to Materialize Self-Managed: 2026-08-13* <br>

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -23,11 +23,69 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 *Released to Materialize Cloud: 2026-08-19* <br>
 *Released to Materialize Self-Managed: 2026-08-20* <br>
 
+### Dictionary compression {#v26.38-dictionary-compression}
+
+{{< public-preview />}}
+
+Dictionary compression reduces the memory that
+[arrangements](/get-started/arrangements/#arrangements) use when a column holds the same values repeatedly. Instead of storing a repeated column value each time it appears, Materialize stores that value once and has each row reference it. This can reduce steady state memory requirements after [hydration](/concepts/hydration/) has completed.
+
+Dictionary compression is off by default. You opt in per cluster with the
+`EXPERIMENTAL ARRANGEMENT COMPRESSION` option:
+
+```mzsql
+-- Turn compression on for a new cluster
+CREATE CLUSTER my_cluster (
+    SIZE = '100cc',
+    EXPERIMENTAL ARRANGEMENT COMPRESSION = true
+);
+
+-- Or turn it on for an existing cluster
+ALTER CLUSTER my_cluster SET (EXPERIMENTAL ARRANGEMENT COMPRESSION = true);
+```
+
+For more information, see:
+- [Guide: Dictionary compression](/transform-data/dictionary-compression/), including [when it helps and when it does not](/transform-data/dictionary-compression/#the-tradeoff)
+- [`CREATE CLUSTER`: Dictionary compression](/sql/create-cluster/#dictionary-compression)
+- [`ALTER CLUSTER`: Dictionary compression](/sql/alter-cluster/#dictionary-compression)
+
+### Integrate with your observability stack {#v26.38-self-managed-observability}
+
+<red>*Materialize Self-Managed only*</red>
+
+Materialize Self-Managed now integrates with the observability tools you already
+run. You can export metrics, and optionally logs, from Materialize to Datadog,
+Honeycomb, Google Cloud Monitoring, Prometheus remote write, or any monitoring
+backend with an Open Telemetry (OTLP) endpoint. Template dashboards and alerts are provided to
+help you get started.
+
+Follow the instructions for your destination:
+- [Datadog](/manage/monitor/self-managed/datadog/)
+- [Honeycomb](/manage/monitor/self-managed/honeycomb/)
+- [Google Cloud Monitoring](/manage/monitor/self-managed/google-cloud-monitoring/)
+- [Prometheus remote write](/manage/monitor/self-managed/prometheus-remote-write/), for Mimir, Amazon Managed Prometheus, or Grafana Cloud
+- [OpenTelemetry](/manage/monitor/self-managed/opentelemetry/), for any other OTLP endpoint, including your own collector
+
+If you don't have an observability stack set up, the [Materialize Terraform
+modules](/self-managed-deployments/installation/#install-using-terraform-modules)
+can deploy one alongside Materialize. It collects metrics from Materialize and
+from your Kubernetes cluster, collects Materialize's container logs and
+Kubernetes events, stores both in your own object storage, and ships [Grafana](/manage/monitor/self-managed/grafana/)
+dashboards and Alertmanager alert rules to query them. The stack is controlled by
+the `enable_observability` variable, which defaults to `true` starting with
+v11.0.0 of the modules.
+
+For more information, see:
+- [Monitoring Self-Managed Materialize](/manage/monitor/self-managed/)
+- [How logs and metrics are stored and delivered](/manage/monitor/self-managed/storage/)
+- [Alerting](/manage/monitor/self-managed/alerting/)
+
 ### Improvements {#v26.38-improvements}
 - **Notice for single-replica sources on multi-replica clusters**: Materialize now warns when a command leaves a cluster holding more than one replica alongside PostgreSQL, MySQL, or SQL Server sources, which always run on a single replica, since the extra replicas make those sources neither more fault tolerant nor faster to ingest.
 - **Self-Managed: Graceful resizing of system clusters**: `ALTER CLUSTER ... SET (SIZE ...)` on a system cluster such as `mz_catalog_server` or `mz_system` now runs as a background graceful reconfiguration, with a 24-hour default deadline and a rollback on timeout, instead of recreating the whole replica set at once, so `SHOW CLUSTERS` settles on the new configuration rather than flipping to it.
 
 ### Agent Skills {#v26.38-agent-skills}
+- **materialize-debug-freshness**: New agent skill for diagnosing why an object is behind wall-clock time, whether that surfaces as a stale materialized view, index, or sink, or as a freshness alert. Running on the read-only tools of the Materialize developer MCP server, it ranks what is lagging, attributes the lag to a single hop, then rules out in-progress hydration, a replica dominated by one dataflow, and per-worker skew before naming the culprit operator and the SQL responsible for the expensive work.
 - **mz-deploy**: New agent skill covering the `mz-deploy` CLI — project layout, the compile/test/apply/stage/promote workflow, deploy IDs and staging suffixes, schema-granularity conflict detection, stable API schemas, profile resolution, and the `EXECUTE UNIT TEST` grammar.
 - **mz-sql-lsp**: New Claude Code plugin, installable from the `agent-skills` repository's new `materialize` plugin marketplace, that registers the `mz-deploy` language server for `.sql` files so agents can use go-to-definition, hover, and workspace symbols in an mz-deploy project instead of text search.
 

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -27,6 +27,10 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 - **Notice for single-replica sources on multi-replica clusters**: Materialize now warns when a command leaves a cluster holding more than one replica alongside PostgreSQL, MySQL, or SQL Server sources, which always run on a single replica, since the extra replicas make those sources neither more fault tolerant nor faster to ingest.
 - **Self-Managed: Graceful resizing of system clusters**: `ALTER CLUSTER ... SET (SIZE ...)` on a system cluster such as `mz_catalog_server` or `mz_system` now runs as a background graceful reconfiguration, with a 24-hour default deadline and a rollback on timeout, instead of recreating the whole replica set at once, so `SHOW CLUSTERS` settles on the new configuration rather than flipping to it.
 
+### Agent Skills {#v26.38-agent-skills}
+- **mz-deploy**: New agent skill covering the `mz-deploy` CLI — project layout, the compile/test/apply/stage/promote workflow, deploy IDs and staging suffixes, schema-granularity conflict detection, stable API schemas, profile resolution, and the `EXECUTE UNIT TEST` grammar.
+- **mz-sql-lsp**: New Claude Code plugin, installable from the `agent-skills` repository's new `materialize` plugin marketplace, that registers the `mz-deploy` language server for `.sql` files so agents can use go-to-definition, hover, and workspace symbols in an mz-deploy project instead of text search.
+
 ### Bug Fixes {#v26.38-bug-fixes}
 - Fixed an `INSERT` that ran concurrently with an `ALTER TABLE ... ADD COLUMN` crashing the server; the insert now fails with a retryable serialization error instead.
 - Fixed an environment restarting every few seconds and never becoming reachable when it held a sealed collection whose dependency had no readable history left; such a collection no longer blocks startup, so an operator can drop and recreate the affected object.

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -8,7 +8,7 @@ rows:
   - Materialize Operator: v26.38
     orchestratord version: v26.38
     environmentd version: v26.38
-    Release date: "2026-08-21"
+    Release date: "2026-08-20"
     Notes: "See [v26.38 release notes](/releases/#v26380)"
   - Materialize Operator: v26.37
     orchestratord version: v26.37

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -5,6 +5,11 @@ columns:
   - column: Release date
   - column: Notes
 rows:
+  - Materialize Operator: v26.38
+    orchestratord version: v26.38
+    environmentd version: v26.38
+    Release date: "2026-08-21"
+    Notes: "See [v26.38 release notes](/releases/#v26380)"
   - Materialize Operator: v26.37
     orchestratord version: v26.37
     environmentd version: v26.37


### PR DESCRIPTION
Dates in RC snapshots are provisional until the release ships. One commit is added per snapshot; the final snapshot sets the real dates.

Snapshot drafts (with PR links) in mz-skills:
- rc.1: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/rc.1/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/rc.1/omitted.md)
- rc.2: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/rc.2/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/rc.2/omitted.md)
- rc.3: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/rc.3/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/rc.3/omitted.md)
- final: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/final/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/final/omitted.md)

**Borderline PRs omitted:** rc.1: 6 — [omitted.md#borderline](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/rc.1/omitted.md#borderline), rc.2: 1 — [omitted.md#borderline](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/rc.2/omitted.md#borderline), rc.3: 1 — [omitted.md#borderline](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/rc.3/omitted.md#borderline), final: 0 — [omitted.md#borderline](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.0/final/omitted.md#borderline)

**Release dates (final): Cloud 2026-08-19, Self-Managed 2026-08-20.** The `final` commit replaces the provisional pair (Cloud 2026-08-20, Self-Managed 2026-08-21) in both `_index.md` and the operator-compatibility YAML. The train was tagged on a Wednesday rather than the Thursday the cadence estimate assumed, so both dates move one day earlier — the same one-day-early pattern `v26.37.0` showed. **These dates are inferred from the `v26.38.0` tag's commit date (2026-08-19T16:31:34Z) plus one day for Self-Managed, not supplied verbatim — please confirm them before merging.**

**What rc.2 added:** the Agent Skills section only (the `mz-deploy` skill and the `mz-sql-lsp` Claude Code plugin, both from `MaterializeInc/agent-skills`). rc.2's single materialize PR — [#38241](https://github.com/MaterializeInc/materialize/pull/38241), a cherry-pick — is held out as experimental; see the release-owner call below.

**What rc.3 added:** nothing published — its commit is empty. rc.3's window was four hours wide (it was cut the same afternoon as rc.2) and held one PR, [#38259](https://github.com/MaterializeInc/materialize/pull/38259), which pins the builtin-schema migration step for `mz_internal.mz_cluster_reconfigurations` to `26.38.0-rc.2` and so repairs a startup assertion failure that rc.2's own cherry-pick (#38241) had introduced. The defect was never in a released version and no upgrade path into v26.38.0 passes through the broken state, so it is omitted. The commit is recorded empty rather than skipped so the branch's subject ledger carries every snapshot of the train.

**What final added:** the real dates and nothing else. The tracking issue [MaterializeInc/release#551](https://github.com/MaterializeInc/release/issues/551) lists no PRs, and `compare v26.38.0-rc.3...v26.38.0` contains exactly one commit — the `materialize-bot` version bump — so no cherry-picks landed on the release branch after rc.3. The window's 2 agent-skills PRs are both repo automation and are omitted. The published content of this release is therefore rc.1's 2 improvements and 10 bug fixes plus rc.2's 2 agent-skills entries.

**Needs a call from the release owner:**
- ~~[#38102](https://github.com/MaterializeInc/materialize/pull/38102) (graceful resizing of system clusters) — confirm parts 1 and 2 ship in v26.38.0.~~ **Resolved at the tag:** both #38102 and [#38101](https://github.com/MaterializeInc/materialize/pull/38101) are confirmed ancestors of `v26.38.0`, so the Improvements entry is correct as published. The rest of rc.1's caveat still holds and was re-checked: **part 3 (`WITH (WAIT FOR '0s')`, the escape hatch for operators who cannot afford the overlap replica set) is not in this release** — nothing after rc.1 added it. The published entry makes no claim about an escape hatch, so no rewrite is needed.
- [#38195](https://github.com/MaterializeInc/materialize/pull/38195) (arrangement dictionary compression) is **held out** as an experimental gate, re-verified at the final tag: `enable_arrangement_dictionary_compression_alpha` reads `true` but its description still says "alpha; not yet production-ready", and the per-cluster `EXPERIMENTAL ARRANGEMENT COMPRESSION` option still defaults off. The flip does change something real for Self-Managed, where that per-cluster option previously had no effect at all. If you want it advertised, add to Improvements: "**Self-Managed: `EXPERIMENTAL ARRANGEMENT COMPRESSION` on a cluster now takes effect**" — noting that existing replicas do not pick it up until they are recreated.
  - **rc.2 addition:** [#38241](https://github.com/MaterializeInc/materialize/pull/38241) is the same feature's graceful-reconfiguration fix — without it, an `ALTER CLUSTER` on a compression-carrying cluster bounces the baseline replicas mid-reconfiguration and leaves an empty `changes` diff in `mz_internal.mz_cluster_reconfigurations`. It is reachable only behind the same `_alpha` gate, so it is omitted alongside #38195. **Decide the two together:** if the option is advertised, #38241 belongs in that entry.
  - **rc.3 addition:** [#38259](https://github.com/MaterializeInc/materialize/pull/38259) is what makes rc.2's #38241 start at all — without it, a server opening an existing catalog aborts, since the migration step was registered at a version ahead of the build. It does not change the decision above either way; it only means the held-out code now runs. All three PRs should still be decided as one. Given the "not yet production-ready" description is unchanged at the release tag, the default reading is to leave the feature unadvertised.
- The regex entry's new limit is a **stated break with released behavior**: a machine-generated pattern carrying more than 2000 character classes (say 3000 `\d`) compiles on every released version and does not compile here, and such a pattern inside an existing view const-folds to an error literal, so the object still loads but queries against it error. Consider whether that deserves its own call-out rather than living inside a bug-fix bullet.

**Note on merge order:** [#38100](https://github.com/MaterializeInc/materialize/pull/38100) (v26.37.0 release notes) has since merged, so this branch — cut from `main` before it — now conflicts, exactly as anticipated. The resolution is trivial: the v26.38.0 section belongs above v26.37.0 at the top of `_index.md`, and the v26.38 row above the v26.37 row in the operator-compatibility YAML.
