### PR TITLE
adapter: pin mz_cluster_reconfigurations migration step to 26.38.0-rc.2

### DIFF
--- a/src/adapter/src/catalog/open/builtin_schema_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_schema_migration.rs
@@ -373,11 +373,9 @@ static MIGRATIONS: LazyLock<Vec<MigrationStep>> = LazyLock::new(|| {
             "mz_iceberg_sinks",
         ),
         // The mz_cluster_reconfigurations MV definition changed (the `changes`
-        // diff now includes the `arrangement_compression` dimension). See the
-        // NOTE above: this version must stay at the workspace's current dev
-        // version until the change ships.
+        // diff now includes the `arrangement_compression` dimension).
         MigrationStep::replacement(
-            "26.39.0-dev.0",
+            "26.38.0-rc.2",
             CatalogItemType::MaterializedView,
             MZ_INTERNAL_SCHEMA,
             "mz_cluster_reconfigurations",


### PR DESCRIPTION
Follow-up to #38241.

That PR registered a `Replacement` step for `mz_cluster_reconfigurations` at `26.39.0-dev.0`, the workspace's dev version. `26.39.0-dev.0 > 26.38.0-rc.2`, so the assertion fails.

The fix: Pin the step to `26.38.0-rc.2`, the first build version that carries the change. That satisfies both ends of the invariant a step version has to satisfy.

## Testing

No test changes. The behaviour this restores is an assertion that only fires with a durable catalog already on disk, so it is covered by the upgrade nightly rather than by a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
