### PR TITLE
docker: pin remaining product image base digests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,6 +97,7 @@ updates:
     - /misc/images/openssh-static
     - /misc/images/tini-static
     - /misc/images/distroless-prod-base
+    - /misc/dbt-materialize
     - /ci/builder
     - /test
   schedule:

--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -7,7 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM node:26-alpine AS builder
+# Pinned by rolling tag + multi-arch index digest so dependabot refreshes the
+# digest for security fixes.
+FROM node:26-alpine@sha256:aadf416b2cdce311a8811ba3f0608a61b77dbf997500e2eafe781b51f6a0b019 AS builder
 
 WORKDIR /app
 

--- a/misc/dbt-materialize/Dockerfile
+++ b/misc/dbt-materialize/Dockerfile
@@ -7,7 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM python:3.10.14
+# Pinned by rolling tag + multi-arch index digest so dependabot refreshes the
+# digest for security fixes.
+FROM python:3.10.14@sha256:9c0e621579faf384d982986f2e0ba86bf09619076842cd0fbd2f24a3bf09f0bc
 
 COPY . dbt-materialize/
 

--- a/misc/images/debian-base/Dockerfile
+++ b/misc/images/debian-base/Dockerfile
@@ -23,4 +23,9 @@ LABEL build.profile=$BUILD_PROFILE
 RUN apt-get update --fix-missing && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends eatmydata \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=foundationdb/foundationdb:7.3.71 /usr/lib/libfdb_c.so /usr/lib/
+# FoundationDB client library, dynamically linked by the Rust binaries.
+# NOTE: keep this reference identical to the COPY in distroless-prod-base and
+# materialized-base, and to the `foundationdb` crate's `fdb-7_3` API feature in
+# the root Cargo.toml. All three images share one FoundationDB cluster during a
+# rolling upgrade, so a bump in one that is not matched in the others is a bug.
+COPY --from=foundationdb/foundationdb:7.3.71@sha256:1c988226e25ecd953475d46aef11fa2133e9e5eefda67e0a463196a4caab2d5d /usr/lib/libfdb_c.so /usr/lib/

--- a/misc/images/distroless-prod-base/Dockerfile
+++ b/misc/images/distroless-prod-base/Dockerfile
@@ -58,14 +58,14 @@ COPY --from=apt-deps /usr/lib/*/liblzma.so.5* /usr/lib/
 COPY --from=apt-deps /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # FoundationDB client library, dynamically linked by environmentd and clusterd.
-# NOTE: this tag is coupled to two other pins and all three must move
+# NOTE: this reference is coupled to two other pins and all three must move
 # together: the same COPY in `debian-base` (both prod bases must ship an
 # identical libfdb_c.so, since environmentd and clusterd share one FoundationDB
 # cluster during a rolling upgrade) and the
 # `foundationdb` crate's `fdb-7_3` API feature in the root Cargo.toml. A
 # dependabot bump here that is not matched in the other two is a bug, not a
 # routine update.
-COPY --from=foundationdb/foundationdb:7.3.71 /usr/lib/libfdb_c.so /usr/lib/
+COPY --from=foundationdb/foundationdb:7.3.71@sha256:1c988226e25ecd953475d46aef11fa2133e9e5eefda67e0a463196a4caab2d5d /usr/lib/libfdb_c.so /usr/lib/
 
 # Replace the base image's glibc example nsswitch.conf, whose `compat`
 # backend segfaults the statically-linked `ssh` (see comments in the file).

--- a/misc/images/materialized-base/Dockerfile
+++ b/misc/images/materialized-base/Dockerfile
@@ -69,9 +69,9 @@ RUN groupadd --system --gid=999 materialize \
     && chown -R materialize /mzdata /scratch /var/run/postgresql /var/lib/nginx /var/log/nginx /run/nginx.pid
 
 # FoundationDB client library, dynamically linked by materialized. Keep this
-# version identical to the COPY in debian-base and distroless-prod-base: all
+# reference identical to the COPY in debian-base and distroless-prod-base: all
 # three share one FoundationDB cluster during a rolling upgrade.
-COPY --from=foundationdb/foundationdb:7.3.71 /usr/lib/libfdb_c.so /usr/lib/
+COPY --from=foundationdb/foundationdb:7.3.71@sha256:1c988226e25ecd953475d46aef11fa2133e9e5eefda67e0a463196a4caab2d5d /usr/lib/libfdb_c.so /usr/lib/
 
 COPY postgresql.conf pg_hba.conf /etc/postgresql/
 

--- a/misc/images/openssh-static/Dockerfile
+++ b/misc/images/openssh-static/Dockerfile
@@ -25,7 +25,9 @@
 #   docker cp extract:/output/ssh ./ssh
 #   docker rm extract
 
-FROM debian:13-slim AS builder
+# Pinned by rolling tag + multi-arch index digest, matching debian-base, so
+# dependabot refreshes the digest for security fixes.
+FROM debian:13-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258 AS builder
 
 ARG AWS_LC_VERSION=v1.54.0
 # OpenSSH >= 10.0 is required: it natively stubs BN_set_flags() for AWS-LC,

--- a/misc/images/tini-static/Dockerfile
+++ b/misc/images/tini-static/Dockerfile
@@ -23,7 +23,9 @@
 #   docker cp extract:/output/tini ./tini
 #   docker rm extract
 
-FROM debian:13-slim AS builder
+# Pinned by rolling tag + multi-arch index digest, matching debian-base, so
+# dependabot refreshes the digest for security fixes.
+FROM debian:13-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258 AS builder
 
 ARG TINI_VERSION=v0.19.0
 


### PR DESCRIPTION
## Motivation

Only five third-party image references in the tree were pinned by digest. Everything else resolved a mutable tag at build time, including references whose content ships to users.

This pins the rest of the references reachable from an image we publish for users, using the rolling tag plus multi-arch index digest convention established by #38263, #38265, and the `debian-base` pin in #38200.

## What is pinned

| File | Reference |
| --- | --- |
| `misc/images/tini-static` | `debian:13-slim` builder |
| `misc/images/openssh-static` | `debian:13-slim` builder |
| `misc/images/debian-base` | `foundationdb:7.3.71` |
| `misc/images/distroless-prod-base` | `foundationdb:7.3.71` |
| `misc/images/materialized-base` | `foundationdb:7.3.71` |
| `console` | `node:26-alpine` builder |
| `misc/dbt-materialize` | `python:3.10.14` |

The FoundationDB reference is the highest value one here. `libfdb_c.so` is copied into `environmentd`, `clusterd`, and `materialized`, so it ships to users, and the three copies must stay byte-identical because those processes share one FoundationDB cluster during a rolling upgrade. That constraint was already recorded in `distroless-prod-base` and `materialized-base` but not in `debian-base`, so a matching note is added there.

## Relationship to #38264

The two MCP images are deliberately not touched here. #38264 pins them and also covers `misc/mcp-materialize-agents`, which this PR had missed. That PR has been rebased onto current main and is independent of this one, so the two can land in either order.

## Dependabot

`/misc/dbt-materialize` was not in the docker ecosystem list, so it is added. A digest pin with no updater watching it freezes the base image forever, which is a worse outcome than the rolling tag it replaces. The other directories touched here were already covered.

## Notes for review

The `debian:13-slim` pin reuses the digest already in the tree rather than what the tag resolves to today. Resolving it fresh would have smuggled a base image bump into a pinning change and desynced the six copies. Moving them is dependabot's job.

Three of the four distinct digests are identical to what their tags resolve to right now, so `debian-base`, `distroless-prod-base`, `materialized-base`, `console`, and `dbt-materialize` get no content change. `tini-static` and `openssh-static` do change, since their builder stages move onto the pinned base, and both will rebuild. Their output is a static binary copied into `scratch`, so this changes the toolchain the binaries were compiled with, not the contents of any runtime image.

All digests were verified to resolve by digest and to carry both `linux/amd64` and `linux/arm64`.

Test fixture images (postgres, mysql, mssql, golang, alpine, node 22 and 24, debezium, panubo/sshd, foundationdb 7.3.77, the fivetran sdk-tester) are deliberately left on tags. They churn more often and no user pulls them, so pinning them buys little and costs dependabot noise.

Unrelated observation, not addressed here: `test/foundationdb` uses `foundationdb/foundationdb:7.3.77` while the three product images pin `7.3.71`.

## Tests

No tests added. This is a build configuration change, covered by the existing image builds in CI.

## Release notes

No user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
