### PR TITLE
Fix pow() to check exponent integrality by value, not representation

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1569,6 +1569,20 @@ fn uuid_generate_v5(a: uuid::Uuid, b: &str) -> uuid::Uuid {
     uuid::Uuid::new_v5(&a, b.as_bytes())
 }
 
+/// Reports whether `n` is an integer *in value*.
+///
+/// The exponent alone does not answer this: `Row` encoding folds trailing
+/// zeroes into the exponent, so `2.0` reaches us either as coefficient `2`
+/// with exponent `0` or as coefficient `20` with exponent `-1` depending on
+/// whether the value made a round trip through a `Row`. Reducing first makes
+/// the answer a property of the value rather than of its representation, which
+/// callers whose fallibility depends on it (see `crate::interpret`) require.
+fn is_integral_numeric(mut n: Numeric) -> bool {
+    numeric::cx_datum().reduce(&mut n);
+    // Reduced integral values always have a non-negative exponent.
+    n.exponent() >= 0
+}
+
 #[sqlfunc(output_type = "Numeric", propagates_nulls = true)]
 fn power_numeric(mut a: Numeric, b: Numeric) -> Result<Numeric, EvalError> {
     if a.is_zero() {
@@ -1581,7 +1595,7 @@ fn power_numeric(mut a: Numeric, b: Numeric) -> Result<Numeric, EvalError> {
             ));
         }
     }
-    if a.is_negative() && b.exponent() < 0 {
+    if a.is_negative() && !is_integral_numeric(b) {
         // Equivalent to PG error:
         // > a negative number raised to a non-integer power yields a complex result
         return Err(EvalError::ComplexOutOfRange("pow".into()));
@@ -3305,6 +3319,39 @@ mod test {
         assert_unique("UnaryFunc", UnaryFunc::variant_names());
         assert_unique("BinaryFunc", BinaryFunc::variant_names());
         assert_unique("VariadicFunc", VariadicFunc::variant_names());
+    }
+
+    #[mz_ore::test]
+    fn power_numeric_integral_exponent_representations() {
+        // `Row` encoding reduces numerics, so the same integral exponent
+        // reaches `power_numeric` with different exponents depending on where
+        // it came from. Whether the call errors must not depend on that, or the
+        // abstract interpreter (which reads its datums back out of a `Row`) can
+        // rule out an error the evaluator produces.
+        let parse = |s: &str| -> Numeric { numeric::cx_datum().parse(s).unwrap() };
+
+        for exponent in ["2", "2.0", "2.000", "2E+0", "0.2E+1"] {
+            let exponent = parse(exponent);
+            let mut reduced = exponent;
+            numeric::cx_datum().reduce(&mut reduced);
+            assert_eq!(
+                power_numeric(parse("-2"), exponent).unwrap(),
+                parse("4"),
+                "unreduced exponent {exponent} (reduced: {reduced})"
+            );
+        }
+
+        for exponent in ["2.5", "-0.1", "0.25E+1"] {
+            let exponent = parse(exponent);
+            assert_eq!(
+                power_numeric(parse("-2"), exponent),
+                Err(EvalError::ComplexOutOfRange("pow".into())),
+                "non-integral exponent {exponent}"
+            );
+        }
+
+        // A NaN exponent stays NaN rather than tripping the integrality guard.
+        assert!(power_numeric(parse("-2.5"), parse("NaN")).unwrap().is_nan());
     }
 
     #[mz_ore::test]

--- a/test/sqllogictest/numeric.slt
+++ b/test/sqllogictest/numeric.slt
@@ -1130,6 +1130,29 @@ SELECT pow(0::numeric, -1::numeric)
 query error function pow cannot return complex numbers
 SELECT pow(-1::numeric, '-.1'::numeric)
 
+# Whether an exponent is integral is a property of its value, not of its
+# representation. `Row` encoding folds trailing zeroes into the exponent, so an
+# integral value computed inline (`1.5 + 0.5`, coefficient 20, exponent -1)
+# reaches `pow` differently than the same value read back out of a `Row`. Both
+# must raise a negative base without complaining about complex results.
+statement ok
+CREATE TABLE pow_operands (base numeric, exponent numeric)
+
+statement ok
+INSERT INTO pow_operands VALUES (-2, 1.5)
+
+query RR
+SELECT pow(base, exponent + 0.5), pow(base, exponent * 2) FROM pow_operands
+----
+4  -8
+
+# A genuinely fractional exponent still errors.
+query error function pow cannot return complex numbers
+SELECT pow(base, exponent) FROM pow_operands
+
+statement ok
+DROP TABLE pow_operands
+
 # Square root
 query RRR
 SELECT sqrt(2::numeric), sqrt(3::numeric), sqrt(0::numeric)


### PR DESCRIPTION
### Motivation

The `pow()` function rejects negative bases with non-integral exponents to avoid complex results. However, the integrality check was examining the exponent's representation (specifically, whether `exponent < 0`) rather than its actual value.

This caused inconsistent behavior: the same integral value could be represented differently depending on whether it was computed inline or read back from a `Row`. For example, `2.0` might arrive as coefficient `2` with exponent `0`, or as coefficient `20` with exponent `-1` after `Row` encoding folds trailing zeroes into the exponent. The old check would incorrectly reject `pow(-2, 2.0)` in the latter case.

### Description

This PR introduces `is_integral_numeric()` which determines whether a numeric value is integral by reducing it first, making integrality a property of the value rather than its representation. The function:

1. Reduces the numeric (which normalizes the representation by folding trailing zeroes into the exponent)
2. Checks if the reduced exponent is non-negative (the defining property of integral values)

The `power_numeric()` function now uses `is_integral_numeric(b)` instead of `b.exponent() < 0` to validate the exponent before computing the power.

### Verification

- Added unit test `power_numeric_integral_exponent_representations()` that verifies the same integral exponent value (represented multiple ways: `"2"`, `"2.0"`, `"2.000"`, `"2E+0"`, `"0.2E+1"`) all produce consistent results
- Added sqllogictest cases that verify the fix works end-to-end when values are computed inline and then read back from a table
- Verified that genuinely fractional exponents still correctly error
- Verified that NaN exponents don't trip the integrality guard

https://claude.ai/code/session_01MkQaXN6bFv9JxFeHpRtof7