### PR TITLE
docs: note that unhydrated (NULL) lag observations are dropped

### DIFF
--- a/doc/user/content/transform-data/monitor-freshness.md
+++ b/doc/user/content/transform-data/monitor-freshness.md
@@ -345,4 +345,11 @@ to itself, and merging only begins above that: 32s and 33s share a bucket, then
 34s and 35s, and so on. The approximation matters for objects that fall minutes
 or hours behind, not for healthy ones.
 
+Lag is also NULL whenever an object has no readable times, which is the case
+while it is still hydrating. Every query above drops those observations with
+`wl.lag IS NOT NULL`, because an unhydrated observation carries no freshness to
+bucket. The percentiles therefore describe only the hydrated part of the window,
+so a window that spans a long hydration, or a restart, summarizes less time than
+its length suggests.
+
 {{< /note >}}


### PR DESCRIPTION
### Motivation

Follow-up to review feedback on [#38461](https://github.com/MaterializeInc/materialize/pull/38461) (already merged): the freshness monitoring guide should call out that NULL lag observations are dropped as unhydrated.

Every query in the guide filters `wl.lag IS NOT NULL`, but the reason was only stated in the CCDF section's artifacts paragraph, and the HDR histogram / percentile section never said what the filter costs you when reading a percentile.

### Description

Extends the measurement note at the end of the HDR histogram section with a paragraph that says lag is NULL whenever an object has no readable times (which is the case while it is still hydrating), that the queries drop those observations, and what that implies for reading the results: the percentiles cover only the hydrated part of the window, so a window spanning a long hydration or a restart summarizes less time than its length suggests.

The wording tracks the controller's actual semantics: `WallclockLag::Undefined` (rendered as NULL) is recorded for collections with no readable times, and a per-replica collection counts as readable when it sinks into a readable storage collection or is hydrated.

Docs-only change, no code touched.

### Verification

Prose change to a single Hugo page; no automated tests apply. Verified the added paragraph renders inside the existing `{{< note >}}` shortcode and stays within the file's line-wrapping conventions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5u4WQKCiWmXmPcD7hTSmi)_