### PR TITLE
ci: bump nanoid to 3.3.18 in the docs-widgets tests

### DIFF
--- a/ci/test/docs-widgets/package-lock.json
+++ b/ci/test/docs-widgets/package-lock.json
@@ -1211,9 +1211,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
nanoid before 3.3.18 loops forever in `customAlphabet` and `customRandom` when called with a size of 0 (GHSA-2v37-7h3g-55p8, CVE-2026-67213).

The dependency is transitive, postcss pulls it in as `^3.3.16`, so the lockfile bump alone resolves it. Nothing in the docs-widgets tests calls the affected generators, so this only clears the alert.

Fixes https://github.com/MaterializeInc/materialize/security/dependabot/595