### PR TITLE
sql: graduate the bounded staleness isolation level

### DIFF
--- a/doc/user/content/reference/isolation-level.md
+++ b/doc/user/content/reference/isolation-level.md
@@ -33,7 +33,7 @@ against Materialize:
 | --- | --- |
 | [**Strict Serializable**](#strict-serializable) | **Default.** Provides serializability and linearizability. |
 | [**Serializable**](#serializable) | Provides serializability but not linearizability. |
-| [**Bounded Staleness `<duration>`**](#bounded-staleness) | **Public preview.** Serves reads at a timestamp at most `<duration>` stale; never blocks, errors if the bound cannot be met. |
+| [**Bounded Staleness `<duration>`**](#bounded-staleness) | Serves reads at a timestamp at most `<duration>` stale; never blocks, errors if the bound cannot be met. |
 | Read Uncommitted, Read Committed, Repeatable Read | Accepted for compatibility; treated as Serializable. |
 {{< /if-released >}}
 
@@ -155,8 +155,6 @@ made available to us (e.g., querying PostgreSQL for the replication slot's LSN).
 
 {{< if-released "v26.29" >}}
 ## Bounded Staleness
-
-{{< public-preview />}}
 
 The Bounded Staleness isolation level lets you trade exact freshness for
 predictable latency. A query under bounded staleness is served at a timestamp

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2679,15 +2679,10 @@ class BoundedStalenessReadAction(Action):
     restored afterwards, since bounded staleness is read-only and would break
     writes."""
 
-    def applicable(self, exe: Executor) -> bool:
-        return exe.db.flags.get("enable_bounded_staleness_isolation", "FALSE") == "TRUE"
-
     def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
         result.extend(
             [
-                # The flag was flipped off between applicable() and run().
-                "is not available",
                 # The freshness bound could not be met. Bounded staleness
                 # never blocks, it errors instead.
                 "not been materialized",
@@ -2988,9 +2983,6 @@ class FlipFlagsAction(Action):
         )
         self.flags_with_values["enable_compute_error_distinct"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_alter_table_add_column"] = BOOLEAN_FLAG_VALUES
-        self.flags_with_values["enable_bounded_staleness_isolation"] = (
-            BOOLEAN_FLAG_VALUES
-        )
         self.flags_with_values["enable_arrangement_dictionary_compression_alpha"] = (
             BOOLEAN_FLAG_VALUES
         )

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1084,9 +1084,9 @@ impl Coordinator {
 
         // If the resolved `transaction_isolation` default names a feature-flagged
         // isolation level whose flag is now disabled (e.g. a role default set
-        // while `bounded staleness` was enabled, then the flag turned off), drop
-        // it so the session falls back to the built-in default rather than
-        // silently using a gated level.
+        // while `strong session serializable` was enabled, then the flag turned
+        // off), drop it so the session falls back to the built-in default rather
+        // than silently using a gated level.
         if let Some(value) = session_defaults.get(TRANSACTION_ISOLATION_VAR_NAME) {
             if check_transaction_isolation_feature_flag(
                 TRANSACTION_ISOLATION_VAR_NAME,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1023,8 +1023,7 @@ fn compat_translate_name(name: &str) -> &str {
 }
 
 /// Enforces feature-flag gating for `transaction_isolation` levels that sit
-/// behind a flag (`bounded staleness <duration>` and
-/// `strong session serializable`).
+/// behind a flag (`strong session serializable`).
 ///
 /// Returns `Ok(())` for any other variable, and for an unparseable value
 /// (parse errors surface on the actual set). This is shared by every path that
@@ -1045,9 +1044,6 @@ pub fn check_transaction_isolation_feature_flag(
     };
     match level {
         IsolationLevel::StrongSessionSerializable => ENABLE_SESSION_TIMELINES.require(system_vars),
-        IsolationLevel::BoundedStaleness(_) => {
-            ENABLE_BOUNDED_STALENESS_ISOLATION.require(system_vars)
-        }
         _ => Ok(()),
     }
 }
@@ -2613,46 +2609,49 @@ mod isolation_feature_flag_tests {
     use super::*;
 
     #[mz_ore::test]
-    fn gates_bounded_staleness_value() {
+    fn gates_strong_session_serializable_value() {
         let mut system_vars = SystemVars::new();
 
-        // Default-on: the value passes the gate.
-        check_transaction_isolation_feature_flag(
-            TRANSACTION_ISOLATION_VAR_NAME,
-            VarInput::Flat("bounded staleness 5s"),
-            &system_vars,
-        )
-        .expect("flag on by default");
-
-        // Turn the flag off: the value is rejected regardless of the letter case
-        // of the variable name. This covers `SET`, `SET "TRANSACTION_ISOLATION"`,
-        // `ALTER ROLE ... SET`, and connection options, which all route through
-        // `SessionVars::set` and this shared check.
-        system_vars
-            .set("enable_bounded_staleness_isolation", VarInput::Flat("off"))
-            .expect("set flag");
+        // The flag defaults off: the value is rejected regardless of the letter
+        // case of the variable name. This covers `SET`,
+        // `SET "TRANSACTION_ISOLATION"`, `ALTER ROLE ... SET`, and connection
+        // options, which all route through `SessionVars::set` and this shared
+        // check.
         for name in ["transaction_isolation", "TRANSACTION_ISOLATION"] {
             let err = check_transaction_isolation_feature_flag(
                 name,
-                VarInput::Flat("bounded staleness 5s"),
+                VarInput::Flat("strong session serializable"),
                 &system_vars,
             )
-            .expect_err("flag off rejects bounded staleness");
+            .expect_err("flag off rejects strong session serializable");
             assert!(matches!(err, VarError::RequiresFeatureFlag { .. }));
         }
 
-        // Non-gated levels are unaffected.
+        // Ungated levels pass regardless of the flag.
+        for level in ["serializable", "bounded staleness 5s"] {
+            check_transaction_isolation_feature_flag(
+                TRANSACTION_ISOLATION_VAR_NAME,
+                VarInput::Flat(level),
+                &system_vars,
+            )
+            .expect("ungated level always allowed");
+        }
+
+        // With the flag on, the gated value passes too.
+        system_vars
+            .set("enable_session_timelines", VarInput::Flat("on"))
+            .expect("set flag");
         check_transaction_isolation_feature_flag(
             TRANSACTION_ISOLATION_VAR_NAME,
-            VarInput::Flat("serializable"),
+            VarInput::Flat("strong session serializable"),
             &system_vars,
         )
-        .expect("serializable always allowed");
+        .expect("flag on");
 
         // Unrelated variables are ignored, even with a gated-looking value.
         check_transaction_isolation_feature_flag(
             CLUSTER.name(),
-            VarInput::Flat("bounded staleness 5s"),
+            VarInput::Flat("strong session serializable"),
             &system_vars,
         )
         .expect("unrelated var ignored");

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2373,12 +2373,6 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
-    {
-        name: enable_bounded_staleness_isolation,
-        desc: "the `bounded staleness <duration>` transaction isolation level",
-        default: true,
-        enable_for_item_parsing: false,
-    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -239,7 +239,6 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_background_alter_cluster
     enable_statement_arrival_logging
     enable_binary_date_bin
-    enable_bounded_staleness_isolation
     enable_coalesce_case_transform
     enable_compute_half_join2
     enable_compute_render_fueled_as_specific_collection

--- a/test/sqllogictest/bounded_staleness.slt
+++ b/test/sqllogictest/bounded_staleness.slt
@@ -13,11 +13,6 @@ mode cockroach
 
 reset-server
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_bounded_staleness_isolation = true;
-----
-COMPLETE 0
-
 # --- parse and SHOW round-trip -----------------------------------------------
 
 statement ok
@@ -229,70 +224,19 @@ RESET transaction_isolation
 statement ok
 DROP TABLE bs_copy
 
-# --- feature-flag gating ------------------------------------------------------
+# --- role default -------------------------------------------------------------
 #
-# The flag defaults to `true` in public preview; explicitly turn it off here to
-# exercise the gating path.
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_bounded_staleness_isolation = false;
-----
-COMPLETE 0
-
-statement error the `bounded staleness <duration>` transaction isolation level is not available
-SET transaction_isolation TO 'bounded staleness 5s'
-
-# The gate must not be bypassable via a quoted, upper-cased variable name.
-statement error the `bounded staleness <duration>` transaction isolation level is not available
-SET "TRANSACTION_ISOLATION" TO 'bounded staleness 5s'
-
-# ... nor via `ALTER ROLE ... SET`.
-statement error the `bounded staleness <duration>` transaction isolation level is not available
-ALTER ROLE materialize SET transaction_isolation = 'bounded staleness 5s'
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_bounded_staleness_isolation = true;
-----
-COMPLETE 0
-
-statement ok
-SET transaction_isolation TO 'bounded staleness 5s'
-
-statement ok
-RESET transaction_isolation
-
-# --- role-default fallback when the flag is later disabled --------------------
-#
-# A role default set while the flag is on must not silently take effect once the
-# flag is turned off; fresh sessions fall back to the built-in default.
+# `ALTER ROLE ... SET` accepts the level, and a fresh session picks it up as its
+# starting isolation.
 
 statement ok
 ALTER ROLE materialize SET transaction_isolation = 'bounded staleness 5s'
 
-# A fresh session picks up the role default while the flag is on.
-simple conn=role_on,user=materialize
+simple conn=role_default,user=materialize
 SHOW transaction_isolation
 ----
 bounded staleness 5s
 COMPLETE 1
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_bounded_staleness_isolation = false;
-----
-COMPLETE 0
-
-# With the flag off, a fresh session falls back to the built-in default rather
-# than applying the gated role default.
-simple conn=role_off,user=materialize
-SHOW transaction_isolation
-----
-strict serializable
-COMPLETE 1
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_bounded_staleness_isolation = true;
-----
-COMPLETE 0
 
 statement ok
 ALTER ROLE materialize RESET transaction_isolation

--- a/test/testdrive/bounded-staleness.td
+++ b/test/testdrive/bounded-staleness.td
@@ -9,9 +9,6 @@
 
 # Bounded staleness isolation — happy-path coverage.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_bounded_staleness_isolation = true
-
 > CREATE TABLE bs_t (a int);
 > INSERT INTO bs_t VALUES (1), (2), (3);
 


### PR DESCRIPTION
### Motivation

`bounded staleness <duration>` shipped in v26.29 behind
`enable_bounded_staleness_isolation`, which has been defaulting on since. The
level is documented as public preview and still carries the gating machinery
that a preview needs. This graduates it: the flag goes away and the docs drop
the preview annotation, so bounded staleness is a supported part of the
`transaction_isolation` surface.

### Description

* Removes `enable_bounded_staleness_isolation` from the feature-flag table.
  `check_transaction_isolation_feature_flag` now gates only `strong session
  serializable`, which is still flagged behind `enable_session_timelines`. The
  shared check and the session-default scrub in `command_handler` therefore
  stay in place; only the bounded staleness arm and the comment's example
  change.
* An environment that persisted the removed parameter via `ALTER SYSTEM` is
  unaffected: an unknown system parameter in catalog storage is warned about
  and ignored at startup (`catalog/apply.rs`, `catalog/open.rs`).
* Drops `{{< public-preview />}}` and the **Public preview.** cell from the
  isolation-level reference. The `{{< if-released "v26.29" >}}` guards are kept,
  since older Self-Managed versions still lack the level entirely.
* Parallel workload no longer gates `BoundedStalenessReadAction` on the flag or
  flips the flag, and the flag leaves the LaunchDarkly consistency allowlist
  (it never had an LD flag, so it was listed under `KNOWN_MISSING_FROM_LD`).

Not included: a release-note entry in `doc/user/content/releases/_index.md`.
That file has no section for the in-flight version, so the GA note belongs with
the release-notes commit for whichever release this lands in.

### Verification

* `test/sqllogictest/bounded_staleness.slt` loses the feature-flag sections and
  keeps the role-default coverage: `ALTER ROLE ... SET` of the level, and a
  fresh session picking it up as its starting isolation.
* `test/testdrive/bounded-staleness.td` no longer enables the flag; the
  happy-path coverage is otherwise unchanged.
* The `mz-sql` unit test for the shared isolation gate now exercises `strong
  session serializable` (rejected with the flag off, accepted with it on) and
  asserts bounded staleness passes ungated.

Release note: This release makes the bounded staleness isolation level
generally available.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfeCp5oXaZ9RayUSdD5aJb)_