### PR TITLE
rust: Use try_update instead of fetch_update

### DIFF
--- a/src/ore/src/pool.rs
+++ b/src/ore/src/pool.rs
@@ -1427,7 +1427,7 @@ impl PoolInner {
         let class_bytes = u64::cast_from(class_size);
         self.counters
             .warm_bytes
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
                 (cur + class_bytes <= cap).then_some(cur + class_bytes)
             })
             .is_ok()
@@ -1531,7 +1531,7 @@ impl PoolInner {
         let reserved = self
             .counters
             .resident_bytes
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
                 // Loaded inside the closure so a CAS retry sees oversize
                 // frees that landed since the last attempt.
                 let oversize = self.counters.oversize_bytes.load(Ordering::Relaxed);
@@ -1647,7 +1647,7 @@ impl PoolInner {
                 let settled = self
                     .counters
                     .resident_bytes
-                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+                    .try_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
                         let next = cur.checked_add(admitted_len)?.saturating_sub(victim_len);
                         let oversize = self.counters.oversize_bytes.load(Ordering::Relaxed);
                         (next <= cur

--- a/src/storage-types/fuzz/fuzz_targets/pushdown_soundness.rs
+++ b/src/storage-types/fuzz/fuzz_targets/pushdown_soundness.rs
@@ -36,9 +36,7 @@ use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::part::PartBuilder;
 use mz_persist_types::stats::{PartStats, PartStatsMetrics};
 use mz_repr::adt::numeric::Numeric;
-use mz_repr::{
-    Datum, Diff, RelationDesc, ReprScalarType, Row, RowArena, SqlScalarType, Timestamp,
-};
+use mz_repr::{Datum, Diff, RelationDesc, ReprScalarType, Row, RowArena, SqlScalarType, Timestamp};
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::SourceData;
 use mz_storage_types::stats::RelationPartStats;
@@ -81,13 +79,28 @@ enum Cmp {
 #[derive(Arbitrary, Debug)]
 enum Pred {
     /// `col <cmp> lit`, the literal drawn like a row value.
-    CmpColLit { col: u8, cmp: Cmp, lit: FuzzDatum },
-    IsNull { col: u8, negate: bool },
+    CmpColLit {
+        col: u8,
+        cmp: Cmp,
+        lit: FuzzDatum,
+    },
+    IsNull {
+        col: u8,
+        negate: bool,
+    },
     /// `(json ->(>) 'key') IS NULL` over the Nested specs from real map stats.
-    JsonbKey { key: u8, stringify: bool },
+    JsonbKey {
+        key: u8,
+        stringify: bool,
+    },
     /// `(c_f64 + a) * b <cmp> c`, aimed at the infinity guard and NaN
     /// arithmetic, with fuzzer-chosen bit patterns.
-    FloatArith { cmp: Cmp, a: u64, b: u64, c: u64 },
+    FloatArith {
+        cmp: Cmp,
+        a: u64,
+        b: u64,
+        c: u64,
+    },
     And(Box<Pred>, Box<Pred>),
     Or(Box<Pred>, Box<Pred>),
     Not(Box<Pred>),
@@ -103,7 +116,10 @@ struct Input {
 
 fn schema() -> RelationDesc {
     RelationDesc::builder()
-        .with_column("c_num", SqlScalarType::Numeric { max_scale: None }.nullable(true))
+        .with_column(
+            "c_num",
+            SqlScalarType::Numeric { max_scale: None }.nullable(true),
+        )
         .with_column("c_f64", SqlScalarType::Float64.nullable(true))
         .with_column("c_str", SqlScalarType::String.nullable(true))
         .with_column("c_json", SqlScalarType::Jsonb.nullable(true))

--- a/src/timely-util/src/column_pager/policy.rs
+++ b/src/timely-util/src/column_pager/policy.rs
@@ -133,7 +133,7 @@ impl TieredPolicy {
             let shrink = prev - new_total;
             let _ = self
                 .budget
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+                .try_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
                     Some(cur.saturating_sub(shrink))
                 });
         }


### PR DESCRIPTION
```
warning: use of deprecated method `std::sync::atomic::Atomic::<usize>::fetch_update`: renamed to `try_update` for consistency
   --> src/timely-util/src/column_pager/policy.rs:136:18
    |
136 |                 .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
    |                  ^^^^^^^^^^^^
    |
```