### PR TITLE
docs: add "Upgrade skills" section to agent skills page

### DIFF
--- a/doc/user/content/integrations/coding-agent-skills.md
+++ b/doc/user/content/integrations/coding-agent-skills.md
@@ -34,7 +34,22 @@ Install the Materialize agent skills with a single command:
 npx skills add MaterializeInc/agent-skills
 ```
 
-Once installed, you can update installed skills by running `npx skills update`.
+## Upgrade skills
+
+We publish upgrades to the Materialize agent skills weekly, so check back
+regularly to pick up the latest documentation and reference material. To upgrade
+the skills you already have installed:
+
+```bash
+npx skills update MaterializeInc/agent-skills
+```
+
+To upgrade every skill installed on your machine, regardless of source, omit the
+repository:
+
+```bash
+npx skills update
+```
 
 ## Claude Code plugins
 


### PR DESCRIPTION
### Motivation

The Agent Skills page tells users how to install the Materialize agent skills,
but upgrading was only a passing sentence at the end of the installation
section, with no mention that we ship skill upgrades on a weekly cadence. Users
who installed once had no signal that there is anything newer to pick up.

### Description

Adds a dedicated `## Upgrade skills` section to
`doc/user/content/integrations/coding-agent-skills.md`, placed between
Installation and the Claude Code plugins section. It:

* States that we publish upgrades to the Materialize agent skills weekly.
* Gives the scoped upgrade command, `npx skills update MaterializeInc/agent-skills`,
  which upgrades just the Materialize skills.
* Gives the unscoped `npx skills update` form for upgrading every installed
  skill regardless of source.

The one-line mention of `npx skills update` that previously trailed the
installation section is removed, since the new section covers it in full.

### Verification

Docs-only change: one Markdown file, no code, no tests. Reviewed the rendered
Markdown structure for correct heading level (`##`, matching its sibling
sections) and fenced code blocks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcpCEjqLyQatAiXboQuEEm)_