### PR TITLE
ore/pool, timely-util/columnar: tighten comments

### DIFF
--- a/src/ore/src/pool.rs
+++ b/src/ore/src/pool.rs
@@ -40,20 +40,6 @@
 //!   pushes the oldest extents to the swap device with `MADV_PAGEOUT`.
 //! * **The swap device** — overflow; reads fault and decompress.
 //!
-//! The identity `total pool RSS <= budget + warm cap + compressed cap`,
-//! where `compressed cap = max(0, rss_target - budget - warm cap)`, makes
-//! every resident byte's ceiling nameable. A zero RSS target (or one below
-//! the budget plus warm cap) collapses the compressed tier and extents page
-//! out as soon as they are written. Heap-backed chunks (oversize payloads
-//! and class-exhaustion fallbacks) sit outside the identity: they can never
-//! be evicted, so the budget is enforced against evictable bytes only.
-//! Slots never reach the swap device: only compressed extents are offered
-//! to it. Pageout is observed rather than assumed: an extent counts against
-//! the compressed tier until the page table shows its whole range unmapped,
-//! so reclaim the kernel declines surfaces as `extent_pageout_incomplete`
-//! (and a tier settled above its capacity) instead of as RSS the ledger
-//! cannot see.
-//!
 //! Residency is a state, not a type. It descends through eviction and
 //! ascends through exactly one transition: an admitting read
 //! ([`ChunkHandle::read_into_admit`]) lifts an evicted chunk back to
@@ -69,11 +55,7 @@
 //! Freeing an `UnbackedResident` chunk is a pure memory operation — the
 //! design's "never write dead data" win, surfaced as `writes_elided` in
 //! [`PoolStats`]. Budget pressure evicts cold chunks via second-chance
-//! FIFOs banded by the caller-supplied generational depth ([`ChunkHints`]):
-//! eviction and eager backing both visit deeper (colder) bands first, so
-//! the youngest data keeps its die-before-write chance longest. Within a
-//! band the FIFO is the design's backstop policy, and unannotated chunks
-//! (depth 0) get exactly that.
+//! FIFOs banded by the caller-supplied generational depth ([`ChunkHints`]).
 
 mod extent;
 mod region;
@@ -242,8 +224,7 @@ pub struct PoolStats {
     pub oversize_payloads: u64,
     /// Live size-classed chunks across all classes, whatever their residency.
     /// For backlog-shaped consumers this tracks the un-drained backlog in
-    /// chunks. (Slots are scoped to residency, so the quantity that exhausts
-    /// a class reservation is the resident subset, bounded by the budget.)
+    /// chunks.
     pub live_chunks: u64,
     /// Uncompressed bytes of currently resident chunks (including oversize).
     pub resident_bytes: u64,
@@ -278,9 +259,7 @@ pub struct PoolStats {
     /// Allocation bytes of resident extents the RSS target cannot push out:
     /// retry-capped arena extents (the kernel declined the reclaim advice
     /// until the retry budget ran out) and heap-fallback extents. The
-    /// compressed tier settles above its capacity by this amount. Climbing
-    /// steadily means pages cannot reach the swap device (no swap, or a
-    /// cgroup that cannot reclaim).
+    /// compressed tier settles above its capacity by this amount.
     pub extent_unreclaimable_bytes: u64,
     /// Extents pushed to the swap device by RSS-target enforcement, with
     /// the whole range observed nonresident afterwards.
@@ -329,9 +308,7 @@ struct Counters {
 #[derive(Debug, Clone)]
 pub struct Pool(Arc<PoolInner>);
 
-/// The shared state behind every [`Pool`] handle: the budget and RSS
-/// ledgers, the size-class slot regions and the extent arena, the eviction
-/// and backing queues, and the spill-thread hand-off. One per process in
+/// The shared state behind every [`Pool`] handle. One per process in
 /// practice; [`Pool`] clones and chunk handles share it through an `Arc`,
 /// so it lives until the last handle and spill thread release it.
 ///
@@ -421,11 +398,7 @@ struct Spill {
     /// first spawned; cleared to fall back to inline eviction.
     enabled: std::sync::atomic::AtomicBool,
     /// Whether idle spill threads eagerly compress unbacked chunks to
-    /// `BackedResident` (write-behind): the chunk stays readable in its slot
-    /// while a compressed extent accumulates on the swap device, so a later
-    /// budget-driven eviction is a pure page release instead of a
-    /// compression. Costs CPU on chunks that die before eviction would have
-    /// reached them; pays at every pressure event.
+    /// `BackedResident` (write-behind); see [`Pool::set_eager_backing`].
     eager: std::sync::atomic::AtomicBool,
     /// Number of spill threads spawned (spawn-once; later config changes
     /// only toggle `enabled`).
@@ -539,9 +512,7 @@ impl ChunkMeta {
 /// Handle to one immutable chunk in a [`Pool`]. Dropping the handle frees the
 /// chunk: the slot (if resident) returns to the region free list with its
 /// physical pages released, and the extent (if any) is deallocated,
-/// discarding any swapped copy for free. Releasing the pages keeps RSS
-/// aligned with the `resident_bytes` gauge the budget enforcer trusts;
-/// without it, freed slots would hold warm pages the enforcer cannot see.
+/// discarding any swapped copy for free.
 #[derive(Debug)]
 pub struct ChunkHandle {
     meta: Arc<ChunkMeta>,
@@ -600,21 +571,16 @@ impl Pool {
 
     /// Allocates a chunk of `len` words and fills it in place: `fill`
     /// receives the chunk's slot memory directly and must overwrite all of
-    /// it (the slot's prior contents are unspecified). The returned handle
+    /// it (the slot's prior contents are unspecified), so serialization
+    /// writes its single copy straight into pool memory. The returned handle
     /// starts `UnbackedResident`. A zero `len` returns a length-0 handle
     /// holding no slot; payloads beyond the largest size class fall back to
     /// a plain heap allocation, always resident, a prototype limitation.
     /// `hints` steer eviction and write-behind policy; callers without
-    /// placement knowledge pass the default.
-    ///
-    /// This is the zero-staging insert: serialization can write its single
-    /// copy straight into pool memory, paying one page population instead of
-    /// staging through caller-side buffers that fault their own pages and
-    /// die immediately after.
-    ///
-    /// `codec` is the chunk's [`ExtentCodec`], fixed for its lifetime: the
-    /// pool invokes it whenever the chunk moves across the extent boundary,
-    /// and takes no interest in the stored form it produces.
+    /// placement knowledge pass the default. `codec` is the chunk's
+    /// [`ExtentCodec`], fixed for its lifetime: the pool invokes it whenever
+    /// the chunk moves across the extent boundary, and takes no interest in
+    /// the stored form it produces.
     ///
     /// Relies on abort-on-panic: a panic in `fill` that was caught would
     /// leak the slot and its resident-bytes accounting. All hosting
@@ -649,16 +615,13 @@ impl Pool {
         }
         let class = region::size_class_for(len_bytes);
         if class.is_none() {
-            // The payload exceeds the largest size class, so it goes straight
-            // to a heap-backed oversize chunk.
             inner
                 .counters
                 .oversize_payloads
                 .fetch_add(1, Ordering::Relaxed);
         }
-        // A class with no free slot degrades to the heap path below: the
-        // resident set outgrew the class reservation, and an unpageable chunk
-        // beats a dead replica. Warn once; the fallback counter tracks scale.
+        // A class with no free slot degrades to the heap path below: an
+        // unpageable chunk beats a dead replica.
         let slot = class.and_then(|class| inner.alloc_slot(class, len_bytes));
         // Whichever home the payload found, it is resident.
         inner
@@ -801,8 +764,9 @@ impl Pool {
 
     /// Enables or disables eager backing: when on, idle spill threads
     /// compress unbacked chunks to `BackedResident` ahead of pressure, so
-    /// budget-driven eviction becomes a pure page release. Only meaningful
-    /// with spill threads spawned.
+    /// budget-driven eviction becomes a pure page release. Costs CPU on
+    /// chunks that die before eviction would have reached them; pays at
+    /// every pressure event. Only meaningful with spill threads spawned.
     pub fn set_eager_backing(&self, eager: bool) {
         self.0.spill.eager.store(eager, Ordering::Relaxed);
         if eager {
@@ -1046,12 +1010,10 @@ impl PoolInner {
             #[cfg(test)]
             run_enforce_budget_hook();
             // A caller turned away since this pass's counter reads may have
-            // left bytes unenforced. Re-run rather than drop them. The Acquire
-            // pairs with the turned-away Release so the re-read sees the bump.
-            //
-            // This swap is the only place the flag is cleared, so no set can be
-            // lost. The cost is that a flag left over from an earlier call's
-            // residual window buys one extra pass here, which is harmless.
+            // left bytes unenforced; re-run rather than drop them. The Acquire
+            // pairs with the turned-away Release so the re-read sees the bump,
+            // and this swap is the only place the flag is cleared, so no set
+            // can be lost.
             //
             // NOTE: a caller turned away between this swap and `drop(guard)`
             // sets the flag but finds no re-reader. That residual window is a
@@ -1339,7 +1301,6 @@ impl PoolInner {
         // Spill threads see a steady job stream, so they keep the grown
         // compression scratch for the next job.
         let extent = SwapExtent::write(&self.extent_arena, data, meta.codec, Scratch::Retain);
-        // Commit under the lock.
         let mut state = meta.state();
         if state.freed {
             // Freed during compression: the extent is garbage; cleanup is
@@ -1461,8 +1422,6 @@ impl PoolInner {
     fn try_alloc_slot(&self, class: usize, len_bytes: usize) -> Option<u32> {
         let (index, warm) = self.regions[class].alloc()?;
         if warm {
-            // The allocation faulted no pages; its bytes leave the warm
-            // pool.
             let class_bytes = u64::cast_from(self.regions[class].class_size());
             self.counters
                 .warm_bytes
@@ -1574,12 +1533,9 @@ impl PoolInner {
                 .fetch_sub(len_bytes, Ordering::Relaxed);
         }
         if let Some(slot) = self.steal_clean_victim(class, meta.len_bytes()) {
-            // The ledger was settled inside the steal: the victim's bytes
-            // out, the admitted chunk's in, with any growth reserved
-            // against the budget. The slot's physical pages transfer
-            // deliberately, but only up to the admitted payload: the
-            // victim's pages past it would stay resident with no ledger
-            // bytes to answer for them.
+            // The slot's physical pages transfer deliberately, but only up
+            // to the admitted payload: the victim's pages past it would
+            // stay resident with no ledger bytes to answer for them.
             self.trim_slot_tail(class, slot, meta.len_bytes());
             self.counters
                 .admissions_steal
@@ -1597,12 +1553,9 @@ impl PoolInner {
     /// touched bit, whose extent already duplicates its slot, so the victim
     /// transitions to `Evicted` with zero I/O, its extent intact, and its
     /// queue entry dropped. The returned slot keeps its physical pages (no
-    /// `dontneed`, no free-list round trip). They hold the victim's stale
-    /// bytes. The ledger is settled inside the steal: the victim's bytes
-    /// leave and the admitted payload's enter in one step, and a steal that
-    /// grows resident bytes must fit the budget like any other admission
-    /// (a shrinking steal always may proceed). `None` when the bounded scan
-    /// finds no such victim, or none whose growth the budget can absorb.
+    /// `dontneed`, no free-list round trip); they hold the victim's stale
+    /// bytes. `None` when the bounded scan finds no such victim, or none
+    /// whose growth the budget can absorb.
     ///
     /// The caller holds its own chunk's state lock. The scan follows the
     /// enforcement discipline (deepest band first, queue guard dropped
@@ -1614,16 +1567,12 @@ impl PoolInner {
     /// without spending touched bits, shuffling FIFO order the way the
     /// backing scan does.
     fn steal_clean_victim(&self, class: usize, admitted_len_bytes: usize) -> Option<u32> {
-        // Bound on entries examined per band before moving to the next.
-        // The budget is per band, not shared across the scan: a deep band
-        // densely populated with touched resident chunks (a probe-heavy
-        // arrangement whose reads refresh every bit) would otherwise spend
-        // the entire scan on hopeless candidates and starve the shallower
-        // bands where the clean-victim stock actually sits (eager backing
-        // stocks young backed chunks in band zero). Eight visits per band
-        // absorb a handful of lock-busy or freshly touched entries without
-        // degrading a hopeless scan into a full queue walk, and cap the
-        // whole scan at eight times the band count.
+        // Bound on entries examined, per band rather than shared across the
+        // scan: a deep band dense with touched resident chunks would
+        // otherwise spend the whole scan on hopeless candidates and starve
+        // the shallower bands where eager backing stocks the clean victims.
+        // Eight visits absorb a few lock-busy or freshly touched entries
+        // without degrading a hopeless scan into a full queue walk.
         const VISITS_PER_BAND: usize = 8;
         for band in (0..DEPTH_BANDS).rev() {
             let mut visits = VISITS_PER_BAND;
@@ -1781,33 +1730,17 @@ impl PoolInner {
     }
 
     /// Routes compressed-cap enforcement off latency-sensitive threads: with
-    /// spill threads running, wakes one to perform the pageouts
-    /// (`MADV_PAGEOUT` is synchronous reclaim — page-table walks, TLB
-    /// shootdowns, writeback submission — bounded per compressed extent but
-    /// not free at chunk rates); without them, enforces inline as the only
-    /// option.
+    /// spill threads spawned, wakes one to perform the pageouts
+    /// (`MADV_PAGEOUT` is synchronous reclaim, bounded per extent but not
+    /// free at chunk rates); without them, enforces inline. The test is for
+    /// thread existence, not `spill.enabled`: spawned threads trim the tier
+    /// in their loop even with eviction hand-off disabled.
     ///
-    /// The routing rule across the two ceilings: budget pressure goes
-    /// through [`PoolInner::enforce_budget`], single-flighted because
-    /// concurrent passes would convoy on redundant compression scans; tier
-    /// pressure goes through this router, and the enforcement itself is
-    /// deliberately *not* single-flighted, since concurrent passes pop
-    /// disjoint victims and each visit is microseconds. Spill threads call
-    /// [`PoolInner::enforce_compressed_cap`] directly (they *are* the
-    /// deferral target), and [`Pool::set_rss_target`] enforces a shrink
-    /// inline so config changes land synchronously, mirroring `set_budget`.
-    ///
-    /// Deferral makes the target eventually-enforced with bounded lag (a
-    /// notify with every spill thread mid-job is absorbed; the next loop
-    /// pass catches up). The backstop below turns that into a bound by
-    /// construction: a caller finding the tier at double its capacity
-    /// enforces inline regardless, so sustained creation can never outrun
-    /// trimming by more than one capacity's worth.
-    ///
-    /// Deferral tests for thread existence alone, not `spill.enabled`:
-    /// spawned threads trim the tier in their loop for as long as they live,
-    /// even with eviction hand-off disabled, so they remain the better home
-    /// for the pageouts.
+    /// Deferral makes the target eventually-enforced with bounded lag, and
+    /// the backstop below turns the lag into a bound by construction: a
+    /// caller finding the reclaimable tier at double its capacity enforces
+    /// inline regardless, so sustained creation can never outrun trimming
+    /// by more than one capacity's worth.
     fn enforce_or_defer_compressed_cap(&self) {
         if self.spill.threads.load(Ordering::Relaxed) > 0 {
             // The inline backstop keys on the bytes enforcement can actually
@@ -1963,8 +1896,7 @@ impl ChunkHandle {
     /// The range narrows only the copy into `dst`: the swap backend's
     /// stored form is a whole compressed block, so a cold read still
     /// faults and decompresses the entire extent, and accounting is that
-    /// of a whole-chunk read. A backend with a rangeable stored form can
-    /// serve the same call with range-proportional I/O.
+    /// of a whole-chunk read.
     pub fn read_range_into(&self, range: Range<usize>, dst: &mut Vec<u64>) {
         self.read_impl(range, dst, false);
     }
@@ -2070,12 +2002,7 @@ impl ChunkHandle {
                         // waste (~a tenth of the decompress cost): the extent
                         // read takes an initialized `&mut [u8]`, so skipping
                         // the fill would mean exposing uninitialized memory
-                        // through a safe reference. Callers that read
-                        // repeatedly amortize it by reusing `dst` within a
-                        // pass, shrinking it back after oversized reads (a
-                        // reused buffer otherwise ratchets to the largest
-                        // chunk it ever carried, invisible to every pool
-                        // gauge; the design doc's reader discipline).
+                        // through a safe reference.
                         dst.resize(range.end - range.start, 0);
                         let bytes: &mut [u8] = bytemuck::cast_slice_mut(dst.as_mut_slice());
                         extent.read_range_into(
@@ -2193,7 +2120,6 @@ impl Drop for ChunkHandle {
                 state.extent = None;
             }
             Residency::Evicted => {
-                // Eviction already released the slot.
                 crate::soft_assert_no_log!(state.slot.is_none(), "evicted chunk holds no slot");
                 if let Some(extent) = &state.extent {
                     pool.note_extent_released(extent);
@@ -2383,8 +2309,6 @@ mod tests {
         handle.read_range_into(SMALL - 1..SMALL + 1, &mut out);
     }
 
-    /// With no RSS target (the default), the compressed tier has zero
-    /// capacity and extents page out as soon as they are written.
     #[mz_ore::test]
     fn default_target_pages_extents_immediately() {
         let pool = test_pool(256 << 20);
@@ -2395,8 +2319,6 @@ mod tests {
         assert_eq!(stats.extent_pageouts, 1);
     }
 
-    /// A pageout pass whose residency observation finds the whole range
-    /// gone uncounts exactly the extent's allocation bytes.
     #[mz_ore::test]
     fn full_pageout_uncounts_exactly_the_extent() {
         let pool = test_pool(256 << 20);
@@ -2412,9 +2334,6 @@ mod tests {
         assert_eq!(stats.extent_pageout_incomplete, 0);
     }
 
-    /// A pageout pass the kernel declines leaves the extent fully counted
-    /// and queued, and increments the incomplete counter. The next pass
-    /// (advice now accepted) pages it out.
     #[mz_ore::test]
     fn incomplete_pageout_keeps_accounting_and_queue_position() {
         let pool = test_pool(256 << 20);
@@ -2458,7 +2377,7 @@ mod tests {
         assert_eq!(
             stats.extent_pageout_incomplete,
             u64::from(extent::PAGEOUT_RETRY_CAP),
-            "advised exactly retry-cap times, then left alone",
+            "advised exactly retry-cap times",
         );
         assert_eq!(stats.extent_pageouts, 0);
         let counted = stats.extent_resident_bytes;
@@ -2477,8 +2396,6 @@ mod tests {
         assert_eq!(read(&handle).len(), SMALL, "capped extent stays readable");
     }
 
-    /// Reading a retry-capped extent faults its pages back in and resets
-    /// the retry budget, so a later pass can page it out.
     #[mz_ore::test]
     fn read_resets_pageout_retry_budget() {
         let pool = test_pool(256 << 20);
@@ -2519,10 +2436,7 @@ mod tests {
         assert_eq!(handle.residency(), Residency::BackedResident);
         let stats = pool.stats();
         assert_eq!(stats.eager_backs, 1);
-        assert_eq!(
-            stats.evictions_compress, 0,
-            "backing is not an eviction and compresses off the eviction counter",
-        );
+        assert_eq!(stats.evictions_compress, 0, "backing is not an eviction");
         assert!(stats.extent_bytes_written > 0);
 
         // Still readable straight from the slot: the chunk is resident.
@@ -2536,18 +2450,12 @@ mod tests {
         assert_eq!(read(&handle), orig);
     }
 
-    /// Once everything reachable is backed, the backing scan reports no
-    /// progress so spill threads park instead of rescanning a fully-backed
-    /// queue forever.
     #[mz_ore::test]
     fn backing_reports_no_progress_when_all_backed() {
         let pool = test_pool(256 << 20);
         let _handle = insert(&pool, &mut payload(SMALL, 31));
         assert!(pool.back_step(), "one unbacked chunk is actionable");
-        assert!(
-            !pool.back_step(),
-            "a fully-backed queue is not progress; callers must park",
-        );
+        assert!(!pool.back_step(), "fully backed: no progress");
         assert_eq!(pool.stats().eager_backs, 1);
     }
 
@@ -2572,8 +2480,6 @@ mod tests {
         assert_eq!(read(&handle), orig);
     }
 
-    /// The warm pool is capped at an eighth of the budget; frees beyond the
-    /// cap release their pages and park cold.
     #[mz_ore::test]
     fn warm_pool_respects_cap() {
         // Budget 1 MiB: warm cap = 128 KiB = two 64 KiB slots.
@@ -2667,9 +2573,6 @@ mod tests {
         assert_eq!(stats.resident_bytes, 0);
     }
 
-    /// `take` is the terminal read: the contents come back and the consumed
-    /// handle frees the chunk, eliding the backing write of a chunk that was
-    /// still unbacked.
     #[mz_ore::test]
     fn take_reads_and_frees() {
         let pool = test_pool(256 << 20);
@@ -2899,9 +2802,6 @@ mod tests {
         assert_eq!(pool.stats().admissions_denied, 1);
     }
 
-    /// Plain reads and `take` never admit: an evicted chunk with plenty of
-    /// budget headroom stays evicted through both, and neither counts a
-    /// denial.
     #[mz_ore::test]
     fn plain_read_and_take_never_admit() {
         let pool = test_pool(256 << 20);
@@ -3640,9 +3540,6 @@ mod tests {
         assert_eq!(stats.resident_bytes, 0, "slot accounting settled");
     }
 
-    /// `take` on a chunk whose backing write is still in flight copies the
-    /// contents out of the slot and cancels the write: the spill thread finds
-    /// the chunk freed, elides the extent, and settles the slot accounting.
     #[mz_ore::test]
     fn spill_take_in_flight_cancels_write() {
         let pool = test_pool(usize::MAX);

--- a/src/ore/src/pool/extent.rs
+++ b/src/ore/src/pool/extent.rs
@@ -359,10 +359,7 @@ impl SwapExtent {
     /// incomplete pass leaves the extent fully resident for accounting and
     /// spends one unit of the retry budget: a single pinned page keeps the
     /// whole extent counted, which is the safe direction, and the retry
-    /// budget exists exactly for such transient pins. Cheap: the
-    /// compression is already paid, the madvise and page-table read are
-    /// microseconds, and the device write happens on the kernel's
-    /// asynchronous writeback path.
+    /// budget exists exactly for such transient pins.
     ///
     /// Callers must not invoke this on a [`SwapExtent::pageout_capped`]
     /// extent.
@@ -588,9 +585,6 @@ mod tests {
         );
     }
 
-    /// The ladder is page-granular, strictly ascending, covers lz4's worst
-    /// case over the largest chunk class, and steps by at most 1.5x above
-    /// the smallest class.
     #[mz_ore::test]
     fn ladder_shape() {
         for page in [4096usize, 16384, 65536] {
@@ -679,8 +673,6 @@ mod tests {
         extent.read_into(&TEST_CODEC, bytemuck::cast_slice_mut(&mut out));
     }
 
-    /// Residency follows the observation, not the advice: a declined pass
-    /// leaves the extent resident, an accepted one marks it gone.
     #[mz_ore::test]
     fn pageout_is_observed_not_trusted() {
         let arena = arena();
@@ -695,8 +687,6 @@ mod tests {
         assert!(!extent.is_resident());
     }
 
-    /// Consecutive declined passes exhaust the retry budget. A read faults
-    /// the pages back in and restores it.
     #[mz_ore::test]
     fn pageout_retry_cap_and_read_reset() {
         let arena = arena();

--- a/src/ore/src/pool/region.rs
+++ b/src/ore/src/pool/region.rs
@@ -229,12 +229,9 @@ impl Region {
 
     /// Allocates a slot index, or `None` if every slot of the class is in
     /// use; the flag reports whether the slot came from the warm list (its
-    /// pages are resident; writing it faults nothing).
-    ///
-    /// Slots are scoped to residency (eviction frees them), so demand scales
-    /// with the *resident* set — bounded by the pool budget plus in-flight
-    /// slack — and exhaustion means residency outgrew the class reservation;
-    /// callers degrade rather than fail.
+    /// pages are resident; writing it faults nothing). Exhaustion means
+    /// residency outgrew the class reservation; callers degrade rather
+    /// than fail.
     pub(crate) fn alloc(&self) -> Option<(u32, bool)> {
         self.slots
             .lock()

--- a/src/timely-util/src/columnar/batcher.rs
+++ b/src/timely-util/src/columnar/batcher.rs
@@ -260,23 +260,13 @@ where
 /// satisfying `cmp` — useful when one side of a sorted merge has long runs
 /// dominated by the other side.
 pub(crate) fn gallop(upper: usize, lower: &mut usize, mut cmp: impl FnMut(usize) -> bool) {
-    // If `cmp` is already false at `*lower`, the run is empty — nothing to do.
     if *lower < upper && cmp(*lower) {
-        // Phase 1 (overshoot): advance by exponentially growing steps as long
-        // as `cmp` holds. After this loop, `*lower` is the last position we
-        // confirmed satisfies `cmp`, and `*lower + step` either falls off the
-        // end or fails `cmp`. The boundary is somewhere in `(*lower, *lower +
-        // step]`.
         let mut step = 1;
         while *lower + step < upper && cmp(*lower + step) {
             *lower += step;
             step <<= 1;
         }
 
-        // Phase 2 (binary descent): halve `step` and probe `*lower + step`,
-        // accepting the advance only when `cmp` still holds. This narrows the
-        // search range by half each iteration, settling on the largest index
-        // still satisfying `cmp`.
         step >>= 1;
         while step > 0 {
             if *lower + step < upper && cmp(*lower + step) {
@@ -285,8 +275,8 @@ pub(crate) fn gallop(upper: usize, lower: &mut usize, mut cmp: impl FnMut(usize)
             step >>= 1;
         }
 
-        // `*lower` now points at the last index where `cmp` holds; the caller
-        // wants the first index where it doesn't, so step past it.
+        // `*lower` is the last index where `cmp` holds; step to the first
+        // where it does not.
         *lower += 1;
     }
 }
@@ -344,12 +334,10 @@ where
             1 => {
                 let other = &mut others[0];
                 let pos = &mut positions[0];
-                // If `self` is empty and `*pos == 0`, we can bulk swap in the other chunk.
                 if self.is_empty() && *pos == 0 {
                     std::mem::swap(self, other);
                     return false;
                 }
-                // Otherwise, bulk copy the remaining data from `other[*pos..]` into `self`.
                 let Column::Typed(self_c) = self else {
                     unreachable!("merger chunks are always Column::Typed");
                 };
@@ -476,11 +464,9 @@ where
                                 gallop(upper_l, &mut left_pos[0], |i| {
                                     (l_d.get(i), l_t.get(i)) < (d2, t2)
                                 });
-                                // Per-leaf bulk copy of the run. Each
-                                // call resolves to an `extend_from_slice`
-                                // on its leaf (recursively for nested
-                                // leaves), which the compiler can
-                                // autovectorize.
+                                // Per-leaf bulk copy of the run: each call
+                                // resolves to an `extend_from_slice` on its
+                                // leaf (recursively for nested leaves).
                                 sd.extend_from_self(l_d, start..left_pos[0]);
                                 st.extend_from_self(l_t, start..left_pos[0]);
                                 sr.extend_from_self(l_r, start..left_pos[0]);
@@ -531,8 +517,6 @@ where
             }
             // `Merger::merge` only ever calls `merge_from` with 0/1/2-input
             // slices (k-way merge isn't part of the merge-batcher contract).
-            // Defensive guard: if someone bumps that, this will panic
-            // immediately rather than silently produce wrong output.
             n => unreachable!("merge_from called with {n} inputs; expected 0, 1, or 2"),
         }
     }
@@ -565,12 +549,6 @@ where
         let self_view = self.borrow();
         let len = self_view.len();
 
-        // Yield to the framework when either output buffer reaches the
-        // ship threshold, so it can ship a full chunk and hand back a
-        // fresh one. Required by the merger's extract contract: the
-        // framework only checks `at_capacity` between calls, so without
-        // an inner-loop yield a single call can fill an output well past
-        // threshold.
         use columnar::Borrow as _;
         let mut owned_t = T::default();
         while *position < len
@@ -592,19 +570,11 @@ where
     }
 }
 
-/// `Merger` impl driving [`MergeBatcher`] over [`Column`]-shaped chunks.
-///
-/// `merge` walks two sorted chains of chunks in lockstep, calling
-/// `Column::merge_from` to consume up to one ship-threshold's worth of input
-/// per pass and shipping `result` to `output` whenever it crosses
-/// `at_capacity`. Exhausted input chunks are reset and pushed to `stash` for
-/// reuse. The drain phase appends remaining full chunks to `output`
-/// directly, with no per-element copy.
-///
-/// `extract` walks each chunk via `Column::extract`, partitioning records
-/// into `kept` (times beyond `upper`) and `ship` (sealed into the output
-/// batch); both grow chunk-by-chunk under the same `at_capacity` ship
-/// signal.
+/// `Merger` impl driving [`MergeBatcher`] over [`Column`]-shaped chunks,
+/// built on the inherent `Column::merge_from` and `Column::extract` methods.
+/// Exhausted input chunks are recycled through `stash`, and remaining full
+/// chunks on a drained side move to the output directly, with no per-element
+/// copy.
 ///
 /// [`MergeBatcher`]: differential_dataflow::trace::implementations::merge_batcher::MergeBatcher
 impl<D, T, R> Merger for ColumnMerger<D, T, R>
@@ -644,20 +614,13 @@ where
                 break;
             }
 
-            // Whole-chunk passthrough fast path. When one head's tail (from
-            // its current position) is sortable-before the other head's
-            // current record, the entire tail can be appended to `output`
-            // without per-record compares or per-leaf byte copies.
-            //
-            // Two probes (one record from each side) settle this — when it
-            // fires, it skips an entire `merge_from` invocation, including
-            // its gallop bulk-copies, and replaces the byte-level extend
-            // with a `mem::replace` of the head into `output`.
-            //
-            // Restricted to `positions[i] == 0` so we can hand the head off
-            // wholesale; partial-tail passthrough would require a 1-input
-            // `merge_from` to materialize the tail into a new chunk, which
-            // is what gallop already handles inside the merge loop.
+            // Whole-chunk passthrough fast path: when one head's tail (from
+            // its current position) sorts entirely before the other head's
+            // current record, the head moves to `output` wholesale, with two
+            // probe records in place of per-record compares and per-leaf
+            // byte copies. Restricted to `positions[i] == 0` so the head can
+            // be handed off intact; a partial tail is what gallop already
+            // handles inside the merge loop.
             let lhs_passthrough = positions[0] == 0 && upper_l > 0 && {
                 let lhs = heads[0].borrow();
                 let rhs = heads[1].borrow();

--- a/src/timely-util/src/columnar/chunk.rs
+++ b/src/timely-util/src/columnar/chunk.rs
@@ -21,22 +21,16 @@
 //!   is freed without I/O.
 //!
 //! Reads of a spilled body are copy-out and scoped to the call that needs
-//! them: the body is read into caller-owned memory and no reference into pool
-//! memory ever exists outside the pool. That contract is what lets the pool
-//! evict with no reader accounting at all.
+//! them, the contract that lets the pool evict with no reader accounting
+//! (see [`mz_ore::pool`]).
 //!
 //! Spilling happens in [`Chunk::settle`], the trait's designated commit point:
 //! chunks moved to settled output are handed to the pool when spilling is
-//! enabled (see [`set_compute_spill_enabled`] and [`set_storage_spill_enabled`]).
-//! The spill destination resolves per commit from three pieces of mutable
-//! state. A thread-local pool override, for tests and benches, wins outright.
-//! Otherwise the compute and storage gates, composed as an OR, route commits
-//! to the process pool installed by [`crate::pool_config`], and with no pool
-//! installed chunks stay resident. A second thread-local holds the reusable
-//! scratch that call-scoped reads of spilled bodies copy into.
-//! Grading is by serialized bytes, the ship size
-//! [`Column`] already targets, rather than by the record-count `TARGET`,
-//! since record count does not bound bytes for variable-width data.
+//! enabled (see [`set_compute_spill_enabled`] and [`set_storage_spill_enabled`]
+//! for how the per-commit destination resolves). Grading is by serialized
+//! bytes, the ship size [`Column`] already targets, rather than by the
+//! record-count `TARGET`, since record count does not bound bytes for
+//! variable-width data.
 //!
 //! Chunks whose data is a `(key, val)` pair additionally implement
 //! [`UnloadChunk`], the bulk-read capability: sorted probe keys in, matching
@@ -141,9 +135,8 @@ static COMPRESS_MIN_DEPTH: AtomicU8 = AtomicU8::new(DEFAULT_COMPRESS_MIN_DEPTH);
 ///
 /// The floor cannot strand a long-lived body uncompressed: a chunk that a
 /// merge carries forward untouched also ages a generation, and its body is
-/// re-spilled under the compressing codec when it crosses the floor. Without
-/// that, key-disjoint input (a monotonically increasing key) would hold its
-/// entire spilled backlog identity-coded for the backlog's lifetime.
+/// re-spilled under the compressing codec when it crosses the floor (see
+/// `survive_merge`).
 ///
 /// `0` compresses every spilled body. Consulted at every commit, so changes
 /// apply to running dataflows.
@@ -442,26 +435,20 @@ impl<D: Columnar, T: Columnar, R: Columnar> ColumnChunk<D, T, R> {
     }
 
     /// Age a chunk that a merge carried forward untouched by one generation.
-    ///
     /// Depth counts merge cadences lived through, not rewrites, so a
-    /// pass-through survivor ages like a merged chunk. The bump itself is
-    /// always free: depth rides on the chunk, so it does not care whether the
-    /// body is shared.
+    /// pass-through survivor ages like a merged chunk; the bump rides on the
+    /// chunk, so it is free whether or not the body is shared.
     ///
     /// An identity-coded body at or past the floor wants migrating, so a
-    /// sole owner re-spills it compressed: surviving a merge disproves the
-    /// imminent-rewrite premise that exempted it, and without the re-spill
+    /// sole owner re-spills it compressed; without the re-spill,
     /// key-disjoint input would keep its whole spilled backlog
     /// identity-coded for as long as it lived. The test is the body's stored
     /// codec against the floor, not a depth transition, so a migration that
-    /// cannot happen now is retried at the next survival rather than
-    /// consumed: skipping it while the body is shared or while no pool is
-    /// installed, or lowering the floor long after a body spilled, all
-    /// converge on a compressed body instead of stranding one.
-    ///
-    /// A shared body is skipped because re-spilling this reference cannot
-    /// change what the other holder stores, and the compaction merger that
-    /// shares bodies rewrites its clones immediately.
+    /// cannot happen now (a shared body, no pool installed, a floor lowered
+    /// long after the spill) is retried at the next survival rather than
+    /// consumed. A shared body is skipped because re-spilling this reference
+    /// cannot change what the other holder stores, and the compaction merger
+    /// that shares bodies rewrites its clones immediately.
     fn survive_merge(self) -> Self
     where
         T: Timestamp,
@@ -642,10 +629,6 @@ where
     ///
     /// Fronts whose data ranges are disjoint never load at all: the resident
     /// fence entries decide, and the lower front moves to the output whole.
-    /// Chunks the merge carries forward untouched (that fast path, and a
-    /// survivor `merge_from` never consumed) age one generation through
-    /// `survive_merge`, which re-spills a body only at the compression-floor
-    /// crossing and otherwise leaves it untouched.
     fn merge(in1: &mut VecDeque<Self>, in2: &mut VecDeque<Self>, out: &mut VecDeque<Self>) {
         // Disjoint fast path: when one front lies strictly below the other's
         // first data item (equal boundary data could still interleave on
@@ -1951,7 +1934,6 @@ mod tests {
         );
     }
 
-    /// A tiny chunk stays resident regardless of the spill gate.
     #[mz_ore::test]
     fn small_chunks_stay_resident() {
         set_spill_override(Some(test_pool()));
@@ -2263,7 +2245,6 @@ mod tests {
         assert_eq!(collect_column(&reread), data);
     }
 
-    /// Merge depth saturates at `u8::MAX` instead of wrapping.
     #[mz_ore::test]
     fn merge_depth_saturates() {
         let a = ColumnChunk::Resident(
@@ -2283,8 +2264,6 @@ mod tests {
         }
     }
 
-    /// `into_column` on a shared resident chunk copies instead of stealing
-    /// the shared body.
     #[mz_ore::test]
     fn into_column_copies_shared_resident() {
         let data: Vec<Tuple> = vec![((1, 1), 0, 1), ((2, 2), 0, 1)];

--- a/src/timely-util/src/columnar/consolidate.rs
+++ b/src/timely-util/src/columnar/consolidate.rs
@@ -21,13 +21,11 @@
 //!    stays bounded. Cancellations and same-key updates collapse here before reaching the
 //!    column-shaped storage. A drain-multiple-of-half-cap trick keeps the leftover in staging,
 //!    so cross-batch keys with the same `(D, T)` continue consolidating on the next sort.
-//! 2. SoA accumulator: one sub-container per column (`D::Container`, `T::Container`,
-//!    `R::Container`). Drains push in fixed-size chunks (`DRAIN_CHUNK_ROWS`) with three
-//!    sequential per-column passes per chunk, so the inner pushes autovectorize. After each
-//!    chunk, check the serialized size; once the accumulator reaches the flush threshold
-//!    (90% of `OUTPUT_TARGET_WORDS`), serialize into an aligned `Vec<u64>` (no zero-fill —
-//!    written by `indexed::encode`) and ship as `Column::Align`. Per-chunk granularity bounds
-//!    overshoot to `K * row_words`. The trailing partial on `finish` ships as `Column::Typed`.
+//! 2. SoA accumulator: one sub-container per column. Drains push in fixed-size chunks
+//!    (`DRAIN_CHUNK_ROWS`) with three sequential per-column passes per chunk, checking the
+//!    serialized size per chunk; at the flush threshold the accumulator is serialized into an
+//!    aligned `Vec<u64>` and shipped as `Column::Align`, and the trailing partial on `finish`
+//!    ships as `Column::Typed`.
 //!
 //! Generic over `(D, T, R): Columnar` via the columnar tuple decomposition
 //! `<(D, T, R) as Columnar>::Container = (D::Container, T::Container, R::Container)`.
@@ -70,13 +68,7 @@ const FLUSH_THRESHOLD_WORDS: usize = OUTPUT_TARGET_WORDS - OUTPUT_TARGET_WORDS /
 const DRAIN_CHUNK_ROWS: usize = 16;
 
 /// A container builder that consolidates `(D, T, R)` updates and emits `Column<(D, T, R)>`.
-///
-/// Stages updates in an AoS `Vec` for in-place consolidation, then drains consolidated rows
-/// in `DRAIN_CHUNK_ROWS`-sized chunks (three sequential per-column passes per chunk) into SoA
-/// sub-containers, flushing whenever the accumulator hits the flush threshold (90% of
-/// `OUTPUT_TARGET_WORDS`). Flushed accumulators are written into aligned `Vec<u64>` (via
-/// `indexed::encode`, no zero-fill) and queued as `Column::Align`. The trailing partial on
-/// `finish` ships as `Column::Typed`.
+/// See the module docs for the two-level buffering pipeline.
 ///
 /// Does **not** maintain FIFO ordering (consolidation reorders updates).
 pub struct ConsolidatingColumnBuilder<D, T, R>
@@ -144,11 +136,8 @@ where
             return;
         }
 
-        // Drain in chunks of `DRAIN_CHUNK_ROWS` rows. Three sequential per-column passes inside
-        // the chunk give the compiler streamable loops it can autovectorize for primitive
-        // containers; the per-chunk size check bounds overshoot of the 90%-of-2-MiB threshold to
-        // ~`K * row_words`. After each chunk, check the serialized size (via `length_in_words`,
-        // not item count, so output Columns stay bounded for variable-width `D` like `Row`).
+        // The per-chunk size check reads serialized words, not item count, so
+        // output columns stay bounded for variable-width `D` like `Row`.
         let mut consumed = 0;
         while consumed < drain_n {
             let take = (drain_n - consumed).min(DRAIN_CHUNK_ROWS);

--- a/src/timely-util/src/columnar/merge_batcher.rs
+++ b/src/timely-util/src/columnar/merge_batcher.rs
@@ -232,9 +232,6 @@ where
     type Time = T;
 
     fn new(logger: Option<Logger>, operator_id: usize) -> Self {
-        // No pager snapshot taken here — `self.pager()` reads
-        // `column_pager::global_pager` per call, so dyncfg-driven re-installs
-        // take effect on the next chunk.
         Self {
             chains: Vec::new(),
             lower: Antichain::from_elem(T::minimum()),
@@ -291,12 +288,10 @@ where
         );
         self.lower = upper;
 
-        // Drop the recycle stash now that this round's hot work is done.
-        // The next merge after the next `push_into` will re-pay one
-        // chunk's worth of leaf-`Vec` grow tax, but that's a few hundred µs
-        // amortized over a seal cycle, well worth handing the leaf bytes
-        // back to the allocator so they're not held resident across what
-        // may be a quiet stretch.
+        // Drop the recycle stash now that this round's hot work is done:
+        // the next merge re-pays one chunk's worth of leaf grow tax, and in
+        // exchange the leaf bytes are not held resident across what may be
+        // a quiet stretch.
         self.stash.clear();
 
         (readied, description)
@@ -433,13 +428,9 @@ where
 /// matches the recycling discipline the upstream `differential_dataflow`
 /// merge-batcher carries via `Merger::merge`'s `stash` parameter.
 ///
-/// Whole-chunk passthrough: heads arrive materialized from [`FetchIter`], so
-/// peeking endpoints is free. When the current head on one side sorts
-/// entirely before the current record on the other side, ship it wholesale
-/// and skip the per-record merge. Gated on `positions[i] == 0` so we hand
-/// the head off intact — partial-tail passthrough would need a 1-input
-/// `merge_from` to copy the tail, which is what the inner loop's gallop
-/// already covers.
+/// Whole-chunk passthrough mirrors the fast path in `super::batcher`'s
+/// `Merger::merge`: a head that sorts entirely before the other side's
+/// current record ships wholesale.
 pub fn merge_chains<D, T, R, Sink>(
     list1: FetchIter<'_, D, T, R>,
     list2: FetchIter<'_, D, T, R>,
@@ -681,8 +672,6 @@ mod tests {
     use super::*;
     use crate::column_pager::{PageDecision, PageEvent, PageHint, PagingPolicy};
 
-    // ----- helpers -----------------------------------------------------------
-
     type KvUpdate = ((u64, u64), u64, i64);
 
     fn col(rows: &[KvUpdate]) -> Column<KvUpdate> {
@@ -803,8 +792,6 @@ mod tests {
         collect_pc(&output, &pager)
     }
 
-    // ----- merge_chains correctness -----------------------------------------
-
     /// Disjoint chains: same data as the legacy passthrough test. Without
     /// passthrough, the merger runs per-record but should still produce the
     /// fully ordered output.
@@ -827,7 +814,6 @@ mod tests {
         assert_eq!(out, expected);
     }
 
-    /// Interleaved chains: every record alternates between the two chains.
     #[mz_ore::test]
     fn merge_chains_interleaved() {
         let out = drive_merge(
@@ -945,8 +931,6 @@ mod tests {
         assert_eq!(collected, expected);
     }
 
-    // ----- extract_chain correctness ----------------------------------------
-
     #[mz_ore::test]
     fn extract_chain_partitions_by_frontier() {
         let pager = ColumnPager::disabled();
@@ -982,8 +966,6 @@ mod tests {
         }
         assert_eq!(shipped.len() + kept.len(), data.len());
     }
-
-    // ----- ColumnMergeBatcher end-to-end ------------------------------------
 
     #[mz_ore::test]
     fn batcher_seal_round_trip() {

--- a/src/timely-util/src/columnar/unload.rs
+++ b/src/timely-util/src/columnar/unload.rs
@@ -27,11 +27,8 @@ use differential_dataflow::trace::chunk::{Chunk, ChunkBatch};
 /// into caller-owned staging.
 ///
 /// This is the bulk, copy-out way to read a chunk: extraction is finished
-/// with a chunk's body when the call returns, so a spilled body is read for
-/// the scope of one call and no reference into pool memory ever exists
-/// outside it. That contract is what lets a buffer pool evict with no reader
-/// accounting, where navigation-style access would need the body kept
-/// readable for as long as the reader holds it.
+/// with a chunk's body when the call returns, so any read of a spilled body
+/// is scoped to one call (the buffer pool's no-reader-accounting contract).
 ///
 /// Callers usually read whole batches, not single chunks: the [`UnloadBatch`]
 /// extension on [`ChunkBatch`] looks up a probe set across the batch's chunk


### PR DESCRIPTION
Comment-only cleanup of `mz_ore::pool` and `mz_timely_util::columnar`. No code changes: every edit is to a doc comment, inline comment, test doc comment, or assert message.

An audit of these modules found the same facts documented in up to five places, doc comments that narrate their function bodies or their callees' contracts, and comments that restate the line below them. This PR applies the resulting rules:

* Every fact keeps exactly one owning comment (the decision point for reasoning, the mechanism for mechanism docs, the public setter or constant for config semantics); other sites now point at the owner or say nothing. Examples: the copy-out read contract is stated once in `mz_ore::pool`, the write-behind tradeoff once on `Pool::set_eager_backing`, the steal-ledger settlement once at its `try_update`, the compression-floor migration rationale once on `survive_merge`.
* Multi-paragraph docs that re-argued decisions documented elsewhere were condensed (`enforce_or_defer_compressed_cap`, `insert_with`, `survive_merge`, the `Merger` impl doc, the pool module doc's RSS-identity paragraph).
* Deleted comments that restate the adjacent code or an assert message, ASCII section-divider banners in test modules, speculative notes about hypothetical future backends, and unverifiable performance color.
* Test doc comments that restated the test's name were removed; docs remain where they carry non-obvious setup or multi-phase protocols.

Safety comments, lock-ordering rules, ledger invariants, kernel-behavior gotchas (pagemap vs. mincore, khugepaged re-collapse, macOS `MADV_DONTNEED`), and magic-constant justifications are untouched.

No tests were added or modified beyond their doc comments and a few shortened assert messages.

Generated with [Claude Code](https://claude.com/claude-code)