### PR TITLE
console: polish connect drawer copy, masking, and psql flow

### DIFF
--- a/console/src/components/connect/ConnectDrawer.test.tsx
+++ b/console/src/components/connect/ConnectDrawer.test.tsx
@@ -21,6 +21,7 @@ import {
   renderComponent,
   setFakeEnvironment,
 } from "~/test/utils";
+import { toBase64 } from "~/utils/format";
 import { parseDbVersion } from "~/version/api";
 
 import ConnectDrawer from "./ConnectDrawer";
@@ -49,6 +50,9 @@ describe("ConnectDrawer", () => {
     ).toBeVisible();
     expect(screen.getByText(/materialize-developer/)).toBeVisible();
     expect(screen.getByText("Install agent skills (optional)")).toBeVisible();
+    expect(
+      screen.getByText(/Agent skills give your coding agent access/),
+    ).toBeVisible();
   });
 
   it("switches MCP config format per client", async () => {
@@ -148,6 +152,15 @@ describe("ConnectDrawer", () => {
       await screen.findByText(/App password created and added to the command/),
     ).toBeVisible();
     expect(screen.getByText(/Authorization: Basic \*+/)).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "visibility" }));
+
+    const expectedToken = toBase64(
+      `${dummyValidUser.email}:mzp_${"1".repeat(32)}${"2".repeat(32)}`,
+    );
+    expect(
+      screen.getByText((content) => content.includes(expectedToken)),
+    ).toBeVisible();
   });
 
   it("shows connection details on the External tools tab", async () => {
@@ -228,6 +241,10 @@ describe("ConnectDrawer", () => {
           `psql "postgres://${encodeURIComponent(dummyValidUser.email)}@${ENVIRONMENT_HOST}:6875/materialize\\?sslmode=require"`,
         ),
       ),
+    ).toBeVisible();
+    expect(screen.getByText("Enter your password")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Create new password" }),
     ).toBeVisible();
   });
 });

--- a/console/src/components/connect/ConnectDrawer.tsx
+++ b/console/src/components/connect/ConnectDrawer.tsx
@@ -17,6 +17,7 @@ import SideDrawer from "~/components/SideDrawer";
 import { useAppConfig } from "~/config/useAppConfig";
 import { User } from "~/external-library-wrappers/frontegg";
 import { type AuthContextProps } from "~/external-library-wrappers/oidc";
+import { useHideIntercomLauncher } from "~/hooks/useIntercom";
 import { useSelfManagedProfile } from "~/hooks/useSelfManagedProfile";
 import { ConnectionIcon, MonitorIcon, TerminalIcon } from "~/icons";
 import { ClusterDetailParams } from "~/platform/clusters/ClusterRoutes";
@@ -233,6 +234,7 @@ const ConnectDrawer = ({
   forAppPassword,
 }: ConnectDrawerProps) => {
   const appConfig = useAppConfig();
+  useHideIntercomLauncher(isOpen);
 
   return (
     <SideDrawer

--- a/console/src/components/connect/ConnectExternalToolsPanel.tsx
+++ b/console/src/components/connect/ConnectExternalToolsPanel.tsx
@@ -7,26 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-import {
-  Box,
-  Button,
-  HStack,
-  Input,
-  Text,
-  useTheme,
-  VStack,
-} from "@chakra-ui/react";
+import { Box, HStack, useTheme, VStack } from "@chakra-ui/react";
 import React, { useState } from "react";
 
-import { SecretCopyableBox } from "~/components/copyableComponents";
-import TextLink from "~/components/TextLink";
-import { useCreateApiToken } from "~/queries/frontegg";
 import { MaterializeTheme } from "~/theme";
 import { obfuscateSecret } from "~/utils/format";
 
 import {
   ConnectionDetailRow,
   ConnectStep,
+  CreateAppPasswordRow,
+  IdTokenRow,
   LabeledCommandBox,
 } from "./connectComponents";
 import {
@@ -34,167 +25,6 @@ import {
   EXTERNAL_TOOLS,
   ExternalToolId,
 } from "./connectOptions";
-
-const DETAIL_LABEL_WIDTH = "88px";
-
-/** Inline app password creation: name it, create it, copy it once. */
-const CreateAppPasswordRow = ({
-  onCreated,
-}: {
-  onCreated: (password: string) => void;
-}) => {
-  const { colors } = useTheme<MaterializeTheme>();
-  const [isNaming, setIsNaming] = useState(false);
-  const [name, setName] = useState("");
-  const {
-    mutate: createAppPassword,
-    isPending,
-    data: newPassword,
-  } = useCreateApiToken();
-
-  React.useEffect(() => {
-    if (newPassword?.password) {
-      onCreated(newPassword.password);
-    }
-  }, [newPassword, onCreated]);
-
-  const create = () => {
-    if (name.trim().length === 0 || isPending) return;
-    createAppPassword({ type: "personal", description: name.trim() });
-  };
-
-  return (
-    <Box>
-      <HStack alignItems="center" spacing="3">
-        <Text
-          fontSize="sm"
-          color={colors.foreground.secondary}
-          w={DETAIL_LABEL_WIDTH}
-          flexShrink={0}
-        >
-          Password
-        </Text>
-        {newPassword?.password ? (
-          <SecretCopyableBox
-            label="Password"
-            contents={newPassword.password}
-            obfuscatedContent={newPassword.obfuscatedPassword}
-            overflow="hidden"
-            flex="1"
-            w="auto"
-            minWidth={0}
-          />
-        ) : isNaming ? (
-          <HStack spacing="2" flex="1">
-            <Input
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              maxW="220px"
-              isDisabled={isPending}
-              placeholder="Password name"
-              aria-label="App password name"
-              autoFocus
-              onKeyDown={(event) => {
-                if (event.key === "Enter") create();
-              }}
-            />
-            <Button
-              variant="primary"
-              size="sm"
-              px="3"
-              flexShrink={0}
-              isLoading={isPending}
-              loadingText="Creating"
-              isDisabled={name.trim().length === 0}
-              onClick={create}
-            >
-              Create
-            </Button>
-            <Button
-              variant="borderless"
-              size="sm"
-              flexShrink={0}
-              isDisabled={isPending}
-              onClick={() => {
-                setIsNaming(false);
-                setName("");
-              }}
-            >
-              Cancel
-            </Button>
-          </HStack>
-        ) : (
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => setIsNaming(true)}
-          >
-            Create new password
-          </Button>
-        )}
-      </HStack>
-      {isNaming && !newPassword?.password && (
-        <Text
-          fontSize="sm"
-          color={colors.foreground.secondary}
-          mt="1.5"
-          ml={`calc(${DETAIL_LABEL_WIDTH} + 12px)`}
-        >
-          You are naming this password. The password itself is generated for
-          you.
-        </Text>
-      )}
-      {newPassword?.password && (
-        <Text
-          fontSize="sm"
-          color={colors.foreground.secondary}
-          mt="1.5"
-          ml={`calc(${DETAIL_LABEL_WIDTH} + 12px)`}
-        >
-          Copy it now. It will not be shown again. Manage in{" "}
-          <TextLink href="/access/app-passwords">App Passwords</TextLink>.
-        </Text>
-      )}
-    </Box>
-  );
-};
-
-/** Self-managed OIDC deployments use the ID token as the SQL password. */
-const IdTokenRow = ({ idToken }: { idToken: string }) => {
-  const { colors } = useTheme<MaterializeTheme>();
-
-  return (
-    <Box>
-      <HStack alignItems="center" spacing="3">
-        <Text
-          fontSize="sm"
-          color={colors.foreground.secondary}
-          w={DETAIL_LABEL_WIDTH}
-          flexShrink={0}
-        >
-          Password
-        </Text>
-        <SecretCopyableBox
-          label="idToken"
-          contents={idToken}
-          obfuscatedContent={obfuscateSecret(idToken)}
-          overflow="hidden"
-          flex="1"
-          w="auto"
-          minWidth={0}
-        />
-      </HStack>
-      <Text
-        fontSize="sm"
-        color={colors.foreground.secondary}
-        mt="1.5"
-        ml={`calc(${DETAIL_LABEL_WIDTH} + 12px)`}
-      >
-        When prompted for a password, paste this ID token.
-      </Text>
-    </Box>
-  );
-};
 
 export interface ConnectExternalToolsPanelProps {
   ctx: ConnectContext;
@@ -219,9 +49,7 @@ export const ConnectExternalToolsPanel = ({
     password: createdPassword,
     ssl: ctx.ssl,
   });
-  // Mask the password in the rendered snippet. The copy button copies the
-  // real value.
-  const displaySnippet = createdPassword
+  const obfuscatedSnippet = createdPassword
     ? snippet.replaceAll(createdPassword, obfuscateSecret(createdPassword))
     : undefined;
 
@@ -277,7 +105,7 @@ export const ConnectExternalToolsPanel = ({
           <LabeledCommandBox
             label={tool.instruction}
             contents={snippet}
-            displayContents={displaySnippet}
+            obfuscatedContents={obfuscatedSnippet}
           />
         </VStack>
       </ConnectStep>

--- a/console/src/components/connect/ConnectMcpPanel.tsx
+++ b/console/src/components/connect/ConnectMcpPanel.tsx
@@ -293,9 +293,7 @@ export const ConnectMcpPanel = ({ ctx }: ConnectMcpPanelProps) => {
     baseUrl: ctx.mcpBaseUrl,
     token: oauthActive ? undefined : (mcpToken ?? MCP_TOKEN_PLACEHOLDER),
   });
-  // Mask the token in the rendered snippet. The copy button copies the real
-  // value.
-  const displaySnippet = mcpToken
+  const obfuscatedSnippet = mcpToken
     ? snippet.replace(mcpToken, obfuscateSecret(mcpToken))
     : undefined;
   const installLink =
@@ -333,7 +331,7 @@ export const ConnectMcpPanel = ({ ctx }: ConnectMcpPanelProps) => {
               : undefined
         }
         contents={snippet}
-        displayContents={displaySnippet}
+        obfuscatedContents={obfuscatedSnippet}
       />
       {ctx.oauthAvailable && (
         <HStack justifyContent="flex-end">
@@ -366,8 +364,8 @@ export const ConnectMcpPanel = ({ ctx }: ConnectMcpPanelProps) => {
   const skillsStep = (
     <VStack alignItems="stretch" spacing="2">
       <Text fontSize="sm" color={colors.foreground.secondary}>
-        Ready-made instructions that help your agent work with Materialize
-        accurately.
+        Agent skills give your coding agent access to Materialize documentation,
+        reference material, and best practices.
       </Text>
       <LabeledCommandBox contents={AGENT_SKILLS_COMMAND} />
     </VStack>

--- a/console/src/components/connect/ConnectTerminalPanel.tsx
+++ b/console/src/components/connect/ConnectTerminalPanel.tsx
@@ -12,7 +12,12 @@ import React from "react";
 
 import { MaterializeTheme } from "~/theme";
 
-import { LabeledCommandBox } from "./connectComponents";
+import {
+  ConnectStep,
+  CreateAppPasswordRow,
+  IdTokenRow,
+  LabeledCommandBox,
+} from "./connectComponents";
 import { buildPsqlCommand, ConnectContext } from "./connectOptions";
 
 export interface ConnectTerminalPanelProps {
@@ -34,17 +39,21 @@ export const ConnectTerminalPanel = ({ ctx }: ConnectTerminalPanelProps) => {
   );
 
   return (
-    <VStack alignItems="stretch" spacing="3">
-      <LabeledCommandBox
-        label="Run this in your terminal:"
-        contents={command}
-      />
-      {ctx.idToken && (
-        <Text fontSize="sm" color={colors.foreground.secondary}>
-          When prompted for a password, paste the ID token from the External
-          tools tab.
-        </Text>
-      )}
+    <VStack alignItems="stretch" spacing="0">
+      <ConnectStep stepNumber={1} title="Run this in your terminal">
+        <LabeledCommandBox contents={command} />
+      </ConnectStep>
+      <ConnectStep stepNumber={2} title="Enter your password" isLast>
+        {ctx.canCreateAppPassword ? (
+          <CreateAppPasswordRow />
+        ) : ctx.idToken ? (
+          <IdTokenRow idToken={ctx.idToken} />
+        ) : (
+          <Text fontSize="sm" color={colors.foreground.secondary}>
+            When prompted, enter the password you sign in with.
+          </Text>
+        )}
+      </ConnectStep>
     </VStack>
   );
 };

--- a/console/src/components/connect/connectComponents.tsx
+++ b/console/src/components/connect/connectComponents.tsx
@@ -7,11 +7,26 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-import { Box, Flex, HStack, Text, useTheme, VStack } from "@chakra-ui/react";
-import React from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  HStack,
+  Input,
+  Text,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
+import React, { useState } from "react";
 
-import { CopyableBox } from "~/components/copyableComponents";
+import {
+  CopyableBox,
+  SecretCopyableBox,
+} from "~/components/copyableComponents";
+import TextLink from "~/components/TextLink";
+import { useCreateApiToken } from "~/queries/frontegg";
 import { MaterializeTheme } from "~/theme";
+import { obfuscateSecret } from "~/utils/format";
 
 export interface ConnectStepProps {
   stepNumber: number;
@@ -64,16 +79,14 @@ export const ConnectStep = ({
 export interface LabeledCommandBoxProps {
   contents: string;
   label?: React.ReactNode;
-  /** Shown instead of `contents`, e.g. with secrets masked. Copying always
-   * copies `contents`. */
-  displayContents?: string;
+  obfuscatedContents?: string;
 }
 
 /** A copyable command or config snippet with an optional instruction above. */
 export const LabeledCommandBox = ({
   contents,
   label,
-  displayContents,
+  obfuscatedContents,
 }: LabeledCommandBoxProps) => {
   const { colors } = useTheme<MaterializeTheme>();
 
@@ -84,12 +97,17 @@ export const LabeledCommandBox = ({
           {label}
         </Text>
       )}
-      <CopyableBox variant="default" wrap contents={contents}>
-        {displayContents}
-      </CopyableBox>
+      <CopyableBox
+        variant="default"
+        wrap
+        contents={contents}
+        obfuscatedContents={obfuscatedContents}
+      />
     </VStack>
   );
 };
+
+const DETAIL_LABEL_WIDTH = "88px";
 
 export interface ConnectionDetailRowProps {
   label: string;
@@ -108,7 +126,7 @@ export const ConnectionDetailRow = ({
       <Text
         fontSize="sm"
         color={colors.foreground.secondary}
-        w="88px"
+        w={DETAIL_LABEL_WIDTH}
         flexShrink={0}
       >
         {label}
@@ -122,6 +140,171 @@ export const ConnectionDetailRow = ({
         w="auto"
       />
     </HStack>
+  );
+};
+
+export interface CreateAppPasswordRowProps {
+  onCreated?: (password: string) => void;
+}
+
+/** Inline app password creation: name it, create it, copy it once. */
+export const CreateAppPasswordRow = ({
+  onCreated,
+}: CreateAppPasswordRowProps) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const [isNaming, setIsNaming] = useState(false);
+  const [name, setName] = useState("");
+  const {
+    mutate: createAppPassword,
+    isPending,
+    data: newPassword,
+  } = useCreateApiToken();
+
+  React.useEffect(() => {
+    if (newPassword?.password) {
+      onCreated?.(newPassword.password);
+    }
+  }, [newPassword, onCreated]);
+
+  const create = () => {
+    if (name.trim().length === 0 || isPending) return;
+    createAppPassword({ type: "personal", description: name.trim() });
+  };
+
+  return (
+    <Box>
+      <HStack alignItems="center" spacing="3">
+        <Text
+          fontSize="sm"
+          color={colors.foreground.secondary}
+          w={DETAIL_LABEL_WIDTH}
+          flexShrink={0}
+        >
+          Password
+        </Text>
+        {newPassword?.password ? (
+          <SecretCopyableBox
+            label="Password"
+            contents={newPassword.password}
+            obfuscatedContent={newPassword.obfuscatedPassword}
+            overflow="hidden"
+            flex="1"
+            w="auto"
+            minWidth={0}
+          />
+        ) : isNaming ? (
+          <HStack spacing="2" flex="1">
+            <Input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              maxW="220px"
+              isDisabled={isPending}
+              placeholder="Password name"
+              aria-label="App password name"
+              autoFocus
+              onKeyDown={(event) => {
+                if (event.key === "Enter") create();
+              }}
+            />
+            <Button
+              variant="primary"
+              size="sm"
+              px="3"
+              flexShrink={0}
+              isLoading={isPending}
+              loadingText="Creating"
+              isDisabled={name.trim().length === 0}
+              onClick={create}
+            >
+              Create
+            </Button>
+            <Button
+              variant="borderless"
+              size="sm"
+              flexShrink={0}
+              isDisabled={isPending}
+              onClick={() => {
+                setIsNaming(false);
+                setName("");
+              }}
+            >
+              Cancel
+            </Button>
+          </HStack>
+        ) : (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setIsNaming(true)}
+          >
+            Create new password
+          </Button>
+        )}
+      </HStack>
+      {isNaming && !newPassword?.password && (
+        <Text
+          fontSize="sm"
+          color={colors.foreground.secondary}
+          mt="1.5"
+          ml={`calc(${DETAIL_LABEL_WIDTH} + 12px)`}
+        >
+          You are naming this password. The password itself is generated for
+          you.
+        </Text>
+      )}
+      {newPassword?.password && (
+        <Text
+          fontSize="sm"
+          color={colors.foreground.secondary}
+          mt="1.5"
+          ml={`calc(${DETAIL_LABEL_WIDTH} + 12px)`}
+        >
+          Copy it now. It will not be shown again. Manage in{" "}
+          <TextLink href="/access/app-passwords">App Passwords</TextLink>.
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+export interface IdTokenRowProps {
+  idToken: string;
+}
+
+/** Self-managed OIDC deployments use the ID token as the SQL password. */
+export const IdTokenRow = ({ idToken }: IdTokenRowProps) => {
+  const { colors } = useTheme<MaterializeTheme>();
+
+  return (
+    <Box>
+      <HStack alignItems="center" spacing="3">
+        <Text
+          fontSize="sm"
+          color={colors.foreground.secondary}
+          w={DETAIL_LABEL_WIDTH}
+          flexShrink={0}
+        >
+          Password
+        </Text>
+        <SecretCopyableBox
+          label="idToken"
+          contents={idToken}
+          obfuscatedContent={obfuscateSecret(idToken)}
+          overflow="hidden"
+          flex="1"
+          w="auto"
+          minWidth={0}
+        />
+      </HStack>
+      <Text
+        fontSize="sm"
+        color={colors.foreground.secondary}
+        mt="1.5"
+        ml={`calc(${DETAIL_LABEL_WIDTH} + 12px)`}
+      >
+        When prompted for a password, paste this ID token.
+      </Text>
+    </Box>
   );
 };
 

--- a/console/src/components/copyableComponents.tsx
+++ b/console/src/components/copyableComponents.tsx
@@ -97,6 +97,7 @@ export const CopyButton: React.FC<
 
 export interface CopyableBoxProps extends BoxProps {
   contents: string;
+  obfuscatedContents?: string;
   variant?: "default" | "compact";
   maxHeight?: string;
   wrap?: boolean;
@@ -105,6 +106,7 @@ export interface CopyableBoxProps extends BoxProps {
 /** Copyable component with a bg box but no line breaks  */
 export const CopyableBox: React.FC<CopyableBoxProps> = ({
   contents,
+  obfuscatedContents,
   variant = "default",
   maxHeight,
   wrap,
@@ -112,9 +114,10 @@ export const CopyableBox: React.FC<CopyableBoxProps> = ({
   ...props
 }) => {
   const { colors } = useTheme<MaterializeTheme>();
+  const [showContents, setShowContents] = useState(false);
   return (
     <HStack
-      alignItems="center"
+      alignItems={wrap ? "flex-start" : "center"}
       spacing={0}
       borderRadius="lg"
       bg={colors.background.secondary}
@@ -140,13 +143,23 @@ export const CopyableBox: React.FC<CopyableBoxProps> = ({
           overflow: "auto",
         })}
       >
-        {props.children ?? contents}
+        {props.children ??
+          (obfuscatedContents && !showContents ? obfuscatedContents : contents)}
       </Box>
+      {obfuscatedContents && (
+        <IconButton
+          variant="transparent"
+          size={variant === "compact" ? "sm" : "md"}
+          aria-label="visibility"
+          icon={showContents ? <EyeOpenIcon /> : <EyeClosedIcon />}
+          onClick={() => setShowContents(!showContents)}
+        />
+      )}
       <CopyButton
         fontSize="md"
         contents={contents}
         size={variant === "compact" ? "sm" : "md"}
-        minH="full"
+        minH={wrap ? undefined : "full"}
         onCopy={onCopy}
       />
     </HStack>

--- a/console/src/hooks/useIntercom.ts
+++ b/console/src/hooks/useIntercom.ts
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-import Intercom from "@intercom/messenger-js-sdk";
+import Intercom, { update } from "@intercom/messenger-js-sdk";
 import { useEffect } from "react";
 
 import { useIntercomJwt } from "~/api/auth";
@@ -31,6 +31,14 @@ export function useIntercom() {
       Intercom({ app_id: APP_ID, intercom_user_jwt: jwt });
     }
   }, [jwt]);
+}
+
+export function useHideIntercomLauncher(hidden: boolean) {
+  useEffect(() => {
+    if (!hidden || !window.Intercom) return;
+    update({ hide_default_launcher: true });
+    return () => update({ hide_default_launcher: false });
+  }, [hidden]);
 }
 
 export default useIntercom;


### PR DESCRIPTION
### Motivation

Feedback fixes for the connect drawer:

* The copy button in multi-line command boxes was vertically centered; it now sits in the top right.
* Command boxes that render masked secrets (the MCP token command, external tool snippets with a created password) now have an unmask toggle, mirroring the app password box.
* The Terminal tab is now numbered steps: run the psql command, then enter your password. The password step offers the same inline "Create new password" flow as the External tools tab (or the ID token on self-managed OIDC).
* The agent skills step now describes what agent skills are.
* The Intercom launcher floats above the drawer and covered the last step's copy button; it is hidden while the drawer is open and restored on close.

`CreateAppPasswordRow` and `IdTokenRow` moved unchanged from the External tools panel into the shared `connectComponents.tsx` so the Terminal tab can reuse them.

### Tips for reviewer

The launcher hiding uses Intercom's `hide_default_launcher` setting rather than z-index because the launcher stacks above Chakra's modal layer. It no-ops when Intercom is not loaded (self-managed).

### Testing

* Extended `ConnectDrawer.test.tsx`: the unmask toggle reveals the real token in the MCP command, and the Terminal tab shows the password step with the create-password flow.


## Verification:
<img width="1278" height="1688" alt="image" src="https://github.com/user-attachments/assets/796748a9-91f6-482c-a22e-c27cb6f49af9" />


- Copy button positioned in the middle of the copy box 
- Matty not blocking the modal 
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)