### PR TITLE
metric sink: skip rows with a null label value (SQL-645)

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -1598,12 +1598,7 @@ impl CatalogState {
         // Extract notices directly from the owned dropped entries.
         for mut entry in dropped_entries {
             drop_ids.extend(entry.global_ids());
-            let metainfo = match entry.item_mut() {
-                CatalogItem::Index(idx) => idx.dataflow_metainfo.take(),
-                CatalogItem::MaterializedView(mv) => mv.dataflow_metainfo.take(),
-                _ => None,
-            };
-            if let Some(mut metainfo) = metainfo {
+            if let Some(metainfo) = entry.item_mut().dataflow_metainfo_mut() {
                 soft_assert_or_log!(
                     metainfo.optimizer_notices.iter().all_unique(),
                     "should have been pushed there by \
@@ -1639,19 +1634,8 @@ impl CatalogState {
                         if let Some(entry) = self.try_get_entry_by_global_id(item_id) {
                             let catalog_item_id = entry.id();
                             let entry = self.get_entry_mut(&catalog_item_id);
-                            let item = entry.item_mut();
-                            match item {
-                                CatalogItem::Index(idx) => {
-                                    if let Some(ref mut m) = idx.dataflow_metainfo {
-                                        m.optimizer_notices.retain(|x| &n != x);
-                                    }
-                                }
-                                CatalogItem::MaterializedView(mv) => {
-                                    if let Some(ref mut m) = mv.dataflow_metainfo {
-                                        m.optimizer_notices.retain(|x| &n != x);
-                                    }
-                                }
-                                _ => {}
+                            if let Some(m) = entry.item_mut().dataflow_metainfo_mut() {
+                                m.optimizer_notices.retain(|x| &n != x);
                             }
                         }
                     }

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1852,6 +1852,16 @@ impl CatalogItem {
         }
     }
 
+    /// Returns a mutable reference to the dataflow metainfo, if this item has one.
+    pub fn dataflow_metainfo_mut(&mut self) -> Option<&mut DataflowMetainfo<Arc<OptimizerNotice>>> {
+        match self {
+            CatalogItem::Index(idx) => idx.dataflow_metainfo.as_mut(),
+            CatalogItem::MaterializedView(mv) => mv.dataflow_metainfo.as_mut(),
+            CatalogItem::MetricSink(ms) => ms.dataflow_metainfo.as_mut(),
+            _ => None,
+        }
+    }
+
     /// Returns mutable references to the plan fields (`optimized_plan`,
     /// `physical_plan`, `dataflow_metainfo`) on plan-bearing items
     /// (`Index`, `MaterializedView`), or `None` for

--- a/src/compute/src/sink/metric_sink.rs
+++ b/src/compute/src/sink/metric_sink.rs
@@ -197,8 +197,9 @@ impl<'scope> SinkRender<'scope> for MetricSinkConnection {
 /// The source relation exposes `metric_name`, `labels`, `value`, and `help` of the required types,
 /// and `shape_metric_sink_source` adds the `metric_kind` and `name_valid` columns this reads.
 /// `resolve` panics if a column is missing. No tree caller enforces this column contract yet; the
-/// SQL planner will. `metric_name` and `value` may still be `Datum::Null`;
-/// the rest are non-null by construction. Column position within the row is unconstrained.
+/// SQL planner will. `metric_name`, `value`, and the values of the `labels` map may still be
+/// `Datum::Null` (a `map[text=>text]` has no per-value nullability); the columns themselves are
+/// non-null by construction. Column position within the row is unconstrained.
 struct ColumnIndices {
     metric_name: usize,
     labels: usize,
@@ -231,6 +232,10 @@ impl ColumnIndices {
 ///
 /// The planner already did the row-wise shaping.
 ///
+/// A null label value stays `None` rather than being coerced to a string. Neither a null nor a
+/// genuine empty-string value is a representable Prometheus label (an empty value reads as absent),
+/// so a row carrying either is skipped downstream instead of published.
+///
 /// Strings borrow from `datums`, so the caller must own what it needs
 /// (see `SinkState::stage_ok`) before the row backing `datums` is dropped.
 fn extract_row<'a>(
@@ -240,7 +245,7 @@ fn extract_row<'a>(
     &'a str,
     Option<MetricKind>,
     bool,
-    Vec<(&'a str, &'a str)>,
+    Vec<(&'a str, Option<&'a str>)>,
     Option<f64>,
     &'a str,
 ) {
@@ -250,10 +255,10 @@ fn extract_row<'a>(
     };
     let metric_kind = MetricKind::from_datum(datums[cols.metric_kind]);
     let name_valid = matches!(datums[cols.name_valid], Datum::True);
-    let mut labels: Vec<(&str, &str)> = datums[cols.labels]
+    let mut labels: Vec<(&str, Option<&str>)> = datums[cols.labels]
         .unwrap_map()
         .iter()
-        .map(|(k, v)| (k, v.unwrap_str()))
+        .map(|(k, v)| (k, (!v.is_null()).then(|| v.unwrap_str())))
         .collect();
     labels.sort();
     let value = match datums[cols.value] {
@@ -269,7 +274,8 @@ fn extract_row<'a>(
 ///
 /// A null value is its own distinct row identity, not a stand-in for any particular number,
 /// so it is kept apart from every `Some(_)` identity rather than coerced to
-/// one.
+/// one. A null label value is likewise distinct from a `''` value, so `{a => NULL}` and
+/// `{a => ''}` retract only against their own inserts even though both are unpublishable.
 /// The name and labels lead the tuple so that a `BTreeMap<RowKey, _>` keeps all rows of one
 /// `(metric_name, labels)` series adjacent.
 ///
@@ -279,7 +285,7 @@ fn extract_row<'a>(
 /// granularity of the `skipped` count for rows that are never published either way.
 type RowKey = (
     String,
-    Vec<(String, String)>,
+    Vec<(String, Option<String>)>,
     Option<u64>,
     Option<MetricKind>,
     bool,
@@ -363,6 +369,13 @@ fn is_valid_label_name(name: &str) -> bool {
     }
 }
 
+/// Whether a label value can be published as-is. A null (`None`) has no value to encode, and an
+/// empty string reads as absent to Prometheus, so `{a => ''}` would fold into `{}`. Both make the
+/// row that carries them unpublishable.
+fn is_publishable_label_value(value: Option<&str>) -> bool {
+    matches!(value, Some(v) if !v.is_empty())
+}
+
 impl SinkState {
     /// Buffers one ok-collection update under its timestamp.
     ///
@@ -375,7 +388,7 @@ impl SinkState {
         metric_name: &str,
         metric_kind: Option<MetricKind>,
         name_valid: bool,
-        labels: &[(&str, &str)],
+        labels: &[(&str, Option<&str>)],
         value: Option<f64>,
         help: &str,
         time: Timestamp,
@@ -385,7 +398,7 @@ impl SinkState {
             metric_name.to_string(),
             labels
                 .iter()
-                .map(|&(k, v)| (k.to_string(), v.to_string()))
+                .map(|&(k, v)| (k.to_string(), v.map(str::to_string)))
                 .collect(),
             value.map(f64::to_bits),
             metric_kind,
@@ -459,8 +472,8 @@ impl SinkState {
     }
 }
 
-/// Counts live working rows dropped for an unsupported `metric_type` or an invalid Prometheus
-/// metric or label name.
+/// Counts live working rows dropped for an unsupported `metric_type`, an invalid Prometheus
+/// metric or label name, or a null or empty label value.
 fn count_skipped(working: &BTreeMap<RowKey, i64>) -> u64 {
     let mut skipped = 0u64;
     for ((_name, labels, _bits, metric_kind, name_valid, _help), acc) in working {
@@ -468,7 +481,10 @@ fn count_skipped(working: &BTreeMap<RowKey, i64>) -> u64 {
             continue;
         }
         let unsupported = metric_kind.is_none();
-        let invalid = !name_valid || !labels.iter().all(|(k, _)| is_valid_label_name(k));
+        let invalid = !name_valid
+            || !labels
+                .iter()
+                .all(|(k, v)| is_publishable_label_value(v.as_deref()) && is_valid_label_name(k));
         if unsupported || invalid {
             skipped += 1;
         }
@@ -478,6 +494,9 @@ fn count_skipped(working: &BTreeMap<RowKey, i64>) -> u64 {
 
 /// Collapses the live, representable rows of `working` into one published entry per
 /// `(metric_name, labels)` series and counts colliding and null-suppressed series.
+///
+/// A row whose label set is not representable (an invalid label name, or a null or empty label
+/// value) is dropped here and counted by [`count_skipped`] instead.
 ///
 /// A series collides when more than one distinct live non-null value exists for its
 /// `(metric_name, labels)`: a genuine conflict of two source rows, unlike an ordinary
@@ -501,13 +520,31 @@ fn rebuild_published(
         let Some(kind) = metric_kind else {
             continue;
         };
+        // A null or empty label value has no representable Prometheus label (an empty value reads
+        // as absent, folding `{a => ''}` into `{}`), so the whole row is unpublishable. Drop it
+        // rather than emit a series the source never had.
+        let Some(labels) = labels
+            .iter()
+            .map(|(k, v)| {
+                is_publishable_label_value(v.as_deref()).then(|| {
+                    (
+                        k.clone(),
+                        v.as_ref().expect("publishable is non-null").clone(),
+                    )
+                })
+            })
+            .collect::<Option<Vec<_>>>()
+        else {
+            continue;
+        };
         if !name_valid || !labels.iter().all(|(k, _)| is_valid_label_name(k)) {
             continue;
         }
-        grouped
-            .entry((name.clone(), labels.clone()))
-            .or_default()
-            .push((bits.map(f64::from_bits), *kind, help.clone()));
+        grouped.entry((name.clone(), labels)).or_default().push((
+            bits.map(f64::from_bits),
+            *kind,
+            help.clone(),
+        ));
     }
 
     let mut published = BTreeMap::new();
@@ -660,7 +697,7 @@ impl SinkCollector {
             ),
             skipped_gauge: gauge(
                 "mz_compute_metric_sink_skipped",
-                "The number of input rows skipped for an unsupported metric type or an invalid name.",
+                "The number of input rows skipped for an unsupported metric type, an invalid name, or a null or empty label value.",
             ),
             conflicts_gauge: gauge(
                 "mz_compute_metric_sink_conflicts",
@@ -727,10 +764,33 @@ mod tests {
     }
 
     /// `label_a()`, borrowed: what `stage_ok` now takes (see `extract_row`).
-    const LABEL_A: &[(&str, &str)] = &[("a", "1")];
+    const LABEL_A: &[(&str, Option<&str>)] = &[("a", Some("1"))];
 
     fn key_m() -> PublishedKey {
         ("m".into(), label_a())
+    }
+
+    /// Mirrors the shaped relation `shape_metric_sink_source` builds: `labels`/`help` are
+    /// non-null by construction, `metric_name`/`value` stay nullable, and `metric_kind`/
+    /// `name_valid` are the planner's computed classification columns.
+    fn shaped_desc() -> RelationDesc {
+        use mz_repr::SqlScalarType;
+
+        RelationDesc::builder()
+            .with_column("metric_name", SqlScalarType::String.nullable(true))
+            .with_column(
+                "labels",
+                SqlScalarType::Map {
+                    value_type: Box::new(SqlScalarType::String),
+                    custom_id: None,
+                }
+                .nullable(false),
+            )
+            .with_column("value", SqlScalarType::Float64.nullable(true))
+            .with_column("help", SqlScalarType::String.nullable(false))
+            .with_column("metric_kind", SqlScalarType::Int32.nullable(true))
+            .with_column("name_valid", SqlScalarType::Bool.nullable(true))
+            .finish()
     }
 
     /// Stages one gauge update for the `(m, {a:1})` series.
@@ -891,26 +951,7 @@ mod tests {
 
     #[mz_ore::test]
     fn extract_row_normalizes_null_datums() {
-        use mz_repr::SqlScalarType;
-
-        // Mirrors the shaped relation `shape_metric_sink_source` builds: `labels`/`help` are
-        // non-null by construction, `metric_name`/`value` stay nullable, and `metric_kind`/
-        // `name_valid` are the planner's computed classification columns.
-        let desc = RelationDesc::builder()
-            .with_column("metric_name", SqlScalarType::String.nullable(true))
-            .with_column(
-                "labels",
-                SqlScalarType::Map {
-                    value_type: Box::new(SqlScalarType::String),
-                    custom_id: None,
-                }
-                .nullable(false),
-            )
-            .with_column("value", SqlScalarType::Float64.nullable(true))
-            .with_column("help", SqlScalarType::String.nullable(false))
-            .with_column("metric_kind", SqlScalarType::Int32.nullable(true))
-            .with_column("name_valid", SqlScalarType::Bool.nullable(true))
-            .finish();
+        let desc = shaped_desc();
         let cols = ColumnIndices::resolve(&desc);
 
         let mut row = Row::default();
@@ -929,9 +970,75 @@ mod tests {
         assert_eq!(name, "");
         assert_eq!(metric_kind, None);
         assert!(!name_valid);
-        assert_eq!(labels, Vec::<(&str, &str)>::new());
+        assert_eq!(labels, Vec::new());
         assert_eq!(value, None);
         assert_eq!(help, "");
+    }
+
+    /// A null map value must survive extraction as `None`; unwrapping it as a string panicked the
+    /// worker and took down the replica.
+    #[mz_ore::test]
+    fn extract_row_keeps_null_label_values() {
+        let desc = shaped_desc();
+        let cols = ColumnIndices::resolve(&desc);
+
+        let mut row = Row::default();
+        {
+            let mut packer = row.packer();
+            packer.push(Datum::String("m"));
+            packer.push_dict_with(|row| {
+                row.push(Datum::String("bad"));
+                row.push(Datum::Null);
+                row.push(Datum::String("good"));
+                row.push(Datum::String("1"));
+            });
+            packer.push(Datum::Float64(1.0.into()));
+            packer.push(Datum::String("h"));
+            packer.push(Datum::Int32(0));
+            packer.push(Datum::True);
+        }
+
+        let datums: Vec<Datum> = row.iter().collect();
+        let (_name, _metric_kind, _name_valid, labels, _value, _help) = extract_row(&cols, &datums);
+        assert_eq!(labels, vec![("bad", None), ("good", Some("1"))]);
+    }
+
+    #[mz_ore::test]
+    fn null_or_empty_label_value_skips_row() {
+        let mut st = SinkState::default();
+        // A null label value has no representable label set: publishes nothing, counts as skipped.
+        st.stage_ok(
+            "m",
+            Some(MetricKind::Gauge),
+            true,
+            &[("a", None)],
+            Some(1.0),
+            "h",
+            Timestamp::from(1),
+            1,
+        );
+        st.integrate(&frontier(2));
+        st.publish_if_healthy();
+        assert!(st.published.is_empty());
+        assert_eq!(st.skipped, 1);
+
+        // An empty label value folds to `{}` in Prometheus, so it is skipped too rather than
+        // published as a bare `{}` series. It is a distinct identity from the null row, so both
+        // stay live and count: `skipped` reaches 2, not 1.
+        st.stage_ok(
+            "m",
+            Some(MetricKind::Gauge),
+            true,
+            &[("a", Some(""))],
+            Some(1.0),
+            "h",
+            Timestamp::from(3),
+            1,
+        );
+        st.integrate(&frontier(4));
+        st.publish_if_healthy();
+        assert!(st.published.is_empty());
+        assert_eq!(st.skipped, 2);
     }
 
     fn pkey(name: &str, labels: &[(&str, &str)]) -> PublishedKey {

--- a/test/sqllogictest/metric_sink.slt
+++ b/test/sqllogictest/metric_sink.slt
@@ -389,63 +389,52 @@ CREATE METRIC SINK rbac_ms FROM rbac_src WITH (PREFIX = 'mz_metric_sink_rbac_')
 ----
 COMPLETE 0
 
-# TODO(linear#SQL-645): re-enable the block below once the sink operator skips a row whose
-# `labels` map carries a null value. Today `extract_row` unwraps such a value as a string and
-# panics, which aborts clusterd, so the test reproduces the crash instead of asserting the
-# behavior it describes.
-#
-# # A `map[text=>text]` legally holds null *values*, and the shaping coalesces only
-# # a null `labels` map as a whole, so such a row reaches the sink operator, which
-# # has no label set it can represent and must skip it. Panicking instead aborts the
-# # whole clusterd process, and the sink re-renders over the same persisted row on
-# # restart, crash-looping every dataflow on the cluster.
-# #
-# # The same sink covers notice bookkeeping: `LiteralConstraints` attaches an "index
-# # too wide" notice for the `metric_name = 'm'` filter over `nulls_idx`, keyed by
-# # the sink's own id, and `DROP METRIC SINK` has to retract it again.
-#
-# statement ok
-# CREATE TABLE nulls (metric_name text, metric_type text, labels map[text=>text], value double, help text)
-#
-# statement ok
-# INSERT INTO nulls VALUES ('m', 'gauge', '{good=>1, bad=>NULL}'::map[text=>text], 1, 'h')
-#
-# statement ok
-# CREATE INDEX nulls_idx ON nulls (metric_name, metric_type)
-#
-# statement ok
-# CREATE VIEW nulls_v AS SELECT * FROM nulls WHERE metric_name = 'm'
-#
-# statement ok
-# CREATE METRIC SINK ms_nulls FROM nulls_v WITH (PREFIX = 'mz_metric_sink_nulls_')
-#
-# # The replica folded that row and still answers: `count(*)` needs a dataflow on
-# # `quickstart`, the cluster the sink runs on.
-#
-# query I
-# SELECT count(*) FROM nulls
-# ----
-# 1
-#
-# # `mz_optimizer_notices` is readable only by `mz_monitor`, hence `mz_system`.
-#
-# simple conn=mz_system,user=mz_system
-# SELECT count(*) FROM mz_internal.mz_optimizer_notices WHERE message LIKE '%nulls_idx%'
-# ----
-# 1
-# COMPLETE 1
-#
-# statement ok
-# DROP METRIC SINK ms_nulls
-#
-# simple conn=mz_system,user=mz_system
-# SELECT count(*) FROM mz_internal.mz_optimizer_notices WHERE message LIKE '%nulls_idx%'
-# ----
-# 0
-# COMPLETE 1
-#
-# statement ok
-# DROP TABLE nulls CASCADE
+# A `map[text=>text]` can hold null *values*, so such a row reaches the sink, which has no label
+# set to represent and must skip it. Panicking instead crash-loops every dataflow on the cluster.
+# This sink also covers notice bookkeeping: `LiteralConstraints` attaches an "index too wide" notice
+# keyed by the sink's own id that `DROP METRIC SINK` must retract.
+
+statement ok
+CREATE TABLE nulls (metric_name text, metric_type text, labels map[text=>text], value double, help text)
+
+statement ok
+INSERT INTO nulls VALUES ('m', 'gauge', '{good=>1, bad=>NULL}'::map[text=>text], 1, 'h')
+
+statement ok
+CREATE INDEX nulls_idx ON nulls (metric_name, metric_type)
+
+statement ok
+CREATE VIEW nulls_v AS SELECT * FROM nulls WHERE metric_name = 'm'
+
+statement ok
+CREATE METRIC SINK ms_nulls FROM nulls_v WITH (PREFIX = 'mz_metric_sink_nulls_')
+
+# The replica folded that row and still answers a `count(*)` on the sink's cluster.
+
+query I
+SELECT count(*) FROM nulls
+----
+1
+
+# `mz_optimizer_notices` is readable only by `mz_monitor`, hence `mz_system`.
+
+simple conn=mz_system,user=mz_system
+SELECT count(*) FROM mz_internal.mz_optimizer_notices WHERE message LIKE '%nulls_idx%'
+----
+1
+COMPLETE 1
+
+statement ok
+DROP METRIC SINK ms_nulls
+
+simple conn=mz_system,user=mz_system
+SELECT count(*) FROM mz_internal.mz_optimizer_notices WHERE message LIKE '%nulls_idx%'
+----
+0
+COMPLETE 1
+
+statement ok
+DROP TABLE nulls CASCADE
 
 # With the flag off the statement is refused, and the error says which flag.
 

--- a/test/testdrive/metric-sink.td
+++ b/test/testdrive/metric-sink.td
@@ -191,3 +191,36 @@ contains:still depended upon by metric sink "s"
 0
 
 > DROP TABLE t
+
+# A null or empty label *value* has no representable Prometheus label set: a null has nothing to
+# encode, and an empty value reads as absent to Prometheus, which would fold `{a => ''}` into `{}`.
+# The sink skips the whole row and counts it in `mz_compute_metric_sink_skipped` rather than
+# publish a mislabeled series. `map_build` keeps a null value (it drops only null keys), so the two
+# rows reach the sink as `{a => NULL}` and `{a => ''}`, distinct identities that are each skipped.
+> CREATE TABLE lt (lv text)
+
+> INSERT INTO lt VALUES (NULL), ('')
+
+> CREATE VIEW lv AS
+  SELECT 'skip_test'::text AS metric_name,
+         'gauge'::text AS metric_type,
+         map_build(LIST[ROW('a', lv)])::map[text=>text] AS labels,
+         1::double AS value,
+         'a metric skipped by the metric sink e2e test'::text AS help
+  FROM lt
+
+> CREATE METRIC SINK s_skip IN CLUSTER quickstart FROM lv WITH (PREFIX = 'mz_metric_sink_skip_')
+
+# Both rows are skipped and stay distinct (a null value is not the same identity as an empty one),
+# so the gauge reads 2, not 1. This retrying read also waits for the scrape to observe the sink;
+# `s_skip` is the only metric sink here, so no `sink`-label filter is needed.
+> SELECT value FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_skipped'
+2
+
+# Neither row publishes a series under the sink's metric name.
+> SELECT count(*) FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_skip_skip_test'
+0
+
+> DROP TABLE lt CASCADE


### PR DESCRIPTION
Problem:
A `map[text=>text]` has no per-value nullability, so a metric sink's
`labels` map can hold nulls. Such a row hit `extract_row`, which unwrapped the
value as a string and panicked the worker. That takes down clusterd, and the
sink re-renders over the same persisted row on restart, crash-looping the whole
cluster.

Separately, `drop_optimizer_notices` handled only `Index` and
`MaterializedView`, so a dropped sink's notices were never retracted.

Solution:
Skip a row whose label set is not representable, counting it in
`mz_compute_metric_sink_skipped`. A null value has nothing to encode, and an
empty string is not a stand-in either, since Prometheus reads it as absent and
would fold `{a => ''}` into `{}`.
Retract a dropped sink's notices through a new `dataflow_metainfo_mut`, the
mutable twin of the existing `dataflow_metainfo` getter, shared by both drop
sites.

Testing:
- unit tests
- a sqllogictest over a filtered, indexed view that exercises both the
panic and the notice retraction on `DROP METRIC SINK`.

Closes: [SQL-645](https://linear.app/materializeinc/issue/SQL-645)