### PR TITLE
v26.38.1 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -19,6 +19,11 @@ Starting with the v26.1.0 release, Materialize releases on a weekly schedule for
 both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for details.
 {{</ note >}}
 
+## v26.38.1
+
+### Bug Fixes {#v26.38.1-bug-fixes}
+- Fixed an environment on AKS losing access to Azure Blob Storage after running for a while, because the projected workload identity token was read only once at startup and Kubernetes had since rotated it; the token file is now re-read on every credential refresh.
+
 ## v26.38.0
 *Released to Materialize Cloud: 2026-08-19* <br>
 


### PR DESCRIPTION
Release notes for v26.38.1, a single-fix hotfix train with no RC snapshots — `final` is its only snapshot, so this PR carries one commit. The dates set here are the real ones, not provisional, but they were **inferred from the `v26.38.1` tag's commit date** rather than supplied: please confirm Cloud 2026-08-19 / Self-Managed 2026-08-20 with the release owner before merging. v26.38.0 was tagged 5.5 hours earlier and claims the same Cloud date, so 2026-08-20 is also plausible for this one.

**Merge ordering:** this branch was cut from a `main` that does not yet contain the v26.38.0 section (#38204 is still open). `## v26.38.1` must end up **above** `## v26.38.0` in `_index.md` — whichever of the two PRs merges second needs its section placed relative to the other by hand.

Snapshot drafts (with PR links) in mz-skills:
- final: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.1/final/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.1/final/omitted.md)

**Borderline PRs omitted:** final: 0 — [review borderline calls](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.1/final/omitted.md#borderline)
