### PR TITLE
CNS-139: docs: document query history and statement logging for self-managed

### DIFF
--- a/doc/user/content/console/monitoring.md
+++ b/doc/user/content/console/monitoring.md
@@ -20,6 +20,6 @@ The **Monitoring** section contains the following screens:
 | Feature | Description |
 |---------|-------------|
 | **Environment Overview** | Review the health of your environment. |
-| **Query History** | Access your query history. |
+| **Query History** | Access your query history. Query history is sampled; in self-managed deployments the sample rate is configurable. See [Query History](/self-managed-deployments/query-history/). |
 | **Sources** | Review your sources. You can select a source to go to its [Database object explorer page](/console/data/). |
 | **Sinks** | Review your sinks. You can select a sink to go to its [Database object explorer page](/console/data/). |

--- a/doc/user/content/console/monitoring.md
+++ b/doc/user/content/console/monitoring.md
@@ -20,6 +20,6 @@ The **Monitoring** section contains the following screens:
 | Feature | Description |
 |---------|-------------|
 | **Environment Overview** | Review the health of your environment. |
-| **Query History** | Access your query history. Query history is sampled; in self-managed deployments the sample rate is configurable. See [Query History](/self-managed-deployments/query-history/). |
+| **Query History** | Access your query history. Query history is sampled. In self-managed deployments, the sample rate is configurable. See [Query History](/self-managed-deployments/query-history/). |
 | **Sources** | Review your sources. You can select a source to go to its [Database object explorer page](/console/data/). |
 | **Sinks** | Review your sinks. You can select a sink to go to its [Database object explorer page](/console/data/). |

--- a/doc/user/content/reference/system-catalog/mz_internal.md
+++ b/doc/user/content/reference/system-catalog/mz_internal.md
@@ -1395,7 +1395,7 @@ logging an execution is controlled by the
 to log nothing; a value of 0.8 means to log approximately 80% of
 statement executions. If `statement_logging_sample_rate` is higher
 than `statement_logging_max_sample_rate`, the latter is used instead. In
-Materialize Cloud, that cap is set by Materialize; in self-managed deployments,
+Materialize Cloud, that cap is set by Materialize. In self-managed deployments,
 it is set by the operator.
 
 | Field                   | Type                         | Meaning                                                                                                                                                                                                                                                                                                    |

--- a/doc/user/content/reference/system-catalog/mz_internal.md
+++ b/doc/user/content/reference/system-catalog/mz_internal.md
@@ -37,9 +37,11 @@ The `mz_object_global_ids` table maps Materialize catalog item IDs to global IDs
 {{< public-preview />}}
 
 {{< warning >}}
-Do not rely on all statements being logged in this view. Materialize
-controls the maximum rate at which statements are sampled, and may change
-this rate at any time.
+Do not rely on all statements being logged in this view. The maximum rate at
+which statements are sampled is capped by the
+`statement_logging_max_sample_rate` system parameter. In Materialize Cloud,
+Materialize controls this cap and may change it at any time. In self-managed
+deployments, it is set by the operator.
 {{< /warning >}}
 
 {{< warning >}}
@@ -54,8 +56,11 @@ Entries in this log may be sampled. The sampling rate is controlled by
 the configuration parameter `statement_logging_sample_rate`, which may be set
 to any value between 0 and 1. For example, to disable statement
 logging entirely for a session, execute `SET
-statement_logging_sample_rate TO 0`. Materialize may apply a lower
-sampling rate than the one set in this parameter.
+statement_logging_sample_rate TO 0`. The effective rate is the lower of this
+parameter and the `statement_logging_max_sample_rate` system parameter, so a
+lower cap may apply than the one set here. In self-managed deployments, see
+[Query History](/self-managed-deployments/query-history/) for how to configure
+the cap.
 
 The view can be accessed by Materialize _superusers_ or users that have been
 granted the [`mz_monitor` role](/security/appendix/appendix-built-in-roles/#system-catalog-roles).
@@ -1389,8 +1394,9 @@ logging an execution is controlled by the
 `statement_logging_sample_rate` configuration parameter. A value of 0 means
 to log nothing; a value of 0.8 means to log approximately 80% of
 statement executions. If `statement_logging_sample_rate` is higher
-than `statement_logging_max_sample_rate` (which is set by Materialize
-and cannot be changed by users), the latter is used instead.
+than `statement_logging_max_sample_rate`, the latter is used instead. In
+Materialize Cloud, that cap is set by Materialize; in self-managed deployments,
+it is set by the operator.
 
 | Field                   | Type                         | Meaning                                                                                                                                                                                                                                                                                                    |
 |-------------------------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/doc/user/content/self-managed-deployments/configuration-system-parameters.md
+++ b/doc/user/content/self-managed-deployments/configuration-system-parameters.md
@@ -211,7 +211,7 @@ The following are some commonly configured system parameters:
 | `max_clusters` | Maximum number of clusters in the region |
 | `max_sources` | Maximum number of sources in the region |
 | `max_sinks` | Maximum number of sinks in the region |
-| `statement_logging_max_sample_rate` | Cap on the fraction of statements recorded in [query history](/self-managed-deployments/query-history/) |
+| `statement_logging_max_sample_rate` | Cap on the fraction of statements recorded in [query history](/self-managed-deployments/query-history/). Setting it here overrides the Helm chart value. |
 
 For a complete list of available system parameters and their descriptions, see
 the [configuration parameters](/sql/alter-system-set/#key-configuration-parameters)
@@ -252,27 +252,6 @@ data:
   system-params.json: |
     {
       "allowed_cluster_replica_sizes": "'25cc', '50cc', '100cc', '200cc'"
-    }
-```
-
-### Sample ConfigMap: Configuring the Query History Sample Rate
-
-The following sample ConfigMap YAML sets the
-`statement_logging_max_sample_rate` parameter, which caps the fraction of
-statements recorded in [query
-history](/self-managed-deployments/query-history/). A value set here overrides
-the Helm chart's default and persists in the catalog:
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: mz-system-params
-  namespace: materialize-environment
-data:
-  system-params.json: |
-    {
-      "statement_logging_max_sample_rate": 0.5
     }
 ```
 

--- a/doc/user/content/self-managed-deployments/configuration-system-parameters.md
+++ b/doc/user/content/self-managed-deployments/configuration-system-parameters.md
@@ -211,6 +211,7 @@ The following are some commonly configured system parameters:
 | `max_clusters` | Maximum number of clusters in the region |
 | `max_sources` | Maximum number of sources in the region |
 | `max_sinks` | Maximum number of sinks in the region |
+| `statement_logging_max_sample_rate` | Cap on the fraction of statements recorded in [query history](/self-managed-deployments/query-history/) |
 
 For a complete list of available system parameters and their descriptions, see
 the [configuration parameters](/sql/alter-system-set/#key-configuration-parameters)
@@ -251,6 +252,27 @@ data:
   system-params.json: |
     {
       "allowed_cluster_replica_sizes": "'25cc', '50cc', '100cc', '200cc'"
+    }
+```
+
+### Sample ConfigMap: Configuring the Query History Sample Rate
+
+The following sample ConfigMap YAML sets the
+`statement_logging_max_sample_rate` parameter, which caps the fraction of
+statements recorded in [query
+history](/self-managed-deployments/query-history/). A value set here overrides
+the Helm chart's default and persists in the catalog:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mz-system-params
+  namespace: materialize-environment
+data:
+  system-params.json: |
+    {
+      "statement_logging_max_sample_rate": 0.5
     }
 ```
 
@@ -311,6 +333,7 @@ kubectl logs -l app=environmentd -n materialize-environment | grep -i "system.*p
 
 ## See also
 
+- [Query History](/self-managed-deployments/query-history/)
 - [Materialize Operator Configuration](/installation/configuration/)
 - [Materialize CRD Field Descriptions](/installation/appendix-materialize-crd-field-descriptions/)
 - [Troubleshooting](/installation/troubleshooting/)

--- a/doc/user/content/self-managed-deployments/configuration-system-parameters.md
+++ b/doc/user/content/self-managed-deployments/configuration-system-parameters.md
@@ -212,6 +212,7 @@ The following are some commonly configured system parameters:
 | `max_sources` | Maximum number of sources in the region |
 | `max_sinks` | Maximum number of sinks in the region |
 | `statement_logging_max_sample_rate` | Cap on the fraction of statements recorded in [query history](/self-managed-deployments/query-history/). Setting it here overrides the Helm chart value. |
+| `statement_logging_target_data_rate` | Sustained bytes per second that statement logging may write. Bounds query history growth on busy instances. |
 
 For a complete list of available system parameters and their descriptions, see
 the [configuration parameters](/sql/alter-system-set/#key-configuration-parameters)

--- a/doc/user/content/self-managed-deployments/query-history.md
+++ b/doc/user/content/self-managed-deployments/query-history.md
@@ -1,0 +1,149 @@
+---
+title: "Query History"
+description: "How query history and statement logging are configured in self-managed Materialize deployments"
+menu:
+  main:
+    parent: "sm-deployments"
+    weight: 72
+---
+
+The Materialize Console includes a **Query History** view, under its
+[**Monitoring**](/console/monitoring/) section, that lists the SQL statements
+recently issued to your Materialize instance along with their duration, status,
+and the cluster that ran them. Query history is available in self-managed
+deployments and is enabled by default.
+
+Query history is backed by *statement logging*: Materialize records a randomly
+sampled fraction of statement executions into the system catalog, most visibly
+[`mz_recent_activity_log`](/reference/system-catalog/mz_internal/#mz_recent_activity_log).
+Sampling means the view is a representative sample of your workload rather than
+a complete audit log.
+
+To see query history in the Console, connect as a Materialize *superuser* or as
+a user granted the [`mz_monitor`
+role](/security/appendix/appendix-built-in-roles/#system-catalog-roles).
+
+## Default sample rate
+
+The Materialize operator Helm chart sets the
+`operator.args.statementLoggingMaxSampleRate` value to `0.1`, so roughly 10% of
+statement executions are logged.
+
+This value is lower than `environmentd`'s own default of `0.99`. Statement
+logging costs CPU on `environmentd` and storage for the retained history, and
+that overhead is most noticeable on the small instances typical of self-managed
+deployments, so the chart samples a fraction of statements instead.
+
+The rate that actually applies to a statement is the smaller of two parameters:
+
+| Parameter | Scope | Meaning |
+|-----------|-------|---------|
+| `statement_logging_sample_rate` | Session | The rate a session asks for. Users may lower it with `SET`. |
+| `statement_logging_max_sample_rate` | System | A cap on the above. The chart value sets this. |
+
+Because the system parameter is a cap, lowering it reduces logging for every
+session regardless of what individual sessions request.
+
+## Tune the sample rate
+
+There are two places to change the maximum sample rate. They interact, so read
+the note on precedence below before picking one.
+
+### Using the Helm chart
+
+Set `operator.args.statementLoggingMaxSampleRate` when installing or upgrading
+the operator:
+
+```shell
+helm upgrade my-materialize-operator materialize/materialize-operator \
+  --set operator.args.statementLoggingMaxSampleRate=0.5
+```
+
+Or, in your `values.yaml`:
+
+```yaml
+operator:
+  args:
+    statementLoggingMaxSampleRate: 0.5
+```
+
+Setting the value to `0` disables statement logging entirely, which leaves the
+Console's Query History view empty. Setting it to `null` inherits
+`environmentd`'s default of `0.99`.
+
+The operator passes this value to `environmentd` as the *default* for
+`statement_logging_max_sample_rate`. Changing it requires a rollout of the
+Materialize instance to take effect. For the full list of chart values, see
+[Materialize Operator
+Configuration](/self-managed-deployments/operator-configuration/).
+
+### Using system parameters
+
+Because the chart value is only a default, you can override it at runtime
+without a rollout, either through the `system-params.json` ConfigMap described
+in [Configuring System
+Parameters](/self-managed-deployments/configuration-system-parameters/):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mz-system-params
+  namespace: materialize-environment
+data:
+  system-params.json: |
+    {
+      "statement_logging_max_sample_rate": 0.5
+    }
+```
+
+Or with [`ALTER SYSTEM SET`](/sql/alter-system-set/), as a superuser:
+
+```sql
+ALTER SYSTEM SET statement_logging_max_sample_rate = 0.5;
+```
+
+{{< note >}}
+A value set through the ConfigMap or `ALTER SYSTEM SET` is stored in the catalog
+and takes precedence over the Helm chart value, which is only a default. While
+such an override is in place, editing
+`operator.args.statementLoggingMaxSampleRate` has no effect.
+
+To go back to the chart-provided value, first remove the parameter from the
+ConfigMap, then run `ALTER SYSTEM RESET statement_logging_max_sample_rate`.
+Removing it from the ConfigMap alone is not enough, because the last synced
+value remains in the catalog. Resetting it while it is still in the ConfigMap is
+also not enough, because the sync loop reapplies it.
+{{< /note >}}
+
+To check the rate currently in effect:
+
+```sql
+SHOW statement_logging_max_sample_rate;
+```
+
+## Cost of raising the sample rate
+
+Raising the sample rate gives more complete query history at the cost of:
+
+- **CPU on `environmentd`**: every logged execution is prepared and written by
+  the control plane, so the overhead scales with your statement throughput, not
+  with your data volume. Instances serving many short queries pay the most.
+
+- **Storage**: logged statements, including their SQL text, are retained in the
+  system catalog and consume space in your blob storage and metadata backend.
+
+Workloads dominated by a high rate of small, fast queries are the ones where a
+high sample rate is most likely to be felt. If you raise the rate, do it
+incrementally and watch `environmentd` CPU utilization. Sampling at `1.0` logs
+every statement and is best reserved for short debugging sessions.
+
+## See also
+
+- [Console monitoring](/console/monitoring/)
+- [`mz_internal` statement logging
+  relations](/reference/system-catalog/mz_internal/#mz_recent_activity_log)
+- [Configuring System
+  Parameters](/self-managed-deployments/configuration-system-parameters/)
+- [Materialize Operator
+  Configuration](/self-managed-deployments/operator-configuration/)

--- a/doc/user/content/self-managed-deployments/query-history.md
+++ b/doc/user/content/self-managed-deployments/query-history.md
@@ -31,9 +31,8 @@ role](/security/appendix/appendix-built-in-roles/#system-catalog-roles).
 The Materialize operator Helm chart sets
 `operator.args.statementLoggingMaxSampleRate` to `0.99`, and leaves
 `operator.args.statementLoggingTargetDataRate` unset so that `environmentd`'s
-own default of 2071 bytes per second applies. Both are the values Materialize
-Cloud runs at, so query history in a self-managed deployment behaves the same as
-in Cloud out of the box.
+own default of 2071 bytes per second applies. Statement logging is therefore on
+by default, sampling nearly every statement up to the byte rate below.
 
 The rate that actually applies to a statement is the smaller of two parameters:
 

--- a/doc/user/content/self-managed-deployments/query-history.md
+++ b/doc/user/content/self-managed-deployments/query-history.md
@@ -26,16 +26,14 @@ To see query history in the Console, connect as a Materialize *superuser* or as
 a user granted the [`mz_monitor`
 role](/security/appendix/appendix-built-in-roles/#system-catalog-roles).
 
-## Default sample rate
+## Defaults
 
-The Materialize operator Helm chart sets the
-`operator.args.statementLoggingMaxSampleRate` value to `0.1`, so roughly 10% of
-statement executions are sampled.
-
-This value is lower than `environmentd`'s own default of `0.99`. Statement
-logging costs CPU on `environmentd` and storage for the retained history, and
-that overhead is most noticeable on the small instances typical of self-managed
-deployments, so the chart samples a fraction of statements instead.
+The Materialize operator Helm chart sets
+`operator.args.statementLoggingMaxSampleRate` to `0.99`, and leaves
+`operator.args.statementLoggingTargetDataRate` unset so that `environmentd`'s
+own default of 2071 bytes per second applies. Both are the values Materialize
+Cloud runs at, so query history in a self-managed deployment behaves the same as
+in Cloud out of the box.
 
 The rate that actually applies to a statement is the smaller of two parameters:
 
@@ -47,17 +45,16 @@ The rate that actually applies to a statement is the smaller of two parameters:
 Because the system parameter is a cap, lowering it reduces logging for every
 session regardless of what individual sessions request.
 
-Sampling is not the only limit. Materialize also throttles statement logging to
-a sustained byte rate, `statement_logging_target_data_rate`, which defaults to
-2071 bytes per second. Sampled executions beyond that budget are dropped, so a
-sample rate of `1.0` does not guarantee that every statement is recorded. On
-busy instances this byte rate, rather than the sample rate, is what actually
-bounds how much history you collect.
+Sampling is not the only limit, and it is not the one that bounds volume.
+Materialize also throttles statement logging to a sustained byte rate,
+`statement_logging_target_data_rate`, and drops sampled executions that would
+exceed it. So a sample rate of `1.0` does not guarantee every statement is
+recorded, and on a busy instance the byte rate is what determines how much
+history you actually accumulate.
 
 {{< note >}}
-Unlike Materialize Cloud, self-managed deployments log statements issued by the
-`mz_system` user by default, because the chart enables
-`enableInternalStatementLogging`. Internal activity, including the Console's own
+The chart also enables `enableInternalStatementLogging`, so statements issued by
+the `mz_system` user are logged. Internal activity, including the Console's own
 catalog queries, is sampled alongside your workload and counts toward the cost
 described below.
 {{< /note >}}
@@ -68,22 +65,24 @@ Two parameters bound how much query history you collect:
 
 | Parameter | Chart value | Bounds |
 |-----------|-------------|--------|
-| `statement_logging_max_sample_rate` | `operator.args.statementLoggingMaxSampleRate` (`0.1`) | The fraction of executions considered for logging. |
-| `statement_logging_target_data_rate` | `operator.args.statementLoggingTargetDataRate` (unset) | The sustained bytes per second written, 2071 by default. |
+| `statement_logging_max_sample_rate` | `operator.args.statementLoggingMaxSampleRate` (`0.99`) | The fraction of executions considered for logging. |
+| `statement_logging_target_data_rate` | `operator.args.statementLoggingTargetDataRate` (unset, so 2071) | The sustained bytes per second written. Must be greater than 0. |
 
-Raise the sample rate for more representative history. Lower the data rate to
-hold storage growth down. Each can be set either through the Helm chart or as a
-system parameter, and those two paths interact, so read the note on precedence
-below before picking one.
+The two are not interchangeable. Lower the data rate to hold storage growth
+down. Lowering the sample rate instead makes query history less representative
+without lowering the ceiling on what statement logging stores, because the byte
+rate is already the binding limit. Each can be set either through the Helm chart
+or as a system parameter, and those two paths interact, so read the note on
+precedence below before picking one.
 
 ### Using the Helm chart
 
-Set `operator.args.statementLoggingMaxSampleRate` when installing or upgrading
-the operator:
+Set either value when installing or upgrading the operator. For example, to
+halve how fast query history grows:
 
 ```shell
 helm upgrade my-materialize-operator materialize/materialize-operator \
-  --set operator.args.statementLoggingMaxSampleRate=0.5
+  --set operator.args.statementLoggingTargetDataRate=1035
 ```
 
 Or, in your `values.yaml`:
@@ -91,20 +90,20 @@ Or, in your `values.yaml`:
 ```yaml
 operator:
   args:
-    statementLoggingMaxSampleRate: 0.5
-    statementLoggingTargetDataRate: 4096
+    statementLoggingMaxSampleRate: 0.99
+    statementLoggingTargetDataRate: 1035
 ```
 
 Setting `statementLoggingMaxSampleRate` to `0` disables statement logging
-entirely. Already-logged
-statements remain visible until they age out of the 24-hour window. Setting the
-value to `null` inherits `environmentd`'s default of `0.99`.
-`statementLoggingTargetDataRate` is unset by default, which inherits
-`environmentd`'s default of 2071 bytes per second.
+entirely. Already-logged statements remain visible until they age out of the
+24-hour window. Setting either value to `null` inherits `environmentd`'s own
+default, `0.99` for the sample rate and 2071 bytes per second for the data rate.
+The data rate must be greater than 0.
 
-The operator passes this value to `environmentd` as the *default* for
-`statement_logging_max_sample_rate`, so it only takes effect when `environmentd`
-restarts. Upgrading the operator does not by itself roll out your Materialize
+The operator passes these values to `environmentd` as the *defaults* for
+`statement_logging_max_sample_rate` and
+`statement_logging_target_data_rate`, so they only take effect when
+`environmentd` restarts. Upgrading the operator does not by itself roll out your Materialize
 instances: you also need to request a rollout, as described in [modifying the
 custom
 resource](/self-managed-deployments/#modifying-the-custom-resource). For the
@@ -113,9 +112,9 @@ Configuration](/self-managed-deployments/operator-configuration/).
 
 ### Using system parameters
 
-Because the chart value is only a default, you can override it at runtime
-without a rollout, either through the `system-params.json` ConfigMap described
-in [Configuring System
+Because the chart values are only defaults, you can override either at runtime
+without a rollout, through the `system-params.json` ConfigMap described in
+[Configuring System
 Parameters](/self-managed-deployments/configuration-system-parameters/):
 
 ```yaml
@@ -127,7 +126,7 @@ metadata:
 data:
   system-params.json: |
     {
-      "statement_logging_max_sample_rate": 0.5
+      "statement_logging_target_data_rate": 1035
     }
 ```
 
@@ -135,14 +134,14 @@ Or with [`ALTER SYSTEM SET`](/sql/alter-system-set/), connected as the
 `mz_system` user:
 
 ```mzsql
-ALTER SYSTEM SET statement_logging_max_sample_rate = 0.5;
+ALTER SYSTEM SET statement_logging_target_data_rate = 1035;
 ```
 
 {{< note >}}
 A value set through the ConfigMap or `ALTER SYSTEM SET` is stored in the catalog
 and takes precedence over the Helm chart value, which is only a default. While
-such an override is in place, editing
-`operator.args.statementLoggingMaxSampleRate` has no effect.
+such an override is in place, editing the corresponding chart value has no
+effect.
 
 To go back to the chart-provided value, first remove the parameter from the
 ConfigMap, then run [`ALTER SYSTEM
@@ -152,32 +151,34 @@ while it is still in the ConfigMap is also not enough, because the sync loop
 reapplies it.
 {{< /note >}}
 
-To check the rate currently in effect:
+To check the values currently in effect:
 
 ```mzsql
 SHOW statement_logging_max_sample_rate;
+SHOW statement_logging_target_data_rate;
 ```
 
-## Cost of raising the sample rate
+## Cost of statement logging
 
-Raising the sample rate gives more complete query history at the cost of:
+Statement logging has two distinct costs, and each is governed by a different
+parameter:
 
-- **CPU on `environmentd`**: every logged execution is prepared and written by
-  the control plane, so the overhead scales with your statement throughput, not
-  with your data volume. Instances serving many short queries pay the most.
+- **CPU on `environmentd`**, governed by the sample rate. Every logged execution
+  is prepared and written by the control plane, so the overhead scales with your
+  statement throughput, not with your data volume. Instances serving many short
+  queries pay the most.
 
-- **Storage**: logged statements, including their SQL text, are retained in the
-  system catalog and consume space in your blob storage and metadata backend.
+- **Storage**, governed by the target data rate. Logged statements, including
+  their SQL text, consume space in your blob storage and metadata backend.
   Although `mz_recent_activity_log` only surfaces the last 24 hours, the
-  underlying statement history collections are not truncated, so their footprint
-  grows for the lifetime of the instance.
+  underlying statement history collections are never truncated, so their
+  footprint grows for the lifetime of the instance.
 
-Workloads dominated by a high rate of small, fast queries are the ones where a
-high sample rate is most likely to be felt. If you raise the rate, do it
-incrementally and watch `environmentd` CPU utilization and your storage
-footprint. Because the byte rate is what bounds sustained growth, lowering
-`statement_logging_target_data_rate` is the more direct control if your concern
-is storage rather than sampling fidelity.
+That second point is the one to plan around: query history is not a fixed-size
+buffer, and its growth rate is set by `statement_logging_target_data_rate`. On
+an instance with limited storage, lower that parameter. Reach for the sample
+rate only when you want to reduce `environmentd` CPU overhead, and expect less
+representative history in exchange.
 
 ## See also
 

--- a/doc/user/content/self-managed-deployments/query-history.md
+++ b/doc/user/content/self-managed-deployments/query-history.md
@@ -15,9 +15,12 @@ deployments and is enabled by default.
 
 Query history is backed by *statement logging*: Materialize records a randomly
 sampled fraction of statement executions into the system catalog, most visibly
-[`mz_recent_activity_log`](/reference/system-catalog/mz_internal/#mz_recent_activity_log).
-Sampling means the view is a representative sample of your workload rather than
-a complete audit log.
+[`mz_recent_activity_log`](/reference/system-catalog/mz_internal/#mz_recent_activity_log),
+which covers the last 24 hours. Sampling means the view is a representative
+sample of your workload rather than a complete audit log. For a complete record
+of DDL, use
+[`mz_audit_events`](/reference/system-catalog/mz_catalog/#mz_audit_events)
+instead.
 
 To see query history in the Console, connect as a Materialize *superuser* or as
 a user granted the [`mz_monitor`
@@ -27,7 +30,7 @@ role](/security/appendix/appendix-built-in-roles/#system-catalog-roles).
 
 The Materialize operator Helm chart sets the
 `operator.args.statementLoggingMaxSampleRate` value to `0.1`, so roughly 10% of
-statement executions are logged.
+statement executions are sampled.
 
 This value is lower than `environmentd`'s own default of `0.99`. Statement
 logging costs CPU on `environmentd` and storage for the retained history, and
@@ -38,11 +41,24 @@ The rate that actually applies to a statement is the smaller of two parameters:
 
 | Parameter | Scope | Meaning |
 |-----------|-------|---------|
-| `statement_logging_sample_rate` | Session | The rate a session asks for. Users may lower it with `SET`. |
+| `statement_logging_sample_rate` | Session | The rate a session asks for. A session may `SET` this to any value between 0 and 1, but only values below the cap have any effect. |
 | `statement_logging_max_sample_rate` | System | A cap on the above. The chart value sets this. |
 
 Because the system parameter is a cap, lowering it reduces logging for every
 session regardless of what individual sessions request.
+
+Sampling is not the only limit. Materialize also throttles statement logging to
+a target byte rate, `statement_logging_target_data_rate`, so executions beyond
+that budget are dropped even at a high sample rate. A sample rate of `1.0`
+therefore does not guarantee that every statement is recorded.
+
+{{< note >}}
+Unlike Materialize Cloud, self-managed deployments log statements issued by the
+`mz_system` user by default, because the chart enables
+`enableInternalStatementLogging`. Internal activity, including the Console's own
+catalog queries, is sampled alongside your workload and counts toward the cost
+described below.
+{{< /note >}}
 
 ## Tune the sample rate
 
@@ -67,14 +83,17 @@ operator:
     statementLoggingMaxSampleRate: 0.5
 ```
 
-Setting the value to `0` disables statement logging entirely, which leaves the
-Console's Query History view empty. Setting it to `null` inherits
-`environmentd`'s default of `0.99`.
+Setting the value to `0` disables statement logging entirely. Already-logged
+statements remain visible until they age out of the 24-hour window. Setting the
+value to `null` inherits `environmentd`'s default of `0.99`.
 
 The operator passes this value to `environmentd` as the *default* for
-`statement_logging_max_sample_rate`. Changing it requires a rollout of the
-Materialize instance to take effect. For the full list of chart values, see
-[Materialize Operator
+`statement_logging_max_sample_rate`, so it only takes effect when `environmentd`
+restarts. Upgrading the operator does not by itself roll out your Materialize
+instances: you also need to request a rollout, as described in [modifying the
+custom
+resource](/self-managed-deployments/#modifying-the-custom-resource). For the
+full list of chart values, see [Materialize Operator
 Configuration](/self-managed-deployments/operator-configuration/).
 
 ### Using system parameters
@@ -97,9 +116,10 @@ data:
     }
 ```
 
-Or with [`ALTER SYSTEM SET`](/sql/alter-system-set/), as a superuser:
+Or with [`ALTER SYSTEM SET`](/sql/alter-system-set/), connected as the
+`mz_system` user:
 
-```sql
+```mzsql
 ALTER SYSTEM SET statement_logging_max_sample_rate = 0.5;
 ```
 
@@ -110,15 +130,16 @@ such an override is in place, editing
 `operator.args.statementLoggingMaxSampleRate` has no effect.
 
 To go back to the chart-provided value, first remove the parameter from the
-ConfigMap, then run `ALTER SYSTEM RESET statement_logging_max_sample_rate`.
-Removing it from the ConfigMap alone is not enough, because the last synced
-value remains in the catalog. Resetting it while it is still in the ConfigMap is
-also not enough, because the sync loop reapplies it.
+ConfigMap, then run [`ALTER SYSTEM
+RESET`](/sql/alter-system-reset/) for it. Removing it from the ConfigMap alone is
+not enough, because the last synced value remains in the catalog. Resetting it
+while it is still in the ConfigMap is also not enough, because the sync loop
+reapplies it.
 {{< /note >}}
 
 To check the rate currently in effect:
 
-```sql
+```mzsql
 SHOW statement_logging_max_sample_rate;
 ```
 
@@ -132,17 +153,22 @@ Raising the sample rate gives more complete query history at the cost of:
 
 - **Storage**: logged statements, including their SQL text, are retained in the
   system catalog and consume space in your blob storage and metadata backend.
+  Although `mz_recent_activity_log` only surfaces the last 24 hours, the
+  underlying statement history collections are not truncated, so their footprint
+  grows for the lifetime of the instance.
 
 Workloads dominated by a high rate of small, fast queries are the ones where a
 high sample rate is most likely to be felt. If you raise the rate, do it
-incrementally and watch `environmentd` CPU utilization. Sampling at `1.0` logs
-every statement and is best reserved for short debugging sessions.
+incrementally and watch `environmentd` CPU utilization and your storage
+footprint.
 
 ## See also
 
 - [Console monitoring](/console/monitoring/)
 - [`mz_internal` statement logging
   relations](/reference/system-catalog/mz_internal/#mz_recent_activity_log)
+- [`ALTER SYSTEM SET`](/sql/alter-system-set/)
+- [`ALTER SYSTEM RESET`](/sql/alter-system-reset/)
 - [Configuring System
   Parameters](/self-managed-deployments/configuration-system-parameters/)
 - [Materialize Operator

--- a/doc/user/content/self-managed-deployments/query-history.md
+++ b/doc/user/content/self-managed-deployments/query-history.md
@@ -48,9 +48,11 @@ Because the system parameter is a cap, lowering it reduces logging for every
 session regardless of what individual sessions request.
 
 Sampling is not the only limit. Materialize also throttles statement logging to
-a target byte rate, `statement_logging_target_data_rate`, so executions beyond
-that budget are dropped even at a high sample rate. A sample rate of `1.0`
-therefore does not guarantee that every statement is recorded.
+a sustained byte rate, `statement_logging_target_data_rate`, which defaults to
+2071 bytes per second. Sampled executions beyond that budget are dropped, so a
+sample rate of `1.0` does not guarantee that every statement is recorded. On
+busy instances this byte rate, rather than the sample rate, is what actually
+bounds how much history you collect.
 
 {{< note >}}
 Unlike Materialize Cloud, self-managed deployments log statements issued by the
@@ -60,10 +62,19 @@ catalog queries, is sampled alongside your workload and counts toward the cost
 described below.
 {{< /note >}}
 
-## Tune the sample rate
+## Tune statement logging
 
-There are two places to change the maximum sample rate. They interact, so read
-the note on precedence below before picking one.
+Two parameters bound how much query history you collect:
+
+| Parameter | Chart value | Bounds |
+|-----------|-------------|--------|
+| `statement_logging_max_sample_rate` | `operator.args.statementLoggingMaxSampleRate` (`0.1`) | The fraction of executions considered for logging. |
+| `statement_logging_target_data_rate` | `operator.args.statementLoggingTargetDataRate` (unset) | The sustained bytes per second written, 2071 by default. |
+
+Raise the sample rate for more representative history. Lower the data rate to
+hold storage growth down. Each can be set either through the Helm chart or as a
+system parameter, and those two paths interact, so read the note on precedence
+below before picking one.
 
 ### Using the Helm chart
 
@@ -81,11 +92,15 @@ Or, in your `values.yaml`:
 operator:
   args:
     statementLoggingMaxSampleRate: 0.5
+    statementLoggingTargetDataRate: 4096
 ```
 
-Setting the value to `0` disables statement logging entirely. Already-logged
+Setting `statementLoggingMaxSampleRate` to `0` disables statement logging
+entirely. Already-logged
 statements remain visible until they age out of the 24-hour window. Setting the
 value to `null` inherits `environmentd`'s default of `0.99`.
+`statementLoggingTargetDataRate` is unset by default, which inherits
+`environmentd`'s default of 2071 bytes per second.
 
 The operator passes this value to `environmentd` as the *default* for
 `statement_logging_max_sample_rate`, so it only takes effect when `environmentd`
@@ -160,7 +175,9 @@ Raising the sample rate gives more complete query history at the cost of:
 Workloads dominated by a high rate of small, fast queries are the ones where a
 high sample rate is most likely to be felt. If you raise the rate, do it
 incrementally and watch `environmentd` CPU utilization and your storage
-footprint.
+footprint. Because the byte rate is what bounds sustained growth, lowering
+`statement_logging_target_data_rate` is the more direct control if your concern
+is storage rather than sampling fidelity.
 
 ## See also
 

--- a/doc/user/content/self-managed-deployments/query-history.md
+++ b/doc/user/content/self-managed-deployments/query-history.md
@@ -8,10 +8,12 @@ menu:
 ---
 
 The Materialize Console includes a **Query History** view, under its
-[**Monitoring**](/console/monitoring/) section, that lists the SQL statements
-recently issued to your Materialize instance along with their duration, status,
-and the cluster that ran them. Query history is available in self-managed
-deployments and is enabled by default.
+[**Monitoring**](/console/monitoring/) section, that lists a sample of the SQL
+statements recently issued to your Materialize instance, along with their
+duration, status, and the cluster that ran them. Query history is available in
+self-managed deployments and is enabled by default in Materialize operator chart
+v26.40.0 and later. Earlier chart versions disabled statement logging outright,
+and the Query History view stays empty on them.
 
 Query history is backed by *statement logging*: Materialize records a randomly
 sampled fraction of statement executions into the system catalog, most visibly
@@ -26,53 +28,50 @@ To see query history in the Console, connect as a Materialize *superuser* or as
 a user granted the [`mz_monitor`
 role](/security/appendix/appendix-built-in-roles/#system-catalog-roles).
 
-## Defaults
+## Configure statement logging
 
-The Materialize operator Helm chart sets
-`operator.args.statementLoggingMaxSampleRate` to `0.99`, and leaves
-`operator.args.statementLoggingTargetDataRate` unset so that `environmentd`'s
-own default of 2071 bytes per second applies. Statement logging is therefore on
-by default, sampling nearly every statement up to the byte rate below.
+Two system parameters bound how much query history you collect. The Materialize
+operator Helm chart ships a value for each:
 
-The rate that actually applies to a statement is the smaller of two parameters:
+| Parameter | Chart value | Default | Bounds |
+|-----------|-------------|---------|--------|
+| `statement_logging_max_sample_rate` | `operator.args.statementLoggingMaxSampleRate` | `0.99` | The fraction of executions considered for logging. |
+| `statement_logging_target_data_rate` | `operator.args.statementLoggingTargetDataRate` | Unset, so `environmentd`'s own 2071 | The sustained bytes per second written. Must be greater than 0. |
 
-| Parameter | Scope | Meaning |
-|-----------|-------|---------|
-| `statement_logging_sample_rate` | Session | The rate a session asks for. A session may `SET` this to any value between 0 and 1, but only values below the cap have any effect. |
-| `statement_logging_max_sample_rate` | System | A cap on the above. The chart value sets this. |
+Statement logging is therefore on by default, sampling nearly every statement up
+to that byte rate.
 
-Because the system parameter is a cap, lowering it reduces logging for every
-session regardless of what individual sessions request.
+A session can request its own rate with `SET statement_logging_sample_rate`. The
+rate that applies to a statement is the smaller of the session's rate and the
+system cap, so lowering the cap reduces logging for every session regardless of
+what individual sessions ask for.
 
 Sampling is not the only limit, and it is not the one that bounds volume.
-Materialize also throttles statement logging to a sustained byte rate,
-`statement_logging_target_data_rate`, and drops sampled executions that would
-exceed it. So a sample rate of `1.0` does not guarantee every statement is
-recorded, and on a busy instance the byte rate is what determines how much
-history you actually accumulate.
+Materialize also throttles statement logging to the target byte rate and drops
+sampled executions that would exceed it. So a sample rate of `1.0` does not
+guarantee every statement is recorded, and on a busy instance the byte rate is
+what determines how much history you actually accumulate.
+
+The two parameters are not interchangeable. Lower the data rate to hold storage
+growth down. Lowering the sample rate instead makes query history less
+representative without lowering the ceiling on what statement logging stores,
+because the byte rate is already the binding limit.
 
 {{< note >}}
-The chart also enables `enableInternalStatementLogging`, so statements issued by
-the `mz_system` user are logged. Internal activity, including the Console's own
-catalog queries, is sampled alongside your workload and counts toward the cost
-described below.
+The chart also enables `enableInternalStatementLogging`, which logs statements
+run by Materialize's internal users: `mz_system`, `mz_support`, and
+`mz_analytics`. This covers both Materialize's own activity, such as the
+Console's catalog queries, and any session you open as one of those users, and
+it counts toward the cost described below.
+
+Statements from your own users are always subject to sampling and are unaffected
+by this setting. Logging in through the Console as a normal user is sampled at
+the rates above either way.
 {{< /note >}}
 
-## Tune statement logging
-
-Two parameters bound how much query history you collect:
-
-| Parameter | Chart value | Bounds |
-|-----------|-------------|--------|
-| `statement_logging_max_sample_rate` | `operator.args.statementLoggingMaxSampleRate` (`0.99`) | The fraction of executions considered for logging. |
-| `statement_logging_target_data_rate` | `operator.args.statementLoggingTargetDataRate` (unset, so 2071) | The sustained bytes per second written. Must be greater than 0. |
-
-The two are not interchangeable. Lower the data rate to hold storage growth
-down. Lowering the sample rate instead makes query history less representative
-without lowering the ceiling on what statement logging stores, because the byte
-rate is already the binding limit. Each can be set either through the Helm chart
-or as a system parameter, and those two paths interact, so read the note on
-precedence below before picking one.
+Either parameter can be set through the Helm chart or as a system parameter, and
+those two paths interact, so read the note on precedence below before picking
+one.
 
 ### Using the Helm chart
 
@@ -135,6 +134,15 @@ Or with [`ALTER SYSTEM SET`](/sql/alter-system-set/), connected as the
 ```mzsql
 ALTER SYSTEM SET statement_logging_target_data_rate = 1035;
 ```
+
+{{< warning >}}
+Setting `statement_logging_max_sample_rate` to `0` this way turns off statement
+logging for the whole instance, and the Console's Query History view stops
+recording new statements. Unlike the Helm chart value, this takes effect
+immediately and without a rollout, so it is easy to disable query history
+without meaning to. Use `SET statement_logging_sample_rate` in a session if you
+only want to stop logging your own statements.
+{{< /warning >}}
 
 {{< note >}}
 A value set through the ConfigMap or `ALTER SYSTEM SET` is stored in the catalog

--- a/doc/user/content/self-managed-deployments/query-history.md
+++ b/doc/user/content/self-managed-deployments/query-history.md
@@ -30,13 +30,21 @@ role](/security/appendix/appendix-built-in-roles/#system-catalog-roles).
 
 ## Configure statement logging
 
-Two system parameters bound how much query history you collect. The Materialize
-operator Helm chart ships a value for each:
+Two system parameters bound how much query history you collect:
 
-| Parameter | Chart value | Default | Bounds |
-|-----------|-------------|---------|--------|
-| `statement_logging_max_sample_rate` | `operator.args.statementLoggingMaxSampleRate` | `0.99` | The fraction of executions considered for logging. |
-| `statement_logging_target_data_rate` | `operator.args.statementLoggingTargetDataRate` | Unset, so `environmentd`'s own 2071 | The sustained bytes per second written. Must be greater than 0. |
+| Parameter | Default | Bounds |
+|-----------|---------|--------|
+| `statement_logging_max_sample_rate` | `0.99` (set by the chart) | The fraction of executions considered for logging. |
+| `statement_logging_target_data_rate` | 2071 (`environmentd`'s own) | The sustained bytes per second written. |
+
+{{< tip >}}
+The Materialize operator Helm chart exposes each parameter as:
+
+- `operator.args.statementLoggingMaxSampleRate`, which it sets to `0.99`, and
+
+- `operator.args.statementLoggingTargetDataRate`, which it leaves unset so
+`environmentd`'s default applies.
+{{< /tip >}}
 
 Statement logging is therefore on by default, sampling nearly every statement up
 to that byte rate.
@@ -136,12 +144,21 @@ ALTER SYSTEM SET statement_logging_target_data_rate = 1035;
 ```
 
 {{< warning >}}
-Setting `statement_logging_max_sample_rate` to `0` this way turns off statement
-logging for the whole instance, and the Console's Query History view stops
-recording new statements. Unlike the Helm chart value, this takes effect
+Setting either parameter to `0` this way turns off statement logging for the
+whole instance, and the Console's Query History view stops recording new
+statements. A sample rate of `0` logs nothing, and a target data rate of `0`
+throttles every statement. Unlike the Helm chart values, these take effect
 immediately and without a rollout, so it is easy to disable query history
-without meaning to. Use `SET statement_logging_sample_rate` in a session if you
-only want to stop logging your own statements.
+without meaning to.
+
+The Helm chart rejects a target data rate of `0`, but `ALTER SYSTEM SET` does
+not, so this is the path where that mistake is possible. Setting the target data
+rate to `NULL` is the opposite hazard: it removes throttling altogether rather
+than restoring the default of 2071, leaving nothing to bound how fast query
+history grows.
+
+To stop logging only your own statements, use `SET
+statement_logging_sample_rate` in your session instead.
 {{< /warning >}}
 
 {{< note >}}

--- a/doc/user/content/transform-data/troubleshooting.md
+++ b/doc/user/content/transform-data/troubleshooting.md
@@ -291,7 +291,7 @@ attribute performance information to each LIR operator.
 ## How do I troubleshoot slow queries?
 
 Materialize stores a (sampled) log of the SQL statements that are issued against
-your Materialize region in the last **three days**, along with various metadata
+your Materialize region in the last **24 hours**, along with various metadata
 about these statements. You can access this log via the **"Query history"** tab
 in the [Materialize console](/console/). You can filter
 and sort statements by type, duration, and other dimensions.
@@ -300,10 +300,11 @@ This data is also available via the
 [mz_internal.mz_recent_activity_log](/reference/system-catalog/mz_internal/#mz_recent_activity_log)
 catalog table.
 
-It's important to note that the default (and max) sample rate for most
-Materialize organizations is 99%, which means that not all statements will be
-captured in the log. The sampling rate is not user-configurable, and may change
-at any time.
+It's important to note that statements are sampled, so not all of them will be
+captured in the log. In Materialize Cloud, the default and maximum sample rate
+for most organizations is 99%, and Materialize may change it at any time. In
+self-managed deployments, the maximum sample rate is set by the operator. See
+[Query History](/self-managed-deployments/query-history/).
 
 If you're looking for a complete audit history, use the [mz_audit_events](/reference/system-catalog/mz_catalog/#mz_audit_events)
 catalog table, which records all DDL commands issued against your Materialize


### PR DESCRIPTION
**DNM until 9/2/26**

Query history is becoming available and enabled by default in self-managed deployments, but the docs said nothing about it. Self-managed operators had no guidance on the shipped sample rate, how to change it, or what it costs.

Linear: https://linear.app/materializeinc/issue/CNS-139/docs-document-query-history-and-statement-logging-for-self

## Changes

- **New page** `self-managed-deployments/query-history.md`: what query history is and who can see it, the two parameters that bound how much is collected, how to tune each via the Helm chart and via system parameters, and the CPU/storage cost of each.
- **`console/monitoring.md`**: notes that query history is sampled and links to the new page.
- **`reference/system-catalog/mz_internal.md`**: no longer says the max sample rate is "set by Materialize and cannot be changed by users". Now distinguishes Cloud (Materialize-controlled) from self-managed (operator-controlled).
- **`transform-data/troubleshooting.md`**: this page claimed outright that "the sampling rate is not user-configurable", which directly contradicts the new page. Also corrected its "three days" window to 24 hours, which is what `mz_recent_activity_log` actually retains.
- **`configuration-system-parameters.md`**: adds both statement-logging parameters to the parameter list.

## Notes for the reviewer

**Merge after #38406 ([CNS-136](https://linear.app/materializeinc/issue/CNS-136)).** That PR exposes the chart values this page documents. Until it lands, the chart still passes `--disable-statement-logging`, so "enabled by default" describes the post-#38406 chart, not `main` today. Documented values track #38406's latest revision: `statementLoggingMaxSampleRate: 0.99` and `statementLoggingTargetDataRate` unset (inheriting 2071 B/s). The console side is #38407/#38408.

Two behaviors are worth a careful look, since both are easy to get wrong and I verified them against the source rather than assuming:

1. **Precedence.** The chart values reach `environmentd` as `--system-parameter-default=...`, so they are only defaults. A ConfigMap or `ALTER SYSTEM SET` value is upserted into the catalog and wins. Undoing an override needs *both* removing the ConfigMap key and `ALTER SYSTEM RESET`: removing the key alone leaves the last synced value in the catalog, and resetting alone gets reapplied by the 1s sync loop.
2. **The sample rate is not the storage lever.** `statement_logging_target_data_rate` throttles sampled statements, so a sample rate of `1.0` does not record everything, and lowering the sample rate does not lower the ceiling on what statement logging stores. Relatedly, the statement history collections are never truncated, so storage grows for the life of the instance even though the view only shows 24 hours. The page therefore points operators at the data rate for storage concerns and at the sample rate only for `environmentd` CPU.

`ALTER SYSTEM SET` for these parameters requires `mz_system`, not just any superuser, since they are not user-modifiable. The page says so.

## Testing

`ci/test/lint-docs.sh` locally: both hugo builds clean, `htmltest` reports only 2 pre-existing AWS Glue link errors also present on the base commit, and `lint-docs-catalog.sh` shows no `.slt` drift from the `mz_internal.md` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

