### PR TITLE
v26.38.2 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -19,6 +19,16 @@ Starting with the v26.1.0 release, Materialize releases on a weekly schedule for
 both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for details.
 {{</ note >}}
 
+## v26.38.2
+*Released to Materialize Cloud: 2026-08-24* <br>
+*Released to Materialize Self-Managed: 2026-08-25* <br>
+
+### Agent Skills {#v26.38.2-agent-skills}
+- **materialize-debug-freshness**: New skill that diagnoses why an object is behind wall-clock time, sweeping source and sink status, attributing lag hop by hop through `mz_materialization_lag`, and — once hydration is confirmed — ranking the dataflows on a replica and then that dataflow's operators back to the query clause responsible.
+
+### Bug Fixes {#v26.38.2-bug-fixes}
+- Fixed slow catalog queries immediately after a zero-downtime upgrade that migrated builtin materialized views: the migrated views and everything downstream of them used to hydrate all at once at cut-over, spiking CPU on `mz_catalog_server`, and now hydrate before cut-over instead.
+
 ## v26.38.0
 *Released to Materialize Cloud: 2026-08-19* <br>
 

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -20,7 +20,6 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 {{</ note >}}
 
 ## v26.38.2
-*Released to Materialize Cloud: 2026-08-24* <br>
 *Released to Materialize Self-Managed: 2026-08-25* <br>
 
 ### Agent Skills {#v26.38.2-agent-skills}

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -20,16 +20,8 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 {{</ note >}}
 
 ## v26.38.2
-*Released to Materialize Self-Managed: 2026-08-25* <br>
-
-### Agent Skills {#v26.38.2-agent-skills}
-- **materialize-debug-freshness**: New skill that diagnoses why an object is behind wall-clock time, sweeping source and sink status, attributing lag hop by hop through `mz_materialization_lag`, and — once hydration is confirmed — ranking the dataflows on a replica and then that dataflow's operators back to the query clause responsible.
-
-### Bug Fixes {#v26.38.2-bug-fixes}
-- Fixed slow catalog queries immediately after a zero-downtime upgrade that migrated builtin materialized views: the migrated views and everything downstream of them used to hydrate all at once at cut-over, spiking CPU on `mz_catalog_server`, and now hydrate before cut-over instead.
-
-## v26.38.0
 *Released to Materialize Cloud: 2026-08-19* <br>
+*Released to Materialize Self-Managed: 2026-08-25* <br>
 
 ### Dictionary compression {#v26.38-dictionary-compression}
 
@@ -57,7 +49,7 @@ For more information, see:
 - [`CREATE CLUSTER`: Dictionary compression](/sql/create-cluster/#dictionary-compression)
 - [`ALTER CLUSTER`: Dictionary compression](/sql/alter-cluster/#dictionary-compression)
 
-<!--
+
 ### Integrate with your observability stack {#v26.38-self-managed-observability}
 
 <red>*Materialize Self-Managed only*</red>
@@ -88,7 +80,6 @@ For more information, see:
 - [Monitoring Self-Managed Materialize](/manage/monitor/self-managed/)
 - [How logs and metrics are stored and delivered](/manage/monitor/self-managed/storage/)
 - [Alerting](/manage/monitor/self-managed/alerting/)
--->
 
 ### Improvements {#v26.38-improvements}
 - **Notice for single-replica sources on multi-replica clusters**: Materialize now warns when a command leaves a cluster holding more than one replica alongside PostgreSQL, MySQL, or SQL Server sources, which always run on a single replica, since the extra replicas make those sources neither more fault tolerant nor faster to ingest.

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -5,6 +5,11 @@ columns:
   - column: Release date
   - column: Notes
 rows:
+  - Materialize Operator: v26.38.2
+    orchestratord version: v26.38.2
+    environmentd version: v26.38.2
+    Release date: "2026-08-25"
+    Notes: "See [v26.38.2 release notes](/releases/#v26382)"
   - Materialize Operator: v26.38
     orchestratord version: v26.38
     environmentd version: v26.38

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -14,7 +14,7 @@ rows:
     orchestratord version: v26.38
     environmentd version: v26.38
     Release date: "2026-08-20"
-    Notes: "See [v26.38 release notes](/releases/#v26380)"
+    Notes: "See [v26.38 release notes](/releases/#v26382)"
   - Materialize Operator: v26.37
     orchestratord version: v26.37
     environmentd version: v26.37


### PR DESCRIPTION
Release notes for v26.38.2.

This train has no RC snapshots — `final` is its only snapshot, so this PR
carries a single commit and the dates are the real ones rather than
provisional estimates: Cloud 2026-08-24, Self-Managed 2026-08-25. Both were
inferred from the `v26.38.2` tag's commit date (2026-08-24T16:07:03Z), so
please confirm them with the release owner before merging.

**Merge ordering.** This branch was cut from a `main` whose `_index.md` tops
out at `## v26.38.0`, and two other release-notes PRs are open ahead of it:
#38365 (v26.38.1) and #38383 (v26.39.0). The final order in `_index.md` must
be `## v26.39.0`, then `## v26.38.2`, then `## v26.38.1`, then `## v26.38.0` —
this section belongs *below* v26.39.0. Whichever of the three merges last will
need its section placed by hand relative to the others.

Snapshot drafts (with PR links) in mz-skills:
- final: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.2/final/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.2/final/omitted.md)

**Borderline PRs omitted:** final: 0 — [omitted.md#borderline](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.38.2/final/omitted.md#borderline)
