### PR TITLE
storage: bail on concurrent shard modification for non-upsert ingestions

### DIFF
--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -372,6 +372,14 @@ pub fn build_ingestion_dataflow(
                     export_id,
                     primary_source_id
                 );
+                // Mirrors the operator selection in `render::sources`: only
+                // `Upsert` exports run through the feedback upsert operator,
+                // which is what the persist sink's concurrent-modification
+                // leniency relies on.
+                let is_upsert_pipeline = matches!(
+                    export.data_config.envelope,
+                    mz_storage_types::sources::envelope::SourceEnvelope::Upsert(_)
+                );
                 let (upper_stream, errors, sink_tokens) = crate::render::persist_sink::render(
                     mz_scope,
                     export_id,
@@ -380,6 +388,7 @@ pub fn build_ingestion_dataflow(
                     storage_state,
                     metrics,
                     Arc::clone(&busy_signal),
+                    is_upsert_pipeline,
                 );
                 upper_streams.push(upper_stream);
                 tokens.extend(sink_tokens);

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -282,6 +282,7 @@ pub(crate) fn render<'scope>(
     storage_state: &StorageState,
     metrics: SourcePersistSinkMetrics,
     busy_signal: Arc<Semaphore>,
+    is_upsert_pipeline: bool,
 ) -> (
     StreamVec<'scope, mz_repr::Timestamp, ()>,
     StreamVec<'scope, mz_repr::Timestamp, Rc<anyhow::Error>>,
@@ -323,6 +324,7 @@ pub(crate) fn render<'scope>(
         storage_state,
         metrics,
         Arc::clone(&busy_signal),
+        is_upsert_pipeline,
     );
 
     (
@@ -893,6 +895,7 @@ fn append_batches<'scope>(
     storage_state: &StorageState,
     metrics: SourcePersistSinkMetrics,
     busy_signal: Arc<Semaphore>,
+    is_upsert_pipeline: bool,
 ) -> (
     StreamVec<'scope, mz_repr::Timestamp, ()>,
     StreamVec<'scope, mz_repr::Timestamp, Rc<anyhow::Error>>,
@@ -902,13 +905,19 @@ fn append_batches<'scope>(
     let shard_id = target.data_shard;
     let target_relation_desc = target.relation_desc.clone();
 
-    // We can only be lenient with concurrent modifications when we know that
-    // this source pipeline is using the feedback upsert operator, which works
-    // correctly when multiple instances of an ingestion pipeline produce
-    // different updates, because of concurrency/non-determinism.
+    // We can only be lenient with concurrent modifications when this export's
+    // pipeline uses the feedback upsert operator, which reconciles the shard's
+    // actual contents with its own output and so converges even when multiple
+    // instances of an ingestion produce different updates. Pipelines without
+    // that feedback (e.g. ENVELOPE NONE CDC sources) have no reconciliation:
+    // a concurrent writer is a replaced incarnation of this same ingestion
+    // whose output can reflect a different snapshot point, and trimming our
+    // batches against its upper fuses the two into a state that never existed
+    // upstream. For those, bail and restart the dataflow instead, which
+    // resumes from the shard's actual committed state.
     let use_continual_feedback_upsert = dyncfgs::STORAGE_USE_CONTINUAL_FEEDBACK_UPSERT
         .get(storage_state.storage_configuration.config_set());
-    let bail_on_concurrent_modification = !use_continual_feedback_upsert;
+    let bail_on_concurrent_modification = !(use_continual_feedback_upsert && is_upsert_pipeline);
 
     let mut read_only_rx = storage_state.read_only_rx.clone();
 


### PR DESCRIPTION
Results of poking around at [SS-427](https://linear.app/materializeinc/issue/SS-427) with claude.

The source persist sink tolerates a compare_and_append upper mismatch by trimming its batch to the shard's actual upper and continuing, on the assumption that whoever advanced the upper wrote the data we would have written. That assumption is only sound for pipelines running the continual feedback upsert operator, which reads the shard back and emits corrections, so concurrent instances converge. The leniency was gated on the global storage_use_continual_feedback_upsert flag (default true), which made it apply to every ingestion, including ENVELOPE NONE CDC pipelines that have no such reconciliation.

For those pipelines a concurrent writer is a replaced incarnation of the same ingestion whose output can encode a different consistency point. A network partition between the controller and a cluster leaves the old dataflow running as a zombie while its snapshot batch sits in indeterminate blob-write retries, and the reconciled replacement snapshots again at a later upstream position. If the zombie's batch lands first, trimming fuses the zombie's snapshot with the replacement's rewinds and replication into a state that never existed upstream. Observed as [SS-427](https://linear.app/materializeinc/issue/SS-427) in the invariants chaos harness: the conservation checker on a newly added MySQL table read a total off by exactly one upstream transaction, durable in the table's history, converging only as later updates rewrote the affected rows.

Scope the leniency to exports whose envelope actually runs the feedback upsert operator, mirroring the operator selection in render::sources. Everything else returns to the pre-feedback-upsert behavior on mismatch: fail the append, restart the dataflow, and resume from the shard's actual committed state, which is consistent no matter which incarnation's prefix landed.