### PR TITLE
docs: correct the partition operations that break publish_via_partition_root

### DIFF
--- a/doc/user/content/ingest-data/postgres/partitioned-tables.md
+++ b/doc/user/content/ingest-data/postgres/partitioned-tables.md
@@ -40,8 +40,8 @@ that uses this option, and doing so can produce incorrect results.
 
 The configuration is accepted rather than rejected: the source is created, the
 initial snapshot is correct, and inserts, updates, and deletes appear to
-replicate normally. Problems surface only once partitions are added, attached,
-or detached. Use one of the approaches on this page instead.
+replicate normally. Problems surface only once partitions are attached,
+detached, or truncated. Use one of the approaches on this page instead.
 
 {{< /warning >}}
 


### PR DESCRIPTION
### Motivation

Review feedback on #38199: the `publish_via_partition_root = true` warning on the PostgreSQL partitioned tables page listed *adding* a partition as one of the operations that surfaces problems. That isn't right. Partitions created with `CREATE TABLE ... PARTITION OF` are always empty, so they move no data into the root table and cause no divergence. Truncating a partition, which does remove root-table data, was missing from the list.

### Description

Replaces "added, attached, or detached" with "attached, detached, or truncated" in the warning. All three of those are DDL that adds or removes root-table data without emitting CDC events, which is precisely the failure mode the warning describes.

### Verification

Docs-only prose change; no code or test surface. The paragraph rewraps to stay within the file's line width.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBUT5iCf2hkNY2hEfruLTp)_