### PR TITLE
docs: list arrangements under concepts in the sidebar

### DIFF
--- a/doc/user/content/concepts/_index.md
+++ b/doc/user/content/concepts/_index.md
@@ -24,6 +24,7 @@ Concept                                  | Description
 [Sources](/concepts/sources/)            | Sources describe an external system you want Materialize to read data from.
 [Views](/concepts/views/)    | Views represent a named query that you want to save for repeated execution. You can use **indexed views** and **materialized views** to incrementally maintain the results of views.
 [Indexes](/concepts/indexes/)            | Indexes represent query results stored in memory.
+[Arrangements](/get-started/arrangements/) | Arrangements are the in-memory data structures that maintain indexes and materialized views.
 [Sinks](/concepts/sinks/)                | Sinks describe an external system you want Materialize to write data to.
 [Snapshotting](/concepts/snapshotting/) | The initial sync of a source's data from an upstream system, before the source can serve queries.
 [Hydration](/concepts/hydration/) | {{< include-from-yaml data="hydration-details" name="definition" >}}

--- a/doc/user/content/get-started/arrangements.md
+++ b/doc/user/content/get-started/arrangements.md
@@ -1,6 +1,11 @@
 ---
 title: "Arrangements"
 description: "Understand how Materialize arrangements work."
+menu:
+  main:
+    parent: concepts
+    weight: 22
+    identifier: 'concepts-arrangements'
 aliases:
   - /overview/arrangements/
 ---


### PR DESCRIPTION
### Motivation

The arrangements page (`/get-started/arrangements/`) has no `menu` front matter, so it never appears in the docs sidebar. Today it is reachable only through inline links from other pages (optimization, dataflow troubleshooting, dictionary compression, `EXPLAIN PLAN`, the introspection catalog reference). Arrangements are a core concept, so the page belongs in the Concepts section of the nav.

### Description

- Added `menu.main` front matter to `doc/user/content/get-started/arrangements.md` with `parent: concepts`, `weight: 22`, and `identifier: concepts-arrangements`, which places it between Indexes (20) and Sinks (25) in the sidebar. The sidebar template is driven purely by Hugo menus, so no file move is needed.
- Added a matching row to the concepts overview table in `doc/user/content/concepts/_index.md`, in the same position.

The page keeps its `/get-started/arrangements/` URL and its `/overview/arrangements/` alias, so all existing links and section anchors stay valid. No redirects needed.

### Verification

Docs-only change. Hugo is not available in this environment, so the change was verified by inspection: the added front matter matches the shape used by the other pages already listed under `concepts` (`clusters.md`, `sources.md`, `views.md`, `indexes.md`, `sinks.md`, `snapshotting.md`, `hydration.md`), and `layouts/partials/sidebar.html` builds the tree from `.Site.Menus.main` alone, independent of the page's content section. No tests were added or modified.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ePZX54i9HXKkfqB3tEu6r)_