### PR TITLE
console: show real source status on the Objects page

### DIFF
--- a/console/src/api/materialize/maintained-objects/hydrationAggregate.test.sql.ts
+++ b/console/src/api/materialize/maintained-objects/hydrationAggregate.test.sql.ts
@@ -26,11 +26,13 @@ const seed = ({
   statuses = "",
   statistics = "",
   replicas = "('r1'), ('r2'), ('r3')",
+  sources = "",
 }: {
   hydration?: string;
   statuses?: string;
   statistics?: string;
   replicas?: string;
+  sources?: string;
 }) => `
   > DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE;
   > CREATE SCHEMA ${TEST_SCHEMA};
@@ -38,6 +40,10 @@ const seed = ({
       object_id TEXT NOT NULL,
       replica_id TEXT,
       hydrated BOOLEAN
+    );
+  > CREATE TABLE ${TEST_SCHEMA}.mz_sources (
+      id TEXT NOT NULL,
+      type TEXT NOT NULL
     );
   > CREATE TABLE ${TEST_SCHEMA}.mz_source_statuses (
       id TEXT NOT NULL,
@@ -57,6 +63,7 @@ const seed = ({
   ${statuses ? `> INSERT INTO ${TEST_SCHEMA}.mz_source_statuses VALUES ${statuses};` : ""}
   ${statistics ? `> INSERT INTO ${TEST_SCHEMA}.mz_source_statistics VALUES ${statistics};` : ""}
   ${replicas ? `> INSERT INTO ${TEST_SCHEMA}.mz_cluster_replicas VALUES ${replicas};` : ""}
+  ${sources ? `> INSERT INTO ${TEST_SCHEMA}.mz_sources VALUES ${sources};` : ""}
 `;
 
 const run = async () => {
@@ -200,12 +207,16 @@ describe("buildHydrationAggregateQuery", () => {
   it("excludes subsources and progress collections from the feed", async () => {
     // The UI hides them, and each source carries one progress collection and
     // often several subsources, so keeping them out shrinks the subscribe.
+    // Subsources also have hydration rows of their own (they run on the
+    // parent's cluster), so the exclusion must hold on both join sides.
     await testdrive(
       seed({
+        hydration: `('u1', 'r1', true), ('u2', 'r1', true)`,
         statuses: `
           ('u1', 'running', NULL, 'postgres'),
           ('u2', 'running', NULL, 'subsource'),
           ('u3', 'running', NULL, 'progress')`,
+        sources: `('u1', 'postgres'), ('u2', 'subsource'), ('u3', 'progress')`,
       }),
     );
 

--- a/console/src/api/materialize/maintained-objects/hydrationAggregate.test.sql.ts
+++ b/console/src/api/materialize/maintained-objects/hydrationAggregate.test.sql.ts
@@ -16,23 +16,60 @@ import { testdrive } from "~/test/sql/mzcompose";
 import { SEARCH_PATH } from "../executeSql";
 import { buildHydrationAggregateQuery } from "./hydrationAggregate";
 
+const TEST_SCHEMA = "test_hydration_aggregate";
+
+/** Shadows the three relations the query reads. Empty value lists are elided. */
+const seed = ({
+  hydration = "",
+  statuses = "",
+  statistics = "",
+}: {
+  hydration?: string;
+  statuses?: string;
+  statistics?: string;
+}) => `
+  > DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE;
+  > CREATE SCHEMA ${TEST_SCHEMA};
+  > CREATE TABLE ${TEST_SCHEMA}.mz_hydration_statuses (
+      object_id TEXT NOT NULL,
+      replica_id TEXT,
+      hydrated BOOLEAN
+    );
+  > CREATE TABLE ${TEST_SCHEMA}.mz_source_statuses (
+      id TEXT NOT NULL,
+      status TEXT NOT NULL,
+      error TEXT
+    );
+  > CREATE TABLE ${TEST_SCHEMA}.mz_source_statistics (
+      id TEXT NOT NULL,
+      replica_id TEXT,
+      snapshot_committed BOOLEAN
+    );
+  ${hydration ? `> INSERT INTO ${TEST_SCHEMA}.mz_hydration_statuses VALUES ${hydration};` : ""}
+  ${statuses ? `> INSERT INTO ${TEST_SCHEMA}.mz_source_statuses VALUES ${statuses};` : ""}
+  ${statistics ? `> INSERT INTO ${TEST_SCHEMA}.mz_source_statistics VALUES ${statistics};` : ""}
+`;
+
+const run = async () => {
+  const compiled = buildHydrationAggregateQuery().compile();
+  const result = await executeSqlHttp(compiled, {
+    sessionVariables: {
+      cluster: QUICKSTART_CLUSTER,
+      search_path: `${TEST_SCHEMA}, ${SEARCH_PATH}`,
+    },
+  });
+  return result.rows.sort((a, b) => a.object_id.localeCompare(b.object_id));
+};
+
 describe("buildHydrationAggregateQuery", () => {
   it("aggregates hydrated and total replicas per object", async () => {
-    const testSchema = "test_hydration_aggregate";
-
     // u1: single replica, hydrated → 1/1
     // u2: 3 replicas, all hydrated → 3/3
     // u3: 3 replicas, 1 hydrated → 1/3
     // u4: 2 replicas, none hydrated → 0/2
-    await testdrive(`
-      > DROP SCHEMA IF EXISTS ${testSchema} CASCADE;
-      > CREATE SCHEMA ${testSchema};
-      > CREATE TABLE ${testSchema}.mz_hydration_statuses (
-          object_id TEXT NOT NULL,
-          replica_id TEXT,
-          hydrated BOOLEAN
-        );
-      > INSERT INTO ${testSchema}.mz_hydration_statuses VALUES
+    await testdrive(
+      seed({
+        hydration: `
           ('u1', 'r1', true),
           ('u2', 'r1', true),
           ('u2', 'r2', true),
@@ -41,20 +78,11 @@ describe("buildHydrationAggregateQuery", () => {
           ('u3', 'r2', false),
           ('u3', 'r3', false),
           ('u4', 'r1', false),
-          ('u4', 'r2', false);
-    `);
-
-    const compiled = buildHydrationAggregateQuery().compile();
-    const result = await executeSqlHttp(compiled, {
-      sessionVariables: {
-        cluster: QUICKSTART_CLUSTER,
-        search_path: `${testSchema}, ${SEARCH_PATH}`,
-      },
-    });
-
-    const rows = result.rows.sort((a, b) =>
-      a.object_id.localeCompare(b.object_id),
+          ('u4', 'r2', false)`,
+      }),
     );
+
+    const rows = await run();
     expect(rows).toHaveLength(4);
 
     expect(rows[0]).toMatchObject({ object_id: "u1" });
@@ -72,38 +100,91 @@ describe("buildHydrationAggregateQuery", () => {
     expect(rows[3]).toMatchObject({ object_id: "u4" });
     expect(Number(rows[3].hydratedReplicas)).toBe(0);
     expect(Number(rows[3].totalReplicas)).toBe(2);
+
+    // No source rows seeded, so the source columns are null throughout.
+    expect(rows[0].sourceStatus).toBeNull();
+    expect(rows[0].snapshotCommitted).toBeNull();
   });
 
   it("treats null hydrated values as not-hydrated for the FILTER clause", async () => {
-    const testSchema = "test_hydration_aggregate";
-
     // A replica that hasn't reported a status yet shows up as a null row;
     // the FILTER (WHERE hydrated) should not count it as hydrated, but the
     // total count still includes it.
-    await testdrive(`
-      > DROP SCHEMA IF EXISTS ${testSchema} CASCADE;
-      > CREATE SCHEMA ${testSchema};
-      > CREATE TABLE ${testSchema}.mz_hydration_statuses (
-          object_id TEXT NOT NULL,
-          replica_id TEXT,
-          hydrated BOOLEAN
-        );
-      > INSERT INTO ${testSchema}.mz_hydration_statuses VALUES
-          ('u1', 'r1', true),
-          ('u1', 'r2', NULL);
-    `);
+    await testdrive(
+      seed({ hydration: `('u1', 'r1', true), ('u1', 'r2', NULL)` }),
+    );
 
-    const compiled = buildHydrationAggregateQuery().compile();
-    const result = await executeSqlHttp(compiled, {
-      sessionVariables: {
-        cluster: QUICKSTART_CLUSTER,
-        search_path: `${testSchema}, ${SEARCH_PATH}`,
-      },
+    const rows = await run();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ object_id: "u1" });
+    expect(Number(rows[0].hydratedReplicas)).toBe(1);
+    expect(Number(rows[0].totalReplicas)).toBe(2);
+  });
+
+  it("joins source status, error and the snapshot flag onto source rows", async () => {
+    await testdrive(
+      seed({
+        hydration: `('u1', 'r1', true), ('u2', 'r1', false)`,
+        statuses: `
+          ('u1', 'running', NULL),
+          ('u2', 'stalled', 'broker unreachable')`,
+        statistics: `('u1', 'r1', true), ('u2', 'r1', false)`,
+      }),
+    );
+
+    const rows = await run();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      object_id: "u1",
+      sourceStatus: "running",
+      sourceError: null,
+      snapshotCommitted: true,
     });
+    expect(rows[1]).toMatchObject({
+      object_id: "u2",
+      sourceStatus: "stalled",
+      sourceError: "broker unreachable",
+      snapshotCommitted: false,
+    });
+  });
 
-    expect(result.rows).toHaveLength(1);
-    expect(result.rows[0]).toMatchObject({ object_id: "u1" });
-    expect(Number(result.rows[0].hydratedReplicas)).toBe(1);
-    expect(Number(result.rows[0].totalReplicas)).toBe(2);
+  it("only reports the snapshot as committed once every replica agrees", async () => {
+    // A replica that is still snapshotting holds the whole source at false, so
+    // the UI keeps showing Snapshotting rather than flipping to Running early.
+    await testdrive(
+      seed({
+        hydration: `('u1', 'r1', true)`,
+        statuses: `('u1', 'running', NULL)`,
+        statistics: `('u1', 'r1', true), ('u1', 'r2', false)`,
+      }),
+    );
+
+    const rows = await run();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      object_id: "u1",
+      snapshotCommitted: false,
+    });
+  });
+
+  it("keeps sources that have a status but no hydration rows", async () => {
+    // Webhook sources are omitted from mz_hydration_statuses, so the FULL
+    // JOIN is what keeps their status visible.
+    await testdrive(
+      seed({
+        hydration: `('u1', 'r1', true)`,
+        statuses: `('u1', 'running', NULL), ('u7', 'running', NULL)`,
+      }),
+    );
+
+    const rows = await run();
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toMatchObject({
+      object_id: "u7",
+      sourceStatus: "running",
+      snapshotCommitted: null,
+    });
+    expect(rows[1].hydratedReplicas).toBeNull();
+    expect(rows[1].totalReplicas).toBeNull();
   });
 });

--- a/console/src/api/materialize/maintained-objects/hydrationAggregate.test.sql.ts
+++ b/console/src/api/materialize/maintained-objects/hydrationAggregate.test.sql.ts
@@ -18,15 +18,19 @@ import { buildHydrationAggregateQuery } from "./hydrationAggregate";
 
 const TEST_SCHEMA = "test_hydration_aggregate";
 
-/** Shadows the three relations the query reads. Empty value lists are elided. */
+/** Shadows the four relations the query reads. Empty value lists are elided.
+ *  `replicas` defaults to the ids the fixtures use, so statistics rows count
+ *  as coming from live replicas unless a test overrides it. */
 const seed = ({
   hydration = "",
   statuses = "",
   statistics = "",
+  replicas = "('r1'), ('r2'), ('r3')",
 }: {
   hydration?: string;
   statuses?: string;
   statistics?: string;
+  replicas?: string;
 }) => `
   > DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE;
   > CREATE SCHEMA ${TEST_SCHEMA};
@@ -38,16 +42,21 @@ const seed = ({
   > CREATE TABLE ${TEST_SCHEMA}.mz_source_statuses (
       id TEXT NOT NULL,
       status TEXT NOT NULL,
-      error TEXT
+      error TEXT,
+      type TEXT NOT NULL
     );
   > CREATE TABLE ${TEST_SCHEMA}.mz_source_statistics (
       id TEXT NOT NULL,
       replica_id TEXT,
       snapshot_committed BOOLEAN
     );
+  > CREATE TABLE ${TEST_SCHEMA}.mz_cluster_replicas (
+      id TEXT NOT NULL
+    );
   ${hydration ? `> INSERT INTO ${TEST_SCHEMA}.mz_hydration_statuses VALUES ${hydration};` : ""}
   ${statuses ? `> INSERT INTO ${TEST_SCHEMA}.mz_source_statuses VALUES ${statuses};` : ""}
   ${statistics ? `> INSERT INTO ${TEST_SCHEMA}.mz_source_statistics VALUES ${statistics};` : ""}
+  ${replicas ? `> INSERT INTO ${TEST_SCHEMA}.mz_cluster_replicas VALUES ${replicas};` : ""}
 `;
 
 const run = async () => {
@@ -126,8 +135,8 @@ describe("buildHydrationAggregateQuery", () => {
       seed({
         hydration: `('u1', 'r1', true), ('u2', 'r1', false)`,
         statuses: `
-          ('u1', 'running', NULL),
-          ('u2', 'stalled', 'broker unreachable')`,
+          ('u1', 'running', NULL, 'kafka'),
+          ('u2', 'stalled', 'broker unreachable', 'kafka')`,
         statistics: `('u1', 'r1', true), ('u2', 'r1', false)`,
       }),
     );
@@ -154,7 +163,7 @@ describe("buildHydrationAggregateQuery", () => {
     await testdrive(
       seed({
         hydration: `('u1', 'r1', true)`,
-        statuses: `('u1', 'running', NULL)`,
+        statuses: `('u1', 'running', NULL, 'kafka')`,
         statistics: `('u1', 'r1', true), ('u1', 'r2', false)`,
       }),
     );
@@ -173,7 +182,7 @@ describe("buildHydrationAggregateQuery", () => {
     await testdrive(
       seed({
         hydration: `('u1', 'r1', true)`,
-        statuses: `('u1', 'running', NULL), ('u7', 'running', NULL)`,
+        statuses: `('u1', 'running', NULL, 'kafka'), ('u7', 'running', NULL, 'webhook')`,
       }),
     );
 
@@ -186,5 +195,59 @@ describe("buildHydrationAggregateQuery", () => {
     });
     expect(rows[1].hydratedReplicas).toBeNull();
     expect(rows[1].totalReplicas).toBeNull();
+  });
+
+  it("excludes subsources and progress collections from the feed", async () => {
+    // The UI hides them, and each source carries one progress collection and
+    // often several subsources, so keeping them out shrinks the subscribe.
+    await testdrive(
+      seed({
+        statuses: `
+          ('u1', 'running', NULL, 'postgres'),
+          ('u2', 'running', NULL, 'subsource'),
+          ('u3', 'running', NULL, 'progress')`,
+      }),
+    );
+
+    const rows = await run();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ object_id: "u1", sourceStatus: "running" });
+  });
+
+  it("ignores statistics rows from dropped replicas", async () => {
+    // Statistics rows can outlive their replica; a dropped replica's stale
+    // false must not pin a committed source back to snapshotting.
+    await testdrive(
+      seed({
+        statuses: `('u1', 'running', NULL, 'kafka')`,
+        statistics: `('u1', 'r1', true), ('u1', 'r_dropped', false)`,
+        replicas: `('r1')`,
+      }),
+    );
+
+    const rows = await run();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      object_id: "u1",
+      snapshotCommitted: true,
+    });
+  });
+
+  it("keeps statistics rows that report no replica", async () => {
+    // Webhook sources report statistics with a null replica_id.
+    await testdrive(
+      seed({
+        statuses: `('u1', 'running', NULL, 'webhook')`,
+        statistics: `('u1', NULL, true)`,
+        replicas: `('r1')`,
+      }),
+    );
+
+    const rows = await run();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      object_id: "u1",
+      snapshotCommitted: true,
+    });
   });
 });

--- a/console/src/api/materialize/maintained-objects/hydrationAggregate.ts
+++ b/console/src/api/materialize/maintained-objects/hydrationAggregate.ts
@@ -34,7 +34,13 @@ export interface HydrationAggregateRow {
  * `snapshot_committed` is aggregated with `bool_and`, so a source only reads as
  * committed once every replica reporting statistics agrees. A replica that has
  * not reported yet contributes no row, so a scale-up cannot flip a committed
- * source back to snapshotting.
+ * source back to snapshotting. Statistics rows can outlive their replica, so
+ * the aggregate is restricted to live replicas (keeping rows with no
+ * `replica_id`, which is how webhook sources report); a dropped replica's
+ * stale row must not pin the flag.
+ *
+ * Subsources and progress collections are excluded: the UI hides them, and
+ * they multiply the feed's cardinality several times over.
  */
 export function buildHydrationAggregateQuery() {
   const hydration = queryBuilder
@@ -48,19 +54,28 @@ export function buildHydrationAggregateQuery() {
     ])
     .groupBy("object_id");
 
+  const statuses = queryBuilder
+    .selectFrom("mz_source_statuses")
+    .where("type", "not in", ["subsource", "progress"])
+    .select(["id", "status", "error"]);
+
   const snapshotCommittedBySource = queryBuilder
-    .selectFrom("mz_source_statistics")
+    .selectFrom("mz_source_statistics as st")
+    .leftJoin("mz_cluster_replicas as r", "r.id", "st.replica_id")
+    .where((eb) =>
+      eb.or([eb("r.id", "is not", null), eb("st.replica_id", "is", null)]),
+    )
     .select((eb) => [
-      "id",
-      sql<boolean | null>`bool_and(${eb.ref("snapshot_committed")})`.as(
+      "st.id",
+      sql<boolean | null>`bool_and(${eb.ref("st.snapshot_committed")})`.as(
         "snapshotCommitted",
       ),
     ])
-    .groupBy("id");
+    .groupBy("st.id");
 
   return queryBuilder
     .selectFrom(hydration.as("h"))
-    .fullJoin("mz_source_statuses as ss", "ss.id", "h.object_id")
+    .fullJoin(statuses.as("ss"), "ss.id", "h.object_id")
     .leftJoin(snapshotCommittedBySource.as("stats"), "stats.id", "ss.id")
     .select([
       sql<string>`coalesce(h.object_id, ss.id)`.as("object_id"),

--- a/console/src/api/materialize/maintained-objects/hydrationAggregate.ts
+++ b/console/src/api/materialize/maintained-objects/hydrationAggregate.ts
@@ -13,16 +13,31 @@ import { queryBuilder } from "~/api/materialize";
 
 export interface HydrationAggregateRow {
   object_id: string;
-  hydratedReplicas: bigint;
-  totalReplicas: bigint;
+  hydratedReplicas: bigint | null;
+  totalReplicas: bigint | null;
+  sourceStatus: string | null;
+  sourceError: string | null;
+  snapshotCommitted: boolean | null;
 }
 
 /**
- * One row per object: how many of its replicas report `hydrated = true`, out
- * of the total replicas recorded in `mz_hydration_statuses`
+ * One row per object: how many of its replicas report `hydrated = true` out of
+ * the total replicas recorded in `mz_hydration_statuses`, plus, for sources,
+ * their ingestion status, error, and snapshot flag.
+ *
+ * Source status rides on this feed rather than its own SUBSCRIBE: it is the
+ * same one-row-per-object grain, and `mz_hydration_statuses` already reads
+ * `mz_source_statistics`, so this adds no new frontier dependency. The join
+ * with `mz_source_statuses` is FULL so webhook sources, which have a status but
+ * no hydration rows, still get a row.
+ *
+ * `snapshot_committed` is aggregated with `bool_and`, so a source only reads as
+ * committed once every replica reporting statistics agrees. A replica that has
+ * not reported yet contributes no row, so a scale-up cannot flip a committed
+ * source back to snapshotting.
  */
 export function buildHydrationAggregateQuery() {
-  return queryBuilder
+  const hydration = queryBuilder
     .selectFrom("mz_hydration_statuses")
     .select((eb) => [
       "object_id",
@@ -32,4 +47,27 @@ export function buildHydrationAggregateQuery() {
       sql<bigint>`count(*)`.as("totalReplicas"),
     ])
     .groupBy("object_id");
+
+  const snapshotCommittedBySource = queryBuilder
+    .selectFrom("mz_source_statistics")
+    .select((eb) => [
+      "id",
+      sql<boolean | null>`bool_and(${eb.ref("snapshot_committed")})`.as(
+        "snapshotCommitted",
+      ),
+    ])
+    .groupBy("id");
+
+  return queryBuilder
+    .selectFrom(hydration.as("h"))
+    .fullJoin("mz_source_statuses as ss", "ss.id", "h.object_id")
+    .leftJoin(snapshotCommittedBySource.as("stats"), "stats.id", "ss.id")
+    .select([
+      sql<string>`coalesce(h.object_id, ss.id)`.as("object_id"),
+      "h.hydratedReplicas",
+      "h.totalReplicas",
+      "ss.status as sourceStatus",
+      "ss.error as sourceError",
+      "stats.snapshotCommitted",
+    ]);
 }

--- a/console/src/api/materialize/maintained-objects/hydrationAggregate.ts
+++ b/console/src/api/materialize/maintained-objects/hydrationAggregate.ts
@@ -43,16 +43,25 @@ export interface HydrationAggregateRow {
  * they multiply the feed's cardinality several times over.
  */
 export function buildHydrationAggregateQuery() {
+  // Subsources have hydration rows of their own (they run on their parent's
+  // cluster), so both sides of the FULL JOIN need the exclusion.
   const hydration = queryBuilder
-    .selectFrom("mz_hydration_statuses")
+    .selectFrom("mz_hydration_statuses as hs")
+    .leftJoin("mz_sources as s", "s.id", "hs.object_id")
+    .where((eb) =>
+      eb.or([
+        eb("s.type", "is", null),
+        eb("s.type", "not in", ["subsource", "progress"]),
+      ]),
+    )
     .select((eb) => [
-      "object_id",
-      sql<bigint>`count(*) FILTER (WHERE ${eb.ref("hydrated")})`.as(
+      "hs.object_id",
+      sql<bigint>`count(*) FILTER (WHERE ${eb.ref("hs.hydrated")})`.as(
         "hydratedReplicas",
       ),
       sql<bigint>`count(*)`.as("totalReplicas"),
     ])
-    .groupBy("object_id");
+    .groupBy("hs.object_id");
 
   const statuses = queryBuilder
     .selectFrom("mz_source_statuses")

--- a/console/src/platform/connectors/utils.ts
+++ b/console/src/platform/connectors/utils.ts
@@ -41,6 +41,28 @@ export const snapshotting = (connector: ConnectorStatusInfo) => {
 };
 
 /**
+ * Explains why a snapshot's record count is approximate, per source type.
+ *
+ * Postgres and MySQL read the count from table statistics (`reltuples` and
+ * equivalents), which drift until an ANALYZE. Kafka derives it from offset
+ * watermarks, which overcount compacted or transactional topics. Either way the
+ * staged/known ratio can plateau below 100% after the snapshot is done, so
+ * `snapshot_committed` decides completion and this note explains the number.
+ */
+export const snapshotEstimateNote = (type: string | null) => {
+  switch (type) {
+    case "postgres":
+    case "mysql":
+    case "sql-server":
+      return "Snapshot progress and row counts are estimates, based on table statistics.";
+    case "kafka":
+      return "Snapshot progress and message counts are estimates.";
+    default:
+      return "Snapshot progress and record counts are estimates.";
+  }
+};
+
+/**
  * Derives a simple `healthy` | `unhealthy` status from the underlying connector status.
  */
 export function connectorHealthStatus(status: ConnectorStatus): HealthStatus {

--- a/console/src/platform/maintained-objects/CriticalPathClusterMetrics.tsx
+++ b/console/src/platform/maintained-objects/CriticalPathClusterMetrics.tsx
@@ -351,11 +351,16 @@ export const ClusterReplicaMetrics = ({
   const atAnchor = buckets.flatMap((bs) =>
     bs.filter((b) => b.bucketStart.getTime() === targetBucketStartMs),
   );
-  // Right after a replica swap the anchor bucket can predate the new
+  // Right after a replica swap the current bucket can predate the new
   // replica's first metrics; fall back to each replica's latest bucket so a
-  // live cluster is not reported as inactive.
+  // live cluster is not reported as inactive. Only for a now-ish anchor: for
+  // a historical anchor an empty bucket means the cluster really had no
+  // replicas then, and present-time metrics must not impersonate it.
+  const anchorIsRecent = Date.now() - targetBucketStartMs < 2 * bucketSizeMs;
   const replicas =
-    atAnchor.length > 0 ? atAnchor : buckets.flatMap((bs) => bs.slice(-1));
+    atAnchor.length > 0 || !anchorIsRecent
+      ? atAnchor
+      : buckets.flatMap((bs) => bs.slice(-1));
   const replicasInWindow: ReplicaInWindow[] = buckets
     .flatMap((bs) => bs.slice(-1))
     .map(({ replicaId, name, size, bucketEnd }) => ({

--- a/console/src/platform/maintained-objects/CriticalPathClusterMetrics.tsx
+++ b/console/src/platform/maintained-objects/CriticalPathClusterMetrics.tsx
@@ -317,22 +317,22 @@ const DroppedReplicasFooter = ({
   );
 };
 
-export interface CriticalPathClusterMetricsProps {
-  node: RenderableNode;
-  pageObjectId: string;
+export interface ClusterReplicaMetricsProps {
+  cluster: Cluster | null;
   timestamp: Date | null;
   bucketSizeMs: number;
   lookbackMs: number;
 }
 
-export const CriticalPathClusterMetrics = ({
-  node,
-  pageObjectId,
+/** Per-replica memory/CPU utilization for one cluster at a point in time,
+ * with any replicas dropped inside the window called out. */
+export const ClusterReplicaMetrics = ({
+  cluster,
   timestamp,
   bucketSizeMs,
   lookbackMs,
-}: CriticalPathClusterMetricsProps) => {
-  const clusterId = node.cluster?.id ?? null;
+}: ClusterReplicaMetricsProps) => {
+  const clusterId = cluster?.id ?? null;
   const {
     data: bucketsByReplicaId,
     isLoading,
@@ -348,9 +348,14 @@ export const CriticalPathClusterMetrics = ({
     Math.floor((timestamp ?? new Date()).getTime() / bucketSizeMs) *
     bucketSizeMs;
   const buckets = Object.values(bucketsByReplicaId ?? {});
-  const replicas = buckets.flatMap((bs) =>
+  const atAnchor = buckets.flatMap((bs) =>
     bs.filter((b) => b.bucketStart.getTime() === targetBucketStartMs),
   );
+  // Right after a replica swap the anchor bucket can predate the new
+  // replica's first metrics; fall back to each replica's latest bucket so a
+  // live cluster is not reported as inactive.
+  const replicas =
+    atAnchor.length > 0 ? atAnchor : buckets.flatMap((bs) => bs.slice(-1));
   const replicasInWindow: ReplicaInWindow[] = buckets
     .flatMap((bs) => bs.slice(-1))
     .map(({ replicaId, name, size, bucketEnd }) => ({
@@ -362,13 +367,8 @@ export const CriticalPathClusterMetrics = ({
 
   return (
     <VStack align="stretch" spacing={3} width="100%">
-      <ClusterMetricsHeader
-        node={node}
-        pageObjectId={pageObjectId}
-        timestamp={timestamp}
-      />
       <ReplicaMetricsList
-        cluster={node.cluster}
+        cluster={cluster}
         replicas={replicas}
         isLoading={isLoading}
         isError={isError}
@@ -380,3 +380,33 @@ export const CriticalPathClusterMetrics = ({
     </VStack>
   );
 };
+
+export interface CriticalPathClusterMetricsProps {
+  node: RenderableNode;
+  pageObjectId: string;
+  timestamp: Date | null;
+  bucketSizeMs: number;
+  lookbackMs: number;
+}
+
+export const CriticalPathClusterMetrics = ({
+  node,
+  pageObjectId,
+  timestamp,
+  bucketSizeMs,
+  lookbackMs,
+}: CriticalPathClusterMetricsProps) => (
+  <VStack align="stretch" spacing={3} width="100%">
+    <ClusterMetricsHeader
+      node={node}
+      pageObjectId={pageObjectId}
+      timestamp={timestamp}
+    />
+    <ClusterReplicaMetrics
+      cluster={node.cluster}
+      timestamp={timestamp}
+      bucketSizeMs={bucketSizeMs}
+      lookbackMs={lookbackMs}
+    />
+  </VStack>
+);

--- a/console/src/platform/maintained-objects/FilterChips.tsx
+++ b/console/src/platform/maintained-objects/FilterChips.tsx
@@ -14,7 +14,7 @@ import React from "react";
 import { MaintainedObjectType } from "~/api/materialize/maintained-objects/constants";
 import { fromSeconds } from "~/utils/format";
 
-import { HYDRATION_LABELS, HydrationBucket } from "./filters";
+import { STATUS_FILTER_LABELS } from "./filters";
 import { MaintainedObjectListItem } from "./queries";
 
 interface Chip {
@@ -80,12 +80,12 @@ const CHIP_SOURCES: ChipSource[] = [
     },
   },
   {
-    columnId: "hydration",
+    columnId: "status",
     build: (column) =>
-      multiSelectChips<HydrationBucket>(
+      multiSelectChips<string>(
         column,
-        "Hydration",
-        (b) => HYDRATION_LABELS[b],
+        "Status",
+        (b) => STATUS_FILTER_LABELS[b],
       ),
   },
 ];

--- a/console/src/platform/maintained-objects/MaintainedObjects.test.tsx
+++ b/console/src/platform/maintained-objects/MaintainedObjects.test.tsx
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -29,6 +29,7 @@ const buildObject = (
   hydratedReplicas: 1,
   totalReplicas: 1,
   lag: null,
+  sourceStatus: null,
   ...overrides,
 });
 
@@ -54,9 +55,11 @@ const eventsSrc = buildObject({
   id: "u103",
   name: "events_src",
   objectType: "source",
+  sourceType: "kafka",
   cluster: { id: "u200", name: "ingest_cluster" },
   hydratedReplicas: 0,
   totalReplicas: 1,
+  sourceStatus: { status: "running", error: null, snapshotCommitted: true },
 });
 
 const buildProps = (
@@ -106,6 +109,63 @@ describe("MaintainedObjects", () => {
 
     // Filter chip summarizes the active filter.
     expect(screen.getByText("Type: index")).toBeVisible();
+  });
+
+  it("shows a source's ingestion status rather than replica hydration", async () => {
+    // A source mid-snapshot has no rehydration latency, so hydration reports 0
+    // of 1 replicas hydrated. That must not surface as "Not Hydrated".
+    const snapshottingSrc = buildObject({
+      id: "u104",
+      name: "snapshotting_src",
+      objectType: "source",
+      sourceType: "postgres",
+      hydratedReplicas: 0,
+      totalReplicas: 1,
+      sourceStatus: {
+        status: "running",
+        error: null,
+        snapshotCommitted: false,
+      },
+    });
+    await renderMaintainedObjects({ objects: [snapshottingSrc] });
+
+    const row = await screen.findByRole("row", { name: /snapshotting_src/ });
+    expect(within(row).getByText("Snapshotting")).toBeVisible();
+    expect(within(row).queryByText("Not Hydrated")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a stalled source's status", async () => {
+    const stalledSrc = buildObject({
+      id: "u105",
+      name: "stalled_src",
+      objectType: "source",
+      sourceType: "kafka",
+      hydratedReplicas: 1,
+      totalReplicas: 1,
+      sourceStatus: {
+        status: "stalled",
+        error: "broker unreachable",
+        snapshotCommitted: true,
+      },
+    });
+    await renderMaintainedObjects({ objects: [stalledSrc] });
+
+    const row = await screen.findByRole("row", { name: /stalled_src/ });
+    expect(within(row).getByText("Stalled")).toBeVisible();
+  });
+
+  it("filters rows by status and reflects it in a chip", async () => {
+    const user = userEvent.setup();
+    await renderMaintainedObjects();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Filter status" }),
+    );
+    await user.click(await screen.findByLabelText("Running"));
+
+    expect(screen.getByText("events_src")).toBeVisible();
+    expect(screen.queryByText("inventory_idx")).not.toBeInTheDocument();
+    expect(screen.getByText("Status: Running")).toBeVisible();
   });
 
   it("filters rows by search term", async () => {

--- a/console/src/platform/maintained-objects/MaintainedObjects.tsx
+++ b/console/src/platform/maintained-objects/MaintainedObjects.tsx
@@ -35,7 +35,7 @@ import { Link as RouterLink, useLocation, useNavigate } from "react-router-dom";
 
 import { createNamespace } from "~/api/materialize";
 import { OUTDATED_THRESHOLD_SECONDS } from "~/api/materialize/cluster/materializationLag";
-import StatusPill from "~/components/StatusPill";
+import StatusPill, { ConnectorStatusPill } from "~/components/StatusPill";
 import { sortingFunctions } from "~/components/Table/tableColumnBuilders";
 import { TablePagination } from "~/components/Table/TablePagination";
 import { TableSearch } from "~/components/Table/TableSearch";
@@ -68,8 +68,8 @@ import { FilterChips } from "./FilterChips";
 import {
   ClusterFilterPanel,
   FreshnessFilterPanel,
-  HydrationFilterPanel,
   ObjectTypeFilterPanel,
+  StatusFilterPanel,
 } from "./filterPanels";
 import {
   bucketForHydration,
@@ -77,10 +77,10 @@ import {
   FILTER_URL_SPECS,
   freshnessFilterFn,
   HYDRATION_LABELS,
-  hydrationFilterFn,
   initialColumnFiltersFromUrl,
   objectTypeFilterFn,
   STATUS_COLOR_SCHEMES,
+  statusFilterFn,
 } from "./filters";
 import { MaintainedObjectListItem } from "./queries";
 
@@ -259,16 +259,47 @@ const FreshnessCell = ({
   );
 };
 
-const StatusCell = ({
+const pendingPill = <Skeleton height="5" width="20" borderRadius="full" />;
+
+/**
+ * Sources report their own ingestion status, so they don't go through replica
+ * hydration. For a source, `hydrated` only tracks whether `rehydration_latency`
+ * is set, which stays false for the whole initial snapshot and would render a
+ * healthy source as `Not Hydrated`.
+ */
+const SourceStatusCell = ({
   row,
   ready,
 }: {
   row: MaintainedObjectListItem;
   ready: boolean;
 }) => {
+  // Status rides on the hydration-aggregate feed, so it can trail the row.
+  if (!row.sourceStatus) return ready ? "-" : pendingPill;
+  return (
+    <ConnectorStatusPill
+      connector={{
+        status: row.sourceStatus.status,
+        type: row.sourceType ?? "",
+        snapshotCommitted: row.sourceStatus.snapshotCommitted,
+      }}
+    />
+  );
+};
+
+const StatusCell = ({
+  row,
+  hydrationReady,
+}: {
+  row: MaintainedObjectListItem;
+  hydrationReady: boolean;
+}) => {
+  if (row.objectType === "source") {
+    return <SourceStatusCell row={row} ready={hydrationReady} />;
+  }
   const { hydratedReplicas, totalReplicas } = row;
   if (totalReplicas === 0) {
-    return ready ? "-" : <Skeleton height="5" width="20" borderRadius="full" />;
+    return hydrationReady ? "-" : pendingPill;
   }
   const bucket = bucketForHydration(hydratedReplicas, totalReplicas);
   if (!bucket) return "-";
@@ -327,17 +358,20 @@ const columns = [
       id: "status",
       header: "Status",
       sortingFn: sortingFunctions.nullsLast,
-      filterFn: hydrationFilterFn,
+      filterFn: statusFilterFn,
       cell: (info) => {
         const meta = info.table.options.meta as MaintainedObjectsTableMeta;
         return (
-          <StatusCell row={info.row.original} ready={meta.hydrationReady} />
+          <StatusCell
+            row={info.row.original}
+            hydrationReady={meta.hydrationReady}
+          />
         );
       },
       meta: {
         tooltip:
-          "Object status derived from replica hydration across all clusters.",
-        renderFilter: (column) => <HydrationFilterPanel column={column} />,
+          "Ingestion status for sources, replica hydration across all clusters for everything else.",
+        renderFilter: (column) => <StatusFilterPanel column={column} />,
       },
     },
   ),

--- a/console/src/platform/maintained-objects/MaintainedObjects.tsx
+++ b/console/src/platform/maintained-objects/MaintainedObjects.tsx
@@ -80,6 +80,7 @@ import {
   initialColumnFiltersFromUrl,
   objectTypeFilterFn,
   STATUS_COLOR_SCHEMES,
+  statusBucketForRow,
   statusFilterFn,
 } from "./filters";
 import { MaintainedObjectListItem } from "./queries";
@@ -351,30 +352,26 @@ const columns = [
       renderFilter: (column) => <FreshnessFilterPanel column={column} />,
     },
   }),
-  columnHelper.accessor(
-    (row) =>
-      row.totalReplicas === 0 ? null : row.hydratedReplicas / row.totalReplicas,
-    {
-      id: "status",
-      header: "Status",
-      sortingFn: sortingFunctions.nullsLast,
-      filterFn: statusFilterFn,
-      cell: (info) => {
-        const meta = info.table.options.meta as MaintainedObjectsTableMeta;
-        return (
-          <StatusCell
-            row={info.row.original}
-            hydrationReady={meta.hydrationReady}
-          />
-        );
-      },
-      meta: {
-        tooltip:
-          "Ingestion status for sources, replica hydration across all clusters for everything else.",
-        renderFilter: (column) => <StatusFilterPanel column={column} />,
-      },
+  columnHelper.accessor((row) => statusBucketForRow(row) ?? null, {
+    id: "status",
+    header: "Status",
+    sortingFn: sortingFunctions.nullsLast,
+    filterFn: statusFilterFn,
+    cell: (info) => {
+      const meta = info.table.options.meta as MaintainedObjectsTableMeta;
+      return (
+        <StatusCell
+          row={info.row.original}
+          hydrationReady={meta.hydrationReady}
+        />
+      );
     },
-  ),
+    meta: {
+      tooltip:
+        "Ingestion status for sources, replica hydration across all clusters for everything else.",
+      renderFilter: (column) => <StatusFilterPanel column={column} />,
+    },
+  }),
   columnHelper.accessor((row) => row.cluster?.name ?? null, {
     id: "clusterName",
     header: "Cluster",

--- a/console/src/platform/maintained-objects/ObjectDetailsCard.tsx
+++ b/console/src/platform/maintained-objects/ObjectDetailsCard.tsx
@@ -21,7 +21,7 @@ import { Link as RouterLink } from "react-router-dom";
 
 import { createNamespace } from "~/api/materialize";
 import { OUTDATED_THRESHOLD_SECONDS } from "~/api/materialize/cluster/materializationLag";
-import StatusPill from "~/components/StatusPill";
+import StatusPill, { ConnectorStatusPill } from "~/components/StatusPill";
 import TextLink from "~/components/TextLink";
 import { DetailItem } from "~/platform/connectors/AsideBox";
 import { absoluteClusterPath } from "~/platform/routeHelpers";
@@ -91,7 +91,7 @@ export const ObjectDetailsCard = ({
             {item.name}
           </Text>
           <LagBadge lag={badgeLag} />
-          <HydrationBadge item={item} />
+          <StatusBadge item={item} />
         </HStack>
 
         <Text textStyle="heading-sm" color={colors.foreground.secondary}>
@@ -143,7 +143,22 @@ export const ObjectDetailsCard = ({
   );
 };
 
-const HydrationBadge = ({ item }: { item: MaintainedObjectListItem }) => {
+/** Mirrors the list's Status column: ingestion status for sources, replica
+ *  hydration for everything else. */
+const StatusBadge = ({ item }: { item: MaintainedObjectListItem }) => {
+  if (item.objectType === "source") {
+    if (!item.sourceStatus) return null;
+    return (
+      <ConnectorStatusPill
+        connector={{
+          status: item.sourceStatus.status,
+          type: item.sourceType ?? "",
+          snapshotCommitted: item.sourceStatus.snapshotCommitted,
+        }}
+        flexShrink={0}
+      />
+    );
+  }
   const bucket = bucketForHydration(item.hydratedReplicas, item.totalReplicas);
   if (!bucket) return null;
   return (

--- a/console/src/platform/maintained-objects/ObjectFreshness.tsx
+++ b/console/src/platform/maintained-objects/ObjectFreshness.tsx
@@ -24,6 +24,7 @@ import { MaterializeTheme } from "~/theme";
 import { formatDate } from "~/utils/dateFormat";
 
 import { LOOKBACK_OPTIONS } from "./constants";
+import { ClusterReplicaMetrics } from "./CriticalPathClusterMetrics";
 import { CriticalPathGraph } from "./CriticalPathGraph";
 import { computeFreshnessBreakdown } from "./freshnessBreakdown";
 import { FreshnessBreakdownStrip } from "./FreshnessBreakdownStrip";
@@ -85,8 +86,9 @@ export const ObjectFreshness = ({
   const breakdown = computeFreshnessBreakdown(criticalPath?.directInputs ?? []);
 
   // Sources ingest from external systems and have no Materialize-internal
-  // upstream chain to walk — hide the critical path section for them.
-  const hasUpstreamChain = item.objectType !== "source";
+  // upstream chain to walk. Their "critical path" is the cluster they ingest
+  // on, so they get its replica metrics instead.
+  const isSource = item.objectType === "source";
 
   return (
     <VStack align="start" spacing={6} width="100%">
@@ -122,7 +124,31 @@ export const ObjectFreshness = ({
             isLocked={isLocked}
           />
 
-          {hasUpstreamChain && (
+          {isSource && (
+            <>
+              <Divider />
+
+              <VStack align="start" spacing={1} width="100%">
+                <Text textStyle="heading-sm">Source cluster metrics</Text>
+                <Text
+                  textStyle="text-small"
+                  color={colors.foreground.secondary}
+                >
+                  Resources of the cluster this source ingests on, at the point
+                  selected on the freshness graph above.
+                </Text>
+              </VStack>
+
+              <ClusterReplicaMetrics
+                cluster={item.cluster}
+                timestamp={anchorTimestamp}
+                bucketSizeMs={bucketSizeMs}
+                lookbackMs={timePeriodMinutes * 60 * 1000}
+              />
+            </>
+          )}
+
+          {!isSource && (
             <>
               <Divider />
 

--- a/console/src/platform/maintained-objects/ObjectMetadata.tsx
+++ b/console/src/platform/maintained-objects/ObjectMetadata.tsx
@@ -27,7 +27,13 @@ export const ObjectMetadata = ({ item }: ObjectMetadataProps) => {
 
   return (
     <VStack align="start" spacing={6} width="100%">
-      {isSource && <SourceDiagnostics sourceId={item.id} />}
+      {isSource && (
+        <SourceDiagnostics
+          sourceId={item.id}
+          sourceType={item.sourceType}
+          sourceStatus={item.sourceStatus}
+        />
+      )}
       <ObjectColumnsList
         databaseName={item.databaseName}
         schemaName={item.schemaName}

--- a/console/src/platform/maintained-objects/SourceDiagnostics.tsx
+++ b/console/src/platform/maintained-objects/SourceDiagnostics.tsx
@@ -10,36 +10,48 @@
 import { Box, Card, Text, useTheme, VStack } from "@chakra-ui/react";
 import React from "react";
 
+import Alert from "~/components/Alert";
 import { DetailItem } from "~/platform/connectors/AsideBox";
+import { snapshotEstimateNote } from "~/platform/connectors/utils";
 import { MaterializeTheme } from "~/theme";
-import { sumPostgresIntervalMs } from "~/util";
 
-import { useObjectSourceStatistics } from "./queries";
+import {
+  MaintainedObjectSourceStatus,
+  useObjectSourceStatistics,
+} from "./queries";
 
 export interface SourceDiagnosticsProps {
   sourceId: string;
+  sourceType: string | null;
+  /** Null until the source status subscribe delivers a row. */
+  sourceStatus: MaintainedObjectSourceStatus | null;
 }
 
-export const SourceDiagnostics = ({ sourceId }: SourceDiagnosticsProps) => {
+/**
+ * Renders only while the source has something diagnostic to say: a status
+ * error, or an in-progress snapshot. Steady-state lifecycle facts live on the
+ * source details page instead.
+ */
+export const SourceDiagnostics = ({
+  sourceId,
+  sourceType,
+  sourceStatus,
+}: SourceDiagnosticsProps) => {
   const { colors } = useTheme<MaterializeTheme>();
   const { data: stats } = useObjectSourceStatistics(sourceId);
 
-  if (!stats) return null;
+  const error = sourceStatus?.error;
+  // `snapshot_committed` is authoritative. Judging by the staged/known ratio
+  // would report a live source as stuck at 99% forever.
+  const snapshotting = sourceStatus?.snapshotCommitted === false;
+  if (!error && !snapshotting) return null;
 
-  const {
-    messagesReceived,
-    snapshotRecordsKnown: snapshotKnown,
-    snapshotRecordsStaged: snapshotStaged,
-    rehydrationLatency,
-  } = stats;
+  const snapshotKnown = stats?.snapshotRecordsKnown ?? 0;
+  const snapshotStaged = stats?.snapshotRecordsStaged ?? 0;
   const snapshotPercent =
     snapshotKnown > 0
-      ? Math.round((snapshotStaged / snapshotKnown) * 100)
+      ? Math.min(100, Math.round((snapshotStaged / snapshotKnown) * 100))
       : null;
-  const snapshotComplete = snapshotPercent === null || snapshotPercent === 100;
-  const rehydrationMs = rehydrationLatency
-    ? sumPostgresIntervalMs(rehydrationLatency)
-    : null;
 
   return (
     <Card
@@ -52,34 +64,16 @@ export const SourceDiagnostics = ({ sourceId }: SourceDiagnosticsProps) => {
       <VStack align="start" spacing={3} width="100%">
         <Text textStyle="heading-sm">Source diagnostics</Text>
 
-        <VStack align="stretch" spacing={2} width="100%">
-          <DetailItem
-            label="Rehydration latency"
-            color={
-              rehydrationMs === null
-                ? colors.accent.orange
-                : colors.foreground.primary
-            }
-          >
-            {rehydrationMs !== null
-              ? `${(rehydrationMs / 1000).toFixed(1)}s`
-              : "Still rehydrating..."}
-          </DetailItem>
-          <DetailItem label="Messages received">
-            {messagesReceived.toLocaleString()}
-          </DetailItem>
-          {snapshotComplete ? (
-            <DetailItem label="Snapshot" color={colors.accent.green}>
-              Complete
+        {error && <Alert variant="error" width="100%" message={error} />}
+
+        {snapshotting && (
+          <VStack align="stretch" spacing={2} width="100%">
+            <DetailItem label="Snapshot progress" color={colors.accent.orange}>
+              {snapshotPercent === null
+                ? "In progress"
+                : `${snapshotPercent}% (${snapshotStaged.toLocaleString()} / ${snapshotKnown.toLocaleString()} records)`}
             </DetailItem>
-          ) : (
-            <>
-              <DetailItem
-                label="Snapshot progress"
-                color={colors.accent.orange}
-              >
-                {`${snapshotPercent}% (${snapshotStaged.toLocaleString()} / ${snapshotKnown.toLocaleString()} records)`}
-              </DetailItem>
+            {snapshotPercent !== null && (
               <Box
                 width="100%"
                 height="1.5"
@@ -94,9 +88,12 @@ export const SourceDiagnostics = ({ sourceId }: SourceDiagnosticsProps) => {
                   transition="width 0.3s ease"
                 />
               </Box>
-            </>
-          )}
-        </VStack>
+            )}
+            <Text textStyle="text-small" color={colors.foreground.secondary}>
+              {snapshotEstimateNote(sourceType)}
+            </Text>
+          </VStack>
+        )}
       </VStack>
     </Card>
   );

--- a/console/src/platform/maintained-objects/criticalPathRenderable.test.ts
+++ b/console/src/platform/maintained-objects/criticalPathRenderable.test.ts
@@ -47,6 +47,7 @@ const buildProbe = (
   hydratedReplicas: 1,
   totalReplicas: 1,
   lag: { value: parse("00:00:10"), ms: 10_000 },
+  sourceStatus: null,
   ...overrides,
 });
 

--- a/console/src/platform/maintained-objects/filterPanels.tsx
+++ b/console/src/platform/maintained-objects/filterPanels.tsx
@@ -30,11 +30,7 @@ import {
 import { MaterializeTheme } from "~/theme";
 import { DurationUnit, fromSeconds, toSeconds } from "~/utils/format";
 
-import {
-  HYDRATION_BUCKETS,
-  HYDRATION_LABELS,
-  HydrationBucket,
-} from "./filters";
+import { STATUS_FILTER_BUCKETS, STATUS_FILTER_LABELS } from "./filters";
 import { MaintainedObjectListItem } from "./queries";
 
 type AnyColumn = Column<MaintainedObjectListItem, unknown>;
@@ -176,11 +172,11 @@ export const ObjectTypeFilterPanel = ({ column }: { column: AnyColumn }) => (
   />
 );
 
-export const HydrationFilterPanel = ({ column }: { column: AnyColumn }) => (
-  <MultiSelectFilterPanel<HydrationBucket>
+export const StatusFilterPanel = ({ column }: { column: AnyColumn }) => (
+  <MultiSelectFilterPanel<string>
     column={column}
-    items={HYDRATION_BUCKETS}
-    getLabel={(b) => HYDRATION_LABELS[b]}
+    items={STATUS_FILTER_BUCKETS}
+    getLabel={(b) => STATUS_FILTER_LABELS[b]}
   />
 );
 

--- a/console/src/platform/maintained-objects/filters.ts
+++ b/console/src/platform/maintained-objects/filters.ts
@@ -13,8 +13,12 @@ import {
   MAINTAINED_OBJECT_TYPES,
   MaintainedObjectType,
 } from "~/api/materialize/maintained-objects/constants";
+import { snapshotting } from "~/platform/connectors/utils";
 
-import { MaintainedObjectListItem } from "./queries";
+import {
+  MaintainedObjectListItem,
+  MaintainedObjectSourceStatus,
+} from "./queries";
 
 /**
  * Row-threshold options for the freshness filter, keyed by seconds. Selecting
@@ -38,7 +42,7 @@ export const HYDRATION_BUCKETS = [
 export type HydrationBucket = (typeof HYDRATION_BUCKETS)[number];
 
 export const HYDRATION_LABELS: Record<HydrationBucket, string> = {
-  hydrated: "Running",
+  hydrated: "Hydrated",
   hydrating: "Hydrating",
   not_hydrated: "Not Hydrated",
 };
@@ -79,9 +83,73 @@ export const objectTypeFilterFn = arrayMatchFilter<MaintainedObjectType>(
   (r) => r.objectType,
 );
 
-export const hydrationFilterFn = arrayMatchFilter<HydrationBucket>((r) =>
-  bucketForHydration(r.hydratedReplicas, r.totalReplicas),
-);
+/**
+ * Status values offered for sources. `snapshotting` is derived rather than
+ * reported: `mz_source_statuses` says `running` throughout the initial
+ * snapshot, so both the pill and this filter fold in `snapshot_committed`.
+ */
+export const SOURCE_STATUS_BUCKETS = [
+  "snapshotting",
+  "running",
+  "starting",
+  "created",
+  "paused",
+  "stalled",
+  "failed",
+] as const;
+export type SourceStatusBucket = (typeof SOURCE_STATUS_BUCKETS)[number];
+
+export const SOURCE_STATUS_LABELS: Record<SourceStatusBucket, string> = {
+  snapshotting: "Snapshotting",
+  running: "Running",
+  starting: "Starting",
+  created: "Created",
+  paused: "Paused",
+  stalled: "Stalled",
+  failed: "Failed",
+};
+
+/** Derives a source's displayed status, matching `ConnectorStatusPill`. */
+export const bucketForSourceStatus = (
+  sourceStatus: MaintainedObjectSourceStatus,
+  sourceType: string | null,
+): string =>
+  snapshotting({
+    status: sourceStatus.status,
+    type: sourceType ?? "",
+    snapshotCommitted: sourceStatus.snapshotCommitted,
+  })
+    ? "snapshotting"
+    : sourceStatus.status;
+
+/** Options the Status filter offers, sources first. */
+export const STATUS_FILTER_BUCKETS = [
+  ...SOURCE_STATUS_BUCKETS,
+  ...HYDRATION_BUCKETS,
+] as const;
+
+export const STATUS_FILTER_LABELS: Record<string, string> = {
+  ...SOURCE_STATUS_LABELS,
+  ...HYDRATION_LABELS,
+};
+
+/**
+ * The bucket the Status cell displays: ingestion status for sources, replica
+ * hydration for everything else. The filter matches on this so it can never
+ * select a value the cell doesn't show.
+ */
+export const statusBucketForRow = (
+  row: MaintainedObjectListItem,
+): string | undefined => {
+  if (row.objectType === "source") {
+    return row.sourceStatus
+      ? bucketForSourceStatus(row.sourceStatus, row.sourceType)
+      : undefined;
+  }
+  return bucketForHydration(row.hydratedReplicas, row.totalReplicas);
+};
+
+export const statusFilterFn = arrayMatchFilter<string>(statusBucketForRow);
 
 export const freshnessFilterFn = (
   row: Row<MaintainedObjectListItem>,
@@ -144,18 +212,20 @@ export const FILTER_URL_SPECS: readonly FilterUrlSpec[] = [
       typeof v === "number" ? { key: "freshness", value: v } : undefined,
   },
   {
-    columnId: "hydration",
+    // Matches the Status column's id. The filter, its URL param and its chip
+    // all have to agree on this key or the filter silently stops round-tripping.
+    columnId: "status",
     fromUrl: (p) =>
       nonEmpty(
         p
-          .getAll("hydration[]")
-          .filter((h): h is HydrationBucket =>
-            (HYDRATION_BUCKETS as readonly string[]).includes(h),
+          .getAll("status[]")
+          .filter((s) =>
+            (STATUS_FILTER_BUCKETS as readonly string[]).includes(s),
           ),
       ),
     toUrl: (v) => {
-      const arr = v as HydrationBucket[];
-      return arr?.length ? { key: "hydration[]", value: arr } : undefined;
+      const arr = v as string[];
+      return arr?.length ? { key: "status[]", value: arr } : undefined;
     },
   },
 ];

--- a/console/src/platform/maintained-objects/queries.ts
+++ b/console/src/platform/maintained-objects/queries.ts
@@ -63,6 +63,22 @@ export interface MaintainedObjectLag {
   ms: number;
 }
 
+/**
+ * Ingestion state from the hydration-aggregate feed, which joins
+ * `mz_source_statuses` and the snapshot flag. This is what the Status column
+ * shows for a source, in place of replica hydration, which for a source only
+ * tracks whether `rehydration_latency` is set and so reads false throughout the
+ * initial snapshot.
+ */
+export interface MaintainedObjectSourceStatus {
+  /** One of `created`, `starting`, `running`, `paused`, `stalled`, `failed`. */
+  status: string;
+  /** Populated when the source is `stalled` or `failed`. */
+  error: string | null;
+  /** Null while no replica has reported statistics yet. */
+  snapshotCommitted: boolean | null;
+}
+
 export interface MaintainedObjectListItem {
   id: string;
   name: string;
@@ -78,6 +94,8 @@ export interface MaintainedObjectListItem {
   totalReplicas: number;
   /** Null until the lag snapshot arrives. */
   lag: MaintainedObjectLag | null;
+  /** Null for non-sources, and until the hydration snapshot arrives. */
+  sourceStatus: MaintainedObjectSourceStatus | null;
 }
 
 const MAINTAINED_OBJECT_TYPE_SET: ReadonlySet<string> = new Set(
@@ -133,9 +151,9 @@ export interface UseMaintainedObjectsListResult {
 
 /**
  * Composes maintained objects from three live sources: `useAllObjects()` for
- * object metadata, plus SUBSCRIBEs for pMAX lag and hydration aggregate. The
- * table renders as soon as object metadata is ready; lag and hydration cells
- * fill in as their snapshots arrive.
+ * object metadata, plus SUBSCRIBEs for pMAX lag and the hydration aggregate,
+ * which also carries source status. The table renders as soon as object
+ * metadata is ready; lag and status cells fill in as their snapshots arrive.
  */
 export const useMaintainedObjectsList = ({
   lookbackMinutes,
@@ -178,6 +196,13 @@ export const useMaintainedObjectsList = ({
         totalReplicas: bigintToNumber(hydrationRow?.totalReplicas),
         lag: lagInterval
           ? { value: lagInterval, ms: sumPostgresIntervalMs(lagInterval) }
+          : null,
+        sourceStatus: hydrationRow?.sourceStatus
+          ? {
+              status: hydrationRow.sourceStatus,
+              error: hydrationRow.sourceError,
+              snapshotCommitted: hydrationRow.snapshotCommitted,
+            }
           : null,
       });
     }

--- a/console/src/platform/sources/SourceOverview/SnapshotProgress.tsx
+++ b/console/src/platform/sources/SourceOverview/SnapshotProgress.tsx
@@ -10,7 +10,11 @@
 import { Box, HStack, Text, useTheme, VStack } from "@chakra-ui/react";
 import React from "react";
 
-import { ConnectorStatusInfo, snapshotting } from "~/platform/connectors/utils";
+import {
+  ConnectorStatusInfo,
+  snapshotEstimateNote,
+  snapshotting,
+} from "~/platform/connectors/utils";
 import { MaterializeTheme } from "~/theme";
 import { pluralize } from "~/util";
 
@@ -36,23 +40,6 @@ const mapSourceTypeToProgressUnit = (type: string, count: number) => {
   }
 };
 
-// The known count for database sources comes from table statistics (Postgres
-// `reltuples` and equivalents), which are estimates that drift until an ANALYZE.
-// Kafka derives it from offset watermarks, which overcount compacted or
-// transactional topics, so the note stays type-specific rather than claiming
-// table statistics everywhere.
-const mapSourceTypeToEstimateNote = (type: string) => {
-  switch (type) {
-    case "postgres":
-    case "mysql":
-    case "sql-server":
-      return "Snapshot progress and row counts are estimates, based on table statistics.";
-    case "kafka":
-      return "Snapshot progress and message counts are estimates.";
-    default:
-      return "Snapshot progress and record counts are estimates.";
-  }
-};
 export const SnapshotProgress = ({
   snapshotRecordsKnown,
   snapshotRecordsStaged,
@@ -112,7 +99,7 @@ export const SnapshotProgress = ({
           </Text>
         </HStack>
         <Text textStyle="text-small" color={colors.foreground.secondary}>
-          {mapSourceTypeToEstimateNote(source.type)}
+          {snapshotEstimateNote(source.type)}
         </Text>
       </VStack>
     </VStack>


### PR DESCRIPTION
## Motivation

Sources on the maintained-objects (Objects) page were described in replica-hydration terms, which misrepresents them three ways:

* The status column showed `Not Hydrated` / `Hydrating` / `Running` buckets derived from `mz_hydration_statuses`. For a source, `hydrated` only tracks whether `rehydration_latency` is set, so a healthy source could read `Not Hydrated` (Slack: #console, Aug 19 thread on what "Not Hydrated" means).
* A source could show `99%` snapshot progress next to `1s` freshness because completion was judged by the staged/known ratio, whose denominator is an estimate that can sit below 100% forever.
* Webhook sources have no hydration rows at all, so they showed no status.

Separately, the source detail panel gave no way to see the ingest cluster's resources while diagnosing a lagging source.

## Changes

One commit per concern, reviewable in order:

1. **Source ingestion status on the Objects page.** The status column, filter, and detail-panel badge show the source's ingestion status (`snapshotting`, `running`, `paused`, `stalled`, ...) via `ConnectorStatusPill`, matching the Sources page. Non-source objects keep the hydration buckets. The filter derives from the same function the cell renders, so it can never offer a value the cell doesn't show. Status rides on the existing hydration-aggregate subscribe: the aggregate now FULL JOINs `mz_source_statuses` (so webhook sources get a row) and carries `bool_and(snapshot_committed)` from `mz_source_statistics`.
2. **Snapshot display keys off `snapshot_committed`.** The diagnostics card uses the authoritative boolean instead of the staged/known ratio, and now renders only when it has something diagnostic to say: a status error, or an in-progress snapshot (with a per-source-type note that counts are estimates, shared with the Sources page via `snapshotEstimateNote`). Steady-state lifecycle facts (rehydration time, messages received) already live on the source details page, so the card no longer duplicates them.
3. **Source cluster metrics on the Freshness tab.** The detail panel shows the ingest cluster's replica memory/CPU at the point selected on the freshness graph, including replicas dropped in the window (reuses the critical-path cluster metrics via a new shared `ClusterReplicaMetrics` component; falls back to each replica's latest bucket when the anchor bucket predates a replica swap).

4. **Feed hardening.** Subsources and progress collections are excluded from the aggregate (the UI hides them, and they multiply the feed's cardinality several times over), and the `snapshot_committed` aggregate is restricted to statistics rows from live replicas (keeping null-`replica_id` rows, which is how webhook sources report), so a dropped replica's stale row cannot pin a committed source back to snapshotting.

## Tests

Extended `hydrationAggregate.test.sql.ts` for the FULL JOIN, `bool_and(snapshot_committed)`, subsource/progress exclusion, and live-replica semantics, and `MaintainedObjects.test.tsx` for the source status column and filter.

Closes [CNS-97](https://linear.app/materializeinc/issue/CNS-97)
Closes [CNS-82](https://linear.app/materializeinc/issue/CNS-82)
Closes [CNS-85](https://linear.app/materializeinc/issue/CNS-85)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
