### PR TITLE
mz-deploy: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6908,7 +6908,7 @@ dependencies = [
 
 [[package]]
 name = "mz-deploy"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "annotate-snippets",
  "async-stream",

--- a/src/mz-deploy/Cargo.toml
+++ b/src/mz-deploy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-deploy"
 description = "Declarative SQL project tooling for Materialize: compile, test, deploy."
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
### Motivation

Bumps the `mz-deploy` CLI to `0.4.0` and cuts a new release. Since `0.3.1` includes a feature enhancement, this is a minor bump per `ci/deploy_mz-deploy/README.md`.

### Features

- Reconcile cluster options generically from `SHOW CREATE CLUSTER`, which adds support for `EXPERIMENTAL ARRANGEMENT COMPRESSION` and means a cluster option Materialize adds later reconciles without a change to `mz-deploy` (#38212).

### Bug fixes

- Stop emitting `ALTER CLUSTER ... RESET (REPLICATION FACTOR)` for a cluster whose live replication factor already matches `default_cluster_replication_factor`. A definition that omits the option no longer reports drift on every apply (#38212).

### Tips for reviewer

Version-only change: `src/mz-deploy/Cargo.toml` plus the matching `Cargo.lock` line. Both listed changes are already merged to `main`; this cut is what makes them available as a released binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)