### PR TITLE
SS-441 Honor write.data.path when placing Iceberg data files

### DIFF
--- a/src/storage/src/sink/iceberg.rs
+++ b/src/storage/src/sink/iceberg.rs
@@ -1471,6 +1471,38 @@ struct BoundedDataFileSet {
     pub data_files: Vec<BoundedDataFile>,
 }
 
+/// Returns the base location for the table's data files, with no trailing separator.
+///
+/// `configured_path` is the catalog's `write.data.path`, or `write.folder-storage.path` where
+/// only the older property is set. `location` is the table's own location, used when the catalog
+/// configures neither.
+///
+/// The result never ends in `/`. Callers join it with a `/` and a file name, and the joined URI
+/// is what lands in the manifest, so a separator left on the end here produces a manifest entry
+/// naming an object that was never written.
+fn data_file_location(configured_path: Option<&str>, location: &str) -> String {
+    // Both properties may legally end in `/`. `DefaultLocationGenerator` stores the value
+    // verbatim and `generate_location` appends `/` plus the file name, so `s3://b/t/data/`
+    // yields `s3://b/t/data//f.parquet`. OpenDAL collapses the `//` when it writes the object,
+    // but the Parquet writer copies the unnormalized URI into the `DataFile`, leaving the
+    // manifest pointing at a key that does not exist and the table unreadable to anyone else.
+    // The reference Iceberg location provider strips them for this reason.
+    if let Some(path) = configured_path {
+        return path.trim_end_matches('/').to_string();
+    }
+
+    // WORKAROUND: S3 Tables catalog incorrectly sets location to the metadata file path
+    // instead of the warehouse root. Strip off the /metadata/*.metadata.json suffix. No
+    // clear way to detect this properly right now, so we use heuristics.
+    let corrected_location = match location.rsplit_once("/metadata/") {
+        Some((a, b)) if b.ends_with(".metadata.json") => a,
+        _ => location,
+    };
+    // Trimmed before the join, not after, or a location ending in `/` moves the doubled
+    // separator into the middle of the URI where a trailing trim cannot reach it.
+    format!("{}/data", corrected_location.trim_end_matches('/'))
+}
+
 /// Construct the envelope-specific closures that [`write_data_files`] needs.
 ///
 /// Write rows into Parquet data files bounded by batch descriptions.
@@ -1557,24 +1589,15 @@ fn write_data_files<'scope, H: EnvelopeHandler + 'static>(
                 // referencing files under `<location>/data` with a 500.
                 //
                 // `DefaultLocationGenerator::new` reads these same properties, but its
-                // fallback misses the S3 Tables correction below, so choose explicitly.
-                let data_location = table_metadata
-                    .properties()
+                // fallback misses the S3 Tables correction, so choose explicitly.
+                let properties = table_metadata.properties();
+                let configured_path = properties
                     .get("write.data.path")
-                    .or_else(|| table_metadata.properties().get("write.folder-storage.path"))
-                    .cloned()
-                    .unwrap_or_else(|| {
-                        // WORKAROUND: S3 Tables catalog incorrectly sets location to the
-                        // metadata file path instead of the warehouse root. Strip off the
-                        // /metadata/*.metadata.json suffix. No clear way to detect this
-                        // properly right now, so we use heuristics.
-                        let location = table_metadata.location();
-                        let corrected_location = match location.rsplit_once("/metadata/") {
-                            Some((a, b)) if b.ends_with(".metadata.json") => a,
-                            _ => location,
-                        };
-                        format!("{}/data", corrected_location)
-                    });
+                    .or_else(|| properties.get("write.folder-storage.path"));
+                let data_location = data_file_location(
+                    configured_path.map(String::as_str),
+                    table_metadata.location(),
+                );
                 debug!(%data_location, "iceberg sink data file location");
                 let location_generator =
                     DefaultLocationGenerator::with_data_location(data_location);
@@ -1927,10 +1950,84 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use iceberg::spec::{PrimitiveType, Type};
+    use iceberg::writer::file_writer::location_generator::LocationGenerator;
     use mz_repr::SqlScalarType;
     use mz_storage_types::sinks::ICEBERG_UINT64_DECIMAL_PRECISION;
+
+    use super::*;
+
+    /// The URI a data file is committed under, as the manifest records it.
+    fn manifest_uri(configured_path: Option<&str>, location: &str) -> String {
+        let data_location = data_file_location(configured_path, location);
+        DefaultLocationGenerator::with_data_location(data_location)
+            .generate_location(None, "part-00000.parquet")
+    }
+
+    /// Asserts the URI addresses exactly one object, i.e. it survives the path normalization
+    /// the object store applies before writing. An empty path segment would make the manifest
+    /// name a key that was never written.
+    fn assert_addresses_one_object(uri: &str) {
+        let path = uri
+            .split_once("://")
+            .map(|(_scheme, path)| path)
+            .unwrap_or(uri);
+        assert!(
+            !path.contains("//"),
+            "URI has an empty path segment, so it does not name the object written: {uri}"
+        );
+    }
+
+    #[mz_ore::test]
+    fn test_data_file_location_trims_configured_path() {
+        // The property the catalog set is honored as-is when it carries no trailing separator.
+        assert_eq!(
+            manifest_uri(Some("s3://bucket/tbl/data"), "s3://bucket/tbl"),
+            "s3://bucket/tbl/data/part-00000.parquet"
+        );
+
+        // A trailing separator is valid in the property, and must not reach the manifest.
+        for configured in [
+            "s3://bucket/tbl/data/",
+            "s3://bucket/tbl/data//",
+            "s3://bucket/tbl/data///",
+        ] {
+            let uri = manifest_uri(Some(configured), "s3://bucket/tbl");
+            assert_addresses_one_object(&uri);
+            assert_eq!(uri, "s3://bucket/tbl/data/part-00000.parquet");
+        }
+    }
+
+    #[mz_ore::test]
+    fn test_data_file_location_trims_table_location() {
+        // With no property set, the data directory hangs off the table location.
+        assert_eq!(
+            manifest_uri(None, "s3://bucket/tbl"),
+            "s3://bucket/tbl/data/part-00000.parquet"
+        );
+
+        // A table location ending in `/` would otherwise double the separator mid-URI, where
+        // trimming the end of the joined string could not fix it.
+        let uri = manifest_uri(None, "s3://bucket/tbl/");
+        assert_addresses_one_object(&uri);
+        assert_eq!(uri, "s3://bucket/tbl/data/part-00000.parquet");
+    }
+
+    #[mz_ore::test]
+    fn test_data_file_location_corrects_s3_tables_metadata_path() {
+        // S3 Tables reports the metadata file as the table location; the data directory has to
+        // hang off the warehouse root instead.
+        assert_eq!(
+            data_file_location(None, "s3://bucket/tbl/metadata/00001-abc.metadata.json"),
+            "s3://bucket/tbl/data"
+        );
+
+        // A path that merely contains `/metadata/` is not a metadata file and is left alone.
+        assert_eq!(
+            data_file_location(None, "s3://bucket/metadata/tbl"),
+            "s3://bucket/metadata/tbl/data"
+        );
+    }
 
     #[mz_ore::test]
     fn test_iceberg_type_overrides() {

--- a/src/storage/src/sink/iceberg.rs
+++ b/src/storage/src/sink/iceberg.rs
@@ -1549,16 +1549,33 @@ fn write_data_files<'scope, H: EnvelopeHandler + 'static>(
                     .context("Failed to merge Materialize metadata into Iceberg schema")?,
                 );
 
-                // WORKAROUND: S3 Tables catalog incorrectly sets location to the metadata file path
-                // instead of the warehouse root. Strip off the /metadata/*.metadata.json suffix.
-                // No clear way to detect this properly right now, so we use heuristics.
-                let location = table_metadata.location();
-                let corrected_location = match location.rsplit_once("/metadata/") {
-                    Some((a, b)) if b.ends_with(".metadata.json") => a,
-                    _ => location,
-                };
-
-                let data_location = format!("{}/data", corrected_location);
+                // A catalog that manages where data files live advertises it through
+                // `write.data.path`. Honor it: catalogs backing an Iceberg table with
+                // their own storage layout reject a commit whose data files sit outside
+                // that path. Unity Catalog, for one, has to register the files in the
+                // Delta log that actually backs the table, and answers a commit
+                // referencing files under `<location>/data` with a 500.
+                //
+                // `DefaultLocationGenerator::new` reads these same properties, but its
+                // fallback misses the S3 Tables correction below, so choose explicitly.
+                let data_location = table_metadata
+                    .properties()
+                    .get("write.data.path")
+                    .or_else(|| table_metadata.properties().get("write.folder-storage.path"))
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        // WORKAROUND: S3 Tables catalog incorrectly sets location to the
+                        // metadata file path instead of the warehouse root. Strip off the
+                        // /metadata/*.metadata.json suffix. No clear way to detect this
+                        // properly right now, so we use heuristics.
+                        let location = table_metadata.location();
+                        let corrected_location = match location.rsplit_once("/metadata/") {
+                            Some((a, b)) if b.ends_with(".metadata.json") => a,
+                            _ => location,
+                        };
+                        format!("{}/data", corrected_location)
+                    });
+                debug!(%data_location, "iceberg sink data file location");
                 let location_generator =
                     DefaultLocationGenerator::with_data_location(data_location);
 


### PR DESCRIPTION
### Motivation

Iceberg tables can set `write.data.path` to place data files somewhere other
than the default `<table location>/data`, which catalogs such as Unity
Catalog rely on. We ignored the property and always wrote to the default
location, so files landed outside where the table metadata said they should.

### Description

Reads `write.data.path` from the table metadata's properties and uses it as
the base location for data files, falling back to the default layout when
the property is absent.

### Verification

Covered by the existing Iceberg sink mzcompose suite, which exercises tables
whose data path is set by the catalog.
