### PR TITLE
SS-369 Add ACCESS DELEGATION option for Iceberg catalog connections

### DIFF
--- a/misc/python/materialize/mzcompose/helpers/iceberg.py
+++ b/misc/python/materialize/mzcompose/helpers/iceberg.py
@@ -226,37 +226,6 @@ def grant_catalog_role_privilege(
     )
 
 
-def load_polaris_vended_credentials(
-    c: "Composition",
-    table: str,
-    namespace: str = "default_namespace",
-    catalog_name: str = "default_catalog",
-) -> dict[str, str]:
-    """Load a table through the REST catalog requesting credential vending, and
-    return the vended storage config (the `config` map, which contains the
-    temporary `s3.access-key-id`, `s3.secret-access-key`, and `s3.session-token`).
-
-    Requires the catalog to have been set up with `vended=True` so the principal
-    is authorized for `LOAD_TABLE_WITH_READ_DELEGATION`.
-    """
-    access_token = get_polaris_access_token(c)
-    resp = c.exec(
-        "polaris",
-        "curl",
-        "-sS",
-        "--fail-with-body",
-        "-X",
-        "GET",
-        "-H",
-        f"Authorization: Bearer {access_token}",
-        "-H",
-        "X-Iceberg-Access-Delegation: vended-credentials",
-        f"http://localhost:8181/api/catalog/v1/{catalog_name}/namespaces/{namespace}/tables/{table}",
-        capture=True,
-    )
-    return json.loads(resp.stdout)["config"]
-
-
 def setup_polaris_for_iceberg(
     c: "Composition",
     bucket_name: str = "test-bucket",

--- a/misc/python/materialize/mzcompose/helpers/iceberg.py
+++ b/misc/python/materialize/mzcompose/helpers/iceberg.py
@@ -98,21 +98,36 @@ def create_polaris_catalog(
     secret_key: str = "",
     endpoint: str = "http://minio:9000",
     region: str = "minio",
+    static_credentials: bool = True,
 ) -> None:
+    """Create a Polaris catalog backed by `bucket_name` in MinIO.
+
+    Catalog properties are returned to clients verbatim on `loadTable`, so the
+    `s3.access-key-id`/`s3.secret-access-key` written here become the credentials
+    every client uses. Pass `static_credentials=False` to leave them out, which
+    makes credential vending the only way a client can reach the bucket. Polaris
+    itself still reaches MinIO through the credentials in its environment.
+    """
+    properties = {
+        "default-base-location": f"s3://{bucket_name}/",
+        "s3.endpoint": endpoint,
+        "s3.path-style-access": "true",
+        "s3.region": region,
+    }
+    if static_credentials:
+        properties["s3.access-key-id"] = username
+        properties["s3.secret-access-key"] = secret_key
+
     catalog_payload = {
         "name": catalog_name,
         "type": "INTERNAL",
-        "properties": {
-            "default-base-location": f"s3://{bucket_name}/",
-            "s3.endpoint": endpoint,
-            "s3.path-style-access": "true",
-            "s3.access-key-id": username,
-            "s3.secret-access-key": secret_key,
-            "s3.region": region,
-        },
+        "properties": properties,
         "storageConfigInfo": {
             "storageType": "S3",
-            "allowedLocations": [f"s3://{bucket_name}/*"],
+            # Allowed locations are prefixes, not globs. Polaris rejects the
+            # catalog unless `default-base-location` sits within one of them, and
+            # a trailing `/*` is matched literally, so it contains nothing.
+            "allowedLocations": [f"s3://{bucket_name}/"],
             "endpoint": endpoint,
             "endpointInternal": endpoint,
             "pathStyleAccess": True,
@@ -124,6 +139,7 @@ def create_polaris_catalog(
         "curl",
         "-sS",
         "-i",
+        "--fail-with-body",
         "-X",
         "POST",
         "-H",
@@ -133,6 +149,30 @@ def create_polaris_catalog(
         "http://localhost:8181/api/management/v1/catalogs",
         "--data-binary",
         json.dumps(catalog_payload),
+    )
+
+
+def assert_polaris_catalog_exists(
+    c: "Composition",
+    access_token: str,
+    catalog_name: str = "default_catalog",
+) -> None:
+    """Read the catalog back, failing here if it is missing.
+
+    A rejected catalog creation otherwise stays invisible until whatever first
+    uses the warehouse reports a 404, which points the investigation at the
+    consumer instead of at setup.
+    """
+    c.exec(
+        "polaris",
+        "curl",
+        "-sS",
+        "--fail-with-body",
+        "-X",
+        "GET",
+        "-H",
+        f"Authorization: Bearer {access_token}",
+        f"http://localhost:8181/api/management/v1/catalogs/{catalog_name}",
     )
 
 
@@ -148,6 +188,7 @@ def create_polaris_namespace(
         "curl",
         "-sS",
         "-i",
+        "--fail-with-body",
         "-X",
         "POST",
         "-H",
@@ -160,6 +201,62 @@ def create_polaris_namespace(
     )
 
 
+def grant_catalog_role_privilege(
+    c: "Composition",
+    access_token: str,
+    privilege: str,
+    catalog_name: str = "default_catalog",
+    catalog_role: str = "catalog_admin",
+) -> None:
+    """Grant a catalog-level privilege to a catalog role."""
+    c.exec(
+        "polaris",
+        "curl",
+        "-sS",
+        "--fail-with-body",
+        "-X",
+        "PUT",
+        "-H",
+        f"Authorization: Bearer {access_token}",
+        "-H",
+        "Content-Type: application/json",
+        f"http://localhost:8181/api/management/v1/catalogs/{catalog_name}/catalog-roles/{catalog_role}/grants",
+        "-d",
+        json.dumps({"type": "catalog", "privilege": privilege}),
+    )
+
+
+def load_polaris_vended_credentials(
+    c: "Composition",
+    table: str,
+    namespace: str = "default_namespace",
+    catalog_name: str = "default_catalog",
+) -> dict[str, str]:
+    """Load a table through the REST catalog requesting credential vending, and
+    return the vended storage config (the `config` map, which contains the
+    temporary `s3.access-key-id`, `s3.secret-access-key`, and `s3.session-token`).
+
+    Requires the catalog to have been set up with `vended=True` so the principal
+    is authorized for `LOAD_TABLE_WITH_READ_DELEGATION`.
+    """
+    access_token = get_polaris_access_token(c)
+    resp = c.exec(
+        "polaris",
+        "curl",
+        "-sS",
+        "--fail-with-body",
+        "-X",
+        "GET",
+        "-H",
+        f"Authorization: Bearer {access_token}",
+        "-H",
+        "X-Iceberg-Access-Delegation: vended-credentials",
+        f"http://localhost:8181/api/catalog/v1/{catalog_name}/namespaces/{namespace}/tables/{table}",
+        capture=True,
+    )
+    return json.loads(resp.stdout)["config"]
+
+
 def setup_polaris_for_iceberg(
     c: "Composition",
     bucket_name: str = "test-bucket",
@@ -167,6 +264,8 @@ def setup_polaris_for_iceberg(
     username: str = "tduser",
     catalog_name: str = "default_catalog",
     namespace: str = "default_namespace",
+    vended: bool = False,
+    static_credentials: bool = True,
 ) -> tuple[str, str]:
     """
     Set up Polaris catalog with MinIO for Iceberg sink usage.
@@ -176,6 +275,17 @@ def setup_polaris_for_iceberg(
     2. Creating a MinIO user with S3 permissions
     3. Starting Polaris with the user's credentials
     4. Creating a catalog and namespace in Polaris
+
+    With `vended=True`, also grant the catalog role the `TABLE_READ_DATA` and
+    `TABLE_WRITE_DATA` privileges. These authorize credential vending, so a
+    client sending the `X-Iceberg-Access-Delegation: vended-credentials` header
+    on `loadTable`/`commit` receives temporary, table-scoped MinIO STS
+    credentials instead of using its own static ones. Polaris mints them via
+    AssumeRole against MinIO using the credentials passed to it below.
+
+    With `static_credentials=False`, the catalog withholds the long-lived S3
+    credentials it would otherwise hand every client, so vending becomes the only
+    path to the bucket. Combine with `vended=True` to require vending.
     """
     from materialize.mzcompose.composition import Service
 
@@ -211,7 +321,10 @@ def setup_polaris_for_iceberg(
         bucket_name=bucket_name,
         username=username,
         secret_key=key,
+        static_credentials=static_credentials,
     )
+
+    assert_polaris_catalog_exists(c, access_token, catalog_name=catalog_name)
 
     create_polaris_namespace(
         c,
@@ -219,5 +332,11 @@ def setup_polaris_for_iceberg(
         namespace=namespace,
         catalog_name=catalog_name,
     )
+
+    if vended:
+        for privilege in ("TABLE_READ_DATA", "TABLE_WRITE_DATA"):
+            grant_catalog_role_privilege(
+                c, access_token, privilege, catalog_name=catalog_name
+            )
 
     return (username, key)

--- a/misc/python/materialize/mzcompose/services/polaris.py
+++ b/misc/python/materialize/mzcompose/services/polaris.py
@@ -18,7 +18,7 @@ class PolarisBootstrap(Service):
         self,
         name: str = "polaris-bootstrap",
         image: str = "apache/polaris-admin-tool",
-        tag: str = "1.2.0-incubating",
+        tag: str = "1.7.0",
         environment: list[str] = [
             "POLARIS_BOOTSTRAP_CREDENTIALS=POLARIS,root,root",
             "POLARIS_PERSISTENCE_TYPE=relational-jdbc",
@@ -50,8 +50,9 @@ class Polaris(Service):
         self,
         name: str = "polaris",
         image: str = "apache/polaris",
-        # Fails with 1.1.0-incubating
-        tag: str = "1.2.0-incubating",
+        # Fails with 1.1.0-incubating. Releases from 1.4.0 on drop the
+        # `-incubating` suffix, so keep this tag in sync with the admin tool's.
+        tag: str = "1.7.0",
         # 8181: api port, 8182: management port
         ports: list[str | int] = [8181, 8182],
         environment: list[str] = [

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -145,6 +145,7 @@ Decoding
 Decorrelated
 Default
 Defaults
+Delegation
 Delete
 Delimited
 Delimiter

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -893,6 +893,7 @@ impl_display_t!(Format);
 // souffrir pour être belle.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ConnectionOptionName {
+    AccessDelegation,
     AccessKeyId,
     AssumeRoleArn,
     AssumeRoleSessionName,
@@ -950,7 +951,8 @@ impl ConnectionOptionName {
             | ConnectionOptionName::SslCertificateAuthority
             | ConnectionOptionName::SslKey
             | ConnectionOptionName::User => true,
-            ConnectionOptionName::AssumeRoleArn
+            ConnectionOptionName::AccessDelegation
+            | ConnectionOptionName::AssumeRoleArn
             | ConnectionOptionName::AssumeRoleSessionName
             | ConnectionOptionName::AvailabilityZones
             | ConnectionOptionName::AwsConnection
@@ -985,6 +987,7 @@ impl ConnectionOptionName {
 impl AstDisplay for ConnectionOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
+            ConnectionOptionName::AccessDelegation => "ACCESS DELEGATION",
             ConnectionOptionName::AccessKeyId => "ACCESS KEY ID",
             ConnectionOptionName::AvailabilityZones => "AVAILABILITY ZONES",
             ConnectionOptionName::AwsConnection => "AWS CONNECTION",

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2994,10 +2994,14 @@ impl<'a> Parser<'a> {
                 USERNAME,
                 WAREHOUSE,
             ])? {
-                ACCESS => {
-                    self.expect_keywords(&[KEY, ID])?;
-                    ConnectionOptionName::AccessKeyId
-                }
+                ACCESS => match self.expect_one_of_keywords(&[KEY, DELEGATION])? {
+                    KEY => {
+                        self.expect_keyword(ID)?;
+                        ConnectionOptionName::AccessKeyId
+                    }
+                    DELEGATION => ConnectionOptionName::AccessDelegation,
+                    _ => unreachable!(),
+                },
                 ASSUME => {
                     self.expect_keyword(ROLE)?;
                     match self.expect_one_of_keywords(&[ARN, SESSION])? {

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -748,6 +748,11 @@ impl ConnectionOptionExtracted {
                                         "invalid CONNECTION: OAUTH2 SERVER URL applies to CREDENTIAL auth, not GCP CONNECTION"
                                     );
                                 }
+                                if self.access_delegation.is_some() {
+                                    sql_bail!(
+                                        "invalid CONNECTION: ICEBERG GCP CONNECTION does not support ACCESS DELEGATION"
+                                    );
+                                }
                                 /// All BigLake Iceberg REST Catalogs use the same catalog URI.
                                 const BIGLAKE_CATALOG_URI: &str =
                                     "https://biglake.googleapis.com/iceberg/v1/restcatalog";

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -34,11 +34,11 @@ use mz_storage_types::connections::inline::ReferencedConnection;
 use mz_storage_types::connections::string_or_secret::StringOrSecret;
 use mz_storage_types::connections::{
     AwsPrivatelink, AwsPrivatelinkConnection, AwsPrivatelinkRule, CsrConnection,
-    CsrConnectionHttpAuth, GlueSchemaRegistryConnection, IcebergCatalogAuth,
-    IcebergCatalogConnection, IcebergCatalogImpl, IcebergCatalogType, KafkaConnection,
-    KafkaSaslConfig, KafkaTlsConfig, KafkaTopicOptions, MySqlConnection, MySqlSslMode,
-    PostgresConnection, RestIcebergCatalog, S3TablesRestIcebergCatalog, SqlServerConnectionDetails,
-    SshConnection, SshTunnel, TlsIdentity, Tunnel,
+    CsrConnectionHttpAuth, GlueSchemaRegistryConnection, IcebergAccessDelegation,
+    IcebergCatalogAuth, IcebergCatalogConnection, IcebergCatalogImpl, IcebergCatalogType,
+    KafkaConnection, KafkaSaslConfig, KafkaTlsConfig, KafkaTopicOptions, MySqlConnection,
+    MySqlSslMode, PostgresConnection, RestIcebergCatalog, S3TablesRestIcebergCatalog,
+    SqlServerConnectionDetails, SshConnection, SshTunnel, TlsIdentity, Tunnel,
 };
 
 use crate::names::Aug;
@@ -49,6 +49,7 @@ use crate::session::vars;
 
 generate_extracted_config!(
     ConnectionOption,
+    (AccessDelegation, IcebergAccessDelegation),
     (AccessKeyId, StringOrSecret),
     (AssumeRoleArn, String),
     (AssumeRoleSessionName, String),
@@ -191,6 +192,7 @@ pub(super) fn validate_options_per_connection_type(
             User,
         ],
         CreateConnectionType::IcebergCatalog => &[
+            AccessDelegation,
             AwsConnection,
             CatalogType,
             Credential,
@@ -704,6 +706,11 @@ impl ConnectionOptionExtracted {
                                 "invalid CONNECTION: ICEBERG s3tablesrest connections do not support OAUTH2 SERVER URL"
                             );
                         }
+                        if self.access_delegation.is_some() {
+                            sql_bail!(
+                                "invalid CONNECTION: ICEBERG s3tablesrest connections do not support ACCESS DELEGATION"
+                            );
+                        }
                         let Some(warehouse) = warehouse else {
                             sql_bail!(
                                 "invalid CONNECTION: ICEBERG s3tablesrest connections must specify WAREHOUSE"
@@ -757,7 +764,11 @@ impl ConnectionOptionExtracted {
                             ),
                         };
 
-                        IcebergCatalogImpl::Rest(RestIcebergCatalog { auth, warehouse })
+                        IcebergCatalogImpl::Rest(RestIcebergCatalog {
+                            auth,
+                            warehouse,
+                            access_delegation: self.access_delegation,
+                        })
                     }
                 };
 

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -20,8 +20,8 @@ use mz_sql_parser::ast::{
     ConnectionDefaultAwsPrivatelink, Expr, Ident, KafkaBroker, KafkaMatchingBrokerRule,
     NetworkPolicyRuleDefinition, RefreshOptionValue, ReplicaDefinition,
 };
-use mz_storage_types::connections::IcebergCatalogType;
 use mz_storage_types::connections::string_or_secret::StringOrSecret;
+use mz_storage_types::connections::{IcebergAccessDelegation, IcebergCatalogType};
 use serde::{Deserialize, Serialize};
 
 use crate::ast::{AstInfo, UnresolvedItemName, Value, WithOptionValue};
@@ -65,6 +65,33 @@ impl TryFromValue<WithOptionValue<Aug>> for IcebergCatalogType {
 impl ImpliedValue for IcebergCatalogType {
     fn implied_value() -> Result<Self, PlanError> {
         sql_bail!("must provide an iceberg catalog type")
+    }
+}
+
+impl TryFromValue<WithOptionValue<Aug>> for IcebergAccessDelegation {
+    fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
+        match String::try_from_value(v)? {
+            s if s.eq_ignore_ascii_case("vended-credentials") => {
+                Ok(IcebergAccessDelegation::VendedCredentials)
+            }
+            _ => sql_bail!("invalid iceberg access delegation, expected 'vended-credentials'"),
+        }
+    }
+
+    fn try_into_value(self, _catalog: &dyn SessionCatalog) -> Option<WithOptionValue<Aug>> {
+        Some(WithOptionValue::Value(Value::String(
+            self.as_header_value().to_string(),
+        )))
+    }
+
+    fn name() -> String {
+        "iceberg access delegation".to_string()
+    }
+}
+
+impl ImpliedValue for IcebergAccessDelegation {
+    fn implied_value() -> Result<Self, PlanError> {
+        sql_bail!("must provide an iceberg access delegation")
     }
 }
 

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -660,9 +660,10 @@ pub struct RestIcebergCatalog<C: ConnectionAccess = InlinedConnection> {
     pub warehouse: Option<String>,
     /// Which form of storage-access delegation to request from the catalog, if any.
     ///
-    /// `None` means never ask. Requesting delegation is not free of consequence: a
-    /// catalog that gates it behind privileges the principal lacks rejects the whole
-    /// request rather than falling back, so this stays opt-in per connection.
+    /// `None` means "do not request storage-access delegation".
+    /// If we do not have permission to request delegated access but request it anyway,
+    /// a catalog can reject our whole request,
+    /// even if we have our own storage credentials to fall back on.
     pub access_delegation: Option<IcebergAccessDelegation>,
 }
 
@@ -1079,9 +1080,7 @@ impl IcebergCatalogConnection<InlinedConnection> {
         };
 
         // `iceberg-rust` turns `header.*` props into headers on every REST request, so
-        // this rides along on `loadTable` and `createTable` alike. Only send it when the
-        // connection asked for delegation: catalogs that gate delegation behind
-        // privileges reject the entire request when the principal lacks them, rather
+        // connection asked for delegation.
         // than falling back to their configured storage credentials.
         if let Some(delegation) = &rest.access_delegation {
             props.insert(

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -97,6 +97,10 @@ const REST_CATALOG_PROP_CREDENTIAL: &str = "credential";
 /// Overrides the OAuth2 token endpoint. Spelled `uri` because that is the property name the
 /// Iceberg REST clients agree on, even though the SQL option says `URL`.
 const REST_CATALOG_PROP_OAUTH2_SERVER_URI: &str = "oauth2-server-uri";
+/// Requests catalog-vended storage credentials. `iceberg-rust` turns `header.*` catalog
+/// properties into headers on every REST request, the same way the Iceberg Java client
+/// carries this one.
+const REST_CATALOG_PROP_ACCESS_DELEGATION: &str = "header.X-Iceberg-Access-Delegation";
 
 /// A credential loader that wraps an aws-sdk-rust credentials provider for use with
 /// iceberg/OpenDAL. This allows us to provide refreshable credentials from the AWS SDK
@@ -654,6 +658,29 @@ pub struct RestIcebergCatalog<C: ConnectionAccess = InlinedConnection> {
     pub auth: IcebergCatalogAuth<C>,
     /// The warehouse for REST catalogs
     pub warehouse: Option<String>,
+    /// Which form of storage-access delegation to request from the catalog, if any.
+    ///
+    /// `None` means never ask. Requesting delegation is not free of consequence: a
+    /// catalog that gates it behind privileges the principal lacks rejects the whole
+    /// request rather than falling back, so this stays opt-in per connection.
+    pub access_delegation: Option<IcebergAccessDelegation>,
+}
+
+/// The value Materialize sends in the Iceberg REST `X-Iceberg-Access-Delegation`
+/// header, naming how the catalog should grant access to table storage.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum IcebergAccessDelegation {
+    /// Ask the catalog to mint temporary, table-scoped storage credentials.
+    VendedCredentials,
+}
+
+impl IcebergAccessDelegation {
+    /// The header value, as spelled in the Iceberg REST specification.
+    pub fn as_header_value(&self) -> &'static str {
+        match self {
+            IcebergAccessDelegation::VendedCredentials => "vended-credentials",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -690,6 +717,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<RestIcebergCatalog, R>
         RestIcebergCatalog {
             auth: self.auth.into_inline_connection(&r),
             warehouse: self.warehouse,
+            access_delegation: self.access_delegation,
         }
     }
 }
@@ -1005,11 +1033,14 @@ impl IcebergCatalogConnection<InlinedConnection> {
                 if let Some(scope) = scope {
                     props.insert(REST_CATALOG_PROP_SCOPE.to_string(), scope.clone());
                 }
+
                 (
                     OpenDalStorageFactory::S3 {
                         // When used with MinIO, Polaris returns a config with:
                         //   s3.access-key-id, s3.secret-access-key, s3.endpoint, ...
-                        // `iceberg-rust` forwards these props to `opendal`.
+                        // `iceberg-rust` forwards these props to `opendal`. When the catalog
+                        // vends instead, it returns per-table `storage-credentials` that
+                        // `iceberg-rust` wires into the same FileIO.
                         // N.B. This is not confirmed to work with other catalog & storage implementations.
                         customized_credential_load: None,
                     },
@@ -1046,6 +1077,18 @@ impl IcebergCatalogConnection<InlinedConnection> {
                 )
             }
         };
+
+        // `iceberg-rust` turns `header.*` props into headers on every REST request, so
+        // this rides along on `loadTable` and `createTable` alike. Only send it when the
+        // connection asked for delegation: catalogs that gate delegation behind
+        // privileges reject the entire request when the principal lacks them, rather
+        // than falling back to their configured storage credentials.
+        if let Some(delegation) = &rest.access_delegation {
+            props.insert(
+                REST_CATALOG_PROP_ACCESS_DELEGATION.to_string(),
+                delegation.as_header_value().to_string(),
+            );
+        }
 
         let mut catalog =
             RestCatalogBuilder::default().with_storage_factory(Arc::new(storage_factory));

--- a/test/iceberg/mzcompose.py
+++ b/test/iceberg/mzcompose.py
@@ -15,9 +15,7 @@ import urllib.error
 import urllib.request
 
 from materialize.mzcompose.composition import Composition, Service
-from materialize.mzcompose.helpers.iceberg import (
-    setup_polaris_for_iceberg,
-)
+from materialize.mzcompose.helpers.iceberg import setup_polaris_for_iceberg
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc, Minio
 from materialize.mzcompose.services.mz import Mz
@@ -43,7 +41,9 @@ SERVICES = [
 ]
 
 
-def _setup(c: Composition) -> str:
+def _setup(
+    c: Composition, vended: bool = False, static_credentials: bool = True
+) -> str:
     """Start fresh and return the S3 access key."""
     c.down(destroy_volumes=True)
     c.up(
@@ -52,7 +52,9 @@ def _setup(c: Composition) -> str:
         Service("polaris-bootstrap", idle=True),
         Service("polaris", idle=True),
     )
-    _, key = setup_polaris_for_iceberg(c)
+    _, key = setup_polaris_for_iceberg(
+        c, vended=vended, static_credentials=static_credentials
+    )
     return key
 
 
@@ -65,6 +67,25 @@ def workflow_default(c: Composition) -> None:
             c.workflow(name)
 
     c.test_parts(list(c.workflows.keys()), process)
+
+
+def workflow_vended_credentials(c: Composition) -> None:
+    """An Iceberg sink must work against a REST catalog that only hands out
+    temporary, table-scoped credentials.
+
+    The Polaris catalog is created with credential vending enabled and without
+    the long-lived S3 credentials it would otherwise return to clients, so
+    Materialize has no static credentials to fall back on. The sink can only
+    reach MinIO with what Polaris mints for it in response to the
+    `X-Iceberg-Access-Delegation: vended-credentials` request the Iceberg
+    catalog connection sends."""
+    key = _setup(c, vended=True, static_credentials=False)
+
+    c.run_testdrive_files(
+        f"--var=s3-access-key={key}",
+        "--var=aws-endpoint=minio:9000",
+        "vended-credentials.td",
+    )
 
 
 def workflow_smoke(c: Composition) -> None:

--- a/test/iceberg/vended-credentials.td
+++ b/test/iceberg/vended-credentials.td
@@ -1,0 +1,71 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# An Iceberg sink must be able to write to storage using only the temporary,
+# table-scoped credentials the REST catalog vends it.
+#
+# The Polaris catalog backing this test is created without client-visible S3
+# credentials, so nothing in the config it returns lets Materialize reach MinIO
+# on its own. The only usable credentials are the ones Polaris mints per table
+# in response to the `X-Iceberg-Access-Delegation: vended-credentials` request
+# that `ACCESS DELEGATION` below turns on. A sink that commits data here
+# therefore exercises the vending path end to end. Were the request dropped, or
+# the vended credentials not threaded into the sink's FileIO, the sink would
+# fail to write rather than pass quietly.
+
+# Delegation is opt-in. Only 'vended-credentials' is accepted.
+! CREATE CONNECTION bad_delegation TO ICEBERG CATALOG (
+    CATALOG TYPE = 'REST',
+    URL = 'http://polaris:8181/api/catalog',
+    CREDENTIAL = 'root:root',
+    WAREHOUSE = 'default_catalog',
+    ACCESS DELEGATION = 'remote-signing'
+  );
+contains:invalid iceberg access delegation
+
+> CREATE CONNECTION vended_polaris TO ICEBERG CATALOG (
+    CATALOG TYPE = 'REST',
+    URL = 'http://polaris:8181/api/catalog',
+    CREDENTIAL = 'root:root',
+    WAREHOUSE = 'default_catalog',
+    SCOPE = 'PRINCIPAL_ROLE:ALL',
+    ACCESS DELEGATION = 'vended-credentials'
+  );
+
+> CREATE TABLE vended_src (a int, b text);
+
+> INSERT INTO vended_src VALUES (1, 'one'), (2, 'two'), (3, 'three');
+
+> CREATE SINK vended_sink
+    FROM vended_src
+    INTO ICEBERG CATALOG CONNECTION vended_polaris (
+        NAMESPACE 'default_namespace',
+        TABLE 'vended_table'
+    )
+    MODE APPEND
+    WITH (COMMIT INTERVAL '1s');
+
+# Iceberg sinks commit asynchronously; wait for at least one commit interval.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
+
+# A sink denied storage credentials stalls with an error instead of staying healthy.
+> SELECT error IS NULL FROM mz_internal.mz_sink_statuses WHERE name = 'vended_sink'
+true
+
+# Read the table back with our own long-lived credentials, which are independent
+# of whatever the catalog vended to Materialize.
+$ duckdb-execute name=vended_iceberg
+CREATE SECRET s3_secret_vended (TYPE S3, KEY_ID 'tduser', SECRET '${arg.s3-access-key}', ENDPOINT '${arg.aws-endpoint}', URL_STYLE 'path', USE_SSL false, REGION 'minio');
+SET unsafe_enable_version_guessing = true;
+
+$ duckdb-query name=vended_iceberg
+SELECT a, b FROM iceberg_scan('s3://test-bucket/default_namespace/vended_table') ORDER BY a
+1 one
+2 two
+3 three


### PR DESCRIPTION
### Motivation

Catalogs such as Unity Catalog and Polaris can mint temporary, table-scoped
storage credentials instead of handing out their own long-lived ones, which
is how a sink writes to storage it holds no static keys for. Requesting them
requires the `X-Iceberg-Access-Delegation` header on catalog requests.

### Description

Adds an `ACCESS DELEGATION = 'vended-credentials'` option to REST Iceberg
catalog connections. When set, Materialize sends the header as a `header.*`
catalog property, which the client applies to every REST request, so it
rides along on `loadTable` and `createTable` alike. The credentials the
catalog returns are wired into the per-table FileIO.

The option is opt-in rather than always-on deliberately. Requesting
delegation is not free of consequence: a catalog that gates it behind
privileges the principal lacks rejects the whole request rather than falling
back to its configured storage credentials, so a connection that would
otherwise work would start failing.

### Verification

New `test/iceberg/vended-credentials.td` and an mzcompose workflow that runs
it against Polaris with MinIO storage, plus parser coverage for the new
option.
