### PR TITLE
compute: derive time dependence from the imports a dataflow reads

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -1024,14 +1024,28 @@ impl ComputeController {
             .map_err(|err| TimeDependenceError::InstanceMissing(err.0))?;
         let mut time_dependencies = Vec::new();
 
-        for id in dataflow.imported_index_ids() {
+        // Only the imports the exports read say anything about how this dataflow's frontier relates
+        // to wall clock. Counting one that optimization left unused reports wall-clock dependence
+        // for a dataflow whose exports are constant, and that earns it a dataflow expiration, which
+        // pins its output frontier at the expiration time. A constant export's frontier is the empty
+        // antichain, so the pin holds it days short of the truth and whoever reads that frontier
+        // never learns the collection can no longer change.
+        let used_imports = dataflow.used_import_ids();
+
+        for id in dataflow
+            .imported_index_ids()
+            .filter(|id| used_imports.contains(id))
+        {
             let dependence = instance
                 .get_time_dependence(id)
                 .map_err(|err| TimeDependenceError::CollectionMissing(err.0))?;
             time_dependencies.push(dependence);
         }
 
-        'source: for id in dataflow.imported_source_ids() {
+        'source: for id in dataflow
+            .imported_source_ids()
+            .filter(|id| used_imports.contains(id))
+        {
             // We first check whether the id is backed by a compute object, in which case we use
             // the time dependence we know. This is true for storage sinks.
             for instance in self.instances.values() {

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -320,6 +320,11 @@ impl<P, S> DataflowDescription<P, S> {
         self.source_imports.keys().copied()
     }
 
+    /// Whether `id` names an import of this dataflow, index or source.
+    pub fn is_import(&self, id: &GlobalId) -> bool {
+        self.index_imports.contains_key(id) || self.source_imports.contains_key(id)
+    }
+
     /// Identifiers of exported objects (indexes and sinks).
     pub fn export_ids(&self) -> impl Iterator<Item = GlobalId> + Clone + '_ {
         self.exported_index_ids().chain(self.exported_sink_ids())
@@ -469,12 +474,32 @@ where
     /// This method behaves like `depends_on` but filters out internal dependencies that are not
     /// included in the dataflow imports.
     pub fn depends_on_imports(&self, collection_id: GlobalId) -> BTreeSet<GlobalId> {
-        let is_import = |id: &GlobalId| {
-            self.source_imports.contains_key(id) || self.index_imports.contains_key(id)
-        };
-
         let deps = self.depends_on(collection_id);
-        deps.into_iter().filter(is_import).collect()
+        deps.into_iter().filter(|id| self.is_import(id)).collect()
+    }
+
+    /// Computes the set of imports the dataflow's exports read, meaning the imports reachable from
+    /// an index export's `on_id` or a sink export's `from`.
+    ///
+    /// This is not the same as [`Self::import_ids`]. An import that no export reaches contributes
+    /// neither contents nor frontier to any of them, and one ends up in the description whenever
+    /// optimization drops the reference to it after the imports were collected, for instance by
+    /// folding a collection to a constant. The answer covers the dataflow as a whole, so an import
+    /// only one export reads is still reported, and a dataflow with no exports reports none.
+    ///
+    /// Panics for an export naming a collection that is neither an import nor built exactly once
+    /// here, which is [`Self::depends_on`]'s precondition on its argument. Rendering resolves the
+    /// same ids, so a description that trips this does not survive being built either.
+    pub fn used_import_ids(&self) -> BTreeSet<GlobalId> {
+        let mut deps = BTreeSet::new();
+        for (index_desc, _typ) in self.index_exports.values() {
+            self.depends_on_into(index_desc.on_id, &mut deps);
+        }
+        for sink_desc in self.sink_exports.values() {
+            self.depends_on_into(sink_desc.from, &mut deps);
+        }
+        deps.retain(|id| self.is_import(id));
+        deps
     }
 }
 
@@ -628,4 +653,145 @@ pub struct BuildDesc<P> {
     pub id: GlobalId,
     /// TODO(database-issues#7533): Add documentation.
     pub plan: P,
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_expr::{AccessStrategy, Id, MirRelationExpr};
+    use mz_repr::{RelationDesc, ReprRelationType, ReprScalarType, SqlRelationType};
+
+    use crate::sinks::{ComputeSinkConnection, ComputeSinkDesc, SubscribeSinkConnection};
+    use crate::sources::{SourceInstanceArguments, SourceInstanceDesc};
+
+    use super::*;
+
+    const READ: GlobalId = GlobalId::User(1);
+    const UNREAD: GlobalId = GlobalId::User(2);
+    const VIEW: GlobalId = GlobalId::Transient(1);
+    const SINK: GlobalId = GlobalId::Transient(2);
+    const INDEX: GlobalId = GlobalId::Transient(3);
+
+    fn typ() -> ReprRelationType {
+        ReprRelationType::new(vec![ReprScalarType::Int64.nullable(false)])
+    }
+
+    /// A dataflow importing `READ` and `UNREAD`, building `VIEW` from `plan`, and exporting a
+    /// subscribe sink over it.
+    fn dataflow(plan: MirRelationExpr) -> DataflowDesc {
+        let source_import = || SourceImport {
+            desc: SourceInstanceDesc {
+                arguments: SourceInstanceArguments { operators: None },
+                storage_metadata: (),
+                typ: SqlRelationType::from_repr(&typ()),
+            },
+            monotonic: false,
+            with_snapshot: true,
+            upper: Antichain::from_elem(Timestamp::MIN),
+        };
+
+        let mut df = DataflowDesc::new("test".to_string());
+        df.source_imports.insert(READ, source_import());
+        df.source_imports.insert(UNREAD, source_import());
+        df.objects_to_build.push(BuildDesc {
+            id: VIEW,
+            plan: OptimizedMirRelationExpr::declare_optimized(plan),
+        });
+        df.sink_exports.insert(
+            SINK,
+            ComputeSinkDesc {
+                from: VIEW,
+                from_desc: RelationDesc::new(SqlRelationType::from_repr(&typ()), ["c"]),
+                connection: ComputeSinkConnection::Subscribe(SubscribeSinkConnection {
+                    output: Vec::new(),
+                }),
+                with_snapshot: true,
+                up_to: Antichain::new(),
+                non_null_assertions: Vec::new(),
+                refresh_schedule: None,
+            },
+        );
+        df
+    }
+
+    #[mz_ore::test]
+    fn used_import_ids_reports_only_read_imports() {
+        let df = dataflow(MirRelationExpr::Get {
+            id: Id::Global(READ),
+            typ: typ(),
+            access_strategy: AccessStrategy::Persist,
+        });
+
+        assert_eq!(df.used_import_ids(), BTreeSet::from([READ]));
+    }
+
+    /// An export the optimizer folded to a constant reads nothing, even though the imports it was
+    /// folded from are still there. This is the shape that must not be reported as reading them.
+    #[mz_ore::test]
+    fn used_import_ids_is_empty_for_a_constant_export() {
+        let df = dataflow(MirRelationExpr::Constant {
+            rows: Ok(Vec::new()),
+            typ: typ(),
+        });
+
+        assert_eq!(df.used_import_ids(), BTreeSet::new());
+    }
+
+    /// Index exports are walked from the collection they are on, just like sink exports are from
+    /// the collection they are from.
+    #[mz_ore::test]
+    fn used_import_ids_covers_index_exports() {
+        let mut df = dataflow(MirRelationExpr::Constant {
+            rows: Ok(Vec::new()),
+            typ: typ(),
+        });
+        let other_view = GlobalId::Transient(4);
+        df.objects_to_build.push(BuildDesc {
+            id: other_view,
+            plan: OptimizedMirRelationExpr::declare_optimized(MirRelationExpr::Get {
+                id: Id::Global(UNREAD),
+                typ: typ(),
+                access_strategy: AccessStrategy::Persist,
+            }),
+        });
+        df.index_exports.insert(
+            INDEX,
+            (
+                IndexDesc {
+                    on_id: other_view,
+                    key: Vec::new(),
+                },
+                typ(),
+            ),
+        );
+
+        assert_eq!(df.used_import_ids(), BTreeSet::from([UNREAD]));
+    }
+
+    /// An imported index is reached through the collection it is on, and reported by the id of the
+    /// index rather than that of the collection.
+    #[mz_ore::test]
+    fn used_import_ids_reports_imported_indexes_by_index_id() {
+        let indexed_view = GlobalId::User(3);
+        let imported_index = GlobalId::User(4);
+
+        let mut df = dataflow(MirRelationExpr::Get {
+            id: Id::Global(indexed_view),
+            typ: typ(),
+            access_strategy: AccessStrategy::Index(Vec::new()),
+        });
+        df.index_imports.insert(
+            imported_index,
+            IndexImport {
+                desc: IndexDesc {
+                    on_id: indexed_view,
+                    key: Vec::new(),
+                },
+                typ: typ(),
+                monotonic: false,
+                with_snapshot: true,
+            },
+        );
+
+        assert_eq!(df.used_import_ids(), BTreeSet::from([imported_index]));
+    }
 }

--- a/src/environmentd/tests/read_then_write.rs
+++ b/src/environmentd/tests/read_then_write.rs
@@ -1952,3 +1952,168 @@ fn test_rejected_in_non_writable_transaction() {
         .get::<_, i32>(0);
     assert_eq!(count, 0, "no rejected write may have landed");
 }
+
+/// A read-then-write must not mistake a frontier that replica expiration held
+/// back for the frontier of its selection.
+///
+/// Replica expiration lets a replica drop diffs beyond the time it expects to be
+/// restarted, and holds a dataflow's output frontier at that time so that nothing
+/// downstream believes data at or after it. A selection that can never change
+/// again has the empty antichain for a frontier, and holding that back reports it
+/// as merely frozen until the expiration, days out. The OCC path reads the
+/// frontier both as "this selection is final" and as the timestamp it writes at,
+/// so a statement over such a selection either parks until the oracle reaches the
+/// expiration or commits its write there and drags the oracle along with it.
+///
+/// What earns a dataflow an expiration in the first place is wall-clock
+/// dependence, which the compute controller derives from the imports its exports
+/// read. Each statement here keeps an import that no export reads: the optimizer
+/// folds the selection to a constant, but only in the global pipeline, which runs
+/// after the dataflow's imports were collected, so the table stays an import.
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_replica_expiration_spares_folded_selections() {
+    // The two branches are the same collection under the filter. The global
+    // pipeline sees that, local optimization does not.
+    const FOLDED: &str = "WITH x AS (SELECT c0 FROM a WHERE TRUE = c0) \
+                          ((SELECT true AS c0 FROM x) EXCEPT ALL (SELECT c0 FROM x))";
+
+    let server = frontend_occ_harness()
+        // Sampled once per replica, when it is created, which for the default
+        // cluster is during bootstrap. So this has to be a default rather than an
+        // `ALTER SYSTEM SET`.
+        .with_system_parameter_default(
+            "compute_replica_expiration_offset".to_string(),
+            "3d".to_string(),
+        )
+        .start_blocking();
+
+    let mut client = server.connect(postgres::NoTls).unwrap();
+    client.batch_execute("CREATE TABLE a (c0 bool)").unwrap();
+    client
+        .batch_execute("INSERT INTO a VALUES (true), (false), (NULL)")
+        .unwrap();
+    client.batch_execute("CREATE TABLE dst (c0 bool)").unwrap();
+
+    let selection = format!("{FOLDED} UNION ALL (VALUES (true))");
+
+    // Pin the premise. Were the fold to move to local optimization, the dataflow
+    // would have no unread import left and none of this would cover the bug.
+    let local: String = client
+        .query_one(
+            &format!("EXPLAIN LOCALLY OPTIMIZED PLAN AS TEXT FOR {selection}"),
+            &[],
+        )
+        .unwrap()
+        .get(0);
+    assert_contains!(local, "materialize.public.a");
+    let global: String = client
+        .query_one(
+            &format!("EXPLAIN OPTIMIZED PLAN AS TEXT FOR {selection}"),
+            &[],
+        )
+        .unwrap()
+        .get(0);
+    assert_contains!(global.as_str(), "Constant");
+    assert!(
+        !global.contains("materialize.public.a"),
+        "the selection no longer folds to a constant, so its frontier is not the \
+         empty antichain and there is nothing here to hold back: {global}"
+    );
+
+    // Bounds a regression: a held frontier parks the statement until the oracle
+    // reaches it, which is three days out.
+    client
+        .batch_execute("SET statement_timeout = '30s'")
+        .unwrap();
+
+    // This one has diffs, so it is the case that turns a held frontier into a
+    // durable write timestamp, and the oracle is the witness. Checked before
+    // reading `dst` back, because a read parks once the oracle is that far ahead.
+    let inserted = client.execute(&format!("INSERT INTO dst {selection}"), &[]);
+    let inserted = inserted.expect("INSERT ... SELECT over a folded selection");
+    assert_eq!(inserted, 1, "the INSERT reported {inserted} rows");
+    let skew: i64 = client
+        .query_one(
+            "SELECT mz_now()::text::bigint - (extract(epoch FROM now()) * 1000)::bigint",
+            &[],
+        )
+        .unwrap()
+        .get(0);
+    assert!(
+        skew.abs() < 60_000,
+        "the oracle is {skew}ms from wall clock, so a write landed at a timestamp \
+         derived from a held frontier"
+    );
+    let rows = client
+        .query_one("SELECT count(*) FROM dst", &[])
+        .unwrap()
+        .get::<_, i64>(0);
+    assert_eq!(rows, 1, "the INSERT did not land exactly one row");
+
+    // This one has no diffs, so it concludes zero rows from the frontier it
+    // observed and then linearizes against it.
+    let updated = client.execute("UPDATE a SET c0 = TRUE WHERE TRUE = a.c0", &[]);
+    let updated = updated.expect("UPDATE over a folded selection");
+    assert_eq!(updated, 0, "the UPDATE reported {updated} rows");
+    let rows = client
+        .query_one("SELECT count(*), count(*) FILTER (WHERE c0) FROM a", &[])
+        .unwrap();
+    assert_eq!(
+        (rows.get::<_, i64>(0), rows.get::<_, i64>(1)),
+        (3, 1),
+        "the UPDATE changed the table"
+    );
+
+    // Ask the process rather than the flag which path those two took: they only
+    // reach the histogram if the frontend sequenced them, and the coordinator's
+    // lock path does not read subscribe frontiers at all.
+    let metrics = server.metrics_registry().gather();
+    let observations = metrics
+        .iter()
+        .find(|m| m.name() == "mz_occ_read_then_write_retry_count")
+        .expect("mz_occ_read_then_write_retry_count metric should be registered")
+        .get_metric()
+        .first()
+        .expect("a single histogram series")
+        .get_histogram()
+        .get_sample_count();
+    assert!(
+        observations >= 2,
+        "the OCC path sequenced {observations} statements, so the INSERT and the \
+         UPDATE did not both go through it"
+    );
+
+    // The same fault reaches a plain subscribe, with no write anywhere: one over a
+    // collection that is already complete has to end. A subscribe is exempt from
+    // `statement_timeout`, so the deadline is ours to impose.
+    let mut worker = server.connect(postgres::NoTls).unwrap();
+    let cancel = worker.cancel_token();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let subscribe = format!("COPY (SUBSCRIBE ({FOLDED})) TO STDOUT");
+    let handle = thread::spawn(move || {
+        let streamed = (|| -> Result<String, String> {
+            let mut reader = worker
+                .copy_out(&subscribe)
+                .map_err(|e| e.to_string_with_causes())?;
+            let mut out = String::new();
+            std::io::Read::read_to_string(&mut reader, &mut out).map_err(|e| e.to_string())?;
+            Ok(out)
+        })();
+        let _ = tx.send(streamed);
+    });
+
+    let streamed = rx.recv_timeout(Duration::from_secs(60));
+    if streamed.is_err() {
+        // Free the subscribe so the server can shut down cleanly.
+        let _ = cancel.cancel_query(postgres::NoTls);
+    }
+    let _ = handle.join();
+    let streamed = streamed
+        .expect(
+            "a subscribe over a collection that can never change again did not end \
+             within 60s, so its frontier was held at the replica expiration",
+        )
+        .expect("subscribe failed");
+    assert_eq!(streamed, "", "the subscribe streamed {streamed:?}");
+}


### PR DESCRIPTION
Fixes the hang and the log spam in [SQL-635](https://linear.app/materializeinc/issue/SQL-635), which are one cause.

## What goes wrong

A dataflow's imports are collected before optimization finishes, so a collection
the optimizer folds to a constant afterwards leaves imports in the description
that nothing reads. `ComputeController::determine_time_dependence` counted those
anyway, reported wall-clock dependence, and that is what earns a dataflow a
dataflow expiration.

Expiration holds the output frontier at the expiration time so nothing
downstream believes data at or after it. A constant export's true frontier is
the empty antichain, so the hold reports it as merely frozen until the
expiration, days out, for as long as the replica lives. Every worker also warns
`frontier not less than expiration` for each such sink, which is the log spam in
the issue.

Whoever reads that frontier is told the collection is frozen rather than
complete:

* A `SUBSCRIBE` over such a selection never ends.
* The frontend OCC read-then-write path takes the empty antichain as "this
  selection can never change again" and otherwise writes at the frontier it last
  observed. So the reported `UPDATE a SET c0 = TRUE WHERE TRUE = a.c0` parks in
  `ensure_read_linearized` until the oracle reaches the expiration and dies on
  `statement_timeout`. Assigning `true` to rows filtered on `c0 = true` cancels
  against its own retractions, and that fold happens in the global pipeline,
  late enough that the table is already an import.
* The same fold with a row left to write is worse. I reproduced
  `INSERT INTO dst WITH x AS (SELECT c0 FROM a WHERE TRUE = c0) ((SELECT true AS
  c0 FROM x) EXCEPT ALL (SELECT c0 FROM x)) UNION ALL (VALUES (true))`
  committing at a timestamp 259,199,635 ms (three days) ahead of wall clock and
  taking the timeline's oracle with it. After that, writes, strict-serializable
  reads, and opening a new session all hang.

`WHERE c0` works and `WHERE TRUE = c0` hangs for exactly this reason: only the
latter folds.

## The fix

Count only the imports the exports read. `DataflowDescription::used_import_ids`
answers that with the walk rendering already does per export, over each index
export's `on_id` and each sink export's `from`, and
`determine_time_dependence` filters its two import loops through it.

This is what `doc/developer/design/20240919_dataflow_expiration.md` asks for. A
dataflow whose inputs' upper is the empty antichain must not expire, and a
dataflow that reads no import at all is that case. The design doc states the
rule as `time_dependence == None`, and reading it literally off the import list
is what produced the bug.

Where the imports are read, the answer is unchanged. The set can only shrink, so
the change can only ever remove an expiration, never add one or make one more
aggressive.

Note this is not specific to read-then-write. Any dataflow with an import
optimization left unread was affected, and `compute_replica_expiration_offset`
defaults to `3d` in CI's mzcompose configuration.

## Tests

`test_replica_expiration_spares_folded_selections` in
`src/environmentd/tests/read_then_write.rs` runs the three statements above
against a replica with a three-day expiration offset: the writing one, checking
the oracle stayed near wall clock before it reads anything back, the parking
one, and a plain `COPY (SUBSCRIBE ...)` that has to end, bounded by a thread and
a channel because a subscribe is exempt from `statement_timeout`. Each of the
three fails without the fix. Its two `EXPLAIN` assertions pin the premise, that
the fold happens in the global pipeline and not locally, so the test cannot go
vacuous unnoticed if that moves.

Four unit tests in `src/compute-types/src/dataflows.rs` cover the new helper,
including that an imported index is reported by index id rather than by the id
of the collection it indexes.

## Left alone deliberately

* The unread import is still rendered, so it still costs a persist source and a
  read hold that pins the table's `since` at the dataflow's `as_of`. Pruning it
  in the optimizer would fix the accounting at its root, but it reaches read
  holds, `as_of` selection, and adapter dependency tracking.
* A frontier that legitimately runs ahead of wall clock, a `REFRESH EVERY`
  materialized view's upper, still yields a far-future write timestamp on the
  OCC path. That is pre-existing and orthogonal to this issue, and it deserves
  its own. `check_runaway_write_ts` already logs an error in that case, which is
  how it showed up here too.

Closes: [SQL-635](https://linear.app/materializeinc/issue/SQL-635)
