### PR TITLE
materialized-base: pin the debian base by digest and cover it with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,6 +82,21 @@ updates:
         - minor
         - patch
 - package-ecosystem: docker
+  directory: /misc/images/materialized-base
+  schedule:
+    interval: weekly
+    day: sunday
+    time: "22:00"
+  # TODO: Add cooldown when https://github.com/dependabot/dependabot-core/issues/14044 is fixed
+  open-pull-requests-limit: 50
+  labels: [A-dependencies]
+  groups:
+    simple:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch
+- package-ecosystem: docker
   directory: /misc/images/debian-base
   schedule:
     interval: weekly

--- a/misc/images/materialized-base/Dockerfile
+++ b/misc/images/materialized-base/Dockerfile
@@ -16,7 +16,9 @@ MZFROM openssh-static AS openssh-static
 
 # In production, we use distroless images based on Debian 13.
 # We retain apt and install more packages in this image for development.
-FROM debian:13-slim
+# Pinned by rolling tag + multi-arch index digest, matching debian-base, so
+# dependabot refreshes the digest for security fixes.
+FROM debian:13-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
 
 ARG CI_SANITIZER=none
 


### PR DESCRIPTION
`misc/images/materialized-base` was the only `debian:13-slim` in this repo without a digest. `debian-base`, `prod-base` and everything downstream of them already pin the same index digest, so this was the odd one out.

```
-FROM debian:13-slim
+FROM debian:13-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
```

plus `/misc/images/materialized-base` added to the docker ecosystem in `.github/dependabot.yml` — the directory was uncovered, so nothing refreshed the base even as a tag.

That digest is deliberately the same one `misc/images/debian-base` already uses, so the two bases move together instead of drifting apart.

### Digest verification

The digest is the multi-arch **index**, not a per-arch manifest. A per-arch pin builds on an arm64 laptop and then fails amd64 CI with `exec format error`:

```
$ docker manifest inspect debian@sha256:3a39a059...
mediaType : application/vnd.oci.image.index.v1+json
is_index  : True
platforms : linux/386, linux/amd64, linux/arm/v5, linux/arm/v7,
            linux/arm64/v8, linux/ppc64le, linux/riscv64, linux/s390x
```

### An alternative worth a reviewer's opinion

This image could instead do `MZFROM debian-base` and inherit the pin automatically, which would remove the possibility of the two drifting again. I did not do that here because `debian-base` also brings its own packages and user setup, so it is a behaviour change rather than a pin. Happy to switch if you would rather have one source of truth.

One of three PRs closing the unpinned production bases in this repo; the others cover the console and MCP images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
