### PR TITLE
persist: skip diff-sum validation for truncated runs

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1357,12 +1357,20 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
     }
 }
 
+/// Validates that `batch` may be appended under the desc `truncate`.
+///
+/// Returns whether `truncate` cuts into `batch`'s own desc, i.e. whether the
+/// batch's parts may hold updates outside the desc they are registered under.
+/// Readers filter such updates out against the registered desc, but write-time
+/// part statistics still count them, so callers must record the bit (see
+/// `RunMeta::bounds_truncated`) to keep stats-based accounting from trusting
+/// the statistics.
 pub(crate) fn validate_truncate_batch<T: Timestamp>(
     batch: &HollowBatch<T>,
     truncate: &Description<T>,
     any_batch_rewrite: bool,
     validate_part_bounds_on_write: bool,
-) -> Result<(), InvalidUsage<T>> {
+) -> Result<bool, InvalidUsage<T>> {
     // If rewrite_ts is used, we don't allow truncation, to keep things simpler
     // to reason about.
     if any_batch_rewrite {
@@ -1391,8 +1399,11 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
         }
     }
 
+    let bounds_truncated = !PartialOrder::less_equal(truncate.lower(), batch.desc.lower())
+        || !PartialOrder::less_equal(batch.desc.upper(), truncate.upper());
+
     if !validate_part_bounds_on_write {
-        return Ok(());
+        return Ok(bounds_truncated);
     }
 
     let batch = &batch.desc;
@@ -1407,7 +1418,7 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
         });
     }
 
-    Ok(())
+    Ok(bounds_truncated)
 }
 
 #[derive(Debug)]

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1399,8 +1399,14 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
         }
     }
 
-    let bounds_truncated = !PartialOrder::less_equal(truncate.lower(), batch.desc.lower())
-        || !PartialOrder::less_equal(batch.desc.upper(), truncate.upper());
+    // The rewrite checks above prove that no part holds data outside
+    // `truncate`: the upper matches exactly and every part's effective lower
+    // bound (its rewrite ts) is at or above `truncate.lower()`. The batch's
+    // own desc being wider does not mean anything is filtered on read, so
+    // comparing against it would spuriously mark every rewritten batch.
+    let bounds_truncated = !any_batch_rewrite
+        && (!PartialOrder::less_equal(truncate.lower(), batch.desc.lower())
+            || !PartialOrder::less_equal(batch.desc.upper(), truncate.upper()));
 
     if !validate_part_bounds_on_write {
         return Ok(bounds_truncated);
@@ -1797,5 +1803,51 @@ mod tests {
         };
         // Verifies that the structured key lower is stored and decoded.
         assert!(part.structured_key_lower().is_some());
+    }
+
+    #[mz_ore::test]
+    fn validate_truncate_batch_bounds() {
+        use crate::internal::state::tests::hollow;
+
+        let desc = |lower: u64, upper: u64| {
+            Description::new(
+                Antichain::from_elem(lower),
+                Antichain::from_elem(upper),
+                Antichain::from_elem(0),
+            )
+        };
+
+        // Appending under the batch's own desc is not a truncation.
+        let batch = hollow(0, 5, &["k"], 1);
+        assert_eq!(
+            validate_truncate_batch(&batch, &desc(0, 5), false, true).expect("valid"),
+            false
+        );
+
+        // A narrower append desc may leave part data outside the registered
+        // bounds, on either side.
+        assert_eq!(
+            validate_truncate_batch(&batch, &desc(1, 5), false, true).expect("valid"),
+            true
+        );
+        assert_eq!(
+            validate_truncate_batch(&batch, &desc(0, 4), false, true).expect("valid"),
+            true
+        );
+
+        // A ts-rewritten batch keeps its write-time lower, but the rewrite
+        // validation proves that no part holds data outside the append desc,
+        // so it must not count as a truncation.
+        let mut rewritten = hollow(0, 5, &["k"], 1);
+        for part in rewritten.parts.iter_mut() {
+            let RunPart::Single(BatchPart::Hollow(part)) = part else {
+                panic!("expected hollow part");
+            };
+            part.ts_rewrite = Some(Antichain::from_elem(3));
+        }
+        assert_eq!(
+            validate_truncate_batch(&rewritten, &desc(2, 5), true, true).expect("valid"),
+            false
+        );
     }
 }

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -612,6 +612,11 @@ pub struct LeasedBatchPart<T> {
     /// still present in state distinguishes a lost lease from a GC bug.
     pub(crate) reader_id: LeasedReaderId,
     pub(crate) filter_pushdown_audit: bool,
+    /// Whether the containing batch has a run that may hold updates outside
+    /// the registered desc (see `RunMeta::bounds_truncated`). A fetch filters
+    /// those updates out, but write-time part statistics count them, so
+    /// optimizations that substitute statistics for a fetch must not fire.
+    pub(crate) bounds_truncated: bool,
 }
 
 impl<T> LeasedBatchPart<T>
@@ -670,6 +675,12 @@ where
             FetchBatchFilter::Listen { .. } | FetchBatchFilter::Compaction { .. } => return,
         };
         if !OPTIMIZE_IGNORED_DATA_FETCH.get(cfg) {
+            return;
+        }
+        // A truncated batch's parts may physically hold updates outside the
+        // registered desc. A fetch filters those out, but the write-time
+        // diffs_sum counts them, so substituting it would fabricate data.
+        if self.bounds_truncated {
             return;
         }
         let (diffs_sum, _stats) = match &self.part {

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -209,7 +209,6 @@ pub(crate) struct MetadataMap(BTreeMap<String, Bytes>);
 ///
 /// It is an error to reuse key names, or to change the type associated with a particular name.
 /// It is polite to choose short names, since they get serialized alongside every struct.
-#[allow(unused)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) struct MetadataKey<V, P = V> {
     name: &'static str,
@@ -217,7 +216,6 @@ pub(crate) struct MetadataKey<V, P = V> {
 }
 
 impl<V, P> MetadataKey<V, P> {
-    #[allow(unused)]
     pub(crate) const fn new(name: &'static str) -> Self {
         MetadataKey {
             name,
@@ -242,7 +240,6 @@ impl MetadataMap {
     }
 
     /// Serialize and insert a new key into the map, replacing any existing value for the key.
-    #[allow(unused)]
     pub fn set<V: RustType<P>, P: prost::Message>(&mut self, key: MetadataKey<V, P>, value: V) {
         self.0.insert(
             String::from(key.name),
@@ -251,7 +248,6 @@ impl MetadataMap {
     }
 
     /// Deserialize a key from the map, if it is present.
-    #[allow(unused)]
     pub fn get<V: RustType<P>, P: prost::Message + Default>(
         &self,
         key: MetadataKey<V, P>,

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -2369,37 +2369,42 @@ pub mod datadriven {
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let input = args.expect_str("input");
+        let legacy = args.optional("legacy").unwrap_or(false);
         let batch = datadriven
             .batches
             .get(input)
             .expect("unknown batch")
             .clone();
-        let compact_req = datadriven
-            .compactions
-            .get(input)
-            .expect("unknown compact req")
-            .clone();
-        let input_batches = compact_req
-            .inputs
-            .iter()
-            .map(|x| x.id)
-            .collect::<BTreeSet<_>>();
-        let lower_spine_bound = input_batches
-            .first()
-            .map(|id| id.0)
-            .expect("at least one batch must be present");
-        let upper_spine_bound = input_batches
-            .last()
-            .map(|id| id.1)
-            .expect("at least one batch must be present");
-        let id = SpineId(lower_spine_bound, upper_spine_bound);
+        let compaction_input = if legacy {
+            CompactionInput::Legacy
+        } else {
+            let compact_req = datadriven
+                .compactions
+                .get(input)
+                .expect("unknown compact req")
+                .clone();
+            let input_batches = compact_req
+                .inputs
+                .iter()
+                .map(|x| x.id)
+                .collect::<BTreeSet<_>>();
+            let lower_spine_bound = input_batches
+                .first()
+                .map(|id| id.0)
+                .expect("at least one batch must be present");
+            let upper_spine_bound = input_batches
+                .last()
+                .map(|id| id.1)
+                .expect("at least one batch must be present");
+            CompactionInput::IdRange(SpineId(lower_spine_bound, upper_spine_bound))
+        };
         let hollow_batch = (*batch.batch).clone();
 
         let (merge_res, maintenance) = datadriven
             .machine
             .merge_res(&FueledMergeRes {
                 output: hollow_batch,
-                input: CompactionInput::IdRange(id),
+                input: compaction_input,
                 new_active_compaction: None,
             })
             .await;

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1835,8 +1835,13 @@ pub mod datadriven {
             .expect("unknown batch")
             .clone();
         let truncated_desc = Description::new(lower, upper, batch.batch.desc.since().clone());
-        let () = validate_truncate_batch(&batch.batch, &truncated_desc, false, true)?;
+        let bounds_truncated = validate_truncate_batch(&batch.batch, &truncated_desc, false, true)?;
         let mut new_hollow_batch = (*batch.batch).clone();
+        if bounds_truncated {
+            for run_meta in &mut new_hollow_batch.run_meta {
+                run_meta.set_bounds_truncated();
+            }
+        }
         new_hollow_batch.desc = truncated_desc;
         let new_batch = IdHollowBatch {
             batch: Arc::new(new_hollow_batch),

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -57,7 +57,7 @@ use uuid::Uuid;
 use crate::critical::{CriticalReaderId, Opaque};
 use crate::error::InvalidUsage;
 use crate::internal::encoding::{
-    LazyInlineBatchPart, LazyPartStats, LazyProto, MetadataMap, parse_id,
+    LazyInlineBatchPart, LazyPartStats, LazyProto, MetadataKey, MetadataMap, parse_id,
 };
 use crate::internal::gc::GcReq;
 use crate::internal::machine::retry_external;
@@ -815,6 +815,30 @@ pub struct RunMeta {
     /// Additional unstructured metadata.
     #[serde(skip_serializing_if = "MetadataMap::is_empty")]
     pub(crate) meta: MetadataMap,
+}
+
+/// Metadata key for [RunMeta::bounds_truncated].
+const RUN_META_BOUNDS_TRUNCATED: MetadataKey<bool> = MetadataKey::new("truncated");
+
+impl RunMeta {
+    /// Whether this run's parts may hold updates outside the registered desc
+    /// of the batch that contains them.
+    ///
+    /// Set when a batch is appended under a desc narrower than the one it was
+    /// written with (truncation). Readers filter such updates out against the
+    /// registered desc, but per-part statistics like `diffs_sum` are computed
+    /// at write time over everything physically in the part, so accounting
+    /// that compares those statistics against data seen through a read must
+    /// skip runs with this bit set.
+    pub(crate) fn bounds_truncated(&self) -> bool {
+        self.meta.get(RUN_META_BOUNDS_TRUNCATED).unwrap_or(false)
+    }
+
+    /// Marks this run as possibly holding updates outside its batch's
+    /// registered desc. See [Self::bounds_truncated].
+    pub(crate) fn set_bounds_truncated(&mut self) {
+        self.meta.set(RUN_META_BOUNDS_TRUNCATED, true);
+    }
 }
 
 /// A subset of a [HollowBatch] corresponding 1:1 to a blob.

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -1055,8 +1055,30 @@ impl<T: Timestamp + Lattice + Codec64> SpineBatch<T> {
         Some(sum)
     }
 
+    /// Get the diff sum across all runs of the given batch.
+    ///
+    /// Returns `None` if any parts don't have statistics, or if any run may
+    /// hold updates outside the batch's registered desc: the statistics count
+    /// those updates but readers filter them out, so no sum computed from the
+    /// statistics can be compared against data seen through a read.
+    fn batch_diffs_sum<D: Monoid + Codec64>(
+        batch: &HollowBatch<T>,
+        metrics: &ColumnarMetrics,
+    ) -> Option<D> {
+        let mut sum = D::zero();
+        for (meta, run) in batch.runs() {
+            if meta.bounds_truncated() {
+                return None;
+            }
+            sum.plus_equals(&Self::diffs_sum(run, metrics)?);
+        }
+        Some(sum)
+    }
+
     /// Get the diff sum from the given batch for the given runs.
-    /// Returns `None` if the runs aren't present or any parts don't have statistics.
+    /// Returns `None` if the runs aren't present, any parts don't have
+    /// statistics, or any of the runs may hold updates outside the batch's
+    /// registered desc (see [Self::batch_diffs_sum]).
     fn diffs_sum_for_runs<D: Monoid + Codec64>(
         batch: &HollowBatch<T>,
         run_ids: &[RunId],
@@ -1068,6 +1090,9 @@ impl<T: Timestamp + Lattice + Codec64> SpineBatch<T> {
         for (meta, run) in batch.runs() {
             let id = meta.id?;
             if run_ids.remove(&id) {
+                if meta.bounds_truncated() {
+                    return None;
+                }
                 sum.plus_equals(&Self::diffs_sum(run, metrics)?);
             }
         }
@@ -1240,12 +1265,13 @@ impl<T: Timestamp + Lattice + Codec64> SpineBatch<T> {
 
         // We need to replace a range of parts. Here we don't care about the run_indices
         // because we must be replacing the entire part(s)
-        let old_diffs_sum = Self::diffs_sum::<D>(
+        let old_diffs_sum =
             self.parts[replacement_range.clone()]
                 .iter()
-                .flat_map(|p| p.batch.parts.iter()),
-            metrics,
-        );
+                .try_fold(D::zero(), |mut sum, p| {
+                    sum.plus_equals(&Self::batch_diffs_sum::<D>(&p.batch, metrics)?);
+                    Some(sum)
+                });
 
         Self::validate_diffs_sum_match(old_diffs_sum, new_diffs_sum, "id range replacement");
 
@@ -1314,8 +1340,8 @@ impl<T: Timestamp + Lattice + Codec64> SpineBatch<T> {
                     new_diffs_sum,
                     "partial batch replacement",
                 );
-                let old_batch_diff_sum = Self::diffs_sum::<D>(batch.parts.iter(), metrics);
-                let new_batch_diff_sum = Self::diffs_sum::<D>(new_batch.parts.iter(), metrics);
+                let old_batch_diff_sum = Self::batch_diffs_sum::<D>(batch, metrics);
+                let new_batch_diff_sum = Self::batch_diffs_sum::<D>(&new_batch, metrics);
                 Self::validate_diffs_sum_match(
                     old_batch_diff_sum,
                     new_batch_diff_sum,
@@ -1375,10 +1401,10 @@ impl<T: Timestamp + Lattice + Codec64> SpineBatch<T> {
         let exact_match = res.output.desc.lower() == self.desc().lower()
             && res.output.desc.upper() == self.desc().upper();
         if exact_match {
-            let old_diffs_sum = Self::diffs_sum::<D>(
-                self.parts.iter().flat_map(|p| p.batch.parts.iter()),
-                metrics,
-            );
+            let old_diffs_sum = self.parts.iter().try_fold(D::zero(), |mut sum, p| {
+                sum.plus_equals(&Self::batch_diffs_sum::<D>(&p.batch, metrics)?);
+                Some(sum)
+            });
 
             if let (Some(old_diffs_sum), Some(new_diffs_sum)) = (old_diffs_sum, new_diffs_sum) {
                 assert_eq!(
@@ -1408,12 +1434,13 @@ impl<T: Timestamp + Lattice + Codec64> SpineBatch<T> {
 
         // Try subset replacement
         if let Some((id, range)) = self.find_replacement_range(&res.output.desc) {
-            let old_diffs_sum = Self::diffs_sum::<D>(
+            let old_diffs_sum =
                 self.parts[range.clone()]
                     .iter()
-                    .flat_map(|p| p.batch.parts.iter()),
-                metrics,
-            );
+                    .try_fold(D::zero(), |mut sum, p| {
+                        sum.plus_equals(&Self::batch_diffs_sum::<D>(&p.batch, metrics)?);
+                        Some(sum)
+                    });
 
             if let (Some(old_diffs_sum), Some(new_diffs_sum)) = (old_diffs_sum, new_diffs_sum) {
                 assert_eq!(

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -944,6 +944,7 @@ where
             let blob = Arc::clone(&self.blob);
             let metrics = Arc::clone(&self.metrics);
             let desc = batch.desc.clone();
+            let bounds_truncated = batch.runs().any(|(meta, _)| meta.bounds_truncated());
             for await part in batch.part_stream(self.shard_id(), &*blob, &*metrics) {
                 yield LeasedBatchPart {
                     metrics: Arc::clone(&self.metrics),
@@ -954,6 +955,7 @@ where
                     lease: lease.clone(),
                     reader_id: self.reader_id.clone(),
                     filter_pushdown_audit: false,
+                    bounds_truncated,
                 }
             }
         }
@@ -1457,6 +1459,103 @@ mod tests {
             "snapshot must have batches for test to be meaningful"
         );
         drop(subscribe);
+    }
+
+    // The ignored-data fetch optimization substitutes a part's write-time
+    // diffs_sum for a real fetch, but a truncated batch's parts may hold
+    // updates that a real fetch would filter out, so it must not fire for
+    // them.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
+    async fn maybe_optimize_ignores_truncated_batches() {
+        use arrow::array::{ArrayRef, StringArray};
+
+        use crate::batch::{INLINE_WRITES_SINGLE_MAX_BYTES, INLINE_WRITES_TOTAL_MAX_BYTES};
+        use crate::cache::PersistClientCache;
+
+        let mut cache = PersistClientCache::new_no_metrics();
+        // Compaction rewrites truncated batches with exact bounds, which
+        // would undo the setup below.
+        cache.cfg.compaction_enabled = false;
+        // The optimization only applies to hollow parts.
+        cache.cfg.set_config(&INLINE_WRITES_SINGLE_MAX_BYTES, 0);
+        cache.cfg.set_config(&INLINE_WRITES_TOTAL_MAX_BYTES, 0);
+        let client = cache
+            .open(crate::PersistLocation::new_in_mem())
+            .await
+            .expect("client construction failed");
+        let (mut write, mut read) = client
+            .expect_open::<String, String, u64, i64>(ShardId::new())
+            .await;
+
+        write
+            .expect_compare_and_append(&[(("0".to_owned(), "zero".to_owned()), 0, 1)], 0, 1)
+            .await;
+
+        // Write a batch over [0, 3) but append it under [1, 3): the update
+        // at 0 stays in the part while every read filters it out.
+        let mut batch = write
+            .expect_batch(
+                &[
+                    (("stale".to_owned(), "stale".to_owned()), 0, 1),
+                    (("1".to_owned(), "one".to_owned()), 1, 1),
+                    (("2".to_owned(), "two".to_owned()), 2, 1),
+                ],
+                0,
+                3,
+            )
+            .await;
+        write
+            .compare_and_append_batch(
+                &mut [&mut batch],
+                Antichain::from_elem(1),
+                Antichain::from_elem(3),
+                true,
+            )
+            .await
+            .expect("invalid usage")
+            .expect("unexpected upper");
+
+        // Advance the upper so a snapshot as_of 3 is available.
+        write
+            .expect_compare_and_append(&[(("3".to_owned(), "three".to_owned()), 3, 1)], 3, 4)
+            .await;
+
+        let parts = read
+            .snapshot(Antichain::from_elem(3))
+            .await
+            .expect("as_of unavailable");
+
+        let mut faked = 0;
+        let mut kept_truncated = 0;
+        for mut part in parts {
+            let key: ArrayRef = Arc::new(StringArray::from(vec!["k"]));
+            let val: ArrayRef = Arc::new(StringArray::from(vec!["v"]));
+            part.maybe_optimize(&cache.cfg, key, val);
+            match part.desc.lower().elements() {
+                [0] => {
+                    // Control: an untruncated batch below the as_of gets its
+                    // fetch optimized away.
+                    assert!(!part.bounds_truncated);
+                    assert!(part.part.is_inline(), "expected a faked part");
+                    faked += 1;
+                }
+                [1] => {
+                    // The truncated batch's statistics count the update at 0,
+                    // so the fetch must happen for real.
+                    assert!(part.bounds_truncated);
+                    assert!(
+                        !part.part.is_inline(),
+                        "must not substitute statistics for a truncated part"
+                    );
+                    kept_truncated += 1;
+                }
+                [3] => (),
+                x => panic!("unexpected part lower {:?}", x),
+            }
+        }
+        assert_eq!(faked, 1);
+        assert_eq!(kept_truncated, 1);
     }
 
     // Verifies that we streaming-consolidate away identical key-values in the same batch.

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -617,7 +617,7 @@ where
             let mut key_storage = None;
             let mut val_storage = None;
             for batch in batches.iter() {
-                let () = validate_truncate_batch(
+                let bounds_truncated = validate_truncate_batch(
                     &batch.batch,
                     &desc,
                     any_batch_rewrite,
@@ -689,7 +689,11 @@ where
                     if start_index != 0 {
                         run_splits.push(start_index);
                     }
-                    run_metas.push(run_meta.clone());
+                    let mut run_meta = run_meta.clone();
+                    if bounds_truncated {
+                        run_meta.set_bounds_truncated();
+                    }
+                    run_metas.push(run_meta);
                 }
                 num_updates += batch.batch.len;
             }

--- a/src/persist-client/tests/machine/regression_diffs_sum_truncated
+++ b/src/persist-client/tests/machine/regression_diffs_sum_truncated
@@ -1,0 +1,67 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for the diff-sum validation applied when a compaction result
+# replaces spine batches. A batch appended under a desc narrower than the one
+# it was written with may physically hold updates outside its registered
+# bounds. Readers (including compaction) filter those out, but the parts'
+# write-time diffs-sum statistics still count them, so the validation must
+# recognize such runs and skip the comparison instead of panicking on the
+# difference.
+
+write-batch output=b0 lower=0 upper=1
+zero 0 1
+----
+parts=1 len=1
+
+compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v2 [1]
+
+# Written over [0, 3) but registered over [1, 3): the update at 0 stays in the
+# part while every read filters it out.
+write-batch output=b1 lower=0 upper=3
+stale 0 1
+one 1 1
+two 2 1
+----
+parts=1 len=3
+
+truncate-batch-desc input=b1 output=b1trunc lower=1 upper=3
+----
+parts=1 len=3
+
+compare-and-append input=b1trunc writer_id=w11111111-1111-1111-1111-111111111111
+----
+v3 [3]
+
+compact output=c0 inputs=(b0,b1trunc) lower=0 upper=3 since=0
+----
+parts=1 len=3
+
+# Give enough fuel to the Spine that b0 and b1trunc merge into one spine batch,
+# so the merge res above has a spine batch covering its id range to land in.
+write-batch output=b2 lower=3 upper=4
+threeA 3 1
+threeB 3 1
+threeC 3 1
+threeD 3 1
+----
+parts=1 len=4
+
+compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v4 [4]
+
+# The compaction output dropped the truncated update, so it sums to one less
+# than the spine batches' statistics. Applying must still succeed, with the
+# diff-sum comparison skipped for the truncated run.
+apply-merge-res input=c0 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v5 true

--- a/src/persist-client/tests/machine/regression_diffs_sum_truncated_legacy
+++ b/src/persist-client/tests/machine/regression_diffs_sum_truncated_legacy
@@ -1,0 +1,69 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for the diff-sum validation on the legacy compaction path,
+# which matches a merge result against the spine by desc alone. When the result
+# covers only a sub-range of a spine batch's parts, validation must skip the
+# comparison if any of those parts is a truncated batch, whose write-time
+# statistics count updates that every read filters out.
+#
+# The sibling case, where the result covers a whole spine batch, is in
+# regression_diffs_sum_truncated.
+
+write-batch output=b0 lower=0 upper=1
+zero 0 1
+----
+parts=1 len=1
+
+compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v2 [1]
+
+# Written over [0, 3) but registered over [1, 3): the update at 0 stays in the
+# part while every read filters it out.
+write-batch output=b1 lower=0 upper=3
+stale 0 1
+one 1 1
+two 2 1
+----
+parts=1 len=3
+
+truncate-batch-desc input=b1 output=b1trunc lower=1 upper=3
+----
+parts=1 len=3
+
+compare-and-append input=b1trunc writer_id=w11111111-1111-1111-1111-111111111111
+----
+v3 [3]
+
+# Compact b1trunc alone, so the output covers [1, 3) rather than the [0, 3) of
+# the spine batch b0 and b1trunc merge into. The truncated update is dropped,
+# so the output sums to one less than b1trunc's statistics.
+compact output=c0 inputs=(b1trunc) lower=1 upper=3 since=0
+----
+parts=1 len=2
+
+# Give enough fuel to the Spine that b0 and b1trunc merge into one spine batch,
+# so the merge res above lands on a sub-range of its parts rather than on a
+# spine batch of its own.
+write-batch output=b2 lower=3 upper=4
+threeA 3 1
+threeB 3 1
+threeC 3 1
+threeD 3 1
+----
+parts=1 len=4
+
+compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v4 [4]
+
+apply-merge-res input=c0 legacy=true
+----
+v5 true


### PR DESCRIPTION
### Motivation

Surfaced by #38015: applying a compaction result panicked with

```
assertion `left == right` failed: merge res diffs sum (10) did not match spine batch diffs sum (11) (id range replacement)
```

The spine's diff-sum conservation checks compare two quantities that are only equal when a batch holds no data outside its registered bounds. `compare_and_append_batch` explicitly allows appending a batch under a desc narrower than the one it was written with (truncation), and every read path filters the out-of-bounds updates against the registered desc. But the parts' `diffs_sum` statistics are computed at write time over everything physically in the part, so for a truncated batch the spine-side sum counts updates that compaction (correctly) never read. The panic is a false positive: no data is lost.

State records neither the inline desc nor per-part time bounds, so the spine cannot detect truncation after the fact. No in-tree writer currently truncates away real data, which is why the checks have held so far; #38015 was the first writer to do it and had to work around this assertion with dataflow restarts and per-timestamp batches.

### Description

Record the truncation at the only moment it is known, append time:

* `validate_truncate_batch` now returns whether the append desc cuts into the batch's own desc, since it already examines both descs.
* `compare_and_append_batch` (and the datadriven `truncate-batch-desc` helper) mark each of the batch's runs with that bit.
* The bit lives in `RunMeta`'s existing `MetadataMap` under the key `"truncated"`, so there is no proto schema change and old versions roundtrip it losslessly. It sits on the run rather than on `HollowBatchPart` because runs move as a unit through incremental compaction (`construct_batch_with_runs_replaced` carries `RunMeta` wholesale) and because the flag then also covers `BatchPart::Inline`.
* All three spine diff-sum validation paths (id-range replacement, partial batch replacement, the classic exact match) now compute their "old" sums run-by-run and skip the comparison when any involved run is marked. `None` already meant "skip" in `validate_diffs_sum_match`, so unflagged batches validate exactly as before.

Compaction outputs are written with exact bounds and fresh run metas, so the mark ages out as truncated regions are rewritten and validation coverage returns on its own.

Rollout note: old versions ignore the metadata key, so an old reader could still trip the assertion during a mixed-version rollout if a new writer truncates away real data. No writer does that today; this change needs to be fully rolled out before one (e.g. #38015) starts relying on it.

### Verification

New datadriven regression test `regression_diffs_sum_truncated`: it registers a batch with an update below its registered lower, fuels a spine merge, and applies the compaction result. Without the skip it reproduces the exact panic above; with it the merge res applies.

Generated with [Claude Code](https://claude.com/claude-code)
