### PR TITLE
adapter: hydrate migrated builtin MVs before 0dt cut-over

### DIFF
--- a/doc/developer/design/20251015_builtin_schema_migration.md
+++ b/doc/developer/design/20251015_builtin_schema_migration.md
@@ -58,7 +58,8 @@ Doing so requires no writes to durable state, and therefore doesn't interfere wi
 
 In the subsequent read-only bootstrap phase, the process creates persist read and write handles using the new schema.
 Read handles perform transparent migration of any data updates that flow through them, so dataflow hydration can proceed using the new schema.
-Write handles only require a matching registered shard schema when writing batches, which is something a read-only process doesn't do.
+Write handles only require a matching registered shard schema when writing batches, which a read-only process performing schema evolution doesn't do: the shard is the leader's live one, so it stays read-only until promotion.
+(Shard replacement is different: there the read-only process does write batches, but to a shard it created for itself. See below.)
 
 Once the read-only process gets promoted to a leader, and runs the builtin schema migration mechanism again, it this time registers the new schema with the persist shard.
 Doing so fences out any processes that planned to evolve the schema to an earlier version.
@@ -75,6 +76,10 @@ A read-only process performing shard replacement reads the migration shard to co
 Notably, it ignores any entries at different versions or deploy generations, to avoid any interference with concurrent in-progress upgrades.
 Depending on the existing migration shard entries, the process either decides to use the existing replacement shard, or to create the replacement shard and write its ID into the migration shard, at the current version.
 It sets the new shard ID as the migrated collection's shard in its in-memory catalog and commences bootstrapping using the replacement shard.
+
+Because this environment exclusively owns the replacement shard, the read-only process force-writes it during bootstrap rather than leaving it read-only until promotion.
+This lets a migrated builtin materialized view and its dependents hydrate before cut-over instead of all at once at cut-over.
+It is safe only for the self-owned replacement shard, never a shard the leader is still serving, which is why it applies to shard replacement and not schema evolution.
 
 A leader process performing shard replacement performs the same steps as in read-only mode.
 Additionally, it cleans up durable state written by earlier versions and/or deploy generations by:

--- a/doc/developer/design/20251015_builtin_schema_migration.md
+++ b/doc/developer/design/20251015_builtin_schema_migration.md
@@ -81,6 +81,11 @@ Because this environment exclusively owns the replacement shard, the read-only p
 This lets a migrated builtin materialized view and its dependents hydrate before cut-over instead of all at once at cut-over.
 It is safe only for the self-owned replacement shard, never a shard the leader is still serving, which is why it applies to shard replacement and not schema evolution.
 
+The force-write is conditional on two things.
+First, the leader must be at v26.17 or later, because every builtin materialized view reads the catalog shard and only leaders from that version on keep its frontier advancing with the current time; against an older leader the dataflow would sit at a stale frontier.
+Second, the `enable_0dt_hydrate_migrated_builtin_mvs` feature flag must be on; it exists as a break-glass revert.
+When either condition does not hold, the migrated materialized views and their dependents are instead excluded from the 0dt caught-up check, which is the older behaviour: promotion proceeds without them and they hydrate at cut-over.
+
 A leader process performing shard replacement performs the same steps as in read-only mode.
 Additionally, it cleans up durable state written by earlier versions and/or deploy generations by:
   - arranging for the previous shards used by the migrated storage collections to be finalized

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -750,6 +750,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "with_0dt_caught_up_check_cutoff",
     "enable_0dt_caught_up_replica_status_check",
     "enable_0dt_caught_up_stability_check",
+    "enable_0dt_hydrate_migrated_builtin_mvs",
     "plan_insights_notice_fast_path_clusters_optimize_duration",
     "enable_expression_cache",
     "mz_metrics_lgalloc_map_refresh_interval",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3284,6 +3284,7 @@ class FlipFlagsAction(Action):
             "with_0dt_caught_up_check_cutoff",
             "with_0dt_caught_up_check_stability_period",
             "enable_0dt_caught_up_stability_check",
+            "enable_0dt_hydrate_migrated_builtin_mvs",
             "enable_statement_lifecycle_logging",
             "enable_introspection_subscribes",
             "plan_insights_notice_fast_path_clusters_optimize_duration",

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -90,6 +90,16 @@ pub const WITH_0DT_CAUGHT_UP_CHECK_STABILITY_PERIOD: Config<Duration> = Config::
     ParameterScope::Environment,
 );
 
+pub const ENABLE_0DT_HYDRATE_MIGRATED_BUILTIN_MVS: Config<bool> = Config::new(
+    "enable_0dt_hydrate_migrated_builtin_mvs",
+    true,
+    "Write-enable replacement-migrated builtin materialized views while read-only during a 0dt \
+     deployment, so they hydrate before cut-over and keep gating promotion. Emergency break-glass \
+     flag: disabling reverts to excluding migrated MVs (and their dependents) from the caught-up \
+     check, which lets promotion proceed with them unhydrated and hydrate at cut-over instead. \
+     Only takes effect when the leader is new enough for the write to make progress.",
+);
+
 /// Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.
 pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: Config<bool> = Config::new(
     "enable_statement_lifecycle_logging",
@@ -511,6 +521,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_0DT_CAUGHT_UP_REPLICA_STATUS_CHECK)
         .add(&ENABLE_0DT_CAUGHT_UP_STABILITY_CHECK)
         .add(&WITH_0DT_CAUGHT_UP_CHECK_STABILITY_PERIOD)
+        .add(&ENABLE_0DT_HYDRATE_MIGRATED_BUILTIN_MVS)
         .add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
         .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
         .add(&ENABLE_FRONTEND_SUBSCRIBES)

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -95,9 +95,11 @@ pub const ENABLE_0DT_HYDRATE_MIGRATED_BUILTIN_MVS: Config<bool> = Config::new(
     true,
     "Write-enable replacement-migrated builtin materialized views while read-only during a 0dt \
      deployment, so they hydrate before cut-over and keep gating promotion. Emergency break-glass \
-     flag: disabling reverts to excluding migrated MVs (and their dependents) from the caught-up \
-     check, which lets promotion proceed with them unhydrated and hydrate at cut-over instead. \
-     Only takes effect when the leader is new enough for the write to make progress.",
+     flag: disabling excludes migrated MVs (and their dependents) from the caught-up check again, \
+     so promotion proceeds with them unhydrated. Not an exact revert: a collection with no live \
+     leader frontier must be hydrated either way. Only takes effect when the leader is new enough \
+     for the write to make progress, and is read once at startup, so changing it means setting it \
+     on the leader and restarting the new deployment.",
 );
 
 /// Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -100,6 +100,7 @@ pub const ENABLE_0DT_HYDRATE_MIGRATED_BUILTIN_MVS: Config<bool> = Config::new(
      leader frontier must be hydrated either way. Only takes effect when the leader is new enough \
      for the write to make progress, and is read once at startup, so changing it means setting it \
      on the leader and restarting the new deployment.",
+    ParameterScope::Environment,
 );
 
 /// Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -648,6 +648,7 @@ impl Catalog {
 
         let OpenCatalogResult {
             catalog,
+            last_seen_version: _,
             migrated_storage_collections_0dt: _,
             new_builtin_collections: _,
             builtin_table_updates: _,

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -61,6 +61,7 @@ use mz_sql::session::user::{MZ_SYSTEM_ROLE_ID, SYSTEM_USER};
 use mz_sql::session::vars::{SessionVars, SystemVars, VarError, VarInput};
 use mz_storage_client::controller::{StorageMetadata, StorageTxn};
 use mz_storage_client::storage_collections::StorageCollections;
+use semver::Version;
 use tracing::{Instrument, info, warn};
 use uuid::Uuid;
 
@@ -73,14 +74,26 @@ use crate::catalog::{BuiltinTableUpdate, Catalog, CatalogState, Config, is_reser
 pub struct InitializeStateResult {
     /// An initialized [`CatalogState`].
     pub state: CatalogState,
-    /// A set of new shards that may need to be initialized (only used by 0dt migration).
+    /// Items whose builtin schema migration allocated a fresh, self-owned persist shard. Only used
+    /// by 0dt migration.
+    ///
+    /// `Replacement`-migrated items only: derived by filtering to items with a global id in
+    /// `MigrationRunResult::new_shards`, which only `migrate_replace` populates. `Evolution`
+    /// migrates in place and reuses the leader's shard, so it never lands here. Read-only write
+    /// paths depend on that: force-writing a shard while read-only is safe only because we
+    /// exclusively own it (see `ComputeController::allow_writes_in_read_only`).
     pub migrated_storage_collections_0dt: BTreeSet<CatalogItemId>,
     /// A set of new builtin items.
     pub new_builtin_collections: BTreeSet<GlobalId>,
     /// A list of builtin table updates corresponding to the initialized state.
     pub builtin_table_updates: Vec<BuiltinTableUpdate>,
-    /// The version of the catalog that existed before initializing the catalog.
-    pub last_seen_version: String,
+    /// The version of the binary that last committed catalog migrations, or `None` for a newly
+    /// initialized catalog.
+    ///
+    /// While this environment is read-only during a 0dt deployment, this is the version of the
+    /// leader environment: the read-only catalog transaction is a savepoint, so our own bump of
+    /// the setting never lands.
+    pub last_seen_version: Option<Version>,
     /// A handle to the expression cache if it's enabled.
     pub expr_cache_handle: Option<ExpressionCacheHandle>,
     /// The global expressions that were cached in `expr_cache_handle`.
@@ -92,7 +105,10 @@ pub struct InitializeStateResult {
 pub struct OpenCatalogResult {
     /// An opened [`Catalog`].
     pub catalog: Catalog,
-    /// A set of new shards that may need to be initialized.
+    /// See [`InitializeStateResult::last_seen_version`].
+    pub last_seen_version: Option<Version>,
+    /// See [`InitializeStateResult::migrated_storage_collections_0dt`]; `Replacement`-migrated
+    /// items only.
     pub migrated_storage_collections_0dt: BTreeSet<CatalogItemId>,
     /// A set of new builtin items.
     pub new_builtin_collections: BTreeSet<GlobalId>,
@@ -430,8 +446,7 @@ impl Catalog {
             .await;
         builtin_table_updates.extend(builtin_table_update);
 
-        let last_seen_version =
-            get_migration_version(&txn).map_or_else(|| "new".into(), |v| v.to_string());
+        let last_seen_version = get_migration_version(&txn);
 
         let mz_authentication_mock_nonce =
             txn.get_authentication_mock_nonce().ok_or_else(|| {
@@ -453,7 +468,9 @@ impl Catalog {
             .await
             .map_err(|e| {
                 Error::new(ErrorKind::FailedCatalogMigration {
-                    last_seen_version: last_seen_version.clone(),
+                    last_seen_version: last_seen_version
+                        .as_ref()
+                        .map_or_else(|| "new".to_string(), |v| v.to_string()),
                     this_version: config.build_info.version,
                     cause: e.to_string(),
                 })
@@ -566,7 +583,7 @@ impl Catalog {
                 migrated_storage_collections_0dt,
                 new_builtin_collections,
                 mut builtin_table_updates,
-                last_seen_version: _,
+                last_seen_version,
                 expr_cache_handle,
                 cached_global_exprs,
                 uncached_local_exprs,
@@ -624,6 +641,7 @@ impl Catalog {
 
             Ok(OpenCatalogResult {
                 catalog,
+                last_seen_version,
                 migrated_storage_collections_0dt,
                 new_builtin_collections,
                 builtin_table_updates,

--- a/src/adapter/src/catalog/open/builtin_schema_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_schema_migration.rs
@@ -37,8 +37,9 @@ use futures::future::BoxFuture;
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use mz_catalog::builtin::{
     BUILTIN_LOOKUP, Builtin, Fingerprint, MZ_CATALOG_RAW, MZ_CATALOG_RAW_DESCRIPTION,
-    MZ_OBJECT_ARRANGEMENT_SIZE_HISTORY_DESCRIPTION, MZ_STORAGE_USAGE_BY_SHARD,
-    MZ_STORAGE_USAGE_BY_SHARD_DESCRIPTION, RUNTIME_ALTERABLE_FINGERPRINT_SENTINEL,
+    MZ_CLUSTER_REPLICA_FRONTIERS_DESCRIPTION, MZ_OBJECT_ARRANGEMENT_SIZE_HISTORY_DESCRIPTION,
+    MZ_STORAGE_USAGE_BY_SHARD, MZ_STORAGE_USAGE_BY_SHARD_DESCRIPTION,
+    RUNTIME_ALTERABLE_FINGERPRINT_SENTINEL,
 };
 use mz_catalog::config::BuiltinItemMigrationConfig;
 use mz_catalog::durable::objects::SystemObjectUniqueIdentifier;
@@ -756,6 +757,15 @@ impl Migration {
             assert_ne!(
                 &*MZ_CATALOG_RAW_DESCRIPTION, object,
                 "mz_catalog_raw cannot be migrated"
+            );
+
+            // The 0dt caught-up gate reads the leader's `mz_cluster_replica_frontiers` shard for
+            // the live frontiers it checks every collection against. Migrating it via `Replacement`
+            // hands us a fresh shard we write ourselves, so the gate would compare us against
+            // ourselves instead of against the leader.
+            assert_ne!(
+                &*MZ_CLUSTER_REPLICA_FRONTIERS_DESCRIPTION, object,
+                "mz_cluster_replica_frontiers cannot be migrated or else the 0dt caught-up gate loses its live-frontier reference"
             );
 
             let Some(object_info) = self.system_objects.get(object) else {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -93,7 +93,8 @@ use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
 use mz_adapter_types::dyncfgs::FRONTEND_READ_THEN_WRITE;
 use mz_adapter_types::dyncfgs::{
-    USER_ID_POOL_BATCH_SIZE, WITH_0DT_DEPLOYMENT_CAUGHT_UP_CHECK_INTERVAL,
+    ENABLE_0DT_HYDRATE_MIGRATED_BUILTIN_MVS, USER_ID_POOL_BATCH_SIZE,
+    WITH_0DT_DEPLOYMENT_CAUGHT_UP_CHECK_INTERVAL,
 };
 use mz_auth::password::Password;
 use mz_build_info::BuildInfo;
@@ -171,6 +172,7 @@ use mz_storage_types::sources::{IngestionDescription, SourceExport, Timeline};
 use mz_timestamp_oracle::{TimestampOracleConfig, WriteTimestamp};
 use mz_transform::dataflow::DataflowMetainfo;
 use opentelemetry::trace::TraceContextExt;
+use semver::Version;
 use serde::Serialize;
 use thiserror::Error;
 use timely::progress::{Antichain, Timestamp as _};
@@ -242,6 +244,17 @@ mod message_handler;
 mod privatelink_status;
 mod sql;
 mod validity;
+
+/// The oldest leader version against which a replacement-migrated builtin materialized view may
+/// write its new persist shard while this environment is still read-only.
+///
+/// Every builtin materialized view reads `mz_internal.mz_catalog_raw`, so its dataflow only makes
+/// progress up to the catalog shard's frontier. Holding that frontier at the current time is the
+/// leader's job, and leaders only started doing it in v26.17. Write-enable such an MV against an
+/// older leader and it sits at a stale frontier and never reports caught up, which blocks
+/// promotion outright instead of merely leaving the collection cold at cut-over. We still support
+/// upgrading from before v26.17, so that leader is a real case, not a hypothetical.
+const MIN_LEADER_VERSION_FOR_MIGRATED_MV_WRITES: Version = Version::new(26, 17, 0);
 
 /// A pool of pre-allocated user IDs to avoid per-DDL persist writes.
 ///
@@ -2450,6 +2463,7 @@ impl Coordinator {
         &mut self,
         boot_ts: Timestamp,
         migrated_storage_collections_0dt: BTreeSet<CatalogItemId>,
+        hydrate_migrated_mvs: bool,
         mut builtin_table_updates: Vec<BuiltinTableUpdate>,
         cached_global_exprs: BTreeMap<GlobalId, GlobalExpressions>,
         uncached_local_exprs: BTreeMap<GlobalId, LocalExpressions>,
@@ -2788,7 +2802,22 @@ impl Coordinator {
                     // If this is a replacement MV, it must remain read-only until the replacement
                     // gets applied.
                     if mview.replacement_target.is_none() {
-                        self.allow_writes(mview.cluster_id, mview.global_id_writes());
+                        let gid = mview.global_id_writes();
+                        if hydrate_migrated_mvs
+                            && migrated_storage_collections_0dt.contains(&entry.id())
+                        {
+                            // `migrated_storage_collections_0dt` is `Replacement`-migrated items
+                            // only, so this is a fresh shard we own: nothing else writes it, and
+                            // writing it while read-only hydrates the MV and its dependents before
+                            // cut-over. An `Evolution`-migrated MV reuses the leader's live shard
+                            // and must never reach here.
+                            self.controller
+                                .compute
+                                .allow_writes_in_read_only(mview.cluster_id, gid)
+                                .unwrap_or_terminate("allow_writes cannot fail");
+                        } else {
+                            self.allow_writes(mview.cluster_id, gid);
+                        }
                     }
                 }
                 CatalogItem::MetricSink(metric_sink) => {
@@ -5036,6 +5065,7 @@ pub fn serve(
         ;
         let OpenCatalogResult {
             mut catalog,
+            last_seen_version,
             migrated_storage_collections_0dt,
             new_builtin_collections,
             builtin_table_updates,
@@ -5091,6 +5121,22 @@ pub fn serve(
             catalog_open_start.elapsed()
         );
 
+        // Whether replacement-migrated builtin MVs may write their new shards before cut-over.
+        // Both `bootstrap` and the readiness gate below read this, and they have to agree.
+        // `MIN_LEADER_VERSION_FOR_MIGRATED_MV_WRITES` explains why the leader's version settles it.
+        //
+        // While we are read-only, `last_seen_version` is that leader's version: our catalog
+        // transaction is a savepoint, so our own bump of the setting never lands. `None` means a
+        // freshly initialized catalog, with nothing migrated and no leader to be compatible with.
+        //
+        // `ENABLE_0DT_HYDRATE_MIGRATED_BUILTIN_MVS` is the break-glass revert: off falls back to
+        // excluding migrated MVs from the caught-up gate, no redeploy needed.
+        let hydrate_migrated_mvs = ENABLE_0DT_HYDRATE_MIGRATED_BUILTIN_MVS
+            .get(catalog.system_config().dyncfgs())
+            && last_seen_version
+                .as_ref()
+                .is_none_or(|version| *version >= MIN_LEADER_VERSION_FOR_MIGRATED_MV_WRITES);
+
         let coord_thread_start = Instant::now();
         info!("startup: coordinator init: coordinator thread start beginning");
 
@@ -5141,18 +5187,16 @@ pub fn serve(
 
                 // A collection that can't advance its write frontier in read-only mode
                 // stalls its transitive dependents too, so exclude those from the caught-up
-                // check as well. That's migrated MVs (their dataflows don't write in
-                // read-only mode) and new builtin MVs (their fresh shard has no writer until
-                // this deployment promotes). An excluded dependent may still be hydrating
-                // right after promotion, a brief blip we accept because these MVs are small
-                // and get a writer at cut-over.
+                // check as well. That's new builtin MVs, whose fresh shard has no writer until
+                // this deployment promotes, plus migrated MVs whenever the leader is too old for
+                // them to write. An excluded dependent may still be hydrating right after
+                // promotion, a brief blip we accept because these MVs are small and get a writer
+                // at cut-over.
                 //
-                // TODO: Consider sending `allow_writes` for the dataflows of migrated MVs, which
-                //       would allow them to make progress even in read-only mode. This doesn't
-                //       work for MVs based on `mz_catalog_raw`, if the leader's version is less
-                //       than v26.17, since before that version the catalog shard's frontier wasn't
-                //       kept up-to-date with the current time. So this workaround has to remain in
-                //       place upgrades from a version less than v26.17 are no longer supported.
+                // A migrated builtin *table* needs no such treatment even though a builtin MV can
+                // read one (`mz_clusters` joins `mz_cluster_replica_size_internal`):
+                // `read_only_mode_table_worker` keeps advancing the uppers of migrated tables, so
+                // an MV over one still catches up.
                 let new_builtin_mvs = new_builtin_collections
                     .iter()
                     .map(|global_id| {
@@ -5163,12 +5207,12 @@ pub fn serve(
                     })
                     .filter(|entry| entry.is_materialized_view())
                     .map(|entry| entry.id());
-                let mut todo: Vec<_> = migrated_storage_collections_0dt
+                let frozen_migrated_mvs = migrated_storage_collections_0dt
                     .iter()
                     .copied()
-                    .filter(|id| catalog.state().get_entry(id).is_materialized_view())
-                    .chain(new_builtin_mvs)
-                    .collect();
+                    .filter(|_| !hydrate_migrated_mvs)
+                    .filter(|id| catalog.state().get_entry(id).is_materialized_view());
+                let mut todo: Vec<_> = new_builtin_mvs.chain(frozen_migrated_mvs).collect();
                 while let Some(item_id) = todo.pop() {
                     let entry = catalog.state().get_entry(&item_id);
                     exclude_collections.extend(entry.global_ids());
@@ -5341,6 +5385,7 @@ pub fn serve(
                         .bootstrap(
                             boot_ts,
                             migrated_storage_collections_0dt,
+                            hydrate_migrated_mvs,
                             builtin_table_updates,
                             cached_global_exprs,
                             uncached_local_exprs,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -250,10 +250,10 @@ mod validity;
 ///
 /// Every builtin materialized view reads `mz_internal.mz_catalog_raw`, so its dataflow only makes
 /// progress up to the catalog shard's frontier. Holding that frontier at the current time is the
-/// leader's job, and leaders only started doing it in v26.17. Write-enable such an MV against an
-/// older leader and it sits at a stale frontier and never reports caught up, which blocks
-/// promotion outright instead of merely leaving the collection cold at cut-over. We still support
-/// upgrading from before v26.17, so that leader is a real case, not a hypothetical.
+/// leader's job, and leaders only started doing it in v26.17 (PR #35402). Write-enable such an MV
+/// against an older leader and it sits at a stale frontier and never reports caught up, which
+/// blocks promotion outright instead of merely leaving the collection cold at cut-over. We still
+/// support upgrading from before v26.17, so that leader is a real case, not a hypothetical.
 const MIN_LEADER_VERSION_FOR_MIGRATED_MV_WRITES: Version = Version::new(26, 17, 0);
 
 /// A pool of pre-allocated user IDs to avoid per-DDL persist writes.
@@ -2799,8 +2799,9 @@ impl Coordinator {
                     self.ship_dataflow(df_desc, mview.cluster_id, mview.target_replica)
                         .await;
 
-                    // If this is a replacement MV, it must remain read-only until the replacement
-                    // gets applied.
+                    // A pending `REPLACEMENT FOR` MV must stay read-only until
+                    // `ALTER ... APPLY REPLACEMENT` swaps it in. Unrelated to the
+                    // builtin-migration `Replacement` mechanism below.
                     if mview.replacement_target.is_none() {
                         let gid = mview.global_id_writes();
                         if hydrate_migrated_mvs
@@ -2811,6 +2812,10 @@ impl Coordinator {
                             // writing it while read-only hydrates the MV and its dependents before
                             // cut-over. An `Evolution`-migrated MV reuses the leader's live shard
                             // and must never reach here.
+                            //
+                            // A *new* builtin MV gets no such treatment: its shard allocation
+                            // lives only in this read-only savepoint, so the promoted leader
+                            // allocates a different shard and discards whatever we wrote.
                             self.controller
                                 .compute
                                 .allow_writes_in_read_only(mview.cluster_id, gid)
@@ -5187,32 +5192,31 @@ pub fn serve(
 
                 // A collection that can't advance its write frontier in read-only mode
                 // stalls its transitive dependents too, so exclude those from the caught-up
-                // check as well. That's new builtin MVs, whose fresh shard has no writer until
-                // this deployment promotes, plus migrated MVs whenever the leader is too old for
-                // them to write. An excluded dependent may still be hydrating right after
-                // promotion, a brief blip we accept because these MVs are small and get a writer
-                // at cut-over.
+                // check as well. That's every *new* builtin collection, whose fresh shard has no
+                // writer until this deployment promotes, plus migrated MVs whenever the leader is
+                // too old for them to write. An excluded dependent may still be hydrating right
+                // after promotion, a brief blip we accept because these collections are small and
+                // get a writer at cut-over.
                 //
-                // A migrated builtin *table* needs no such treatment even though a builtin MV can
-                // read one (`mz_clusters` joins `mz_cluster_replica_size_internal`):
-                // `read_only_mode_table_worker` keeps advancing the uppers of migrated tables, so
-                // an MV over one still catches up.
-                let new_builtin_mvs = new_builtin_collections
-                    .iter()
-                    .map(|global_id| {
-                        catalog
-                            .state()
-                            .try_get_entry_by_global_id(global_id)
-                            .expect("new builtin collections have catalog entries")
-                    })
-                    .filter(|entry| entry.is_materialized_view())
-                    .map(|entry| entry.id());
+                // Seeded from all of `new_builtin_collections`, not just the MVs: a new builtin
+                // table or source has no read-only writer either (`register_table_collections`
+                // retains only *migrated* tables), so an MV reading one never advances past its
+                // empty frontier. A *migrated* table is the opposite case, even though a builtin
+                // MV can read one (`mz_clusters` joins `mz_cluster_replica_size_internal`):
+                // `read_only_mode_table_worker` keeps advancing migrated tables' uppers.
+                let new_builtin_items = new_builtin_collections.iter().map(|global_id| {
+                    catalog
+                        .state()
+                        .try_get_entry_by_global_id(global_id)
+                        .expect("new builtin collections have catalog entries")
+                        .id()
+                });
                 let frozen_migrated_mvs = migrated_storage_collections_0dt
                     .iter()
                     .copied()
                     .filter(|_| !hydrate_migrated_mvs)
                     .filter(|id| catalog.state().get_entry(id).is_materialized_view());
-                let mut todo: Vec<_> = new_builtin_mvs.chain(frozen_migrated_mvs).collect();
+                let mut todo: Vec<_> = new_builtin_items.chain(frozen_migrated_mvs).collect();
                 while let Some(item_id) = todo.pop() {
                     let entry = catalog.state().get_entry(&item_id);
                     exclude_collections.extend(entry.global_ids());

--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -272,10 +272,11 @@ impl Coordinator {
         // set. `mz_cluster_replica_frontiers` is a controller-managed builtin
         // written with ±1 diffs, so it satisfies that invariant.
         //
-        // NOTE: these are the leader's frontiers only because we read the leader's shard. A
-        // release that `Replacement`-migrates `mz_cluster_replica_frontiers` itself, or a test
-        // forcing replacement across all builtins, hands us a shard we write ourselves, and the
-        // lag check below then compares this deployment against itself.
+        // NOTE: these are the leader's frontiers only because we read the leader's shard.
+        // `validate_migration_steps` forbids migrating `mz_cluster_replica_frontiers` for this
+        // reason, so a declared migration can't reach here. A test forcing replacement across all
+        // builtins bypasses that guard, hands us a shard we write ourselves, and the lag check
+        // below then compares this deployment against itself.
         let live_frontiers = self
             .controller
             .storage_collections

--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -271,6 +271,11 @@ impl Coordinator {
         // `snapshot_latest` requires that the collection consolidates to a
         // set. `mz_cluster_replica_frontiers` is a controller-managed builtin
         // written with ±1 diffs, so it satisfies that invariant.
+        //
+        // NOTE: these are the leader's frontiers only because we read the leader's shard. A
+        // release that `Replacement`-migrates `mz_cluster_replica_frontiers` itself, or a test
+        // forcing replacement across all builtins, hands us a shard we write ourselves, and the
+        // lag check below then compares this deployment against itself.
         let live_frontiers = self
             .controller
             .storage_collections
@@ -634,12 +639,37 @@ impl Coordinator {
                             self.controller.storage.collection_hydrated(id)?
                         }
                     };
+
+                    // Also require the frontier to be within the allowed lag, the bound the
+                    // live-frontier path applies, with `now` standing in for the missing live
+                    // frontier. Hydration is one-shot: a collection that hydrated and then stalled
+                    // would otherwise satisfy this branch forever.
+                    //
+                    // NOTE: there is deliberately no `cutoff` escape hatch here. A frontier frozen
+                    // at the minimum is exactly what this gate must catch, so a collection stuck
+                    // here blocks promotion until `with_0dt_deployment_max_wait` elapses.
+                    let write_frontier_plus_allowed_lag = Antichain::from_iter(
+                        write_frontier
+                            .iter()
+                            .map(|t| t.step_forward_by(&allowed_lag)),
+                    );
+                    let within_lag = PartialOrder::less_equal(
+                        &Antichain::from_elem(now),
+                        &write_frontier_plus_allowed_lag,
+                    );
+
                     tracing::info!(
                         ?write_frontier,
                         %collection_hydrated,
+                        %within_lag,
+                        ?allowed_lag,
+                        ?now,
                         "collection {id} not in live frontiers"
                     );
-                    if write_frontier.less_equal(&Timestamp::minimum()) || !collection_hydrated {
+                    if write_frontier.less_equal(&Timestamp::minimum())
+                        || !collection_hydrated
+                        || !within_lag
+                    {
                         all_caught_up = false;
                     }
                     continue;

--- a/src/adapter/src/coord/caught_up.rs
+++ b/src/adapter/src/coord/caught_up.rs
@@ -614,10 +614,32 @@ impl Coordinator {
             let live_write_frontier = match live_frontiers.get(&id) {
                 Some(frontier) => frontier,
                 None => {
-                    // The collection didn't previously exist, so consider
-                    // ourselves hydrated as long as our write_ts is > 0.
-                    tracing::info!(?write_frontier, "collection {id} not in live frontiers");
-                    if write_frontier.less_equal(&Timestamp::minimum()) {
+                    // No live frontier to compare against, either because the collection didn't
+                    // exist on the leader or because the leader hosts it as something
+                    // `mz_cluster_replica_frontiers` doesn't track. A table→MV conversion is the
+                    // latter: it keeps the table's `GlobalId`, still a table on the leader, so the
+                    // new MV lands here instead of the strong path below.
+                    //
+                    // Require hydration, not just a write frontier past the minimum. A fresh MV's
+                    // sink reaches frontier 1 after one batch, which would otherwise look caught
+                    // up mid-hydration and bring back the cut-over spike this gate prevents.
+                    let collection_hydrated = match collection_type {
+                        CollectionType::Compute => {
+                            self.controller
+                                .compute
+                                .collection_hydrated(cluster.id, id)
+                                .await?
+                        }
+                        CollectionType::Storage => {
+                            self.controller.storage.collection_hydrated(id)?
+                        }
+                    };
+                    tracing::info!(
+                        ?write_frontier,
+                        %collection_hydrated,
+                        "collection {id} not in live frontiers"
+                    );
+                    if write_frontier.less_equal(&Timestamp::minimum()) || !collection_hydrated {
                         all_caught_up = false;
                     }
                     continue;

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -709,7 +709,7 @@ async fn upgrade_check(
 
     let msg = format!(
         "catalog upgrade from {} to {} would succeed in about {} ms",
-        last_seen_version,
+        last_seen_version.map_or_else(|| "new".into(), |v| v.to_string()),
         BUILD_INFO.human_version(None),
         dur.as_millis(),
     );

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -836,6 +836,16 @@ pub static MZ_OBJECT_ARRANGEMENT_SIZE_HISTORY_DESCRIPTION: LazyLock<SystemObject
         object_type: CatalogItemType::Table,
         object_name: MZ_OBJECT_ARRANGEMENT_SIZE_HISTORY.name.to_string(),
     });
+
+/// Identifies [`MZ_CLUSTER_REPLICA_FRONTIERS`] for the schema-migration guard in
+/// `builtin_schema_migration.rs`, which forbids migrating this source because the 0dt
+/// caught-up gate reads the leader's shard for it to learn the live frontiers.
+pub static MZ_CLUSTER_REPLICA_FRONTIERS_DESCRIPTION: LazyLock<SystemObjectDescription> =
+    LazyLock::new(|| SystemObjectDescription {
+        schema_name: MZ_CLUSTER_REPLICA_FRONTIERS.schema.to_string(),
+        object_type: CatalogItemType::Source,
+        object_name: MZ_CLUSTER_REPLICA_FRONTIERS.name.to_string(),
+    });
 pub const MZ_SYSTEM_ROLE: BuiltinRole = BuiltinRole {
     id: MZ_SYSTEM_ROLE_ID,
     name: SYSTEM_USER_NAME,

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -53,6 +53,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 use mz_ore::soft_assert_or_log;
+use mz_ore::soft_panic_or_log;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_persist_types::PersistLocation;
 use mz_repr::{GlobalId, RelationDesc, Row, Timestamp};
@@ -1177,6 +1178,47 @@ impl ComputeController {
             return Ok(());
         }
 
+        self.allow_writes_inner(instance_id, collection_id)
+    }
+
+    /// Like [`Self::allow_writes`], but takes effect even in read-only mode.
+    ///
+    /// The caller must guarantee that no other environment writes the collection's output shard.
+    /// In a 0dt deployment that means a shard this environment created for itself, the replacement
+    /// shard of a `Replacement`-migrated builtin collection, never one the leader is still serving
+    /// from. `Evolution` migrates in place and reuses the leader's shard, so it must not reach this
+    /// path. Violating the guarantee races two writers on one shard.
+    ///
+    /// This is the compute-side counterpart to the storage controller's `force_writable` handling
+    /// of migrated storage collections. Migrated builtin tables are storage collections that
+    /// storage force-writes read-only; migrated builtin MVs are compute collections that only this
+    /// path can force-write. Both rest on the same guarantee (this environment exclusively owns the
+    /// replacement shard) but run on separate write paths, so each needs its own bypass.
+    pub fn allow_writes_in_read_only(
+        &mut self,
+        instance_id: ComputeInstanceId,
+        collection_id: GlobalId,
+    ) -> Result<(), CollectionUpdateError> {
+        // Every builtin eligible for the read-only bypass has a system id. A non-system id means
+        // the caller's `Replacement`-only invariant broke, so degrade to the read-only no-op (cold
+        // collection at cut-over) rather than risk writing a shard the leader still serves. Mirrors
+        // the storage-side tripwire in `StorageController::register_introspection_collection`.
+        if self.read_only && !collection_id.is_system() {
+            soft_panic_or_log!(
+                "allow_writes_in_read_only called for non-system collection {collection_id}; \
+                 falling back to read-only no-op"
+            );
+            return Ok(());
+        }
+
+        self.allow_writes_inner(instance_id, collection_id)
+    }
+
+    fn allow_writes_inner(
+        &mut self,
+        instance_id: ComputeInstanceId,
+        collection_id: GlobalId,
+    ) -> Result<(), CollectionUpdateError> {
         let instance = self.instance_mut(instance_id)?;
 
         // Validation

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -1183,26 +1183,40 @@ impl ComputeController {
 
     /// Like [`Self::allow_writes`], but takes effect even in read-only mode.
     ///
-    /// The caller must guarantee that no other environment writes the collection's output shard.
+    /// The caller must guarantee that no leader environment writes the collection's output shard.
     /// In a 0dt deployment that means a shard this environment created for itself, the replacement
     /// shard of a `Replacement`-migrated builtin collection, never one the leader is still serving
     /// from. `Evolution` migrates in place and reuses the leader's shard, so it must not reach this
     /// path. Violating the guarantee races two writers on one shard.
+    ///
+    /// NOTE: ownership is exclusive per (build version, deploy generation), not per process: the
+    /// migration shard entry naming the shard is keyed by that pair and a read-only catalog open is
+    /// a savepoint, so two read-only processes of one generation both write it. Same shape as a
+    /// multi-replica materialized view, which the self-correcting persist sink tolerates (see the
+    /// `mz_compute::sink::materialized_view` module docs).
     ///
     /// This is the compute-side counterpart to the storage controller's `force_writable` handling
     /// of migrated storage collections. Migrated builtin tables are storage collections that
     /// storage force-writes read-only; migrated builtin MVs are compute collections that only this
     /// path can force-write. Both rest on the same guarantee (this environment exclusively owns the
     /// replacement shard) but run on separate write paths, so each needs its own bypass.
+    ///
+    /// NOTE: the replica-side handler enables persist compaction process-wide on the clusterd
+    /// (`ComputeState::handle_allow_writes`), which this path is the first to trigger inside a
+    /// read-only deployment.
     pub fn allow_writes_in_read_only(
         &mut self,
         instance_id: ComputeInstanceId,
         collection_id: GlobalId,
     ) -> Result<(), CollectionUpdateError> {
-        // Every builtin eligible for the read-only bypass has a system id. A non-system id means
-        // the caller's `Replacement`-only invariant broke, so degrade to the read-only no-op (cold
-        // collection at cut-over) rather than risk writing a shard the leader still serves. Mirrors
-        // the storage-side tripwire in `StorageController::register_introspection_collection`.
+        // Every builtin eligible for this bypass has a system id, so a non-system id means the
+        // caller's `Replacement`-only invariant broke. No-op rather than risk writing a shard the
+        // leader still serves. The collection then sits in the caught-up gate on an unwritten
+        // shard and blocks promotion, which is the loud, safe direction to fail.
+        //
+        // Storage asserts the same invariant hard, in
+        // `StorageController::register_introspection_collection`. The asymmetry is deliberate: a
+        // soft panic keeps a caller bug visible in CI and Sentry without downing production.
         if self.read_only && !collection_id.is_system() {
             soft_panic_or_log!(
                 "allow_writes_in_read_only called for non-system collection {collection_id}; \

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -137,6 +137,7 @@ pub struct TestHarness {
     internal_console_redirect_url: Option<String>,
     metrics_registry: Option<MetricsRegistry>,
     code_version: semver::Version,
+    force_builtin_schema_migration: Option<String>,
     capture: Option<SharedStorage>,
     pub environment_id: EnvironmentId,
 }
@@ -242,6 +243,7 @@ impl Default for TestHarness {
                 ..Default::default()
             },
             code_version: crate::BUILD_INFO.semver_version(),
+            force_builtin_schema_migration: None,
             environment_id: EnvironmentId::for_tests(),
             capture: None,
         }
@@ -692,6 +694,13 @@ impl TestHarness {
         self
     }
 
+    /// Forces every builtin storage collection through the given migration mechanism,
+    /// `"evolution"` or `"replacement"`.
+    pub fn with_force_builtin_schema_migration(mut self, mechanism: &str) -> Self {
+        self.force_builtin_schema_migration = Some(mechanism.into());
+        self
+    }
+
     pub fn with_capture(mut self, storage: SharedStorage) -> Self {
         self.capture = Some(storage);
         self
@@ -944,7 +953,7 @@ impl Listeners {
                 helm_chart_version: None,
                 license_key: ValidatedLicenseKey::for_tests(),
                 external_login_password_mz_system: config.external_login_password_mz_system,
-                force_builtin_schema_migration: None,
+                force_builtin_schema_migration: config.force_builtin_schema_migration,
             })
             .await?;
 

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -11,6 +11,7 @@
 
 #![recursion_limit = "256"]
 
+use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Write;
 use std::io::Write as _;
@@ -2542,32 +2543,72 @@ async fn test_leader_promotion_mixed_code_version() {
     client_this.simple_query("SELECT 1").await.unwrap();
 }
 
-/// Regression test for builtin MVs migrated by shard replacement: they must be hydrated by the
-/// time the read-only deployment reports `ReadyToPromote`.
+/// The migrated builtin MVs that the 0dt hydration tests read.
 ///
-/// A replacement migration hands the new deployment a fresh shard that no other environment
-/// writes. Leave the MV's dataflow read-only and that shard stays empty, so the MV and everything
-/// downstream of it drop out of the 0dt caught-up gate and then all hydrate at once at cut-over.
+/// `mz_clusters` is the interesting one: it joins the `mz_cluster_replica_size_internal` builtin
+/// table, whose replacement shard is written once at bootstrap and thereafter only kept moving by
+/// `read_only_mode_table_worker`.
+const FORCED_BUILTIN_MIGRATION_MVS: &[&str] =
+    &["mz_catalog.mz_databases", "mz_catalog.mz_clusters"];
+
+/// How long a single read of a migrated builtin MV may take before it counts as unreadable.
+const MIGRATED_BUILTIN_MV_READ_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Reads every MV in [`FORCED_BUILTIN_MIGRATION_MVS`], reporting whether all of them returned rows.
 ///
-/// Reaching `ReadyToPromote` at all is the other half of the assertion. Write-enabling puts these
-/// MVs back *into* the gate, so anything they cannot catch up to now blocks promotion instead of
-/// being waved through. `mz_clusters` is the interesting case: it joins the
-/// `mz_cluster_replica_size_internal` builtin table, whose replacement shard is written once at
-/// bootstrap and thereafter only kept moving by `read_only_mode_table_worker`.
-#[mz_ore::test(tokio::test(flavor = "multi_thread"))]
-#[cfg_attr(miri, ignore)] // too slow
+/// Each read gets its own connection, dropped on timeout so the session ends and takes the peek
+/// with it. `statement_timeout` bounds INSERT/UPDATE/DELETE, not a `SELECT` waiting on a frontier,
+/// so it would leave the poll loop hanging on an unwritten replacement shard.
 #[allow(clippy::disallowed_methods)]
-async fn test_0dt_migrated_builtin_mv_hydrates_before_promotion() {
+async fn migrated_builtin_mvs_readable(server: &test_util::TestServer) -> bool {
+    for relation in FORCED_BUILTIN_MIGRATION_MVS {
+        let client = server.connect().await.unwrap();
+        let query = format!("SELECT count(*) FROM {relation}");
+        let read = tokio::time::timeout(
+            MIGRATED_BUILTIN_MV_READ_TIMEOUT,
+            client.query_one(&query, &[]),
+        );
+        match read.await {
+            Ok(Ok(row)) => {
+                let count: i64 = row.get(0);
+                if count == 0 {
+                    tracing::info!("`{query}` returned 0 rows");
+                    return false;
+                }
+            }
+            Ok(Err(err)) => {
+                tracing::info!("`{query}` errored: {err}");
+                return false;
+            }
+            Err(_) => {
+                tracing::info!(
+                    "`{query}` did not return within {MIGRATED_BUILTIN_MV_READ_TIMEOUT:?}"
+                );
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Boots a leader deployment plus a read-only deployment whose builtins were force-migrated by
+/// shard replacement, and reports whether the migrated builtin MVs had become readable by the time
+/// the read-only deployment first said `ReadyToPromote`.
+///
+/// Status and readability are polled in the same loop on purpose. Reading the MVs only *after*
+/// observing `ReadyToPromote` proves nothing about ordering: a peek against an unwritten
+/// replacement shard blocks, but so does a peek against an MV that is merely late.
+#[allow(clippy::disallowed_methods)]
+async fn migrated_builtin_mvs_readable_at_ready_to_promote(hydrate_migrated_mvs: bool) -> bool {
     let tmpdir = TempDir::new().unwrap();
     let harness = test_util::TestHarness::default()
         .unsafe_mode()
         .data_directory(tmpdir.path())
         .with_deploy_generation(1)
-        // Tick often, and tolerate far less lag and require a far shorter healthy streak than
-        // production, so the test both finishes quickly and actually exercises the gate: a
-        // collection frozen at `boot_ts + 1` drifts outside a 5s tolerance long before a 10s
-        // streak can complete, where the 60s production tolerance would hide it for a whole
-        // minute.
+        // Tick often, and tolerate far less lag than production, so the test finishes quickly and
+        // actually exercises the gate. The allowed lag has to stay *below* the stability period: a
+        // frozen collection looks caught up for as long as the tolerance lasts, so it must fall
+        // out of tolerance before an uninterrupted streak can complete.
         .with_system_parameter_default(
             "0dt_deployment_hydration_check_interval".to_string(),
             "1s".to_string(),
@@ -2579,14 +2620,18 @@ async fn test_0dt_migrated_builtin_mv_hydrates_before_promotion() {
         .with_system_parameter_default(
             "with_0dt_caught_up_check_stability_period".to_string(),
             "10s".to_string(),
+        )
+        .with_system_parameter_default(
+            "enable_0dt_hydrate_migrated_builtin_mvs".to_string(),
+            hydrate_migrated_mvs.to_string(),
         );
 
-    // The leader generation.
+    // The leader deployment.
     let server_leader = harness.clone().start().await;
     let client_leader = server_leader.connect().await.unwrap();
     client_leader.simple_query("SELECT 1").await.unwrap();
 
-    // The new generation, booting read-only. Forcing the `replacement` mechanism gives every
+    // The new deployment, booting read-only. Forcing the `replacement` mechanism gives every
     // builtin storage collection a fresh shard, which is what a release carrying a
     // `MigrationStep::replacement` does for the collections it names.
     let server_new = harness
@@ -2601,42 +2646,81 @@ async fn test_0dt_migrated_builtin_mv_hydrates_before_promotion() {
         server_new.internal_http_local_addr()
     ))
     .unwrap();
+
+    // Readability is monotonic, so latching the first `true` can only understate how early the MVs
+    // hydrated, never overstate it, and a readable-mid-tick race can't fail the test spuriously.
+    // The budget stays inside nextest's 240s kill for this package, so a gate that never opens
+    // fails the assertion rather than timing the test out.
+    let mvs_readable = Cell::new(false);
     Retry::default()
-        .max_duration(Duration::from_secs(300))
-        .retry_async(|_state| async {
-            let res = reqwest::Client::new()
-                .get(status_url.clone())
-                .send()
-                .await
-                .unwrap();
-            assert_eq!(res.status(), StatusCode::OK);
-            let response = res.text().await.unwrap();
-            tracing::info!("leader status of the new generation: {response}");
-            assert_ne!(response, r#"{"status":"IsLeader"}"#);
-            if response == r#"{"status":"ReadyToPromote"}"# {
-                Ok(())
-            } else {
-                Err(())
+        .max_duration(Duration::from_secs(120))
+        .retry_async(|_state| {
+            let status_url = status_url.clone();
+            let server_new = &server_new;
+            let mvs_readable = &mvs_readable;
+            async move {
+                if !mvs_readable.get() {
+                    mvs_readable.set(migrated_builtin_mvs_readable(server_new).await);
+                }
+
+                let res = reqwest::Client::new().get(status_url).send().await.unwrap();
+                assert_eq!(res.status(), StatusCode::OK);
+                let response = res.text().await.unwrap();
+                tracing::info!(
+                    mvs_readable = mvs_readable.get(),
+                    "leader status of the new deployment: {response}"
+                );
+                assert_ne!(response, r#"{"status":"IsLeader"}"#);
+                if response == r#"{"status":"ReadyToPromote"}"# {
+                    Ok(())
+                } else {
+                    Err(())
+                }
             }
         })
         .await
-        .unwrap();
+        .expect("new deployment never reported ReadyToPromote");
 
-    // The new generation says it is ready to take over, so a migrated builtin MV has to be
-    // readable from it while it is still read-only. With no writer on the replacement shard this
-    // peek never returns, so bound it rather than hang the test.
-    //
     // NOTE: we never promote. Cut-over `halt!`s the process, taking the test with it.
-    let client_new = server_new.connect().await.unwrap();
-    for relation in ["mz_databases", "mz_clusters"] {
-        let query = format!("SELECT count(*) FROM mz_catalog.{relation}");
-        let rows = tokio::time::timeout(Duration::from_secs(60), client_new.query(&query, &[]))
-            .await
-            .unwrap_or_else(|_| panic!("`{query}` never returned on the read-only generation"))
-            .unwrap();
-        let count: i64 = rows[0].get(0);
-        assert!(count > 0, "`{query}` returned {count}");
-    }
+    mvs_readable.get()
+}
+
+/// Regression test for builtin MVs migrated by shard replacement: they must be hydrated by the
+/// time the read-only deployment reports `ReadyToPromote`.
+///
+/// A replacement migration hands the new deployment a fresh shard that no other environment
+/// writes. Leave the MV's dataflow read-only and that shard stays empty, so the MV and everything
+/// downstream of it drop out of the 0dt caught-up gate and then all hydrate at once at cut-over.
+///
+/// Reaching `ReadyToPromote` at all is the other half of the assertion. Write-enabling puts these
+/// MVs back *into* the gate, so anything they cannot catch up to now blocks promotion instead of
+/// being waved through.
+///
+/// NOTE: this covers the ordering, not the gate's lag comparison. Forcing `replacement` replaces
+/// `mz_cluster_replica_frontiers` too, and the gate reads its "live" frontiers out of that
+/// collection, so here it compares this deployment against itself.
+#[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(miri, ignore)] // too slow
+async fn test_0dt_migrated_builtin_mv_hydrates_before_promotion() {
+    assert!(
+        migrated_builtin_mvs_readable_at_ready_to_promote(true).await,
+        "migrated builtin MVs were not readable when the new deployment reported ReadyToPromote"
+    );
+}
+
+/// The break-glass half of [`test_0dt_migrated_builtin_mv_hydrates_before_promotion`]: with
+/// `enable_0dt_hydrate_migrated_builtin_mvs` off, the migrated MVs are excluded from the caught-up
+/// gate again, so the deployment reports `ReadyToPromote` with them still unhydrated.
+///
+/// The two tests differ only in the flag, so a change that reaches `ReadyToPromote` without
+/// hydrating cannot pass both.
+#[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(miri, ignore)] // too slow
+async fn test_0dt_migrated_builtin_mv_flag_off_promotes_unhydrated() {
+    assert!(
+        !migrated_builtin_mvs_readable_at_ready_to_promote(false).await,
+        "migrated builtin MVs hydrated even with enable_0dt_hydrate_migrated_builtin_mvs off"
+    );
 }
 
 // Test that websockets observe cancellation.

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2542,6 +2542,103 @@ async fn test_leader_promotion_mixed_code_version() {
     client_this.simple_query("SELECT 1").await.unwrap();
 }
 
+/// Regression test for builtin MVs migrated by shard replacement: they must be hydrated by the
+/// time the read-only deployment reports `ReadyToPromote`.
+///
+/// A replacement migration hands the new deployment a fresh shard that no other environment
+/// writes. Leave the MV's dataflow read-only and that shard stays empty, so the MV and everything
+/// downstream of it drop out of the 0dt caught-up gate and then all hydrate at once at cut-over.
+///
+/// Reaching `ReadyToPromote` at all is the other half of the assertion. Write-enabling puts these
+/// MVs back *into* the gate, so anything they cannot catch up to now blocks promotion instead of
+/// being waved through. `mz_clusters` is the interesting case: it joins the
+/// `mz_cluster_replica_size_internal` builtin table, whose replacement shard is written once at
+/// bootstrap and thereafter only kept moving by `read_only_mode_table_worker`.
+#[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(miri, ignore)] // too slow
+#[allow(clippy::disallowed_methods)]
+async fn test_0dt_migrated_builtin_mv_hydrates_before_promotion() {
+    let tmpdir = TempDir::new().unwrap();
+    let harness = test_util::TestHarness::default()
+        .unsafe_mode()
+        .data_directory(tmpdir.path())
+        .with_deploy_generation(1)
+        // Tick often, and tolerate far less lag and require a far shorter healthy streak than
+        // production, so the test both finishes quickly and actually exercises the gate: a
+        // collection frozen at `boot_ts + 1` drifts outside a 5s tolerance long before a 10s
+        // streak can complete, where the 60s production tolerance would hide it for a whole
+        // minute.
+        .with_system_parameter_default(
+            "0dt_deployment_hydration_check_interval".to_string(),
+            "1s".to_string(),
+        )
+        .with_system_parameter_default(
+            "with_0dt_caught_up_check_allowed_lag".to_string(),
+            "5s".to_string(),
+        )
+        .with_system_parameter_default(
+            "with_0dt_caught_up_check_stability_period".to_string(),
+            "10s".to_string(),
+        );
+
+    // The leader generation.
+    let server_leader = harness.clone().start().await;
+    let client_leader = server_leader.connect().await.unwrap();
+    client_leader.simple_query("SELECT 1").await.unwrap();
+
+    // The new generation, booting read-only. Forcing the `replacement` mechanism gives every
+    // builtin storage collection a fresh shard, which is what a release carrying a
+    // `MigrationStep::replacement` does for the collections it names.
+    let server_new = harness
+        .clone()
+        .with_deploy_generation(2)
+        .with_force_builtin_schema_migration("replacement")
+        .start()
+        .await;
+
+    let status_url = Url::parse(&format!(
+        "http://{}/api/leader/status",
+        server_new.internal_http_local_addr()
+    ))
+    .unwrap();
+    Retry::default()
+        .max_duration(Duration::from_secs(300))
+        .retry_async(|_state| async {
+            let res = reqwest::Client::new()
+                .get(status_url.clone())
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::OK);
+            let response = res.text().await.unwrap();
+            tracing::info!("leader status of the new generation: {response}");
+            assert_ne!(response, r#"{"status":"IsLeader"}"#);
+            if response == r#"{"status":"ReadyToPromote"}"# {
+                Ok(())
+            } else {
+                Err(())
+            }
+        })
+        .await
+        .unwrap();
+
+    // The new generation says it is ready to take over, so a migrated builtin MV has to be
+    // readable from it while it is still read-only. With no writer on the replacement shard this
+    // peek never returns, so bound it rather than hang the test.
+    //
+    // NOTE: we never promote. Cut-over `halt!`s the process, taking the test with it.
+    let client_new = server_new.connect().await.unwrap();
+    for relation in ["mz_databases", "mz_clusters"] {
+        let query = format!("SELECT count(*) FROM mz_catalog.{relation}");
+        let rows = tokio::time::timeout(Duration::from_secs(60), client_new.query(&query, &[]))
+            .await
+            .unwrap_or_else(|_| panic!("`{query}` never returned on the read-only generation"))
+            .unwrap();
+        let count: i64 = rows[0].get(0);
+        assert!(count > 0, "`{query}` returned {count}");
+    }
+}
+
 // Test that websockets observe cancellation.
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_wait` on OS `linux`

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -3181,6 +3181,10 @@ where
         // In read-only mode we create a new shard for all migrated storage collections. So we
         // "trick" the write task into thinking that it's not in read-only mode so something is
         // advancing this new shard.
+        //
+        // This is the storage-side of forcing writes to a self-owned replacement shard while
+        // read-only. Migrated builtin MVs need the same treatment on their own write path; see
+        // `ComputeController::allow_writes_in_read_only`.
         let force_writable = self.read_only && self.migrated_storage_collections.contains(&id);
         if force_writable {
             assert!(id.is_system(), "unexpected non-system global id: {id:?}");

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -1819,6 +1819,11 @@ def workflow_builtin_schema_migrations_replacement(c: Composition) -> None:
         # caught-up gate they would hydrate at cut-over instead, spiking catalog-server CPU. Reading
         # them here from the read-only generation asserts the write-enable-while-read-only path
         # actually filled those shards.
+        #
+        # NOTE: this covers hydration, not the caught-up gate's lag comparison.
+        # `force_migrations="replacement"` replaces `mz_cluster_replica_frontiers` too, and the gate
+        # reads the leader's "live" frontiers out of that collection, so here it compares this
+        # generation against itself.
         for relation in ["mz_databases", "mz_clusters"]:
             count = c.sql_query(
                 f"SELECT count(*) FROM mz_catalog.{relation}",

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -1813,6 +1813,20 @@ def workflow_builtin_schema_migrations_replacement(c: Composition) -> None:
     ):
         c.up("mz_new")
         c.await_mz_deployment_status(DeploymentStatus.READY_TO_PROMOTE, "mz_new")
+
+        # The new generation is ready to promote while still read-only, so its migrated builtin MVs
+        # must already be hydrated off their replacement shards. If they were excluded from the
+        # caught-up gate they would hydrate at cut-over instead, spiking catalog-server CPU. Reading
+        # them here from the read-only generation asserts the write-enable-while-read-only path
+        # actually filled those shards.
+        for relation in ["mz_databases", "mz_clusters"]:
+            count = c.sql_query(
+                f"SELECT count(*) FROM mz_catalog.{relation}",
+                service="mz_new",
+                reuse_connection=False,
+            )[0][0]
+            assert count > 0, f"{relation} returned {count} on the read-only generation"
+
         c.promote_mz("mz_new")
         c.await_mz_deployment_status(DeploymentStatus.IS_LEADER, "mz_new")
 


### PR DESCRIPTION
Problem:
A builtin schema migration using the `Replacement` mechanism hands the new deployment a fresh persist shard. Nothing writes that shard while the deployment is read-only, because `ComputeController::allow_writes` no-ops in read-only mode, so the MV's write frontier never advances and the 0dt readiness gate has to drop it and everything downstream of it from the caught-up check. The deployment then promotes with those collections unhydrated, and they all hydrate at once at cut-over, spiking catalog-server CPU and degrading catalog queries.

Solution:
The replacement shard is exclusively owned by this deployment, so the MV can write it while we are still read-only. Do that, and keep the MV in the readiness gate, so it hydrates before cut-over instead of at it.

Previously we didn't do this for builtins derived from mz_catalog because catalog shard frontier was not held. However, as of 26.17 it is, so gate the behaviour on the version of the old leader.

Testing:
- New environmentd integration test `test_0dt_migrated_builtin_mv_hydrates_before_promotion` boots a read-only generation with a forced `replacement` migration and asserts the migrated builtin MVs `mz_databases` and `mz_clusters` are readable before it reports `ReadyToPromote`, proving they hydrate before cut-over rather than at it.
- Extended the `0dt` mzcompose workflow `builtin-schema-migrations-replacement` to read those MVs from the read-only generation before promotion, guarding the same invariant through a real cross-version upgrade.
