### PR TITLE
mcp: pin the python base by digest and cover it with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,6 +97,8 @@ updates:
     - /misc/images/openssh-static
     - /misc/images/tini-static
     - /misc/images/distroless-prod-base
+    - /misc/mcp-materialize
+    - /misc/mcp-materialize-agents
     - /ci/builder
     - /test
   schedule:

--- a/misc/mcp-materialize-agents/Dockerfile
+++ b/misc/mcp-materialize-agents/Dockerfile
@@ -7,7 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM python:3.13-alpine
+# Pinned by rolling tag + multi-arch index digest so dependabot refreshes the
+# digest for security fixes.
+FROM python:3.13-alpine@sha256:540c7d91f98ff6880174c40e99067bf5941eb54d818a7a5e094d188b196a934d
 
 RUN pip install uv
 

--- a/misc/mcp-materialize/Dockerfile
+++ b/misc/mcp-materialize/Dockerfile
@@ -7,7 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM python:3.13-alpine
+# Pinned by rolling tag + multi-arch index digest so dependabot refreshes the
+# digest for security fixes.
+FROM python:3.13-alpine@sha256:540c7d91f98ff6880174c40e99067bf5941eb54d818a7a5e094d188b196a934d
 
 RUN pip install uv
 


### PR DESCRIPTION
`misc/mcp-materialize` and `misc/mcp-materialize-agents` both ran on a floating `python:3.13-alpine` tag with no digest, in directories dependabot did not cover — so the base was neither pinned nor refreshed.

```
-FROM python:3.13-alpine
+FROM python:3.13-alpine@sha256:540c7d91f98ff6880174c40e99067bf5941eb54d818a7a5e094d188b196a934d
```

plus `/misc/mcp-materialize` and `/misc/mcp-materialize-agents` added to the docker ecosystem in `.github/dependabot.yml`.

Both halves are needed: a digest alone freezes the base, coverage alone leaves it mutable. The tag stays *rolling* (`3.13-alpine`) on purpose — dependabot only refreshes a digest when the tag rolls, so a version-stamped tag plus a digest would never update.

Alpine is fine here, sitting alongside debian-slim as an acceptable minimal base, so this is a pinning fix rather than a base migration.

### Digest verification

The digest is the multi-arch **index**, not a per-arch manifest — a per-arch pin builds on an arm64 laptop and dies in amd64 CI with `exec format error`:

```
$ docker manifest inspect python@sha256:540c7d91...
mediaType : application/vnd.oci.image.index.v1+json
is_index  : True
platforms : linux/386, linux/amd64, linux/arm/v6, linux/arm/v7,
            linux/arm64/v8, linux/ppc64le, linux/riscv64, linux/s390x
```

### Worth considering separately

`dhi.io` publishes a hardened `python`, including an alpine variant — I confirmed `dhi.io/python:3.13-alpine3.22` carries openssl 3.5.7 where the current upstream alpine base is behind. That would be a rung up from plain alpine, but it is a base migration rather than a pin, so it does not belong in this PR.

One of three PRs closing the unpinned production bases in this repo; the others cover the console images and `materialized-base`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
