### PR TITLE
Make sure scenario version applies for source ingestion

### DIFF
--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -2521,7 +2521,9 @@ class Scenario(ABC):
       3. `teardown(runner)` once.
     """
 
-    VERSION: str = "1.0.0"
+    def version(self) -> str:
+        """Version recorded as ``scenario_version`` in result rows."""
+        return "1.0.0"
 
     @abstractmethod
     def name(self) -> str: ...
@@ -3165,6 +3167,9 @@ class StrongScalingSweep(_ClusterSizeSweepBase):
         self._name = name
         self._workload = workload
 
+    def version(self) -> str:
+        return self._workload.VERSION
+
     def name(self) -> str:
         return self._name
 
@@ -3202,6 +3207,9 @@ class WeakScalingSweep(_ClusterSizeSweepBase):
         self._name = name
         self._workload = workload
         self._initial_scale = workload.scale
+
+    def version(self) -> str:
+        return self._workload.VERSION
 
     def name(self) -> str:
         return self._name
@@ -3255,6 +3263,9 @@ class EnvdCpuSweep(Scenario):
         self._name = name
         self._workload = workload
         self._fixed_replica_size: str | None = None
+
+    def version(self) -> str:
+        return self._workload.VERSION
 
     def name(self) -> str:
         return self._name
@@ -3330,6 +3341,9 @@ class EnvdObjectsSweep(Scenario):
         self._name = name
         self._workload = workload
         self._sizes = sizes
+
+    def version(self) -> str:
+        return self._workload.VERSION
 
     def name(self) -> str:
         return self._name
@@ -4140,7 +4154,7 @@ def run_scenario(
     """
     runner = ScenarioRunner(
         scenario.name(),
-        scenario.VERSION,
+        scenario.version(),
         0,
         scenario.mode(),
         connection,


### PR DESCRIPTION
### Motivation
Part of: [SS-432](https://linear.app/materializeinc/issue/SS-432)

https://github.com/MaterializeInc/materialize/pull/38363#issuecomment-5348827670

I bumped the source ingestion scenario to indicate we couldn't compare against historical runs due to a bump in the mysql version. This didn't actually work because the scenario is wrapped with a `StrongScalingSweep` (or one of a couple other classes), which inherits from the root Scenario the old version. So we want to make the individual source ingestion version bump take precedence over the StrongScalingSweep etc. versions.

### Description
Makes the version a method that different implementations can override. We have the wrapping scenarios delegate to the underlying workloads.

This will let us override other specific workloads independently, but we will either need to patch in some sort of version fudging or bump the other global version if we tweak `StrongScalingSweep` in the future.

### Verification

