### PR TITLE
compute: move long test modules out of line

### DIFF
--- a/src/compute/AGENTS.md
+++ b/src/compute/AGENTS.md
@@ -29,6 +29,13 @@ Rendering is generic.
 Do not add special-interest structures serving other parts of the code here.
 If something special is needed, build the right abstractions to absorb the special-casing in a localized implementation.
 
+## Tests
+
+Move a module's `#[cfg(test)] mod tests` out of line once it exceeds 200 lines.
+Declare it as `#[cfg(test)] mod tests;` and put the body in `<module>/tests.rs`, the way `src/cluster-controller/src/lib.rs` does.
+Out-of-line tests still reach private items through `super::`, so moving them requires no visibility changes.
+A production module and its tests are read for different reasons, and a test module several times the size of the code it covers buries that code.
+
 ## Priorities
 
 Maintainability over complexity.


### PR DESCRIPTION
Several modules in `mz-compute` carry test modules many times the size of the production code they cover, so the code has to be scrolled past to read. `src/cluster-controller` already uses the out-of-line pattern, where `#[cfg(test)] mod tests;` points at a sibling `tests.rs`. This records that as the crate convention, with a threshold so it is decidable rather than a matter of taste.

Out-of-line tests still reach private items through `super::`, so moving a module needs no visibility changes.

Worth landing before #38386 and the seven PRs stacked on it, which follow this rule and between them move about 5,900 lines of in-file test modules out of line.
