### PR TITLE
compute: drop the duplicated instants from the hydration times relation [closed: not worth the churn]

### DIFF
--- a/doc/developer/design/20260817_compute_hydration_timestamps.md
+++ b/doc/developer/design/20260817_compute_hydration_timestamps.md
@@ -236,6 +236,28 @@ event, occurred_at` recovers the dataflow-level facts, and the redundancy is vis
 rather than implied. The column also means the relation carries the export-to-dataflow
 mapping that `mz_compute_exports_per_worker` holds, for eight bytes a row.
 
+**One reading per term.** `mz_compute_hydration_times_per_worker.hydrated_at` is the
+durability reading, taken when the reported output frontier passes the as-of. That
+frontier is the meet of the write and compute frontiers, so for a collection that
+sinks to persist it moves only once the output is durable, while for an index, which
+produces its output by writing its own trace, it coincides with computation. One
+column therefore meant two different things depending on the object type, and a
+consumer could not tell which without knowing what it was looking at.
+
+The lifecycle log splits that ambiguity into separate terms rather than redefining the
+column: `hydrated` is always the dataflow-progress reading and `written` is always the
+durability one, neither depending on the object type. `hydrated_at` and `time_ns` stay
+where they are, because `mz_compute_hydration_statuses` and the blue-green readiness
+query are defined on them, and moving readiness onto the earlier compute reading would
+have it cut over before the output is durable.
+
+What does move is `installed_at` and `started_at`. Those were unambiguous, so keeping
+them in both relations meant two mechanisms maintaining the same instants and the same
+`installed_at <= started_at` invariant. They are now the lifecycle log's `installed`
+and `started` events alone. The two relations join on `(export_id, worker_id)`, both
+being per worker, so a consumer that wants the queueing interval and the duration
+together reads them from one join rather than from one row.
+
 **`installed` is the denominator.** A consumer asking whether every worker has reached
 a stage cannot count rows and compare against a worker count it does not have, and it
 should not have to join the catalog to find one. The relation is append-only, so a

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -353,18 +353,24 @@ impl LogVariant {
                 .with_key(vec![0, 1])
                 .finish(),
 
+            // NOTE: `hydrated_at` here is the *durability* reading, taken when the reported
+            // output frontier passes the as-of. That frontier is the meet of the write and
+            // compute frontiers, so for a collection that sinks to persist it moves only once
+            // the output is durable, while for an index, which produces its output by writing
+            // its own trace, it coincides with computation. One column therefore meant two
+            // things depending on the object.
+            //
+            // `mz_compute_lifecycle_events_per_worker` splits that ambiguity into separate
+            // terms: its `hydrated` is the dataflow-progress reading and its `written` is the
+            // durability one, so neither depends on the object type. This relation keeps the
+            // combined reading, because `mz_compute_hydration_statuses` and the blue-green
+            // readiness query are defined on it. The instants that were unambiguous,
+            // `installed_at` and `started_at`, moved to the lifecycle relation rather than
+            // being maintained in both.
             LogVariant::Compute(ComputeLog::HydrationTime) => RelationDesc::builder()
                 .with_column("export_id", SqlScalarType::String.nullable(false))
                 .with_column("worker_id", SqlScalarType::UInt64.nullable(false))
                 .with_column("time_ns", SqlScalarType::UInt64.nullable(true))
-                .with_column(
-                    "installed_at",
-                    SqlScalarType::TimestampTz { precision: None }.nullable(false),
-                )
-                .with_column(
-                    "started_at",
-                    SqlScalarType::TimestampTz { precision: None }.nullable(true),
-                )
                 .with_column(
                     "hydrated_at",
                     SqlScalarType::TimestampTz { precision: None }.nullable(true),

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -735,10 +735,6 @@ impl DemuxState {
             make_string_datum(export_id, &mut self.scratch_string_a),
             Datum::UInt64(u64::cast_from(self.worker_id)),
             Datum::from(time_ns),
-            epoch_offset_datum(timestamps.installed_at),
-            timestamps
-                .started_at
-                .map_or(Datum::Null, epoch_offset_datum),
             timestamps
                 .hydrated_at
                 .map_or(Datum::Null, epoch_offset_datum),
@@ -860,6 +856,10 @@ impl DemuxState {
 }
 
 /// Wallclock instants of an export's hydration lifecycle, as durations since the Unix epoch.
+///
+/// Only `hydrated_at` reaches `mz_compute_hydration_times_per_worker`. `installed_at` and
+/// `started_at` are kept to order and back-fill the lifecycle log's `installed` and `started`
+/// events, which are where a consumer reads them.
 ///
 /// These are sampled from compute logging event times, which advance off an `Instant` anchored to
 /// the epoch once per worker when logging is initialized. They are therefore monotone within a
@@ -1184,8 +1184,7 @@ impl DemuxHandler<'_, '_, '_> {
         &mut self,
         HydrationStartReference { export_id }: Ref<'_, HydrationStart>,
     ) {
-        let ts = self.ts();
-        // Stamp the event time rather than `ts`, as in `handle_export`.
+        // Stamp the event time rather than the rounded update timestamp, as in `handle_export`.
         let started_at = self.time;
         let export_id = Columnar::into_owned(export_id);
 
@@ -1200,22 +1199,12 @@ impl DemuxHandler<'_, '_, '_> {
             return;
         }
 
-        let old_timestamps = export.hydration_timestamps;
         export.hydration_timestamps.started_at = Some(started_at);
-        let new_timestamps = export.hydration_timestamps;
-        let time_ns = export.hydration_time_ns;
 
-        let retraction = self
-            .state
-            .pack_hydration_time_update(export_id, time_ns, &old_timestamps);
-        self.output
-            .hydration_time
-            .give((retraction, ts, Diff::MINUS_ONE));
-        let insertion = self
-            .state
-            .pack_hydration_time_update(export_id, time_ns, &new_timestamps);
-        self.output.hydration_time.give((insertion, ts, Diff::ONE));
-
+        // No `hydration_time` output here. That relation carries only `time_ns` and
+        // `hydrated_at`, neither of which this event changes, so the retract-and-reinsert pair
+        // would be a no-op. `started_at` is now kept only to guard this handler and to
+        // back-fill `started` in `handle_hydration`.
         self.log_lifecycle(export_id, LifecycleStage::Started);
     }
 

--- a/test/sqllogictest/mz_catalog_server_index_accounting.slt
+++ b/test/sqllogictest/mz_catalog_server_index_accounting.slt
@@ -358,8 +358,6 @@ mz_compute_hydration_times  replica_id
 mz_compute_hydration_times  time_ns
 mz_compute_hydration_times_per_worker  export_id
 mz_compute_hydration_times_per_worker  hydrated_at
-mz_compute_hydration_times_per_worker  installed_at
-mz_compute_hydration_times_per_worker  started_at
 mz_compute_hydration_times_per_worker  time_ns
 mz_compute_hydration_times_per_worker  worker_id
 mz_compute_import_frontiers_per_worker  export_id

--- a/test/testdrive/hydration-timestamps.td
+++ b/test/testdrive/hydration-timestamps.td
@@ -7,72 +7,101 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Test the hydration lifecycle timestamps reported by
-# `mz_introspection.mz_compute_hydration_times_per_worker`, alongside the
-# `time_ns` duration the relation has always carried.
+# Test the hydration lifecycle across the two relations that report it.
+#
+# `mz_introspection.mz_compute_hydration_times_per_worker` carries `time_ns` and
+# `hydrated_at`, the durability reading: the instant the reported output frontier
+# passed the as-of. `mz_introspection.mz_compute_lifecycle_events_per_worker`
+# carries the stages, including the `installed` and `started` instants that this
+# relation used to duplicate. The interesting assertions are therefore the ones
+# that join the two, since a reader gets the queueing interval from one and the
+# duration from the other.
 #
 # These tests rely on testdrive's retry feature, as dataflows take an unknown
-# (but hopefully small) time to be installed and to hydrate. The one section
-# that must not retry, so that a transient invariant violation is not retried
-# away, comes last, since `set-max-tries` has no way to restore the default.
+# (but hopefully small) time to be installed and to hydrate. The section that
+# must not retry, so that a transient invariant violation is not retried away,
+# comes last, since `set-max-tries` has no way to restore the default.
 
 $ set-sql-timeout duration=60s
 
 > CREATE CLUSTER test SIZE 'scale=1,workers=2'
 > SET cluster = test
 
-# Log collections are never suspended and never receive a `Schedule` command,
-# so they must still report a complete set of timestamps.
+# Log collections are never suspended and never receive a `Schedule` command, so
+# they must still reach every stage and report a duration.
 
 > SELECT DISTINCT
-      installed_at IS NOT NULL,
-      started_at IS NOT NULL,
-      hydrated_at IS NOT NULL
-  FROM mz_introspection.mz_compute_hydration_times_per_worker
-  WHERE export_id LIKE 's%'
+      max(l.occurred_at) FILTER (WHERE l.event = 'installed') IS NOT NULL,
+      max(l.occurred_at) FILTER (WHERE l.event = 'started') IS NOT NULL,
+      max(l.occurred_at) FILTER (WHERE l.event = 'hydrated') IS NOT NULL
+  FROM mz_introspection.mz_compute_lifecycle_events_per_worker l
+  WHERE l.export_id LIKE 's%'
+  GROUP BY l.export_id, l.worker_id
 true true true
 
-# A hydrated object reports all three timestamps, ordered.
+> SELECT DISTINCT hydrated_at IS NOT NULL, time_ns IS NOT NULL
+  FROM mz_introspection.mz_compute_hydration_times_per_worker
+  WHERE export_id LIKE 's%'
+true true
+
+# A hydrated object reaches all three stages, ordered, and reports a duration.
 
 > CREATE TABLE t (a int)
 > CREATE INDEX idx IN CLUSTER test ON t (a)
 
 > SELECT DISTINCT
-      h.installed_at IS NOT NULL,
-      h.started_at >= h.installed_at,
-      h.hydrated_at >= h.started_at,
-      h.time_ns IS NOT NULL
+      max(l.occurred_at) FILTER (WHERE l.event = 'started')
+          >= max(l.occurred_at) FILTER (WHERE l.event = 'installed'),
+      max(l.occurred_at) FILTER (WHERE l.event = 'hydrated')
+          >= max(l.occurred_at) FILTER (WHERE l.event = 'started')
+  FROM mz_introspection.mz_compute_lifecycle_events_per_worker l
+  JOIN mz_indexes i ON (i.id = l.export_id)
+  WHERE i.name = 'idx'
+  GROUP BY l.export_id, l.worker_id
+true true
+
+> SELECT DISTINCT h.hydrated_at IS NOT NULL, h.time_ns IS NOT NULL
   FROM mz_introspection.mz_compute_hydration_times_per_worker h
   JOIN mz_indexes i ON (i.id = h.export_id)
   WHERE i.name = 'idx'
-true true true true
+true true
 
-# The timestamps are wallclock instants, not offsets from some arbitrary
-# origin, so they must land in the recent past.
+# `hydrated_at` is a wallclock instant, not an offset from some arbitrary origin,
+# so it must land in the recent past.
 
-> SELECT DISTINCT h.installed_at BETWEEN now() - '1 hour'::interval AND now()
+> SELECT DISTINCT h.hydrated_at BETWEEN now() - '1 hour'::interval AND now()
   FROM mz_introspection.mz_compute_hydration_times_per_worker h
   JOIN mz_indexes i ON (i.id = h.export_id)
   WHERE i.name = 'idx'
 true
 
-# `time_ns` and the timestamps measure the same interval by different means:
-# `time_ns` from an `Instant` taken when the export state is created, the
-# timestamps from logging event times rounded to microseconds. They must agree,
-# which is what makes the retained `time_ns` column and the new columns tell one
-# consistent story. The tolerance is generous because the point is to catch a
-# wrong interval or a units error, not to pin down the rounding.
+# `time_ns` and the two relations' instants measure the same interval by
+# different means: `time_ns` from an `Instant` taken when the export state is
+# created, the instants from logging event times rounded to microseconds. They
+# must agree, which is what makes the duration in one relation and the stages in
+# the other tell one story. Both relations are per worker, so the join carries
+# `worker_id`; joining on `export_id` alone would multiply each row by the number
+# of workers. The tolerance is generous because the point is to catch a wrong
+# interval or a units error, not to pin down the rounding.
 
 > SELECT DISTINCT
-      abs(extract(epoch FROM (h.hydrated_at - h.installed_at)) - h.time_ns / 1e9) < 1
+      abs(extract(epoch FROM (h.hydrated_at - l.installed_at)) - h.time_ns / 1e9) < 1
   FROM mz_introspection.mz_compute_hydration_times_per_worker h
+  JOIN (
+      SELECT
+          export_id,
+          worker_id,
+          max(occurred_at) FILTER (WHERE event = 'installed') AS installed_at
+      FROM mz_introspection.mz_compute_lifecycle_events_per_worker
+      GROUP BY export_id, worker_id
+  ) l ON (l.export_id = h.export_id AND l.worker_id = h.worker_id)
   JOIN mz_indexes i ON (i.id = h.export_id)
   WHERE i.name = 'idx'
 true
 
-# An object whose inputs are unavailable is never scheduled, so it reports an
-# `installed_at` but no `started_at`. A cluster with no replicas never advances
-# the frontiers of the collections it maintains, which is what makes the input
+# An object whose inputs are unavailable is never scheduled, so it reports
+# `installed` but no `started`. A cluster with no replicas never advances the
+# frontiers of the collections it maintains, which is what makes the input
 # unavailable here.
 
 > CREATE CLUSTER source_cluster SIZE 'scale=1,workers=1', REPLICATION FACTOR 0
@@ -81,38 +110,45 @@ true
 > CREATE INDEX idx_waiting IN CLUSTER test ON mv_unavailable (a)
 
 > SELECT DISTINCT
-      h.installed_at IS NOT NULL,
-      h.started_at IS NULL,
-      h.hydrated_at IS NULL,
-      h.time_ns IS NULL
+      count(*) FILTER (WHERE l.event = 'installed') = 1,
+      count(*) FILTER (WHERE l.event = 'started') = 0,
+      count(*) FILTER (WHERE l.event = 'hydrated') = 0
+  FROM mz_introspection.mz_compute_lifecycle_events_per_worker l
+  JOIN mz_indexes i ON (i.id = l.export_id)
+  WHERE i.name = 'idx_waiting'
+  GROUP BY l.export_id, l.worker_id
+true true true
+
+> SELECT DISTINCT h.hydrated_at IS NULL, h.time_ns IS NULL
   FROM mz_introspection.mz_compute_hydration_times_per_worker h
   JOIN mz_indexes i ON (i.id = h.export_id)
   WHERE i.name = 'idx_waiting'
-true true true true
+true true
 
-# Once the input becomes available the object is scheduled and hydrates, and
-# the queueing interval it spent waiting is visible as
-# `started_at - installed_at`.
+# Once the input becomes available the object is scheduled and hydrates, and the
+# queueing interval it spent waiting is visible as `started - installed`.
 
 > ALTER CLUSTER source_cluster SET (REPLICATION FACTOR 1)
 
 > SELECT DISTINCT
-      h.started_at > h.installed_at,
-      h.hydrated_at >= h.started_at
-  FROM mz_introspection.mz_compute_hydration_times_per_worker h
-  JOIN mz_indexes i ON (i.id = h.export_id)
+      max(l.occurred_at) FILTER (WHERE l.event = 'started')
+          > max(l.occurred_at) FILTER (WHERE l.event = 'installed'),
+      max(l.occurred_at) FILTER (WHERE l.event = 'hydrated')
+          >= max(l.occurred_at) FILTER (WHERE l.event = 'started')
+  FROM mz_introspection.mz_compute_lifecycle_events_per_worker l
+  JOIN mz_indexes i ON (i.id = l.export_id)
   WHERE i.name = 'idx_waiting'
+  GROUP BY l.export_id, l.worker_id
 true true
 
 > DROP INDEX idx_waiting
 > DROP MATERIALIZED VIEW mv_unavailable
 > DROP CLUSTER source_cluster
 
-# An object queued behind `compute_hydration_concurrency` reports an
-# `installed_at` but no `started_at`, exactly as one waiting on its inputs
-# does. `mv_stuck` oscillates between one row and no rows, so it never
-# converges and holds the single hydration slot indefinitely, in constant
-# memory.
+# An object queued behind `compute_hydration_concurrency` reports `installed` but
+# no `started`, exactly as one waiting on its inputs does. `mv_stuck` oscillates
+# between one row and no rows, so it never converges and holds the single
+# hydration slot indefinitely, in constant memory.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET compute_hydration_concurrency = 1;
@@ -129,23 +165,27 @@ ALTER SYSTEM SET compute_hydration_concurrency = 1;
       )
   SELECT * FROM x
 
-# An in-flight object is distinguishable from one that never started: it has a
-# `started_at` but no `hydrated_at`.
-> SELECT DISTINCT h.started_at IS NOT NULL, h.hydrated_at IS NULL
-  FROM mz_introspection.mz_compute_hydration_times_per_worker h
-  JOIN mz_materialized_views mv ON (mv.id = h.export_id)
+# An in-flight object is distinguishable from one that never started: it has
+# `started` but no `hydrated`.
+> SELECT DISTINCT
+      count(*) FILTER (WHERE l.event = 'started') = 1,
+      count(*) FILTER (WHERE l.event = 'hydrated') = 0
+  FROM mz_introspection.mz_compute_lifecycle_events_per_worker l
+  JOIN mz_materialized_views mv ON (mv.id = l.export_id)
   WHERE mv.name = 'mv_stuck'
+  GROUP BY l.export_id, l.worker_id
 true true
 
 > CREATE INDEX idx_queued IN CLUSTER queued ON t (a)
 
 > SELECT DISTINCT
-      h.installed_at IS NOT NULL,
-      h.started_at IS NULL,
-      h.hydrated_at IS NULL
-  FROM mz_introspection.mz_compute_hydration_times_per_worker h
-  JOIN mz_indexes i ON (i.id = h.export_id)
+      count(*) FILTER (WHERE l.event = 'installed') = 1,
+      count(*) FILTER (WHERE l.event = 'started') = 0,
+      count(*) FILTER (WHERE l.event = 'hydrated') = 0
+  FROM mz_introspection.mz_compute_lifecycle_events_per_worker l
+  JOIN mz_indexes i ON (i.id = l.export_id)
   WHERE i.name = 'idx_queued'
+  GROUP BY l.export_id, l.worker_id
 true true true
 
 > DROP INDEX idx_queued
@@ -156,60 +196,77 @@ true true true
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM RESET compute_hydration_concurrency;
 
-# An import-free dataflow has nothing to suspend, so it carries `started_at`
-# from creation rather than acquiring it when its `Schedule` lands. That keeps the
-# row truthful while it hydrates: it reads as hydrating rather than as queued
-# behind something that is not queueing it.
+# An import-free dataflow has nothing to suspend, so it reports `started` from
+# creation rather than acquiring it when its `Schedule` lands. That keeps the log
+# truthful while it hydrates: it reads as hydrating rather than as queued behind
+# something that is not queueing it.
 #
 # An index is used rather than a materialized view because a constant
 # materialized view runs to the empty frontier and its dataflow shuts down,
-# taking the row with it. The two stamps land in the same turn but are separate
+# taking the rows with it. The two stamps land in the same turn but are separate
 # log events, so they are microseconds apart rather than equal.
 
 > CREATE VIEW v_const AS SELECT 1 AS a
 > CREATE INDEX idx_const IN CLUSTER test ON v_const (a)
 
 > SELECT DISTINCT
-      h.installed_at IS NOT NULL,
-      h.started_at >= h.installed_at,
-      h.started_at - h.installed_at < '1 second'::interval,
-      h.hydrated_at >= h.started_at
-  FROM mz_introspection.mz_compute_hydration_times_per_worker h
-  JOIN mz_indexes i ON (i.id = h.export_id)
+      max(l.occurred_at) FILTER (WHERE l.event = 'started')
+          >= max(l.occurred_at) FILTER (WHERE l.event = 'installed'),
+      max(l.occurred_at) FILTER (WHERE l.event = 'started')
+          - max(l.occurred_at) FILTER (WHERE l.event = 'installed')
+          < '1 second'::interval,
+      max(l.occurred_at) FILTER (WHERE l.event = 'hydrated')
+          >= max(l.occurred_at) FILTER (WHERE l.event = 'started')
+  FROM mz_introspection.mz_compute_lifecycle_events_per_worker l
+  JOIN mz_indexes i ON (i.id = l.export_id)
   WHERE i.name = 'idx_const'
-true true true true
+  GROUP BY l.export_id, l.worker_id
+true true true
 
 > DROP INDEX idx_const
 > DROP VIEW v_const
 
-# The ordering invariant `installed_at <= started_at <= hydrated_at` must hold
-# for every row, and no row may report a later stage without its predecessors.
-# Assert it repeatedly while import-free dataflows are created and torn down,
-# since those are the paths that stamp outside `handle_schedule`. Retries are
-# disabled from here on, so that a violation cannot be retried away.
+# The two relations must not contradict each other. A row reporting a duration
+# must have a `hydrated` stage behind it, and its `hydrated_at` must not precede
+# the export's `installed`. Assert it repeatedly while import-free dataflows are
+# created and torn down, since those are the paths that stamp outside
+# `handle_schedule`. Retries are disabled from here on, so that a violation
+# cannot be retried away.
 
 $ set-max-tries max-tries=1
 
 > CREATE MATERIALIZED VIEW mv_const1 IN CLUSTER test AS SELECT 1
-> SELECT count(*) FROM mz_introspection.mz_compute_hydration_times_per_worker
-  WHERE installed_at IS NULL
-     OR (started_at IS NULL AND hydrated_at IS NOT NULL)
-     OR started_at < installed_at
-     OR hydrated_at < started_at
+> SELECT count(*)
+  FROM mz_introspection.mz_compute_hydration_times_per_worker h
+  JOIN (
+      SELECT
+          export_id,
+          worker_id,
+          max(occurred_at) FILTER (WHERE event = 'installed') AS installed_at,
+          count(*) FILTER (WHERE event = 'hydrated') AS hydrated_events
+      FROM mz_introspection.mz_compute_lifecycle_events_per_worker
+      GROUP BY export_id, worker_id
+  ) l ON (l.export_id = h.export_id AND l.worker_id = h.worker_id)
+  WHERE (h.time_ns IS NOT NULL AND h.hydrated_at IS NULL)
+     OR (h.hydrated_at IS NOT NULL AND l.hydrated_events = 0)
+     OR h.hydrated_at < l.installed_at
+     OR l.installed_at IS NULL
 0
 
 > CREATE MATERIALIZED VIEW mv_const2 IN CLUSTER test AS SELECT 2
-> SELECT count(*) FROM mz_introspection.mz_compute_hydration_times_per_worker
-  WHERE installed_at IS NULL
-     OR (started_at IS NULL AND hydrated_at IS NOT NULL)
-     OR started_at < installed_at
-     OR hydrated_at < started_at
-0
-
-> CREATE MATERIALIZED VIEW mv_const3 IN CLUSTER test AS SELECT 3
-> SELECT count(*) FROM mz_introspection.mz_compute_hydration_times_per_worker
-  WHERE installed_at IS NULL
-     OR (started_at IS NULL AND hydrated_at IS NOT NULL)
-     OR started_at < installed_at
-     OR hydrated_at < started_at
+> SELECT count(*)
+  FROM mz_introspection.mz_compute_hydration_times_per_worker h
+  JOIN (
+      SELECT
+          export_id,
+          worker_id,
+          max(occurred_at) FILTER (WHERE event = 'installed') AS installed_at,
+          count(*) FILTER (WHERE event = 'hydrated') AS hydrated_events
+      FROM mz_introspection.mz_compute_lifecycle_events_per_worker
+      GROUP BY export_id, worker_id
+  ) l ON (l.export_id = h.export_id AND l.worker_id = h.worker_id)
+  WHERE (h.time_ns IS NOT NULL AND h.hydrated_at IS NULL)
+     OR (h.hydrated_at IS NOT NULL AND l.hydrated_events = 0)
+     OR h.hydrated_at < l.installed_at
+     OR l.installed_at IS NULL
 0


### PR DESCRIPTION
> **Closed, not deferred.** The duplication this removes is real but internal, and removing it makes the relation worse to read.

`mz_compute_hydration_times_per_worker` carries `time_ns`, a duration whose origin is the export's creation. Dropping `installed_at` moves that origin into a different relation, so the relation no longer explains its own duration: interpreting it means either a join against the lifecycle log or the non-obvious `hydrated_at - time_ns`. Before, the instants and the duration cross-checked each other inside one row, which is what let the ordering invariant be asserted locally.

Against that, the duplication costs two `Duration` fields per export per worker and a few lines of packing, and is invisible to consumers. The removal gives no consumer a capability it did not have. Meanwhile it churns a downstream consumer that is being built against these relations right now.

"Remove the duplication" was the right instinct about an internal wart. The wart turns out to be cheaper than the surgery.

**What survives from this PR:** the reasoning about why `hydrated_at` cannot be pivoted from the lifecycle log's `hydrated` — the first is the durability reading, taken when the reported output frontier passes the as-of, and the second is the dataflow-progress reading. Since `mz_compute_hydration_statuses.hydrated` is `time_ns IS NOT NULL` and feeds blue-green readiness, redefining it would have readiness cut over before the output is durable. That is now recorded as a frozen commitment in the design doc's "What the timestamps promise, and what they do not", along with the rest of the consumer-facing compatibility contract.

If this is ever revisited, the smaller and more defensible cut is to drop only `started_at`, keeping `installed_at` so `time_ns`'s origin stays in the row.