### PR TITLE
docs: hide the temporal filter pushdown section

### DIFF
--- a/doc/user/content/transform-data/patterns/temporal-filters.md
+++ b/doc/user/content/transform-data/patterns/temporal-filters.md
@@ -290,6 +290,16 @@ Unfortunately, this record does not pass the filter and is excluded from process
 In conclusion: if you want to account for late arriving data up to some given time duration, you must adjust your temporal filter to allow for such records to make an appearance in the result set.
 This is often referred to as a **grace period**.
 
+<!--
+The temporal filter pushdown documentation is hidden while the optimization is
+being reworked: the guarantees described below do not currently hold for most
+temporal filters. The anchor is kept because pages across the docs, including
+published release notes, link to `#temporal-filter-pushdown`.
+-->
+<a id="temporal-filter-pushdown" name="temporal-filter-pushdown"></a>
+
+{{< hide >}}
+
 ## Temporal filter pushdown
 
 All of the queries in the previous examples only return results based on recently-added events.
@@ -325,3 +335,5 @@ Some common functions, such as casting from a string to a timestamp, can prevent
 {{< note >}}
 See the guide on [partitioning and filter pushdown](/transform-data/patterns/partition-by/) for a **private preview** feature that can make the filter pushdown optimization more predictable.
 {{< /note >}}
+
+{{< /hide >}}


### PR DESCRIPTION
### Motivation

The [temporal filter pushdown section](<https://materialize.com/docs/transform-data/patterns/temporal-filters/#temporal-filter-pushdown>) tells readers that filters matching the patterns shown on that page are pushed down to the storage layer, and that this substantially improves ad-hoc query latency and cuts the time to start serving results after a materialized view is created or its cluster restarts. As of v26.34 that does not hold for most temporal filters, so the section promises behavior users do not get.

Requested by the docs discussion on filter pushdown; removing it for now is the agreed short-term step while the longer-term question of how much of filter pushdown to support is decided separately.

### Description

Wrap the section in `{{< hide >}}` rather than deleting it, so the text stays in the source while the optimization is reworked. This follows the existing use of that shortcode in `reference/system-catalog/mz_catalog.md`.

The one non-obvious part is the anchor stub. Nineteen links across the docs point at `#temporal-filter-pushdown`, including six webhook guides that recommend `try_parse_monotonic_iso8601_timestamp` specifically for this reason, `explain-plan.md`, `explain-filter-pushdown.md`, `functions/pushdown.md`, `troubleshooting.md`, and two published release notes that should not be rewritten. Hiding the heading removes the anchor those links target, which would leave all nineteen dangling and fail `htmltest`. An explicit `<a id="temporal-filter-pushdown" name="temporal-filter-pushdown">` stub is left outside the hidden block so the links still resolve to this page. Raw HTML is passed through: `doc/user/config.toml` sets `markup.goldmark.renderer.unsafe = true`, and the same pattern is already used in `headless/partition-by-option-description.md`.

Not addressed here, and worth a decision separately: `/sql/functions/pushdown/`, `/sql/explain-filter-pushdown/`, the pushdown discussion on the partitioning guide, and the webhook guides' recommendations all still describe the optimization. This PR covers only the section that was called out.

Docs-only, no release note.

### Verification

Docs-only change. `hugo`/`htmltest` are not available in this environment, so verified by hand: `{{< hide >}}` renders nothing (`{{if false}}` in `doc/user/layouts/shortcodes/hide.html`), the shortcode already wraps a section containing a heading elsewhere in the docs, and the anchor stub sits outside the hidden block so it still renders. The `lint-docs` CI step will run `hugo` and `htmltest` over the result and is the real check on the nineteen inbound links.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)