### PR TITLE
console: move the remaining Node 20 pins to Node 24

### DIFF
--- a/console/misc/docker/Dockerfile
+++ b/console/misc/docker/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 

--- a/console/package.json
+++ b/console/package.json
@@ -361,7 +361,7 @@
     "defaults"
   ],
   "volta": {
-    "node": "20.12.2",
+    "node": "24.19.0",
     "yarn": "4.14.1"
   },
   "packageManager": "yarn@4.14.1",


### PR DESCRIPTION
### Motivation

Vercel emailed us that the `console` project is on Node.js 20, which is EOL — they reject new builds on it after 2026-10-01. The Vercel-side setting is fixed in MaterializeInc/i2#3698; this PR clears the leftover Node 20 pins in this repo.

Worth stating up front, because it changes how urgent this looks: **the console's Vercel builds are already on Node 24.** All three deploy paths (`ci/deploy/console.sh`, `ci/test/console/vercel-preview.sh`, `ci/deploy/console-impersonation.sh`) run `vercel build` + `vercel deploy --prebuilt` under `bin/ci-builder run stable`, and ci-builder has been `FROM node:24-trixie-slim` since a152e93834 (2026-07-15). Vercel never runs the build, so the deadline does not threaten our deploys. What's left is hygiene.

### Description

Two independent commits, so either can be dropped:

1. **`console/package.json`** — `volta.node` `20.12.2` → `24.19.0` (current Node 24 LTS). This was the last thing steering local dev to Node 20; CI ignores it (uses corepack plus the image's node). `volta.yarn` and `packageManager` are unchanged.

2. **`console/misc/docker/Dockerfile`** — `node:20-alpine` → `node:24-alpine`. This is the hand-built self-hosted/impersonation image described in `console/misc/docker/README.md`, not built by CI. It was the only actual Node 20 execution left in the console.

Deliberately **not** changed:

- **`engines.node: ">=20.12.2"`** stays as is. 24 already satisfies it, and tightening it to `>=24` would make Yarn complain in `console/Dockerfile`, which builds on Node 22. Raising the floor is a separate decision.
- **`console/Dockerfile` (`node:22-alpine`)** stays. Node 22 is supported until 2027, so it is not part of this deadline.

### Verification

Built `console/misc/docker/Dockerfile` as committed on this branch, with BuildKit, and ran the result:

- `corepack enable` and `yarn install --immutable` succeed on `node:24-alpine` (25s; only the peer-dependency warnings this repo already emits).
- `yarn build` succeeds — vite 6.4.3, 5906 modules transformed, built in 13.2s, with `SOURCE_MAPS=true` and the Sentry plugin active (it skips the upload with no auth token, as expected locally).
- The resulting 126MB image starts and serves: `docker run -p 3000:8080 -e MZ_ENDPOINT=...` returns HTTP 200 and the console `index.html`.

The Volta bump is unverified by execution, and inert for CI by inspection: nothing under `ci/`, `bin/`, `misc/`, or `.github/` reads `volta`, and both ci-builder variants (`ci-builder-full` and `ci-builder-console`) already take node from `FROM node:24-trixie-slim`.

Note that CI will run the full console suite on this PR (both files match the `console/**` input filter), but **none of those steps build `misc/docker/Dockerfile` or read the Volta pin** — a green build here is not evidence for either change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
