### PR TITLE
sql: mention avg(interval) in the sum(interval) error message

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3844,7 +3844,12 @@ pub static PG_CATALOG_BUILTINS: LazyLock<BTreeMap<&'static str, Func>> = LazyLoc
                 // prevents `sum(NULL)` from choosing the `Float64`
                 // implementation, so that we match PostgreSQL's behavior.
                 // Plus we will one day want to support this overload.
-                bail_unsupported!("sum(interval)");
+                //
+                // The message mentions `avg` because `avg(interval)` desugars
+                // to `sum(interval) / count(interval)` before type checking
+                // (see `plan_avg` in `transform_ast.rs`), so this error is all
+                // a user who typed only `avg` gets to see.
+                bail_unsupported!("sum(interval) and avg(interval)");
             }) => Interval, 2113;
         },
 

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -1517,3 +1517,12 @@ query T
 SELECT ('1 month 10 days'::interval)::text;
 ----
 1 mon 10 days
+
+# `avg(interval)` desugars to `sum(interval) / count(interval)` before type
+# checking, so the unsupported-sum error is the only message a user who typed
+# `avg` sees. It must mention both function names.
+statement error sum\(interval\) and avg\(interval\) not yet supported
+SELECT sum('1 day'::interval)
+
+statement error sum\(interval\) and avg\(interval\) not yet supported
+SELECT avg('1 day'::interval)


### PR DESCRIPTION
### Motivation

`avg(x)` desugars to `sum(x) / count(x)` before type checking (`plan_avg` in `transform_ast.rs`), so a user who writes `avg(some_interval)` gets "sum(interval) not yet supported" and cannot tell where the `sum` came from. Nate [ran into this](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1787529576654579?thread_ts=1787529558.518229&cid=CU7ELJ6E9): a query computing `avg(finished_at - began_at)` over `mz_internal.mz_recent_activity_log` produced an error about a function the query never mentions.

Touches [CS-341](https://linear.app/materializeinc/issue/CS-341), database-issues#5285, database-issues#9761, database-issues#8346 (the underlying feature ask stays open; this only improves the message).

### Description

Since the desugaring happens before types are known, we cannot report `avg(interval)` specifically at the rewrite site. Instead, the unsupported-sum error now names both functions: `sum(interval) and avg(interval) not yet supported`.

The `ci-regexp` in database-issues#5285 has already been updated to match both the old and new message text.

### Verification

Added a sqllogictest regression test in `test/sqllogictest/interval.slt` pinning the message for both the `sum` and `avg` spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
