### PR TITLE
SS-441 Honor write.data.path when placing Iceberg data files

### DIFF
--- a/src/storage/src/sink/iceberg.rs
+++ b/src/storage/src/sink/iceberg.rs
@@ -1548,16 +1548,33 @@ fn write_data_files<'scope, H: EnvelopeHandler + 'static>(
                     .context("Failed to merge Materialize metadata into Iceberg schema")?,
                 );
 
-                // WORKAROUND: S3 Tables catalog incorrectly sets location to the metadata file path
-                // instead of the warehouse root. Strip off the /metadata/*.metadata.json suffix.
-                // No clear way to detect this properly right now, so we use heuristics.
-                let location = table_metadata.location();
-                let corrected_location = match location.rsplit_once("/metadata/") {
-                    Some((a, b)) if b.ends_with(".metadata.json") => a,
-                    _ => location,
-                };
-
-                let data_location = format!("{}/data", corrected_location);
+                // A catalog that manages where data files live advertises it through
+                // `write.data.path`. Honor it: catalogs backing an Iceberg table with
+                // their own storage layout reject a commit whose data files sit outside
+                // that path. Unity Catalog, for one, has to register the files in the
+                // Delta log that actually backs the table, and answers a commit
+                // referencing files under `<location>/data` with a 500.
+                //
+                // `DefaultLocationGenerator::new` reads these same properties, but its
+                // fallback misses the S3 Tables correction below, so choose explicitly.
+                let data_location = table_metadata
+                    .properties()
+                    .get("write.data.path")
+                    .or_else(|| table_metadata.properties().get("write.folder-storage.path"))
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        // WORKAROUND: S3 Tables catalog incorrectly sets location to the
+                        // metadata file path instead of the warehouse root. Strip off the
+                        // /metadata/*.metadata.json suffix. No clear way to detect this
+                        // properly right now, so we use heuristics.
+                        let location = table_metadata.location();
+                        let corrected_location = match location.rsplit_once("/metadata/") {
+                            Some((a, b)) if b.ends_with(".metadata.json") => a,
+                            _ => location,
+                        };
+                        format!("{}/data", corrected_location)
+                    });
+                debug!(%data_location, "iceberg sink data file location");
                 let location_generator =
                     DefaultLocationGenerator::with_data_location(data_location);
 


### PR DESCRIPTION
> **Top of a three-PR stack.** Base is `patrick/iceberg-vended` (#38181), which sits on `patrick/iceberg-unity-catalog` (#38373). Merge order: #38373, #38181, then this.

The Iceberg sink hardcoded its data-file location to `<table location>/data`, ignoring the `write.data.path` property the catalog advertises. Catalogs that manage their own storage layout reject a commit whose data files sit outside that path.

### How this surfaced

Unity Catalog's Iceberg tables are backed by Delta, so an Iceberg commit must be translated into a Delta commit that registers the incoming data files. Files written under `<location>/_iceberg/data` are outside the path it manages, and the commit fails server-side with nothing in the response identifying the cause:

```
500 Internal Server Error
{"error":{"message":"Could not process table operation. [ErrorCode: 2012]",
          "type":"ServiceFailureException","code":500}}
```

The sink retries five times and then stalls, so the symptom is a sink that writes data files happily and never commits.

Comparing against a client whose commits Unity Catalog accepts (DuckDB, writing to the same catalog) showed the difference: its data file sat at the table root, matching the advertised `write.data.path`, and its commit produced a new `_delta_log` entry. Ours sat a directory deeper under `_iceberg/data`, and no Delta commit was ever created.

The request body was not the problem — with the `mz-*` snapshot properties removed and the `assert-ref-snapshot-id` requirement dropped, an otherwise byte-standard commit still failed. Only the file placement mattered.

### The change

Prefer `write.data.path`, then `write.folder-storage.path`, and fall back to the previous `<location>/data` heuristic only when neither is set. That keeps the S3 Tables workaround intact, since it exists precisely for a catalog that does not advertise a data path.

`DefaultLocationGenerator::new` reads the same two properties, but its fallback lacks the S3 Tables correction, so the choice is made explicitly here rather than delegated to the library.

Also logs the resolved location at `debug`, because a wrong data path otherwise only manifests as an opaque catalog error at commit time.

### Testing

No new automated test. The existing `test/iceberg` Polaris setup exercises only the fallback path — Polaris does not set `write.data.path`, so those workflows cover the unchanged branch and should be unaffected. Verifying the new branch needs a catalog that advertises a data path, which the harness has no way to stand up today. Confirmed manually against a Unity Catalog managed table.

### Release notes

This release will fix Iceberg sinks failing to commit against catalogs that manage their own data-file layout, such as Databricks Unity Catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)