### PR TITLE
ci: Nightly fixes (2026-08-19)

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -168,6 +168,7 @@ steps:
           args: [--miri-full]
     agents:
       queue: hetzner-aarch64-16cpu-32gb
+    skip: "Has been creating more toil than use"
     sanitizer: skip
 
   - group: Benchmarks

--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -28,6 +28,12 @@ def get_ancestor_overrides_for_performance_regressions(
 
     min_ancestor_mz_version_per_commit = dict()
 
+    if scenario_class_name == "MySqlInitialLoadMultiWorkerSampled":
+        # PR#38094 (storage: Fast approximate snapshot partitioning) increased wallclock by ~30%
+        min_ancestor_mz_version_per_commit[
+            "de8eac0d1683ffd788dfba6edaa88aef7f0f1740"
+        ] = MzVersion.parse_mz("v26.39.0")
+
     if scenario_class_name == "FastPathFilterNoIndex":
         # PR#38151 (Sql-150: Temporary objects to the catalog) increased wallclock by ~10%
         min_ancestor_mz_version_per_commit[


### PR DESCRIPTION
@peterdukelarsen I'm guessing this is an expected tradeoff:
```
NAME                                | TYPE            |      THIS       |      OTHER      |  UNIT  | THRESHOLD  |  Regression?  | 'THIS' is
--------------------------------------------------------------------------------------------------------------------------------------------------------
MySqlInitialLoadMultiWorkerSampled  | wallclock       |           2.923 |           2.258 |   s    |    10%     |    !!YES!!    | worse:  29.4% slower
MySqlInitialLoadMultiWorkerSampled  | memory_mz       |        1512.500 |        1524.902 |   MB   |    60%     |      no       | better:  0.8% less
MySqlInitialLoadMultiWorkerSampled  | memory_clusterd |         172.387 |         129.578 |   MB   |    60%     |      no       | worse:  33.0% more
```
Seen in [Feature benchmark against merge base or 'latest' 5](https://buildkite.com/materialize/nightly/builds/18121#01a01736-1416-4bf6-987b-ca14ebd0a209)