### PR TITLE
docs: add nofollow to View as Markdown links.

### DIFF
--- a/doc/user/layouts/_default/list.html
+++ b/doc/user/layouts/_default/list.html
@@ -7,7 +7,7 @@
     {{- if not (strings.HasSuffix $basePath "/") -}}{{- $basePath = printf "%s/" $basePath -}}{{- end -}}
     {{- $pagePath := .RelPermalink | strings.TrimPrefix $basePath -}}
     {{- $mdURL := printf "%smarkdown-docs/%sindex.md" $basePath $pagePath -}}
-    <a class="btn-ghost" href="{{ $mdURL }}">View as Markdown</a>
+    <a class="btn-ghost" href="{{ $mdURL }}" rel="nofollow">View as Markdown</a>
   </div>
 {{ end }}
 

--- a/doc/user/layouts/_default/single.html
+++ b/doc/user/layouts/_default/single.html
@@ -7,7 +7,7 @@
     {{- if not (strings.HasSuffix $basePath "/") -}}{{- $basePath = printf "%s/" $basePath -}}{{- end -}}
     {{- $pagePath := .RelPermalink | strings.TrimPrefix $basePath -}}
     {{- $mdURL := printf "%smarkdown-docs/%sindex.md" $basePath $pagePath -}}
-    <a class="btn-ghost" href="{{ $mdURL }}">View as Markdown</a>
+    <a class="btn-ghost" href="{{ $mdURL }}" rel="nofollow">View as Markdown</a>
   </div>
 {{ end }}
 


### PR DESCRIPTION
## Summary
- Adds `rel="nofollow"` to the "View as Markdown" links so HTML docs stop advertising `/docs/markdown-docs/` URLs to crawlers.
- Crawl blocking lives in www-temporary, which owns `https://materialize.com/robots.txt` the remainder of the changes are made there. 
