### PR TITLE
frontegg-auth: resolve the group claim path against all JWT claims

### DIFF
--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -794,8 +794,27 @@ impl Claims {
     /// Returns the user's group memberships extracted from the JWT claim at
     /// `claim_path` for group-to-role sync. See
     /// [`mz_auth::group_claims::extract_groups`] for semantics.
+    ///
+    /// `claim_path` resolves against the full claim set, not just
+    /// [`Claims::unknown_claims`]. Serde's `flatten` collects only the keys
+    /// that no named field above claimed, so a claim backed by a strongly
+    /// typed field, `roles` among them, is absent from that map and would
+    /// otherwise be unreachable no matter how `oidc_group_claim` is set.
+    /// Resolving against a JSON view of the whole struct keeps every claim the
+    /// IdP sent reachable, so a given `oidc_group_claim` value selects the same
+    /// claim here as it does under the OIDC authenticator, whose claims struct
+    /// types almost nothing and therefore never shadowed anything.
     pub fn groups(&self, claim_path: &str) -> Option<Vec<String>> {
-        mz_auth::group_claims::extract_groups(&self.unknown_claims, claim_path)
+        match serde_json::to_value(self) {
+            Ok(serde_json::Value::Object(claims)) => {
+                let claims = claims.into_iter().collect();
+                mz_auth::group_claims::extract_groups(&claims, claim_path)
+            }
+            // Serializing `Claims` cannot fail. Resolving against the untyped
+            // claims alone still serves every nested path, so fall back rather
+            // than skip the sync outright.
+            _ => mz_auth::group_claims::extract_groups(&self.unknown_claims, claim_path),
+        }
     }
 }
 
@@ -920,6 +939,18 @@ mod tests {
         let claims = claims_with(json!({"groups": ["analytics", "engineering"]}));
         assert_eq!(
             claims.groups("groups"),
+            Some(vec!["analytics".to_string(), "engineering".to_string()])
+        );
+    }
+
+    /// `roles` is a strongly typed field, so serde's `flatten` never routes it
+    /// into `unknown_claims`. It still has to be selectable as the group claim.
+    #[mz_ore::test]
+    fn groups_from_typed_roles_claim() {
+        let mut claims = claims_with(json!({}));
+        claims.roles = vec!["analytics".to_string(), "engineering".to_string()];
+        assert_eq!(
+            claims.groups("roles"),
             Some(vec!["analytics".to_string(), "engineering".to_string()])
         );
     }


### PR DESCRIPTION
### Motivation

`oidc_group_claim` selects which JWT claim group-to-role sync reads group names from. On the Frontegg authenticator, that lookup ran against `Claims::unknown_claims`, the `#[serde(flatten)]` catch-all:

```rust
pub fn groups(&self, claim_path: &str) -> Option<Vec<String>> {
    mz_auth::group_claims::extract_groups(&self.unknown_claims, claim_path)
}
```

Serde's `flatten` collects only the keys that no named field claimed. `Claims` declares ten named fields, so `sub`, `exp`, `iss`, `type`, `email`, `userId`, `tenantId`, `roles`, `permissions`, and `metadata` never appear in that map and could not be selected as the group claim at all, however `oidc_group_claim` was set.

`roles` is the claim an operator is most likely to reach for. Frontegg emits it natively and populates it from group-to-role mappings, so mapping IdP groups to Frontegg roles and syncing those role names is the obvious configuration, and it needs no custom claim, no JWT prehook, and no group cache. Today that setting is accepted and then silently finds nothing: extraction returns `None`, which `maybe_sync_jwt_groups` treats as "claim absent, skip sync". That branch logs nothing and sends no client notice, so there is no signal anywhere that the configured claim is unreachable.

The OIDC authenticator does not have this problem. `OidcClaims` types only `iss`, `exp`, `iat`, and `aud`, so every other claim lands in its flatten map and resolves normally, `roles` included. The same `oidc_group_claim` value therefore selected different claims depending on the authenticator, which defeats the purpose of routing both through the shared `mz_auth::group_claims` extractor.

### Change

Resolve the claim path against a JSON view of the whole `Claims` struct rather than the flatten map alone. `Claims` already derives `Serialize` with `rename_all = "camelCase"`, so the reconstructed keys match the wire format.

The typed fields are left in place, `is_admin` reads `roles` directly. Nested untyped paths such as `customClaims.groups` keep resolving exactly as before. `roles` becomes reachable generically, with no special case for it.

### Tests

Adds `groups_from_typed_roles_claim` to the `frontegg-auth` unit tests, covering selection of a claim backed by a typed field. The existing `groups_absent_returns_none`, `groups_empty_returns_some_empty`, and `groups_populated_returns_some_values` cases continue to cover the untyped paths.

### Release notes

This release will allow `oidc_group_claim` to select any claim present in the JWT when using Frontegg authentication, including `roles`. Previously, claims that Materialize parses into typed fields, such as `roles` and `permissions`, could not be used as the group claim, and configuring one caused group-to-role sync to be skipped without any error or notice.