### PR TITLE
DO NOT MERGE: page serialized edge bodies into the buffer pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8998,6 +8998,7 @@ dependencies = [
  "lz4_flex",
  "mz-ore",
  "num-traits",
+ "prometheus",
  "proptest",
  "rand 0.9.4",
  "serde",

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -500,6 +500,90 @@ metrics:
   - server_name
   source: src/service/src/transport/metrics.rs
   visibility: internal
+- name: mz_column_align_buffer_bytes_minted_total
+  help: Allocation bytes of serialized column bodies minted.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_drops_total
+  help: Serialized column bodies dropped.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_inflight_bytes
+  help: Allocation bytes of serialized column bodies currently alive.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_inflight_bytes_peak
+  help: High-water mark of allocation bytes of serialized column bodies alive at once.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_inflight_count
+  help: Serialized column bodies currently alive.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_lifetime_max_nanoseconds
+  help: High-water mark of a serialized column body's life, uncapped by histogram buckets.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_lifetime_seconds_bucket
+  help: Time from minting a serialized column body to dropping it.
+  labels:
+  - le
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_lifetime_seconds_count
+  help: Time from minting a serialized column body to dropping it.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_lifetime_seconds_sum
+  help: Time from minting a serialized column body to dropping it.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_mints_total
+  help: Serialized column bodies minted.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_size_bytes_bucket
+  help: Allocation size of serialized column bodies at mint.
+  labels:
+  - le
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_size_bytes_count
+  help: Allocation size of serialized column bodies at mint.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_size_bytes_sum
+  help: Allocation size of serialized column bodies at mint.
+  labels:
+  - origin
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
+- name: mz_column_align_buffer_tracking_enabled
+  help: Whether align-buffer lifetime recording is on. Every other align-buffer metric is frozen while this is zero.
+  source: src/timely-util/src/columnar/align_buffer/metrics.rs
+  visibility: internal
 - name: mz_column_pager_budget_configured_bytes
   help: Most-recently-configured total budget for the column-pager tiered policy.
   source: src/timely-util/src/column_pager/metrics.rs

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -258,6 +258,7 @@ def get_variable_system_parameters(
         ),
         # On by default in tests so the recording path is exercised, while
         # production keeps the code default of off.
+        VariableSystemParameter("enable_column_edge_paging", "true", ["true", "false"]),
         VariableSystemParameter(
             "enable_column_align_buffer_tracking",
             "true",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -256,6 +256,13 @@ def get_variable_system_parameters(
             "true",
             ["true", "false"],
         ),
+        # On by default in tests so the recording path is exercised, while
+        # production keeps the code default of off.
+        VariableSystemParameter(
+            "enable_column_align_buffer_tracking",
+            "true",
+            ["true", "false"],
+        ),
         VariableSystemParameter(
             "enable_adapter_frontend_occ_read_then_write",
             "true" if version >= MzVersion.parse_mz("v26.36.0-dev") else "false",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -623,7 +623,6 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "compute_mv_sink_advance_persist_frontiers",
     "compute_prometheus_introspection_scrape_interval",
     "enable_compute_replica_expiration",
-    "enable_compute_render_fueled_as_specific_collection",
     "compute_logical_backpressure_max_retained_capabilities",
     "compute_logical_backpressure_inflight_slack",
     "persist_fetch_semaphore_cost_adjustment",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3145,7 +3145,6 @@ class FlipFlagsAction(Action):
             "enable_compute_replica_expiration",
             "compute_mv_sink_advance_persist_frontiers",
             "compute_replica_expiration_offset",
-            "enable_compute_render_fueled_as_specific_collection",
             "compute_temporal_bucketing_summary",
             "enable_compute_logical_backpressure",
             "enable_replica_targeted_materialized_views",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3061,6 +3061,7 @@ class FlipFlagsAction(Action):
         self.flags_with_values["enable_column_align_buffer_tracking"] = (
             BOOLEAN_FLAG_VALUES
         )
+        self.flags_with_values["enable_column_edge_paging"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_upsert_paged_spill"] = BOOLEAN_FLAG_VALUES
         # 0 forces the estimated-size path for every table, the default forces
         # the exact COUNT(*) path for workload-sized tables.

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3058,6 +3058,9 @@ class FlipFlagsAction(Action):
             "0.01",
             "0.02",
         ]
+        self.flags_with_values["enable_column_align_buffer_tracking"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_upsert_paged_spill"] = BOOLEAN_FLAG_VALUES
         # 0 forces the estimated-size path for every table, the default forces
         # the exact COUNT(*) path for workload-sized tables.

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -176,6 +176,26 @@ pub const COLUMN_PAGED_BATCHER_POOL_RSS_TARGET_FRACTION: Config<f64> = Config::n
 )
 .scoped(ParameterScope::Replica);
 
+/// Record how long serialized column bodies (`Column::Align` payloads) live
+/// and how many bytes of them are alive at once, per producing origin, as
+/// `mz_column_align_buffer_*`.
+///
+/// A body on a dataflow edge is owned by whoever holds the container, outside
+/// the buffer pool's ledger, so its bytes are invisible to pool pressure
+/// decisions. That is the population the metrics are for; bodies retained by a
+/// sink or a merge chain, and bodies a read produced, are recorded under their
+/// own origins so they can be told apart from the edges.
+///
+/// Off in production because recording costs an `Instant::now` and a handful
+/// of atomics per body, on a path that mints one per shipped chunk. On in the
+/// test configuration so the recording path is exercised.
+pub const ENABLE_COLUMN_ALIGN_BUFFER_TRACKING: Config<bool> = Config::new(
+    "enable_column_align_buffer_tracking",
+    false,
+    "Record lifetime and in-flight-byte metrics for serialized column bodies, per origin.",
+)
+.scoped(ParameterScope::Replica);
+
 /// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
 pub const ENABLE_MZ_JOIN_CORE: Config<bool> = Config::new(
     "enable_mz_join_core",
@@ -601,4 +621,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COLUMN_PAGED_BATCHER_SPILL_WORKER_COUNT)
         .add(&COLUMN_PAGED_BATCHER_EAGER_BACKING)
         .add(&COLUMN_PAGED_BATCHER_POOL_RSS_TARGET_FRACTION)
+        .add(&ENABLE_COLUMN_ALIGN_BUFFER_TRACKING)
 }

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -424,13 +424,6 @@ pub const COMPUTE_FLAT_MAP_FUEL: Config<usize> = Config::new(
     "The amount of output the flat-map operator produces before yielding.",
 );
 
-/// Whether to render `as_specific_collection` using a fueled flat-map operator.
-pub const ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION: Config<bool> = Config::new(
-    "enable_compute_render_fueled_as_specific_collection",
-    true,
-    "When enabled, renders `as_specific_collection` using a fueled flat-map operator.",
-);
-
 /// Whether to apply logical backpressure in compute dataflows.
 pub const ENABLE_COMPUTE_LOGICAL_BACKPRESSURE: Config<bool> = Config::new(
     "enable_compute_logical_backpressure",
@@ -598,7 +591,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COMPUTE_APPLY_COLUMN_DEMANDS)
         .add(&COMPUTE_FLAT_MAP_FUEL)
         .add(&CONSOLIDATING_VEC_GROWTH_DAMPENER)
-        .add(&ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION)
         .add(&ENABLE_COMPUTE_LOGICAL_BACKPRESSURE)
         .add(&COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES)
         .add(&COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK)

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -196,6 +196,25 @@ pub const ENABLE_COLUMN_ALIGN_BUFFER_TRACKING: Config<bool> = Config::new(
 )
 .scoped(ParameterScope::Replica);
 
+/// Page serialized column bodies on dataflow edges into the process buffer
+/// pool instead of the heap.
+///
+/// A shipped body is owned by whoever holds the container and belongs to no
+/// budget, yet measurement puts its life at seconds under memory pressure and
+/// its peak in-flight bytes above the whole pool budget. Paging moves those
+/// bytes into the pool's ledger, where they are budgeted and evictable for the
+/// interval between minting a body and the consumer reaching it. The first
+/// borrow copies the body back out, because the pool hands out no references.
+///
+/// Also installs the buffer pool, on the same terms as the chunk-spill gates:
+/// with no pool installed, bodies stay on the heap regardless of this flag.
+pub const ENABLE_COLUMN_EDGE_PAGING: Config<bool> = Config::new(
+    "enable_column_edge_paging",
+    false,
+    "Page serialized column bodies on dataflow edges into the process buffer pool.",
+)
+.scoped(ParameterScope::Replica);
+
 /// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
 pub const ENABLE_MZ_JOIN_CORE: Config<bool> = Config::new(
     "enable_mz_join_core",
@@ -613,5 +632,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COLUMN_PAGED_BATCHER_SPILL_WORKER_COUNT)
         .add(&COLUMN_PAGED_BATCHER_EAGER_BACKING)
         .add(&COLUMN_PAGED_BATCHER_POOL_RSS_TARGET_FRACTION)
+        .add(&ENABLE_COLUMN_EDGE_PAGING)
         .add(&ENABLE_COLUMN_ALIGN_BUFFER_TRACKING)
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -381,7 +381,11 @@ impl ComputeState {
 
             let compute_spill = ENABLE_COLUMN_PAGED_BATCHER_SPILL.get(config);
             let storage_spill = mz_storage_types::dyncfgs::ENABLE_UPSERT_PAGED_SPILL.get(config);
-            if !(compute_spill || storage_spill) {
+            // Edge paging is a third consumer of the same singleton, and
+            // installs it on the same terms: whichever gate is on first
+            // reserves the address space and spawns the spill threads.
+            let edge_paging = ENABLE_COLUMN_EDGE_PAGING.get(config);
+            if !(compute_spill || storage_spill || edge_paging) {
                 debug!("chunk spill: gates off, leaving the buffer pool uninstalled");
             } else {
                 let spill_threads = COLUMN_PAGED_BATCHER_SPILL_WORKER_COUNT.get(config);
@@ -416,6 +420,7 @@ impl ComputeState {
                     info!(
                         compute_spill,
                         storage_spill,
+                        edge_paging,
                         fraction,
                         ram,
                         budget_bytes = total,
@@ -435,6 +440,12 @@ impl ComputeState {
         // config apply writes. Flips take effect for bodies minted afterwards.
         mz_timely_util::columnar::align_buffer::metrics::set_tracking_enabled(
             ENABLE_COLUMN_ALIGN_BUFFER_TRACKING.get(config),
+        );
+        // Written unconditionally, including when no pool was installed above,
+        // so turning the flag back off takes effect. With no pool the paging
+        // path is inert anyway.
+        mz_timely_util::columnar::align_buffer::set_edge_paging_enabled(
+            ENABLE_COLUMN_EDGE_PAGING.get(config),
         );
 
         // Remember the maintenance interval locally to avoid reading it from the config set on

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -430,6 +430,13 @@ impl ComputeState {
             }
         }
 
+        // Serialized column bodies are minted from operator code with no
+        // handle on the config set, so the gate is a process-global flag the
+        // config apply writes. Flips take effect for bodies minted afterwards.
+        mz_timely_util::columnar::align_buffer::metrics::set_tracking_enabled(
+            ENABLE_COLUMN_ALIGN_BUFFER_TRACKING.get(config),
+        );
+
         // Remember the maintenance interval locally to avoid reading it from the config set on
         // every server iteration.
         self.server_maintenance_interval = COMPUTE_SERVER_MAINTENANCE_INTERVAL.get(config);

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -937,9 +937,19 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 let (err_v, err_collection) =
                     Variable::new(self.scope, Product::new(Default::default(), inner));
 
+                // Re-encode the read-edge to columnar so `Get`s on this rec
+                // binding (e.g. as a Union input) see a columnar edge. The
+                // feedback `Variable` itself stays `Vec` (set at `oks_v.set`
+                // below); the recursive value flows `Vec` through the loop, and
+                // only the externally-visible collection is re-containered. The
+                // re-encode is a stateless, timestamp-agnostic pass-through, so
+                // it does not alter the iterative frontier or fixpoint behavior.
                 self.insert_id(
                     Id::Local(*id),
-                    CollectionBundle::from_collections(oks_collection, err_collection),
+                    CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks_collection)),
+                        err_collection,
+                    ),
                 );
                 variables.insert(Id::Local(*id), (oks_v, err_v));
             }
@@ -1009,10 +1019,14 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 let bundle = self.remove_id(Id::Local(id)).unwrap();
                 let (oks, err) = bundle.collection.unwrap();
                 let oks = oks.into_vec();
+                // Extract into the outer scope and re-encode the read-edge to
+                // columnar, so `Get`s on the extracted binding see a columnar
+                // edge. `leave_dynamic` has already stripped the iteration
+                // coordinate, so this runs in the parent scope.
                 self.insert_id(
                     Id::Local(id),
-                    CollectionBundle::from_collections(
-                        oks.leave_dynamic(level + 1),
+                    CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks.leave_dynamic(level + 1))),
                         err.leave_dynamic(level + 1),
                     ),
                 );

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -165,7 +165,7 @@ use crate::extensions::temporal_bucket::TemporalBucketing;
 use crate::logging::compute::{
     ComputeEvent, DataflowGlobal, LirMapping, LirMetadata, LogDataflowErrors, OperatorHydration,
 };
-use crate::render::columnar::CollectionEdge;
+use crate::render::columnar::{CollectionEdge, vec_to_columnar};
 use crate::render::context::{ArrangementFlavor, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{ErrBatcher, ErrBuilder, ErrSpine, KeyBatcher, MzTimestamp};
@@ -374,8 +374,11 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    let bundle = crate::render::CollectionBundle::from_collections(
-                        oks.enter(region),
+                    // Imports read row-shaped data from persist; encode it to the
+                    // columnar edge at the boundary. The batches are already
+                    // consolidated, so this leaf-encode is non-consolidating.
+                    let bundle = crate::render::CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks.enter(region))),
                         errs.enter(region),
                     );
                     // Associate collection bundle with the source identifier.
@@ -474,8 +477,11 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    let bundle = crate::render::CollectionBundle::from_collections(
-                        oks.enter_region(region),
+                    // Imports read row-shaped data from persist; encode it to the
+                    // columnar edge at the boundary. The batches are already
+                    // consolidated, so this leaf-encode is non-consolidating.
+                    let bundle = crate::render::CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks.enter_region(region))),
                         errs.enter_region(region),
                     );
                     // Associate collection bundle with the source identifier.
@@ -667,7 +673,13 @@ where
                         start_signal,
                         |e, _| e.clone(),
                     );
-                    CollectionBundle::from_collections(oks, errs)
+                    // The filtered index collection is row-shaped; encode it to
+                    // the columnar edge at the boundary. It is already
+                    // consolidated, so this leaf-encode is non-consolidating.
+                    CollectionBundle::from_edge(
+                        CollectionEdge::Columnar(vec_to_columnar(oks)),
+                        errs,
+                    )
                 }
             };
             self.update_id(Id::Global(idx.on_id), bundle);

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1378,11 +1378,17 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                             .get(&self.config_set)
                             .try_into()
                             .expect("must fit");
+                        // Temporal bucketing (node C8) is `Vec`-internal: decode
+                        // the edge into it, then re-encode the `Vec` result to
+                        // columnar so this Union input stays columnar and
+                        // `concat_many` sees no mixed variants.
                         let os = os.into_vec();
-                        CollectionEdge::Vec(T::maybe_apply_temporal_bucketing(
-                            os.inner,
-                            self.as_of_frontier.clone(),
-                            summary,
+                        CollectionEdge::Columnar(vec_to_columnar(
+                            T::maybe_apply_temporal_bucketing(
+                                os.inner,
+                                self.as_of_frontier.clone(),
+                                summary,
+                            ),
                         ))
                     } else {
                         os

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -374,7 +374,7 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    // Imports read row-shaped data from persist; encode it to the
+                    // Imports read row-shaped data from persist. Encode it to the
                     // columnar edge at the boundary. The batches are already
                     // consolidated, so this leaf-encode is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
@@ -477,7 +477,7 @@ pub fn build_compute_dataflow(
                 );
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
-                    // Imports read row-shaped data from persist; encode it to the
+                    // Imports read row-shaped data from persist. Encode it to the
                     // columnar edge at the boundary. The batches are already
                     // consolidated, so this leaf-encode is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
@@ -673,7 +673,7 @@ where
                         start_signal,
                         |e, _| e.clone(),
                     );
-                    // The filtered index collection is row-shaped; encode it to
+                    // The filtered index collection is row-shaped. Encode it to
                     // the columnar edge at the boundary. It is already
                     // consolidated, so this leaf-encode is non-consolidating.
                     CollectionBundle::from_edge(

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1259,17 +1259,12 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                             mfp,
                             Some((key, row)),
                             self.until.clone(),
-                            &self.config_set,
                         );
                         CollectionBundle::from_edge(oks, errs)
                     }
                     mz_compute_types::plan::GetPlan::Collection(mfp) => {
-                        let (oks, errs) = collection.as_collection_core(
-                            mfp,
-                            None,
-                            self.until.clone(),
-                            &self.config_set,
-                        );
+                        let (oks, errs) =
+                            collection.as_collection_core(mfp, None, self.until.clone());
                         CollectionBundle::from_edge(oks, errs)
                     }
                 }
@@ -1284,12 +1279,8 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                 if mfp.is_identity() {
                     input
                 } else {
-                    let (oks, errs) = input.as_collection_core(
-                        mfp,
-                        input_key_val,
-                        self.until.clone(),
-                        &self.config_set,
-                    );
+                    let (oks, errs) =
+                        input.as_collection_core(mfp, input_key_val, self.until.clone());
                     CollectionBundle::from_edge(oks, errs)
                 }
             }

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -146,6 +146,7 @@ use mz_timely_util::scope_label::ScopeExt;
 use timely::PartialOrder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::core::to_stream::ToStreamBuilder;
 use timely::dataflow::operators::vec::ToStream;
 use timely::dataflow::operators::vec::{BranchWhen, Filter};
 use timely::dataflow::operators::{Capability, Operator, Probe, probe};
@@ -169,6 +170,7 @@ use crate::render::context::{ArrangementFlavor, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{ErrBatcher, ErrBuilder, ErrSpine, KeyBatcher, MzTimestamp};
 use mz_row_spine::{DatumSeq, RowRowBatcher, RowRowBuilder};
+use mz_timely_util::columnar::consolidate::ConsolidatingColumnBuilder;
 
 pub(crate) mod columnar;
 pub mod context;
@@ -1177,22 +1179,31 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                 // We should advance times in constant collections to start from `as_of`.
                 let as_of_frontier = self.as_of_frontier.clone();
                 let until = self.until.clone();
-                let ok_collection = rows
-                    .into_iter()
-                    .filter_map(move |(row, mut time, diff)| {
-                        time.advance_by(as_of_frontier.borrow());
-                        if !until.less_equal(&time) {
-                            Some((
-                                row,
-                                <T as Refines<mz_repr::Timestamp>>::to_inner(time),
-                                diff,
-                            ))
-                        } else {
-                            None
-                        }
-                    })
-                    .to_stream(self.scope)
-                    .as_collection();
+                // Build the ok rows columnar, so this literal source emits the
+                // columnar edge. Advancing times to `as_of` can collapse
+                // distinct original times onto one time, so rows the planner
+                // left distinct may become duplicates here; a
+                // `ConsolidatingColumnBuilder` folds those within the batch (the
+                // rows are already owned, so the give is a move into staging).
+                let ok_collection = CollectionEdge::Columnar(
+                    rows.into_iter()
+                        .filter_map(move |(row, mut time, diff)| {
+                            time.advance_by(as_of_frontier.borrow());
+                            if !until.less_equal(&time) {
+                                Some((
+                                    row,
+                                    <T as Refines<mz_repr::Timestamp>>::to_inner(time),
+                                    diff,
+                                ))
+                            } else {
+                                None
+                            }
+                        })
+                        .to_stream_with_builder::<_, ConsolidatingColumnBuilder<Row, T, Diff>>(
+                            self.scope,
+                        )
+                        .as_collection(),
+                );
 
                 let mut error_time: mz_repr::Timestamp = Timestamp::minimum();
                 error_time.advance_by(self.as_of_frontier.borrow());
@@ -1208,7 +1219,7 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                     .to_stream(self.scope)
                     .as_collection();
 
-                CollectionBundle::from_collections(ok_collection, err_collection)
+                CollectionBundle::from_edge(ok_collection, err_collection)
             }
             Get { id, keys, plan } => {
                 // Recover the collection from `self` and then apply `mfp` to it.

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1238,7 +1238,7 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                             self.until.clone(),
                             &self.config_set,
                         );
-                        CollectionBundle::from_collections(oks, errs)
+                        CollectionBundle::from_edge(oks, errs)
                     }
                     mz_compute_types::plan::GetPlan::Collection(mfp) => {
                         let (oks, errs) = collection.as_collection_core(
@@ -1247,7 +1247,7 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                             self.until.clone(),
                             &self.config_set,
                         );
-                        CollectionBundle::from_collections(oks, errs)
+                        CollectionBundle::from_edge(oks, errs)
                     }
                 }
             }
@@ -1267,7 +1267,7 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                         self.until.clone(),
                         &self.config_set,
                     );
-                    CollectionBundle::from_collections(oks, errs)
+                    CollectionBundle::from_edge(oks, errs)
                 }
             }
             FlatMap {

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -940,7 +940,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // Re-encode the read-edge to columnar so `Get`s on this rec
                 // binding (e.g. as a Union input) see a columnar edge. The
                 // feedback `Variable` itself stays `Vec` (set at `oks_v.set`
-                // below); the recursive value flows `Vec` through the loop, and
+                // below). The recursive value flows `Vec` through the loop, and
                 // only the externally-visible collection is re-containered. The
                 // re-encode is a stateless, timestamp-agnostic pass-through, so
                 // it does not alter the iterative frontier or fixpoint behavior.

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -165,7 +165,9 @@ use crate::extensions::temporal_bucket::TemporalBucketing;
 use crate::logging::compute::{
     ComputeEvent, DataflowGlobal, LirMapping, LirMetadata, LogDataflowErrors, OperatorHydration,
 };
-use crate::render::columnar::{CollectionEdge, vec_to_columnar};
+use crate::render::columnar::{
+    columnar_consolidate, columnar_negate, columnar_to_vec, concat_many, vec_to_columnar,
+};
 use crate::render::context::{ArrangementFlavor, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{ErrBatcher, ErrBuilder, ErrSpine, KeyBatcher, MzTimestamp};
@@ -378,7 +380,7 @@ pub fn build_compute_dataflow(
                     // columnar edge at the boundary. The batches are already
                     // consolidated, so this leaf-encode is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
-                        CollectionEdge::Columnar(vec_to_columnar(oks.enter(region))),
+                        vec_to_columnar(oks.enter(region)),
                         errs.enter(region),
                     );
                     // Associate collection bundle with the source identifier.
@@ -481,7 +483,7 @@ pub fn build_compute_dataflow(
                     // columnar edge at the boundary. The batches are already
                     // consolidated, so this leaf-encode is non-consolidating.
                     let bundle = crate::render::CollectionBundle::from_edge(
-                        CollectionEdge::Columnar(vec_to_columnar(oks.enter_region(region))),
+                        vec_to_columnar(oks.enter_region(region)),
                         errs.enter_region(region),
                     );
                     // Associate collection bundle with the source identifier.
@@ -676,10 +678,7 @@ where
                     // The filtered index collection is row-shaped. Encode it to
                     // the columnar edge at the boundary. It is already
                     // consolidated, so this leaf-encode is non-consolidating.
-                    CollectionBundle::from_edge(
-                        CollectionEdge::Columnar(vec_to_columnar(oks)),
-                        errs,
-                    )
+                    CollectionBundle::from_edge(vec_to_columnar(oks), errs)
                 }
             };
             self.update_id(Id::Global(idx.on_id), bundle);
@@ -947,10 +946,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // iterative frontier or fixpoint behavior.
                 self.insert_id(
                     Id::Local(*id),
-                    CollectionBundle::from_edge(
-                        CollectionEdge::Columnar(vec_to_columnar(oks_collection)),
-                        err_collection,
-                    ),
+                    CollectionBundle::from_edge(vec_to_columnar(oks_collection), err_collection),
                 );
                 variables.insert(Id::Local(*id), (oks_v, err_v));
             }
@@ -966,7 +962,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // We need to ensure that the raw collection exists, but do not have enough information
                 // here to cause that to happen.
                 let (oks, mut err) = bundle.collection.clone().unwrap();
-                let oks = oks.into_vec();
+                let oks = columnar_to_vec(oks);
                 decoded_oks.insert(id, oks.clone());
                 self.insert_id(Id::Local(id), bundle);
                 let (oks_v, err_v) = variables.remove(&Id::Local(id)).unwrap();
@@ -1033,7 +1029,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 self.insert_id(
                     Id::Local(id),
                     CollectionBundle::from_edge(
-                        CollectionEdge::Columnar(vec_to_columnar(oks.leave_dynamic(level + 1))),
+                        vec_to_columnar(oks.leave_dynamic(level + 1)),
                         err.leave_dynamic(level + 1),
                     ),
                 );
@@ -1218,25 +1214,24 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                 // left distinct may become duplicates here; a
                 // `ConsolidatingColumnBuilder` folds those within the batch (the
                 // rows are already owned, so the give is a move into staging).
-                let ok_collection = CollectionEdge::Columnar(
-                    rows.into_iter()
-                        .filter_map(move |(row, mut time, diff)| {
-                            time.advance_by(as_of_frontier.borrow());
-                            if !until.less_equal(&time) {
-                                Some((
-                                    row,
-                                    <T as Refines<mz_repr::Timestamp>>::to_inner(time),
-                                    diff,
-                                ))
-                            } else {
-                                None
-                            }
-                        })
-                        .to_stream_with_builder::<_, ConsolidatingColumnBuilder<Row, T, Diff>>(
-                            self.scope,
-                        )
-                        .as_collection(),
-                );
+                let ok_collection = rows
+                    .into_iter()
+                    .filter_map(move |(row, mut time, diff)| {
+                        time.advance_by(as_of_frontier.borrow());
+                        if !until.less_equal(&time) {
+                            Some((
+                                row,
+                                <T as Refines<mz_repr::Timestamp>>::to_inner(time),
+                                diff,
+                            ))
+                        } else {
+                            None
+                        }
+                    })
+                    .to_stream_with_builder::<_, ConsolidatingColumnBuilder<Row, T, Diff>>(
+                        self.scope,
+                    )
+                    .as_collection();
 
                 let mut error_time: mz_repr::Timestamp = Timestamp::minimum();
                 error_time.advance_by(self.as_of_frontier.borrow());
@@ -1359,7 +1354,7 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                     .collection
                     .clone()
                     .expect("Negate input must be an unarranged collection");
-                CollectionBundle::from_edge(oks.negate(), errs)
+                CollectionBundle::from_edge(columnar_negate(oks), errs)
             }
             Threshold {
                 input,
@@ -1393,13 +1388,11 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                         // Temporal bucketing operates on `Vec`: decode the edge
                         // into it, then re-encode the result so this Union input
                         // is a columnar edge like every other.
-                        let os = os.into_vec();
-                        CollectionEdge::Columnar(vec_to_columnar(
-                            T::maybe_apply_temporal_bucketing(
-                                os.inner,
-                                self.as_of_frontier.clone(),
-                                summary,
-                            ),
+                        let os = columnar_to_vec(os);
+                        vec_to_columnar(T::maybe_apply_temporal_bucketing(
+                            os.inner,
+                            self.as_of_frontier.clone(),
+                            summary,
                         ))
                     } else {
                         os
@@ -1407,9 +1400,9 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                     oks.push(os);
                     errs.push(es);
                 }
-                let oks = CollectionEdge::concat_many(self.scope, oks);
+                let oks = concat_many(self.scope, oks);
                 let oks = if consolidate_output {
-                    oks.consolidate_named("UnionConsolidation")
+                    columnar_consolidate(oks, "UnionConsolidation")
                 } else {
                     oks
                 };
@@ -1490,16 +1483,8 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                     .collection
                     .as_mut()
                     .expect("CollectionBundle invariant");
-                match oks {
-                    CollectionEdge::Vec(c) => {
-                        let stream = self.log_operator_hydration_inner(c.inner.clone(), lir_id);
-                        *c = stream.as_collection();
-                    }
-                    CollectionEdge::Columnar(c) => {
-                        let stream = self.log_operator_hydration_inner(c.inner.clone(), lir_id);
-                        *c = stream.as_collection();
-                    }
-                }
+                let stream = self.log_operator_hydration_inner(oks.inner.clone(), lir_id);
+                *oks = stream.as_collection();
             }
         }
     }

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1378,10 +1378,9 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                             .get(&self.config_set)
                             .try_into()
                             .expect("must fit");
-                        // Temporal bucketing (node C8) is `Vec`-internal: decode
-                        // the edge into it, then re-encode the `Vec` result to
-                        // columnar so this Union input stays columnar and
-                        // `concat_many` sees no mixed variants.
+                        // Temporal bucketing operates on `Vec`: decode the edge
+                        // into it, then re-encode the result so this Union input
+                        // is a columnar edge like every other.
                         let os = os.into_vec();
                         CollectionEdge::Columnar(vec_to_columnar(
                             T::maybe_apply_temporal_bucketing(

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -940,10 +940,11 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // Re-encode the read-edge to columnar so `Get`s on this rec
                 // binding (e.g. as a Union input) see a columnar edge. The
                 // feedback `Variable` itself stays `Vec` (set at `oks_v.set`
-                // below). The recursive value flows `Vec` through the loop, and
-                // only the externally-visible collection is re-containered. The
-                // re-encode is a stateless, timestamp-agnostic pass-through, so
-                // it does not alter the iterative frontier or fixpoint behavior.
+                // below), so each iteration crosses the container boundary
+                // twice: encoded here for the readers, decoded once per binding
+                // where the value is fed back. The re-encode is a stateless,
+                // timestamp-agnostic pass-through, so it does not alter the
+                // iterative frontier or fixpoint behavior.
                 self.insert_id(
                     Id::Local(*id),
                     CollectionBundle::from_edge(
@@ -953,7 +954,10 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 );
                 variables.insert(Id::Local(*id), (oks_v, err_v));
             }
-            // Now render each of the rec bindings.
+            // Now render each of the rec bindings. The decoded value is kept so
+            // the extraction below reuses it instead of decoding the same stream
+            // a second time.
+            let mut decoded_oks = BTreeMap::new();
             let mut rec_iter = recs.into_iter().peekable();
             while let Some(RecBind { id, value, limit }) = rec_iter.next() {
                 let last = rec_iter.peek().is_none();
@@ -963,6 +967,7 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
                 // here to cause that to happen.
                 let (oks, mut err) = bundle.collection.clone().unwrap();
                 let oks = oks.into_vec();
+                decoded_oks.insert(id, oks.clone());
                 self.insert_id(Id::Local(id), bundle);
                 let (oks_v, err_v) = variables.remove(&Id::Local(id)).unwrap();
 
@@ -1017,8 +1022,10 @@ impl<'scope> Context<'scope, Product<mz_repr::Timestamp, PointStamp<u64>>> {
             // Now extract each of the rec bindings into the outer scope.
             for id in rec_ids.into_iter() {
                 let bundle = self.remove_id(Id::Local(id)).unwrap();
-                let (oks, err) = bundle.collection.unwrap();
-                let oks = oks.into_vec();
+                let (_, err) = bundle.collection.unwrap();
+                let oks = decoded_oks
+                    .remove(&id)
+                    .expect("rec binding decoded while rendering above");
                 // Extract into the outer scope and re-encode the read-edge to
                 // columnar, so `Get`s on the extracted binding see a columnar
                 // edge. `leave_dynamic` has already stripped the iteration

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -34,11 +34,13 @@ use columnar::{Columnar, Index};
 use differential_dataflow::{AsCollection, Collection, VecCollection};
 use mz_repr::{DatumVec, DatumVecBorrow, Diff, Row};
 use mz_timely_util::columnar::Column;
+use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
-use mz_timely_util::operator::CollectionExt;
+use mz_timely_util::columnar::{Col2KeyBatcher, columnar_exchange};
+use mz_timely_util::operator::{CollectionExt, consolidate_pact};
 use timely::ContainerBuilder;
 use timely::container::CapacityContainerBuilder;
-use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::{Operator, OutputBuilder};
 use timely::dataflow::{Scope, Stream, StreamVec};
@@ -254,14 +256,7 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
             CollectionEdge::Vec(c) => CollectionEdge::Vec(CollectionExt::consolidate_named::<
                 KeyBatcher<_, _, _>,
             >(c, name)),
-            CollectionEdge::Columnar(c) => {
-                // TODO: Consolidate natively over columns. The pieces exist
-                // (`columnar_exchange`, the columnar merge batchers), which
-                // would avoid the row round-trip below.
-                let c = columnar_to_vec(c);
-                let c = CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(c, name);
-                CollectionEdge::Columnar(vec_to_columnar(c))
-            }
+            CollectionEdge::Columnar(c) => CollectionEdge::Columnar(columnar_consolidate(c, name)),
         }
     }
 }
@@ -294,6 +289,80 @@ where
                         for (v, t, d) in data.borrow().into_index_iter() {
                             let d = -Diff::into_owned(d);
                             session.give((v, t, &d));
+                        }
+                    });
+                }
+            },
+        )
+        .as_collection()
+}
+
+/// Consolidates a [`ColumnarCollection`] natively, without a row round-trip.
+///
+/// Mirrors the `Vec` arm's [`CollectionExt::consolidate_named`], but keeps the
+/// data columnar throughout: the input is reshaped into the `((Row, ()), T,
+/// Diff)` shape the key batcher consumes, merged by [`Col2KeyBatcher`] under a
+/// [`columnar_exchange`] pact, then unpacked back into a `Column`. Rows, times,
+/// and diffs are pushed from their borrowed forms, so no owned [`Row`] is
+/// materialized on the hot path.
+///
+/// This uses [`consolidate_pact`], not `mz_arrange_core`. A consolidate emits a
+/// consolidated collection, so building and reading back a maintained trace
+/// would be wasted work. [`Col2KeyBatcher`] and the `Vec` arm's `KeyBatcher`
+/// produce the same `ColumnationStack` output and differ only in their input
+/// chunker, so the unpack loop matches the `Vec` arm's.
+pub fn columnar_consolidate<'scope, T>(
+    collection: ColumnarCollection<'scope, T, Row, Diff>,
+    name: &str,
+) -> ColumnarCollection<'scope, T, Row, Diff>
+where
+    T: RenderTimestamp,
+{
+    // Reshape `(Row, T, Diff)` into `((Row, ()), T, Diff)`, the key-batcher
+    // shape. The unit value carries no data; the whole `Row` is the key.
+    let keyed = collection
+        .inner
+        .unary::<ColumnBuilder<((Row, ()), T, Diff)>, _, _, _>(
+            Pipeline,
+            &format!("ConsolidateKey {name}"),
+            |_cap, _info| {
+                move |input, output| {
+                    input.for_each(|time, data| {
+                        let mut session = output.session_with_builder(&time);
+                        for (row, t, d) in data.borrow().into_index_iter() {
+                            session.give(((row, ()), t, d));
+                        }
+                    });
+                }
+            },
+        );
+
+    let exchange =
+        ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, (), T, Diff>);
+    let consolidated = consolidate_pact::<batcher::Chunker<_>, Col2KeyBatcher<Row, T, Diff>, _, _>(
+        keyed, exchange, name,
+    );
+
+    // Unpack the sealed chains back into a `Column`, dropping the unit value.
+    //
+    // TODO: This drains a whole sealed snapshot in one activation, an
+    // un-fueled burst hazard on large consolidations. It is the same behavior
+    // as the `Vec` arm's `consolidate_named` unpack (see
+    // `mz_timely_util::operator::consolidate_named`), not new here. A future
+    // fuel fix should cover both arms, so the burst is not fixed on one and
+    // left on the other.
+    consolidated
+        .unary::<ColumnBuilder<(Row, T, Diff)>, _, _, _>(
+            Pipeline,
+            &format!("Unpack {name}"),
+            |_cap, _info| {
+                move |input, output| {
+                    input.for_each(|time, data| {
+                        let mut session = output.session_with_builder(&time);
+                        for ((row, ()), t, d) in
+                            data.iter().flatten().flat_map(|chunk| chunk.iter())
+                        {
+                            session.give((row, t, d));
                         }
                     });
                 }
@@ -539,24 +608,54 @@ mod tests {
     fn consolidate_named_preserves_columnar() {
         let row1 = Row::pack_slice(&[Datum::Int32(1)]);
         let row2 = Row::pack_slice(&[Datum::Int32(2)]);
-        let expected = vec![(row1.clone(), Timestamp::from(0_u64), Diff::from(2))];
-        let captured = timely::execute_directly(move |worker| {
+        let row3 = Row::pack_slice(&[Datum::Int32(3)]);
+        // Accumulation and cancellation across two distinct timestamps:
+        // `row1` accumulates to two at t=0 and to one at t=1 (kept separate by
+        // time); `row2` cancels at t=0 and `row3` cancels at t=1, so both are
+        // absent from the output.
+        let expected = vec![
+            (row1.clone(), Timestamp::from(0_u64), Diff::from(2)),
+            (row1.clone(), Timestamp::from(1_u64), Diff::ONE),
+        ];
+
+        // The columnar arm keeps the `Columnar` variant. No-ColumnarToVec is a
+        // by-inspection property: `consolidate_named`'s columnar arm calls
+        // `columnar_consolidate` (native `Col2KeyBatcher` merge), never
+        // `columnar_to_vec`. The `into_vec` below is the capture harness
+        // decoding for the test only, not part of the consolidate.
+        let (vec_captured, col_captured) = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut input, collection) = scope.new_collection();
-                let edge =
-                    CollectionEdge::Columnar(vec_to_columnar(collection)).consolidate_named("Test");
-                assert!(matches!(edge, CollectionEdge::Columnar(_)));
-                let captured = edge.into_vec().inner.capture();
-                // `row1` accumulates to a diff of two, `row2` cancels.
+                let mut captures = Vec::new();
+                for edge in [
+                    CollectionEdge::Vec(collection.clone()),
+                    CollectionEdge::Columnar(vec_to_columnar(collection)),
+                ] {
+                    let is_columnar = matches!(edge, CollectionEdge::Columnar(_));
+                    let edge = edge.consolidate_named("Test");
+                    assert_eq!(matches!(edge, CollectionEdge::Columnar(_)), is_columnar);
+                    captures.push(edge.into_vec().inner.capture());
+                }
+                let col = captures.pop().unwrap();
+                let vec = captures.pop().unwrap();
+                // t=0: row1 accumulates (+1, +1), row2 cancels (+1, -1).
+                input.advance_to(Timestamp::from(0_u64));
                 input.update(row1.clone(), Diff::ONE);
-                input.update(row1, Diff::ONE);
+                input.update(row1.clone(), Diff::ONE);
                 input.update(row2.clone(), Diff::ONE);
                 input.update(row2, -Diff::ONE);
+                // t=1: row1 survives (+1), row3 cancels (+1, -1).
                 input.advance_to(Timestamp::from(1_u64));
+                input.update(row1, Diff::ONE);
+                input.update(row3.clone(), Diff::ONE);
+                input.update(row3, -Diff::ONE);
+                input.advance_to(Timestamp::from(2_u64));
                 input.flush();
-                captured
+                (vec, col)
             })
         });
-        assert_eq!(extract_sorted(captured), expected);
+        let vec_updates = extract_sorted(vec_captured);
+        assert_eq!(vec_updates, expected);
+        assert_eq!(extract_sorted(col_captured), vec_updates);
     }
 }

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -127,17 +127,15 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
 
     /// Concatenates a collection of edges.
     ///
-    /// Every producer emits the columnar variant, so the inputs concatenate
-    /// natively into the columnar variant.
+    /// The inputs are all columnar, so they concatenate natively into the
+    /// columnar variant.
     pub fn concat_many<I>(scope: Scope<'scope, T>, edges: I) -> Self
     where
         I: IntoIterator<Item = Self>,
     {
         let cols = edges.into_iter().map(|edge| match edge {
             CollectionEdge::Columnar(c) => c,
-            // No producer emits `Vec` after the migration, so a `Vec` input
-            // cannot reach here. The `Vec` arm and this `unreachable!` are
-            // removed together when the enum collapses to a columnar alias.
+            // No producer emits `Vec`, so a `Vec` input cannot reach here.
             CollectionEdge::Vec(_) => unreachable!("no producer emits a `Vec` edge"),
         });
         CollectionEdge::Columnar(differential_dataflow::collection::concatenate(

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -281,8 +281,11 @@ where
 
 /// Repacks a row-based collection into columnar batches.
 ///
-/// A transitional seam-healer, visible in rendered dataflows as a
-/// `VecToColumnar` operator. Repacking copies row bytes but allocates no
+/// The sanctioned leaf encode from `Vec` to the columnar edge, visible in
+/// rendered dataflows as a `VecToColumnar` operator. Row-serializing leaves
+/// (sinks, `LetRec`, temporal bucketing, join internals, TopK fallible-limit)
+/// stay `Vec`-shaped internally and encode to the columnar edge at their
+/// boundary through this pass. Repacking copies row bytes but allocates no
 /// per-record `Row`s.
 pub fn vec_to_columnar<'scope, T>(
     collection: VecCollection<'scope, T, Row, Diff>,
@@ -311,10 +314,12 @@ where
 
 /// Decodes columnar batches into a row-based collection.
 ///
-/// A transitional seam-healer, visible in rendered dataflows as a
-/// `ColumnarToVec` operator. Decoding allocates an owned [`Row`] per record,
-/// so it should only guard consumers that have not yet learned the columnar
-/// form.
+/// The sanctioned leaf decode from the columnar edge to `Vec`, visible in
+/// rendered dataflows as a `ColumnarToVec` operator. Row-serializing leaves
+/// (sinks, `LetRec`, temporal bucketing, join internals, TopK fallible-limit)
+/// decode the columnar edge at their boundary through this pass. Decoding
+/// allocates an owned [`Row`] per record, so it stays confined to those leaf
+/// boundaries.
 pub fn columnar_to_vec<'scope, T>(
     collection: ColumnarCollection<'scope, T, Row, Diff>,
 ) -> VecCollection<'scope, T, Row, Diff>

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -66,7 +66,10 @@ pub type ColumnarCollection<'scope, T, D, R> = Collection<'scope, T, Column<(D, 
 /// `concat`s repack the row-based inputs and produce the columnar variant.
 #[derive(Clone)]
 pub enum CollectionEdge<'scope, T: RenderTimestamp> {
-    /// Row-formatted collection. Today's default for every producer.
+    /// Row-formatted collection. No producer constructs this after the
+    /// migration; the variant and its remaining match arms are removed when the
+    /// enum collapses to a columnar alias.
+    #[allow(dead_code)]
     Vec(VecCollection<'scope, T, Row, Diff>),
     /// Columnar collection. Currently unused by any producer; reserved for the
     /// producer flip at the end of the migration.
@@ -124,28 +127,23 @@ impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
 
     /// Concatenates a collection of edges.
     ///
-    /// Edges of one shared variant concatenate natively. Mixed inputs upgrade
-    /// the row-based edges through [`vec_to_columnar`] and produce the
-    /// columnar variant. Repacking rows into columns copies bytes but
-    /// allocates no per-record `Row`s, so upgrading is the cheap direction.
+    /// Every producer emits the columnar variant, so the inputs concatenate
+    /// natively into the columnar variant.
     pub fn concat_many<I>(scope: Scope<'scope, T>, edges: I) -> Self
     where
         I: IntoIterator<Item = Self>,
     {
-        let mut vecs = Vec::new();
-        let mut cols = Vec::new();
-        for edge in edges {
-            match edge {
-                CollectionEdge::Vec(c) => vecs.push(c),
-                CollectionEdge::Columnar(c) => cols.push(c),
-            }
-        }
-        if cols.is_empty() {
-            CollectionEdge::Vec(differential_dataflow::collection::concatenate(scope, vecs))
-        } else {
-            cols.extend(vecs.into_iter().map(vec_to_columnar));
-            CollectionEdge::Columnar(differential_dataflow::collection::concatenate(scope, cols))
-        }
+        let cols = edges.into_iter().map(|edge| match edge {
+            CollectionEdge::Columnar(c) => c,
+            // No producer emits `Vec` after the migration, so a `Vec` input
+            // cannot reach here. The `Vec` arm and this `unreachable!` are
+            // removed together when the enum collapses to a columnar alias.
+            CollectionEdge::Vec(_) => unreachable!("no producer emits a `Vec` edge"),
+        });
+        CollectionEdge::Columnar(differential_dataflow::collection::concatenate(
+            scope,
+            cols.collect::<Vec<_>>(),
+        ))
     }
 
     /// Applies `logic` to each record in this edge, exposing the record as a

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -21,7 +21,7 @@
 //! introspection.
 
 use columnar::primitive::Empties;
-use columnar::{Columnar, Container, Index, Len};
+use columnar::{Borrow, Columnar, Container, Index, Len, Push};
 use differential_dataflow::{AsCollection, Collection, VecCollection};
 use mz_ore::cast::CastFrom;
 use mz_repr::{DatumVec, DatumVecBorrow, Diff, Row};
@@ -128,16 +128,56 @@ where
     (ok_stream, err_stream)
 }
 
+/// Negates the diff of every record in `column`, rebuilding only the diff column.
+///
+/// A `Typed` input hands its row and time columns over untouched, so only the
+/// diffs are rebuilt, which is 8 bytes per record. A serialized input keeps all
+/// three columns in one buffer, so its rows and times are copied in bulk.
+///
+/// Negation stays checked: `Neg for Overflowing` runs `overflowing_neg` and
+/// reports overflow, which `-Diff::MIN` triggers.
+///
+/// TODO: Negate a `Typed` input's diffs in place rather than rebuilding them.
+/// This cannot go through `columnar::IndexMut`: `Overflows` stores the raw
+/// integer and materializes `Overflowing` on read, so there is no wrapper in
+/// memory to borrow mutably, and handing out `&mut` to the raw integer would let
+/// writes bypass the checked arithmetic. It needs a checked bulk operation on the
+/// container instead, keeping the overflow check inside.
+fn negate_column<T>(column: Column<(Row, T, Diff)>) -> Column<(Row, T, Diff)>
+where
+    T: RenderTimestamp,
+{
+    /// Collects the negation of every diff in `diffs` into a fresh column.
+    fn negated_diffs<'a, D>(diffs: &'a D) -> <Diff as Columnar>::Container
+    where
+        D: Len + Index<Ref = Diff> + 'a,
+    {
+        let mut negated = <Diff as Columnar>::Container::default();
+        for index in 0..diffs.len() {
+            negated.push(-diffs.get(index));
+        }
+        negated
+    }
+
+    match column {
+        Column::Typed((rows, times, diffs)) => {
+            let negated = negated_diffs(&diffs.borrow());
+            Column::Typed((rows, times, negated))
+        }
+        column => {
+            let view = column.borrow();
+            let len = view.len();
+            let mut negated = <(Row, T, Diff) as Columnar>::Container::default();
+            let (rows, times, diffs) = &mut negated;
+            rows.extend_from_self(view.0, 0..len);
+            times.extend_from_self(view.1, 0..len);
+            *diffs = negated_diffs(&view.2);
+            Column::Typed(negated)
+        }
+    }
+}
+
 /// Negates the diff of every record in a [`ColumnarCollection`].
-///
-/// Rows and times are pushed from their borrowed forms. Only the diff is
-/// materialized, and it is `Copy`.
-///
-/// TODO: Rebuild only the diff column. Borrow the input column, build one owned
-/// negated diff column from the borrowed diffs, and re-encode using the borrowed
-/// row and time columns directly, so row and time bytes are copied once rather
-/// than pushed per record. The serialized (`Align` / `Bytes`) input case needs
-/// care, since all columns share a single buffer.
 pub fn columnar_negate<'scope, T>(
     collection: ColumnarCollection<'scope, T, Row, Diff>,
 ) -> ColumnarCollection<'scope, T, Row, Diff>
@@ -146,17 +186,14 @@ where
 {
     collection
         .inner
-        .unary::<ColumnBuilder<(Row, T, Diff)>, _, _, _>(
+        .unary::<CapacityContainerBuilder<Column<(Row, T, Diff)>>, _, _, _>(
             Pipeline,
             "ColumnarNegate",
             |_cap, _info| {
                 move |input, output| {
                     input.for_each(|time, data| {
-                        let mut session = output.session_with_builder(&time);
-                        for (v, t, d) in data.borrow().into_index_iter() {
-                            let d = -Diff::into_owned(d);
-                            session.give((v, t, &d));
-                        }
+                        let mut negated = negate_column(std::mem::take(data));
+                        output.session(&time).give_container(&mut negated);
                     });
                 }
             },

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -30,8 +30,10 @@
 //! `ColumnarToVec` operator. Repack seams therefore stay visible in dataflow
 //! introspection, so they can be found and retired.
 
-use columnar::{Columnar, Index};
+use columnar::primitive::Empties;
+use columnar::{Columnar, Container, Index, Len};
 use differential_dataflow::{AsCollection, Collection, VecCollection};
+use mz_ore::cast::CastFrom;
 use mz_repr::{DatumVec, DatumVecBorrow, Diff, Row};
 use mz_timely_util::columnar::Column;
 use mz_timely_util::columnar::batcher;
@@ -297,20 +299,50 @@ where
         .as_collection()
 }
 
+/// Reshapes `(Row, T, Diff)` into the `((Row, ()), T, Diff)` shape the key
+/// batcher consumes, moving whole sub-columns instead of visiting records.
+///
+/// `<() as Columnar>::Container` is a record count, so the value column carries
+/// no data and the reshape only has to relabel the key column and set that
+/// count. A `Typed` input hands its sub-columns over untouched. A serialized
+/// input is copied one column at a time, which is a bulk copy per column rather
+/// than a re-encode per record.
+fn pack_unit_value<T>(column: Column<(Row, T, Diff)>) -> Column<((Row, ()), T, Diff)>
+where
+    T: RenderTimestamp,
+{
+    match column {
+        Column::Typed((rows, times, diffs)) => {
+            let count = u64::cast_from(rows.len());
+            Column::Typed(((rows, Empties { count, empty: () }), times, diffs))
+        }
+        column => {
+            let view = column.borrow();
+            let len = view.len();
+            let mut packed = <((Row, ()), T, Diff) as Columnar>::Container::default();
+            let ((rows, units), times, diffs) = &mut packed;
+            rows.extend_from_self(view.0, 0..len);
+            units.count += u64::cast_from(len);
+            times.extend_from_self(view.1, 0..len);
+            diffs.extend_from_self(view.2, 0..len);
+            Column::Typed(packed)
+        }
+    }
+}
+
 /// Consolidates a [`ColumnarCollection`] natively, without a row round-trip.
 ///
 /// Mirrors the `Vec` arm's [`CollectionExt::consolidate_named`], but keeps the
 /// data columnar throughout: the input is reshaped into the `((Row, ()), T,
 /// Diff)` shape the key batcher consumes, merged by [`Col2KeyBatcher`] under a
-/// [`columnar_exchange`] pact, then unpacked back into a `Column`. Rows, times,
-/// and diffs are pushed from their borrowed forms, so no owned [`Row`] is
-/// materialized on the hot path.
+/// [`columnar_exchange`] pact, then unpacked back into a `Column`. The reshape
+/// and the unpack move whole sub-columns, so neither visits a record and no
+/// owned [`Row`] is materialized on the hot path. The exchange pact still
+/// re-encodes per record, see the TODO at the pact.
 ///
 /// This uses [`consolidate_pact`], not `mz_arrange_core`. A consolidate emits a
 /// consolidated collection, so building and reading back a maintained trace
-/// would be wasted work. [`Col2KeyBatcher`] and the `Vec` arm's `KeyBatcher`
-/// produce the same `ColumnationStack` output and differ only in their input
-/// chunker, so the unpack loop matches the `Vec` arm's.
+/// would be wasted work.
 pub fn columnar_consolidate<'scope, T>(
     collection: ColumnarCollection<'scope, T, Row, Diff>,
     name: &str,
@@ -319,24 +351,29 @@ where
     T: RenderTimestamp,
 {
     // Reshape `(Row, T, Diff)` into `((Row, ()), T, Diff)`, the key-batcher
-    // shape. The unit value carries no data; the whole `Row` is the key.
+    // shape. The unit value carries no data, the whole `Row` is the key. The
+    // container builder's type matches the reshaped column so `give_container`
+    // hands the batch through without a builder re-encoding it.
     let keyed = collection
         .inner
-        .unary::<ColumnBuilder<((Row, ()), T, Diff)>, _, _, _>(
+        .unary::<CapacityContainerBuilder<Column<((Row, ()), T, Diff)>>, _, _, _>(
             Pipeline,
             &format!("ConsolidateKey {name}"),
             |_cap, _info| {
                 move |input, output| {
                     input.for_each(|time, data| {
-                        let mut session = output.session_with_builder(&time);
-                        for (row, t, d) in data.borrow().into_index_iter() {
-                            session.give(((row, ()), t, d));
-                        }
+                        let mut packed = pack_unit_value(std::mem::take(data));
+                        output.session(&time).give_container(&mut packed);
                     });
                 }
             },
         );
 
+    // TODO: This pact re-serializes every record into a per-destination
+    // `ColumnBuilder`, the one remaining full re-encode on this path. Routing a
+    // column in bulk needs contiguous ranges of records sharing a destination,
+    // which the exchange function cannot identify from a hash per record, so
+    // bulk routing needs a different formulation and is left as future work.
     let exchange =
         ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, (), T, Diff>);
     let consolidated = consolidate_pact::<batcher::Chunker<_>, Col2KeyBatcher<Row, T, Diff>, _, _>(
@@ -345,6 +382,12 @@ where
 
     // Unpack the sealed chains back into a `Column`, dropping the unit value.
     //
+    // This visits records where the reshape above does not: the batcher hands
+    // back `ColumnationStack` chunks, which store tuples row-major, so there are
+    // no sub-columns to move. Pushing into a `Column` container rather than a
+    // `ColumnBuilder` still avoids serializing here, since a `Pipeline` edge
+    // carries the typed container as-is.
+    //
     // TODO: This drains a whole sealed snapshot in one activation, an
     // un-fueled burst hazard on large consolidations. It is the same behavior
     // as the `Vec` arm's `consolidate_named` unpack (see
@@ -352,13 +395,13 @@ where
     // fuel fix should cover both arms, so the burst is not fixed on one and
     // left on the other.
     consolidated
-        .unary::<ColumnBuilder<(Row, T, Diff)>, _, _, _>(
+        .unary::<CapacityContainerBuilder<Column<(Row, T, Diff)>>, _, _, _>(
             Pipeline,
             &format!("Unpack {name}"),
             |_cap, _info| {
                 move |input, output| {
                     input.for_each(|time, data| {
-                        let mut session = output.session_with_builder(&time);
+                        let mut session = output.session(&time);
                         for ((row, ()), t, d) in
                             data.iter().flatten().flat_map(|chunk| chunk.iter())
                         {
@@ -441,6 +484,8 @@ mod tests {
     use differential_dataflow::input::Input;
     use mz_ore::cast::CastFrom;
     use mz_repr::{Datum, Timestamp};
+    use timely::container::PushInto;
+    use timely::dataflow::channels::ContainerBytes;
     use timely::dataflow::operators::Capture;
     use timely::dataflow::operators::capture::{Event, Extract};
 
@@ -602,6 +647,97 @@ mod tests {
         assert_eq!(vec_updates, extract_sorted(col_captured));
         // Each output row retains at most the first datum of its input.
         assert!(vec_updates.iter().all(|(r, _, _)| r.iter().count() <= 1));
+    }
+
+    /// Builds a `Column` holding `records`, in the requested representation.
+    ///
+    /// `pack_unit_value` moves sub-columns for `Typed` input and copies them for
+    /// serialized input, so both representations have to be covered.
+    fn column_of(
+        records: &[(Row, Timestamp, Diff)],
+        serialized: bool,
+    ) -> Column<(Row, Timestamp, Diff)> {
+        let mut column = Column::<(Row, Timestamp, Diff)>::default();
+        for (row, time, diff) in records {
+            column.push_into((row, time, diff));
+        }
+        if !serialized {
+            return column;
+        }
+        let mut bytes: Vec<u8> = Vec::new();
+        column.into_bytes(&mut bytes);
+        // `into_bytes` writes whole `u64` words, and `Align` wants them as
+        // words. Native byte order, matching how the words were written.
+        assert_eq!(bytes.len() % 8, 0);
+        let words = bytes
+            .chunks_exact(8)
+            .map(|w| u64::from_ne_bytes(w.try_into().expect("chunk is 8 bytes")))
+            .collect();
+        Column::Align(words)
+    }
+
+    #[mz_ore::test]
+    fn pack_unit_value_preserves_records() {
+        let records = vec![
+            (
+                Row::pack_slice(&[Datum::Int32(1)]),
+                Timestamp::from(0_u64),
+                Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::Int32(2)]),
+                Timestamp::from(1_u64),
+                -Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::String("wide enough to not be inline")]),
+                Timestamp::from(7_u64),
+                Diff::from(3),
+            ),
+        ];
+
+        for serialized in [false, true] {
+            let packed = pack_unit_value(column_of(&records, serialized));
+            let observed: Vec<_> = packed
+                .borrow()
+                .into_index_iter()
+                .map(|((row, ()), t, d)| {
+                    (
+                        <Row as Columnar>::into_owned(row),
+                        <Timestamp as Columnar>::into_owned(t),
+                        <Diff as Columnar>::into_owned(d),
+                    )
+                })
+                .collect();
+            assert_eq!(observed, records, "serialized={serialized}");
+
+            // A tuple container reports the length of its first column only, so
+            // iteration above cannot see the unit column's count. That count is
+            // set explicitly rather than pushed per record, and a wrong one
+            // silently misreports the value column to the batcher, so assert it.
+            let Column::Typed(((_, units), _, _)) = &packed else {
+                panic!("pack_unit_value returns a typed column");
+            };
+            assert_eq!(
+                usize::cast_from(units.count),
+                records.len(),
+                "unit column count, serialized={serialized}"
+            );
+        }
+    }
+
+    #[mz_ore::test]
+    fn pack_unit_value_handles_empty() {
+        // The unit column's length is set from the key column rather than
+        // pushed per record, so the empty case is worth pinning.
+        for serialized in [false, true] {
+            let packed = pack_unit_value(column_of(&[], serialized));
+            assert_eq!(packed.borrow().len(), 0, "serialized={serialized}");
+            let Column::Typed(((_, units), _, _)) = &packed else {
+                panic!("pack_unit_value returns a typed column");
+            };
+            assert_eq!(units.count, 0, "serialized={serialized}");
+        }
     }
 
     #[mz_ore::test]

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -13,7 +13,7 @@
 //! edges between Plan nodes carry. Every producer emits this representation.
 //!
 //! Within a Plan node, operators may freely materialize `Vec` collections. Only
-//! the inter-node edge format is constrained. A node that produces a row-based
+//! the collection edge format is constrained. A node that produces a row-based
 //! collection re-encodes it to the columnar edge at its output leaf via
 //! [`vec_to_columnar`]. A node that must consume rows decodes at its input leaf
 //! via [`columnar_to_vec`]. Both are named operators (`VecToColumnar`,
@@ -49,7 +49,7 @@ use crate::render::errors::DataflowErrorSer;
 pub type ColumnarCollection<'scope, T, D, R> = Collection<'scope, T, Column<(D, T, R)>>;
 
 /// A dataflow edge between Plan nodes: a columnar collection of `(Row, Diff)`
-/// updates. Every producer emits this representation; a row-based producer
+/// updates. Every producer emits this representation. A row-based producer
 /// re-encodes to it at its output leaf via [`vec_to_columnar`].
 pub type CollectionEdge<'scope, T> = ColumnarCollection<'scope, T, Row, Diff>;
 
@@ -66,7 +66,7 @@ where
 /// Applies `logic` to each record in `edge`, exposing the record as a borrowed
 /// [`DatumVecBorrow`] and giving it ok and err output sessions.
 ///
-/// `max_demand` bounds the number of columns decoded per row; pass `usize::MAX`
+/// `max_demand` bounds the number of columns decoded per row. Pass `usize::MAX`
 /// to decode all columns.
 ///
 /// This is the canonical entry point for "decoding consumers" (operators that
@@ -105,8 +105,8 @@ where
             let mut ok_output = ok_output.activate();
             let mut err_output = err_output.activate();
             input.for_each(|time, data| {
-                // Retain the input capability to derive a `Capability` for each output;
-                // the `Session` type alias is fixed to `Capability<T>`.
+                // Retain the input capability to derive a `Capability` for each
+                // output. The `Session` type alias is fixed to `Capability<T>`.
                 let ok_cap = time.retain(0);
                 let err_cap = time.retain(1);
                 let mut ok_session = ok_output.session_with_builder(&ok_cap);

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -560,14 +560,17 @@ mod tests {
         }
         let mut bytes: Vec<u8> = Vec::new();
         column.into_bytes(&mut bytes);
-        // `into_bytes` writes whole `u64` words, and `Align` wants them as
-        // words. Native byte order, matching how the words were written.
-        assert_eq!(bytes.len() % 8, 0);
-        let words = bytes
-            .chunks_exact(8)
-            .map(|w| u64::from_ne_bytes(w.try_into().expect("chunk is 8 bytes")))
-            .collect();
-        Column::Align(words)
+        // Round-trip through the container's own byte form rather than building a
+        // serialized variant by hand, so this does not depend on which payload
+        // type that variant holds.
+        let serialized = <Column<(Row, Timestamp, Diff)> as ContainerBytes>::from_bytes(
+            timely::bytes::arc::BytesMut::from(bytes).freeze(),
+        );
+        assert!(
+            !matches!(serialized, Column::Typed(_)),
+            "round-trip should produce a serialized column"
+        );
+        serialized
     }
 
     #[mz_ore::test]

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -9,26 +9,16 @@
 
 //! Columnar dataflow edge support.
 //!
-//! Defines [`CollectionEdge`], a wrapper that lets dataflow edges between Plan
-//! nodes carry either row-based ([`VecCollection`]) or columnar
-//! ([`ColumnarCollection`]) batches of `(D, T, R)` updates.
+//! Defines [`CollectionEdge`], the columnar batch representation that dataflow
+//! edges between Plan nodes carry. Every producer emits this representation.
 //!
-//! # Migration model
-//!
-//! The migration is consumer-first: every Plan-node consumer learns to accept
-//! both variants before any producer emits the columnar variant. Producers can
-//! then flip to columnar one at a time.
-//!
-//! Within a Plan node, operators may freely materialize Vec collections; only
-//! the inter-node edge format is constrained. A decode from columnar to Vec at
-//! a consumer's input is acceptable only when the consumer would have decoded
-//! `Row` to [`mz_repr::Datum`] anyway. Pure passthrough consumers (Negate,
-//! Union) round-trip the columnar variant without decoding.
-//!
-//! Consumers that have not yet learned the columnar form fall back to
-//! [`CollectionEdge::into_vec`], which decodes through the named
-//! `ColumnarToVec` operator. Repack seams therefore stay visible in dataflow
-//! introspection, so they can be found and retired.
+//! Within a Plan node, operators may freely materialize `Vec` collections. Only
+//! the inter-node edge format is constrained. A node that produces a row-based
+//! collection re-encodes it to the columnar edge at its output leaf via
+//! [`vec_to_columnar`]. A node that must consume rows decodes at its input leaf
+//! via [`columnar_to_vec`]. Both are named operators (`VecToColumnar`,
+//! `ColumnarToVec`), so those leaf seams stay visible in dataflow
+//! introspection.
 
 use columnar::primitive::Empties;
 use columnar::{Columnar, Container, Index, Len};
@@ -39,7 +29,7 @@ use mz_timely_util::columnar::Column;
 use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::{Col2KeyBatcher, columnar_exchange};
-use mz_timely_util::operator::{CollectionExt, consolidate_pact};
+use mz_timely_util::operator::consolidate_pact;
 use timely::ContainerBuilder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
@@ -50,7 +40,6 @@ use timely::dataflow::{Scope, Stream, StreamVec};
 use crate::render::RenderTimestamp;
 use crate::render::context::{ECB, Session};
 use crate::render::errors::DataflowErrorSer;
-use crate::typedefs::KeyBatcher;
 
 /// A columnar collection of `(D, T, R)` updates traveling on a compute
 /// dataflow edge.
@@ -59,204 +48,84 @@ use crate::typedefs::KeyBatcher;
 /// container is [`Column<(D, T, R)>`] instead of `Vec<(D, T, R)>`.
 pub type ColumnarCollection<'scope, T, D, R> = Collection<'scope, T, Column<(D, T, R)>>;
 
-/// A dataflow edge carrying records as either a row-based [`VecCollection`] or
-/// a [`ColumnarCollection`].
-///
-/// Producers choose a variant; consumers must accept either. Variant-mixing
-/// `concat`s repack the row-based inputs and produce the columnar variant.
-#[derive(Clone)]
-pub enum CollectionEdge<'scope, T: RenderTimestamp> {
-    /// Row-formatted collection. No producer constructs this after the
-    /// migration; the variant and its remaining match arms are removed when the
-    /// enum collapses to a columnar alias.
-    #[allow(dead_code)]
-    Vec(VecCollection<'scope, T, Row, Diff>),
-    /// Columnar collection. Currently unused by any producer; reserved for the
-    /// producer flip at the end of the migration.
-    Columnar(ColumnarCollection<'scope, T, Row, Diff>),
+/// A dataflow edge between Plan nodes: a columnar collection of `(Row, Diff)`
+/// updates. Every producer emits this representation; a row-based producer
+/// re-encodes to it at its output leaf via [`vec_to_columnar`].
+pub type CollectionEdge<'scope, T> = ColumnarCollection<'scope, T, Row, Diff>;
+
+/// Concatenates a collection of columnar edges.
+pub fn concat_many<'scope, T, I>(scope: Scope<'scope, T>, edges: I) -> CollectionEdge<'scope, T>
+where
+    T: RenderTimestamp,
+    I: IntoIterator<Item = CollectionEdge<'scope, T>>,
+{
+    let cols: Vec<_> = edges.into_iter().collect();
+    differential_dataflow::collection::concatenate(scope, cols)
 }
 
-impl<'scope, T: RenderTimestamp> CollectionEdge<'scope, T> {
-    /// The scope containing this edge.
-    pub fn scope(&self) -> Scope<'scope, T> {
-        match self {
-            CollectionEdge::Vec(c) => c.inner.scope(),
-            CollectionEdge::Columnar(c) => c.inner.scope(),
+/// Applies `logic` to each record in `edge`, exposing the record as a borrowed
+/// [`DatumVecBorrow`] and giving it ok and err output sessions.
+///
+/// `max_demand` bounds the number of columns decoded per row; pass `usize::MAX`
+/// to decode all columns.
+///
+/// This is the canonical entry point for "decoding consumers" (operators that
+/// read [`mz_repr::Datum`]s from each row anyway). It iterates the columnar
+/// batch directly without going through an owned [`Row`].
+pub fn flat_map_datums<'scope, T, DCB, L>(
+    edge: CollectionEdge<'scope, T>,
+    max_demand: usize,
+    mut logic: L,
+) -> (
+    Stream<'scope, T, DCB::Container>,
+    StreamVec<'scope, T, (DataflowErrorSer, T, Diff)>,
+)
+where
+    T: RenderTimestamp,
+    DCB: ContainerBuilder,
+    L: for<'a> FnMut(
+            &'a mut DatumVecBorrow<'_>,
+            T,
+            Diff,
+            &mut Session<T, DCB>,
+            &mut Session<T, ECB<T>>,
+        ) -> usize
+        + 'static,
+{
+    let scope = edge.inner.scope();
+    let mut builder = OperatorBuilder::new("CollectionFlatMap".to_string(), scope);
+    let (ok_output, ok_stream) = builder.new_output();
+    let mut ok_output = OutputBuilder::<_, DCB>::from(ok_output);
+    let (err_output, err_stream) = builder.new_output();
+    let mut err_output = OutputBuilder::<_, ECB<T>>::from(err_output);
+    let mut input = builder.new_input(edge.inner, Pipeline);
+    builder.build(move |_capabilities| {
+        let mut datums = DatumVec::new();
+        move |_frontiers| {
+            let mut ok_output = ok_output.activate();
+            let mut err_output = err_output.activate();
+            input.for_each(|time, data| {
+                // Retain the input capability to derive a `Capability` for each output;
+                // the `Session` type alias is fixed to `Capability<T>`.
+                let ok_cap = time.retain(0);
+                let err_cap = time.retain(1);
+                let mut ok_session = ok_output.session_with_builder(&ok_cap);
+                let mut err_session = err_output.session_with_builder(&err_cap);
+                // Rows are read from the borrowed column, never materialized as
+                // owned `Row`s.
+                for (v, t, d) in data.borrow().into_index_iter() {
+                    logic(
+                        &mut datums.borrow_with_limit(v, max_demand),
+                        Columnar::into_owned(t),
+                        Columnar::into_owned(d),
+                        &mut ok_session,
+                        &mut err_session,
+                    );
+                }
+            });
         }
-    }
-
-    /// Brings the edge into a sub-region of its current scope.
-    pub fn enter_region<'inner>(self, region: Scope<'inner, T>) -> CollectionEdge<'inner, T> {
-        match self {
-            CollectionEdge::Vec(c) => CollectionEdge::Vec(c.enter_region(region)),
-            CollectionEdge::Columnar(c) => CollectionEdge::Columnar(c.enter_region(region)),
-        }
-    }
-
-    /// Leaves a sub-region back to the outer scope.
-    pub fn leave_region<'outer>(self, outer: Scope<'outer, T>) -> CollectionEdge<'outer, T> {
-        match self {
-            CollectionEdge::Vec(c) => CollectionEdge::Vec(c.leave_region(outer)),
-            CollectionEdge::Columnar(c) => CollectionEdge::Columnar(c.leave_region(outer)),
-        }
-    }
-
-    /// The edge as a row-based [`VecCollection`].
-    ///
-    /// The Vec arm is returned as is. The columnar arm decodes through
-    /// [`columnar_to_vec`], which allocates an owned [`Row`] per record.
-    /// Consumers that can work on the columnar form directly should do so
-    /// instead of calling this.
-    pub fn into_vec(self) -> VecCollection<'scope, T, Row, Diff> {
-        match self {
-            CollectionEdge::Vec(c) => c,
-            CollectionEdge::Columnar(c) => columnar_to_vec(c),
-        }
-    }
-
-    /// Negates the diff on every record in this edge.
-    ///
-    /// Preserves variant. The columnar arm uses [`columnar_negate`], which
-    /// negates diffs without decoding rows.
-    pub fn negate(self) -> Self {
-        match self {
-            CollectionEdge::Vec(c) => CollectionEdge::Vec(c.negate()),
-            CollectionEdge::Columnar(c) => CollectionEdge::Columnar(columnar_negate(c)),
-        }
-    }
-
-    /// Concatenates a collection of edges.
-    ///
-    /// The inputs are all columnar, so they concatenate natively into the
-    /// columnar variant.
-    pub fn concat_many<I>(scope: Scope<'scope, T>, edges: I) -> Self
-    where
-        I: IntoIterator<Item = Self>,
-    {
-        let cols = edges.into_iter().map(|edge| match edge {
-            CollectionEdge::Columnar(c) => c,
-            // No producer emits `Vec`, so a `Vec` input cannot reach here.
-            CollectionEdge::Vec(_) => unreachable!("no producer emits a `Vec` edge"),
-        });
-        CollectionEdge::Columnar(differential_dataflow::collection::concatenate(
-            scope,
-            cols.collect::<Vec<_>>(),
-        ))
-    }
-
-    /// Applies `logic` to each record in this edge, exposing the record as a
-    /// borrowed [`DatumVecBorrow`] and giving it ok and err output sessions.
-    ///
-    /// `max_demand` bounds the number of columns decoded per row; pass
-    /// `usize::MAX` to decode all columns.
-    ///
-    /// This is the canonical unified entry point for "decoding consumers"
-    /// (operators that read [`mz_repr::Datum`]s from each row anyway). The
-    /// Vec arm uses [`DatumVec::borrow_with_limit`] on each [`Row`]; the
-    /// Columnar arm iterates the columnar batch directly without going
-    /// through an owned [`Row`].
-    pub fn flat_map_datums<DCB, L>(
-        self,
-        max_demand: usize,
-        mut logic: L,
-    ) -> (
-        Stream<'scope, T, DCB::Container>,
-        StreamVec<'scope, T, (DataflowErrorSer, T, Diff)>,
-    )
-    where
-        DCB: ContainerBuilder,
-        L: for<'a> FnMut(
-                &'a mut DatumVecBorrow<'_>,
-                T,
-                Diff,
-                &mut Session<T, DCB>,
-                &mut Session<T, ECB<T>>,
-            ) -> usize
-            + 'static,
-    {
-        match self {
-            CollectionEdge::Vec(c) => {
-                let scope = c.inner.scope();
-                let mut builder = OperatorBuilder::new("CollectionFlatMap".to_string(), scope);
-                let (ok_output, ok_stream) = builder.new_output();
-                let mut ok_output = OutputBuilder::<_, DCB>::from(ok_output);
-                let (err_output, err_stream) = builder.new_output();
-                let mut err_output = OutputBuilder::<_, ECB<T>>::from(err_output);
-                let mut input = builder.new_input(c.inner, Pipeline);
-                builder.build(move |_capabilities| {
-                    let mut datums = DatumVec::new();
-                    move |_frontiers| {
-                        let mut ok_output = ok_output.activate();
-                        let mut err_output = err_output.activate();
-                        input.for_each(|time, data| {
-                            // Retain the input capability to derive a `Capability` for each output;
-                            // the `Session` type alias is fixed to `Capability<T>`.
-                            let ok_cap = time.retain(0);
-                            let err_cap = time.retain(1);
-                            let mut ok_session = ok_output.session_with_builder(&ok_cap);
-                            let mut err_session = err_output.session_with_builder(&err_cap);
-                            for (v, t, d) in data.drain(..) {
-                                logic(
-                                    &mut datums.borrow_with_limit(&v, max_demand),
-                                    t,
-                                    d,
-                                    &mut ok_session,
-                                    &mut err_session,
-                                );
-                            }
-                        });
-                    }
-                });
-                (ok_stream, err_stream)
-            }
-            CollectionEdge::Columnar(c) => {
-                let scope = c.inner.scope();
-                let mut builder = OperatorBuilder::new("CollectionFlatMap".to_string(), scope);
-                let (ok_output, ok_stream) = builder.new_output();
-                let mut ok_output = OutputBuilder::<_, DCB>::from(ok_output);
-                let (err_output, err_stream) = builder.new_output();
-                let mut err_output = OutputBuilder::<_, ECB<T>>::from(err_output);
-                let mut input = builder.new_input(c.inner, Pipeline);
-                builder.build(move |_capabilities| {
-                    let mut datums = DatumVec::new();
-                    move |_frontiers| {
-                        let mut ok_output = ok_output.activate();
-                        let mut err_output = err_output.activate();
-                        input.for_each(|time, data| {
-                            // Retain the input capability to derive a `Capability` for each output;
-                            // the `Session` type alias is fixed to `Capability<T>`.
-                            let ok_cap = time.retain(0);
-                            let err_cap = time.retain(1);
-                            let mut ok_session = ok_output.session_with_builder(&ok_cap);
-                            let mut err_session = err_output.session_with_builder(&err_cap);
-                            // Rows are read from the borrowed column, never
-                            // materialized as owned `Row`s.
-                            for (v, t, d) in data.borrow().into_index_iter() {
-                                logic(
-                                    &mut datums.borrow_with_limit(v, max_demand),
-                                    Columnar::into_owned(t),
-                                    Columnar::into_owned(d),
-                                    &mut ok_session,
-                                    &mut err_session,
-                                );
-                            }
-                        });
-                    }
-                });
-                (ok_stream, err_stream)
-            }
-        }
-    }
-
-    /// Consolidates updates in the edge, preserving variant.
-    pub fn consolidate_named(self, name: &str) -> Self {
-        match self {
-            CollectionEdge::Vec(c) => CollectionEdge::Vec(CollectionExt::consolidate_named::<
-                KeyBatcher<_, _, _>,
-            >(c, name)),
-            CollectionEdge::Columnar(c) => CollectionEdge::Columnar(columnar_consolidate(c, name)),
-        }
-    }
+    });
+    (ok_stream, err_stream)
 }
 
 /// Negates the diff of every record in a [`ColumnarCollection`].
@@ -538,7 +407,7 @@ mod tests {
     }
 
     #[mz_ore::test]
-    fn negate_flips_diffs_on_columnar_arm() {
+    fn columnar_negate_flips_diffs() {
         let rows = test_rows();
         let expected: Vec<_> = {
             let mut updates: Vec<_> = rows
@@ -551,9 +420,8 @@ mod tests {
         let captured = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut input, collection) = scope.new_collection();
-                let edge = CollectionEdge::Columnar(vec_to_columnar(collection)).negate();
-                assert!(matches!(edge, CollectionEdge::Columnar(_)));
-                let captured = edge.into_vec().inner.capture();
+                let edge = columnar_negate(vec_to_columnar(collection));
+                let captured = columnar_to_vec(edge).inner.capture();
                 for row in rows {
                     input.update(row, Diff::ONE);
                 }
@@ -582,15 +450,11 @@ mod tests {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut input1, collection1) = scope.new_collection();
                 let (mut input2, collection2) = scope.new_collection();
-                let edge = CollectionEdge::concat_many(
+                let edge = concat_many(
                     scope,
-                    [
-                        CollectionEdge::Columnar(vec_to_columnar(collection1)),
-                        CollectionEdge::Columnar(vec_to_columnar(collection2)),
-                    ],
+                    [vec_to_columnar(collection1), vec_to_columnar(collection2)],
                 );
-                assert!(matches!(edge, CollectionEdge::Columnar(_)));
-                let captured = edge.into_vec().inner.capture();
+                let captured = columnar_to_vec(edge).inner.capture();
                 let (first, rest) = rows.split_first().unwrap();
                 input1.update(first.clone(), Diff::ONE);
                 input2.update(first.clone(), Diff::ONE);
@@ -609,40 +473,32 @@ mod tests {
 
     #[mz_ore::test]
     fn flat_map_datums_arms_agree() {
-        // Project the first datum of each row, exercising `max_demand` on both
-        // arms. The two captures must extract identical updates.
+        // Project the first datum of each row, exercising `max_demand`.
         let rows = test_rows();
-        let (vec_captured, col_captured) = timely::execute_directly(move |worker| {
+        let captured = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut input, collection) = scope.new_collection();
-                let mut captures = Vec::new();
-                for edge in [
-                    CollectionEdge::Vec(collection.clone()),
-                    CollectionEdge::Columnar(vec_to_columnar(collection)),
-                ] {
-                    let (oks, _errs) = edge.flat_map_datums::<RowBuilder, _>(
-                        1,
-                        |datums, t, d, ok_session, _err_session| {
-                            ok_session.give((Row::pack(datums.iter()), t, d));
-                            1
-                        },
-                    );
-                    captures.push(oks.capture());
-                }
-                let col = captures.pop().unwrap();
-                let vec = captures.pop().unwrap();
+                let (oks, _errs) = flat_map_datums::<_, RowBuilder, _>(
+                    vec_to_columnar(collection),
+                    1,
+                    |datums, t, d, ok_session, _err_session| {
+                        ok_session.give((Row::pack(datums.iter()), t, d));
+                        1
+                    },
+                );
+                let captured = oks.capture();
                 for row in rows {
                     input.update(row, Diff::ONE);
                 }
                 input.advance_to(Timestamp::from(1_u64));
                 input.flush();
-                (vec, col)
+                captured
             })
         });
-        let vec_updates = extract_sorted(vec_captured);
-        assert_eq!(vec_updates, extract_sorted(col_captured));
+        let updates = extract_sorted(captured);
+        assert!(!updates.is_empty());
         // Each output row retains at most the first datum of its input.
-        assert!(vec_updates.iter().all(|(r, _, _)| r.iter().count() <= 1));
+        assert!(updates.iter().all(|(r, _, _)| r.iter().count() <= 1));
     }
 
     /// Builds a `Column` holding `records`, in the requested representation.
@@ -737,7 +593,7 @@ mod tests {
     }
 
     #[mz_ore::test]
-    fn consolidate_named_preserves_columnar() {
+    fn columnar_consolidate_accumulates_and_cancels() {
         let row1 = Row::pack_slice(&[Datum::Int32(1)]);
         let row2 = Row::pack_slice(&[Datum::Int32(2)]);
         let row3 = Row::pack_slice(&[Datum::Int32(3)]);
@@ -750,26 +606,11 @@ mod tests {
             (row1.clone(), Timestamp::from(1_u64), Diff::ONE),
         ];
 
-        // The columnar arm keeps the `Columnar` variant. No-ColumnarToVec is a
-        // by-inspection property: `consolidate_named`'s columnar arm calls
-        // `columnar_consolidate` (native `Col2KeyBatcher` merge), never
-        // `columnar_to_vec`. The `into_vec` below is the capture harness
-        // decoding for the test only, not part of the consolidate.
-        let (vec_captured, col_captured) = timely::execute_directly(move |worker| {
+        let captured = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut input, collection) = scope.new_collection();
-                let mut captures = Vec::new();
-                for edge in [
-                    CollectionEdge::Vec(collection.clone()),
-                    CollectionEdge::Columnar(vec_to_columnar(collection)),
-                ] {
-                    let is_columnar = matches!(edge, CollectionEdge::Columnar(_));
-                    let edge = edge.consolidate_named("Test");
-                    assert_eq!(matches!(edge, CollectionEdge::Columnar(_)), is_columnar);
-                    captures.push(edge.into_vec().inner.capture());
-                }
-                let col = captures.pop().unwrap();
-                let vec = captures.pop().unwrap();
+                let edge = columnar_consolidate(vec_to_columnar(collection), "Test");
+                let captured = columnar_to_vec(edge).inner.capture();
                 // t=0: row1 accumulates (+1, +1), row2 cancels (+1, -1).
                 input.advance_to(Timestamp::from(0_u64));
                 input.update(row1.clone(), Diff::ONE);
@@ -783,11 +624,9 @@ mod tests {
                 input.update(row3, -Diff::ONE);
                 input.advance_to(Timestamp::from(2_u64));
                 input.flush();
-                (vec, col)
+                captured
             })
         });
-        let vec_updates = extract_sorted(vec_captured);
-        assert_eq!(vec_updates, expected);
-        assert_eq!(extract_sorted(col_captured), vec_updates);
+        assert_eq!(extract_sorted(captured), expected);
     }
 }

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -568,7 +568,7 @@ mod tests {
     }
 
     #[mz_ore::test]
-    fn concat_many_mixed_upgrades_to_columnar() {
+    fn concat_many_concatenates_columnar() {
         let rows = test_rows();
         let expected: Vec<_> = {
             let mut updates: Vec<_> = rows
@@ -587,7 +587,7 @@ mod tests {
                 let edge = CollectionEdge::concat_many(
                     scope,
                     [
-                        CollectionEdge::Vec(collection1),
+                        CollectionEdge::Columnar(vec_to_columnar(collection1)),
                         CollectionEdge::Columnar(vec_to_columnar(collection2)),
                     ],
                 );

--- a/src/compute/src/render/columnar.rs
+++ b/src/compute/src/render/columnar.rs
@@ -197,7 +197,7 @@ where
 
 /// Consolidates a [`ColumnarCollection`] natively, without a row round-trip.
 ///
-/// Mirrors the `Vec` arm's [`CollectionExt::consolidate_named`], but keeps the
+/// Mirrors the `Vec` arm's `CollectionExt::consolidate_named`, but keeps the
 /// data columnar throughout: the input is reshaped into the `((Row, ()), T,
 /// Diff)` shape the key batcher consumes, merged by [`Col2KeyBatcher`] under a
 /// [`columnar_exchange`] pact, then unpacked back into a `Column`. The reshape

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -419,14 +419,6 @@ pub struct CollectionBundle<'scope, T: RenderTimestamp> {
 }
 
 impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
-    /// Construct a new collection bundle from update streams.
-    pub fn from_collections(
-        oks: VecCollection<'scope, T, Row, Diff>,
-        errs: VecCollection<'scope, T, DataflowErrorSer, Diff>,
-    ) -> Self {
-        Self::from_edge(CollectionEdge::Vec(oks), errs)
-    }
-
     /// Construct a new collection bundle from a [`CollectionEdge`] and an error stream.
     pub fn from_edge(
         oks: CollectionEdge<'scope, T>,

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -1868,7 +1868,7 @@ mod tests {
     /// The shared arrangement->collection materialization carries the columnar
     /// edge. Reduce, Threshold, and bucketed TopK emit arrangements; when their
     /// result is demanded as a collection it flows through
-    /// `as_specific_collection`, so this flip makes those outputs columnar with
+    /// `as_specific_collection`, so those outputs are columnar with
     /// no `ColumnarToVec`.
     ///
     /// Correctness: the materialized rows must equal the arranged input. Keying

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -22,8 +22,7 @@ use differential_dataflow::trace::{Cursor, Navigable, TraceReader};
 use differential_dataflow::{AsCollection, VecCollection};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::{
-    ENABLE_COLUMN_PAGED_BATCHER, ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION,
-    ENABLE_COMPUTE_TEMPORAL_BUCKETING, TEMPORAL_BUCKETING_SUMMARY,
+    ENABLE_COLUMN_PAGED_BATCHER, ENABLE_COMPUTE_TEMPORAL_BUCKETING, TEMPORAL_BUCKETING_SUMMARY,
 };
 use mz_compute_types::plan::scalar::{LirScalarExpr, mfp_mir_to_lir_plan, mfp_plan_lir_to_mir};
 use mz_compute_types::plan::{ArrangementStrategy, AvailableCollections};
@@ -57,7 +56,7 @@ use crate::render::{LinearJoinSpec, MaybeBucketByTime, RenderTimestamp};
 use crate::typedefs::{
     ErrAgent, ErrBatcher, ErrBuilder, ErrEnter, ErrSpine, RowRowAgent, RowRowEnter, RowRowSpine,
 };
-use mz_row_spine::{DatumSeq, RowRowBuilder, RowRowColPagedBuilder};
+use mz_row_spine::{RowRowBuilder, RowRowColPagedBuilder};
 
 /// Dataflow-local collections and arrangements.
 ///
@@ -236,40 +235,6 @@ pub enum ArrangementFlavor<'scope, T: RenderTimestamp> {
 }
 
 impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
-    /// Presents `self` as a stream of updates.
-    ///
-    /// Deprecated: This function is not fueled and hence risks flattening the whole arrangement.
-    ///
-    /// This method presents the contents as they are, without further computation.
-    /// If you have logic that could be applied to each record, consider using the
-    /// `flat_map` methods which allows this and can reduce the work done.
-    #[deprecated(note = "Use `flat_map` instead.")]
-    pub fn as_collection(
-        &self,
-    ) -> (
-        VecCollection<'scope, T, Row, Diff>,
-        VecCollection<'scope, T, DataflowErrorSer, Diff>,
-    ) {
-        let mut datums = DatumVec::new();
-        let logic = move |k: DatumSeq, v: DatumSeq| {
-            let temp_storage = RowArena::new();
-            let mut datums_borrow = datums.borrow();
-            k.extend_datums(&temp_storage, &mut datums_borrow, None);
-            v.extend_datums(&temp_storage, &mut datums_borrow, None);
-            SharedRow::pack(&**datums_borrow)
-        };
-        match &self {
-            ArrangementFlavor::Local(oks, errs) => (
-                oks.clone().as_collection(logic),
-                errs.clone().as_collection(|k, &()| k.clone()),
-            ),
-            ArrangementFlavor::Trace(_, oks, errs) => (
-                oks.clone().as_collection(logic),
-                errs.clone().as_collection(|k, &()| k.clone()),
-            ),
-        }
-    }
-
     /// Constructs and applies logic to elements of `self` and returns the results.
     ///
     /// The `logic` callback receives a borrow of the decoded datum vector, a timestamp, a
@@ -558,9 +523,8 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// Therefore, it should be used when the appropriate transformation
     /// was planned as part of a following MFP.
     ///
-    /// If `key` is specified, the function converts the arrangement to a collection. It uses either
-    /// the fueled `flat_map` or `as_collection` method, depending on the flag
-    /// [`ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION`].
+    /// If `key` is specified, the function converts the arrangement to a collection using a
+    /// fueled `flat_map` operator.
     ///
     /// The keyed path materializes the arrangement as the columnar edge, so an
     /// arrangement-producing operator (Reduce, Threshold, bucketed TopK) whose
@@ -570,7 +534,6 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     pub fn as_specific_collection(
         &self,
         key: Option<&[LirScalarExpr]>,
-        config_set: &ConfigSet,
     ) -> (
         CollectionEdge<'scope, T>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
@@ -589,28 +552,22 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 let arranged = self.arranged.get(key).unwrap_or_else(|| {
                     panic!("The collection arranged by {:?} doesn't exist.", key)
                 });
-                if ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION.get(config_set) {
-                    // Decode all columns (max_demand usize::MAX) and pack each cursor record
-                    // into a `Column`, so the materialized collection carries the columnar edge.
-                    // Output is 1:1 from the already-consolidated cursor, so a non-consolidating
-                    // `ColumnBuilder` matches the row-based `CapacityContainerBuilder` this
-                    // replaced; the packed row is pushed borrowed, holding no owned `Row` per
-                    // record.
-                    let (ok, err) = arranged.flat_map_ok::<ColumnBuilder<(Row, T, Diff)>, _>(
-                        None,
-                        usize::MAX,
-                        |borrow, t, r, ok_session| {
-                            let row = SharedRow::pack(borrow.iter());
-                            ok_session.give((&row, &t, &r));
-                            1
-                        },
-                    );
-                    (CollectionEdge::Columnar(ok.as_collection()), err)
-                } else {
-                    #[allow(deprecated)]
-                    let (oks, errs) = arranged.as_collection();
-                    (CollectionEdge::Vec(oks), errs)
-                }
+                // Decode all columns (max_demand usize::MAX) and pack each cursor record
+                // into a `Column`, so the materialized collection carries the columnar edge.
+                // Output is 1:1 from the already-consolidated cursor, so a non-consolidating
+                // `ColumnBuilder` matches the row-based `CapacityContainerBuilder` this
+                // replaced; the packed row is pushed borrowed, holding no owned `Row` per
+                // record.
+                let (ok, err) = arranged.flat_map_ok::<ColumnBuilder<(Row, T, Diff)>, _>(
+                    None,
+                    usize::MAX,
+                    |borrow, t, r, ok_session| {
+                        let row = SharedRow::pack(borrow.iter());
+                        ok_session.give((&row, &t, &r));
+                        1
+                    },
+                );
+                (CollectionEdge::Columnar(ok.as_collection()), err)
             }
         }
     }
@@ -921,7 +878,6 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         mfp_plan: MfpPlan<LirScalarExpr>,
         key_val: Option<(Vec<LirScalarExpr>, Option<Row>)>,
         until: Antichain<mz_repr::Timestamp>,
-        config_set: &ConfigSet,
     ) -> (
         CollectionEdge<'scope, T>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
@@ -949,7 +905,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 // Keyed identity materializes an existing arrangement.
                 // `as_specific_collection` returns the columnar edge, so the
                 // reduce/threshold/topk result carries columnar downstream.
-                Some(key) => self.as_specific_collection(Some(&key), config_set),
+                Some(key) => self.as_specific_collection(Some(&key)),
             };
         }
 
@@ -1066,7 +1022,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         let form_raw_collection = collections.raw || will_create_arrangement;
         if form_raw_collection && self.collection.is_none() {
             let (oks, errs) =
-                self.as_collection_core(input_mfp, input_key.map(|k| (k, None)), until, config_set);
+                self.as_collection_core(input_mfp, input_key.map(|k| (k, None)), until);
             // Apply temporal bucketing when the lowering selected `TemporalBucketing` and
             // we will build at least one arrangement. This path fires when the collection
             // must be formed from scratch (e.g., from an arrangement via as_collection_core).
@@ -1523,7 +1479,6 @@ fn walk_cursor<C, F>(
 #[cfg(test)]
 mod tests {
     use differential_dataflow::input::Input;
-    use mz_compute_types::dyncfgs::all_dyncfgs;
     use mz_expr::{EvalError, MapFilterProject};
     use mz_repr::{Datum, ReprScalarType, Timestamp};
     use timely::dataflow::operators::Capture;
@@ -1727,15 +1682,13 @@ mod tests {
             .collect();
         expected.sort();
 
-        let config_set = ConfigSet::default();
         let (producer_is_columnar, passthrough_is_columnar, produced) =
             timely::execute_directly(move |worker| {
                 worker.dataflow::<Timestamp, _, _>(|scope| {
                     let (mut input, collection) = scope.new_collection();
                     let (_err_input, errs) = scope.new_collection::<DataflowErrorSer, Diff>();
                     let bundle = CollectionBundle::from_edge(CollectionEdge::Vec(collection), errs);
-                    let (edge, _errs) =
-                        bundle.as_collection_core(mfp, None, Antichain::new(), &config_set);
+                    let (edge, _errs) = bundle.as_collection_core(mfp, None, Antichain::new());
                     let producer_is_columnar = matches!(edge, CollectionEdge::Columnar(_));
                     // Tee the producer output for a content check, then feed the
                     // original edge into the arrange input.
@@ -1778,7 +1731,6 @@ mod tests {
     #[mz_ore::test]
     fn as_collection_core_identity_passes_edge_through() {
         for columnar_input in [false, true] {
-            let config_set = ConfigSet::default();
             let is_columnar = timely::execute_directly(move |worker| {
                 worker.dataflow::<Timestamp, _, _>(|scope| {
                     let (mut input, collection) = scope.new_collection::<Row, Diff>();
@@ -1792,8 +1744,7 @@ mod tests {
                     let identity = MapFilterProject::<LirScalarExpr>::new(1)
                         .into_plan()
                         .expect("identity mfp");
-                    let (out, _errs) =
-                        bundle.as_collection_core(identity, None, Antichain::new(), &config_set);
+                    let (out, _errs) = bundle.as_collection_core(identity, None, Antichain::new());
                     let is_columnar = matches!(out, CollectionEdge::Columnar(_));
                     input.update(Row::pack_slice(&[Datum::Int64(1)]), Diff::ONE);
                     input.advance_to(Timestamp::from(1u64));
@@ -1839,14 +1790,12 @@ mod tests {
             ),
         ];
 
-        let config_set = ConfigSet::default();
         let captured = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut input, collection) = scope.new_collection();
                 let (_err_input, errs) = scope.new_collection::<DataflowErrorSer, Diff>();
                 let bundle = CollectionBundle::from_edge(CollectionEdge::Vec(collection), errs);
-                let (edge, _errs) =
-                    bundle.as_collection_core(mfp, None, Antichain::new(), &config_set);
+                let (edge, _errs) = bundle.as_collection_core(mfp, None, Antichain::new());
                 assert!(
                     matches!(edge, CollectionEdge::Columnar(_)),
                     "a non-identity MFP must produce a columnar edge"
@@ -1887,9 +1836,6 @@ mod tests {
             .collect();
         expected.sort();
 
-        // A populated set so the fueled-materialization flag resolves to its
-        // default (`true`); `ConfigSet::default()` alone would panic on lookup.
-        let config_set = all_dyncfgs(ConfigSet::default());
         let (is_columnar, captured) = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut input, collection) = scope.new_collection();
@@ -1915,7 +1861,7 @@ mod tests {
                     0..1,
                     ArrangementFlavor::Local(arranged, err_arranged),
                 );
-                let (edge, _errs) = bundle.as_specific_collection(Some(&key), &config_set);
+                let (edge, _errs) = bundle.as_specific_collection(Some(&key));
                 let is_columnar = matches!(edge, CollectionEdge::Columnar(_));
                 let captured = edge.into_vec().inner.capture();
 

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -13,6 +13,7 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use columnar::{Columnar, Index};
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::cursor::{BatchCursor, BatchKey, BatchVal};
@@ -32,6 +33,7 @@ use mz_ore::soft_assert_or_log;
 use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, DatumVecBorrow, Diff, GlobalId, Row, RowArena, SharedRow};
 use mz_storage_types::controller::CollectionMetadata;
+use mz_timely_util::columnar::Column;
 use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, Col2ValPagedBatcher, columnar_exchange};
@@ -1068,7 +1070,6 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .collection
                     .take()
                     .expect("Collection constructed above");
-                let oks = oks.into_vec();
                 // Apply temporal bucketing if the collection already existed on
                 // the bundle (e.g., from an upstream temporal Mfp or Get) and we
                 // haven't bucketed yet. This is the common path for temporal-MFP
@@ -1086,7 +1087,15 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                         .try_into()
                         .expect("must fit");
                     bucketed = true;
-                    T::maybe_apply_temporal_bucketing(oks.inner, as_of.clone(), summary)
+                    // Temporal bucketing consumes and produces a `Vec` edge, so
+                    // decode here. This is the sanctioned leaf decode where a
+                    // `Vec`-internal operator meets the columnar edge.
+                    let oks = oks.into_vec();
+                    CollectionEdge::Vec(T::maybe_apply_temporal_bucketing(
+                        oks.inner,
+                        as_of.clone(),
+                        summary,
+                    ))
                 } else {
                     oks
                 };
@@ -1099,7 +1108,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     use_paged_path,
                 );
                 let errs_concat: KeyCollection<_, _, _> = errs.clone().concat(errs_keyed).into();
-                self.collection = Some((CollectionEdge::Vec(passthrough), errs));
+                self.collection = Some((passthrough, errs));
                 let errs =
                     errs_concat.mz_arrange::<
                         ColumnationChunker<_>,
@@ -1128,62 +1137,140 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// teeing the stream.
     fn arrange_collection(
         name: &String,
-        oks: VecCollection<'scope, T, Row, Diff>,
+        oks: CollectionEdge<'scope, T>,
         key: Vec<LirScalarExpr>,
         thinning: Vec<usize>,
         use_paged_path: bool,
     ) -> (
         Arranged<'scope, RowRowAgent<T, Diff>>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
-        VecCollection<'scope, T, Row, Diff>,
+        CollectionEdge<'scope, T>,
     ) {
         // This operator implements a `map_fallible`, but produces columnar updates for the ok
         // stream. The `map_fallible` cannot be used here because the closure cannot return
         // references, which is what we need to push into columnar streams. Instead, we use a
         // bespoke operator that also optimizes reuse of allocations across individual updates.
-        let mut builder = OperatorBuilder::new("FormArrangementKey".to_string(), oks.inner.scope());
-        let (ok_output, ok_stream) = builder.new_output();
-        let mut ok_output =
-            OutputBuilder::<_, ColumnBuilder<((Row, Row), T, Diff)>>::from(ok_output);
-        let (err_output, err_stream) = builder.new_output();
-        let mut err_output = OutputBuilder::from(err_output);
-        let (passthrough_output, passthrough_stream) = builder.new_output();
-        let mut passthrough_output = OutputBuilder::from(passthrough_output);
-        let mut input = builder.new_input(oks.inner, Pipeline);
-        builder.set_notify_for(0, FrontierInterest::Never);
-        builder.build(move |_capabilities| {
-            let mut key_buf = Row::default();
-            let mut val_buf = Row::default();
-            let mut datums = DatumVec::new();
-            move |_frontiers| {
-                // Scoped to the activation so the arena's retained capacity does not outlive a
-                // single scheduling invocation; cleared per row to reuse it within the batch.
-                let mut temp_storage = RowArena::new();
-                let mut ok_output = ok_output.activate();
-                let mut err_output = err_output.activate();
-                let mut passthrough_output = passthrough_output.activate();
-                input.for_each(|time, data| {
-                    let mut ok_session = ok_output.session_with_builder(&time);
-                    let mut err_session = err_output.session(&time);
-                    for (row, time, diff) in data.iter() {
-                        temp_storage.clear();
-                        let datums = datums.borrow_with(row);
-                        let key_iter = key.iter().map(|k| k.eval(&datums, &temp_storage));
-                        match key_buf.packer().try_extend(key_iter) {
-                            Ok(()) => {
-                                let val_datum_iter = thinning.iter().map(|c| datums[*c]);
-                                val_buf.packer().extend(val_datum_iter);
-                                ok_session.give(((&*key_buf, &*val_buf), time, diff));
+        //
+        // The two arms differ only in how records are read from the input container and in the
+        // variant of the passthrough output, which preserves the input variant. The ok output is
+        // columnar in both arms, since the arrangement key/value is always columnar.
+        let (ok_stream, err_stream, passthrough) = match oks {
+            CollectionEdge::Vec(oks) => {
+                let mut builder =
+                    OperatorBuilder::new("FormArrangementKey".to_string(), oks.inner.scope());
+                let (ok_output, ok_stream) = builder.new_output();
+                let mut ok_output =
+                    OutputBuilder::<_, ColumnBuilder<((Row, Row), T, Diff)>>::from(ok_output);
+                let (err_output, err_stream) = builder.new_output();
+                let mut err_output = OutputBuilder::from(err_output);
+                let (passthrough_output, passthrough_stream) = builder.new_output();
+                let mut passthrough_output = OutputBuilder::from(passthrough_output);
+                let mut input = builder.new_input(oks.inner, Pipeline);
+                builder.set_notify_for(0, FrontierInterest::Never);
+                builder.build(move |_capabilities| {
+                    let mut key_buf = Row::default();
+                    let mut val_buf = Row::default();
+                    let mut datums = DatumVec::new();
+                    move |_frontiers| {
+                        // Scoped to the activation so the arena's retained capacity does not
+                        // outlive a single scheduling invocation; cleared per row to reuse it
+                        // within the batch.
+                        let mut temp_storage = RowArena::new();
+                        let mut ok_output = ok_output.activate();
+                        let mut err_output = err_output.activate();
+                        let mut passthrough_output = passthrough_output.activate();
+                        input.for_each(|time, data| {
+                            let mut ok_session = ok_output.session_with_builder(&time);
+                            let mut err_session = err_output.session(&time);
+                            for (row, time, diff) in data.iter() {
+                                temp_storage.clear();
+                                let datums = datums.borrow_with(row);
+                                let key_iter = key.iter().map(|k| k.eval(&datums, &temp_storage));
+                                match key_buf.packer().try_extend(key_iter) {
+                                    Ok(()) => {
+                                        let val_datum_iter = thinning.iter().map(|c| datums[*c]);
+                                        val_buf.packer().extend(val_datum_iter);
+                                        ok_session.give(((&*key_buf, &*val_buf), time, diff));
+                                    }
+                                    Err(e) => {
+                                        err_session.give((e.into(), time.clone(), *diff));
+                                    }
+                                }
                             }
-                            Err(e) => {
-                                err_session.give((e.into(), time.clone(), *diff));
-                            }
-                        }
+                            passthrough_output.session(&time).give_container(data);
+                        });
                     }
-                    passthrough_output.session(&time).give_container(data);
                 });
+                (
+                    ok_stream,
+                    err_stream,
+                    CollectionEdge::Vec(passthrough_stream.as_collection()),
+                )
             }
-        });
+            CollectionEdge::Columnar(oks) => {
+                let mut builder =
+                    OperatorBuilder::new("FormArrangementKey".to_string(), oks.inner.scope());
+                let (ok_output, ok_stream) = builder.new_output();
+                let mut ok_output =
+                    OutputBuilder::<_, ColumnBuilder<((Row, Row), T, Diff)>>::from(ok_output);
+                let (err_output, err_stream) = builder.new_output();
+                let mut err_output = OutputBuilder::from(err_output);
+                let (passthrough_output, passthrough_stream) = builder.new_output();
+                // The passthrough forwards the input `Column` unchanged; its builder's container
+                // type must match the input so `give_container` can hand the batch through.
+                let mut passthrough_output = OutputBuilder::<
+                    _,
+                    CapacityContainerBuilder<Column<(Row, T, Diff)>>,
+                >::from(passthrough_output);
+                let mut input = builder.new_input(oks.inner, Pipeline);
+                builder.set_notify_for(0, FrontierInterest::Never);
+                builder.build(move |_capabilities| {
+                    let mut key_buf = Row::default();
+                    let mut val_buf = Row::default();
+                    let mut datums = DatumVec::new();
+                    move |_frontiers| {
+                        // Scoped to the activation so the arena's retained capacity does not
+                        // outlive a single scheduling invocation; cleared per row to reuse it
+                        // within the batch.
+                        let mut temp_storage = RowArena::new();
+                        let mut ok_output = ok_output.activate();
+                        let mut err_output = err_output.activate();
+                        let mut passthrough_output = passthrough_output.activate();
+                        input.for_each(|time, data| {
+                            let mut ok_session = ok_output.session_with_builder(&time);
+                            let mut err_session = err_output.session(&time);
+                            // Rows are read from the borrowed column, never materialized as
+                            // owned `Row`s. Times and diffs are owned only on the error path.
+                            for (row, t, d) in data.borrow().into_index_iter() {
+                                temp_storage.clear();
+                                let datums = datums.borrow_with(row);
+                                let key_iter = key.iter().map(|k| k.eval(&datums, &temp_storage));
+                                match key_buf.packer().try_extend(key_iter) {
+                                    Ok(()) => {
+                                        let val_datum_iter = thinning.iter().map(|c| datums[*c]);
+                                        val_buf.packer().extend(val_datum_iter);
+                                        ok_session.give(((&*key_buf, &*val_buf), t, d));
+                                    }
+                                    Err(e) => {
+                                        err_session.give((
+                                            e.into(),
+                                            Columnar::into_owned(t),
+                                            Columnar::into_owned(d),
+                                        ));
+                                    }
+                                }
+                            }
+                            passthrough_output.session(&time).give_container(data);
+                        });
+                    }
+                });
+                (
+                    ok_stream,
+                    err_stream,
+                    CollectionEdge::Columnar(passthrough_stream.as_collection()),
+                )
+            }
+        };
 
         let exchange =
             ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, T, Diff>);
@@ -1204,11 +1291,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 RowRowSpine<_, _>,
             >(exchange, name)
         };
-        (
-            oks,
-            err_stream.as_collection(),
-            passthrough_stream.as_collection(),
-        )
+        (oks, err_stream.as_collection(), passthrough)
     }
 }
 
@@ -1397,4 +1480,168 @@ fn walk_cursor<C, F>(
         }
     }
     *fuel -= work;
+}
+
+#[cfg(test)]
+mod tests {
+    use differential_dataflow::input::Input;
+    use mz_expr::EvalError;
+    use mz_repr::{Datum, ReprScalarType, Timestamp};
+    use timely::dataflow::operators::Capture;
+    use timely::dataflow::operators::capture::{Event, Extract};
+
+    use super::*;
+    use crate::render::columnar::vec_to_columnar;
+
+    type OkUpdate = ((Row, Row), Timestamp, Diff);
+    type ErrUpdate = (DataflowErrorSer, Timestamp, Diff);
+    type Captured<D> = std::sync::mpsc::Receiver<Event<Timestamp, Vec<D>>>;
+
+    fn extract_ok(captured: Captured<OkUpdate>) -> Vec<OkUpdate> {
+        let mut updates: Vec<_> = captured
+            .extract()
+            .into_iter()
+            .flat_map(|(_, data)| data)
+            .collect();
+        updates.sort();
+        updates
+    }
+
+    // `DataflowErrorSer` is not `Ord`, so project the error to its debug string
+    // to get a stable, comparable ordering. The time and diff still ride along,
+    // so this verifies the columnar arm's `into_owned` on the error path
+    // reconstructs the same `(time, diff)` as the `Vec` arm.
+    fn extract_err(captured: Captured<ErrUpdate>) -> Vec<(String, Timestamp, Diff)> {
+        let mut updates: Vec<_> = captured
+            .extract()
+            .into_iter()
+            .flat_map(|(_, data)| data)
+            .map(|(e, t, d)| (format!("{e:?}"), t, d))
+            .collect();
+        updates.sort();
+        updates
+    }
+
+    /// Arranges `rows` (each stamped with its own time) as both a `Vec` edge and
+    /// the equivalent columnar edge, keyed by `key`, and returns the sorted ok
+    /// and err outputs of each arm plus whether the columnar arm kept the
+    /// columnar passthrough variant.
+    fn arrange_both_arms(
+        rows: Vec<(Row, u64)>,
+        key: Vec<LirScalarExpr>,
+    ) -> (
+        Vec<OkUpdate>,
+        Vec<OkUpdate>,
+        Vec<(String, Timestamp, Diff)>,
+        Vec<(String, Timestamp, Diff)>,
+        bool,
+    ) {
+        let thinning = vec![0, 1];
+        let (ok_vec, ok_col, err_vec, err_col, col_is_columnar) =
+            timely::execute_directly(move |worker| {
+                worker.dataflow::<Timestamp, _, _>(|scope| {
+                    let (mut input, collection) = scope.new_collection();
+
+                    let (vec_arranged, vec_errs, _vec_passthrough) =
+                        CollectionBundle::<Timestamp>::arrange_collection(
+                            &"vec".to_string(),
+                            CollectionEdge::Vec(collection.clone()),
+                            key.clone(),
+                            thinning.clone(),
+                            false,
+                        );
+                    let (col_arranged, col_errs, col_passthrough) =
+                        CollectionBundle::<Timestamp>::arrange_collection(
+                            &"col".to_string(),
+                            CollectionEdge::Columnar(vec_to_columnar(collection)),
+                            key,
+                            thinning,
+                            false,
+                        );
+                    let col_is_columnar = matches!(col_passthrough, CollectionEdge::Columnar(_));
+
+                    let ok_vec = vec_arranged
+                        .as_collection(|k, v| (k.to_row(), v.to_row()))
+                        .inner
+                        .capture();
+                    let ok_col = col_arranged
+                        .as_collection(|k, v| (k.to_row(), v.to_row()))
+                        .inner
+                        .capture();
+                    let err_vec = vec_errs.inner.capture();
+                    let err_col = col_errs.inner.capture();
+
+                    let max_time = rows.iter().map(|(_, t)| *t).max().unwrap_or(0);
+                    for (row, time) in rows {
+                        input.update_at(row, Timestamp::from(time), Diff::ONE);
+                    }
+                    input.advance_to(Timestamp::from(max_time + 1));
+                    input.flush();
+                    (ok_vec, ok_col, err_vec, err_col, col_is_columnar)
+                })
+            });
+        (
+            extract_ok(ok_vec),
+            extract_ok(ok_col),
+            extract_err(err_vec),
+            extract_err(err_col),
+            col_is_columnar,
+        )
+    }
+
+    // Uniform two-column rows so `Column(0)` keys and full-row thinning are in
+    // bounds for every record. Times span three distinct values so the columnar
+    // arm's per-record time handling is exercised, not just t=0.
+    fn test_rows() -> Vec<(Row, u64)> {
+        vec![
+            (Row::pack_slice(&[Datum::Int32(1), Datum::String("a")]), 0),
+            (Row::pack_slice(&[Datum::Int32(2), Datum::String("b")]), 1),
+            (Row::pack_slice(&[Datum::Int32(1), Datum::String("a")]), 1),
+            (Row::pack_slice(&[Datum::Int32(3), Datum::Null]), 2),
+        ]
+    }
+
+    /// The columnar arm of the arrange input produces the same arranged contents
+    /// as the `Vec` arm and keeps the columnar passthrough variant.
+    ///
+    /// What this proves: correctness of the columnar key-forming path (a mangled
+    /// key or dropped record would diverge from the `Vec` arm) and that the
+    /// columnar arm actually ran (the passthrough stays `Columnar`).
+    ///
+    /// What it does NOT prove: absence of a silent decode. A hypothetical
+    /// `columnar_to_vec` on the ok path would yield identical contents and still
+    /// return a `Columnar` passthrough. The no-decode property holds by code
+    /// inspection: the columnar arm reads records via `into_index_iter` on the
+    /// borrowed column and never calls `into_vec`.
+    #[mz_ore::test]
+    fn arrange_collection_arms_agree() {
+        let (ok_vec, ok_col, err_vec, err_col, col_is_columnar) =
+            arrange_both_arms(test_rows(), vec![LirScalarExpr::column(0)]);
+
+        assert!(
+            col_is_columnar,
+            "columnar arrange input must keep the columnar passthrough variant"
+        );
+        assert!(!ok_vec.is_empty());
+        assert_eq!(ok_vec, ok_col);
+        assert!(err_vec.is_empty() && err_col.is_empty());
+    }
+
+    /// A key expression that always errors drives every record onto the error
+    /// path, exercising the columnar arm's `into_owned` reconstruction of the
+    /// error's `(time, diff)`. The two arms must agree on the errors, and the ok
+    /// output must be empty on both.
+    #[mz_ore::test]
+    fn arrange_collection_arms_agree_on_error_path() {
+        let key = vec![LirScalarExpr::literal(
+            Err(EvalError::DivisionByZero),
+            ReprScalarType::Int32,
+        )];
+        let (ok_vec, ok_col, err_vec, err_col, _col_is_columnar) =
+            arrange_both_arms(test_rows(), key);
+
+        assert!(ok_vec.is_empty() && ok_col.is_empty());
+        assert!(!err_vec.is_empty());
+        assert_eq!(err_vec, err_col);
+    }
 }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -36,6 +36,7 @@ use mz_storage_types::controller::CollectionMetadata;
 use mz_timely_util::columnar::Column;
 use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
+use mz_timely_util::columnar::consolidate::ConsolidatingColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, Col2ValPagedBatcher, columnar_exchange};
 use mz_timely_util::columnation::ColumnationChunker;
 use timely::ContainerBuilder;
@@ -301,7 +302,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
     /// The `max_demand` parameter limits the number of columns decoded from the
     /// input. Only the first `max_demand` columns are decoded. Pass `usize::MAX` to
     /// decode all columns.
-    pub fn flat_map<D, DCB, L>(
+    pub fn flat_map<DCB, L>(
         &self,
         key: Option<&Row>,
         max_demand: usize,
@@ -311,8 +312,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
     )
     where
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, T, Diff)>,
+        DCB: ContainerBuilder,
         L: for<'a, 'b> FnMut(
                 &'a mut DatumVecBorrow<'b>,
                 T,
@@ -326,7 +326,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
         // decode (and the activation-scoped arena it decodes into).
         match &self {
             ArrangementFlavor::Local(oks, errs) => {
-                let (oks, mfp_errs) = CollectionBundle::<T>::flat_map_core_fallible::<_, _, DCB, _>(
+                let (oks, mfp_errs) = CollectionBundle::<T>::flat_map_core_fallible::<_, DCB, _>(
                     oks.clone(),
                     key,
                     max_demand,
@@ -338,7 +338,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
                 (oks, errs)
             }
             ArrangementFlavor::Trace(_, oks, errs) => {
-                let (oks, mfp_errs) = CollectionBundle::<T>::flat_map_core_fallible::<_, _, DCB, _>(
+                let (oks, mfp_errs) = CollectionBundle::<T>::flat_map_core_fallible::<_, DCB, _>(
                     oks.clone(),
                     key,
                     max_demand,
@@ -621,7 +621,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// The `max_demand` parameter limits the number of columns decoded from the
     /// input. Only the first `max_demand` columns are decoded. Pass `usize::MAX` to
     /// decode all columns.
-    pub fn flat_map<D, DCB, L>(
+    pub fn flat_map<DCB, L>(
         &self,
         key_val: Option<(Vec<LirScalarExpr>, Option<Row>)>,
         max_demand: usize,
@@ -631,8 +631,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
     )
     where
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, T, Diff)>,
+        DCB: ContainerBuilder,
         L: for<'a> FnMut(
                 &'a mut DatumVecBorrow<'_>,
                 T,
@@ -648,7 +647,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         if let Some((key, val)) = key_val {
             self.arrangement(&key)
                 .expect("Should have ensured during planning that this arrangement exists.")
-                .flat_map::<_, DCB, _>(val.as_ref(), max_demand, logic)
+                .flat_map::<DCB, _>(val.as_ref(), max_demand, logic)
         } else {
             let (oks, errs) = self
                 .collection
@@ -670,7 +669,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// callback writes ok results into the first session and errors into the second, returning
     /// the number of records produced. See [`ArrangementFlavor::flat_map`] for the fuel
     /// rationale.
-    fn flat_map_core_fallible<Tr, D, DCB, L>(
+    fn flat_map_core_fallible<Tr, DCB, L>(
         trace: Arranged<'scope, Tr>,
         key: Option<&<<BatchCursor<Tr> as Cursor>::KeyContainer as BatchContainer>::Owned>,
         max_demand: usize,
@@ -685,8 +684,10 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         for<'a> BatchCursor<Tr>:
             Cursor<Key<'a>: ExtendDatums, Val<'a>: ExtendDatums, Time = T, Diff = mz_repr::Diff>,
         <<BatchCursor<Tr> as Cursor>::KeyContainer as BatchContainer>::Owned: PartialEq,
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, T, Diff)>,
+        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
+        // call site rather than here. This lets a caller push borrowed records into a columnar
+        // builder that has no owned-tuple `Push`.
+        DCB: ContainerBuilder,
         // `logic` receives the key and value already decoded into a `DatumVecBorrow`. The decode
         // (and its arena/`DatumVec`) lives in the per-activation closure below, so it is scoped to
         // a single scheduling invocation rather than to the operator.
@@ -912,10 +913,10 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         until: Antichain<mz_repr::Timestamp>,
         config_set: &ConfigSet,
     ) -> (
-        VecCollection<'scope, T, mz_repr::Row, Diff>,
+        CollectionEdge<'scope, T>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
     ) {
-        // If the MFP is trivial, we can just call `as_collection`.
+        // If the MFP is trivial, we can just return the collection.
         // In the case that we weren't going to apply the `key_val` optimization,
         // this path results in a slightly smaller and faster
         // dataflow graph, and is intended to fix
@@ -928,7 +929,21 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
 
         if mfp_plan.is_identity() && !has_key_val {
             let key = key_val.map(|(k, _v)| k);
-            return self.as_specific_collection(key.as_deref(), config_set);
+            return match key {
+                // Unarranged identity: hand the edge straight through, so a
+                // columnar producer stays columnar without a `ColumnarToVec` hop.
+                None => self
+                    .collection
+                    .clone()
+                    .expect("The unarranged collection doesn't exist."),
+                // Keyed identity reads an existing arrangement, which is
+                // row-based. Wrap it as a `Vec` edge. `as_specific_collection`
+                // stays the consumer leaf.
+                Some(key) => {
+                    let (oks, errs) = self.as_specific_collection(Some(&key), config_set);
+                    (CollectionEdge::Vec(oks), errs)
+                }
+            };
         }
 
         // Apply demand-based column pruning. We round-trip through MIR
@@ -948,48 +963,54 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         // Wrap in an `Rc` so that lifetimes work out.
         let until = std::rc::Rc::new(until);
 
-        let (stream, errors) = self
-            .flat_map::<_, ConsolidatingContainerBuilder<Vec<(Row, T, Diff)>>, _>(
-                key_val,
-                max_demand,
-                move |row_datums, time, diff, ok_session, err_session| {
-                    let mut row_builder = SharedRow::get();
-                    let until = std::rc::Rc::clone(&until);
-                    let temp_storage = RowArena::new();
-                    let row_iter = row_datums.iter();
-                    let mut datums_local = datum_vec.borrow();
-                    datums_local.extend(row_iter);
-                    let event_time = time.event_time();
-                    let mut work: usize = 0;
-                    for result in mfp_plan.evaluate(
-                        &mut datums_local,
-                        &temp_storage,
-                        event_time,
-                        diff.clone(),
-                        move |time| !until.less_equal(time),
-                        &mut row_builder,
-                    ) {
-                        work += 1;
-                        match result {
-                            Ok((row, event_time, diff)) => {
-                                // Copy the whole time, and re-populate event time.
-                                let mut time: T = time.clone();
-                                *time.event_time_mut() = event_time;
-                                ok_session.give((row, time, diff));
-                            }
-                            Err((e, event_time, diff)) => {
-                                // Copy the whole time, and re-populate event time.
-                                let mut time: T = time.clone();
-                                *time.event_time_mut() = event_time;
-                                err_session.give((e, time, diff));
-                            }
+        // The ok output is built into a `Column`, so this producer emits the
+        // columnar edge. `ConsolidatingColumnBuilder` folds within-batch
+        // duplicates, matching the row-based `ConsolidatingContainerBuilder`
+        // this replaced. It stages owned `(Row, T, Diff)` tuples to consolidate
+        // in place, so the records are given owned; `mfp_plan.evaluate` already
+        // produces a fresh owned `Row` per result, so this is a move into
+        // staging, not a new allocation.
+        let (stream, errors) = self.flat_map::<ConsolidatingColumnBuilder<Row, T, Diff>, _>(
+            key_val,
+            max_demand,
+            move |row_datums, time, diff, ok_session, err_session| {
+                let mut row_builder = SharedRow::get();
+                let until = std::rc::Rc::clone(&until);
+                let temp_storage = RowArena::new();
+                let row_iter = row_datums.iter();
+                let mut datums_local = datum_vec.borrow();
+                datums_local.extend(row_iter);
+                let event_time = time.event_time();
+                let mut work: usize = 0;
+                for result in mfp_plan.evaluate(
+                    &mut datums_local,
+                    &temp_storage,
+                    event_time,
+                    diff.clone(),
+                    move |time| !until.less_equal(time),
+                    &mut row_builder,
+                ) {
+                    work += 1;
+                    match result {
+                        Ok((row, event_time, diff)) => {
+                            // Copy the whole time, and re-populate event time.
+                            let mut time: T = time.clone();
+                            *time.event_time_mut() = event_time;
+                            ok_session.give((row, time, diff));
+                        }
+                        Err((e, event_time, diff)) => {
+                            // Copy the whole time, and re-populate event time.
+                            let mut time: T = time.clone();
+                            *time.event_time_mut() = event_time;
+                            err_session.give((e, time, diff));
                         }
                     }
-                    work
-                },
-            );
+                }
+                work
+            },
+        );
 
-        (stream.as_collection(), errors)
+        (CollectionEdge::Columnar(stream.as_collection()), errors)
     }
     pub fn ensure_collections(
         mut self,
@@ -1055,11 +1076,18 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .try_into()
                     .expect("must fit");
                 bucketed = true;
-                T::maybe_apply_temporal_bucketing(oks.inner, as_of.clone(), summary)
+                // Temporal bucketing consumes and produces a `Vec` edge, so
+                // decode here. This is the sanctioned leaf decode where a
+                // `Vec`-internal operator meets the columnar edge.
+                CollectionEdge::Vec(T::maybe_apply_temporal_bucketing(
+                    oks.into_vec().inner,
+                    as_of.clone(),
+                    summary,
+                ))
             } else {
                 oks
             };
-            self.collection = Some((CollectionEdge::Vec(oks), errs));
+            self.collection = Some((oks, errs));
         }
         for (key, _, thinning) in collections.arranged {
             if !self.arranged.contains_key(&key) {
@@ -1345,7 +1373,7 @@ where
     }
     /// Perform roughly `fuel` work through the cursor, applying `logic` and sending results to
     /// the two output sessions.
-    fn do_work<D, DCB, L>(
+    fn do_work<DCB, L>(
         &mut self,
         key: Option<&C::Key<'_>>,
         logic: &mut L,
@@ -1353,8 +1381,9 @@ where
         ok_output: &mut OutputBuilderSession<'_, C::Time, DCB>,
         err_output: &mut OutputBuilderSession<'_, C::Time, ECB<C::Time>>,
     ) where
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, C::Time, C::Diff)>,
+        // The push bound lives at `logic`'s `give` call site, not here, so a caller can push
+        // borrowed records into a columnar builder that has no owned-tuple `Push`.
+        DCB: ContainerBuilder,
         L: FnMut(
             C::Key<'_>,
             C::Val<'_>,
@@ -1485,7 +1514,7 @@ fn walk_cursor<C, F>(
 #[cfg(test)]
 mod tests {
     use differential_dataflow::input::Input;
-    use mz_expr::EvalError;
+    use mz_expr::{EvalError, MapFilterProject};
     use mz_repr::{Datum, ReprScalarType, Timestamp};
     use timely::dataflow::operators::Capture;
     use timely::dataflow::operators::capture::{Event, Extract};
@@ -1643,5 +1672,187 @@ mod tests {
         assert!(ok_vec.is_empty() && ok_col.is_empty());
         assert!(!err_vec.is_empty());
         assert_eq!(err_vec, err_col);
+    }
+
+    fn extract_row_updates(
+        captured: Captured<(Row, Timestamp, Diff)>,
+    ) -> Vec<(Row, Timestamp, Diff)> {
+        let mut updates: Vec<_> = captured
+            .extract()
+            .into_iter()
+            .flat_map(|(_, data)| data)
+            .collect();
+        updates.sort();
+        updates
+    }
+
+    /// A `Get -> ArrangeBy` chain carries the columnar arm end to end. A
+    /// non-identity MFP drives `as_collection_core` down its columnar producer
+    /// path, and feeding that edge into the arrange input keeps the columnar
+    /// passthrough, so no `ColumnarToVec` sits on the arrange path.
+    ///
+    /// The producer output is checked against the projected input. Arrange
+    /// correctness itself is covered by `arrange_collection_arms_agree`; here we
+    /// only assert the variant survives the hand-off.
+    #[mz_ore::test]
+    fn get_arrange_by_carries_columnar_end_to_end() {
+        let rows = vec![
+            (Row::pack_slice(&[Datum::Int64(1), Datum::Int64(10)]), 0u64),
+            (Row::pack_slice(&[Datum::Int64(2), Datum::Int64(20)]), 1),
+            (Row::pack_slice(&[Datum::Int64(1), Datum::Int64(10)]), 1),
+        ];
+        // Project away column 1; the output row carries only column 0. A
+        // projection is non-identity, so `as_collection_core` takes the columnar
+        // producer path rather than the identity passthrough.
+        let mfp = MapFilterProject::<LirScalarExpr>::new(2)
+            .project(vec![0])
+            .into_plan()
+            .expect("mfp");
+        let mut expected: Vec<(Row, Timestamp, Diff)> = rows
+            .iter()
+            .map(|(r, t)| {
+                let col0 = r.iter().next().unwrap();
+                (Row::pack_slice(&[col0]), Timestamp::from(*t), Diff::ONE)
+            })
+            .collect();
+        expected.sort();
+
+        let config_set = ConfigSet::default();
+        let (producer_is_columnar, passthrough_is_columnar, produced) =
+            timely::execute_directly(move |worker| {
+                worker.dataflow::<Timestamp, _, _>(|scope| {
+                    let (mut input, collection) = scope.new_collection();
+                    let (_err_input, errs) = scope.new_collection::<DataflowErrorSer, Diff>();
+                    let bundle = CollectionBundle::from_edge(CollectionEdge::Vec(collection), errs);
+                    let (edge, _errs) =
+                        bundle.as_collection_core(mfp, None, Antichain::new(), &config_set);
+                    let producer_is_columnar = matches!(edge, CollectionEdge::Columnar(_));
+                    // Tee the producer output for a content check, then feed the
+                    // original edge into the arrange input.
+                    let produced = edge.clone().into_vec().inner.capture();
+                    let (_arranged, _arrange_errs, passthrough) =
+                        CollectionBundle::<Timestamp>::arrange_collection(
+                            &"arrange".to_string(),
+                            edge,
+                            vec![LirScalarExpr::column(0)],
+                            vec![0],
+                            false,
+                        );
+                    let passthrough_is_columnar =
+                        matches!(passthrough, CollectionEdge::Columnar(_));
+
+                    let max_time = rows.iter().map(|(_, t)| *t).max().unwrap();
+                    for (row, time) in rows {
+                        input.update_at(row, Timestamp::from(time), Diff::ONE);
+                    }
+                    input.advance_to(Timestamp::from(max_time + 1));
+                    input.flush();
+                    (producer_is_columnar, passthrough_is_columnar, produced)
+                })
+            });
+
+        assert!(
+            producer_is_columnar,
+            "a non-identity MFP must produce a columnar edge"
+        );
+        assert!(
+            passthrough_is_columnar,
+            "the arrange input must keep the columnar passthrough (no ColumnarToVec)"
+        );
+        assert_eq!(extract_row_updates(produced), expected);
+    }
+
+    /// The reworked identity fast-path returns the unarranged input edge
+    /// unchanged, so a columnar producer stays columnar and a `Vec` producer
+    /// stays `Vec` with no repack in either direction.
+    #[mz_ore::test]
+    fn as_collection_core_identity_passes_edge_through() {
+        for columnar_input in [false, true] {
+            let config_set = ConfigSet::default();
+            let is_columnar = timely::execute_directly(move |worker| {
+                worker.dataflow::<Timestamp, _, _>(|scope| {
+                    let (mut input, collection) = scope.new_collection::<Row, Diff>();
+                    let (_err_input, errs) = scope.new_collection::<DataflowErrorSer, Diff>();
+                    let edge = if columnar_input {
+                        CollectionEdge::Columnar(vec_to_columnar(collection))
+                    } else {
+                        CollectionEdge::Vec(collection)
+                    };
+                    let bundle = CollectionBundle::from_edge(edge, errs);
+                    let identity = MapFilterProject::<LirScalarExpr>::new(1)
+                        .into_plan()
+                        .expect("identity mfp");
+                    let (out, _errs) =
+                        bundle.as_collection_core(identity, None, Antichain::new(), &config_set);
+                    let is_columnar = matches!(out, CollectionEdge::Columnar(_));
+                    input.update(Row::pack_slice(&[Datum::Int64(1)]), Diff::ONE);
+                    input.advance_to(Timestamp::from(1u64));
+                    input.flush();
+                    is_columnar
+                })
+            });
+            assert_eq!(
+                is_columnar, columnar_input,
+                "the identity fast-path must preserve the input edge variant"
+            );
+        }
+    }
+
+    /// The columnar producer folds within-batch duplicates: input rows that
+    /// project to the same output row at the same time collapse to one record
+    /// with summed diff, matching the row-based `ConsolidatingContainerBuilder`
+    /// this replaced. A plain `ColumnBuilder` would emit both records.
+    #[mz_ore::test]
+    fn as_collection_core_consolidates_within_batch() {
+        // `[1, 10]` and `[1, 20]` both project (dropping column 1) to `[1]` at
+        // t=0, so their `+1` diffs must fold to `+2`. `[2, 30]` projects to a
+        // distinct record.
+        let rows = vec![
+            Row::pack_slice(&[Datum::Int64(1), Datum::Int64(10)]),
+            Row::pack_slice(&[Datum::Int64(1), Datum::Int64(20)]),
+            Row::pack_slice(&[Datum::Int64(2), Datum::Int64(30)]),
+        ];
+        let mfp = MapFilterProject::<LirScalarExpr>::new(2)
+            .project(vec![0])
+            .into_plan()
+            .expect("mfp");
+        let expected = vec![
+            (
+                Row::pack_slice(&[Datum::Int64(1)]),
+                Timestamp::from(0u64),
+                Diff::from(2),
+            ),
+            (
+                Row::pack_slice(&[Datum::Int64(2)]),
+                Timestamp::from(0u64),
+                Diff::ONE,
+            ),
+        ];
+
+        let config_set = ConfigSet::default();
+        let captured = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let (_err_input, errs) = scope.new_collection::<DataflowErrorSer, Diff>();
+                let bundle = CollectionBundle::from_edge(CollectionEdge::Vec(collection), errs);
+                let (edge, _errs) =
+                    bundle.as_collection_core(mfp, None, Antichain::new(), &config_set);
+                assert!(
+                    matches!(edge, CollectionEdge::Columnar(_)),
+                    "a non-identity MFP must produce a columnar edge"
+                );
+                let captured = edge.into_vec().inner.capture();
+                // Feed all rows at the same time in one batch so the fold is
+                // within-batch, not a downstream re-consolidation.
+                for row in rows {
+                    input.update_at(row, Timestamp::from(0u64), Diff::ONE);
+                }
+                input.advance_to(Timestamp::from(1u64));
+                input.flush();
+                captured
+            })
+        });
+
+        assert_eq!(extract_row_updates(captured), expected);
     }
 }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -19,7 +19,7 @@ use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::cursor::{BatchCursor, BatchKey, BatchVal};
 use differential_dataflow::trace::implementations::BatchContainer;
 use differential_dataflow::trace::{Cursor, Navigable, TraceReader};
-use differential_dataflow::{AsCollection, Data, VecCollection};
+use differential_dataflow::{AsCollection, VecCollection};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::{
     ENABLE_COLUMN_PAGED_BATCHER, ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION,
@@ -40,7 +40,7 @@ use mz_timely_util::columnar::consolidate::ConsolidatingColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, Col2ValPagedBatcher, columnar_exchange};
 use mz_timely_util::columnation::ColumnationChunker;
 use timely::ContainerBuilder;
-use timely::container::{CapacityContainerBuilder, PushInto};
+use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::operators::Capability;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
@@ -356,7 +356,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
     /// session, cannot produce errors, and returns the number of records produced (see
     /// [`Self::flat_map`] for fuel semantics). The returned err collection comes solely from
     /// the arrangement; no extra operator is built to carry an empty MFP-error stream.
-    pub fn flat_map_ok<D, DCB, L>(
+    pub fn flat_map_ok<DCB, L>(
         &self,
         key: Option<&Row>,
         max_demand: usize,
@@ -366,14 +366,16 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
     )
     where
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, T, Diff)>,
+        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
+        // call site, letting a caller push borrowed records into a columnar builder that has no
+        // owned-tuple `Push`.
+        DCB: ContainerBuilder,
         L: for<'a, 'b> FnMut(&'a mut DatumVecBorrow<'b>, T, Diff, &mut Session<T, DCB>) -> usize
             + 'static,
     {
         match &self {
             ArrangementFlavor::Local(oks, errs) => {
-                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, _, DCB, _>(
+                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, DCB, _>(
                     oks.clone(),
                     key,
                     max_demand,
@@ -384,7 +386,7 @@ impl<'scope, T: RenderTimestamp> ArrangementFlavor<'scope, T> {
                 (oks, errs)
             }
             ArrangementFlavor::Trace(_, oks, errs) => {
-                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, _, DCB, _>(
+                let oks = CollectionBundle::<T>::flat_map_core_ok::<_, DCB, _>(
                     oks.clone(),
                     key,
                     max_demand,
@@ -559,12 +561,18 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// If `key` is specified, the function converts the arrangement to a collection. It uses either
     /// the fueled `flat_map` or `as_collection` method, depending on the flag
     /// [`ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION`].
+    ///
+    /// The keyed path materializes the arrangement as the columnar edge, so an
+    /// arrangement-producing operator (Reduce, Threshold, bucketed TopK) whose
+    /// result is demanded as a collection carries columnar downstream. The
+    /// unkeyed path returns the unarranged `.collection` edge as-is, preserving
+    /// its variant.
     pub fn as_specific_collection(
         &self,
         key: Option<&[LirScalarExpr]>,
         config_set: &ConfigSet,
     ) -> (
-        VecCollection<'scope, T, Row, Diff>,
+        CollectionEdge<'scope, T>,
         VecCollection<'scope, T, DataflowErrorSer, Diff>,
     ) {
         // Any operator that uses this method was told to use a particular
@@ -573,34 +581,35 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         //
         // If it doesn't, we panic.
         match key {
-            None => {
-                let (oks, errs) = self
-                    .collection
-                    .clone()
-                    .expect("The unarranged collection doesn't exist.");
-                (oks.into_vec(), errs)
-            }
+            None => self
+                .collection
+                .clone()
+                .expect("The unarranged collection doesn't exist."),
             Some(key) => {
                 let arranged = self.arranged.get(key).unwrap_or_else(|| {
                     panic!("The collection arranged by {:?} doesn't exist.", key)
                 });
                 if ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION.get(config_set) {
-                    // Decode all columns, pass max_demand as usize::MAX. Output is 1:1 from the
-                    // cursor (no duplicates), so a non-consolidating container builder is the
-                    // right choice.
-                    let (ok, err) = arranged
-                        .flat_map_ok::<_, CapacityContainerBuilder<Vec<(Row, T, Diff)>>, _>(
-                            None,
-                            usize::MAX,
-                            |borrow, t, r, ok_session| {
-                                ok_session.give((SharedRow::pack(borrow.iter()), t, r));
-                                1
-                            },
-                        );
-                    (ok.as_collection(), err)
+                    // Decode all columns (max_demand usize::MAX) and pack each cursor record
+                    // into a `Column`, so the materialized collection carries the columnar edge.
+                    // Output is 1:1 from the already-consolidated cursor, so a non-consolidating
+                    // `ColumnBuilder` matches the row-based `CapacityContainerBuilder` this
+                    // replaced; the packed row is pushed borrowed, holding no owned `Row` per
+                    // record.
+                    let (ok, err) = arranged.flat_map_ok::<ColumnBuilder<(Row, T, Diff)>, _>(
+                        None,
+                        usize::MAX,
+                        |borrow, t, r, ok_session| {
+                            let row = SharedRow::pack(borrow.iter());
+                            ok_session.give((&row, &t, &r));
+                            1
+                        },
+                    );
+                    (CollectionEdge::Columnar(ok.as_collection()), err)
                 } else {
                     #[allow(deprecated)]
-                    arranged.as_collection()
+                    let (oks, errs) = arranged.as_collection();
+                    (CollectionEdge::Vec(oks), errs)
                 }
             }
         }
@@ -793,7 +802,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
     /// fallible variant for fuel semantics). Use this when the caller statically knows it
     /// will never produce `DataflowErrorSer` records, to avoid building a second output port
     /// and the empty err stream that would follow it.
-    fn flat_map_core_ok<Tr, D, DCB, L>(
+    fn flat_map_core_ok<Tr, DCB, L>(
         trace: Arranged<'scope, Tr>,
         key: Option<&<<BatchCursor<Tr> as Cursor>::KeyContainer as BatchContainer>::Owned>,
         max_demand: usize,
@@ -805,10 +814,11 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         for<'a> BatchCursor<Tr>:
             Cursor<Key<'a>: ExtendDatums, Val<'a>: ExtendDatums, Time = T, Diff = mz_repr::Diff>,
         <<BatchCursor<Tr> as Cursor>::KeyContainer as BatchContainer>::Owned: PartialEq,
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, T, Diff)>,
-        // See `flat_map_core_fallible`: `logic` takes already-decoded datums; the decode lives in
-        // the per-activation closure below.
+        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
+        // call site rather than here (see `flat_map_core_fallible`).
+        DCB: ContainerBuilder,
+        // `logic` takes already-decoded datums; the decode lives in the per-activation closure
+        // below.
         L: for<'a, 'b> FnMut(
                 &'a mut DatumVecBorrow<'b>,
                 T,
@@ -936,13 +946,10 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .collection
                     .clone()
                     .expect("The unarranged collection doesn't exist."),
-                // Keyed identity reads an existing arrangement, which is
-                // row-based. Wrap it as a `Vec` edge. `as_specific_collection`
-                // stays the consumer leaf.
-                Some(key) => {
-                    let (oks, errs) = self.as_specific_collection(Some(&key), config_set);
-                    (CollectionEdge::Vec(oks), errs)
-                }
+                // Keyed identity materializes an existing arrangement.
+                // `as_specific_collection` returns the columnar edge, so the
+                // reduce/threshold/topk result carries columnar downstream.
+                Some(key) => self.as_specific_collection(Some(&key), config_set),
             };
         }
 
@@ -1426,15 +1433,16 @@ where
 
     /// Perform roughly `fuel` work through the cursor, applying `logic` and sending results to
     /// the single output session.
-    fn do_work<D, DCB, L>(
+    fn do_work<DCB, L>(
         &mut self,
         key: Option<&C::Key<'_>>,
         logic: &mut L,
         fuel: &mut usize,
         ok_output: &mut OutputBuilderSession<'_, C::Time, DCB>,
     ) where
-        D: Data,
-        DCB: ContainerBuilder + PushInto<(D, C::Time, C::Diff)>,
+        // The builder accepts whatever `logic` gives it, so the push bound lives at the `give`
+        // call site rather than here.
+        DCB: ContainerBuilder,
         L: FnMut(C::Key<'_>, C::Val<'_>, C::Time, C::Diff, &mut Session<C::Time, DCB>) -> usize,
     {
         let mut ok_session = ok_output.session_with_builder(&self.capability);
@@ -1514,6 +1522,7 @@ fn walk_cursor<C, F>(
 #[cfg(test)]
 mod tests {
     use differential_dataflow::input::Input;
+    use mz_compute_types::dyncfgs::all_dyncfgs;
     use mz_expr::{EvalError, MapFilterProject};
     use mz_repr::{Datum, ReprScalarType, Timestamp};
     use timely::dataflow::operators::Capture;
@@ -1853,6 +1862,76 @@ mod tests {
             })
         });
 
+        assert_eq!(extract_row_updates(captured), expected);
+    }
+
+    /// The shared arrangement->collection materialization carries the columnar
+    /// edge. Reduce, Threshold, and bucketed TopK emit arrangements; when their
+    /// result is demanded as a collection it flows through
+    /// `as_specific_collection`, so this flip makes those outputs columnar with
+    /// no `ColumnarToVec`.
+    ///
+    /// Correctness: the materialized rows must equal the arranged input. Keying
+    /// by column 0 and thinning the value to column 1 reconstructs the original
+    /// two-column row. No-decode is a by-inspection property: the fueled path
+    /// builds a `ColumnBuilder` via `flat_map_ok` and never calls
+    /// `columnar_to_vec`; the `into_vec` below is the capture harness only.
+    #[mz_ore::test]
+    fn as_specific_collection_materializes_columnar() {
+        let rows = test_rows();
+        let key = vec![LirScalarExpr::column(0)];
+        let mut expected: Vec<(Row, Timestamp, Diff)> = rows
+            .iter()
+            .map(|(r, t)| (r.clone(), Timestamp::from(*t), Diff::ONE))
+            .collect();
+        expected.sort();
+
+        // A populated set so the fueled-materialization flag resolves to its
+        // default (`true`); `ConfigSet::default()` alone would panic on lookup.
+        let config_set = all_dyncfgs(ConfigSet::default());
+        let (is_columnar, captured) = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let (arranged, arr_errs, _passthrough) =
+                    CollectionBundle::<Timestamp>::arrange_collection(
+                        &"agg".to_string(),
+                        CollectionEdge::Vec(collection),
+                        key.clone(),
+                        vec![1],
+                        false,
+                    );
+                let err_arranged = {
+                    let kc: KeyCollection<_, _, _> = arr_errs.into();
+                    kc.mz_arrange::<
+                        ColumnationChunker<_>,
+                        ErrBatcher<_, _>,
+                        ErrBuilder<_, _>,
+                        ErrSpine<_, _>,
+                    >("agg-errs")
+                };
+                // An arrangement-only bundle, as Reduce/Threshold/TopK produce.
+                let bundle = CollectionBundle::from_columns(
+                    0..1,
+                    ArrangementFlavor::Local(arranged, err_arranged),
+                );
+                let (edge, _errs) = bundle.as_specific_collection(Some(&key), &config_set);
+                let is_columnar = matches!(edge, CollectionEdge::Columnar(_));
+                let captured = edge.into_vec().inner.capture();
+
+                let max_time = rows.iter().map(|(_, t)| *t).max().unwrap();
+                for (row, time) in rows {
+                    input.update_at(row, Timestamp::from(time), Diff::ONE);
+                }
+                input.advance_to(Timestamp::from(max_time + 1));
+                input.flush();
+                (is_columnar, captured)
+            })
+        });
+
+        assert!(
+            is_columnar,
+            "as_specific_collection must materialize the arrangement as a columnar edge"
+        );
         assert_eq!(extract_row_updates(captured), expected);
     }
 }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -51,7 +51,7 @@ use timely::progress::{Antichain, Timestamp};
 
 use crate::compute_state::ComputeState;
 use crate::extensions::arrange::{KeyCollection, MzArrange, MzArrangeCore};
-use crate::render::columnar::CollectionEdge;
+use crate::render::columnar::{CollectionEdge, vec_to_columnar};
 use crate::render::errors::{DataflowErrorSer, ErrorLogger};
 use crate::render::{LinearJoinSpec, MaybeBucketByTime, RenderTimestamp};
 use crate::typedefs::{
@@ -1083,14 +1083,15 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                     .try_into()
                     .expect("must fit");
                 bucketed = true;
-                // Temporal bucketing consumes and produces a `Vec` edge, so
-                // decode here. This is the sanctioned leaf decode where a
-                // `Vec`-internal operator meets the columnar edge.
-                CollectionEdge::Vec(T::maybe_apply_temporal_bucketing(
+                // Temporal bucketing is `Vec`-internal: it consumes and
+                // produces a `Vec` stream. Decode the edge into it, then re-encode
+                // the `Vec` result to columnar at the boundary so the bucketed
+                // output edge stays columnar like every other producer.
+                CollectionEdge::Columnar(vec_to_columnar(T::maybe_apply_temporal_bucketing(
                     oks.into_vec().inner,
                     as_of.clone(),
                     summary,
-                ))
+                )))
             } else {
                 oks
             };
@@ -1114,26 +1115,26 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 } else {
                     strategy
                 };
-                let oks = if matches!(effective_strategy, ArrangementStrategy::TemporalBucketing)
-                    && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(config_set)
-                {
-                    let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
-                        .get(config_set)
-                        .try_into()
-                        .expect("must fit");
-                    bucketed = true;
-                    // Temporal bucketing consumes and produces a `Vec` edge, so
-                    // decode here. This is the sanctioned leaf decode where a
-                    // `Vec`-internal operator meets the columnar edge.
-                    let oks = oks.into_vec();
-                    CollectionEdge::Vec(T::maybe_apply_temporal_bucketing(
-                        oks.inner,
-                        as_of.clone(),
-                        summary,
-                    ))
-                } else {
-                    oks
-                };
+                let oks =
+                    if matches!(effective_strategy, ArrangementStrategy::TemporalBucketing)
+                        && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(config_set)
+                    {
+                        let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
+                            .get(config_set)
+                            .try_into()
+                            .expect("must fit");
+                        bucketed = true;
+                        // Temporal bucketing is `Vec`-internal: it consumes
+                        // and produces a `Vec` stream. Decode the edge into it, then
+                        // re-encode the `Vec` result to columnar at the boundary so the
+                        // bucketed output edge stays columnar like every other producer.
+                        let oks = oks.into_vec();
+                        CollectionEdge::Columnar(vec_to_columnar(
+                            T::maybe_apply_temporal_bucketing(oks.inner, as_of.clone(), summary),
+                        ))
+                    } else {
+                        oks
+                    };
                 let use_paged_path = ENABLE_COLUMN_PAGED_BATCHER.get(config_set);
                 let (oks, errs_keyed, passthrough) = Self::arrange_collection(
                     &name,

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -50,7 +50,7 @@ use timely::progress::{Antichain, Timestamp};
 
 use crate::compute_state::ComputeState;
 use crate::extensions::arrange::{KeyCollection, MzArrange, MzArrangeCore};
-use crate::render::columnar::{CollectionEdge, vec_to_columnar};
+use crate::render::columnar::{CollectionEdge, columnar_to_vec, flat_map_datums, vec_to_columnar};
 use crate::render::errors::{DataflowErrorSer, ErrorLogger};
 use crate::render::{LinearJoinSpec, MaybeBucketByTime, RenderTimestamp};
 use crate::typedefs::{
@@ -559,7 +559,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                         1
                     },
                 );
-                (CollectionEdge::Columnar(ok.as_collection()), err)
+                (ok.as_collection(), err)
             }
         }
     }
@@ -611,7 +611,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 .collection
                 .clone()
                 .expect("Invariant violated: CollectionBundle contains no collection.");
-            let (ok_stream, err_stream) = oks.flat_map_datums::<DCB, _>(max_demand, logic);
+            let (ok_stream, err_stream) = flat_map_datums::<_, DCB, _>(oks, max_demand, logic);
             let errs = errs.concat(err_stream.as_collection());
             (ok_stream, errs)
         }
@@ -965,7 +965,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
             },
         );
 
-        (CollectionEdge::Columnar(stream.as_collection()), errors)
+        (stream.as_collection(), errors)
     }
     pub fn ensure_collections(
         mut self,
@@ -1035,11 +1035,11 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 // produces a `Vec` stream. Decode the edge into it, then re-encode
                 // the `Vec` result to columnar at the boundary so the bucketed
                 // output edge stays columnar like every other producer.
-                CollectionEdge::Columnar(vec_to_columnar(T::maybe_apply_temporal_bucketing(
-                    oks.into_vec().inner,
+                vec_to_columnar(T::maybe_apply_temporal_bucketing(
+                    columnar_to_vec(oks).inner,
                     as_of.clone(),
                     summary,
-                )))
+                ))
             } else {
                 oks
             };
@@ -1063,26 +1063,27 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 } else {
                     strategy
                 };
-                let oks =
-                    if matches!(effective_strategy, ArrangementStrategy::TemporalBucketing)
-                        && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(config_set)
-                    {
-                        let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
-                            .get(config_set)
-                            .try_into()
-                            .expect("must fit");
-                        bucketed = true;
-                        // Temporal bucketing is `Vec`-internal: it consumes
-                        // and produces a `Vec` stream. Decode the edge into it, then
-                        // re-encode the `Vec` result to columnar at the boundary so the
-                        // bucketed output edge stays columnar like every other producer.
-                        let oks = oks.into_vec();
-                        CollectionEdge::Columnar(vec_to_columnar(
-                            T::maybe_apply_temporal_bucketing(oks.inner, as_of.clone(), summary),
-                        ))
-                    } else {
-                        oks
-                    };
+                let oks = if matches!(effective_strategy, ArrangementStrategy::TemporalBucketing)
+                    && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(config_set)
+                {
+                    let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
+                        .get(config_set)
+                        .try_into()
+                        .expect("must fit");
+                    bucketed = true;
+                    // Temporal bucketing is `Vec`-internal: it consumes
+                    // and produces a `Vec` stream. Decode the edge into it, then
+                    // re-encode the `Vec` result to columnar at the boundary so the
+                    // bucketed output edge stays columnar like every other producer.
+                    let oks = columnar_to_vec(oks);
+                    vec_to_columnar(T::maybe_apply_temporal_bucketing(
+                        oks.inner,
+                        as_of.clone(),
+                        summary,
+                    ))
+                } else {
+                    oks
+                };
                 let use_paged_path = ENABLE_COLUMN_PAGED_BATCHER.get(config_set);
                 let (oks, errs_keyed, passthrough) = Self::arrange_collection(
                     &name,
@@ -1135,125 +1136,66 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
         // references, which is what we need to push into columnar streams. Instead, we use a
         // bespoke operator that also optimizes reuse of allocations across individual updates.
         //
-        // The two arms differ only in how records are read from the input container and in the
-        // variant of the passthrough output, which preserves the input variant. The ok output is
-        // columnar in both arms, since the arrangement key/value is always columnar.
-        let (ok_stream, err_stream, passthrough) = match oks {
-            CollectionEdge::Vec(oks) => {
-                let mut builder =
-                    OperatorBuilder::new("FormArrangementKey".to_string(), oks.inner.scope());
-                let (ok_output, ok_stream) = builder.new_output();
-                let mut ok_output =
-                    OutputBuilder::<_, ColumnBuilder<((Row, Row), T, Diff)>>::from(ok_output);
-                let (err_output, err_stream) = builder.new_output();
-                let mut err_output = OutputBuilder::from(err_output);
-                let (passthrough_output, passthrough_stream) = builder.new_output();
-                let mut passthrough_output = OutputBuilder::from(passthrough_output);
-                let mut input = builder.new_input(oks.inner, Pipeline);
-                builder.set_notify_for(0, FrontierInterest::Never);
-                builder.build(move |_capabilities| {
-                    let mut key_buf = Row::default();
-                    let mut val_buf = Row::default();
-                    let mut datums = DatumVec::new();
-                    move |_frontiers| {
-                        // Scoped to the activation so the arena's retained capacity does not
-                        // outlive a single scheduling invocation; cleared per row to reuse it
-                        // within the batch.
-                        let mut temp_storage = RowArena::new();
-                        let mut ok_output = ok_output.activate();
-                        let mut err_output = err_output.activate();
-                        let mut passthrough_output = passthrough_output.activate();
-                        input.for_each(|time, data| {
-                            let mut ok_session = ok_output.session_with_builder(&time);
-                            let mut err_session = err_output.session(&time);
-                            for (row, time, diff) in data.iter() {
-                                temp_storage.clear();
-                                let datums = datums.borrow_with(row);
-                                let key_iter = key.iter().map(|k| k.eval(&datums, &temp_storage));
-                                match key_buf.packer().try_extend(key_iter) {
-                                    Ok(()) => {
-                                        let val_datum_iter = thinning.iter().map(|c| datums[*c]);
-                                        val_buf.packer().extend(val_datum_iter);
-                                        ok_session.give(((&*key_buf, &*val_buf), time, diff));
-                                    }
-                                    Err(e) => {
-                                        err_session.give((e.into(), time.clone(), *diff));
-                                    }
+        // The passthrough output forwards the input `Column` unchanged, so downstream consumers
+        // can reuse the collection without teeing.
+        let (ok_stream, err_stream, passthrough) = {
+            let mut builder =
+                OperatorBuilder::new("FormArrangementKey".to_string(), oks.inner.scope());
+            let (ok_output, ok_stream) = builder.new_output();
+            let mut ok_output =
+                OutputBuilder::<_, ColumnBuilder<((Row, Row), T, Diff)>>::from(ok_output);
+            let (err_output, err_stream) = builder.new_output();
+            let mut err_output = OutputBuilder::from(err_output);
+            let (passthrough_output, passthrough_stream) = builder.new_output();
+            // The passthrough forwards the input `Column` unchanged; its builder's container
+            // type must match the input so `give_container` can hand the batch through.
+            let mut passthrough_output = OutputBuilder::<
+                _,
+                CapacityContainerBuilder<Column<(Row, T, Diff)>>,
+            >::from(passthrough_output);
+            let mut input = builder.new_input(oks.inner, Pipeline);
+            builder.set_notify_for(0, FrontierInterest::Never);
+            builder.build(move |_capabilities| {
+                let mut key_buf = Row::default();
+                let mut val_buf = Row::default();
+                let mut datums = DatumVec::new();
+                move |_frontiers| {
+                    // Scoped to the activation so the arena's retained capacity does not
+                    // outlive a single scheduling invocation; cleared per row to reuse it
+                    // within the batch.
+                    let mut temp_storage = RowArena::new();
+                    let mut ok_output = ok_output.activate();
+                    let mut err_output = err_output.activate();
+                    let mut passthrough_output = passthrough_output.activate();
+                    input.for_each(|time, data| {
+                        let mut ok_session = ok_output.session_with_builder(&time);
+                        let mut err_session = err_output.session(&time);
+                        // Rows are read from the borrowed column, never materialized as
+                        // owned `Row`s. Times and diffs are owned only on the error path.
+                        for (row, t, d) in data.borrow().into_index_iter() {
+                            temp_storage.clear();
+                            let datums = datums.borrow_with(row);
+                            let key_iter = key.iter().map(|k| k.eval(&datums, &temp_storage));
+                            match key_buf.packer().try_extend(key_iter) {
+                                Ok(()) => {
+                                    let val_datum_iter = thinning.iter().map(|c| datums[*c]);
+                                    val_buf.packer().extend(val_datum_iter);
+                                    ok_session.give(((&*key_buf, &*val_buf), t, d));
+                                }
+                                Err(e) => {
+                                    err_session.give((
+                                        e.into(),
+                                        Columnar::into_owned(t),
+                                        Columnar::into_owned(d),
+                                    ));
                                 }
                             }
-                            passthrough_output.session(&time).give_container(data);
-                        });
-                    }
-                });
-                (
-                    ok_stream,
-                    err_stream,
-                    CollectionEdge::Vec(passthrough_stream.as_collection()),
-                )
-            }
-            CollectionEdge::Columnar(oks) => {
-                let mut builder =
-                    OperatorBuilder::new("FormArrangementKey".to_string(), oks.inner.scope());
-                let (ok_output, ok_stream) = builder.new_output();
-                let mut ok_output =
-                    OutputBuilder::<_, ColumnBuilder<((Row, Row), T, Diff)>>::from(ok_output);
-                let (err_output, err_stream) = builder.new_output();
-                let mut err_output = OutputBuilder::from(err_output);
-                let (passthrough_output, passthrough_stream) = builder.new_output();
-                // The passthrough forwards the input `Column` unchanged; its builder's container
-                // type must match the input so `give_container` can hand the batch through.
-                let mut passthrough_output = OutputBuilder::<
-                    _,
-                    CapacityContainerBuilder<Column<(Row, T, Diff)>>,
-                >::from(passthrough_output);
-                let mut input = builder.new_input(oks.inner, Pipeline);
-                builder.set_notify_for(0, FrontierInterest::Never);
-                builder.build(move |_capabilities| {
-                    let mut key_buf = Row::default();
-                    let mut val_buf = Row::default();
-                    let mut datums = DatumVec::new();
-                    move |_frontiers| {
-                        // Scoped to the activation so the arena's retained capacity does not
-                        // outlive a single scheduling invocation; cleared per row to reuse it
-                        // within the batch.
-                        let mut temp_storage = RowArena::new();
-                        let mut ok_output = ok_output.activate();
-                        let mut err_output = err_output.activate();
-                        let mut passthrough_output = passthrough_output.activate();
-                        input.for_each(|time, data| {
-                            let mut ok_session = ok_output.session_with_builder(&time);
-                            let mut err_session = err_output.session(&time);
-                            // Rows are read from the borrowed column, never materialized as
-                            // owned `Row`s. Times and diffs are owned only on the error path.
-                            for (row, t, d) in data.borrow().into_index_iter() {
-                                temp_storage.clear();
-                                let datums = datums.borrow_with(row);
-                                let key_iter = key.iter().map(|k| k.eval(&datums, &temp_storage));
-                                match key_buf.packer().try_extend(key_iter) {
-                                    Ok(()) => {
-                                        let val_datum_iter = thinning.iter().map(|c| datums[*c]);
-                                        val_buf.packer().extend(val_datum_iter);
-                                        ok_session.give(((&*key_buf, &*val_buf), t, d));
-                                    }
-                                    Err(e) => {
-                                        err_session.give((
-                                            e.into(),
-                                            Columnar::into_owned(t),
-                                            Columnar::into_owned(d),
-                                        ));
-                                    }
-                                }
-                            }
-                            passthrough_output.session(&time).give_container(data);
-                        });
-                    }
-                });
-                (
-                    ok_stream,
-                    err_stream,
-                    CollectionEdge::Columnar(passthrough_stream.as_collection()),
-                )
-            }
+                        }
+                        passthrough_output.session(&time).give_container(data);
+                    });
+                }
+            });
+            (ok_stream, err_stream, passthrough_stream.as_collection())
         };
 
         let exchange =
@@ -1508,76 +1450,46 @@ mod tests {
         updates
     }
 
-    /// Arranges `rows` (each stamped with its own time) as both a `Vec` edge and
-    /// the equivalent columnar edge, keyed by `key`, and returns the sorted ok
-    /// and err outputs of each arm plus whether the columnar arm kept the
-    /// columnar passthrough variant.
-    fn arrange_both_arms(
+    /// Arranges `rows` (each stamped with its own time) as a columnar edge, keyed
+    /// by `key` with the full row as the value, and returns the sorted ok and err
+    /// outputs read back from the arrangement.
+    fn arrange_columnar(
         rows: Vec<(Row, u64)>,
         key: Vec<LirScalarExpr>,
-    ) -> (
-        Vec<OkUpdate>,
-        Vec<OkUpdate>,
-        Vec<(String, Timestamp, Diff)>,
-        Vec<(String, Timestamp, Diff)>,
-        bool,
-    ) {
+    ) -> (Vec<OkUpdate>, Vec<(String, Timestamp, Diff)>) {
         let thinning = vec![0, 1];
-        let (ok_vec, ok_col, err_vec, err_col, col_is_columnar) =
-            timely::execute_directly(move |worker| {
-                worker.dataflow::<Timestamp, _, _>(|scope| {
-                    let (mut input, collection) = scope.new_collection();
+        let (ok, err) = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let (arranged, errs, _passthrough) =
+                    CollectionBundle::<Timestamp>::arrange_collection(
+                        &"col".to_string(),
+                        vec_to_columnar(collection),
+                        key,
+                        thinning,
+                        false,
+                    );
+                let ok = arranged
+                    .as_collection(|k, v| (k.to_row(), v.to_row()))
+                    .inner
+                    .capture();
+                let err = errs.inner.capture();
 
-                    let (vec_arranged, vec_errs, _vec_passthrough) =
-                        CollectionBundle::<Timestamp>::arrange_collection(
-                            &"vec".to_string(),
-                            CollectionEdge::Vec(collection.clone()),
-                            key.clone(),
-                            thinning.clone(),
-                            false,
-                        );
-                    let (col_arranged, col_errs, col_passthrough) =
-                        CollectionBundle::<Timestamp>::arrange_collection(
-                            &"col".to_string(),
-                            CollectionEdge::Columnar(vec_to_columnar(collection)),
-                            key,
-                            thinning,
-                            false,
-                        );
-                    let col_is_columnar = matches!(col_passthrough, CollectionEdge::Columnar(_));
-
-                    let ok_vec = vec_arranged
-                        .as_collection(|k, v| (k.to_row(), v.to_row()))
-                        .inner
-                        .capture();
-                    let ok_col = col_arranged
-                        .as_collection(|k, v| (k.to_row(), v.to_row()))
-                        .inner
-                        .capture();
-                    let err_vec = vec_errs.inner.capture();
-                    let err_col = col_errs.inner.capture();
-
-                    let max_time = rows.iter().map(|(_, t)| *t).max().unwrap_or(0);
-                    for (row, time) in rows {
-                        input.update_at(row, Timestamp::from(time), Diff::ONE);
-                    }
-                    input.advance_to(Timestamp::from(max_time + 1));
-                    input.flush();
-                    (ok_vec, ok_col, err_vec, err_col, col_is_columnar)
-                })
-            });
-        (
-            extract_ok(ok_vec),
-            extract_ok(ok_col),
-            extract_err(err_vec),
-            extract_err(err_col),
-            col_is_columnar,
-        )
+                let max_time = rows.iter().map(|(_, t)| *t).max().unwrap_or(0);
+                for (row, time) in rows {
+                    input.update_at(row, Timestamp::from(time), Diff::ONE);
+                }
+                input.advance_to(Timestamp::from(max_time + 1));
+                input.flush();
+                (ok, err)
+            })
+        });
+        (extract_ok(ok), extract_err(err))
     }
 
     // Uniform two-column rows so `Column(0)` keys and full-row thinning are in
-    // bounds for every record. Times span three distinct values so the columnar
-    // arm's per-record time handling is exercised, not just t=0.
+    // bounds for every record. Times span three distinct values so the per-record
+    // time handling is exercised, not just t=0.
     fn test_rows() -> Vec<(Row, u64)> {
         vec![
             (Row::pack_slice(&[Datum::Int32(1), Datum::String("a")]), 0),
@@ -1587,48 +1499,39 @@ mod tests {
         ]
     }
 
-    /// The columnar arm of the arrange input produces the same arranged contents
-    /// as the `Vec` arm and keeps the columnar passthrough variant.
-    ///
-    /// What this proves: correctness of the columnar key-forming path (a mangled
-    /// key or dropped record would diverge from the `Vec` arm) and that the
-    /// columnar arm actually ran (the passthrough stays `Columnar`).
-    ///
-    /// What it does NOT prove: absence of a silent decode. A hypothetical
-    /// `columnar_to_vec` on the ok path would yield identical contents and still
-    /// return a `Columnar` passthrough. The no-decode property holds by code
-    /// inspection: the columnar arm reads records via `into_index_iter` on the
-    /// borrowed column and never calls `into_vec`.
+    /// The columnar arrange input forms the arrangement keyed by column 0 with the
+    /// full row as the value, producing exactly the input records. A mangled key
+    /// or a dropped record would diverge from the expected set.
     #[mz_ore::test]
-    fn arrange_collection_arms_agree() {
-        let (ok_vec, ok_col, err_vec, err_col, col_is_columnar) =
-            arrange_both_arms(test_rows(), vec![LirScalarExpr::column(0)]);
+    fn arrange_collection_keys_correctly() {
+        let rows = test_rows();
+        let mut expected: Vec<OkUpdate> = rows
+            .iter()
+            .map(|(row, t)| {
+                let key = Row::pack_slice(&[row.iter().next().unwrap()]);
+                ((key, row.clone()), Timestamp::from(*t), Diff::ONE)
+            })
+            .collect();
+        expected.sort();
 
-        assert!(
-            col_is_columnar,
-            "columnar arrange input must keep the columnar passthrough variant"
-        );
-        assert!(!ok_vec.is_empty());
-        assert_eq!(ok_vec, ok_col);
-        assert!(err_vec.is_empty() && err_col.is_empty());
+        let (ok, err) = arrange_columnar(rows, vec![LirScalarExpr::column(0)]);
+        assert_eq!(ok, expected);
+        assert!(err.is_empty());
     }
 
     /// A key expression that always errors drives every record onto the error
     /// path, exercising the columnar arm's `into_owned` reconstruction of the
-    /// error's `(time, diff)`. The two arms must agree on the errors, and the ok
-    /// output must be empty on both.
+    /// error's `(time, diff)`. The ok output must be empty and the errors present.
     #[mz_ore::test]
-    fn arrange_collection_arms_agree_on_error_path() {
+    fn arrange_collection_error_path() {
         let key = vec![LirScalarExpr::literal(
             Err(EvalError::DivisionByZero),
             ReprScalarType::Int32,
         )];
-        let (ok_vec, ok_col, err_vec, err_col, _col_is_columnar) =
-            arrange_both_arms(test_rows(), key);
+        let (ok, err) = arrange_columnar(test_rows(), key);
 
-        assert!(ok_vec.is_empty() && ok_col.is_empty());
-        assert!(!err_vec.is_empty());
-        assert_eq!(err_vec, err_col);
+        assert!(ok.is_empty());
+        assert!(!err.is_empty());
     }
 
     fn extract_row_updates(
@@ -1643,16 +1546,12 @@ mod tests {
         updates
     }
 
-    /// A `Get -> ArrangeBy` chain carries the columnar arm end to end. A
-    /// non-identity MFP drives `as_collection_core` down its columnar producer
-    /// path, and feeding that edge into the arrange input keeps the columnar
-    /// passthrough, so no `ColumnarToVec` sits on the arrange path.
-    ///
-    /// The producer output is checked against the projected input. Arrange
-    /// correctness itself is covered by `arrange_collection_arms_agree`; here we
-    /// only assert the variant survives the hand-off.
+    /// A `Get -> ArrangeBy` chain: a non-identity MFP drives `as_collection_core`
+    /// down its columnar producer path, and feeding that edge into the arrange
+    /// input produces the projected rows. Arrange correctness itself is covered by
+    /// `arrange_collection_keys_correctly`; here we check the producer output.
     #[mz_ore::test]
-    fn get_arrange_by_carries_columnar_end_to_end() {
+    fn get_arrange_by_produces_projected_rows() {
         let rows = vec![
             (Row::pack_slice(&[Datum::Int64(1), Datum::Int64(10)]), 0u64),
             (Row::pack_slice(&[Datum::Int64(2), Datum::Int64(20)]), 1),
@@ -1674,81 +1573,67 @@ mod tests {
             .collect();
         expected.sort();
 
-        let (producer_is_columnar, passthrough_is_columnar, produced) =
-            timely::execute_directly(move |worker| {
-                worker.dataflow::<Timestamp, _, _>(|scope| {
-                    let (mut input, collection) = scope.new_collection();
-                    let (_err_input, errs) = scope.new_collection::<DataflowErrorSer, Diff>();
-                    let bundle = CollectionBundle::from_edge(CollectionEdge::Vec(collection), errs);
-                    let (edge, _errs) = bundle.as_collection_core(mfp, None, Antichain::new());
-                    let producer_is_columnar = matches!(edge, CollectionEdge::Columnar(_));
-                    // Tee the producer output for a content check, then feed the
-                    // original edge into the arrange input.
-                    let produced = edge.clone().into_vec().inner.capture();
-                    let (_arranged, _arrange_errs, passthrough) =
-                        CollectionBundle::<Timestamp>::arrange_collection(
-                            &"arrange".to_string(),
-                            edge,
-                            vec![LirScalarExpr::column(0)],
-                            vec![0],
-                            false,
-                        );
-                    let passthrough_is_columnar =
-                        matches!(passthrough, CollectionEdge::Columnar(_));
+        let produced = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let (_err_input, errs) = scope.new_collection::<DataflowErrorSer, Diff>();
+                let bundle = CollectionBundle::from_edge(vec_to_columnar(collection), errs);
+                let (edge, _errs) = bundle.as_collection_core(mfp, None, Antichain::new());
+                // Tee the producer output for a content check, then feed the
+                // original edge into the arrange input.
+                let produced = columnar_to_vec(edge.clone()).inner.capture();
+                let (_arranged, _arrange_errs, _passthrough) =
+                    CollectionBundle::<Timestamp>::arrange_collection(
+                        &"arrange".to_string(),
+                        edge,
+                        vec![LirScalarExpr::column(0)],
+                        vec![0],
+                        false,
+                    );
 
-                    let max_time = rows.iter().map(|(_, t)| *t).max().unwrap();
-                    for (row, time) in rows {
-                        input.update_at(row, Timestamp::from(time), Diff::ONE);
-                    }
-                    input.advance_to(Timestamp::from(max_time + 1));
-                    input.flush();
-                    (producer_is_columnar, passthrough_is_columnar, produced)
-                })
-            });
+                let max_time = rows.iter().map(|(_, t)| *t).max().unwrap();
+                for (row, time) in rows {
+                    input.update_at(row, Timestamp::from(time), Diff::ONE);
+                }
+                input.advance_to(Timestamp::from(max_time + 1));
+                input.flush();
+                produced
+            })
+        });
 
-        assert!(
-            producer_is_columnar,
-            "a non-identity MFP must produce a columnar edge"
-        );
-        assert!(
-            passthrough_is_columnar,
-            "the arrange input must keep the columnar passthrough (no ColumnarToVec)"
-        );
         assert_eq!(extract_row_updates(produced), expected);
     }
 
-    /// The reworked identity fast-path returns the unarranged input edge
-    /// unchanged, so a columnar producer stays columnar and a `Vec` producer
-    /// stays `Vec` with no repack in either direction.
+    /// The identity fast-path returns the unarranged input edge unchanged, with no
+    /// repack, so its contents pass straight through.
     #[mz_ore::test]
     fn as_collection_core_identity_passes_edge_through() {
-        for columnar_input in [false, true] {
-            let is_columnar = timely::execute_directly(move |worker| {
-                worker.dataflow::<Timestamp, _, _>(|scope| {
-                    let (mut input, collection) = scope.new_collection::<Row, Diff>();
-                    let (_err_input, errs) = scope.new_collection::<DataflowErrorSer, Diff>();
-                    let edge = if columnar_input {
-                        CollectionEdge::Columnar(vec_to_columnar(collection))
-                    } else {
-                        CollectionEdge::Vec(collection)
-                    };
-                    let bundle = CollectionBundle::from_edge(edge, errs);
-                    let identity = MapFilterProject::<LirScalarExpr>::new(1)
-                        .into_plan()
-                        .expect("identity mfp");
-                    let (out, _errs) = bundle.as_collection_core(identity, None, Antichain::new());
-                    let is_columnar = matches!(out, CollectionEdge::Columnar(_));
-                    input.update(Row::pack_slice(&[Datum::Int64(1)]), Diff::ONE);
-                    input.advance_to(Timestamp::from(1u64));
-                    input.flush();
-                    is_columnar
-                })
-            });
-            assert_eq!(
-                is_columnar, columnar_input,
-                "the identity fast-path must preserve the input edge variant"
-            );
-        }
+        let expected = vec![(
+            Row::pack_slice(&[Datum::Int64(1)]),
+            Timestamp::from(0u64),
+            Diff::ONE,
+        )];
+        let captured = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection::<Row, Diff>();
+                let (_err_input, errs) = scope.new_collection::<DataflowErrorSer, Diff>();
+                let bundle = CollectionBundle::from_edge(vec_to_columnar(collection), errs);
+                let identity = MapFilterProject::<LirScalarExpr>::new(1)
+                    .into_plan()
+                    .expect("identity mfp");
+                let (out, _errs) = bundle.as_collection_core(identity, None, Antichain::new());
+                let captured = columnar_to_vec(out).inner.capture();
+                input.update_at(
+                    Row::pack_slice(&[Datum::Int64(1)]),
+                    Timestamp::from(0u64),
+                    Diff::ONE,
+                );
+                input.advance_to(Timestamp::from(1u64));
+                input.flush();
+                captured
+            })
+        });
+        assert_eq!(extract_row_updates(captured), expected);
     }
 
     /// The columnar producer folds within-batch duplicates: input rows that
@@ -1786,13 +1671,9 @@ mod tests {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut input, collection) = scope.new_collection();
                 let (_err_input, errs) = scope.new_collection::<DataflowErrorSer, Diff>();
-                let bundle = CollectionBundle::from_edge(CollectionEdge::Vec(collection), errs);
+                let bundle = CollectionBundle::from_edge(vec_to_columnar(collection), errs);
                 let (edge, _errs) = bundle.as_collection_core(mfp, None, Antichain::new());
-                assert!(
-                    matches!(edge, CollectionEdge::Columnar(_)),
-                    "a non-identity MFP must produce a columnar edge"
-                );
-                let captured = edge.into_vec().inner.capture();
+                let captured = columnar_to_vec(edge).inner.capture();
                 // Feed all rows at the same time in one batch so the fold is
                 // within-batch, not a downstream re-consolidation.
                 for row in rows {
@@ -1828,13 +1709,13 @@ mod tests {
             .collect();
         expected.sort();
 
-        let (is_columnar, captured) = timely::execute_directly(move |worker| {
+        let captured = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut input, collection) = scope.new_collection();
                 let (arranged, arr_errs, _passthrough) =
                     CollectionBundle::<Timestamp>::arrange_collection(
                         &"agg".to_string(),
-                        CollectionEdge::Vec(collection),
+                        vec_to_columnar(collection),
                         key.clone(),
                         vec![1],
                         false,
@@ -1854,8 +1735,7 @@ mod tests {
                     ArrangementFlavor::Local(arranged, err_arranged),
                 );
                 let (edge, _errs) = bundle.as_specific_collection(Some(&key));
-                let is_columnar = matches!(edge, CollectionEdge::Columnar(_));
-                let captured = edge.into_vec().inner.capture();
+                let captured = columnar_to_vec(edge).inner.capture();
 
                 let max_time = rows.iter().map(|(_, t)| *t).max().unwrap();
                 for (row, time) in rows {
@@ -1863,14 +1743,10 @@ mod tests {
                 }
                 input.advance_to(Timestamp::from(max_time + 1));
                 input.flush();
-                (is_columnar, captured)
+                captured
             })
         });
 
-        assert!(
-            is_columnar,
-            "as_specific_collection must materialize the arrangement as a columnar edge"
-        );
         assert_eq!(extract_row_updates(captured), expected);
     }
 }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -1698,7 +1698,7 @@ mod tests {
     /// by column 0 and thinning the value to column 1 reconstructs the original
     /// two-column row. No-decode is a by-inspection property: the fueled path
     /// builds a `ColumnBuilder` via `flat_map_ok` and never calls
-    /// `columnar_to_vec`; the `into_vec` below is the capture harness only.
+    /// `columnar_to_vec`; the decode below is the capture harness only.
     #[mz_ore::test]
     fn as_specific_collection_materializes_columnar() {
         let rows = test_rows();

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -9,19 +9,26 @@
 
 use std::collections::VecDeque;
 
+use columnar::{Columnar, Index};
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use mz_compute_types::dyncfgs::COMPUTE_FLAT_MAP_FUEL;
 use mz_compute_types::plan::scalar::LirScalarExpr;
 use mz_expr::TableFunc;
 use mz_expr::{Eval, MfpPlan};
 use mz_repr::{DatumVec, RowArena, SharedRow};
-use mz_repr::{Diff, Row, Timestamp};
+use mz_repr::{Diff, Row, RowRef, Timestamp};
+use mz_timely_util::columnar::Column;
 use mz_timely_util::operator::StreamExt;
+use timely::Container;
+use timely::container::DrainContainer;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Capability;
 use timely::dataflow::operators::generic::Session;
+use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 
+use crate::render::RenderTimestamp;
+use crate::render::columnar::CollectionEdge;
 use crate::render::context::{CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 
@@ -36,9 +43,6 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
         mfp_plan: MfpPlan<LirScalarExpr>,
     ) -> CollectionBundle<'scope, T> {
         let until = self.until.clone();
-        let (ok_collection, err_collection) =
-            input.as_specific_collection(input_key.as_deref(), &self.config_set);
-        let stream = ok_collection.inner;
         let scope = input.scope();
 
         // Budget to limit the number of rows processed in a single invocation.
@@ -47,7 +51,103 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
         // a batch. A `generate_series` can still cause unavailability if it generates many rows.
         let budget = COMPUTE_FLAT_MAP_FUEL.get(&self.config_set);
 
-        let (oks, errs) = stream.unary_fallible(Pipeline, "FlatMapStage", move |_, info| {
+        // The unarranged path (no key) reads the input `CollectionEdge` directly,
+        // so the columnar arm never decodes rows at the input. The keyed path
+        // reads an existing arrangement, already columnar internally, and is
+        // presented as a `Vec` edge here.
+        let (edge, err_collection) = match input_key.as_deref() {
+            None => input
+                .collection
+                .clone()
+                .expect("The unarranged collection doesn't exist."),
+            Some(key) => {
+                let (oks, errs) = input.as_specific_collection(Some(key), &self.config_set);
+                (CollectionEdge::Vec(oks), errs)
+            }
+        };
+
+        let (oks, errs) = match edge {
+            CollectionEdge::Vec(c) => {
+                flat_map_stage(c.inner, scope, exprs, func, mfp_plan, until, budget)
+            }
+            CollectionEdge::Columnar(c) => {
+                flat_map_stage(c.inner, scope, exprs, func, mfp_plan, until, budget)
+            }
+        };
+
+        use differential_dataflow::AsCollection;
+        let ok_collection = oks.as_collection();
+        let new_err_collection = errs.as_collection();
+        let err_collection = err_collection.concat(new_err_collection);
+        CollectionBundle::from_collections(ok_collection, err_collection)
+    }
+}
+
+/// Output ok-session container builder for [`flat_map_stage`].
+type FlatMapOk<T> = ConsolidatingContainerBuilder<Vec<(Row, T, Diff)>>;
+/// Output err-session container builder for [`flat_map_stage`].
+type FlatMapErr<T> = ConsolidatingContainerBuilder<Vec<(DataflowErrorSer, T, Diff)>>;
+
+/// Yields the `(row, time, diff)` records of one queued FlatMap input batch.
+///
+/// The two edge arms differ only in how records are read from a queued batch:
+/// the `Vec` arm drains owned rows, the `Column` arm iterates the borrowed
+/// column and never materializes an owned [`Row`]. Everything else in the
+/// FlatMap operator (the fuel queue, budget, and re-activation) is shared
+/// through [`flat_map_stage`].
+trait FlatMapBatch<T> {
+    /// Calls `logic` once per record, presenting the row as a borrowed
+    /// [`RowRef`] and the time and diff by reference.
+    fn for_each_record(&mut self, logic: impl FnMut(&RowRef, &T, &Diff));
+}
+
+impl<T: RenderTimestamp> FlatMapBatch<T> for Vec<(Row, T, Diff)> {
+    fn for_each_record(&mut self, mut logic: impl FnMut(&RowRef, &T, &Diff)) {
+        for (row, time, diff) in self.drain(..) {
+            logic(&row, &time, &diff);
+        }
+    }
+}
+
+impl<T: RenderTimestamp> FlatMapBatch<T> for Column<(Row, T, Diff)> {
+    fn for_each_record(&mut self, mut logic: impl FnMut(&RowRef, &T, &Diff)) {
+        // Rows are read from the borrowed column, never materialized as owned
+        // `Row`s. Times and diffs are owned only to hand `logic` a reference.
+        for (row, t, d) in self.borrow().into_index_iter() {
+            logic(row, &Columnar::into_owned(t), &Columnar::into_owned(d));
+        }
+    }
+}
+
+/// The fueled FlatMap operator, generic over the input edge arm.
+///
+/// This is the sole owner of the fuel machinery, so the `Vec` and `Column`
+/// arms cannot drift apart. Incoming batches are queued; each activation
+/// processes queued batches and drains each record's table-function expansion
+/// through the mfp, decrementing a per-activation `budget`. When the budget is
+/// exhausted the operator re-activates itself and stops, deferring the rest of
+/// the queue to a later activation. This bounds the work a single
+/// `generate_series` can do before yielding the worker.
+fn flat_map_stage<'scope, T, C>(
+    stream: Stream<'scope, T, C>,
+    scope: Scope<'scope, T>,
+    exprs: Vec<LirScalarExpr>,
+    func: TableFunc,
+    mfp_plan: MfpPlan<LirScalarExpr>,
+    until: Antichain<Timestamp>,
+    budget: usize,
+) -> (
+    Stream<'scope, T, Vec<(Row, T, Diff)>>,
+    Stream<'scope, T, Vec<(DataflowErrorSer, T, Diff)>>,
+)
+where
+    T: RenderTimestamp,
+    C: Container + DrainContainer + Clone + Default + FlatMapBatch<T> + 'static,
+{
+    stream.unary_fallible::<FlatMapOk<T>, FlatMapErr<T>, _, _>(
+        Pipeline,
+        "FlatMapStage",
+        move |_, info| {
             let activator = scope.activator_for(info.address);
             let mut queue = VecDeque::new();
             Box::new(move |input, ok_output, err_output| {
@@ -63,67 +163,101 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
                     queue.push_back((cap.retain(0), cap.retain(1), std::mem::take(data)))
                 });
 
-                while let Some((ok_cap, err_cap, data)) = queue.pop_front() {
+                while let Some((ok_cap, err_cap, mut data)) = queue.pop_front() {
                     let mut ok_session = ok_output.session_with_builder(&ok_cap);
                     let mut err_session = err_output.session_with_builder(&err_cap);
 
-                    'input: for (input_row, time, diff) in data {
-                        let temp_storage = RowArena::new();
-
-                        // Unpack datums for expression evaluation.
-                        let datums_local = datums.borrow_with(&input_row);
-                        let args = exprs
-                            .iter()
-                            .map(|e| e.eval(&datums_local, &temp_storage))
-                            .collect::<Result<Vec<_>, _>>();
-                        let args = match args {
-                            Ok(args) => args,
-                            Err(e) => {
-                                err_session.give((e.into(), time, diff));
-                                continue 'input;
-                            }
-                        };
-                        let mut extensions = match func.eval(&args, &temp_storage) {
-                            Ok(exts) => exts.fuse(),
-                            Err(e) => {
-                                err_session.give((e.into(), time, diff));
-                                continue 'input;
-                            }
-                        };
-
-                        // Draw additional columns out of the table func evaluation.
-                        while let Some((extension, output_diff)) = extensions.next() {
-                            table_func_output.push((extension, output_diff));
-                            table_func_output.extend((&mut extensions).take(1023));
-                            // We could consolidate `table_func_output`, but it seems unlikely to be productive.
-                            drain_through_mfp(
-                                &input_row,
-                                &time,
-                                &diff,
-                                &mut datums_mfp,
-                                &table_func_output,
-                                &mfp_plan,
-                                &until,
-                                &mut ok_session,
-                                &mut err_session,
-                                &mut budget,
-                            );
-                            table_func_output.clear();
-                        }
-                    }
+                    data.for_each_record(|input_row, time, diff| {
+                        process_flat_map_row(
+                            input_row,
+                            time,
+                            diff,
+                            &exprs,
+                            &func,
+                            &mfp_plan,
+                            &until,
+                            &mut datums,
+                            &mut datums_mfp,
+                            &mut table_func_output,
+                            &mut ok_session,
+                            &mut err_session,
+                            &mut budget,
+                        );
+                    });
                     if budget == 0 {
                         activator.activate();
                         break;
                     }
                 }
             })
-        });
+        },
+    )
+}
 
-        use differential_dataflow::AsCollection;
-        let ok_collection = oks.as_collection();
-        let new_err_collection = errs.as_collection();
-        let err_collection = err_collection.concat(new_err_collection);
-        CollectionBundle::from_collections(ok_collection, err_collection)
+/// Expands one input record's table function and drains it through the mfp.
+///
+/// Evaluates `exprs` to the table-function arguments, then `func`, chunking the
+/// expansion so [`drain_through_mfp`] amortizes the input-row decode. Argument
+/// or function evaluation errors emit to the err session and return early. The
+/// output budget is decremented inside [`drain_through_mfp`].
+fn process_flat_map_row<T>(
+    input_row: &RowRef,
+    time: &T,
+    diff: &Diff,
+    exprs: &[LirScalarExpr],
+    func: &TableFunc,
+    mfp_plan: &MfpPlan<LirScalarExpr>,
+    until: &Antichain<Timestamp>,
+    datums: &mut DatumVec,
+    datums_mfp: &mut DatumVec,
+    table_func_output: &mut Vec<(Row, Diff)>,
+    ok_session: &mut Session<'_, '_, T, FlatMapOk<T>, Capability<T>>,
+    err_session: &mut Session<'_, '_, T, FlatMapErr<T>, Capability<T>>,
+    budget: &mut usize,
+) where
+    T: RenderTimestamp,
+{
+    let temp_storage = RowArena::new();
+
+    // Unpack datums for expression evaluation.
+    let datums_local = datums.borrow_with(input_row);
+    let args = exprs
+        .iter()
+        .map(|e| e.eval(&datums_local, &temp_storage))
+        .collect::<Result<Vec<_>, _>>();
+    let args = match args {
+        Ok(args) => args,
+        Err(e) => {
+            err_session.give((e.into(), time.clone(), *diff));
+            return;
+        }
+    };
+    let mut extensions = match func.eval(&args, &temp_storage) {
+        Ok(exts) => exts.fuse(),
+        Err(e) => {
+            err_session.give((e.into(), time.clone(), *diff));
+            return;
+        }
+    };
+
+    // Draw additional columns out of the table func evaluation.
+    while let Some((extension, output_diff)) = extensions.next() {
+        table_func_output.push((extension, output_diff));
+        table_func_output.extend((&mut extensions).take(1023));
+        // We could consolidate `table_func_output`, but it seems unlikely to be productive.
+        drain_through_mfp(
+            input_row,
+            time,
+            diff,
+            datums_mfp,
+            table_func_output,
+            mfp_plan,
+            until,
+            ok_session,
+            err_session,
+            budget,
+        );
+        table_func_output.clear();
     }
 }
 
@@ -131,30 +265,18 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
 ///
 /// The method decodes `input_row`, and should be amortized across non-trivial `extensions`.
 fn drain_through_mfp<T>(
-    input_row: &Row,
+    input_row: &RowRef,
     input_time: &T,
     input_diff: &Diff,
     datum_vec: &mut DatumVec,
     extensions: &[(Row, Diff)],
     mfp_plan: &MfpPlan<LirScalarExpr>,
     until: &Antichain<Timestamp>,
-    ok_output: &mut Session<
-        '_,
-        '_,
-        T,
-        ConsolidatingContainerBuilder<Vec<(Row, T, Diff)>>,
-        Capability<T>,
-    >,
-    err_output: &mut Session<
-        '_,
-        '_,
-        T,
-        ConsolidatingContainerBuilder<Vec<(DataflowErrorSer, T, Diff)>>,
-        Capability<T>,
-    >,
+    ok_output: &mut Session<'_, '_, T, FlatMapOk<T>, Capability<T>>,
+    err_output: &mut Session<'_, '_, T, FlatMapErr<T>, Capability<T>>,
     budget: &mut usize,
 ) where
-    T: crate::render::RenderTimestamp,
+    T: RenderTimestamp,
 {
     let temp_storage = RowArena::new();
     let mut row_builder = SharedRow::get();
@@ -196,5 +318,182 @@ fn drain_through_mfp<T>(
                 }
             };
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use differential_dataflow::input::Input;
+    use mz_expr::MapFilterProject;
+    use mz_repr::{Datum, ReprScalarType};
+    use timely::dataflow::operators::Inspect;
+    use timely::dataflow::operators::capture::{Capture, Extract};
+
+    use super::*;
+    use crate::render::columnar::vec_to_columnar;
+
+    // `generate_series(1, stop, 1)` reading `stop` from column 1 of the input
+    // row, with an identity mfp over the (start, stop, generated) triple.
+    fn flat_map_args() -> (Vec<LirScalarExpr>, TableFunc, MfpPlan<LirScalarExpr>) {
+        let exprs = vec![
+            LirScalarExpr::column(0),
+            LirScalarExpr::column(1),
+            LirScalarExpr::literal_ok(Datum::Int64(1), ReprScalarType::Int64),
+        ];
+        let func = TableFunc::GenerateSeriesInt64;
+        let mfp = MapFilterProject::<LirScalarExpr>::new(3)
+            .into_plan()
+            .expect("identity mfp");
+        (exprs, func, mfp)
+    }
+
+    fn input_row(stop: i64) -> Row {
+        Row::pack_slice(&[Datum::Int64(1), Datum::Int64(stop)])
+    }
+
+    /// Runs one input row at each of `batches` distinct timestamps through
+    /// `flat_map_stage` with the given fuel `budget`, driving the worker one
+    /// step at a time. Returns how many steps were needed to produce all
+    /// output and the total output-record count.
+    fn run_fueled(batches: u64, stop: i64, budget: usize) -> (usize, usize) {
+        let expected = usize::try_from(batches).unwrap() * usize::try_from(stop).unwrap();
+        timely::execute_directly(move |worker| {
+            let collected = Rc::new(RefCell::new(0usize));
+            let sink = Rc::clone(&collected);
+            let mut input = worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (input, collection) = scope.new_collection();
+                let (exprs, func, mfp) = flat_map_args();
+                let stream = collection.inner;
+                let scope = stream.scope();
+                let (oks, _errs) =
+                    flat_map_stage(stream, scope, exprs, func, mfp, Antichain::new(), budget);
+                oks.inspect(move |_| *sink.borrow_mut() += 1);
+                input
+            });
+
+            // Feed one row per timestamp as a separate batch. Distinct times
+            // keep the per-batch output from consolidating away.
+            for i in 0..batches {
+                input.advance_to(Timestamp::from(i));
+                input.update(input_row(stop), Diff::ONE);
+                input.flush();
+            }
+            input.advance_to(Timestamp::from(batches));
+            input.flush();
+
+            let mut steps = 0;
+            while *collected.borrow() < expected {
+                worker.step();
+                steps += 1;
+                assert!(steps < 10_000, "flat map did not converge");
+            }
+            (steps, *collected.borrow())
+        })
+    }
+
+    #[mz_ore::test]
+    fn flat_map_fuel_bounds_per_activation() {
+        // A fuel budget of one forces the operator to yield after each queued
+        // batch and re-activate, so several batches take several activations.
+        // An unbounded budget drains the whole queue in a single activation.
+        // This is the availability guard the fuel machinery exists for.
+        let (fueled_steps, fueled_count) = run_fueled(4, 3, 1);
+        let (unfueled_steps, unfueled_count) = run_fueled(4, 3, usize::MAX);
+        assert_eq!(fueled_count, 12);
+        assert_eq!(unfueled_count, 12);
+        assert_eq!(
+            unfueled_steps, 1,
+            "unbounded budget drains in one activation"
+        );
+        assert!(
+            fueled_steps > unfueled_steps,
+            "fuel budget must spread work across activations: fueled={fueled_steps} unfueled={unfueled_steps}"
+        );
+    }
+
+    #[mz_ore::test]
+    fn flat_map_arms_agree() {
+        // The `Vec` and `Column` input arms must produce identical `(row, time,
+        // diff)` output. Multiple timestamps and a retraction exercise time
+        // handling and negative diffs. The columnar arm's `Columnar::into_owned`
+        // for time and diff runs on every ok record here (the input decode has
+        // no fallible/try_extend path, so the standing fallible-key rule does
+        // not apply), and this comparison proves it decodes correctly.
+        let (vec_captured, col_captured) = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let mut captures = Vec::new();
+                for columnar in [false, true] {
+                    let (exprs, func, mfp) = flat_map_args();
+                    let edge = if columnar {
+                        CollectionEdge::Columnar(vec_to_columnar(collection.clone()))
+                    } else {
+                        CollectionEdge::Vec(collection.clone())
+                    };
+                    let (oks, _errs) = match edge {
+                        CollectionEdge::Vec(c) => {
+                            let stream = c.inner;
+                            let scope = stream.scope();
+                            flat_map_stage(
+                                stream,
+                                scope,
+                                exprs,
+                                func,
+                                mfp,
+                                Antichain::new(),
+                                usize::MAX,
+                            )
+                        }
+                        CollectionEdge::Columnar(c) => {
+                            let stream = c.inner;
+                            let scope = stream.scope();
+                            flat_map_stage(
+                                stream,
+                                scope,
+                                exprs,
+                                func,
+                                mfp,
+                                Antichain::new(),
+                                usize::MAX,
+                            )
+                        }
+                    };
+                    captures.push(oks.capture());
+                }
+                let col = captures.pop().unwrap();
+                let vec = captures.pop().unwrap();
+                // t=0: generate_series(1, 2); t=1: generate_series(1, 3);
+                // t=2: retract the t=0 row.
+                input.advance_to(Timestamp::from(0_u64));
+                input.update(input_row(2), Diff::ONE);
+                input.advance_to(Timestamp::from(1_u64));
+                input.update(input_row(3), Diff::ONE);
+                input.advance_to(Timestamp::from(2_u64));
+                input.update(input_row(2), -Diff::ONE);
+                input.advance_to(Timestamp::from(3_u64));
+                input.flush();
+                (vec, col)
+            })
+        });
+
+        let extract_sorted = |captured: std::sync::mpsc::Receiver<_>| {
+            let mut updates: Vec<(Row, Timestamp, Diff)> = captured
+                .extract()
+                .into_iter()
+                .flat_map(|(_, data)| data)
+                .collect();
+            updates.sort();
+            updates
+        };
+        let vec_updates = extract_sorted(vec_captured);
+        assert!(!vec_updates.is_empty());
+        assert!(
+            vec_updates.iter().any(|(_, _, d)| *d < Diff::ZERO),
+            "the retraction must survive as a negative diff"
+        );
+        assert_eq!(vec_updates, extract_sorted(col_captured));
     }
 }

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -18,6 +18,7 @@ use mz_expr::{Eval, MfpPlan};
 use mz_repr::{DatumVec, RowArena, SharedRow};
 use mz_repr::{Diff, Row, RowRef, Timestamp};
 use mz_timely_util::columnar::Column;
+use mz_timely_util::columnar::consolidate::ConsolidatingColumnBuilder;
 use mz_timely_util::operator::StreamExt;
 use timely::Container;
 use timely::container::DrainContainer;
@@ -76,15 +77,19 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
         };
 
         use differential_dataflow::AsCollection;
-        let ok_collection = oks.as_collection();
+        let ok_collection = CollectionEdge::Columnar(oks.as_collection());
         let new_err_collection = errs.as_collection();
         let err_collection = err_collection.concat(new_err_collection);
-        CollectionBundle::from_collections(ok_collection, err_collection)
+        CollectionBundle::from_edge(ok_collection, err_collection)
     }
 }
 
 /// Output ok-session container builder for [`flat_map_stage`].
-type FlatMapOk<T> = ConsolidatingContainerBuilder<Vec<(Row, T, Diff)>>;
+///
+/// Consolidating like the err builder, but emits `Column<(Row, T, Diff)>` so
+/// the FlatMap output travels as the columnar edge. Output rows are freshly
+/// built by the mfp, so the owned give into staging is a move, not a new alloc.
+type FlatMapOk<T> = ConsolidatingColumnBuilder<Row, T, Diff>;
 /// Output err-session container builder for [`flat_map_stage`].
 type FlatMapErr<T> = ConsolidatingContainerBuilder<Vec<(DataflowErrorSer, T, Diff)>>;
 
@@ -137,7 +142,7 @@ fn flat_map_stage<'scope, T, C>(
     until: Antichain<Timestamp>,
     budget: usize,
 ) -> (
-    Stream<'scope, T, Vec<(Row, T, Diff)>>,
+    Stream<'scope, T, Column<(Row, T, Diff)>>,
     Stream<'scope, T, Vec<(DataflowErrorSer, T, Diff)>>,
 )
 where
@@ -329,7 +334,7 @@ mod tests {
     use differential_dataflow::input::Input;
     use mz_expr::MapFilterProject;
     use mz_repr::{Datum, ReprScalarType};
-    use timely::dataflow::operators::Inspect;
+    use timely::dataflow::operators::InspectCore;
     use timely::dataflow::operators::capture::{Capture, Extract};
 
     use super::*;
@@ -370,7 +375,13 @@ mod tests {
                 let scope = stream.scope();
                 let (oks, _errs) =
                     flat_map_stage(stream, scope, exprs, func, mfp, Antichain::new(), budget);
-                oks.inspect(move |_| *sink.borrow_mut() += 1);
+                // The columnar output ships whole `Column`s, so count records
+                // through the container rather than per raw element.
+                oks.inspect_container(move |event| {
+                    if let Ok((_time, data)) = event {
+                        *sink.borrow_mut() += data.borrow().into_index_iter().count();
+                    }
+                });
                 input
             });
 
@@ -479,21 +490,105 @@ mod tests {
             })
         });
 
-        let extract_sorted = |captured: std::sync::mpsc::Receiver<_>| {
-            let mut updates: Vec<(Row, Timestamp, Diff)> = captured
-                .extract()
-                .into_iter()
-                .flat_map(|(_, data)| data)
-                .collect();
-            updates.sort();
-            updates
-        };
-        let vec_updates = extract_sorted(vec_captured);
+        let vec_updates = extract_sorted_columns(vec_captured);
         assert!(!vec_updates.is_empty());
         assert!(
             vec_updates.iter().any(|(_, _, d)| *d < Diff::ZERO),
             "the retraction must survive as a negative diff"
         );
-        assert_eq!(vec_updates, extract_sorted(col_captured));
+        assert_eq!(vec_updates, extract_sorted_columns(col_captured));
+    }
+
+    /// Decodes a capture of the columnar FlatMap output into sorted owned
+    /// `(row, time, diff)` updates.
+    fn extract_sorted_columns(
+        captured: std::sync::mpsc::Receiver<
+            timely::dataflow::operators::capture::Event<Timestamp, Column<(Row, Timestamp, Diff)>>,
+        >,
+    ) -> Vec<(Row, Timestamp, Diff)> {
+        let mut updates: Vec<(Row, Timestamp, Diff)> = captured
+            .extract()
+            .into_iter()
+            .flat_map(|(_, col)| {
+                col.borrow()
+                    .into_index_iter()
+                    .map(|(v, t, d)| {
+                        (
+                            Columnar::into_owned(v),
+                            Columnar::into_owned(t),
+                            Columnar::into_owned(d),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        updates.sort();
+        updates
+    }
+
+    #[mz_ore::test]
+    fn flat_map_output_consolidates_within_batch() {
+        // Two distinct input rows whose table-function expansions overlap once
+        // the mfp projects away the differing `stop` column. The overlapping
+        // output rows land at the same time in one batch, so the consolidating
+        // columnar output builder must fold them into summed diffs.
+        let captured = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut input, collection) = scope.new_collection();
+                let exprs = vec![
+                    LirScalarExpr::column(0),
+                    LirScalarExpr::column(1),
+                    LirScalarExpr::literal_ok(Datum::Int64(1), ReprScalarType::Int64),
+                ];
+                let func = TableFunc::GenerateSeriesInt64;
+                // Project to only the generated value (column 2), collapsing the
+                // two input rows' distinct (start, stop) prefixes.
+                let mfp = MapFilterProject::<LirScalarExpr>::new(3)
+                    .project(vec![2])
+                    .into_plan()
+                    .expect("project mfp");
+                let stream = collection.inner;
+                let scope = stream.scope();
+                let (oks, _errs) = flat_map_stage(
+                    stream,
+                    scope,
+                    exprs,
+                    func,
+                    mfp,
+                    Antichain::new(),
+                    usize::MAX,
+                );
+                let captured = oks.capture();
+                // Both rows at t=0: generate_series(1, 2) -> {1, 2},
+                // generate_series(1, 3) -> {1, 2, 3}. Generated 1 and 2 appear on
+                // both, so they must fold to a diff of two.
+                input.advance_to(Timestamp::from(0_u64));
+                input.update(input_row(2), Diff::ONE);
+                input.update(input_row(3), Diff::ONE);
+                input.advance_to(Timestamp::from(1_u64));
+                input.flush();
+                captured
+            })
+        });
+
+        let updates = extract_sorted_columns(captured);
+        let expected = vec![
+            (
+                Row::pack_slice(&[Datum::Int64(1)]),
+                Timestamp::from(0_u64),
+                Diff::from(2),
+            ),
+            (
+                Row::pack_slice(&[Datum::Int64(2)]),
+                Timestamp::from(0_u64),
+                Diff::from(2),
+            ),
+            (
+                Row::pack_slice(&[Datum::Int64(3)]),
+                Timestamp::from(0_u64),
+                Diff::ONE,
+            ),
+        ];
+        assert_eq!(updates, expected);
     }
 }

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -29,7 +29,6 @@ use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 
 use crate::render::RenderTimestamp;
-use crate::render::columnar::CollectionEdge;
 use crate::render::context::{CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 
@@ -52,10 +51,9 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
         // a batch. A `generate_series` can still cause unavailability if it generates many rows.
         let budget = COMPUTE_FLAT_MAP_FUEL.get(&self.config_set);
 
-        // The unarranged path (no key) reads the input `CollectionEdge` directly,
-        // so the columnar arm never decodes rows at the input. The keyed path
-        // materializes an existing arrangement, which `as_specific_collection`
-        // presents as a columnar edge.
+        // The unarranged path (no key) reads the input edge directly. The keyed
+        // path materializes an existing arrangement, which
+        // `as_specific_collection` presents as a columnar edge.
         let (edge, err_collection) = match input_key.as_deref() {
             None => input
                 .collection
@@ -64,17 +62,10 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
             Some(key) => input.as_specific_collection(Some(key)),
         };
 
-        let (oks, errs) = match edge {
-            CollectionEdge::Vec(c) => {
-                flat_map_stage(c.inner, scope, exprs, func, mfp_plan, until, budget)
-            }
-            CollectionEdge::Columnar(c) => {
-                flat_map_stage(c.inner, scope, exprs, func, mfp_plan, until, budget)
-            }
-        };
+        let (oks, errs) = flat_map_stage(edge.inner, scope, exprs, func, mfp_plan, until, budget);
 
         use differential_dataflow::AsCollection;
-        let ok_collection = CollectionEdge::Columnar(oks.as_collection());
+        let ok_collection = oks.as_collection();
         let new_err_collection = errs.as_collection();
         let err_collection = err_collection.concat(new_err_collection);
         CollectionBundle::from_edge(ok_collection, err_collection)
@@ -423,56 +414,27 @@ mod tests {
     }
 
     #[mz_ore::test]
-    fn flat_map_arms_agree() {
-        // The `Vec` and `Column` input arms must produce identical `(row, time,
-        // diff)` output. Multiple timestamps and a retraction exercise time
-        // handling and negative diffs. The columnar arm's `Columnar::into_owned`
-        // for time and diff runs on every ok record here (the input decode has
-        // no fallible/try_extend path, so the standing fallible-key rule does
-        // not apply), and this comparison proves it decodes correctly.
-        let (vec_captured, col_captured) = timely::execute_directly(move |worker| {
+    fn flat_map_reads_columnar_input() {
+        // Reads the columnar input edge, expands the table function, and emits the
+        // `(row, time, diff)` output. Multiple timestamps and a retraction exercise
+        // time handling and negative diffs; the columnar input's
+        // `Columnar::into_owned` for time and diff runs on every ok record.
+        let captured = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut input, collection) = scope.new_collection();
-                let mut captures = Vec::new();
-                for columnar in [false, true] {
-                    let (exprs, func, mfp) = flat_map_args();
-                    let edge = if columnar {
-                        CollectionEdge::Columnar(vec_to_columnar(collection.clone()))
-                    } else {
-                        CollectionEdge::Vec(collection.clone())
-                    };
-                    let (oks, _errs) = match edge {
-                        CollectionEdge::Vec(c) => {
-                            let stream = c.inner;
-                            let scope = stream.scope();
-                            flat_map_stage(
-                                stream,
-                                scope,
-                                exprs,
-                                func,
-                                mfp,
-                                Antichain::new(),
-                                usize::MAX,
-                            )
-                        }
-                        CollectionEdge::Columnar(c) => {
-                            let stream = c.inner;
-                            let scope = stream.scope();
-                            flat_map_stage(
-                                stream,
-                                scope,
-                                exprs,
-                                func,
-                                mfp,
-                                Antichain::new(),
-                                usize::MAX,
-                            )
-                        }
-                    };
-                    captures.push(oks.capture());
-                }
-                let col = captures.pop().unwrap();
-                let vec = captures.pop().unwrap();
+                let (exprs, func, mfp) = flat_map_args();
+                let stream = vec_to_columnar(collection).inner;
+                let scope = stream.scope();
+                let (oks, _errs) = flat_map_stage(
+                    stream,
+                    scope,
+                    exprs,
+                    func,
+                    mfp,
+                    Antichain::new(),
+                    usize::MAX,
+                );
+                let captured = oks.capture();
                 // t=0: generate_series(1, 2); t=1: generate_series(1, 3);
                 // t=2: retract the t=0 row.
                 input.advance_to(Timestamp::from(0_u64));
@@ -483,17 +445,16 @@ mod tests {
                 input.update(input_row(2), -Diff::ONE);
                 input.advance_to(Timestamp::from(3_u64));
                 input.flush();
-                (vec, col)
+                captured
             })
         });
 
-        let vec_updates = extract_sorted_columns(vec_captured);
-        assert!(!vec_updates.is_empty());
+        let updates = extract_sorted_columns(captured);
+        assert!(!updates.is_empty());
         assert!(
-            vec_updates.iter().any(|(_, _, d)| *d < Diff::ZERO),
+            updates.iter().any(|(_, _, d)| *d < Diff::ZERO),
             "the retraction must survive as a negative diff"
         );
-        assert_eq!(vec_updates, extract_sorted_columns(col_captured));
     }
 
     /// Decodes a capture of the columnar FlatMap output into sorted owned

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -54,17 +54,14 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
 
         // The unarranged path (no key) reads the input `CollectionEdge` directly,
         // so the columnar arm never decodes rows at the input. The keyed path
-        // reads an existing arrangement, already columnar internally, and is
-        // presented as a `Vec` edge here.
+        // materializes an existing arrangement, which `as_specific_collection`
+        // presents as a columnar edge.
         let (edge, err_collection) = match input_key.as_deref() {
             None => input
                 .collection
                 .clone()
                 .expect("The unarranged collection doesn't exist."),
-            Some(key) => {
-                let (oks, errs) = input.as_specific_collection(Some(key), &self.config_set);
-                (CollectionEdge::Vec(oks), errs)
-            }
+            Some(key) => input.as_specific_collection(Some(key), &self.config_set),
         };
 
         let (oks, errs) = match edge {

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -61,7 +61,7 @@ impl<'scope, T: crate::render::RenderTimestamp> Context<'scope, T> {
                 .collection
                 .clone()
                 .expect("The unarranged collection doesn't exist."),
-            Some(key) => input.as_specific_collection(Some(key), &self.config_set),
+            Some(key) => input.as_specific_collection(Some(key)),
         };
 
         let (oks, errs) = match edge {

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -20,8 +20,6 @@ use mz_repr::{Diff, Row, RowRef, Timestamp};
 use mz_timely_util::columnar::Column;
 use mz_timely_util::columnar::consolidate::ConsolidatingColumnBuilder;
 use mz_timely_util::operator::StreamExt;
-use timely::Container;
-use timely::container::DrainContainer;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Capability;
 use timely::dataflow::operators::generic::Session;
@@ -81,48 +79,16 @@ type FlatMapOk<T> = ConsolidatingColumnBuilder<Row, T, Diff>;
 /// Output err-session container builder for [`flat_map_stage`].
 type FlatMapErr<T> = ConsolidatingContainerBuilder<Vec<(DataflowErrorSer, T, Diff)>>;
 
-/// Yields the `(row, time, diff)` records of one queued FlatMap input batch.
+/// The fueled FlatMap operator.
 ///
-/// The two edge arms differ only in how records are read from a queued batch:
-/// the `Vec` arm drains owned rows, the `Column` arm iterates the borrowed
-/// column and never materializes an owned [`Row`]. Everything else in the
-/// FlatMap operator (the fuel queue, budget, and re-activation) is shared
-/// through [`flat_map_stage`].
-trait FlatMapBatch<T> {
-    /// Calls `logic` once per record, presenting the row as a borrowed
-    /// [`RowRef`] and the time and diff by reference.
-    fn for_each_record(&mut self, logic: impl FnMut(&RowRef, &T, &Diff));
-}
-
-impl<T: RenderTimestamp> FlatMapBatch<T> for Vec<(Row, T, Diff)> {
-    fn for_each_record(&mut self, mut logic: impl FnMut(&RowRef, &T, &Diff)) {
-        for (row, time, diff) in self.drain(..) {
-            logic(&row, &time, &diff);
-        }
-    }
-}
-
-impl<T: RenderTimestamp> FlatMapBatch<T> for Column<(Row, T, Diff)> {
-    fn for_each_record(&mut self, mut logic: impl FnMut(&RowRef, &T, &Diff)) {
-        // Rows are read from the borrowed column, never materialized as owned
-        // `Row`s. Times and diffs are owned only to hand `logic` a reference.
-        for (row, t, d) in self.borrow().into_index_iter() {
-            logic(row, &Columnar::into_owned(t), &Columnar::into_owned(d));
-        }
-    }
-}
-
-/// The fueled FlatMap operator, generic over the input edge arm.
-///
-/// This is the sole owner of the fuel machinery, so the `Vec` and `Column`
-/// arms cannot drift apart. Incoming batches are queued; each activation
-/// processes queued batches and drains each record's table-function expansion
-/// through the mfp, decrementing a per-activation `budget`. When the budget is
-/// exhausted the operator re-activates itself and stops, deferring the rest of
-/// the queue to a later activation. This bounds the work a single
-/// `generate_series` can do before yielding the worker.
-fn flat_map_stage<'scope, T, C>(
-    stream: Stream<'scope, T, C>,
+/// Incoming batches are queued; each activation processes queued batches and
+/// drains each record's table-function expansion through the mfp, decrementing
+/// a per-activation `budget`. When the budget is exhausted the operator
+/// re-activates itself and stops, deferring the rest of the queue to a later
+/// activation. This bounds the work a single `generate_series` can do before
+/// yielding the worker.
+fn flat_map_stage<'scope, T>(
+    stream: Stream<'scope, T, Column<(Row, T, Diff)>>,
     scope: Scope<'scope, T>,
     exprs: Vec<LirScalarExpr>,
     func: TableFunc,
@@ -135,7 +101,6 @@ fn flat_map_stage<'scope, T, C>(
 )
 where
     T: RenderTimestamp,
-    C: Container + DrainContainer + Clone + Default + FlatMapBatch<T> + 'static,
 {
     stream.unary_fallible::<FlatMapOk<T>, FlatMapErr<T>, _, _>(
         Pipeline,
@@ -156,15 +121,20 @@ where
                     queue.push_back((cap.retain(0), cap.retain(1), std::mem::take(data)))
                 });
 
-                while let Some((ok_cap, err_cap, mut data)) = queue.pop_front() {
+                while let Some((ok_cap, err_cap, data)) = queue.pop_front() {
                     let mut ok_session = ok_output.session_with_builder(&ok_cap);
                     let mut err_session = err_output.session_with_builder(&err_cap);
 
-                    data.for_each_record(|input_row, time, diff| {
+                    // Rows are read from the borrowed column, never materialized
+                    // as owned `Row`s. Times and diffs are owned only to pass
+                    // them by reference.
+                    for (input_row, t, d) in data.borrow().into_index_iter() {
+                        let time = Columnar::into_owned(t);
+                        let diff = Columnar::into_owned(d);
                         process_flat_map_row(
                             input_row,
-                            time,
-                            diff,
+                            &time,
+                            &diff,
                             &exprs,
                             &func,
                             &mfp_plan,
@@ -176,7 +146,7 @@ where
                             &mut err_session,
                             &mut budget,
                         );
-                    });
+                    }
                     if budget == 0 {
                         activator.activate();
                         break;
@@ -359,7 +329,9 @@ mod tests {
             let mut input = worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (input, collection) = scope.new_collection();
                 let (exprs, func, mfp) = flat_map_args();
-                let stream = collection.inner;
+                // Feed the operator the columnar edge it is given in production,
+                // so the fuel assertions below cover the shipped path.
+                let stream = vec_to_columnar(collection).inner;
                 let scope = stream.scope();
                 let (oks, _errs) =
                     flat_map_stage(stream, scope, exprs, func, mfp, Antichain::new(), budget);
@@ -505,7 +477,7 @@ mod tests {
                     .project(vec![2])
                     .into_plan()
                     .expect("project mfp");
-                let stream = collection.inner;
+                let stream = vec_to_columnar(collection).inner;
                 let scope = stream.scope();
                 let (oks, _errs) = flat_map_stage(
                     stream,

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -39,6 +39,7 @@ use timely::dataflow::operators::vec::Map;
 use timely::progress::Antichain;
 
 use crate::render::RenderTimestamp;
+use crate::render::columnar::{CollectionEdge, vec_to_columnar};
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{RowRowAgent, RowRowEnter};
@@ -245,7 +246,13 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                     .leave_region(self.scope),
             )
         });
-        CollectionBundle::from_collections(oks, errs)
+        // The delta join is Vec-internal (half_join, the `ok_err` demux, the
+        // time-unpair map, and the per-path finalization all operate on `Vec`).
+        // Encode the concatenated node output to the columnar edge once here.
+        // This is the sanctioned leaf-encode; a columnar `half_join`/algorithm is
+        // a differential-side follow-up. Non-consolidating: the per-path
+        // finalization already consolidated whatever it consolidates.
+        CollectionBundle::from_edge(CollectionEdge::Columnar(vec_to_columnar(oks)), errs)
     }
 }
 

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -39,7 +39,7 @@ use timely::dataflow::operators::vec::Map;
 use timely::progress::Antichain;
 
 use crate::render::RenderTimestamp;
-use crate::render::columnar::{columnar_to_vec, vec_to_columnar};
+use crate::render::columnar::{CollectionEdge, flat_map_datums, vec_to_columnar};
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{RowRowAgent, RowRowEnter};
@@ -686,12 +686,7 @@ where
             .collection
             .clone()
             .expect("The unarranged collection doesn't exist.");
-        let (oks, errs2) = build_update_stream_stream(
-            columnar_to_vec(oks),
-            as_of,
-            source_relation,
-            initial_closure,
-        );
+        let (oks, errs2) = build_update_stream_stream(oks, as_of, source_relation, initial_closure);
         return (oks, errs2.concat(errs));
     };
     match bundle.arrangement(&source_key) {
@@ -839,7 +834,7 @@ where
 /// first relation can be seeded from a raw collection, since the as-of filtering that the other
 /// paths rely on is only available from an arrangement's times. We assert that here.
 fn build_update_stream_stream<'scope, T>(
-    stream: VecCollection<'scope, T, Row, Diff>,
+    edge: CollectionEdge<'scope, T>,
     _as_of: Antichain<mz_repr::Timestamp>,
     source_relation: usize,
     initial_closure: JoinClosure,
@@ -855,18 +850,38 @@ where
     assert_eq!(source_relation, 0);
 
     type CB<C> = ConsolidatingContainerBuilder<C>;
-    stream.flat_map_fallible::<CB<_>, CB<_>, _, _, _, _>("UpdateStream", {
-        // Reuseable allocation for unpacking.
-        let mut datums = DatumVec::new();
-        move |row| {
+    // The closure reads datums and builds a fresh row, so the input row is only
+    // ever borrowed. Reading it from the column directly keeps this path from
+    // materializing an owned `Row` per record.
+    let (oks, errs) = flat_map_datums::<_, CB<Vec<(Row, T, Diff)>>, _>(edge, usize::MAX, {
+        let mut datum_vec = DatumVec::new();
+        move |row_datums, time, diff, ok_session, err_session| {
             let mut row_builder = SharedRow::get();
             let temp_storage = RowArena::new();
-            let mut datums_local = datums.borrow_with(&row);
-            initial_closure
-                .apply(&mut datums_local, &temp_storage, &mut row_builder)
+            // `JoinClosure::apply` unifies the lifetimes of `&self`, the datums,
+            // and the arena. Copying the datums into a local vec lets that
+            // lifetime shrink to this call. The copy moves datum references, not
+            // row data.
+            let mut datums = datum_vec.borrow();
+            datums.extend(row_datums.iter());
+            // `cloned` detaches the result from `temp_storage` and the shared row
+            // builder, both of which drop at the end of this call.
+            match initial_closure
+                .apply(&mut datums, &temp_storage, &mut row_builder)
                 .map(|row| row.cloned())
-                .map_err(DataflowErrorSer::from)
                 .transpose()
+            {
+                Some(Ok(row)) => {
+                    ok_session.give((row, time, diff));
+                    1
+                }
+                None => 0,
+                Some(Err(e)) => {
+                    err_session.give((DataflowErrorSer::from(e), time, diff));
+                    1
+                }
+            }
         }
-    })
+    });
+    (oks.as_collection(), errs.as_collection())
 }

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -39,7 +39,7 @@ use timely::dataflow::operators::vec::Map;
 use timely::progress::Antichain;
 
 use crate::render::RenderTimestamp;
-use crate::render::columnar::{CollectionEdge, vec_to_columnar};
+use crate::render::columnar::{columnar_to_vec, vec_to_columnar};
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::typedefs::{RowRowAgent, RowRowEnter};
@@ -252,7 +252,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
         // This is the sanctioned leaf-encode; a columnar `half_join`/algorithm is
         // a differential-side follow-up. Non-consolidating: the per-path
         // finalization already consolidated whatever it consolidates.
-        CollectionBundle::from_edge(CollectionEdge::Columnar(vec_to_columnar(oks)), errs)
+        CollectionBundle::from_edge(vec_to_columnar(oks), errs)
     }
 }
 
@@ -686,8 +686,12 @@ where
             .collection
             .clone()
             .expect("The unarranged collection doesn't exist.");
-        let (oks, errs2) =
-            build_update_stream_stream(oks.into_vec(), as_of, source_relation, initial_closure);
+        let (oks, errs2) = build_update_stream_stream(
+            columnar_to_vec(oks),
+            as_of,
+            source_relation,
+            initial_closure,
+        );
         return (oks, errs2.concat(errs));
     };
     match bundle.arrangement(&source_key) {

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -13,6 +13,7 @@
 
 use std::time::{Duration, Instant};
 
+use columnar::{Columnar, Index};
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::arrangement::Arranged;
@@ -24,6 +25,7 @@ use mz_compute_types::dyncfgs::{
 };
 use mz_compute_types::plan::join::JoinClosure;
 use mz_compute_types::plan::join::linear_join::{LinearJoinPlan, LinearStagePlan};
+use mz_compute_types::plan::scalar::LirScalarExpr;
 use mz_dyncfg::ConfigSet;
 use mz_expr::Eval;
 use mz_repr::fixed_length::ExtendDatums;
@@ -38,6 +40,7 @@ use timely::dataflow::operators::OkErr;
 
 use crate::extensions::arrange::MzArrangeCore;
 use crate::render::RenderTimestamp;
+use crate::render::columnar::CollectionEdge;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::render::join::mz_join_core::mz_join_core;
@@ -189,8 +192,10 @@ impl YieldSpec {
 
 /// Different forms the streamed data might take.
 enum JoinedFlavor<'scope, T: RenderTimestamp> {
-    /// Streamed data as a collection.
-    Collection(VecCollection<'scope, T, Row, Diff>),
+    /// Streamed data as a collection edge. `differential_join` forms its
+    /// arrangement key off the edge, so a columnar source flows in without a
+    /// `ColumnarToVec` decode.
+    Collection(CollectionEdge<'scope, T>),
     /// A dataflow-local arrangement.
     Local(Arranged<'scope, RowRowAgent<T, Diff>>),
     /// An imported arrangement.
@@ -241,39 +246,60 @@ where
             (_, initial_closure) => {
                 // TODO: extract closure from the first stage in the join plan, should it exist.
                 // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
-                let (joined, errs) = inputs[linear_plan.source_relation]
-                    .as_specific_collection(linear_plan.source_key.as_deref(), &self.config_set);
+                let (joined, errs) = match linear_plan.source_key.as_deref() {
+                    // No source key: consume the input edge directly rather than
+                    // decoding it to `Vec`. `differential_join` forms the source
+                    // arrangement key off this edge below (C1 borrowed-push
+                    // pattern), so a columnar source has no `ColumnarToVec` hop.
+                    None => inputs[linear_plan.source_relation]
+                        .collection
+                        .clone()
+                        .expect("The unarranged collection doesn't exist."),
+                    // With a source key the input is read from an existing
+                    // arrangement, which is already columnar internally; wrap its
+                    // decoded rows as a `Vec` edge.
+                    Some(key) => {
+                        let (oks, errs) = inputs[linear_plan.source_relation]
+                            .as_specific_collection(Some(key), &self.config_set);
+                        (CollectionEdge::Vec(oks), errs)
+                    }
+                };
                 errors.push(errs.enter_region(inner));
-                let mut joined = joined.enter_region(inner);
+                let joined = joined.enter_region(inner);
 
                 // In the current code this should always be `None`, but we have this here should
                 // we change that and want to know what we should be doing.
                 if let Some(closure) = initial_closure {
                     // If there is no starting arrangement, then we can run filters
                     // directly on the starting collection.
-                    // If there is only one input, we are done joining, so run filters
+                    // If there is only one input, we are done joining, so run filters.
+                    // `into_vec` is the identity on the `Vec` arm, so this is
+                    // unchanged for `Vec` sources; a columnar source decodes here,
+                    // but this branch is never taken in current lowering.
                     let name = "LinearJoinInitialization";
                     type CB<C> = ConsolidatingContainerBuilder<C>;
-                    let (j, errs) = joined.flat_map_fallible::<CB<_>, CB<_>, _, _, _, _>(name, {
-                        // Reuseable allocation for unpacking.
-                        let mut datums = DatumVec::new();
-                        move |row| {
-                            let mut row_builder = SharedRow::get();
-                            let temp_storage = RowArena::new();
-                            let mut datums_local = datums.borrow_with(&row);
-                            // TODO(mcsherry): re-use `row` allocation.
-                            closure
-                                .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                                .map(|row| row.cloned())
-                                .map_err(DataflowErrorSer::from)
-                                .transpose()
-                        }
-                    });
-                    joined = j;
+                    let (j, errs) = joined
+                        .into_vec()
+                        .flat_map_fallible::<CB<_>, CB<_>, _, _, _, _>(name, {
+                            // Reuseable allocation for unpacking.
+                            let mut datums = DatumVec::new();
+                            move |row| {
+                                let mut row_builder = SharedRow::get();
+                                let temp_storage = RowArena::new();
+                                let mut datums_local = datums.borrow_with(&row);
+                                // TODO(mcsherry): re-use `row` allocation.
+                                closure
+                                    .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                                    .map(|row| row.cloned())
+                                    .map_err(DataflowErrorSer::from)
+                                    .transpose()
+                            }
+                        });
                     errors.push(errs);
+                    JoinedFlavor::Collection(CollectionEdge::Vec(j))
+                } else {
+                    JoinedFlavor::Collection(joined)
                 }
-
-                JoinedFlavor::Collection(joined)
             }
         };
 
@@ -287,14 +313,18 @@ where
                 stage_plan,
                 &mut errors,
             );
-            // Update joined results and capture any errors.
-            joined = JoinedFlavor::Collection(stream);
+            // Update joined results and capture any errors. Stage output is a
+            // `Vec` collection.
+            joined = JoinedFlavor::Collection(CollectionEdge::Vec(stream));
         }
 
         // We have completed the join building, but may have work remaining.
         // For example, we may have expressions not pushed down (e.g. literals)
         // and projections that could not be applied (e.g. column repetition).
-        let bundle = if let JoinedFlavor::Collection(mut joined) = joined {
+        let bundle = if let JoinedFlavor::Collection(joined) = joined {
+            // The join output is a `Vec` collection, so `into_vec` is the identity
+            // on the `Vec` arm.
+            let mut joined = joined.into_vec();
             if let Some(closure) = linear_plan.final_closure {
                 let name = "LinearJoinFinalization";
                 type CB<C> = ConsolidatingContainerBuilder<C>;
@@ -346,67 +376,13 @@ where
     ) -> VecCollection<'s, T, Row, Diff> {
         // If we have only a streamed collection, we must first form an arrangement.
         if let JoinedFlavor::Collection(stream) = joined {
-            let name = "LinearJoinKeyPreparation";
-            let (keyed, errs) = stream
-                .inner
-                .unary_fallible::<ColumnBuilder<((Row, Row), T, Diff)>, _, _, _>(
-                    Pipeline,
-                    name,
-                    |_, _| {
-                        Box::new(move |input, ok, errs| {
-                            let mut temp_storage = RowArena::new();
-                            let mut key_buf = Row::default();
-                            let mut val_buf = Row::default();
-                            let mut datums = DatumVec::new();
-                            input.for_each(|time, data| {
-                                let mut ok_session = ok.session_with_builder(&time);
-                                let mut err_session = errs.session(&time);
-                                for (row, time, diff) in data.iter() {
-                                    temp_storage.clear();
-                                    let datums_local = datums.borrow_with(row);
-                                    let datums = stream_key
-                                        .iter()
-                                        .map(|e| e.eval(&datums_local, &temp_storage));
-                                    let result = key_buf.packer().try_extend(datums);
-                                    match result {
-                                        Ok(()) => {
-                                            val_buf.packer().extend(
-                                                stream_thinning.iter().map(|e| datums_local[*e]),
-                                            );
-                                            ok_session.give(((&key_buf, &val_buf), time, diff));
-                                        }
-                                        Err(e) => {
-                                            err_session.give((e.into(), time.clone(), *diff));
-                                        }
-                                    }
-                                }
-                            });
-                        })
-                    },
-                );
-
-            errors.push(errs.as_collection());
-
-            let exchange = ExchangeCore::<ColumnBuilder<_>, _>::new_core(
-                columnar_exchange::<Row, Row, T, Diff>,
+            let (arranged, errs) = arrange_join_input(
+                stream,
+                stream_key,
+                stream_thinning,
+                ENABLE_COLUMN_PAGED_BATCHER.get(&self.config_set),
             );
-            let arranged = if ENABLE_COLUMN_PAGED_BATCHER.get(&self.config_set) {
-                keyed.mz_arrange_core::<
-                    _,
-                    batcher::ColumnChunker<_>,
-                    Col2ValPagedBatcher<_, _, _, _>,
-                    RowRowColPagedBuilder<_, _>,
-                    RowRowSpine<_, _>,
-                >(exchange, "JoinStage")
-            } else {
-                keyed.mz_arrange_core::<
-                    _,
-                    batcher::Chunker<_>,
-                    Col2ValBatcher<_, _, _, _>,
-                    RowRowBuilder<_, _>,
-                    RowRowSpine<_, _>,
-                >(exchange, "JoinStage")
-            };
+            errors.push(errs);
             joined = JoinedFlavor::Local(arranged);
         }
 
@@ -540,5 +516,307 @@ where
 
             (oks, None)
         }
+    }
+}
+
+/// Forms the source arrangement for a streamed join input off a collection edge.
+///
+/// Both arms build the same `((key, value), t, d)` columnar updates and push the
+/// key and value borrowed into a `ColumnBuilder`, which the `Col2Val` batcher
+/// consumes. This is the zero-allocation pattern: no owned `Row` per record on
+/// the ok path. The arms differ only in how records are read, the `Vec` arm from
+/// the owned container and the columnar arm from the borrowed column, and in the
+/// error path, which owns time and diff.
+fn arrange_join_input<'s, T>(
+    edge: CollectionEdge<'s, T>,
+    stream_key: Vec<LirScalarExpr>,
+    stream_thinning: Vec<usize>,
+    use_paged_path: bool,
+) -> (
+    Arranged<'s, RowRowAgent<T, Diff>>,
+    VecCollection<'s, T, DataflowErrorSer, Diff>,
+)
+where
+    T: Lattice + RenderTimestamp,
+{
+    let name = "LinearJoinKeyPreparation";
+    let (keyed, errs) = match edge {
+        CollectionEdge::Vec(stream) => stream
+            .inner
+            .unary_fallible::<ColumnBuilder<((Row, Row), T, Diff)>, _, _, _>(
+                Pipeline,
+                name,
+                |_, _| {
+                    Box::new(move |input, ok, errs| {
+                        let mut temp_storage = RowArena::new();
+                        let mut key_buf = Row::default();
+                        let mut val_buf = Row::default();
+                        let mut datums = DatumVec::new();
+                        input.for_each(|time, data| {
+                            let mut ok_session = ok.session_with_builder(&time);
+                            let mut err_session = errs.session(&time);
+                            for (row, time, diff) in data.iter() {
+                                temp_storage.clear();
+                                let datums_local = datums.borrow_with(row);
+                                let datums = stream_key
+                                    .iter()
+                                    .map(|e| e.eval(&datums_local, &temp_storage));
+                                match key_buf.packer().try_extend(datums) {
+                                    Ok(()) => {
+                                        val_buf.packer().extend(
+                                            stream_thinning.iter().map(|e| datums_local[*e]),
+                                        );
+                                        ok_session.give(((&key_buf, &val_buf), time, diff));
+                                    }
+                                    Err(e) => {
+                                        err_session.give((e.into(), time.clone(), *diff));
+                                    }
+                                }
+                            }
+                        });
+                    })
+                },
+            ),
+        CollectionEdge::Columnar(stream) => stream
+            .inner
+            .unary_fallible::<ColumnBuilder<((Row, Row), T, Diff)>, _, _, _>(
+                Pipeline,
+                name,
+                |_, _| {
+                    Box::new(move |input, ok, errs| {
+                        let mut temp_storage = RowArena::new();
+                        let mut key_buf = Row::default();
+                        let mut val_buf = Row::default();
+                        let mut datums = DatumVec::new();
+                        input.for_each(|time, data| {
+                            let mut ok_session = ok.session_with_builder(&time);
+                            let mut err_session = errs.session(&time);
+                            // Rows are read from the borrowed column; the key and
+                            // value are pushed borrowed. Time and diff are owned
+                            // only on the error path.
+                            for (row, time, diff) in data.borrow().into_index_iter() {
+                                temp_storage.clear();
+                                let datums_local = datums.borrow_with(row);
+                                let datums = stream_key
+                                    .iter()
+                                    .map(|e| e.eval(&datums_local, &temp_storage));
+                                match key_buf.packer().try_extend(datums) {
+                                    Ok(()) => {
+                                        val_buf.packer().extend(
+                                            stream_thinning.iter().map(|e| datums_local[*e]),
+                                        );
+                                        ok_session.give(((&key_buf, &val_buf), time, diff));
+                                    }
+                                    Err(e) => {
+                                        err_session.give((
+                                            e.into(),
+                                            Columnar::into_owned(time),
+                                            Columnar::into_owned(diff),
+                                        ));
+                                    }
+                                }
+                            }
+                        });
+                    })
+                },
+            ),
+    };
+
+    let exchange =
+        ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, T, Diff>);
+    let arranged = if use_paged_path {
+        keyed.mz_arrange_core::<
+            _,
+            batcher::ColumnChunker<_>,
+            Col2ValPagedBatcher<_, _, _, _>,
+            RowRowColPagedBuilder<_, _>,
+            RowRowSpine<_, _>,
+        >(exchange, "JoinStage")
+    } else {
+        keyed.mz_arrange_core::<
+            _,
+            batcher::Chunker<_>,
+            Col2ValBatcher<_, _, _, _>,
+            RowRowBuilder<_, _>,
+            RowRowSpine<_, _>,
+        >(exchange, "JoinStage")
+    };
+    (arranged, errs.as_collection())
+}
+
+#[cfg(test)]
+mod tests {
+    use differential_dataflow::input::Input;
+    use mz_expr::EvalError;
+    use mz_repr::{Datum, ReprScalarType, Timestamp};
+    use timely::dataflow::operators::Capture;
+    use timely::dataflow::operators::capture::{Event, Extract};
+
+    use super::*;
+    use crate::render::columnar::vec_to_columnar;
+
+    type KeyedUpdate = ((Row, Row), Timestamp, Diff);
+    type ErrUpdate = (DataflowErrorSer, Timestamp, Diff);
+    type Captured<D> = std::sync::mpsc::Receiver<Event<Timestamp, Vec<D>>>;
+
+    fn extract_sorted(captured: Captured<KeyedUpdate>) -> Vec<KeyedUpdate> {
+        let mut updates: Vec<_> = captured
+            .extract()
+            .into_iter()
+            .flat_map(|(_, data)| data)
+            .collect();
+        updates.sort();
+        updates
+    }
+
+    // `DataflowErrorSer` is not `Ord`, so project the error to its debug string
+    // for a stable ordering. The time and diff ride along, so this verifies the
+    // columnar arm's `into_owned` on the error path reconstructs the same
+    // `(time, diff)` as the `Vec` arm.
+    fn extract_err(captured: Captured<ErrUpdate>) -> Vec<(String, Timestamp, Diff)> {
+        let mut updates: Vec<_> = captured
+            .extract()
+            .into_iter()
+            .flat_map(|(_, data)| data)
+            .map(|(e, t, d)| (format!("{e:?}"), t, d))
+            .collect();
+        updates.sort();
+        updates
+    }
+
+    /// Input rows tagged with distinct timestamps and mixed-sign diffs. The two
+    /// `-1` records retract at a `(row, time)` with no matching insertion, so they
+    /// survive the `InputSession`'s pre-send consolidation and exercise a negative
+    /// diff on the ok path (pushed borrowed, not owned).
+    fn test_input() -> Vec<(Row, u64, Diff)> {
+        vec![
+            (
+                Row::pack_slice(&[Datum::Int32(1), Datum::String("a")]),
+                0,
+                Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::Int32(2), Datum::String("b")]),
+                1,
+                Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::Int32(1), Datum::String("c")]),
+                2,
+                Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::Int32(3), Datum::Null]),
+                2,
+                Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::Int32(2), Datum::String("b")]),
+                2,
+                -Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::Int32(4), Datum::String("d")]),
+                1,
+                -Diff::ONE,
+            ),
+        ]
+    }
+
+    /// Runs `arrange_join_input` against the same input fed once as a `Vec` edge
+    /// and once as a columnar edge, keying by `key` with column 1 as the value.
+    /// Returns the sorted ok updates (read back from each arrangement) and the
+    /// sorted err updates of each arm.
+    #[allow(clippy::type_complexity)]
+    fn run_both_arms(
+        input: Vec<(Row, u64, Diff)>,
+        key: Vec<LirScalarExpr>,
+    ) -> (
+        Vec<KeyedUpdate>,
+        Vec<KeyedUpdate>,
+        Vec<(String, Timestamp, Diff)>,
+        Vec<(String, Timestamp, Diff)>,
+    ) {
+        let (ok_vec, ok_col, err_vec, err_col) = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut handle, collection) = scope.new_collection();
+                let mut ok_caps = Vec::new();
+                let mut err_caps = Vec::new();
+                for edge in [
+                    CollectionEdge::Vec(collection.clone()),
+                    CollectionEdge::Columnar(vec_to_columnar(collection)),
+                ] {
+                    let (arranged, errs) = arrange_join_input(edge, key.clone(), vec![1], false);
+                    let keyed = arranged.as_collection(|k, v| (k.to_row(), v.to_row()));
+                    ok_caps.push(keyed.inner.capture());
+                    err_caps.push(errs.inner.capture());
+                }
+                let err_col = err_caps.pop().unwrap();
+                let err_vec = err_caps.pop().unwrap();
+                let ok_col = ok_caps.pop().unwrap();
+                let ok_vec = ok_caps.pop().unwrap();
+                for (row, time, diff) in input {
+                    handle.update_at(row, Timestamp::from(time), diff);
+                }
+                handle.advance_to(Timestamp::from(3_u64));
+                handle.flush();
+                (ok_vec, ok_col, err_vec, err_col)
+            })
+        });
+        (
+            extract_sorted(ok_vec),
+            extract_sorted(ok_col),
+            extract_err(err_vec),
+            extract_err(err_col),
+        )
+    }
+
+    /// The columnar arm of `arrange_join_input` forms the same keyed arrangement
+    /// as the `Vec` arm, across several distinct timestamps and a retraction.
+    ///
+    /// This proves the columnar key-forming is correct and that the columnar arm
+    /// ran (the input is fed through `vec_to_columnar`). It does not prove the
+    /// absence of a silent `ColumnarToVec` decode on the ok path: such a decode
+    /// would yield identical contents. No-decode holds by code inspection, the
+    /// columnar arm reads via `into_index_iter` and pushes the key and value
+    /// borrowed into the `ColumnBuilder`, never calling `into_vec`.
+    ///
+    /// The stream key here is infallible column projection, so `try_extend` never
+    /// fails and the ok path pushes the diff borrowed. The retraction records
+    /// exercise a negative diff on that borrowed ok path. `Columnar::into_owned`
+    /// runs only on the error path, which `arrange_join_input_arms_agree_on_error_path`
+    /// covers.
+    #[mz_ore::test]
+    fn arrange_join_input_arms_agree() {
+        let (ok_vec, ok_col, err_vec, err_col) =
+            run_both_arms(test_input(), vec![LirScalarExpr::column(0)]);
+        assert!(!ok_vec.is_empty());
+        assert_eq!(ok_vec, ok_col);
+        assert!(err_vec.is_empty() && err_col.is_empty());
+        // A retraction survives into the arrangement, so the ok path handled a
+        // negative (borrowed) diff.
+        assert!(ok_vec.iter().any(|(_, _, d)| *d < Diff::ZERO));
+        // Key is column 0, value is column 1 (the thinning), so both are single
+        // datums.
+        for ((key, value), _t, _d) in &ok_vec {
+            assert_eq!(key.iter().count(), 1);
+            assert_eq!(value.iter().count(), 1);
+        }
+    }
+
+    /// A key expression that always errors drives every record onto the
+    /// `try_extend` Err branch, exercising the columnar arm's `Columnar::into_owned`
+    /// reconstruction of each error's `(time, diff)`. Both arms must agree on the
+    /// errors, and the ok output must be empty on both.
+    #[mz_ore::test]
+    fn arrange_join_input_arms_agree_on_error_path() {
+        let key = vec![LirScalarExpr::literal(
+            Err(EvalError::DivisionByZero),
+            ReprScalarType::Int32,
+        )];
+        let (ok_vec, ok_col, err_vec, err_col) = run_both_arms(test_input(), key);
+        assert!(ok_vec.is_empty() && ok_col.is_empty());
+        assert!(!err_vec.is_empty());
+        assert_eq!(err_vec, err_col);
     }
 }

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -30,14 +30,15 @@ use mz_dyncfg::ConfigSet;
 use mz_expr::Eval;
 use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, Diff, Row, RowArena, SharedRow};
+use mz_timely_util::columnar::Column;
 use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::consolidate::ConsolidatingColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, Col2ValPagedBatcher, columnar_exchange};
 use mz_timely_util::operator::{CollectionExt, StreamExt};
-use timely::dataflow::Scope;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::operators::OkErr;
+use timely::dataflow::{Scope, Stream};
 
 use crate::extensions::arrange::MzArrangeCore;
 use crate::render::RenderTimestamp;
@@ -193,10 +194,14 @@ impl YieldSpec {
 
 /// Different forms the streamed data might take.
 enum JoinedFlavor<'scope, T: RenderTimestamp> {
-    /// Streamed data as a collection edge. `differential_join` forms its
-    /// arrangement key off the edge, so a columnar source flows in without a
-    /// `ColumnarToVec` decode.
-    Collection(CollectionEdge<'scope, T>),
+    /// The join's source input as a collection edge, before it enters the first
+    /// stage. `differential_join` forms its arrangement key off the edge, so a
+    /// columnar source flows in without a `ColumnarToVec` decode.
+    Edge(CollectionEdge<'scope, T>),
+    /// The intra-operator multi-stage accumulator. `mz_join_core` is
+    /// `Vec`-internal, so the accumulator is a bare `VecCollection`, not an
+    /// inter-node edge.
+    Collection(VecCollection<'scope, T, Row, Diff>),
     /// A dataflow-local arrangement.
     Local(Arranged<'scope, RowRowAgent<T, Diff>>),
     /// An imported arrangement.
@@ -296,9 +301,9 @@ where
                             }
                         });
                     errors.push(errs);
-                    JoinedFlavor::Collection(CollectionEdge::Vec(j))
+                    JoinedFlavor::Collection(j)
                 } else {
-                    JoinedFlavor::Collection(joined)
+                    JoinedFlavor::Edge(joined)
                 }
             }
         };
@@ -313,62 +318,70 @@ where
                 stage_plan,
                 &mut errors,
             );
-            // Update joined results and capture any errors. Stage output is a
-            // `Vec` collection.
-            joined = JoinedFlavor::Collection(CollectionEdge::Vec(stream));
+            // Update joined results and capture any errors. `mz_join_core`
+            // produces a `Vec` collection, the intra-operator accumulator.
+            joined = JoinedFlavor::Collection(stream);
         }
 
         // We have completed the join building, but may have work remaining.
         // For example, we may have expressions not pushed down (e.g. literals)
         // and projections that could not be applied (e.g. column repetition).
-        let bundle = if let JoinedFlavor::Collection(joined) = joined {
-            let ok_edge = if let Some(closure) = linear_plan.final_closure {
-                // The finalization closure computes fresh output rows, so build them into
-                // a `ConsolidatingColumnBuilder` (owned give), matching the prior
-                // `ConsolidatingContainerBuilder` and folding within-batch duplicates.
-                let name = "LinearJoinFinalization";
-                type OkCB<T> = ConsolidatingColumnBuilder<Row, T, Diff>;
-                type ErrCB<C> = ConsolidatingContainerBuilder<C>;
-                let (updates, errs) = joined
-                    .into_vec()
-                    .flat_map_fallible::<OkCB<T>, ErrCB<_>, _, _, _, _>(name, {
-                        // Reuseable allocation for unpacking.
-                        let mut datums = DatumVec::new();
-                        move |row| {
-                            let mut row_builder = SharedRow::get();
-                            let temp_storage = RowArena::new();
-                            let mut datums_local = datums.borrow_with(&row);
-                            // TODO(mcsherry): re-use `row` allocation.
-                            closure
-                                .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                                .map(|row| row.cloned())
-                                .map_err(DataflowErrorSer::from)
-                                .transpose()
-                        }
-                    });
-                errors.push(errs);
-                CollectionEdge::Columnar(updates)
-            } else {
-                // Identity finalization: the raw stage output is the result.
-                // `mz_join_core` produces a `Vec` collection (intra-operator,
-                // unchanged), so encode it to the columnar edge via the sanctioned
-                // leaf-encode, non-consolidating to match the raw output. A columnar
-                // source (single-input join) is already an edge and passes through
-                // with no round-trip.
-                match joined {
-                    CollectionEdge::Columnar(c) => CollectionEdge::Columnar(c),
-                    CollectionEdge::Vec(s) => CollectionEdge::Columnar(vec_to_columnar(s)),
-                }
+        // The result is either the source edge (single-input join, no stages) or
+        // the `Vec` accumulator (after one or more stages); it is never arranged.
+        let ok_edge = if let Some(closure) = linear_plan.final_closure {
+            // The finalization closure computes fresh output rows, so build them into
+            // a `ConsolidatingColumnBuilder` (owned give), matching the prior
+            // `ConsolidatingContainerBuilder` and folding within-batch duplicates. A
+            // source edge is decoded to `Vec` first (`into_vec` is the identity on the
+            // `Vec` arm); the accumulator is already a `VecCollection`.
+            let input = match joined {
+                JoinedFlavor::Edge(edge) => edge.into_vec(),
+                JoinedFlavor::Collection(collection) => collection,
+                _ => panic!("Unexpectedly arranged join output"),
             };
-
-            // Return joined results and all produced errors collected together.
-            CollectionBundle::from_edge(
-                ok_edge,
-                differential_dataflow::collection::concatenate(inner, errors),
-            )
+            let name = "LinearJoinFinalization";
+            type OkCB<T> = ConsolidatingColumnBuilder<Row, T, Diff>;
+            type ErrCB<C> = ConsolidatingContainerBuilder<C>;
+            let (updates, errs) = input.flat_map_fallible::<OkCB<T>, ErrCB<_>, _, _, _, _>(name, {
+                // Reuseable allocation for unpacking.
+                let mut datums = DatumVec::new();
+                move |row| {
+                    let mut row_builder = SharedRow::get();
+                    let temp_storage = RowArena::new();
+                    let mut datums_local = datums.borrow_with(&row);
+                    // TODO(mcsherry): re-use `row` allocation.
+                    closure
+                        .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                        .map(|row| row.cloned())
+                        .map_err(DataflowErrorSer::from)
+                        .transpose()
+                }
+            });
+            errors.push(errs);
+            CollectionEdge::Columnar(updates)
         } else {
-            panic!("Unexpectedly arranged join output");
+            // Identity finalization: the raw output is the result, encoded to the
+            // columnar edge via the sanctioned leaf-encode, non-consolidating to match
+            // the raw output. A columnar source (single-input join) is already an edge
+            // and passes through with no round-trip; the `Vec` accumulator and a `Vec`
+            // source encode via `vec_to_columnar`.
+            match joined {
+                JoinedFlavor::Edge(CollectionEdge::Columnar(c)) => CollectionEdge::Columnar(c),
+                JoinedFlavor::Edge(CollectionEdge::Vec(s)) => {
+                    CollectionEdge::Columnar(vec_to_columnar(s))
+                }
+                JoinedFlavor::Collection(collection) => {
+                    CollectionEdge::Columnar(vec_to_columnar(collection))
+                }
+                _ => panic!("Unexpectedly arranged join output"),
+            }
         };
+
+        // Return joined results and all produced errors collected together.
+        let bundle = CollectionBundle::from_edge(
+            ok_edge,
+            differential_dataflow::collection::concatenate(inner, errors),
+        );
         bundle.leave_region(self.scope)
     }
 
@@ -387,16 +400,29 @@ where
         }: LinearStagePlan,
         errors: &mut Vec<VecCollection<'s, T, DataflowErrorSer, Diff>>,
     ) -> VecCollection<'s, T, Row, Diff> {
-        // If we have only a streamed collection, we must first form an arrangement.
-        if let JoinedFlavor::Collection(stream) = joined {
-            let (arranged, errs) = arrange_join_input(
-                stream,
-                stream_key,
-                stream_thinning,
-                ENABLE_COLUMN_PAGED_BATCHER.get(&self.config_set),
-            );
-            errors.push(errs);
-            joined = JoinedFlavor::Local(arranged);
+        // If we have a streamed input, we must first form an arrangement. The
+        // source edge keys off the `CollectionEdge` (a columnar source has no
+        // `ColumnarToVec` hop); the intra-operator accumulator is a bare
+        // `VecCollection` and keys off its `Vec`-forming logic.
+        let use_paged_path = ENABLE_COLUMN_PAGED_BATCHER.get(&self.config_set);
+        match joined {
+            JoinedFlavor::Edge(edge) => {
+                let (arranged, errs) =
+                    arrange_join_input(edge, stream_key, stream_thinning, use_paged_path);
+                errors.push(errs);
+                joined = JoinedFlavor::Local(arranged);
+            }
+            JoinedFlavor::Collection(collection) => {
+                let (arranged, errs) = arrange_join_collection(
+                    collection,
+                    stream_key,
+                    stream_thinning,
+                    use_paged_path,
+                );
+                errors.push(errs);
+                joined = JoinedFlavor::Local(arranged);
+            }
+            JoinedFlavor::Local(_) | JoinedFlavor::Trace(_) => {}
         }
 
         // Demultiplex the four different cross products of arrangement types we might have.
@@ -405,8 +431,8 @@ where
             .expect("Arrangement absent despite explicit construction");
 
         match joined {
-            JoinedFlavor::Collection(_) => {
-                unreachable!("JoinedFlavor::VecCollection variant avoided at top of method");
+            JoinedFlavor::Edge(_) | JoinedFlavor::Collection(_) => {
+                unreachable!("streamed join input arranged at top of method");
             }
             JoinedFlavor::Local(local) => match arrangement {
                 ArrangementFlavor::Local(oks, errs1) => {
@@ -532,6 +558,95 @@ where
     }
 }
 
+/// Keys a row-formatted join input stream into columnar `((key, value), t, d)`
+/// updates, splitting off key-evaluation errors into a separate stream.
+///
+/// The key and value are pushed borrowed into a `ColumnBuilder` (C1's
+/// zero-allocation pattern: no owned `Row` per record on the ok path); the error
+/// path owns time and diff. Shared by the `Vec` arm of [`arrange_join_input`]
+/// (source edge) and by [`arrange_join_collection`] (the intra-operator
+/// accumulator), both of which key a `Vec`-formatted stream.
+fn key_join_input_vec<'s, T>(
+    stream: Stream<'s, T, Vec<(Row, T, Diff)>>,
+    stream_key: Vec<LirScalarExpr>,
+    stream_thinning: Vec<usize>,
+) -> (
+    Stream<'s, T, Column<((Row, Row), T, Diff)>>,
+    Stream<'s, T, Vec<(DataflowErrorSer, T, Diff)>>,
+)
+where
+    T: RenderTimestamp,
+{
+    stream.unary_fallible::<ColumnBuilder<((Row, Row), T, Diff)>, _, _, _>(
+        Pipeline,
+        "LinearJoinKeyPreparation",
+        |_, _| {
+            Box::new(move |input, ok, errs| {
+                let mut temp_storage = RowArena::new();
+                let mut key_buf = Row::default();
+                let mut val_buf = Row::default();
+                let mut datums = DatumVec::new();
+                input.for_each(|time, data| {
+                    let mut ok_session = ok.session_with_builder(&time);
+                    let mut err_session = errs.session(&time);
+                    for (row, time, diff) in data.iter() {
+                        temp_storage.clear();
+                        let datums_local = datums.borrow_with(row);
+                        let datums = stream_key
+                            .iter()
+                            .map(|e| e.eval(&datums_local, &temp_storage));
+                        match key_buf.packer().try_extend(datums) {
+                            Ok(()) => {
+                                val_buf
+                                    .packer()
+                                    .extend(stream_thinning.iter().map(|e| datums_local[*e]));
+                                ok_session.give(((&key_buf, &val_buf), time, diff));
+                            }
+                            Err(e) => {
+                                err_session.give((e.into(), time.clone(), *diff));
+                            }
+                        }
+                    }
+                });
+            })
+        },
+    )
+}
+
+/// Exchanges keyed join updates by key and arranges them into a `RowRowSpine`.
+fn arrange_keyed_join_input<'s, T>(
+    keyed: Stream<'s, T, Column<((Row, Row), T, Diff)>>,
+    errs: Stream<'s, T, Vec<(DataflowErrorSer, T, Diff)>>,
+    use_paged_path: bool,
+) -> (
+    Arranged<'s, RowRowAgent<T, Diff>>,
+    VecCollection<'s, T, DataflowErrorSer, Diff>,
+)
+where
+    T: Lattice + RenderTimestamp,
+{
+    let exchange =
+        ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, T, Diff>);
+    let arranged = if use_paged_path {
+        keyed.mz_arrange_core::<
+            _,
+            batcher::ColumnChunker<_>,
+            Col2ValPagedBatcher<_, _, _, _>,
+            RowRowColPagedBuilder<_, _>,
+            RowRowSpine<_, _>,
+        >(exchange, "JoinStage")
+    } else {
+        keyed.mz_arrange_core::<
+            _,
+            batcher::Chunker<_>,
+            Col2ValBatcher<_, _, _, _>,
+            RowRowBuilder<_, _>,
+            RowRowSpine<_, _>,
+        >(exchange, "JoinStage")
+    };
+    (arranged, errs.as_collection())
+}
+
 /// Forms the source arrangement for a streamed join input off a collection edge.
 ///
 /// Both arms build the same `((key, value), t, d)` columnar updates and push the
@@ -554,49 +669,15 @@ fn arrange_join_input<'s, T>(
 where
     T: Lattice + RenderTimestamp,
 {
-    let name = "LinearJoinKeyPreparation";
     let (keyed, errs) = match edge {
-        CollectionEdge::Vec(stream) => stream
-            .inner
-            .unary_fallible::<ColumnBuilder<((Row, Row), T, Diff)>, _, _, _>(
-                Pipeline,
-                name,
-                |_, _| {
-                    Box::new(move |input, ok, errs| {
-                        let mut temp_storage = RowArena::new();
-                        let mut key_buf = Row::default();
-                        let mut val_buf = Row::default();
-                        let mut datums = DatumVec::new();
-                        input.for_each(|time, data| {
-                            let mut ok_session = ok.session_with_builder(&time);
-                            let mut err_session = errs.session(&time);
-                            for (row, time, diff) in data.iter() {
-                                temp_storage.clear();
-                                let datums_local = datums.borrow_with(row);
-                                let datums = stream_key
-                                    .iter()
-                                    .map(|e| e.eval(&datums_local, &temp_storage));
-                                match key_buf.packer().try_extend(datums) {
-                                    Ok(()) => {
-                                        val_buf.packer().extend(
-                                            stream_thinning.iter().map(|e| datums_local[*e]),
-                                        );
-                                        ok_session.give(((&key_buf, &val_buf), time, diff));
-                                    }
-                                    Err(e) => {
-                                        err_session.give((e.into(), time.clone(), *diff));
-                                    }
-                                }
-                            }
-                        });
-                    })
-                },
-            ),
+        CollectionEdge::Vec(stream) => {
+            key_join_input_vec(stream.inner, stream_key, stream_thinning)
+        }
         CollectionEdge::Columnar(stream) => stream
             .inner
             .unary_fallible::<ColumnBuilder<((Row, Row), T, Diff)>, _, _, _>(
                 Pipeline,
-                name,
+                "LinearJoinKeyPreparation",
                 |_, _| {
                     Box::new(move |input, ok, errs| {
                         let mut temp_storage = RowArena::new();
@@ -636,27 +717,27 @@ where
                 },
             ),
     };
+    arrange_keyed_join_input(keyed, errs, use_paged_path)
+}
 
-    let exchange =
-        ExchangeCore::<ColumnBuilder<_>, _>::new_core(columnar_exchange::<Row, Row, T, Diff>);
-    let arranged = if use_paged_path {
-        keyed.mz_arrange_core::<
-            _,
-            batcher::ColumnChunker<_>,
-            Col2ValPagedBatcher<_, _, _, _>,
-            RowRowColPagedBuilder<_, _>,
-            RowRowSpine<_, _>,
-        >(exchange, "JoinStage")
-    } else {
-        keyed.mz_arrange_core::<
-            _,
-            batcher::Chunker<_>,
-            Col2ValBatcher<_, _, _, _>,
-            RowRowBuilder<_, _>,
-            RowRowSpine<_, _>,
-        >(exchange, "JoinStage")
-    };
-    (arranged, errs.as_collection())
+/// Forms the arrangement for the intra-operator `Vec` accumulator of a linear
+/// join. Unlike [`arrange_join_input`], the accumulator is a bare `VecCollection`
+/// rather than a collection edge: `mz_join_core` is `Vec`-internal, so the
+/// accumulator never carries the inter-node edge type.
+fn arrange_join_collection<'s, T>(
+    collection: VecCollection<'s, T, Row, Diff>,
+    stream_key: Vec<LirScalarExpr>,
+    stream_thinning: Vec<usize>,
+    use_paged_path: bool,
+) -> (
+    Arranged<'s, RowRowAgent<T, Diff>>,
+    VecCollection<'s, T, DataflowErrorSer, Diff>,
+)
+where
+    T: Lattice + RenderTimestamp,
+{
+    let (keyed, errs) = key_join_input_vec(collection.inner, stream_key, stream_thinning);
+    arrange_keyed_join_input(keyed, errs, use_paged_path)
 }
 
 #[cfg(test)]
@@ -833,5 +914,47 @@ mod tests {
         assert!(ok_vec.is_empty() && ok_col.is_empty());
         assert!(!err_vec.is_empty());
         assert_eq!(err_vec, err_col);
+    }
+
+    /// The bare-`VecCollection` accumulator path (`arrange_join_collection`, used
+    /// for join stages after the first) forms the same keyed arrangement as
+    /// feeding the identical input through `arrange_join_input`'s `Vec` edge arm.
+    /// Both share `key_join_input_vec`, so this guards the accumulator wiring,
+    /// not the keying.
+    #[mz_ore::test]
+    fn arrange_join_collection_matches_vec_edge() {
+        let key = vec![LirScalarExpr::column(0)];
+        let input = test_input();
+        let (edge_ok, acc_ok) = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut handle, collection) = scope.new_collection();
+                let (edge_arr, _edge_errs) = arrange_join_input(
+                    CollectionEdge::Vec(collection.clone()),
+                    key.clone(),
+                    vec![1],
+                    false,
+                );
+                let (acc_arr, _acc_errs) =
+                    arrange_join_collection(collection, key.clone(), vec![1], false);
+                let edge_ok = edge_arr
+                    .as_collection(|k, v| (k.to_row(), v.to_row()))
+                    .inner
+                    .capture();
+                let acc_ok = acc_arr
+                    .as_collection(|k, v| (k.to_row(), v.to_row()))
+                    .inner
+                    .capture();
+                for (row, time, diff) in input {
+                    handle.update_at(row, Timestamp::from(time), diff);
+                }
+                handle.advance_to(Timestamp::from(3_u64));
+                handle.flush();
+                (edge_ok, acc_ok)
+            })
+        });
+        let edge_ok = extract_sorted(edge_ok);
+        let acc_ok = extract_sorted(acc_ok);
+        assert!(!edge_ok.is_empty());
+        assert_eq!(edge_ok, acc_ok);
     }
 }

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -255,14 +255,13 @@ where
                         .collection
                         .clone()
                         .expect("The unarranged collection doesn't exist."),
-                    // With a source key the input is read from an existing
-                    // arrangement, which is already columnar internally; wrap its
-                    // decoded rows as a `Vec` edge.
-                    Some(key) => {
-                        let (oks, errs) = inputs[linear_plan.source_relation]
-                            .as_specific_collection(Some(key), &self.config_set);
-                        (CollectionEdge::Vec(oks), errs)
-                    }
+                    // With a source key the input is materialized from an existing
+                    // arrangement, which `as_specific_collection` presents as a
+                    // columnar edge. `differential_join` forms the source key off
+                    // this edge below, so the columnar source has no `ColumnarToVec`
+                    // hop.
+                    Some(key) => inputs[linear_plan.source_relation]
+                        .as_specific_collection(Some(key), &self.config_set),
                 };
                 errors.push(errs.enter_region(inner));
                 let joined = joined.enter_region(inner);

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -266,8 +266,9 @@ where
                     // columnar edge. `differential_join` forms the source key off
                     // this edge below, so the columnar source has no `ColumnarToVec`
                     // hop.
-                    Some(key) => inputs[linear_plan.source_relation]
-                        .as_specific_collection(Some(key), &self.config_set),
+                    Some(key) => {
+                        inputs[linear_plan.source_relation].as_specific_collection(Some(key))
+                    }
                 };
                 errors.push(errs.enter_region(inner));
                 let joined = joined.enter_region(inner);

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -199,8 +199,8 @@ enum JoinedFlavor<'scope, T: RenderTimestamp> {
     /// columnar source flows in without a `ColumnarToVec` decode.
     Edge(CollectionEdge<'scope, T>),
     /// The intra-operator multi-stage accumulator. `mz_join_core` is
-    /// `Vec`-internal, so the accumulator is a bare `VecCollection`, not an
-    /// inter-node edge.
+    /// `Vec`-internal, so the accumulator is a bare `VecCollection`, not a
+    /// collection edge.
     Collection(VecCollection<'scope, T, Row, Diff>),
     /// A dataflow-local arrangement.
     Local(Arranged<'scope, RowRowAgent<T, Diff>>),
@@ -723,7 +723,7 @@ where
 /// Forms the arrangement for the intra-operator `Vec` accumulator of a linear
 /// join. Unlike [`arrange_join_input`], the accumulator is a bare `VecCollection`
 /// rather than a collection edge: `mz_join_core` is `Vec`-internal, so the
-/// accumulator never carries the inter-node edge type.
+/// accumulator never carries the collection edge type.
 fn arrange_join_collection<'s, T>(
     collection: VecCollection<'s, T, Row, Diff>,
     stream_key: Vec<LirScalarExpr>,

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -32,6 +32,7 @@ use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_timely_util::columnar::batcher;
 use mz_timely_util::columnar::builder::ColumnBuilder;
+use mz_timely_util::columnar::consolidate::ConsolidatingColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, Col2ValPagedBatcher, columnar_exchange};
 use mz_timely_util::operator::{CollectionExt, StreamExt};
 use timely::dataflow::Scope;
@@ -40,7 +41,7 @@ use timely::dataflow::operators::OkErr;
 
 use crate::extensions::arrange::MzArrangeCore;
 use crate::render::RenderTimestamp;
-use crate::render::columnar::CollectionEdge;
+use crate::render::columnar::{CollectionEdge, vec_to_columnar};
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::render::join::mz_join_core::mz_join_core;
@@ -321,35 +322,48 @@ where
         // For example, we may have expressions not pushed down (e.g. literals)
         // and projections that could not be applied (e.g. column repetition).
         let bundle = if let JoinedFlavor::Collection(joined) = joined {
-            // The join output is a `Vec` collection, so `into_vec` is the identity
-            // on the `Vec` arm.
-            let mut joined = joined.into_vec();
-            if let Some(closure) = linear_plan.final_closure {
+            let ok_edge = if let Some(closure) = linear_plan.final_closure {
+                // The finalization closure computes fresh output rows, so build them into
+                // a `ConsolidatingColumnBuilder` (owned give), matching the prior
+                // `ConsolidatingContainerBuilder` and folding within-batch duplicates.
                 let name = "LinearJoinFinalization";
-                type CB<C> = ConsolidatingContainerBuilder<C>;
-                let (updates, errs) = joined.flat_map_fallible::<CB<_>, CB<_>, _, _, _, _>(name, {
-                    // Reuseable allocation for unpacking.
-                    let mut datums = DatumVec::new();
-                    move |row| {
-                        let mut row_builder = SharedRow::get();
-                        let temp_storage = RowArena::new();
-                        let mut datums_local = datums.borrow_with(&row);
-                        // TODO(mcsherry): re-use `row` allocation.
-                        closure
-                            .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                            .map(|row| row.cloned())
-                            .map_err(DataflowErrorSer::from)
-                            .transpose()
-                    }
-                });
-
-                joined = updates;
+                type OkCB<T> = ConsolidatingColumnBuilder<Row, T, Diff>;
+                type ErrCB<C> = ConsolidatingContainerBuilder<C>;
+                let (updates, errs) = joined
+                    .into_vec()
+                    .flat_map_fallible::<OkCB<T>, ErrCB<_>, _, _, _, _>(name, {
+                        // Reuseable allocation for unpacking.
+                        let mut datums = DatumVec::new();
+                        move |row| {
+                            let mut row_builder = SharedRow::get();
+                            let temp_storage = RowArena::new();
+                            let mut datums_local = datums.borrow_with(&row);
+                            // TODO(mcsherry): re-use `row` allocation.
+                            closure
+                                .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                                .map(|row| row.cloned())
+                                .map_err(DataflowErrorSer::from)
+                                .transpose()
+                        }
+                    });
                 errors.push(errs);
-            }
+                CollectionEdge::Columnar(updates)
+            } else {
+                // Identity finalization: the raw stage output is the result.
+                // `mz_join_core` produces a `Vec` collection (intra-operator,
+                // unchanged), so encode it to the columnar edge via the sanctioned
+                // leaf-encode, non-consolidating to match the raw output. A columnar
+                // source (single-input join) is already an edge and passes through
+                // with no round-trip.
+                match joined {
+                    CollectionEdge::Columnar(c) => CollectionEdge::Columnar(c),
+                    CollectionEdge::Vec(s) => CollectionEdge::Columnar(vec_to_columnar(s)),
+                }
+            };
 
             // Return joined results and all produced errors collected together.
-            CollectionBundle::from_collections(
-                joined,
+            CollectionBundle::from_edge(
+                ok_edge,
                 differential_dataflow::collection::concatenate(inner, errors),
             )
         } else {
@@ -525,7 +539,9 @@ where
 /// consumes. This is the zero-allocation pattern: no owned `Row` per record on
 /// the ok path. The arms differ only in how records are read, the `Vec` arm from
 /// the owned container and the columnar arm from the borrowed column, and in the
-/// error path, which owns time and diff.
+/// error path, which owns time and diff. The columnar arm runs whenever the input
+/// edge is columnar, which the source-key path (via `as_specific_collection`) and
+/// upstream producers emit.
 fn arrange_join_input<'s, T>(
     edge: CollectionEdge<'s, T>,
     stream_key: Vec<LirScalarExpr>,

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -42,7 +42,7 @@ use timely::dataflow::{Scope, Stream};
 
 use crate::extensions::arrange::MzArrangeCore;
 use crate::render::RenderTimestamp;
-use crate::render::columnar::{CollectionEdge, vec_to_columnar};
+use crate::render::columnar::{CollectionEdge, columnar_to_vec, vec_to_columnar};
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::render::join::mz_join_core::mz_join_core;
@@ -284,8 +284,7 @@ where
                     // but this branch is never taken in current lowering.
                     let name = "LinearJoinInitialization";
                     type CB<C> = ConsolidatingContainerBuilder<C>;
-                    let (j, errs) = joined
-                        .into_vec()
+                    let (j, errs) = columnar_to_vec(joined)
                         .flat_map_fallible::<CB<_>, CB<_>, _, _, _, _>(name, {
                             // Reuseable allocation for unpacking.
                             let mut datums = DatumVec::new();
@@ -336,7 +335,7 @@ where
             // source edge is decoded to `Vec` first (`into_vec` is the identity on the
             // `Vec` arm); the accumulator is already a `VecCollection`.
             let input = match joined {
-                JoinedFlavor::Edge(edge) => edge.into_vec(),
+                JoinedFlavor::Edge(edge) => columnar_to_vec(edge),
                 JoinedFlavor::Collection(collection) => collection,
                 _ => panic!("Unexpectedly arranged join output"),
             };
@@ -359,21 +358,15 @@ where
                 }
             });
             errors.push(errs);
-            CollectionEdge::Columnar(updates)
+            updates
         } else {
-            // Identity finalization: the raw output is the result, encoded to the
-            // columnar edge via the sanctioned leaf-encode, non-consolidating to match
-            // the raw output. A columnar source (single-input join) is already an edge
-            // and passes through with no round-trip; the `Vec` accumulator and a `Vec`
-            // source encode via `vec_to_columnar`.
+            // Identity finalization: the raw output is the result. The source edge
+            // (single-input join) is already columnar and passes through; the `Vec`
+            // accumulator encodes via `vec_to_columnar`, non-consolidating to match
+            // the raw output.
             match joined {
-                JoinedFlavor::Edge(CollectionEdge::Columnar(c)) => CollectionEdge::Columnar(c),
-                JoinedFlavor::Edge(CollectionEdge::Vec(s)) => {
-                    CollectionEdge::Columnar(vec_to_columnar(s))
-                }
-                JoinedFlavor::Collection(collection) => {
-                    CollectionEdge::Columnar(vec_to_columnar(collection))
-                }
+                JoinedFlavor::Edge(edge) => edge,
+                JoinedFlavor::Collection(collection) => vec_to_columnar(collection),
                 _ => panic!("Unexpectedly arranged join output"),
             }
         };
@@ -650,14 +643,10 @@ where
 
 /// Forms the source arrangement for a streamed join input off a collection edge.
 ///
-/// Both arms build the same `((key, value), t, d)` columnar updates and push the
-/// key and value borrowed into a `ColumnBuilder`, which the `Col2Val` batcher
-/// consumes. This is the zero-allocation pattern: no owned `Row` per record on
-/// the ok path. The arms differ only in how records are read, the `Vec` arm from
-/// the owned container and the columnar arm from the borrowed column, and in the
-/// error path, which owns time and diff. The columnar arm runs whenever the input
-/// edge is columnar, which the source-key path (via `as_specific_collection`) and
-/// upstream producers emit.
+/// Reads records from the borrowed column and pushes the key and value borrowed
+/// into a `ColumnBuilder`, which the `Col2Val` batcher consumes: a zero-allocation
+/// pattern with no owned `Row` per record on the ok path. Only the error path
+/// owns time and diff.
 fn arrange_join_input<'s, T>(
     edge: CollectionEdge<'s, T>,
     stream_key: Vec<LirScalarExpr>,
@@ -670,54 +659,49 @@ fn arrange_join_input<'s, T>(
 where
     T: Lattice + RenderTimestamp,
 {
-    let (keyed, errs) = match edge {
-        CollectionEdge::Vec(stream) => {
-            key_join_input_vec(stream.inner, stream_key, stream_thinning)
-        }
-        CollectionEdge::Columnar(stream) => stream
-            .inner
-            .unary_fallible::<ColumnBuilder<((Row, Row), T, Diff)>, _, _, _>(
-                Pipeline,
-                "LinearJoinKeyPreparation",
-                |_, _| {
-                    Box::new(move |input, ok, errs| {
-                        let mut temp_storage = RowArena::new();
-                        let mut key_buf = Row::default();
-                        let mut val_buf = Row::default();
-                        let mut datums = DatumVec::new();
-                        input.for_each(|time, data| {
-                            let mut ok_session = ok.session_with_builder(&time);
-                            let mut err_session = errs.session(&time);
-                            // Rows are read from the borrowed column; the key and
-                            // value are pushed borrowed. Time and diff are owned
-                            // only on the error path.
-                            for (row, time, diff) in data.borrow().into_index_iter() {
-                                temp_storage.clear();
-                                let datums_local = datums.borrow_with(row);
-                                let datums = stream_key
-                                    .iter()
-                                    .map(|e| e.eval(&datums_local, &temp_storage));
-                                match key_buf.packer().try_extend(datums) {
-                                    Ok(()) => {
-                                        val_buf.packer().extend(
-                                            stream_thinning.iter().map(|e| datums_local[*e]),
-                                        );
-                                        ok_session.give(((&key_buf, &val_buf), time, diff));
-                                    }
-                                    Err(e) => {
-                                        err_session.give((
-                                            e.into(),
-                                            Columnar::into_owned(time),
-                                            Columnar::into_owned(diff),
-                                        ));
-                                    }
+    let (keyed, errs) = edge
+        .inner
+        .unary_fallible::<ColumnBuilder<((Row, Row), T, Diff)>, _, _, _>(
+            Pipeline,
+            "LinearJoinKeyPreparation",
+            |_, _| {
+                Box::new(move |input, ok, errs| {
+                    let mut temp_storage = RowArena::new();
+                    let mut key_buf = Row::default();
+                    let mut val_buf = Row::default();
+                    let mut datums = DatumVec::new();
+                    input.for_each(|time, data| {
+                        let mut ok_session = ok.session_with_builder(&time);
+                        let mut err_session = errs.session(&time);
+                        // Rows are read from the borrowed column; the key and
+                        // value are pushed borrowed. Time and diff are owned
+                        // only on the error path.
+                        for (row, time, diff) in data.borrow().into_index_iter() {
+                            temp_storage.clear();
+                            let datums_local = datums.borrow_with(row);
+                            let datums = stream_key
+                                .iter()
+                                .map(|e| e.eval(&datums_local, &temp_storage));
+                            match key_buf.packer().try_extend(datums) {
+                                Ok(()) => {
+                                    val_buf
+                                        .packer()
+                                        .extend(stream_thinning.iter().map(|e| datums_local[*e]));
+                                    ok_session.give(((&key_buf, &val_buf), time, diff));
+                                }
+                                Err(e) => {
+                                    err_session.give((
+                                        e.into(),
+                                        Columnar::into_owned(time),
+                                        Columnar::into_owned(diff),
+                                    ));
                                 }
                             }
-                        });
-                    })
-                },
-            ),
-    };
+                        }
+                    });
+                })
+            },
+        );
     arrange_keyed_join_input(keyed, errs, use_paged_path)
 }
 
@@ -820,117 +804,84 @@ mod tests {
         ]
     }
 
-    /// Runs `arrange_join_input` against the same input fed once as a `Vec` edge
-    /// and once as a columnar edge, keying by `key` with column 1 as the value.
-    /// Returns the sorted ok updates (read back from each arrangement) and the
-    /// sorted err updates of each arm.
-    #[allow(clippy::type_complexity)]
-    fn run_both_arms(
+    /// Runs `arrange_join_input` against the columnar input edge, keying by `key`
+    /// with column 1 as the value. Returns the sorted ok updates (read back from
+    /// the arrangement) and the sorted err updates.
+    fn run_columnar(
         input: Vec<(Row, u64, Diff)>,
         key: Vec<LirScalarExpr>,
-    ) -> (
-        Vec<KeyedUpdate>,
-        Vec<KeyedUpdate>,
-        Vec<(String, Timestamp, Diff)>,
-        Vec<(String, Timestamp, Diff)>,
-    ) {
-        let (ok_vec, ok_col, err_vec, err_col) = timely::execute_directly(move |worker| {
+    ) -> (Vec<KeyedUpdate>, Vec<(String, Timestamp, Diff)>) {
+        let (ok, err) = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut handle, collection) = scope.new_collection();
-                let mut ok_caps = Vec::new();
-                let mut err_caps = Vec::new();
-                for edge in [
-                    CollectionEdge::Vec(collection.clone()),
-                    CollectionEdge::Columnar(vec_to_columnar(collection)),
-                ] {
-                    let (arranged, errs) = arrange_join_input(edge, key.clone(), vec![1], false);
-                    let keyed = arranged.as_collection(|k, v| (k.to_row(), v.to_row()));
-                    ok_caps.push(keyed.inner.capture());
-                    err_caps.push(errs.inner.capture());
-                }
-                let err_col = err_caps.pop().unwrap();
-                let err_vec = err_caps.pop().unwrap();
-                let ok_col = ok_caps.pop().unwrap();
-                let ok_vec = ok_caps.pop().unwrap();
+                let (arranged, errs) =
+                    arrange_join_input(vec_to_columnar(collection), key, vec![1], false);
+                let keyed = arranged.as_collection(|k, v| (k.to_row(), v.to_row()));
+                let ok = keyed.inner.capture();
+                let err = errs.inner.capture();
                 for (row, time, diff) in input {
                     handle.update_at(row, Timestamp::from(time), diff);
                 }
                 handle.advance_to(Timestamp::from(3_u64));
                 handle.flush();
-                (ok_vec, ok_col, err_vec, err_col)
+                (ok, err)
             })
         });
-        (
-            extract_sorted(ok_vec),
-            extract_sorted(ok_col),
-            extract_err(err_vec),
-            extract_err(err_col),
-        )
+        (extract_sorted(ok), extract_err(err))
     }
 
-    /// The columnar arm of `arrange_join_input` forms the same keyed arrangement
-    /// as the `Vec` arm, across several distinct timestamps and a retraction.
-    ///
-    /// This proves the columnar key-forming is correct and that the columnar arm
-    /// ran (the input is fed through `vec_to_columnar`). It does not prove the
-    /// absence of a silent `ColumnarToVec` decode on the ok path: such a decode
-    /// would yield identical contents. No-decode holds by code inspection, the
-    /// columnar arm reads via `into_index_iter` and pushes the key and value
-    /// borrowed into the `ColumnBuilder`, never calling `into_vec`.
+    /// `arrange_join_input` forms the keyed arrangement from the columnar input
+    /// across several distinct timestamps and a retraction.
     ///
     /// The stream key here is infallible column projection, so `try_extend` never
     /// fails and the ok path pushes the diff borrowed. The retraction records
     /// exercise a negative diff on that borrowed ok path. `Columnar::into_owned`
-    /// runs only on the error path, which `arrange_join_input_arms_agree_on_error_path`
-    /// covers.
+    /// runs only on the error path, which `arrange_join_input_error_path` covers.
     #[mz_ore::test]
-    fn arrange_join_input_arms_agree() {
-        let (ok_vec, ok_col, err_vec, err_col) =
-            run_both_arms(test_input(), vec![LirScalarExpr::column(0)]);
-        assert!(!ok_vec.is_empty());
-        assert_eq!(ok_vec, ok_col);
-        assert!(err_vec.is_empty() && err_col.is_empty());
+    fn arrange_join_input_keys_correctly() {
+        let (ok, err) = run_columnar(test_input(), vec![LirScalarExpr::column(0)]);
+        assert!(!ok.is_empty());
+        assert!(err.is_empty());
         // A retraction survives into the arrangement, so the ok path handled a
         // negative (borrowed) diff.
-        assert!(ok_vec.iter().any(|(_, _, d)| *d < Diff::ZERO));
+        assert!(ok.iter().any(|(_, _, d)| *d < Diff::ZERO));
         // Key is column 0, value is column 1 (the thinning), so both are single
         // datums.
-        for ((key, value), _t, _d) in &ok_vec {
+        for ((key, value), _t, _d) in &ok {
             assert_eq!(key.iter().count(), 1);
             assert_eq!(value.iter().count(), 1);
         }
     }
 
     /// A key expression that always errors drives every record onto the
-    /// `try_extend` Err branch, exercising the columnar arm's `Columnar::into_owned`
-    /// reconstruction of each error's `(time, diff)`. Both arms must agree on the
-    /// errors, and the ok output must be empty on both.
+    /// `try_extend` Err branch, exercising `Columnar::into_owned` reconstruction
+    /// of each error's `(time, diff)`. The ok output must be empty.
     #[mz_ore::test]
-    fn arrange_join_input_arms_agree_on_error_path() {
+    fn arrange_join_input_error_path() {
         let key = vec![LirScalarExpr::literal(
             Err(EvalError::DivisionByZero),
             ReprScalarType::Int32,
         )];
-        let (ok_vec, ok_col, err_vec, err_col) = run_both_arms(test_input(), key);
-        assert!(ok_vec.is_empty() && ok_col.is_empty());
-        assert!(!err_vec.is_empty());
-        assert_eq!(err_vec, err_col);
+        let (ok, err) = run_columnar(test_input(), key);
+        assert!(ok.is_empty());
+        assert!(!err.is_empty());
     }
 
     /// The bare-`VecCollection` accumulator path (`arrange_join_collection`, used
-    /// for join stages after the first) forms the same keyed arrangement as
-    /// feeding the identical input through `arrange_join_input`'s `Vec` edge arm.
-    /// Both share `key_join_input_vec`, so this guards the accumulator wiring,
-    /// not the keying.
+    /// for join stages after the first) forms the same keyed arrangement as the
+    /// columnar source edge path (`arrange_join_input`). The two use different
+    /// keying implementations (`arrange_join_input` keys inline off the borrowed
+    /// column, `arrange_join_collection` keys via `key_join_input_vec`), so this
+    /// cross-checks the two keying paths against each other.
     #[mz_ore::test]
-    fn arrange_join_collection_matches_vec_edge() {
+    fn arrange_join_collection_matches_edge() {
         let key = vec![LirScalarExpr::column(0)];
         let input = test_input();
         let (edge_ok, acc_ok) = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut handle, collection) = scope.new_collection();
                 let (edge_arr, _edge_errs) = arrange_join_input(
-                    CollectionEdge::Vec(collection.clone()),
+                    vec_to_columnar(collection.clone()),
                     key.clone(),
                     vec![1],
                     false,

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -561,9 +561,9 @@ where
 /// Keys a row-formatted join input stream into columnar `((key, value), t, d)`
 /// updates, splitting off key-evaluation errors into a separate stream.
 ///
-/// The key and value are pushed borrowed into a `ColumnBuilder` (C1's
-/// zero-allocation pattern: no owned `Row` per record on the ok path); the error
-/// path owns time and diff. Shared by the `Vec` arm of [`arrange_join_input`]
+/// The key and value are pushed borrowed into a `ColumnBuilder`, so the ok path
+/// materializes no owned `Row` per record. The error path owns time and diff.
+/// Shared by the `Vec` arm of [`arrange_join_input`]
 /// (source edge) and by [`arrange_join_collection`] (the intra-operator
 /// accumulator), both of which key a `Vec`-formatted stream.
 fn key_join_input_vec<'s, T>(

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -557,9 +557,9 @@ where
 ///
 /// The key and value are pushed borrowed into a `ColumnBuilder`, so the ok path
 /// materializes no owned `Row` per record. The error path owns time and diff.
-/// Shared by the `Vec` arm of [`arrange_join_input`]
-/// (source edge) and by [`arrange_join_collection`] (the intra-operator
-/// accumulator), both of which key a `Vec`-formatted stream.
+/// Called by [`arrange_join_collection`] for the intra-operator accumulator,
+/// which is row-formatted. [`arrange_join_input`] does the same job for the
+/// columnar source edge, reading records from the borrowed column instead.
 fn key_join_input_vec<'s, T>(
     stream: Stream<'s, T, Vec<(Row, T, Diff)>>,
     stream_key: Vec<LirScalarExpr>,
@@ -573,7 +573,7 @@ where
 {
     stream.unary_fallible::<ColumnBuilder<((Row, Row), T, Diff)>, _, _, _>(
         Pipeline,
-        "LinearJoinKeyPreparation",
+        "LinearJoinAccumulatorKeyPreparation",
         |_, _| {
             Box::new(move |input, ok, errs| {
                 let mut temp_storage = RowArena::new();

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -249,8 +249,8 @@ where
                 let (joined, errs) = match linear_plan.source_key.as_deref() {
                     // No source key: consume the input edge directly rather than
                     // decoding it to `Vec`. `differential_join` forms the source
-                    // arrangement key off this edge below (C1 borrowed-push
-                    // pattern), so a columnar source has no `ColumnarToVec` hop.
+                    // arrangement key off this edge below, pushing rows borrowed,
+                    // so a columnar source has no `ColumnarToVec` hop.
                     None => inputs[linear_plan.source_relation]
                         .collection
                         .clone()

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -108,7 +108,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
 
             let (key_val_input, err) = input
                 .enter_region(inner)
-                .flat_map::<_, ConsolidatingContainerBuilder<Vec<((Row, Row), T, Diff)>>, _>(
+                .flat_map::<ConsolidatingContainerBuilder<Vec<((Row, Row), T, Diff)>>, _>(
                     input_key.map(|k| (k, None)),
                     max_demand,
                     move |row_datums, time, diff, ok_session, err_session| {

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -30,6 +30,7 @@ use timely::progress::Antichain;
 
 use crate::compute_state::SinkToken;
 use crate::logging::compute::LogDataflowErrors;
+use crate::render::columnar::columnar_to_vec;
 use crate::render::context::Context;
 use crate::render::errors::DataflowErrorSer;
 use crate::render::{RenderTimestamp, StartSignal};
@@ -68,7 +69,7 @@ impl<'g, T: RenderTimestamp> Context<'g, T> {
             .lookup_id(mz_expr::Id::Global(sink.from))
             .expect("Sink source collection not loaded");
         let (ok_collection, mut err_collection) = if let Some((oks, errs)) = &bundle.collection {
-            (oks.clone().into_vec(), errs.clone())
+            (columnar_to_vec(oks.clone()), errs.clone())
         } else {
             let (key, _arrangement) = bundle
                 .arranged
@@ -85,7 +86,7 @@ impl<'g, T: RenderTimestamp> Context<'g, T> {
             // above.
             let (oks, errs) =
                 bundle.as_collection_core(mfp_plan, Some((key.clone(), None)), self.until.clone());
-            (oks.into_vec(), errs)
+            (columnar_to_vec(oks), errs)
         };
 
         // Attach logging of dataflow errors.

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -80,12 +80,16 @@ impl<'g, T: RenderTimestamp> Context<'g, T> {
             let mut mfp = MapFilterProject::<LirScalarExpr>::new(unthinned_arity);
             mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
             let mfp_plan = mfp.into_plan().expect("MFP planning failed");
-            bundle.as_collection_core(
+            // The sink serializes rows, so decode to `Vec` here. This is the
+            // sanctioned sink leaf, the same seam as the raw-collection arm
+            // above.
+            let (oks, errs) = bundle.as_collection_core(
                 mfp_plan,
                 Some((key.clone(), None)),
                 self.until.clone(),
                 &self.config_set,
-            )
+            );
+            (oks.into_vec(), errs)
         };
 
         // Attach logging of dataflow errors.

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -83,12 +83,8 @@ impl<'g, T: RenderTimestamp> Context<'g, T> {
             // The sink serializes rows, so decode to `Vec` here. This is the
             // sanctioned sink leaf, the same seam as the raw-collection arm
             // above.
-            let (oks, errs) = bundle.as_collection_core(
-                mfp_plan,
-                Some((key.clone(), None)),
-                self.until.clone(),
-                &self.config_set,
-            );
+            let (oks, errs) =
+                bundle.as_collection_core(mfp_plan, Some((key.clone(), None)), self.until.clone());
             (oks.into_vec(), errs)
         };
 

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -15,6 +15,7 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use columnar::{Columnar, Index};
 use differential_dataflow::AsCollection;
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
@@ -41,10 +42,13 @@ use timely::Container;
 use timely::container::{CapacityContainerBuilder, PushInto};
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Operator;
+use timely::dataflow::operators::generic::OutputBuilder;
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::{ClearContainer, MzReduce};
 use crate::render::Pairer;
+use crate::render::columnar::CollectionEdge;
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::render::errors::MaybeValidatingRow;
@@ -64,7 +68,13 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         top_k_plan: TopKPlan,
         temporal_bucketing_strategy: ArrangementStrategy,
     ) -> CollectionBundle<'scope, T> {
-        let (ok_input, err_input) = input.as_specific_collection(None, &self.config_set);
+        // Consume the input as a columnar-capable edge rather than decoding it to
+        // `Vec` up front. The arrangement key is formed off the edge below via
+        // `map_topk_key`, so no `ColumnarToVec` sits on the common input path.
+        let (ok_input, err_input) = input
+            .collection
+            .clone()
+            .expect("The unarranged collection doesn't exist.");
 
         // Bucket the per-row input stream when lowering chose `TemporalBucketing`.
         // `TopK` builds its own arrangement(s) inside the variants below, bypassing
@@ -99,6 +109,11 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                  `mz_now()` has been const-folded and no temporal bucketing is set",
             );
         }
+        // Temporal bucketing consumes and produces a `Vec` stream, so decode the
+        // edge here. This is the sanctioned leaf decode. It only
+        // fires under `ENABLE_COMPUTE_TEMPORAL_BUCKETING` and the `TemporalBucketing`
+        // strategy, both off on the common path, so the columnar edge otherwise
+        // flows straight through.
         let ok_input = if matches!(
             temporal_bucketing_strategy,
             ArrangementStrategy::TemporalBucketing
@@ -108,7 +123,11 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                 .get(&self.config_set)
                 .try_into()
                 .expect("must fit");
-            T::maybe_apply_temporal_bucketing(ok_input.inner, self.as_of_frontier.clone(), summary)
+            CollectionEdge::Vec(T::maybe_apply_temporal_bucketing(
+                ok_input.into_vec().inner,
+                self.as_of_frontier.clone(),
+                summary,
+            ))
         } else {
             ok_input
         };
@@ -138,7 +157,13 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     // thus needs to be checked.
                     let expr = expr.clone();
                     let mut datum_vec = mz_repr::DatumVec::new();
-                    let errors = ok_input.clone().flat_map(move |row| {
+                    // A literal, non-negative limit skips this branch entirely, so this
+                    // per-row evaluation only runs for column or otherwise fallible
+                    // limits. On the `Vec` edge `into_vec` is the identity, so the
+                    // `Vec` path is unchanged. On a columnar edge it is a narrow
+                    // sanctioned decode
+                    // confined to this rare path.
+                    let errors = ok_input.clone().into_vec().flat_map(move |row| {
                         let temp_storage = mz_repr::RowArena::new();
                         let datums = datum_vec.borrow_with(&row);
                         match expr.eval(&datums[..], &temp_storage) {
@@ -201,15 +226,10 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     }
 
                     // Map the group key along with the row and consolidate if required to do so.
-                    let mut datum_vec = mz_repr::DatumVec::new();
                     let ok_scope = ok_input.scope();
-                    let collection = ok_input
-                        .map(move |row| {
-                            let group_row = {
-                                let datums = datum_vec.borrow_with(&row);
-                                SharedRow::pack(group_key.iter().map(|i| datums[*i]))
-                            };
-                            (group_row, row)
+                    let collection =
+                        map_topk_key(ok_input, "MonotonicTopK input", move |datums, _row| {
+                            SharedRow::pack(group_key.iter().map(|i| datums[*i]))
                         })
                         .consolidate_named_if::<KeyBatcher<_, _, _>>(
                             must_consolidate,
@@ -321,7 +341,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
     /// Constructs a TopK dataflow subgraph.
     fn build_topk<'s>(
         &self,
-        collection: VecCollection<'s, T, Row, Diff>,
+        collection: CollectionEdge<'s, T>,
         group_key: Vec<usize>,
         order_key: Vec<mz_expr::ColumnOrder>,
         offset: usize,
@@ -333,17 +353,10 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         VecCollection<'s, T, DataflowErrorSer, Diff>,
     ) {
         let pairer = Pairer::new(1);
-        let mut datum_vec = mz_repr::DatumVec::new();
-        let mut collection = collection.map({
-            move |row| {
-                let group_row = {
-                    let row_hash = row.hashed();
-                    let datums = datum_vec.borrow_with(&row);
-                    let iterator = group_key.iter().map(|i| datums[*i]);
-                    pairer.merge(std::iter::once(Datum::from(row_hash)), iterator)
-                };
-                (group_row, row)
-            }
+        let mut collection = map_topk_key(collection, "TopK input", move |datums, row| {
+            let row_hash = row.hashed();
+            let iterator = group_key.iter().map(|i| datums[*i]);
+            pairer.merge(std::iter::once(Datum::from(row_hash)), iterator)
         });
 
         let mut validating = true;
@@ -516,7 +529,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
 
     fn render_top1_monotonic<'s>(
         &self,
-        collection: VecCollection<'s, T, Row, Diff>,
+        collection: CollectionEdge<'s, T>,
         group_key: Vec<usize>,
         order_key: Vec<mz_expr::ColumnOrder>,
         arity: usize,
@@ -541,22 +554,13 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         // corresponding to evaluating our aggregate, instead of having to do a hierarchical
         // reduction. We start by mapping the group key along with the row and consolidating
         // if required to do so.
-        let collection = collection
-            .map({
-                let mut datum_vec = mz_repr::DatumVec::new();
-                move |row| {
-                    // Scoped to allow borrow of `row` to drop.
-                    let group_key = {
-                        let datums = datum_vec.borrow_with(&row);
-                        SharedRow::pack(group_key.iter().map(|i| datums[*i]))
-                    };
-                    (group_key, row)
-                }
-            })
-            .consolidate_named_if::<KeyBatcher<_, _, _>>(
-                must_consolidate,
-                "Consolidated MonotonicTop1 input",
-            );
+        let collection = map_topk_key(collection, "MonotonicTop1 input", move |datums, _row| {
+            SharedRow::pack(group_key.iter().map(|i| datums[*i]))
+        })
+        .consolidate_named_if::<KeyBatcher<_, _, _>>(
+            must_consolidate,
+            "Consolidated MonotonicTop1 input",
+        );
 
         // It should be now possible to ensure that we have a monotonic collection and process it.
         let error_logger = self.error_logger();
@@ -601,6 +605,82 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                 },
             );
         (result, errs)
+    }
+}
+
+/// Forms the `(key, value)` arrangement input the TopK stages consume, reading
+/// directly from a columnar input edge.
+///
+/// `key` receives the borrowed datums of an input row and the owned row, and
+/// returns the arrangement key. The value is always the full input row, because
+/// every TopK stage carries the row through to its output.
+///
+/// The output is a `VecCollection<(Row, Row)>` because the TopK downstream
+/// (`KeyBatcher`, `MzReduce`) is `Vec`-based. The columnar arm therefore still
+/// decodes the value `Row` of every record inline via `Columnar::into_owned`,
+/// which costs the same as `columnar_to_vec`'s body. This is not C1's zero-copy
+/// borrowed-push: it removes the separate `ColumnarToVec` decode operator and the
+/// intermediate `Vec<(Row, T, Diff)>` container it would produce, but it does not
+/// avoid the per-record decode, because there is no columnar batcher to push
+/// borrowed rows into here. The `Vec` arm maps the collection directly and reuses
+/// the owned input row, so it is behaviorally identical to consuming the
+/// collection directly.
+fn map_topk_key<'s, T, L>(
+    edge: CollectionEdge<'s, T>,
+    name: &str,
+    mut key: L,
+) -> VecCollection<'s, T, (Row, Row), Diff>
+where
+    T: crate::render::RenderTimestamp,
+    L: FnMut(&[Datum], &Row) -> Row + 'static,
+{
+    match edge {
+        CollectionEdge::Vec(oks) => {
+            let mut datum_vec = mz_repr::DatumVec::new();
+            oks.map(move |row| {
+                let key_row = {
+                    let datums = datum_vec.borrow_with(&row);
+                    key(&datums, &row)
+                };
+                (key_row, row)
+            })
+        }
+        CollectionEdge::Columnar(oks) => {
+            let mut builder = OperatorBuilder::new(name.to_string(), oks.inner.scope());
+            let (output, stream) = builder.new_output();
+            let mut output =
+                OutputBuilder::<_, CapacityContainerBuilder<Vec<((Row, Row), T, Diff)>>>::from(
+                    output,
+                );
+            let mut input = builder.new_input(oks.inner, Pipeline);
+            builder.build(move |_capabilities| {
+                let mut datum_vec = mz_repr::DatumVec::new();
+                move |_frontiers| {
+                    let mut output = output.activate();
+                    input.for_each(|time, data| {
+                        let mut session = output.session_with_builder(&time);
+                        // The value row is decoded to an owned `Row` here because the
+                        // output is `Vec`-based. This is the same per-record cost as
+                        // `columnar_to_vec`, just without the separate decode operator
+                        // and its intermediate container. The key is formed from the
+                        // borrowed datums. Time and diff are owned per record.
+                        for (row, t, d) in data.borrow().into_index_iter() {
+                            let value_row: Row = Columnar::into_owned(row);
+                            let key_row = {
+                                let datums = datum_vec.borrow_with(&value_row);
+                                key(&datums, &value_row)
+                            };
+                            session.give((
+                                (key_row, value_row),
+                                Columnar::into_owned(t),
+                                Columnar::into_owned(d),
+                            ));
+                        }
+                    });
+                }
+            });
+            stream.as_collection()
+        }
     }
 }
 
@@ -1152,6 +1232,137 @@ pub mod monoids {
     impl IsZero for Top1MonoidLocal {
         fn is_zero(&self) -> bool {
             false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use differential_dataflow::input::Input;
+    use mz_repr::{Datum, Timestamp};
+    use timely::dataflow::operators::Capture;
+    use timely::dataflow::operators::capture::{Event, Extract};
+
+    use super::*;
+    use crate::render::columnar::vec_to_columnar;
+
+    type KeyedUpdate = ((Row, Row), Timestamp, Diff);
+    type Captured = std::sync::mpsc::Receiver<Event<Timestamp, Vec<KeyedUpdate>>>;
+
+    fn extract_sorted(captured: Captured) -> Vec<KeyedUpdate> {
+        let mut updates: Vec<_> = captured
+            .extract()
+            .into_iter()
+            .flat_map(|(_, data)| data)
+            .collect();
+        updates.sort();
+        updates
+    }
+
+    /// Input rows tagged with distinct timestamps. Feeding several timestamps
+    /// makes both arms exercise per-record time handling. The columnar arm owns
+    /// time and diff per record via `Columnar::into_owned` on the ok path. The
+    /// two `-1` records exercise `Columnar::into_owned` on a negative diff. They
+    /// retract at a `(row, time)` that has no matching insertion, so they survive
+    /// the `InputSession`'s pre-send consolidation and reach the operator.
+    fn test_input() -> Vec<(Row, u64, Diff)> {
+        vec![
+            (
+                Row::pack_slice(&[Datum::Int32(1), Datum::String("a")]),
+                0,
+                Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::Int32(2), Datum::String("b")]),
+                1,
+                Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::Int32(1), Datum::String("a")]),
+                2,
+                Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::Int32(3), Datum::Null]),
+                2,
+                Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::Int32(2), Datum::String("b")]),
+                2,
+                -Diff::ONE,
+            ),
+            (
+                Row::pack_slice(&[Datum::Int32(4), Datum::String("d")]),
+                1,
+                -Diff::ONE,
+            ),
+        ]
+    }
+
+    /// Runs `map_topk_key` against the same input fed once as a `Vec` edge and
+    /// once as a columnar edge, forming a hash-and-group key exactly as
+    /// `build_topk` does. Returns the sorted `(key, value)` updates of each arm.
+    fn run_both_arms(input: Vec<(Row, u64, Diff)>) -> (Vec<KeyedUpdate>, Vec<KeyedUpdate>) {
+        let (vec, col) = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut handle, collection) = scope.new_collection();
+                let mut captures = Vec::new();
+                for edge in [
+                    CollectionEdge::Vec(collection.clone()),
+                    CollectionEdge::Columnar(vec_to_columnar(collection)),
+                ] {
+                    let pairer = Pairer::new(1);
+                    let group_key = [0usize];
+                    let keyed = map_topk_key(edge, "test", move |datums, row| {
+                        let hash = row.hashed();
+                        let iterator = group_key.iter().map(|i| datums[*i]);
+                        pairer.merge(std::iter::once(Datum::from(hash)), iterator)
+                    });
+                    captures.push(keyed.inner.capture());
+                }
+                let col = captures.pop().unwrap();
+                let vec = captures.pop().unwrap();
+                for (row, time, diff) in input {
+                    handle.update_at(row, Timestamp::from(time), diff);
+                }
+                handle.advance_to(Timestamp::from(3_u64));
+                handle.flush();
+                (vec, col)
+            })
+        });
+        (extract_sorted(vec), extract_sorted(col))
+    }
+
+    /// The columnar arm of `map_topk_key` forms the same `(key, value)` updates
+    /// as the `Vec` arm, across several distinct timestamps.
+    ///
+    /// This proves the columnar key-forming is correct and that the columnar arm
+    /// ran (the input is fed through `vec_to_columnar`). It does not prove the
+    /// absence of a silent `ColumnarToVec` decode on the ok path: such a decode
+    /// would yield identical contents. No-decode holds by code inspection, the
+    /// columnar arm reads via `into_index_iter` and never calls `into_vec`.
+    ///
+    /// The key closure here is infallible (projection plus hash plus pack), so
+    /// there is no fallible-key path to test, unlike the arrange operator's key.
+    /// `Columnar::into_owned` for time and diff runs on the ok path for every
+    /// record, so the multi-timestamp, mixed-sign input exercises it on both
+    /// positive and negative diffs.
+    #[mz_ore::test]
+    fn map_topk_key_arms_agree() {
+        let (vec_updates, col_updates) = run_both_arms(test_input());
+        assert!(!vec_updates.is_empty());
+        assert_eq!(vec_updates, col_updates);
+        // Retractions reach the operator, so the columnar arm decoded a negative
+        // diff via `Columnar::into_owned`.
+        assert!(vec_updates.iter().any(|(_, _, d)| *d < Diff::ZERO));
+        // The value is the full input row. The key is `(hash, group_column)`, so
+        // the group component mirrors column 0 of the value row.
+        for ((key, value), _t, _d) in &vec_updates {
+            let key_datums: Vec<_> = key.iter().collect();
+            let value_datums: Vec<_> = value.iter().collect();
+            assert_eq!(key_datums.len(), 2);
+            assert_eq!(key_datums[1], value_datums[0]);
         }
     }
 }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -49,7 +49,7 @@ use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::{ClearContainer, MzReduce};
 use crate::render::Pairer;
-use crate::render::columnar::CollectionEdge;
+use crate::render::columnar::{CollectionEdge, vec_to_columnar};
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::render::errors::MaybeValidatingRow;
@@ -110,11 +110,12 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                  `mz_now()` has been const-folded and no temporal bucketing is set",
             );
         }
-        // Temporal bucketing consumes and produces a `Vec` stream, so decode the
-        // edge here. This is the sanctioned leaf decode. It only
-        // fires under `ENABLE_COMPUTE_TEMPORAL_BUCKETING` and the `TemporalBucketing`
-        // strategy, both off on the common path, so the columnar edge otherwise
-        // flows straight through.
+        // Temporal bucketing is `Vec`-internal: it consumes and produces a `Vec`
+        // stream. Decode the edge into it, then re-encode the `Vec` result to
+        // columnar at the boundary so the bucketed input edge stays columnar. It
+        // only fires under `ENABLE_COMPUTE_TEMPORAL_BUCKETING` and the
+        // `TemporalBucketing` strategy, both off on the common path, so the
+        // columnar edge otherwise flows straight through.
         let ok_input = if matches!(
             temporal_bucketing_strategy,
             ArrangementStrategy::TemporalBucketing
@@ -124,11 +125,11 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                 .get(&self.config_set)
                 .try_into()
                 .expect("must fit");
-            CollectionEdge::Vec(T::maybe_apply_temporal_bucketing(
+            CollectionEdge::Columnar(vec_to_columnar(T::maybe_apply_temporal_bucketing(
                 ok_input.into_vec().inner,
                 self.as_of_frontier.clone(),
                 summary,
-            ))
+            )))
         } else {
             ok_input
         };
@@ -160,9 +161,8 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     let mut datum_vec = mz_repr::DatumVec::new();
                     // A literal, non-negative limit skips this branch entirely, so this
                     // per-row evaluation only runs for column or otherwise fallible
-                    // limits. On the `Vec` edge `into_vec` is the identity, so the
-                    // `Vec` path is unchanged. On a columnar edge it is a narrow
-                    // sanctioned decode
+                    // limits. On the `Vec` edge `into_vec` is the identity, so Wave 1 is
+                    // unchanged. On a columnar edge it is a narrow sanctioned decode
                     // confined to this rare path.
                     let errors = ok_input.clone().into_vec().flat_map(move |row| {
                         let temp_storage = mz_repr::RowArena::new();
@@ -622,8 +622,8 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
 /// avoid the per-record decode, because there is no columnar batcher to push
 /// borrowed rows into here. The `Vec` arm maps the collection directly and reuses
 /// the owned input row, so it is behaviorally identical to consuming the
-/// collection directly. The columnar arm runs whenever the TopK input edge is
-/// columnar.
+/// collection as before this migration. The columnar arm runs whenever the TopK
+/// input edge is columnar, which the upstream producers now emit.
 fn map_topk_key<'s, T, L>(
     edge: CollectionEdge<'s, T>,
     name: &str,

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -49,7 +49,7 @@ use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::{ClearContainer, MzReduce};
 use crate::render::Pairer;
-use crate::render::columnar::{CollectionEdge, vec_to_columnar};
+use crate::render::columnar::{CollectionEdge, columnar_to_vec, vec_to_columnar};
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::render::errors::MaybeValidatingRow;
@@ -125,11 +125,11 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                 .get(&self.config_set)
                 .try_into()
                 .expect("must fit");
-            CollectionEdge::Columnar(vec_to_columnar(T::maybe_apply_temporal_bucketing(
-                ok_input.into_vec().inner,
+            vec_to_columnar(T::maybe_apply_temporal_bucketing(
+                columnar_to_vec(ok_input).inner,
                 self.as_of_frontier.clone(),
                 summary,
-            )))
+            ))
         } else {
             ok_input
         };
@@ -161,10 +161,9 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     let mut datum_vec = mz_repr::DatumVec::new();
                     // A literal, non-negative limit skips this branch entirely, so this
                     // per-row evaluation only runs for column or otherwise fallible
-                    // limits. On the `Vec` edge `into_vec` is the identity, so the
-                    // `Vec` path is unchanged. On a columnar edge it is a narrow
-                    // sanctioned decode confined to this rare path.
-                    let errors = ok_input.clone().into_vec().flat_map(move |row| {
+                    // limits. The columnar decode is a narrow sanctioned leaf confined
+                    // to this rare path.
+                    let errors = columnar_to_vec(ok_input.clone()).flat_map(move |row| {
                         let temp_storage = mz_repr::RowArena::new();
                         let datums = datum_vec.borrow_with(&row);
                         match expr.eval(&datums[..], &temp_storage) {
@@ -614,16 +613,13 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
 /// every TopK stage carries the row through to its output.
 ///
 /// The output is a `VecCollection<(Row, Row)>` because the TopK downstream
-/// (`KeyBatcher`, `MzReduce`) is `Vec`-based. The columnar arm therefore still
-/// decodes the value `Row` of every record inline via `Columnar::into_owned`,
-/// which costs the same as `columnar_to_vec`'s body. This is not a zero-copy
-/// borrowed-push: it removes the separate `ColumnarToVec` decode operator and the
-/// intermediate `Vec<(Row, T, Diff)>` container it would produce, but it does not
+/// (`KeyBatcher`, `MzReduce`) is `Vec`-based, so the value `Row` of every record
+/// is decoded inline via `Columnar::into_owned` (the same per-record cost as
+/// `columnar_to_vec`'s body). This removes the separate `ColumnarToVec` decode
+/// operator and its intermediate `Vec<(Row, T, Diff)>` container, but does not
 /// avoid the per-record decode, because there is no columnar batcher to push
-/// borrowed rows into here. The `Vec` arm maps the collection directly and reuses
-/// the owned input row, so it is behaviorally identical to consuming the
-/// collection directly. The columnar arm runs whenever the TopK input edge is
-/// columnar.
+/// borrowed rows into here. The key is formed from the borrowed datums. Time and
+/// diff are owned per record.
 fn map_topk_key<'s, T, L>(
     edge: CollectionEdge<'s, T>,
     name: &str,
@@ -633,54 +629,38 @@ where
     T: crate::render::RenderTimestamp,
     L: FnMut(&[Datum], &Row) -> Row + 'static,
 {
-    match edge {
-        CollectionEdge::Vec(oks) => {
-            let mut datum_vec = mz_repr::DatumVec::new();
-            oks.map(move |row| {
-                let key_row = {
-                    let datums = datum_vec.borrow_with(&row);
-                    key(&datums, &row)
-                };
-                (key_row, row)
-            })
-        }
-        CollectionEdge::Columnar(oks) => {
-            let mut builder = OperatorBuilder::new(name.to_string(), oks.inner.scope());
-            let (output, stream) = builder.new_output();
-            let mut output =
-                OutputBuilder::<_, CapacityContainerBuilder<Vec<((Row, Row), T, Diff)>>>::from(
-                    output,
-                );
-            let mut input = builder.new_input(oks.inner, Pipeline);
-            builder.build(move |_capabilities| {
-                let mut datum_vec = mz_repr::DatumVec::new();
-                move |_frontiers| {
-                    let mut output = output.activate();
-                    input.for_each(|time, data| {
-                        let mut session = output.session_with_builder(&time);
-                        // The value row is decoded to an owned `Row` here because the
-                        // output is `Vec`-based. This is the same per-record cost as
-                        // `columnar_to_vec`, just without the separate decode operator
-                        // and its intermediate container. The key is formed from the
-                        // borrowed datums. Time and diff are owned per record.
-                        for (row, t, d) in data.borrow().into_index_iter() {
-                            let value_row: Row = Columnar::into_owned(row);
-                            let key_row = {
-                                let datums = datum_vec.borrow_with(&value_row);
-                                key(&datums, &value_row)
-                            };
-                            session.give((
-                                (key_row, value_row),
-                                Columnar::into_owned(t),
-                                Columnar::into_owned(d),
-                            ));
-                        }
-                    });
+    let mut builder = OperatorBuilder::new(name.to_string(), edge.inner.scope());
+    let (output, stream) = builder.new_output();
+    let mut output =
+        OutputBuilder::<_, CapacityContainerBuilder<Vec<((Row, Row), T, Diff)>>>::from(output);
+    let mut input = builder.new_input(edge.inner, Pipeline);
+    builder.build(move |_capabilities| {
+        let mut datum_vec = mz_repr::DatumVec::new();
+        move |_frontiers| {
+            let mut output = output.activate();
+            input.for_each(|time, data| {
+                let mut session = output.session_with_builder(&time);
+                // The value row is decoded to an owned `Row` here because the
+                // output is `Vec`-based. This is the same per-record cost as
+                // `columnar_to_vec`, just without the separate decode operator
+                // and its intermediate container. The key is formed from the
+                // borrowed datums. Time and diff are owned per record.
+                for (row, t, d) in data.borrow().into_index_iter() {
+                    let value_row: Row = Columnar::into_owned(row);
+                    let key_row = {
+                        let datums = datum_vec.borrow_with(&value_row);
+                        key(&datums, &value_row)
+                    };
+                    session.give((
+                        (key_row, value_row),
+                        Columnar::into_owned(t),
+                        Columnar::into_owned(d),
+                    ));
                 }
             });
-            stream.as_collection()
         }
-    }
+    });
+    stream.as_collection()
 }
 
 /// Drops the hash-key pairing from a consolidated `(hash_key, row)` TopK result,
@@ -709,7 +689,7 @@ where
                 });
             }
         });
-    CollectionEdge::Columnar(stream.as_collection())
+    stream.as_collection()
 }
 
 /// Build a stage of a topk reduction. Maintains the _retractions_ of the output instead of emitted
@@ -1272,7 +1252,7 @@ mod tests {
     use timely::dataflow::operators::capture::{Event, Extract};
 
     use super::*;
-    use crate::render::columnar::vec_to_columnar;
+    use crate::render::columnar::{columnar_to_vec, vec_to_columnar};
 
     type KeyedUpdate = ((Row, Row), Timestamp, Diff);
     type Captured = std::sync::mpsc::Receiver<Event<Timestamp, Vec<KeyedUpdate>>>;
@@ -1328,65 +1308,50 @@ mod tests {
         ]
     }
 
-    /// Runs `map_topk_key` against the same input fed once as a `Vec` edge and
-    /// once as a columnar edge, forming a hash-and-group key exactly as
-    /// `build_topk` does. Returns the sorted `(key, value)` updates of each arm.
-    fn run_both_arms(input: Vec<(Row, u64, Diff)>) -> (Vec<KeyedUpdate>, Vec<KeyedUpdate>) {
-        let (vec, col) = timely::execute_directly(move |worker| {
+    /// Runs `map_topk_key` against the columnar input edge, forming a
+    /// hash-and-group key exactly as `build_topk` does. Returns the sorted
+    /// `(key, value)` updates.
+    fn run_columnar(input: Vec<(Row, u64, Diff)>) -> Vec<KeyedUpdate> {
+        let captured = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut handle, collection) = scope.new_collection();
-                let mut captures = Vec::new();
-                for edge in [
-                    CollectionEdge::Vec(collection.clone()),
-                    CollectionEdge::Columnar(vec_to_columnar(collection)),
-                ] {
-                    let pairer = Pairer::new(1);
-                    let group_key = [0usize];
-                    let keyed = map_topk_key(edge, "test", move |datums, row| {
+                let pairer = Pairer::new(1);
+                let group_key = [0usize];
+                let keyed =
+                    map_topk_key(vec_to_columnar(collection), "test", move |datums, row| {
                         let hash = row.hashed();
                         let iterator = group_key.iter().map(|i| datums[*i]);
                         pairer.merge(std::iter::once(Datum::from(hash)), iterator)
                     });
-                    captures.push(keyed.inner.capture());
-                }
-                let col = captures.pop().unwrap();
-                let vec = captures.pop().unwrap();
+                let captured = keyed.inner.capture();
                 for (row, time, diff) in input {
                     handle.update_at(row, Timestamp::from(time), diff);
                 }
                 handle.advance_to(Timestamp::from(3_u64));
                 handle.flush();
-                (vec, col)
+                captured
             })
         });
-        (extract_sorted(vec), extract_sorted(col))
+        extract_sorted(captured)
     }
 
-    /// The columnar arm of `map_topk_key` forms the same `(key, value)` updates
-    /// as the `Vec` arm, across several distinct timestamps.
+    /// `map_topk_key` forms the `(key, value)` updates from the columnar input
+    /// across several distinct timestamps.
     ///
-    /// This proves the columnar key-forming is correct and that the columnar arm
-    /// ran (the input is fed through `vec_to_columnar`). It does not prove the
-    /// absence of a silent `ColumnarToVec` decode on the ok path: such a decode
-    /// would yield identical contents. No-decode holds by code inspection, the
-    /// columnar arm reads via `into_index_iter` and never calls `into_vec`.
-    ///
-    /// The key closure here is infallible (projection plus hash plus pack), so
-    /// there is no fallible-key path to test, unlike the arrange operator's key.
-    /// `Columnar::into_owned` for time and diff runs on the ok path for every
+    /// The key closure is infallible (projection plus hash plus pack), so there is
+    /// no fallible-key path. `Columnar::into_owned` for time and diff runs on every
     /// record, so the multi-timestamp, mixed-sign input exercises it on both
     /// positive and negative diffs.
     #[mz_ore::test]
-    fn map_topk_key_arms_agree() {
-        let (vec_updates, col_updates) = run_both_arms(test_input());
-        assert!(!vec_updates.is_empty());
-        assert_eq!(vec_updates, col_updates);
-        // Retractions reach the operator, so the columnar arm decoded a negative
-        // diff via `Columnar::into_owned`.
-        assert!(vec_updates.iter().any(|(_, _, d)| *d < Diff::ZERO));
+    fn map_topk_key_forms_key() {
+        let updates = run_columnar(test_input());
+        assert!(!updates.is_empty());
+        // Retractions reach the operator, so a negative diff was decoded via
+        // `Columnar::into_owned`.
+        assert!(updates.iter().any(|(_, _, d)| *d < Diff::ZERO));
         // The value is the full input row. The key is `(hash, group_column)`, so
         // the group component mirrors column 0 of the value row.
-        for ((key, value), _t, _d) in &vec_updates {
+        for ((key, value), _t, _d) in &updates {
             let key_datums: Vec<_> = key.iter().collect();
             let value_datums: Vec<_> = value.iter().collect();
             assert_eq!(key_datums.len(), 2);
@@ -1427,21 +1392,19 @@ mod tests {
             .collect();
         expected.sort();
 
-        let (is_columnar, captured) = timely::execute_directly(move |worker| {
+        let captured = timely::execute_directly(move |worker| {
             worker.dataflow::<Timestamp, _, _>(|scope| {
                 let (mut handle, collection) = scope.new_collection();
                 let edge = topk_result_to_columnar(collection);
-                let is_columnar = matches!(edge, CollectionEdge::Columnar(_));
-                let captured = edge.into_vec().inner.capture();
+                let captured = columnar_to_vec(edge).inner.capture();
                 for (kv, time, diff) in rows {
                     handle.update_at(kv, Timestamp::from(time), diff);
                 }
                 handle.advance_to(Timestamp::from(3u64));
                 handle.flush();
-                (is_columnar, captured)
+                captured
             })
         });
-        assert!(is_columnar, "the TopK output must be a columnar edge");
 
         let mut got: Vec<(Row, Timestamp, Diff)> = captured
             .extract()

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -36,6 +36,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::soft_assert_or_log;
 use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{Datum, DatumVec, Diff, ReprScalarType, Row, SharedRow};
+use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnation::ColumnationChunker;
 use mz_timely_util::operator::CollectionExt;
 use timely::Container;
@@ -301,10 +302,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                         "requested no validation, but received error collection"
                     );
 
-                    CollectionBundle::from_collections(
-                        result.map(|(_key_hash, row)| row),
-                        err_collection,
-                    )
+                    CollectionBundle::from_edge(topk_result_to_columnar(result), err_collection)
                 }
                 TopKPlan::Basic(BasicTopKPlan {
                     group_key,
@@ -327,7 +325,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                         ok_input, group_key, order_key, offset, limit, arity, buckets,
                     );
                     err_collection = err_collection.concat(errs);
-                    CollectionBundle::from_collections(oks, err_collection)
+                    CollectionBundle::from_edge(oks, err_collection)
                 }
             };
 
@@ -349,7 +347,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         arity: usize,
         buckets: Vec<u64>,
     ) -> (
-        VecCollection<'s, T, Row, Diff>,
+        CollectionEdge<'s, T>,
         VecCollection<'s, T, DataflowErrorSer, Diff>,
     ) {
         let pairer = Pairer::new(1);
@@ -425,7 +423,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
             err_collection = errs;
         }
         (
-            collection.map(|(_key_hash, row)| row),
+            topk_result_to_columnar(collection),
             err_collection.expect("at least one stage validated its inputs"),
         )
     }
@@ -624,7 +622,8 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
 /// avoid the per-record decode, because there is no columnar batcher to push
 /// borrowed rows into here. The `Vec` arm maps the collection directly and reuses
 /// the owned input row, so it is behaviorally identical to consuming the
-/// collection directly.
+/// collection directly. The columnar arm runs whenever the TopK input edge is
+/// columnar.
 fn map_topk_key<'s, T, L>(
     edge: CollectionEdge<'s, T>,
     name: &str,
@@ -682,6 +681,35 @@ where
             stream.as_collection()
         }
     }
+}
+
+/// Drops the hash-key pairing from a consolidated `(hash_key, row)` TopK result,
+/// producing the columnar output edge.
+///
+/// The input is consolidated upstream and the hash key is a function of the row,
+/// so distinct `(hash_key, row)` entries have distinct rows. Dropping the key is
+/// therefore injective and the output carries no within-batch duplicates, so a
+/// non-consolidating `ColumnBuilder` matches the prior `map`. The row is pushed
+/// borrowed, materializing no owned `Row` per record.
+fn topk_result_to_columnar<'s, T>(
+    collection: VecCollection<'s, T, (Row, Row), Diff>,
+) -> CollectionEdge<'s, T>
+where
+    T: crate::render::RenderTimestamp,
+{
+    let stream = collection
+        .inner
+        .unary::<ColumnBuilder<(Row, T, Diff)>, _, _, _>(Pipeline, "TopKUnkey", |_cap, _info| {
+            move |input, output| {
+                input.for_each(|time, data| {
+                    let mut session = output.session_with_builder(&time);
+                    for ((_key_hash, row), t, d) in data.drain(..) {
+                        session.give((&row, &t, &d));
+                    }
+                });
+            }
+        });
+    CollectionEdge::Columnar(stream.as_collection())
 }
 
 /// Build a stage of a topk reduction. Maintains the _retractions_ of the output instead of emitted
@@ -1364,5 +1392,62 @@ mod tests {
             assert_eq!(key_datums.len(), 2);
             assert_eq!(key_datums[1], value_datums[0]);
         }
+    }
+
+    /// `topk_result_to_columnar` drops the hash-key pairing and produces a
+    /// columnar edge whose rows are the value component, preserving times and
+    /// diffs. This is the output flip for the monotonic and basic TopK plans.
+    #[mz_ore::test]
+    fn topk_result_to_columnar_drops_key() {
+        let key = Row::pack_slice(&[Datum::Int64(7)]);
+        let rows = vec![
+            (
+                (key.clone(), Row::pack_slice(&[Datum::Int32(1)])),
+                0u64,
+                Diff::ONE,
+            ),
+            (
+                (key.clone(), Row::pack_slice(&[Datum::Int32(2)])),
+                1u64,
+                Diff::ONE,
+            ),
+            // Retracts at a `(row, time)` with no insertion, so it survives the
+            // `InputSession`'s pre-send consolidation and exercises a borrowed
+            // negative diff.
+            (
+                (key.clone(), Row::pack_slice(&[Datum::Int32(1)])),
+                2u64,
+                -Diff::ONE,
+            ),
+        ];
+        let mut expected: Vec<(Row, Timestamp, Diff)> = rows
+            .iter()
+            .map(|((_, v), t, d)| (v.clone(), Timestamp::from(*t), *d))
+            .collect();
+        expected.sort();
+
+        let (is_columnar, captured) = timely::execute_directly(move |worker| {
+            worker.dataflow::<Timestamp, _, _>(|scope| {
+                let (mut handle, collection) = scope.new_collection();
+                let edge = topk_result_to_columnar(collection);
+                let is_columnar = matches!(edge, CollectionEdge::Columnar(_));
+                let captured = edge.into_vec().inner.capture();
+                for (kv, time, diff) in rows {
+                    handle.update_at(kv, Timestamp::from(time), diff);
+                }
+                handle.advance_to(Timestamp::from(3u64));
+                handle.flush();
+                (is_columnar, captured)
+            })
+        });
+        assert!(is_columnar, "the TopK output must be a columnar edge");
+
+        let mut got: Vec<(Row, Timestamp, Diff)> = captured
+            .extract()
+            .into_iter()
+            .flat_map(|(_, data)| data)
+            .collect();
+        got.sort();
+        assert_eq!(got, expected);
     }
 }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -161,9 +161,9 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     let mut datum_vec = mz_repr::DatumVec::new();
                     // A literal, non-negative limit skips this branch entirely, so this
                     // per-row evaluation only runs for column or otherwise fallible
-                    // limits. On the `Vec` edge `into_vec` is the identity, so Wave 1 is
-                    // unchanged. On a columnar edge it is a narrow sanctioned decode
-                    // confined to this rare path.
+                    // limits. On the `Vec` edge `into_vec` is the identity, so the
+                    // `Vec` path is unchanged. On a columnar edge it is a narrow
+                    // sanctioned decode confined to this rare path.
                     let errors = ok_input.clone().into_vec().flat_map(move |row| {
                         let temp_storage = mz_repr::RowArena::new();
                         let datums = datum_vec.borrow_with(&row);
@@ -622,8 +622,8 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
 /// avoid the per-record decode, because there is no columnar batcher to push
 /// borrowed rows into here. The `Vec` arm maps the collection directly and reuses
 /// the owned input row, so it is behaviorally identical to consuming the
-/// collection as before this migration. The columnar arm runs whenever the TopK
-/// input edge is columnar, which the upstream producers now emit.
+/// collection directly. The columnar arm runs whenever the TopK input edge is
+/// columnar.
 fn map_topk_key<'s, T, L>(
     edge: CollectionEdge<'s, T>,
     name: &str,

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -1396,7 +1396,8 @@ mod tests {
 
     /// `topk_result_to_columnar` drops the hash-key pairing and produces a
     /// columnar edge whose rows are the value component, preserving times and
-    /// diffs. This is the output flip for the monotonic and basic TopK plans.
+    /// diffs. This produces the columnar output for the monotonic and basic TopK
+    /// plans.
     #[mz_ore::test]
     fn topk_result_to_columnar_drops_key() {
         let key = Row::pack_slice(&[Datum::Int64(7)]);

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -618,7 +618,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
 /// The output is a `VecCollection<(Row, Row)>` because the TopK downstream
 /// (`KeyBatcher`, `MzReduce`) is `Vec`-based. The columnar arm therefore still
 /// decodes the value `Row` of every record inline via `Columnar::into_owned`,
-/// which costs the same as `columnar_to_vec`'s body. This is not C1's zero-copy
+/// which costs the same as `columnar_to_vec`'s body. This is not a zero-copy
 /// borrowed-push: it removes the separate `ColumnarToVec` decode operator and the
 /// intermediate `Vec<(Row, T, Diff)>` container it would produce, but it does not
 /// avoid the per-record decode, because there is no columnar batcher to push

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -49,7 +49,7 @@ use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::{ClearContainer, MzReduce};
 use crate::render::Pairer;
-use crate::render::columnar::{CollectionEdge, columnar_to_vec, vec_to_columnar};
+use crate::render::columnar::{CollectionEdge, columnar_to_vec, flat_map_datums, vec_to_columnar};
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
 use crate::render::errors::DataflowErrorSer;
 use crate::render::errors::MaybeValidatingRow;
@@ -158,23 +158,38 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     // the expression might still return a negative limit and
                     // thus needs to be checked.
                     let expr = expr.clone();
-                    let mut datum_vec = mz_repr::DatumVec::new();
                     // A literal, non-negative limit skips this branch entirely, so this
                     // per-row evaluation only runs for column or otherwise fallible
-                    // limits. The columnar decode is a narrow sanctioned leaf confined
-                    // to this rare path.
-                    let errors = columnar_to_vec(ok_input.clone()).flat_map(move |row| {
-                        let temp_storage = mz_repr::RowArena::new();
-                        let datums = datum_vec.borrow_with(&row);
-                        match expr.eval(&datums[..], &temp_storage) {
-                            Ok(l) if l != Datum::Null && l.unwrap_int64() < 0 => {
-                                Some(EvalError::NegLimit.into())
+                    // limits. The limit expression only reads datums, so they come
+                    // from the borrowed column and no owned `Row` is built. This
+                    // stage emits errors only; its ok output stays empty.
+                    let (_, errors) = flat_map_datums::<
+                        _,
+                        CapacityContainerBuilder<Vec<(Row, T, Diff)>>,
+                        _,
+                    >(ok_input.clone(), usize::MAX, {
+                        let mut datum_vec = mz_repr::DatumVec::new();
+                        move |row_datums, time, diff, _ok_session, err_session| {
+                            let temp_storage = mz_repr::RowArena::new();
+                            // `eval` unifies the lifetimes of the expression, the
+                            // datums, and the arena. Copying the datums into a local
+                            // vec lets that lifetime shrink to this call.
+                            let mut datums = datum_vec.borrow();
+                            datums.extend(row_datums.iter());
+                            match expr.eval(&datums[..], &temp_storage) {
+                                Ok(l) if l != Datum::Null && l.unwrap_int64() < 0 => {
+                                    err_session.give((EvalError::NegLimit.into(), time, diff));
+                                    1
+                                }
+                                Ok(_) => 0,
+                                Err(e) => {
+                                    err_session.give((e.into(), time, diff));
+                                    1
+                                }
                             }
-                            Ok(_) => None,
-                            Err(e) => Some(e.into()),
                         }
                     });
-                    err_collection = err_collection.concat(errors);
+                    err_collection = err_collection.concat(errors.as_collection());
                 }
             }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -106,6 +106,7 @@ pub async fn serve(
         mz_timely_util::column_pager::tiered_policy(),
     );
     mz_timely_util::pool_config::metrics::register(metrics_registry);
+    mz_timely_util::columnar::align_buffer::metrics::register(metrics_registry);
 
     let config = Config {
         persist_clients,

--- a/src/compute/src/sink/correction_v2.rs
+++ b/src/compute/src/sink/correction_v2.rs
@@ -1511,7 +1511,12 @@ struct ChunkBuilder<D: Data> {
 impl<D: Data> Default for ChunkBuilder<D> {
     fn default() -> Self {
         Self {
-            inner: Default::default(),
+            // These chunks are retained in the correction chains across
+            // timestamps rather than shipped, so they are stamped apart from
+            // dataflow-edge traffic in the align-buffer metrics.
+            inner: mz_timely_util::columnar::builder::ColumnBuilder::with_origin(
+                mz_timely_util::columnar::align_buffer::Origin::Correction,
+            ),
         }
     }
 }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -53,6 +53,7 @@ allocation-counter = { workspace = true, optional = true }
 [dev-dependencies]
 criterion.workspace = true
 itertools.workspace = true
+prometheus.workspace = true
 proptest.workspace = true
 rand.workspace = true
 tempfile.workspace = true

--- a/src/timely-util/src/column_pager.rs
+++ b/src/timely-util/src/column_pager.rs
@@ -46,6 +46,7 @@ use timely::bytes::arc::BytesMut;
 use timely::dataflow::channels::ContainerBytes;
 
 use crate::columnar::Column;
+use crate::columnar::align_buffer::{AlignBuffer, Origin};
 
 /// Compression codec applied to a paged-out column.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -367,7 +368,7 @@ impl ColumnPager {
     ///
     /// Backend / codec semantics:
     ///
-    /// * Uncompressed, [`Column::Align`]: the inner `Vec<u64>` is moved into
+    /// * Uncompressed, [`Column::Align`]: the buffer's allocation is moved into
     ///   the pager handle with no copies. Swap backend keeps the allocation
     ///   resident; file backend writes it out and drops it.
     /// * Uncompressed, other variants: the column is serialized via
@@ -405,7 +406,10 @@ impl ColumnPager {
                     col.into_bytes(&mut buf);
                     mz_ore::soft_assert_eq_no_log!(buf.len() % 8, 0);
                     col.clear();
-                    Column::Align(bytemuck::allocation::pod_collect_to_vec::<u8, u64>(&buf))
+                    Column::Align(AlignBuffer::from_words(
+                        Origin::Pager,
+                        bytemuck::allocation::pod_collect_to_vec::<u8, u64>(&buf),
+                    ))
                 } else {
                     std::mem::take(col)
                 };
@@ -424,8 +428,10 @@ impl ColumnPager {
                 let body: Vec<u64> = match std::mem::take(col) {
                     // Move the aligned buffer straight into the pager: the
                     // allocation transfers with no copy. `take` already left
-                    // `col` as a refill-ready `Typed` default.
-                    Column::Align(v) => v,
+                    // `col` as a refill-ready `Typed` default. The buffer's
+                    // tracked life ends here, where it stops being a column
+                    // body and becomes pager-owned storage.
+                    Column::Align(v) => v.into_words(),
                     mut other => {
                         let mut buf = Vec::with_capacity(len_bytes);
                         other.into_bytes(&mut buf);
@@ -517,7 +523,7 @@ impl ColumnPager {
                 self.policy.record(PageEvent::PagedIn {
                     bytes: meta.len_bytes,
                 });
-                Column::Align(body)
+                Column::Align(AlignBuffer::from_words(Origin::Fetch, body))
             }
             PagedColumn::Compressed { inner, meta } => {
                 let mut decoded = Vec::with_capacity(meta.len_bytes);
@@ -766,7 +772,8 @@ mod tests {
         });
         let cp = ColumnPager::new(as_dyn(&policy));
         let body: Vec<u64> = (1u64..=512).collect();
-        let mut col: Column<i64> = Column::Align(body.clone());
+        let mut col: Column<i64> =
+            Column::Align(AlignBuffer::from_words(Origin::Pager, body.clone()));
         let paged = cp.page(&mut col);
         assert!(matches!(paged, PagedColumn::Paged { .. }));
         // After paging an Align variant, `col` is reset to the typed default.
@@ -774,7 +781,7 @@ mod tests {
         let rt = cp.take(paged);
         // Round-tripped column should produce identical bytes.
         match rt {
-            Column::Align(v) => assert_eq!(v, body),
+            Column::Align(v) => assert_eq!(v.as_words(), body),
             other => panic!("expected Align, got {:?}", std::mem::discriminant(&other)),
         }
     }

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -109,6 +109,9 @@ impl<C: Columnar> Column<C> {
     pub fn is_empty(&self) -> bool {
         match self {
             Column::Typed(t) => t.is_empty(),
+            // The `Align` arm avoids decoding whenever the producer recorded a
+            // count, which matters for a paged body: see `record_count`.
+            Column::Align(a) if a.records().is_some() => a.records() == Some(0),
             Column::Bytes(_) | Column::Align(_) => self.borrow().is_empty(),
         }
     }
@@ -158,7 +161,18 @@ where
 impl<C: Columnar> Accountable for Column<C> {
     #[inline]
     fn record_count(&self) -> i64 {
-        self.borrow().len().try_into().expect("Must fit")
+        // Timely asks for this at both push and pull. A paged body answers
+        // from its resident count rather than decoding, because materializing
+        // here would pull it back onto the heap before it ever sat in a queue,
+        // which is the entire interval paging covers.
+        let records = match self {
+            Column::Align(a) => a.records(),
+            _ => None,
+        };
+        records
+            .unwrap_or_else(|| self.borrow().len())
+            .try_into()
+            .expect("Must fit")
     }
 }
 impl<C: Columnar> DrainContainer for Column<C> {

--- a/src/timely-util/src/columnar.rs
+++ b/src/timely-util/src/columnar.rs
@@ -17,6 +17,7 @@
 
 #![deny(missing_docs)]
 
+pub mod align_buffer;
 pub mod batcher;
 pub mod builder;
 pub mod builder_input;
@@ -39,6 +40,7 @@ use timely::bytes::arc::Bytes;
 use timely::container::{DrainContainer, PushInto, SizableContainer};
 use timely::dataflow::channels::ContainerBytes;
 
+use crate::columnar::align_buffer::{AlignBuffer, Origin};
 use crate::columnation::ColInternalMerger;
 
 /// A batcher for columnar storage.
@@ -79,8 +81,8 @@ pub enum Column<C: Columnar> {
     /// Reasons could include misalignment, cloning of data, or wanting
     /// to release the `Bytes` as a scarce resource.
     ///
-    /// `Vec<u64>` guarantees `u64` alignment for the contained bytes.
-    Align(Vec<u64>),
+    /// [`AlignBuffer`] guarantees `u64` alignment for the contained bytes.
+    Align(AlignBuffer),
 }
 
 impl<C: Columnar> Column<C> {
@@ -143,7 +145,10 @@ where
             Column::Typed(t) => Column::Typed(t.clone()),
             Column::Bytes(b) => {
                 assert_eq!(b.len() % 8, 0);
-                Self::Align(bytemuck::allocation::pod_collect_to_vec(b))
+                Self::Align(AlignBuffer::from_words(
+                    Origin::Decode,
+                    bytemuck::allocation::pod_collect_to_vec(b),
+                ))
             }
             Column::Align(a) => Column::Align(a.clone()),
         }
@@ -246,7 +251,10 @@ impl<C: Columnar> ContainerBytes for Column<C> {
         } else {
             // We failed to cast the slice, so we'll reallocate. `Vec<u64>`
             // is u64-aligned by construction.
-            Self::Align(bytemuck::allocation::pod_collect_to_vec(&bytes[..]))
+            Self::Align(AlignBuffer::from_words(
+                Origin::Decode,
+                bytemuck::allocation::pod_collect_to_vec(&bytes[..]),
+            ))
         }
     }
 
@@ -264,7 +272,9 @@ impl<C: Columnar> ContainerBytes for Column<C> {
         match self {
             Column::Typed(t) => indexed::write(writer, &t.borrow()).unwrap(),
             Column::Bytes(b) => writer.write_all(b).unwrap(),
-            Column::Align(a) => writer.write_all(bytemuck::cast_slice(a)).unwrap(),
+            Column::Align(a) => writer
+                .write_all(bytemuck::cast_slice(a.as_words()))
+                .unwrap(),
         }
     }
 }
@@ -328,7 +338,8 @@ mod tests {
         let mut region: Vec<u64> = vec![0; raw.len() / 8];
         let region_bytes = bytemuck::cast_slice_mut(&mut region[..]);
         region_bytes[..raw.len()].copy_from_slice(&raw);
-        let column_align: Column<i32> = Column::Align(region);
+        let column_align: Column<i32> =
+            Column::Align(AlignBuffer::from_words(Origin::Decode, region));
         let column_align2 = column_align.clone();
 
         assert_eq!(

--- a/src/timely-util/src/columnar/align_buffer.rs
+++ b/src/timely-util/src/columnar/align_buffer.rs
@@ -24,8 +24,8 @@
 //! See [`metrics`] for what is recorded and how to turn recording on.
 
 use std::ops::Deref;
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 use columnar::AsBytes;
 use columnar::bytes::indexed;
@@ -153,9 +153,16 @@ pub struct AlignBuffer {
 enum Body {
     /// Words on the heap.
     Heap(Vec<u64>),
-    /// Words in the buffer pool, copied out on first access.
+    /// Words in the buffer pool, copied out and freed on first access.
     Paged {
-        handle: ChunkHandle,
+        /// The pool chunk, present until the body is materialized.
+        ///
+        /// A `Mutex` rather than a `RefCell` because a `Column` crosses
+        /// worker threads, and taking the handle out is what lets
+        /// materialization free the chunk: holding both the slot and the
+        /// heap copy for the rest of the body's life would make paging cost
+        /// memory rather than save it.
+        spilled: Mutex<Option<ChunkHandle>>,
         resident: OnceLock<Vec<u64>>,
     },
 }
@@ -243,7 +250,7 @@ impl AlignBuffer {
         let charge = metrics::record_mint(origin, words);
         Some(AlignBuffer {
             body: Body::Paged {
-                handle,
+                spilled: Mutex::new(Some(handle)),
                 resident: OnceLock::new(),
             },
             words,
@@ -280,9 +287,9 @@ impl AlignBuffer {
         self.release();
         match std::mem::replace(&mut self.body, Body::Heap(Vec::new())) {
             Body::Heap(words) => words,
-            Body::Paged { handle, resident } => {
-                resident.into_inner().unwrap_or_else(|| read_out(&handle))
-            }
+            Body::Paged { spilled, resident } => resident
+                .into_inner()
+                .unwrap_or_else(|| Self::take_spilled(&spilled)),
         }
     }
 
@@ -315,11 +322,28 @@ impl AlignBuffer {
         matches!(&self.body, Body::Paged { resident, .. } if resident.get().is_none())
     }
 
+    /// Copies a paged body out of the pool and frees the chunk, at most once.
+    fn take_spilled(spilled: &Mutex<Option<ChunkHandle>>) -> Vec<u64> {
+        let handle = spilled
+            .lock()
+            .expect("spill mutex poisoned")
+            .take()
+            .expect("the handle is present until the body is materialized");
+        let mut words = Vec::new();
+        // `take` copies out and frees, where `read_into` would leave the chunk
+        // allocated and hold the body twice for the rest of its life.
+        handle.take(&mut words);
+        metrics::record_unpage(words.capacity());
+        words
+    }
+
     /// The words, copying a paged body out of the pool on first call.
     fn resident_words(&self) -> &[u64] {
         match &self.body {
             Body::Heap(words) => words,
-            Body::Paged { handle, resident } => resident.get_or_init(|| read_out(handle)),
+            Body::Paged { spilled, resident } => {
+                resident.get_or_init(|| Self::take_spilled(spilled))
+            }
         }
     }
 
@@ -344,14 +368,6 @@ impl AlignBuffer {
             metrics::record_drop(self.origin, charge);
         }
     }
-}
-
-/// Copies a paged body out of the pool, counting the round trip.
-fn read_out(handle: &ChunkHandle) -> Vec<u64> {
-    let mut words = Vec::new();
-    handle.read_into(&mut words);
-    metrics::record_unpage(words.capacity());
-    words
 }
 
 impl Deref for AlignBuffer {

--- a/src/timely-util/src/columnar/align_buffer.rs
+++ b/src/timely-util/src/columnar/align_buffer.rs
@@ -1,0 +1,255 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! [`AlignBuffer`]: the owned serialized body behind
+//! [`Column::Align`](crate::columnar::Column::Align), and the instrumentation
+//! that measures how long such bodies live.
+//!
+//! Every `Column::Align` payload is one of these. The population is wider than
+//! the bodies in flight between operators: it also covers bodies deliberately
+//! retained by a sink or a merge chain, bodies relocated off the network, and
+//! bodies copied out of a backing store. Each buffer records the [`Origin`]
+//! that minted it, so those groups can be read apart.
+//!
+//! A buffer is immutable once built. Every constructor sizes it before the
+//! value exists, which is what lets the tracker charge a byte count that stays
+//! correct for the buffer's whole life.
+//!
+//! See [`metrics`] for what is recorded and how to turn recording on.
+
+use std::ops::Deref;
+
+use columnar::AsBytes;
+use columnar::bytes::indexed;
+
+pub mod metrics;
+
+/// What minted a buffer. Recorded per buffer so the metrics separate bodies in
+/// flight on a dataflow edge from bodies that are retained on purpose or that a
+/// read produced.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Origin {
+    /// Shipped by [`ColumnBuilder`](crate::columnar::builder::ColumnBuilder):
+    /// a body on a dataflow edge.
+    Ship,
+    /// Shipped by
+    /// [`ConsolidatingColumnBuilder`](crate::columnar::consolidate::ConsolidatingColumnBuilder):
+    /// also a body on a dataflow edge.
+    Consolidate,
+    /// Minted by the container builder behind the materialized-view sink's
+    /// correction buffer, which holds its chunks across timestamps. Split out
+    /// from [`Origin::Ship`] because a retained body's life says nothing about
+    /// a body in flight on an edge.
+    Correction,
+    /// Serialized to a fitting size by the column pager, which does this to
+    /// every typed body it is handed, before parking or paging it. Covers both
+    /// arrangement merge chains and the sink correction chains, which route
+    /// through the pager whatever the batcher gate says. A correction chunk the
+    /// builder minted itself is [`Origin::Correction`]; one the pager
+    /// serialized lands here.
+    Pager,
+    /// Copied out of a backing store to serve a read.
+    Fetch,
+    /// Relocated from received bytes that could not be borrowed in place,
+    /// because of misalignment or because a clone was needed.
+    Decode,
+}
+
+impl Origin {
+    /// Every origin, in metric-label order.
+    pub const ALL: [Origin; 6] = [
+        Origin::Ship,
+        Origin::Consolidate,
+        Origin::Correction,
+        Origin::Pager,
+        Origin::Fetch,
+        Origin::Decode,
+    ];
+
+    /// The `origin` metric label value.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Origin::Ship => "ship",
+            Origin::Consolidate => "consolidate",
+            Origin::Correction => "correction",
+            Origin::Pager => "pager",
+            Origin::Fetch => "fetch",
+            Origin::Decode => "decode",
+        }
+    }
+
+    /// This origin's index into the per-origin counter array.
+    const fn index(self) -> usize {
+        match self {
+            Origin::Ship => 0,
+            Origin::Consolidate => 1,
+            Origin::Correction => 2,
+            Origin::Pager => 3,
+            Origin::Fetch => 4,
+            Origin::Decode => 5,
+        }
+    }
+}
+
+/// An owned, immutable, `u64`-aligned serialized column body: the payload of
+/// [`Column::Align`](crate::columnar::Column::Align).
+///
+/// `u64` alignment is what lets
+/// [`Column::borrow`](crate::columnar::Column::borrow) decode the body in
+/// place, so the words are held as a `Vec<u64>` rather than a `Vec<u8>`.
+pub struct AlignBuffer {
+    words: Vec<u64>,
+    origin: Origin,
+    /// The mint instant and the bytes charged to the in-flight gauges, present
+    /// exactly when tracking was on at construction.
+    ///
+    /// The charge is stored rather than recomputed at drop because
+    /// [`metrics::set_tracking_enabled`] can flip while buffers are in flight.
+    /// Crediting back a buffer that was never charged would walk the gauges
+    /// away from the truth, and the arithmetic is unsigned.
+    charge: Option<metrics::Charge>,
+}
+
+impl AlignBuffer {
+    /// Serializes `item`'s columnar byte slices into a buffer sized to fit
+    /// them exactly.
+    ///
+    /// `indexed::encode` appends through `push`/`extend_from_slice`, so an
+    /// exact `with_capacity` means no word is written twice and no word is
+    /// zero-initialized before its real value lands.
+    pub fn encode<'a, A>(origin: Origin, item: &A) -> Self
+    where
+        A: AsBytes<'a>,
+    {
+        let mut words = Vec::with_capacity(indexed::length_in_words(item));
+        indexed::encode(&mut words, item);
+        Self::from_words(origin, words)
+    }
+
+    /// Builds a buffer by filling a `Vec<u64>` in place, for producers whose
+    /// length only the filler knows, such as a copy-out from a backing store.
+    pub fn build(origin: Origin, fill: impl FnOnce(&mut Vec<u64>)) -> Self {
+        let mut words = Vec::new();
+        fill(&mut words);
+        Self::from_words(origin, words)
+    }
+
+    /// Takes ownership of an already-serialized buffer.
+    pub fn from_words(origin: Origin, words: Vec<u64>) -> Self {
+        let charge = metrics::record_mint(origin, words.capacity());
+        AlignBuffer {
+            words,
+            origin,
+            charge,
+        }
+    }
+
+    /// Surrenders the allocation to a caller that will own it from here on.
+    /// The buffer's tracked life ends at this call, not when the returned
+    /// `Vec` is dropped.
+    pub fn into_words(mut self) -> Vec<u64> {
+        self.release();
+        std::mem::take(&mut self.words)
+    }
+
+    /// The serialized body.
+    ///
+    /// [`Deref`] covers call sites whose parameter type is a slice; this
+    /// exists for the ones that are generic over it, where deref coercion has
+    /// nothing to coerce toward.
+    #[inline]
+    pub fn as_words(&self) -> &[u64] {
+        &self.words
+    }
+
+    /// What minted this buffer.
+    pub fn origin(&self) -> Origin {
+        self.origin
+    }
+
+    /// Records the end of the tracked life, at most once.
+    fn release(&mut self) {
+        if let Some(charge) = self.charge.take() {
+            metrics::record_drop(self.origin, charge);
+        }
+    }
+}
+
+impl Deref for AlignBuffer {
+    type Target = [u64];
+    #[inline]
+    fn deref(&self) -> &[u64] {
+        &self.words
+    }
+}
+
+impl Clone for AlignBuffer {
+    /// A clone is a separate allocation with its own life, so it is minted and
+    /// tracked in its own right. It inherits the origin, because a body cloned
+    /// to fan out to a second consumer is still on the edge that produced it.
+    fn clone(&self) -> Self {
+        Self::from_words(self.origin, self.words.clone())
+    }
+}
+
+impl Drop for AlignBuffer {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+impl std::fmt::Debug for AlignBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AlignBuffer")
+            .field("origin", &self.origin)
+            .field("words", &self.words.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Origin indices are dense and distinct, which the counter array indexes
+    /// by without a bounds story of its own.
+    #[mz_ore::test]
+    fn origin_indices_are_dense() {
+        for (expected, origin) in Origin::ALL.into_iter().enumerate() {
+            assert_eq!(origin.index(), expected, "{origin:?}");
+        }
+    }
+
+    /// Labels are distinct, so the metric series do not collide.
+    #[mz_ore::test]
+    fn origin_labels_are_distinct() {
+        let mut labels: Vec<_> = Origin::ALL.iter().map(|o| o.label()).collect();
+        labels.sort_unstable();
+        let count = labels.len();
+        labels.dedup();
+        assert_eq!(labels.len(), count);
+    }
+
+    /// `into_words` hands out the same bytes the buffer held.
+    #[mz_ore::test]
+    fn into_words_round_trips() {
+        let buf = AlignBuffer::from_words(Origin::Ship, vec![1, 2, 3]);
+        assert_eq!(&*buf, &[1, 2, 3]);
+        assert_eq!(buf.into_words(), vec![1, 2, 3]);
+    }
+
+    /// A clone is independent of its source and keeps the origin.
+    #[mz_ore::test]
+    fn clone_inherits_origin() {
+        let buf = AlignBuffer::from_words(Origin::Decode, vec![7; 4]);
+        let clone = buf.clone();
+        assert_eq!(clone.origin(), Origin::Decode);
+        assert_eq!(&*clone, &*buf);
+    }
+}

--- a/src/timely-util/src/columnar/align_buffer.rs
+++ b/src/timely-util/src/columnar/align_buffer.rs
@@ -24,9 +24,14 @@
 //! See [`metrics`] for what is recorded and how to turn recording on.
 
 use std::ops::Deref;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use columnar::AsBytes;
 use columnar::bytes::indexed;
+use mz_ore::pool::{ChunkHandle, ChunkHints, Pool};
+
+use crate::columnar::chunk::LZ4_CODEC;
 
 pub mod metrics;
 
@@ -56,6 +61,12 @@ pub enum Origin {
     Pager,
     /// Copied out of a backing store to serve a read.
     Fetch,
+    /// Materialized out of the buffer pool because a consumer borrowed a
+    /// paged edge body. Distinct from [`Origin::Fetch`], which is a trace
+    /// chunk read: an `Unpage` mint is an edge body whose paging round trip
+    /// completed, so the count says how often paging actually cost a copy
+    /// rather than how many bodies were paged.
+    Unpage,
     /// Relocated from received bytes that could not be borrowed in place,
     /// because of misalignment or because a clone was needed.
     Decode,
@@ -63,12 +74,13 @@ pub enum Origin {
 
 impl Origin {
     /// Every origin, in metric-label order.
-    pub const ALL: [Origin; 6] = [
+    pub const ALL: [Origin; 7] = [
         Origin::Ship,
         Origin::Consolidate,
         Origin::Correction,
         Origin::Pager,
         Origin::Fetch,
+        Origin::Unpage,
         Origin::Decode,
     ];
 
@@ -80,6 +92,7 @@ impl Origin {
             Origin::Correction => "correction",
             Origin::Pager => "pager",
             Origin::Fetch => "fetch",
+            Origin::Unpage => "unpage",
             Origin::Decode => "decode",
         }
     }
@@ -92,7 +105,8 @@ impl Origin {
             Origin::Correction => 2,
             Origin::Pager => 3,
             Origin::Fetch => 4,
-            Origin::Decode => 5,
+            Origin::Unpage => 5,
+            Origin::Decode => 6,
         }
     }
 }
@@ -104,7 +118,19 @@ impl Origin {
 /// [`Column::borrow`](crate::columnar::Column::borrow) decode the body in
 /// place, so the words are held as a `Vec<u64>` rather than a `Vec<u8>`.
 pub struct AlignBuffer {
-    words: Vec<u64>,
+    body: Body,
+    /// Serialized length in words. Resident in both states, because
+    /// `length_in_bytes` is on the hot path and a paged body must answer it
+    /// without a copy-out.
+    words: usize,
+    /// Record count, when the producer knew it at mint.
+    ///
+    /// Resident for the same reason as `words`, and load-bearing for paging:
+    /// `Column`'s `Accountable::record_count` would otherwise decode the body,
+    /// and Timely calls it at both push and pull. A paged body that
+    /// materialized there would be back on the heap before it ever sat in a
+    /// queue, which is the whole interval paging exists to cover.
+    records: Option<usize>,
     origin: Origin,
     /// The mint instant and the bytes charged to the in-flight gauges, present
     /// exactly when tracking was on at construction.
@@ -116,6 +142,55 @@ pub struct AlignBuffer {
     charge: Option<metrics::Charge>,
 }
 
+/// Where a buffer's words live.
+///
+/// A paged body is owned by the buffer pool, so it is budgeted and evictable
+/// for as long as nobody looks at it. The pool hands out no references, so the
+/// first look copies the body out and the buffer stays heap-backed from then
+/// on: paging covers the interval between minting a body and the consumer
+/// reaching it, which measurement puts at seconds under memory pressure and is
+/// where essentially all of an edge body's life is spent.
+enum Body {
+    /// Words on the heap.
+    Heap(Vec<u64>),
+    /// Words in the buffer pool, copied out on first access.
+    Paged {
+        handle: ChunkHandle,
+        resident: OnceLock<Vec<u64>>,
+    },
+}
+
+/// Whether newly minted edge bodies go to the buffer pool. Read once per mint.
+static EDGE_PAGING: AtomicBool = AtomicBool::new(false);
+
+/// Bodies below this stay on the heap: the pool's smallest size class is
+/// 64 KiB, so paging under it trades no meaningful memory for slot waste.
+/// Edge bodies cluster at ~1.8 MiB, so this only excludes the ragged tail a
+/// builder flushes at the end of a run.
+const PAGE_MIN_BYTES: usize = 64 << 10;
+
+/// Turns edge paging on or off for this process. Takes effect for bodies
+/// minted after the call; bodies already paged stay paged.
+pub fn set_edge_paging_enabled(enabled: bool) {
+    EDGE_PAGING.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether edge paging is on.
+pub fn edge_paging_enabled() -> bool {
+    EDGE_PAGING.load(Ordering::Relaxed)
+}
+
+/// The pool edge bodies page to, if any. `None` leaves them on the heap, which
+/// is the behavior with the gate off or before a config apply has installed and
+/// budgeted a pool.
+fn edge_pool() -> Option<Pool> {
+    if EDGE_PAGING.load(Ordering::Relaxed) {
+        crate::pool_config::active_pool()
+    } else {
+        None
+    }
+}
+
 impl AlignBuffer {
     /// Serializes `item`'s columnar byte slices into a buffer sized to fit
     /// them exactly.
@@ -123,13 +198,59 @@ impl AlignBuffer {
     /// `indexed::encode` appends through `push`/`extend_from_slice`, so an
     /// exact `with_capacity` means no word is written twice and no word is
     /// zero-initialized before its real value lands.
-    pub fn encode<'a, A>(origin: Origin, item: &A) -> Self
+    pub fn encode<'a, A>(origin: Origin, records: usize, item: &A) -> Self
     where
         A: AsBytes<'a>,
     {
-        let mut words = Vec::with_capacity(indexed::length_in_words(item));
-        indexed::encode(&mut words, item);
-        Self::from_words(origin, words)
+        let words = indexed::length_in_words(item);
+        if let Some(paged) = Self::page(origin, records, words, item) {
+            return paged;
+        }
+        let mut heap = Vec::with_capacity(words);
+        indexed::encode(&mut heap, item);
+        let mut buffer = Self::from_words(origin, heap);
+        buffer.records = Some(records);
+        buffer
+    }
+
+    /// Serializes `item` straight into a pool slot, or returns `None` when the
+    /// body is not worth a slot or no pool is installed.
+    ///
+    /// This is the zero-staging path: the single copy lands in pool memory, so
+    /// a shipped body costs one page population instead of faulting a fresh
+    /// heap allocation that dies a few seconds later.
+    fn page<'a, A>(origin: Origin, records: usize, words: usize, item: &A) -> Option<Self>
+    where
+        A: AsBytes<'a>,
+    {
+        if words * 8 < PAGE_MIN_BYTES {
+            return None;
+        }
+        let pool = edge_pool()?;
+        let handle = pool.insert_with(words, ChunkHints::default(), &LZ4_CODEC, |dst| {
+            let bytes: &mut [u8] = bytemuck::cast_slice_mut(dst);
+            let mut cursor = std::io::Cursor::new(bytes);
+            indexed::write(&mut cursor, item).expect("writing to a slice cannot fail");
+            // `insert_with` requires the fill to overwrite the whole slot, and
+            // the slot was sized from `length_in_words`. A short write would
+            // leave the tail unspecified and decode as garbage.
+            assert_eq!(
+                usize::try_from(cursor.position()).expect("position fits usize"),
+                words * 8,
+                "serialized body must fill the slot exactly",
+            );
+        });
+        let charge = metrics::record_mint(origin, words);
+        Some(AlignBuffer {
+            body: Body::Paged {
+                handle,
+                resident: OnceLock::new(),
+            },
+            words,
+            records: Some(records),
+            origin,
+            charge,
+        })
     }
 
     /// Builds a buffer by filling a `Vec<u64>` in place, for producers whose
@@ -144,7 +265,9 @@ impl AlignBuffer {
     pub fn from_words(origin: Origin, words: Vec<u64>) -> Self {
         let charge = metrics::record_mint(origin, words.capacity());
         AlignBuffer {
-            words,
+            words: words.len(),
+            body: Body::Heap(words),
+            records: None,
             origin,
             charge,
         }
@@ -155,7 +278,49 @@ impl AlignBuffer {
     /// `Vec` is dropped.
     pub fn into_words(mut self) -> Vec<u64> {
         self.release();
-        std::mem::take(&mut self.words)
+        match std::mem::replace(&mut self.body, Body::Heap(Vec::new())) {
+            Body::Heap(words) => words,
+            Body::Paged { handle, resident } => {
+                resident.into_inner().unwrap_or_else(|| read_out(&handle))
+            }
+        }
+    }
+
+    /// The record count, when the producer knew it at mint. Serialized bodies
+    /// built from raw words (a network relocation, a backing-store read) do
+    /// not, and answer `None`.
+    #[inline]
+    pub fn records(&self) -> Option<usize> {
+        self.records
+    }
+
+    /// The serialized length in words.
+    ///
+    /// Inherent so it shadows the [`Deref`] slice's `len`, which would
+    /// materialize a paged body to answer.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.words
+    }
+
+    /// Whether the body is empty, without materializing it.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.words == 0
+    }
+
+    /// Whether the body still lives in the pool.
+    #[inline]
+    pub fn is_paged(&self) -> bool {
+        matches!(&self.body, Body::Paged { resident, .. } if resident.get().is_none())
+    }
+
+    /// The words, copying a paged body out of the pool on first call.
+    fn resident_words(&self) -> &[u64] {
+        match &self.body {
+            Body::Heap(words) => words,
+            Body::Paged { handle, resident } => resident.get_or_init(|| read_out(handle)),
+        }
     }
 
     /// The serialized body.
@@ -165,7 +330,7 @@ impl AlignBuffer {
     /// nothing to coerce toward.
     #[inline]
     pub fn as_words(&self) -> &[u64] {
-        &self.words
+        self.resident_words()
     }
 
     /// What minted this buffer.
@@ -181,11 +346,19 @@ impl AlignBuffer {
     }
 }
 
+/// Copies a paged body out of the pool, counting the round trip.
+fn read_out(handle: &ChunkHandle) -> Vec<u64> {
+    let mut words = Vec::new();
+    handle.read_into(&mut words);
+    metrics::record_unpage(words.capacity());
+    words
+}
+
 impl Deref for AlignBuffer {
     type Target = [u64];
     #[inline]
     fn deref(&self) -> &[u64] {
-        &self.words
+        self.resident_words()
     }
 }
 
@@ -194,7 +367,24 @@ impl Clone for AlignBuffer {
     /// tracked in its own right. It inherits the origin, because a body cloned
     /// to fan out to a second consumer is still on the edge that produced it.
     fn clone(&self) -> Self {
-        Self::from_words(self.origin, self.words.clone())
+        match &self.body {
+            Body::Heap(words) => {
+                let mut clone = Self::from_words(self.origin, words.clone());
+                clone.records = self.records;
+                clone
+            }
+            // A paged body materializes to be cloned. `ChunkHandle` is not
+            // `Clone`, deliberately: one handle owns one chunk, and sharing
+            // would move the pool to refcounted ownership for the sake of a
+            // path that barely runs. Cloning an edge body is rare (a fan-out
+            // to a second consumer), and the copy is what the pool's
+            // no-references contract would charge for the read anyway.
+            Body::Paged { .. } => {
+                let mut clone = Self::from_words(self.origin, self.resident_words().to_vec());
+                clone.records = self.records;
+                clone
+            }
+        }
     }
 }
 
@@ -208,7 +398,8 @@ impl std::fmt::Debug for AlignBuffer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AlignBuffer")
             .field("origin", &self.origin)
-            .field("words", &self.words.len())
+            .field("words", &self.words)
+            .field("paged", &self.is_paged())
             .finish_non_exhaustive()
     }
 }

--- a/src/timely-util/src/columnar/align_buffer.rs
+++ b/src/timely-util/src/columnar/align_buffer.rs
@@ -23,6 +23,7 @@
 //!
 //! See [`metrics`] for what is recorded and how to turn recording on.
 
+use std::cell::RefCell;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -175,6 +176,66 @@ static EDGE_PAGING: AtomicBool = AtomicBool::new(false);
 /// Edge bodies cluster at ~1.8 MiB, so this only excludes the ragged tail a
 /// builder flushes at the end of a run.
 const PAGE_MIN_BYTES: usize = 64 << 10;
+
+thread_local! {
+    /// One retired heap body, kept for the next materialization on this thread
+    /// to refill.
+    ///
+    /// Capacity one, and per worker thread rather than per operator. That
+    /// distinction is the whole safety argument: a per-builder buffer would be
+    /// held by every idle operator on every worker, which is why Timely's own
+    /// container recycling is disabled. One body per thread is 2 MiB times the
+    /// worker count and does not grow with the dataflow.
+    static UNPAGE_STASH: RefCell<Option<Vec<u64>>> = const { RefCell::new(None) };
+}
+
+/// Words a stashed buffer may retain, one ship-sized body. Matches
+/// `SCRATCH_RETAIN_WORDS` in [`crate::columnar::chunk`], which bounds the
+/// equivalent read scratch on the chunk paths.
+const STASH_RETAIN_WORDS: usize = 1 << 18;
+
+/// Retires `words` into this thread's slot, if it is worth keeping and the slot
+/// is free.
+///
+/// `try_with` because a buffer can be dropped while the thread's locals are
+/// being torn down, where `with` would panic.
+fn stash_words(mut words: Vec<u64>) {
+    if words.capacity() == 0 || words.capacity() > STASH_RETAIN_WORDS {
+        return;
+    }
+    words.clear();
+    let _ = UNPAGE_STASH.try_with(|cell| {
+        let mut slot = cell.borrow_mut();
+        // Only fill an empty slot, so no `Vec` is dropped while the borrow is
+        // held and the slot cannot churn between two live bodies.
+        if slot.is_none() {
+            *slot = Some(words);
+        }
+    });
+}
+
+/// This thread's retired buffer, or a fresh empty one.
+fn take_stashed_words() -> Vec<u64> {
+    UNPAGE_STASH
+        .try_with(|cell| cell.borrow_mut().take())
+        .ok()
+        .flatten()
+        .unwrap_or_default()
+}
+
+/// The capacity of this thread's retired buffer, or `None` when the slot is
+/// empty.
+///
+/// Exists so tests can assert the buffer is retired and then consumed. Pointer
+/// equality is not a sound substitute: the allocator may hand back the same
+/// address whether or not the slot was used.
+#[doc(hidden)]
+pub fn stashed_capacity() -> Option<usize> {
+    UNPAGE_STASH
+        .try_with(|cell| cell.borrow().as_ref().map(Vec::capacity))
+        .ok()
+        .flatten()
+}
 
 /// Turns edge paging on or off for this process. Takes effect for bodies
 /// minted after the call; bodies already paged stay paged.
@@ -329,7 +390,10 @@ impl AlignBuffer {
             .expect("spill mutex poisoned")
             .take()
             .expect("the handle is present until the body is materialized");
-        let mut words = Vec::new();
+        // Refill this thread's retired buffer rather than faulting a fresh
+        // one. `read_impl` clears the destination itself, so a stashed buffer
+        // with spare capacity is filled without allocating at all.
+        let mut words = take_stashed_words();
         // `take` copies out and frees, where `read_into` would leave the chunk
         // allocated and hold the body twice for the rest of its life.
         handle.take(&mut words);
@@ -407,6 +471,16 @@ impl Clone for AlignBuffer {
 impl Drop for AlignBuffer {
     fn drop(&mut self) {
         self.release();
+        // Retire the heap allocation, whichever state held it. A paged body
+        // that was never materialized has no heap buffer, and dropping the
+        // `spilled` handle here is what frees its pool chunk.
+        let words = match std::mem::replace(&mut self.body, Body::Heap(Vec::new())) {
+            Body::Heap(words) => Some(words),
+            Body::Paged { resident, .. } => resident.into_inner(),
+        };
+        if let Some(words) = words {
+            stash_words(words);
+        }
     }
 }
 

--- a/src/timely-util/src/columnar/align_buffer/metrics.rs
+++ b/src/timely-util/src/columnar/align_buffer/metrics.rs
@@ -60,6 +60,7 @@ static COUNTERS: [Counters; Origin::ALL.len()] = [
     Counters::new(),
     Counters::new(),
     Counters::new(),
+    Counters::new(),
 ];
 
 /// The per-origin histogram handles, resolved once by [`register`]. Absent
@@ -168,6 +169,24 @@ pub(super) fn record_mint(origin: Origin, capacity_words: usize) -> Option<Charg
         minted: Instant::now(),
         bytes,
     })
+}
+
+/// Records a paged body being copied out of the pool.
+///
+/// Count and bytes only, deliberately: the copy becomes part of an existing
+/// buffer rather than a buffer of its own, so it has no life of its own to
+/// time and no in-flight bytes to hold. The [`Origin::Unpage`] in-flight and
+/// lifetime series therefore stay at zero, and `mints_total` there is the
+/// useful number: how often paging actually cost a copy-out.
+pub(super) fn record_unpage(capacity_words: usize) {
+    if !TRACKING.load(Ordering::Relaxed) {
+        return;
+    }
+    let counters = counters(Origin::Unpage);
+    counters.mints.fetch_add(1, Ordering::Relaxed);
+    counters
+        .bytes_minted
+        .fetch_add(u64::cast_from(capacity_words) * 8, Ordering::Relaxed);
 }
 
 /// Credits back a buffer whose life just ended, and records how long it lasted.

--- a/src/timely-util/src/columnar/align_buffer/metrics.rs
+++ b/src/timely-util/src/columnar/align_buffer/metrics.rs
@@ -1,0 +1,258 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Lifetime and footprint instrumentation for
+//! [`AlignBuffer`](super::AlignBuffer), keyed by [`Origin`].
+//!
+//! Recording answers two questions per origin: how long a serialized body
+//! stays alive, and how many bytes of them are alive at once.
+//!
+//! Both are read per origin because the answer differs by producer. Bodies on a
+//! dataflow edge ([`Origin::Ship`], [`Origin::Consolidate`]) are the ones the
+//! question is about: they are owned by whoever holds the container and belong
+//! to no budget. The other origins are recorded so they can be told apart from
+//! the edges, not because they share their behavior. [`Origin::Correction`]
+//! and [`Origin::Pager`] bodies are retained on purpose, and [`Origin::Fetch`]
+//! and [`Origin::Decode`] bodies come from a read rather than a producer.
+//!
+//! Recording is off until [`set_tracking_enabled`], because it costs an
+//! [`Instant::now`] and a handful of atomics per buffer, on a path that mints
+//! one buffer per shipped chunk. Consult
+//! [`mz_column_align_buffer_tracking_enabled`](register) before reading a zero
+//! as an absence of traffic.
+//!
+//! The gate may flip while buffers are in flight. A buffer minted while
+//! recording was off carries no charge and stays uncounted for its whole life,
+//! so the in-flight gauges never credit back bytes they were never charged. The
+//! consequence is that the gauges undercount until every buffer that predates
+//! the flip has died.
+//!
+//! Tests live in `tests/align_buffer_metrics.rs`: the gate and the registration
+//! are process-global, so anything asserting on them needs a binary where it is
+//! the only test.
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Instant;
+
+use mz_ore::cast::{CastFrom, CastLossy};
+use mz_ore::metric;
+use mz_ore::metrics::raw::HistogramVec;
+use mz_ore::metrics::{ComputedUIntGauge, Histogram, MakeCollectorOpts, MetricsRegistry};
+use mz_ore::stats::histogram_seconds_buckets;
+
+use super::Origin;
+
+/// Whether buffers record their life. Read once per mint.
+static TRACKING: AtomicBool = AtomicBool::new(false);
+
+/// Per-origin counters, indexed by `Origin::index`.
+static COUNTERS: [Counters; Origin::ALL.len()] = [
+    Counters::new(),
+    Counters::new(),
+    Counters::new(),
+    Counters::new(),
+    Counters::new(),
+    Counters::new(),
+];
+
+/// The per-origin histogram handles, resolved once by [`register`]. Absent
+/// until then, which is the normal state in tests and benches, where the
+/// counters still work and only the distributions are skipped.
+static HISTOGRAMS: OnceLock<Histograms> = OnceLock::new();
+
+/// Size classes to grade buffers against, in bytes. Powers of two spanning the
+/// buffer pool's size classes (64 KiB to 8 MiB) with a rung either side, so a
+/// distribution that piles up just under a class boundary is visible as such.
+const SIZE_BUCKETS: [f64; 13] = [
+    4096.0,
+    8192.0,
+    16384.0,
+    32768.0,
+    65536.0,
+    131_072.0,
+    262_144.0,
+    524_288.0,
+    1_048_576.0,
+    2_097_152.0,
+    4_194_304.0,
+    8_388_608.0,
+    16_777_216.0,
+];
+
+/// One origin's counters. Levels and monotonic totals both live here; the
+/// `_total` suffix on a metric name, not its type, marks it monotonic.
+struct Counters {
+    mints: AtomicU64,
+    drops: AtomicU64,
+    bytes_minted: AtomicU64,
+    inflight_bytes: AtomicU64,
+    inflight_count: AtomicU64,
+    inflight_bytes_peak: AtomicU64,
+    lifetime_max_nanos: AtomicU64,
+}
+
+impl Counters {
+    const fn new() -> Counters {
+        Counters {
+            mints: AtomicU64::new(0),
+            drops: AtomicU64::new(0),
+            bytes_minted: AtomicU64::new(0),
+            inflight_bytes: AtomicU64::new(0),
+            inflight_count: AtomicU64::new(0),
+            inflight_bytes_peak: AtomicU64::new(0),
+            lifetime_max_nanos: AtomicU64::new(0),
+        }
+    }
+}
+
+/// Pre-resolved per-origin histograms, so recording a sample is an array index
+/// rather than a label lookup under the vec's lock.
+struct Histograms {
+    lifetime: [Histogram; Origin::ALL.len()],
+    size: [Histogram; Origin::ALL.len()],
+}
+
+/// What a tracked buffer carries for the duration of its life. The byte count
+/// is the one charged at mint, so the credit at drop matches it exactly even
+/// if the gate flipped in between.
+pub(super) struct Charge {
+    minted: Instant,
+    bytes: u64,
+}
+
+fn counters(origin: Origin) -> &'static Counters {
+    &COUNTERS[origin.index()]
+}
+
+/// Turns recording on or off for this process. Takes effect for buffers minted
+/// after the call; buffers already in flight keep the tracking state they were
+/// minted with.
+pub fn set_tracking_enabled(enabled: bool) {
+    TRACKING.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether recording is on.
+pub fn tracking_enabled() -> bool {
+    TRACKING.load(Ordering::Relaxed)
+}
+
+/// Charges a newly minted buffer of `capacity_words` words, returning what it
+/// must carry to be credited back at drop, or `None` when recording is off.
+pub(super) fn record_mint(origin: Origin, capacity_words: usize) -> Option<Charge> {
+    if !TRACKING.load(Ordering::Relaxed) {
+        return None;
+    }
+    let bytes = u64::cast_from(capacity_words) * 8;
+    let counters = counters(origin);
+    counters.mints.fetch_add(1, Ordering::Relaxed);
+    counters.bytes_minted.fetch_add(bytes, Ordering::Relaxed);
+    counters.inflight_count.fetch_add(1, Ordering::Relaxed);
+    // `fetch_add` returns the previous value, so the level after this mint is
+    // the sum. Two concurrent mints can each miss the other's contribution to
+    // the peak, which understates it by at most one buffer per race.
+    let inflight = counters.inflight_bytes.fetch_add(bytes, Ordering::Relaxed) + bytes;
+    counters
+        .inflight_bytes_peak
+        .fetch_max(inflight, Ordering::Relaxed);
+    if let Some(histograms) = HISTOGRAMS.get() {
+        histograms.size[origin.index()].observe(f64::cast_lossy(bytes));
+    }
+    Some(Charge {
+        minted: Instant::now(),
+        bytes,
+    })
+}
+
+/// Credits back a buffer whose life just ended, and records how long it lasted.
+pub(super) fn record_drop(origin: Origin, charge: Charge) {
+    let elapsed = charge.minted.elapsed();
+    let counters = counters(origin);
+    counters.drops.fetch_add(1, Ordering::Relaxed);
+    counters
+        .inflight_bytes
+        .fetch_sub(charge.bytes, Ordering::Relaxed);
+    counters.inflight_count.fetch_sub(1, Ordering::Relaxed);
+    // Histogram buckets are capped, and the top of the distribution is the
+    // whole question here, so keep an uncapped high-water mark beside them.
+    // This is not hypothetical: a 1.9x-oversubscribed replica put 1.8% of its
+    // bodies past the top bucket, and only this gauge recovered the 142s peak.
+    let nanos = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
+    counters
+        .lifetime_max_nanos
+        .fetch_max(nanos, Ordering::Relaxed);
+    if let Some(histograms) = HISTOGRAMS.get() {
+        histograms.lifetime[origin.index()].observe(elapsed.as_secs_f64());
+    }
+}
+
+/// Installs the align-buffer metrics into `registry`. Idempotent; repeated
+/// calls after the first are no-ops.
+pub fn register(registry: &MetricsRegistry) {
+    static REGISTERED: OnceLock<()> = OnceLock::new();
+    REGISTERED.get_or_init(|| {
+        // Every name and help string is a literal at the `metric!` call so the
+        // metrics-catalog scanner (`bin/gen-metrics-catalog`), which reads the
+        // source rather than the expanded macro, can index them.
+        let lifetime: HistogramVec = registry.register(metric!(
+            name: "mz_column_align_buffer_lifetime_seconds",
+            help: "Time from minting a serialized column body to dropping it.",
+            var_labels: ["origin"],
+            // Ceiling from measurement, not taste: on a replica whose working
+            // set was ~1.9x its RAM, 1.8% of bodies outlived 64s and the
+            // longest reached 142s, which censored p99 into `+Inf` and made it
+            // unrecoverable from the buckets. 1024s leaves room for a deeper
+            // pressure regime to still resolve its tail.
+            buckets: histogram_seconds_buckets(0.000_008, 1024.0),
+        ));
+        let size: HistogramVec = registry.register(metric!(
+            name: "mz_column_align_buffer_size_bytes",
+            help: "Allocation size of serialized column bodies at mint.",
+            var_labels: ["origin"],
+            buckets: SIZE_BUCKETS.to_vec(),
+        ));
+        let histograms = Histograms {
+            lifetime: Origin::ALL.map(|origin| lifetime.with_label_values(&[origin.label()])),
+            size: Origin::ALL.map(|origin| size.with_label_values(&[origin.label()])),
+        };
+        // Only `register` writes this, under `get_or_init`, so it cannot lose.
+        let _ = HISTOGRAMS.set(histograms);
+
+        let _tracking: ComputedUIntGauge = registry.register_computed_gauge(
+            metric!(
+                name: "mz_column_align_buffer_tracking_enabled",
+                help: "Whether align-buffer lifetime recording is on. Every other align-buffer metric is frozen while this is zero.",
+            ),
+            || u64::from(tracking_enabled()),
+        );
+
+        for origin in Origin::ALL {
+            let label = origin.label();
+            gauge(registry, metric!(name: "mz_column_align_buffer_mints_total", help: "Serialized column bodies minted.", const_labels: {"origin" => label}), origin, |c| c.mints.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_drops_total", help: "Serialized column bodies dropped.", const_labels: {"origin" => label}), origin, |c| c.drops.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_bytes_minted_total", help: "Allocation bytes of serialized column bodies minted.", const_labels: {"origin" => label}), origin, |c| c.bytes_minted.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_inflight_bytes", help: "Allocation bytes of serialized column bodies currently alive.", const_labels: {"origin" => label}), origin, |c| c.inflight_bytes.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_inflight_count", help: "Serialized column bodies currently alive.", const_labels: {"origin" => label}), origin, |c| c.inflight_count.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_inflight_bytes_peak", help: "High-water mark of allocation bytes of serialized column bodies alive at once.", const_labels: {"origin" => label}), origin, |c| c.inflight_bytes_peak.load(Ordering::Relaxed));
+            gauge(registry, metric!(name: "mz_column_align_buffer_lifetime_max_nanoseconds", help: "High-water mark of a serialized column body's life, uncapped by histogram buckets.", const_labels: {"origin" => label}), origin, |c| c.lifetime_max_nanos.load(Ordering::Relaxed));
+        }
+    });
+}
+
+/// Registers one computed gauge over one origin's counters, read at scrape
+/// time.
+fn gauge(
+    registry: &MetricsRegistry,
+    opts: MakeCollectorOpts,
+    origin: Origin,
+    field: fn(&Counters) -> u64,
+) {
+    let _gauge: ComputedUIntGauge =
+        registry.register_computed_gauge(opts, move || field(counters(origin)));
+}

--- a/src/timely-util/src/columnar/builder.rs
+++ b/src/timely-util/src/columnar/builder.rs
@@ -17,12 +17,12 @@
 
 use std::collections::VecDeque;
 
-use columnar::bytes::indexed;
 use columnar::{Clear, Columnar, Len, Push};
 use timely::container::PushInto;
 use timely::container::{ContainerBuilder, LengthPreservingContainerBuilder};
 
 use crate::columnar::Column;
+use crate::columnar::align_buffer::{AlignBuffer, Origin};
 
 /// A container builder for `Column<C>`.
 pub struct ColumnBuilder<C: Columnar> {
@@ -35,6 +35,24 @@ pub struct ColumnBuilder<C: Columnar> {
     finished: Option<Column<C>>,
     /// Completed containers pending to be sent.
     pending: VecDeque<Column<C>>,
+    /// The origin stamped on every buffer this builder mints.
+    origin: Origin,
+}
+
+impl<C: Columnar> ColumnBuilder<C> {
+    /// A builder that stamps its buffers with `origin` rather than the
+    /// [`Origin::Ship`] that [`Default`] uses.
+    ///
+    /// For builders whose chunks are retained rather than sent, so their
+    /// lifetimes do not land in the same metric series as bodies in flight on a
+    /// dataflow edge. Timely constructs container builders through `Default`,
+    /// which is why shipping is the default and retention is the opt-in.
+    pub fn with_origin(origin: Origin) -> Self {
+        ColumnBuilder {
+            origin,
+            ..Default::default()
+        }
+    }
 }
 
 impl<C: Columnar, T> PushInto<T> for ColumnBuilder<C>
@@ -47,22 +65,23 @@ where
         // Mint a container once the serialized size reaches the ship threshold.
         use columnar::Borrow;
         if crate::columnar::at_serialized_capacity(&self.current.borrow()) {
-            /// Move the contents from `current` to a `Vec<u64>` allocation built via
-            /// `indexed::encode` (so no zero-init pre-pass), and push it to `pending`.
+            /// Move the contents from `current` into a fitting [`AlignBuffer`]
+            /// and push it to `pending`.
             #[cold]
-            fn outlined_align<C>(current: &mut C::Container, pending: &mut VecDeque<Column<C>>)
-            where
+            fn outlined_align<C>(
+                current: &mut C::Container,
+                pending: &mut VecDeque<Column<C>>,
+                origin: Origin,
+            ) where
                 C: Columnar,
             {
                 use columnar::Borrow;
-                let words = indexed::length_in_words(&current.borrow());
-                let mut alloc: Vec<u64> = Vec::with_capacity(words);
-                indexed::encode(&mut alloc, &current.borrow());
-                pending.push_back(Column::Align(alloc));
+                let buffer = AlignBuffer::encode(origin, &current.borrow());
+                pending.push_back(Column::Align(buffer));
                 current.clear();
             }
 
-            outlined_align(&mut self.current, &mut self.pending);
+            outlined_align(&mut self.current, &mut self.pending, self.origin);
         }
     }
 }
@@ -74,6 +93,7 @@ impl<C: Columnar> Default for ColumnBuilder<C> {
             current: Default::default(),
             finished: None,
             pending: Default::default(),
+            origin: Origin::Ship,
         }
     }
 }

--- a/src/timely-util/src/columnar/builder.rs
+++ b/src/timely-util/src/columnar/builder.rs
@@ -75,8 +75,9 @@ where
             ) where
                 C: Columnar,
             {
-                use columnar::Borrow;
-                let buffer = AlignBuffer::encode(origin, &current.borrow());
+                use columnar::{Borrow, Len};
+                let view = current.borrow();
+                let buffer = AlignBuffer::encode(origin, view.len(), &view);
                 pending.push_back(Column::Align(buffer));
                 current.clear();
             }

--- a/src/timely-util/src/columnar/chunk.rs
+++ b/src/timely-util/src/columnar/chunk.rs
@@ -62,6 +62,7 @@ use timely::dataflow::channels::ContainerBytes;
 use timely::progress::Timestamp;
 use timely::progress::frontier::AntichainRef;
 
+use crate::columnar::align_buffer::{AlignBuffer, Origin};
 use crate::columnar::batcher::{ColumnChunker, gallop};
 use crate::columnar::unload::UnloadChunk;
 use crate::columnar::{Column, at_serialized_capacity};
@@ -252,9 +253,9 @@ impl<D: Columnar, T: Columnar, R: Columnar> ColumnChunk<D, T, R> {
                 Rc::try_unwrap(col).unwrap_or_else(|shared| copy_column(&shared))
             }
             ColumnChunk::Spilled(body) => {
-                let mut words = Vec::new();
-                body.handle.read_into(&mut words);
-                Column::Align(words)
+                Column::Align(AlignBuffer::build(Origin::Fetch, |words| {
+                    body.handle.read_into(words)
+                }))
             }
         }
     }
@@ -1745,13 +1746,13 @@ mod tests {
         let Column::Align(words) = &column else {
             panic!("a spilled body reads back as Column::Align");
         };
-        let words = words.clone();
+        let words = words.as_words().to_vec();
         let respilled = force_spill(ColumnChunk::from_column(column), &pool);
         let reread = respilled.into_column();
         let Column::Align(words2) = &reread else {
             panic!("a spilled body reads back as Column::Align");
         };
-        assert_eq!(&words, words2, "byte-identical round trip");
+        assert_eq!(words, words2.as_words(), "byte-identical round trip");
         assert_eq!(collect_column(&reread), data);
     }
 

--- a/src/timely-util/src/columnar/consolidate.rs
+++ b/src/timely-util/src/columnar/consolidate.rs
@@ -42,6 +42,7 @@ use differential_dataflow::difference::Semigroup;
 use timely::container::{ContainerBuilder, PushInto};
 
 use crate::columnar::Column;
+use crate::columnar::align_buffer::{AlignBuffer, Origin};
 
 /// Per-buffer byte budget for the staging cap. Matches the 8 KiB basis DD's
 /// `ConsolidatingContainerBuilder` uses via `timely::container::buffer::default_capacity`.
@@ -180,7 +181,7 @@ where
         self.staging.drain(..consumed);
     }
 
-    /// Serialize the SoA accumulator into a `Column::Align` via `indexed::encode`, which
+    /// Serialize the SoA accumulator into a fitting [`AlignBuffer`], which
     /// builds the buffer with `Vec::push`/`extend_from_slice` so no memory is initialized
     /// twice.
     #[cold]
@@ -195,9 +196,8 @@ where
         );
         self.cur_len = 0;
 
-        let mut buf: Vec<u64> = Vec::with_capacity(indexed::length_in_words(&cur.borrow()));
-        indexed::encode(&mut buf, &cur.borrow());
-        self.pending.push_back(Column::Align(buf));
+        let buffer = AlignBuffer::encode(Origin::Consolidate, &cur.borrow());
+        self.pending.push_back(Column::Align(buffer));
     }
 }
 

--- a/src/timely-util/src/columnar/consolidate.rs
+++ b/src/timely-util/src/columnar/consolidate.rs
@@ -194,9 +194,10 @@ where
             std::mem::take(&mut self.cur_t),
             std::mem::take(&mut self.cur_r),
         );
+        let records = self.cur_len;
         self.cur_len = 0;
 
-        let buffer = AlignBuffer::encode(Origin::Consolidate, &cur.borrow());
+        let buffer = AlignBuffer::encode(Origin::Consolidate, records, &cur.borrow());
         self.pending.push_back(Column::Align(buffer));
     }
 }

--- a/src/timely-util/tests/align_buffer_metrics.rs
+++ b/src/timely-util/tests/align_buffer_metrics.rs
@@ -1,0 +1,196 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! End-to-end check that align-buffer recording reaches Prometheus.
+//!
+//! Its own test binary because registration and the recording gate are
+//! process-global: `register` installs into exactly one registry per process,
+//! and a sibling test toggling the gate would race this one. Everything here
+//! runs in one test function for the same reason.
+
+use mz_ore::cast::CastLossy;
+use mz_ore::metrics::MetricsRegistry;
+use mz_timely_util::columnar::Column;
+use mz_timely_util::columnar::align_buffer::{AlignBuffer, Origin, metrics};
+use mz_timely_util::columnar::builder::ColumnBuilder;
+use prometheus::proto::MetricFamily;
+use timely::container::{ContainerBuilder, PushInto};
+
+/// Records to push through the builder. Each `(u64, u64)` serializes to 16
+/// bytes and the ship threshold is 2 MiB, so this crosses it a few times over
+/// and the builder is guaranteed to mint buffers rather than hold one partial
+/// chunk.
+const RECORDS: u64 = 400_000;
+
+/// The one metric sample matching `name` and `origin`, or `None` if the series
+/// is absent.
+fn sample(families: &[MetricFamily], name: &str, origin: &str) -> Option<f64> {
+    let family = families.iter().find(|f| f.name() == name)?;
+    let metric = family.get_metric().iter().find(|m| {
+        m.get_label()
+            .iter()
+            .any(|l| l.name() == "origin" && l.value() == origin)
+    })?;
+    Some(metric.get_gauge().value())
+}
+
+/// Observation count of the histogram series matching `name` and `origin`.
+fn histogram_count(families: &[MetricFamily], name: &str, origin: &str) -> Option<u64> {
+    let family = families.iter().find(|f| f.name() == name)?;
+    let metric = family.get_metric().iter().find(|m| {
+        m.get_label()
+            .iter()
+            .any(|l| l.name() == "origin" && l.value() == origin)
+    })?;
+    Some(metric.get_histogram().get_sample_count())
+}
+
+/// Value of an unlabeled gauge series.
+fn plain_gauge(families: &[MetricFamily], name: &str) -> Option<f64> {
+    let family = families.iter().find(|f| f.name() == name)?;
+    Some(family.get_metric().first()?.get_gauge().value())
+}
+
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // too slow
+fn ship_buffers_reach_prometheus() {
+    let registry = MetricsRegistry::new();
+    metrics::register(&registry);
+
+    // With the gate off, shipping must leave every series alone. This also
+    // pins down that a zero reading means "not recording", not "no traffic".
+    assert!(!metrics::tracking_enabled());
+    let untracked = ship(RECORDS);
+    assert!(untracked > 0, "builder shipped nothing to measure");
+    let families = registry.gather();
+    assert_eq!(
+        plain_gauge(&families, "mz_column_align_buffer_tracking_enabled"),
+        Some(0.0)
+    );
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_mints_total", "ship"),
+        Some(0.0),
+        "recording is off, so nothing may be counted",
+    );
+
+    metrics::set_tracking_enabled(true);
+    let shipped = ship(RECORDS);
+    let families = registry.gather();
+
+    assert_eq!(
+        plain_gauge(&families, "mz_column_align_buffer_tracking_enabled"),
+        Some(1.0),
+    );
+
+    let mints =
+        sample(&families, "mz_column_align_buffer_mints_total", "ship").expect("ship mints series");
+    let drops =
+        sample(&families, "mz_column_align_buffer_drops_total", "ship").expect("ship drops series");
+    assert_eq!(
+        mints,
+        f64::cast_lossy(shipped),
+        "every shipped chunk mints exactly one buffer",
+    );
+    assert_eq!(mints, drops, "every buffer was dropped by end of scope");
+
+    // Everything minted has been dropped, so the level is back to zero while
+    // the high-water mark and the byte total retain what passed through.
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_inflight_bytes", "ship"),
+        Some(0.0),
+    );
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_inflight_count", "ship"),
+        Some(0.0),
+    );
+    let peak = sample(
+        &families,
+        "mz_column_align_buffer_inflight_bytes_peak",
+        "ship",
+    )
+    .expect("ship peak series");
+    assert!(peak > 0.0, "peak in-flight bytes stayed at zero");
+    let bytes = sample(
+        &families,
+        "mz_column_align_buffer_bytes_minted_total",
+        "ship",
+    )
+    .expect("ship bytes series");
+    assert!(bytes >= peak, "bytes minted {bytes} below peak {peak}");
+    assert!(
+        sample(
+            &families,
+            "mz_column_align_buffer_lifetime_max_nanoseconds",
+            "ship"
+        )
+        .expect("ship lifetime max series")
+            > 0.0,
+    );
+
+    // Both distributions observed once per buffer: sizes at mint, lifetimes at
+    // drop.
+    assert_eq!(
+        histogram_count(&families, "mz_column_align_buffer_size_bytes", "ship"),
+        Some(shipped),
+    );
+    assert_eq!(
+        histogram_count(&families, "mz_column_align_buffer_lifetime_seconds", "ship"),
+        Some(shipped),
+    );
+
+    // Origins with no traffic report zero rather than going missing, so a
+    // dashboard panel does not show a gap for an idle producer.
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_mints_total", "decode"),
+        Some(0.0),
+    );
+
+    // A buffer minted with the gate off must stay uncounted even if the gate
+    // flips on before it dies. Crediting back a charge that was never made
+    // would underflow the unsigned in-flight gauge.
+    metrics::set_tracking_enabled(false);
+    let untracked = AlignBuffer::from_words(Origin::Decode, vec![0u64; 1024]);
+    metrics::set_tracking_enabled(true);
+    drop(untracked);
+    let families = registry.gather();
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_drops_total", "decode"),
+        Some(0.0),
+        "a buffer minted with the gate off must not be counted at drop",
+    );
+    assert_eq!(
+        sample(&families, "mz_column_align_buffer_inflight_bytes", "decode"),
+        Some(0.0),
+    );
+
+    metrics::set_tracking_enabled(false);
+}
+
+/// Pushes `records` records through a [`ColumnBuilder`], draining every chunk
+/// it mints, and returns how many chunks it shipped. Each chunk is dropped
+/// before the next is extracted, so all of them are dropped by the time this
+/// returns.
+fn ship(records: u64) -> u64 {
+    let mut builder = ColumnBuilder::<(u64, u64)>::default();
+    let mut shipped = 0;
+    for i in 0..records {
+        builder.push_into((i, i));
+        while let Some(container) = builder.extract() {
+            assert!(
+                matches!(container, Column::Align(_)),
+                "a shipped chunk is a serialized body",
+            );
+            shipped += 1;
+        }
+    }
+    // `finish` hands back the trailing partial chunk as `Typed`, which is not
+    // an align buffer; drain it so the builder holds nothing at drop.
+    while builder.finish().is_some() {}
+    shipped
+}

--- a/src/timely-util/tests/align_buffer_paging.rs
+++ b/src/timely-util/tests/align_buffer_paging.rs
@@ -17,7 +17,9 @@
 
 use columnar::{Borrow, Push};
 use mz_timely_util::columnar::Column;
-use mz_timely_util::columnar::align_buffer::{AlignBuffer, Origin, set_edge_paging_enabled};
+use mz_timely_util::columnar::align_buffer::{
+    AlignBuffer, Origin, set_edge_paging_enabled, stashed_capacity,
+};
 use mz_timely_util::pool_config::{PoolPagerConfig, apply_pool_config};
 use timely::Accountable;
 use timely::dataflow::channels::ContainerBytes;
@@ -159,6 +161,34 @@ fn edge_paging() {
         "materializing must release the chunk, not keep a second copy",
     );
     drop(transient);
+
+    // The buffer a materialized body leaves behind is retired to this thread's
+    // slot and refilled by the next materialization, so a steady stream of
+    // paged bodies allocates once rather than once per body. Per thread and
+    // capacity one, never per operator: a per-builder buffer would be held by
+    // every idle operator on every worker.
+    let a = encode(RECORDS);
+    let _ = a.as_words();
+    drop(a);
+    let retired = stashed_capacity();
+    assert!(
+        retired.is_some_and(|c| c >= heap_words.len()),
+        "a materialized body retires its buffer, got {retired:?}",
+    );
+    let b = encode(RECORDS);
+    assert!(b.is_paged());
+    assert_eq!(
+        stashed_capacity(),
+        retired,
+        "an unmaterialized body must not disturb the slot",
+    );
+    assert_eq!(b.as_words(), &heap_words[..]);
+    assert_eq!(
+        stashed_capacity(),
+        None,
+        "materializing must consume the retired buffer, not allocate afresh",
+    );
+    drop(b);
 
     // A clone of a paged body is a heap body with the same contents: the pool
     // hands out no second owner, so the clone pays the copy.

--- a/src/timely-util/tests/align_buffer_paging.rs
+++ b/src/timely-util/tests/align_buffer_paging.rs
@@ -46,6 +46,13 @@ fn encode(records: u64) -> AlignBuffer {
     AlignBuffer::encode(Origin::Ship, usize::try_from(records).unwrap(), &view)
 }
 
+/// Live chunks in the process pool, or 0 before one is installed.
+fn pool_live_chunks() -> u64 {
+    mz_timely_util::pool_config::active_pool()
+        .map(|p| p.stats().live_chunks)
+        .unwrap_or(0)
+}
+
 /// The decoded `(u64, u64)` pairs a column holds.
 fn decode(column: &Column<(u64, u64)>) -> Vec<(u64, u64)> {
     use columnar::{Index, Len};
@@ -132,6 +139,26 @@ fn edge_paging() {
         Some(usize::try_from(RECORDS).unwrap()),
         "materializing keeps the resident record count",
     );
+
+    // Materializing frees the pool chunk rather than holding the body in both
+    // places: a run where every body is borrowed would otherwise cost more
+    // memory than not paging at all.
+    let before = pool_live_chunks();
+    let transient = encode(RECORDS);
+    assert!(transient.is_paged());
+    assert_eq!(
+        pool_live_chunks(),
+        before + 1,
+        "a paged body holds exactly one chunk",
+    );
+    let _ = transient.as_words();
+    assert!(!transient.is_paged());
+    assert_eq!(
+        pool_live_chunks(),
+        before,
+        "materializing must release the chunk, not keep a second copy",
+    );
+    drop(transient);
 
     // A clone of a paged body is a heap body with the same contents: the pool
     // hands out no second owner, so the clone pays the copy.

--- a/src/timely-util/tests/align_buffer_paging.rs
+++ b/src/timely-util/tests/align_buffer_paging.rs
@@ -1,0 +1,148 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Edge paging: serialized bodies live in the buffer pool until borrowed.
+//!
+//! Its own test binary because both pieces of state are process-global and
+//! have no teardown: `apply_pool_config` installs a pool singleton for the life
+//! of the process, and the paging gate is a static. A sibling test minting
+//! bodies would land in the same pool and race the gate, so everything here
+//! runs in one test function.
+
+use columnar::{Borrow, Push};
+use mz_timely_util::columnar::Column;
+use mz_timely_util::columnar::align_buffer::{AlignBuffer, Origin, set_edge_paging_enabled};
+use mz_timely_util::pool_config::{PoolPagerConfig, apply_pool_config};
+use timely::Accountable;
+use timely::dataflow::channels::ContainerBytes;
+
+/// Records per body. Each `(u64, u64)` serializes to 16 bytes, so this clears
+/// the 64 KiB paging floor several times over without reaching the ~2 MiB ship
+/// threshold, which keeps the test about paging rather than about shipping.
+const RECORDS: u64 = 20_000;
+
+/// A body too small to be worth a pool slot, under the 64 KiB floor.
+const TINY_RECORDS: u64 = 8;
+
+/// Builds a container of `records` `(u64, u64)` pairs.
+fn container(records: u64) -> <(u64, u64) as columnar::Columnar>::Container {
+    let mut c = <(u64, u64) as columnar::Columnar>::Container::default();
+    for i in 0..records {
+        c.push(&(i, i));
+    }
+    c
+}
+
+/// Encodes `records` rows, stamped as an edge body.
+fn encode(records: u64) -> AlignBuffer {
+    let c = container(records);
+    let view = c.borrow();
+    AlignBuffer::encode(Origin::Ship, usize::try_from(records).unwrap(), &view)
+}
+
+/// The decoded `(u64, u64)` pairs a column holds.
+fn decode(column: &Column<(u64, u64)>) -> Vec<(u64, u64)> {
+    use columnar::{Index, Len};
+    let view = column.borrow();
+    (0..view.len())
+        .map(|i| {
+            let (a, b) = view.get(i);
+            (*a, *b)
+        })
+        .collect()
+}
+
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // unsupported operation: foreign function calls (mmap, madvise)
+fn edge_paging() {
+    // Reference encoding, gate off. Everything below is compared against this,
+    // so paging is held to producing byte-identical bodies.
+    set_edge_paging_enabled(false);
+    let heap = encode(RECORDS);
+    assert!(!heap.is_paged(), "gate off must leave the body on the heap");
+    let heap_words = heap.as_words().to_vec();
+    let heap_rows = decode(&Column::Align(heap));
+
+    // A gate with no pool installed is still inert: paging must never be a
+    // half-configured state that silently drops the body somewhere else.
+    set_edge_paging_enabled(true);
+    assert!(
+        !encode(RECORDS).is_paged(),
+        "no pool installed means no paging, whatever the gate says",
+    );
+
+    let installed = apply_pool_config(PoolPagerConfig {
+        budget_bytes: 1 << 30,
+        spill_threads: 0,
+        eager_backing: false,
+        rss_target_bytes: 0,
+    });
+    assert!(installed, "pool reservation expected to succeed in tests");
+
+    // Below the floor, a body stays on the heap even with pool and gate ready.
+    assert!(
+        !encode(TINY_RECORDS).is_paged(),
+        "a body under the size-class floor is not worth a slot",
+    );
+
+    let paged = encode(RECORDS);
+    assert!(paged.is_paged(), "gate plus pool must page the body");
+
+    // The point of the design: the metadata every hot path needs is resident,
+    // so none of it drags the body back out of the pool. Timely asks for
+    // `record_count` at both push and pull, and materializing there would undo
+    // paging before the body ever sat in a queue.
+    assert_eq!(
+        paged.len(),
+        heap_words.len(),
+        "word count without a copy-out"
+    );
+    assert_eq!(paged.records(), Some(usize::try_from(RECORDS).unwrap()));
+    assert!(!paged.is_empty());
+    assert!(paged.is_paged(), "reading metadata must not materialize");
+
+    let column = Column::Align(paged);
+    assert_eq!(column.record_count(), i64::try_from(RECORDS).unwrap());
+    assert_eq!(column.length_in_bytes(), heap_words.len() * 8);
+    assert!(!column.is_empty());
+    let Column::Align(ref still) = column else {
+        unreachable!("constructed as Align")
+    };
+    assert!(
+        still.is_paged(),
+        "record_count, length_in_bytes and is_empty must all stay off the body",
+    );
+
+    // Borrowing is what pays for the copy, and it must reproduce the body
+    // exactly.
+    assert_eq!(decode(&column), heap_rows, "paged body decodes identically");
+    let Column::Align(ref materialized) = column else {
+        unreachable!("constructed as Align")
+    };
+    assert!(!materialized.is_paged(), "a borrow materializes the body");
+    assert_eq!(materialized.as_words(), &heap_words[..]);
+    assert_eq!(
+        materialized.records(),
+        Some(usize::try_from(RECORDS).unwrap()),
+        "materializing keeps the resident record count",
+    );
+
+    // A clone of a paged body is a heap body with the same contents: the pool
+    // hands out no second owner, so the clone pays the copy.
+    let fresh = encode(RECORDS);
+    assert!(fresh.is_paged());
+    let clone = fresh.clone();
+    assert_eq!(clone.as_words(), &heap_words[..]);
+    assert_eq!(clone.records(), fresh.records());
+
+    // `into_words` yields the same bytes from either state.
+    assert_eq!(encode(RECORDS).into_words(), heap_words);
+
+    set_edge_paging_enabled(false);
+}

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -242,7 +242,6 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_bounded_staleness_isolation
     enable_coalesce_case_transform
     enable_compute_half_join2
-    enable_compute_render_fueled_as_specific_collection
     enable_date_bin_hopping
     enable_default_connection_validation
     enable_dequadratic_eqprop_map

--- a/test/sqllogictest/degenerate.slt
+++ b/test/sqllogictest/degenerate.slt
@@ -19,3 +19,36 @@ INSERT INTO t1 VALUES (NULL)
 query I
 SELECT * FROM t1 WHERE NOT (f1 = f1)
 ----
+
+# Constant collections render into a columnar edge (node P2). Duplicate constant
+# rows land at the same (advanced) time, so the producer folds them within the
+# batch; the query result must still show the correct multiplicity.
+query I rowsort
+SELECT a FROM (VALUES (1), (1), (2)) t(a)
+----
+1
+1
+2
+
+# A constant feeding an indexed view exercises the columnar producer against an
+# ArrangeBy consumer, and the aggregate below against a Reduce consumer.
+statement ok
+CREATE VIEW cv AS SELECT a FROM (VALUES (1), (1), (2), (3)) t(a)
+
+statement ok
+CREATE DEFAULT INDEX ON cv
+
+query II rowsort
+SELECT a, count(*) FROM cv GROUP BY a
+----
+1
+2
+2
+1
+3
+1
+
+query I
+SELECT sum(a) FROM cv
+----
+7

--- a/test/sqllogictest/degenerate.slt
+++ b/test/sqllogictest/degenerate.slt
@@ -20,7 +20,7 @@ query I
 SELECT * FROM t1 WHERE NOT (f1 = f1)
 ----
 
-# Constant collections render into a columnar edge (node P2). Duplicate constant
+# Constant collections render into a columnar edge. Duplicate constant
 # rows land at the same (advanced) time, so the producer folds them within the
 # batch; the query result must still show the correct multiplicity.
 query I rowsort

--- a/test/sqllogictest/introspection/relations.slt
+++ b/test/sqllogictest/introspection/relations.slt
@@ -65,9 +65,10 @@ FormArrangementKey  Concatenate  alloc::vec::Vec<(mz_compute::render::errors::Da
 InputRegion:␠materialize.public.test_primary_idx  BuildRegion:␠materialize.public.test_primary_idx  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 InputRegion:␠materialize.public.test_primary_idx  BuildRegion:␠materialize.public.test_primary_idx  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  Probe  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
-LogOperatorHydration␠(1)  FormArrangementKey  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+LogOperatorHydration␠(1)  FormArrangementKey  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 OkErr  SuppressEarlyProgress  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 SuppressEarlyProgress  LimitProgress(Dataflow:␠materialize.public.test_primary_idx)  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+VecToColumnar  BuildingObject(User(2))  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 decode_backpressure_probe(u1)  Feedback  alloc::vec::Vec<core::convert::Infallible>
 expire_stream_at(materialize.public.test_primary_idx_export_index_errs)  LogDataflowErrorsStream  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyBatch<mz_compute::typedefs::spines::MzStack<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 expire_stream_at(materialize.public.test_primary_idx_export_index_oks)  InspectBatch  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
@@ -97,11 +98,12 @@ GROUP BY type;
 2  alloc::vec::Vec<(usize,␠mz_persist_client::fetch::ExchangeableBatchPart<mz_repr::timestamp::Timestamp>)>
 2  alloc::vec::Vec<mz_txn_wal::txn_read::DataRemapEntry<mz_repr::timestamp::Timestamp>>
 4  alloc::vec::Vec<(core::result::Result<mz_repr::row::Row,␠mz_compute::render::errors::DataflowErrorSer>,␠(mz_repr::timestamp::Timestamp,␠mz_storage_operators::persist_source::Subtime),␠mz_ore::overflowing::Overflowing<i64>)>
+4  mz_timely_util::columnar::Column<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 5  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyBatch<mz_compute::typedefs::spines::MzStack<((mz_compute::render::errors::DataflowErrorSer,␠()),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
 5  alloc::vec::Vec<core::convert::Infallible>
 6  alloc::vec::Vec<(mz_compute::render::errors::DataflowErrorSer,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
+6  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 6  alloc::vec::Vec<alloc::rc::Rc<differential_dataflow::trace::implementations::ord_neu::val_batch::OrdValBatch<mz_row_spine::spines::RowRowLayout<((mz_repr::row::Row,␠mz_repr::row::Row),␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>>>>
-9  alloc::vec::Vec<(mz_repr::row::Row,␠mz_repr::timestamp::Timestamp,␠mz_ore::overflowing::Overflowing<i64>)>
 
 query TTT rowsort
 SELECT mdod_from.name AS from_name,

--- a/test/sqllogictest/temporal_bucketing.slt
+++ b/test/sqllogictest/temporal_bucketing.slt
@@ -276,3 +276,114 @@ materialize.public.mv_except_distinct_buckets_at_reduce:
 Target cluster: quickstart
 
 EOF
+
+# -----------------------------------------------------------------------------
+# Runtime tests (node Ta). With `enable_compute_temporal_bucketing` on, the
+# bucketed dataflow edges are re-encoded to the columnar representation instead
+# of re-wrapping `Vec`. These tests turn the flag on and assert the bucketed
+# dataflows still produce the correct logical results, and that a consolidating
+# `Union` concatenating a bucketed input with a `Direct` input yields the right
+# output (the mixed `concat_many` case, now columnar on both legs).
+# -----------------------------------------------------------------------------
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_compute_temporal_bucketing = true
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE rt_events (k INT NOT NULL, event_time TIMESTAMP NOT NULL)
+
+# Far-future event times so the temporal predicates hold regardless of the
+# wall clock at query time, keeping the results deterministic.
+statement ok
+INSERT INTO rt_events VALUES
+  (1, '2999-01-01 00:00:00'),
+  (1, '2999-01-02 00:00:00'),
+  (2, '2999-01-03 00:00:00'),
+  (3, '2999-01-04 00:00:00')
+
+statement ok
+CREATE TABLE rt_other (k INT NOT NULL)
+
+statement ok
+INSERT INTO rt_other VALUES (2), (99)
+
+# Bucketed Reduce: temporal filter above a GROUP BY. Hits the arrangement
+# re-encode in `context.rs`.
+statement ok
+CREATE MATERIALIZED VIEW rt_reduce AS
+SELECT k, count(*)
+FROM rt_events
+WHERE event_time + INTERVAL '45 day' > mz_now()
+GROUP BY k
+
+query II rowsort
+SELECT * FROM rt_reduce
+----
+1  2
+2  1
+3  1
+
+# Bucketed TopK: temporal filter under ORDER BY ... LIMIT. Hits the re-encode
+# in `top_k.rs`.
+statement ok
+CREATE MATERIALIZED VIEW rt_topk AS
+SELECT k
+FROM rt_events
+WHERE event_time + INTERVAL '45 day' > mz_now()
+ORDER BY event_time
+LIMIT 3
+
+query I rowsort
+SELECT * FROM rt_topk
+----
+1
+1
+2
+
+# Mixed Union: `EXCEPT ALL` of a temporal-filtered leg (bucketed) against a
+# plain relation (Direct) lowers to a consolidating `Union` with per-input
+# strategies `[TemporalBucketing, Direct]`. After node Ta both legs reach
+# `concat_many` as columnar edges.
+query T multiline
+EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR
+CREATE MATERIALIZED VIEW rt_union AS
+SELECT k FROM rt_events WHERE event_time + INTERVAL '45 day' > mz_now()
+EXCEPT ALL
+SELECT k FROM rt_other
+----
+materialize.public.rt_union:
+  Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
+    ArrangeBy
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=() }
+      Union consolidate_output=true
+        temporal_bucketing_strategies=[TemporalBucketing, Direct]
+        Get::Collection materialize.public.rt_events
+          raw=true
+        Negate
+          Get::PassArrangements materialize.public.rt_other
+            raw=true
+
+Source materialize.public.rt_events
+  project=(#0)
+  filter=((mz_now() < timestamp_to_mz_timestamp((#1{event_time} + 45 days))))
+Source materialize.public.rt_other
+
+Target cluster: quickstart
+
+EOF
+
+statement ok
+CREATE MATERIALIZED VIEW rt_union AS
+SELECT k FROM rt_events WHERE event_time + INTERVAL '45 day' > mz_now()
+EXCEPT ALL
+SELECT k FROM rt_other
+
+query I rowsort
+SELECT * FROM rt_union
+----
+1
+1
+3

--- a/test/sqllogictest/temporal_bucketing.slt
+++ b/test/sqllogictest/temporal_bucketing.slt
@@ -278,12 +278,12 @@ Target cluster: quickstart
 EOF
 
 # -----------------------------------------------------------------------------
-# Runtime tests (node Ta). With `enable_compute_temporal_bucketing` on, the
+# Runtime tests. With `enable_compute_temporal_bucketing` on, the
 # bucketed dataflow edges are re-encoded to the columnar representation instead
 # of re-wrapping `Vec`. These tests turn the flag on and assert the bucketed
 # dataflows still produce the correct logical results, and that a consolidating
 # `Union` concatenating a bucketed input with a `Direct` input yields the right
-# output (the mixed `concat_many` case, now columnar on both legs).
+# output, which reaches `concat_many` as a columnar edge like the other leg.
 # -----------------------------------------------------------------------------
 
 simple conn=mz_system,user=mz_system
@@ -344,7 +344,7 @@ SELECT * FROM rt_topk
 
 # Mixed Union: `EXCEPT ALL` of a temporal-filtered leg (bucketed) against a
 # plain relation (Direct) lowers to a consolidating `Union` with per-input
-# strategies `[TemporalBucketing, Direct]`. After node Ta both legs reach
+# strategies `[TemporalBucketing, Direct]`. Both legs reach
 # `concat_many` as columnar edges.
 query T multiline
 EXPLAIN PHYSICAL PLAN AS VERBOSE TEXT FOR

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -670,6 +670,19 @@ WITH MUTUALLY RECURSIVE
     bar(x list_numeric_scale_2) as (SELECT LIST['1'::TEXT])
 SELECT x FROM bar
 
+# A distinct `UNION` whose recursive term is a bare identity `Get` on the rec
+# binding, placed directly as a `Union` input alongside a `Constant`. The
+# identity `Get` returns the binding's collection edge as-is, so this exercises
+# a recursive binding feeding a `Union` unchanged. The union is idempotent under
+# `distinct`, so the binding reaches a fixed point of {1, 2}.
+query I rowsort
+WITH MUTUALLY RECURSIVE
+  foo (x int) AS (VALUES (1), (2) UNION SELECT * FROM foo)
+SELECT * FROM foo
+----
+1
+2
+
 ## Adapted from https://www.sqlite.org/lang_with.html#outlandish_recursive_query_examples
 query T multiline
 WITH MUTUALLY RECURSIVE


### PR DESCRIPTION
Measurement branch, not for review. Builds on #38324 (columnar rendering stack + align-buffer metrics), adding the dataflow-edge pager itself.

Measurement so far has established that edge bodies are not transient: their peak in-flight bytes run 129% to 221% of the whole pool budget depending on configuration, their lifetime is seconds at the median under memory pressure and minutes in the tail, and the holder is channel queues rather than operator state. That last point is what makes this cheap, because a queued body is by definition not borrowed.

Design:

* `AlignBuffer` becomes two-state rather than `Column` gaining a `Paged` variant. A fourth variant would touch ~90 exhaustive matches across 11 files; hiding the state behind the existing `Deref`/`as_words` touches none, since a paged body materializes on first access exactly where a heap body was already read.
* Two pieces of metadata stay resident. The word count, because `length_in_bytes` is hot. And the record count, because `Column`'s `Accountable::record_count` decodes the body and Timely calls it at **both push and pull** — a paged body materializing there would be back on the heap before it ever sat in a queue, which is the whole interval this covers. An inherent `len` shadows the `Deref` slice's.
* The mint is zero-staging: serialization writes its single copy straight into the pool slot rather than into a heap allocation that faults its own pages and dies seconds later.
* A paged clone materializes. `ChunkHandle` is deliberately not `Clone`, and giving it one would move the pool to refcounted chunk ownership for a path that barely runs.
* Bodies under 64 KiB stay on the heap, the pool's smallest size class.

Gated behind `enable_column_edge_paging`, off in production, on in the test configuration, and inert unless a config apply has installed a pool. `Origin::Unpage` counts materializations, so the round-trip cost is measured rather than assumed.

Tests are in their own binary: the pool singleton and the gate are process-global with no teardown, the same constraint that already forced `tests/align_buffer_metrics.rs` to stand alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)