### PR TITLE
ci: self-heal cargo caches that kill build scripts with a bare ENOENT

### DIFF
--- a/bin/clear-corrupted-cargo-target-dir
+++ b/bin/clear-corrupted-cargo-target-dir
@@ -27,8 +27,25 @@ incremental_build_failure_pattern+="|signal: 11, SIGSEGV"
 
 registry_fetch_failure_pattern="unable to update registry"
 
+# A cached build-script binary poisoned by cargo cache corruption dies with a
+# bare ENOENT before doing any work. Both halves are required, and the error
+# must be the exact bare line: "failed to run custom build command" alone is
+# any build-script bug, which a retry cannot fix, and a build script that
+# fails on a missing file with an error context of its own produces the ENOENT
+# in a "Caused by:" detail line instead of the bare "Error:" line.
+custom_build_script_enoent() {
+  grep -q "failed to run custom build command" "$1" \
+    && grep -qE '^[[:space:]]*Error: No such file or directory \(os error 2\)[[:space:]]*$' "$1"
+}
+
 if grep -qE "$incremental_build_failure_pattern" "$1"; then
   echo "--- Detected incremental build failure, clearing cargo target directories"
+  rm -rf target target-xcompile || true
+  exit 199
+fi
+
+if custom_build_script_enoent "$1"; then
+  echo "--- Detected corrupted cached build script, clearing cargo target directories"
   rm -rf target target-xcompile || true
   exit 199
 fi

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -142,7 +142,23 @@ def run_and_detect_retryable_build_failure(
             "unable to update registry",
         ]
         combined = stdout_contents + stderr_contents
-        if any(msg in combined for msg in incremental_build_failure_msgs):
+        # A cached build-script binary poisoned by cargo cache corruption dies
+        # with a bare ENOENT before doing any work. Both halves are required,
+        # and the error must be the exact bare line: "failed to run custom
+        # build command" alone is any build-script bug, which a retry cannot
+        # fix, and a build script that fails on a missing file with an error
+        # context of its own produces the ENOENT in a "Caused by:" detail line
+        # instead of the bare "Error:" line.
+        custom_build_script_enoent = (
+            "failed to run custom build command" in combined
+            and any(
+                line.strip() == "Error: No such file or directory (os error 2)"
+                for line in combined.splitlines()
+            )
+        )
+        if custom_build_script_enoent or any(
+            msg in combined for msg in incremental_build_failure_msgs
+        ):
             raise RustIncrementalBuildFailure()
         if any(msg in combined for msg in registry_fetch_failure_msgs):
             raise CargoRegistryFetchFailure()


### PR DESCRIPTION
### Motivation

On 2026-08-21 the merge-skew-cargo-check step failed org-wide for about an hour: a corrupted cached build-script binary on the single merge-skew agent died with a bare "No such file or directory", a signature `bin/clear-corrupted-cargo-target-dir` does not recognize, so the self-heal never fired and every PR's check stayed red until the agent was replaced by hand. See for example https://buildkite.com/materialize/test/builds/132291#01a02515-b30e-4809-b330-98cdb7fbfe9d (test-pipeline builds 132290 through 132298 all failed identically, across unrelated branches).

### Description

Recognize the signature in `bin/clear-corrupted-cargo-target-dir` and wipe-and-retry, mirrored in `run_and_detect_retryable_build_failure` per the existing sync comments. Both halves of the signature are required, and the ENOENT must be the exact bare error line: "failed to run custom build command" alone is any build-script bug, which a retry cannot fix, and a build script that fails on a missing file with an error context of its own reports the ENOENT indented under "Caused by:" rather than on the bare "Error:" line, so genuine build-script bugs (which are user code, not cache corruption) do not trigger cache wipes.

A follow-up PR (kept in draft for now) adds a warning annotation on every self-healing wipe so that recurring corruption stays observable instead of manifesting only as repeatedly cold builds.

### Verification

The script detects the actual incident log from build 132298 (exit 199), detects a synthetic bare-pair log, and correctly ignores both a log carrying only the "failed to run custom build command" half and a log where the ENOENT appears in a "Caused by:" detail line of a contextful build-script error. The Python side raises `RustIncrementalBuildFailure` for the bare pair and falls through to a plain `CalledProcessError` for the contextful case.
