### PR TITLE
sql: pluralize the object type in abbreviated grants

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -5836,8 +5836,8 @@ impl<T: AstInfo> AstDisplay for AbbreviatedGrantStatement<T> {
         f.write_str("GRANT ");
         f.write_node(&self.privileges);
         f.write_str(" ON ");
-        f.write_node(&self.object_type);
-        f.write_str("S TO ");
+        write_grant_object_type_plural(f, &self.object_type);
+        f.write_str(" TO ");
         f.write_node(&display::comma_separated(&self.grantees));
     }
 }
@@ -5860,8 +5860,8 @@ impl<T: AstInfo> AstDisplay for AbbreviatedRevokeStatement<T> {
         f.write_str("REVOKE ");
         f.write_node(&self.privileges);
         f.write_str(" ON ");
-        f.write_node(&self.object_type);
-        f.write_str("S FROM ");
+        write_grant_object_type_plural(f, &self.object_type);
+        f.write_str(" FROM ");
         f.write_node(&display::comma_separated(&self.revokees));
     }
 }

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -378,6 +378,27 @@ fn test_grant_revoke_all_policies_roundtrips() {
 }
 
 #[mz_ore::test]
+fn test_alter_default_privileges_policies_roundtrips() {
+    for sql in [
+        "ALTER DEFAULT PRIVILEGES FOR ROLE owner GRANT USAGE ON POLICIES TO j",
+        "ALTER DEFAULT PRIVILEGES FOR ROLE owner REVOKE USAGE ON POLICIES FROM j",
+    ] {
+        let displayed = parse_statements(sql)
+            .unwrap_or_else(|e| panic!("{sql:?} should parse: {e}"))
+            .into_iter()
+            .next()
+            .unwrap()
+            .ast
+            .to_ast_string_simple();
+        assert!(
+            displayed.contains("ON POLICIES") && !displayed.contains("POLICYS"),
+            "{sql:?} mis-pluralized network policies: {displayed:?}"
+        );
+        assert_display_roundtrips(sql);
+    }
+}
+
+#[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
 fn test_negated_cast_display_roundtrip() {
     // `- <number>` folds into a negative literal at parse time and the `::` cast


### PR DESCRIPTION
### Motivation

The grammar spells the plural of a network policy as the single keyword
`POLICIES`, and the parser maps it straight to `ObjectType::NetworkPolicy`.
Rendering went the other way through the singular display, `NETWORK POLICY`,
with a bare `S` appended:

```rust
f.write_node(&self.object_type);   // "NETWORK POLICY"
f.write_str("S TO ");              // -> "NETWORK POLICYS TO"
```

So a statement parsed from `ON POLICIES` redisplays as `ON NETWORK POLICYS`,
which is wrong twice over. The plural grammar does not use the word `NETWORK` at
all, and `POLICY` does not pluralize to `POLICYS`. The result does not reparse,
which breaks the display/parse round trip the parser is supposed to hold.

Every other object type escapes this because its singular display is already the
plural stem and English only needs the `S`: `TABLE` to `TABLES`, `SCHEMA` to
`SCHEMAS`, `CLUSTER` to `CLUSTERS`. `NETWORK POLICY` is the one irregular spelling
in the set.

This same defect was already found and fixed once, for the
`GRANT ... ON ALL POLICIES IN SCHEMA ...` form. That fix is
`write_grant_object_type_plural`, and `test_grant_revoke_all_policies_roundtrips`
is its regression test, filed off a `parse_display_roundtrip` fuzz crash on
`GRANT CREATE ON ALL POLICIES TO j`. The helper landed with three callers, all
inside `GrantTargetSpecification`. The two abbreviated statement formatters were
never routed through it, and the `acl` testdata has no `POLICIES` case, so the
second instance survived.

### What this does

Points `AbbreviatedGrantStatement` and `AbbreviatedRevokeStatement` at the helper
that already handles this, two lines each. No new logic.

### Where the bad text is observable

Statement logging records two SQL columns, and they are computed differently.
`sql` keeps the raw text as the user typed it unless
`StatementKind::is_sensitive` covers the statement, so for an
`ALTER DEFAULT PRIVILEGES` it is untouched. `redacted_sql` is rendered from the
AST unconditionally:

```rust
redacted_sql: stmt.map(|s| s.to_ast_string_redacted()).unwrap_or_default(),
```

So every such statement is stored with the mis-pluralized text, reachable as:

```sql
SELECT DISTINCT redacted_sql
FROM mz_internal.mz_sql_text
WHERE redacted_sql LIKE '%NETWORK POLICYS%';
```

and through everything built on it: `mz_sql_text_redacted`,
`mz_recent_sql_text`, `mz_recent_activity_log`, and
`mz_recent_activity_log_redacted`.

This matters most for `mz_monitor_redacted` consumers, since the redacted column
is the only SQL text they can read, and for these statements it hands them
something that will not reparse. Anyone replaying or diffing redacted history
gets a syntax error rather than the statement that ran.

The planner is unaffected. `sql::plan::statement::acl` reads the AST and never
reformats it, so execution has always been correct. Only the rendered text is
wrong.

### Tests

Added `test_alter_default_privileges_policies_roundtrips` in
`src/sql-parser/tests/sqlparser_common.rs`, mirroring the sibling test for the
`ON ALL POLICIES` form. It asserts both the grant and the revoke direction render
`ON POLICIES`, never `POLICYS`, and round-trip through
`assert_display_roundtrips`. Reverting the change makes it fail with
`ON NETWORK POLICYS`.

### Release notes

This release will fix the SQL text recorded for `ALTER DEFAULT PRIVILEGES ... ON
POLICIES` statements in statement logging, which was stored in the `redacted_sql`
column as the unparseable `ON NETWORK POLICYS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
