### PR TITLE
adapter: pin mz_cluster_reconfigurations migration step to 26.38.0-rc.2

### DIFF
--- a/src/adapter/src/catalog/open/builtin_schema_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_schema_migration.rs
@@ -372,12 +372,16 @@ static MIGRATIONS: LazyLock<Vec<MigrationStep>> = LazyLock::new(|| {
             MZ_CATALOG_SCHEMA,
             "mz_iceberg_sinks",
         ),
-        // The mz_cluster_reconfigurations MV definition changed (the `changes`
-        // diff now includes the `arrangement_compression` dimension). See the
-        // NOTE above: this version must stay at the workspace's current dev
-        // version until the change ships.
+        // The mz_cluster_reconfigurations MV definition changed, the `changes`
+        // diff now includes the `arrangement_compression` dimension.
+        //
+        // This step is pinned to a release-candidate version rather than a dev
+        // version because the change also ships on the v26.38.0 release line,
+        // where the first build carrying it is 26.38.0-rc.2. A step above that
+        // build's version fails the `step.version <= target_version` check in
+        // `validate_migration_steps`, panicking at catalog open.
         MigrationStep::replacement(
-            "26.39.0-dev.0",
+            "26.38.0-rc.2",
             CatalogItemType::MaterializedView,
             MZ_INTERNAL_SCHEMA,
             "mz_cluster_reconfigurations",


### PR DESCRIPTION
Follow-up to #38241.

## The problem

That PR registered a `Replacement` step for `mz_cluster_reconfigurations` at `26.39.0-dev.0`, the workspace's dev version. The comment on the step said the version must stay at the current dev version until the change ships in a release, which is the right rule for a change that only lives on `main`.

This change does not only live on `main`. It was cherry-picked onto the v26.38.0 release line, and `v26.38.0-rc.2` was cut directly on top of it. So that release build carries a migration step whose version orders above its own build version, and `validate_migration_steps` asserts the opposite:

```rust
assert!(
    step.version <= self.target_version,
    "migration step version greater than target version: {} > {}",
    step.version,
    self.target_version,
);
```

`target_version` is this process's build version. `26.39.0-dev.0 > 26.38.0-rc.2`, so the assertion fails. It runs unconditionally in `Migration::run`, before the same-version early return, on every catalog open where `get_migration_version` finds a durable version. An rc build carrying the step at `26.39.0-dev.0` therefore panics at startup for every environment that already has a catalog.

## The fix

Pin the step to `26.38.0-rc.2`, the first build version that carries the change. That satisfies both ends of the invariant a step version has to sit inside:

* It does not exceed the build version of any build carrying the change, so `validate_migration_steps` passes on the release line and on `main` (`26.38.0-rc.2 <= 26.39.0-dev.0`).
* It still exceeds `26.38.0-rc.1` and `26.37.0`, the last versions that do not carry the change, so `plan_migration`'s `s.version > source_version` filter runs the replacement when upgrading from them.

Upgrades from `v26.38.0` onward skip the step, which is correct: those builds already have the new MV definition, so their fingerprint already matches and there is nothing to migrate.

The step keeps its position in `MIGRATIONS`, which is ordered by version, because `26.38.0-dev.0 < 26.38.0-rc.2 < 26.39.0-dev.0`.

The comment above the step is rewritten to record why this one is pinned to a release-candidate version while its neighbours are pinned to dev versions.

## Testing

No test changes. The behaviour this restores is an assertion that only fires with a durable catalog already on disk, so it is covered by the upgrade nightly rather than by a unit test.

Note that the `mz_audit_events` step immediately below stays at `26.39.0-dev.0`. The change requiring it (#37958) is on `main` only, not on the v26.38.0 release line, so the dev version is still correct there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
