### PR TITLE
ci: build at a fixed path in ci-builder by default & Run "free" lints on main

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -253,6 +253,14 @@ case "$cmd" in
         npm_dir=$HOME/.npm-builder
         mkdir -p "$(pwd)/target-xcompile" ~/.kube "$claude_dir" "$codex_dir" "$npm_dir"
 
+        container_workdir=$workdir
+        if is_truthy "${CI_BUILDER_FIXED_WORKDIR:-${CI:-0}}"; then
+            if [[ "$workdir" != "$(pwd)" ]]; then
+                die "the fixed workdir requires invoking ci-builder from the repository root (set CI_BUILDER_FIXED_WORKDIR=0 to opt out)"
+            fi
+            container_workdir=/workspace
+        fi
+
         args=(
             --cidfile "$cid_file"
             --rm --interactive
@@ -262,8 +270,8 @@ case "$cmd" in
             --volume "$HOME/.claude.json:/tmp/.claude.json"
             --volume "$codex_dir:/tmp/.codex"
             --volume "$npm_dir:/tmp/.npm"
-            --volume "$workdir:$workdir"
-            --workdir "$workdir"
+            --volume "$workdir:$container_workdir"
+            --workdir "$container_workdir"
             --env XDG_CACHE_HOME=/mnt/build/cache
             --env MZ_SOFT_ASSERTIONS
             --env NO_COLOR

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -306,9 +306,15 @@ so it is executed.""",
         and fail_build_reason is None
     ):
         trim_test_selection_id(pipeline, set())
-        # Make the website always deploy
+        # lint-docs is required for website deploy, the others are free because an agent is always around anyway
         for step in steps(pipeline):
-            if step.get("id") == "lint-docs":
+            if step.get("id") in (
+                "lint-docs",
+                "lint-macos",
+                "lint-fast",
+                "lint-clippy",
+                "lint-doctests",
+            ):
                 step.pop("skip", None)
 
     # Surface label-driven changes as a Buildkite annotation, since otherwise

--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -14,6 +14,11 @@ set -euo pipefail
 . misc/shlib/shlib.bash
 . test/cloudtest/config.bash
 
+# The kind cluster setup hands repository paths to the host Docker daemon as
+# bind mount sources, which requires container paths to equal host paths. See
+# CI_BUILDER_FIXED_WORKDIR in bin/ci-builder.
+export CI_BUILDER_FIXED_WORKDIR=0
+
 run_args=(
     "--junitxml=junit_cloudtest_$BUILDKITE_JOB_ID.xml"
 )

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -13,6 +13,11 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
+# mzcompose (and the compositions it runs) hands repository paths to the host
+# Docker daemon as bind mount sources, which requires container paths to equal
+# host paths. See CI_BUILDER_FIXED_WORKDIR in bin/ci-builder.
+export CI_BUILDER_FIXED_WORKDIR=0
+
 builder=${BUILDKITE_PLUGIN_MZCOMPOSE_CI_BUILDER:-min}
 
 if is_truthy "${CI_HEAP_PROFILES:-}"; then

--- a/ci/test/coverage_report.sh
+++ b/ci/test/coverage_report.sh
@@ -29,7 +29,12 @@ bin/ci-annotate-errors junit_coverage*.xml || true
 ci_unimportant_heading "Create coverage report"
 REPORT=coverage_without_unittests_"$BUILDKITE_BUILD_ID"
 REPORT_UNITTESTS=coverage_with_unittests_"$BUILDKITE_BUILD_ID"
-find coverage -name '*.lcov' -exec sed -i "s#SF:/var/lib/buildkite-agent/builds/buildkite-[^/]*/materialize/[^/]*/#SF:#" {} +
+# Binaries embed the checkout path of the agent that compiled them: /workspace
+# for builds with CI_BUILDER_FIXED_WORKDIR, the Buildkite checkout path
+# otherwise (e.g. the cargo-test job).
+find coverage -name '*.lcov' -exec sed -i \
+  -e "s#SF:/workspace/#SF:#" \
+  -e "s#SF:/var/lib/buildkite-agent/builds/buildkite-[^/]*/materialize/[^/]*/#SF:#" {} +
 find coverage -name '*.lcov' -not -name 'cargotest.lcov' -exec genhtml -o "$REPORT" {} +
 find coverage -name '*.lcov' -exec genhtml -o "$REPORT_UNITTESTS" {} +
 

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -787,6 +787,9 @@ steps:
           queue: linux-x86_64
         env:
           CI: "true"
+          # The kind cluster setup hands repository paths to the host Docker
+          # daemon. See CI_BUILDER_FIXED_WORKDIR in bin/ci-builder.
+          CI_BUILDER_FIXED_WORKDIR: "0"
         coverage: skip
         sanitizer: skip
         ci_glue_exempt: true

--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -25,14 +25,16 @@ from materialize import MZ_ROOT, buildkite, ci_util
 # - Negative values indicate that the line has only been covered in unit tests.
 Coverage = dict[str, OrderedDict[int, int | None]]
 # Normalizes an absolute lcov SF path to a repo-relative path so it can be
-# matched against the keys from find_modified_lines(). Only the buildkite
-# alternative yields an actual repo file (starting with `src/`). The external
+# matched against the keys from find_modified_lines(). Only the /workspace
+# (CI_BUILDER_FIXED_WORKDIR builds) and buildkite alternatives yield an actual
+# repo file (starting with `src/`). The external
 # and rustlib alternatives exist so the assert below does not fire on
 # dependency sources, they never match a modified repo file.
 SOURCE_RE = re.compile(
     r"""
     ( external/(.*$)
     | /usr/local/lib/rustlib/(.*$)
+    | /workspace/(src/.*$)
     | /var/lib/buildkite-agent/builds/buildkite-.*/materialize/[^/]*/(src/.*$)
     )""",
     re.VERBOSE,


### PR DESCRIPTION
This increases cache reusage for Rust compilation, especially when one build occurs on Test pipeline and the other in Nightly, which are symlinked to the same path in our Buildkite setup