### PR TITLE
kafka: stop setting a producer property on every client

### DIFF
--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -1077,10 +1077,6 @@ pub fn create_new_client_config(
         timeout_config.socket_timeout.as_millis().to_string(),
     );
     config.set(
-        "transaction.timeout.ms",
-        timeout_config.transaction_timeout.as_millis().to_string(),
-    );
-    config.set(
         "socket.connection.setup.timeout.ms",
         timeout_config
             .socket_connection_setup_timeout

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -310,7 +310,7 @@ impl TransactionalProducer {
         options.insert("queue.buffering.max.messages", "0".into());
         // Make the Kafka producer wait at least 10 ms before sending out MessageSets
         options.insert("queue.buffering.max.ms", format!("{}", 10));
-        // Time out transactions after 60 seconds
+        // Time out transactions after `transaction_timeout`.
         options.insert(
             "transaction.timeout.ms",
             format!("{}", timeout_config.transaction_timeout.as_millis()),


### PR DESCRIPTION
`create_new_client_config` set `transaction.timeout.ms` on the shared config every rdkafka client is built from. librdkafka accepts it only on producers and logs
```
CONFWARN [thrd:app]: Configuration property transaction.timeout.ms is a producer property and will be ignored by this consumer instance
```
Also corrects the comment at the sink's own set, which claimed 60 seconds while the value it sets defaults to 600.