### PR TITLE
v26.28.1 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -654,6 +654,13 @@ For more information, see [Syntax: CREATE SINK... INTO ICEBERG](/sql/create-sink
 - Fixed a crash caused by duplicate statement execution logging that could bring down the entire environment.
 - Fixed array values failing to write to Iceberg sinks due to the array dimension being stored as a narrower integer type than Iceberg requires.
 
+## v26.28.1
+*Released to Materialize Cloud: 2026-06-17* <br>
+*Released to Materialize Self-Managed: 2026-06-18* <br>
+
+### Bug Fixes {#v26.28.1-bug-fixes}
+- Fixed Avro-formatted sources failing to decode records after a nullable column's type was promoted to a wider numeric type (e.g., `int` to `double`).
+
 ## v26.28.0
 *Released to Materialize Cloud: 2026-06-11* <br>
 *Released to Materialize Self-Managed: 2026-06-12* <br>

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -65,6 +65,11 @@ rows:
     environmentd version: v26.29
     Release date: "2026-06-19"
     Notes: "See [v26.29 release notes](/releases/#v26290)"
+  - Materialize Operator: v26.28.1
+    orchestratord version: v26.28.1
+    environmentd version: v26.28.1
+    Release date: "2026-06-18"
+    Notes: "See [v26.28.1 release notes](/releases/#v26281)"
   - Materialize Operator: v26.28
     orchestratord version: v26.28
     environmentd version: v26.28


### PR DESCRIPTION
Release notes for v26.28.1, a single-fix patch train backfilled roughly ten weeks after the tag. The `## v26.28.1` section is inserted between `## v26.29.0` and `## v26.28.0` in the releases index, and a matching row is added to the self-managed operator compatibility table.

This train has **no RC snapshots** — `final` is its only snapshot, so this PR carries a single commit and the dates are real rather than provisional.

Snapshot drafts (with PR links) in mz-skills:
- final: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.28.1/final/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.28.1/final/omitted.md)

**Borderline PRs omitted:** final: 0 — [omitted.md#borderline](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.28.1/final/omitted.md#borderline)

### Please confirm before merging: the release dates

Both dates are **inferred**, not supplied: the `v26.28.1` tag's commit date (2026-06-17T04:04:41Z) for Cloud, plus one day for Self-Managed. Two reasons to check them:

- The tag was cut **26 minutes** after [#37087](https://github.com/MaterializeInc/materialize/pull/37087) merged to `main`, and `v26.29.0` was tagged later the same day and reached Cloud on 2026-06-18. That timing looks like an out-of-band patch for customers pinned to the v26.28 train rather than a broad Cloud rollout — in which case the Cloud line should read `*Released to Materialize Cloud: 2026-06-17 on as-needs basis*` (the v26.24.1 / v26.36.0 convention), or be dropped in favour of a Self-Managed-only line (the v26.24.2 / v26.24.3 convention).
- As written, the Self-Managed date 2026-06-18 is the same day `v26.29.0` reached Cloud.

### Duplicate wording under `## v26.30.1` is expected

The identical bullet already appears under `## v26.30.1`. #37087 merged to `main` on 2026-06-17 and was cherry-picked onto the v26.28 release branch the same day, so the `main` line carried it into the v26.30.1 notes independently. Both statements are true of their respective releases; the wording is reused verbatim on purpose so the two sections stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
