### PR TITLE
persist: Make compare_and_evolve_schema idempotent (SQL-616)

### DIFF
--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1665,13 +1665,6 @@ where
             .schemas
             .last_key_value()
             .expect("all shards have a schema");
-        if *current_id != expected {
-            return Break(NoOpStateTransition(CaESchema::ExpectedMismatch {
-                schema_id: *current_id,
-                key: K::decode_schema(&current.key),
-                val: V::decode_schema(&current.val),
-            }));
-        }
 
         let current_key = K::decode_schema(&current.key);
         let current_key_dt = EncodedSchemas::decode_data_type(&current.key_data_type);
@@ -1681,13 +1674,29 @@ where
         let key_dt = data_type(key_schema);
         let val_dt = data_type(val_schema);
 
-        // If the schema is exactly the same as the current one, no-op.
+        // If the schema is exactly the same as the current one, no-op. NOTE:
+        // this check has to come before the `expected` one, otherwise the
+        // command is not idempotent: `apply_unbatched_idempotent_cmd` retries
+        // indeterminate errors, so a CaS that committed but lost its response
+        // gets re-run against state that already carries its own evolution.
+        //
+        // Returning Ok when `*current_id != expected` is safe: register_schema
+        // never mints two ids for the same content, so a content match is the
+        // current schema and a stale `expected` just lags the committed retry.
         if current_key == *key_schema
             && current_key_dt == key_dt
             && current_val == *val_schema
             && current_val_dt == val_dt
         {
             return Break(NoOpStateTransition(CaESchema::Ok(*current_id)));
+        }
+
+        if *current_id != expected {
+            return Break(NoOpStateTransition(CaESchema::ExpectedMismatch {
+                schema_id: *current_id,
+                key: current_key,
+                val: current_val,
+            }));
         }
 
         let key_fn = backward_compatible(&current_key_dt, &key_dt);

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -782,8 +782,11 @@ impl PersistClient {
     /// [backward_compatible]: mz_persist_types::schema::backward_compatible
     ///
     /// To prevent races, the caller must declare what it believes to be the
-    /// latest schema id. If this doesn't match reality,
-    /// [CaESchema::ExpectedMismatch] is returned.
+    /// latest schema id. A request that already matches the current schema
+    /// returns [CaESchema::Ok] even if `expected` is stale, so retried or
+    /// duplicated evolutions are idempotent. [CaESchema::ExpectedMismatch]
+    /// means a genuine divergence: the current schema matches neither the
+    /// request nor `expected`.
     pub async fn compare_and_evolve_schema<K, V, T, D>(
         &self,
         shard_id: ShardId,

--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -441,10 +441,22 @@ mod tests {
     use mz_persist_types::stats::{NoneStats, StructStats};
     use timely::progress::Antichain;
 
-    use crate::Diagnostics;
+    use async_trait::async_trait;
+    use mz_ore::metrics::MetricsRegistry;
+    use mz_persist::location::{
+        CaSResult, Consensus, ExternalError, ResultStream, SeqNo, VersionedData,
+    };
+    use mz_persist::mem::{MemBlob, MemBlobConfig, MemConsensus};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use crate::async_runtime::IsolatedRuntime;
+    use crate::cache::StateCache;
     use crate::cli::admin::info_log_non_zero_metrics;
+    use crate::internal::metrics::Metrics;
     use crate::read::ReadHandle;
+    use crate::rpc::NoopPubSubSender;
     use crate::tests::new_test_client;
+    use crate::{Diagnostics, PersistClient, PersistConfig};
 
     use super::*;
 
@@ -682,6 +694,128 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(write1.write_schemas.id.unwrap(), SchemaId(1));
+    }
+
+    /// A [Consensus] that, once armed, runs one `compare_and_set` and then
+    /// reports it as timed out. Models the metadata store committing a write
+    /// but losing the response, which persist surfaces as an indeterminate
+    /// error.
+    ///
+    /// UnreliableConsensus can also run-then-timeout, but only probabilistically
+    /// and per-op-kind. This test needs one deterministic timeout on one
+    /// `compare_and_set`.
+    #[derive(Debug)]
+    struct LoseOneCasResponse {
+        inner: Arc<dyn Consensus>,
+        armed: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Consensus for LoseOneCasResponse {
+        fn list_keys(&self) -> ResultStream<'_, String> {
+            self.inner.list_keys()
+        }
+
+        async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError> {
+            self.inner.head(key).await
+        }
+
+        async fn compare_and_set(
+            &self,
+            key: &str,
+            new: VersionedData,
+        ) -> Result<CaSResult, ExternalError> {
+            // Delegate first so the write commits, then drop the response. A
+            // committed-but-lost CaS is the case under test.
+            let res = self.inner.compare_and_set(key, new).await;
+            if self.armed.swap(false, Ordering::SeqCst) {
+                return Err(ExternalError::new_timeout(Instant::now()));
+            }
+            res
+        }
+
+        async fn scan(
+            &self,
+            key: &str,
+            from: SeqNo,
+            limit: usize,
+        ) -> Result<Vec<VersionedData>, ExternalError> {
+            self.inner.scan(key, from, limit).await
+        }
+
+        async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<Option<usize>, ExternalError> {
+            self.inner.truncate(key, seqno).await
+        }
+    }
+
+    /// Regression test for SQL-616. `compare_and_evolve_schema` runs through
+    /// `apply_unbatched_idempotent_cmd`, which retries indeterminate errors. A
+    /// retry re-runs the command against state that already carries our own
+    /// evolution, so it must report success rather than an expectation
+    /// mismatch.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn compare_and_evolve_schema_indeterminate_retry() {
+        let cfg = PersistConfig::new_for_tests();
+        let armed = Arc::new(AtomicBool::new(false));
+        let consensus = Arc::new(LoseOneCasResponse {
+            inner: Arc::new(MemConsensus::default()),
+            armed: Arc::clone(&armed),
+        });
+        let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
+        let client = PersistClient::new(
+            cfg,
+            Arc::new(MemBlob::open(MemBlobConfig::default())),
+            consensus,
+            Arc::clone(&metrics),
+            Arc::new(IsolatedRuntime::new_for_tests()),
+            Arc::new(StateCache::new_no_metrics()),
+            Arc::new(NoopPubSubSender),
+        )
+        .expect("client construction failed");
+
+        let d = Diagnostics::for_tests();
+        let shard_id = ShardId::new();
+        let schema0 = StringsSchema(vec![false]);
+        let schema1 = StringsSchema(vec![false, true]);
+
+        let mut write0 = client
+            .open_writer::<Strings, (), u64, i64>(
+                shard_id,
+                Arc::new(schema0),
+                Arc::new(UnitSchema),
+                d.clone(),
+            )
+            .await
+            .unwrap();
+        write0.try_register_schema().await;
+        assert_eq!(write0.write_schemas.id.unwrap(), SchemaId(0));
+
+        // Check that the evolve actually retried, not just that some CaS
+        // consumed the arm. Single writer, no compaction, so only the evolve's
+        // CaS can.
+        let retries_before = metrics.retries.idempotent_cmd.retries.get();
+        armed.store(true, Ordering::SeqCst);
+        let res = client
+            .compare_and_evolve_schema::<Strings, (), u64, i64>(
+                shard_id,
+                SchemaId(0),
+                &schema1,
+                &UnitSchema,
+                d.clone(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !armed.load(Ordering::SeqCst),
+            "indeterminate error was never injected"
+        );
+        assert!(
+            metrics.retries.idempotent_cmd.retries.get() > retries_before,
+            "evolve did not retry an indeterminate error"
+        );
+        // Old check order returns ExpectedMismatch here; the fix returns Ok.
+        assert_eq!(res, CaESchema::Ok(SchemaId(1)));
     }
 
     fn strings(xs: &[((Strings, ()), u64, i64)]) -> Vec<Vec<&str>> {

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -2140,15 +2140,20 @@ impl StorageCollections for StorageCollectionsImpl {
         );
 
         match schema_result {
-            CaESchema::Ok(id) => id,
-            // TODO(alter_table): If we get an expected mismatch we should retry.
+            // id unused: the desc is re-derived below.
+            CaESchema::Ok(_id) => {}
+            // Not retried by design. compare_and_evolve_schema now absorbs a
+            // committed-but-lost CaS, so an ExpectedMismatch here is a genuine
+            // divergence (current matches neither the request nor `expected`)
+            // that must surface rather than retry.
             CaESchema::ExpectedMismatch {
                 schema_id,
                 key,
                 val,
             } => {
                 mz_ore::soft_panic_or_log!(
-                    "schema expectation mismatch {schema_id:?}, {key:?}, {val:?}"
+                    "schema expectation mismatch, expected {expected_schema:?} \
+                     but found {schema_id:?}, {key:?}, {val:?}"
                 );
                 return Err(StorageError::Generic(anyhow::anyhow!(
                     "schema expected mismatch, {existing_collection:?}",


### PR DESCRIPTION
Problem:
An ALTER TABLE ... ADD COLUMN took down the coordinator with the following error:

    thread 'coordinator' panicked at storage_collections.rs:2150:17:
    schema expectation mismatch SchemaId(1), RelationDesc { ... }

The trigger is a compare_and_set against the metadata store that commits but whose response is lost (a timeout or dropped connection), which persist surfaces as an indeterminate error rather than a success.

compare_and_evolve_schema runs through apply_unbatched_idempotent_cmd, which retries indeterminate errors, the CaS is re-run. On the re-run the state already carries the evolution the first attempt committed: `expected` is still the pre-evolution SchemaId(1), but the current schema is the evolved one.

The command performs two checks: whether the requested schema is already in place (compare the schema contents, return Ok), and whether current_id matches the caller's `expected` (return ExpectedMismatch otherwise). The `expected` check ran first, so on the re-run it took the mismatch branch and never reached the already-in-place check that would have recognized the evolution as already done. The schema had evolved exactly as asked; only the answer on the re-run was wrong, and that wrong answer panicked the coordinator.

Solution:
- Reorder the two checks so the already-in-place check runs before the `expected` check, matching what register_schema does. That makes the command idempotent: a committed-but-retried CaS (or an identical concurrent evolution) returns Ok instead of a spurious mismatch. A genuine mismatch, where the current schema differs from both the request and `expected`, still reports ExpectedMismatch.
- The TODO suggesting we retry the caller on ExpectedMismatch is removed as retrying there cannot converge: the caller re-issues with the same stale `expected`, the current schema is already evolved, so every attempt re-hits the mismatch and loops.
- Name the expected schema id in the alter_table_desc panic. It printed only the current one, which could not be told apart from real catalog/persist divergence.

Testing:
New schema::tests::compare_and_evolve_schema_indeterminate_retry, which arms a Consensus wrapper to commit one compare_and_set and then report it as timed out.

The existing compare_and_evolve_schema test covers the genuine-mismatch path.
