### PR TITLE
doc: design durable subscribe

### DIFF
--- a/doc/developer/design/20260825_durable_subscribe.md
+++ b/doc/developer/design/20260825_durable_subscribe.md
@@ -25,10 +25,12 @@ per subscribe, and on reconnect it re-runs the subscribe from scratch, holding
 the stale snapshot behind a `resubscribing` flag until a new snapshot completes.
 The manual escape is documented in
 `doc/user/content/transform-data/patterns/durable-subscriptions.md`, a shipped
-private-preview feature already titled "Durable subscriptions", which instructs
-users to set a `RETAIN HISTORY` duration, record progress timestamps themselves,
-and resume with `AS OF <last_progress_mz_timestamp - 1>`. Every part of that is
-a responsibility we are asking the client to carry, including the off-by-one.
+private-preview page that instructs users to set a `RETAIN HISTORY` duration,
+record progress timestamps themselves, and resume with `AS OF
+<last_progress_mz_timestamp - 1>`. Every part of that is a responsibility we are
+asking the client to carry, including the off-by-one. That page was titled
+"Durable subscriptions", which this design renames to "Resuming subscriptions" to
+free the name for the object.
 
 A second problem sits underneath the first. `SUBSCRIBE` has no persisted output,
 so it has no reconciliation point of the kind that makes materialized views
@@ -82,8 +84,8 @@ rest on the client's unverifiable claim about what it holds.
 A durable subscription is a named catalog object that holds a read hold on a
 storage collection, and that the consumer advances by acknowledging what it has
 committed. The hold defines a window of readable time, the consumer's
-acknowledgement is what moves the window's lower edge, and a wall-clock time to
-live bounds how long the window may stay open without progress. A consumer that
+acknowledgement is what moves the window's lower edge, and a wall-clock deadline
+bounds how long the window may stay open without progress. A consumer that
 reconnects reads from wherever inside that window it likes, and by default from
 the position the server remembers.
 
@@ -161,7 +163,7 @@ must read with as-of `t - 1`, which requires `since <= t - 1`. Storing the
 acknowledged frontier and converting at every use site invites exactly the
 off-by-one the manual pattern documents, so instead:
 
-**`ACKNOWLEDGE ... AT t` sets `H := t - 1`.** One conversion, in one place, at
+**`ACKNOWLEDGE ... UP TO t` sets `H := t - 1`.** One conversion, in one place, at
 the moment the claim is recorded. Everything downstream, the hold, the default
 as-of, the window bound, and the introspection column, reads `H` directly and
 performs no arithmetic.
@@ -199,7 +201,7 @@ holds on inputs to forwarded collections, allowing their compaction".
 
 Left alone, that defeats the feature. A client that connects once and stays
 connected acknowledges faithfully, its position tracks the write frontier, the
-time to live never fires, and `since` sits at its attach-time as-of forever.
+acknowledgement deadline never fires, and `since` sits at its attach-time as-of forever.
 Retention would be bounded only across reconnections, which is the abnormal
 case.
 
@@ -216,11 +218,22 @@ consumer had seen them. A durable subscription answers exactly that question:
 ### Object model
 
 ```mzsql
-CREATE DURABLE SUBSCRIPTION <name> ON <object> WITH (TTL = <interval>);
-CREATE DURABLE SUBSCRIPTION <name> WITH (TTL = <interval>) AS <select>;
+CREATE DURABLE SUBSCRIPTION <name> ON <object> WITH (ACKNOWLEDGE WITHIN <interval>);
+CREATE DURABLE SUBSCRIPTION <name> WITH (ACKNOWLEDGE WITHIN <interval>) AS <select>;
+ALTER DURABLE SUBSCRIPTION <name> SET (ACKNOWLEDGE WITHIN <interval>);
+ALTER DURABLE SUBSCRIPTION <name> RESET;
+ALTER DURABLE SUBSCRIPTION <name> OWNER TO <role>;
+DROP DURABLE SUBSCRIPTION [IF EXISTS] <name>;
 ```
 
-`TTL` is required. Making it optional would mean a default of unbounded
+The option is spelled to mirror `RETAIN HISTORY FOR '1h'`, the adjacent retention
+control, rather than as a `TTL` acronym. It names the obligation it imposes on
+the reader, which is accurate now that the bound is wall-clock time since the
+last acknowledgement rather than a retention distance. `ALTER ... OWNER TO` falls
+out of routing the object through `Op::UpdateOwner` and needs no separate
+mechanism.
+
+`ACKNOWLEDGE WITHIN` is required. Making it optional would mean a default of unbounded
 retention, which is the failure mode this feature exists to avoid.
 
 The object is a durable `create_sql`-based catalog item. Item kind is derived by
@@ -299,6 +312,15 @@ redundant data; the failure mode of an off-by-one as-of is missing data.
 arithmetic trap, so a batch consumer can drain up to a timestamp, commit,
 acknowledge that same timestamp, and exit.
 
+Three clauses of plain `SUBSCRIBE` are rejected on this form. `ENVELOPE UPSERT`
+and `ENVELOPE DEBEZIUM` cannot be produced correctly when resuming without a
+snapshot, because neither the sink nor the server holds the prior value for a key
+the resumed stream has not seen, and since `SNAPSHOT` defaults to `false` here
+the broken combination would be the default one. `AS OF AT LEAST` asks the system
+to choose a timestamp no earlier than a floor, which conflicts with resolving the
+as-of from `H`. `WITHIN TIMESTAMP ORDER BY` is unaffected and remains available,
+since it only orders rows within a timestamp.
+
 ### Snapshot on resume
 
 **`SNAPSHOT` defaults to `false` on the durable form**, inverting the default of
@@ -330,7 +352,7 @@ That yields three modes, spanning what a resuming client can want:
   meaning: consent to a gap.
 
 Three modes across two statements, with no fourth mechanism. If a client
-reconciles when it meant to restart, the waste is bounded by the time to live.
+reconciles when it meant to restart, the waste is bounded by the deadline.
 
 `WITH (PROGRESS)` is required whenever the client intends to acknowledge. A
 progress message is the only thing that establishes that a timestamp is
@@ -356,7 +378,7 @@ reconnect fail for seconds.
 
 ### Acknowledging
 
-`ACKNOWLEDGE DURABLE SUBSCRIPTION <name> AT <timestamp>` asserts that the client
+`ACKNOWLEDGE DURABLE SUBSCRIPTION <name> UP TO <timestamp>` asserts that the client
 has durably processed every update at times strictly before the given timestamp,
 and sets `H := timestamp - 1`.
 
@@ -370,10 +392,20 @@ The statement needs its own non-DDL durable write path.
 
 `ACKNOWLEDGE` is monotone, idempotent, and non-transactional. It takes effect
 immediately and is not rolled back, because the client really did commit the
-data. Validation requires no stream context, which is what allows it to arrive
-on any connection: the new value must be at or above the current one, and at or
-below the target's write frontier. Ordering against the row stream is
-irrelevant, since an acknowledgement is a claim about the client's own state.
+data. A value at or below the current position is accepted and has no effect
+rather than being rejected, so that a client retrying after an ambiguous failure
+does not have to distinguish "already applied" from "too low". A value beyond
+the target's write frontier is an error, since the client cannot have processed
+what was never sent. Ordering against the row stream is irrelevant, since an
+acknowledgement is a claim about the client's own state, which is also what
+allows the statement to arrive on any connection.
+
+The bound is exclusive, matching `UP TO` on `SUBSCRIBE` rather than introducing a
+third convention. A progress message at `t` states that nothing further will
+arrive strictly before `t`, and `ACKNOWLEDGE ... UP TO t` states that everything
+strictly before `t` is processed, so the number a client reads from the progress
+message is the number it sends back unchanged. Reading `UP TO t` and then
+acknowledging `UP TO t` is likewise symmetric.
 
 The in-memory value is a coalescing buffer. A periodic task writes it durably
 and downgrades the hold. Retained history is therefore the client's true
@@ -391,22 +423,22 @@ At the scale this must support, the flush is the hot path. See "Scale".
 
 ### Expiry
 
-The time to live is measured on the **wall clock**, as time since the last
+The acknowledgement deadline is measured on the **wall clock**, as time since the last
 acknowledgement, not as a distance between `H` and the write frontier.
 
 Anchoring it to the write frontier fails in both directions. A `REFRESH` MV
 rounds its frontiers up to the next refresh, so its lag is at least one refresh
-interval even for a client that acknowledges instantly, and a correct time to
-live would have to be aware of every refresh policy in the object's ancestry,
+interval even for a client that acknowledges instantly, and a correct deadline
+would have to be aware of every refresh policy in the object's ancestry,
 the way replica expiration computes its offset. In the other direction a stalled
 source, a paused source, or a zero-replica cluster freezes the frontier, so a
-frontier-anchored time to live never fires precisely when releasing the hold
+frontier-anchored acknowledgement deadline never fires precisely when releasing the hold
 matters most. A wall clock is uniform across every target type and needs no
 knowledge of the target's schedule.
 
 The last-acknowledgement wall-clock time is recorded durably alongside `H`,
 which the periodic flush is already writing. Keeping it only in memory would
-grant every subscription a fresh time to live on every environment restart.
+grant every subscription a fresh acknowledgement deadline on every environment restart.
 
 On expiry the subscription is marked expired durably and only then is the hold
 released. Ordering matters: releasing first and crashing before recording expiry
@@ -426,7 +458,7 @@ expired is an error, since it would silently fence a live reader.
 stateDiagram-v2
     [*] --> Active: CREATE DURABLE SUBSCRIPTION
     Active --> Active: ACKNOWLEDGE
-    Active --> Expired: no ACKNOWLEDGE within TTL
+    Active --> Expired: no ACKNOWLEDGE within the deadline
     Expired --> Active: ALTER ... RESET
     Active --> [*]: DROP
     Expired --> [*]: DROP
@@ -436,10 +468,10 @@ Expiry is evaluated by the same periodic task that flushes, which already holds
 the state it needs. Evaluating it lazily at attach would need no background task
 but would never release an abandoned subscription's hold.
 
-`CREATE` must reject a time to live below a fixed multiple of the flush cadence.
-The value compared against the time to live is the durable one, which trails the
-client's claim by up to one flush interval, so a time to live near the cadence
-would expire clients that are acknowledging correctly.
+`CREATE` must reject a deadline below a fixed multiple of the flush cadence. The
+value compared against the deadline is the durable one, which trails the client's
+claim by up to one flush interval, so a deadline near the cadence would expire
+clients that are acknowledging correctly.
 
 ### Delivery semantics
 
@@ -570,8 +602,8 @@ Documenting them is deliberate; fixing them is separable work.
   as-of from `least_valid_read()` over their inputs, so one lagging subscriber
   makes a subsequent create backfill the whole retained history. For
   materialized views that as-of is written durably into `create_sql`. Retention
-  is therefore not consumer-local, and the wall-clock time to live is the only
-  thing bounding the blast radius.
+  is therefore not consumer-local, and the wall-clock deadline is the only thing
+  bounding the blast radius.
 
 * **Read-only mode and zero-downtime upgrade.** Every existing read policy is a
   function of the write frontier, which is what makes two generations agree
@@ -579,8 +611,8 @@ Documenting them is deliberate; fixing them is separable work.
   generations could disagree about. Concretely: `SUBSCRIBE` is permitted in
   read-only mode while a new `Plan::Acknowledge` would fall into the planner's
   catch-all and be refused, so clients would attach, stream, and have every
-  acknowledgement rejected until the time to live killed a subscription whose
-  client did nothing wrong. The flush and expiry task must be read-only gated,
+  acknowledgement rejected until the deadline killed a subscription whose client
+  did nothing wrong. The flush and expiry task must be read-only gated,
   like every comparable periodic coordinator task. Note that the obvious gate is
   the wrong one: savepoint mode, which zero-downtime upgrade uses, reports
   itself as not read-only.
@@ -609,7 +641,7 @@ Documenting them is deliberate; fixing them is separable work.
 
 * **Empty and regressing frontiers.** The tree already carries three
   incompatible conventions for the lag of a collection with an empty upper. The
-  wall-clock time to live sidesteps this for expiry, but the introspection lag
+  wall-clock deadline sidesteps this for expiry, but the introspection lag
   column still has to pick one.
 
 * **Stale as-ofs on transaction-managed tables** are supported by design but are
@@ -634,8 +666,8 @@ subscribe transaction, and that the attach reads storage rather than an index.
 Add an index to the target as part of the test, since that is the case that
 would otherwise fail every resume.
 
-It deliberately does not validate the batched flush, the wall-clock time to
-live, or the WebSocket path.
+It deliberately does not validate the batched flush, the wall-clock deadline, or
+the WebSocket path.
 
 A second spike is worth running against the console, the intended first
 consumer, whose reconnect logic this feature replaces: point `SubscribeManager`
@@ -665,7 +697,7 @@ attribute it to, and it leaves the client responsible for remembering a
 timestamp. It remains the right answer for exactly-once consumers, which is why
 it stays documented rather than being replaced.
 
-**A frontier-anchored time to live.** More directly expresses "bound the
+**A frontier-anchored acknowledgement deadline.** More directly expresses "bound the
 retained history", and was the first draft's choice. It requires every consumer
 of a `REFRESH` MV to reason about every refresh policy in the ancestry, and it
 never fires for a frozen frontier, which is when releasing the hold matters
@@ -730,12 +762,12 @@ generalize to other sinks that track consumer progress.
 
 * No tracking issue exists yet. One must be filed and linked above before this
   document merges.
-* What are the default flush cadence, the minimum time to live as a multiple of
-  it, and the dyncfg ceiling on the time to live?
+* What are the default flush cadence, the minimum deadline as a multiple of
+  it, and the dyncfg ceiling on the deadline?
 * Can the durable attach be made to bypass index import cleanly, or does that
   need a change to dataflow construction? This is the one implementation
   question that could change the shape of the attach path.
-* How is the wall-clock time to live evaluated across a long environment
+* How is the wall-clock acknowledgement deadline evaluated across a long environment
   outage? Recording the last-acknowledgement time durably means a multi-hour
   restart expires every subscription on boot, which is defensible but should be
   a deliberate choice.

--- a/doc/developer/design/20260825_durable_subscribe.md
+++ b/doc/developer/design/20260825_durable_subscribe.md
@@ -89,6 +89,25 @@ bounds how long the window may stay open without progress. A consumer that
 reconnects reads from wherever inside that window it likes, and by default from
 the position the server remembers.
 
+### Why a timestamp is a better resume token than a log position
+
+A Materialize timestamp is a global commit order, not a per-collection sequence
+number, and that is the property that makes this feature worth more than a
+resumable log tail. Two consequences matter.
+
+A single timestamp identifies a consistent cut across *every* collection in the
+timeline, so a consumer reading several collections can assemble a transactional
+snapshot by buffering each stream until its progress message passes `t`. Systems
+built on write-ahead-log positions cannot do this from the positions alone,
+because the positions of concurrent non-conflicting transactions interleave, so
+they need transaction boundaries and synthetic pre-commit watermarks to recover
+an order the timestamp gives for free.
+
+A timestamp is also meaningful to the client. It is comparable against
+`mz_now()`, against other subscriptions, and against the timestamps the client
+already sees in query results, whereas a log position is an opaque token whose
+only defined operation is comparison with another token from the same source.
+
 ### Read holds and read policies
 
 This design leans on a distinction the codebase makes in its mechanisms but has
@@ -321,6 +340,18 @@ to choose a timestamp no earlier than a floor, which conflicts with resolving th
 as-of from `H`. `WITHIN TIMESTAMP ORDER BY` is unaffected and remains available,
 since it only orders rows within a timestamp.
 
+Rejecting the envelopes reads like ruling out the keyed consumer, so it is worth
+saying why it does not. A consumer that maintains its own replica already holds
+the prior value, which is why every sync engine surveyed keeps its own previous
+state rather than asking the upstream for it. The raw diff stream is what those
+consumers want, and it gives them more than a Postgres feed does: every
+retraction carries the **full old row**, which is `REPLICA IDENTITY FULL`
+semantics by construction, with no per-table configuration and no table
+ownership. `WITHIN TIMESTAMP ORDER BY mz_diff` then orders every retraction
+before every addition within a timestamp, which is exactly the ordering an
+insert-or-replace store needs. So the keyed consumer is served by the default
+form, not excluded from it.
+
 ### Snapshot on resume
 
 **`SNAPSHOT` defaults to `false` on the durable form**, inverting the default of
@@ -438,7 +469,15 @@ knowledge of the target's schedule.
 
 The last-acknowledgement wall-clock time is recorded durably alongside `H`,
 which the periodic flush is already writing. Keeping it only in memory would
-grant every subscription a fresh acknowledgement deadline on every environment restart.
+grant every subscription a fresh deadline on every environment restart.
+
+The ceiling on the deadline should be expressed in **hours**, not minutes. A
+minute suits an interactive client, but a server-side consumer's outages are
+deploys, crash loops, and image rollbacks, which are tens-of-minutes events, and
+a ceiling below that turns every such event into a full resync. Relatedly, a long
+*environment* outage should pause the deadline rather than consume it: the
+subscription's client was not given a chance to acknowledge, so expiring it on
+boot would punish it for our downtime.
 
 On expiry the subscription is marked expired durably and only then is the hold
 released. Ordering matters: releasing first and crashing before recording expiry
@@ -453,6 +492,16 @@ lag that killed it. `ALTER DURABLE SUBSCRIPTION <name> RESET` re-arms it at the
 current frontier, preserving identity, ownership, and grants, and making the
 client's consent to a gap explicit. `RESET` on a subscription that has not
 expired is an error, since it would silently fence a live reader.
+
+Consent may also be given **in band**, on the attach itself, as `WITH (RESET IF
+EXPIRED)`, meaning "if this subscription has expired, reset it, snapshot at the
+current time, and tell me you did". Every sync engine surveyed has such a signal, under
+names like `reset-required`, `must-refetch`, and `CLEAR`, because a server-side
+consumer recovering from an outage needs to recover in its reconnect path rather
+than by issuing a privileged data-definition statement. The loud-failure property
+is preserved either way: the default attach still fails, and the reset is
+reported to the client that asked for it rather than being silent. `ALTER ...
+RESET` remains for operators.
 
 ```mermaid
 stateDiagram-v2
@@ -476,10 +525,19 @@ clients that are acknowledging correctly.
 ### Delivery semantics
 
 A durable subscription is **at-least-once**. The client commits, then
-acknowledges, and a failure in between means re-delivery. Consumers must
-deduplicate on the timestamp and row, and must not treat the stream as an event
-log, because a resumed interval may consolidate differently than it did
-originally.
+acknowledges, and a failure in between means re-delivery.
+
+The idempotence rule is per timestamp, not per row: **apply each timestamp
+atomically, record which timestamp you applied, and skip timestamps already
+applied.** Deduplicating on the timestamp and row is not sufficient, because a
+resumed interval may consolidate differently than it did originally, so the same
+logical change can arrive as a different set of `(row, diff)` tuples. It is also
+not necessary, because resume always lands on a timestamp boundary, so
+re-delivery is always of whole timestamps. Every sync engine surveyed already
+works this way, applying one upstream commit atomically and recording the
+resulting version inside the same transaction.
+
+A consumer must therefore not treat the stream as an event log.
 
 This is a deliberate step back from what the manual pattern achieves, and the
 existing user documentation is explicit that writing the data and the position
@@ -592,6 +650,38 @@ socket, add one inbound arm to the subscribe loop's `select!`, and process only
 `connection_error` doubles as the liveness prober, which wants revisiting once a
 real reader exists.
 
+### Testing
+
+Testdrive covers the lifecycle: create, attach, acknowledge, detach, reattach,
+and assert the resumed stream contains neither a snapshot nor a gap. The gap
+assertion is the one that matters, and the `H = ack - 1` boundary is what it
+tests, so it must include an update at exactly the acknowledged timestamp.
+
+A restart test is mandatory, and its purpose is to prove that the hold is
+re-acquired from durable state where a policy would silently ratchet away. Note
+that an earlier draft justified a restart platform check as catching an
+`enable_for_item_parsing` boot failure, which is self-refuting: CI runs new
+feature flags on, so such a check would run with the flag enabled and pass. The
+boot-failure risk is real but is a release-ordering concern, not a testable one.
+
+Then the cases that would otherwise fail silently:
+
+* **An index on the target.** Attach must still resume, since dataflow
+  construction would otherwise import the index and constrain the as-of by its
+  compute `since`. Include this in the earliest test, because it is the normal
+  case for an indexed relation and would break every resume.
+* **Fencing**, with two connections, asserting the first stream errors.
+* **Expiry**, asserting the error names the subscription. The deadline is
+  wall-clock, so drive it with a very short deadline rather than by waiting.
+* **`DROP` of the target without `CASCADE`** fails while a subscription exists.
+* **Rejected surface**: temporal filters, multi-collection `FROM`, joins and
+  aggregations, `ENVELOPE UPSERT`, `ENVELOPE DEBEZIUM`, and `AS OF AT LEAST`.
+* **Acknowledging at or below the current position** is accepted as a no-op.
+* **A consistent cut across two subscriptions**: buffer both to the same
+  timestamp and assert the union matches a `SELECT ... AS OF` at that timestamp.
+  This is the property that makes the single-target restriction tolerable, so it
+  should be asserted rather than assumed.
+
 ### Known quirks and interactions
 
 These are consequences of existing behavior that this design does not fix.
@@ -628,10 +718,44 @@ Documenting them is deliberate; fixing them is separable work.
   documented teardown then produces exactly the "does not exist" ambiguity this
   design rejects for expiry.
 
-* **`ALTER TABLE ... ADD COLUMN`** mints a new `GlobalId` on the same shard, and
-  with `SNAPSHOT = false` there is no boundary at which to signal the arity
-  change. Expiring subscriptions on the target is the chosen behavior; the hold
-  itself survives.
+* **`ALTER TABLE ... ADD COLUMN`** is gated behind `enable_alter_table_add_column`,
+  which defaults to false and is undocumented, so this is a forward-looking note
+  rather than a behavior users can reach. If it is enabled, the statement mints a
+  new `GlobalId` on the same shard while the hold survives via primary links, and
+  a subscription on the target would see its row arity change with no marker
+  saying why. Expiring the subscription is the conservative answer. A better one,
+  should schema change become supported, is to keep the hold and `H` and fail
+  only the in-flight attach, so a reconnect resumes at the same position with the
+  new shape: the arity changes *at a timestamp*, so a boundary does exist even
+  under `SNAPSHOT = false`.
+
+* **Combining several subscriptions is safe but unassisted.** Because a timestamp
+  is a global cut, a consumer reading N collections can buffer each stream until
+  its progress message passes `t` and then apply the union at `t` as a
+  transactionally consistent snapshot. That works today and needs nothing from
+  us, but the consumer pays for it: liveness is the minimum over N, so one
+  `REFRESH` target paces the whole set; expiry is per-subscription, so one
+  expiry breaks the joint cut and recovery is per-collection; and each checkpoint
+  costs N `ACKNOWLEDGE` statements. The recipe should be documented, and it is
+  the argument for the multi-target follow-up.
+
+* **Timelines are not comparable.** Collections in different timelines have
+  incomparable timestamps, so the recipe above is unsound across them. A
+  subscription should reject a target outside the default `EpochMilliseconds`
+  timeline, or the restriction must be documented.
+
+* **There is no mapping from an upstream position to a Materialize timestamp.**
+  A consumer that writes to an upstream database and then needs to know when its
+  own write became visible in Materialize cannot ask. This is invisible if only
+  the read path is modeled, and it is what a sync engine needs to retire an
+  optimistic write. Out of scope here, but it is a hard dependency for that class
+  of consumer and is worth naming so nobody assumes this feature covers it.
+
+* **The WebSocket transport has no batch flow control.** That API supports
+  neither `DECLARE`, `FETCH`, `CLOSE`, nor `COPY`, so a WebSocket reader cannot
+  pull in batches and depends entirely on the inbound-`ACKNOWLEDGE` arm described
+  under "Protocol". For the console, which is the intended first consumer, that
+  arm is not an optimization but the only acknowledgement channel.
 
 * **Rollback ordering.** `item_type()` panics on an unknown `create_sql` prefix,
   and topological sorting parses every item's `create_sql` with `expect`. Both
@@ -763,7 +887,8 @@ generalize to other sinks that track consumer progress.
 * No tracking issue exists yet. One must be filed and linked above before this
   document merges.
 * What are the default flush cadence, the minimum deadline as a multiple of
-  it, and the dyncfg ceiling on the deadline?
+  it, and the dyncfg ceiling on the deadline? The ceiling should be in hours per
+  "Expiry", but the value is undecided.
 * Can the durable attach be made to bypass index import cleanly, or does that
   need a change to dataflow construction? This is the one implementation
   question that could change the shape of the attach path.

--- a/doc/developer/design/20260825_durable_subscribe.md
+++ b/doc/developer/design/20260825_durable_subscribe.md
@@ -1,0 +1,749 @@
+# Durable subscribe
+
+- Associated: no tracking issue filed yet, see "Open questions".
+
+## The Problem
+
+`SUBSCRIBE` cannot be resumed. A client that loses its connection has no way to
+continue from where it stopped, so it must re-run the subscribe and process a
+fresh snapshot before it sees a single new update. The cost falls on exactly the
+clients least able to absorb it, because a browser tab or an edge function
+reconnects often and holds no durable local state to fall back on. This makes
+reconnection a data-volume event rather than a control-plane event.
+
+The gap is not a missing streaming mechanism. `SUBSCRIBE ... AS OF t WITH
+(SNAPSHOT = false)` already expresses "give me the diffs after `t`". What is
+missing is any guarantee that `t` remains readable: nothing holds the
+collection's `since` on the consumer's behalf, and the default compaction window
+is one second (`DEFAULT_LOGICAL_COMPACTION_WINDOW_MILLIS` in
+`src/adapter-types/src/compaction.rs`). A client that remembers a timestamp and
+comes back a second later finds it already compacted away.
+
+Our own console demonstrates the workaround and its cost.
+`console/src/api/materialize/SubscribeManager.ts` opens one dedicated WebSocket
+per subscribe, and on reconnect it re-runs the subscribe from scratch, holding
+the stale snapshot behind a `resubscribing` flag until a new snapshot completes.
+The manual escape is documented in
+`doc/user/content/transform-data/patterns/durable-subscriptions.md`, a shipped
+private-preview feature already titled "Durable subscriptions", which instructs
+users to set a `RETAIN HISTORY` duration, record progress timestamps themselves,
+and resume with `AS OF <last_progress_mz_timestamp - 1>`. Every part of that is
+a responsibility we are asking the client to carry, including the off-by-one.
+
+A second problem sits underneath the first. `SUBSCRIBE` has no persisted output,
+so it has no reconciliation point of the kind that makes materialized views
+robust. The materialized view sink is self-correcting because it reads its own
+output shard back through persist feedback into a `Correction` buffer
+(`src/compute/src/sink/correction_v2.rs`) and writes only the delta needed to
+make the shard match the dataflow's desired output, which is what survives
+restarts and replica changes. Resume correctness for a subscribe would otherwise
+rest on the client's unverifiable claim about what it holds.
+
+## Success Criteria
+
+* A client that reconnects within an agreed window continues from where it
+  stopped, with no new snapshot and no gap.
+* The server owns the resume point. A client is not required to durably remember
+  a timestamp, because the clients that need this most cannot.
+* History retained on a consumer's behalf is bounded, and the bound holds while
+  the consumer is connected, not only across reconnections.
+* The bound is expressed per consumer and does not require the consumer to
+  reason about the target's refresh or ingestion schedule.
+* Retention is visible. An operator can see which consumer holds history and how
+  far behind it is.
+* Losing the resume point is a named, loud failure. No configuration or failure
+  sequence may produce a silently skipped range of updates.
+* The mechanism is reachable from the transports clients actually use: the
+  WebSocket SQL API, and pgwire from any mainstream driver.
+
+## Out of Scope
+
+* **Arbitrary SQL.** A subscription reads one collection, optionally through a
+  projection and filter. See "Query scope".
+* **Indexes and views as targets.** An arrangement lives in cluster memory, so
+  no durable hold can be offered over it.
+* **Exactly-once delivery.** See "Delivery semantics", which explains why this
+  is a deliberate step back from what the manual pattern can achieve, and how
+  such consumers are still served.
+* **The PostgreSQL replication protocol.** `CopyBoth` is not implemented in
+  `src/pgwire/`, and "Alternatives" explains why adding it would not reach most
+  clients anyway.
+* **Concurrent readers of one subscription.** A subscription is single-reader by
+  construction.
+* **Changing materialized view self-correction.** This design consumes it and
+  does not modify it.
+* **Fixing the as-of selection of newly created objects.** A subscription's hold
+  lowers the as-of chosen for objects created later over the same inputs. This
+  is a pre-existing property of as-of selection that the feature makes easier to
+  trigger. See "Known quirks and interactions".
+
+## Solution Proposal
+
+A durable subscription is a named catalog object that holds a read hold on a
+storage collection, and that the consumer advances by acknowledging what it has
+committed. The hold defines a window of readable time, the consumer's
+acknowledgement is what moves the window's lower edge, and a wall-clock time to
+live bounds how long the window may stay open without progress. A consumer that
+reconnects reads from wherever inside that window it likes, and by default from
+the position the server remembers.
+
+### Read holds and read policies
+
+This design leans on a distinction the codebase makes in its mechanisms but has
+never written down, and getting it wrong is what made the first draft of this
+document unimplementable. The three concepts are:
+
+* A **read policy** is a rule that derives a frontier from a collection's write
+  frontier, re-evaluated as that frontier advances. `RETAIN HISTORY` and the
+  one-second default are policies. A policy expresses "keep this much history
+  behind the frontier", so it moves forward on its own.
+
+* A **read hold** is a token, acquired by a named party at a specific frontier
+  and released explicitly. `acquire_read_holds` grants one at the collection's
+  current `since` and returns `Result<Vec<ReadHold>, CollectionMissing>`;
+  `ReadHold::try_downgrade` moves it and can fail. A hold expresses "this party
+  still needs to read from here".
+
+* The **capability**, and therefore `since`, is the meet of the policy-derived
+  frontier and every outstanding hold.
+
+A durable subscription is a party that holds a hold. It is emphatically not a
+policy, and the first draft's `ReadPolicy::ValidFrom` plus
+`ReadPolicy::Multiple` composition does not work:
+
+* `ReadPolicy::Multiple` has zero construction sites in the tree. It is an
+  unexercised variant, and `Multiple(vec![])` yields an empty antichain, which
+  drops the collection.
+* Policy installation is a one-way ratchet. In
+  `src/storage-client/src/storage_collections.rs`, the new capability is applied
+  only `if PartialOrder::less_equal(&collection.implied_capability, &new_read_capability)`,
+  while `collection.read_policy = policy` is stored unconditionally. Installing
+  a lower frontier behind an already-advanced capability is a silent no-op, and
+  the trait documentation says so: it "will not 'recover' the read capability if
+  the prior capability is already ahead of it".
+* The installation API cannot express it. Policies are derived from a bare
+  `CompactionWindow` at every call site, and bootstrap groups collections by
+  `CompactionWindow`, so there is no shape in which a per-collection constant
+  frontier survives.
+* Any later `ALTER ... RETAIN HISTORY`, or the periodic metrics-retention
+  update, re-installs a window policy over the collection and would irreversibly
+  discard the subscription's contribution.
+* Policies report nothing. `set_read_policies` returns `()`, and when persist
+  refuses a since downgrade the returned frontier is discarded by the caller. A
+  hold, by contrast, tells you the frontier you actually got.
+
+Holds also already interoperate with the rest of the system in the ways this
+feature needs: `DROP` honors holds, and holds are deliberately acquired at the
+earliest readable time specifically so that one controller can hold a frontier
+back while another acquires at the same early point.
+
+### The readable window
+
+The subscription's durable state is a single frontier, `H`, the earliest as-of a
+reader may request. The hold keeps `since <= H`, so the readable window is
+`[H, upper)` and a reader may attach at any as-of inside it.
+
+`H` is derived from the acknowledgement, and the conversion is where the first
+draft was wrong. The subscribe sink decides what to emit in
+`src/compute/src/sink/subscribe.rs`:
+
+```rust
+let beyond_as_of = if with_snapshot {
+    as_of.less_equal(time)
+} else {
+    as_of.less_than(time)
+};
+```
+
+Without a snapshot, an as-of of `t` emits times **strictly greater** than `t`.
+So a client that has processed everything before `t` and wants to resume at `t`
+must read with as-of `t - 1`, which requires `since <= t - 1`. Storing the
+acknowledged frontier and converting at every use site invites exactly the
+off-by-one the manual pattern documents, so instead:
+
+**`ACKNOWLEDGE ... AT t` sets `H := t - 1`.** One conversion, in one place, at
+the moment the claim is recorded. Everything downstream, the hold, the default
+as-of, the window bound, and the introspection column, reads `H` directly and
+performs no arithmetic.
+
+```text
+                H = ack - 1
+                |
+   compacted    |<------ readable window ------>|
+   ------------ [ ============================= ) ------->
+                                              upper
+```
+
+The two attach forms both land inside the window. `SNAPSHOT = false` with as-of
+`H` yields times greater than `H`, meaning at or after the acknowledged
+position, which is a gapless continuation. `SNAPSHOT = true` with as-of `H + 1`
+yields a snapshot at the acknowledged position followed by later updates, which
+is what a client that lost its local state needs.
+
+A client may also pass an explicit `AS OF` anywhere in the window, with the
+ordinary meaning it has everywhere else in `SUBSCRIBE`. The window is what the
+hold provides, and it is provided to whoever can read the collection: a plain
+`SUBSCRIBE TO <target> AS OF <x>` for any `x` in the window also works, and works
+*because* a subscription is holding `since` back.
+
+### One hold, not two
+
+A running subscribe dataflow needs its input to stay readable, and today the
+compute controller gives it a hold pinned at the dataflow's as-of that never
+relaxes for the collection's lifetime. `forward_implied_capabilities` in
+`src/compute-client/src/controller/instance.rs` is the only thing that would
+relax it, and it returns early unless the cluster has no replicas, then skips
+write-only collections with the comment "Collection is write-only, i.e. a sink."
+Its own documentation names the consequence: forwarding is what "relaxes read
+holds on inputs to forwarded collections, allowing their compaction".
+
+Left alone, that defeats the feature. A client that connects once and stays
+connected acknowledges faithfully, its position tracks the write frontier, the
+time to live never fires, and `since` sits at its attach-time as-of forever.
+Retention would be bounded only across reconnections, which is the abnormal
+case.
+
+Therefore the subscription's hold **is** the dataflow's input floor. The durable
+attach installs no separate pinned hold; the dataflow reads behind the
+subscription's hold, and the hold moves when the client acknowledges. This is
+also why the general objection in `forward_implied_capabilities` does not apply
+here. That comment worries that advancing a sink's capability could skip input
+times across a replica restart, with no way to know whether the external
+consumer had seen them. A durable subscription answers exactly that question:
+`H` is the client's own statement about what it has processed, so restarting at
+`H` is correct by construction rather than a guess.
+
+### Object model
+
+```mzsql
+CREATE DURABLE SUBSCRIPTION <name> ON <object> WITH (TTL = <interval>);
+CREATE DURABLE SUBSCRIPTION <name> WITH (TTL = <interval>) AS <select>;
+```
+
+`TTL` is required. Making it optional would mean a default of unbounded
+retention, which is the failure mode this feature exists to avoid.
+
+The object is a durable `create_sql`-based catalog item. Item kind is derived by
+parsing the `create_sql` prefix via `item_type()`, so no new durable item shape
+is needed for the definition itself, and `to_serialized`/`into_serialized`
+return `(create_sql, global_id, BTreeMap::new())` as `Index` does. It owns no
+dataflow and no compute of its own, so there is no dataflow plan to bootstrap
+and no as-of to select at boot. The boot work is to re-acquire its hold.
+
+Mirroring `Index` is right for serialization and wrong for dependencies.
+`dependency_prevents_drop` in `src/sql/src/plan/statement/ddl.rs` keys off the
+dependent's item type and returns `false` only for
+`CatalogItemType::Index`. A new arm must return `true`, so that dropping a
+target with a live subscription requires `CASCADE`. The match is exhaustive, so
+omitting the arm is a compile error rather than a latent bug.
+
+`SELECT` on the target is checked at attach as well as at create, because
+privileges can be revoked while a subscription sits idle. The statement is
+feature-gated, and that flag must set `enable_for_item_parsing: true`, since
+bootstrap replans every durable item's `create_sql` through the planner and a
+gate that is off in production would fail catalog boot.
+
+### Query scope
+
+The `AS <select>` form accepts a projection and filter over a single collection,
+which is exactly the class that lowers to a map-filter-project pushed into the
+persist read. That class needs no state, no dataflow, and no rehydration, and
+therefore no reconciliation point of its own, which is what keeps it compatible
+with a hold on the underlying collection. Filters and projections commute with
+differencing, and a projection that collapses distinct rows merely consolidates
+their diffs into a valid stream over the projected relation.
+
+Everything else is rejected: joins, aggregations, `DISTINCT`, subqueries, and
+more than one collection in the `FROM` clause. Temporal filters over `mz_now()`
+are rejected too, because they are not map-filter-project, they require a
+dataflow, and they restructure retractions into the far future.
+
+The projection lives in the definition rather than being chosen per attach. Both
+are sound, since `H` is a frontier on the underlying collection and any
+projection over the same interval is individually correct, but definition-time
+means the object fully describes its stream, introspection is meaningful, and a
+client cannot change the row shape it deduplicates against between
+reconnections.
+
+An error from the projection, such as a division by zero, surfaces as a stream
+error. `H` does not move, because only `ACKNOWLEDGE` moves it, so the client
+reconnects into the same error until the offending data changes.
+
+### Attaching
+
+```mzsql
+SUBSCRIBE USING DURABLE SUBSCRIPTION <name> WITH (PROGRESS, SNAPSHOT = false);
+```
+
+The form takes no target, because the object already names it. Omitting `AS OF`
+resolves it from `H`, which is the intended path and the one that requires no
+arithmetic from the client.
+
+`AS OF` is accepted, with the ordinary semantics it has everywhere else in
+`SUBSCRIBE`, and must fall inside the window. It exists for consumers that track
+their own position and are ahead of what they have acknowledged, which would
+otherwise re-receive the whole unacknowledged window on every reconnection. The
+alternative of forbidding it is recorded under "Alternatives".
+
+Keeping the ordinary semantics keeps the `-1`. Under `SNAPSHOT = false`, an
+as-of of `t` emits times strictly greater than `t`, so a consumer resuming at its
+committed position `T` must pass `T - 1`. This is a documented pitfall rather
+than a solved problem, and it is a silent one: passing `T` skips every update at
+`T`. Consumers that would rather not carry the arithmetic have a strictly safer
+option, since updates carry `mz_timestamp`: omit `AS OF`, resume from `H`, and
+discard everything below `T` on receipt. The failure mode of a filter is
+redundant data; the failure mode of an off-by-one as-of is missing data.
+
+`UP TO` is also accepted. It constrains the upper edge, where the
+`!up_to.less_equal(time)` boundary yields a clean half-open interval and no
+arithmetic trap, so a batch consumer can drain up to a timestamp, commit,
+acknowledge that same timestamp, and exit.
+
+### Snapshot on resume
+
+**`SNAPSHOT` defaults to `false` on the durable form**, inverting the default of
+plain `SUBSCRIBE`. Resuming is the whole point of the statement, and a default
+that re-snapshots would make it useless without an explicit option. The
+inconsistency is deliberate and worth the surprise.
+
+The snapshot, when requested, is always taken **at the acknowledged position**,
+never at the latest time. A snapshot at the latest time would leave the client
+holding state at a time it has not acknowledged and cannot name, silently
+invalidating its position.
+
+That yields three modes, spanning what a resuming client can want:
+
+* **Continue.** `SNAPSHOT = false`, as-of `H`. The client holds state at or past
+  the acknowledged position and wants the diffs onward. The common case, and the
+  default.
+
+* **Reconcile at position.** `SNAPSHOT = true`, as-of `H + 1`. The client knows
+  its position but suspects its state has diverged, and wants the authoritative
+  state *at the position it claims* so it can compare. This is the same
+  operation the materialized view sink performs against its own output shard,
+  and it is readable because the hold keeps `since <= H`.
+
+* **Restart.** `ALTER DURABLE SUBSCRIPTION ... RESET`, then attach. The client
+  lost everything and wants current state. Reconciling at an old position would
+  deliver historical state plus every diff since, which is strictly more work
+  than a snapshot at the current time, and `RESET` already carries the right
+  meaning: consent to a gap.
+
+Three modes across two statements, with no fourth mechanism. If a client
+reconciles when it meant to restart, the waste is bounded by the time to live.
+
+`WITH (PROGRESS)` is required whenever the client intends to acknowledge. A
+progress message is the only thing that establishes that a timestamp is
+complete: not every timestamp produces one, and a row at time `t` does not imply
+that `t` is finished. Without progress messages a client cannot compute a safe
+acknowledgement at all, so this is a requirement rather than a recommendation.
+
+**The attach must read the storage collection, not an index.** When an index
+exists on the target, dataflow construction imports the index instead of the
+source, which puts a compute collection in the id bundle, and subscribe
+constrains its as-of by `least_valid_read()` over the whole bundle. The
+subscription holds the storage `since`; the index's compute `since` follows the
+one-second default, so a resume from an older position would fail with
+`AdapterError::ImpossibleTimestampConstraints`. For an indexed relation, which
+is the normal case for the console, that would make every resume fail. Reading
+from storage is also the cheaper path, since it avoids rehydration.
+
+Attach takes an epoch and fences any previous reader, whose stream errors out.
+Fencing rather than lease expiry suits the intended clients, because a
+disconnected browser tab usually leaves a half-open connection the server has
+not yet noticed, and waiting for a lease to expire would make a legitimate
+reconnect fail for seconds.
+
+### Acknowledging
+
+`ACKNOWLEDGE DURABLE SUBSCRIPTION <name> AT <timestamp>` asserts that the client
+has durably processed every update at times strictly before the given timestamp,
+and sets `H := timestamp - 1`.
+
+**`ACKNOWLEDGE` must not be classified as DDL.** `must_serialize_ddl` returns
+early when `!StatementClassification::from(stmt).is_ddl()`, and a DDL
+classification would be actively harmful: the first acknowledgement in a
+subscribe transaction would take the environment-wide `serialized_ddl` lock,
+held until the transaction ends and therefore for the life of the subscribe,
+blocking all other DDL; a second one in the same transaction would soft-panic.
+The statement needs its own non-DDL durable write path.
+
+`ACKNOWLEDGE` is monotone, idempotent, and non-transactional. It takes effect
+immediately and is not rolled back, because the client really did commit the
+data. Validation requires no stream context, which is what allows it to arrive
+on any connection: the new value must be at or above the current one, and at or
+below the target's write frontier. Ordering against the row stream is
+irrelevant, since an acknowledgement is a claim about the client's own state.
+
+The in-memory value is a coalescing buffer. A periodic task writes it durably
+and downgrades the hold. Retained history is therefore the client's true
+position plus at most one flush interval. Because the durable write is what
+authorizes compaction, a lost flush costs retention, never correctness.
+
+Cursor state lives in a dedicated durable `StateUpdateKind` rather than in
+`create_sql`. Rewriting `create_sql` per flush is possible, and
+`Op::AlterRetainHistory` is precedent for mutating a durable item that way, but
+it would make every flush a full catalog transaction with an audit-log entry and
+turn `SHOW CREATE` into a moving value. `create_sql` is a definition and `H` is
+state.
+
+At the scale this must support, the flush is the hot path. See "Scale".
+
+### Expiry
+
+The time to live is measured on the **wall clock**, as time since the last
+acknowledgement, not as a distance between `H` and the write frontier.
+
+Anchoring it to the write frontier fails in both directions. A `REFRESH` MV
+rounds its frontiers up to the next refresh, so its lag is at least one refresh
+interval even for a client that acknowledges instantly, and a correct time to
+live would have to be aware of every refresh policy in the object's ancestry,
+the way replica expiration computes its offset. In the other direction a stalled
+source, a paused source, or a zero-replica cluster freezes the frontier, so a
+frontier-anchored time to live never fires precisely when releasing the hold
+matters most. A wall clock is uniform across every target type and needs no
+knowledge of the target's schedule.
+
+The last-acknowledgement wall-clock time is recorded durably alongside `H`,
+which the periodic flush is already writing. Keeping it only in memory would
+grant every subscription a fresh time to live on every environment restart.
+
+On expiry the subscription is marked expired durably and only then is the hold
+released. Ordering matters: releasing first and crashing before recording expiry
+would leave a subscription that looks valid while `since` has advanced past its
+`H`. Recording expiry first is self-healing, because an expired subscription
+acquires no hold on boot. The reverse crash, a recorded expiry with the hold
+still held, resolves itself the same way.
+
+The object survives expiry, which is what makes the state reportable. Attach
+fails with an error naming the subscription, the position it expired at, and the
+lag that killed it. `ALTER DURABLE SUBSCRIPTION <name> RESET` re-arms it at the
+current frontier, preserving identity, ownership, and grants, and making the
+client's consent to a gap explicit. `RESET` on a subscription that has not
+expired is an error, since it would silently fence a live reader.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active: CREATE DURABLE SUBSCRIPTION
+    Active --> Active: ACKNOWLEDGE
+    Active --> Expired: no ACKNOWLEDGE within TTL
+    Expired --> Active: ALTER ... RESET
+    Active --> [*]: DROP
+    Expired --> [*]: DROP
+```
+
+Expiry is evaluated by the same periodic task that flushes, which already holds
+the state it needs. Evaluating it lazily at attach would need no background task
+but would never release an abandoned subscription's hold.
+
+`CREATE` must reject a time to live below a fixed multiple of the flush cadence.
+The value compared against the time to live is the durable one, which trails the
+client's claim by up to one flush interval, so a time to live near the cadence
+would expire clients that are acknowledging correctly.
+
+### Delivery semantics
+
+A durable subscription is **at-least-once**. The client commits, then
+acknowledges, and a failure in between means re-delivery. Consumers must
+deduplicate on the timestamp and row, and must not treat the stream as an event
+log, because a resumed interval may consolidate differently than it did
+originally.
+
+This is a deliberate step back from what the manual pattern achieves, and the
+existing user documentation is explicit that writing the data and the position
+in one transaction is what makes that pattern exactly-once. A server-side
+cursor structurally cannot offer that, because the acknowledgement is a separate
+round trip after the commit.
+
+Such consumers are still served. One that records its own committed position `T`
+in the same transaction as the data keeps exactly-once, and the subscription
+supplies the retention guarantee that the history back to `H` is still there. It
+has two ways to skip what it already has:
+
+* **Discard on receipt.** Resume from `H` and drop every update below `T`. Costs
+  bandwidth proportional to the unacknowledged window, and cannot lose data.
+* **Position the read.** Pass `AS OF T - 1`. Costs nothing, and loses data
+  silently if the arithmetic is wrong.
+
+Filtering is the better default and positioning is the better optimization. The
+consumer keeps owning correctness either way, which is where it has to live,
+since only the consumer knows what it committed.
+
+### Scale
+
+The target is one to ten thousand concurrent subscriptions, which are
+**provisioned per logical consumer** and reused across reconnections, not
+created per session or per page load. The distinction is load-bearing: creating
+a subscription is a catalog transaction on the coordinator, and every durable
+item is replanned at boot, so churn is far more expensive than population.
+
+Three consequences for the implementation:
+
+* **The flush must batch.** Ten thousand subscriptions flushing individually
+  once a second is ten thousand catalog transactions per second, which is not
+  viable. One durable write must carry many cursors, and the cadence must scale
+  with population rather than being a fixed per-subscription interval.
+
+* **The per-collection minimum must be incremental.** Recomputing a
+  collection's floor by scanning its subscriptions on every flush is quadratic
+  in the shared-collection case, which is the case ten thousand implies.
+
+* **Boot cost is linear in population.** Ten thousand items add replanning work
+  at startup. This is the price of the catalog-item model and the reason
+  subscriptions must not be per-session.
+
+### Observability
+
+`mz_durable_subscriptions` reports each subscription's name, target, owner, time
+to live, `H`, wall-clock time since last acknowledgement, validity state, and
+the position at which an expired subscription died. The cursor rows are
+available through `mz_catalog_raw`, which exposes durable `StateUpdateKind`
+rows, but the lag column is not catalog state: write frontiers live in
+`mz_internal.mz_frontiers`, so the relation needs a join against an
+introspection source. `mz_catalog_raw` is system-user only, so the
+operator-facing relation needs its own grants.
+
+The name is deliberately distinct from `mz_internal.mz_subscriptions`, which
+lists running `SUBSCRIBE` statements and is what the console and the in-tree
+cancellation tests join against. A durable subscription appears in the new
+relation whether or not anything is reading it. `mz_history_retention_strategies`
+is the closest prior art for retention observability and the new relation should
+be consistent with it.
+
+A `parse_catalog_create_sql` arm is required. Contrary to a claim in an earlier
+draft, that function has no catch-all: the match is exhaustive by design, with
+the in-source rationale that "one unclassified `create_sql` takes out
+`mz_objects`, `mz_indexes`, and every sibling view at once", so a new statement
+variant is a compile error. The real hazard is landing in the reject group where
+`Subscribe(_)` already sits, which would break every catalog view that scans
+`Item` rows.
+
+### Protocol
+
+Which acknowledgement channel is available depends on how the client reads, and
+the binding constraint is a property of the PostgreSQL protocol rather than of
+any driver. During plain `COPY OUT` there is no legal frontend-to-server data
+path: the protocol documentation states the frontend cannot abort the transfer
+except by closing the connection or issuing a cancel request, and libpq's
+`PQputCopyData` admits `COPY_IN` and `COPY_BOTH` while excluding `COPY_OUT`.
+Drivers then fail in incompatible ways, from silent indefinite queueing in
+node-postgres to a thread block in pgjdbc to an immediate error in pgx, asyncpg,
+and postgres.js to a compile error in sqlx. Our own loop matches the constraint:
+it selects on `wait_closed`, which polls socket readiness on a timer and never
+reads bytes.
+
+| Read path | Ack channel |
+| --- | --- |
+| `DECLARE` plus `FETCH` | `ACKNOWLEDGE` between `FETCH`es, same connection |
+| Streaming `COPY OUT` | Second connection, protocol-mandated |
+| WebSocket | Same connection, inbound frame |
+
+Interleaving between `FETCH`es is reachable from every mainstream driver,
+because each `FETCH` is a self-contained round trip that releases whatever
+per-connection lock the driver holds, and it is already what our documentation
+recommends. Naming the object is what makes the second-connection path clean:
+cancellation must locate a session through `mz_subscriptions` and `mz_sessions`,
+whereas an acknowledgement addresses the subscription by name.
+
+An earlier draft claimed all three paths need `TransactionOps::Subscribe`
+relaxed. They probably do not. That op is recorded only when the subscribe's
+`when` is `QueryWhen::Immediately`, and a durable attach resolves an as-of, so
+the durable form does not enter the gate at all. The load-bearing protocol
+requirement is the non-DDL classification described under "Acknowledging".
+
+For WebSocket the server is half-duplex per statement: `run_ws` reads one
+request, executes it to completion while holding the socket, and only then reads
+again, while `connection_error` writes a periodic ping without ever reading. The
+minimal change is a tight allowlist rather than general concurrency: split the
+socket, add one inbound arm to the subscribe loop's `select!`, and process only
+`ACKNOWLEDGE` there. That arm is polled in a loop so it must be cancel-safe, and
+`connection_error` doubles as the liveness prober, which wants revisiting once a
+real reader exists.
+
+### Known quirks and interactions
+
+These are consequences of existing behavior that this design does not fix.
+Documenting them is deliberate; fixing them is separable work.
+
+* **A subscription's hold lowers the as-of of objects created later.**
+  `CREATE MATERIALIZED VIEW`, `CREATE INDEX`, and `CREATE SINK` all take their
+  as-of from `least_valid_read()` over their inputs, so one lagging subscriber
+  makes a subsequent create backfill the whole retained history. For
+  materialized views that as-of is written durably into `create_sql`. Retention
+  is therefore not consumer-local, and the wall-clock time to live is the only
+  thing bounding the blast radius.
+
+* **Read-only mode and zero-downtime upgrade.** Every existing read policy is a
+  function of the write frontier, which is what makes two generations agree
+  without coordination; `H` is durable state, so it is the first floor two
+  generations could disagree about. Concretely: `SUBSCRIBE` is permitted in
+  read-only mode while a new `Plan::Acknowledge` would fall into the planner's
+  catch-all and be refused, so clients would attach, stream, and have every
+  acknowledgement rejected until the time to live killed a subscription whose
+  client did nothing wrong. The flush and expiry task must be read-only gated,
+  like every comparable periodic coordinator task. Note that the obvious gate is
+  the wrong one: savepoint mode, which zero-downtime upgrade uses, reports
+  itself as not read-only.
+
+* **Name transforms and hand-maintained matches.** `src/sql/src/ast/transform.rs`
+  carries several matches over statement kinds that end in `unreachable!()`, and
+  the most recently added item kind is missing from one of them. These run for
+  every item in a renamed schema, so `ALTER SCHEMA ... SWAP`, the documented
+  blue/green cutover, panics the coordinator without a new arm.
+
+* **Blue/green cutover is a name swap.** Ids and shards are untouched, so a
+  subscription keeps streaming the decommissioned collection, and the
+  documented teardown then produces exactly the "does not exist" ambiguity this
+  design rejects for expiry.
+
+* **`ALTER TABLE ... ADD COLUMN`** mints a new `GlobalId` on the same shard, and
+  with `SNAPSHOT = false` there is no boundary at which to signal the arity
+  change. Expiring subscriptions on the target is the chosen behavior; the hold
+  itself survives.
+
+* **Rollback ordering.** `item_type()` panics on an unknown `create_sql` prefix,
+  and topological sorting parses every item's `create_sql` with `expect`. Both
+  sit upstream of the feature flag, so once a single row exists, rolling back to
+  a binary that predates the parser makes the environment unbootable. This is a
+  release-ordering constraint, not something a test catches.
+
+* **Empty and regressing frontiers.** The tree already carries three
+  incompatible conventions for the lag of a collection with an empty upper. The
+  wall-clock time to live sidesteps this for expiry, but the introspection lag
+  column still has to pick one.
+
+* **Stale as-ofs on transaction-managed tables** are supported by design but are
+  not a hot path today, and read-only mode has no transaction-shard handle at
+  all. Which of the logical and physical uppers acknowledgement validation
+  compares against needs to be pinned down.
+
+## Minimal Viable Prototype
+
+The prototype is the hold path end to end against a table, with no expiry, no
+fencing, no projection, and no observability. Create the object, acquire a hold
+and downgrade it from a synchronously written `H`, implement `ACKNOWLEDGE` as a
+non-DDL statement, and drive it from testdrive: acknowledge, restart
+`environmentd`, reattach with `SNAPSHOT = false`, and assert the stream resumes
+with neither a snapshot nor a gap.
+
+That validates the four claims this design rests on and is cheapest to be wrong
+about: that a hold re-acquired from durable state genuinely survives a restart
+where a policy would not, that `H = ack - 1` puts the boundary in the right
+place, that a non-DDL `ACKNOWLEDGE` neither deadlocks nor panics inside a
+subscribe transaction, and that the attach reads storage rather than an index.
+Add an index to the target as part of the test, since that is the case that
+would otherwise fail every resume.
+
+It deliberately does not validate the batched flush, the wall-clock time to
+live, or the WebSocket path.
+
+A second spike is worth running against the console, the intended first
+consumer, whose reconnect logic this feature replaces: point `SubscribeManager`
+at a durable subscription and delete the `resubscribing` path.
+
+## Alternatives
+
+**A read policy contribution rather than a hold.** This was the first draft, and
+"Read holds and read policies" records why it fails: `ReadPolicy::Multiple` is
+unconstructed, installation only ratchets capabilities upward, the installation
+API is keyed by `CompactionWindow`, an ordinary `ALTER ... RETAIN HISTORY` would
+discard the contribution, and nothing in the path reports failure.
+
+**Resuming from `since` with no durable position.** Since compaction is monotone
+and durable in persist, `since` is itself a record of progress, suggesting a
+resume at `max(H, since)` with nothing stored hot. The default compaction window
+is one second, so `since` records what other readers permit rather than what
+this consumer consumed, and it is exact only when the subscription is the sole
+reader. Worse, when the in-memory position has moved past the last flush, a
+restart would resume above the durable position and skip the difference. Safe
+under the commit-before-acknowledge contract, but silent.
+
+**A duration-based floor, meaning `RETAIN HISTORY` alone.** This is the shipped
+manual pattern. A duration is a guess in both directions, too short bricking the
+client with no explanation and too long growing storage with no consumer to
+attribute it to, and it leaves the client responsible for remembering a
+timestamp. It remains the right answer for exactly-once consumers, which is why
+it stays documented rather than being replaced.
+
+**A frontier-anchored time to live.** More directly expresses "bound the
+retained history", and was the first draft's choice. It requires every consumer
+of a `REFRESH` MV to reason about every refresh policy in the ancestry, and it
+never fires for a frozen frontier, which is when releasing the hold matters
+most.
+
+**An object owning its own query and output shard.** Self-contained, with one
+`DROP` cleaning up compute, storage, and cursor together, and an unambiguous
+hold because the reader is the only consumer. It duplicates compute and storage
+whenever consumers share a query, and one object per consumer does not reach the
+target scale.
+
+**Cursor state in `create_sql`, or outside the catalog.** The former makes every
+flush a catalog transaction with an audit entry and a moving `SHOW CREATE`; the
+latter is cheapest per write but reintroduces two durable locations that must
+agree on create and drop.
+
+**Forbidding `AS OF` on the durable form.** Considered, because the `less_than`
+boundary makes a client-supplied timestamp a silent-data-loss pitfall, and
+because discarding on `mz_timestamp` covers the same need with a failure mode of
+redundancy rather than silence. Rejected because avoiding one documented pitfall
+is the only thing it buys, while the cost is real: a consumer that acknowledges
+lazily would re-receive its entire unacknowledged window on every reconnection,
+with no way to opt out. Two positioning conventions, an inclusive keyword for the
+durable form alongside the exclusive `AS OF` elsewhere, was also considered and
+rejected as worse than the pitfall, since it makes users learn a second
+convention that exists in exactly one place.
+
+**Non-exclusive readers.** Taking the maximum of concurrent acknowledgements
+needs no epoch, but two readers would advance each other's floor past unread
+data, which is undetectable data loss.
+
+**Advancing the hold on expiry instead of expiring the subscription.** Reclaims
+storage while keeping the subscription usable, at the cost of the client
+receiving a later stream and never learning a gap occurred.
+
+**Dropping the object on expiry.** Frees the name, but "does not exist" is
+indistinguishable from a typo, so the client cannot tell it must handle a gap.
+
+**`CopyBoth`.** The idiomatic PostgreSQL answer, with ordering for free. It does
+not exist in `src/pgwire/`, we are only a `CopyBoth` client against upstream
+PostgreSQL, it is absent from several major drivers and ack-only in others, and
+it inherits the walsender simple-query restriction and pooler refusal.
+
+## Follow-up work
+
+**A consistent cut across several collections.** One subscription over multiple
+collections sharing a position would deliver a resumable, consistent
+multi-relation cut, which is the capability that replication slots, warehouse
+change streams, and log-based consumer groups do not provide. The single-target
+design here is the smaller first step, and multiple targets extend the same hold
+and cursor machinery rather than requiring a different one.
+
+**As-of selection for newly created objects.** The quirk above is worth fixing
+on its own merits: a new dataflow needs a readable as-of, not the oldest
+readable one.
+
+**Relaxing sink input holds in general.** This design special-cases durable
+subscriptions because their consumer's position is known. The same reasoning may
+generalize to other sinks that track consumer progress.
+
+## Open questions
+
+* No tracking issue exists yet. One must be filed and linked above before this
+  document merges.
+* What are the default flush cadence, the minimum time to live as a multiple of
+  it, and the dyncfg ceiling on the time to live?
+* Can the durable attach be made to bypass index import cleanly, or does that
+  need a change to dataflow construction? This is the one implementation
+  question that could change the shape of the attach path.
+* How is the wall-clock time to live evaluated across a long environment
+  outage? Recording the last-acknowledgement time durably means a multi-hour
+  restart expires every subscription on boot, which is defensible but should be
+  a deliberate choice.
+* Is `ALTER DURABLE SUBSCRIPTION ... RESET` in the first release, or is `DROP`
+  and `CREATE` acceptable initially at the cost of re-granting privileges?
+* Can retained bytes be attributed to an individual subscription, or only to the
+  collection?
+* Which upper does acknowledgement validation compare against for a
+  transaction-managed table, logical or physical?
+* Once the WebSocket subscribe loop has a real reader, should liveness move from
+  writing pings to observing pongs?

--- a/doc/developer/design/20260825_durable_subscribe.md
+++ b/doc/developer/design/20260825_durable_subscribe.md
@@ -376,14 +376,19 @@ That yields three modes, spanning what a resuming client can want:
   operation the materialized view sink performs against its own output shard,
   and it is readable because the hold keeps `since <= H`.
 
-* **Restart.** `ALTER DURABLE SUBSCRIPTION ... RESET`, then attach. The client
+* **Restart**, available only for an expired subscription: `WITH (RESET)`, or
+  `ALTER DURABLE SUBSCRIPTION ... RESET` then attach. The client
   lost everything and wants current state. Reconciling at an old position would
   deliver historical state plus every diff since, which is strictly more work
   than a snapshot at the current time, and `RESET` already carries the right
   meaning: consent to a gap.
 
-Three modes across two statements, with no fourth mechanism. If a client
-reconciles when it meant to restart, the waste is bounded by the deadline.
+A live subscription deliberately cannot be fast-forwarded, by either spelling of
+`RESET`, because that would discard data it is still holding history for and
+would fence a reader that has not failed. A client that loses its local state
+while its subscription is live therefore reconciles rather than restarting, and
+pays a replay bounded by the deadline. That bound is what makes refusing the
+fast-forward affordable.
 
 `WITH (PROGRESS)` is required whenever the client intends to acknowledge. A
 progress message is the only thing that establishes that a timestamp is
@@ -493,15 +498,36 @@ current frontier, preserving identity, ownership, and grants, and making the
 client's consent to a gap explicit. `RESET` on a subscription that has not
 expired is an error, since it would silently fence a live reader.
 
-Consent may also be given **in band**, on the attach itself, as `WITH (RESET IF
-EXPIRED)`, meaning "if this subscription has expired, reset it, snapshot at the
-current time, and tell me you did". Every sync engine surveyed has such a signal, under
-names like `reset-required`, `must-refetch`, and `CLEAR`, because a server-side
-consumer recovering from an outage needs to recover in its reconnect path rather
-than by issuing a privileged data-definition statement. The loud-failure property
-is preserved either way: the default attach still fails, and the reset is
-reported to the client that asked for it rather than being silent. `ALTER ...
-RESET` remains for operators.
+Consent may also be given **in band**, so that a server-side consumer recovering
+from an outage needs no privileged data-definition statement in its reconnect
+path. Every sync engine surveyed has such a signal, under names like
+`reset-required`, `must-refetch`, and `CLEAR`. The mechanism is two attaches
+rather than one option:
+
+* A plain attach on an expired subscription **fails**, with an error
+  distinguishable from every other attach failure so a client can branch on it.
+* `SUBSCRIBE ... WITH (RESET)` resets the subscription to the current time and
+  delivers a snapshot there. It errors if the subscription has *not* expired, so
+  it cannot silently fence a live reader.
+
+Two statements rather than one, because of how a consumer knows it received a
+fresh snapshot rather than a continuation. A single reset-if-needed attach cannot
+tell it, and the stream has no channel for the answer: a snapshot is a batch of
+`+1` diffs at the as-of, indistinguishable from genuine insertions at that
+timestamp, and signalling it otherwise would mean either a new column on every
+`SUBSCRIBE` or a session notice, which is advisory and routinely ignored. With
+two attaches the client knows because it *asked*, having branched on the expiry
+error. One extra round trip, only on the rare expiry path, for an unambiguous
+answer.
+
+The opening progress message is a useful cross-check but not a substitute for
+this. `SUBSCRIBE`'s first emitted update is guaranteed to be a progress message
+carrying the as-of, so a client that retained its own last acknowledged position
+can compare the two and detect a gap. But a client that relies on the server to
+hold its position is exactly the one that may not have retained it, so the
+guarantee cannot carry the signal on its own.
+
+`ALTER ... RESET` remains for operators.
 
 ```mermaid
 stateDiagram-v2

--- a/doc/user/content/headless/sql-command-privileges/acknowledge.md
+++ b/doc/user/content/headless/sql-command-privileges/acknowledge.md
@@ -1,0 +1,5 @@
+---
+headless: true
+---
+- Ownership of the durable subscription.
+- `SELECT` privileges on the object it subscribes to.

--- a/doc/user/content/headless/sql-command-privileges/alter-durable-subscription.md
+++ b/doc/user/content/headless/sql-command-privileges/alter-durable-subscription.md
@@ -1,0 +1,4 @@
+---
+headless: true
+---
+- Ownership of the durable subscription.

--- a/doc/user/content/headless/sql-command-privileges/create-durable-subscription.md
+++ b/doc/user/content/headless/sql-command-privileges/create-durable-subscription.md
@@ -1,0 +1,6 @@
+---
+headless: true
+---
+- `CREATE` privileges on the containing schema.
+- `SELECT` privileges on the object being subscribed to.
+- `USAGE` privileges on the schema containing that object.

--- a/doc/user/content/headless/sql-command-privileges/drop-durable-subscription.md
+++ b/doc/user/content/headless/sql-command-privileges/drop-durable-subscription.md
@@ -1,0 +1,4 @@
+---
+headless: true
+---
+- Ownership of the durable subscription.

--- a/doc/user/content/sql/acknowledge.md
+++ b/doc/user/content/sql/acknowledge.md
@@ -6,6 +6,8 @@ menu:
     parent: 'commands'
 ---
 
+{{< private-preview />}}
+
 `ACKNOWLEDGE` tells Materialize how far you have processed a [durable
 subscription](/sql/create-durable-subscription/), which advances the position it
 resumes from and releases the history before it.
@@ -13,7 +15,7 @@ resumes from and releases the history before it.
 ## Syntax
 
 ```mzsql
-ACKNOWLEDGE DURABLE SUBSCRIPTION <name> AT <timestamp>
+ACKNOWLEDGE DURABLE SUBSCRIPTION <name> UP TO <timestamp>
 ;
 ```
 
@@ -30,18 +32,17 @@ Acknowledge the `mz_timestamp` of a progress message, which is why
 [`SUBSCRIBE`](/sql/subscribe/#progress) must be run `WITH (PROGRESS)` when you
 intend to acknowledge. A progress message with timestamp `t` means no further
 updates will arrive at times strictly before `t`, which is exactly the claim
-`ACKNOWLEDGE ... AT t` makes back to Materialize.
+`ACKNOWLEDGE ... UP TO t` makes back to Materialize. The bound is exclusive in
+both directions, so the number you read from the progress message is the number
+you send back unchanged.
 
 Do not acknowledge the timestamp of an ordinary row. Not every timestamp
 produces a progress message, and a row at time `t` does not mean that time `t`
 is complete, so acknowledging it can skip updates you have not seen.
 
-You do not have to subtract anything from the timestamp you acknowledge. When you
-resume without an explicit `AS OF`, Materialize positions the subscription so
-that you receive updates at and after the acknowledged time, whether or not you
-request a snapshot. The subtraction is only needed if you choose to pass [`AS
-OF`](/sql/create-durable-subscription/#where-reading-starts) yourself, which is
-an exclusive bound.
+`UP TO` is exclusive here for the same reason it is exclusive on
+[`SUBSCRIBE`](/sql/subscribe/#up-to), which makes the batch pattern symmetric:
+read `UP TO` a timestamp, then acknowledge `UP TO` that same timestamp.
 
 ### Order of operations
 
@@ -53,8 +54,8 @@ are gone and cannot be re-delivered.
 
 `ACKNOWLEDGE` is:
 
-*   **Monotone.** Acknowledging a timestamp at or below the current position has
-    no effect. It is not an error, so retrying is safe.
+*   **Monotone.** Acknowledging a timestamp at or below the current position is
+    accepted and has no effect, so retrying is safe.
 
 *   **Idempotent.** Sending the same acknowledgement twice is indistinguishable
     from sending it once.
@@ -63,8 +64,10 @@ are gone and cannot be re-delivered.
     not undone by `ROLLBACK`. This is deliberate: your data really was
     committed, so rolling back must not un-acknowledge it.
 
-Acknowledging a timestamp above the current time of the target object is an
-error.
+Acknowledging a timestamp beyond the object's write frontier is an error. The
+frontier is the largest timestamp for which the subscription could have sent you
+a progress message, and it is reported for every object in
+[`mz_internal.mz_frontiers`](/reference/system-catalog/mz_internal/#mz_frontiers).
 
 ### Where you can run it
 
@@ -78,30 +81,51 @@ Running `ACKNOWLEDGE` while no one is reading the subscription is allowed. This
 matters for the separate-connection case, where the reading connection may drop
 while an acknowledgement is in flight.
 
-### Effect on storage
+### Effect on resuming and on storage
 
-The acknowledged position determines how much history Materialize retains for
-the subscription. Acknowledging more often releases storage sooner; acknowledging
-less often reduces round trips but retains more. Materialize records the position
-durably on a short interval rather than on every statement, so history is
-released slightly after you acknowledge.
+The acknowledged position is where the subscription resumes, and it determines
+how much history Materialize retains. Acknowledging more often releases storage
+sooner and shortens the replay after a failure; acknowledging less often reduces
+round trips. Materialize records the position durably on a short interval rather
+than on every statement, so history is released slightly after you acknowledge.
+
+When you resume without an explicit `AS OF`, Materialize positions the
+subscription so that you receive updates at and after the acknowledged time. With
+`SNAPSHOT true` you receive the state *as of* that time, with updates at that
+time already folded in, followed by later updates. Either way you do not subtract
+anything. The subtraction is only needed if you choose to pass [`AS
+OF`](/sql/create-durable-subscription/#where-reading-starts-and-stops) yourself,
+which is an exclusive bound.
 
 ## Examples
-
-```mzsql
-ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed AT 1723459200000;
-```
 
 Acknowledging from a progress message received on the same connection:
 
 ```mzsql
 FETCH ALL c WITH (timeout = '1s');
---  mz_timestamp  | mz_progressed | mz_diff | ...
---  1723459200000 | t             |         |
-ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed AT 1723459200000;
 ```
+
+```nofmt
+ mz_timestamp  | mz_progressed | mz_diff | auction_id | amount
+---------------+---------------+---------+------------+--------
+ 1723459199000 | f             |       1 |          1 |     42
+ 1723459200000 | t             |         |            |
+```
+
+```mzsql
+ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed UP TO 1723459200000;
+```
+
+## Privileges
+
+The privileges required to execute this statement are:
+
+{{% include-headless "/headless/sql-command-privileges/acknowledge" %}}
 
 ## Related pages
 
 *   [`CREATE DURABLE SUBSCRIPTION`](/sql/create-durable-subscription/)
+*   [`ALTER DURABLE SUBSCRIPTION`](/sql/alter-durable-subscription/)
+*   [`DROP DURABLE SUBSCRIPTION`](/sql/drop-durable-subscription/)
 *   [`SUBSCRIBE`](/sql/subscribe/)
+*   [Resuming subscriptions](/transform-data/patterns/durable-subscriptions/)

--- a/doc/user/content/sql/acknowledge.md
+++ b/doc/user/content/sql/acknowledge.md
@@ -1,0 +1,107 @@
+---
+title: "ACKNOWLEDGE"
+description: "`ACKNOWLEDGE` advances the position of a durable subscription."
+menu:
+  main:
+    parent: 'commands'
+---
+
+`ACKNOWLEDGE` tells Materialize how far you have processed a [durable
+subscription](/sql/create-durable-subscription/), which advances the position it
+resumes from and releases the history before it.
+
+## Syntax
+
+```mzsql
+ACKNOWLEDGE DURABLE SUBSCRIPTION <name> AT <timestamp>
+;
+```
+
+| Field | Use |
+| --- | --- |
+| `<name>` | The durable subscription to advance. |
+| `<timestamp>` | An [`mz_timestamp`](/sql/types/mz_timestamp/). Asserts that you have durably processed every update at times **strictly before** this value. |
+
+## Details
+
+### What to acknowledge
+
+Acknowledge the `mz_timestamp` of a progress message, which is why
+[`SUBSCRIBE`](/sql/subscribe/#progress) must be run `WITH (PROGRESS)` when you
+intend to acknowledge. A progress message with timestamp `t` means no further
+updates will arrive at times strictly before `t`, which is exactly the claim
+`ACKNOWLEDGE ... AT t` makes back to Materialize.
+
+Do not acknowledge the timestamp of an ordinary row. Not every timestamp
+produces a progress message, and a row at time `t` does not mean that time `t`
+is complete, so acknowledging it can skip updates you have not seen.
+
+You do not have to subtract anything from the timestamp you acknowledge. When you
+resume without an explicit `AS OF`, Materialize positions the subscription so
+that you receive updates at and after the acknowledged time, whether or not you
+request a snapshot. The subtraction is only needed if you choose to pass [`AS
+OF`](/sql/create-durable-subscription/#where-reading-starts) yourself, which is
+an exclusive bound.
+
+### Order of operations
+
+Commit your data first, then acknowledge. If you acknowledge before your own
+processing is durable, and your application then fails, the acknowledged updates
+are gone and cannot be re-delivered.
+
+### Semantics
+
+`ACKNOWLEDGE` is:
+
+*   **Monotone.** Acknowledging a timestamp at or below the current position has
+    no effect. It is not an error, so retrying is safe.
+
+*   **Idempotent.** Sending the same acknowledgement twice is indistinguishable
+    from sending it once.
+
+*   **Not transactional.** The acknowledgement takes effect immediately and is
+    not undone by `ROLLBACK`. This is deliberate: your data really was
+    committed, so rolling back must not un-acknowledge it.
+
+Acknowledging a timestamp above the current time of the target object is an
+error.
+
+### Where you can run it
+
+`ACKNOWLEDGE` may be run on the same connection as the subscription, interleaved
+between `FETCH` statements, or on a separate connection. Because a subscription
+is named, no coordination between connections is needed, and because
+acknowledgements are monotone, they cannot arrive out of order in any way that
+matters.
+
+Running `ACKNOWLEDGE` while no one is reading the subscription is allowed. This
+matters for the separate-connection case, where the reading connection may drop
+while an acknowledgement is in flight.
+
+### Effect on storage
+
+The acknowledged position determines how much history Materialize retains for
+the subscription. Acknowledging more often releases storage sooner; acknowledging
+less often reduces round trips but retains more. Materialize records the position
+durably on a short interval rather than on every statement, so history is
+released slightly after you acknowledge.
+
+## Examples
+
+```mzsql
+ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed AT 1723459200000;
+```
+
+Acknowledging from a progress message received on the same connection:
+
+```mzsql
+FETCH ALL c WITH (timeout = '1s');
+--  mz_timestamp  | mz_progressed | mz_diff | ...
+--  1723459200000 | t             |         |
+ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed AT 1723459200000;
+```
+
+## Related pages
+
+*   [`CREATE DURABLE SUBSCRIPTION`](/sql/create-durable-subscription/)
+*   [`SUBSCRIBE`](/sql/subscribe/)

--- a/doc/user/content/sql/alter-durable-subscription.md
+++ b/doc/user/content/sql/alter-durable-subscription.md
@@ -1,45 +1,52 @@
 ---
 title: "ALTER DURABLE SUBSCRIPTION"
-description: "`ALTER DURABLE SUBSCRIPTION` changes the time to live of a durable subscription, or resets one that has expired."
+description: "`ALTER DURABLE SUBSCRIPTION` changes the acknowledgement deadline of a durable subscription, resets one that has expired, or transfers ownership."
 menu:
   main:
     parent: 'commands'
 ---
 
-`ALTER DURABLE SUBSCRIPTION` changes the time to live of a [durable
-subscription](/sql/create-durable-subscription/), or resets one that has
-expired.
+{{< private-preview />}}
+
+`ALTER DURABLE SUBSCRIPTION` changes the acknowledgement deadline of a [durable
+subscription](/sql/create-durable-subscription/), resets one that has expired, or
+transfers its ownership.
 
 ## Syntax
 
 ```mzsql
-ALTER DURABLE SUBSCRIPTION <name> SET (TTL = <interval>);
+ALTER DURABLE SUBSCRIPTION <name> SET (ACKNOWLEDGE WITHIN <interval>);
 ALTER DURABLE SUBSCRIPTION <name> RESET;
+ALTER DURABLE SUBSCRIPTION <name> OWNER TO <new_owner>;
 ```
 
 | Field | Use |
 | --- | --- |
-| `SET (TTL = <interval>)` | Change how long you have to acknowledge. Takes effect immediately, including for a subscription that is currently behind. |
+| `SET (ACKNOWLEDGE WITHIN <interval>)` | Change how long you may go without acknowledging. Takes effect immediately, including for a subscription that is currently behind. |
 | `RESET` | Re-arm an expired subscription at the current time. |
+| `OWNER TO <new_owner>` | Transfer ownership to another role. |
 
 ## Details
 
-### Setting the time to live
+### Changing the acknowledgement deadline
 
-Increasing the `TTL` gives a reader more time to recover, and increases the
+Increasing the deadline gives a reader more time to recover, and increases the
 history that may be retained on its behalf. Decreasing it can expire a
-subscription immediately, if the reader is already further behind than the new
-value allows.
+subscription immediately, if the reader has already gone longer than the new
+value without acknowledging.
 
-The `TTL` must remain above the system-wide minimum, which exists because the
-acknowledged position is recorded durably on an interval. A time to live close to
-that interval would expire readers that are acknowledging correctly.
+The value must fall between the system-wide minimum and maximum, the same bounds
+[`CREATE DURABLE SUBSCRIPTION`](/sql/create-durable-subscription/#acknowledgement-deadline)
+enforces. A minimum exists because the acknowledged position is recorded durably
+on an interval, so a deadline close to that interval would expire readers that
+are acknowledging correctly.
 
 ### Resetting an expired subscription
 
-`RESET` moves an expired subscription back to the current time and makes it
-usable again. It does not recover the history that was released when the
-subscription expired, so the next read must request a snapshot.
+`RESET` moves an expired subscription to the current time and makes it usable
+again. It does not recover the history that was released when the subscription
+expired, so the next read must request `SNAPSHOT true` to get a usable starting
+state.
 
 Use `RESET` rather than dropping and recreating: it preserves the subscription's
 name, owner, and privileges. Requiring it, instead of silently resuming from
@@ -52,14 +59,27 @@ by resetting its position is not something to do by accident.
 ## Examples
 
 ```mzsql
-ALTER DURABLE SUBSCRIPTION winning_bids_feed SET (TTL = '5m');
+ALTER DURABLE SUBSCRIPTION winning_bids_feed SET (ACKNOWLEDGE WITHIN '5m');
 ```
 
 ```mzsql
 ALTER DURABLE SUBSCRIPTION winning_bids_feed RESET;
 ```
 
+```mzsql
+ALTER DURABLE SUBSCRIPTION winning_bids_feed OWNER TO analytics_owner;
+```
+
+## Privileges
+
+The privileges required to execute this statement are:
+
+{{% include-headless "/headless/sql-command-privileges/alter-durable-subscription" %}}
+
 ## Related pages
 
 *   [`CREATE DURABLE SUBSCRIPTION`](/sql/create-durable-subscription/)
+*   [`ACKNOWLEDGE`](/sql/acknowledge/)
 *   [`DROP DURABLE SUBSCRIPTION`](/sql/drop-durable-subscription/)
+*   [`SUBSCRIBE`](/sql/subscribe/)
+*   [Resuming subscriptions](/transform-data/patterns/durable-subscriptions/)

--- a/doc/user/content/sql/alter-durable-subscription.md
+++ b/doc/user/content/sql/alter-durable-subscription.md
@@ -1,0 +1,65 @@
+---
+title: "ALTER DURABLE SUBSCRIPTION"
+description: "`ALTER DURABLE SUBSCRIPTION` changes the time to live of a durable subscription, or resets one that has expired."
+menu:
+  main:
+    parent: 'commands'
+---
+
+`ALTER DURABLE SUBSCRIPTION` changes the time to live of a [durable
+subscription](/sql/create-durable-subscription/), or resets one that has
+expired.
+
+## Syntax
+
+```mzsql
+ALTER DURABLE SUBSCRIPTION <name> SET (TTL = <interval>);
+ALTER DURABLE SUBSCRIPTION <name> RESET;
+```
+
+| Field | Use |
+| --- | --- |
+| `SET (TTL = <interval>)` | Change how long you have to acknowledge. Takes effect immediately, including for a subscription that is currently behind. |
+| `RESET` | Re-arm an expired subscription at the current time. |
+
+## Details
+
+### Setting the time to live
+
+Increasing the `TTL` gives a reader more time to recover, and increases the
+history that may be retained on its behalf. Decreasing it can expire a
+subscription immediately, if the reader is already further behind than the new
+value allows.
+
+The `TTL` must remain above the system-wide minimum, which exists because the
+acknowledged position is recorded durably on an interval. A time to live close to
+that interval would expire readers that are acknowledging correctly.
+
+### Resetting an expired subscription
+
+`RESET` moves an expired subscription back to the current time and makes it
+usable again. It does not recover the history that was released when the
+subscription expired, so the next read must request a snapshot.
+
+Use `RESET` rather than dropping and recreating: it preserves the subscription's
+name, owner, and privileges. Requiring it, instead of silently resuming from
+whatever history happens to remain, is what keeps a gap in the data from passing
+unnoticed.
+
+`RESET` on a subscription that has not expired is an error. Fencing a live reader
+by resetting its position is not something to do by accident.
+
+## Examples
+
+```mzsql
+ALTER DURABLE SUBSCRIPTION winning_bids_feed SET (TTL = '5m');
+```
+
+```mzsql
+ALTER DURABLE SUBSCRIPTION winning_bids_feed RESET;
+```
+
+## Related pages
+
+*   [`CREATE DURABLE SUBSCRIPTION`](/sql/create-durable-subscription/)
+*   [`DROP DURABLE SUBSCRIPTION`](/sql/drop-durable-subscription/)

--- a/doc/user/content/sql/create-durable-subscription.md
+++ b/doc/user/content/sql/create-durable-subscription.md
@@ -1,0 +1,353 @@
+---
+title: "CREATE DURABLE SUBSCRIPTION"
+description: "`CREATE DURABLE SUBSCRIPTION` creates a named, resumable subscription whose progress Materialize tracks for you."
+menu:
+  main:
+    parent: 'commands'
+---
+
+`CREATE DURABLE SUBSCRIPTION` creates a named subscription that Materialize can
+resume. Materialize tracks how far you have processed, and retains exactly the
+history you still need.
+
+## Conceptual framework
+
+A plain [`SUBSCRIBE`](/sql/subscribe/) has no memory. If the connection drops,
+the next `SUBSCRIBE` starts over, and unless you configured a [history retention
+period](/transform-data/patterns/durable-subscriptions/) and recorded your own
+timestamps, it starts over with a full snapshot.
+
+A durable subscription moves both of those responsibilities into Materialize:
+
+*   **Materialize remembers your position.** You acknowledge what you have
+    processed with [`ACKNOWLEDGE`](/sql/acknowledge/), and Materialize stores
+    that position durably. Your application does not need to persist a
+    timestamp, which matters for clients that have nowhere durable to put one,
+    such as a browser or an edge function.
+
+*   **Materialize retains exactly the history you need.** The acknowledged
+    position, not a fixed duration, determines how much history is kept. You do
+    not have to guess a history retention period that is long enough to cover
+    an outage but short enough to afford.
+
+The trade for that convenience is delivery semantics. A durable subscription is
+**at-least-once**: after you reconnect, you may see updates you already
+processed. See [Delivery semantics](#delivery-semantics).
+
+## Syntax
+
+```mzsql
+CREATE DURABLE SUBSCRIPTION <name> ON <object_name>
+WITH (TTL = <interval>)
+;
+
+CREATE DURABLE SUBSCRIPTION <name>
+WITH (TTL = <interval>) AS
+SELECT <columns> FROM <object_name> [WHERE <predicate>]
+;
+```
+
+| Field | Use |
+| --- | --- |
+| `<name>` | A name for the subscription. Used by [`SUBSCRIBE`](/sql/subscribe/) and [`ACKNOWLEDGE`](/sql/acknowledge/). |
+| `<object_name>` | The source, table, or materialized view to subscribe to. |
+| `TTL` | **Required.** How long you have to acknowledge. A positive [interval](/sql/types/interval/) value, for example `'1m'`. See [Time to live](#time-to-live). |
+| `AS SELECT ...` | An optional projection and filter over a single object. See [Supported objects and queries](#supported-objects-and-queries). |
+
+## Details
+
+### Supported objects and queries
+
+A durable subscription can target a source, a table, or a materialized view.
+Views and indexes are not supported, because Materialize cannot durably retain
+history for them.
+
+The `AS SELECT` form accepts a projection and a filter over a **single** object,
+which Materialize evaluates while reading it. This covers selecting a subset of
+columns, computing derived columns, and filtering rows. It does not create a
+dataflow and adds no compute cost, which is why it does not change the resume
+behavior described below.
+
+Anything more than that is rejected, including joins, aggregations, `DISTINCT`,
+subqueries, and more than one object in the `FROM` clause. Temporal filters,
+meaning predicates over [`mz_now()`](/sql/functions/now_and_mz_now/), are also
+rejected. To subscribe durably to a query of that kind, create a [materialized
+view](/sql/create-materialized-view/) for it and target the view. That is also
+the faster option at resume time: resuming against a stored collection reads
+recent data from storage, whereas subscribing to a query builds a new dataflow
+that must rehydrate first.
+
+A projection can cause distinct rows to become identical, in which case their
+changes combine. The result is still a correct stream of changes to the
+projected relation.
+
+If the projection or filter produces an error for some row, for example a
+division by zero, the subscription returns that error. Your position is
+unchanged, because only [`ACKNOWLEDGE`](/sql/acknowledge/) moves it, so
+reconnecting returns the same error until the offending data changes.
+
+### Time to live
+
+`TTL` is the maximum time you may go without acknowledging. It bounds both your
+exposure and Materialize's storage:
+
+*   If you acknowledge within the `TTL`, Materialize guarantees that the
+    unacknowledged history is still available when you reconnect.
+
+*   If you do not, the subscription **expires**. Materialize stops retaining
+    history for it, and the next attempt to use it fails with an error rather
+    than silently skipping the gap. See [Expiry](#expiry).
+
+Choose a `TTL` that covers the outages you expect to recover from, plus the time
+your application needs to restart. A minute is a reasonable starting point for
+an interactive client. There is a system-wide maximum; ask your administrator if
+you need a longer one.
+
+A durable subscription retains history from the moment you create it, whether or
+not anything is reading from it. Creating one and never using it retains history
+until the `TTL` expires it.
+
+History is retained for the object according to the **furthest behind** of its
+readers. If several durable subscriptions target one object, one reader that
+stops acknowledging holds history for all of them until its `TTL` expires it.
+Keep the `TTL` no longer than you need for this reason, not only for your own
+storage.
+
+### Intended use
+
+Create a durable subscription per logical consumer, once, and reuse it across
+reconnections. It is a provisioned resource, like a table or a view: it is
+recorded durably, it appears in the catalog, and creating or dropping one is a
+data definition statement.
+
+Do not create one per page load or per session. Creating and dropping thousands
+of short-lived subscriptions is far more expensive than reusing a few long-lived
+ones, and every subscription that exists adds to startup work. Give each
+consumer a stable name and reconnect to it.
+
+### Expiry
+
+When a subscription expires, it is not dropped. It remains visible in
+[`mz_internal.mz_durable_subscriptions`](#monitoring), showing the position it
+expired at and how long it had gone without acknowledging, so you can tell an
+expiry apart from a subscription that never existed.
+
+Attempting to subscribe using an expired subscription returns an error. To start
+using it again, run [`ALTER DURABLE SUBSCRIPTION ... RESET`](/sql/alter-durable-subscription/),
+which re-arms it at the current time. Resetting acknowledges that you are
+accepting a gap in the data and will need a new snapshot.
+
+### Progress messages are required
+
+Subscribe `WITH (PROGRESS)` whenever you intend to acknowledge. A progress
+message is the only thing that tells you a timestamp is complete, and therefore
+the only safe thing to acknowledge. Not every timestamp produces a progress
+message, and receiving a row at time `t` does not mean that time `t` is
+finished, so acknowledging a row's timestamp can skip updates you have not seen.
+
+### Where reading starts
+
+By default, omit `AS OF` and Materialize resumes from the position you last
+acknowledged, computing the boundary so that you receive updates at and after
+that position. This requires nothing from you and is the recommended path.
+
+You may pass `AS OF` to start somewhere else inside the retained history, which
+is useful if you track your own position and are further along than your last
+acknowledgement. It behaves exactly as it does for a plain
+[`SUBSCRIBE`](/sql/subscribe/#as-of).
+
+{{< warning >}}
+
+`AS OF` is an **exclusive** lower bound under `SNAPSHOT false`: `SUBSCRIBE` emits
+updates at times *strictly greater* than the timestamp you pass. To receive
+updates at time `T`, pass `AS OF T - 1`. Passing `T` silently skips every update
+at `T`.
+
+If you would rather not carry that arithmetic, omit `AS OF` and filter instead.
+Every update carries `mz_timestamp`, so a consumer that has committed through `T`
+can drop everything below `T` on arrival. Receiving data you already have costs
+bandwidth; asking for the wrong starting timestamp costs data.
+
+{{</ warning >}}
+
+`UP TO` is also accepted, and is useful for draining a bounded batch: read up to
+a timestamp, commit, acknowledge that same timestamp, and disconnect.
+
+### Snapshots
+
+`SNAPSHOT` defaults to **`false`** here, which is the opposite of a plain
+[`SUBSCRIBE`](/sql/subscribe/#snapshot). Resuming without re-snapshotting is the
+purpose of a durable subscription, so it is the default.
+
+A requested snapshot is taken **at your acknowledged position**, not at the
+current time, so that the state you receive corresponds to a position you can
+name. That gives three ways to reconnect:
+
+*   **Continue**, with `SNAPSHOT false`. You hold state at or past your
+    acknowledged position and want the changes since. This is the default and
+    the common case.
+
+*   **Reconcile**, with `SNAPSHOT true`. You know your position but suspect your
+    local state has drifted. You receive the authoritative state as of your
+    acknowledged position, which you can compare against what you hold, followed
+    by subsequent changes.
+
+*   **Start over**, with [`ALTER DURABLE SUBSCRIPTION ...
+    RESET`](/sql/alter-durable-subscription/) and then subscribing. You have lost
+    your local state and want current data. Reconciling at an old position would
+    hand you historical state plus every change since, which is more work than
+    starting fresh.
+
+### Delivery semantics
+
+A durable subscription delivers **at least once**. You process a batch, commit
+it, and then acknowledge. If your application fails between the commit and the
+acknowledgement, Materialize still has the older position, so it re-sends
+updates you already processed.
+
+Your consumer must therefore be idempotent. Deduplicate on the combination of
+`mz_timestamp` and the row, and do not treat the stream as an event log: after a
+resume, the same logical change may arrive consolidated differently than it did
+the first time.
+
+{{< important >}}
+
+If you need **exactly-once** processing, keep recording your own progress
+timestamp and writing it in the same transaction as the data it covers, as
+described in [Durable
+subscriptions](/transform-data/patterns/durable-subscriptions/#note-about-idempotency).
+
+You can still use a durable subscription for this. Acknowledge as normal to
+control how much history is retained, and on reconnection discard every update
+below your own committed timestamp. Materialize supplies the guarantee that the
+history is still there; your recorded timestamp supplies the deduplication.
+
+{{</ important >}}
+
+### Privileges
+
+Creating a durable subscription requires `SELECT` on the target object.
+`SELECT` is checked again each time you subscribe, so revoking it stops an
+existing subscription from being used.
+
+Dropping the target object fails while a durable subscription exists on it,
+unless you use `CASCADE`.
+
+Changing the target's columns, for example with `ALTER TABLE ... ADD COLUMN`,
+expires every durable subscription on it. The shape of the stream cannot change
+underneath a reader.
+
+### Monitoring
+
+`mz_internal.mz_durable_subscriptions` reports each subscription's acknowledged
+position, how long it has gone without acknowledging, how far behind the object
+it is, and whether it has expired. Use it to find subscriptions that are holding
+history:
+
+```mzsql
+SELECT name, target, acknowledged_at, time_since_ack, lag, state
+FROM mz_internal.mz_durable_subscriptions
+ORDER BY time_since_ack DESC;
+```
+
+`time_since_ack` is what the `TTL` is compared against, so it is the column that
+predicts an expiry. `lag` is the distance to the object's current time, which is
+what predicts how much data a reconnection will replay.
+
+This relation is distinct from
+[`mz_internal.mz_subscriptions`](/reference/system-catalog/mz_internal/#mz_subscriptions),
+which lists `SUBSCRIBE` statements that are running right now. A durable
+subscription appears in `mz_durable_subscriptions` whether or not anything is
+currently reading from it.
+
+## Examples
+
+### Create a subscription
+
+```mzsql
+CREATE DURABLE SUBSCRIPTION winning_bids_feed
+ON winning_bids
+WITH (TTL = '1m');
+```
+
+### Read from it the first time
+
+The first time you read, request a snapshot to bootstrap your application.
+`PROGRESS` is required, because progress messages are what tell you a timestamp
+is complete and therefore safe to acknowledge.
+
+```mzsql
+BEGIN;
+DECLARE c CURSOR FOR
+  SUBSCRIBE USING DURABLE SUBSCRIPTION winning_bids_feed
+  WITH (PROGRESS, SNAPSHOT true);
+```
+
+Then loop: fetch a batch, and buffer it until a progress message arrives.
+
+```mzsql
+FETCH ALL c WITH (timeout = '1s');
+```
+
+When you receive a row with `mz_progressed` set to `true`, everything before its
+`mz_timestamp` is complete. Process the buffered data, commit it, and then
+acknowledge that timestamp on the same connection:
+
+```mzsql
+ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed AT 1723459200000;
+```
+
+You do not need to acknowledge every progress message. Acknowledging less often
+reduces round trips, at the cost of re-processing more data after a failure and
+retaining more history in the meantime.
+
+### Resume after a disconnection
+
+Reconnect and subscribe again, this time without a snapshot. You do not supply a
+timestamp, because Materialize has it:
+
+```mzsql
+BEGIN;
+DECLARE c CURSOR FOR
+  SUBSCRIBE USING DURABLE SUBSCRIPTION winning_bids_feed
+  WITH (PROGRESS, SNAPSHOT false);
+```
+
+The first message you receive is a progress message carrying the timestamp the
+subscription resumed at, so your application can confirm it matches what it
+expected.
+
+If your application also lost its local state, request `SNAPSHOT true` instead.
+You then receive a snapshot as of the acknowledged position, followed by
+subsequent updates.
+
+### Only one reader at a time
+
+A durable subscription has a single position, so only one reader may use it at a
+time. Subscribing again takes over: the new reader starts streaming and the
+previous reader's stream fails with an error.
+
+This is deliberate. It means a client that reconnects does not have to wait for
+its own abandoned connection to time out. It also means you should not point two
+application instances at the same durable subscription, and if you do, they will
+take turns rather than share the work.
+
+### Acknowledging from another connection
+
+If you read with a streaming `SUBSCRIBE` rather than `DECLARE` and `FETCH`, the
+PostgreSQL protocol does not allow you to send anything on that connection while
+results are streaming. Acknowledge from a second connection instead. A
+subscription is addressed by name, so no coordination between the connections is
+needed:
+
+```mzsql
+ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed AT 1723459200000;
+```
+
+## Related pages
+
+*   [`ACKNOWLEDGE`](/sql/acknowledge/)
+*   [`ALTER DURABLE SUBSCRIPTION`](/sql/alter-durable-subscription/)
+*   [`DROP DURABLE SUBSCRIPTION`](/sql/drop-durable-subscription/)
+*   [`SUBSCRIBE`](/sql/subscribe/)
+*   [Durable subscriptions](/transform-data/patterns/durable-subscriptions/)

--- a/doc/user/content/sql/create-durable-subscription.md
+++ b/doc/user/content/sql/create-durable-subscription.md
@@ -151,10 +151,18 @@ When a subscription expires, it is not dropped. It remains visible in
 expired at and how long it had gone without acknowledging, so you can tell an
 expiry apart from a subscription that never existed.
 
-Attempting to subscribe using an expired subscription returns an error. To start
-using it again, run [`ALTER DURABLE SUBSCRIPTION ... RESET`](/sql/alter-durable-subscription/),
-which re-arms it at the current time. Resetting acknowledges that you are
-accepting a gap in the data and will need a new snapshot.
+Attempting to subscribe using an expired subscription returns an error. There are
+two ways to start using it again, and both require you to accept that there is a
+gap in the data:
+
+*   Run [`ALTER DURABLE SUBSCRIPTION ... RESET`](/sql/alter-durable-subscription/),
+    which re-arms it at the current time. You then subscribe with `SNAPSHOT true`
+    to get a usable starting state.
+
+*   Subscribe with `WITH (RESET IF EXPIRED)`, which resets the subscription in
+    the same statement if it has expired and reports that it did so. This is the
+    option to use in an automated reconnect path, since it needs no separate
+    privileged statement.
 
 ### Acknowledging requires progress messages
 
@@ -231,10 +239,23 @@ it, and then acknowledge. If your application fails between the commit and the
 acknowledgement, Materialize still has the older position, so it re-sends
 updates you already processed.
 
-Your consumer must therefore be idempotent. Deduplicate on the combination of
-`mz_timestamp` and the row, and do not treat the stream as an event log: after a
-resume, the same logical change may arrive consolidated differently than it did
-the first time.
+Your consumer must therefore be idempotent, and the unit of idempotence is the
+**timestamp**, not the row. Apply all the updates at one `mz_timestamp`
+together, record that you applied it, and skip timestamps you have already
+applied. Resuming always starts on a timestamp boundary, so anything re-sent is
+re-sent as whole timestamps.
+
+Do not deduplicate on the combination of `mz_timestamp` and the row. After a
+resume the same logical change may arrive consolidated differently than it did
+the first time, so per-row comparison cannot distinguish a re-delivery from a
+genuine second change. For the same reason, do not treat the stream as an event
+log.
+
+Materialize does not enforce uniqueness, since tables support neither [primary
+keys nor unique constraints](/sql/create-table/#known-limitations). If you apply
+updates into a keyed store, you are responsible for the key being unique in the
+subscribed data. Note that a projection in the `AS SELECT` form can make
+distinct rows identical, which combines their changes.
 
 {{< important >}}
 
@@ -266,10 +287,6 @@ take turns rather than share the work.
 
 Dropping the target object fails while a durable subscription exists on it,
 unless you use `CASCADE`.
-
-Changing the target's columns, for example with `ALTER TABLE ... ADD COLUMN`,
-expires every durable subscription on it. The shape of the stream cannot change
-underneath a reader.
 
 `SELECT` on the target is checked each time you subscribe, not only when you
 create the subscription, so revoking it stops an existing subscription from

--- a/doc/user/content/sql/create-durable-subscription.md
+++ b/doc/user/content/sql/create-durable-subscription.md
@@ -151,18 +151,33 @@ When a subscription expires, it is not dropped. It remains visible in
 expired at and how long it had gone without acknowledging, so you can tell an
 expiry apart from a subscription that never existed.
 
-Attempting to subscribe using an expired subscription returns an error. There are
-two ways to start using it again, and both require you to accept that there is a
-gap in the data:
+Attempting to subscribe using an expired subscription returns a distinguishable
+error, so an automated reconnect can branch on it. There are two ways to start
+using the subscription again, and both require you to accept that there is a gap
+in the data:
+
+*   Subscribe `WITH (RESET)`, which resets the subscription to the current time
+    and delivers a snapshot there. Use this in a reconnect path: it needs no
+    privileged statement, and because you asked for it, you know the data you
+    receive is a fresh snapshot rather than a continuation. It returns an error
+    if the subscription has not expired, so it cannot displace a live reader by
+    accident.
 
 *   Run [`ALTER DURABLE SUBSCRIPTION ... RESET`](/sql/alter-durable-subscription/),
     which re-arms it at the current time. You then subscribe with `SNAPSHOT true`
-    to get a usable starting state.
+    to get a usable starting state. This is the operator path.
 
-*   Subscribe with `WITH (RESET IF EXPIRED)`, which resets the subscription in
-    the same statement if it has expired and reports that it did so. This is the
-    option to use in an automated reconnect path, since it needs no separate
-    privileged statement.
+{{< note >}}
+
+Do not try to detect a reset by inspecting the stream. A snapshot arrives as
+ordinary insertions at the resume timestamp, so it cannot be told apart from real
+inserts at that time. Ask for the reset explicitly, and you know what you got.
+
+If you do keep your own record of the last position you acknowledged, you can
+cross-check it: the first message of any subscribe is a progress message carrying
+the timestamp the subscription resumed at.
+
+{{</ note >}}
 
 ### Acknowledging requires progress messages
 
@@ -225,12 +240,17 @@ name. That gives three ways to reconnect:
     acknowledged position, which you can compare against what you hold, followed
     by subsequent changes.
 
-*   **Start over**, with [`ALTER DURABLE SUBSCRIPTION ...
-    RESET`](/sql/alter-durable-subscription/) and then subscribing `WITH
-    (SNAPSHOT true)`. You have lost your local state and want current data.
-    `RESET` moves the position to the current time, so the snapshot is taken
-    there. Reconciling at an old position instead would hand you historical
-    state plus every change since, which is more work than starting fresh.
+*   **Start over**, which applies only to a subscription that has
+    [expired](#expiry). Subscribe `WITH (RESET)`, or run [`ALTER DURABLE
+    SUBSCRIPTION ... RESET`](/sql/alter-durable-subscription/) and then subscribe
+    `WITH (SNAPSHOT true)`. Either moves the position to the current time, so the
+    snapshot is taken there.
+
+A subscription that has *not* expired cannot be fast-forwarded, because doing so
+would discard data it is still holding history for. If you lost your local state
+while the subscription is still live, reconcile instead: you receive the state at
+your acknowledged position and then replay from there, and that replay is bounded
+by `ACKNOWLEDGE WITHIN`.
 
 ### Delivery semantics
 

--- a/doc/user/content/sql/create-durable-subscription.md
+++ b/doc/user/content/sql/create-durable-subscription.md
@@ -6,6 +6,8 @@ menu:
     parent: 'commands'
 ---
 
+{{< private-preview />}}
+
 `CREATE DURABLE SUBSCRIPTION` creates a named subscription that Materialize can
 resume. Materialize tracks how far you have processed, and retains exactly the
 history you still need.
@@ -19,11 +21,11 @@ timestamps, it starts over with a full snapshot.
 
 A durable subscription moves both of those responsibilities into Materialize:
 
-*   **Materialize remembers your position.** You acknowledge what you have
-    processed with [`ACKNOWLEDGE`](/sql/acknowledge/), and Materialize stores
-    that position durably. Your application does not need to persist a
-    timestamp, which matters for clients that have nowhere durable to put one,
-    such as a browser or an edge function.
+*   **Materialize remembers your position.** You report progress with
+    [`ACKNOWLEDGE`](/sql/acknowledge/), and Materialize stores that position
+    durably. Your application does not need to persist a timestamp, which
+    matters for clients that have nowhere durable to put one, such as a browser
+    or an edge function.
 
 *   **Materialize retains exactly the history you need.** The acknowledged
     position, not a fixed duration, determines how much history is kept. You do
@@ -38,11 +40,11 @@ processed. See [Delivery semantics](#delivery-semantics).
 
 ```mzsql
 CREATE DURABLE SUBSCRIPTION <name> ON <object_name>
-WITH (TTL = <interval>)
+WITH (ACKNOWLEDGE WITHIN <interval>)
 ;
 
 CREATE DURABLE SUBSCRIPTION <name>
-WITH (TTL = <interval>) AS
+WITH (ACKNOWLEDGE WITHIN <interval>) AS
 SELECT <columns> FROM <object_name> [WHERE <predicate>]
 ;
 ```
@@ -51,24 +53,33 @@ SELECT <columns> FROM <object_name> [WHERE <predicate>]
 | --- | --- |
 | `<name>` | A name for the subscription. Used by [`SUBSCRIBE`](/sql/subscribe/) and [`ACKNOWLEDGE`](/sql/acknowledge/). |
 | `<object_name>` | The source, table, or materialized view to subscribe to. |
-| `TTL` | **Required.** How long you have to acknowledge. A positive [interval](/sql/types/interval/) value, for example `'1m'`. See [Time to live](#time-to-live). |
+| `ACKNOWLEDGE WITHIN` | **Required.** How long you may go without acknowledging. A positive [interval](/sql/types/interval/) value, for example `'1m'`. See [Acknowledgement deadline](#acknowledgement-deadline). |
 | `AS SELECT ...` | An optional projection and filter over a single object. See [Supported objects and queries](#supported-objects-and-queries). |
 
 ## Details
 
+### Starting position
+
+A new subscription's position is the time at which you created it, and its
+acknowledgement deadline starts running from then. Reading it for the first time
+therefore gives you the state as of creation, not as of now, so create a
+subscription at the point you are ready to start consuming rather than well in
+advance.
+
 ### Supported objects and queries
 
 A durable subscription can target a source, a table, or a materialized view.
-Views and indexes are not supported, because Materialize cannot durably retain
-history for them.
+Neither views nor indexes are supported, for different reasons: a view stores no
+data at all, and an index lives in the memory of a single cluster, so in neither
+case is there durable history to retain.
 
-The `AS SELECT` form accepts a projection and a filter over a **single** object,
-which Materialize evaluates while reading it. This covers selecting a subset of
-columns, computing derived columns, and filtering rows. It does not create a
-dataflow and adds no compute cost, which is why it does not change the resume
-behavior described below.
+The `AS SELECT` form accepts a projection and a filter over a **single** object.
+Materialize evaluates them while reading the object, so this form builds no
+dataflow, adds no compute cost, and resumes exactly as the `ON <object_name>`
+form does. This covers selecting a subset of columns, computing derived columns,
+and filtering rows.
 
-Anything more than that is rejected, including joins, aggregations, `DISTINCT`,
+Anything more is rejected, including joins, aggregations, `DISTINCT`,
 subqueries, and more than one object in the `FROM` clause. Temporal filters,
 meaning predicates over [`mz_now()`](/sql/functions/now_and_mz_now/), are also
 rejected. To subscribe durably to a query of that kind, create a [materialized
@@ -86,34 +97,42 @@ division by zero, the subscription returns that error. Your position is
 unchanged, because only [`ACKNOWLEDGE`](/sql/acknowledge/) moves it, so
 reconnecting returns the same error until the offending data changes.
 
-### Time to live
+### Acknowledgement deadline
 
-`TTL` is the maximum time you may go without acknowledging. It bounds both your
-exposure and Materialize's storage:
+`ACKNOWLEDGE WITHIN` is the maximum time you may go without acknowledging,
+measured on the wall clock:
 
-*   If you acknowledge within the `TTL`, Materialize guarantees that the
+*   If you acknowledge within it, Materialize guarantees that the
     unacknowledged history is still available when you reconnect.
 
 *   If you do not, the subscription **expires**. Materialize stops retaining
     history for it, and the next attempt to use it fails with an error rather
     than silently skipping the gap. See [Expiry](#expiry).
 
-Choose a `TTL` that covers the outages you expect to recover from, plus the time
+Choose a value that covers the outages you expect to recover from, plus the time
 your application needs to restart. A minute is a reasonable starting point for
-an interactive client. There is a system-wide maximum; ask your administrator if
-you need a longer one.
+an interactive client. There is a system-wide minimum and maximum; ask your
+administrator if you need a value outside them.
 
 A durable subscription retains history from the moment you create it, whether or
 not anything is reading from it. Creating one and never using it retains history
-until the `TTL` expires it.
+until the deadline expires it.
 
-History is retained for the object according to the **furthest behind** of its
-readers. If several durable subscriptions target one object, one reader that
-stops acknowledging holds history for all of them until its `TTL` expires it.
-Keep the `TTL` no longer than you need for this reason, not only for your own
-storage.
+Retention has two costs beyond your own storage, both of which argue for keeping
+the deadline short:
 
-### Intended use
+*   **History is retained for the object according to the furthest behind of
+    its readers.** If several durable subscriptions target one object, one
+    reader that stops acknowledging holds history for all of them until its
+    deadline expires it.
+
+*   **Objects created later must process the retained history.** A
+    [`CREATE MATERIALIZED VIEW`](/sql/create-materialized-view/),
+    [`CREATE INDEX`](/sql/create-index/), or [`CREATE SINK`](/sql/create-sink/)
+    over the same object starts from the oldest time still retained, so a
+    lagging subscription makes those statements backfill more data.
+
+### Create one subscription per consumer
 
 Create a durable subscription per logical consumer, once, and reuse it across
 reconnections. It is a provisioned resource, like a table or a view: it is
@@ -137,7 +156,7 @@ using it again, run [`ALTER DURABLE SUBSCRIPTION ... RESET`](/sql/alter-durable-
 which re-arms it at the current time. Resetting acknowledges that you are
 accepting a gap in the data and will need a new snapshot.
 
-### Progress messages are required
+### Acknowledging requires progress messages
 
 Subscribe `WITH (PROGRESS)` whenever you intend to acknowledge. A progress
 message is the only thing that tells you a timestamp is complete, and therefore
@@ -145,7 +164,7 @@ the only safe thing to acknowledge. Not every timestamp produces a progress
 message, and receiving a row at time `t` does not mean that time `t` is
 finished, so acknowledging a row's timestamp can skip updates you have not seen.
 
-### Where reading starts
+### Where reading starts and stops
 
 By default, omit `AS OF` and Materialize resumes from the position you last
 acknowledged, computing the boundary so that you receive updates at and after
@@ -170,8 +189,14 @@ bandwidth; asking for the wrong starting timestamp costs data.
 
 {{</ warning >}}
 
-`UP TO` is also accepted, and is useful for draining a bounded batch: read up to
-a timestamp, commit, acknowledge that same timestamp, and disconnect.
+`UP TO` bounds where reading stops, exclusively, and is useful for draining a
+bounded batch: read `UP TO` a timestamp, commit, acknowledge `UP TO` that same
+timestamp, and disconnect.
+
+`ENVELOPE UPSERT`, `ENVELOPE DEBEZIUM`, and `AS OF AT LEAST` are not supported
+on a durable subscription. The envelopes cannot be produced correctly when
+resuming without a snapshot, because neither the sink nor Materialize holds the
+prior value for a key the resumed stream has not seen.
 
 ### Snapshots
 
@@ -193,10 +218,11 @@ name. That gives three ways to reconnect:
     by subsequent changes.
 
 *   **Start over**, with [`ALTER DURABLE SUBSCRIPTION ...
-    RESET`](/sql/alter-durable-subscription/) and then subscribing. You have lost
-    your local state and want current data. Reconciling at an old position would
-    hand you historical state plus every change since, which is more work than
-    starting fresh.
+    RESET`](/sql/alter-durable-subscription/) and then subscribing `WITH
+    (SNAPSHOT true)`. You have lost your local state and want current data.
+    `RESET` moves the position to the current time, so the snapshot is taken
+    there. Reconciling at an old position instead would hand you historical
+    state plus every change since, which is more work than starting fresh.
 
 ### Delivery semantics
 
@@ -214,21 +240,29 @@ the first time.
 
 If you need **exactly-once** processing, keep recording your own progress
 timestamp and writing it in the same transaction as the data it covers, as
-described in [Durable
+described in [Resuming
 subscriptions](/transform-data/patterns/durable-subscriptions/#note-about-idempotency).
 
 You can still use a durable subscription for this. Acknowledge as normal to
-control how much history is retained, and on reconnection discard every update
-below your own committed timestamp. Materialize supplies the guarantee that the
-history is still there; your recorded timestamp supplies the deduplication.
+control how much history is retained, and on reconnection skip what you already
+have, either by discarding updates below your own committed timestamp or by
+passing `AS OF`. See [Where reading starts and
+stops](#where-reading-starts-and-stops) for the trade between the two.
 
 {{</ important >}}
 
-### Privileges
+### Only one reader at a time
 
-Creating a durable subscription requires `SELECT` on the target object.
-`SELECT` is checked again each time you subscribe, so revoking it stops an
-existing subscription from being used.
+A durable subscription has a single position, so only one reader may use it at a
+time. Subscribing again takes over: the new reader starts streaming and the
+previous reader's stream fails with an error.
+
+This is deliberate. It means a client that reconnects does not have to wait for
+its own abandoned connection to time out. It also means you should not point two
+application instances at the same durable subscription, and if you do, they will
+take turns rather than share the work.
+
+### Changes to the target object
 
 Dropping the target object fails while a durable subscription exists on it,
 unless you use `CASCADE`.
@@ -236,6 +270,10 @@ unless you use `CASCADE`.
 Changing the target's columns, for example with `ALTER TABLE ... ADD COLUMN`,
 expires every durable subscription on it. The shape of the stream cannot change
 underneath a reader.
+
+`SELECT` on the target is checked each time you subscribe, not only when you
+create the subscription, so revoking it stops an existing subscription from
+being used.
 
 ### Monitoring
 
@@ -245,14 +283,14 @@ it is, and whether it has expired. Use it to find subscriptions that are holding
 history:
 
 ```mzsql
-SELECT name, target, acknowledged_at, time_since_ack, lag, state
+SELECT name, target, acknowledged_up_to, time_since_ack, lag, state
 FROM mz_internal.mz_durable_subscriptions
 ORDER BY time_since_ack DESC;
 ```
 
-`time_since_ack` is what the `TTL` is compared against, so it is the column that
-predicts an expiry. `lag` is the distance to the object's current time, which is
-what predicts how much data a reconnection will replay.
+`time_since_ack` is what `ACKNOWLEDGE WITHIN` is compared against, so it is the
+column that predicts an expiry. `lag` is the distance to the object's current
+time, which is what predicts how much data a reconnection will replay.
 
 This relation is distinct from
 [`mz_internal.mz_subscriptions`](/reference/system-catalog/mz_internal/#mz_subscriptions),
@@ -267,14 +305,13 @@ currently reading from it.
 ```mzsql
 CREATE DURABLE SUBSCRIPTION winning_bids_feed
 ON winning_bids
-WITH (TTL = '1m');
+WITH (ACKNOWLEDGE WITHIN '1m');
 ```
 
 ### Read from it the first time
 
-The first time you read, request a snapshot to bootstrap your application.
-`PROGRESS` is required, because progress messages are what tell you a timestamp
-is complete and therefore safe to acknowledge.
+Request a snapshot to bootstrap your application, and `PROGRESS` so you can tell
+when a timestamp is complete:
 
 ```mzsql
 BEGIN;
@@ -283,18 +320,34 @@ DECLARE c CURSOR FOR
   WITH (PROGRESS, SNAPSHOT true);
 ```
 
-Then loop: fetch a batch, and buffer it until a progress message arrives.
+Then loop, buffering each batch until a progress message arrives:
 
 ```mzsql
 FETCH ALL c WITH (timeout = '1s');
 ```
 
-When you receive a row with `mz_progressed` set to `true`, everything before its
-`mz_timestamp` is complete. Process the buffered data, commit it, and then
-acknowledge that timestamp on the same connection:
+```nofmt
+ mz_timestamp  | mz_progressed | mz_diff | auction_id | amount
+---------------+---------------+---------+------------+--------
+ 1723459199000 | f             |       1 |          1 |     42
+ 1723459199000 | f             |       1 |          2 |     67
+ 1723459200000 | t             |         |            |
+```
+
+The final row has `mz_progressed` set to `true`, so everything before
+`1723459200000` is complete. Process the two buffered updates, commit them, and
+then acknowledge that timestamp on the same connection:
 
 ```mzsql
-ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed AT 1723459200000;
+ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed UP TO 1723459200000;
+```
+
+Continue fetching and acknowledging for as long as you want to consume. When you
+are done, close the cursor and end the transaction:
+
+```mzsql
+CLOSE c;
+COMMIT;
 ```
 
 You do not need to acknowledge every progress message. Acknowledging less often
@@ -303,36 +356,27 @@ retaining more history in the meantime.
 
 ### Resume after a disconnection
 
-Reconnect and subscribe again, this time without a snapshot. You do not supply a
-timestamp, because Materialize has it:
+Reconnect and subscribe again, this time without a snapshot. You supply no
+timestamp, because Materialize has your position:
 
 ```mzsql
 BEGIN;
 DECLARE c CURSOR FOR
   SUBSCRIBE USING DURABLE SUBSCRIPTION winning_bids_feed
-  WITH (PROGRESS, SNAPSHOT false);
+  WITH (PROGRESS);
 ```
 
-The first message you receive is a progress message carrying the timestamp the
-subscription resumed at, so your application can confirm it matches what it
-expected.
+`SNAPSHOT` defaults to `false` on this form, so the stream continues rather than
+re-snapshotting. The first message you receive is a progress message carrying
+the timestamp the subscription resumed at, so your application can confirm it
+matches what it expected.
 
-If your application also lost its local state, request `SNAPSHOT true` instead.
-You then receive a snapshot as of the acknowledged position, followed by
-subsequent updates.
+If your application also lost its local state, request `SNAPSHOT true` to
+receive the state as of your acknowledged position, or
+[`RESET`](/sql/alter-durable-subscription/) the subscription to start from the
+current time instead.
 
-### Only one reader at a time
-
-A durable subscription has a single position, so only one reader may use it at a
-time. Subscribing again takes over: the new reader starts streaming and the
-previous reader's stream fails with an error.
-
-This is deliberate. It means a client that reconnects does not have to wait for
-its own abandoned connection to time out. It also means you should not point two
-application instances at the same durable subscription, and if you do, they will
-take turns rather than share the work.
-
-### Acknowledging from another connection
+### Acknowledge from another connection
 
 If you read with a streaming `SUBSCRIBE` rather than `DECLARE` and `FETCH`, the
 PostgreSQL protocol does not allow you to send anything on that connection while
@@ -341,8 +385,14 @@ subscription is addressed by name, so no coordination between the connections is
 needed:
 
 ```mzsql
-ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed AT 1723459200000;
+ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed UP TO 1723459200000;
 ```
+
+## Privileges
+
+The privileges required to execute this statement are:
+
+{{% include-headless "/headless/sql-command-privileges/create-durable-subscription" %}}
 
 ## Related pages
 
@@ -350,4 +400,5 @@ ACKNOWLEDGE DURABLE SUBSCRIPTION winning_bids_feed AT 1723459200000;
 *   [`ALTER DURABLE SUBSCRIPTION`](/sql/alter-durable-subscription/)
 *   [`DROP DURABLE SUBSCRIPTION`](/sql/drop-durable-subscription/)
 *   [`SUBSCRIBE`](/sql/subscribe/)
-*   [Durable subscriptions](/transform-data/patterns/durable-subscriptions/)
+*   [`CREATE MATERIALIZED VIEW`](/sql/create-materialized-view/)
+*   [Resuming subscriptions](/transform-data/patterns/durable-subscriptions/)

--- a/doc/user/content/sql/drop-durable-subscription.md
+++ b/doc/user/content/sql/drop-durable-subscription.md
@@ -1,0 +1,49 @@
+---
+title: "DROP DURABLE SUBSCRIPTION"
+description: "`DROP DURABLE SUBSCRIPTION` removes a durable subscription and releases the history it retains."
+menu:
+  main:
+    parent: 'commands'
+---
+
+`DROP DURABLE SUBSCRIPTION` removes a [durable
+subscription](/sql/create-durable-subscription/) and releases the history it was
+retaining.
+
+## Syntax
+
+```mzsql
+DROP DURABLE SUBSCRIPTION [IF EXISTS] <name>
+;
+```
+
+| Field | Use |
+| --- | --- |
+| `IF EXISTS` | Do not return an error if the subscription does not exist. |
+| `<name>` | The durable subscription to remove. |
+
+## Details
+
+Dropping a durable subscription releases its hold on the target's history
+immediately. Any reader currently streaming from it fails with an error.
+
+The position is gone. Recreating a subscription with the same name gives you a
+new one positioned at the current time, not the one you dropped, so the next
+read needs a snapshot. To keep a subscription's identity and privileges while
+moving it to the current time, use [`ALTER DURABLE SUBSCRIPTION ...
+RESET`](/sql/alter-durable-subscription/) instead.
+
+Dropping the subscription is also how you stop paying for retained history that
+nobody is reading. A subscription that is merely idle continues to retain
+history until its time to live expires it.
+
+## Examples
+
+```mzsql
+DROP DURABLE SUBSCRIPTION winning_bids_feed;
+```
+
+## Related pages
+
+*   [`CREATE DURABLE SUBSCRIPTION`](/sql/create-durable-subscription/)
+*   [`ALTER DURABLE SUBSCRIPTION`](/sql/alter-durable-subscription/)

--- a/doc/user/content/sql/drop-durable-subscription.md
+++ b/doc/user/content/sql/drop-durable-subscription.md
@@ -6,6 +6,8 @@ menu:
     parent: 'commands'
 ---
 
+{{< private-preview />}}
+
 `DROP DURABLE SUBSCRIPTION` removes a [durable
 subscription](/sql/create-durable-subscription/) and releases the history it was
 retaining.
@@ -28,14 +30,14 @@ Dropping a durable subscription releases its hold on the target's history
 immediately. Any reader currently streaming from it fails with an error.
 
 The position is gone. Recreating a subscription with the same name gives you a
-new one positioned at the current time, not the one you dropped, so the next
-read needs a snapshot. To keep a subscription's identity and privileges while
+new one positioned at the current time, not the one you dropped, so the next read
+needs `SNAPSHOT true`. To keep a subscription's identity and privileges while
 moving it to the current time, use [`ALTER DURABLE SUBSCRIPTION ...
 RESET`](/sql/alter-durable-subscription/) instead.
 
 Dropping the subscription is also how you stop paying for retained history that
 nobody is reading. A subscription that is merely idle continues to retain
-history until its time to live expires it.
+history until its acknowledgement deadline expires it.
 
 ## Examples
 
@@ -43,7 +45,16 @@ history until its time to live expires it.
 DROP DURABLE SUBSCRIPTION winning_bids_feed;
 ```
 
+## Privileges
+
+The privileges required to execute this statement are:
+
+{{% include-headless "/headless/sql-command-privileges/drop-durable-subscription" %}}
+
 ## Related pages
 
 *   [`CREATE DURABLE SUBSCRIPTION`](/sql/create-durable-subscription/)
 *   [`ALTER DURABLE SUBSCRIPTION`](/sql/alter-durable-subscription/)
+*   [`ACKNOWLEDGE`](/sql/acknowledge/)
+*   [`SUBSCRIBE`](/sql/subscribe/)
+*   [Resuming subscriptions](/transform-data/patterns/durable-subscriptions/)

--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -38,6 +38,14 @@ SUBSCRIBE [TO] <object_name | (SELECT ...)>
 [UP TO <timestamp_expression>]
 ;
 
+SUBSCRIBE USING DURABLE SUBSCRIPTION <name>
+[ENVELOPE UPSERT (KEY (<key1>, ...)) | ENVELOPE DEBEZIUM (KEY (<key1>, ...))]
+[WITHIN TIMESTAMP ORDER BY <column1> [ASC | DESC] [NULLS LAST | NULLS FIRST], ...]
+[WITH (<option_name> [= <option_value>], ...)]
+[AS OF [AT LEAST] <timestamp_expression>]
+[UP TO <timestamp_expression>]
+;
+
 ```
 
 where:
@@ -578,14 +586,26 @@ DROP SOURCE auction CASCADE;
 ### Durable subscriptions
 
 Because `SUBSCRIBE` requests happen over the network, these connections might
-get disrupted for both expected and unexpected reasons. You can adjust the
-[history retention
-period](/transform-data/patterns/durable-subscriptions/#history-retention-period)
-for the objects a subscription depends on, and then use [`AS OF`](#as-of) to
-pick up where you left off on connection drops—this ensures that no data is lost
-in the subscription process, and avoids the need for re-snapshotting the data.
+get disrupted for both expected and unexpected reasons. There are two ways to
+recover without re-snapshotting.
 
-For more information, see [durable
+The `SUBSCRIBE USING DURABLE SUBSCRIPTION <name>` form reads from a [`CREATE
+DURABLE SUBSCRIPTION`](/sql/create-durable-subscription/) object, which means
+Materialize tracks your position for you. You report progress with
+[`ACKNOWLEDGE`](/sql/acknowledge/), Materialize retains exactly the history you
+have not acknowledged, and you resume without supplying a timestamp. `SNAPSHOT`
+defaults to `false` on this form, and a requested snapshot is taken at your
+acknowledged position. Only one reader may use a durable subscription at a time,
+and subscribing again takes over from the previous reader.
+
+Alternatively, you can adjust the [history retention
+period](/transform-data/patterns/durable-subscriptions/#history-retention-period)
+for the objects a subscription depends on, record the progress timestamp in your
+own application, and then use [`AS OF`](#as-of) to pick up where you left off.
+This requires more from your application, but it is the only option that
+supports exactly-once processing.
+
+For more information on both, see [durable
 subscriptions](/transform-data/patterns/durable-subscriptions/).
 
 ## Privileges

--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -39,10 +39,9 @@ SUBSCRIBE [TO] <object_name | (SELECT ...)>
 ;
 
 SUBSCRIBE USING DURABLE SUBSCRIPTION <name>
-[ENVELOPE UPSERT (KEY (<key1>, ...)) | ENVELOPE DEBEZIUM (KEY (<key1>, ...))]
 [WITHIN TIMESTAMP ORDER BY <column1> [ASC | DESC] [NULLS LAST | NULLS FIRST], ...]
 [WITH (<option_name> [= <option_value>], ...)]
-[AS OF [AT LEAST] <timestamp_expression>]
+[AS OF <timestamp_expression>]
 [UP TO <timestamp_expression>]
 ;
 
@@ -74,7 +73,7 @@ The following options are valid within the `WITH` clause.
 
 | Option name | Value type | Default | Describes                                                                                                                         |
 | ----------- | ---------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `SNAPSHOT`  | `boolean`  | `true`  | Whether to emit a snapshot of the current state of the relation at the start of the operation. See [`SNAPSHOT`](#snapshot). |
+| `SNAPSHOT`  | `boolean`  | `true`, but `false` for `USING DURABLE SUBSCRIPTION`  | Whether to emit a snapshot of the current state of the relation at the start of the operation. See [`SNAPSHOT`](#snapshot). |
 | `PROGRESS`  | `boolean`  | `false` | Whether to include detailed progress information. See [`PROGRESS`](#progress).                                              |
 
 ## Details
@@ -172,7 +171,12 @@ The value in the `UP TO` clause is automatically [cast to `mz_timestamp`](../../
 
 ### Interaction of `AS OF` and `UP TO`
 
-The lower timestamp bound specified by `AS OF` is inclusive, whereas the upper bound specified by `UP TO` is exclusive. Thus, a `SUBSCRIBE` query whose `AS OF` is equal to its `UP TO` will terminate after returning zero rows.
+The lower timestamp bound specified by `AS OF` is inclusive when a snapshot is
+emitted, and **exclusive** under [`WITH (SNAPSHOT = false)`](#snapshot), where
+`SUBSCRIBE` emits only updates at times strictly greater than the `AS OF`
+timestamp. The upper bound specified by `UP TO` is always exclusive. Thus, a
+`SUBSCRIBE` query whose `AS OF` is equal to its `UP TO` will terminate after
+returning zero rows.
 
 A `SUBSCRIBE` whose `UP TO` is less than its `AS OF` timestamp (whether that
 timestamp was specified in an `AS OF` clause or chosen by the system) will
@@ -202,6 +206,11 @@ By default, `SUBSCRIBE` begins by emitting a snapshot of the subscribed relation
 consists of a series of updates at its [`AS OF`](#as-of) timestamp describing the
 contents of the relation. After the snapshot, `SUBSCRIBE` emits further updates as
 they occur.
+
+This default is inverted for `SUBSCRIBE USING DURABLE SUBSCRIPTION`, where
+`SNAPSHOT` defaults to `false`, and a requested snapshot is taken at the
+subscription's acknowledged position rather than at the current time. See
+[`CREATE DURABLE SUBSCRIPTION`](/sql/create-durable-subscription/#snapshots).
 
 For updates in the snapshot, the `mz_timestamp` field will be fast-forwarded to the `AS OF` timestamp.
 For example, an insert that occurred before the `SUBSCRIBE` began would appear in the snapshot.
@@ -595,17 +604,21 @@ Materialize tracks your position for you. You report progress with
 [`ACKNOWLEDGE`](/sql/acknowledge/), Materialize retains exactly the history you
 have not acknowledged, and you resume without supplying a timestamp. `SNAPSHOT`
 defaults to `false` on this form, and a requested snapshot is taken at your
-acknowledged position. Only one reader may use a durable subscription at a time,
-and subscribing again takes over from the previous reader.
+acknowledged position. `ENVELOPE UPSERT`, `ENVELOPE DEBEZIUM`, and `AS OF AT
+LEAST` are not supported on this form. Only one reader may use a durable
+subscription at a time, and subscribing again takes over from the previous
+reader.
 
 Alternatively, you can adjust the [history retention
 period](/transform-data/patterns/durable-subscriptions/#history-retention-period)
 for the objects a subscription depends on, record the progress timestamp in your
 own application, and then use [`AS OF`](#as-of) to pick up where you left off.
-This requires more from your application, but it is the only option that
-supports exactly-once processing.
+This requires more from your application, but recording the position yourself is
+what makes exactly-once processing possible, because you can write it in the same
+transaction as the data. A durable subscription supplies retention; your own
+recorded position supplies exactly-once.
 
-For more information on both, see [durable
+For more information on both, see [resuming
 subscriptions](/transform-data/patterns/durable-subscriptions/).
 
 ## Privileges

--- a/doc/user/content/transform-data/patterns/durable-subscriptions.md
+++ b/doc/user/content/transform-data/patterns/durable-subscriptions.md
@@ -28,6 +28,34 @@ application following a connection disruption, you can:
   data](#enabling-durable-subscriptions-in-your-application) at specific points
   in time to pick up data processing where you left off.
 
+## Choosing an approach
+
+There are two ways to recover a subscription, and they differ in who keeps track
+of your position.
+
+- A [`CREATE DURABLE SUBSCRIPTION`](/sql/create-durable-subscription/) object
+  makes Materialize keep track. You acknowledge what you have processed,
+  Materialize retains exactly the history you still need, and you resume without
+  supplying a timestamp. Use this when your application has nowhere durable to
+  record a timestamp, such as a browser or an edge function, or when you do not
+  want to guess a history retention period. Delivery is at-least-once, so your
+  consumer must be idempotent.
+
+- The pattern described on the rest of this page makes **your application** keep
+  track. You set a history retention period, record the progress timestamp
+  yourself, and pass it back as `AS OF` when you resume. This is more work, and
+  it requires choosing a retention period up front, but it is the only way to
+  achieve **exactly-once** processing, because it lets you commit the data and
+  the position in a single transaction. See [Note about
+  idempotency](#note-about-idempotency).
+
+The two compose. You can create a durable subscription for its retention
+guarantee while still recording your own position: acknowledge to control how
+much history is kept, and then either pass your own `AS OF` when you resume, or
+omit it and discard every update below your committed timestamp. Filtering
+cannot lose data and costs bandwidth; `AS OF` costs nothing and loses data
+silently if you forget that it is an exclusive bound.
+
 ## History retention period
 
 {{< private-preview />}}

--- a/doc/user/content/transform-data/patterns/durable-subscriptions.md
+++ b/doc/user/content/transform-data/patterns/durable-subscriptions.md
@@ -1,6 +1,6 @@
 ---
-title: "Durable subscriptions"
-description: "How to enable lossless, durable subscriptions to your changing results in Materialize"
+title: "Resuming subscriptions"
+description: "How to resume a subscription after a connection drop without losing or re-snapshotting data"
 menu:
   main:
     parent: 'sql-patterns'
@@ -18,15 +18,14 @@ the network, subscriptions might get disrupted for both expected and unexpected
 reasons. In such cases, it can be useful to have a mechanism to gracefully
 recover data processing.
 
-To avoid the need for re-processing data that was already sent to your external
-application following a connection disruption, you can:
-
-- Adjust the [history retention period](#history-retention-period) for the
-  objects that a subscription depends on, and
-
-- [Access past versions of this
-  data](#enabling-durable-subscriptions-in-your-application) at specific points
-  in time to pick up data processing where you left off.
+To avoid re-processing data that was already sent to your external application
+following a connection disruption, you have two options: let Materialize track
+your position with a [durable
+subscription](/sql/create-durable-subscription/), or track it yourself by
+adjusting the [history retention period](#history-retention-period) and
+[accessing past versions of the
+data](#enabling-durable-subscriptions-in-your-application) at the point you left
+off.
 
 ## Choosing an approach
 

--- a/doc/user/data/sql_commands_all.yml
+++ b/doc/user/data/sql_commands_all.yml
@@ -3,6 +3,10 @@ columns:
   - column: object
   - column: labels
 rows:
+  - command: "[`ACKNOWLEDGE`](/sql/acknowledge)"
+    object: "Durable Subscription"
+    labels:
+      - "output"
   - command: "[`ALTER CLUSTER`](/sql/alter-cluster)"
     object: "Cluster"
     labels:
@@ -26,6 +30,11 @@ rows:
       - "privilege"
   - command: "[`ALTER DATABASE`](/sql/alter-database)"
     object: "Database"
+    labels:
+      - "object"
+      - "owner"
+  - command: "[`ALTER DURABLE SUBSCRIPTION`](/sql/alter-durable-subscription)"
+    object: "Durable Subscription"
     labels:
       - "object"
       - "owner"
@@ -126,6 +135,10 @@ rows:
     object: "Database"
     labels:
       - "object"
+  - command: "[`CREATE DURABLE SUBSCRIPTION`](/sql/create-durable-subscription)"
+    object: "Durable Subscription"
+    labels:
+      - "object"
   - command: "[`CREATE INDEX`](/sql/create-index)"
     object: "Index"
     labels:
@@ -202,6 +215,10 @@ rows:
       - "object"
   - command: "[`DROP DATABASE`](/sql/drop-database)"
     object: "Database"
+    labels:
+      - "object"
+  - command: "[`DROP DURABLE SUBSCRIPTION`](/sql/drop-durable-subscription)"
+    object: "Durable Subscription"
     labels:
       - "object"
   - command: "[`DROP INDEX`](/sql/drop-index)"

--- a/doc/user/data/sql_commands_all.yml
+++ b/doc/user/data/sql_commands_all.yml
@@ -6,6 +6,7 @@ rows:
   - command: "[`ACKNOWLEDGE`](/sql/acknowledge)"
     object: "Durable Subscription"
     labels:
+      - "other"
       - "output"
   - command: "[`ALTER CLUSTER`](/sql/alter-cluster)"
     object: "Cluster"


### PR DESCRIPTION
Design document for a resumable `SUBSCRIBE`, plus the user documentation written alongside it.

A `SUBSCRIBE` cannot be resumed today. `AS OF` already expresses the resume, but nothing holds the timestamp readable, and the default compaction window is one second, so a client that remembers a position finds it compacted away. Our own console shows the cost: it opens one WebSocket per subscribe and re-runs from scratch on reconnect, holding a stale snapshot behind a `resubscribing` flag until a new snapshot completes.

The proposal is a durable subscription: a named catalog object holding a read hold on a storage collection, advanced by an `ACKNOWLEDGE` statement. The hold defines a window of readable time, the acknowledgement moves its lower edge, and a wall-clock deadline bounds how long the window stays open without progress.

### Core decisions

* **A read hold, not a read policy.** `ReadPolicy::Multiple` has zero construction sites, policy installation only ratchets capabilities upward so a lower frontier installed behind an advanced one is a silent no-op, the installation API is keyed by `CompactionWindow` and cannot express a per-collection constant, and an ordinary `ALTER ... RETAIN HISTORY` would discard the contribution irreversibly. Holds report the frontier actually acquired; policies report nothing.
* **One hold, not two.** The compute controller never relaxes a sink's input hold, so a continuously connected reader would pin history from its attach point forever and the deadline would never notice. The subscription's hold is therefore the attached dataflow's input floor.
* **A wall-clock deadline, not a frontier distance.** A `REFRESH` materialized view would otherwise need a value aware of every refresh policy in its ancestry, and a stalled source, paused source, or zero-replica cluster freezes the frontier precisely when releasing the hold matters most.
* **A timestamp is a better resume token than a log position.** One timestamp names a consistent cut across every collection in the timeline. Log positions of concurrent non-conflicting transactions interleave, so systems built on them need transaction boundaries and synthetic pre-commit watermarks to recover the order a timestamp gives for free.

### Surface

```mzsql
CREATE DURABLE SUBSCRIPTION s ON t WITH (ACKNOWLEDGE WITHIN '1m');
SUBSCRIBE USING DURABLE SUBSCRIPTION s WITH (PROGRESS);
ACKNOWLEDGE DURABLE SUBSCRIPTION s UP TO 1723459200000;
```

`ACKNOWLEDGE ... UP TO` reuses the one exclusive-upper convention `SUBSCRIBE` already has, rather than adding a third; `AT` read as inclusive while meaning exclusive. `ACKNOWLEDGE WITHIN` mirrors the adjacent `RETAIN HISTORY FOR '1h'` and names the obligation accurately now that the bound is wall-clock. `SNAPSHOT` defaults to `false` here, inverting plain `SUBSCRIBE`, and a requested snapshot is taken at the acknowledged position so the state received corresponds to a position the client can name. `ENVELOPE UPSERT`, `ENVELOPE DEBEZIUM`, and `AS OF AT LEAST` are rejected.

Recovery from expiry is two attaches, not one option. A plain attach on an expired subscription fails with a distinguishable error, and `SUBSCRIBE ... WITH (RESET)` resets to the current time and delivers a snapshot there. The reason is that a consumer otherwise cannot tell a fresh snapshot from a continuation: a snapshot arrives as insertions at the resume timestamp, indistinguishable from genuine insertions at that time, and the alternatives are a new column on every `SUBSCRIBE` or an advisory session notice. With two attaches the client knows because it asked. A live subscription deliberately cannot be fast-forwarded by either spelling of `RESET`, since that would discard data it still holds history for; a client that lost local state while live reconciles instead, paying a replay bounded by `ACKNOWLEDGE WITHIN`.

### Reviews folded in

The document has been through an adversarial design review and the repository's documentation review, and was then evaluated against what a local-first sync engine would require of it, reading Zero, ElectricSQL, PowerSync, and Replicache documentation.

That last review inverted one conclusion worth calling out. Rejecting the envelopes looked like it excluded the natural keyed consumer, but every engine surveyed keeps its own previous state rather than asking the upstream for old values, and the raw diff stream gives them more than a Postgres feed does: every retraction carries the full old row, which is `REPLICA IDENTITY FULL` semantics by construction, and `WITHIN TIMESTAMP ORDER BY mz_diff` orders retractions before additions within a timestamp. It also corrected the idempotence rule, which had said to deduplicate on the timestamp and row. The unit is the timestamp: apply each atomically, record it, skip ones already applied, which works because resume always lands on a timestamp boundary.

Verdict on consumability: a PowerSync-shaped engine could consume this with changes. Zero could not without work outside this design, because its upstream must also host its own mutation bookkeeping tables, with `lastMutationID` incremented in the same transaction as the user's write and replicated back through the feed, and Materialize supports neither primary keys nor `UPDATE` inside transactions.

A "Known quirks and interactions" section documents rather than fixes several existing behaviors the feature makes easier to trigger, including that a subscription's hold lowers the as-of chosen for objects created later over the same inputs, which for materialized views is written durably into `create_sql`; that combining several subscriptions into a consistent cut is safe but unassisted, and unsound across timelines; and that no mapping exists from an upstream source position to the Materialize timestamp at which it became visible, which is a hard dependency for any consumer that needs to correlate its own writes with the feed.

### On the user documentation

The pages under `doc/user/` document a feature that does not exist. They were written as part of designing it, to expose awkwardness in the SQL surface, and they earned the place. Writing them is what surfaced that progress messages are mandatory rather than optional, that the deadline must be required rather than defaulted, that retention is the minimum over readers so one stuck reader holds history for all of them, that at-least-once delivery is a genuine step back from what the existing manual pattern achieves for consumers with a transactional sink, and that the reset path had no way to tell a consumer what it had received.

**They must not merge before the feature exists.** Hugo would publish them. They are here for review of the contract, and the intent is to land them with the implementation. Happy to move them under `doc/developer/design/` as an appendix if reviewers prefer.

`doc/user/content/transform-data/patterns/durable-subscriptions.md` is a shipped private-preview page that was titled "Durable subscriptions", documenting the manual `RETAIN HISTORY` plus client-recorded-timestamp pattern. This renames it to "Resuming subscriptions" to free the name. The manual pattern stays documented, because recording the position yourself is what makes exactly-once possible.

### Open questions

Seven are listed in the document. The two most likely to change the shape of the implementation are whether the durable attach can bypass index import cleanly, and the value of the deadline ceiling, which should be in hours rather than the minutes an interactive client needs.

No tracking issue is filed yet; one is needed before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)