### PR TITLE
persist: gracefully handle when no gc work is to be done

### DIFF
--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -257,13 +257,9 @@ where
         let mut gc_results = GcResults::default();
 
         if rollups_to_remove_from_state.is_empty() {
-            // If there are no rollups to remove from state (either the work has already
-            // been done, or the there aren't enough rollups <= seqno_since to have any
-            // to delete), we can safely exit. We still call remove_rollups to clear
-            // active_gc if it was set, so the next GC isn't suppressed.
-            let (_removed, maintenance) = machine.remove_rollups(&[]).await;
-            machine.applier.metrics.gc.noop.inc();
-            return (maintenance, gc_results);
+            // Either the work has already been done, or there aren't enough rollups
+            // <= seqno_since to have any to delete.
+            return Self::skip_gc(machine, gc_results).await;
         }
 
         debug!(
@@ -281,7 +277,16 @@ where
                 .fetch_live_diffs_through(&req.shard_id, req.new_seqno_since)
                 .await;
 
-            let initial_seqno = diffs.first().expect("state is initialized").seqno;
+            // An empty result means Consensus holds no diff at or below `new_seqno_since`.
+            // Some other process has already truncated past this request, so the request's
+            // goal is met and there are no diffs left from which to derive blob deletions.
+            let Some(initial_seqno) = diffs.first().map(|x| x.seqno) else {
+                debug!(
+                    ?req,
+                    "skipping gc - consensus already truncated past seqno_since. concurrent GC?"
+                );
+                return Self::skip_gc(machine, gc_results).await;
+            };
 
             let Some(initial_rollup) = gc_rollups.get(initial_seqno) else {
                 // The latest state is always expected to have a reference to a rollup for the
@@ -296,7 +301,7 @@ where
                     ?gc_rollups,
                     "skipping gc - no rollup at initial seqno. concurrent GC?"
                 );
-                return (RoutineMaintenance::default(), gc_results);
+                return Self::skip_gc(machine, gc_results).await;
             };
 
             let Some(state) = machine
@@ -310,7 +315,7 @@ where
                     ?gc_rollups,
                     "skipping gc - deleted rollup at initial seqno. concurrent GC?"
                 );
-                return (RoutineMaintenance::default(), gc_results);
+                return Self::skip_gc(machine, gc_results).await;
             };
 
             UntypedStateVersionsIter::new(
@@ -445,6 +450,17 @@ where
                 .post_gc_calculations_seconds,
         );
 
+        (maintenance, gc_results)
+    }
+
+    /// Finishes a GC pass that turned out to have no work to do, either because
+    /// another process already did it or because there was never any to begin with.
+    async fn skip_gc(
+        machine: &Machine<K, V, T, D>,
+        gc_results: GcResults,
+    ) -> (RoutineMaintenance, GcResults) {
+        let (_removed, maintenance) = machine.remove_rollups(&[]).await;
+        machine.applier.metrics.gc.noop.inc();
         (maintenance, gc_results)
     }
 

--- a/src/persist-client/tests/machine/regression_gc_concurrent_truncation
+++ b/src/persist-client/tests/machine/regression_gc_concurrent_truncation
@@ -1,0 +1,103 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for PER-12. Under active GC, gc_and_truncate decides whether
+# it has work from the locally cached state, but fetches the diffs it needs
+# fresh from Consensus. A GC request can carry a `seqno_since` from arbitrarily
+# far in the past, because maybe_gc caps each request at
+# `last_gc_req + persist_gc_max_versions` and a queued request can be overtaken
+# by another process. If a concurrent GC has truncated to a rollup above that
+# `seqno_since`, `fetch_live_diffs_through` returns nothing while the cached
+# rollups map still suggests there is work to do. That empty result means the
+# work is already done, not that the shard is uninitialized, so GC must skip
+# the pass rather than panic on it.
+
+# Disable inline writes so the batch parts land in Blob, where GC can see them.
+dyncfg
+persist_inline_writes_single_max_bytes 0
+persist_inline_writes_total_max_bytes 0
+persist_gc_use_active_gc true
+----
+ok
+
+write-batch output=b0 lower=0 upper=1
+k1 0 1
+----
+parts=1 len=1
+
+compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v2 [1]
+
+write-batch output=b1 lower=1 upper=2
+k2 1 1
+----
+parts=1 len=1
+
+compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v3 [2]
+
+write-rollup output=v3
+----
+state=v3 diffs=[v1, v4)
+
+add-rollup input=v3
+----
+v4
+
+write-batch output=b2 lower=2 upper=3
+k3 2 1
+----
+parts=1 len=1
+
+compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v5 [3]
+
+write-rollup output=v5
+----
+state=v5 diffs=[v4, v6)
+
+add-rollup input=v5
+----
+v6
+
+write-batch output=b3 lower=3 upper=4
+k4 3 1
+----
+parts=1 len=1
+
+compare-and-append input=b3 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v7 [4]
+
+write-rollup output=v7
+----
+state=v7 diffs=[v6, v8)
+
+add-rollup input=v7
+----
+v8
+
+# GC only ever truncates to the seqno of a rollup <= its own seqno_since, so this
+# stands in for a concurrent GC that ran with a seqno_since >= 7 and truncated to
+# the rollup at v7. It has not yet reached its final step of removing the now-dead
+# rollups from state, so the GC below still sees rollups at v0, v3 and v5 and
+# believes it has work to do.
+consensus-truncate to_seqno=v7
+----
+Some(7)
+
+# A GC request that was assigned earlier, for a seqno_since that the truncation
+# above has already passed. No live diff remains at or below v6, so this pass has
+# nothing to collect and must skip rather than panic.
+gc to_seqno=v6
+----
+v8 batch_parts=0 rollups=0 truncated= state_rollups=


### PR DESCRIPTION
The decision to process GC request using `gc_and_truncate` is made using the local state knowledge of the shard but during the actual processing a fresh state is fetched from consensus. There can be an arbitrary delay and staleness between these two moments which means that a GC request that is about to get processed has no work to do because another process did it in the meantime.

The code would previously panic if such a race happened. This PR gracefully handles the stale GC request by marking it as done and exiting.

Fixes [PER-12](https://linear.app/materializeinc/issue/PER-12)
