### PR TITLE
timely-util: measure serialized column body lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8998,6 +8998,7 @@ dependencies = [
  "lz4_flex",
  "mz-ore",
  "num-traits",
+ "prometheus",
  "proptest",
  "rand 0.9.4",
  "serde",

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -500,6 +500,90 @@ metrics:
   - server_name
   source: src/service/src/transport/metrics.rs
   visibility: internal
+- name: mz_column_align_buffer_bytes_minted_total
+  help: Allocation bytes of serialized column bodies minted.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_drops_total
+  help: Serialized column bodies dropped.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_inflight_bytes
+  help: Allocation bytes of serialized column bodies currently alive.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_inflight_bytes_peak
+  help: High-water mark of allocation bytes of serialized column bodies alive at once.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_inflight_count
+  help: Serialized column bodies currently alive.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_lifetime_max_nanoseconds
+  help: High-water mark of a serialized column body's life, uncapped by histogram buckets.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_lifetime_seconds_bucket
+  help: Time from minting a serialized column body to dropping it.
+  labels:
+  - le
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_lifetime_seconds_count
+  help: Time from minting a serialized column body to dropping it.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_lifetime_seconds_sum
+  help: Time from minting a serialized column body to dropping it.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_mints_total
+  help: Serialized column bodies minted.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_size_bytes_bucket
+  help: Allocation size of serialized column bodies at mint.
+  labels:
+  - le
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_size_bytes_count
+  help: Allocation size of serialized column bodies at mint.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_size_bytes_sum
+  help: Allocation size of serialized column bodies at mint.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_tracking_enabled
+  help: Whether align-buffer lifetime recording is on. Every other align-buffer metric is frozen while this is zero.
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
 - name: mz_column_pager_budget_configured_bytes
   help: Most-recently-configured total budget for the column-pager tiered policy.
   source: src/timely-util/src/column_pager/metrics.rs

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -256,6 +256,13 @@ def get_variable_system_parameters(
             "true",
             ["true", "false"],
         ),
+        # On by default in tests so the recording path is exercised, while
+        # production keeps the code default of off.
+        VariableSystemParameter(
+            "enable_column_align_buffer_tracking",
+            "true",
+            ["true", "false"],
+        ),
         VariableSystemParameter(
             "enable_adapter_frontend_occ_read_then_write",
             "true" if version >= MzVersion.parse_mz("v26.36.0-dev") else "false",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3058,6 +3058,9 @@ class FlipFlagsAction(Action):
             "0.01",
             "0.02",
         ]
+        self.flags_with_values["enable_column_align_buffer_tracking"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_upsert_paged_spill"] = BOOLEAN_FLAG_VALUES
         # 0 forces the estimated-size path for every table, the default forces
         # the exact COUNT(*) path for workload-sized tables.

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -176,6 +176,26 @@ pub const COLUMN_PAGED_BATCHER_POOL_RSS_TARGET_FRACTION: Config<f64> = Config::n
 )
 .scoped(ParameterScope::Replica);
 
+/// Record how long serialized column bodies (`Column::Align` payloads) live
+/// and how many bytes of them are alive at once, per producing origin, as
+/// `mz_column_align_buffer_*`.
+///
+/// A body on a dataflow edge is owned by whoever holds the container, outside
+/// the buffer pool's ledger, so its bytes are invisible to pool pressure
+/// decisions. That is the population the metrics are for; bodies retained by a
+/// sink or a merge chain, and bodies a read produced, are recorded under their
+/// own origins so they can be told apart from the edges.
+///
+/// Off in production because recording costs an `Instant::now` and a handful
+/// of atomics per body, on a path that mints one per shipped chunk. On in the
+/// test configuration so the recording path is exercised.
+pub const ENABLE_COLUMN_ALIGN_BUFFER_TRACKING: Config<bool> = Config::new(
+    "enable_column_align_buffer_tracking",
+    false,
+    "Record lifetime and in-flight-byte metrics for serialized column bodies, per origin.",
+)
+.scoped(ParameterScope::Replica);
+
 /// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
 pub const ENABLE_MZ_JOIN_CORE: Config<bool> = Config::new(
     "enable_mz_join_core",
@@ -601,4 +621,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COLUMN_PAGED_BATCHER_SPILL_WORKER_COUNT)
         .add(&COLUMN_PAGED_BATCHER_EAGER_BACKING)
         .add(&COLUMN_PAGED_BATCHER_POOL_RSS_TARGET_FRACTION)
+        .add(&ENABLE_COLUMN_ALIGN_BUFFER_TRACKING)
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -430,6 +430,13 @@ impl ComputeState {
             }
         }
 
+        // Serialized column bodies are minted from operator code with no
+        // handle on the config set, so the gate is a process-global flag the
+        // config apply writes. Flips take effect for bodies minted afterwards.
+        mz_timely_util::columnar::align_buffer::metrics::set_tracking_enabled(
+            ENABLE_COLUMN_ALIGN_BUFFER_TRACKING.get(config),
+        );
+
         // Remember the maintenance interval locally to avoid reading it from the config set on
         // every server iteration.
         self.server_maintenance_interval = COMPUTE_SERVER_MAINTENANCE_INTERVAL.get(config);

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -106,6 +106,7 @@ pub async fn serve(
         mz_timely_util::column_pager::tiered_policy(),
     );
     mz_timely_util::pool_config::metrics::register(metrics_registry);
+    mz_timely_util::columnar::align_buffer::metrics::register(metrics_registry);
 
     let config = Config {
         persist_clients,

--- a/src/compute/src/sink/correction_v2.rs
+++ b/src/compute/src/sink/correction_v2.rs
@@ -1511,7 +1511,12 @@ struct ChunkBuilder<D: Data> {
 impl<D: Data> Default for ChunkBuilder<D> {
     fn default() -> Self {
         Self {
-            inner: Default::default(),
+            // These chunks are retained in the correction chains across
+            // timestamps rather than shipped, so they are stamped apart from
+            // dataflow-edge traffic in the align-buffer metrics.
+            inner: mz_timely_util::columnar::builder::ColumnBuilder::with_origin(
+                mz_timely_util::columnar::align_buffer::Origin::Correction,
+            ),
         }
     }
 }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -53,6 +53,7 @@ allocation-counter = { workspace = true, optional = true }
 [dev-dependencies]
 criterion.workspace = true
 itertools.workspace = true
+prometheus.workspace = true
 proptest.workspace = true
 rand.workspace = true
 tempfile.workspace = true

--- a/src/timely-util/src/column_pager.rs
+++ b/src/timely-util/src/column_pager.rs
@@ -46,6 +46,7 @@ use timely::bytes::arc::BytesMut;
 use timely::dataflow::channels::ContainerBytes;
 
 use crate::columnar::Column;
+use crate::columnar::align_buffer::{AlignBuffer, Origin};
 
 /// Compression codec applied to a paged-out column.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -367,7 +368,7 @@ impl ColumnPager {
     ///
     /// Backend / codec semantics:
     ///
-    /// * Uncompressed, [`Column::Align`]: the inner `Vec<u64>` is moved into
+    /// * Uncompressed, [`Column::Align`]: the buffer's allocation is moved into
     ///   the pager handle with no copies. Swap backend keeps the allocation
     ///   resident; file backend writes it out and drops it.
     /// * Uncompressed, other variants: the column is serialized via
@@ -405,7 +406,10 @@ impl ColumnPager {
                     col.into_bytes(&mut buf);
                     mz_ore::soft_assert_eq_no_log!(buf.len() % 8, 0);
                     col.clear();
-                    Column::Align(bytemuck::allocation::pod_collect_to_vec::<u8, u64>(&buf))
+                    Column::Align(AlignBuffer::from_words(
+                        Origin::Pager,
+                        bytemuck::allocation::pod_collect_to_vec::<u8, u64>(&buf),
+                    ))
                 } else {
                     std::mem::take(col)
                 };
@@ -424,8 +428,10 @@ impl ColumnPager {
                 let body: Vec<u64> = match std::mem::take(col) {
                     // Move the aligned buffer straight into the pager: the
                     // allocation transfers with no copy. `take` already left
-                    // `col` as a refill-ready `Typed` default.
-                    Column::Align(v) => v,
+                    // `col` as a refill-ready `Typed` default. The buffer's
+                    // tracked life ends here, where it stops being a column
+                    // body and becomes pager-owned storage.
+                    Column::Align(v) => v.into_words(),
                     mut other => {
                         let mut buf = Vec::with_capacity(len_bytes);
                         other.into_bytes(&mut buf);
@@ -517,7 +523,7 @@ impl ColumnPager {
                 self.policy.record(PageEvent::PagedIn {
                     bytes: meta.len_bytes,
                 });
-                Column::Align(body)
+                Column::Align(AlignBuffer::from_words(Origin::Fetch, body))
             }
             PagedColumn::Compressed { inner, meta } => {
                 let mut decoded = Vec::with_capacity(meta.len_bytes);
@@ -766,7 +772,8 @@ mod tests {
         });
         let cp = ColumnPager::new(as_dyn(&policy));
         let body: Vec<u64> = (1u64..=512).collect();
-        let mut col: Column<i64> = Column::Align(body.clone());
+        let mut col: Column<i64> =
+            Column::Align(AlignBuffer::from_words(Origin::Pager, body.clone()));
         let paged = cp.page(&mut col);
         assert!(matches!(paged, PagedColumn::Paged { .. }));
         // After paging an Align variant, `col` is reset to the typed default.
@@ -774,7 +781,7 @@ mod tests {
         let rt = cp.take(paged);
         // Round-tripped column should produce identical bytes.
         match rt {
-            Column::Align(v) => assert_eq!(v, body),
+            Column::Align(v) => assert_eq!(v.as_words(), body),
             other => panic!("expected Align, got {:?}", std::mem::discriminant(&other)),
         }
     }

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -17,6 +17,7 @@
 
 #![deny(missing_docs)]
 
+pub mod align_buffer;
 pub mod batcher;
 pub mod builder;
 pub mod builder_input;
@@ -39,6 +40,7 @@ use timely::bytes::arc::Bytes;
 use timely::container::{DrainContainer, PushInto, SizableContainer};
 use timely::dataflow::channels::ContainerBytes;
 
+use crate::columnar::align_buffer::{AlignBuffer, Origin};
 use crate::columnation::ColInternalMerger;
 
 /// A batcher for columnar storage.
@@ -79,8 +81,8 @@ pub enum Column<C: Columnar> {
     /// Reasons could include misalignment, cloning of data, or wanting
     /// to release the `Bytes` as a scarce resource.
     ///
-    /// `Vec<u64>` guarantees `u64` alignment for the contained bytes.
-    Align(Vec<u64>),
+    /// [`AlignBuffer`] guarantees `u64` alignment for the contained bytes.
+    Align(AlignBuffer),
 }
 
 impl<C: Columnar> Column<C> {
@@ -143,7 +145,10 @@ where
             Column::Typed(t) => Column::Typed(t.clone()),
             Column::Bytes(b) => {
                 assert_eq!(b.len() % 8, 0);
-                Self::Align(bytemuck::allocation::pod_collect_to_vec(b))
+                Self::Align(AlignBuffer::from_words(
+                    Origin::Decode,
+                    bytemuck::allocation::pod_collect_to_vec(b),
+                ))
             }
             Column::Align(a) => Column::Align(a.clone()),
         }
@@ -246,7 +251,10 @@ impl<C: Columnar> ContainerBytes for Column<C> {
         } else {
             // We failed to cast the slice, so we'll reallocate. `Vec<u64>`
             // is u64-aligned by construction.
-            Self::Align(bytemuck::allocation::pod_collect_to_vec(&bytes[..]))
+            Self::Align(AlignBuffer::from_words(
+                Origin::Decode,
+                bytemuck::allocation::pod_collect_to_vec(&bytes[..]),
+            ))
         }
     }
 
@@ -264,7 +272,9 @@ impl<C: Columnar> ContainerBytes for Column<C> {
         match self {
             Column::Typed(t) => indexed::write(writer, &t.borrow()).unwrap(),
             Column::Bytes(b) => writer.write_all(b).unwrap(),
-            Column::Align(a) => writer.write_all(bytemuck::cast_slice(a)).unwrap(),
+            Column::Align(a) => writer
+                .write_all(bytemuck::cast_slice(a.as_words()))
+                .unwrap(),
         }
     }
 }
@@ -328,7 +338,8 @@ mod tests {
         let mut region: Vec<u64> = vec![0; raw.len() / 8];
         let region_bytes = bytemuck::cast_slice_mut(&mut region[..]);
         region_bytes[..raw.len()].copy_from_slice(&raw);
-        let column_align: Column<i32> = Column::Align(region);
+        let column_align: Column<i32> =
+            Column::Align(AlignBuffer::from_words(Origin::Decode, region));
         let column_align2 = column_align.clone();
 
         assert_eq!(

--- a/src/timely-util/src/columnar/align_buffer.rs
+++ b/src/timely-util/src/columnar/align_buffer.rs
@@ -1,0 +1,255 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! [`AlignBuffer`]: the owned serialized body behind
+//! [`Column::Align`](crate::columnar::Column::Align), and the instrumentation
+//! that measures how long such bodies live.
+//!
+//! Every `Column::Align` payload is one of these. The population is wider than
+//! the bodies in flight between operators: it also covers bodies deliberately
+//! retained by a sink or a merge chain, bodies relocated off the network, and
+//! bodies copied out of a backing store. Each buffer records the [`Origin`]
+//! that minted it, so those groups can be read apart.
+//!
+//! A buffer is immutable once built. Every constructor sizes it before the
+//! value exists, which is what lets the tracker charge a byte count that stays
+//! correct for the buffer's whole life.
+//!
+//! See [`metrics`] for what is recorded and how to turn recording on.
+
+use std::ops::Deref;
+
+use columnar::AsBytes;
+use columnar::bytes::indexed;
+
+pub mod metrics;
+
+/// What minted a buffer. Recorded per buffer so the metrics separate bodies in
+/// flight on a dataflow edge from bodies that are retained on purpose or that a
+/// read produced.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Origin {
+    /// Shipped by [`ColumnBuilder`](crate::columnar::builder::ColumnBuilder):
+    /// a body on a dataflow edge.
+    Ship,
+    /// Shipped by
+    /// [`ConsolidatingColumnBuilder`](crate::columnar::consolidate::ConsolidatingColumnBuilder):
+    /// also a body on a dataflow edge.
+    Consolidate,
+    /// Minted by the container builder behind the materialized-view sink's
+    /// correction buffer, which holds its chunks across timestamps. Split out
+    /// from [`Origin::Ship`] because a retained body's life says nothing about
+    /// a body in flight on an edge.
+    Correction,
+    /// Serialized to a fitting size by the column pager, which does this to
+    /// every typed body it is handed, before parking or paging it. Covers both
+    /// arrangement merge chains and the sink correction chains, which route
+    /// through the pager whatever the batcher gate says. A correction chunk the
+    /// builder minted itself is [`Origin::Correction`]; one the pager
+    /// serialized lands here.
+    Pager,
+    /// Copied out of a backing store to serve a read.
+    Fetch,
+    /// Relocated from received bytes that could not be borrowed in place,
+    /// because of misalignment or because a clone was needed.
+    Decode,
+}
+
+impl Origin {
+    /// Every origin, in metric-label order.
+    pub const ALL: [Origin; 6] = [
+        Origin::Ship,
+        Origin::Consolidate,
+        Origin::Correction,
+        Origin::Pager,
+        Origin::Fetch,
+        Origin::Decode,
+    ];
+
+    /// The `origin` metric label value.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Origin::Ship => "ship",
+            Origin::Consolidate => "consolidate",
+            Origin::Correction => "correction",
+            Origin::Pager => "pager",
+            Origin::Fetch => "fetch",
+            Origin::Decode => "decode",
+        }
+    }
+
+    /// This origin's index into the per-origin counter array.
+    const fn index(self) -> usize {
+        match self {
+            Origin::Ship => 0,
+            Origin::Consolidate => 1,
+            Origin::Correction => 2,
+            Origin::Pager => 3,
+            Origin::Fetch => 4,
+            Origin::Decode => 5,
+        }
+    }
+}
+
+/// An owned, immutable, `u64`-aligned serialized column body: the payload of
+/// [`Column::Align`](crate::columnar::Column::Align).
+///
+/// `u64` alignment is what lets
+/// [`Column::borrow`](crate::columnar::Column::borrow) decode the body in
+/// place, so the words are held as a `Vec<u64>` rather than a `Vec<u8>`.
+pub struct AlignBuffer {
+    words: Vec<u64>,
+    origin: Origin,
+    /// The mint instant and the bytes charged to the in-flight gauges, present
+    /// exactly when tracking was on at construction.
+    ///
+    /// The charge is stored rather than recomputed at drop because
+    /// [`metrics::set_tracking_enabled`] can flip while buffers are in flight.
+    /// Crediting back a buffer that was never charged would walk the gauges
+    /// away from the truth, and the arithmetic is unsigned.
+    charge: Option<metrics::Charge>,
+}
+
+impl AlignBuffer {
+    /// Serializes `item`'s columnar byte slices into a buffer sized to fit
+    /// them exactly.
+    ///
+    /// `indexed::encode` appends through `push`/`extend_from_slice`, so an
+    /// exact `with_capacity` means no word is written twice and no word is
+    /// zero-initialized before its real value lands.
+    pub fn encode<'a, A>(origin: Origin, item: &A) -> Self
+    where
+        A: AsBytes<'a>,
+    {
+        let mut words = Vec::with_capacity(indexed::length_in_words(item));
+        indexed::encode(&mut words, item);
+        Self::from_words(origin, words)
+    }
+
+    /// Builds a buffer by filling a `Vec<u64>` in place, for producers whose
+    /// length only the filler knows, such as a copy-out from a backing store.
+    pub fn build(origin: Origin, fill: impl FnOnce(&mut Vec<u64>)) -> Self {
+        let mut words = Vec::new();
+        fill(&mut words);
+        Self::from_words(origin, words)
+    }
+
+    /// Takes ownership of an already-serialized buffer.
+    pub fn from_words(origin: Origin, words: Vec<u64>) -> Self {
+        let charge = metrics::record_mint(origin, words.capacity());
+        AlignBuffer {
+            words,
+            origin,
+            charge,
+        }
+    }
+
+    /// Surrenders the allocation to a caller that will own it from here on.
+    /// The buffer's tracked life ends at this call, not when the returned
+    /// `Vec` is dropped.
+    pub fn into_words(mut self) -> Vec<u64> {
+        self.release();
+        std::mem::take(&mut self.words)
+    }
+
+    /// The serialized body.
+    ///
+    /// [`Deref`] covers call sites whose parameter type is a slice; this
+    /// exists for the ones that are generic over it, where deref coercion has
+    /// nothing to coerce toward.
+    #[inline]
+    pub fn as_words(&self) -> &[u64] {
+        &self.words
+    }
+
+    /// What minted this buffer.
+    pub fn origin(&self) -> Origin {
+        self.origin
+    }
+
+    /// Records the end of the tracked life, at most once.
+    fn release(&mut self) {
+        if let Some(charge) = self.charge.take() {
+            metrics::record_drop(self.origin, charge);
+        }
+    }
+}
+
+impl Deref for AlignBuffer {
+    type Target = [u64];
+    #[inline]
+    fn deref(&self) -> &[u64] {
+        &self.words
+    }
+}
+
+impl Clone for AlignBuffer {
+    /// A clone is a separate allocation with its own life, so it is minted and
+    /// tracked in its own right. It inherits the origin, because a body cloned
+    /// to fan out to a second consumer is still on the edge that produced it.
+    fn clone(&self) -> Self {
+        Self::from_words(self.origin, self.words.clone())
+    }
+}
+
+impl Drop for AlignBuffer {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+impl std::fmt::Debug for AlignBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AlignBuffer")
+            .field("origin", &self.origin)
+            .field("words", &self.words.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Origin indices are dense and distinct, which the counter array indexes
+    /// by without a bounds story of its own.
+    #[mz_ore::test]
+    fn origin_indices_are_dense() {
+        for (expected, origin) in Origin::ALL.into_iter().enumerate() {
+            assert_eq!(origin.index(), expected, "{origin:?}");
+        }
+    }
+
+    /// Labels are distinct, so the metric series do not collide.
+    #[mz_ore::test]
+    fn origin_labels_are_distinct() {
+        let mut labels: Vec<_> = Origin::ALL.iter().map(|o| o.label()).collect();
+        labels.sort_unstable();
+        let count = labels.len();
+        labels.dedup();
+        assert_eq!(labels.len(), count);
+    }
+
+    /// `into_words` hands out the same bytes the buffer held.
+    #[mz_ore::test]
+    fn into_words_round_trips() {
+        let buf = AlignBuffer::from_words(Origin::Ship, vec![1, 2, 3]);
+        assert_eq!(&*buf, &[1, 2, 3]);
+        assert_eq!(buf.into_words(), vec![1, 2, 3]);
+    }
+
+    /// A clone is independent of its source and keeps the origin.
+    #[mz_ore::test]
+    fn clone_inherits_origin() {
+        let buf = AlignBuffer::from_words(Origin::Decode, vec![7; 4]);
+        let clone = buf.clone();
+        assert_eq!(clone.origin(), Origin::Decode);
+        assert_eq!(&*clone, &*buf);
+    }
+}

--- a/src/timely-util/src/columnar/align_buffer/metrics.rs
+++ b/src/timely-util/src/columnar/align_buffer/metrics.rs
@@ -1,0 +1,258 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Lifetime and footprint instrumentation for
+//! [`AlignBuffer`](super::AlignBuffer), keyed by [`Origin`].
+//!
+//! Recording answers two questions per origin: how long a serialized body
+//! stays alive, and how many bytes of them are alive at once.
+//!
+//! Both are read per origin because the answer differs by producer. Bodies on a
+//! dataflow edge ([`Origin::Ship`], [`Origin::Consolidate`]) are the ones the
+//! question is about: they are owned by whoever holds the container and belong
+//! to no budget. The other origins are recorded so they can be told apart from
+//! the edges, not because they share their behavior. [`Origin::Correction`]
+//! and [`Origin::Pager`] bodies are retained on purpose, and [`Origin::Fetch`]
+//! and [`Origin::Decode`] bodies come from a read rather than a producer.
+//!
+//! Recording is off until [`set_tracking_enabled`], because it costs an
+//! [`Instant::now`] and a handful of atomics per buffer, on a path that mints
+//! one buffer per shipped chunk. Consult
+//! [`mz_column_align_buffer_tracking_enabled`](register) before reading a zero
+//! as an absence of traffic.
+//!
+//! The gate may flip while buffers are in flight. A buffer minted while
+//! recording was off carries no charge and stays uncounted for its whole life,
+//! so the in-flight gauges never credit back bytes they were never charged. The
+//! consequence is that the gauges undercount until every buffer that predates
+//! the flip has died.
+//!
+//! Tests live in `tests/align_buffer_metrics.rs`: the gate and the registration
+//! are process-global, so anything asserting on them needs a binary where it is
+//! the only test.
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Instant;
+
+use mz_ore::cast::{CastFrom, CastLossy};
+use mz_ore::metric;
+use mz_ore::metrics::raw::HistogramVec;
+use mz_ore::metrics::{ComputedUIntGauge, Histogram, MakeCollectorOpts, MetricsRegistry};
+use mz_ore::stats::histogram_seconds_buckets;
+
+use super::Origin;
+
+/// Whether buffers record their life. Read once per mint.
+static TRACKING: AtomicBool = AtomicBool::new(false);
+
+/// Per-origin counters, indexed by `Origin::index`.
+static COUNTERS: [Counters; Origin::ALL.len()] = [
+    Counters::new(),
+    Counters::new(),
+    Counters::new(),
+    Counters::new(),
+    Counters::new(),
+    Counters::new(),
+];
+
+/// The per-origin histogram handles, resolved once by [`register`]. Absent
+/// until then, which is the normal state in tests and benches, where the
+/// counters still work and only the distributions are skipped.
+static HISTOGRAMS: OnceLock<Histograms> = OnceLock::new();
+
+/// Size classes to grade buffers against, in bytes. Powers of two spanning the
+/// buffer pool's size classes (64 KiB to 8 MiB) with a rung either side, so a
+/// distribution that piles up just under a class boundary is visible as such.
+const SIZE_BUCKETS: [f64; 13] = [
+    4096.0,
+    8192.0,
+    16384.0,
+    32768.0,
+    65536.0,
+    131_072.0,
+    262_144.0,
+    524_288.0,
+    1_048_576.0,
+    2_097_152.0,
+    4_194_304.0,
+    8_388_608.0,
+    16_777_216.0,
+];
+
+/// One origin's counters. Levels and monotonic totals both live here; the
+/// `_total` suffix on a metric name, not its type, marks it monotonic.
+struct Counters {
+    mints: AtomicU64,
+    drops: AtomicU64,
+    bytes_minted: AtomicU64,
+    inflight_bytes: AtomicU64,
+    inflight_count: AtomicU64,
+    inflight_bytes_peak: AtomicU64,
+    lifetime_max_nanos: AtomicU64,
+}
+
+impl Counters {
+    const fn new() -> Counters {
+        Counters {
+            mints: AtomicU64::new(0),
+            drops: AtomicU64::new(0),
+            bytes_minted: AtomicU64::new(0),
+            inflight_bytes: AtomicU64::new(0),
+            inflight_count: AtomicU64::new(0),
+            inflight_bytes_peak: AtomicU64::new(0),
+            lifetime_max_nanos: AtomicU64::new(0),
+        }
+    }
+}
+
+/// Pre-resolved per-origin histograms, so recording a sample is an array index
+/// rather than a label lookup under the vec's lock.
+struct Histograms {
+    lifetime: [Histogram; Origin::ALL.len()],
+    size: [Histogram; Origin::ALL.len()],
+}
+
+/// What a tracked buffer carries for the duration of its life. The byte count
+/// is the one charged at mint, so the credit at drop matches it exactly even
+/// if the gate flipped in between.
+pub(super) struct Charge {
+    minted: Instant,
+    bytes: u64,
+}
+
+fn counters(origin: Origin) -> &'static Counters {
+    &COUNTERS[origin.index()]
+}
+
+/// Turns recording on or off for this process. Takes effect for buffers minted
+/// after the call; buffers already in flight keep the tracking state they were
+/// minted with.
+pub fn set_tracking_enabled(enabled: bool) {
+    TRACKING.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether recording is on.
+pub fn tracking_enabled() -> bool {
+    TRACKING.load(Ordering::Relaxed)
+}
+
+/// Charges a newly minted buffer of `capacity_words` words, returning what it
+/// must carry to be credited back at drop, or `None` when recording is off.
+pub(super) fn record_mint(origin: Origin, capacity_words: usize) -> Option<Charge> {
+    if !TRACKING.load(Ordering::Relaxed) {
+        return None;
+    }
+    let bytes = u64::cast_from(capacity_words) * 8;
+    let counters = counters(origin);
+    counters.mints.fetch_add(1, Ordering::Relaxed);
+    counters.bytes_minted.fetch_add(bytes, Ordering::Relaxed);
+    counters.inflight_count.fetch_add(1, Ordering::Relaxed);
+    // `fetch_add` returns the previous value, so the level after this mint is
+    // the sum. Two concurrent mints can each miss the other's contribution to
+    // the peak, which understates it by at most one buffer per race.
+    let inflight = counters.inflight_bytes.fetch_add(bytes, Ordering::Relaxed) + bytes;
+    counters
+        .inflight_bytes_peak
+        .fetch_max(inflight, Ordering::Relaxed);
+    if let Some(histograms) = HISTOGRAMS.get() {
+        histograms.size[origin.index()].observe(f64::cast_lossy(bytes));
+    }
+    Some(Charge {
+        minted: Instant::now(),
+        bytes,
+    })
+}
+
+/// Credits back a buffer whose life just ended, and records how long it lasted.
+pub(super) fn record_drop(origin: Origin, charge: Charge) {
+    let elapsed = charge.minted.elapsed();
+    let counters = counters(origin);
+    counters.drops.fetch_add(1, Ordering::Relaxed);
+    counters
+        .inflight_bytes
+        .fetch_sub(charge.bytes, Ordering::Relaxed);
+    counters.inflight_count.fetch_sub(1, Ordering::Relaxed);
+    // Histogram buckets are capped, and the top of the distribution is the
+    // whole question here, so keep an uncapped high-water mark beside them.
+    // This is not hypothetical: a 1.9x-oversubscribed replica put 1.8% of its
+    // bodies past the top bucket, and only this gauge recovered the 142s peak.
+    let nanos = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
+    counters
+        .lifetime_max_nanos
+        .fetch_max(nanos, Ordering::Relaxed);
+    if let Some(histograms) = HISTOGRAMS.get() {
+        histograms.lifetime[origin.index()].observe(elapsed.as_secs_f64());
+    }
+}
+
+/// Installs the align-buffer metrics into `registry`. Idempotent; repeated
+/// calls after the first are no-ops.
+pub fn register(registry: &MetricsRegistry) {
+    static REGISTERED: OnceLock<()> = OnceLock::new();
+    REGISTERED.get_or_init(|| {
+        // Every name and help string is a literal at the `metric!` call so the
+        // metrics-catalog scanner (`bin/gen-metrics-catalog`), which reads the
+        // source rather than the expanded macro, can index them.
+        let lifetime: HistogramVec = registry.register(metric!(
+            name: "mz_column_align_buffer_lifetime_seconds",
+            help: "Time from minting a serialized column body to dropping it.",
+            var_labels: ["origin"],
+            // Ceiling from measurement, not taste: on a replica whose working
+            // set was ~1.9x its RAM, 1.8% of bodies outlived 64s and the
+            // longest reached 142s, which censored p99 into `+Inf` and made it
+            // unrecoverable from the buckets. 1024s leaves room for a deeper
+            // pressure regime to still resolve its tail.
+            buckets: histogram_seconds_buckets(0.000_008, 1024.0),
+        ));
+        let size: HistogramVec = registry.register(metric!(
+            name: "mz_column_align_buffer_size_bytes",
+            help: "Allocation size of serialized column bodies at mint.",
+            var_labels: ["origin"],
+            buckets: SIZE_BUCKETS.to_vec(),
+        ));
+        let histograms = Histograms {
+            lifetime: Origin::ALL.map(|origin| lifetime.with_label_values(&[origin.label()])),
+            size: Origin::ALL.map(|origin| size.with_label_values(&[origin.label()])),
+        };
+        // Only `register` writes this, under `get_or_init`, so it cannot lose.
+        let _ = HISTOGRAMS.set(histograms);
+
+        let _tracking: ComputedUIntGauge = registry.register_computed_gauge(
+            metric!(
+                name: "mz_column_align_buffer_tracking_enabled",
+                help: "Whether align-buffer lifetime recording is on. Every other align-buffer metric is frozen while this is zero.",
+            ),
+            || u64::from(tracking_enabled()),
+        );
+
+        for origin in Origin::ALL {
+            let label = origin.label();
+            gauge(registry, metric!(name: "mz_column_align_buffer_mints_total", help: "Serialized column bodies minted.", const_labels: {"origin" => label}), origin, |c| c.mints.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_drops_total", help: "Serialized column bodies dropped.", const_labels: {"origin" => label}), origin, |c| c.drops.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_bytes_minted_total", help: "Allocation bytes of serialized column bodies minted.", const_labels: {"origin" => label}), origin, |c| c.bytes_minted.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_inflight_bytes", help: "Allocation bytes of serialized column bodies currently alive.", const_labels: {"origin" => label}), origin, |c| c.inflight_bytes.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_inflight_count", help: "Serialized column bodies currently alive.", const_labels: {"origin" => label}), origin, |c| c.inflight_count.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_inflight_bytes_peak", help: "High-water mark of allocation bytes of serialized column bodies alive at once.", const_labels: {"origin" => label}), origin, |c| c.inflight_bytes_peak.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_lifetime_max_nanoseconds", help: "High-water mark of a serialized column body's life, uncapped by histogram buckets.", const_labels: {"origin" => label}), origin, |c| c.lifetime_max_nanos.load(Ordering::Relaxed));
+        }
+    });
+}
+
+/// Registers one computed gauge over one origin's counters, read at scrape
+/// time.
+fn gauge(
+    registry: &MetricsRegistry,
+    opts: MakeCollectorOpts,
+    origin: Origin,
+    field: fn(&Counters) -> u64,
+) {
+    let _gauge: ComputedUIntGauge =
+        registry.register_computed_gauge(opts, move || field(counters(origin)));
+}

--- a/src/timely-util/src/columnar/builder.rs
+++ b/src/timely-util/src/columnar/builder.rs
@@ -17,12 +17,12 @@
 
 use std::collections::VecDeque;
 
-use columnar::bytes::indexed;
 use columnar::{Clear, Columnar, Len, Push};
 use timely::container::PushInto;
 use timely::container::{ContainerBuilder, LengthPreservingContainerBuilder};
 
 use crate::columnar::Column;
+use crate::columnar::align_buffer::{AlignBuffer, Origin};
 
 /// A container builder for `Column<C>`.
 pub struct ColumnBuilder<C: Columnar> {
@@ -35,6 +35,24 @@ pub struct ColumnBuilder<C: Columnar> {
     finished: Option<Column<C>>,
     /// Completed containers pending to be sent.
     pending: VecDeque<Column<C>>,
+    /// The origin stamped on every buffer this builder mints.
+    origin: Origin,
+}
+
+impl<C: Columnar> ColumnBuilder<C> {
+    /// A builder that stamps its buffers with `origin` rather than the
+    /// [`Origin::Ship`] that [`Default`] uses.
+    ///
+    /// For builders whose chunks are retained rather than sent, so their
+    /// lifetimes do not land in the same metric series as bodies in flight on a
+    /// dataflow edge. Timely constructs container builders through `Default`,
+    /// which is why shipping is the default and retention is the opt-in.
+    pub fn with_origin(origin: Origin) -> Self {
+        ColumnBuilder {
+            origin,
+            ..Default::default()
+        }
+    }
 }
 
 impl<C: Columnar, T> PushInto<T> for ColumnBuilder<C>
@@ -47,22 +65,23 @@ where
         // Mint a container once the serialized size reaches the ship threshold.
         use columnar::Borrow;
         if crate::columnar::at_serialized_capacity(&self.current.borrow()) {
-            /// Move the contents from `current` to a `Vec<u64>` allocation built via
-            /// `indexed::encode` (so no zero-init pre-pass), and push it to `pending`.
+            /// Move the contents from `current` into a fitting [`AlignBuffer`]
+            /// and push it to `pending`.
             #[cold]
-            fn outlined_align<C>(current: &mut C::Container, pending: &mut VecDeque<Column<C>>)
-            where
+            fn outlined_align<C>(
+                current: &mut C::Container,
+                pending: &mut VecDeque<Column<C>>,
+                origin: Origin,
+            ) where
                 C: Columnar,
             {
                 use columnar::Borrow;
-                let words = indexed::length_in_words(&current.borrow());
-                let mut alloc: Vec<u64> = Vec::with_capacity(words);
-                indexed::encode(&mut alloc, &current.borrow());
-                pending.push_back(Column::Align(alloc));
+                let buffer = AlignBuffer::encode(origin, &current.borrow());
+                pending.push_back(Column::Align(buffer));
                 current.clear();
             }
 
-            outlined_align(&mut self.current, &mut self.pending);
+            outlined_align(&mut self.current, &mut self.pending, self.origin);
         }
     }
 }
@@ -74,6 +93,7 @@ impl<C: Columnar> Default for ColumnBuilder<C> {
             current: Default::default(),
             finished: None,
             pending: Default::default(),
+            origin: Origin::Ship,
         }
     }
 }

--- a/src/timely-util/src/columnar/chunk.rs
+++ b/src/timely-util/src/columnar/chunk.rs
@@ -62,6 +62,7 @@ use timely::dataflow::channels::ContainerBytes;
 use timely::progress::Timestamp;
 use timely::progress::frontier::AntichainRef;
 
+use crate::columnar::align_buffer::{AlignBuffer, Origin};
 use crate::columnar::batcher::{ColumnChunker, gallop};
 use crate::columnar::unload::UnloadChunk;
 use crate::columnar::{Column, at_serialized_capacity};
@@ -252,9 +253,9 @@ impl<D: Columnar, T: Columnar, R: Columnar> ColumnChunk<D, T, R> {
                 Rc::try_unwrap(col).unwrap_or_else(|shared| copy_column(&shared))
             }
             ColumnChunk::Spilled(body) => {
-                let mut words = Vec::new();
-                body.handle.read_into(&mut words);
-                Column::Align(words)
+                Column::Align(AlignBuffer::build(Origin::Fetch, |words| {
+                    body.handle.read_into(words)
+                }))
             }
         }
     }
@@ -1745,13 +1746,13 @@ mod tests {
         let Column::Align(words) = &column else {
             panic!("a spilled body reads back as Column::Align");
         };
-        let words = words.clone();
+        let words = words.as_words().to_vec();
         let respilled = force_spill(ColumnChunk::from_column(column), &pool);
         let reread = respilled.into_column();
         let Column::Align(words2) = &reread else {
             panic!("a spilled body reads back as Column::Align");
         };
-        assert_eq!(&words, words2, "byte-identical round trip");
+        assert_eq!(words, words2.as_words(), "byte-identical round trip");
         assert_eq!(collect_column(&reread), data);
     }
 

--- a/src/timely-util/src/columnar/consolidate.rs
+++ b/src/timely-util/src/columnar/consolidate.rs
@@ -42,6 +42,7 @@ use differential_dataflow::difference::Semigroup;
 use timely::container::{ContainerBuilder, PushInto};
 
 use crate::columnar::Column;
+use crate::columnar::align_buffer::{AlignBuffer, Origin};
 
 /// Per-buffer byte budget for the staging cap. Matches the 8 KiB basis DD's
 /// `ConsolidatingContainerBuilder` uses via `timely::container::buffer::default_capacity`.
@@ -180,7 +181,7 @@ where
         self.staging.drain(..consumed);
     }
 
-    /// Serialize the SoA accumulator into a `Column::Align` via `indexed::encode`, which
+    /// Serialize the SoA accumulator into a fitting [`AlignBuffer`], which
     /// builds the buffer with `Vec::push`/`extend_from_slice` so no memory is initialized
     /// twice.
     #[cold]
@@ -195,9 +196,8 @@ where
         );
         self.cur_len = 0;
 
-        let mut buf: Vec<u64> = Vec::with_capacity(indexed::length_in_words(&cur.borrow()));
-        indexed::encode(&mut buf, &cur.borrow());
-        self.pending.push_back(Column::Align(buf));
+        let buffer = AlignBuffer::encode(Origin::Consolidate, &cur.borrow());
+        self.pending.push_back(Column::Align(buffer));
     }
 }
 

--- a/src/timely-util/tests/align_buffer_metrics.rs
+++ b/src/timely-util/tests/align_buffer_metrics.rs
@@ -1,0 +1,196 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! End-to-end check that align-buffer recording reaches Prometheus.
+//!
+//! Its own test binary because registration and the recording gate are
+//! process-global: `register` installs into exactly one registry per process,
+//! and a sibling test toggling the gate would race this one. Everything here
+//! runs in one test function for the same reason.
+
+use mz_ore::cast::CastLossy;
+use mz_ore::metrics::MetricsRegistry;
+use mz_timely_util::columnar::Column;
+use mz_timely_util::columnar::align_buffer::{AlignBuffer, Origin, metrics};
+use mz_timely_util::columnar::builder::ColumnBuilder;
+use prometheus::proto::MetricFamily;
+use timely::container::{ContainerBuilder, PushInto};
+
+/// Records to push through the builder. Each `(u64, u64)` serializes to 16
+/// bytes and the ship threshold is 2 MiB, so this crosses it a few times over
+/// and the builder is guaranteed to mint buffers rather than hold one partial
+/// chunk.
+const RECORDS: u64 = 400_000;
+
+/// The one metric sample matching `name` and `origin`, or `None` if the series
+/// is absent.
+fn sample(families: &[MetricFamily], name: &str, origin: &str) -> Option<f64> {
+    let family = families.iter().find(|f| f.name() == name)?;
+    let metric = family.get_metric().iter().find(|m| {
+        m.get_label()
+            .iter()
+            .any(|l| l.name() == "origin" && l.value() == origin)
+    })?;
+    Some(metric.get_gauge().value())
+}
+
+/// Observation count of the histogram series matching `name` and `origin`.
+fn histogram_count(families: &[MetricFamily], name: &str, origin: &str) -> Option<u64> {
+    let family = families.iter().find(|f| f.name() == name)?;
+    let metric = family.get_metric().iter().find(|m| {
+        m.get_label()
+            .iter()
+            .any(|l| l.name() == "origin" && l.value() == origin)
+    })?;
+    Some(metric.get_histogram().get_sample_count())
+}
+
+/// Value of an unlabeled gauge series.
+fn plain_gauge(families: &[MetricFamily], name: &str) -> Option<f64> {
+    let family = families.iter().find(|f| f.name() == name)?;
+    Some(family.get_metric().first()?.get_gauge().value())
+}
+
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // too slow
+fn ship_buffers_reach_prometheus() {
+    let registry = MetricsRegistry::new();
+    metrics::register(&registry);
+
+    // With the gate off, shipping must leave every series alone. This also
+    // pins down that a zero reading means "not recording", not "no traffic".
+    assert!(!metrics::tracking_enabled());
+    let untracked = ship(RECORDS);
+    assert!(untracked > 0, "builder shipped nothing to measure");
+    let families = registry.gather();
+    assert_eq!(
+        plain_gauge(&families, "mz_column_align_buffer_tracking_enabled"),
+        Some(0.0)
+    );
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_mints_total", "ship"),
+        Some(0.0),
+        "recording is off, so nothing may be counted",
+    );
+
+    metrics::set_tracking_enabled(true);
+    let shipped = ship(RECORDS);
+    let families = registry.gather();
+
+    assert_eq!(
+        plain_gauge(&families, "mz_column_align_buffer_tracking_enabled"),
+        Some(1.0),
+    );
+
+    let mints =
+        sample(&families, "mz_column_align_buffer_mints_total", "ship").expect("ship mints series");
+    let drops =
+        sample(&families, "mz_column_align_buffer_drops_total", "ship").expect("ship drops series");
+    assert_eq!(
+        mints,
+        f64::cast_lossy(shipped),
+        "every shipped chunk mints exactly one buffer",
+    );
+    assert_eq!(mints, drops, "every buffer was dropped by end of scope");
+
+    // Everything minted has been dropped, so the level is back to zero while
+    // the high-water mark and the byte total retain what passed through.
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_inflight_bytes", "ship"),
+        Some(0.0),
+    );
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_inflight_count", "ship"),
+        Some(0.0),
+    );
+    let peak = sample(
+        &families,
+        "mz_column_align_buffer_inflight_bytes_peak",
+        "ship",
+    )
+    .expect("ship peak series");
+    assert!(peak > 0.0, "peak in-flight bytes stayed at zero");
+    let bytes = sample(
+        &families,
+        "mz_column_align_buffer_bytes_minted_total",
+        "ship",
+    )
+    .expect("ship bytes series");
+    assert!(bytes >= peak, "bytes minted {bytes} below peak {peak}");
+    assert!(
+        sample(
+            &families,
+            "mz_column_align_buffer_lifetime_max_nanoseconds",
+            "ship"
+        )
+        .expect("ship lifetime max series")
+            > 0.0,
+    );
+
+    // Both distributions observed once per buffer: sizes at mint, lifetimes at
+    // drop.
+    assert_eq!(
+        histogram_count(&families, "mz_column_align_buffer_size_bytes", "ship"),
+        Some(shipped),
+    );
+    assert_eq!(
+        histogram_count(&families, "mz_column_align_buffer_lifetime_seconds", "ship"),
+        Some(shipped),
+    );
+
+    // Origins with no traffic report zero rather than going missing, so a
+    // dashboard panel does not show a gap for an idle producer.
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_mints_total", "decode"),
+        Some(0.0),
+    );
+
+    // A buffer minted with the gate off must stay uncounted even if the gate
+    // flips on before it dies. Crediting back a charge that was never made
+    // would underflow the unsigned in-flight gauge.
+    metrics::set_tracking_enabled(false);
+    let untracked = AlignBuffer::from_words(Origin::Decode, vec![0u64; 1024]);
+    metrics::set_tracking_enabled(true);
+    drop(untracked);
+    let families = registry.gather();
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_drops_total", "decode"),
+        Some(0.0),
+        "a buffer minted with the gate off must not be counted at drop",
+    );
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_inflight_bytes", "decode"),
+        Some(0.0),
+    );
+
+    metrics::set_tracking_enabled(false);
+}
+
+/// Pushes `records` records through a [`ColumnBuilder`], draining every chunk
+/// it mints, and returns how many chunks it shipped. Each chunk is dropped
+/// before the next is extracted, so all of them are dropped by the time this
+/// returns.
+fn ship(records: u64) -> u64 {
+    let mut builder = ColumnBuilder::<(u64, u64)>::default();
+    let mut shipped = 0;
+    for i in 0..records {
+        builder.push_into((i, i));
+        while let Some(container) = builder.extract() {
+            assert!(
+                matches!(container, Column::Align(_)),
+                "a shipped chunk is a serialized body",
+            );
+            shipped += 1;
+        }
+    }
+    // `finish` hands back the trailing partial chunk as `Typed`, which is not
+    // an align buffer; drain it so the builder holds nothing at drop.
+    while builder.finish().is_some() {}
+    shipped
+}


### PR DESCRIPTION
Serialized column bodies (`Column::Align` payloads) are the one part of the columnar path's footprint that no budget accounts for. A body on a dataflow edge is owned by whoever holds the container, outside the buffer pool's ledger, so its bytes are invisible to pool pressure decisions and the kernel is left to reclaim them, faulting a Timely worker to do it.

This wraps the payload in `AlignBuffer` and records, per producing origin, how long each body lives and how many bytes of them are alive at once. Origins separate bodies in flight on an edge (`ship`, `consolidate`) from bodies that are deliberately retained (`correction`, `pager`) and bodies a read produced (`fetch`, `decode`), because a retained body's life says nothing about a body in flight.

The numbers decide the next step: whether these bodies are short-lived and small enough in aggregate to be served by a recycler whose bytes are reserved against the pool's budget, or whether they live long enough that the pool has to manage them like any other chunk.

Off in production, on in the test configuration, gated by `enable_column_align_buffer_tracking`.
