### PR TITLE
design: add cluster branches design doc

### DIFF
--- a/doc/developer/design/20260814_cluster_branches.md
+++ b/doc/developer/design/20260814_cluster_branches.md
@@ -1,0 +1,247 @@
+# Cluster Branches
+
+- Associated:
+  - [PRD](https://app.notion.com/p/materialize/Help-Claude-Optimize-my-dataflows-Part-2-Branches-3b913f48d37b80a0bfccd8af3fe83c42) "Help Claude Optimize my dataflows: Part 2, Branches" (Pranshu)
+
+## The Problem
+
+Agents needs mechanisms to propose changes to Materialize e.g., add an index, rewrite a view, resize a cluster. Whether such a change is beneficial must be verified against an environment. Presently, the only options are to mutate production, which is unsafe, or to hand-build a parallel cluster and copy its inputs, which is slow and manual. As a result an agent proposes changes it has not tested.
+
+The changes an agent proposes are compute changes: will this index fit in memory, will this rewrite keep up with ingest, does this cluster still fit at a smaller size. Answering that means running the change on real data and load, on compute isolated from production and sized the way you're testing. In Materialize the cluster is the unit of compute isolation, so the sandbox we want is a forked cluster: isolated, right-sized compute to run and measure the change against production's live data, without touching production's own compute.
+
+The agent forks a cluster, changes it, measures against production, and hands the diff back as a PR.
+
+## Success Criteria
+
+- **Create latency.** Branching a cluster completes in under a second, independent of the data volume on that cluster.
+- **Isolation.** A change made in a branch (a new, altered, or dropped index/MV/view, or table DML and schema change) leaves production and every other branch unchanged in both query results and catalog.
+- **Liveness.** A re-rendered object in a branch advances against the live source frontier, so its measured lag reflects real ingest rather than a frozen snapshot.
+- **Observability.** An agent can measure a branch object's memory, CPU utilization and its freshness. We can observe whether it is hydrated, through existing introspection. Those figures are representative of what the same object would cost in production.
+- **No production impact.** Live branches do not measurably change production read latency or compaction over the shards they share.
+- **Change retrieval.** A branch's changes can be read back as runnable DDL, so a human can apply them to production themselves.
+- **Privacy.** A role cannot observe or use a branch it did not create.
+
+## Out of Scope
+
+- **Promotion / merge back into main.** exit is a PR with a human in the loop, not an in-database `PROMOTE`.
+- **Branch off a branch.** branches only off `main`.
+- **Cross-branch comparison in a single query.** No inline `object@branch` qualifier.
+- **Mid-branch rebase.** No moving a branch's point-in-time forward after create.
+- **Branch-local source re-ingestion.** A source is read-only in a branch. The intended way to add columns is `CREATE TABLE FROM SOURCE`, standing up a branch-local re-read of the external upstream, isolated from production.
+
+Promotion and branch-off-a-branch are deferred but must not be precluded. How the design leaves room for each is called out in the Solution below.
+
+## Usage
+
+The feature sits behind one flag, `enable_branching`.
+
+**1. Preflight.** `EXPLAIN CREATE BRANCH` reports the branch's scope and what it reads, creating nothing.
+
+```
+EXPLAIN CREATE BRANCH FROM CLUSTER fraud_features;
+
+Branched (cluster fraud_features): 5 objects
+  1 materialized view, 4 indexes
+Forkable inputs (forked at branch point): 1
+  materialize.fraud.labels           (table, writable)
+Shared live inputs (read-only): 12
+  materialize.fraud.transactions     (source)
+  materialize.fraud.enriched_events  (table, read-only, fed by source)
+  materialize.fraud.user_profiles    (materialized view, other cluster)
+  9 views
+Warnings: 1
+  Table materialize.fraud.labels is forked, but materialize.fraud.user_profiles
+  (materialized view on another cluster, not branched) also reads it and will not
+  see the branch's writes. Branch that cluster too for a consistent view.
+```
+
+The warning covers a table that is forked here but also read through a cluster that is not in this branch. That path keeps reading production, so it never sees the branch's writes. Branching that cluster too forks the shared table once, and every branched cluster reads the one fork consistently.
+
+**2. Create.** You create and size the branch cluster, then map each production cluster to one. Multi-cluster branches list one `prod -> branch` map per line.
+
+```sql
+CREATE CLUSTER exp_fraud (SIZE = '6400cc');
+
+CREATE BRANCH exp_delta_joins
+    FROM CLUSTER fraud_features IN CLUSTER exp_fraud
+    WITH (EXPIRES IN = '48h');
+```
+
+`SHOW BRANCHES` lists your branches, owner-scoped.
+
+```
+SHOW BRANCHES;
+
+ name            | created          | expires          | clusters
+-----------------+------------------+------------------+-----------------------------
+ exp_delta_joins | 2026-08-11 09:14 | 2026-08-13 09:14 | fraud_features -> exp_fraud
+```
+
+**3. Enter and iterate.** `SET branch` reroutes this session's name resolution into the branch. `RESET branch` returns to production.
+
+```sql
+SET branch = exp_delta_joins;
+
+CREATE MATERIALIZED VIEW materialize.fraud.txn_features_v2 AS ...;
+CREATE INDEX object_type_by_id ON materialize.fraud.object_type (id);
+```
+
+**4. Measure.** Existing introspection resolves within the branch: `mz_cluster_replica_utilization` for memory and CPU fit, `mz_materialization_lag` for freshness against live ingest. A branch gives a warm, live, isolated place to answer "does the rewrite fit on this size" and "does it keep up".
+
+**5. Extract.** `SHOW BRANCH CHANGES` diffs the branch against its branch point. `AS SQL` re-serializes each change into runnable DDL for a PR.
+
+```
+SHOW BRANCH CHANGES exp_delta_joins;
+
+ object                              | change  | detail
+-------------------------------------+---------+--------------------------
+ materialize.fraud.txn_features_v2   | added   | materialized view
+ materialize.fraud.object_type_by_id | added   | index
+ materialize.fraud.feature_rollup    | altered | redefined, added risk_tier
+```
+
+**6. Tear down.** `DROP BRANCH exp_delta_joins`, or let `EXPIRES` lapse. Creation is gated by `GRANT CREATE ON BRANCH TO <role>`, and a role sees and uses only its own branches.
+
+A branch covers the following categories of object. Only the first is *in* the branched cluster; how others are treated is based on what those objects depend on.
+
+| Object kind | Category | In the branch |
+|---|---|---|
+| **Indexes, MVs** | Cluster-resident | Branch-owned. Add, drop, or redefine freely; each gets its own branch identity. |
+| **Sinks** | Cluster-resident | Inert by default, so a branch never writes to production's destination. `ALTER` a sink to a new destination (a different one is required) and it starts writing there. |
+| **Tables** | Forkable input | Not on any cluster. A writable table reachable from the branched cluster's dataflows is forked at the branch point, so DML and schema changes are real and isolated to the branch. A read-only table (one fed by a source) is not forked; it is a shared live input, read live like a source. |
+| **Sources** | Shared live input | Live and read-only. Data keeps flowing, but you cannot alter them. |
+| **Views** | Shared live input | Read-only. A view is just SQL folded into a dependent dataflow; to change one, create a new view inside the branch. |
+
+## Solution Proposal
+
+A branch forks one or more clusters. The design principle: a branch **runs the branched cluster's own objects, reads everything outside the cluster live, and forks only the writable tables it reaches.** It reads on production's timeline, starting at the branch point and tracking forward with the live frontier, so its objects stay as fresh as production's rather than frozen at a snapshot. The branch cluster re-renders the branched cluster's indexes and materialized views, so their memory and CPU are real and measurable at the branch's chosen size. Inputs from outside the branched cluster, sources and objects on other clusters, are read from the same live shards that serve production, never recomputed. The only storage a branch adds is the new data it writes to a forked table, and nothing unchanged is duplicated. `CREATE BRANCH` records catalog metadata and nothing else, so it scales with object count, not data size. The cost a branch does incur is re-rendering the cluster's in-memory compute state on the branch replicas.
+
+### Forking a written table
+
+A table the branch writes needs its data isolated as production must not see the branch's writes, and the branch must not see production's later writes. The branch gets this by **forking the table's shard at the branch point**. The fork is a new shard that references production's history as of the branch point by pointer: the blobs holding data at or below `branch_ts` stay in production's shard, shared and immutable, and the fork points at them. The branch's writes append above `branch_ts` as new, self-owned data, while production's later writes append only to production's shard. From the branch point the two histories diverge, and neither sees the other's.
+
+No data is copied, at create or on write. Because the shard is an append-only log of diffs an update or delete of an inherited row is a new compensating diff appended above `branch_ts`, leaving the shared blobs untouched. The fork is a metadata operation, so it is independent of data size. Forking a persist shard, results in **its own compaction frontier** (`since`) so production's table compacts independently. The fork holds a retained reference to the shared blobs it inherited, so production's garbage collection keeps exactly those instead of reclaiming them while a branch still points at them.
+
+The detailed persist design (blob addressing, the cutoff, compaction boundaries, retention through the existing GC path, and txns registration) is in [Forking a table shard in persist](./20260814_cluster_branches_persist_fork.md).
+
+### Reads without taxing production
+
+A branch touches production's storage only to read its out-of-cluster inputs: the sources and objects on other clusters its dataflows depend on. A reader of a persist shard holds a read hold on it, pinning the shard's `since` no further back than that reader still needs.
+
+A branch reads in two phases. While an object hydrates, it reads its inputs as of `branch_ts`, so it holds those input shards' `since` at `branch_ts` until it catches up, a hold proportional to hydration time. Once caught up it follows the live frontier, and its read holds advance forward with it, sitting near live like production's own consumers.  So a branch never pins `since` back long term.
+
+Note: an alternative design (which is in the alternative section) is freezing the inputs at the branch point, which holds every input at `branch_ts` for the branch's whole life. However, because a branch tracks forward instead, production's compaction and read latency are unaffected.
+
+### Hydration
+
+Every object on the branched cluster, index or materialized view, re-renders on the branch replicas, so its arrangements must be warmed from persist. The cost is not paid at create. It is deferred and is proportional to data size.
+
+At a high level two rejected options are:
+- **Lazy hydrate from persist.** The branch object installs on first use and warms via the normal path. Correct, zero new mechanism, but the first query pays full hydration.
+- **Shared-cluster shortcut.** Home the branch's dataflows on the production cluster itself. An unchanged object then shares the arrangements already resident on each replica through an ordinary trace import, rather than rebuilding them, so there is no hydration, at the cost of sharing production's compute and memory. This is the documented cheap path when you accept shared compute.
+
+Instead, this design proposes **arrangement checkpointing**: capture every arrangement in a dataflow as of the branch point and restore them onto the branch replicas, so the branch resumes a dataflow instead of rebuilding one. It is scoped as a **general primitive**, since the same mechanism gives fast replica bring-up, fast restart, and fast blue/green cutover, with branches as its first consumer. Checkpointing is applied only where it pays: a dataflow with joins or aggregates, whose in-memory state is far smaller than its inputs, not a plain index on a table, where the fork already shares production's blobs and a checkpoint would only make the branch ready later. `SHOW BRANCH` reports each object's hydration state, so an agent knows when the branch is warm enough to measure.
+
+The detailed compute design (capturing the whole dataflow graph, non-blocking capture, restoring traces with no upstream differential change, and the cost model for when it pays) is in [Hydration](./20260814_cluster_branches_hydration.md).
+
+### What a branch can answer, and when
+
+The ability for a branch to give feedback to an agent is hierarchical, and each level need increasing hydration. Therefore, an agent gets the cheap answers first and pays data-proportional time only for the last one.
+
+- **Plan and validity (no hydration).** Does it plan, and does the optimizer use the new index or accept the rewrite. Available at create.
+- **Result equivalence (hydrate to serve).** Does the rewrite return the same answers, checked as of a bounded time. Needs the arrangement warm enough to serve, not caught up to live.
+- **Keep-up and fit (hydrate to live).** Does it keep up with live ingest, and its steady-state memory and CPU. The only level proportional to data size, and what checkpointing accelerates.
+
+### Sinks
+
+A branch re-renders the branched cluster's sinks like its other objects, but a sink is **inert** by default: the branch runs the sink's dataflow, so its compute is still measurable, but starts no external writer, so nothing reaches production's destination. This is the hard invariant, a branch never writes to a production sink's destination.
+
+To exercise a sink for real, `ALTER` it to a new destination, which must differ from production's, and only then does the branch start a writer against the new destination. An `ALTER` that targets the production sink's own destination is rejected, so the safe default cannot be bypassed by accident.
+
+### Catalog identity and resolution
+
+Each branch object has its own catalog identity, so a branch MV, index, or table is a real catalog item. `CREATE BRANCH` writes the branch header, the per-object identities, and a snapshot of the branch-point catalog, all in one atomic catalog transaction. That snapshot is what `SHOW BRANCH CHANGES` later diffs against. These two properties, decoupled per-object identity and a single atomic transaction over many objects, are what a future promote would need to swap a branch's objects into production in one step, so keeping them here leaves promotion addable without a redesign.
+
+Entering a branch is a session overlay, modeled on the session-scoped temporary-item overlay that already shadows the global catalog at the catalog resolver. An object in the branch's scope, a cluster-resident object on the branched cluster or one the branch itself created, resolves to its branch item. A source resolves to the live production source, and everything else falls through to production.
+
+All DDL on branch-owned objects is unrestricted: create, alter, or drop them freely. A newly created object lands on the branch cluster in its production schema and shadows any production object of the same name within the branch session. Shared live inputs stay read-only, as the object table above notes, so to change one you add a new object rather than altering it.
+
+### Tracking changes
+
+`SHOW BRANCH CHANGES` is a catalog diff, not a data scan. It compares the branch's current catalog against the branch-point snapshot: an object present in the branch but not the snapshot is *added*, one in the snapshot but not the branch is *dropped*, and one in both with a changed definition is *altered*. Because every catalog item stores its canonical `create_sql`, `AS SQL` reconstructs runnable DDL by re-serializing each changed object's definition. A schema change to a branched table, an `ALTER TABLE`, is a catalog change too, so it appears here.
+
+Row-level writes to a branched table are data, not catalog, so they are not in this diff. They are exactly what the table's fork appended above the branch point, so they can be read back as a consolidated diff over that range if we later choose to emit them as DML.
+
+### Timestamps
+
+**The branch point.** `branch_ts` is the single logical time that the whole branch is anchored to: table fork cuts off there, checkpoints are captured as of it, and live inputs begin there before tracking forward. It must be a time every input can serve.
+
+The timestamp oracle selects one `branch_ts` in the valid read interval over all the branch's inputs at once, `max(since) <= branch_ts < min(upper)` across every forkable and shared-live input.
+
+Note that a healthy input put `branch_ts` near live, while lagging input pin `branch_ts` back to its `upper`, so the branch starts as fresh as its slowest input. This matches the semantics of a multi-input query. If the interval is empty, meaning an input has compacted past another's frontier, create fails like an unservable read.
+
+Furthermore becuase `branch_ts >= since` at selection and the branch takes its read holds atomically at create, no input's `since` can have passed `branch_ts`, so the fork can always pin the inherited blobs there. In the future, a multi-cluster branch selects one `branch_ts` over the union of every mapped cluster's inputs.
+
+Consequently, a branch reads on production's timeline. Live inputs read at the live frontier. A branched table advances on the branch's writes and on normal table progress, so it never stalls downstream reads. Branch-cluster objects advance at their dataflow frontier fed by those inputs. Every read uses the normal timestamp oracle.
+
+### Lifecycle
+
+`WITH (EXPIRES IN = '48h')` computes an absolute expiry at create. A background sweep drops expired branches through the **same teardown as `DROP BRANCH`**: release the branch's read holds so production compaction can advance again, release any table-fork storage, tombstone the catalog rows, and tear down the branch's dataflows. The user's branch cluster is never auto-dropped, since they own its cost.
+
+Expiry is the default so abandoned agent branches self-clean, while `DROP` is the deterministic reclaim.
+
+Across an `environmentd` restart or generation cutover a branch behaves like any other catalog object: its durable state is the catalog rows and the persist fork's shard and retained reference, and its read holds and dataflows are reconciled from the catalog on bootstrap like every other object's. That retained reference, not the runtime read hold, keeps the inherited blobs alive in the meantime, so no branch-specific recovery path is needed.
+
+### RBAC
+
+Branches are owner-private. `GRANT CREATE ON BRANCH TO <role>` gates creation. A role sees and uses only branches it created, and cannot detect that another role's branch exists, so `SHOW BRANCHES` and every branch reference are owner-scoped with no information leak.
+
+Superusers can see and drop any branch for operational cleanup.
+
+## Minimal Viable Prototype
+
+Single-cluster branch, behind `enable_branching`, hydrating lazily (no checkpointing yet)
+
+1. `EXPLAIN CREATE BRANCH FROM CLUSTER fraud_features` reports scope and upstream inputs.
+2. `CREATE CLUSTER exp_fraud` then `CREATE BRANCH ... IN CLUSTER exp_fraud`, sub-second.
+3. `SET branch`, then `CREATE INDEX` / `CREATE MATERIALIZED VIEW`, and an `INSERT` into a branched table, inside it.
+4. Introspection over the branch cluster's replica shows utilization and lag against live ingest.
+5. `SHOW BRANCH CHANGES ... AS SQL` re-serializes the change to runnable DDL.
+6. `DROP BRANCH` tears it all down.
+
+This validates the UX, live-forward reads against a source, the table fork (the `INSERT` diverges from production), the resolution overlay, and the live-source freshness that makes the measurement meaningful. It does not require the checkpointing workstream.
+
+## Alternatives
+
+### Scope unit: cluster vs environment vs schema
+
+- **Environment (branch everything).** Simplest model (Neon, Supabase), but it re-renders every cluster to test a change touching one, and needs a parallel control plane (an environment is one `environmentd`, so would require multi-envd support). Cluster scope reproduces it on demand by branching every cluster, without either cost.
+- **Schema.** A schema's objects cut across clusters, so blast radius and compute isolation is lost (PlanetScale is schema-scoped).
+- **Cluster (chosen).** Already Materialize's unit of isolation, sizing, and billing, so blast radius, fit, and cost stay explicit. Environment branching falls out by branching every cluster.
+
+### Reading inputs: live vs frozen at the branch point
+
+- **Freeze at the branch point.** Read a frozen fork of each input. Deterministic, but it pins cold storage per branch, stops the branch tracking live ingest, and defeats the freshness measurement.
+- **Read live, track forward (chosen).** The branch is an ordinary extra reader whose read holds advance forward, so production's compaction is untaxed. Forking is reserved for the one thing needing isolated writable storage, a written table.
+
+### Hydration: checkpoint vs peer-to-peer vs lazy-only
+
+- **Peer-to-peer remote read.** The branch replica pulls an arrangement from a live production replica's memory. It couples bring-up to a running production replica and its worker layout, and needs a new cross-cluster transport.
+- **Lazy-only.** Correct, but every unchanged index pays full hydration on first use, which undercuts the cheap-sandbox promise for large indexes.
+- **Checkpoint to persist (chosen target).** Decoupled from production being up, reuses persist's blob storage, generalizes to replica bring-up and restart. Costs a persist round-trip and a re-exchange on differing worker counts.
+
+### Exit: PR vs in-database promotion
+
+In-database promotion needs merge queues, conflict handling, catch-up, and a rollback window. The scope for this work is `SHOW BRANCH CHANGES AS SQL` into a PR with a human in the loop. The design keeps promotion *addable* (decoupled per-object identity, atomic multi-object catalog transaction) without shaping around it.
+
+## Open questions
+
+1. **Freezing inputs for reproducibility.** Reads are live by default and track forward. Do we also want an opt-in mode to freeze a branch's inputs at the branch point for a deterministic experiment, or is live-only fine for v1? Live-only proposed.
+2. **Promote of a source-bearing cluster.** A source's ingestion runs on its origin cluster, not the branch cluster, so a future promote of a cluster that owns a source would need to hand ingestion over. Out of scope now, recorded so the promote design accounts for it.
+3. **Expiry and churn defaults.** Default `EXPIRES IN`, the per-owner branch quota, and the create/drop rate limit.
+4. **Alterable sinks scope.** Sinks are inert by default and become writable only via `ALTER` to a new destination.
+5. **Exporting table DML.** `SHOW BRANCH CHANGES` exports DDL. A branched table's row writes are recoverable from its fork, so should we also emit them as DML for the PR, or leave experimental data in the branch? DDL-only proposed for v1.
+
+---
+
+Detailed designs for the two core mechanisms: [Forking a table shard in persist](./20260814_cluster_branches_persist_fork.md) and [Hydration](./20260814_cluster_branches_hydration.md).

--- a/doc/developer/design/20260814_cluster_branches_hydration.md
+++ b/doc/developer/design/20260814_cluster_branches_hydration.md
@@ -1,0 +1,93 @@
+# Cluster Branches: Hydration
+
+- Parent: [`20260814_cluster_branches.md`](./20260814_cluster_branches.md)
+
+This document details how a **cluster-resident object** on a branch cluster is hydrated. Every index and materialized view on the branched cluster re-renders on the branch replicas, so each carries in-memory arrangements that must be warmed, whether its definition changed or not. Everything else the branch reads (sources, tables, and objects on other clusters) already exists as a persist shard, so the branch reads it directly, with no arrangement to hydrate.
+
+The in-memory state to warm is an **arrangement**: an incrementally maintained trace of `(key, value, time, diff)` updates. An arrangement is derived, so the branch replicas can always rebuild it by reading the inputs from persist starting at `branch_ts`, and the branch's read holds already retain those inputs. That lazy rebuild is the always-correct floor, together with the shared-cluster shortcut when the branch is homed on production's own cluster (both covered in the parent doc). It is correct but pays a full recompute on first use: read the inputs, sort, and re-run every operator.
+
+**Checkpointing** is an optimization: copy production's already-built arrangements onto the branch replicas so the branch resumes a dataflow instead of rebuilding one. It is a general primitive, the same mechanism giving fast replica bring-up, fast restart, and fast blue/green cutover, with branches as its first consumer.
+
+## What a checkpoint contains: the whole dataflow graph
+
+A checkpoint is **every arrangement in the dataflow**, not just the exported one. Arrangements *are* the operator state, e.g., a join's persistent state is its two input arrangements. Checkpointing only the exported arrangement cannot seed the operators that maintain it, so the branch would recompute the expensive part anyway.
+
+Each arrangement is captured **as of `branch_ts`**, not as a trace with history. Reading a trace as-of `branch_ts` yields the consolidated state at that time, stamped `branch_ts`, which restores into a single batch that lines up exactly with the live batches that follow it.
+
+Note: we collect both the `oks` and the `errs` arrangements.
+
+## Maintained state is arrangements, except under recursion
+
+The "every arrangement" claim rests on arrangements being the whole of an operator's maintained state. This generally holds at a settled frontier.
+
+However, recursion is the exception. `WITH MUTUALLY RECURSIVE` renders its body in an iterative scope, so every arrangement inside the loop is timestamped by a product of the data time and an iteration coordinate, not by the data time alone. `branch_ts` names a point on the data time only, so an as-of-`branch_ts` read does not pick out a single consistent state of a loop arrangement, and restoring the converged output as one batch discards the per-iteration state the loop needs to resume incrementally.
+
+For simplicity we can exclude such dataflows from checkpointing and fall back to lazy rebuild, which is always correct. A loop-aware checkpoint would capture and restore across the product timestamp.
+
+## Capture
+
+Capture runs on **production's workers**, where the arrangements live. It adds a new compute command, sent to those workers to capture a dataflow's arrangements as of a given time, and a matching response reporting when each is captured, so the coordinator can tell a branch its checkpoint is ready. Each arrangement is read through an ordinary cursor as-of `branch_ts`, emitting consolidated updates.
+
+No quiescence is needed for the checkpoint as differential times are logical. Each trace read as-of `branch_ts` is the true state at `branch_ts` independently of every other trace.
+
+The condition per arrangement is `since <= branch_ts`. The upper bound `branch_ts < upper` is automatic: a cursor read as-of `branch_ts` waits for the arrangement to advance past it. `since <= branch_ts` is held by a read hold taken at capture, which prevents the arrangement from compacting past `branch_ts` while it is read.
+
+## The checkpoint format: keyed shards
+
+An arrangement is sorted by its key, and the checkpoint stores it the same way: a persist shard whose key is the arrangement's key. Persist returns that shard's parts already in key order, so restoring becomes a merge of already-sorted pieces and avoids a re-sort.
+
+Building an arrangement from scratch has to sort its input by key, so a checkpoint that already comes back in key order skips it. The obvious alternative, storing the checkpoint the way an ordinary table shard is stored with the whole row as the key, comes back ordered by the row and not by the arrangement's key, so restoring it would have to re-sort into key order, which costs as much as arranging the input from scratch and saves nothing.
+
+## Restore: inject pre-populated traces
+
+Restore reinstates each captured arrangement as an operator's starting state. Every trace in a dataflow is constructed through `Trace::new` and wrapping them in a spine whose `Trace::new` consults a **per-worker restore registry** lets a pre-populated trace stand in wherever the registry holds state under that arrangement's name. Because differential builds even its internal arrangements (a reduce's output trace) through the same spine constructor, this reaches the arrangements differential creates as well as ours. The restored arrangement is handed into the dataflow as an ordinary imported `Arranged`, indistinguishable downstream from a shared one.
+
+Loading onto a different worker count exchanges the sorted runs by key before the merge. A matching worker count and partitioning is a fast path that skips the exchange.
+
+## From the checkpoint to live
+
+Hydration is snapshot-plus-listen: the checkpoint is the snapshot at `branch_ts`, restored as one contiguous batch, and the branch's own input reads supply the diffs strictly above `branch_ts`, so updates at `branch_ts` are not double-applied. The object is not queryable until its arrangements are restored, then it serves as of its frontier and tracks live. This is the same serve versus block policy that we have today.
+
+## Identity and validity: names and fingerprint
+
+Capture and restore must agree on a name for every arrangement. As opposed to a positional name, we could instead derive the name from the **LIR plan** (node path plus the arrangement's key) and register it during render.
+
+A checkpoint is valid only for the same plan. The branch's plan differs from production's in `GlobalId`s by construction. So any checks would need account for a branches object-identity.
+
+## What to checkpoint: the cost model
+
+Checkpointing is not always a win: it skips recomputation but pays to write and read the state instead. So if there is little computation to skip it costs more than it saves. We can therefore decide whether to rebuild or checkpoint per dataflow, and have the same end state.
+
+    rebuild:     read(inputs) + sort + recompute(every operator)
+    checkpoint:  write(state)  + read(state) + merge(no sort)
+
+Checkpointing removes the sort and the operator recomputation, and adds a state write and read.
+
+- **A plain index on a table: do not checkpoint.** There are no operators to skip, since the dataflow only arranges its input, and the state is the same size as that input. So the checkpoint adds a full input-sized write and removes almost nothing.
+- **An index over a join or aggregate: checkpoint.** The operator work it skips, matching a join or folding an aggregate, can be the expensive part. For an aggregate the state is also much smaller than the input, so the write and read are proportionally cheap too. For a join the state is input-sized.
+
+## Readiness
+
+A branch object reports hydrated through the existing hydration-status signal, and `SHOW BRANCHES` distinguishes `warming` from `ready`. No new readiness mechanism is needed.
+
+## Related work: out-of-core
+
+The out-of-core [work](https://app.notion.com/p/materialize/Out-of-core-implementation-strategy-39813f48d37b80d8a068eb23603d8f03) is related but solves a different problem: capacity, a running arrangement exceeding RAM, rather than bring-up latency, a fresh arrangement starting warm. It pages continuously to ephemeral local storage. Checkpointing captures and restores at discrete moments to durable persist. There could be overlap in the out-of-core work's **chunk** primitive, a serializable arrangement representation shared across wire, batcher, and spine: if it lands, a checkpoint could reference chunks rather than cursor-read and re-encode.
+
+## Alternatives
+
+### What a checkpoint contains
+
+- **Every arrangement, as-of `branch_ts` (chosen).** Restores a resumable dataflow, and the as-of form is the smallest thing that restores correctly.
+- **Only the exported arrangement.** Cannot seed the operators that maintain it, so the branch recomputes the expensive part anyway.
+- **Trace with history.** Faithful, but the branch never reads below `branch_ts`, so history is dead weight that costs more to write.
+
+### Checkpoint format
+
+- **Keyed persist shard (chosen).** Key order makes restore a merge, not a sort, the only version whose load is cheaper than arranging the input. Generic persist brings batch management and GC.
+- **MV persist sink over `SourceData`.** The obvious reuse, but it writes the unkeyed shape and cannot bound itself from above (`up_to` is unimplemented for persist sinks), so it restores no cheaper and needs an external watcher to terminate.
+
+### Capture timing
+
+- **On demand at branch create (chosen).** Captures exactly at `branch_ts`, with nothing maintained when no branch exists, at the cost of a state write on the critical path.
+- **Continuous background checkpoints.** The natural fit for replica bring-up and restart, and they take the write off the branch's critical path, but out of scope (but could be useful for hydration etc)

--- a/doc/developer/design/20260814_cluster_branches_persist_fork.md
+++ b/doc/developer/design/20260814_cluster_branches_persist_fork.md
@@ -1,0 +1,92 @@
+# Cluster Branches: Forking a table shard in persist
+
+- Parent: [`20260814_cluster_branches.md`](./20260814_cluster_branches.md)
+
+This document details the persist primitive that branches need: a fork of a **table** shard at the branch point. Nothing else forks: the cluster's own indexes and materialized views re-render on the branch, and inputs from outside the cluster (sources, objects on other clusters) are read from their live shards. Only a writable table is forked. A read-only table, like a source, is read from its live shard.
+
+## The fork
+
+A branch that writes a table needs the table's data isolated: it starts from production's contents as of the branch point, then diverges, with production never seeing the branch's writes and the branch never seeing production's later writes. Two properties are required. Create is **metadata-only** (sub-second, no data copied), and the fork **does not tax production** (compaction should not be held back, no read amplification).
+
+A fork is a new persist shard whose trace is seeded from the source shard's state at `branch_ts`:
+
+- Inherited batches (at or below `branch_ts`) are referenced from the fork's trace, but their parts still live in the **source** shard's blobs. Nothing is copied.
+- The branch's own writes append above `branch_ts` as ordinary, self-owned batches in the fork's own blobs.
+- After initialization the fork is an ordinary shard, with two twists covered below: some parts are foreign, and one inherited batch is cut off.
+
+Fork initialization mirrors `maybe_init_shard`, seeding the fork's first state from the source's snapshot at `branch_ts` (`since = min`, `upper = branch_ts + 1`) instead of an empty trace.
+
+## Addressing the source's blobs
+
+Blob keys are resolved relative to the shard: the fetch path prepends the shard id, so every part is assumed to live under its own shard's prefix. A fork's inherited parts do not.
+
+Each batch part carries a `source_shard: Option<ShardId>` (on `HollowBatchPart`). The resolution rule is: use `source_shard` when set, the local shard when `None` to address keys.
+
+## Cutting off post-branch data
+
+Almost every inherited batch is entirely at or below `branch_ts` (`upper <= branch_ts + 1`). At most one batch per run straddles the point (`lower <= branch_ts < upper`): its blob holds updates both before and after `branch_ts`, and the fork must keep only the former. `ts_rewrite` advances timestamps and is not a cutoff, so this is new.
+
+The straddling inherited batch is tagged with `cutoff_ts = branch_ts`, and its `upper` is clamped to `branch_ts + 1` in the fork's trace. The fetch path drops any update with `time > cutoff_ts` when reading that batch. Fork initialization only marks the batch, so create stays metadata-only.
+
+Fork initialization takes a brief read hold on the source at `branch_ts`, pinning its `since` there while it references the inherited blobs, then releases it. The hold spans only creation: once the retained reference is registered, the immutable blobs keep their pre-`branch_ts` times regardless of later compaction. The hold succeeds whenever `since <= branch_ts`, which is guaranteed by how `branch_ts` is chosen. It is selected in the valid read interval over all inputs, so `since <= branch_ts` by construction (see the parent doc's Timestamps section), and the branch takes its read holds atomically at selection, so no input's `since` can advance past `branch_ts` before the hold is taken.
+
+This self-corrects. When the fork later compacts the straddling batch together with its own batches, the filtered result is written into a fork-owned blob and the cutoff bakes in, so the read-time filter disappears through ordinary compaction with no work paid at create.
+
+## Compaction and blob sharing
+
+Production and the fork are separate traces, each with its own `since`. They are independent except that the fork's inherited parts point at production's blobs.
+
+The model is that **branch points are compaction boundaries** on a shared history resulting in multiple `since` frontiers. Compaction consolidates within the segments the frontiers delimit and preserves each boundary, and a reader at any `since` reads the segments at or below it. Mapped onto the fork:
+
+- **Above `branch_ts`:** production compacts its own trace freely, since the fork does not reference production's data up there and holds its own writes instead. The fork compacts its own writes freely. There is no interaction.
+- **At or below `branch_ts`:** as production's `since` advances, production compacts its history as usual, writing new consolidated blobs. The only constraint is physical deletion: production's garbage collection must not delete a specific blob while the fork still points at it. Production is not held back from compacting, only from deleting the pinned blobs.
+- **On teardown:** the fork's `since` and its references go away, so production's next collection reclaims those blobs and everything catches up.
+
+## Retention through garbage collection
+
+Garbage collection is driven by `seqno_since`: it removes blobs referenced only by state versions below the watermark, then truncates state. Retention is therefore already expressed as "a blob is kept while live state references it," and that is the path a fork's pin rides. Registration may change, but the deletion logic does not: it keeps referenced blobs and reclaims the moment the reference is gone, for any release reason.
+
+The pin must retain blobs **without holding the source's compaction `since`**. The mechanisms are distinct: compaction advances `since` by writing new state versions, while blob deletion keys off `seqno_since`. No existing reader type separates them, though. The seqno capability that gates blob deletion lives only on `LeasedReaderState`, which also holds a `since`, and `CriticalReaderState` holds a `since` but no seqno. So the fork needs a **new retain-only reference kind** that the `seqno_since` collection honors without contributing a `since`.
+
+The reference pins the specific inherited blob keys. At create, the fork's inherited parts are enumerated (`RunPart::part_stream`) and their keys registered as held on the source, so collection keeps exactly them. This keeps retention proportional to the branch point rather than to production's churn since the branch point.
+
+This overhead on the source grows with the number of branches, not with how much production writes after the branch point. Each branch pins the source blobs that hold its inherited data. The pin lands in two places: the pinned blob keys go into the source's own state, and the original blobs stay alive even after production has recompacted that history into fresh ones, so the source keeps both copies. Neither part grows over time. Both are fixed when the branch is created and sized to the branch point, so ten branches cost about ten times as much, and each one's share is reclaimed when its branch is torn down.
+
+## Making the fork a writable table
+
+A branched table must accept `INSERT`, `UPDATE`, and `ALTER`. Table writes go through the txns (txn-wal) system, which sequences writes across table shards and advances their frontiers, including empty progress when there are no writes.
+
+The fork shard is registered through the ordinary table-registration path: bind the branch table's `GlobalId -> fork ShardId` via `insert_collection_metadata` (populated through `ids_to_register`), and register it with `register_table_collections`. Branch writes then take the existing table-write path.
+
+The fork shard is **not empty at registration**: it already carries the inherited batches, and its `upper` is `branch_ts + 1`. Txns registration normally advances a fresh data shard's upper with an empty append at the register timestamp (`register`). Registering the fork at a timestamp at or above `branch_ts + 1` treats its inherited content as pre-registration history, read via snapshot, with txns tracking it from the register timestamp forward.
+
+## Lifecycle
+
+Teardown (`DROP BRANCH`, expiry, or eviction, covered in the parent doc) releases the fork's retained reference on the source. Production's next collection then reclaims any blob no live fork still pins. The fork shard's own blobs, holding the branch's writes, are deleted with the fork. Release is one path for every teardown reason.
+
+## Alternatives
+
+### Blob addressing
+
+- **Per-part `source_shard` (chosen).** Confines foreignness to fork batches.
+- **Absolute, self-describing blob keys.** Cleaner abstractly, but changes the key model globally on the hot read path to serve a fork-only feature.
+
+### Cutting off post-branch data
+
+- **Read-time filter (chosen).** Marks the straddling batch and filters on read, keeping create metadata-only, and self-heals through compaction.
+- **Init-time rewrite.** Clean reads forever, but does real IO at create for a cost compaction removes anyway.
+
+### Compaction model
+
+- **Fork shares blobs, per-trace sinces (chosen).** Writes above `branch_ts` need isolation regardless, so separate traces plus blob sharing gets the boundary semantics with least machinery.
+- **Native multi-`since` on a single shard.** More general (time travel, many readers at different frontiers), but a large persist change.
+
+### Retention
+
+- **Use the existing collection path (chosen).** The pin is a retained reference on a normal state transition, and collection is unchanged in spirit.
+- **A dedicated blob-reference table or per-blob refcounts.** Both require additional metadata management, and refcounts fight persist's immutable-blob model.
+
+### Retention granularity
+
+- **Pin the specific inherited keys (chosen).** Retention stays proportional to the branch point.
+- **Hold a seqno at `branch_ts`.** Reuses existing machinery, no new reference kind, but `seqno_since` is a single watermark so it over-retains all of production's since-compacted history for the branch's life.


### PR DESCRIPTION
Introduce the cluster branches design: a copy-on-write fork of one or more clusters that reads production's live data in place and copies only the tables it writes, giving an agent a sub-second, live, isolated sandbox to test and measure dataflow changes before proposing them.

Covers scope, usage, the read/copy model, catalog identity and the session resolution overlay, lifecycle and RBAC, plus two detailed sub-docs: copy-on-write in persist and arrangement-checkpoint hydration.