### PR TITLE
docs: note that NULL freshness observations are dropped

### DIFF
--- a/doc/user/content/transform-data/monitor-freshness.md
+++ b/doc/user/content/transform-data/monitor-freshness.md
@@ -345,4 +345,11 @@ to itself, and merging only begins above that: 32s and 33s share a bucket, then
 34s and 35s, and so on. The approximation matters for objects that fall minutes
 or hours behind, not for healthy ones.
 
+The queries also drop rows where `lag` is NULL. A NULL means the object was not
+readable when the observation was taken, usually because it had not finished
+hydrating, so there is no lag to bucket. Dropping those rows is not neutral:
+Materialize treats an unreadable object as lagging more than any finite
+measurement, so an object that spent part of the window unhydrated looks better
+in this distribution than it behaved.
+
 {{< /note >}}


### PR DESCRIPTION
### Motivation

Review feedback on [#38461](https://github.com/MaterializeInc/materialize/pull/38461) from @DAlperin: *"Lets also note that we drop NULL observations as not hydrated."*

That comment landed about 40 seconds before the PR was squash-merged, so it could
not be addressed there. Follow-up rather than an amendment, since a merged PR
cannot carry new work.

### Description

The HDR histogram queries filter rows where `lag` is NULL, but that was only
visible in a SQL comment inside the code block. This states it in the prose and
adds what the filtering costs, which is the part a reader quoting a percentile
needs.

A NULL `lag` is `WallclockLag::Undefined`, recorded when a collection is not
readable (`readable_storage_collections.contains(id) || collection.hydrated()`
in `src/compute-client/src/controller/instance.rs`), which for a compute object
means it has not finished hydrating. `WallclockLag::into_interval_datum` maps
`Undefined` to `Datum::Null`.

The non-obvious part is that dropping those rows is not a neutral omission.
`WallclockLag::max` deliberately treats `Undefined` as greater than any `Seconds`
value, with the comment *"we never report low lag values when a collection was
actually unreadable for some amount of time."* So the system's own ordering puts
an unreadable collection above every finite lag, and filtering NULLs flatters an
object that spent part of the window unhydrated. The note says so.

This goes in the section's existing note rather than a new one, since that
section was deliberately trimmed to a single note in the merged PR.

### Verification

Prose-only, 7 added lines, no query changes, so the SQL in the page is untouched
and its outputs still hold.

- Hugo builds the site cleanly; the section still renders with exactly one note
  block, no unrendered shortcodes, and the figure still resolves.
- The claims about `Undefined` were read off the source rather than inferred:
  `WallclockLag` in `src/storage-client/src/controller.rs` (the enum, `max`, and
  `into_interval_datum`) and its construction in
  `src/compute-client/src/controller/instance.rs`.
- `bin/format-docs` was run. This change touches no Rust, Python, or Protobuf,
  so `bin/fmt --check` is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGmH2APDAvST56ePHdWze9)_