### PR TITLE
ci: fix dependabot coverage for cargo-fuzz and console/misc/docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,16 @@
 version: 2
 updates:
+# `/test/cargo-fuzz` is deliberately absent. The fuzz crates reach the root
+# workspace through `path` dependencies, so dependabot resolves that directory to
+# the root `Cargo.toml` and proposes edits to it while owning neither the root
+# `Cargo.lock` nor the fuzz manifests. Every such PR fails `--locked` and
+# duplicates the `/` PR for the same crate. Keeping the fuzz pins equal to the
+# root is enforced by `check_fuzz_versions_mirror_root` in `bin/lint-cargo`
+# instead, so a semver-incompatible root bump has to update the affected
+# `src/*/fuzz/Cargo.toml` by hand in the same PR.
 - package-ecosystem: cargo
   directories:
     - /
-    - /test/cargo-fuzz
   schedule:
     interval: weekly
     day: sunday
@@ -82,113 +89,16 @@ updates:
         - minor
         - patch
 - package-ecosystem: docker
-  directory: /console
-  schedule:
-    interval: weekly
-    day: sunday
-    time: "22:00"
-  # TODO: Add cooldown when https://github.com/dependabot/dependabot-core/issues/14044 is fixed
-  open-pull-requests-limit: 50
-  labels: [A-dependencies]
-  groups:
-    simple:
-      applies-to: version-updates
-      update-types:
-        - minor
-        - patch
-- package-ecosystem: docker
-  directory: /console/misc/docker
-  directory: /misc/images/materialized-base
-  schedule:
-    interval: weekly
-    day: sunday
-    time: "22:00"
-  # TODO: Add cooldown when https://github.com/dependabot/dependabot-core/issues/14044 is fixed
-  open-pull-requests-limit: 50
-  labels: [A-dependencies]
-  groups:
-    simple:
-      applies-to: version-updates
-      update-types:
-        - minor
-        - patch
-- package-ecosystem: docker
-  directory: /misc/images/debian-base
-  schedule:
-    interval: weekly
-    day: sunday
-    time: "22:00"
-  # TODO: Add cooldown when https://github.com/dependabot/dependabot-core/issues/14044 is fixed
-  open-pull-requests-limit: 50
-  labels: [A-dependencies]
-  groups:
-    simple:
-      applies-to: version-updates
-      update-types:
-        - minor
-        - patch
-- package-ecosystem: docker
-  directory: /misc/images/openssh-static
-  schedule:
-    interval: weekly
-    day: sunday
-    time: "22:00"
-  # TODO: Add cooldown when https://github.com/dependabot/dependabot-core/issues/14044 is fixed
-  open-pull-requests-limit: 50
-  labels: [A-dependencies]
-  groups:
-    simple:
-      applies-to: version-updates
-      update-types:
-        - minor
-        - patch
-- package-ecosystem: docker
-  directory: /misc/images/tini-static
-  schedule:
-    interval: weekly
-    day: sunday
-    time: "22:00"
-  # TODO: Add cooldown when https://github.com/dependabot/dependabot-core/issues/14044 is fixed
-  open-pull-requests-limit: 50
-  labels: [A-dependencies]
-  groups:
-    simple:
-      applies-to: version-updates
-      update-types:
-        - minor
-        - patch
-- package-ecosystem: docker
-  directory: /misc/images/distroless-prod-base
-  schedule:
-    interval: weekly
-    day: sunday
-    time: "22:00"
-  # TODO: Add cooldown when https://github.com/dependabot/dependabot-core/issues/14044 is fixed
-  open-pull-requests-limit: 50
-  labels: [A-dependencies]
-  groups:
-    simple:
-      applies-to: version-updates
-      update-types:
-        - minor
-        - patch
-- package-ecosystem: docker
-  directory: /ci/builder
-  schedule:
-    interval: weekly
-    day: sunday
-    time: "22:00"
-  # TODO: Add cooldown when https://github.com/dependabot/dependabot-core/issues/14044 is fixed
-  open-pull-requests-limit: 50
-  labels: [A-dependencies]
-  groups:
-    simple:
-      applies-to: version-updates
-      update-types:
-        - minor
-        - patch
-- package-ecosystem: docker
-  directory: /test
+  directories:
+    - /console
+    - /console/misc/docker
+    - /misc/images/materialized-base
+    - /misc/images/debian-base
+    - /misc/images/openssh-static
+    - /misc/images/tini-static
+    - /misc/images/distroless-prod-base
+    - /ci/builder
+    - /test
   schedule:
     interval: weekly
     day: sunday

--- a/console/misc/docker/Dockerfile
+++ b/console/misc/docker/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM node:20-alpine AS builder
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Two configured directories were not actually covered, in opposite ways.

`/test/cargo-fuzz` produced only unmergeable PRs. The fuzz crates reach the root workspace through `path` dependencies, so dependabot resolves that directory to the root `Cargo.toml` and edits it while owning neither the root `Cargo.lock` nor the fuzz manifests. Thirteen such PRs have opened, none merged, and no dependabot commit ever touched `src/*/fuzz/Cargo.toml`. Drop it, and say why in a comment. `check_fuzz_versions_mirror_root` in `bin/lint-cargo` still enforces the pins, tripping only on a semver-incompatible root bump.

`/console/misc/docker` was added as a second `directory:` key in an existing entry, and YAML keeps only the last, so it resolved to `/misc/images/materialized-base`. Collapse the eight byte-identical docker entries into one `directories:` list rather than add a ninth. Dependabot can now group updates across docker directories into one PR.

Pin that Dockerfile's builder by multi-arch index digest, matching the nginx base in the same file, so the new coverage has something stable to refresh.