### PR TITLE
CNS-138: console: distinct query history empty state when statement logging sampling is off

### DIFF
--- a/console/src/api/materialize/query-history/__snapshots__/statementLoggingMaxSampleRate.test.ts.snap
+++ b/console/src/api/materialize/query-history/__snapshots__/statementLoggingMaxSampleRate.test.ts.snap
@@ -1,0 +1,8 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`queries > buildStatementLoggingMaxSampleRateQuery produces the expected query 1`] = `
+{
+  "parameters": [],
+  "sql": "SHOW statement_logging_max_sample_rate",
+}
+`;

--- a/console/src/api/materialize/query-history/statementLoggingMaxSampleRate.test.ts
+++ b/console/src/api/materialize/query-history/statementLoggingMaxSampleRate.test.ts
@@ -1,0 +1,20 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { queryBuilder } from "~/api/materialize";
+
+import { buildStatementLoggingMaxSampleRateQuery } from "./statementLoggingMaxSampleRate";
+
+describe("queries", () => {
+  it("buildStatementLoggingMaxSampleRateQuery produces the expected query", () => {
+    const { sql, parameters } =
+      buildStatementLoggingMaxSampleRateQuery().compile(queryBuilder);
+    expect({ sql, parameters }).toMatchSnapshot();
+  });
+});

--- a/console/src/api/materialize/query-history/statementLoggingMaxSampleRate.ts
+++ b/console/src/api/materialize/query-history/statementLoggingMaxSampleRate.ts
@@ -1,0 +1,47 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { QueryKey } from "@tanstack/react-query";
+import { sql } from "kysely";
+
+import { executeSqlV2, queryBuilder } from "~/api/materialize";
+
+export const buildStatementLoggingMaxSampleRateQuery = () => {
+  return sql<{
+    statement_logging_max_sample_rate: string;
+  }>`SHOW statement_logging_max_sample_rate`;
+};
+
+/**
+ * Fetches the system-wide cap on the statement logging sample rate. The effective rate is
+ * `min(session statement_logging_sample_rate, this)`, so a value of `0` means statement
+ * logging is off for everyone and query history can never have rows.
+ *
+ * Returns `null` if the variable could not be read.
+ */
+export default async function fetchStatementLoggingMaxSampleRate({
+  queryKey,
+  requestOptions,
+}: {
+  queryKey: QueryKey;
+  requestOptions: RequestInit;
+}) {
+  const compiledQuery =
+    buildStatementLoggingMaxSampleRateQuery().compile(queryBuilder);
+
+  const response = await executeSqlV2({
+    queries: compiledQuery,
+    queryKey,
+    requestOptions,
+  });
+
+  const row = response.rows?.[0];
+
+  return row ? parseFloat(row.statement_logging_max_sample_rate) : null;
+}

--- a/console/src/api/materialize/query-history/statementLoggingMaxSampleRate.ts
+++ b/console/src/api/materialize/query-history/statementLoggingMaxSampleRate.ts
@@ -23,7 +23,7 @@ export const buildStatementLoggingMaxSampleRateQuery = () => {
  * `min(session statement_logging_sample_rate, this)`, so a value of `0` means statement
  * logging is off for everyone and query history can never have rows.
  *
- * Returns `null` if the variable could not be read.
+ * Returns `null` if the variable could not be read as a number.
  */
 export default async function fetchStatementLoggingMaxSampleRate({
   queryKey,
@@ -41,7 +41,7 @@ export default async function fetchStatementLoggingMaxSampleRate({
     requestOptions,
   });
 
-  const row = response.rows?.[0];
+  const rate = parseFloat(response.rows[0]?.statement_logging_max_sample_rate);
 
-  return row ? parseFloat(row.statement_logging_max_sample_rate) : null;
+  return Number.isFinite(rate) ? rate : null;
 }

--- a/console/src/platform/query-history/QueryHistoryList.test.tsx
+++ b/console/src/platform/query-history/QueryHistoryList.test.tsx
@@ -66,9 +66,15 @@ const useFetchQueryHistoryUsersColumns: Array<Column> = [
   buildColumn({ name: "email" }),
 ];
 
+// The schema defaults `dateRange` to a window ending at `new Date()`, so handlers must
+// reuse the same parsed filters the component is rendered with in order to match.
+const PARSED_DEFAULT_SCHEMA_VALUES = queryHistoryListSchema.parse(
+  DEFAULT_SCHEMA_VALUES,
+);
+
 const DEFAULT_FETCH_QUERY_LIST_HANDLER = buildSqlQueryHandlerV2({
   queryKey: queryHistoryQueryKeys.list({
-    filters: queryHistoryListSchema.parse(DEFAULT_SCHEMA_VALUES),
+    filters: PARSED_DEFAULT_SCHEMA_VALUES,
     isRedacted: false,
     isV0_132_0: false,
   }),
@@ -102,25 +108,7 @@ const buildMaxSampleRateHandler = (rate: string) =>
     }),
   });
 
-const PARSED_DEFAULT_SCHEMA_VALUES = queryHistoryListSchema.parse(
-  DEFAULT_SCHEMA_VALUES,
-);
-
 const ALL_COLUMNS = COLUMNS.map(({ key }) => key);
-
-// `queryHistoryListSchema` defaults `dateRange` to `new Date()`, so a handler only
-// matches if it is keyed off the same parsed filters the component was rendered with.
-const EMPTY_LIST_HANDLER = buildSqlQueryHandlerV2({
-  queryKey: queryHistoryQueryKeys.list({
-    filters: PARSED_DEFAULT_SCHEMA_VALUES,
-    isRedacted: false,
-    isV0_132_0: false,
-  }),
-  results: mapKyselyToTabular({
-    rows: [],
-    columns: useFetchQueryHistoryListColumns,
-  }),
-});
 
 const DEFAULT_PRIVILEGES_HANDLER = buildMockPrivilegesQueryHandler({
   isSuperUser: false,
@@ -411,8 +399,6 @@ describe("QueryHistoryList", () => {
   });
 
   it("Should show the filter-oriented empty state when sampling is enabled", async () => {
-    server.use(EMPTY_LIST_HANDLER);
-
     await renderComponent(
       <QueryHistoryList
         initialFilters={PARSED_DEFAULT_SCHEMA_VALUES}
@@ -431,7 +417,7 @@ describe("QueryHistoryList", () => {
   });
 
   it("Should show a sampling disabled empty state when the max sample rate is zero", async () => {
-    server.use(EMPTY_LIST_HANDLER, buildMaxSampleRateHandler("0"));
+    server.use(buildMaxSampleRateHandler("0"));
 
     await renderComponent(
       <QueryHistoryList

--- a/console/src/platform/query-history/QueryHistoryList.test.tsx
+++ b/console/src/platform/query-history/QueryHistoryList.test.tsx
@@ -94,11 +94,33 @@ const DEFAULT_FETCH_QUERY_HISTORY_USERS_HANDLER = buildSqlQueryHandlerV2({
   }),
 });
 
+const buildMaxSampleRateHandler = (rate: string) =>
+  buildSqlQueryHandlerV2({
+    queryKey: queryHistoryQueryKeys.statementLoggingMaxSampleRate(),
+    results: mapKyselyToTabular({
+      rows: [{ statement_logging_max_sample_rate: rate }],
+    }),
+  });
+
 const PARSED_DEFAULT_SCHEMA_VALUES = queryHistoryListSchema.parse(
   DEFAULT_SCHEMA_VALUES,
 );
 
 const ALL_COLUMNS = COLUMNS.map(({ key }) => key);
+
+// `queryHistoryListSchema` defaults `dateRange` to `new Date()`, so a handler only
+// matches if it is keyed off the same parsed filters the component was rendered with.
+const EMPTY_LIST_HANDLER = buildSqlQueryHandlerV2({
+  queryKey: queryHistoryQueryKeys.list({
+    filters: PARSED_DEFAULT_SCHEMA_VALUES,
+    isRedacted: false,
+    isV0_132_0: false,
+  }),
+  results: mapKyselyToTabular({
+    rows: [],
+    columns: useFetchQueryHistoryListColumns,
+  }),
+});
 
 const DEFAULT_PRIVILEGES_HANDLER = buildMockPrivilegesQueryHandler({
   isSuperUser: false,
@@ -127,6 +149,7 @@ describe("QueryHistoryList", () => {
     server.use(DEFAULT_FETCH_QUERY_LIST_HANDLER);
     server.use(DEFAULT_FETCH_CLUSTER_LIST_HANDLER);
     server.use(DEFAULT_FETCH_QUERY_HISTORY_USERS_HANDLER);
+    server.use(buildMaxSampleRateHandler("0.99"));
   });
 
   afterEach(() => {
@@ -385,6 +408,49 @@ describe("QueryHistoryList", () => {
     );
     // Expect empty state
     expect(await screen.findByText("No results found.")).toBeVisible();
+  });
+
+  it("Should show the filter-oriented empty state when sampling is enabled", async () => {
+    server.use(EMPTY_LIST_HANDLER);
+
+    await renderComponent(
+      <QueryHistoryList
+        initialFilters={PARSED_DEFAULT_SCHEMA_VALUES}
+        initialColumns={DEFAULT_COLUMNS}
+      />,
+      {
+        initializeState: ({ set }) =>
+          setFakeEnvironment(set, "aws/us-east-1", healthyEnvironment),
+      },
+    );
+
+    expect(await screen.findByText("No results found.")).toBeVisible();
+    expect(
+      screen.queryByText("Statement logging is turned off."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("Should show a sampling disabled empty state when the max sample rate is zero", async () => {
+    server.use(EMPTY_LIST_HANDLER, buildMaxSampleRateHandler("0"));
+
+    await renderComponent(
+      <QueryHistoryList
+        initialFilters={PARSED_DEFAULT_SCHEMA_VALUES}
+        initialColumns={DEFAULT_COLUMNS}
+      />,
+      {
+        initializeState: ({ set }) =>
+          setFakeEnvironment(set, "aws/us-east-1", healthyEnvironment),
+      },
+    );
+
+    expect(
+      await screen.findByText("Statement logging is turned off."),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/ALTER SYSTEM SET statement_logging_max_sample_rate/),
+    ).toBeVisible();
+    expect(screen.queryByText("No results found.")).not.toBeInTheDocument();
   });
 
   // TODO (robinclowers): Fix and renenable this https://github.com/MaterializeInc/console/issues/2482

--- a/console/src/platform/query-history/QueryHistoryList.tsx
+++ b/console/src/platform/query-history/QueryHistoryList.tsx
@@ -45,7 +45,10 @@ import ClusterFilter from "./ClusterFilter";
 import ColumnFilter from "./ColumnFilter";
 import DateRangeInput from "./DateRangeInput";
 import FilterMenu from "./FilterMenu";
-import { useFetchQueryHistoryList } from "./queries";
+import {
+  useFetchQueryHistoryList,
+  useFetchStatementLoggingMaxSampleRate,
+} from "./queries";
 import QueryHistoryTable from "./QueryHistoryTable";
 import {
   formatSelectedDates,
@@ -96,6 +99,34 @@ const EmptyState = () => {
                 : userFilter}
               <br />
               Date range: {formattedDateFilterStr}
+            </>
+          }
+        />
+      </EmptyListHeader>
+    </EmptyListWrapper>
+  );
+};
+
+export const SamplingDisabledState = () => {
+  const { colors } = useTheme<MaterializeTheme>();
+
+  return (
+    <EmptyListWrapper>
+      <EmptyListHeader>
+        <Circle p={2} bg={colors.background.secondary}>
+          <ActivityIcon color={colors.foreground.secondary} />
+        </Circle>
+        <EmptyListHeaderContents
+          title="Statement logging is turned off."
+          helpText={
+            <>
+              The statement logging sample rate is set to zero, so no queries
+              are recorded. To start recording queries, raise the sample rate in
+              your Materialize operator&rsquo;s Helm chart values, or run{" "}
+              <Text as="span" textStyle="monospace">
+                ALTER SYSTEM SET statement_logging_max_sample_rate = 0.99
+              </Text>
+              .
             </>
           }
         />
@@ -174,6 +205,9 @@ export const QueryHistoryList = ({
 
   const isV0_132_0 = useEnvironmentGate("0.132.0") ?? true;
 
+  const { data: maxSampleRate, isLoading: isMaxSampleRateLoading } =
+    useFetchStatementLoggingMaxSampleRate();
+
   const {
     isError: isQueryHistoryListError,
     data: queryHistoryListData,
@@ -193,8 +227,13 @@ export const QueryHistoryList = ({
 
   const isError = isPrivilegesError || isQueryHistoryListError;
 
-  const isLoading = isPrivilegesLoading || isQueryHistoryListLoading;
+  const isLoading =
+    isPrivilegesLoading || isQueryHistoryListLoading || isMaxSampleRateLoading;
   const isEmpty = queryHistoryListData?.rows.length === 0;
+  const isSamplingDisabled = isEmpty && maxSampleRate === 0;
+  // Nudging the user at the filter controls only makes sense when narrowing
+  // them is what could produce rows.
+  const isFilterEmpty = isEmpty && !isSamplingDisabled;
 
   const isUnauthorized = isPrivilegesSuccess && !isAuthorized;
 
@@ -215,12 +254,14 @@ export const QueryHistoryList = ({
             <HStack>
               <UserFilter
                 submitForm={submitForm}
-                variant={isEmpty ? "focused" : "default"}
+                variant={isFilterEmpty ? "focused" : "default"}
               />
               <ClusterFilter submitForm={submitForm} />
               <DateRangeInput
                 onSubmit={onSubmit}
-                toggleButtonProps={isEmpty ? { variant: "focused" } : undefined}
+                toggleButtonProps={
+                  isFilterEmpty ? { variant: "focused" } : undefined
+                }
               />
               <FilterMenu onSubmit={onSubmit} />
             </HStack>
@@ -246,7 +287,9 @@ export const QueryHistoryList = ({
               >
                 <Spinner data-testid="loading-spinner" />
               </Stack>
-            ) : isEmpty ? (
+            ) : isSamplingDisabled ? (
+              <SamplingDisabledState />
+            ) : isFilterEmpty ? (
               <EmptyState />
             ) : (
               <QueryHistoryTable

--- a/console/src/platform/query-history/QueryHistoryList.tsx
+++ b/console/src/platform/query-history/QueryHistoryList.tsx
@@ -107,7 +107,7 @@ const EmptyState = () => {
   );
 };
 
-export const SamplingDisabledState = () => {
+const SamplingDisabledState = () => {
   const { colors } = useTheme<MaterializeTheme>();
 
   return (
@@ -121,12 +121,12 @@ export const SamplingDisabledState = () => {
           helpText={
             <>
               The statement logging sample rate is set to zero, so no queries
-              are recorded. To start recording queries, raise the sample rate in
-              your Materialize operator&rsquo;s Helm chart values, or run{" "}
+              are recorded. Ask an administrator to raise it with{" "}
               <Text as="span" textStyle="monospace">
-                ALTER SYSTEM SET statement_logging_max_sample_rate = 0.99
+                ALTER SYSTEM SET statement_logging_max_sample_rate
               </Text>
-              .
+              . In self-managed deployments it can also be set through the
+              Materialize operator&apos;s Helm chart values.
             </>
           }
         />
@@ -205,9 +205,6 @@ export const QueryHistoryList = ({
 
   const isV0_132_0 = useEnvironmentGate("0.132.0") ?? true;
 
-  const { data: maxSampleRate, isLoading: isMaxSampleRateLoading } =
-    useFetchStatementLoggingMaxSampleRate();
-
   const {
     isError: isQueryHistoryListError,
     data: queryHistoryListData,
@@ -223,16 +220,22 @@ export const QueryHistoryList = ({
     },
   );
 
+  const isEmpty = queryHistoryListData?.rows.length === 0;
+
+  // Only needed to disambiguate an empty result set, so keep it off the path
+  // that renders rows.
+  const { data: maxSampleRate, isLoading: isMaxSampleRateLoading } =
+    useFetchStatementLoggingMaxSampleRate({ enabled: isEmpty });
+
   useSyncObjectToSearchParams(urlParamObject);
 
   const isError = isPrivilegesError || isQueryHistoryListError;
 
   const isLoading =
     isPrivilegesLoading || isQueryHistoryListLoading || isMaxSampleRateLoading;
-  const isEmpty = queryHistoryListData?.rows.length === 0;
   const isSamplingDisabled = isEmpty && maxSampleRate === 0;
-  // Nudging the user at the filter controls only makes sense when narrowing
-  // them is what could produce rows.
+  // Sampling being off, not an over-narrow filter, is what the user has to fix,
+  // so don't draw attention to the filter controls.
   const isFilterEmpty = isEmpty && !isSamplingDisabled;
 
   const isUnauthorized = isPrivilegesSuccess && !isAuthorized;

--- a/console/src/platform/query-history/queries.ts
+++ b/console/src/platform/query-history/queries.ts
@@ -32,6 +32,7 @@ import {
   QueryHistoryListRow,
 } from "~/api/materialize/query-history/queryHistoryList";
 import { fetchQueryHistoryUsers } from "~/api/materialize/query-history/queryHistoryUsers";
+import fetchStatementLoggingMaxSampleRate from "~/api/materialize/query-history/statementLoggingMaxSampleRate";
 import {
   getRecentQueryData,
   initialPlaceholderDataBuilders,
@@ -63,6 +64,11 @@ export const queryHistoryQueryKeys = {
     [...queryHistoryQueryKeys.all(), buildQueryKeyPart("clusters")] as const,
   users: () =>
     [...queryHistoryQueryKeys.all(), buildQueryKeyPart("users")] as const,
+  statementLoggingMaxSampleRate: () =>
+    [
+      ...queryHistoryQueryKeys.all(),
+      buildQueryKeyPart("statement-logging-max-sample-rate"),
+    ] as const,
   detail: ({ executionId }: { executionId: string }) =>
     [
       ...queryHistoryQueryKeys.all(),
@@ -129,6 +135,18 @@ export function useFetchQueryHistoryUsers() {
         id: row.email,
         name: row.email,
       }));
+    },
+  });
+}
+
+export function useFetchStatementLoggingMaxSampleRate() {
+  return useQuery({
+    queryKey: queryHistoryQueryKeys.statementLoggingMaxSampleRate(),
+    queryFn: ({ queryKey, signal }) => {
+      return fetchStatementLoggingMaxSampleRate({
+        queryKey,
+        requestOptions: { signal },
+      });
     },
   });
 }

--- a/console/src/platform/query-history/queries.ts
+++ b/console/src/platform/query-history/queries.ts
@@ -139,7 +139,9 @@ export function useFetchQueryHistoryUsers() {
   });
 }
 
-export function useFetchStatementLoggingMaxSampleRate() {
+export function useFetchStatementLoggingMaxSampleRate(options?: {
+  enabled?: boolean;
+}) {
   return useQuery({
     queryKey: queryHistoryQueryKeys.statementLoggingMaxSampleRate(),
     queryFn: ({ queryKey, signal }) => {
@@ -148,6 +150,7 @@ export function useFetchStatementLoggingMaxSampleRate() {
         requestOptions: { signal },
       });
     },
+    enabled: options?.enabled,
   });
 }
 


### PR DESCRIPTION
https://linear.app/materializeinc/issue/CNS-138/console-distinct-empty-state-when-the-statement-logging-sample-rate-is

## Problem

Query history is backed by statement logging, which an operator can turn off by setting the sample rate to `0`. When that happens the console showed the generic filter-oriented "No results found." state, so the user could not tell sampling was off from their filters being too narrow.

## Solution

* New API module `console/src/api/materialize/query-history/statementLoggingMaxSampleRate.ts` reads `SHOW statement_logging_max_sample_rate`, following the existing `maxReplicasPerCluster.ts` pattern. The effective rate is `min(session statement_logging_sample_rate, system statement_logging_max_sample_rate)`, so the cap alone detects a hard opt-out.
* `QueryHistoryList` renders a distinct `SamplingDisabledState` when the result set is empty and the cap is `0`, naming both ways to raise it: `ALTER SYSTEM SET statement_logging_max_sample_rate`, and the Materialize operator's Helm chart values for self-managed. The filter-oriented state is unchanged for a non-zero rate.

The new query is gated on `enabled: isEmpty`, so it never runs on the path that renders rows.

## Testing

Snapshot test for the compiled query, plus two cases in `QueryHistoryList.test.tsx` covering both empty-state branches.

While adding them I found `DEFAULT_FETCH_QUERY_LIST_HANDLER` never matched anything: the schema defaults `dateRange` to a window ending at `new Date()`, so its separate `queryHistoryListSchema.parse(...)` produced different filters than the `PARSED_DEFAULT_SCHEMA_VALUES` the component renders with. The handler now reuses the same parsed value.

## Notes for the reviewer

* Rebased onto main now that #38407 ([CNS-137](https://linear.app/materializeinc/issue/CNS-137)) has landed. This branch previously carried a cherry-pick of @leedqin's #36533 un-gate; main has that change already, so the duplicate commit was dropped in the rebase. #36533 is now redundant and can be closed.
* The Helm chart value the copy alludes to comes from #38406 ([CNS-136](https://linear.app/materializeinc/issue/CNS-136)). The message deliberately names no specific chart key, so it stays accurate regardless of what that PR settles on.
* The copy renders in both deployment modes and mentions Helm only in a self-managed-qualified sentence, rather than branching on `AppConfigSwitch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
