### PR TITLE
cluster spec sheet: make the MySQL seeding instructions bloat-proof

### DIFF
--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -2161,6 +2161,7 @@ class SourceIngestionScenario(ClusterScalingScenario):
         #         UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) h
         # ) nums
         # WHERE n BETWEEN 1 AND 50000000;
+        # OPTIMIZE TABLE tbl;
 
         # Kafka (Confluent)
         # node /usr/local/bin/datagen -f avro -n 50000000 -w 0 -p qa_cluster_spec_sheet -s table.json


### PR DESCRIPTION
### Motivation

Old single-threaded snapshots would run count(*) then read all rows in a table in just 4m. Now it takes 3m30s just to run a count(*), which likely accounts for the performance regression flagged here: https://linear.app/materializeinc/issue/QAR-144/mysql-ingestion-performance-extremely-bad-on-large-cluster-50x-bad-on.

Specific trigger is unclear but I suspect the data was re-inserted fragmented whereas historically someone had run OPTIMIZE TABLE tbl before. I want to try to get the table into a consistent state across reseeds.

### Changes

Add an OPTIMIZE TABLE tbl to ensure the table is more consistently densly packed.
