### PR TITLE
environmentd: quote the SQL the memory visualizer builds

### DIFF
--- a/src/environmentd/src/http/static/js/fetch.js
+++ b/src/environmentd/src/http/static/js/fetch.js
@@ -18,7 +18,7 @@
  * interpolated value has to go through this or `sqlIdent`. Doubling the quote
  * is the whole of the escaping, as `standard_conforming_strings` is fixed on.
  *
- * @param {string} value - The value to quote
+ * @param {unknown} value - The value to quote, coerced to a string first
  * @returns {string} - The value as a SQL string literal, quotes included
  */
 function sqlLiteral(value) {
@@ -28,7 +28,7 @@ function sqlLiteral(value) {
 /**
  * Quote a name as a SQL identifier. See `sqlLiteral` on why this is required.
  *
- * @param {string} name - The name to quote
+ * @param {unknown} name - The name to quote, coerced to a string first
  * @returns {string} - The name as a quoted SQL identifier, quotes included
  */
 function sqlIdent(name) {

--- a/src/environmentd/src/http/static/js/fetch.js
+++ b/src/environmentd/src/http/static/js/fetch.js
@@ -10,6 +10,32 @@
 'use strict';
 
 /**
+ * Quote a value as a SQL string literal.
+ *
+ * What these pages interpolate into a query is attacker-controlled: URL
+ * parameters, and catalog names anyone with CREATE on a schema gets to choose.
+ * The query then runs in the session of whoever opened the page, so every
+ * interpolated value has to go through this or `sqlIdent`. Doubling the quote
+ * is the whole of the escaping, as `standard_conforming_strings` is fixed on.
+ *
+ * @param {string} value - The value to quote
+ * @returns {string} - The value as a SQL string literal, quotes included
+ */
+function sqlLiteral(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+/**
+ * Quote a name as a SQL identifier. See `sqlLiteral` on why this is required.
+ *
+ * @param {string} name - The name to quote
+ * @returns {string} - The name as a quoted SQL identifier, quotes included
+ */
+function sqlIdent(name) {
+  return `"${String(name).replace(/"/g, '""')}"`;
+}
+
+/**
  * Execute a SQL query against the /api/sql endpoint.
  *
  * @param {string} sql - SQL query string

--- a/src/environmentd/src/http/static/js/hierarchical-memory.jsx
+++ b/src/environmentd/src/http/static/js/hierarchical-memory.jsx
@@ -11,10 +11,6 @@
 
 const hpccWasm = window['@hpcc-js/wasm'];
 
-function formatNameForQuery(name) {
-  return `'${name.replace('\'', '\'\'')}'`;
-}
-
 const { useState, useEffect } = React;
 
 function Dataflows(props) {
@@ -34,8 +30,8 @@ function Dataflows(props) {
       const {
         results: [_set_cluster, _set_replica, addr_table, oper_table, chan_table, records_table],
       } = await query(`
-                SET cluster = ${formatNameForQuery(props.clusterName)};
-                SET cluster_replica = ${formatNameForQuery(props.replicaName)};
+                SET cluster = ${sqlLiteral(props.clusterName)};
+                SET cluster_replica = ${sqlLiteral(props.replicaName)};
                 SELECT
                     id, address
                 FROM

--- a/src/environmentd/src/http/static/js/memory.jsx
+++ b/src/environmentd/src/http/static/js/memory.jsx
@@ -11,10 +11,6 @@
 
 const hpccWasm = window['@hpcc-js/wasm'];
 
-function formatNameForQuery(name) {
-  return `'${name.replace('\'', '\'\'')}'`;
-}
-
 const { useState, useEffect } = React;
 
 function Views(props) {
@@ -57,8 +53,8 @@ function Views(props) {
       const {
         results: [_set_cluster, _set_replica, records_table],
       } = await query(`
-        SET cluster = ${formatNameForQuery(props.clusterName)};
-        SET cluster_replica = ${formatNameForQuery(props.replicaName)};
+        SET cluster = ${sqlLiteral(props.clusterName)};
+        SET cluster_replica = ${sqlLiteral(props.replicaName)};
         SELECT
           id, name, batches, records, size, capacity, allocations
         FROM
@@ -166,6 +162,13 @@ function View(props) {
     setGraph(null);
 
     const load = async () => {
+      // The id can arrive from the URL, and is interpolated below as a
+      // number, a position no quoting makes an arbitrary string safe in.
+      const dataflowId = Number(props.dataflowId);
+      if (!Number.isInteger(dataflowId)) {
+        throw `invalid dataflow id ${props.dataflowId}`;
+      }
+
       // Use mz_dataflow_operator_parents for hierarchy - much cleaner than computing from addresses.
       // The query computes:
       // 1. All operators in the dataflow with their parent_id
@@ -175,8 +178,8 @@ function View(props) {
       const {
         results: [_set_cluster, _set_replica, stats_table, operators_table, addresses_table, channels_table],
       } = await query(`
-        SET cluster = ${formatNameForQuery(props.clusterName)};
-        SET cluster_replica = ${formatNameForQuery(props.replicaName)};
+        SET cluster = ${sqlLiteral(props.clusterName)};
+        SET cluster_replica = ${sqlLiteral(props.replicaName)};
 
         -- Dataflow stats
         SELECT
@@ -184,7 +187,7 @@ function View(props) {
         FROM
           mz_introspection.mz_records_per_dataflow
         WHERE
-          id = ${props.dataflowId};
+          id = ${dataflowId};
 
         -- All operators with parent relationships, scope detection, and stats
         WITH dataflow_operators AS (
@@ -196,7 +199,7 @@ function View(props) {
             FROM mz_introspection.mz_dataflow_operators o
             LEFT JOIN mz_introspection.mz_dataflow_operator_parents p ON o.id = p.id
             JOIN mz_introspection.mz_dataflow_addresses a ON o.id = a.id
-            WHERE a.address[1] = ${props.dataflowId}
+            WHERE a.address[1] = ${dataflowId}
         ),
         scope_ids AS (
             SELECT DISTINCT parent_id as id FROM dataflow_operators WHERE parent_id IS NOT NULL
@@ -219,7 +222,7 @@ function View(props) {
         -- All addresses in the dataflow (for channel edge lookups)
         SELECT id, address
         FROM mz_introspection.mz_dataflow_addresses
-        WHERE address[1] = ${props.dataflowId};
+        WHERE address[1] = ${dataflowId};
 
         -- Channel edges with message counts and ports (for tracing through region boundaries)
         SELECT
@@ -235,7 +238,7 @@ function View(props) {
             ON channels.id = counts.channel_id
         WHERE channels.id IN (
             SELECT id FROM mz_introspection.mz_dataflow_addresses
-            WHERE address[1] = ${props.dataflowId}
+            WHERE address[1] = ${dataflowId}
         );
       `);
 
@@ -590,13 +593,13 @@ async function getCreateView(dataflow_name) {
   // which we will use with SHOW CREATE VIEW to show the SQL that created this
   // dataflow.
   //
-  // There are known problems with this method. It doesn't know anything about
-  // SQL parsing or escaping, assumes the dataflow operator's name is of a very
-  // specific shape, and assumes a CREATE VIEW statement made an index which made
-  // this dataflow. So we assume that problems can happen at any level here and
-  // will cleanly bail if anything doesn't exactly match what we want. In that
-  // case we will not show the SQL. This is intended to be good enough for most
-  // users for now.
+  // There are known problems with this method. It assumes the dataflow
+  // operator's name is of a very specific shape, so a name containing a dot
+  // defeats the regex, and assumes a CREATE VIEW statement made an index which
+  // made this dataflow. So we assume that problems can happen at any level here
+  // and will cleanly bail if anything doesn't exactly match what we want. In
+  // that case we will not show the SQL. This is intended to be good enough for
+  // most users for now.
   const match = dataflow_name.match(/^Dataflow: (.*)\.(.*)\.(.*)$/);
   if (!match) {
     throw 'unknown dataflow name pattern';
@@ -628,9 +631,9 @@ async function getCreateView(dataflow_name) {
                         mz_catalog.mz_schemas AS sc,
                         mz_catalog.mz_indexes AS idx
                       WHERE
-                        db.name = '${match[1]}'
-                        AND sc.name = '${match[2]}'
-                        AND idx.name = '${match[3]}'
+                        db.name = ${sqlLiteral(match[1])}
+                        AND sc.name = ${sqlLiteral(match[2])}
+                        AND idx.name = ${sqlLiteral(match[3])}
                     )
               )
                 AS v ON s.id = v.schema_id
@@ -643,7 +646,9 @@ async function getCreateView(dataflow_name) {
   const name = view_name_table.rows[0];
   const {
     results: [create_table],
-  } = await query(`SHOW CREATE VIEW "${name[0]}"."${name[1]}"."${name[2]}"`);
+  } = await query(
+    `SHOW CREATE VIEW ${sqlIdent(name[0])}.${sqlIdent(name[1])}.${sqlIdent(name[2])}`
+  );
   return { name: create_table.rows[0][0], create: create_table.rows[0][1] };
 }
 

--- a/src/environmentd/src/http/static/js/memory.jsx
+++ b/src/environmentd/src/http/static/js/memory.jsx
@@ -595,11 +595,12 @@ async function getCreateView(dataflow_name) {
   //
   // There are known problems with this method. It assumes the dataflow
   // operator's name is of a very specific shape, so a name containing a dot
-  // defeats the regex, and assumes a CREATE VIEW statement made an index which
-  // made this dataflow. So we assume that problems can happen at any level here
-  // and will cleanly bail if anything doesn't exactly match what we want. In
-  // that case we will not show the SQL. This is intended to be good enough for
-  // most users for now.
+  // splits at the wrong dots and the catalog lookup below finds nothing, and
+  // it assumes a CREATE VIEW statement made an index which made this dataflow.
+  // So we assume that problems can happen at any level here and will cleanly
+  // bail if anything doesn't exactly match what we want. In that case we will
+  // not show the SQL. This is intended to be good enough for most users for
+  // now.
   const match = dataflow_name.match(/^Dataflow: (.*)\.(.*)\.(.*)$/);
   if (!match) {
     throw 'unknown dataflow name pattern';

--- a/test/dataflow-visualizer/mzcompose.py
+++ b/test/dataflow-visualizer/mzcompose.py
@@ -47,6 +47,13 @@ FIXTURE_TABLE = "visualizer_fixture"
 FIXTURE_VIEW = "visualizer_fixture_view"
 FIXTURE_INDEX = "visualizer_fixture_idx"
 
+# A second indexed view whose name carries both quote kinds: the /memory page
+# only renders its SHOW CREATE VIEW panel if it escapes what it interpolates.
+# The index name stays plain so the page's `Dataflow: <db>.<schema>.<index>`
+# parse still succeeds.
+FIXTURE_QUOTED_VIEW = "visualizer_quoted\"_'_view"
+FIXTURE_QUOTED_INDEX = "visualizer_quoted_idx"
+
 SERVICES = [
     Materialized(),
     Service(
@@ -62,6 +69,8 @@ SERVICES = [
                 f"FIXTURE_REPLICA={FIXTURE_REPLICA}",
                 f"FIXTURE_VIEW={FIXTURE_VIEW}",
                 f"FIXTURE_INDEX={FIXTURE_INDEX}",
+                f"FIXTURE_QUOTED_VIEW={FIXTURE_QUOTED_VIEW}",
+                f"FIXTURE_QUOTED_INDEX={FIXTURE_QUOTED_INDEX}",
             ],
         },
     ),
@@ -93,12 +102,17 @@ def create_fixture_dataflow(c: Composition) -> None:
     Idempotent, so that re-running the workflow against a composition that is
     already up does not have to start from `down -v`.
     """
+    quoted_view_ident = '"' + FIXTURE_QUOTED_VIEW.replace('"', '""') + '"'
     c.sql(f"""
         CREATE TABLE IF NOT EXISTS {FIXTURE_TABLE} (id int, other int);
         CREATE VIEW IF NOT EXISTS {FIXTURE_VIEW} AS
             SELECT id, other FROM {FIXTURE_TABLE};
         CREATE INDEX IF NOT EXISTS {FIXTURE_INDEX}
             IN CLUSTER {FIXTURE_CLUSTER} ON {FIXTURE_VIEW} (id);
+        CREATE VIEW IF NOT EXISTS {quoted_view_ident} AS
+            SELECT id, other FROM {FIXTURE_TABLE};
+        CREATE INDEX IF NOT EXISTS {FIXTURE_QUOTED_INDEX}
+            IN CLUSTER {FIXTURE_CLUSTER} ON {quoted_view_ident} (id);
         INSERT INTO {FIXTURE_TABLE} VALUES (1, 1);
         """)
 
@@ -109,19 +123,20 @@ def create_fixture_dataflow(c: Composition) -> None:
         startup_params={"cluster": FIXTURE_CLUSTER, "cluster_replica": FIXTURE_REPLICA}
     ) as conn:
         cursor = conn.cursor()
-        while True:
-            cursor.execute(
-                b"SELECT count(*) FROM mz_introspection.mz_records_per_dataflow "
-                b"WHERE name LIKE %s",
-                (f"Dataflow: %.{FIXTURE_INDEX}",),
-            )
-            row = cursor.fetchone()
-            assert row is not None
-            if row[0] > 0:
-                return
-            if time.time() > deadline:
-                raise AssertionError(
-                    f"index {FIXTURE_INDEX} did not show up in "
-                    f"mz_records_per_dataflow on {FIXTURE_CLUSTER}.{FIXTURE_REPLICA}"
+        for index in (FIXTURE_INDEX, FIXTURE_QUOTED_INDEX):
+            while True:
+                cursor.execute(
+                    b"SELECT count(*) FROM mz_introspection.mz_records_per_dataflow "
+                    b"WHERE name LIKE %s",
+                    (f"Dataflow: %.{index}",),
                 )
-            time.sleep(1)
+                row = cursor.fetchone()
+                assert row is not None
+                if row[0] > 0:
+                    break
+                if time.time() > deadline:
+                    raise AssertionError(
+                        f"index {index} did not show up in "
+                        f"mz_records_per_dataflow on {FIXTURE_CLUSTER}.{FIXTURE_REPLICA}"
+                    )
+                time.sleep(1)

--- a/test/dataflow-visualizer/tests/fixture.ts
+++ b/test/dataflow-visualizer/tests/fixture.ts
@@ -27,8 +27,16 @@ export const FIXTURE_VIEW =
 export const FIXTURE_INDEX =
   process.env.FIXTURE_INDEX ?? 'visualizer_fixture_idx';
 
-// How the fixture's dataflow is named in the visualizer's dataflow table.
+// A view whose name carries both quote kinds, for the SQL quoting test. See
+// `mzcompose.py` on why the index name stays plain.
+export const FIXTURE_QUOTED_VIEW =
+  process.env.FIXTURE_QUOTED_VIEW ?? `visualizer_quoted"_'_view`;
+export const FIXTURE_QUOTED_INDEX =
+  process.env.FIXTURE_QUOTED_INDEX ?? 'visualizer_quoted_idx';
+
+// How the fixtures' dataflows are named in the visualizer's dataflow table.
 export const FIXTURE_DATAFLOW = `Dataflow: materialize.public.${FIXTURE_INDEX}`;
+export const FIXTURE_QUOTED_DATAFLOW = `Dataflow: materialize.public.${FIXTURE_QUOTED_INDEX}`;
 
 /** A page URL that pins the cluster replica the page should show. */
 export function replicaPage(

--- a/test/dataflow-visualizer/tests/memory.spec.ts
+++ b/test/dataflow-visualizer/tests/memory.spec.ts
@@ -129,6 +129,23 @@ test.describe('/memory page', () => {
     await expect(viz).toContainText('CREATE VIEW');
   });
 
+  test('SQL quoting escapes every quote, not just the first', async ({
+    page,
+  }) => {
+    // The pages build SQL by interpolating URL parameters and catalog names,
+    // and run it as whoever opened the page, so an escaper that stops after
+    // the first quote of a name is no better than none.
+    await openMemoryPage(page, '/memory');
+
+    const quoted = await page.evaluate(() => {
+      const w = window as any;
+      return { literal: w.sqlLiteral(`a'b'c`), ident: w.sqlIdent(`a"b"c`) };
+    });
+
+    expect(quoted.literal).toBe(`'a''b''c'`);
+    expect(quoted.ident).toBe(`"a""b""c"`);
+  });
+
   test('graphviz renders SVG when dataflow is expanded', async ({ page }) => {
     await openMemoryPage(page, fixturePage('/memory'));
     await expandFixtureDataflow(page);

--- a/test/dataflow-visualizer/tests/memory.spec.ts
+++ b/test/dataflow-visualizer/tests/memory.spec.ts
@@ -11,6 +11,8 @@ import { test, expect, Page } from '@playwright/test';
 import {
   FIXTURE_CLUSTER,
   FIXTURE_DATAFLOW,
+  FIXTURE_QUOTED_DATAFLOW,
+  FIXTURE_QUOTED_VIEW,
   FIXTURE_REPLICA,
   FIXTURE_VIEW,
   fixturePage,
@@ -23,7 +25,7 @@ async function openMemoryPage(page: Page, url: string) {
 }
 
 /**
- * Expand the fixture dataflow.
+ * Expand a fixture dataflow by its name in the dataflow table.
  *
  * Addressing the row by name matters: the table is ordered by record count
  * descending, a dataflow that arranges nothing reports NULL rather than zero
@@ -32,10 +34,10 @@ async function openMemoryPage(page: Page, url: string) {
  * Expanding a transient one races its teardown, and the page then reports an
  * unknown dataflow id instead of a graph.
  */
-async function expandFixtureDataflow(page: Page) {
+async function expandDataflow(page: Page, dataflow = FIXTURE_DATAFLOW) {
   const row = page
     .locator('table.dataflows tbody tr')
-    .filter({ hasText: FIXTURE_DATAFLOW });
+    .filter({ hasText: dataflow });
   await expect(row).toBeVisible();
   await row.locator('button').click();
 }
@@ -109,7 +111,7 @@ test.describe('/memory page', () => {
     page,
   }) => {
     await openMemoryPage(page, fixturePage('/memory'));
-    await expandFixtureDataflow(page);
+    await expandDataflow(page);
 
     const viz = vizSection(page);
     await expect(viz).toBeVisible();
@@ -122,7 +124,7 @@ test.describe('/memory page', () => {
     // that reaches outside `mz_introspection`, so nothing else catches it
     // breaking.
     await openMemoryPage(page, fixturePage('/memory'));
-    await expandFixtureDataflow(page);
+    await expandDataflow(page);
 
     const viz = vizSection(page);
     await expect(viz).toContainText(`View: materialize.public.${FIXTURE_VIEW}`);
@@ -146,9 +148,26 @@ test.describe('/memory page', () => {
     expect(quoted.ident).toBe(`"a""b""c"`);
   });
 
+  test('a view name that needs quoting still resolves to its SQL', async ({
+    page,
+  }) => {
+    // The fixture view's name carries both quote kinds. Interpolated raw into
+    // SHOW CREATE VIEW, the statement fails to parse and the page quietly
+    // drops the SQL panel (console.debug only), so the panel being present is
+    // what pins the quoting at its call sites.
+    await openMemoryPage(page, fixturePage('/memory'));
+    await expandDataflow(page, FIXTURE_QUOTED_DATAFLOW);
+
+    const viz = vizSection(page);
+    await expect(viz).toContainText(
+      `View: materialize.public.${FIXTURE_QUOTED_VIEW}`
+    );
+    await expect(viz).toContainText('CREATE VIEW');
+  });
+
   test('graphviz renders SVG when dataflow is expanded', async ({ page }) => {
     await openMemoryPage(page, fixturePage('/memory'));
-    await expandFixtureDataflow(page);
+    await expandDataflow(page);
 
     // Wait for SVG to be rendered by graphviz
     const svg = page.locator('svg').first();


### PR DESCRIPTION
The /memory page resolves an expanded dataflow back to the view its index was built on, and interpolated both the index name it parses out of the dataflow name and the view name that lookup returns straight into the statements it sends to /api/sql. Those names are chosen by whoever created the object, and the statements run in the session of whoever opened the page, so a catalog name carrying a quote could run SQL with the viewer's privileges.

The escaper the pages already had for cluster and replica names passed a string rather than a regex to String.replace, so it escaped only the first quote of a name, which is no escaping at all for a name carrying two. Those two names come straight from URL parameters, as does the dataflow id, which is interpolated as a number and so cannot be made safe by quoting at all, and is now rejected unless it is an integer.

Both pages now quote through sqlLiteral and sqlIdent in fetch.js, which they already share for the /api/sql call itself, and a browser test pins that both helpers escape every quote rather than just the first.

Found via the QA LLM review, sorry for only catching it after the PR merged: https://github.com/MaterializeInc/materialize/pull/38359#issuecomment-5348811439