### PR TITLE
compute: run the MV sink batch read-back under block_in_place

### DIFF
--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -68,6 +68,7 @@ use timely::dataflow::operators::vec::Broadcast;
 use timely::dataflow::operators::{Capability, CapabilitySet};
 use timely::progress::Antichain;
 use timely::progress::frontier::AntichainRef;
+use tokio::runtime::Handle;
 use tokio::sync::{mpsc, watch};
 use tracing::trace;
 
@@ -868,9 +869,8 @@ mod write {
                 )
                 .await;
 
-                // Reading the consolidated updates back only clones them into the batch builder,
-                // which awaits at every part flush, so it stays on the async task. Chain ok and
-                // err correction iterators directly, avoiding an intermediate Vec allocation.
+                // Chain ok and err correction iterators directly, avoiding an intermediate Vec
+                // allocation.
                 let oks = corrections
                     .ok
                     .consolidated_updates_before(&desc.upper)
@@ -888,10 +888,17 @@ mod write {
                     return corrections;
                 }
 
-                let batch = writer
-                    .batch(updates, desc.lower, desc.upper)
-                    .await
-                    .expect("valid usage");
+                // Feeding the builder pulls the updates out of the correction buffers on the
+                // calling thread: every pull clones a row and can page a chunk back in, while the
+                // builder only awaits once a part fills, i.e. after `blob_target_size` times
+                // `batch_builder_max_outstanding_parts` worth of updates. That is the same stall
+                // the consolidation above avoids, so it gets the same treatment.
+                // `block_in_place` rather than `spawn_blocking`, because the updates borrow the
+                // buffers and the builder needs an async context.
+                let batch = tokio::task::block_in_place(|| {
+                    Handle::current().block_on(writer.batch(updates, desc.lower, desc.upper))
+                })
+                .expect("valid usage");
                 let proto_batch = batch.into_transmittable_batch();
                 if let Err(err) = resp_tx.send(WriteResponse {
                     batch: Some(proto_batch),


### PR DESCRIPTION
Follow-up to #38118, which moved the sync MV sink's correction maintenance to a blocking thread but left the read-back that follows it on the async task, with a comment claiming the batch builder's part flushes bound how long that occupies a Tokio worker. They do not. `BatchBuilder::add` only awaits once a part fills, and the part writes are spawned, so the builder awaits nothing until more than `persist_batch_builder_max_outstanding_parts` (2) writes are in flight. Feeding it therefore pulls on the order of two parts' worth of updates, `persist_blob_target_size` (128 MiB) each, before the first real yield. Every pull clones a row out of a correction chunk and, with the pager enabled, can page that chunk back in, so the worker ends up blocked in the kernel for the same reason the maintenance pass was.

`emitted` holds every update below `upper`, so the read-back sweeps a buffer as large as the pass that already runs on a blocking thread. Move it there too: the blocking closure keeps ownership of the buffers, consolidates, and streams the consolidated updates back over a bounded channel in chunks, and the async task feeds those chunks to the persist batch builder. The row clones and page-ins land on a preemptible thread, and the handoff adds at most a few thousand buffered updates.

`writer` no longer needs an exclusive borrow, because the builder is created with `WriteHandle::builder` rather than `WriteHandle::batch`.

Based on QA LLM review: https://github.com/MaterializeInc/qa-llm-review/blob/master/commit-bugs/done/analysis-commit-0f7e5b187226c54a5feefd91feb929af6642c8b8.md

### Release notes

This release will not include user-visible changes.
