### PR TITLE
test/lang/js: Bump js-yaml to 4.3.1

### DIFF
--- a/test/lang/js/package.json
+++ b/test/lang/js/package.json
@@ -22,7 +22,7 @@
     "@babel/core": "^7.29.6",
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
     "@tootallnate/once": "^2.0.1",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "lodash": ">=4.18.0"
   },
   "prettier": {

--- a/test/lang/js/yarn.lock
+++ b/test/lang/js/yarn.lock
@@ -2696,10 +2696,10 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+js-yaml@^3.13.1, js-yaml@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Two high-severity advisories against js-yaml 4.x, both quadratic-CPU denial of service in the loader:

* GHSA-52cp-r559-cp3m (CVE-2026-59869), fixed in 4.3.0: chained merge keys make merged-key enumeration O(N^2) in document size.
* GHSA-5p4m-2wfm-xmqj, fixed in 4.3.1: `!!omap` duplicate-key detection uses a linear scan per element, so resolution is O(n^2) in the number of entries. `!!omap` is in the default schema, so a plain `yaml.load()` is affected.

The version here comes from a `resolutions` override rather than a direct dependency, so dependabot cannot bump it on its own. The only consumer is `@istanbuljs/load-nyc-config`, which requests `^3.13.1` and has been served the 4.x override all along.

Dependabot alerts 541 and 591.
