### PR TITLE
orchestratord: allow setting a PriorityClass on environmentd and clusterd pods

### DIFF
--- a/doc/user/data/self_managed/materialize_operator_chart_parameter.yml
+++ b/doc/user/data/self_managed/materialize_operator_chart_parameter.yml
@@ -7,7 +7,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 359
+  linenumber: 367
   dependency: ""
   isglobal: false
 - key: balancerd.defaultResources.limits
@@ -19,7 +19,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 368
+  linenumber: 376
   dependency: ""
   isglobal: false
 - key: balancerd.defaultResources.requests
@@ -31,7 +31,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 372
+  linenumber: 380
   dependency: ""
   isglobal: false
 - key: balancerd.enabled
@@ -43,7 +43,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 351
+  linenumber: 359
   dependency: ""
   isglobal: false
 - key: balancerd.nodeSelector
@@ -55,7 +55,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 355
+  linenumber: 363
   dependency: ""
   isglobal: false
 - key: balancerd.tolerations
@@ -67,7 +67,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 363
+  linenumber: 371
   dependency: ""
   isglobal: false
 - key: clusterd.affinity
@@ -79,7 +79,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 343
+  linenumber: 347
   dependency: ""
   isglobal: false
 - key: clusterd.nodeSelector
@@ -91,7 +91,19 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 327
+  linenumber: 331
+  dependency: ""
+  isglobal: false
+- key: clusterd.priorityClassName
+  type: string
+  notationtype: ""
+  autodefault: ""
+  default: '`nil`'
+  autodescription: PriorityClass to use for clusterd pods spawned by the operator. The PriorityClass must already exist. Kubernetes rejects a pod that names one it cannot resolve, so a typo here stops these pods being created at all.
+  description: PriorityClass to use for clusterd pods spawned by the operator. The PriorityClass must already exist. Kubernetes rejects a pod that names one it cannot resolve, so a typo here stops these pods being created at all.
+  section: ""
+  column: 3
+  linenumber: 355
   dependency: ""
   isglobal: false
 - key: clusterd.scratchfsNodeSelector
@@ -103,7 +115,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 332
+  linenumber: 336
   dependency: ""
   isglobal: false
 - key: clusterd.swapNodeSelector
@@ -115,7 +127,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 338
+  linenumber: 342
   dependency: ""
   isglobal: false
 - key: clusterd.tolerations
@@ -127,7 +139,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 347
+  linenumber: 351
   dependency: ""
   isglobal: false
 - key: console.affinity
@@ -139,7 +151,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 388
+  linenumber: 396
   dependency: ""
   isglobal: false
 - key: console.defaultResources.limits
@@ -151,7 +163,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 397
+  linenumber: 405
   dependency: ""
   isglobal: false
 - key: console.defaultResources.requests
@@ -163,7 +175,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 401
+  linenumber: 409
   dependency: ""
   isglobal: false
 - key: console.enabled
@@ -175,7 +187,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 378
+  linenumber: 386
   dependency: ""
   isglobal: false
 - key: console.imageTagMapOverride
@@ -187,7 +199,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 380
+  linenumber: 388
   dependency: ""
   isglobal: false
 - key: console.nodeSelector
@@ -199,7 +211,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 384
+  linenumber: 392
   dependency: ""
   isglobal: false
 - key: console.tolerations
@@ -211,7 +223,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 392
+  linenumber: 400
   dependency: ""
   isglobal: false
 - key: environmentd.affinity
@@ -235,7 +247,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 313
+  linenumber: 317
   dependency: ""
   isglobal: false
 - key: environmentd.defaultResources.requests
@@ -247,7 +259,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 317
+  linenumber: 321
   dependency: ""
   isglobal: false
 - key: environmentd.nodeSelector
@@ -260,6 +272,18 @@
   section: ""
   column: 3
   linenumber: 300
+  dependency: ""
+  isglobal: false
+- key: environmentd.priorityClassName
+  type: string
+  notationtype: ""
+  autodefault: ""
+  default: '`nil`'
+  autodescription: PriorityClass to use for environmentd pods spawned by the operator. The PriorityClass must already exist. Kubernetes rejects a pod that names one it cannot resolve, so a typo here stops these pods being created at all.
+  description: PriorityClass to use for environmentd pods spawned by the operator. The PriorityClass must already exist. Kubernetes rejects a pod that names one it cannot resolve, so a typo here stops these pods being created at all.
+  section: ""
+  column: 3
+  linenumber: 312
   dependency: ""
   isglobal: false
 - key: environmentd.tolerations
@@ -283,7 +307,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 461
+  linenumber: 469
   dependency: ""
   isglobal: false
 - key: networkPolicies.egress.enabled
@@ -295,7 +319,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 459
+  linenumber: 467
   dependency: ""
   isglobal: false
 - key: networkPolicies.enabled
@@ -307,7 +331,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 446
+  linenumber: 454
   dependency: ""
   isglobal: false
 - key: networkPolicies.ingress.cidrs
@@ -319,7 +343,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 455
+  linenumber: 463
   dependency: ""
   isglobal: false
 - key: networkPolicies.ingress.enabled
@@ -331,7 +355,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 453
+  linenumber: 461
   dependency: ""
   isglobal: false
 - key: networkPolicies.internal.enabled
@@ -343,7 +367,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 449
+  linenumber: 457
   dependency: ""
   isglobal: false
 - key: observability.enabled
@@ -355,7 +379,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 427
+  linenumber: 435
   dependency: ""
   isglobal: false
 - key: observability.podMetrics.enabled
@@ -367,7 +391,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 432
+  linenumber: 440
   dependency: ""
   isglobal: false
 - key: observability.prometheus.scrapeAnnotations.enabled
@@ -379,7 +403,7 @@
   description: ""
   section: ""
   column: 7
-  linenumber: 436
+  linenumber: 444
   dependency: ""
   isglobal: false
 - key: operator.additionalMaterializeCRDColumns
@@ -943,7 +967,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 408
+  linenumber: 416
   dependency: ""
   isglobal: false
 - key: schedulerName
@@ -955,7 +979,7 @@
   description: Optionally use a non-default kubernetes scheduler.
   section: ""
   column: 1
-  linenumber: 411
+  linenumber: 419
   dependency: ""
   isglobal: false
 - key: serviceAccount.annotations
@@ -967,7 +991,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 422
+  linenumber: 430
   dependency: ""
   isglobal: false
 - key: serviceAccount.create
@@ -979,7 +1003,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 416
+  linenumber: 424
   dependency: ""
   isglobal: false
 - key: serviceAccount.name
@@ -991,7 +1015,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 418
+  linenumber: 426
   dependency: ""
   isglobal: false
 - key: storage.storageClass.allowVolumeExpansion
@@ -1003,7 +1027,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 502
+  linenumber: 510
   dependency: ""
   isglobal: false
 - key: storage.storageClass.create
@@ -1015,7 +1039,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 488
+  linenumber: 496
   dependency: ""
   isglobal: false
 - key: storage.storageClass.name
@@ -1027,7 +1051,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 491
+  linenumber: 499
   dependency: ""
   isglobal: false
 - key: storage.storageClass.parameters
@@ -1039,7 +1063,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 497
+  linenumber: 505
   dependency: ""
   isglobal: false
 - key: storage.storageClass.provisioner
@@ -1051,7 +1075,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 494
+  linenumber: 502
   dependency: ""
   isglobal: false
 - key: storage.storageClass.reclaimPolicy
@@ -1063,7 +1087,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 503
+  linenumber: 511
   dependency: ""
   isglobal: false
 - key: storage.storageClass.volumeBindingMode
@@ -1075,7 +1099,7 @@
   description: ""
   section: ""
   column: 5
-  linenumber: 504
+  linenumber: 512
   dependency: ""
   isglobal: false
 - key: telemetry.enabled
@@ -1087,7 +1111,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 439
+  linenumber: 447
   dependency: ""
   isglobal: false
 - key: telemetry.segmentApiKey
@@ -1099,7 +1123,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 440
+  linenumber: 448
   dependency: ""
   isglobal: false
 - key: telemetry.segmentClientSide
@@ -1111,7 +1135,7 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 441
+  linenumber: 449
   dependency: ""
   isglobal: false
 - key: tls.defaultCertificateSpecs
@@ -1123,6 +1147,6 @@
   description: ""
   section: ""
   column: 3
-  linenumber: 465
+  linenumber: 473
   dependency: ""
   isglobal: false

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -115,6 +115,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `balancerd.tolerations` | Tolerations to use for balancerd pods spawned by the operator | ``{}`` |
 | `clusterd.affinity` | Affinity to use for clusterd pods spawned by the operator | ``{}`` |
 | `clusterd.nodeSelector` | Node selector to use for all clusterd pods spawned by the operator | ``{}`` |
+| `clusterd.priorityClassName` | PriorityClass to use for clusterd pods spawned by the operator. The PriorityClass must already exist. Kubernetes rejects a pod that names one it cannot resolve, so a typo here stops these pods being created at all. | ``nil`` |
 | `clusterd.scratchfsNodeSelector` | Additional node selector to use for clusterd pods when using an LVM scratch disk. This will be merged with the values in `nodeSelector`. | ``{"materialize.cloud/scratch-fs": "true"}`` |
 | `clusterd.swapNodeSelector` | Additional node selector to use for clusterd pods when using swap. This will be merged with the values in `nodeSelector`. | ``{"materialize.cloud/swap": "true"}`` |
 | `clusterd.tolerations` | Tolerations to use for clusterd pods spawned by the operator | ``{}`` |
@@ -129,6 +130,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `environmentd.defaultResources.limits` | Default resource limits for environmentd's CPU and memory if not set in the Materialize CR | ``{"memory":"4Gi"}`` |
 | `environmentd.defaultResources.requests` | Default resources requested for environmentd's CPU and memory if not set in the Materialize CR | ``{"cpu":"1","memory":"4095Mi"}`` |
 | `environmentd.nodeSelector` | Node selector to use for environmentd pods spawned by the operator | ``{}`` |
+| `environmentd.priorityClassName` | PriorityClass to use for environmentd pods spawned by the operator. The PriorityClass must already exist. Kubernetes rejects a pod that names one it cannot resolve, so a typo here stops these pods being created at all. | ``nil`` |
 | `environmentd.tolerations` | Tolerations to use for environmentd pods spawned by the operator | ``{}`` |
 | `networkPolicies.egress.cidrs` | CIDR blocks to allow egress to | ``["0.0.0.0/0"]`` |
 | `networkPolicies.egress.enabled` | Whether to enable egress network policies to sources and sinks | ``false`` |

--- a/misc/helm-charts/operator/templates/deployment.yaml
+++ b/misc/helm-charts/operator/templates/deployment.yaml
@@ -192,6 +192,9 @@ spec:
         - '--environmentd-toleration={{ toJson $toleration }}'
         {{- end }}
         {{- end }}
+        {{- if .Values.environmentd.priorityClassName }}
+        - "--environmentd-priority-class-name={{ .Values.environmentd.priorityClassName }}"
+        {{- end }}
         {{- if .Values.environmentd.defaultResources }}
         - '--environmentd-default-resources={{ toJson .Values.environmentd.defaultResources }}'
         {{- end }}
@@ -207,6 +210,9 @@ spec:
         {{- range $toleration := .Values.clusterd.tolerations }}
         - '--clusterd-toleration={{ toJson $toleration }}'
         {{- end }}
+        {{- end }}
+        {{- if .Values.clusterd.priorityClassName }}
+        - "--clusterd-priority-class-name={{ .Values.clusterd.priorityClassName }}"
         {{- end }}
         {{- if .Values.balancerd.nodeSelector }}
         {{- range $key, $value := .Values.balancerd.nodeSelector }}

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -274,9 +274,9 @@ tests:
 
 - it: should not pass the scheduler when not configured
   asserts:
-  - notContains:
-      path: spec.template.spec.containers[0].args
-      content: "--scheduler-name"
+  - notMatchRegex:
+      path: spec.template.spec.containers[0].args[*]
+      pattern: "^--scheduler-name"
 
 - it: should pass the scheduler when configured
   set:
@@ -285,6 +285,34 @@ tests:
   - contains:
       path: spec.template.spec.containers[0].args
       content: "--scheduler-name=my-scheduler"
+
+- it: should not pass the environmentd priority class when not configured
+  asserts:
+  - notMatchRegex:
+      path: spec.template.spec.containers[0].args[*]
+      pattern: "^--environmentd-priority-class-name"
+
+- it: should pass the environmentd priority class when configured
+  set:
+    environmentd.priorityClassName: mz-environmentd-high
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: "--environmentd-priority-class-name=mz-environmentd-high"
+
+- it: should not pass the clusterd priority class when not configured
+  asserts:
+  - notMatchRegex:
+      path: spec.template.spec.containers[0].args[*]
+      pattern: "^--clusterd-priority-class-name"
+
+- it: should pass the clusterd priority class when configured
+  set:
+    clusterd.priorityClassName: mz-clusterd-high
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: "--clusterd-priority-class-name=mz-clusterd-high"
 
 - it: should have license key checks disabled by default
   asserts:

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -306,6 +306,10 @@ environmentd:
   # @notationType -- k8s/tolerations
   # @default -- ``{}``
   tolerations: {}
+  # -- PriorityClass to use for environmentd pods spawned by the operator. The
+  # PriorityClass must already exist. Kubernetes rejects a pod that names one
+  # it cannot resolve, so a typo here stops these pods being created at all.
+  priorityClassName:
   # @notationType -- k8s/resources
   defaultResources:
     # -- Default resource limits for environmentd's CPU and memory
@@ -345,6 +349,10 @@ clusterd:
   # @notationType -- k8s/tolerations
   # @default -- ``{}``
   tolerations: {}
+  # -- PriorityClass to use for clusterd pods spawned by the operator. The
+  # PriorityClass must already exist. Kubernetes rejects a pod that names one
+  # it cannot resolve, so a typo here stops these pods being created at all.
+  priorityClassName:
 
 balancerd:
   # -- Flag to indicate whether to create balancerd pods for the environments

--- a/src/environmentd/src/environmentd/main.rs
+++ b/src/environmentd/src/environmentd/main.rs
@@ -181,6 +181,9 @@ pub struct Args {
     /// Name of a non-default Kubernetes scheduler, if any.
     #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SCHEDULER_NAME")]
     orchestrator_kubernetes_scheduler_name: Option<String>,
+    /// Name of a `PriorityClass` to assign to services, if any.
+    #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_PRIORITY_CLASS_NAME")]
+    orchestrator_kubernetes_priority_class_name: Option<String>,
     /// Annotations to apply to all services created by the Kubernetes orchestrator
     /// in the form `KEY=VALUE`.
     #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_ANNOTATION")]
@@ -822,6 +825,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                     .block_on(KubernetesOrchestrator::new(KubernetesOrchestratorConfig {
                         context: args.orchestrator_kubernetes_context.clone(),
                         scheduler_name: args.orchestrator_kubernetes_scheduler_name,
+                        priority_class_name: args.orchestrator_kubernetes_priority_class_name,
                         service_annotations: args
                             .orchestrator_kubernetes_service_annotation
                             .into_iter()

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -76,6 +76,8 @@ pub struct KubernetesOrchestratorConfig {
     pub context: String,
     /// The name of a non-default Kubernetes scheduler to use, if any.
     pub scheduler_name: Option<String>,
+    /// The name of a `PriorityClass` to assign to services, if any.
+    pub priority_class_name: Option<String>,
     /// Annotations to install on every service created by the orchestrator.
     pub service_annotations: BTreeMap<String, String>,
     /// Labels to install on every service created by the orchestrator.
@@ -1200,6 +1202,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 security_context,
                 node_selector: Some(node_selector),
                 scheduler_name: self.config.scheduler_name.clone(),
+                priority_class_name: self.config.priority_class_name.clone(),
                 service_account: self.config.service_account.clone(),
                 affinity: Some(affinity),
                 topology_spread_constraints: topology_spread,

--- a/src/orchestratord/src/bin/orchestratord.rs
+++ b/src/orchestratord/src/bin/orchestratord.rs
@@ -236,11 +236,15 @@ pub struct Args {
     #[clap(long, value_parser = parse_resources)]
     environmentd_default_resources: Option<ResourceRequirements>,
     #[clap(long)]
+    environmentd_priority_class_name: Option<String>,
+    #[clap(long)]
     clusterd_node_selector: Vec<KeyValueArg<String, String>>,
     #[clap(long, value_parser = parse_affinity)]
     clusterd_affinity: Option<Affinity>,
     #[clap(long = "clusterd-toleration", value_parser = parse_tolerations)]
     clusterd_tolerations: Option<Vec<Toleration>>,
+    #[clap(long)]
+    clusterd_priority_class_name: Option<String>,
     #[clap(long)]
     balancerd_node_selector: Vec<KeyValueArg<String, String>>,
     #[clap(long, value_parser = parse_affinity)]
@@ -666,9 +670,11 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             environmentd_affinity: args.environmentd_affinity,
             environmentd_tolerations: args.environmentd_tolerations,
             environmentd_default_resources: args.environmentd_default_resources,
+            environmentd_priority_class_name: args.environmentd_priority_class_name,
             clusterd_node_selector: args.clusterd_node_selector,
             clusterd_affinity: args.clusterd_affinity,
             clusterd_tolerations: args.clusterd_tolerations,
+            clusterd_priority_class_name: args.clusterd_priority_class_name,
             image_pull_policy: args.image_pull_policy,
             network_policies_internal_enabled: args.network_policies_internal_enabled,
             network_policies_ingress_enabled: args.network_policies_ingress_enabled,

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -89,9 +89,13 @@ pub struct Config {
     pub environmentd_affinity: Option<Affinity>,
     pub environmentd_tolerations: Option<Vec<Toleration>>,
     pub environmentd_default_resources: Option<ResourceRequirements>,
+    /// The name of a `PriorityClass` to assign to environmentd pods, if any.
+    pub environmentd_priority_class_name: Option<String>,
     pub clusterd_node_selector: Vec<KeyValueArg<String, String>>,
     pub clusterd_affinity: Option<Affinity>,
     pub clusterd_tolerations: Option<Vec<Toleration>>,
+    /// The name of a `PriorityClass` to assign to clusterd pods, if any.
+    pub clusterd_priority_class_name: Option<String>,
     pub image_pull_policy: KubernetesImagePullPolicy,
     pub network_policies_internal_enabled: bool,
     pub network_policies_ingress_enabled: bool,

--- a/src/orchestratord/src/controller/materialize/generation.rs
+++ b/src/orchestratord/src/controller/materialize/generation.rs
@@ -73,6 +73,18 @@ static V154_DEV0: LazyLock<Version> = LazyLock::new(|| Version {
 });
 pub const V161: Version = Version::new(0, 161, 0);
 
+/// Version at which `environmentd` learned
+/// `--orchestrator-kubernetes-priority-class-name`. Older images reject the
+/// unknown argument and fail to start, so the flag is only forwarded at or
+/// above this version.
+static V26_40_0: LazyLock<Version> = LazyLock::new(|| Version {
+    major: 26,
+    minor: 40,
+    patch: 0,
+    pre: Prerelease::new("dev.0").expect("dev.0 is valid prerelease"),
+    build: BuildMetadata::new("").expect("empty string is valid buildmetadata"),
+});
+
 static V26_1_0: LazyLock<Version> = LazyLock::new(|| Version {
     major: 26,
     minor: 1,
@@ -804,6 +816,13 @@ fn create_environmentd_statefulset_object(
             scheduler_name
         ));
     }
+    if mz.meets_minimum_version(&V26_40_0) {
+        if let Some(priority_class_name) = &config.clusterd_priority_class_name {
+            args.push(format!(
+                "--orchestrator-kubernetes-priority-class-name={priority_class_name}"
+            ));
+        }
+    }
     if mz.meets_minimum_version(&V154_DEV0) {
         args.extend(
             mz.spec
@@ -1246,6 +1265,7 @@ fn create_environmentd_statefulset_object(
             ),
             affinity: config.environmentd_affinity.clone(),
             scheduler_name: config.scheduler_name.clone(),
+            priority_class_name: config.environmentd_priority_class_name.clone(),
             service_account_name: Some(mz.service_account_name()),
             volumes: Some(volumes),
             security_context: Some(PodSecurityContext {

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -768,6 +768,84 @@ class BalancerdNodeSelector(Modification):
         retry(check, 240)
 
 
+# Must match test/orchestratord/priorityclass.yaml.
+PRIORITY_CLASS_NAME = "mz-test-priority"
+PRIORITY_CLASS_VALUE = 1000000000
+# Release in which environmentd learned
+# --orchestrator-kubernetes-priority-class-name.
+PRIORITY_CLASS_VERSION = "v26.40.0"
+
+
+def assert_priority_class(pod: dict[str, Any], expected: str | None) -> None:
+    """Assert a pod's priority class by name and by resolved value.
+
+    `spec.priority` is filled in by the API server from the named class, so
+    checking it is what distinguishes a class Kubernetes actually resolved from
+    a string the operator copied into the spec.
+    """
+    spec = pod["spec"]
+    name = pod["metadata"]["name"]
+    actual = spec.get("priorityClassName")
+    priority = spec.get("priority")
+    if expected is None:
+        assert not actual, f"{name}: unexpected priorityClassName {actual}"
+        assert not priority, f"{name}: unexpected priority {priority}"
+    else:
+        assert actual == expected, f"{name}: expected {expected}, got {actual}"
+        assert (
+            priority == PRIORITY_CLASS_VALUE
+        ), f"{name}: expected priority {PRIORITY_CLASS_VALUE}, got {priority}"
+
+
+class PriorityClassName(Modification):
+    @classmethod
+    def values(cls, version: MzVersion) -> list[Any]:
+        return [None, PRIORITY_CLASS_NAME]
+
+    @classmethod
+    def default(cls) -> Any:
+        return None
+
+    def modify(self, definition: dict[str, Any]) -> None:
+        if not self.value:
+            return
+        definition["operator"]["environmentd"]["priorityClassName"] = self.value
+        definition["operator"]["clusterd"]["priorityClassName"] = self.value
+        # environmentd and clusterd only pick up generation-affecting changes on
+        # a requested rollout, so without this the pods keep the spec they were
+        # created with and the assertions below check the wrong generation.
+        request = str(uuid.uuid4())
+        if definition["materialize"]["apiVersion"] == "materialize.cloud/v1alpha1":
+            definition["materialize"]["spec"]["requestRollout"] = request
+        definition["materialize"]["spec"]["forceRollout"] = request
+
+    def validate(self, mods: dict[type[Modification], Any]) -> None:
+        version = MzVersion.parse_mz(mods[EnvironmentdImageRef])
+        # The operator sets environmentd's class directly, but forwards
+        # clusterd's to environmentd behind a version gate, so an older image
+        # gets one and not the other.
+        clusterd_expected = (
+            self.value
+            if version >= MzVersion.parse_mz(PRIORITY_CLASS_VERSION)
+            else None
+        )
+
+        def check() -> None:
+            environmentd = get_environmentd_data()["items"]
+            clusterd = get_clusterd_data()["items"]
+            # A class the API server cannot resolve yields no pod at all, which
+            # an assertion over an empty list would otherwise call a pass.
+            assert environmentd, "no environmentd pods"
+            assert clusterd, "no clusterd pods"
+            for pod in environmentd:
+                assert_priority_class(pod, self.value)
+            for pod in clusterd:
+                assert_priority_class(pod, clusterd_expected)
+
+        # Clusterd is recreated by the rollout and can take a while
+        retry(check, 240)
+
+
 class ConsoleEnabled(Modification):
     @classmethod
     def values(cls, version: MzVersion) -> list[Any]:
@@ -4569,6 +4647,14 @@ def setup(c: Composition, args) -> dict[str, Any]:
                 "apply",
                 "-f",
                 MZ_ROOT / "test" / "orchestratord" / "storageclass.yaml",
+            ]
+        )
+        spawn.runv(
+            [
+                "kubectl",
+                "apply",
+                "-f",
+                MZ_ROOT / "test" / "orchestratord" / "priorityclass.yaml",
             ]
         )
 

--- a/test/orchestratord/priorityclass.yaml
+++ b/test/orchestratord/priorityclass.yaml
@@ -1,0 +1,12 @@
+# test/orchestratord/priorityclass.yaml, applied beside storageclass.yaml (:4571).
+# `value` is required. `globalDefault: false` keeps the unset baseline testable:
+# a global default would put a class on every pod, including the None case.
+# `preemptionPolicy: Never` keeps the test from evicting anything in the cluster.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: mz-test-priority
+value: 1000000000
+globalDefault: false
+preemptionPolicy: Never
+description: "Test fixture for the priorityClassName chart values."


### PR DESCRIPTION
## Problem

The operator sets no priority class on environmentd or clusterd pods, so they run
at priority 0. Any higher-priority pod can evict them when a node fills up. We
lost a clusterd replica mid-hydration to a cluster-critical DaemonSet rollout,
which aborted the deploy. The chart offers no way to raise these pods.

## Solution

Two new chart values, `environmentd.priorityClassName` and
`clusterd.priorityClassName`. They sit next to the per-component `nodeSelector`,
`affinity` and `tolerations` that both components already have. Each becomes an
orchestratord argument. `environmentd.priorityClassName` sets
`priorityClassName` on the environmentd StatefulSet's pod template.
`clusterd.priorityClassName` reaches clusterd through environmentd, forwarded as
`--orchestrator-kubernetes-priority-class-name`.

Both default to unset, which renders no argument and leaves every pod spec
byte-identical.

balancerd and console are left out on purpose. Both default to two replicas and
neither holds state, so an eviction costs a connection rather than a
rehydration. The operator's own pod is out for the same reason. It runs two
replicas behind leader election and a PodDisruptionBudget.

The forwarded clusterd argument is gated on
`meets_minimum_version(&V26_40_0)`, so `clusterd.priorityClassName` needs an
environmentd at v26.40 or newer. `clusterd.affinity` and `clusterd.tolerations`
are gated on `V144` three lines above it. environmentd exits on an unknown
argument. Without the gate, an instance pinned to an older
`environmentdImageRef` would fail to start once the value was set.

## Testing

`helm unittest misc/helm-charts/operator` covers both values, absent when unset
and present when set. The negative cases use `notMatchRegex` over the argument
list. `notContains` cannot fail here. It compares whole elements, and the
rendered element always carries `=<value>`.

`test/orchestratord/mzcompose.py` gains a `PriorityClassName` modification. It
installs the chart against a real PriorityClass, requests a rollout, and waits
for it to complete. It then asserts that environmentd and clusterd pods carry
both `spec.priorityClassName` and the resolved `spec.priority`. The resolved
integer is the assertion that matters. It proves the API server admitted the
class. The string alone only proves the operator copied it. On an older
`environmentdImageRef` it asserts the split instead: environmentd carries the
class, clusterd does not, and environmentd is running.

## For the reviewer

- **Neither value reaches a running pod until the next rollout.** Setting either
  one changes the environmentd StatefulSet spec. Every instance then flips to
  `UpToDate=False` with reason `WaitingForApproval`, and waits for
  `spec.requestRollout` to change. That is the operator's standing behaviour for
  any generation-affecting change. Worth knowing before reaching for this value
  during an incident. Nothing moves until you roll.
- **A user-defined PriorityClass cannot outrank a cluster-critical one.**
  Kubernetes caps user-created classes at 1000000000.
  `system-cluster-critical` sits at 2000000000. Moving these pods off 0 takes
  them out of the victim queue ahead of ordinary workloads, which covers most of
  a cluster. It does not make them immune to the DaemonSet in the Problem
  section when they are the only pods on the node worth evicting. Surviving that
  needs capacity the DaemonSet does not have to take, so a dedicated node pool,
  not a priority class.
- **Prefer a class with `preemptionPolicy: Never`.** During the rollout that
  applies the value, the new generation's pods carry the class. The generation
  still serving traffic does not. On a full node the new pods can evict the old
  ones. `Never` stops that. The cost is that the new pods wait for capacity
  instead of taking it. A rollout on a full cluster then stays Pending until a
  node appears. `preemptionPolicy` has to live on the PriorityClass. The API
  server rejects it in a pod spec when the pod names a class.
- **Create the class before setting the value.** Kubernetes refuses a pod that
  names a class it cannot resolve. A StatefulSet surfaces that only as a
  `FailedCreate` event.
- **The chart's default `operator.image.tag` trails the chart version between
  releases.** Install from a git checkout with either value set, and the argument
  goes to an orchestratord that does not accept it. Released charts pin a
  matching image.
- No Rust test. `generation.rs` has no test module, so the orchestratord suite is
  the only automated cover for the gate.
- I also fixed the `schedulerName` negative chart test, which carries the same
  `notContains` defect. This change edits the block directly beneath it.
- `V154_DEV0` is built with an empty prerelease under an
  `.expect("dev.0 is valid prerelease")` message, so the pod-annotations gate
  wants a final 0.154.0. Left alone, since changing it moves a gate this change
  does not touch.
- Three things for you to decide: whether the `schedulerName` fix should go
  separately, whether `Chart.yaml` needs the version bump its CONTRIBUTING asks
  for (the version looks release-managed by `bin/helm-chart-version-bump`, and
  #38406 did not bump it), and whether to open an `A-docs` issue for the
  scheduling guidance in the bullets above, since no self-managed page covers it
  today.
