### PR TITLE
ci: Nightly fixes (2026-08-16)

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -6422,12 +6422,7 @@ ddl_action_list = ActionList(
         (CreateTypeAction, 2),
         (DropTypeAction, 2),
         (CreateNetworkPolicyAction, 1),
-        # TODO: Reenable once ALTER NETWORK POLICY resolves quoted (e.g.
-        # hyphenated) names. It looks the policy up by its quoted display form,
-        # so it fails with "unknown network policy" for any name that requires
-        # quoting, even though CREATE and DROP work.
-        # See https://linear.app/materializeinc/issue/CLO-143
-        # (AlterNetworkPolicyAction, 1),
+        (AlterNetworkPolicyAction, 1),
         (DropNetworkPolicyAction, 1),
         (RenameSchemaAction, 10),
         (RenameTableAction, 10),

--- a/test/rqg/mzcompose.py
+++ b/test/rqg/mzcompose.py
@@ -26,6 +26,7 @@ from materialize.mzcompose.composition import (
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.rqg import RQG
+from materialize.ui import UIError
 from materialize.version_ancestor_overrides import (
     ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS,
 )
@@ -331,6 +332,13 @@ class StoreOtherTag(argparse.Action):
             tag = resolve_ancestor_image_tag(
                 ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS
             )
+
+            if tag is None:
+                raise UIError(
+                    f"Could not resolve --other-tag={values} to an image tag, "
+                    f"no version to compare against"
+                )
+
             print(f"Resolving --other-tag to {tag}")
         else:
             tag = str(values)

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -69,6 +69,7 @@ from materialize.test_analytics.data.scalability_framework import (
     scalability_framework_result_storage,
 )
 from materialize.test_analytics.test_analytics_db import TestAnalyticsDb
+from materialize.ui import UIError
 from materialize.util import YesNoOnce, all_subclasses
 from materialize.version_ancestor_overrides import (
     ANCESTOR_OVERRIDES_FOR_SCALABILITY_REGRESSIONS,
@@ -339,6 +340,12 @@ def get_baseline_and_other_endpoints(
                 )
 
                 if resolved_target is None:
+                    if specified_target == regression_against_target:
+                        raise UIError(
+                            f"Could not resolve --regression-against={specified_target} "
+                            "to an image tag, so no regression comparison can be performed"
+                        )
+
                     print(
                         f"Skipping target {specified_target}: no ancestor image could be resolved"
                     )

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -337,6 +337,13 @@ def get_baseline_and_other_endpoints(
                 resolved_target = resolve_ancestor_image_tag(
                     ANCESTOR_OVERRIDES_FOR_SCALABILITY_REGRESSIONS
                 )
+
+                if resolved_target is None:
+                    print(
+                        f"Skipping target {specified_target}: no ancestor image could be resolved"
+                    )
+                    continue
+
             endpoint = MaterializeContainer(
                 composition=c,
                 specified_target=specified_target,
@@ -384,7 +391,7 @@ def report_regression_result(
     outcome: ComparisonOutcome,
 ) -> None:
     if baseline_endpoint is None:
-        print("No regression detection because '--regression-against' param is not set")
+        print("No regression detection because there is no baseline endpoint")
         return
 
     baseline_desc = endpoint_name_to_description(baseline_endpoint.try_load_version())

--- a/test/version-consistency/mzcompose.py
+++ b/test/version-consistency/mzcompose.py
@@ -31,6 +31,7 @@ from materialize.output_consistency.execution.query_output_mode import (
 from materialize.output_consistency.output_consistency_test import (
     upload_output_consistency_results_to_test_analytics,
 )
+from materialize.ui import UIError
 from materialize.version_ancestor_overrides import (
     ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS,
 )
@@ -87,6 +88,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     port_mz_default_this, port_mz_system_this = 6875, 6877
     port_mz_default_other, port_mz_system_other = 16875, 16877
     tag_mz_other = resolve_tag(args.other_tag)
+
+    if tag_mz_other is None:
+        raise UIError(
+            f"Could not resolve --other-tag={args.other_tag} to an image tag, "
+            f"no version to compare against"
+        )
 
     print(f"Using {tag_mz_other} as tag for other mz version")
 


### PR DESCRIPTION
Based on https://buildkite.com/materialize/nightly/builds/18090 & https://buildkite.com/materialize/nightly/builds/18092

We haven't had to use version overrides in scalability framework in a while, and they have apparently broken!

Test run: https://buildkite.com/materialize/nightly/builds/18091 & https://buildkite.com/materialize/nightly/builds/18093