### PR TITLE
build(deps): Bump ws to 7.5.13 in test/lang/js

### DIFF
--- a/test/lang/js/yarn.lock
+++ b/test/lang/js/yarn.lock
@@ -3546,9 +3546,9 @@ write-file-atomic@^3.0.0:
     typedarray-to-buffer "^3.1.5"
 
 ws@^7.4.6:
-  version "7.5.10"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
-  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+  version "7.5.13"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.13.tgz#12aa507eaca76c295c278b1aebf4698ab2c1845f"
+  integrity sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
In ws before 7.5.11 a peer can send a high volume of very small frames and data chunks to force the receiver into allocating per-fragment structural wrappers that are not counted against `maxPayload`, so modest network traffic can drive the process into OOM.

`ws` is a dev-only transitive dependency here, reached through jest's jsdom, and jsdom's `^7.4.6` range already admits the patched release, so this is a lockfile-only change. The other JS lockfiles in the repo (`console/yarn.lock`, `ci/test/docs-widgets/package-lock.json`) already resolve ws at 8.21.0 and are unaffected.

Ref: GHSA-96hv-2xvq-fx4p, CVE-2026-48779
Alert: https://github.com/MaterializeInc/materialize/security/dependabot/494