### PR TITLE
Bump version for MySQL ingestion scenario due to RDS instance type change

### DIFF
--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -2111,6 +2111,9 @@ class CopyFromStdinEnvdStrongScalingScenario(ClusterScalingScenario):
 
 
 class SourceIngestionScenario(ClusterScalingScenario):
+    # 1.1.0: MySQL RDS instance type changed
+    VERSION: str = "1.1.0"
+
     def name(self) -> str:
         return "source_ingestion"
 


### PR DESCRIPTION
### Motivation
Part of: [SS-432](https://linear.app/materializeinc/issue/SS-432)

The MySQL RDS instance backing SourceIngestionScenario is being upsized, which makes new results incomparable with prior runs.

### Description
Bumping the scenario VERSION so the analytics data reflects the discontinuity.


### Verification
