### PR TITLE
ci: record the accepted write-performance step for OCC read-then-write

### DIFF
--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -28,6 +28,12 @@ def get_ancestor_overrides_for_performance_regressions(
 
     min_ancestor_mz_version_per_commit = dict()
 
+    if scenario_class_name in ("ManySmallUpdates", "Update"):
+        # PR#37923 (adapter: sequence read-then-write from the session task with OCC) increases wallclock for writes, and clusterd memory for ManySmallUpdates
+        min_ancestor_mz_version_per_commit[
+            "4f0805a4d8d8e398f2fdfe10d5bdbe70b16924a4"
+        ] = MzVersion.parse_mz("v26.39.0")
+
     if scenario_class_name == "ParallelDataflows":
         # PR#32095 (Dictionary compressed arrangements) increased wallclock by ~10%
         min_ancestor_mz_version_per_commit[
@@ -242,6 +248,8 @@ _MIN_ANCESTOR_MZ_VERSION_PER_COMMIT_TO_ACCOUNT_FOR_SCALABILITY_REGRESSIONS: dict
     str, MzVersion
 ] = {
     # insert newer commits at the top
+    # PR#37923 (adapter: sequence read-then-write from the session task with OCC) reduces write throughput
+    "4f0805a4d8d8e398f2fdfe10d5bdbe70b16924a4": MzVersion.parse_mz("v26.39.0"),
     # PR#31309 ([adapter] don't block on builtin table write in Session creation) increases latency for inserts
     "e8c42c65afb7acd55eb7e530a92c89a9165f2e33": MzVersion.parse_mz("v0.133.0"),
     # PR#30238 (adapter: Remove the global write lock) introduces regressions against v0.123.0


### PR DESCRIPTION
Sequencing read-then-write from the session task with OCC (#37923) trades write throughput for correctness under concurrent writers. This registers the accepted step so the benchmarks stop reporting it against `main`.

This is needed rather than optional: `misc/python/materialize/mzcompose/__init__.py` defaults `enable_adapter_frontend_occ_read_then_write` to `true` from `v26.36.0-dev`, so every suite already runs the OCC path. Without the pin, the comparison is against a released version that still takes the lock path, and the three scenarios below fail on every nightly until a release containing #37923 becomes the baseline.

### Measured

Nightly 18086, on the head that merged as `4f0805a4d8d8`:

| scenario | measured | previously recorded |
| --- | --- | --- |
| `ManySmallUpdates` | 3.4-3.7x wallclock over three runs, clusterd memory +57-73% | 1.7-1.9x, +56% |
| `Update` | +33-45% wallclock | 1.4x |
| `UpdateWorkload` | -24% tps at concurrency 1 | -36-39% |

`UpdateWorkload` came out *better* than previously recorded. `ManySmallUpdates` came out about twice as bad, so the design doc was corrected in `6d0718ac` rather than pinning against a stale figure.

### Why the step is structural

Every read-then-write installs a subscribe dataflow, waits for its snapshot and tears it down, where the lock path used a cheap fast-path peek. Small writes have nothing to amortize that fixed cost over. `ManySmallUpdates` is the worst case because each of its statements collapses a residue class, so roughly 90% of them match no rows, and a zero-row write still has to linearize its read, which needs a group commit that has nothing to write. High write throughput is a stated non-goal of the design.

### Which version

The merge landed *after* the v26.38.0 branch was cut (`release: bump to version v26.39.0-dev.0` is an ancestor of `4f0805a4d8d8`), so the step first ships in **v26.39.0**. Pinning v26.38.0 would compare against a version that does not contain the change, and the regression would still be reported.

The convention in this file is "the dev version in the workspace at that commit, with `-dev.0` stripped", which I checked against three existing entries: `e8c42c6` was 0.133.0-dev.0 and pins v0.133.0, `9867845` was 0.124.0-dev.0 and pins v0.124.0, `90644c4` was 26.29.0-dev.0 and pins v26.29.0. `4f0805a4` is 26.39.0-dev.0.

### Precedent

`PR#30238 (adapter: Remove the global write lock)` is the same family of change and is pinned the same way, at `v0.124.0`.

### Verification

Both overrides resolve for the intended scenarios and not for others:

```
ManySmallUpdates  -> v26.39.0
Update            -> v26.39.0
Retraction (ctl)  -> None
scalability       -> v26.39.0  | newest-first index: 0
```

The scalability dict is explicitly ordered newest-first, so the new entry goes at the top. `v26.39.0` is the current dev version and need not be published yet.

Closes [SQL-634](https://linear.app/materializeinc/issue/SQL-634).
