### PR TITLE
adapter: let the oracle choose the read-then-write write timestamp

### DIFF
--- a/doc/developer/design/20260210_incremental_occ_read_then_write.md
+++ b/doc/developer/design/20260210_incremental_occ_read_then_write.md
@@ -49,9 +49,9 @@ a subscribe that continually tracks the current state of the data.
 - Removing the in-process locks immediately. During rollout, the old lock-based
   path and the new OCC path coexist behind a feature flag. The locks can be
   removed once the OCC path is fully rolled out.
-- Mixed read/write transactions. A write that reads persisted state commits at
-  the frontier it observed, which it cannot postpone until COMMIT, so it runs
-  only as a single statement. A write that reads nothing does compose with
+- Mixed read/write transactions. A write that reads persisted state commits at a
+  timestamp the oracle handed out while the statement ran, which it cannot
+  postpone until COMMIT, so it runs only as a single statement. A write that reads nothing does compose with
   transactions: its diffs are frontier-independent, so they are buffered as
   session write ops and land when the transaction commits. That covers, for
   example, `INSERT INTO t SELECT generate_series(1, 20000)`, whose values are
@@ -65,12 +65,13 @@ subscribe-based OCC loop:
 1. Open a subscribe on the read expression (the `selection` from the
    `ReadThenWrite` plan), starting at the timestamp determined by the oracle
 2. Accumulate diffs from the subscribe
-3. When the subscribe frontier advances to T (meaning we have a consistent
-   snapshot), attempt to write the accumulated diffs at timestamp T
-4. If the write succeeds, done
-5. If the write fails because another writer already committed at timestamp T,
-   the subscribe will deliver the new state; go back to step 3 with the updated
-   diffs
+3. Take the write timestamp T from the timeline's oracle, one step above its
+   write timestamp, which is the smallest value the group committer accepts
+4. Once the subscribe frontier has advanced to T, so the accumulated diffs below
+   T are complete, attempt to write those diffs at T
+5. If the write succeeds, done
+6. If the write fails because another writer already took T, adopt the timestamp
+   the committer reports as next eligible and go back to step 4 with it
 
 This approach is correct by construction: the subscribe always reflects the
 committed state of the data, and the timestamped write mechanism ensures that
@@ -144,17 +145,36 @@ Session Task                         Coordinator
   |                                      |
   |   +-- OCC Loop ------------------+   |
   |   | receive diffs from subscribe |   |
-  |   | on frontier advance:         |   |
-  |   |   consolidate diffs          |   |
+  |   | target T from the oracle     |   |
+  |   | once frontier >= T:          |   |
+  |   |   consolidate diffs below T  |   |
   |   |   AttemptTimestampedWrite -> |-->|-- group_commit()
   |   |   <-- Success/Failed --------|<--|
-  |   |   if Failed: continue loop   |   |
+  |   |   if Failed: T = next, loop  |   |
   |   |   if Success: break          |   |
   |   +------------------------------+   |
   |                                      |
   |-- DropInternalSubscribe -----------> |
   |                                      |
 ```
+
+The target `T` comes from the oracle, not from the subscribe's frontier. A
+frontier certifies what the loop has a complete view of, which is a different
+question from which timestamp to write at, and the two coincide only when the
+selection's inputs are caught up with the oracle. An input can legitimately sit
+far in the future, a materialized view with a `REFRESH` schedule for instance, so
+taking `T` from the frontier would move the write timeline to that future and
+keep it there. The frontier gates the write, the oracle chooses it, and three
+invariants hold for every write the loop makes: the frontier is at or above `T`
+before it submits, the payload is every diff strictly below `T`, and `T` is above
+the statement's `as_of`, which is where the snapshot arrives.
+
+Note that the frontier being at or above `T` does not make the two equal. The
+frontier is a minimum over the selection's inputs, so it bounds neither `T` nor
+the target table's upper. Where it runs above `T`, a selection that reads the
+target table sees diffs the payload excludes, the compare-and-append refuses, and
+the loop retries at a higher target. Persist arbitrates the timestamp, not the
+frontier.
 
 ### Timestamped writes
 
@@ -230,16 +250,20 @@ selection.
 
 ### The timestamped write ensures atomicity
 
-The write is submitted at the timestamp corresponding to the subscribe's
-frontier. The group commit machinery checks that this timestamp hasn't been
+The write is submitted at a timestamp taken from the timeline's oracle, once the
+subscribe's frontier has reached it so that the accumulated diffs below it are
+complete. The group commit machinery checks that this timestamp hasn't been
 passed by the oracle:
 
 - If the timestamp is still valid: the write is committed at exactly that
   timestamp, and the oracle is advanced past it. Any concurrent OCC loops that
   were targeting the same timestamp will fail and retry.
 - If the timestamp has already passed (another write committed first): the
-  write also fails. The OCC loop continues, the subscribe delivers the updates
-  from the intervening write, and the loop retries at the new frontier.
+  write also fails, and the reply names the next eligible timestamp. The OCC
+  loop adopts that as its new target, waits for the subscribe's frontier to
+  reach it, which folds the intervening writes' updates into the payload, and
+  retries. The reported timestamp is always strictly above the rejected one, so
+  the retries make progress.
 
 This ensures that the write is always based on the state of the data at exactly
 the write timestamp. There is no window for lost updates: either the write
@@ -255,6 +279,22 @@ subscribe-based OCC loop, we might observe data timestamped beyond the current
 oracle read timestamp. However, actually applying the write bumps the oracle
 read timestamp to at least the write timestamp, so at write time it holds that
 `write_ts <= oracle_read_ts`. The linearization invariant is maintained.
+
+A statement that matches no rows performs no write, so nothing advances the
+oracle for it. It reports the timestamp its view is complete through and waits
+for the oracle read timestamp to reach that. A selection already empty at `as_of`
+is complete through `as_of`, which the statement linearized before its subscribe
+started, so the wait is satisfied at once. A selection that empties later reports
+the later timestamp and waits for a group commit.
+
+Reporting the frontier the subscribe observed would also be correct, but the
+subscribe follows Persist, which runs ahead of the oracle, so that frontier is
+usually a timestamp the oracle has not published and every zero-row answer would
+wait for a commit. The lower timestamp is not weaker: the answer describes the
+selection at the timestamp it reports, later reads land at or above it, and rows
+written after it are later in the serial order, as they would be for a SELECT
+there. Answering from state the oracle has not published is the hazard, and that
+is the direction the wait covers.
 
 ### Single timestamped write per group commit round
 
@@ -324,13 +364,19 @@ that the next reader does not take them for bugs.
   When inputs are caught up the lock path's window is milliseconds wide and also
   needs a materially conflicting write plus a reader inside it, which is
   presumably why it went unnoticed.
-- **A lagging dependency blocks rather than waits.** This is the price of the
-  strengthening above. A selection dependency that persistently lags by more
-  than about one `default_timestamp_interval` makes every attempt conflict,
-  because the observed frontier is bounded by the lagging input while the write
-  timestamp keeps advancing with the oracle. The statement then burns retries
-  until `statement_timeout` instead of committing, where the lock path's peek
-  simply waited for the input to catch up.
+- **A lagging dependency delays rather than being read stale.** This is the
+  price of the strengthening above. The write timestamp comes from the oracle,
+  and the loop waits for the subscribe's frontier to certify it before
+  submitting, so a lagging selection dependency delays the statement by its lag.
+  A dependency that catches up commits normally. One that persistently lags by
+  more than about one `default_timestamp_interval` never lets an attempt land:
+  every wait ends with the oracle already past the target, the committer refuses
+  it and names a newer one, and the next wait is again bounded by the lagging
+  input. Each round costs one of `max_occ_retries`, but the rounds are paced by
+  frontier advances rather than spinning, so what ends the statement is
+  `statement_timeout`, which it runs out while holding an OCC permit and its
+  subscribe. The lock path's peek simply waited for the input to catch up and
+  then committed.
 - **Statement lifecycle events.** The frontend path records an
   `optimization-finished` event for a DML, the coordinator path does not,
   because it hands the read-then-write's inner peek a trivial logging context
@@ -357,11 +403,19 @@ that the next reader does not take them for bugs.
   limit on the coordinator path and succeed on the frontend path. We keep the
   frontend's accounting: it matches what the write actually appends, one entry
   with a large diff.
-- **The write-timeline throttle.** A timestamped write does not go through the
-  throttle that a blind write's group commit applies, because its timestamp
-  comes from an observed subscribe frontier rather than from the clock. See the
-  doc comment on `GroupCommitter::commit_timestamped` for the full list of what
-  that path skips and why.
+- **The write-timeline throttle.** A blind write's group commit sleeps in the
+  committer until the wall clock catches up with the oracle's write timestamp,
+  keeping the timeline from running ahead of the clock. A timestamped write
+  cannot be throttled that way: its timestamp is fixed before it reaches the
+  committer, so sleeping would only delay a write that already has to land at
+  that timestamp. The committer instead refuses a target above
+  `write_ts_upper_bound(now)` outright. That refusal is unreachable in normal
+  operation, since the target is one step above the oracle's write timestamp and
+  the oracle clamps itself to the clock. It fires only for a write timeline that
+  has already run away from the clock, which is an environment-level invariant
+  violation rather than something a statement can provoke. See the doc comment on
+  `GroupCommitter::commit_timestamped` for the full list of what that path skips
+  and why.
 - **Zero-row `INSERT ... RETURNING`.** Both paths report `INSERT 0 0` with no
   result set when no rows match, because the coordinator decides the response
   kind from the evaluated RETURNING rows and there are none. Postgres returns an
@@ -398,10 +452,10 @@ throughput (left) and latency (right). Key observations:
   a subscribe sees only progress from another table's write. They do still
   contend, in three ways: the concurrency semaphore is process-global across
   tables and clusters, the conflict predicate is the global oracle plus the
-  shared txns-shard upper, so two writers that observed the same frontier refuse
-  each other, and each timestamped write is its own committer round rather than
-  merging into a shared group commit. Every write benchmark is single-table, so
-  the cross-table case is unmeasured.
+  shared txns-shard upper, so two writers that took the same target timestamp
+  refuse each other, and each timestamped write is its own committer round rather
+  than merging into a shared group commit. Every write benchmark is single-table,
+  so the cross-table case is unmeasured.
 
 The chart above is from the PoC, which benchmarked `UPDATE t SET x = x + 1` over
 a larger table (the regime where OCC wins). It does not capture the small-write
@@ -417,16 +471,29 @@ three runs) and `Update` 1.4x slower (33-45%), and the scalability
 `ManySmallUpdates` is the worst case for this design, and the reason is worth
 recording. Its statements set every matched row's `f1` to one shared random
 value, which merges a whole residue class, so the class count only shrinks and
-roughly 90% of its 100 updates end up matching no rows. A statement that matches
-nothing still has to linearize its read, and the oracle advances only when a
-group commit applies, so each of those statements needs a commit that has nothing
-to write. We ask for one rather than waiting for the periodic keepalive, which
-costs a commit round trip per statement instead of up to a full
-`default_timestamp_interval`. That is the difference between 3.5x and 157x, but
-it is not free, and a workload dominated by zero-row writes pays it on every
-statement. The residue is the price of the linearization guarantee rather than a
-defect: correctness requires the oracle to advance, and only a commit advances
-it.
+roughly 90% of its 100 updates end up matching no rows. Such a statement has
+nothing to write, and the oracle advances only when a group commit applies, so
+linearizing a timestamp the oracle has not reached costs a commit that carries
+nothing. Asking for one rather than waiting for the periodic keepalive is the
+difference between 3.5x and 157x. A selection already empty at its `as_of` needs
+no commit at all, which is this workload's shape, and what remains is a selection
+that empties later. That residue is the price of the linearization guarantee
+rather than a defect, since only a commit advances the oracle.
+
+Note: the figures above were measured before the write timestamp came from the
+oracle and a zero-row answer reported the timestamp its view is complete through.
+Those two remove the commit itself. Group commits per statement fall from about
+1.09 to between 0.13 and 0.37, roughly 75 fewer commits over the scenario's 100
+statements.
+
+What that removal is worth in wallclock depends on what a commit costs, so it does
+not reproduce everywhere. Comparing the same two images, `ManySmallUpdates` runs
+0.73s against 1.34s on a local Docker setup and 0.761s against 0.755s on the CI
+benchmark agents. The removed commits are the same in both, so the 0.6s locally
+puts a commit at roughly 8ms there, a metadata store round trip on that disk, while
+on the agents the same 75 commits disappear into run-to-run noise. The feature
+benchmark therefore cannot see this improvement, and a future change that put the
+commit back would not show up as a regression there either.
 
 The PoC's large-write win does not survive here. `Update` is itself a large
 mutation, a full-table update over 10^6 rows, and it is 1.4x slower. An `UPDATE`

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -445,11 +445,11 @@ impl GroupCommitter {
     ///
     /// What [`Self::commit`] does that this skips, and why that is safe:
     ///
-    /// * The wall-clock throttle. `target_timestamp` is the caller's to choose, so
-    ///   instead of sleeping until the clock catches up we refuse a target above
-    ///   [`write_ts_upper_bound`] outright. Sleeping is the wrong answer for a caller
-    ///   whose target can be hours out, and committing there would advance the oracle
-    ///   with it.
+    /// * The wall-clock throttle. `target_timestamp` is the caller's to choose, and a
+    ///   target above [`write_ts_upper_bound`] is refused rather than slept off.
+    ///   Committing there would advance the oracle with it, and a caller that took its
+    ///   target from the oracle cannot exceed the bound unless the timeline has already
+    ///   run away, which sleeping would not resolve.
     /// * A [`GroupCommitPermit`]. The caller bounds how many of these are in
     ///   flight, and that is the backpressure for this path.
     /// * Merging queued commits. There is nothing to merge into: these diffs

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -144,6 +144,10 @@ pub enum AdapterError {
     /// The write timestamp ran past what the write timeline may be advanced to,
     /// so nothing was appended. See `coord::timeline::write_ts_upper_bound` for
     /// the bound and why exceeding it is not recoverable.
+    ///
+    /// The timestamp comes from the timeline's oracle, so reaching this means the
+    /// oracle has run away from the wall clock rather than that the statement
+    /// asked for anything unusual.
     ReadThenWriteTimestampTooFarAhead {
         target_timestamp: mz_repr::Timestamp,
         limit: mz_repr::Timestamp,
@@ -929,7 +933,10 @@ impl AdapterError {
             }
             AdapterError::ReadThenWriteContention => SqlState::T_R_SERIALIZATION_FAILURE,
             AdapterError::ReadThenWriteTimestampTooFarAhead { .. } => {
-                SqlState::FEATURE_NOT_SUPPORTED
+                // An invariant violation in the environment rather than a property of
+                // the statement: the write timeline has run away from the wall clock.
+                // Nothing the client sends can produce or avoid it.
+                SqlState::INTERNAL_ERROR
             }
             AdapterError::CollectionUnreadable { .. } => SqlState::NO_DATA_FOUND,
             AdapterError::NoClusterReplicasAvailable { .. } => SqlState::FEATURE_NOT_SUPPORTED,

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -84,6 +84,34 @@
 //! durable in the first case and there was never anything to write in the
 //! second, so all they do is make the disagreement loud.
 //!
+//! ## The frontier certifies, the oracle chooses
+//!
+//! The target `T` comes from the oracle, and a progress message at `F` only
+//! certifies completeness below `F`, so it gates the write rather than choosing
+//! its timestamp. The design doc's "The OCC loop" says why. Three invariants
+//! hold for every write this path makes:
+//!
+//! * `F >= T` before it submits, so the payload is a complete view of `T - 1`.
+//! * The payload is every diff below `T`, strictly. A diff at `T` is concurrent
+//!   with the write and waits for a later target.
+//! * `T > as_of`, so the snapshot, which arrives at `as_of`, is in the payload.
+//!
+//! NOTE: `F >= T` does not make the two equal, because `F` is a minimum over the
+//! selection's inputs. Where `F` runs above `T`, a selection that reads the
+//! target table makes the compare-and-append refuse, and retrying higher is the
+//! design rather than a failure.
+//!
+//! ## A zero-row answer
+//!
+//! A write linearizes itself, because group commit advances the oracle before it
+//! acknowledges. An answer of "no rows" performs no write, so the loop reports
+//! the timestamp its view is complete through and the caller waits for the
+//! oracle to reach it. A selection empty at `as_of` is complete through `as_of`,
+//! which the caller put behind the oracle before the subscribe started, so that
+//! answer waits for nothing, while reporting the frontier the subscribe observed
+//! would cost a group commit every time. The design doc's "Linearization" argues
+//! why the lower timestamp is not the weaker guarantee.
+//!
 //! ## Rollout note
 //!
 //! The `FRONTEND_READ_THEN_WRITE` dyncfg is read once at process startup and
@@ -104,7 +132,6 @@ use std::time::Duration;
 
 use bytesize::ByteSize;
 use differential_dataflow::consolidation;
-use itertools::Itertools;
 use mz_catalog::memory::error::ErrorKind;
 use mz_cluster_client::ReplicaId;
 use mz_compute_types::ComputeInstanceId;
@@ -121,6 +148,7 @@ use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::vars::IsolationLevel;
 use mz_storage_client::client::TableData;
 use mz_storage_types::sources::Timeline;
+use mz_timestamp_oracle::TimestampOracle;
 use prometheus::Histogram;
 use timely::progress::Antichain;
 use tokio::sync::mpsc;
@@ -226,19 +254,18 @@ enum OccOutcome {
     },
     /// The selection was empty, so there was nothing to write.
     ///
-    /// `observed_ts` is the timestamp emptiness was concluded at, and is
-    /// `None` only when the selection reads no persisted state. When it is
-    /// `Some`, the caller must linearize against it before responding: the
-    /// subscribe follows Persist, which runs ahead of the oracle, so the
-    /// emptiness can be concluded from state no oracle-timestamped read can
-    /// reach yet.
+    /// `empty_as_of` is the timestamp the emptiness holds at, and the caller must
+    /// bring the oracle's read timestamp up to it before responding. `None` when
+    /// the subscribe ran to completion, where the emptiness holds at every
+    /// timestamp. See the module docs for why the choice of timestamp matters.
     NoRowsMatched {
         response: ExecuteResponse,
-        observed_ts: Option<Timestamp>,
+        empty_as_of: Option<Timestamp>,
     },
-    /// Diffs from a selection that reads no persisted state. The subscribe ran
-    /// to completion, so they are frontier-independent and the caller chooses
-    /// whether to submit them now or buffer them into the transaction.
+    /// Diffs no frontier can change, from a subscribe that ran to completion.
+    /// The close says the selection can never change again, not that it reads
+    /// nothing persisted, and either way the caller chooses whether to submit
+    /// them now or buffer them into the transaction.
     Blind {
         response: ExecuteResponse,
         diffs: Vec<(Row, Diff)>,
@@ -403,12 +430,13 @@ fn validate_read_then_write(
 
     let timeline = catalog.validate_timeline_context(depends_on.iter().copied())?;
 
-    // The write commits at the frontier the subscribe observed, and that
-    // frontier is only comparable with the target table's upper on
-    // `EpochMilliseconds`. A selection in another timeline counts something
-    // else, transactions rather than milliseconds for a CDCv2 source, so the
-    // conflict check would refuse every attempt and the statement would burn
-    // until `statement_timeout`. Refuse it up front instead.
+    // The loop waits for the subscribe's frontier to reach a target timestamp
+    // taken from the `EpochMilliseconds` oracle, and it is the target table's
+    // upper the write then competes for. A selection in another timeline
+    // counts something else, transactions rather than milliseconds for a CDCv2
+    // source, so its frontier is not comparable with that target and the
+    // statement would burn until `statement_timeout`. Refuse it up front
+    // instead.
     //
     // Only `INSERT ... SELECT` reaches this. A DELETE or UPDATE selection
     // includes the target table, so a foreign timeline already fails above
@@ -451,7 +479,7 @@ fn validate_read_then_write(
 fn build_success_response(
     kind: &MutationKind,
     returning: &[MirScalarExpr],
-    all_diffs: &[(Row, Timestamp, Diff)],
+    diffs: &[(Row, Diff)],
     max_result_size: u64,
     max_query_result_size: u64,
     row_set_finishing_seconds: &Histogram,
@@ -459,9 +487,9 @@ fn build_success_response(
     if returning.is_empty() {
         // For UPDATE each changed row produces a retraction (-1) and an
         // insertion (+1), so we divide by 2 below.
-        let row_count = all_diffs
+        let row_count = diffs
             .iter()
-            .map(|(_, _, diff)| diff.into_inner().unsigned_abs())
+            .map(|(_, diff)| diff.into_inner().unsigned_abs())
             .sum::<u64>();
         let row_count = usize::try_from(row_count).expect("positive row count must fit in usize");
 
@@ -484,7 +512,7 @@ fn build_success_response(
     let mut projected_byte_size: u64 = 0;
     let early_cap = std::cmp::min(max_result_size, max_query_result_size);
 
-    for (row, _ts, diff) in all_diffs {
+    for (row, diff) in diffs {
         let include = match kind {
             MutationKind::Delete => diff.is_negative(),
             MutationKind::Update | MutationKind::Insert => diff.is_positive(),
@@ -818,22 +846,20 @@ impl PeekClient {
         // Linearize the read BEFORE subscribing or writing: block until
         // the oracle for this query's timeline has advanced to `as_of`.
         //
-        // The up-front ordering is load-bearing. If `as_of` is in the far
-        // future (e.g. reading from a `REFRESH AT` MV with a far-future
-        // since), submitting a write at `chosen_ts >= as_of` would have
-        // the group commit bump the oracle to that far-future value,
-        // stalling every subsequent write on the `EpochMilliseconds`
-        // timeline until then. So a pathological far-future RTW must park
-        // here without ever touching the oracle. This park is unbounded on
-        // its own, the caller bounds it by `statement_timeout`.
-        //
-        // NOTE: A far-future read reaching a write at all is the
-        // counterintuitive step. It does not simply hang on its read the way
-        // the coordinator's peek path would. Refresh-MV uppers legitimately run
-        // ahead of the wall clock, the upper being the next refresh boundary,
-        // so the subscribe can observe frontiers past `as_of` immediately, and
-        // we derive the write timestamp from those observed frontiers.
+        // Ordering is load-bearing: this leaves the oracle at or above `as_of`,
+        // which is what makes the loop's target clear `as_of` and so include the
+        // snapshot. A far-future `as_of` parks here until the clock arrives,
+        // bounded by `statement_timeout`.
         self.ensure_read_linearized(&timeline, as_of).await?;
+
+        // The loop takes its write target from this oracle, and reaching one takes
+        // `&mut self`, which the loop does not have. `None` for a
+        // timestamp-independent selection, which reads at `Timestamp::maximum()`
+        // and so always leaves through the blind path rather than reaching a write.
+        let write_oracle = match governing_timeline(&timeline) {
+            Some(tl) => Some(Arc::clone(self.ensure_oracle(tl).await?)),
+            None => None,
+        };
 
         let subscribe_handle = self
             .create_internal_subscribe(
@@ -866,6 +892,7 @@ impl PeekClient {
                 conn_id.clone(),
                 statement_logging_id,
                 as_of,
+                write_oracle,
                 &attempt_state,
             )
             .await;
@@ -902,39 +929,30 @@ impl PeekClient {
             }
             Ok(OccOutcome::NoRowsMatched {
                 response,
-                observed_ts,
+                empty_as_of,
             }) => {
-                // A write would have linearized this for us, because group
-                // commit advances the oracle before it answers. With nothing
-                // to write we have to do it ourselves, or we report an empty
-                // selection from state a later strict-serializable read cannot
-                // see yet, and that read finds the rows we said were not
-                // there.
-                //
-                // An `observed_ts` for a statement we meant to stage is the
+                // An `empty_as_of` for a statement we meant to stage is the
                 // same predicate disagreement the `Committed` arm guards
                 // against: the syntactic answer said it reads nothing, the
                 // subscribe then read persisted state. Nothing is durable here,
                 // so there is nothing to undo, but the disagreement itself is
                 // the bug and it would otherwise park silently.
                 soft_assert_or_log!(
-                    !(stages_rows && observed_ts.is_some()),
+                    !(stages_rows && empty_as_of.is_some()),
                     "read-then-write observed a read timestamp for a statement \
                      it meant to stage"
                 );
                 end_own_transaction(session, stages_rows);
-                match observed_ts {
-                    Some(observed_ts) => {
-                        // Nothing is left to write and `run_occ_loop` consumed
-                        // the subscribe handle, so its dataflow is already gone
-                        // and the permit guards nothing. `observed_ts` is an
-                        // upper, so this parks until the *next* write applies,
-                        // which on an idle system is the next keepalive, up to
-                        // a full `default_timestamp_interval`. Holding one of
-                        // the few permits for that would throttle unrelated
-                        // writes for no benefit.
+                match empty_as_of {
+                    Some(empty_as_of) => {
+                        // The wait is a no-op where the oracle is already past
+                        // `empty_as_of`, which is the common `WHERE <no match>`,
+                        // and otherwise costs the group commit that
+                        // `ensure_read_linearized` asks for. Either way the
+                        // subscribe handle is gone, so the permit guards nothing
+                        // and holding it would throttle unrelated writes.
                         drop(permit.take());
-                        self.ensure_read_linearized(&timeline, observed_ts)
+                        self.ensure_read_linearized(&timeline, empty_as_of)
                             .await
                             .map(|()| response)
                     }
@@ -1267,22 +1285,23 @@ impl PeekClient {
     /// Run the OCC loop: drain the subscribe at `as_of`, apply the
     /// mutation, and submit the resulting diffs as a write.
     ///
-    /// Semantically this is a SELECT at `as_of` followed by an INSERT.
-    /// Because we hold no write lock, a concurrent writer may bump the
-    /// target table's upper past our chosen write timestamp, in which
-    /// case the coordinator returns `WriteResult::TimestampPassed`. We
-    /// then wait for the subscribe to advance and retry, up to
-    /// `max_occ_retries` times.
+    /// Semantically a SELECT at `target - 1` followed by an INSERT at `target`.
+    /// `write_oracle` chooses `target`, the subscribe's frontier certifies the
+    /// payload is complete below it, and a target the target table has moved
+    /// past comes back as `WriteResult::TimestampPassed`, whose next eligible
+    /// timestamp the loop adopts. At most `max_occ_retries` attempts.
     ///
-    /// A subscribe that ends on its own reads no persisted state, so its diffs
-    /// are frontier-independent. Those are returned as [`OccOutcome::Blind`]
-    /// for the caller to submit or buffer, and this never writes them.
+    /// A subscribe that ends on its own has diffs no frontier can change, and
+    /// those are returned as [`OccOutcome::Blind`] rather than written.
     ///
-    /// Read linearization is the caller's responsibility, on both ends.
-    /// `as_of` must already be linearized (oracle read_ts >= `as_of`) on
-    /// entry, and an [`OccOutcome::NoRowsMatched`] carrying an `observed_ts`
-    /// must be linearized against it before the response goes out. See
-    /// `ensure_read_linearized` at the call site.
+    /// Contract on the caller, both ends of the read: the oracle's read
+    /// timestamp must be at or above `as_of` on entry, and an
+    /// [`OccOutcome::NoRowsMatched`] must be linearized against its
+    /// `empty_as_of` before the response goes out.
+    ///
+    /// `write_oracle` is `None` only for a timestamp-independent selection. Such
+    /// a statement reads at `Timestamp::maximum()`, so it observes no progress
+    /// past its `as_of` and always leaves through the blind path.
     ///
     /// Returns `(retry_count, result)` so the caller can record OCC retry
     /// metrics regardless of whether the operation succeeded or failed.
@@ -1301,235 +1320,301 @@ impl PeekClient {
         conn_id: mz_adapter_types::connection::ConnectionId,
         statement_logging_id: Option<StatementLoggingId>,
         as_of: Timestamp,
+        write_oracle: Option<Arc<dyn TimestampOracle<Timestamp> + Send + Sync>>,
         attempt_state: &FrontendWriteAttemptState,
     ) -> (usize, Result<OccOutcome, AdapterError>) {
         let mut state = OccState::new();
 
-        // Correctness invariant for retries:
+        // The timestamp the next attempt writes at, chosen when we are first
+        // ready to attempt one and replaced only by a conflict. `None` until
+        // then.
+        let mut write_target: Option<Timestamp> = None;
+
+        // The smallest timestamp an attempt may target. `as_of` itself is out,
+        // since the payload has to contain the snapshot the subscribe emits
+        // there.
         //
-        // `all_diffs` accumulates *all* rows ever received from the subscribe,
-        // across retries. The subscribe emits a snapshot (at the as_of
-        // timestamp) followed by incremental updates. We consolidate on every
-        // progress message (flattening timestamps to MIN first), so after
-        // consolidation `all_diffs` always represents "what the query returns
-        // as of the latest progress timestamp". Old snapshot rows that were
-        // retracted by newer updates cancel out, and new rows appear. This is
-        // exactly the set of diffs we want to write.
-        //
-        // Consolidating on every progress also means the NoRowsMatched check
-        // works correctly across retries: if the consolidated result becomes
-        // logically empty (all diffs cancel out), `all_diffs` will be empty
-        // and we early-return without attempting a write.
+        // `as_of` is `Timestamp::MAX` for a selection with no timestamp at all,
+        // which is the selection whose subscribe closes on its own and leaves
+        // through the blind path rather than a write. There is no timestamp
+        // above `MAX`, so saturating keeps this total instead of asserting a
+        // property of a value the write path never uses.
+        let min_target = as_of.try_step_forward().unwrap_or(as_of);
+
+        // Retry invariant: the payload is the selection consolidated at
+        // `target - 1`, and the diffs at or above `target` are concurrent with
+        // the write, so a retry folds them in only once it raises the target.
         let result = loop {
             if let Some(error) = attempt_state.requested_error() {
                 break Err(error);
             }
-            let msg = match subscribe_handle.recv().await {
-                Some(msg) => msg,
-                None => {
-                    // Channel closed cleanly: the SELECT is constant (no
-                    // table dependency), so the diffs do not depend on any
-                    // read frontier. The caller decides where they go, so we
-                    // flatten to `Timestamp::MIN` for `consolidate_updates`.
-                    state.consolidate(Timestamp::MIN);
-                    if state.all_diffs.is_empty() {
-                        break Ok(OccOutcome::NoRowsMatched {
-                            response: build_no_rows_response(&kind),
-                            observed_ts: None,
-                        });
-                    }
-                    let success_response = match build_success_response(
-                        &kind,
-                        &returning,
-                        &state.all_diffs,
-                        max_result_size,
-                        max_query_result_size,
-                        &row_set_finishing_seconds,
-                    ) {
-                        Ok(response) => response,
-                        Err(e) => break Err(e),
-                    };
-                    let diffs = state
-                        .all_diffs
-                        .iter()
-                        .map(|(row, _ts, diff)| (row.clone(), *diff))
-                        .collect_vec();
 
-                    break Ok(OccOutcome::Blind {
-                        response: success_response,
-                        diffs,
-                    });
+            // Before a target is chosen, `min_target` is a lower bound on it, so
+            // folding there consolidates the snapshot without admitting a diff a
+            // write would have to treat as concurrent.
+            let fold_target = write_target.unwrap_or(min_target);
+
+            // Already certified for the target we hold? Write. Otherwise wait for
+            // the next subscribe message. Waiting first would hang after a
+            // conflict, since an input settled until its next refresh sends
+            // nothing further and does not close the channel either.
+            //
+            // Termination: the write arm awaits a round trip and only a conflict
+            // returns to this one, raising `retry_count` towards
+            // `max_occ_retries`, so neither arm spins.
+            let attempt_write = match write_target {
+                Some(target) if state.current_upper.is_some_and(|upper| upper >= target) => true,
+                _ => {
+                    let msg = match subscribe_handle.recv().await {
+                        Some(msg) => msg,
+                        None => {
+                            // The channel closed cleanly, which says the
+                            // selection can never change again, so these diffs
+                            // are frontier-independent. It does not say the
+                            // selection reads nothing persisted, a sealed
+                            // `REFRESH AT` MV closes cleanly too. Either way no
+                            // target separates them, and the caller decides
+                            // where they go.
+                            state.fold_all();
+                            if state.payload.is_empty() {
+                                break Ok(OccOutcome::NoRowsMatched {
+                                    response: build_no_rows_response(&kind),
+                                    empty_as_of: None,
+                                });
+                            }
+                            let success_response = match build_success_response(
+                                &kind,
+                                &returning,
+                                &state.payload,
+                                max_result_size,
+                                max_query_result_size,
+                                &row_set_finishing_seconds,
+                            ) {
+                                Ok(response) => response,
+                                Err(e) => break Err(e),
+                            };
+
+                            break Ok(OccOutcome::Blind {
+                                response: success_response,
+                                diffs: std::mem::take(&mut state.payload),
+                            });
+                        }
+                    };
+
+                    match process_message(
+                        msg,
+                        &mut state,
+                        as_of,
+                        fold_target,
+                        max_result_size,
+                        &table_desc,
+                    ) {
+                        ProcessResult::Continue { ready_to_write } => ready_to_write,
+                        ProcessResult::NoRowsMatched { empty_as_of } => {
+                            break Ok(OccOutcome::NoRowsMatched {
+                                response: build_no_rows_response(&kind),
+                                empty_as_of: Some(empty_as_of),
+                            });
+                        }
+                        ProcessResult::Error(e) => break Err(e),
+                    }
                 }
             };
 
-            match process_message(msg, &mut state, as_of, max_result_size, &table_desc) {
-                ProcessResult::Continue { ready_to_write } => {
-                    if !ready_to_write {
-                        continue;
-                    }
+            if !attempt_write {
+                continue;
+            }
 
-                    // Drain pending messages before attempting write
-                    let drain_err = loop {
-                        match subscribe_handle.try_recv() {
-                            Ok(msg) => {
-                                match process_message(
-                                    msg,
-                                    &mut state,
-                                    as_of,
-                                    max_result_size,
-                                    &table_desc,
-                                ) {
-                                    ProcessResult::Continue { .. } => {}
-                                    ProcessResult::NoRowsMatched { observed_ts } => {
-                                        break Some(Ok(OccOutcome::NoRowsMatched {
-                                            response: build_no_rows_response(&kind),
-                                            observed_ts: Some(observed_ts),
-                                        }));
-                                    }
-                                    ProcessResult::Error(e) => {
-                                        break Some(Err(e));
-                                    }
-                                }
+            // Drain buffered messages before attempting the write.
+            let drain_err = loop {
+                match subscribe_handle.try_recv() {
+                    Ok(msg) => {
+                        match process_message(
+                            msg,
+                            &mut state,
+                            as_of,
+                            fold_target,
+                            max_result_size,
+                            &table_desc,
+                        ) {
+                            ProcessResult::Continue { .. } => {}
+                            ProcessResult::NoRowsMatched { empty_as_of } => {
+                                break Some(Ok(OccOutcome::NoRowsMatched {
+                                    response: build_no_rows_response(&kind),
+                                    empty_as_of: Some(empty_as_of),
+                                }));
                             }
-                            Err(mpsc::error::TryRecvError::Empty) => break None,
-                            // The subscribe can finish (coordinator drops the
-                            // sender after `process_response` returns true)
-                            // between our last recv() and this drain. This is
-                            // benign, all buffered messages have already been
-                            // consumed via the Ok(msg) arm above.
-                            Err(mpsc::error::TryRecvError::Disconnected) => break None,
-                        }
-                    };
-                    if let Some(result) = drain_err {
-                        break result;
-                    }
-
-                    let write_ts = state
-                        .current_upper
-                        .expect("must have seen progress to be ready to write");
-
-                    // Invariant: every diff we are about to write comes from a
-                    // time strictly below `write_ts`. `consolidate` below
-                    // rewrites all diff timestamps to `write_ts`, so a diff from
-                    // at or after `write_ts` would durably record rows that
-                    // reflect state from after the timestamp they were written
-                    // at.
-                    //
-                    // The drain can get ahead of the frontier: a subscribe sends
-                    // a batch's data and the following progress as two separate
-                    // channel messages, so `try_recv` can pick up data from the
-                    // next batch and then see `Empty`, leaving `current_upper`
-                    // at the older progress. When that happens we do not write.
-                    // Waiting for the next progress message re-establishes the
-                    // invariant, and it is bounded by `statement_timeout` like
-                    // every other wait in this loop.
-                    if state
-                        .max_data_ts
-                        .is_some_and(|max_data_ts| max_data_ts >= write_ts)
-                    {
-                        continue;
-                    }
-
-                    // Consolidate any rows received during the drain
-                    // (the bulk was already consolidated on the last progress).
-                    state.consolidate(write_ts);
-
-                    let success_response = match build_success_response(
-                        &kind,
-                        &returning,
-                        &state.all_diffs,
-                        max_result_size,
-                        max_query_result_size,
-                        &row_set_finishing_seconds,
-                    ) {
-                        Ok(response) => response,
-                        Err(e) => break Err(e),
-                    };
-
-                    // Submit write.
-                    //
-                    // TODO(aljoscha): Store `Arc<Row>` in `all_diffs` if this
-                    // shows up in profiles. Every attempt clones every row, and
-                    // we retry up to `max_occ_retries` times.
-                    attempt_state.mark_write_submitted();
-                    let result = self
-                        .call_coordinator(|tx| Command::AttemptWrite {
-                            conn_id: conn_id.clone(),
-                            target_id,
-                            target_global_id,
-                            diffs: state
-                                .all_diffs
-                                .iter()
-                                .map(|(row, _ts, diff)| (row.clone(), *diff))
-                                .collect_vec(),
-                            write_ts: Some(write_ts),
-                            tx,
-                        })
-                        .await;
-
-                    match classify_write_result(result, target_id, attempt_state) {
-                        WriteOutcome::Committed(timestamp) => {
-                            if let Some(id) = statement_logging_id {
-                                self.log_set_timestamp(id, timestamp);
+                            ProcessResult::Error(e) => {
+                                break Some(Err(e));
                             }
-                            // N.B. subscribe_handle is dropped here, which
-                            // fires off the cleanup message.
-                            break Ok(OccOutcome::Committed {
-                                response: success_response,
-                                write_ts: timestamp,
-                            });
-                        }
-                        WriteOutcome::Failed(err) => break Err(err),
-                        WriteOutcome::Conflict {
-                            next_eligible_timestamp,
-                        } => {
-                            // The write definitively did not land, so the
-                            // attempt is resolved. Clearing `write_submitted`
-                            // lets a cancel or statement timeout that fires
-                            // during the upcoming subscribe wait resolve
-                            // promptly instead of awaiting a write result.
-                            attempt_state.mark_write_resolved();
-                            // Do not advance `state.current_upper` (and
-                            // therefore `write_ts`) from `next_eligible_timestamp`.
-                            // The diffs in `all_diffs` are only known to be
-                            // correct as of subscribe progress we have actually
-                            // observed. Retrying at a newer oracle timestamp
-                            // before subscribe progress catches up would risk
-                            // applying stale diffs at the wrong timestamp. So
-                            // on a conflict we wait for the subscribe to
-                            // progress and retry using that observed frontier.
-                            state.retry_count += 1;
-                            // Cancellation wins over the retry budget: if both
-                            // apply, the user asked us to stop and that is the
-                            // more truthful answer.
-                            if let Some(error) = attempt_state.requested_error() {
-                                break Err(error);
-                            }
-                            if state.retry_count > max_occ_retries {
-                                // Contention is a user-visible condition, not
-                                // an internal invariant violation, and every
-                                // attempt was refused before anything was
-                                // appended, so the statement is retryable.
-                                break Err(AdapterError::ReadThenWriteContention);
-                            }
-                            tracing::debug!(
-                                retry_count = state.retry_count,
-                                write_ts = %write_ts,
-                                next_eligible_timestamp = %next_eligible_timestamp,
-                                "OCC write conflict, retrying"
-                            );
-                            continue;
                         }
                     }
+                    Err(mpsc::error::TryRecvError::Empty) => break None,
+                    // The subscribe can finish (coordinator drops the sender
+                    // after `process_response` returns true) between our last
+                    // recv() and this drain. This is benign, all buffered
+                    // messages have already been consumed via the Ok(msg) arm
+                    // above.
+                    Err(mpsc::error::TryRecvError::Disconnected) => break None,
                 }
-                ProcessResult::NoRowsMatched { observed_ts } => {
-                    break Ok(OccOutcome::NoRowsMatched {
-                        response: build_no_rows_response(&kind),
-                        observed_ts: Some(observed_ts),
+            };
+            if let Some(result) = drain_err {
+                break result;
+            }
+
+            let upper = state
+                .current_upper
+                .expect("a write attempt requires an observed frontier");
+
+            let target = match write_target {
+                Some(target) => target,
+                None => {
+                    let Some(oracle) = &write_oracle else {
+                        // Invariant: a statement with no governing timeline
+                        // reads at `as_of == Timestamp::maximum()`, so it
+                        // observes no progress past its `as_of` and leaves
+                        // through the blind arm above rather than reaching a
+                        // write.
+                        soft_panic_or_log!(
+                            "read-then-write reached a write attempt with no governing timeline"
+                        );
+                        break Err(AdapterError::Internal(
+                            "read-then-write has no oracle to take a write timestamp from".into(),
+                        ));
+                    };
+
+                    // One step above the oracle's write timestamp is the smallest
+                    // value `commit_timestamped` accepts.
+                    let peek_write_ts = oracle.peek_write_ts().await;
+                    let Some(chosen) = peek_write_ts.try_step_forward() else {
+                        // A timeline that reached `Timestamp::MAX` is a broken
+                        // environment, not anything this statement did.
+                        soft_panic_or_log!(
+                            "read-then-write cannot target a timestamp above the write \
+                             timeline's timestamp {peek_write_ts}"
+                        );
+                        break Err(AdapterError::Internal(format!(
+                            "write timeline exhausted at timestamp {peek_write_ts}"
+                        )));
+                    };
+
+                    // Unreachable while the oracle's read timestamp is at or
+                    // above `as_of` on entry, and the clamp keeps the payload
+                    // rule rather than only reporting the violation.
+                    if chosen < min_target {
+                        soft_panic_or_log!(
+                            "read-then-write target {chosen} does not clear the as_of {as_of}, \
+                             so the payload would miss the snapshot"
+                        );
+                    }
+                    let chosen = std::cmp::max(chosen, min_target);
+
+                    write_target = Some(chosen);
+                    chosen
+                }
+            };
+
+            // Fold in what the drain picked up, plus anything a target raised
+            // by the last conflict now admits.
+            state.fold_below(target);
+
+            // A write at `target` needs every diff below it, which is what
+            // progress at or above `target` certifies. Waiting for the next
+            // message is bounded by `statement_timeout`, like every wait here.
+            if upper < target {
+                continue;
+            }
+
+            if state.payload.is_empty() {
+                // Everything below `target` cancelled out, so there is nothing to
+                // write and the answer holds as of `target - 1`. Diffs pending at
+                // or above `target` are concurrent with the write this would have
+                // been and do not enter it.
+                break Ok(OccOutcome::NoRowsMatched {
+                    response: build_no_rows_response(&kind),
+                    empty_as_of: Some(empty_as_of(target)),
+                });
+            }
+
+            let success_response = match build_success_response(
+                &kind,
+                &returning,
+                &state.payload,
+                max_result_size,
+                max_query_result_size,
+                &row_set_finishing_seconds,
+            ) {
+                Ok(response) => response,
+                Err(e) => break Err(e),
+            };
+
+            // Submit write.
+            //
+            // TODO(aljoscha): Store `Arc<Row>` in the payload if this shows up
+            // in profiles. Every attempt clones every row, and we retry up to
+            // `max_occ_retries` times.
+            attempt_state.mark_write_submitted();
+            let result = self
+                .call_coordinator(|tx| Command::AttemptWrite {
+                    conn_id: conn_id.clone(),
+                    target_id,
+                    target_global_id,
+                    diffs: state.payload.clone(),
+                    write_ts: Some(target),
+                    tx,
+                })
+                .await;
+
+            match classify_write_result(result, target_id, attempt_state) {
+                WriteOutcome::Committed(timestamp) => {
+                    if let Some(id) = statement_logging_id {
+                        self.log_set_timestamp(id, timestamp);
+                    }
+                    // N.B. subscribe_handle is dropped here, which fires off
+                    // the cleanup message.
+                    break Ok(OccOutcome::Committed {
+                        response: success_response,
+                        write_ts: timestamp,
                     });
                 }
-                ProcessResult::Error(e) => {
-                    break Err(e);
+                WriteOutcome::Failed(err) => break Err(err),
+                WriteOutcome::Conflict {
+                    next_eligible_timestamp,
+                } => {
+                    // The write definitively did not land, so the attempt is
+                    // resolved. Clearing `write_submitted` lets a cancel or
+                    // statement timeout that fires during the upcoming
+                    // subscribe wait resolve promptly instead of awaiting a
+                    // write result.
+                    attempt_state.mark_write_resolved();
+                    // Adopt the timestamp the committer reported as next
+                    // eligible. The accumulated diffs say nothing about it
+                    // yet, and they do not have to: the readiness check above
+                    // holds the next attempt until the subscribe has certified
+                    // everything below the new target, and the fold then moves
+                    // the diffs in between into the payload.
+                    write_target = Some(next_eligible_timestamp);
+                    state.retry_count += 1;
+                    // Cancellation wins over the retry budget: if both apply,
+                    // the user asked us to stop and that is the more truthful
+                    // answer.
+                    if let Some(error) = attempt_state.requested_error() {
+                        break Err(error);
+                    }
+                    if state.retry_count > max_occ_retries {
+                        // Contention is a user-visible condition, not an
+                        // internal invariant violation, and every attempt was
+                        // refused before anything was appended, so the
+                        // statement is retryable.
+                        break Err(AdapterError::ReadThenWriteContention);
+                    }
+                    tracing::debug!(
+                        retry_count = state.retry_count,
+                        write_ts = %target,
+                        next_eligible_timestamp = %next_eligible_timestamp,
+                        "OCC write conflict, retrying"
+                    );
+                    continue;
                 }
             }
         };
@@ -1549,50 +1634,93 @@ struct ValidationResult {
 }
 
 /// Accumulated state for the OCC loop in `run_occ_loop`.
+///
+/// Every diff the subscribe ever sent is kept, split at [`Self::split`]. The
+/// split only rises, so each diff crosses it once.
 struct OccState {
-    all_diffs: Vec<(Row, Timestamp, Diff)>,
+    /// Consolidated net diffs from strictly below [`Self::split`].
+    payload: Vec<(Row, Diff)>,
+    /// Diffs at or above [`Self::split`], consolidated by `(row, timestamp)`.
+    pending: Vec<(Row, Timestamp, Diff)>,
+    /// Where the last fold split the diffs, `None` before the first one.
+    split: Option<Timestamp>,
+    /// Timestamp of the last progress message, which certifies that no diff
+    /// will arrive below it.
     current_upper: Option<Timestamp>,
-    /// The largest timestamp among the data rows accumulated since the last
-    /// [`Self::consolidate`], which is where the diffs' own timestamps are
-    /// erased. `None` means every accumulated diff is already known to be from
-    /// before `current_upper`.
-    max_data_ts: Option<Timestamp>,
     retry_count: usize,
+    /// Row bytes held in `payload` and `pending` together, which is what the
+    /// `max_result_size` check measures. `pending` is consolidated by
+    /// `(row, timestamp)`, so a row touched at several timestamps occupies
+    /// several entries until a rising split folds them together, and the count
+    /// can exceed the size of the payload that eventually goes out.
     byte_size: u64,
 }
 
 impl OccState {
     fn new() -> Self {
         Self {
-            all_diffs: Vec::new(),
+            payload: Vec::new(),
+            pending: Vec::new(),
+            split: None,
             current_upper: None,
-            max_data_ts: None,
             retry_count: 0,
             byte_size: 0,
         }
     }
 
-    /// Forward all diff timestamps to `target_ts` and consolidate.
+    /// Raises the split to `split`, moving the diffs below it into the payload.
     ///
-    /// After consolidation, `all_diffs` represents the net state of the
-    /// query as of `target_ts`. Rows that were retracted by newer updates
-    /// cancel out, and `byte_size` is recomputed to reflect the
-    /// consolidated data.
+    /// Lowering it is a bug: the payload is consolidated and never re-split, so
+    /// the diffs above a lowered split would stay in it. We clamp to the old
+    /// split, which keeps the payload's contract intact.
+    fn fold_below(&mut self, split: Timestamp) {
+        let split = match self.split {
+            Some(previous) if split < previous => {
+                soft_panic_or_log!(
+                    "read-then-write folded at {split}, below its previous split {previous}"
+                );
+                previous
+            }
+            _ => split,
+        };
+        self.split = Some(split);
+        self.fold(Some(split));
+    }
+
+    /// Moves every accumulated diff into the payload, whatever its timestamp.
     ///
-    /// The caller must have established that every diff comes from a time at or
-    /// before `target_ts`, otherwise the consolidated set claims to describe
-    /// `target_ts` while reflecting state from after it.
-    fn consolidate(&mut self, target_ts: Timestamp) {
-        for (_, ts, _) in self.all_diffs.iter_mut() {
-            *ts = target_ts;
+    /// Only valid once the subscribe has run to completion, where the diffs are
+    /// frontier-independent and no split separates them.
+    fn fold_all(&mut self) {
+        self.fold(None);
+    }
+
+    /// Moves the diffs below `split`, or all of them when it is `None`, into the
+    /// payload, consolidates both halves, and recomputes `byte_size`.
+    fn fold(&mut self, split: Option<Timestamp>) {
+        for (row, ts, diff) in std::mem::take(&mut self.pending) {
+            match split {
+                Some(split) if ts >= split => self.pending.push((row, ts, diff)),
+                _ => self.payload.push((row, diff)),
+            }
         }
-        consolidation::consolidate_updates(&mut self.all_diffs);
+        consolidation::consolidate(&mut self.payload);
+        consolidation::consolidate_updates(&mut self.pending);
         self.byte_size = self
-            .all_diffs
+            .payload
             .iter()
-            .map(|(row, _, _)| u64::cast_from(row.byte_len()))
+            .map(|(row, _)| u64::cast_from(row.byte_len()))
+            .chain(
+                self.pending
+                    .iter()
+                    .map(|(row, _, _)| u64::cast_from(row.byte_len())),
+            )
             .sum();
-        self.max_data_ts = None;
+    }
+
+    /// Whether nothing has been accumulated on either side of the split.
+    fn is_empty(&self) -> bool {
+        self.payload.is_empty() && self.pending.is_empty()
     }
 }
 
@@ -1601,22 +1729,28 @@ enum ProcessResult {
     Continue {
         ready_to_write: bool,
     },
-    /// The consolidated selection is empty as of `observed_ts`.
+    /// The consolidated selection is empty, as of the timestamp reported. See
+    /// [`OccOutcome::NoRowsMatched`].
     NoRowsMatched {
-        observed_ts: Timestamp,
+        empty_as_of: Timestamp,
     },
     Error(AdapterError),
 }
 
 /// Process one subscribe message, updating `state` in place.
 ///
-/// Data rows are accumulated into `state.all_diffs` (with per-row constraint
-/// and max-result-size checks). Progress messages trigger consolidation and
-/// can promote the accumulated diffs to "ready to write".
+/// Data rows are accumulated into `state` (with per-row constraint and
+/// max-result-size checks). Progress messages fold everything below
+/// `fold_target` into the payload and can promote the accumulated diffs to
+/// "ready to write".
+///
+/// `fold_target` must not exceed the timestamp the next write attempt uses, or
+/// the payload takes in a diff that is concurrent with that write.
 fn process_message(
     response: PeekResponseUnary,
     state: &mut OccState,
     as_of: Timestamp,
+    fold_target: Timestamp,
     max_result_size: u64,
     table_desc: &RelationDesc,
 ) -> ProcessResult {
@@ -1665,29 +1799,29 @@ fn process_message(
                     state.current_upper = Some(ts);
                     saw_progress = true;
 
-                    // Consolidate incrementally on each progress
-                    // message. This keeps memory bounded by the
-                    // consolidated size and makes the byte_size check
-                    // below accurate (except for rows received between
-                    // two progress messages, which is a small window).
-                    state.consolidate(ts);
+                    // Fold and consolidate incrementally on each progress
+                    // message. This keeps memory bounded by the consolidated
+                    // size and makes the byte_size check below accurate (except
+                    // for rows received between two progress messages, which is
+                    // a small window).
+                    state.fold_below(fold_target);
 
-                    // The very first progress message we receive is
-                    // always at `as_of`, emitted synchronously by
-                    // `ActiveSubscribe::initialize` *before* any data
-                    // batch is processed. At that point `all_diffs` is
-                    // empty by construction, regardless of whether the
-                    // snapshot is actually empty, so we must not
-                    // conclude `NoRowsMatched` from it. Progress
-                    // messages emitted later from `process_response`
-                    // are gated on `batch.upper > as_of`, so any
-                    // progress with `ts > as_of` is past the initial
-                    // one and an empty `all_diffs` then genuinely
-                    // means no rows matched. See
-                    // `src/adapter/src/active_compute_sink.rs` for
-                    // the emission order.
-                    if ts > as_of && state.all_diffs.is_empty() {
-                        return ProcessResult::NoRowsMatched { observed_ts: ts };
+                    // NOTE: The first progress message is always at `as_of`,
+                    // emitted by `ActiveSubscribe::initialize` before any data
+                    // batch, so the accumulation is empty there whatever the
+                    // snapshot holds. Later progress is gated on `batch.upper >
+                    // as_of` (see `crate::active_compute_sink`), so `ts > as_of`
+                    // is what distinguishes a real answer from that first one.
+                    //
+                    // Nothing accumulated at all, so no write is coming and the
+                    // loop would otherwise wait for diffs that will not arrive.
+                    // Our view is complete below `ts` and the payload covers
+                    // below `fold_target`, so the emptiness holds as of one below
+                    // the earlier of the two.
+                    if ts > as_of && state.is_empty() {
+                        return ProcessResult::NoRowsMatched {
+                            empty_as_of: empty_as_of(std::cmp::min(ts, fold_target)),
+                        };
                     }
                 } else {
                     let Some(diff_datum) = datums.next() else {
@@ -1724,21 +1858,13 @@ fn process_message(
                             ByteSize::b(max_result_size)
                         )));
                     }
-                    state.max_data_ts = Some(match state.max_data_ts {
-                        Some(max_ts) => std::cmp::max(max_ts, ts),
-                        None => ts,
-                    });
-                    state.all_diffs.push((data_row, ts, diff));
+                    state.pending.push((data_row, ts, diff));
                 }
             }
 
-            // We're ready to write once we've seen a progress
-            // message and have accumulated any diffs. Data rows can
-            // only arrive *after* the initial progress at `as_of`
-            // (see the note in the progress branch), so a non-empty
-            // `all_diffs` here implies we're past the initial
-            // progress.
-            let ready_to_write = saw_progress && !state.all_diffs.is_empty();
+            // The complement of the zero-row exit above: something accumulated
+            // means a write is coming, nothing at all means there is none.
+            let ready_to_write = saw_progress && !state.is_empty();
             ProcessResult::Continue { ready_to_write }
         }
         PeekResponseUnary::Error(e) => {
@@ -1752,6 +1878,16 @@ fn process_message(
         }
         PeekResponseUnary::Canceled => ProcessResult::Error(AdapterError::Canceled),
     }
+}
+
+/// The timestamp an answer holds as of, given a view complete strictly below
+/// `complete_below`.
+///
+/// Both callers derive `complete_below` from a timestamp strictly above the
+/// subscribe's `as_of`, so it is never `Timestamp::MIN` and the saturating
+/// fallback is unreachable.
+fn empty_as_of(complete_below: Timestamp) -> Timestamp {
+    complete_below.step_back().unwrap_or(complete_below)
 }
 
 /// Build the response returned when no rows matched the selection.
@@ -1840,5 +1976,211 @@ fn apply_mutation_to_mir(
         // INSERT: rows pass through unchanged, the subscribe emits them with
         // diff +1.
         MutationKind::Insert => expr,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_repr::adt::numeric;
+    use mz_repr::{Datum, IntoRowIterator};
+
+    use super::*;
+
+    fn row(value: i64) -> Row {
+        Row::pack_slice(&[Datum::Int64(value)])
+    }
+
+    /// A progress message in the subscribe's `SubscribeOutput::Diffs` shape:
+    /// `mz_timestamp, mz_progressed, mz_diff, data...`.
+    fn progress(ts: u64) -> PeekResponseUnary {
+        let mut row = Row::default();
+        let mut packer = row.packer();
+        packer.push(Datum::from(numeric::Numeric::from(ts)));
+        packer.push(Datum::True);
+        packer.push(Datum::Null);
+        PeekResponseUnary::Rows(Box::new(row.into_row_iter()))
+    }
+
+    /// Accumulates `(row value, timestamp, diff)` triples the way
+    /// `process_message` does, without going through a subscribe.
+    fn accumulate(diffs: impl IntoIterator<Item = (i64, u64, i64)>) -> OccState {
+        let mut state = OccState::new();
+        for (value, ts, diff) in diffs {
+            state
+                .pending
+                .push((row(value), Timestamp::new(ts), Diff::from(diff)));
+        }
+        state
+    }
+
+    /// The target is the boundary the write turns on, so the off-by-one is the
+    /// whole point: a diff at exactly the target is concurrent with the write
+    /// and must not be in its payload.
+    #[mz_ore::test]
+    fn test_fold_below_splits_at_the_target() {
+        let mut state = accumulate([(1, 9, 1), (2, 10, 1), (3, 11, 1)]);
+        state.fold_below(Timestamp::new(10));
+
+        assert_eq!(state.payload, vec![(row(1), Diff::ONE)]);
+        assert_eq!(
+            state.pending,
+            vec![
+                (row(2), Timestamp::new(10), Diff::ONE),
+                (row(3), Timestamp::new(11), Diff::ONE),
+            ]
+        );
+    }
+
+    /// A retry raises the target, which is what admits the diffs that were
+    /// concurrent with the attempt that lost.
+    #[mz_ore::test]
+    fn test_fold_below_moves_each_diff_once() {
+        let mut state = accumulate([(1, 9, 1), (2, 10, 1), (3, 11, 1)]);
+
+        state.fold_below(Timestamp::new(10));
+        assert_eq!(state.payload, vec![(row(1), Diff::ONE)]);
+
+        state.fold_below(Timestamp::new(11));
+        assert_eq!(
+            state.payload,
+            vec![(row(1), Diff::ONE), (row(2), Diff::ONE)]
+        );
+        assert_eq!(state.pending, vec![(row(3), Timestamp::new(11), Diff::ONE)]);
+
+        state.fold_below(Timestamp::new(12));
+        assert_eq!(
+            state.payload,
+            vec![
+                (row(1), Diff::ONE),
+                (row(2), Diff::ONE),
+                (row(3), Diff::ONE),
+            ]
+        );
+        assert!(state.pending.is_empty());
+    }
+
+    /// A row inserted and retracted below the target leaves nothing behind,
+    /// which is what makes the payload the net change rather than a log.
+    #[mz_ore::test]
+    fn test_fold_below_cancels_opposite_diffs() {
+        let mut state = accumulate([(1, 9, 1), (1, 10, -1), (2, 9, 1)]);
+        state.fold_below(Timestamp::new(11));
+
+        assert_eq!(state.payload, vec![(row(2), Diff::ONE)]);
+        assert!(state.pending.is_empty());
+        assert!(!state.is_empty());
+    }
+
+    /// The same rows stay pending or move to the payload depending on the
+    /// target, so a size check that saw only one half would let a statement
+    /// past `max_result_size` by picking the other one.
+    #[mz_ore::test]
+    fn test_byte_size_counts_payload_and_pending() {
+        let row_bytes = u64::cast_from(row(1).byte_len());
+
+        let mut state = accumulate([(1, 9, 1), (2, 10, 1), (3, 11, 1)]);
+        state.fold_below(Timestamp::new(10));
+        assert_eq!(state.payload.len(), 1);
+        assert_eq!(state.pending.len(), 2);
+        assert_eq!(state.byte_size, 3 * row_bytes);
+
+        state.fold_below(Timestamp::new(12));
+        assert!(state.pending.is_empty());
+        assert_eq!(state.byte_size, 3 * row_bytes);
+    }
+
+    /// A subscribe that ran to completion has no target to split on, and
+    /// cancellation still applies.
+    #[mz_ore::test]
+    fn test_fold_all_takes_every_timestamp() {
+        let mut state = accumulate([(1, 9, 1), (1, 10, -1), (2, u64::MAX, 1)]);
+        state.fold_all();
+
+        assert_eq!(state.payload, vec![(row(2), Diff::ONE)]);
+        assert!(state.pending.is_empty());
+    }
+
+    /// A zero-row answer holds as of the timestamp the answer was reached at,
+    /// never an input's frontier. The caller waits for the oracle to reach
+    /// whatever it gets, and an input settled until its next refresh reports a
+    /// frontier days out, so reporting that would spend the statement's timeout
+    /// on an answer of "0 rows".
+    #[mz_ore::test]
+    fn test_zero_rows_report_the_answer_not_the_frontier() {
+        let as_of = Timestamp::new(10);
+        let desc = RelationDesc::empty();
+
+        // First pass, where the fold target is `as_of + 1`. The answer holds at
+        // `as_of`, which the caller linearized before the subscribe started, so
+        // it costs no wait however far out the frontier is.
+        let mut state = OccState::new();
+        match process_message(
+            progress(u64::MAX / 2),
+            &mut state,
+            as_of,
+            as_of.step_forward(),
+            u64::MAX,
+            &desc,
+        ) {
+            ProcessResult::NoRowsMatched { empty_as_of } => assert_eq!(empty_as_of, as_of),
+            _ => panic!("an empty selection past `as_of` must report no rows matched"),
+        }
+
+        // A target raised by a conflict, with the frontier past it. The answer
+        // holds at one below the target, the same timestamp a write there would
+        // have been read at.
+        let fold_target = Timestamp::new(20);
+        let mut state = OccState::new();
+        match process_message(
+            progress(u64::MAX / 2),
+            &mut state,
+            as_of,
+            fold_target,
+            u64::MAX,
+            &desc,
+        ) {
+            ProcessResult::NoRowsMatched { empty_as_of } => {
+                assert_eq!(empty_as_of, Timestamp::new(19))
+            }
+            _ => panic!("an empty selection past `as_of` must report no rows matched"),
+        }
+
+        // A frontier below the target certifies less, so the answer holds one
+        // below the frontier instead.
+        let mut state = OccState::new();
+        match process_message(
+            progress(15),
+            &mut state,
+            as_of,
+            fold_target,
+            u64::MAX,
+            &desc,
+        ) {
+            ProcessResult::NoRowsMatched { empty_as_of } => {
+                assert_eq!(empty_as_of, Timestamp::new(14))
+            }
+            _ => panic!("an empty selection past `as_of` must report no rows matched"),
+        }
+    }
+
+    /// Diffs waiting above the target mean a write is still coming, so the
+    /// answer is not "no rows" yet even with an empty payload.
+    #[mz_ore::test]
+    fn test_pending_diffs_are_not_a_zero_row_answer() {
+        let as_of = Timestamp::new(10);
+        let desc = RelationDesc::empty();
+
+        let mut state = accumulate([(1, 30, 1)]);
+        match process_message(
+            progress(20),
+            &mut state,
+            as_of,
+            as_of.step_forward(),
+            u64::MAX,
+            &desc,
+        ) {
+            ProcessResult::Continue { ready_to_write } => assert!(ready_to_write),
+            _ => panic!("a selection with diffs above the target must not report no rows"),
+        }
     }
 }

--- a/src/environmentd/tests/read_then_write.rs
+++ b/src/environmentd/tests/read_then_write.rs
@@ -2118,24 +2118,23 @@ fn test_replica_expiration_spares_folded_selections() {
     assert_eq!(streamed, "", "the subscribe streamed {streamed:?}");
 }
 
-/// A read-then-write whose write timestamp would run past what the write timeline
-/// may be advanced to has to be refused, not committed.
+/// A read-then-write over an input whose frontier runs far ahead of the wall clock
+/// commits near the clock, not at that frontier.
 ///
-/// The OCC path derives its write timestamp from the frontier its subscribe observed,
-/// and a selection over a materialized view with a `REFRESH` option settles until the
-/// next refresh, so that frontier is legitimately hours or days ahead of the clock.
-/// Committing there advances the timeline's oracle with it, and the oracle is monotone
-/// and durable, so every later write and strict-serializable read on the timeline blocks
-/// until the clock catches up, restarts included. Under `serializable` it is worse than a
-/// block: reads pick a timestamp near the clock, so the acknowledged write stays
-/// invisible.
+/// The write timestamp comes from the timeline's oracle, and the subscribe's frontier
+/// only certifies which diffs the write has a complete view of. That split is what
+/// makes this statement ordinary: a selection over a materialized view with a `REFRESH`
+/// option settles until the next refresh, so its frontier is legitimately hours or days
+/// ahead of the clock. Committing there would advance the timeline's oracle with it, and
+/// the oracle is monotone and durable, so every later write and strict-serializable read
+/// on the timeline blocks until the clock catches up, restarts included.
 ///
 /// The MV here refreshes once a few seconds out and once far away. Past the near
-/// refresh it is readable, and its upper is then the far one, which is what makes the
-/// write target far future deterministically rather than by racing a refresh interval.
+/// refresh it is readable, and its upper is then the far one, which puts the frontier
+/// far in the future deterministically rather than by racing a refresh interval.
 #[mz_ore::test]
 #[allow(clippy::disallowed_methods)]
-fn test_far_future_write_timestamp_is_refused() {
+fn test_refresh_mv_write_commits_near_wall_clock() {
     let server = frontend_occ_harness()
         .unsafe_mode()
         .with_system_parameter_default("enable_refresh_every_mvs".to_string(), "true".to_string())
@@ -2161,18 +2160,13 @@ fn test_far_future_write_timestamp_is_refused() {
         .batch_execute("SET statement_timeout = '60s'")
         .unwrap();
 
-    let err = client
+    let rows = client
         .execute("INSERT INTO dst SELECT a FROM mv", &[])
-        .expect_err("a write at a far-future timestamp must be refused");
-    let message = server_error_message(&err);
-    assert!(
-        message.contains("past the highest timestamp the write timeline may be advanced to"),
-        "unexpected error for a far-future write: {message}"
-    );
+        .expect("a write over a far-future frontier commits near the clock");
+    assert_eq!(rows, 3, "the whole MV must have been written");
 
-    // The refusal has to happen before the append, so the oracle never learns the
-    // far-future timestamp. Checked before anything reads `dst`, because a read cannot be
-    // served once the oracle is out there.
+    // Checked before anything reads `dst`, because a read cannot be served once the
+    // oracle is out there.
     let skew: i64 = client
         .query_one(
             "SELECT mz_now()::text::bigint - (extract(epoch FROM now()) * 1000)::bigint",
@@ -2182,8 +2176,14 @@ fn test_far_future_write_timestamp_is_refused() {
         .get(0);
     assert!(
         skew.abs() < 60_000,
-        "the oracle is {skew}ms from wall clock, so the refused write reached it anyway"
+        "the oracle is {skew}ms from wall clock, so the write timestamp came from the frontier"
     );
+
+    let rows = client
+        .query_one("SELECT count(*) FROM dst", &[])
+        .unwrap()
+        .get::<_, i64>(0);
+    assert_eq!(rows, 3, "the committed write must be readable");
 
     // The timeline is still usable, both for writes and for reads of the target.
     client.batch_execute("INSERT INTO dst VALUES (4)").unwrap();
@@ -2191,5 +2191,58 @@ fn test_far_future_write_timestamp_is_refused() {
         .query_one("SELECT count(*) FROM dst", &[])
         .unwrap()
         .get::<_, i64>(0);
-    assert_eq!(rows, 1, "the refused write must not have landed");
+    assert_eq!(rows, 4, "the timeline still takes writes");
+}
+
+/// A `serializable` session reads back a read-then-write it committed over a far-future
+/// frontier.
+///
+/// A `serializable` read picks a timestamp near the wall clock and never consults the
+/// oracle, so a write committed hours or days ahead of the clock is not merely slow to
+/// see, it is invisible for that long. Strict serializability hides that: those reads
+/// linearize against the oracle, so they would block instead. This pins read-your-writes
+/// for the isolation level that cannot block its way to correctness.
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_serializable_read_sees_own_refresh_mv_write() {
+    let server = frontend_occ_harness()
+        .unsafe_mode()
+        .with_system_parameter_default("enable_refresh_every_mvs".to_string(), "true".to_string())
+        .start_blocking();
+    let mut client = server.connect(postgres::NoTls).unwrap();
+
+    client.batch_execute("CREATE TABLE src (a INT)").unwrap();
+    client
+        .batch_execute("INSERT INTO src VALUES (1), (2), (3)")
+        .unwrap();
+    client.batch_execute("CREATE TABLE dst (a INT)").unwrap();
+    client
+        .batch_execute(
+            "CREATE MATERIALIZED VIEW mv \
+             WITH (REFRESH AT mz_now()::text::int8 + 3000, REFRESH AT '3000-01-01') \
+             AS SELECT a FROM src",
+        )
+        .unwrap();
+
+    // The read side still parks until the near refresh, whatever the isolation level.
+    client
+        .batch_execute("SET statement_timeout = '60s'")
+        .unwrap();
+    client
+        .batch_execute("SET transaction_isolation = 'serializable'")
+        .unwrap();
+
+    let rows = client
+        .execute("INSERT INTO dst SELECT a FROM mv", &[])
+        .expect("a write over a far-future frontier commits near the clock");
+    assert_eq!(rows, 3, "the whole MV must have been written");
+
+    let rows = client
+        .query_one("SELECT count(*) FROM dst", &[])
+        .unwrap()
+        .get::<_, i64>(0);
+    assert_eq!(
+        rows, 3,
+        "a serializable read must see the session's own write"
+    );
 }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4845,13 +4845,33 @@ def workflow_test_occ_zero_row_write_linearization(c: Composition) -> None:
     The `group_commit_before_apply_write` failpoint holds the winning writer
     inside that window, the same one a second `environmentd` process opens on
     its own with no ordering against local Persist visibility.
+
+    The winner is a blind INSERT into a second table rather than a write to the
+    target, because a blind write takes its timestamp from the oracle before it
+    parks. Its `W` is therefore below the target the UPDATE picks, so the UPDATE
+    folds the winner's effect into an empty payload and reaches its zero-row answer
+    without submitting anything, while the oracle still cannot serve reads at `W`.
+
+    A winner that took a timestamped write, an OCC `DELETE` on the target for
+    instance, does not witness this. `commit_timestamped` only peeks the oracle, so
+    a parked one leaves the write timestamp untouched, the UPDATE picks `W` itself,
+    and its submission queues behind the parked winner on the group committer. The
+    refusal then cannot come back until the winner has applied `W`, so the answer
+    is only ever reached after the oracle already covers it and the assertion below
+    holds whether or not the zero-row path linearizes at all.
+
+    NOTE: The premise relies on the UPDATE's frontier reaching `W + 1` even though
+    the winner wrote a different table, which holds because a txns-shard append
+    advances the readable upper of every registered table. If that ever stops
+    holding, the UPDATE waits for its frontier rather than for the oracle, and an
+    attempt passes without witnessing anything.
     """
 
     # Every txns-shard write parks here while armed, including the keepalives
     # that advance table uppers, so this has to be a bounded `sleep` and not a
-    # `pause`: a keepalive would take the `pause` first and the winning DELETE
-    # would never get to append. The window only has to outlast a peek and one
-    # subscribe dataflow installation.
+    # `pause`: a keepalive would take the `pause` first and the winning INSERT
+    # would never get to append. The window has to outlast a peek, one subscribe
+    # dataflow installation, and the UPDATE's own wait for the oracle.
     failpoint = "group_commit_before_apply_write"
     arm = f"SET failpoints = '{failpoint}=sleep(10000)'"
     disarm = f"SET failpoints = '{failpoint}=off'"
@@ -4870,8 +4890,9 @@ def workflow_test_occ_zero_row_write_linearization(c: Composition) -> None:
         }
         return values[f"{metric}_count"], values[f"{metric}_sum"]
 
-    def count(cur: Cursor, key: int) -> int:
-        cur.execute(f"SELECT count(*) FROM t WHERE k = {key}".encode())
+    def guard_rows(cur: Cursor, key: int) -> int:
+        """Rows of `guard` for `key`, which is what the UPDATE's selection reads."""
+        cur.execute(f"SELECT count(*) FROM guard WHERE g = {key}".encode())
         row = cur.fetchone()
         assert row is not None
         return int(row[0])
@@ -4886,6 +4907,9 @@ def workflow_test_occ_zero_row_write_linearization(c: Composition) -> None:
     ):
         c.up("materialized")
         c.sql("CREATE TABLE t (k int, v int)")
+        # A row here empties the UPDATE's selection. Keyed per attempt, so an
+        # attempt never starts from a selection an earlier one already emptied.
+        c.sql("CREATE TABLE guard (g int)")
 
         # Ask the process rather than the catalog which path it takes: the UPDATE
         # only reaches the histogram if the frontend sequenced it.
@@ -4909,78 +4933,94 @@ def workflow_test_occ_zero_row_write_linearization(c: Composition) -> None:
             # read cannot.
             probe.execute("SET transaction_isolation = 'serializable'")
 
-            # The UPDATE's subscribe can instead report progress at the table's
-            # pre-append upper, with the row still there, then submit a write,
-            # queue behind the parked committer, and conclude zero rows only once
-            # the oracle has caught up. That proves nothing either way, so such an
-            # attempt is retried; the write conflict count tells the two apart.
+            # An attempt only says something while the window is open. The
+            # failpoint's `sleep` can expire first, and then the guard row is
+            # readable through the oracle and the UPDATE reports zero rows for the
+            # ordinary reason. The witness below tells the two apart, and an
+            # attempt that lost the window is retried with a fresh key.
             for attempt in range(1, 4):
                 key = attempt
                 c.sql(f"INSERT INTO t VALUES ({key}, 1)")
                 armed = Event()
 
-                def delete_winner(key: int = key) -> None:
+                def guard_winner(key: int = key) -> None:
                     armed.wait()
-                    # Lands its append and advances t's upper, then the committer
+                    # Takes its timestamp from the oracle, lands its append, then
                     # parks before applying that timestamp to the oracle.
-                    winner_cur.execute(f"DELETE FROM t WHERE k = {key}".encode())
+                    winner_cur.execute(f"INSERT INTO guard VALUES ({key})".encode())
 
-                winner = PropagatingThread(target=delete_winner, name="winner")
+                winner = PropagatingThread(target=guard_winner, name="winner")
                 winner.start()
                 control.execute(arm)
                 armed.set()
 
                 # The winner's append is visible in Persist from here on ...
                 deadline = time.time() + 120
-                while count(probe, key) > 0:
+                while guard_rows(probe, key) == 0:
                     assert (
                         time.time() < deadline
-                    ), "the winning DELETE never became visible in Persist"
+                    ), "the winning INSERT never became visible in Persist"
                     time.sleep(0.1)
                 # ... and the oracle cannot serve reads at it yet, which is what
                 # puts us inside the window. This witness says nothing about the
                 # UPDATE, so it stays valid once the zero-row path waits.
-                before = count(session, key)
+                before = guard_rows(session, key)
 
                 conflicts = occ_writes()[1]
                 started = time.time()
-                session.execute(f"UPDATE t SET v = v + 1 WHERE k = {key}".encode())
+                session.execute(
+                    f"UPDATE t SET v = v + 1 WHERE k = {key} "
+                    f"AND NOT EXISTS (SELECT 1 FROM guard WHERE g = {key})".encode()
+                )
                 matched = session.rowcount
                 elapsed = time.time() - started
-                after = count(session, key)
+                after = guard_rows(session, key)
                 conflicts = occ_writes()[1] - conflicts
 
                 control.execute(disarm)
                 # `off` does not interrupt a `sleep` under way, so this waits out
                 # the rest of the window.
                 winner.join(timeout=120)
-                assert not winner.is_alive(), "the winning DELETE never finished"
+                assert not winner.is_alive(), "the winning INSERT never finished"
 
                 print(
                     f"attempt {attempt}: UPDATE matched {matched} row(s) in "
                     f"{elapsed:.1f}s with {conflicts} write conflict(s); "
-                    f"strict-serializable reads saw {before} row(s) before it and "
-                    f"{after} row(s) after"
+                    f"strict-serializable reads saw {before} guard row(s) before it "
+                    f"and {after} after"
                 )
                 assert matched == 0, (
-                    f"the UPDATE matched {matched} row(s) with the winner's delete "
-                    "already visible, so it never took the zero-row path"
+                    f"the UPDATE matched {matched} row(s) with the guard row already "
+                    "visible, so it never took the zero-row path"
                 )
-                if before == 0 or conflicts > 0:
+                if before > 0:
+                    # The guard row was already readable through the oracle, so
+                    # the zero-row answer needed no linearization and this attempt
+                    # witnesses nothing.
                     continue
 
-                assert after == 0, (
+                assert conflicts == 0, (
+                    f"the UPDATE lost {conflicts} write conflict(s), so it submitted "
+                    "a write and its answer came back only after the parked winner "
+                    "applied, which leaves the assertion below with nothing to witness"
+                )
+
+                # Without the linearization the UPDATE returns while the oracle is
+                # still below the guard row's timestamp, so this read lands below it
+                # too and reports 0: a statement that answered "no rows" from state
+                # the following read cannot see.
+                assert after == 1, (
                     "the UPDATE reported zero rows matched from state the oracle had "
-                    f"not applied yet, and a strict-serializable read after it saw "
-                    f"{after} row(s): the zero-row response was not linearized against "
-                    "the write that emptied the selection"
+                    "not applied yet, and a strict-serializable read after it saw "
+                    f"{after} guard row(s): the zero-row response was not linearized "
+                    "against the write that emptied the selection"
                 )
                 break
             else:
                 raise AssertionError(
-                    "no attempt got the UPDATE to report zero rows from the newer "
-                    "state without first submitting a write, so the window was never "
-                    "observed"
+                    "no attempt ran its UPDATE while the winning INSERT was "
+                    "visible in Persist but not yet through the oracle, so the "
+                    "window was never observed"
                 )
 
 


### PR DESCRIPTION
Closes: [SQL-641](https://linear.app/materializeinc/issue/SQL-641)

Stacked on #38320. Makes the far-future write timestamp correct rather than merely refused. Rebased onto main now that #37924 has landed.

## The conflation

The OCC loop wrote at the frontier its subscribe reported. A frontier certifies *what the loop has a complete view of*. Choosing *which timestamp to write at* is a separate decision, and the two coincide only because the target table is usually what pins the frontier. Nothing in the code stated that dependency, and the comment on the conflict arm was the same constraint seen from the other side, satisfied by pulling the target down to the frontier.

They come apart when another input pins it. A materialized view with a `REFRESH` option settles until its next refresh, so a selection over one reports a frontier hours or days out while the target table's upper is still near the clock.

## The scheme

* **Target.** `T = peek_write_ts + 1`, the smallest value `commit_timestamped` accepts. A conflict hands back `next_eligible_timestamp`, adopted verbatim.
* **Readiness.** `F >= T`. A progress message at `F` certifies completeness strictly below `F`, which is the snapshot at `T - 1`.
* **Payload.** Diffs with `t < T`, strictly. A diff at `T` is concurrent with the write and waits for a later target.
* **`T > as_of`**, because the snapshot arrives at `as_of` and has to be in the payload. `ensure_read_linearized(as_of)` guarantees it by leaving the oracle at or above `as_of`.

Readiness gives `T <= F`, not equality. Where `F` is above `T` the payload excludes diffs in `[T, F)`, and for a selection reading the target table those say the table moved past `T`, so the compare-and-append refuses and the loop retries higher. Persist arbitrates, not the frontier. This path produces that window itself: the committer appends at the target and applies it to the oracle only afterwards, so while one write sits in between, a second statement's target is a step behind the table's upper. Retries converge because both refusals name a strictly higher timestamp and the loop waits for the frontier to certify each one.

## Zero rows stop waiting on a frontier

`NoRowsMatched` linearized against the frontier the emptiness was concluded at, which is what made a settled-frontier statement park for days. The rule is now stated once, on `OccOutcome::NoRowsMatched.empty_as_of`: the answer holds as of the timestamp our view is complete through, and the caller brings the oracle up to that. It is `empty_as_of(min(frontier, target))`, whichever certifies less. For the common `UPDATE ... WHERE <no match>` that is the statement's own `as_of`, linearized before the subscribe started, so the answer costs no group commit at all.

That removes the commit a zero-row statement used to need: group commits per statement fall from about 1.09 to 0.13-0.37, some 75 fewer over `ManySmallUpdates`' 100 statements. What that is worth in wallclock depends on what a commit costs. Comparing the same two images, the scenario runs 0.73s against 1.34s locally and 0.761s against 0.755s on the CI benchmark agents, so the feature benchmark cannot see this improvement. See the comment below for the full measurement.

## Also

`OccState` splits into a consolidated `payload` (below the target) and timestamped `pending` (at or after it), which subsumes `max_data_ts` and the guard that refused to write when a diff at or after the target had been accumulated. `byte_size` spans both halves, so `max_result_size` still measures everything accumulated.

Net effect: no timestamp this path writes at, and no wait it performs, is governed by an input's frontier. Every one is governed by the oracle, which is clamped to the clock. That is also what makes the path immune to a frontier that is wrong rather than merely far out, which is how #38260 presented.

## Tests

* `test_refresh_mv_write_commits_near_wall_clock`: the far-future case from #38320 succeeds, commits 3 rows, leaves the oracle near the clock, and the timeline still takes writes.
* `test_serializable_read_sees_own_refresh_mv_write`: a `serializable` session reads back its own refresh-MV-sourced write. This is the anomaly the old behavior produced, invisible to strict-serializable tests because those block instead.
* `workflow_test_occ_zero_row_write_linearization` is reworked so that it still witnesses what it claims. Its winner is now a blind `INSERT` into a table the selection is gated on, rather than an OCC `DELETE` on the target. A timestamped winner leaves the oracle untouched while parked, so the UPDATE would pick the winner's own timestamp, submit, and queue behind it on the group committer, and its answer would only come back after the winner applied. A blind winner allocates before parking, so the UPDATE's target clears it, the answer is reached with no submission, and the linearization wait is observable again.
* Unit tests on the fold, where the off-by-ones live.

## Reviewer notes

One behavior change: **a statement whose frontier lags the oracle ends in `StatementTimeout` rather than `ReadThenWriteContention`**, since it waits for the frontier instead of burning retries, and holds its OCC permit while it waits. The design doc describes this as the intended behavior now.

A diff that arrives at or after the chosen target is not in the statement's answer, which is ordinary concurrency rather than a change of behavior. Diffs below the target are written as before.

Two things left undone on purpose:

* `UpperConflict` reports `next_eligible = target + 1` when `InvalidUppers` already carries the real upper. Plumbing it through would converge in one retry instead of `k`. `k` is 1 or 2 in practice.







