### PR TITLE
bump k8s-openapi to 1.34 again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,7 +398,7 @@ jemalloc_pprof = "0.8.2"
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 junit-report = "0.8.3"
 k8s-controller = "0.12.0"
-k8s-openapi = { version = "0.27.0", features = ["schemars", "v1_32"] }
+k8s-openapi = { version = "0.27.0", features = ["schemars", "v1_34"] }
 kube = { version = "3.1.0", default-features = false, features = ["client", "derive", "openssl-tls", "runtime"] }
 launchdarkly-server-sdk = { version = "3.1.1", default-features = false, features = ["hyper-rustls-native-roots", "crypto-aws-lc-rs"] }
 launchdarkly-sdk-transport = "0.1.4"


### PR DESCRIPTION
### Motivation

this change appears to have been accidentally reverted in #37669 