### PR TITLE
Fix DOT graph rendering for operator names with quotes

### DIFF
--- a/src/environmentd/src/http/static/js/hierarchical-memory.jsx
+++ b/src/environmentd/src/http/static/js/hierarchical-memory.jsx
@@ -78,7 +78,7 @@ function ClusterReplicaView() {
       {loading ? (
         <div>Loading...</div>
       ) : error ? (
-        <div>error: {error}</div>
+        <div>error: {String(error)}</div>
       ) : (
         <div>
           <label htmlFor="cluster_replica">Cluster Replica </label>
@@ -270,16 +270,17 @@ function Dataflows(props) {
           const labels = ids_seen.map((id) => {
             let name = id_to_name[id];
             if (name != null) {
+              const label = escapeDotLabel(`${id} : ${name}`);
               if (scope_children.has(addrStr(id_to_addr[id]))) {
                 // indicate subgraphs
-                return `${id} [label="${id} : ${name}",shape=house,style=filled,color=green,fillcolor="#bbffbb"]`;
+                return `${id} [label="${label}",shape=house,style=filled,color=green,fillcolor="#bbffbb"]`;
               } else {
                 let my_records = records["".concat(id)];
                 if (my_records != null) {
                   let my_size = Math.ceil(my_records[1]/1024);
-                  return `${id} [label= "${id} : ${name}\nrecords: ${my_records[0]}, ${my_size} KiB",style=filled,color=red,fillcolor="#ffbbbb",shape=box]`;
+                  return `${id} [label= "${label}\nrecords: ${my_records[0]}, ${my_size} KiB",style=filled,color=red,fillcolor="#ffbbbb",shape=box]`;
                 } else {
-                  return `${id} [label="${id} : ${name}",shape=box]`;
+                  return `${id} [label="${label}",shape=box]`;
                 }
               }
             } else {
@@ -325,7 +326,7 @@ function Dataflows(props) {
       {loading ? (
         <div>Loading...</div>
       ) : error ? (
-        <div>error: {error}</div>
+        <div>error: {String(error)}</div>
       ) : (
         <div>
           {page}
@@ -400,6 +401,13 @@ async function getCreateView(dataflow_name) {
 
 function addrStr(addr) {
   return addr.join(', ');
+}
+
+// Escape special characters in DOT labels. Operator names routinely contain
+// double quotes, e.g. `ArrangeBy[[Column(0, "id")]]`, which would otherwise
+// terminate the quoted label and make the whole graph unparseable.
+function escapeDotLabel(str) {
+  return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 function toggle_active(e) {

--- a/src/environmentd/src/http/static/js/memory.jsx
+++ b/src/environmentd/src/http/static/js/memory.jsx
@@ -79,7 +79,7 @@ function ClusterReplicaView() {
       {loading ? (
         <div>Loading...</div>
       ) : error ? (
-        <div>error: {error}</div>
+        <div>error: {String(error)}</div>
       ) : (
         <div>
           <label htmlFor="cluster_replica">Cluster Replica </label>
@@ -192,7 +192,7 @@ function Views(props) {
       {loading ? (
         <div>Loading...</div>
       ) : error ? (
-        <div>error: {error}</div>
+        <div>error: {String(error)}</div>
       ) : (
         <div>
           <table class="dataflows">
@@ -658,7 +658,7 @@ function View(props) {
       {loading ? (
         <div>Loading...</div>
       ) : error ? (
-        <div>error: {error}</div>
+        <div>error: {String(error)}</div>
       ) : (
         <div>
           <h3>

--- a/test/dataflow-visualizer/tests/hierarchical-memory.spec.ts
+++ b/test/dataflow-visualizer/tests/hierarchical-memory.spec.ts
@@ -39,6 +39,11 @@ test.describe('/hierarchical-memory page', () => {
   });
 
   test('page renders without crashing after data load', async ({ page }) => {
+    // A render-time throw unmounts the React tree while leaving the document
+    // intact, so assert on the rendered content rather than on <body>.
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error));
+
     await page.goto('/hierarchical-memory');
 
     // Wait for dropdown to appear (indicates initial load complete)
@@ -46,9 +51,11 @@ test.describe('/hierarchical-memory page', () => {
     await expect(dropdown).toBeVisible({ timeout: 20000 });
 
     // The page queries data and renders - give it time
-    // Then verify the page hasn't completely crashed (body still exists)
     await page.waitForTimeout(3000);
-    await expect(page.locator('body')).toBeVisible();
+
+    await expect(dropdown).toBeVisible();
+    await expect(page.locator('#content2')).not.toContainText('error:');
+    expect(pageErrors.map(String)).toEqual([]);
   });
 
   test('URL updates with cluster parameters after selection', async ({ page }) => {
@@ -61,6 +68,52 @@ test.describe('/hierarchical-memory page', () => {
     // URL should have been updated with cluster params
     await expect(page).toHaveURL(/cluster_name=/);
     await expect(page).toHaveURL(/replica_name=/);
+  });
+
+  test('renders graphs for operator names containing double quotes', async ({
+    page,
+    request,
+  }) => {
+    // An arrangement operator embeds the debug formatting of its key in its
+    // name, so an index on a named column is called something like
+    // `ArrangeBy[[Column(0, "id")]]`. Those double quotes have to be escaped
+    // before they reach a DOT label, otherwise they terminate the label early
+    // and GraphViz rejects the whole graph.
+    for (const query of [
+      'CREATE TABLE IF NOT EXISTS quoted_name_regression (id int, other int)',
+      'CREATE INDEX IF NOT EXISTS quoted_name_regression_idx ON quoted_name_regression (id)',
+    ]) {
+      const response = await request.post('/api/sql', { data: { query } });
+      // /api/sql reports SQL failures in the body, not the status code.
+      const body = response.ok() ? await response.json() : null;
+      const failure = !body
+        ? `HTTP ${response.status()}`
+        : body.results?.find((result) => result.error)?.error?.message;
+      // The endpoint runs as an unprivileged role, so DDL may be refused
+      // depending on how the environment is configured. Skip visibly rather
+      // than reporting a visualizer bug that isn't one.
+      test.skip(!!failure, `could not set up test index: ${failure}`);
+    }
+
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error));
+
+    await page.goto(
+      '/hierarchical-memory?cluster_name=quickstart&replica_name=r1'
+    );
+
+    const content = page.locator('#content2');
+
+    // Scope graphs live inside collapsed `.content` divs, so assert on
+    // presence rather than visibility.
+    await expect
+      .poll(() => content.locator('svg').count(), { timeout: 20000 })
+      .toBeGreaterThan(0);
+
+    // The arrangement label rendered, quotes and all.
+    await expect(content).toContainText('ArrangeBy');
+    await expect(content).not.toContainText('error:');
+    expect(pageErrors.map(String)).toEqual([]);
   });
 
   test('can switch cluster replicas', async ({ page }) => {


### PR DESCRIPTION
### Motivation

Operator names in Materialize can contain double quotes (e.g., `ArrangeBy[[Column(0, "id")]]`). When these names are embedded in DOT graph labels without proper escaping, the quotes terminate the label prematurely, causing GraphViz to reject the entire graph. This breaks the hierarchical-memory visualizer for any dataflow containing such operators.

### Description

This PR fixes DOT graph generation by properly escaping special characters in operator names:

1. **Added `escapeDotLabel()` function** in `hierarchical-memory.jsx` that escapes backslashes and double quotes according to DOT syntax requirements. This function is applied to all operator name labels before they're embedded in DOT graph definitions.

2. **Improved error handling** across both visualizer files (`hierarchical-memory.jsx` and `memory.jsx`) by converting error objects to strings with `String(error)` instead of relying on implicit toString conversion. This ensures error messages render correctly even for non-standard error types.

3. **Enhanced test coverage** with a new test case that verifies graphs render correctly for operators with quoted names. The test creates a table and index (which generates an `ArrangeBy` operator with quotes), then verifies the visualizer renders without errors and displays the operator name correctly.

4. **Improved existing test robustness** by capturing page errors and checking for error messages in rendered content, rather than just checking if the body element exists. This provides better detection of render-time failures.

### Verification

- New test `renders graphs for operator names containing double quotes` validates the fix by creating a table with an index and verifying the visualizer renders the operator name correctly without GraphViz errors.
- Existing test `page renders without crashing after data load` enhanced to capture and assert on page errors.
- All changes are backward compatible and don't affect existing functionality.

https://claude.ai/code/session_01DSKUa7Eu3SxYdwLT2SoXXV