### PR TITLE
compute: bound the unbudgeted parts of an index peek's scan

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -956,17 +956,17 @@ metrics:
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_cursor_setup_seconds_bucket
-  help: Time setting up cursor and literal constraints.
+  help: Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_cursor_setup_seconds_count
-  help: Time setting up cursor and literal constraints.
+  help: Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_cursor_setup_seconds_sum
-  help: Time setting up cursor and literal constraints.
+  help: Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_error_scan_seconds_bucket
@@ -1054,17 +1054,17 @@ metrics:
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_bucket
-  help: Time iterating rows and evaluating MFP.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_count
-  help: Time iterating rows and evaluating MFP.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_sum
-  help: Time iterating rows and evaluating MFP.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_seek_fulfillment_seconds_bucket

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -970,17 +970,17 @@ metrics:
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_error_scan_seconds_bucket
-  help: Time scanning the error trace for errors.
+  help: Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_error_scan_seconds_count
-  help: Time scanning the error trace for errors.
+  help: Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_error_scan_seconds_sum
-  help: Time scanning the error trace for errors.
+  help: Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_frontier_check_seconds_bucket

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -69,17 +69,19 @@ use tokio::sync::{oneshot, watch};
 use tracing::{Level, debug, error, info, span, trace, warn};
 use uuid::Uuid;
 
-use crate::arrangement::manager::{PaddedTrace, TraceBundle, TraceManager};
+use crate::arrangement::manager::{TraceBundle, TraceManager};
 use crate::logging;
 use crate::logging::compute::{CollectionLogging, ComputeEvent, PeekEvent};
 use crate::logging::initialize::LoggingTraces;
 use crate::metrics::{CollectionMetrics, WorkerMetrics};
 use crate::render::{LinearJoinSpec, StartSignal};
 use crate::server::{ComputeInstanceContext, ResponseSender};
-use crate::typedefs::ErrAgent;
 
+mod error_scan;
 mod peek_result_iterator;
 mod peek_stash;
+
+use self::error_scan::{ErrorScan, ErrorScanState, ErrorScanStep};
 
 /// Cheap handles on the dyncfgs that bound how many rows a peek may examine.
 ///
@@ -157,15 +159,7 @@ fn peek_row_iteration_limit(config: &ConfigSet) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
-    use differential_dataflow::trace::cursor::CursorList;
-    use differential_dataflow::trace::{Batcher, Builder};
     use mz_dyncfg::ConfigUpdates;
-    use mz_expr::EvalError;
-    use mz_timely_util::columnation::ColumnationStack;
-    use timely::container::PushInto;
-
-    use crate::render::errors::DataflowErrorSer;
-    use crate::typedefs::{ErrBatcher, ErrBuilder};
 
     use super::*;
 
@@ -201,172 +195,6 @@ mod tests {
             tracker.track_next(),
             Err(PeekError::RowIterationLimitExceeded { limit: 5 })
         );
-    }
-
-    /// The time at which the peeks in these tests read.
-    const PEEK_TIMESTAMP: Timestamp = Timestamp::new(1);
-
-    /// A distinct error for `index`.
-    ///
-    /// The order of the serialized form does not follow `index`, so a test that cares where a
-    /// key falls in the walk sorts the errors and picks by position.
-    fn error(index: usize) -> DataflowErrorSer {
-        DataflowErrorSer::from(EvalError::Internal(format!("error {index}").into()))
-    }
-
-    /// Builds a walk over a single-batch error trace holding `updates`, bounded by
-    /// `row_iteration_limit`.
-    fn error_scan(
-        updates: Vec<((DataflowErrorSer, ()), Timestamp, Diff)>,
-        row_iteration_limit: Option<usize>,
-    ) -> ErrorScan {
-        let mut batcher = ErrBatcher::<Timestamp, Diff>::new(None, 0);
-        let mut chunk = ColumnationStack::with_capacity(updates.len());
-        for update in updates {
-            chunk.push_into(update);
-        }
-        batcher.push_into(chunk);
-        let (mut chain, description) = batcher.seal(Antichain::from_elem(Timestamp::MAX));
-        let batch = ErrBuilder::<Timestamp, Diff>::seal(&mut chain, description);
-        let storage = vec![batch];
-        let cursor = CursorList::new(vec![storage[0].cursor()], &storage);
-        ErrorScan {
-            cursor,
-            storage,
-            row_iteration_tracker: PeekRowIterationTracker::new(row_iteration_limit, 0),
-            scan_time: Duration::ZERO,
-        }
-    }
-
-    /// Updates that put `error` in the trace at a multiplicity that cancels to zero at
-    /// [`PEEK_TIMESTAMP`].
-    ///
-    /// The two updates sit at different times so that they survive consolidation: a key whose
-    /// updates consolidate away is not in the trace at all, and the walk never sees it.
-    fn cancelling(error: &DataflowErrorSer) -> Vec<((DataflowErrorSer, ()), Timestamp, Diff)> {
-        vec![
-            ((error.clone(), ()), Timestamp::new(0), Diff::ONE),
-            ((error.clone(), ()), PEEK_TIMESTAMP, Diff::MINUS_ONE),
-        ]
-    }
-
-    /// Runs `scan` to an answer in slices of `fuel_per_step` units, and returns that answer, the
-    /// fuel the walk spent, and the number of calls it took.
-    fn run_sliced(scan: &mut ErrorScan, fuel_per_step: usize) -> (ErrorScanStep, usize, usize) {
-        let mut consumed = 0;
-        // Bounded so that a walk which restarts from the first key on each resumption fails the
-        // test instead of hanging it.
-        for calls in 1..=100 {
-            let mut fuel = fuel_per_step;
-            let outcome = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
-            consumed += fuel_per_step - fuel;
-            if !matches!(outcome, ErrorScanStep::OutOfFuel) {
-                return (outcome, consumed, calls);
-            }
-        }
-        panic!("walk did not answer within 100 resumptions");
-    }
-
-    /// An error trace whose keys cancel to zero at the peek's timestamp is walked key by key
-    /// before the error behind them is found. That walk spends fuel per key, so it suspends and
-    /// resumes rather than running the trace out in one call, and slicing it changes neither the
-    /// answer nor the work it costs.
-    #[mz_ore::test]
-    fn error_scan_is_fueled_and_resumable() {
-        let mut errors: Vec<DataflowErrorSer> = (0..64).map(error).collect();
-        errors.sort();
-        let (answering, cancelled) = errors.split_last().expect("non-empty");
-
-        let mut updates: Vec<_> = cancelled.iter().flat_map(cancelling).collect();
-        updates.push(((answering.clone(), ()), Timestamp::new(0), Diff::ONE));
-        let expected = || ErrorScanStep::Answer(answering.deserialize().into());
-
-        // The walk visits every cancelling key and then the key that answers.
-        let expected_fuel = errors.len();
-
-        let mut scan = error_scan(updates.clone(), None);
-        let mut fuel = usize::MAX;
-        let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
-        assert_eq!(unbudgeted, expected());
-        assert_eq!(usize::MAX - fuel, expected_fuel);
-
-        // One unit of fuel per call: the walk answers only if each resumption picks up where the
-        // last stopped, and the fuel it spends in total says it neither repeated nor skipped a
-        // key.
-        let mut scan = error_scan(updates, None);
-        let (sliced, consumed, calls) = run_sliced(&mut scan, 1);
-        assert_eq!(sliced, expected());
-        assert_eq!(consumed, expected_fuel);
-        assert!(calls > 1, "the budget did not slice the walk");
-    }
-
-    /// A walk that finds no error hands the ok scan the number of rows it examined, and slicing
-    /// the walk neither loses nor repeats a key in that count.
-    #[mz_ore::test]
-    fn error_scan_threads_row_count_across_suspensions() {
-        let errors: Vec<DataflowErrorSer> = (0..64).map(error).collect();
-        let updates: Vec<_> = errors.iter().flat_map(cancelling).collect();
-
-        // Every key cancels, so the walk visits all of them and then the position past the last
-        // key, which is where it learns the trace is exhausted.
-        let expected_fuel = errors.len() + 1;
-
-        let mut scan = error_scan(updates.clone(), None);
-        let mut fuel = usize::MAX;
-        let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
-        assert_eq!(
-            unbudgeted,
-            ErrorScanStep::Clean {
-                rows_iterated: errors.len()
-            }
-        );
-        assert_eq!(usize::MAX - fuel, expected_fuel);
-
-        let mut scan = error_scan(updates, None);
-        let (sliced, consumed, calls) = run_sliced(&mut scan, 3);
-        assert_eq!(
-            sliced,
-            ErrorScanStep::Clean {
-                rows_iterated: errors.len()
-            }
-        );
-        assert_eq!(consumed, expected_fuel);
-        assert!(calls > 1, "the budget did not slice the walk");
-    }
-
-    /// The row-iteration limit bounds the error walk too, not only the ok scan that follows it.
-    /// A walk that trips the limit answers with [`PeekError::RowIterationLimitExceeded`] at the
-    /// key that exceeds it, and it answers at that same key whether it ran in one call or was
-    /// sliced into fueled steps. The count the limit is checked against is a count of keys the
-    /// walk examined, so slicing must move neither the answer nor the key it comes from.
-    #[mz_ore::test]
-    fn error_scan_row_iteration_limit_trips_at_the_same_key_when_sliced() {
-        let errors: Vec<DataflowErrorSer> = (0..64).map(error).collect();
-        let updates: Vec<_> = errors.iter().flat_map(cancelling).collect();
-
-        // Well short of the number of keys, so the limit ends the walk rather than the end of
-        // the trace does.
-        let limit = 20;
-        assert!(limit < errors.len(), "the limit must trip mid-walk");
-        let expected = || ErrorScanStep::Answer(PeekError::RowIterationLimitExceeded { limit });
-        // The walk examines `limit` keys and trips on the one after them. That count is also the
-        // fuel it spends, because both are charged once per cursor position.
-        let expected_fuel = limit + 1;
-
-        let mut scan = error_scan(updates.clone(), Some(limit));
-        let mut fuel = usize::MAX;
-        let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
-        assert_eq!(unbudgeted, expected());
-        assert_eq!(usize::MAX - fuel, expected_fuel);
-
-        let mut scan = error_scan(updates, Some(limit));
-        let (sliced, consumed, calls) = run_sliced(&mut scan, 3);
-        assert_eq!(sliced, expected());
-        assert_eq!(
-            consumed, expected_fuel,
-            "slicing the walk must not move the key the limit trips on"
-        );
-        assert!(calls > 1, "the budget did not slice the walk");
     }
 }
 
@@ -1904,151 +1732,6 @@ pub struct IndexPeek {
     /// Only [`ErrorScanState::Scanning`] holds a cursor, so a peek that is not walking its error
     /// trace pins no error batches.
     error_scan: ErrorScanState,
-}
-
-/// The error trace of an index, as [`TraceBundle::errs_mut`] hands it out.
-type ErrsHandle = PaddedTrace<ErrAgent<Timestamp, Diff>>;
-
-/// The state of an index peek's walk over its error trace.
-///
-/// The walk latches on the outcome that ends it. [`ErrorScanState::Clean`] and
-/// [`ErrorScanState::Answered`] record which of the two terminal outcomes occurred and hold the
-/// value needed to report it again, so a later step repeats it without walking the trace a second
-/// time and without holding a cursor. The two are separate variants because they decide different
-/// fates for the peek: a clean trace sends it on to the ok trace, an answer is its response.
-enum ErrorScanState {
-    /// The walk has not started, and holds no cursor yet.
-    NotStarted,
-    /// The walk is under way, and resumes from the cursor position it stopped on.
-    Scanning(ErrorScan),
-    /// The walk reached the end of the trace without finding an error, having examined
-    /// `rows_iterated` rows.
-    Clean { rows_iterated: usize },
-    /// The walk found the error that answers the peek.
-    Answered(PeekError),
-}
-
-/// A walk over an index peek's error trace, suspendable between cursor positions.
-///
-/// Owns the cursor, the batches it reads from, the count of rows the walk has examined, and the
-/// worker time it has spent. Each of those outlives a single [`ErrorScan::step`]: the cursor and
-/// its batches because a suspended walk resumes at the key it stopped on, the count because the
-/// row-iteration limit spans the error trace and the ok trace together, and the time because the
-/// scan's cost is the sum of its slices rather than the wall clock spanning them.
-///
-/// It owns nothing of the ok trace, of the rows a peek returns, or of their size: a peek reaches
-/// those only once this walk reports [`ErrorScanStep::Clean`].
-struct ErrorScan {
-    cursor: peek_result_iterator::TraceCursor<ErrsHandle>,
-    storage: peek_result_iterator::TraceStorage<ErrsHandle>,
-    row_iteration_tracker: PeekRowIterationTracker,
-    /// Worker time spent walking, summed over the calls the walk was sliced into.
-    scan_time: Duration,
-}
-
-/// The outcome of a fueled [`ErrorScan::step`].
-#[derive(Debug, PartialEq)]
-enum ErrorScanStep {
-    /// The error trace holds no error at the peek's timestamp, so the peek's answer comes from
-    /// the ok trace. `rows_iterated` is the count the walk accrued, which the ok scan continues
-    /// from.
-    Clean { rows_iterated: usize },
-    /// The peek's answer: an error the trace holds at the peek's timestamp, or a failure of the
-    /// peek itself.
-    Answer(PeekError),
-    /// The fuel ran out before the walk reached either. The walk resumes at the cursor position
-    /// it stopped on, and that position has not been examined yet.
-    OutOfFuel,
-}
-
-impl ErrorScan {
-    /// Opens a walk over `errs`.
-    ///
-    /// The walk starts without a row-iteration limit. The limit in effect is the caller's to
-    /// supply through [`ErrorScan::set_row_iteration_limit`] before each step.
-    fn new(errs: &mut ErrsHandle) -> Self {
-        let scan_start = Instant::now();
-        let (cursor, storage) = errs.cursor();
-        Self {
-            cursor,
-            storage,
-            row_iteration_tracker: PeekRowIterationTracker::new(None, 0),
-            scan_time: scan_start.elapsed(),
-        }
-    }
-
-    /// Adopts the row-iteration limit that is in effect, without forgetting the rows the walk has
-    /// already examined.
-    fn set_row_iteration_limit(&mut self, limit: Option<usize>) {
-        self.row_iteration_tracker.set_limit(limit);
-    }
-
-    /// Advances the walk until it has an answer for the peek, the cursor is exhausted, or `fuel`
-    /// runs out, whichever comes first. Decrements `fuel` by the number of cursor positions
-    /// visited.
-    ///
-    /// A key whose diffs cancel to zero at `peek_timestamp` yields no answer, so fuel is charged
-    /// per position rather than per answer. Otherwise a trace that has accumulated many such keys
-    /// would run to its end within a single step, which is the stall the budget exists to bound.
-    ///
-    /// A terminal outcome does not latch here. [`IndexPeek::step_error_scan`] holds the state that
-    /// latches it, so that a caller which steps again gets that outcome back without the walk
-    /// examining the position it stopped on a second time. The latch cannot live in the walk
-    /// itself: a walk that latched its own outcome could not release the `cursor` and `storage`
-    /// it is reading through, short of making both fields `Option`s that every step unwraps, and
-    /// a finished peek would go on pinning error batches it will never read again.
-    fn step(
-        &mut self,
-        peek_timestamp: Timestamp,
-        target_id: GlobalId,
-        fuel: &mut usize,
-    ) -> ErrorScanStep {
-        let step_start = Instant::now();
-
-        let outcome = loop {
-            if *fuel == 0 {
-                break ErrorScanStep::OutOfFuel;
-            }
-            *fuel -= 1;
-
-            if !self.cursor.key_valid(&self.storage) {
-                break ErrorScanStep::Clean {
-                    rows_iterated: self.row_iteration_tracker.rows_iterated(),
-                };
-            }
-
-            if let Err(error) = self.row_iteration_tracker.track_next() {
-                break ErrorScanStep::Answer(error);
-            }
-
-            let mut copies = Diff::ZERO;
-            self.cursor.map_times(&self.storage, |time, diff| {
-                if time.less_equal(&peek_timestamp) {
-                    copies += diff;
-                }
-            });
-            if copies.is_negative() {
-                let error = self.cursor.key(&self.storage);
-                error!(
-                    target = %target_id, diff = %copies, %error,
-                    "index peek encountered negative multiplicities in error trace",
-                );
-                break ErrorScanStep::Answer(PeekError::unstructured(format!(
-                    "Invalid data in source errors, \
-                    saw retractions ({}) for row that does not exist: {}",
-                    -copies, error,
-                )));
-            }
-            if copies.is_positive() {
-                let error = self.cursor.key(&self.storage).deserialize();
-                break ErrorScanStep::Answer(error.into());
-            }
-            self.cursor.step_key(&self.storage);
-        };
-
-        self.scan_time += step_start.elapsed();
-        outcome
-    }
 }
 
 /// Histogram metrics for index peek phases.

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1954,7 +1954,10 @@ impl ErrorScan {
     ///
     /// A terminal outcome does not latch here. [`IndexPeek::step_error_scan`] holds the state that
     /// latches it, so that a caller which steps again gets that outcome back without the walk
-    /// examining the position it stopped on a second time.
+    /// examining the position it stopped on a second time. The latch cannot live in the walk
+    /// itself: a walk that latched its own outcome could not release the `cursor` and `storage`
+    /// it is reading through, short of making both fields `Option`s that every step unwraps, and
+    /// a finished peek would go on pinning error batches it will never read again.
     fn step(
         &mut self,
         peek_timestamp: Timestamp,
@@ -2088,6 +2091,11 @@ impl IndexPeek {
     }
 
     /// Collects data for a known-complete peek from the ok stream.
+    ///
+    /// Call this at most once per readiness. The two phases it drives are not equally
+    /// resumable: the error walk latches its state across calls, while the ok scan rebuilds its
+    /// iterator from the start of the ok trace and accumulates into locals that are dropped when
+    /// the call returns. A second call therefore re-walks the whole ok trace.
     fn collect_finished_data(
         &mut self,
         max_result_size: u64,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -69,13 +69,14 @@ use tokio::sync::{oneshot, watch};
 use tracing::{Level, debug, error, info, span, trace, warn};
 use uuid::Uuid;
 
-use crate::arrangement::manager::{TraceBundle, TraceManager};
+use crate::arrangement::manager::{PaddedTrace, TraceBundle, TraceManager};
 use crate::logging;
 use crate::logging::compute::{CollectionLogging, ComputeEvent, PeekEvent};
 use crate::logging::initialize::LoggingTraces;
 use crate::metrics::{CollectionMetrics, WorkerMetrics};
 use crate::render::{LinearJoinSpec, StartSignal};
 use crate::server::{ComputeInstanceContext, ResponseSender};
+use crate::typedefs::ErrAgent;
 
 mod peek_result_iterator;
 mod peek_stash;
@@ -156,7 +157,15 @@ fn peek_row_iteration_limit(config: &ConfigSet) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
+    use differential_dataflow::trace::cursor::CursorList;
+    use differential_dataflow::trace::{Batcher, Builder};
     use mz_dyncfg::ConfigUpdates;
+    use mz_expr::EvalError;
+    use mz_timely_util::columnation::ColumnationStack;
+    use timely::container::PushInto;
+
+    use crate::render::errors::DataflowErrorSer;
+    use crate::typedefs::{ErrBatcher, ErrBuilder};
 
     use super::*;
 
@@ -192,6 +201,129 @@ mod tests {
             tracker.track_next(),
             Err(PeekError::RowIterationLimitExceeded { limit: 5 })
         );
+    }
+
+    /// The time at which the peeks in these tests read.
+    const PEEK_TIMESTAMP: Timestamp = Timestamp::new(1);
+
+    /// A distinct error for `index`.
+    ///
+    /// The order of the serialized form does not follow `index`, so a test that cares where a
+    /// key falls in the walk sorts the errors and picks by position.
+    fn error(index: usize) -> DataflowErrorSer {
+        DataflowErrorSer::from(EvalError::Internal(format!("error {index}").into()))
+    }
+
+    /// Builds a walk over a single-batch error trace holding `updates`.
+    fn error_scan(updates: Vec<((DataflowErrorSer, ()), Timestamp, Diff)>) -> ErrorScan {
+        let mut batcher = ErrBatcher::<Timestamp, Diff>::new(None, 0);
+        let mut chunk = ColumnationStack::with_capacity(updates.len());
+        for update in updates {
+            chunk.push_into(update);
+        }
+        batcher.push_into(chunk);
+        let (mut chain, description) = batcher.seal(Antichain::from_elem(Timestamp::MAX));
+        let batch = ErrBuilder::<Timestamp, Diff>::seal(&mut chain, description);
+        let storage = vec![batch];
+        let cursor = CursorList::new(vec![storage[0].cursor()], &storage);
+        ErrorScan {
+            cursor,
+            storage,
+            row_iteration_tracker: PeekRowIterationTracker::new(None, 0),
+            scan_time: Duration::ZERO,
+        }
+    }
+
+    /// Updates that put `error` in the trace at a multiplicity that cancels to zero at
+    /// [`PEEK_TIMESTAMP`].
+    ///
+    /// The two updates sit at different times so that they survive consolidation: a key whose
+    /// updates consolidate away is not in the trace at all, and the walk never sees it.
+    fn cancelling(error: &DataflowErrorSer) -> Vec<((DataflowErrorSer, ()), Timestamp, Diff)> {
+        vec![
+            ((error.clone(), ()), Timestamp::new(0), Diff::ONE),
+            ((error.clone(), ()), PEEK_TIMESTAMP, Diff::MINUS_ONE),
+        ]
+    }
+
+    /// Runs `scan` to an answer in slices of `fuel_per_step` units, and returns that answer, the
+    /// fuel the walk spent, and the number of calls it took.
+    fn run_sliced(scan: &mut ErrorScan, fuel_per_step: usize) -> (ErrorScanStep, usize, usize) {
+        let mut consumed = 0;
+        // Bounded so that a walk which restarts from the first key on each resumption fails the
+        // test instead of hanging it.
+        for calls in 1..=100 {
+            let mut fuel = fuel_per_step;
+            let outcome = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
+            consumed += fuel_per_step - fuel;
+            if !matches!(outcome, ErrorScanStep::OutOfFuel) {
+                return (outcome, consumed, calls);
+            }
+        }
+        panic!("walk did not answer within 100 resumptions");
+    }
+
+    /// An error trace whose keys cancel to zero at the peek's timestamp is walked key by key
+    /// before the error behind them is found. That walk spends fuel per key, so it suspends and
+    /// resumes rather than running the trace out in one call, and slicing it changes neither the
+    /// answer nor the work it costs.
+    #[mz_ore::test]
+    fn error_scan_is_fueled_and_resumable() {
+        let mut errors: Vec<DataflowErrorSer> = (0..64).map(error).collect();
+        errors.sort();
+        let (answering, cancelled) = errors.split_last().expect("non-empty");
+
+        let mut updates: Vec<_> = cancelled.iter().flat_map(cancelling).collect();
+        updates.push(((answering.clone(), ()), Timestamp::new(0), Diff::ONE));
+        let expected = PeekResponse::Error(answering.deserialize().into());
+
+        // The walk visits every cancelling key and then the key that answers.
+        let expected_fuel = errors.len();
+
+        let mut scan = error_scan(updates.clone());
+        let mut fuel = usize::MAX;
+        let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
+        assert!(matches!(&unbudgeted, ErrorScanStep::Answer(response) if response == &expected));
+        assert_eq!(usize::MAX - fuel, expected_fuel);
+
+        // One unit of fuel per call: the walk answers only if each resumption picks up where the
+        // last stopped, and the fuel it spends in total says it neither repeated nor skipped a
+        // key.
+        let mut scan = error_scan(updates);
+        let (sliced, consumed, calls) = run_sliced(&mut scan, 1);
+        assert!(matches!(&sliced, ErrorScanStep::Answer(response) if response == &expected));
+        assert_eq!(consumed, expected_fuel);
+        assert!(calls > 1, "the budget did not slice the walk");
+    }
+
+    /// A walk that finds no error hands the ok scan the number of rows it examined, and slicing
+    /// the walk neither loses nor repeats a key in that count.
+    #[mz_ore::test]
+    fn error_scan_threads_row_count_across_suspensions() {
+        let errors: Vec<DataflowErrorSer> = (0..64).map(error).collect();
+        let updates: Vec<_> = errors.iter().flat_map(cancelling).collect();
+
+        // Every key cancels, so the walk visits all of them and then the position past the last
+        // key, which is where it learns the trace is exhausted.
+        let expected_fuel = errors.len() + 1;
+
+        let mut scan = error_scan(updates.clone());
+        let mut fuel = usize::MAX;
+        let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
+        assert!(matches!(
+            unbudgeted,
+            ErrorScanStep::Clean { rows_iterated } if rows_iterated == errors.len()
+        ));
+        assert_eq!(usize::MAX - fuel, expected_fuel);
+
+        let mut scan = error_scan(updates);
+        let (sliced, consumed, calls) = run_sliced(&mut scan, 3);
+        assert!(matches!(
+            sliced,
+            ErrorScanStep::Clean { rows_iterated } if rows_iterated == errors.len()
+        ));
+        assert_eq!(consumed, expected_fuel);
+        assert!(calls > 1, "the budget did not slice the walk");
     }
 }
 
@@ -1475,6 +1607,7 @@ impl PendingPeek {
             peek,
             trace_bundle,
             span: tracing::Span::current(),
+            error_scan: None,
         })
     }
 
@@ -1723,6 +1856,122 @@ pub struct IndexPeek {
     trace_bundle: TraceBundle,
     /// The `tracing::Span` tracking this peek's operation
     span: tracing::Span,
+    /// The walk over the error trace, while it is in progress.
+    ///
+    /// `None` before the walk starts and once it finishes, so that a peek that is not scanning
+    /// holds no error batches.
+    error_scan: Option<ErrorScan>,
+}
+
+/// The error trace of an index, as [`TraceBundle::errs_mut`] hands it out.
+type ErrsHandle = PaddedTrace<ErrAgent<Timestamp, Diff>>;
+
+/// A walk over an index peek's error trace, suspendable between cursor positions.
+///
+/// Owns the cursor, the batches it reads from, the count of rows the walk has examined, and the
+/// worker time it has spent. Each of those outlives a single [`ErrorScan::step`]: the cursor and
+/// its batches because a suspended walk resumes at the key it stopped on, the count because the
+/// row-iteration limit spans the error trace and the ok trace together, and the time because the
+/// scan's cost is the sum of its slices rather than the wall clock spanning them.
+///
+/// It owns nothing of the ok trace, of the rows a peek returns, or of their size: a peek reaches
+/// those only once this walk reports [`ErrorScanStep::Clean`].
+struct ErrorScan {
+    cursor: peek_result_iterator::TraceCursor<ErrsHandle>,
+    storage: peek_result_iterator::TraceStorage<ErrsHandle>,
+    row_iteration_tracker: PeekRowIterationTracker,
+    /// Worker time spent walking, summed over the calls the walk was sliced into.
+    scan_time: Duration,
+}
+
+/// The outcome of a fueled [`ErrorScan::step`].
+enum ErrorScanStep {
+    /// The error trace holds no error at the peek's timestamp, so the peek's answer comes from
+    /// the ok trace. `rows_iterated` is the count the walk accrued, which the ok scan continues
+    /// from.
+    Clean { rows_iterated: usize },
+    /// The peek's answer: an error the trace holds at the peek's timestamp, or a failure of the
+    /// peek itself.
+    Answer(PeekResponse),
+    /// The fuel ran out before the walk reached either. The walk resumes at the cursor position
+    /// it stopped on, and that position has not been examined yet.
+    OutOfFuel,
+}
+
+impl ErrorScan {
+    /// Opens a walk over `errs`.
+    fn new(errs: &mut ErrsHandle, row_iteration_limit: Option<usize>) -> Self {
+        let scan_start = Instant::now();
+        let (cursor, storage) = errs.cursor();
+        Self {
+            cursor,
+            storage,
+            row_iteration_tracker: PeekRowIterationTracker::new(row_iteration_limit, 0),
+            scan_time: scan_start.elapsed(),
+        }
+    }
+
+    /// Advances the walk until it has an answer for the peek, the cursor is exhausted, or `fuel`
+    /// runs out, whichever comes first. Decrements `fuel` by the number of cursor positions
+    /// visited.
+    ///
+    /// A key whose diffs cancel to zero at `peek_timestamp` yields no answer, so fuel is charged
+    /// per position rather than per answer. Otherwise a trace that has accumulated many such keys
+    /// would run to its end within a single step, which is the stall the budget exists to bound.
+    fn step(
+        &mut self,
+        peek_timestamp: Timestamp,
+        target_id: GlobalId,
+        fuel: &mut usize,
+    ) -> ErrorScanStep {
+        let step_start = Instant::now();
+
+        let outcome = loop {
+            if *fuel == 0 {
+                break ErrorScanStep::OutOfFuel;
+            }
+            *fuel -= 1;
+
+            if !self.cursor.key_valid(&self.storage) {
+                break ErrorScanStep::Clean {
+                    rows_iterated: self.row_iteration_tracker.rows_iterated(),
+                };
+            }
+
+            if let Err(error) = self.row_iteration_tracker.track_next() {
+                break ErrorScanStep::Answer(PeekResponse::Error(error));
+            }
+
+            let mut copies = Diff::ZERO;
+            self.cursor.map_times(&self.storage, |time, diff| {
+                if time.less_equal(&peek_timestamp) {
+                    copies += diff;
+                }
+            });
+            if copies.is_negative() {
+                let error = self.cursor.key(&self.storage);
+                error!(
+                    target = %target_id, diff = %copies, %error,
+                    "index peek encountered negative multiplicities in error trace",
+                );
+                break ErrorScanStep::Answer(PeekResponse::Error(PeekError::unstructured(
+                    format!(
+                        "Invalid data in source errors, \
+                        saw retractions ({}) for row that does not exist: {}",
+                        -copies, error,
+                    ),
+                )));
+            }
+            if copies.is_positive() {
+                let error = self.cursor.key(&self.storage).deserialize();
+                break ErrorScanStep::Answer(PeekResponse::Error(error.into()));
+            }
+            self.cursor.step_key(&self.storage);
+        };
+
+        self.scan_time += step_start.elapsed();
+        outcome
+    }
 }
 
 /// Histogram metrics for index peek phases.
@@ -1812,45 +2061,16 @@ impl IndexPeek {
         row_iteration_limit: Option<usize>,
         metrics: &IndexPeekMetrics<'_>,
     ) -> PeekStatus {
-        let error_scan_start = Instant::now();
-
         // Check if there exist any errors and, if so, return whatever one we
         // find first.
-        let mut row_iteration_tracker = PeekRowIterationTracker::new(row_iteration_limit, 0);
-        let (mut cursor, storage) = self.trace_bundle.errs_mut().cursor();
-        while cursor.key_valid(&storage) {
-            if let Err(error) = row_iteration_tracker.track_next() {
-                return PeekStatus::Ready(PeekResponse::Error(error));
-            }
-
-            let mut copies = Diff::ZERO;
-            cursor.map_times(&storage, |time, diff| {
-                if time.less_equal(&self.peek.timestamp) {
-                    copies += diff;
-                }
-            });
-            if copies.is_negative() {
-                let error = cursor.key(&storage);
-                error!(
-                    target = %self.peek.target.id(), diff = %copies, %error,
-                    "index peek encountered negative multiplicities in error trace",
-                );
-                return PeekStatus::Ready(PeekResponse::Error(PeekError::unstructured(format!(
-                    "Invalid data in source errors, \
-                    saw retractions ({}) for row that does not exist: {}",
-                    -copies, error,
-                ))));
-            }
-            if copies.is_positive() {
-                let error = cursor.key(&storage).deserialize();
-                return PeekStatus::Ready(PeekResponse::Error(error.into()));
-            }
-            cursor.step_key(&storage);
-        }
-
-        metrics
-            .error_scan_seconds
-            .observe(error_scan_start.elapsed().as_secs_f64());
+        //
+        // No caller supplies a scan budget, so the walk runs to an answer in one step.
+        let mut fuel = usize::MAX;
+        let rows_iterated = match self.step_error_scan(row_iteration_limit, metrics, &mut fuel) {
+            ErrorScanStep::Clean { rows_iterated } => rows_iterated,
+            ErrorScanStep::Answer(response) => return PeekStatus::Ready(response),
+            ErrorScanStep::OutOfFuel => unreachable!("stepped with unbounded fuel"),
+        };
 
         Self::collect_ok_finished_data(
             &self.peek,
@@ -1859,9 +2079,41 @@ impl IndexPeek {
             peek_stash_eligible,
             peek_stash_threshold_bytes,
             row_iteration_limit,
-            row_iteration_tracker.rows_iterated(),
+            rows_iterated,
             metrics,
         )
+    }
+
+    /// Advances this peek's walk over its error trace, starting it if it has not started,
+    /// charging one unit of `fuel` per cursor position.
+    ///
+    /// The walk resumes where a previous call left off, so a caller must not treat
+    /// [`ErrorScanStep::OutOfFuel`] as an end of scan.
+    fn step_error_scan(
+        &mut self,
+        row_iteration_limit: Option<usize>,
+        metrics: &IndexPeekMetrics<'_>,
+        fuel: &mut usize,
+    ) -> ErrorScanStep {
+        if self.error_scan.is_none() {
+            self.error_scan = Some(ErrorScan::new(
+                self.trace_bundle.errs_mut(),
+                row_iteration_limit,
+            ));
+        }
+        let scan = self.error_scan.as_mut().expect("scan is present");
+        let outcome = scan.step(self.peek.timestamp, self.peek.target.id(), fuel);
+
+        if let ErrorScanStep::Clean { .. } = outcome {
+            // The ok trace answers the peek from here on, so release the error batches rather
+            // than pin them for the rest of the peek.
+            let scan = self.error_scan.take().expect("scan is present");
+            metrics
+                .error_scan_seconds
+                .observe(scan.scan_time.as_secs_f64());
+        }
+
+        outcome
     }
 
     /// Collects data for a known-complete peek from the ok stream.

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -214,8 +214,12 @@ mod tests {
         DataflowErrorSer::from(EvalError::Internal(format!("error {index}").into()))
     }
 
-    /// Builds a walk over a single-batch error trace holding `updates`.
-    fn error_scan(updates: Vec<((DataflowErrorSer, ()), Timestamp, Diff)>) -> ErrorScan {
+    /// Builds a walk over a single-batch error trace holding `updates`, bounded by
+    /// `row_iteration_limit`.
+    fn error_scan(
+        updates: Vec<((DataflowErrorSer, ()), Timestamp, Diff)>,
+        row_iteration_limit: Option<usize>,
+    ) -> ErrorScan {
         let mut batcher = ErrBatcher::<Timestamp, Diff>::new(None, 0);
         let mut chunk = ColumnationStack::with_capacity(updates.len());
         for update in updates {
@@ -229,7 +233,7 @@ mod tests {
         ErrorScan {
             cursor,
             storage,
-            row_iteration_tracker: PeekRowIterationTracker::new(None, 0),
+            row_iteration_tracker: PeekRowIterationTracker::new(row_iteration_limit, 0),
             scan_time: Duration::ZERO,
         }
     }
@@ -280,7 +284,7 @@ mod tests {
         // The walk visits every cancelling key and then the key that answers.
         let expected_fuel = errors.len();
 
-        let mut scan = error_scan(updates.clone());
+        let mut scan = error_scan(updates.clone(), None);
         let mut fuel = usize::MAX;
         let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
         assert_eq!(unbudgeted, expected());
@@ -289,7 +293,7 @@ mod tests {
         // One unit of fuel per call: the walk answers only if each resumption picks up where the
         // last stopped, and the fuel it spends in total says it neither repeated nor skipped a
         // key.
-        let mut scan = error_scan(updates);
+        let mut scan = error_scan(updates, None);
         let (sliced, consumed, calls) = run_sliced(&mut scan, 1);
         assert_eq!(sliced, expected());
         assert_eq!(consumed, expected_fuel);
@@ -307,7 +311,7 @@ mod tests {
         // key, which is where it learns the trace is exhausted.
         let expected_fuel = errors.len() + 1;
 
-        let mut scan = error_scan(updates.clone());
+        let mut scan = error_scan(updates.clone(), None);
         let mut fuel = usize::MAX;
         let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
         assert_eq!(
@@ -318,7 +322,7 @@ mod tests {
         );
         assert_eq!(usize::MAX - fuel, expected_fuel);
 
-        let mut scan = error_scan(updates);
+        let mut scan = error_scan(updates, None);
         let (sliced, consumed, calls) = run_sliced(&mut scan, 3);
         assert_eq!(
             sliced,
@@ -327,6 +331,41 @@ mod tests {
             }
         );
         assert_eq!(consumed, expected_fuel);
+        assert!(calls > 1, "the budget did not slice the walk");
+    }
+
+    /// The row-iteration limit bounds the error walk too, not only the ok scan that follows it.
+    /// A walk that trips the limit answers with [`PeekError::RowIterationLimitExceeded`] at the
+    /// key that exceeds it, and it answers at that same key whether it ran in one call or was
+    /// sliced into fueled steps. The count the limit is checked against is a count of keys the
+    /// walk examined, so slicing must move neither the answer nor the key it comes from.
+    #[mz_ore::test]
+    fn error_scan_row_iteration_limit_trips_at_the_same_key_when_sliced() {
+        let errors: Vec<DataflowErrorSer> = (0..64).map(error).collect();
+        let updates: Vec<_> = errors.iter().flat_map(cancelling).collect();
+
+        // Well short of the number of keys, so the limit ends the walk rather than the end of
+        // the trace does.
+        let limit = 20;
+        assert!(limit < errors.len(), "the limit must trip mid-walk");
+        let expected = || ErrorScanStep::Answer(PeekError::RowIterationLimitExceeded { limit });
+        // The walk examines `limit` keys and trips on the one after them. That count is also the
+        // fuel it spends, because both are charged once per cursor position.
+        let expected_fuel = limit + 1;
+
+        let mut scan = error_scan(updates.clone(), Some(limit));
+        let mut fuel = usize::MAX;
+        let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
+        assert_eq!(unbudgeted, expected());
+        assert_eq!(usize::MAX - fuel, expected_fuel);
+
+        let mut scan = error_scan(updates, Some(limit));
+        let (sliced, consumed, calls) = run_sliced(&mut scan, 3);
+        assert_eq!(sliced, expected());
+        assert_eq!(
+            consumed, expected_fuel,
+            "slicing the walk must not move the key the limit trips on"
+        );
         assert!(calls > 1, "the budget did not slice the walk");
     }
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -275,7 +275,7 @@ mod tests {
 
         let mut updates: Vec<_> = cancelled.iter().flat_map(cancelling).collect();
         updates.push(((answering.clone(), ()), Timestamp::new(0), Diff::ONE));
-        let expected = PeekResponse::Error(answering.deserialize().into());
+        let expected = || ErrorScanStep::Answer(answering.deserialize().into());
 
         // The walk visits every cancelling key and then the key that answers.
         let expected_fuel = errors.len();
@@ -283,7 +283,7 @@ mod tests {
         let mut scan = error_scan(updates.clone());
         let mut fuel = usize::MAX;
         let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
-        assert!(matches!(&unbudgeted, ErrorScanStep::Answer(response) if response == &expected));
+        assert_eq!(unbudgeted, expected());
         assert_eq!(usize::MAX - fuel, expected_fuel);
 
         // One unit of fuel per call: the walk answers only if each resumption picks up where the
@@ -291,7 +291,7 @@ mod tests {
         // key.
         let mut scan = error_scan(updates);
         let (sliced, consumed, calls) = run_sliced(&mut scan, 1);
-        assert!(matches!(&sliced, ErrorScanStep::Answer(response) if response == &expected));
+        assert_eq!(sliced, expected());
         assert_eq!(consumed, expected_fuel);
         assert!(calls > 1, "the budget did not slice the walk");
     }
@@ -310,18 +310,22 @@ mod tests {
         let mut scan = error_scan(updates.clone());
         let mut fuel = usize::MAX;
         let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
-        assert!(matches!(
+        assert_eq!(
             unbudgeted,
-            ErrorScanStep::Clean { rows_iterated } if rows_iterated == errors.len()
-        ));
+            ErrorScanStep::Clean {
+                rows_iterated: errors.len()
+            }
+        );
         assert_eq!(usize::MAX - fuel, expected_fuel);
 
         let mut scan = error_scan(updates);
         let (sliced, consumed, calls) = run_sliced(&mut scan, 3);
-        assert!(matches!(
+        assert_eq!(
             sliced,
-            ErrorScanStep::Clean { rows_iterated } if rows_iterated == errors.len()
-        ));
+            ErrorScanStep::Clean {
+                rows_iterated: errors.len()
+            }
+        );
         assert_eq!(consumed, expected_fuel);
         assert!(calls > 1, "the budget did not slice the walk");
     }
@@ -1607,7 +1611,7 @@ impl PendingPeek {
             peek,
             trace_bundle,
             span: tracing::Span::current(),
-            error_scan: None,
+            error_scan: ErrorScanState::NotStarted,
         })
     }
 
@@ -1856,15 +1860,34 @@ pub struct IndexPeek {
     trace_bundle: TraceBundle,
     /// The `tracing::Span` tracking this peek's operation
     span: tracing::Span,
-    /// The walk over the error trace, while it is in progress.
+    /// The state of the walk over the error trace.
     ///
-    /// `None` before the walk starts and once it finishes, so that a peek that is not scanning
-    /// holds no error batches.
-    error_scan: Option<ErrorScan>,
+    /// Only [`ErrorScanState::Scanning`] holds a cursor, so a peek that is not walking its error
+    /// trace pins no error batches.
+    error_scan: ErrorScanState,
 }
 
 /// The error trace of an index, as [`TraceBundle::errs_mut`] hands it out.
 type ErrsHandle = PaddedTrace<ErrAgent<Timestamp, Diff>>;
+
+/// The state of an index peek's walk over its error trace.
+///
+/// The walk latches on the outcome that ends it. [`ErrorScanState::Clean`] and
+/// [`ErrorScanState::Answered`] record which of the two terminal outcomes occurred and hold the
+/// value needed to report it again, so a later step repeats it without walking the trace a second
+/// time and without holding a cursor. The two are separate variants because they decide different
+/// fates for the peek: a clean trace sends it on to the ok trace, an answer is its response.
+enum ErrorScanState {
+    /// The walk has not started, and holds no cursor yet.
+    NotStarted,
+    /// The walk is under way, and resumes from the cursor position it stopped on.
+    Scanning(ErrorScan),
+    /// The walk reached the end of the trace without finding an error, having examined
+    /// `rows_iterated` rows.
+    Clean { rows_iterated: usize },
+    /// The walk found the error that answers the peek.
+    Answered(PeekError),
+}
 
 /// A walk over an index peek's error trace, suspendable between cursor positions.
 ///
@@ -1885,6 +1908,7 @@ struct ErrorScan {
 }
 
 /// The outcome of a fueled [`ErrorScan::step`].
+#[derive(Debug, PartialEq)]
 enum ErrorScanStep {
     /// The error trace holds no error at the peek's timestamp, so the peek's answer comes from
     /// the ok trace. `rows_iterated` is the count the walk accrued, which the ok scan continues
@@ -1892,7 +1916,7 @@ enum ErrorScanStep {
     Clean { rows_iterated: usize },
     /// The peek's answer: an error the trace holds at the peek's timestamp, or a failure of the
     /// peek itself.
-    Answer(PeekResponse),
+    Answer(PeekError),
     /// The fuel ran out before the walk reached either. The walk resumes at the cursor position
     /// it stopped on, and that position has not been examined yet.
     OutOfFuel,
@@ -1900,15 +1924,24 @@ enum ErrorScanStep {
 
 impl ErrorScan {
     /// Opens a walk over `errs`.
-    fn new(errs: &mut ErrsHandle, row_iteration_limit: Option<usize>) -> Self {
+    ///
+    /// The walk starts without a row-iteration limit. The limit in effect is the caller's to
+    /// supply through [`ErrorScan::set_row_iteration_limit`] before each step.
+    fn new(errs: &mut ErrsHandle) -> Self {
         let scan_start = Instant::now();
         let (cursor, storage) = errs.cursor();
         Self {
             cursor,
             storage,
-            row_iteration_tracker: PeekRowIterationTracker::new(row_iteration_limit, 0),
+            row_iteration_tracker: PeekRowIterationTracker::new(None, 0),
             scan_time: scan_start.elapsed(),
         }
+    }
+
+    /// Adopts the row-iteration limit that is in effect, without forgetting the rows the walk has
+    /// already examined.
+    fn set_row_iteration_limit(&mut self, limit: Option<usize>) {
+        self.row_iteration_tracker.set_limit(limit);
     }
 
     /// Advances the walk until it has an answer for the peek, the cursor is exhausted, or `fuel`
@@ -1918,6 +1951,10 @@ impl ErrorScan {
     /// A key whose diffs cancel to zero at `peek_timestamp` yields no answer, so fuel is charged
     /// per position rather than per answer. Otherwise a trace that has accumulated many such keys
     /// would run to its end within a single step, which is the stall the budget exists to bound.
+    ///
+    /// A terminal outcome does not latch here. [`IndexPeek::step_error_scan`] holds the state that
+    /// latches it, so that a caller which steps again gets that outcome back without the walk
+    /// examining the position it stopped on a second time.
     fn step(
         &mut self,
         peek_timestamp: Timestamp,
@@ -1939,7 +1976,7 @@ impl ErrorScan {
             }
 
             if let Err(error) = self.row_iteration_tracker.track_next() {
-                break ErrorScanStep::Answer(PeekResponse::Error(error));
+                break ErrorScanStep::Answer(error);
             }
 
             let mut copies = Diff::ZERO;
@@ -1954,17 +1991,15 @@ impl ErrorScan {
                     target = %target_id, diff = %copies, %error,
                     "index peek encountered negative multiplicities in error trace",
                 );
-                break ErrorScanStep::Answer(PeekResponse::Error(PeekError::unstructured(
-                    format!(
-                        "Invalid data in source errors, \
-                        saw retractions ({}) for row that does not exist: {}",
-                        -copies, error,
-                    ),
+                break ErrorScanStep::Answer(PeekError::unstructured(format!(
+                    "Invalid data in source errors, \
+                    saw retractions ({}) for row that does not exist: {}",
+                    -copies, error,
                 )));
             }
             if copies.is_positive() {
                 let error = self.cursor.key(&self.storage).deserialize();
-                break ErrorScanStep::Answer(PeekResponse::Error(error.into()));
+                break ErrorScanStep::Answer(error.into());
             }
             self.cursor.step_key(&self.storage);
         };
@@ -2068,7 +2103,7 @@ impl IndexPeek {
         let mut fuel = usize::MAX;
         let rows_iterated = match self.step_error_scan(row_iteration_limit, metrics, &mut fuel) {
             ErrorScanStep::Clean { rows_iterated } => rows_iterated,
-            ErrorScanStep::Answer(response) => return PeekStatus::Ready(response),
+            ErrorScanStep::Answer(error) => return PeekStatus::Ready(PeekResponse::Error(error)),
             ErrorScanStep::OutOfFuel => unreachable!("stepped with unbounded fuel"),
         };
 
@@ -2089,28 +2124,55 @@ impl IndexPeek {
     ///
     /// The walk resumes where a previous call left off, so a caller must not treat
     /// [`ErrorScanStep::OutOfFuel`] as an end of scan.
+    ///
+    /// The outcome that ends the walk latches. Once the walk has reported
+    /// [`ErrorScanStep::Clean`] or [`ErrorScanStep::Answer`], every further call reports that same
+    /// outcome, spends no fuel, and reads no trace. An answer therefore stays an answer, and a
+    /// peek that must report an error can never be sent on to return rows instead.
     fn step_error_scan(
         &mut self,
         row_iteration_limit: Option<usize>,
         metrics: &IndexPeekMetrics<'_>,
         fuel: &mut usize,
     ) -> ErrorScanStep {
-        if self.error_scan.is_none() {
-            self.error_scan = Some(ErrorScan::new(
-                self.trace_bundle.errs_mut(),
-                row_iteration_limit,
-            ));
+        match &self.error_scan {
+            ErrorScanState::NotStarted => {
+                self.error_scan =
+                    ErrorScanState::Scanning(ErrorScan::new(self.trace_bundle.errs_mut()));
+            }
+            ErrorScanState::Scanning(_) => {}
+            ErrorScanState::Clean { rows_iterated } => {
+                return ErrorScanStep::Clean {
+                    rows_iterated: *rows_iterated,
+                };
+            }
+            ErrorScanState::Answered(error) => return ErrorScanStep::Answer(error.clone()),
         }
-        let scan = self.error_scan.as_mut().expect("scan is present");
-        let outcome = scan.step(self.peek.timestamp, self.peek.target.id(), fuel);
 
-        if let ErrorScanStep::Clean { .. } = outcome {
-            // The ok trace answers the peek from here on, so release the error batches rather
-            // than pin them for the rest of the peek.
-            let scan = self.error_scan.take().expect("scan is present");
-            metrics
-                .error_scan_seconds
-                .observe(scan.scan_time.as_secs_f64());
+        let ErrorScanState::Scanning(scan) = &mut self.error_scan else {
+            unreachable!("walk is under way");
+        };
+        // The limit bounds the peek, not the call, so a walk already under way adopts the limit
+        // that is in effect now rather than the one that was in effect when it started.
+        scan.set_row_iteration_limit(row_iteration_limit);
+        let outcome = scan.step(self.peek.timestamp, self.peek.target.id(), fuel);
+        let scan_time = scan.scan_time;
+
+        // Both terminal outcomes drop the walk, so that a peek pins error batches only while it
+        // is reading them.
+        match &outcome {
+            ErrorScanStep::Clean { rows_iterated } => {
+                self.error_scan = ErrorScanState::Clean {
+                    rows_iterated: *rows_iterated,
+                };
+                // Reached at most once per peek, because the latched state answers any
+                // further call. A scan that answers with an error observes nothing.
+                metrics.error_scan_seconds.observe(scan_time.as_secs_f64());
+            }
+            ErrorScanStep::Answer(error) => {
+                self.error_scan = ErrorScanState::Answered(error.clone());
+            }
+            ErrorScanStep::OutOfFuel => {}
         }
 
         outcome

--- a/src/compute/src/compute_state/error_scan.rs
+++ b/src/compute/src/compute_state/error_scan.rs
@@ -1,0 +1,348 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! An index peek's walk over its error trace, the phase that runs before
+//! [`PeekResultIterator`](super::peek_result_iterator::PeekResultIterator) walks the ok trace.
+
+use std::time::{Duration, Instant};
+
+use differential_dataflow::trace::{Cursor, TraceReader};
+use mz_compute_client::protocol::response::PeekError;
+use mz_repr::{Diff, GlobalId, Timestamp};
+use timely::order::PartialOrder;
+use tracing::error;
+
+use crate::arrangement::manager::PaddedTrace;
+use crate::typedefs::ErrAgent;
+
+use super::{PeekRowIterationTracker, peek_result_iterator};
+
+/// The error trace of an index, as
+/// [`TraceBundle::errs_mut`](crate::arrangement::manager::TraceBundle::errs_mut) hands it out.
+pub(super) type ErrsHandle = PaddedTrace<ErrAgent<Timestamp, Diff>>;
+
+/// The state of an index peek's walk over its error trace.
+///
+/// The walk latches on the outcome that ends it. [`ErrorScanState::Clean`] and
+/// [`ErrorScanState::Answered`] record which of the two terminal outcomes occurred and hold the
+/// value needed to report it again, so a later step repeats it without walking the trace a second
+/// time and without holding a cursor. The two are separate variants because they decide different
+/// fates for the peek: a clean trace sends it on to the ok trace, an answer is its response.
+pub(super) enum ErrorScanState {
+    /// The walk has not started, and holds no cursor yet.
+    NotStarted,
+    /// The walk is under way, and resumes from the cursor position it stopped on.
+    Scanning(ErrorScan),
+    /// The walk reached the end of the trace without finding an error, having examined
+    /// `rows_iterated` rows.
+    Clean { rows_iterated: usize },
+    /// The walk found the error that answers the peek.
+    Answered(PeekError),
+}
+
+/// A walk over an index peek's error trace, suspendable between cursor positions.
+///
+/// Owns the cursor, the batches it reads from, the count of rows the walk has examined, and the
+/// worker time it has spent. Each of those outlives a single [`ErrorScan::step`]: the cursor and
+/// its batches because a suspended walk resumes at the key it stopped on, the count because the
+/// row-iteration limit spans the error trace and the ok trace together, and the time because the
+/// scan's cost is the sum of its slices rather than the wall clock spanning them.
+///
+/// It owns nothing of the ok trace, of the rows a peek returns, or of their size: a peek reaches
+/// those only once this walk reports [`ErrorScanStep::Clean`].
+pub(super) struct ErrorScan {
+    cursor: peek_result_iterator::TraceCursor<ErrsHandle>,
+    storage: peek_result_iterator::TraceStorage<ErrsHandle>,
+    row_iteration_tracker: PeekRowIterationTracker,
+    /// Worker time spent walking, summed over the calls the walk was sliced into.
+    pub(super) scan_time: Duration,
+}
+
+/// The outcome of a fueled [`ErrorScan::step`].
+#[derive(Debug, PartialEq)]
+pub(super) enum ErrorScanStep {
+    /// The error trace holds no error at the peek's timestamp, so the peek's answer comes from
+    /// the ok trace. `rows_iterated` is the count the walk accrued, which the ok scan continues
+    /// from.
+    Clean { rows_iterated: usize },
+    /// The peek's answer: an error the trace holds at the peek's timestamp, or a failure of the
+    /// peek itself.
+    Answer(PeekError),
+    /// The fuel ran out before the walk reached either. The walk resumes at the cursor position
+    /// it stopped on, and that position has not been examined yet.
+    OutOfFuel,
+}
+
+impl ErrorScan {
+    /// Opens a walk over `errs`.
+    ///
+    /// The walk starts without a row-iteration limit. The limit in effect is the caller's to
+    /// supply through [`ErrorScan::set_row_iteration_limit`] before each step.
+    pub(super) fn new(errs: &mut ErrsHandle) -> Self {
+        let scan_start = Instant::now();
+        let (cursor, storage) = errs.cursor();
+        Self {
+            cursor,
+            storage,
+            row_iteration_tracker: PeekRowIterationTracker::new(None, 0),
+            scan_time: scan_start.elapsed(),
+        }
+    }
+
+    /// Adopts the row-iteration limit that is in effect, without forgetting the rows the walk has
+    /// already examined.
+    pub(super) fn set_row_iteration_limit(&mut self, limit: Option<usize>) {
+        self.row_iteration_tracker.set_limit(limit);
+    }
+
+    /// Advances the walk until it has an answer for the peek, the cursor is exhausted, or `fuel`
+    /// runs out, whichever comes first. Decrements `fuel` by the number of cursor positions
+    /// visited.
+    ///
+    /// A key whose diffs cancel to zero at `peek_timestamp` yields no answer, so fuel is charged
+    /// per position rather than per answer. Otherwise a trace that has accumulated many such keys
+    /// would run to its end within a single step, which is the stall the budget exists to bound.
+    ///
+    /// A terminal outcome does not latch here.
+    /// [`IndexPeek::step_error_scan`](super::IndexPeek::step_error_scan) holds the state that
+    /// latches it, so that a caller which steps again gets that outcome back without the walk
+    /// examining the position it stopped on a second time. The latch cannot live in the walk
+    /// itself: a walk that latched its own outcome could not release the `cursor` and `storage`
+    /// it is reading through, short of making both fields `Option`s that every step unwraps, and
+    /// a finished peek would go on pinning error batches it will never read again.
+    pub(super) fn step(
+        &mut self,
+        peek_timestamp: Timestamp,
+        target_id: GlobalId,
+        fuel: &mut usize,
+    ) -> ErrorScanStep {
+        let step_start = Instant::now();
+
+        let outcome = loop {
+            if *fuel == 0 {
+                break ErrorScanStep::OutOfFuel;
+            }
+            *fuel -= 1;
+
+            if !self.cursor.key_valid(&self.storage) {
+                break ErrorScanStep::Clean {
+                    rows_iterated: self.row_iteration_tracker.rows_iterated(),
+                };
+            }
+
+            if let Err(error) = self.row_iteration_tracker.track_next() {
+                break ErrorScanStep::Answer(error);
+            }
+
+            let mut copies = Diff::ZERO;
+            self.cursor.map_times(&self.storage, |time, diff| {
+                if time.less_equal(&peek_timestamp) {
+                    copies += diff;
+                }
+            });
+            if copies.is_negative() {
+                let error = self.cursor.key(&self.storage);
+                error!(
+                    target = %target_id, diff = %copies, %error,
+                    "index peek encountered negative multiplicities in error trace",
+                );
+                break ErrorScanStep::Answer(PeekError::unstructured(format!(
+                    "Invalid data in source errors, \
+                    saw retractions ({}) for row that does not exist: {}",
+                    -copies, error,
+                )));
+            }
+            if copies.is_positive() {
+                let error = self.cursor.key(&self.storage).deserialize();
+                break ErrorScanStep::Answer(error.into());
+            }
+            self.cursor.step_key(&self.storage);
+        };
+
+        self.scan_time += step_start.elapsed();
+        outcome
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use differential_dataflow::trace::cursor::CursorList;
+    use differential_dataflow::trace::{Batcher, Builder, Navigable};
+    use mz_expr::EvalError;
+    use mz_timely_util::columnation::ColumnationStack;
+    use timely::container::PushInto;
+    use timely::progress::Antichain;
+
+    use crate::render::errors::DataflowErrorSer;
+    use crate::typedefs::{ErrBatcher, ErrBuilder};
+
+    use super::*;
+
+    /// The time at which the peeks in these tests read.
+    const PEEK_TIMESTAMP: Timestamp = Timestamp::new(1);
+
+    /// A distinct error for `index`.
+    ///
+    /// The order of the serialized form does not follow `index`, so a test that cares where a
+    /// key falls in the walk sorts the errors and picks by position.
+    fn error(index: usize) -> DataflowErrorSer {
+        DataflowErrorSer::from(EvalError::Internal(format!("error {index}").into()))
+    }
+
+    /// Builds a walk over a single-batch error trace holding `updates`, bounded by
+    /// `row_iteration_limit`.
+    fn error_scan(
+        updates: Vec<((DataflowErrorSer, ()), Timestamp, Diff)>,
+        row_iteration_limit: Option<usize>,
+    ) -> ErrorScan {
+        let mut batcher = ErrBatcher::<Timestamp, Diff>::new(None, 0);
+        let mut chunk = ColumnationStack::with_capacity(updates.len());
+        for update in updates {
+            chunk.push_into(update);
+        }
+        batcher.push_into(chunk);
+        let (mut chain, description) = batcher.seal(Antichain::from_elem(Timestamp::MAX));
+        let batch = ErrBuilder::<Timestamp, Diff>::seal(&mut chain, description);
+        let storage = vec![batch];
+        let cursor = CursorList::new(vec![storage[0].cursor()], &storage);
+        ErrorScan {
+            cursor,
+            storage,
+            row_iteration_tracker: PeekRowIterationTracker::new(row_iteration_limit, 0),
+            scan_time: Duration::ZERO,
+        }
+    }
+
+    /// Updates that put `error` in the trace at a multiplicity that cancels to zero at
+    /// [`PEEK_TIMESTAMP`].
+    ///
+    /// The two updates sit at different times so that they survive consolidation: a key whose
+    /// updates consolidate away is not in the trace at all, and the walk never sees it.
+    fn cancelling(error: &DataflowErrorSer) -> Vec<((DataflowErrorSer, ()), Timestamp, Diff)> {
+        vec![
+            ((error.clone(), ()), Timestamp::new(0), Diff::ONE),
+            ((error.clone(), ()), PEEK_TIMESTAMP, Diff::MINUS_ONE),
+        ]
+    }
+
+    /// Runs `scan` to an answer in slices of `fuel_per_step` units, and returns that answer, the
+    /// fuel the walk spent, and the number of calls it took.
+    fn run_sliced(scan: &mut ErrorScan, fuel_per_step: usize) -> (ErrorScanStep, usize, usize) {
+        let mut consumed = 0;
+        // Bounded so that a walk which restarts from the first key on each resumption fails the
+        // test instead of hanging it.
+        for calls in 1..=100 {
+            let mut fuel = fuel_per_step;
+            let outcome = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
+            consumed += fuel_per_step - fuel;
+            if !matches!(outcome, ErrorScanStep::OutOfFuel) {
+                return (outcome, consumed, calls);
+            }
+        }
+        panic!("walk did not answer within 100 resumptions");
+    }
+
+    /// An error trace whose keys cancel to zero at the peek's timestamp is walked key by key
+    /// before the error behind them is found. That walk spends fuel per key, so it suspends and
+    /// resumes rather than running the trace out in one call, and slicing it changes neither the
+    /// answer nor the work it costs.
+    #[mz_ore::test]
+    fn error_scan_is_fueled_and_resumable() {
+        let mut errors: Vec<DataflowErrorSer> = (0..64).map(error).collect();
+        errors.sort();
+        let (answering, cancelled) = errors.split_last().expect("non-empty");
+
+        let mut updates: Vec<_> = cancelled.iter().flat_map(cancelling).collect();
+        updates.push(((answering.clone(), ()), Timestamp::new(0), Diff::ONE));
+        let expected = || ErrorScanStep::Answer(answering.deserialize().into());
+
+        // The walk visits every cancelling key and then the key that answers.
+        let expected_fuel = errors.len();
+
+        let mut scan = error_scan(updates.clone(), None);
+        let mut fuel = usize::MAX;
+        let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
+        assert_eq!(unbudgeted, expected());
+        assert_eq!(usize::MAX - fuel, expected_fuel);
+
+        // One unit of fuel per call: the walk answers only if each resumption picks up where the
+        // last stopped, and the fuel it spends in total says it neither repeated nor skipped a
+        // key.
+        let mut scan = error_scan(updates, None);
+        let (sliced, consumed, calls) = run_sliced(&mut scan, 1);
+        assert_eq!(sliced, expected());
+        assert_eq!(consumed, expected_fuel);
+        assert!(calls > 1, "the budget did not slice the walk");
+    }
+
+    /// A walk that finds no error hands the ok scan the number of rows it examined, and slicing
+    /// the walk neither loses nor repeats a key in that count.
+    #[mz_ore::test]
+    fn error_scan_threads_row_count_across_suspensions() {
+        let errors: Vec<DataflowErrorSer> = (0..64).map(error).collect();
+        let updates: Vec<_> = errors.iter().flat_map(cancelling).collect();
+
+        // Every key cancels, so the walk visits all of them and then the position past the last
+        // key, which is where it learns the trace is exhausted.
+        let expected_fuel = errors.len() + 1;
+
+        let mut scan = error_scan(updates.clone(), None);
+        let mut fuel = usize::MAX;
+        let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
+        assert_eq!(
+            unbudgeted,
+            ErrorScanStep::Clean {
+                rows_iterated: errors.len()
+            }
+        );
+        assert_eq!(usize::MAX - fuel, expected_fuel);
+
+        let mut scan = error_scan(updates, None);
+        let (sliced, consumed, calls) = run_sliced(&mut scan, 3);
+        assert_eq!(
+            sliced,
+            ErrorScanStep::Clean {
+                rows_iterated: errors.len()
+            }
+        );
+        assert_eq!(consumed, expected_fuel);
+        assert!(calls > 1, "the budget did not slice the walk");
+    }
+
+    /// The row-iteration limit bounds the error walk too, not only the ok scan that follows it.
+    /// A walk that trips the limit answers with [`PeekError::RowIterationLimitExceeded`] at the
+    /// key that exceeds it, and it answers at that same key whether it ran in one call or was
+    /// sliced into fueled steps. The count the limit is checked against is a count of keys the
+    /// walk examined, so slicing must move neither the answer nor the key it comes from.
+    #[mz_ore::test]
+    fn error_scan_row_iteration_limit_trips_at_the_same_key_when_sliced() {
+        let errors: Vec<DataflowErrorSer> = (0..64).map(error).collect();
+        let updates: Vec<_> = errors.iter().flat_map(cancelling).collect();
+
+        // Well short of the number of keys, so the limit ends the walk rather than the end of
+        // the trace does.
+        let limit = 20;
+        assert!(limit < errors.len(), "the limit must trip mid-walk");
+        let expected = || ErrorScanStep::Answer(PeekError::RowIterationLimitExceeded { limit });
+        // The walk examines `limit` keys and trips on the one after them. That count is also the
+        // fuel it spends, because both are charged once per cursor position.
+        let expected_fuel = limit + 1;
+
+        let mut scan = error_scan(updates.clone(), Some(limit));
+        let mut fuel = usize::MAX;
+        let unbudgeted = scan.step(PEEK_TIMESTAMP, GlobalId::User(1), &mut fuel);
+        assert_eq!(unbudgeted, expected());
+        assert_eq!(usize::MAX - fuel, expected_fuel);
+
+        let mut scan = error_scan(updates, Some(limit));
+        let (sliced, consumed, calls) = run_sliced(&mut scan, 3);
+        assert_eq!(sliced, expected());
+        assert_eq!(
+            consumed, expected_fuel,
+            "slicing the walk must not move the key the limit trips on"
+        );
+        assert!(calls > 1, "the budget did not slice the walk");
+    }
+}

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -482,7 +482,8 @@ mod tests {
     use differential_dataflow::trace::cursor::CursorList;
     use differential_dataflow::trace::implementations::ord_neu::OrdValBatcher;
     use differential_dataflow::trace::{Batcher, Builder, Navigable};
-    use mz_repr::{Datum, Row, Timestamp};
+    use mz_expr::MirScalarExpr;
+    use mz_repr::{Datum, ReprScalarType, Row, Timestamp};
     use mz_row_spine::{ArcOrdValBuilder, ArcOrdValSpine};
     use timely::container::PushInto;
     use timely::progress::Antichain;
@@ -615,6 +616,152 @@ mod tests {
             row_iteration_tracker: PeekRowIterationTracker::new(None, 0),
             exhausted: false,
         }
+    }
+
+    /// Builds an iterator over `keys` with no literal constraints, filtered by `predicate`.
+    ///
+    /// Mirrors [`iterator`], but omits the literal column so `predicate` can address the key at
+    /// column 0 directly.
+    fn iterator_without_literals(
+        keys: &[Row],
+        predicate: mz_expr::MirScalarExpr,
+    ) -> PeekResultIterator<TestTrace> {
+        let (cursor, storage) = trace(keys);
+        // The cursor's key is the only datum; there are no literals and the values are empty.
+        let map_filter_project = mz_expr::MapFilterProject::new(1)
+            .filter([predicate])
+            .into_plan()
+            .expect("valid plan")
+            .into_nontemporal()
+            .expect("non-temporal plan");
+        PeekResultIterator {
+            target_id: GlobalId::User(1),
+            cursor,
+            storage,
+            map_filter_project,
+            peek_timestamp: Timestamp::MIN,
+            row_builder: Row::default(),
+            datum_vec: DatumVec::new(),
+            literals: None,
+            rows_processed: 0,
+            row_iteration_tracker: PeekRowIterationTracker::new(None, 0),
+            exhausted: false,
+        }
+    }
+
+    /// Fuel must be spent walking the rows a `map_filter_project` rejects, not only the rows it
+    /// returns. Otherwise a highly selective filter over a large arrangement could walk the
+    /// entire arrangement inside a single fueled step, which is exactly the unbounded work the
+    /// budget exists to prevent.
+    #[mz_ore::test]
+    fn filtered_scan_charges_fuel_for_rejected_rows() {
+        let keys: Vec<Row> = (0..10).map(row).collect();
+        let accepted = 9u8;
+        // Keeps only the last key; every earlier key is visited and rejected.
+        let predicate = MirScalarExpr::column(0).call_binary(
+            MirScalarExpr::literal(Ok(Datum::UInt8(accepted)), ReprScalarType::UInt8),
+            mz_expr::func::Gte,
+        );
+        let mut iterator = iterator_without_literals(&keys, predicate);
+
+        let mut rejected = 0;
+        let mut found = None;
+        // Bounded so that a step which spends fuel without ever surfacing the accepted row
+        // fails the test instead of hanging it.
+        for _ in 0..100 {
+            let mut fuel = 1;
+            match iterator.step(&mut fuel) {
+                Step::OutOfFuel => {
+                    assert_eq!(
+                        fuel, 0,
+                        "a one-unit slice must spend its unit on the row it visited"
+                    );
+                    rejected += 1;
+                }
+                Step::Row(row) => {
+                    found = Some(row.expect("no error"));
+                    break;
+                }
+                Step::Done => panic!("scan exhausted before reaching the accepted row"),
+            }
+        }
+        let found = found.expect("scan did not reach the accepted row within 100 steps");
+
+        // A step that charged fuel only for rows it returns would reach the accepted row on the
+        // very first call, leaving `rejected` at 0 instead of one per skipped key.
+        assert_eq!(
+            rejected, 9,
+            "fuel must be spent on the 9 rejected rows before the accepted one"
+        );
+        let expected_row = Row::pack_slice(&[Datum::UInt8(accepted)]);
+        assert_eq!(found, (expected_row, NonZeroI64::new(1).expect("non-zero")));
+    }
+
+    /// Resuming a filtered scan with fresh fuel after each `OutOfFuel` must continue from where
+    /// it stopped: it yields the same rows, in the same order, as an unbudgeted walk, and the
+    /// total fuel spent across every slice equals the fuel an unbudgeted walk spends. Matching
+    /// final rows alone would not catch a resumption that re-walks rows it already visited, or
+    /// one that drops a suspended position, since both can still land on the right answer while
+    /// doing the wrong amount of work.
+    #[mz_ore::test]
+    fn filtered_scan_is_fueled_and_resumable() {
+        let keys: Vec<Row> = (0..30).map(row).collect();
+        let threshold = 20u8;
+        let predicate = || {
+            MirScalarExpr::column(0).call_binary(
+                MirScalarExpr::literal(Ok(Datum::UInt8(threshold)), ReprScalarType::UInt8),
+                mz_expr::func::Gte,
+            )
+        };
+
+        let mut unbudgeted = iterator_without_literals(&keys, predicate());
+        let mut unbudgeted_rows = Vec::new();
+        let mut unbudgeted_fuel = 0;
+        loop {
+            let mut fuel = usize::MAX;
+            let step = unbudgeted.step(&mut fuel);
+            unbudgeted_fuel += usize::MAX - fuel;
+            match step {
+                Step::Row(row) => unbudgeted_rows.push(row.expect("no error")),
+                Step::Done => break,
+                Step::OutOfFuel => unreachable!("fuel is unbounded"),
+            }
+        }
+        // Every one of the 30 rows costs one unit to visit, whether accepted or rejected, plus
+        // one more unit for the position where the cursor is found exhausted. A charge that
+        // skipped rejected rows, or double-charged some subset of rows, would move this total
+        // even though it does not depend on how the walk is sliced into fueled steps.
+        assert_eq!(unbudgeted_fuel, keys.len() + 1);
+
+        let mut budgeted = iterator_without_literals(&keys, predicate());
+        let mut budgeted_rows = Vec::new();
+        let mut budgeted_fuel = 0;
+        let mut completed = false;
+        // Bounded so that a regression which restarts the walk on every resume fails the test
+        // instead of hanging it.
+        for _ in 0..100 {
+            let mut fuel = 4;
+            let step = budgeted.step(&mut fuel);
+            budgeted_fuel += 4 - fuel;
+            match step {
+                Step::Row(row) => budgeted_rows.push(row.expect("no error")),
+                Step::OutOfFuel => {}
+                Step::Done => {
+                    completed = true;
+                    break;
+                }
+            }
+        }
+        assert!(completed, "scan did not finish within 100 resumptions");
+
+        assert_eq!(
+            budgeted_rows, unbudgeted_rows,
+            "a fueled walk must return the same rows, in the same order, as an unbudgeted one"
+        );
+        assert_eq!(
+            budgeted_fuel, unbudgeted_fuel,
+            "slicing the walk into small fuel budgets must not repeat or skip cursor positions"
+        );
     }
 
     /// A literal-constrained scan returns the rows of the literals the trace holds, whether it

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -49,8 +49,35 @@ struct Literals<Tr: TraceReader<Batch: Navigable>> {
     literals: <BatchCursor<Tr> as Cursor>::KeyContainer,
     /// The range of the literals that are still available.
     range: Range<usize>,
-    /// The current index in the literals.
-    current_index: Option<usize>,
+    /// Where the cursor sits relative to the literal list.
+    position: LiteralPosition,
+}
+
+/// Where a [`Literals`]' cursor sits relative to the literal list.
+///
+/// [`LiteralPosition::Seeking`] and [`LiteralPosition::Exhausted`] are distinct states: the
+/// former still owes rows, the latter is the end of the scan. Collapsing them would make a
+/// deferred initial seek indistinguishable from a finished one, and every literal-constrained
+/// peek would return no rows.
+enum LiteralPosition {
+    /// A seek is outstanding: it has either not started yet, or it ran out of fuel part-way
+    /// through the literal list. The cursor is parked at a position no literal has claimed, so
+    /// no row may be read until the seek completes. [`Literals::range`] holds the literals that
+    /// remain to be tried.
+    Seeking,
+    /// The cursor sits on the key of the literal at this index.
+    At(usize),
+    /// Every literal has been tried; the scan is done.
+    Exhausted,
+}
+
+/// The outcome of a fueled [`Literals::seek_next_literal_key`].
+enum SeekOutcome {
+    /// The seek finished: the cursor sits on a matching literal, or the literals are exhausted.
+    Complete,
+    /// Fuel ran out with literals left to try. Seeking again resumes at the next untried
+    /// literal.
+    OutOfFuel,
 }
 
 impl<Tr> Literals<Tr>
@@ -59,10 +86,11 @@ where
     BatchCursor<Tr>: Cursor<KeyContainer: BatchContainer<Owned: Ord>>,
 {
     /// Construct a new `Literals` from a mutable slice of literals. Sorts contents.
+    ///
+    /// Does not seek the trace cursor. The initial seek runs on the first fueled step instead,
+    /// so that its cost is charged to a budget rather than paid before any budget exists.
     fn new(
         literals: &mut [<<BatchCursor<Tr> as Cursor>::KeyContainer as BatchContainer>::Owned],
-        cursor: &mut TraceCursor<Tr>,
-        storage: &TraceStorage<Tr>,
     ) -> Self {
         // We have to sort the literal constraints because cursor.seek_key can
         // seek only forward.
@@ -73,40 +101,70 @@ where
             container.push_own(constraint)
         }
         let range = 0..container.len();
-        let mut this = Self {
+        Self {
             literals: container,
             range,
-            current_index: None,
-        };
-        this.seek_next_literal_key(cursor, storage);
-        this
+            position: LiteralPosition::Seeking,
+        }
     }
 
-    /// Returns the current literal, if any.
+    /// Returns the current literal, if the cursor sits on one.
+    ///
+    /// Returns `None` while a seek is outstanding and once the literals are exhausted; in
+    /// neither case does the cursor point at a row that belongs to a literal.
     fn peek(&self) -> Option<BatchKey<'_, Tr>> {
-        self.current_index
-            .and_then(|index| self.literals.get(index))
+        match self.position {
+            LiteralPosition::At(index) => self.literals.get(index),
+            LiteralPosition::Seeking | LiteralPosition::Exhausted => None,
+        }
+    }
+
+    /// Returns `true` if a seek has to run before the cursor sits on a matching literal.
+    fn seek_pending(&self) -> bool {
+        matches!(self.position, LiteralPosition::Seeking)
     }
 
     /// Returns `true` if there are no more literals to process.
     fn is_exhausted(&self) -> bool {
-        self.current_index.is_none()
+        matches!(self.position, LiteralPosition::Exhausted)
     }
 
-    /// Seeks the cursor to the next key of a matching literal, if any.
-    fn seek_next_literal_key(&mut self, cursor: &mut TraceCursor<Tr>, storage: &TraceStorage<Tr>) {
-        while let Some(index) = self.range.next() {
+    /// Seeks the cursor to the next key of a matching literal, if any, charging one unit of
+    /// `fuel` per `seek_key` call.
+    ///
+    /// Returns [`SeekOutcome::OutOfFuel`] if literals remain untried when the fuel runs out.
+    /// The walk resumes from that literal on the next call, so a caller must not treat a
+    /// suspended seek as an end of scan.
+    ///
+    /// A literal list whose entries are mostly absent from the trace costs one seek per absent
+    /// literal, which is why the walk is fueled rather than run to completion.
+    fn seek_next_literal_key(
+        &mut self,
+        cursor: &mut TraceCursor<Tr>,
+        storage: &TraceStorage<Tr>,
+        fuel: &mut usize,
+    ) -> SeekOutcome {
+        // Until a literal matches, the cursor is parked on a key no literal claims. Recording
+        // that keeps a suspended seek from being read as "sitting on the previous literal".
+        self.position = LiteralPosition::Seeking;
+        while !self.range.is_empty() {
+            if *fuel == 0 {
+                return SeekOutcome::OutOfFuel;
+            }
+            *fuel -= 1;
+            let index = self.range.next().expect("range is not empty");
             let literal = self.literals.get(index).expect("index out of bounds");
             cursor.seek_key(storage, literal);
             if cursor.get_key(storage).map_or(true, |key| key == literal) {
-                self.current_index = Some(index);
-                return;
+                self.position = LiteralPosition::At(index);
+                return SeekOutcome::Complete;
             }
             // The cursor landed on a record that has a different key,
             // meaning that there is no record whose key would match the
             // current literal.
         }
-        self.current_index = None;
+        self.position = LiteralPosition::Exhausted;
+        SeekOutcome::Complete
     }
 }
 
@@ -134,9 +192,8 @@ where
         row_iteration_limit: Option<usize>,
         rows_iterated: usize,
     ) -> Self {
-        let (mut cursor, storage) = trace_reader.cursor();
-        let literals = literal_constraints
-            .map(|constraints| Literals::new(constraints, &mut cursor, &storage));
+        let (cursor, storage) = trace_reader.cursor();
+        let literals = literal_constraints.map(Literals::new);
 
         Self {
             target_id,
@@ -211,6 +268,16 @@ pub enum Step {
     OutOfFuel,
 }
 
+/// The outcome of a [`PeekResultIterator::step_key`].
+enum KeyStep {
+    /// The cursor sits on a new key, which has at least one value.
+    Advanced,
+    /// No key remains.
+    Exhausted,
+    /// The fuel ran out inside the literal seek. The seek resumes at the next untried literal.
+    OutOfFuel,
+}
+
 impl<Tr> PeekResultIterator<Tr>
 where
     Tr: TraceReader<Batch: Navigable>,
@@ -224,7 +291,8 @@ where
 {
     /// Advances the cursor until it produces a row, the cursor is exhausted,
     /// or `fuel` runs out, whichever comes first. Decrements `fuel` by the
-    /// number of cursor positions visited.
+    /// number of cursor positions visited, a literal seek's `seek_key` calls
+    /// included.
     ///
     /// Fuel is charged per cursor position, not per row returned, so a
     /// selective `map_filter_project` cannot starve the caller of yield
@@ -235,6 +303,23 @@ where
         }
 
         let result = loop {
+            // An outstanding literal seek runs before the per-position charge below. The seek
+            // spends fuel of its own, and charging first would let a caller holding a single
+            // unit spend it here without the seek ever advancing.
+            if let Some(literals) = &mut self.literals
+                && literals.seek_pending()
+            {
+                match literals.seek_next_literal_key(&mut self.cursor, &self.storage, fuel) {
+                    SeekOutcome::Complete => {}
+                    // The seek stopped part-way through the literal list: the cursor is at a
+                    // valid intermediate position and no row came out of it. `Done` would drop
+                    // the rows of the literals not yet tried, and there is no row to hand back,
+                    // so report the budget. The literal list position is retained, so stepping
+                    // again resumes with the next untried literal.
+                    SeekOutcome::OutOfFuel => return Step::OutOfFuel,
+                }
+            }
+
             if *fuel == 0 {
                 return Step::OutOfFuel;
             }
@@ -249,9 +334,10 @@ where
             }
 
             if !self.cursor.val_valid(&self.storage) {
-                let exhausted = self.step_key();
-                if exhausted {
-                    return Step::Done;
+                match self.step_key(fuel) {
+                    KeyStep::Advanced => {}
+                    KeyStep::Exhausted => return Step::Done,
+                    KeyStep::OutOfFuel => return Step::OutOfFuel,
                 }
             }
 
@@ -348,20 +434,22 @@ where
         }
     }
 
-    /// Steps the key forward, respecting literal constraints.
-    ///
-    /// Returns `true` if we are exhausted.
-    fn step_key(&mut self) -> bool {
+    /// Steps the key forward, respecting literal constraints and charging `fuel` for the
+    /// literal seek.
+    fn step_key(&mut self, fuel: &mut usize) -> KeyStep {
         assert!(
             !self.cursor.val_valid(&self.storage),
             "must only step key when the vals for a key are exhausted"
         );
 
         if let Some(literals) = &mut self.literals {
-            literals.seek_next_literal_key(&mut self.cursor, &self.storage);
+            match literals.seek_next_literal_key(&mut self.cursor, &self.storage, fuel) {
+                SeekOutcome::Complete => {}
+                SeekOutcome::OutOfFuel => return KeyStep::OutOfFuel,
+            }
 
             if literals.is_exhausted() {
-                return true;
+                return KeyStep::Exhausted;
             }
         } else {
             self.cursor.step_key(&self.storage);
@@ -369,7 +457,7 @@ where
 
         if !self.cursor.key_valid(&self.storage) {
             // We're exhausted!
-            return true;
+            return KeyStep::Exhausted;
         }
 
         assert!(
@@ -377,6 +465,186 @@ where
             "there must always be at least one val per key"
         );
 
-        false
+        KeyStep::Advanced
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use differential_dataflow::trace::cursor::CursorList;
+    use differential_dataflow::trace::implementations::ord_neu::OrdValBatcher;
+    use differential_dataflow::trace::{Batcher, Builder, Navigable};
+    use mz_repr::{Datum, Row, Timestamp};
+    use mz_row_spine::{ArcOrdValBuilder, ArcOrdValSpine};
+    use timely::container::PushInto;
+    use timely::progress::Antichain;
+
+    use super::*;
+
+    type TestTrace = ArcOrdValSpine<Row, Row, Timestamp, Diff>;
+
+    fn row(value: u8) -> Row {
+        Row::pack_slice(&[Datum::UInt8(value)])
+    }
+
+    /// Builds a single-batch trace holding `keys`, and a cursor over it.
+    fn trace(keys: &[Row]) -> (TraceCursor<TestTrace>, TraceStorage<TestTrace>) {
+        let updates: Vec<((Row, Row), Timestamp, Diff)> = keys
+            .iter()
+            .map(|key| ((key.clone(), Row::default()), Timestamp::MIN, Diff::ONE))
+            .collect();
+        let mut batcher = OrdValBatcher::<Row, Row, Timestamp, Diff>::new(None, 0);
+        batcher.push_into(updates);
+        let (mut chain, description) = batcher.seal(Antichain::from_elem(Timestamp::MAX));
+        let batch = ArcOrdValBuilder::<Row, Row, Timestamp, Diff>::seal(&mut chain, description);
+        let storage = vec![batch];
+        let cursor = CursorList::new(vec![storage[0].cursor()], &storage);
+        (cursor, storage)
+    }
+
+    /// A literal list whose entries are mostly absent from the trace costs one seek per absent
+    /// literal. That walk is fueled: it suspends when the fuel runs out and resumes at the
+    /// literal it stopped on, rather than running the whole list in one call.
+    #[mz_ore::test]
+    fn literal_seek_is_fueled_and_resumable() {
+        // The trace holds the smallest row and the largest literal, so seeking to the match
+        // costs one `seek_key` per literal, all but the last of them a miss.
+        let mut rows: Vec<Row> = (0..=100).map(row).collect();
+        rows.sort();
+        let (absent, literals) = rows.split_first().expect("non-empty");
+        let matching = literals.last().expect("non-empty").clone();
+        let literal_count = literals.len();
+
+        let (mut cursor, storage) = trace(&[absent.clone(), matching.clone()]);
+        let mut constraints = literals.to_vec();
+        let mut subject = Literals::<TestTrace>::new(&mut constraints);
+
+        // Construction does not seek: the cursor still sits on the trace's first key, and the
+        // literals have neither landed on a key nor run out.
+        assert!(subject.seek_pending());
+        assert!(!subject.is_exhausted());
+        assert_eq!(subject.peek(), None);
+        assert_eq!(cursor.get_key(&storage), Some(absent));
+
+        // Five units of fuel buy five seeks and no more.
+        let mut fuel = 5;
+        assert!(matches!(
+            subject.seek_next_literal_key(&mut cursor, &storage, &mut fuel),
+            SeekOutcome::OutOfFuel
+        ));
+        assert_eq!(fuel, 0);
+        assert!(subject.seek_pending());
+        assert!(!subject.is_exhausted());
+        assert_eq!(subject.peek(), None);
+
+        // Resuming in five-unit slices lands on the matching literal after exactly as many
+        // seeks as there are literals. A resume that restarted the walk, or one that skipped
+        // the literal it suspended on, would not add up.
+        let mut seeks = 5;
+        loop {
+            let mut fuel = 5;
+            let outcome = subject.seek_next_literal_key(&mut cursor, &storage, &mut fuel);
+            seeks += 5 - fuel;
+            if let SeekOutcome::Complete = outcome {
+                break;
+            }
+        }
+        assert_eq!(seeks, literal_count);
+        assert_eq!(subject.peek(), Some(&matching));
+        assert!(!subject.is_exhausted());
+
+        // The same seek run with unbounded fuel costs the same, so slicing it neither lost nor
+        // repeated work.
+        let (mut cursor, storage) = trace(&[absent.clone(), matching.clone()]);
+        let mut constraints = literals.to_vec();
+        let mut subject = Literals::<TestTrace>::new(&mut constraints);
+        let mut fuel = usize::MAX;
+        assert!(matches!(
+            subject.seek_next_literal_key(&mut cursor, &storage, &mut fuel),
+            SeekOutcome::Complete
+        ));
+        assert_eq!(usize::MAX - fuel, literal_count);
+        assert_eq!(subject.peek(), Some(&matching));
+
+        // Past the last literal the seek reports exhaustion rather than suspending, even
+        // though it spends no fuel doing so.
+        let mut fuel = 0;
+        assert!(matches!(
+            subject.seek_next_literal_key(&mut cursor, &storage, &mut fuel),
+            SeekOutcome::Complete
+        ));
+        assert!(subject.is_exhausted());
+        assert_eq!(subject.peek(), None);
+    }
+
+    /// Builds an iterator over `keys`, constrained to `constraints`.
+    ///
+    /// Mirrors [`PeekResultIterator::new`], which cannot be used here because it takes a trace
+    /// rather than a cursor over one.
+    fn iterator(keys: &[Row], constraints: &mut [Row]) -> PeekResultIterator<TestTrace> {
+        let (cursor, storage) = trace(keys);
+        // The cursor's key and the literal each contribute one datum; the values are empty.
+        let map_filter_project = mz_expr::MapFilterProject::new(2)
+            .into_plan()
+            .expect("valid plan")
+            .into_nontemporal()
+            .expect("non-temporal plan");
+        PeekResultIterator {
+            target_id: GlobalId::User(1),
+            cursor,
+            storage,
+            map_filter_project,
+            peek_timestamp: Timestamp::MIN,
+            row_builder: Row::default(),
+            datum_vec: DatumVec::new(),
+            literals: Some(Literals::new(constraints)),
+            rows_processed: 0,
+            row_iteration_tracker: PeekRowIterationTracker::new(None, 0),
+            exhausted: false,
+        }
+    }
+
+    /// A literal-constrained scan returns the rows of the literals the trace holds, whether it
+    /// is stepped with unbounded fuel or one unit at a time. Deferring the initial seek out of
+    /// the constructor must not turn "no seek yet" into "no literals left", which would empty
+    /// out every literal-constrained peek.
+    #[mz_ore::test]
+    fn literal_constrained_scan_returns_matching_rows() {
+        let keys: Vec<Row> = (0..=5).map(row).collect();
+        // Two of the three literals are in the trace; the third is past its end.
+        let constraints = vec![row(1), row(4), row(9)];
+        let expected: Vec<(Row, NonZeroI64)> = [1, 4]
+            .into_iter()
+            .map(|value| {
+                let row = Row::pack_slice(&[Datum::UInt8(value), Datum::UInt8(value)]);
+                (row, NonZeroI64::new(1).expect("non-zero"))
+            })
+            .collect();
+
+        let unbounded: Vec<_> = iterator(&keys, &mut constraints.clone())
+            .map(|row| row.expect("no error"))
+            .collect();
+        assert_eq!(unbounded, expected);
+
+        // One unit of fuel per call: every literal seek suspends, so the scan only completes if
+        // each resumption picks up where the last stopped.
+        let mut iterator = iterator(&keys, &mut constraints.clone());
+        let mut fueled = Vec::new();
+        let mut done = false;
+        // Bounded so that a step that spends fuel without advancing fails the test instead of
+        // hanging it.
+        for _ in 0..100 {
+            let mut fuel = 1;
+            match iterator.step(&mut fuel) {
+                Step::Row(row) => fueled.push(row.expect("no error")),
+                Step::OutOfFuel => continue,
+                Step::Done => {
+                    done = true;
+                    break;
+                }
+            }
+        }
+        assert!(done, "scan did not finish");
+        assert_eq!(fueled, expected);
     }
 }

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -16,9 +16,9 @@ use mz_compute_client::protocol::response::PeekError;
 
 /// The merged cursor a [`TraceReader::cursor`] hands out over all of a trace's batches: a
 /// [`CursorList`] over the per-batch cursors.
-type TraceCursor<Tr> = CursorList<BatchCursor<Tr>>;
+pub(super) type TraceCursor<Tr> = CursorList<BatchCursor<Tr>>;
 /// Backing storage for a [`TraceCursor`]: the batches the cursor borrows from.
-type TraceStorage<Tr> = Vec<<Tr as TraceReader>::Batch>;
+pub(super) type TraceStorage<Tr> = Vec<<Tr as TraceReader>::Batch>;
 use mz_repr::fixed_length::ExtendDatums;
 use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena};
 use timely::order::PartialOrder;

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -303,7 +303,8 @@ where
     ///
     /// Fuel is charged per cursor position, not per row returned, so a
     /// selective `map_filter_project` cannot starve the caller of yield
-    /// points. Returning with fuel left over means the cursor is exhausted.
+    /// points. [`Step::OutOfFuel`] is returned only once the budget is spent,
+    /// so a caller that sees it has more of the scan left to drive.
     pub fn step(&mut self, fuel: &mut usize) -> Step {
         if self.exhausted {
             return Step::Done;

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -717,16 +717,27 @@ mod tests {
         let mut unbudgeted = iterator_without_literals(&keys, predicate());
         let mut unbudgeted_rows = Vec::new();
         let mut unbudgeted_fuel = 0;
-        loop {
+        let mut unbudgeted_completed = false;
+        // Bounded for the same reason the budgeted walk below is. A regression that leaves the
+        // cursor parked on a row it already returned never reaches `Done`, and an unbounded loop
+        // would hang the suite rather than name the walk that failed to terminate.
+        for _ in 0..100 {
             let mut fuel = usize::MAX;
             let step = unbudgeted.step(&mut fuel);
             unbudgeted_fuel += usize::MAX - fuel;
             match step {
                 Step::Row(row) => unbudgeted_rows.push(row.expect("no error")),
-                Step::Done => break,
+                Step::Done => {
+                    unbudgeted_completed = true;
+                    break;
+                }
                 Step::OutOfFuel => unreachable!("fuel is unbounded"),
             }
         }
+        assert!(
+            unbudgeted_completed,
+            "the unbudgeted walk did not reach the end of the cursor within 100 steps"
+        );
         // Every one of the 30 rows costs one unit to visit, whether accepted or rejected, plus
         // one more unit for the position where the cursor is found exhausted. A charge that
         // skipped rejected rows, or double-charged some subset of rows, would move this total
@@ -781,9 +792,17 @@ mod tests {
             })
             .collect();
 
-        let unbounded: Vec<_> = iterator(&keys, &mut constraints.clone())
-            .map(|row| row.expect("no error"))
-            .collect();
+        // Taken one row at a time under a bound rather than collected. A regression that leaves
+        // the cursor parked on a row it already returned yields rows forever, and collecting
+        // would hang the suite rather than name the walk that failed to terminate.
+        let mut unbounded_iterator = iterator(&keys, &mut constraints.clone());
+        let mut unbounded = Vec::new();
+        for _ in 0..100 {
+            match unbounded_iterator.next() {
+                Some(row) => unbounded.push(row.expect("no error")),
+                None => break,
+            }
+        }
         assert_eq!(unbounded, expected);
 
         // One unit of fuel per call: every literal seek suspends, so the scan only completes if

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -67,7 +67,7 @@ enum LiteralPosition {
     Seeking,
     /// The cursor sits on the key of the literal at this index.
     At(usize),
-    /// Every literal has been tried; the scan is done.
+    /// Every literal has been tried. The scan is done.
     Exhausted,
 }
 
@@ -110,7 +110,7 @@ where
 
     /// Returns the current literal, if the cursor sits on one.
     ///
-    /// Returns `None` while a seek is outstanding and once the literals are exhausted; in
+    /// Returns `None` while a seek is outstanding and once the literals are exhausted. In
     /// neither case does the cursor point at a row that belongs to a literal.
     fn peek(&self) -> Option<BatchKey<'_, Tr>> {
         match self.position {
@@ -259,9 +259,14 @@ where
 
 /// The outcome of a single fueled [`PeekResultIterator::step`].
 pub enum Step {
-    /// A result row, or the error that ended the scan.
+    /// A result row, or an error.
+    ///
+    /// Only the row-iteration limit's error ends the scan. An error out of the
+    /// `map_filter_project` does not, so a caller that steps again after one resumes the walk at
+    /// the next value.
     Row(Result<(Row, NonZeroI64), PeekError>),
-    /// The cursor is exhausted. Further steps also return `Done`.
+    /// The cursor is exhausted. Further steps also return `Done`, re-derived from the cursor on
+    /// each call rather than latched, at a cost of one unit of fuel per call.
     Done,
     /// The fuel ran out before a row was found. The iterator resumes exactly where it
     /// stopped. The cursor itself may sit on an arbitrary intermediate key if a literal
@@ -597,7 +602,7 @@ mod tests {
     /// rather than a cursor over one.
     fn iterator(keys: &[Row], constraints: &mut [Row]) -> PeekResultIterator<TestTrace> {
         let (cursor, storage) = trace(keys);
-        // The cursor's key and the literal each contribute one datum; the values are empty.
+        // The cursor's key and the literal each contribute one datum. The values are empty.
         let map_filter_project = mz_expr::MapFilterProject::new(2)
             .into_plan()
             .expect("valid plan")
@@ -627,7 +632,7 @@ mod tests {
         predicate: mz_expr::MirScalarExpr,
     ) -> PeekResultIterator<TestTrace> {
         let (cursor, storage) = trace(keys);
-        // The cursor's key is the only datum; there are no literals and the values are empty.
+        // The cursor's key is the only datum. There are no literals and the values are empty.
         let map_filter_project = mz_expr::MapFilterProject::new(1)
             .filter([predicate])
             .into_plan()
@@ -657,7 +662,7 @@ mod tests {
     fn filtered_scan_charges_fuel_for_rejected_rows() {
         let keys: Vec<Row> = (0..10).map(row).collect();
         let accepted = 9u8;
-        // Keeps only the last key; every earlier key is visited and rejected.
+        // Keeps only the last key. Every earlier key is visited and rejected.
         let predicate = MirScalarExpr::column(0).call_binary(
             MirScalarExpr::literal(Ok(Datum::UInt8(accepted)), ReprScalarType::UInt8),
             mz_expr::func::Gte,
@@ -776,13 +781,13 @@ mod tests {
     }
 
     /// A literal-constrained scan returns the rows of the literals the trace holds, whether it
-    /// is stepped with unbounded fuel or one unit at a time. Deferring the initial seek out of
-    /// the constructor must not turn "no seek yet" into "no literals left", which would empty
-    /// out every literal-constrained peek.
+    /// is stepped with unbounded fuel or one unit at a time. The initial seek runs on the first
+    /// fueled step, so "no seek yet" has to stay distinct from "no literals left". Conflating
+    /// the two would empty out every literal-constrained peek.
     #[mz_ore::test]
     fn literal_constrained_scan_returns_matching_rows() {
         let keys: Vec<Row> = (0..=5).map(row).collect();
-        // Two of the three literals are in the trace; the third is past its end.
+        // Two of the three literals are in the trace. The third is past its end.
         let constraints = vec![row(1), row(4), row(9)];
         let expected: Vec<(Row, NonZeroI64)> = [1, 4]
             .into_iter()

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -263,8 +263,10 @@ pub enum Step {
     Row(Result<(Row, NonZeroI64), PeekError>),
     /// The cursor is exhausted. Further steps also return `Done`.
     Done,
-    /// The fuel ran out before a row was found. The cursor sits at the next
-    /// position to attempt, so stepping again resumes exactly there.
+    /// The fuel ran out before a row was found. The iterator resumes exactly where it
+    /// stopped. The cursor itself may sit on an arbitrary intermediate key if a literal
+    /// seek was suspended, because resumption is driven by `Literals::range` rather than
+    /// by cursor position.
     OutOfFuel,
 }
 
@@ -389,12 +391,18 @@ where
         key_item.extend_datums(&arena, &mut borrow, None);
         row_item.extend_datums(&arena, &mut borrow, None);
 
-        if let Some(literals) = &mut self.literals
-            && let Some(literal) = literals.peek()
-        {
+        if let Some(literals) = &mut self.literals {
             // The peek was created from an IndexedFilter join. We have to add those columns
             // here that the join would add in a dataflow.
-            maybe_literal = literal;
+            //
+            // `step` only reaches row extraction once any pending literal seek has completed
+            // and the literals are not exhausted, so the cursor is always positioned on a
+            // matching literal at this point. Treating a `None` here as "no literal to add"
+            // would silently produce a datum vec one column short, which the MFP evaluation
+            // below would then apply to the wrong arity.
+            maybe_literal = literals
+                .peek()
+                .expect("literal position must be at a matching literal during row extraction");
             maybe_literal.extend_datums(&arena, &mut borrow, None);
         }
         if let Some(result) = self
@@ -541,14 +549,19 @@ mod tests {
         // seeks as there are literals. A resume that restarted the walk, or one that skipped
         // the literal it suspended on, would not add up.
         let mut seeks = 5;
-        loop {
+        let mut completed = false;
+        // Bounded so that a regression which restarts the walk from literal 0 on each resume
+        // fails the test instead of hanging it.
+        for _ in 0..100 {
             let mut fuel = 5;
             let outcome = subject.seek_next_literal_key(&mut cursor, &storage, &mut fuel);
             seeks += 5 - fuel;
             if let SeekOutcome::Complete = outcome {
+                completed = true;
                 break;
             }
         }
+        assert!(completed, "seek did not complete within 100 resumptions");
         assert_eq!(seeks, literal_count);
         assert_eq!(subject.peek(), Some(&matching));
         assert!(!subject.is_exhausted());

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -232,12 +232,12 @@ impl ComputeMetrics {
             ), role)),
             index_peek_cursor_setup_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_cursor_setup_seconds",
-                help: "Time setting up cursor and literal constraints.",
+                help: "Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_row_iteration_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_row_iteration_seconds",
-                help: "Time iterating rows and evaluating MFP.",
+                help: "Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_row_iteration_rows: registry.register(with_role(metric!(

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -227,7 +227,7 @@ impl ComputeMetrics {
             ), role)),
             index_peek_error_scan_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_error_scan_seconds",
-                help: "Time scanning the error trace for errors.",
+                help: "Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_cursor_setup_seconds: registry.register(with_role(metric!(


### PR DESCRIPTION
Closes the two places a fast-path index peek's scan escaped its fuel budget. Both are unbounded inline stalls on the timely worker today, independent of the rest of the design.

The literal-constraint seek walked forward one `seek_key` per absent literal, from `Literals::new` at construction and again from inside `step`'s loop under a single fuel charge. It is now fuel-aware and resumable. Deferring the seek out of the constructor requires distinguishing "has not started seeking" from "exhausted", which the previous optional index conflated by using `None` for both, so `LiteralPosition` now names all three states. Collapsing them would make every literal-constrained peek return no rows.

The error-trace scan ran `while cursor.key_valid(..)` with no budget, walking past keys whose diffs cancel to zero before any ok row is read. It is now a fueled, suspendable phase in `compute_state/error_scan.rs`, spending the same currency as the ok walk. `ErrorScanState` latches the outcome so a scan that answered with an error can never be mistaken for a clean one, which would otherwise turn an error-answering peek into one that returns rows.

Also adds the fuel-accounting tests deferred from the layer below, including that fuel is charged for rows the MFP rejects. That is the property that makes the budget proof against a selective filter, and it is why fuel is charged per cursor position rather than per row returned.

Ships inert: every caller passes `usize::MAX`. The driver that supplies a real budget comes later.

Two things for whoever writes that driver. `collect_finished_data` is half re-entrant, since the error phase keeps latched state while the ok phase rebuilds its iterator and accumulates into locals; a re-entering driver recomputes the same answer, but ok-side rows on the discarded passes go uncounted against the row-iteration limit. And the accepted double charge when a `step_key` suspension resumes means an `IN`-list peek gets roughly half the throughput per unit of budget that a naive calculation predicts.

🤖 Opened by [Claude Code](https://claude.com/claude-code) on behalf of @antiguru