### PR TITLE
compute: remove the enable_compute_temporal_bucketing flag

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -125,7 +125,6 @@ def get_minimal_system_parameters(
         "enable_statement_lifecycle_logging": "true",
         "enable_storage_introspection_logs": "true",
         "enable_compute_error_distinct": "true",
-        "enable_compute_temporal_bucketing": "true",
         "enable_union_cancellation_after_relation_cse": "true",
         "enable_variadic_left_join_lowering": "true",
         "enable_worker_core_affinity": "true",
@@ -146,6 +145,11 @@ def get_minimal_system_parameters(
         config["enable_columnar_lgalloc"] = "false"
     if version < MzVersion.parse_mz("v26.25.0-dev"):
         config["enable_multi_replica_sources"] = "true"
+    # Temporal bucketing runs unconditionally from v26.40 on. Older binaries
+    # still read the flag and default it off, so pin it on for them to keep
+    # mixed-version runs exercising the same path as current versions.
+    if version < MzVersion.parse_mz("v26.40.0-dev"):
+        config["enable_compute_temporal_bucketing"] = "true"
 
     if sanitizer_enabled():
         config["with_0dt_deployment_max_wait"] = "18000s"

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2984,9 +2984,6 @@ class FlipFlagsAction(Action):
             "65536",
             "1048576",
         ]
-        self.flags_with_values["enable_compute_temporal_bucketing"] = (
-            BOOLEAN_FLAG_VALUES
-        )
         self.flags_with_values["enable_compute_error_distinct"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_alter_table_add_column"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_arrangement_dictionary_compression_alpha"] = (

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -286,14 +286,6 @@ pub const CORRECTION_V2_CHUNK_SIZE: Config<usize> = Config::new(
     ParameterScope::Replica,
 );
 
-/// Whether to enable temporal bucketing in compute.
-pub const ENABLE_COMPUTE_TEMPORAL_BUCKETING: Config<bool> = Config::new(
-    "enable_compute_temporal_bucketing",
-    false,
-    "Whether to enable temporal bucketing in compute.",
-    ParameterScope::Environment,
-);
-
 /// The summary to apply to the frontier in temporal bucketing in compute.
 pub const TEMPORAL_BUCKETING_SUMMARY: Config<Duration> = Config::new(
     "compute_temporal_bucketing_summary",
@@ -691,7 +683,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_CORRECTION_V2)
         .add(&CORRECTION_V2_CHAIN_PROPORTIONALITY)
         .add(&CORRECTION_V2_CHUNK_SIZE)
-        .add(&ENABLE_COMPUTE_TEMPORAL_BUCKETING)
         .add(&TEMPORAL_BUCKETING_SUMMARY)
         .add(&LINEAR_JOIN_YIELDING)
         .add(&ENABLE_LGALLOC)

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -160,8 +160,6 @@ pub enum ArrangementStrategy {
     Direct,
     /// Insert temporal bucketing in front of the arrangement, to delay future-stamped
     /// updates (e.g., from `mz_now()` MFPs) until their bucket boundary releases them.
-    /// Honoured only when `ENABLE_COMPUTE_TEMPORAL_BUCKETING` is set; otherwise behaves like
-    /// `Direct`.
     TemporalBucketing,
 }
 

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -125,8 +125,7 @@ use mz_compute_types::dataflows::{DataflowDescription, IndexDesc};
 use mz_compute_types::dyncfgs::{
     COMPUTE_APPLY_COLUMN_DEMANDS, COMPUTE_LOGICAL_BACKPRESSURE_INFLIGHT_SLACK,
     COMPUTE_LOGICAL_BACKPRESSURE_MAX_RETAINED_CAPABILITIES, ENABLE_COMPUTE_LOGICAL_BACKPRESSURE,
-    ENABLE_COMPUTE_TEMPORAL_BUCKETING, ENABLE_ERROR_DISTINCT, SUBSCRIBE_SNAPSHOT_OPTIMIZATION,
-    TEMPORAL_BUCKETING_SUMMARY,
+    ENABLE_ERROR_DISTINCT, SUBSCRIBE_SNAPSHOT_OPTIMIZATION, TEMPORAL_BUCKETING_SUMMARY,
 };
 use mz_compute_types::plan::render_plan::{
     self, BindStage, LetBind, LetFreePlan, RecBind, RenderPlan,
@@ -1386,9 +1385,7 @@ impl<'scope, T: RenderTimestamp + MaybeBucketByTime> Context<'scope, T> {
                     // Apply per-input temporal bucketing. No-op for `Direct`.
                     // Only consolidating Unions carry non-`Direct` strategies;
                     // see the `Union` arm of `lower_mir_expr_stack_safe`.
-                    let os = if matches!(strategy, ArrangementStrategy::TemporalBucketing)
-                        && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(&self.config_set)
-                    {
+                    let os = if matches!(strategy, ArrangementStrategy::TemporalBucketing) {
                         let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
                             .get(&self.config_set)
                             .try_into()

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -21,8 +21,7 @@ use differential_dataflow::trace::{Cursor, Navigable, TraceReader};
 use differential_dataflow::{AsCollection, Data, VecCollection};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::{
-    ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION, ENABLE_COMPUTE_TEMPORAL_BUCKETING,
-    TEMPORAL_BUCKETING_SUMMARY,
+    ENABLE_COMPUTE_RENDER_FUELED_AS_SPECIFIC_COLLECTION, TEMPORAL_BUCKETING_SUMMARY,
 };
 use mz_compute_types::plan::scalar::{LirScalarExpr, mfp_mir_to_lir_plan, mfp_plan_lir_to_mir};
 use mz_compute_types::plan::{ArrangementStrategy, AvailableCollections};
@@ -1130,9 +1129,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
             } else {
                 ArrangementStrategy::Direct
             };
-            let oks = if matches!(effective_strategy, ArrangementStrategy::TemporalBucketing)
-                && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(config_set)
-            {
+            let oks = if matches!(effective_strategy, ArrangementStrategy::TemporalBucketing) {
                 let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
                     .get(config_set)
                     .try_into()
@@ -1163,9 +1160,7 @@ impl<'scope, T: RenderTimestamp> CollectionBundle<'scope, T> {
                 } else {
                     strategy
                 };
-                let oks = if matches!(effective_strategy, ArrangementStrategy::TemporalBucketing)
-                    && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(config_set)
-                {
+                let oks = if matches!(effective_strategy, ArrangementStrategy::TemporalBucketing) {
                     let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
                         .get(config_set)
                         .try_into()

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -26,7 +26,7 @@ use differential_dataflow::trace::implementations::BatchContainer;
 use differential_dataflow::trace::{Builder, Cursor, Navigable, Trace};
 use differential_dataflow::{Data, VecCollection};
 use itertools::Itertools;
-use mz_compute_types::dyncfgs::{ENABLE_COMPUTE_TEMPORAL_BUCKETING, TEMPORAL_BUCKETING_SUMMARY};
+use mz_compute_types::dyncfgs::TEMPORAL_BUCKETING_SUMMARY;
 use mz_compute_types::plan::ArrangementStrategy;
 use mz_compute_types::plan::reduce::{
     AccumulablePlan, BasicPlan, BucketedPlan, HierarchicalPlan, KeyValPlan, LirAggregateExpr,
@@ -167,8 +167,7 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
             let key_val_collection = if matches!(
                 temporal_bucketing_strategy,
                 ArrangementStrategy::TemporalBucketing
-            ) && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(&self.config_set)
-            {
+            ) {
                 let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
                     .get(&self.config_set)
                     .try_into()

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -23,7 +23,7 @@ use differential_dataflow::operators::iterate::Variable as SemigroupVariable;
 use differential_dataflow::trace::cursor::{BatchCursor, BatchValOwn};
 use differential_dataflow::trace::{Builder, Cursor, Navigable, Trace};
 use differential_dataflow::{Data, VecCollection};
-use mz_compute_types::dyncfgs::{ENABLE_COMPUTE_TEMPORAL_BUCKETING, TEMPORAL_BUCKETING_SUMMARY};
+use mz_compute_types::dyncfgs::TEMPORAL_BUCKETING_SUMMARY;
 use mz_compute_types::plan::ArrangementStrategy;
 use mz_compute_types::plan::scalar::LirScalarExpr;
 use mz_compute_types::plan::top_k::{
@@ -102,8 +102,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         let ok_input = if matches!(
             temporal_bucketing_strategy,
             ArrangementStrategy::TemporalBucketing
-        ) && ENABLE_COMPUTE_TEMPORAL_BUCKETING.get(&self.config_set)
-        {
+        ) {
             let summary: mz_repr::Timestamp = TEMPORAL_BUCKETING_SUMMARY
                 .get(&self.config_set)
                 .try_into()

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -461,6 +461,7 @@ KNOWN_STALE_LD_FLAGS: set[str] = set("""
     constraint_based_timestamp_selection
     enable_0dt_deployment
     enable_aws_msk_iam_auth
+    enable_compute_temporal_bucketing
     enable_consolidate_after_union_negate
     enable_continual_task_builtins
     enable_continual_task_transform
@@ -533,7 +534,6 @@ INTENTIONAL_LD_OVERRIDES: set[str] = {
     "enable_cast_elimination",
     "enable_compute_correction_v2",
     "enable_compute_error_distinct",
-    "enable_compute_temporal_bucketing",
     "enable_new_outer_join_lowering",
     "enable_upsert_v2",
     "enable_variadic_left_join_lowering",


### PR DESCRIPTION
### Motivation

Closes [CPU-213](https://linear.app/materializeinc/issue/CPU-213).

`enable_compute_temporal_bucketing` has been served on in cloud for a long time while the compiled-in default stayed off. That left self-managed deployments and local `bin/sqllogictest` runs on the unbucketed path, and kept the flag on the LaunchDarkly consistency test's triage allowlist.

### Description

Removes the flag. Temporal bucketing now runs wherever lowering picks `ArrangementStrategy::TemporalBucketing`. The lowering decisions are unchanged, only the render-time gate is gone. `compute_temporal_bucketing_summary` stays as the bucket-width knob.

User-visible effect: on self-managed deployments that had not enabled the flag, dataflows with `mz_now()` temporal filters now keep future-dated updates in temporal buckets in front of arrangements (Reduce, TopK, consolidating Union, ArrangeBy) until shortly before they take effect, instead of merging them into the arrangement right away and re-merging them on every compaction. Cloud and deployments that had already enabled the flag see no change.

Test plumbing:
- Parallel workload no longer flips the flag.
- mzcompose keeps pinning the flag on for upgrade-from binaries older than v26.40, which still read it and default it off.
- The LaunchDarkly consistency test moves the flag from `INTENTIONAL_LD_OVERRIDES` to `KNOWN_STALE_LD_FLAGS`. The LD flag itself should be archived once this ships.

### Verification

No new tests. `test/sqllogictest/temporal_bucketing.slt` and `explain/default.slt` already pin down the lowering decisions, which this change does not touch. CI sqllogictest ran with the flag on via mzcompose's default system parameters, so the existing goldens already reflect the bucketed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
