### PR TITLE
ci/lint: only fail check-no-diff on changes made by the lint itself

### DIFF
--- a/ci/test/lint-main/after/check-no-diff.sh
+++ b/ci/test/lint-main/after/check-no-diff.sh
@@ -8,6 +8,11 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+#
+# Fails if the lint checks modified the working tree, which usually means a
+# generated file is stale. Changes that existed before the checks ran, as
+# snapshotted by before/save-diff-state.sh, do not count: a dirty tree, such
+# as the working copy of a colocated jj repo, must be able to pass the lint.
 
 set -euo pipefail
 
@@ -15,6 +20,20 @@ cd "$(dirname "$0")/../../../.."
 
 . misc/shlib/shlib.bash
 
-try git diff --compact-summary --exit-code
+check_no_new_diff() {
+    local before=target/lint/diff-before.patch
+    if [[ ! -f "$before" ]]; then
+        # No snapshot, so require a fully clean tree.
+        git diff --compact-summary --exit-code
+        return
+    fi
+    if ! git diff | cmp -s "$before" -; then
+        echo "The lint checks changed the working tree (< before, > after):"
+        diff target/lint/diff-before.summary <(git diff --compact-summary) || true
+        return 1
+    fi
+}
+
+try check_no_new_diff
 
 try_status_report

--- a/ci/test/lint-main/before/save-diff-state.sh
+++ b/ci/test/lint-main/before/save-diff-state.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# Snapshots the working tree's diff before the lint checks run, so that
+# after/check-no-diff.sh can flag only changes made by the checks themselves.
+# A tree that is dirty going in, such as the working copy of a colocated jj
+# repo, which git always sees as uncommitted changes, must not fail the lint
+# on its own.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../../../.."
+
+mkdir -p target/lint
+git diff > target/lint/diff-before.patch
+git diff --compact-summary > target/lint/diff-before.summary


### PR DESCRIPTION
### Motivation

`bin/lint`'s final `check-no-diff.sh` runs `git diff --exit-code`, so it fails on any working tree that was dirty before the checks ran. In a colocated jj repo the working copy is always dirty from git's perspective (git HEAD points at the working copy's parent), so `bin/lint` could never pass there without first shuffling the change into git HEAD. Plain git trees with uncommitted changes hit the same false failure.

### Description

The check's real job is to catch checks that modify the tree, i.e. stale generated or misformatted files. So instead of requiring a clean tree, a new `before/save-diff-state.sh` snapshots `git diff` before the checks run, and `check-no-diff.sh` fails only if the diff changed while they ran, printing which files are newly modified. On CI the tree starts clean, so behavior there is unchanged. If no snapshot exists (the script run standalone), it falls back to the old fully-clean requirement.

### Verification

Ran `bin/lint` on a dirty colocated jj tree: passes where it previously failed. Manually verified that modifying a tracked file between the snapshot and the check still fails, pinpointing the new file, and that the no-snapshot fallback still rejects a dirty tree.

Generated with [Claude Code](https://claude.com/claude-code)
