### PR TITLE
adapter: refuse a write timestamp past the write timeline's bound

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -4976,6 +4976,20 @@ pub fn serve(
             .expect("inserted above")
             .oracle;
 
+        // The catalog shard's upper is durable, so a write that once landed far ahead of the
+        // clock is re-applied to the oracle here on every boot and cannot be waited out. We
+        // report it rather than refusing to start: the timeline is stalled either way, and a
+        // process that will not boot turns that into a total outage plus a crash loop.
+        let boot_now: mz_repr::Timestamp = (now)().into();
+        if catalog_upper > timeline::write_ts_upper_bound(&boot_now) {
+            tracing::error!(
+                %catalog_upper, %boot_now,
+                "catalog upper is far ahead of the wall clock, so writes and \
+                strict-serializable reads on the EpochMilliseconds timeline will block \
+                until the clock catches up",
+            );
+        }
+
         let mut boot_ts = if read_only_controllers {
             let read_ts = epoch_millis_oracle.read_ts().await;
             std::cmp::max(read_ts, catalog_upper)

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -64,6 +64,7 @@ use tokio::sync::{Notify, OwnedMutexGuard, OwnedSemaphorePermit, Semaphore, mpsc
 use tracing::{Instrument, Span, info, warn};
 
 use crate::catalog::{BuiltinTableUpdate, Catalog, CatalogUpperHandle};
+use crate::coord::timeline::write_ts_upper_bound;
 use crate::coord::{Coordinator, Message, PendingTxn, PlanValidity};
 use crate::metrics::Metrics;
 use crate::session::{EndTransactionAction, GroupCommitWriteLocks, Session, WriteLocks};
@@ -173,6 +174,12 @@ pub enum WriteResult {
     TimestampPassed {
         target_timestamp: Timestamp,
         next_eligible_timestamp: Timestamp,
+    },
+    /// The requested timestamp ran further ahead of the wall clock than the write
+    /// timeline may be advanced, so the write was refused before it was attempted.
+    TimestampTooFarAhead {
+        target_timestamp: Timestamp,
+        limit: Timestamp,
     },
     /// The write was canceled before it entered the committer.
     Canceled,
@@ -438,8 +445,11 @@ impl GroupCommitter {
     ///
     /// What [`Self::commit`] does that this skips, and why that is safe:
     ///
-    /// * The wall-clock throttle. `target_timestamp` is the caller's to choose,
-    ///   and it must not run the write timeline ahead of the clock.
+    /// * The wall-clock throttle. `target_timestamp` is the caller's to choose, so
+    ///   instead of sleeping until the clock catches up we refuse a target above
+    ///   [`write_ts_upper_bound`] outright. Sleeping is the wrong answer for a caller
+    ///   whose target can be hours out, and committing there would advance the oracle
+    ///   with it.
     /// * A [`GroupCommitPermit`]. The caller bounds how many of these are in
     ///   flight, and that is the backpressure for this path.
     /// * Merging queued commits. There is nothing to merge into: these diffs
@@ -462,6 +472,18 @@ impl GroupCommitter {
             result.send(WriteResult::TimestampPassed {
                 target_timestamp,
                 next_eligible_timestamp: oracle_write_ts.step_forward(),
+            });
+            return ControlFlow::Continue(());
+        }
+
+        // Committing here would apply the target to the oracle below, which is what makes
+        // it stick. See `write_ts_upper_bound`.
+        let now: Timestamp = (self.now)().into();
+        let limit = write_ts_upper_bound(&now);
+        if target_timestamp > limit {
+            result.send(WriteResult::TimestampTooFarAhead {
+                target_timestamp,
+                limit,
             });
             return ControlFlow::Continue(());
         }

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -347,25 +347,38 @@ impl Coordinator {
     }
 }
 
-/// Convenience function for calculating the current upper bound that we want to
-/// prevent the global timestamp from exceeding.
-fn upper_bound(now: &mz_repr::Timestamp) -> mz_repr::Timestamp {
+/// The highest timestamp the `EpochMilliseconds` write timeline may be advanced to
+/// while the wall clock reads `now`.
+///
+/// A write above this is a runaway: the oracle is monotone and durable, so every later
+/// write and strict-serializable read on the timeline blocks until the wall clock catches
+/// up, across restarts. Group commit stays under it by allocating from the oracle, which
+/// clamps to the clock. A caller that chooses its own write timestamp has to be checked
+/// against it, see `GroupCommitter::commit_timestamped`.
+pub(crate) fn write_ts_upper_bound(now: &mz_repr::Timestamp) -> mz_repr::Timestamp {
     const TIMESTAMP_INTERVAL_MS: u64 = 5000;
     const TIMESTAMP_INTERVAL_UPPER_BOUND: u64 = 2;
 
     now.saturating_add(TIMESTAMP_INTERVAL_MS * TIMESTAMP_INTERVAL_UPPER_BOUND)
 }
 
-/// Logs an error when `timestamp` is further ahead of `now` than a local write timestamp
-/// should ever be, the signal that the `EpochMilliseconds` timeline has run away (e.g. after a
-/// wall-clock regression).
+/// Reports a write timestamp that is further ahead of `now` than
+/// [`write_ts_upper_bound`] allows, the signal that the `EpochMilliseconds` timeline has
+/// run away (e.g. after a wall-clock regression, or from a durably poisoned oracle).
+///
+/// This is a detector, not a guard: the timestamp has already been chosen, and every
+/// caller that can still refuse one checks the bound itself. It logs rather than fails,
+/// because every way left to reach it is a condition this process inherited. A durable
+/// runaway is re-applied to the oracle on every boot, and a backwards clock step is what
+/// the group committer's throttle waits out, so failing here would turn a stalled
+/// timeline into a crash loop.
 pub(crate) fn check_runaway_write_ts(now: &mz_repr::Timestamp, timestamp: mz_repr::Timestamp) {
-    let upper_bound = upper_bound(now);
+    let upper_bound = write_ts_upper_bound(now);
     if timestamp > upper_bound {
         error!(
             %now,
-            "Setting local write timestamp to {timestamp}, which is more than \
-            the desired upper bound {upper_bound}."
+            "setting local write timestamp to {timestamp}, which is more than \
+            the desired upper bound {upper_bound}"
         );
     }
 }

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -141,6 +141,13 @@ pub enum AdapterError {
     /// The statement is retryable: every attempt was refused before anything
     /// was appended, so nothing it intended has been committed.
     ReadThenWriteContention,
+    /// The write timestamp ran past what the write timeline may be advanced to,
+    /// so nothing was appended. See `coord::timeline::write_ts_upper_bound` for
+    /// the bound and why exceeding it is not recoverable.
+    ReadThenWriteTimestampTooFarAhead {
+        target_timestamp: mz_repr::Timestamp,
+        limit: mz_repr::Timestamp,
+    },
     CollectionUnreadable {
         id: String,
     },
@@ -852,6 +859,11 @@ impl AdapterError {
                 "Concurrent writes to the target table kept this statement from \
                  committing. Retry the statement, or lower the write concurrency.".into()
             ),
+            AdapterError::ReadThenWriteTimestampTooFarAhead { .. } => Some(
+                "The write timestamp this statement would have committed at is far ahead of \
+                 the wall clock. Committing there would keep writes and strict-serializable \
+                 reads on this timeline from proceeding until the clock caught up.".into()
+            ),
             AdapterError::CollectionUnreadable { .. } => Some(
                 "This could be because the collection has recently been dropped.".into()
             ),
@@ -916,6 +928,9 @@ impl AdapterError {
                 SqlState::T_R_SERIALIZATION_FAILURE
             }
             AdapterError::ReadThenWriteContention => SqlState::T_R_SERIALIZATION_FAILURE,
+            AdapterError::ReadThenWriteTimestampTooFarAhead { .. } => {
+                SqlState::FEATURE_NOT_SUPPORTED
+            }
             AdapterError::CollectionUnreadable { .. } => SqlState::NO_DATA_FOUND,
             AdapterError::NoClusterReplicasAvailable { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::OperationProhibitsTransaction(_) => SqlState::ACTIVE_SQL_TRANSACTION,
@@ -1296,6 +1311,16 @@ impl fmt::Display for AdapterError {
                 write!(
                     f,
                     "read-then-write exceeded maximum retry attempts under contention"
+                )
+            }
+            AdapterError::ReadThenWriteTimestampTooFarAhead {
+                target_timestamp,
+                limit,
+            } => {
+                write!(
+                    f,
+                    "read-then-write would have to commit at {target_timestamp}, past the \
+                     highest timestamp the write timeline may be advanced to ({limit})"
                 )
             }
             AdapterError::CollectionUnreadable { id } => {

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -278,6 +278,13 @@ fn classify_write_result(
                 .requested_error()
                 .unwrap_or(AdapterError::Canceled),
         ),
+        WriteResult::TimestampTooFarAhead {
+            target_timestamp,
+            limit,
+        } => WriteOutcome::Failed(AdapterError::ReadThenWriteTimestampTooFarAhead {
+            target_timestamp,
+            limit,
+        }),
         WriteResult::ReadOnly => WriteOutcome::Failed(AdapterError::ReadOnly),
         WriteResult::TargetChanged => {
             // A concurrent DDL gave the table a new generation after we

--- a/src/environmentd/tests/read_then_write.rs
+++ b/src/environmentd/tests/read_then_write.rs
@@ -2117,3 +2117,79 @@ fn test_replica_expiration_spares_folded_selections() {
         .expect("subscribe failed");
     assert_eq!(streamed, "", "the subscribe streamed {streamed:?}");
 }
+
+/// A read-then-write whose write timestamp would run past what the write timeline
+/// may be advanced to has to be refused, not committed.
+///
+/// The OCC path derives its write timestamp from the frontier its subscribe observed,
+/// and a selection over a materialized view with a `REFRESH` option settles until the
+/// next refresh, so that frontier is legitimately hours or days ahead of the clock.
+/// Committing there advances the timeline's oracle with it, and the oracle is monotone
+/// and durable, so every later write and strict-serializable read on the timeline blocks
+/// until the clock catches up, restarts included. Under `serializable` it is worse than a
+/// block: reads pick a timestamp near the clock, so the acknowledged write stays
+/// invisible.
+///
+/// The MV here refreshes once a few seconds out and once far away. Past the near
+/// refresh it is readable, and its upper is then the far one, which is what makes the
+/// write target far future deterministically rather than by racing a refresh interval.
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_far_future_write_timestamp_is_refused() {
+    let server = frontend_occ_harness()
+        .unsafe_mode()
+        .with_system_parameter_default("enable_refresh_every_mvs".to_string(), "true".to_string())
+        .start_blocking();
+    let mut client = server.connect(postgres::NoTls).unwrap();
+
+    client.batch_execute("CREATE TABLE src (a INT)").unwrap();
+    client
+        .batch_execute("INSERT INTO src VALUES (1), (2), (3)")
+        .unwrap();
+    client.batch_execute("CREATE TABLE dst (a INT)").unwrap();
+    client
+        .batch_execute(
+            "CREATE MATERIALIZED VIEW mv \
+             WITH (REFRESH AT mz_now()::text::int8 + 3000, REFRESH AT '3000-01-01') \
+             AS SELECT a FROM src",
+        )
+        .unwrap();
+
+    // Reaching the write at all means waiting for the near refresh: until then the MV
+    // holds no readable content and the read parks instead.
+    client
+        .batch_execute("SET statement_timeout = '60s'")
+        .unwrap();
+
+    let err = client
+        .execute("INSERT INTO dst SELECT a FROM mv", &[])
+        .expect_err("a write at a far-future timestamp must be refused");
+    let message = server_error_message(&err);
+    assert!(
+        message.contains("past the highest timestamp the write timeline may be advanced to"),
+        "unexpected error for a far-future write: {message}"
+    );
+
+    // The refusal has to happen before the append, so the oracle never learns the
+    // far-future timestamp. Checked before anything reads `dst`, because a read cannot be
+    // served once the oracle is out there.
+    let skew: i64 = client
+        .query_one(
+            "SELECT mz_now()::text::bigint - (extract(epoch FROM now()) * 1000)::bigint",
+            &[],
+        )
+        .unwrap()
+        .get(0);
+    assert!(
+        skew.abs() < 60_000,
+        "the oracle is {skew}ms from wall clock, so the refused write reached it anyway"
+    );
+
+    // The timeline is still usable, both for writes and for reads of the target.
+    client.batch_execute("INSERT INTO dst VALUES (4)").unwrap();
+    let rows = client
+        .query_one("SELECT count(*) FROM dst", &[])
+        .unwrap()
+        .get::<_, i64>(0);
+    assert_eq!(rows, 1, "the refused write must not have landed");
+}


### PR DESCRIPTION
Part of: [SQL-641](https://linear.app/materializeinc/issue/SQL-641)

Safeguard for the write timestamp the frontend OCC read-then-write path chooses. Independent of #38260. #38322 stacks on this and makes the far-future case work rather than merely be refused.

## The hole

`GroupCommitter::commit_timestamped` documented an obligation it never discharged:

```
/// * The wall-clock throttle. `target_timestamp` is the caller's to choose,
///   and it must not run the write timeline ahead of the clock.
```

Nothing checked it. Every other write allocates from the oracle, `GREATEST(write_ts + 1, now())`, so it cannot jump. A caller-chosen target can, and the oracle is monotone and durable:

* Under the default **strict serializable**, every later write and read on the timeline blocks until the wall clock catches up.
* Under **serializable** it is worse. Those reads never consult the oracle (`needs_linearized_read_ts` is false for them), so they pick a timestamp near the clock and an acknowledged write stays invisible.
* It **survives restart** through the catalog shard's upper, which boot re-applies to the oracle. The startup sleep that once waited for the clock is gone.

The frontend path produces such a target today, no bug involved: it writes at the frontier its subscribe observed, and a selection over a `REFRESH` materialized view settles until its next refresh. With `REFRESH EVERY '15 seconds'` that is a ~6s oracle jump. With a coarser interval it is a stalled environment.

## What this does

**Enforces the bound where it is stated.** A target above `write_ts_upper_bound(now)` is refused before the append, and the session turns `WriteResult::TimestampTooFarAhead` into a statement error. The ceiling is the same `now + 2 * 5000ms` that `check_runaway_write_ts` already measured against, now named. A backstop, not the fix: the worst outcome becomes one failed statement instead of a stalled timeline, for any caller of the timestamped-write API.

**Leaves the detector logging.** `check_runaway_write_ts` stays an `error!`. With the refusal above in place, every way left to reach it is a runaway this process inherited, a durable one re-applied at boot or a backwards clock step, and the group committer's throttle is written to wait those out. Failing there would turn a stalled timeline into a crash loop, which is the opposite of what the boot check below decides.

**Reports the restart channel.** Boot logs an error when the catalog upper is already past the bound. It does not refuse to start: the timeline is stalled either way, and a process that will not boot turns that into an outage plus a crash loop.

## Tests

`test_far_future_write_timestamp_is_refused` builds a genuinely far-future target from a materialized view with two refreshes, one seconds out so the view becomes readable, one in the year 3000 so the target is deterministic rather than racing a refresh interval. It asserts the refusal, that the oracle did not move (checked before reading the target back, since a read cannot be served once the oracle is out there), and that the timeline still takes a write and a read.

The error is `FEATURE_NOT_SUPPORTED` here because retrying does not help while the frontier stays out there. #38322 changes the producer set to "the oracle itself ran away" and moves it to `INTERNAL_ERROR` with a hint that matches.



