### PR TITLE
compute: walk an expensive index peek off the serving worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6773,6 +6773,7 @@ dependencies = [
  "mz-proto",
  "mz-repr",
  "mz-row-spine",
+ "mz-secrets",
  "mz-storage-operators",
  "mz-storage-types",
  "mz-timely-util",

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -1095,6 +1095,12 @@ metrics:
   help: Total time processing index peeks, from process_peek entry to response. Excluding peeks that use the peek response stash.
   source: src/compute/src/metrics.rs
   visibility: internal
+- name: mz_index_peek_walks_total
+  help: 'The number of index peek walks, by the substrate they ran on: `inline` on the timely worker, `offloaded` away from it. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.'
+  labels:
+  - substrate
+  source: src/compute/src/metrics.rs
+  visibility: internal
 - name: mz_kafka_partition_offset_max
   help: High watermark offset on broker for partition
   labels:

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -956,31 +956,31 @@ metrics:
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_cursor_setup_seconds_bucket
-  help: Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.
+  help: Time opening the trace cursor and sorting the literal constraints. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker. Excludes seeking the cursor to the literals, which is part of row iteration.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_cursor_setup_seconds_count
-  help: Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.
+  help: Time opening the trace cursor and sorting the literal constraints. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker. Excludes seeking the cursor to the literals, which is part of row iteration.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_cursor_setup_seconds_sum
-  help: Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.
+  help: Time opening the trace cursor and sorting the literal constraints. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker. Excludes seeking the cursor to the literals, which is part of row iteration.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_error_scan_seconds_bucket
-  help: Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.
+  help: Time scanning the error trace for errors. Sums the time of the calls the scan was sliced into, so it excludes the gaps between them. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker. Only scans that find no error are observed.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_error_scan_seconds_count
-  help: Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.
+  help: Time scanning the error trace for errors. Sums the time of the calls the scan was sliced into, so it excludes the gaps between them. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker. Only scans that find no error are observed.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_error_scan_seconds_sum
-  help: Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.
+  help: Time scanning the error trace for errors. Sums the time of the calls the scan was sliced into, so it excludes the gaps between them. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker. Only scans that find no error are observed.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_frontier_check_seconds_bucket
@@ -1044,17 +1044,17 @@ metrics:
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_result_sort_seconds_bucket
-  help: Time sorting intermediate results during peek collection.
+  help: Time sorting intermediate results during peek collection. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_result_sort_seconds_count
-  help: Time sorting intermediate results during peek collection.
+  help: Time sorting intermediate results during peek collection. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_result_sort_seconds_sum
-  help: Time sorting intermediate results during peek collection.
+  help: Time sorting intermediate results during peek collection. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_collection_seconds_bucket
@@ -1086,17 +1086,17 @@ metrics:
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_bucket
-  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the time of the calls the walk was sliced into, so it excludes the gaps between them. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_count
-  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the time of the calls the walk was sliced into, so it excludes the gaps between them. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_sum
-  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the time of the calls the walk was sliced into, so it excludes the gaps between them. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_seek_fulfillment_seconds_bucket
@@ -1114,21 +1114,21 @@ metrics:
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_total_seconds_bucket
-  help: Total time processing index peeks, from process_peek entry to response. Excluding peeks that use the peek response stash.
+  help: Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek polled repeatedly or walked in several slices contributes several observations. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_total_seconds_count
-  help: Total time processing index peeks, from process_peek entry to response. Excluding peeks that use the peek response stash.
+  help: Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek polled repeatedly or walked in several slices contributes several observations. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_total_seconds_sum
-  help: Total time processing index peeks, from process_peek entry to response. Excluding peeks that use the peek response stash.
+  help: Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek polled repeatedly or walked in several slices contributes several observations. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_walks_total
-  help: 'The number of index peek walks, by the substrate they ran on: `inline` on the timely worker, `offloaded` away from it. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.'
+  help: 'The number of index peek walks that reached an outcome, by the substrate they ended on: `inline` on the timely worker, `offloaded` away from it. A cancelled walk reaches no outcome and is counted on neither. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.'
   labels:
   - substrate
   source: src/compute/src/metrics.rs

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -1114,21 +1114,21 @@ metrics:
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_total_seconds_bucket
-  help: Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek polled repeatedly or walked in several slices contributes several observations. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.
+  help: 'Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk''s end either promotes it or diverts it to the peek stash. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.'
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_total_seconds_count
-  help: Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek polled repeatedly or walked in several slices contributes several observations. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.
+  help: 'Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk''s end either promotes it or diverts it to the peek stash. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.'
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_total_seconds_sum
-  help: Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek polled repeatedly or walked in several slices contributes several observations. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.
+  help: 'Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk''s end either promotes it or diverts it to the peek stash. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.'
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_walks_total
-  help: 'The number of index peek walks that reached an outcome, by the substrate they ended on: `inline` on the timely worker, `offloaded` away from it. A cancelled walk reaches no outcome and is counted on neither. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.'
+  help: 'The number of index peek walks that reached an outcome, by the substrate they ended on: `inline` on the timely worker, `offloaded` away from it. A walk cancelled before it reaches an outcome is counted on neither. An offloaded walk cancelled after that, while its result is on its way back to the worker, counts as `offloaded`. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.'
   labels:
   - substrate
   source: src/compute/src/metrics.rs

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -997,6 +997,38 @@ metrics:
   help: Time checking trace frontiers.
   source: src/compute/src/metrics.rs
   visibility: internal
+- name: mz_index_peek_offload_seconds_bucket
+  help: Time an offloaded index peek walk spent away from the timely worker, from the promotion to the outcome, including the wait for a permit.
+  labels:
+  - le
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_offload_seconds_count
+  help: Time an offloaded index peek walk spent away from the timely worker, from the promotion to the outcome, including the wait for a permit.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_offload_seconds_sum
+  help: Time an offloaded index peek walk spent away from the timely worker, from the promotion to the outcome, including the wait for a permit.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_permit_queue_depth
+  help: 'The number of offloaded index peek walks waiting for a permit to run. The queue is a signal rather than a bound: it is drained rather than capped, so sustained growth here is what says the drain rate is too low.'
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_permit_wait_seconds_bucket
+  help: Time an offloaded index peek walk waited for a permit before it started running. Only walks that were admitted are observed, so a walk cancelled while waiting is absent rather than reported as a long wait.
+  labels:
+  - le
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_permit_wait_seconds_count
+  help: Time an offloaded index peek walk waited for a permit before it started running. Only walks that were admitted are observed, so a walk cancelled while waiting is absent rather than reported as a long wait.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_permit_wait_seconds_sum
+  help: Time an offloaded index peek walk waited for a permit before it started running. Only walks that were admitted are observed, so a walk cancelled while waiting is absent rather than reported as a long wait.
+  source: src/compute/src/metrics.rs
+  visibility: internal
 - name: mz_index_peek_result_sort_rows_bucket
   help: Number of intermediate result rows sorted during peek collection, summed across sort operations.
   labels:

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -773,6 +773,7 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "compute_index_peek_inline_budget",
     "compute_index_peek_activation_budget",
     "compute_index_peek_yield_granularity",
+    "compute_index_peek_permits",
     "compute_peek_response_stash_read_batch_size_bytes",
     "compute_peek_response_stash_read_memory_budget_bytes",
     "compute_peek_stash_num_batches",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -136,6 +136,11 @@ def get_minimal_system_parameters(
         config["compute_peek_row_iteration_limit"] = "1000000000"
         config["enable_compute_peek_row_iteration_limit"] = "true"
 
+        # Exercise the peek offload path in tests while it defaults off in
+        # production. The budgets stay at their code defaults so tests make the
+        # same placement decisions production makes.
+        config["enable_compute_index_peek_offload"] = "true"
+
     if version < MzVersion.parse_mz("v0.163.0-dev"):
         config["enable_compute_active_dataflow_cancelation"] = "true"
 
@@ -763,6 +768,11 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "mz_metrics_lgalloc_refresh_interval",
     "mz_metrics_rusage_refresh_interval",
     "compute_peek_response_stash_batch_max_runs",
+    # The offload's budgets, left at their code defaults so tests exercise the
+    # placement decisions production makes. parallel-workload varies them.
+    "compute_index_peek_inline_budget",
+    "compute_index_peek_activation_budget",
+    "compute_index_peek_yield_granularity",
     "compute_peek_response_stash_read_batch_size_bytes",
     "compute_peek_response_stash_read_memory_budget_bytes",
     "compute_peek_stash_num_batches",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3012,11 +3012,21 @@ class FlipFlagsAction(Action):
             "1000000000",
         ]
         # The production default, a value that yields after every position,
-        # and one that never yields within a walk.
+        # and one that covers any walk this workload produces in a single
+        # slice.
+        #
+        # The coarse value is capped rather than set to a billion, because an
+        # offloaded slice runs on an async task that yields only at slice
+        # boundaries. A slice that spans a whole walk therefore occupies a
+        # tokio worker thread for its duration, and the permit count is not
+        # sized to leave threads over for the rest of the process's async work.
+        # A hundred thousand positions is well past any arrangement this
+        # workload builds, so it exercises the same single-slice walk while
+        # keeping one slice short enough not to stall the runtime.
         self.flags_with_values["compute_index_peek_yield_granularity"] = [
             "10000",
             "1",
-            "1000000000",
+            "100000",
         ]
         # The default, which is one permit per worker in the process, a bound
         # that serializes every promoted walk, and one that never queues.

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3018,6 +3018,13 @@ class FlipFlagsAction(Action):
             "1",
             "1000000000",
         ]
+        # The default, which is one permit per worker in the process, a bound
+        # that serializes every promoted walk, and one that never queues.
+        self.flags_with_values["compute_index_peek_permits"] = [
+            "0",
+            "1",
+            "1000",
+        ]
         self.flags_with_values["compute_peek_response_stash_threshold_bytes"] = [
             "0",  # "force enabled"
             "1048576",  # 1 MiB, an in-between value

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3003,14 +3003,20 @@ class FlipFlagsAction(Action):
             "1",
             "1000000000",
         ]
+        # The production default, a value that lets one activation serve a
+        # single position across all peeks, and one that lifts the aggregate
+        # so every pending peek spends its full inline budget in one pass.
         self.flags_with_values["compute_index_peek_activation_budget"] = [
-            "1024",
             "8192",
+            "1",
             "1000000000",
         ]
+        # The production default, a value that yields after every position,
+        # and one that never yields within a walk.
         self.flags_with_values["compute_index_peek_yield_granularity"] = [
-            "1",
             "10000",
+            "1",
+            "1000000000",
         ]
         self.flags_with_values["compute_peek_response_stash_threshold_bytes"] = [
             "0",  # "force enabled"

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2993,6 +2993,25 @@ class FlipFlagsAction(Action):
             BOOLEAN_FLAG_VALUES
         )
         self.flags_with_values["compute_peek_row_iteration_limit"] = ["1000000000"]
+        self.flags_with_values["enable_compute_index_peek_offload"] = (
+            BOOLEAN_FLAG_VALUES
+        )
+        # The production default, a value that offloads all but the shortest
+        # peeks, and one that keeps every peek inline.
+        self.flags_with_values["compute_index_peek_inline_budget"] = [
+            "1024",
+            "1",
+            "1000000000",
+        ]
+        self.flags_with_values["compute_index_peek_activation_budget"] = [
+            "1024",
+            "8192",
+            "1000000000",
+        ]
+        self.flags_with_values["compute_index_peek_yield_granularity"] = [
+            "1",
+            "10000",
+        ]
         self.flags_with_values["compute_peek_response_stash_threshold_bytes"] = [
             "0",  # "force enabled"
             "1048576",  # 1 MiB, an in-between value

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -633,6 +633,84 @@ pub const PEEK_ROW_ITERATION_LIMIT: Config<usize> = Config::new(
     ParameterScope::Environment,
 );
 
+/// Whether a fast-path index peek may move its walk off the timely worker.
+///
+/// Off, a peek walks the arrangement to completion on the worker that owns it, so an expensive
+/// peek delays every other message that worker serves. On, a peek that outruns
+/// [`INDEX_PEEK_INLINE_BUDGET`] is promoted and finishes away from the worker.
+///
+/// The kill switch for the whole mechanism, and off by default so production placement is
+/// unchanged until the path earns trust. Replica-scoped, like the budgets it gates: promotion decides where a walk runs on the replica
+/// that serves the peek and changes nothing a client can observe, so replicas may disagree and one
+/// replica can be reverted without touching the environment.
+pub const ENABLE_INDEX_PEEK_OFFLOAD: Config<bool> = Config::new(
+    "enable_compute_index_peek_offload",
+    false,
+    "Whether a fast-path index peek may move its walk off the timely worker.",
+    ParameterScope::Replica,
+);
+
+/// How far one peek may walk on the worker before it is promoted, in consumed cursor positions.
+///
+/// Sized for point lookups rather than for scans. A peek that finishes within the budget never
+/// leaves the worker and pays none of the offload's cost, and a peek that exceeds it has been
+/// measured to be expensive rather than predicted to be, which is what lets a point lookup over a
+/// skewed hot key offload without being special-cased.
+///
+/// Counted in cursor positions visited, not in rows returned, because the result iterator steps
+/// the cursor without returning anything whenever the MFP rejects a row, so a selective filter
+/// over a large arrangement walks arbitrarily far while returning nothing and would never spend a
+/// row-counted budget. Wall-clock bounds are excluded for two reasons. Under memory pressure a
+/// time bound anti-correlates with progress, because one major fault consumes a whole slice, while
+/// a count bound guarantees this many positions of progress however slow each one is. And at this
+/// granularity a deadline is unreachable anyway, since the yielding machinery reads the clock only
+/// once per 1024 work units. The accepted consequence is that a single slice has no duration
+/// bound, only a position bound.
+///
+/// Read through a handle rather than captured once, so a change reaches peeks already in flight
+/// without discarding the positions they have walked.
+pub const INDEX_PEEK_INLINE_BUDGET: Config<usize> = Config::new(
+    "compute_index_peek_inline_budget",
+    1024,
+    "How far one index peek may walk on the timely worker, in consumed cursor positions, before it is offloaded.",
+    ParameterScope::Replica,
+);
+
+/// What all peeks together may spend in one worker activation, in consumed cursor positions.
+///
+/// Every activation visits every pending peek, so a per-peek inline budget with no aggregate lets
+/// N pending peeks cost N times [`INDEX_PEEK_INLINE_BUDGET`] in a single pass, unbounded in N.
+/// Peeks that do not get a turn are served first on the next activation.
+///
+/// The default is eight times the inline budget, so a burst of eight point-lookup-sized peeks is
+/// served in one activation. Raising the ratio drains a burst in fewer activations, lowering it
+/// caps how long one activation withholds the worker from everything else it serves.
+///
+/// Counted in the same unit as [`INDEX_PEEK_INLINE_BUDGET`], for the same reasons, and likewise
+/// read through a handle.
+pub const INDEX_PEEK_ACTIVATION_BUDGET: Config<usize> = Config::new(
+    "compute_index_peek_activation_budget",
+    8 * 1024,
+    "What all index peeks together may spend in one timely worker activation, in consumed cursor positions.",
+    ParameterScope::Replica,
+);
+
+/// How often a promoted scan checks for cancellation and yields, in consumed cursor positions.
+///
+/// At a plausible 100ns to 1us per position this bounds cancellation latency to single-digit
+/// milliseconds while leaving the yield overhead immaterial. Larger than
+/// [`INDEX_PEEK_INLINE_BUDGET`] because a promoted scan is off the worker's critical path, so its
+/// slices answer to cancellation latency rather than to the worker's availability.
+///
+/// Counted in the same unit as [`INDEX_PEEK_INLINE_BUDGET`], for the same reasons, and likewise
+/// read through a handle.
+pub const INDEX_PEEK_YIELD_GRANULARITY: Config<usize> = Config::new(
+    "compute_index_peek_yield_granularity",
+    10000,
+    "How often an offloaded index peek scan checks for cancellation and yields, in consumed cursor positions.",
+    ParameterScope::Replica,
+);
+
 /// The collection interval for the Prometheus metrics introspection source.
 ///
 /// Set to zero to disable scraping and retract any existing data.
@@ -720,6 +798,10 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&PEEK_STASH_BATCH_SIZE)
         .add(&ENABLE_PEEK_ROW_ITERATION_LIMIT)
         .add(&PEEK_ROW_ITERATION_LIMIT)
+        .add(&ENABLE_INDEX_PEEK_OFFLOAD)
+        .add(&INDEX_PEEK_INLINE_BUDGET)
+        .add(&INDEX_PEEK_ACTIVATION_BUDGET)
+        .add(&INDEX_PEEK_YIELD_GRANULARITY)
         .add(&COMPUTE_PROMETHEUS_INTROSPECTION_SCRAPE_INTERVAL)
         .add(&SUBSCRIBE_SNAPSHOT_OPTIMIZATION)
         .add(&MV_SINK_ADVANCE_PERSIST_FRONTIERS)
@@ -742,5 +824,17 @@ mod tests {
     fn peek_row_iteration_limit_defaults() {
         assert!(!*ENABLE_PEEK_ROW_ITERATION_LIMIT.default());
         assert_eq!(*PEEK_ROW_ITERATION_LIMIT.default(), 1000);
+    }
+
+    #[mz_ore::test]
+    fn index_peek_offload_defaults() {
+        // Production safety and test coverage are separate settings. The test configuration turns
+        // the offload on through `system_parameter_default`, which only works while the code
+        // default stays off.
+        assert!(!*ENABLE_INDEX_PEEK_OFFLOAD.default());
+        assert_eq!(*INDEX_PEEK_INLINE_BUDGET.default(), 1024);
+        assert_eq!(*INDEX_PEEK_YIELD_GRANULARITY.default(), 10000);
+        // The aggregate must admit at least one full inline slice, else no peek can finish inline.
+        assert!(*INDEX_PEEK_ACTIVATION_BUDGET.default() >= *INDEX_PEEK_INLINE_BUDGET.default());
     }
 }

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -733,6 +733,35 @@ pub const INDEX_PEEK_YIELD_GRANULARITY: Config<usize> = Config::new(
     ParameterScope::Replica,
 );
 
+/// How many promoted index peek scans may run at once in one replica process.
+///
+/// Zero asks for one per timely worker the process runs. A peek that walks on its worker occupies
+/// one core, so peek CPU is capped today at one core per worker by the very coupling promotion
+/// breaks. One permit per worker preserves exactly that ceiling, which is why it is the default
+/// rather than a tuned number.
+///
+/// The count is per process rather than per replica because the semaphore that enforces it lives
+/// in one process. A replica that runs as several processes would admit a replica-total count in
+/// each of them and over-admit by the process count.
+///
+/// It bounds running scans and nothing else. Scans that do not fit queue, which costs queue
+/// entries rather than threads. Queue depth is a signal to alert on rather than a second bound,
+/// because capping it would mean failing peeks.
+///
+/// Read when a scan asks to run rather than captured, so a change reaches every scan not yet
+/// admitted. Lowering the count takes back only the permits that are free at that moment, since a
+/// walk already under way is not interrupted by a configuration change, and the remainder is taken
+/// back as those walks return their permits.
+///
+/// Replica-scoped. It selects no execution path and changes no result, it only bounds how much of
+/// the replica process's own CPU promoted walks may use at once.
+pub const INDEX_PEEK_PERMITS: Config<usize> = Config::new(
+    "compute_index_peek_permits",
+    0,
+    "How many offloaded index peek scans may run at once in one replica process. Zero means one per timely worker the process runs.",
+    ParameterScope::Replica,
+);
+
 /// The collection interval for the Prometheus metrics introspection source.
 ///
 /// Set to zero to disable scraping and retract any existing data.
@@ -824,6 +853,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&INDEX_PEEK_INLINE_BUDGET)
         .add(&INDEX_PEEK_ACTIVATION_BUDGET)
         .add(&INDEX_PEEK_YIELD_GRANULARITY)
+        .add(&INDEX_PEEK_PERMITS)
         .add(&COMPUTE_PROMETHEUS_INTROSPECTION_SCRAPE_INTERVAL)
         .add(&SUBSCRIBE_SNAPSHOT_OPTIMIZATION)
         .add(&MV_SINK_ADVANCE_PERSIST_FRONTIERS)
@@ -856,6 +886,9 @@ mod tests {
         assert!(!*ENABLE_INDEX_PEEK_OFFLOAD.default());
         assert_eq!(*INDEX_PEEK_INLINE_BUDGET.default(), 1024);
         assert_eq!(*INDEX_PEEK_YIELD_GRANULARITY.default(), 10000);
+        // Zero is not "no promoted scan may run", it is "one per worker this process runs", a
+        // count no constant here can express.
+        assert_eq!(*INDEX_PEEK_PERMITS.default(), 0);
         // The aggregate must admit at least one full inline slice, else no peek can finish inline.
         assert!(*INDEX_PEEK_ACTIVATION_BUDGET.default() >= *INDEX_PEEK_INLINE_BUDGET.default());
         // A promoted walk is off the worker's critical path, so its slices answer to cancellation
@@ -888,5 +921,6 @@ mod tests {
             INDEX_PEEK_YIELD_GRANULARITY.scope(),
             ParameterScope::Replica
         );
+        assert_eq!(INDEX_PEEK_PERMITS.scope(), ParameterScope::Replica);
     }
 }

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -640,14 +640,19 @@ pub const PEEK_ROW_ITERATION_LIMIT: Config<usize> = Config::new(
 /// [`INDEX_PEEK_INLINE_BUDGET`] is promoted and finishes away from the worker.
 ///
 /// The kill switch for the whole mechanism, and off by default so production placement is
-/// unchanged until the path earns trust. Replica-scoped, like the budgets it gates: promotion decides where a walk runs on the replica
-/// that serves the peek and changes nothing a client can observe, so replicas may disagree and one
-/// replica can be reverted without touching the environment.
+/// unchanged until the path earns trust.
+///
+/// Environment-scoped because it selects between two execution paths whose output-equivalence is
+/// an assumption rather than a guarantee. A peek is broadcast to every replica of its cluster and
+/// the first answer wins, so a value that differs by replica means the same peek walks inline on
+/// one replica and promoted on another. Where the two paths do agree, one value everywhere costs
+/// nothing. Where they do not, per-replica divergence turns a single defect into query results
+/// that differ by which replica answered first.
 pub const ENABLE_INDEX_PEEK_OFFLOAD: Config<bool> = Config::new(
     "enable_compute_index_peek_offload",
     false,
     "Whether a fast-path index peek may move its walk off the timely worker.",
-    ParameterScope::Replica,
+    ParameterScope::Environment,
 );
 
 /// How far one peek may walk on the worker before it is promoted, in consumed cursor positions.
@@ -669,11 +674,17 @@ pub const ENABLE_INDEX_PEEK_OFFLOAD: Config<bool> = Config::new(
 ///
 /// Read through a handle rather than captured once, so a change reaches peeks already in flight
 /// without discarding the positions they have walked.
+///
+/// Environment-scoped because the threshold decides which peeks leave the worker. A value that
+/// differs by replica selects a different execution path for the same peek exactly as
+/// [`ENABLE_INDEX_PEEK_OFFLOAD`] does, gated by a count instead of by a boolean, and a peek is
+/// broadcast to every replica of its cluster. Divergence is unsafe for that reason, not because
+/// the number itself is delicate.
 pub const INDEX_PEEK_INLINE_BUDGET: Config<usize> = Config::new(
     "compute_index_peek_inline_budget",
     1024,
     "How far one index peek may walk on the timely worker, in consumed cursor positions, before it is offloaded.",
-    ParameterScope::Replica,
+    ParameterScope::Environment,
 );
 
 /// What all peeks together may spend in one worker activation, in consumed cursor positions.
@@ -688,11 +699,16 @@ pub const INDEX_PEEK_INLINE_BUDGET: Config<usize> = Config::new(
 ///
 /// Counted in the same unit as [`INDEX_PEEK_INLINE_BUDGET`], for the same reasons, and likewise
 /// read through a handle.
+///
+/// Environment-scoped on the same grounds as [`INDEX_PEEK_INLINE_BUDGET`]. The aggregate decides
+/// which peeks get a turn in an activation and therefore which ones are promoted, so a value that
+/// differs by replica routes the same broadcast peek down different execution paths depending on
+/// which replica served it.
 pub const INDEX_PEEK_ACTIVATION_BUDGET: Config<usize> = Config::new(
     "compute_index_peek_activation_budget",
     8 * 1024,
     "What all index peeks together may spend in one timely worker activation, in consumed cursor positions.",
-    ParameterScope::Replica,
+    ParameterScope::Environment,
 );
 
 /// How often a promoted scan checks for cancellation and yields, in consumed cursor positions.
@@ -704,6 +720,12 @@ pub const INDEX_PEEK_ACTIVATION_BUDGET: Config<usize> = Config::new(
 ///
 /// Counted in the same unit as [`INDEX_PEEK_INLINE_BUDGET`], for the same reasons, and likewise
 /// read through a handle.
+///
+/// Replica-scoped, unlike the switch and the two budgets. It selects no execution path and changes
+/// no result. It only sets how often a walk that is already promoted yields and rechecks
+/// cancellation, which is the timing of the replica process's own execution. Divergence is safe
+/// for that reason, and useful: a replica whose promoted walks starve its other work can be
+/// retuned on its own.
 pub const INDEX_PEEK_YIELD_GRANULARITY: Config<usize> = Config::new(
     "compute_index_peek_yield_granularity",
     10000,
@@ -836,5 +858,9 @@ mod tests {
         assert_eq!(*INDEX_PEEK_YIELD_GRANULARITY.default(), 10000);
         // The aggregate must admit at least one full inline slice, else no peek can finish inline.
         assert!(*INDEX_PEEK_ACTIVATION_BUDGET.default() >= *INDEX_PEEK_INLINE_BUDGET.default());
+        // A promoted walk is off the worker's critical path, so its slices answer to cancellation
+        // latency rather than to the worker's availability and are coarser than an inline slice.
+        // Were they finer, promotion would buy a walk more interruptions than it had inline.
+        assert!(*INDEX_PEEK_YIELD_GRANULARITY.default() > *INDEX_PEEK_INLINE_BUDGET.default());
     }
 }

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -675,6 +675,10 @@ pub const ENABLE_INDEX_PEEK_OFFLOAD: Config<bool> = Config::new(
 /// Read through a handle rather than captured once, so a change reaches peeks already in flight
 /// without discarding the positions they have walked.
 ///
+/// Zero walks one position rather than none. A peek granted no fuel suspends before it has walked
+/// anywhere, and a suspension holding no full batch is a promotion, so zero would promote every
+/// point lookup for a walk that visited nothing.
+///
 /// Environment-scoped because the threshold decides which peeks leave the worker. A value that
 /// differs by replica selects a different execution path for the same peek exactly as
 /// [`ENABLE_INDEX_PEEK_OFFLOAD`] does, gated by a count instead of by a boolean, and a peek is

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -863,4 +863,30 @@ mod tests {
         // Were they finer, promotion would buy a walk more interruptions than it had inline.
         assert!(*INDEX_PEEK_YIELD_GRANULARITY.default() > *INDEX_PEEK_INLINE_BUDGET.default());
     }
+
+    /// A peek is broadcast to every replica of a cluster and the first answer wins, so a parameter
+    /// deciding whether a walk is promoted must resolve to one value for all of them. Letting one
+    /// diverge would answer the same peek by the inline path on one replica and the promoted path
+    /// on another, which turns any inequivalence between the two paths into results that depend on
+    /// which replica replied. The yield granularity selects no path and changes no output, so it is
+    /// the one parameter here a replica may resolve for itself.
+    #[mz_ore::test]
+    fn index_peek_offload_parameter_scopes() {
+        assert_eq!(
+            ENABLE_INDEX_PEEK_OFFLOAD.scope(),
+            ParameterScope::Environment
+        );
+        assert_eq!(
+            INDEX_PEEK_INLINE_BUDGET.scope(),
+            ParameterScope::Environment
+        );
+        assert_eq!(
+            INDEX_PEEK_ACTIVATION_BUDGET.scope(),
+            ParameterScope::Environment
+        );
+        assert_eq!(
+            INDEX_PEEK_YIELD_GRANULARITY.scope(),
+            ParameterScope::Replica
+        );
+    }
 }

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -57,6 +57,7 @@ core_affinity = "0.8.3"
 
 [dev-dependencies]
 criterion.workspace = true
+mz-secrets = { path = "../secrets" }
 mz-storage-types = { path = "../storage-types", features = ["proptest"] }
 proptest.workspace = true
 rand.workspace = true

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1454,6 +1454,19 @@ impl<'a> ActiveComputeState<'a> {
 
     /// Scan pending peeks and attempt to retire each.
     pub fn process_peeks(&mut self) {
+        // This runs on every iteration of the worker loop, tens of thousands of times a second on
+        // a busy worker, and the overwhelming majority of those find no pending peek. Returning
+        // before anything is read or allocated keeps that case as cheap as it was before peeks had
+        // budgets, which is also what the kill switch has to restore.
+        //
+        // A `peek_resume_at` left set here cannot strand a peek: with no pending peek there is
+        // nothing to serve, and a resume point names a position in the uuid ordering rather than
+        // an entry, so the sweep that follows the next peek's arrival rotates correctly whether or
+        // not the peek it names still exists.
+        if self.compute_state.pending_peeks.is_empty() {
+            return;
+        }
+
         let mut upper = Antichain::new();
         let mut pending_peeks = std::mem::take(&mut self.compute_state.pending_peeks);
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -2955,12 +2955,16 @@ mod peek_sweep_tests {
         );
     }
 
-    /// Cancelling a promoted peek answers it once, as cancelled, and the walk it left behind
-    /// answers nothing of its own.
+    /// Cancelling a promoted peek answers it once, as cancelled, and no later activation answers
+    /// it again.
     ///
-    /// The walk holds the sending end of a channel whose receiver goes with the pending peek that
-    /// was removed, so a walk that reached an outcome after the cancellation has nowhere to put
-    /// it. Later activations must not produce a second response for the same peek.
+    /// This is the worker's half of a cancellation. The entry the cancellation removes owns the
+    /// handle to the walk, so removing it aborts the walk, and what the activations that follow
+    /// have to produce is nothing at all: no second response, and no count on either substrate for
+    /// a walk that never reached an outcome. The cancellation lands before the promoted task has
+    /// been polled, because nothing here awaits between the sweep that promoted it and the
+    /// cancellation. What a walk that was already running does with a cancellation is pinned by
+    /// `peek_offload::tests::a_walk_cancelled_while_running_reports_no_outcome`.
     #[mz_ore::test(tokio::test)]
     async fn a_cancelled_promoted_peek_is_answered_once() {
         let keys = wide_ok_rows(WIDE_INDEX_KEYS);

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -2458,7 +2458,7 @@ pub(crate) mod index_peek_tests {
     use differential_dataflow::operators::arrange::TraceAgent;
     use differential_dataflow::trace::{Batcher, Builder, Trace};
     use mz_expr::RowSetFinishing;
-    use mz_repr::{Datum, Diff, RelationDesc};
+    use mz_repr::{Datum, Diff, RelationDesc, SqlScalarType};
     use mz_row_spine::{RowRowBatcher, RowRowBuilder, RowRowSpine};
     use mz_timely_util::columnation::ColumnationStack;
     use timely::container::PushInto;
@@ -2553,6 +2553,10 @@ pub(crate) mod index_peek_tests {
     /// one without return rows of the same shape: the cursor's key is one datum, the values are
     /// empty, and a literal constraint contributes a second datum that a join in a dataflow would
     /// have added.
+    ///
+    /// The result description carries that one column, because its arity is what decides whether
+    /// the peek's finishing streams, and a finishing that streams is what makes a peek eligible
+    /// for the peek stash.
     pub(crate) fn index_peek(
         finishing: RowSetFinishing,
         literal_constraints: Option<Vec<Row>>,
@@ -2564,9 +2568,12 @@ pub(crate) mod index_peek_tests {
             .expect("valid plan")
             .into_nontemporal()
             .expect("non-temporal plan");
+        let result_desc = RelationDesc::builder()
+            .with_column("value", SqlScalarType::UInt64.nullable(false))
+            .finish();
         Peek {
             target: PeekTarget::Index { id: TARGET_ID },
-            result_desc: RelationDesc::empty(),
+            result_desc,
             literal_constraints,
             uuid: Uuid::nil(),
             timestamp: PEEK_TIMESTAMP,
@@ -2574,6 +2581,20 @@ pub(crate) mod index_peek_tests {
             map_filter_project,
             otel_ctx: OpenTelemetryContext::empty(),
         }
+    }
+
+    /// The keys of an index holding `count` distinct rows, in the order the ok walk visits them.
+    ///
+    /// The datum is wider than [`ok_row`]'s so that an index can be built with more positions than
+    /// the production inline budget allows a peek to walk on the worker. Sorted here rather than
+    /// assumed, because the trace holds its keys in [`Row`] order and the answer a full walk gives
+    /// is that order.
+    pub(crate) fn wide_ok_rows(count: u64) -> Vec<Row> {
+        let mut keys: Vec<Row> = (0..count)
+            .map(|value| Row::pack_slice(&[Datum::UInt64(value)]))
+            .collect();
+        keys.sort();
+        keys
     }
 
     /// The metrics an index peek observes into, registered into a registry the test owns so it
@@ -2705,13 +2726,19 @@ pub(crate) mod index_peek_tests {
         }
     }
 
-    /// The rows a completed peek over `values` answers with.
-    fn row_collection(values: impl IntoIterator<Item = u8>) -> RowCollection {
-        let rows = values
+    /// The rows a completed peek answers with, each at a multiplicity of one and in the order the
+    /// walk produced them.
+    pub(crate) fn row_collection(rows: impl IntoIterator<Item = Row>) -> RowCollection {
+        let rows = rows
             .into_iter()
-            .map(|value| (ok_row(value), NonZeroUsize::new(1).expect("non-zero")))
+            .map(|row| (row, NonZeroUsize::new(1).expect("non-zero")))
             .collect();
         RowCollection::new(rows, &[])
+    }
+
+    /// The answer a peek gives when its walk completes over `rows`.
+    pub(crate) fn rows_answer(rows: impl IntoIterator<Item = Row>) -> PeekResponse {
+        PeekResponse::Rows(vec![row_collection(rows)])
     }
 
     /// A peek whose scan runs to completion is answered with the rows it accumulated, and reports
@@ -2737,7 +2764,7 @@ pub(crate) mod index_peek_tests {
 
         assert_eq!(
             Answer::from(answer),
-            Answer::Ready(PeekResponse::Rows(vec![row_collection(0..6)]))
+            Answer::Ready(rows_answer((0..6).map(ok_row)))
         );
         assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 1));
     }
@@ -2794,6 +2821,41 @@ pub(crate) mod index_peek_tests {
         );
 
         assert_eq!(Answer::from(answer), Answer::UsePeekStash);
+        assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 0));
+    }
+
+    /// A peek whose walk both fills a batch and runs out of fuel is diverted to the stash rather
+    /// than promoted, and the driver that diverted it accounts for the walk.
+    ///
+    /// This is the livelock the placement policy is built around. A promoted scan holding a full
+    /// batch has nowhere to write it, so stepping it spends no fuel and advances no cursor, and a
+    /// driver that resumed it would yield forever. The two causes of a suspension coincide here,
+    /// which is the case a promotion condition written as "the fuel ran out" would get wrong.
+    #[mz_ore::test]
+    fn a_batch_ready_suspension_is_diverted_rather_than_promoted() {
+        let keys: Vec<Row> = (0..6).map(ok_row).collect();
+        let mut subject = index_peek_over(
+            index_peek(trivial_finishing(), None),
+            &keys,
+            cancelling_errors(0),
+        );
+        let metrics = TestMetrics::new();
+
+        // A threshold of zero bytes is crossed by the first row the ok walk produces. One
+        // position reaches the end of the empty error trace and the second produces that row, so
+        // the scan suspends holding a full batch and out of fuel, with both causes of a
+        // suspension in force at once.
+        let mut fuel = 2;
+        let answer = subject.collect_finished_data(
+            u64::MAX,
+            true,
+            0,
+            None,
+            &mut fuel,
+            &metrics.as_metrics(),
+        );
+        assert_eq!(Answer::from(answer), Answer::UsePeekStash);
+        assert_eq!(fuel, 0, "the slice spent every position it was given");
         assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 0));
     }
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -2346,8 +2346,10 @@ impl CollectionState {
 mod peek_sweep_tests {
     use mz_compute_types::dyncfgs::{
         ENABLE_INDEX_PEEK_OFFLOAD, INDEX_PEEK_ACTIVATION_BUDGET, INDEX_PEEK_INLINE_BUDGET,
+        PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES,
     };
     use mz_dyncfg::ConfigUpdates;
+    use mz_persist_client::Schemas;
     use mz_persist_client::cache::PersistClientCache;
     use mz_secrets::InMemorySecretsController;
     use mz_storage_types::connections::ConnectionContext;
@@ -2379,6 +2381,14 @@ mod peek_sweep_tests {
     /// How many keys the index the budget tests peek holds. Small, because what those tests turn
     /// on is how many peeks got a turn rather than how far each one walked.
     const SMALL_INDEX_KEYS: u64 = 6;
+
+    /// How many rows a walk accumulates before its batch is full, in the tests that drive a
+    /// hand-back.
+    ///
+    /// More than the inline slice can accumulate within the production budget and fewer than the
+    /// wide index holds, which is what puts the crossing after the promotion rather than before it
+    /// or never.
+    const HAND_BACK_AT_ROWS: u64 = 1_500;
 
     /// How many activations a test drives before it declares a peek stuck.
     ///
@@ -2537,8 +2547,13 @@ mod peek_sweep_tests {
         /// Runs activations until nothing is pending, and reports the responses they produced.
         ///
         /// Bounded, so a peek that never answers fails here rather than hanging the suite. The
-        /// yield between activations is what lets a promoted walk's task run, which on a
+        /// pause between activations is what lets a promoted walk's task run, which on a
         /// single-threaded runtime happens nowhere else.
+        ///
+        /// The pause is a sleep rather than a yield because a peek taken to the stash waits on an
+        /// upload whose work happens off this runtime. Yielding would spin against that instead of
+        /// letting it finish, which would turn the bound into a measure of how fast the machine
+        /// runs the spin.
         async fn drain(&mut self) -> Vec<(Uuid, PeekResponse)> {
             let mut responses = Vec::new();
             for _ in 0..SWEEP_BOUND {
@@ -2547,7 +2562,7 @@ mod peek_sweep_tests {
                 if self.state.pending_peeks.is_empty() {
                     return responses;
                 }
-                tokio::task::yield_now().await;
+                tokio::time::sleep(Duration::from_millis(1)).await;
             }
             panic!("peeks were still pending after {SWEEP_BOUND} activations");
         }
@@ -2983,38 +2998,181 @@ mod peek_sweep_tests {
         );
     }
 
-    /// A promoted walk that hands back reaches the worker, which answers the peek rather than
-    /// leaving it pending on a walk that has stopped.
+    /// A harness whose peek of the whole wide index is promoted and whose promoted walk then
+    /// crosses the stash threshold, swept once so that the peek is already promoted.
     ///
-    /// The stash location is cleared between the promotion and the hand-back, so that the hand-back
-    /// takes the arm with nowhere to write the rows. That is the arm a replica configured without
-    /// a stash location takes, and reaching it any other way means driving a real upload to
-    /// persist, which the peek stash owns rather than this driver.
-    #[mz_ore::test(tokio::test)]
-    async fn a_promoted_hand_back_answers_when_there_is_nowhere_to_write() {
-        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
-        let row_size = keys[0].byte_len() + size_of::<NonZeroUsize>();
-        // Above what the inline slice can accumulate within the production budget and below what
-        // the whole index holds, so the walk crosses the threshold after it has been promoted.
-        let threshold = 1_500 * row_size;
+    /// `location` is the replica's peek stash location, which has to be present here whatever the
+    /// hand-back is meant to find: a replica without one makes no scan stash-eligible, so its
+    /// walks never fill a batch and never hand back at all.
+    fn promoted_walk_that_hands_back(keys: &[Row], location: PersistLocation) -> Harness {
         assert!(
-            *INDEX_PEEK_INLINE_BUDGET.default() * row_size < threshold,
-            "the inline slice must promote a scan that still has room"
+            u64::cast_from(*INDEX_PEEK_INLINE_BUDGET.default()) < HAND_BACK_AT_ROWS
+                && HAND_BACK_AT_ROWS < WIDE_INDEX_KEYS,
+            "the walk must cross the stash threshold after it is promoted and before it ends"
         );
+        // The threshold is a size rather than a count, because the size of what a scan has
+        // accumulated is what it compares against.
+        let row_size = keys[0].byte_len() + size_of::<NonZeroUsize>();
+        let threshold = usize::cast_from(HAND_BACK_AT_ROWS) * row_size;
 
         let mut harness = Harness::new(move |updates| {
             updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
             updates.add(&ENABLE_PEEK_RESPONSE_STASH, true);
             updates.add(&PEEK_RESPONSE_STASH_THRESHOLD_BYTES, threshold);
         });
-        harness.state.peek_stash_persist_location = Some(PersistLocation::new_in_mem());
+        harness.state.peek_stash_persist_location = Some(location);
         harness.add_pending(
             index_peek_with_uuid(PEEK_A, None),
-            trace_bundle(&keys, cancelling_errors(0)),
+            trace_bundle(keys, cancelling_errors(0)),
         );
 
         harness.sweep();
-        assert_eq!(harness.pending(PEEK_A), Some("offloaded"));
+        assert_eq!(
+            harness.pending(PEEK_A),
+            Some("offloaded"),
+            "the walk must leave the worker before it crosses the threshold"
+        );
+        harness
+    }
+
+    /// Runs activations until the promoted walk of `PEEK_A` has handed back.
+    ///
+    /// Bounded, so a walk that never hands back fails here rather than hanging the suite. The
+    /// yield between activations is what lets the promoted task run.
+    async fn sweep_until_handed_back(harness: &mut Harness) {
+        for _ in 0..SWEEP_BOUND {
+            if harness.pending(PEEK_A) != Some("offloaded") {
+                return;
+            }
+            tokio::task::yield_now().await;
+            harness.sweep();
+        }
+        panic!("the promoted walk had not handed back after {SWEEP_BOUND} activations");
+    }
+
+    /// The rows a stashed peek response holds, read back out of `location` the way the coordinator
+    /// reads one, in [`Row`] order.
+    ///
+    /// A stashed response names a persist batch rather than carrying the answer, so what the peek
+    /// owes its caller is only visible from the batch. The batch is ordered as persist consolidates
+    /// it rather than as the peek would have answered, and the coordinator orders what it reads
+    /// back, so the rows are sorted here and compared as the set they are.
+    async fn stashed_rows(
+        harness: &Harness,
+        location: &PersistLocation,
+        response: PeekResponse,
+    ) -> Vec<Row> {
+        let PeekResponse::Stashed(stashed) = response else {
+            panic!("a peek taken to the stash answers with a stashed response, not {response:?}");
+        };
+
+        // Opened out of the harness's own cache, because two `PersistLocation`s naming the same
+        // in-memory URI reach the same blob only through the cache that opened them.
+        let mut client = harness
+            .state
+            .persist_clients
+            .open(location.clone())
+            .await
+            .expect("the in-memory location opens");
+
+        let shard_id = stashed.shard_id;
+        let batches = stashed
+            .batches
+            .into_iter()
+            .map(|batch| client.batch_from_transmittable_batch(&shard_id, batch))
+            .collect();
+        let read_schemas: Schemas<SourceData, ()> = Schemas {
+            id: None,
+            key: Arc::new(stashed.relation_desc),
+            val: Arc::new(UnitSchema),
+        };
+        let mut cursor = client
+            .read_batches_consolidated::<_, _, _, i64>(
+                shard_id,
+                Antichain::from_elem(Timestamp::default()),
+                read_schemas,
+                batches,
+                |_stats| true,
+                *PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES.default(),
+            )
+            .await
+            .expect("the batches are readable at the timestamp they were written at");
+
+        let mut rows = Vec::new();
+        while let Some(updates) = cursor.next().await {
+            for ((key, _val), _time, diff) in updates {
+                assert_eq!(diff, 1, "the index holds each key once");
+                rows.push(key.0.expect("the peek stash holds no errors"));
+            }
+        }
+        rows.sort();
+
+        // Deleted as the coordinator deletes them once it has read them. A batch dropped without
+        // this leaves its blob keys behind and says so in a warning.
+        for batch in cursor.into_lease() {
+            batch.delete().await;
+        }
+        rows
+    }
+
+    /// A promoted walk that hands back with a stash location present takes the peek to the stash,
+    /// which answers it with the rows the peek would have answered with inline.
+    ///
+    /// This is the arm every hand-back in production takes, because a replica's stash location is
+    /// set once at instance creation and nothing clears it. The peek has to become pending on the
+    /// stash rather than be answered where the hand-back arrives: the rows are produced by a
+    /// second walk that the worker pumps over the activations that follow, and answering here
+    /// would drop them.
+    #[mz_ore::test(tokio::test)]
+    async fn a_promoted_hand_back_takes_the_peek_to_the_stash() {
+        // The wide keys carry the `UInt64` the peek's result description declares, which is the
+        // schema the stash writes its batch under. The narrow fixture rows do not.
+        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+        let location = PersistLocation::new_in_mem();
+        let mut harness = promoted_walk_that_hands_back(&keys, location.clone());
+
+        sweep_until_handed_back(&mut harness).await;
+
+        assert_eq!(
+            harness.pending(PEEK_A),
+            Some("stash"),
+            "the hand-back starts a stash upload and leaves the peek waiting on it"
+        );
+        assert_eq!(
+            harness.peek_responses(),
+            vec![],
+            "a peek handed to the stash is not answered where the hand-back arrives"
+        );
+        assert_eq!(
+            harness.walks(),
+            (0, 1),
+            "a hand-back is a terminal outcome of the promoted walk"
+        );
+
+        let mut responses = harness.drain().await;
+        assert_eq!(responses.len(), 1, "the stashed peek answers once");
+        let (uuid, response) = responses.pop().expect("length checked");
+        assert_eq!(uuid, PEEK_A);
+        assert_eq!(
+            stashed_rows(&harness, &location, response).await,
+            keys,
+            "the stash holds the rows the peek would have answered with inline"
+        );
+    }
+
+    /// A promoted walk that hands back with nowhere to write the rows answers the peek with an
+    /// error rather than leaving it pending on a walk that has stopped.
+    ///
+    /// This arm is defensive only. Reaching it takes a replica that loses its stash location
+    /// between the promotion and the hand-back, which nothing does, and the location is cleared
+    /// here to stand in for that: `handle_create_instance` sets it and nothing clears it, while a
+    /// replica that never had one makes no scan stash-eligible, so none of its walks fills a batch
+    /// and hands back in the first place. The arm production takes is
+    /// [`a_promoted_hand_back_takes_the_peek_to_the_stash`]'s.
+    #[mz_ore::test(tokio::test)]
+    async fn a_promoted_hand_back_answers_when_there_is_nowhere_to_write() {
+        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+        let mut harness = promoted_walk_that_hands_back(&keys, PersistLocation::new_in_mem());
 
         harness.state.peek_stash_persist_location = None;
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -75,11 +75,14 @@ use crate::render::{LinearJoinSpec, StartSignal};
 use crate::server::{ComputeInstanceContext, ResponseSender};
 
 mod error_scan;
+mod peek_metrics;
 mod peek_offload;
 mod peek_result_iterator;
 mod peek_scan;
 mod peek_stash;
 
+use self::peek_metrics::IndexPeekMetrics;
+use self::peek_metrics::PeekWalkMetrics;
 pub(crate) use self::peek_offload::PeekPermits;
 use self::peek_offload::{OffloadConfig, OffloadOutcome, OffloadedPeek};
 use self::peek_scan::{IndexPeekScan, PeekScan, ScanOutcome};
@@ -281,6 +284,12 @@ pub struct ComputeState {
     /// process.
     pub peek_permits: Arc<PeekPermits>,
 
+    /// The metrics an index peek walk reports, whichever driver runs it.
+    ///
+    /// Held here rather than assembled per peek, because a promotion clones it into the task and
+    /// the inline driver reads it on every activation of every pending peek.
+    peek_walk_metrics: PeekWalkMetrics,
+
     /// Collections awaiting schedule instruction by the controller.
     ///
     /// Each entry stores a reference to a token that can be dropped to unsuspend the collection's
@@ -321,6 +330,7 @@ impl ComputeState {
     ) -> Self {
         let traces = TraceManager::new(metrics.clone());
         let command_history = ComputeCommandHistory::new(metrics.for_history());
+        let peek_walk_metrics = PeekWalkMetrics::new(&metrics);
 
         Self {
             collections: Default::default(),
@@ -342,6 +352,7 @@ impl ComputeState {
             metrics_registry,
             workers_per_process,
             peek_permits,
+            peek_walk_metrics,
             suspended_collections: Default::default(),
             server_maintenance_interval: Duration::ZERO,
             init_system_time: mz_ore::now::SYSTEM_TIME(),
@@ -1202,22 +1213,7 @@ impl<'a> ActiveComputeState<'a> {
                         .compute_state
                         .metrics
                         .index_peek_frontier_check_seconds,
-                    error_scan_seconds: &self.compute_state.metrics.index_peek_error_scan_seconds,
-                    cursor_setup_seconds: &self
-                        .compute_state
-                        .metrics
-                        .index_peek_cursor_setup_seconds,
-                    row_iteration_seconds: &self
-                        .compute_state
-                        .metrics
-                        .index_peek_row_iteration_seconds,
-                    row_iteration_rows: &self.compute_state.metrics.index_peek_row_iteration_rows,
-                    result_sort_seconds: &self.compute_state.metrics.index_peek_result_sort_seconds,
-                    result_sort_rows: &self.compute_state.metrics.index_peek_result_sort_rows,
-                    row_collection_seconds: &self
-                        .compute_state
-                        .metrics
-                        .index_peek_row_collection_seconds,
+                    walk: &self.compute_state.peek_walk_metrics,
                 };
 
                 let status = peek.seek_fulfillment(
@@ -1249,10 +1245,7 @@ impl<'a> ActiveComputeState<'a> {
                             scan,
                             &permits,
                             OffloadConfig::new(&self.compute_state.worker_config),
-                            self.compute_state
-                                .metrics
-                                .index_peek_walks_offloaded
-                                .clone(),
+                            self.compute_state.peek_walk_metrics.clone(),
                             self.timely_worker.sync_activator_for([].into()),
                         );
 
@@ -1837,22 +1830,6 @@ pub struct IndexPeek {
     span: tracing::Span,
 }
 
-/// Histogram metrics for index peek phases.
-///
-/// This struct bundles references to the various histogram metrics used to
-/// instrument the index peek processing pipeline.
-pub(crate) struct IndexPeekMetrics<'a> {
-    pub seek_fulfillment_seconds: &'a prometheus::Histogram,
-    pub frontier_check_seconds: &'a prometheus::Histogram,
-    pub error_scan_seconds: &'a prometheus::Histogram,
-    pub cursor_setup_seconds: &'a prometheus::Histogram,
-    pub row_iteration_seconds: &'a prometheus::Histogram,
-    pub row_iteration_rows: &'a prometheus::Histogram,
-    pub result_sort_seconds: &'a prometheus::Histogram,
-    pub result_sort_rows: &'a prometheus::Histogram,
-    pub row_collection_seconds: &'a prometheus::Histogram,
-}
-
 impl IndexPeek {
     /// Attempts to fulfill the peek and reports success.
     ///
@@ -1945,15 +1922,14 @@ impl IndexPeek {
         let mut fuel = usize::MAX;
         let outcome = scan.step(row_iteration_limit, &mut fuel);
 
-        // Both phases that precede the ok walk are reported only for a peek that reached that
-        // walk, so a peek answered by its error trace reports neither.
-        if scan.error_trace_clean() {
-            metrics
-                .error_scan_seconds
-                .observe(scan.error_scan_time().as_secs_f64());
-            metrics
-                .cursor_setup_seconds
-                .observe(scan.cursor_setup_time().as_secs_f64());
+        // A suspension the offload can resume is the one outcome that leaves the walk unfinished,
+        // so it is the one outcome this driver reports nothing for. Everything else ends the walk
+        // here, and this driver is the one that accounts for it.
+        let promoted = matches!(outcome, ScanOutcome::Suspended) && !scan.batch_ready();
+        let phases = scan.phases();
+        if !promoted {
+            metrics.walk.walked_inline();
+            metrics.walk.observe_error_phase(&phases);
         }
 
         let rows = match outcome {
@@ -1961,8 +1937,8 @@ impl IndexPeek {
             ScanOutcome::Failed(error) => return PeekStatus::Ready(PeekResponse::Error(error)),
             // A scan that suspends without a batch has work left and rows it is still allowed to
             // accumulate, so it is resumed rather than disposed of. Every position it has walked
-            // travels with it, which is what makes the promotion cost one hand-off instead of a
-            // second walk.
+            // travels with it, and so does the account of what those positions cost, which is what
+            // makes the promotion cost one hand-off instead of a second walk.
             ScanOutcome::Suspended if !scan.batch_ready() => return PeekStatus::Promote(scan),
             // Diversion is sound only for a scan whose error walk is over. The stash answers the
             // peek from a walk of the ok trace alone and never reads the error trace, so a peek
@@ -1987,33 +1963,13 @@ impl IndexPeek {
             }
         };
 
-        metrics
-            .row_iteration_seconds
-            .observe(scan.row_iteration_time().as_secs_f64());
-        metrics
-            .row_iteration_rows
-            .observe(f64::cast_lossy(scan.rows_processed()));
-        metrics
-            .result_sort_seconds
-            .observe(scan.result_sort_time().as_secs_f64());
-        metrics
-            .result_sort_rows
-            .observe(f64::cast_lossy(scan.rows_sorted()));
+        metrics.walk.observe_ok_phase(&phases);
 
-        let row_collection_start = Instant::now();
-        let rows = rows
-            .into_iter()
-            .map(|(row, copies)| {
-                let copies = NonZeroUsize::try_from(copies).expect("fits into usize");
-                (row, copies)
-            })
-            .collect();
-        let collection = RowCollection::new(rows, &self.peek.finishing.order_by);
-        metrics
-            .row_collection_seconds
-            .observe(row_collection_start.elapsed().as_secs_f64());
-
-        PeekStatus::Ready(PeekResponse::Rows(vec![collection]))
+        PeekStatus::Ready(
+            metrics
+                .walk
+                .rows_response(rows, &self.peek.finishing.order_by),
+        )
     }
 }
 
@@ -2265,6 +2221,8 @@ pub(crate) mod index_peek_tests {
     use timely::container::PushInto;
     use timely::dataflow::operators::generic::OperatorInfo;
 
+    use crate::metrics::ComputeMetrics;
+    use crate::server::ComputeRuntimeRole;
     use crate::typedefs::{ErrAgent, ErrSpine, RowRowAgent};
 
     use super::error_scan::tests::{
@@ -2375,96 +2333,85 @@ pub(crate) mod index_peek_tests {
         }
     }
 
-    /// The histograms an index peek observes into, owned by the test that reads them back.
+    /// The metrics an index peek observes into, registered into a registry the test owns so it
+    /// can read them back.
     struct TestMetrics {
-        seek_fulfillment_seconds: prometheus::Histogram,
-        frontier_check_seconds: prometheus::Histogram,
-        error_scan_seconds: prometheus::Histogram,
-        cursor_setup_seconds: prometheus::Histogram,
-        row_iteration_seconds: prometheus::Histogram,
-        row_iteration_rows: prometheus::Histogram,
-        result_sort_seconds: prometheus::Histogram,
-        result_sort_rows: prometheus::Histogram,
-        row_collection_seconds: prometheus::Histogram,
-    }
-
-    fn histogram(name: &str) -> prometheus::Histogram {
-        prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(name, name))
-            .expect("valid histogram")
+        metrics: WorkerMetrics,
+        walk: PeekWalkMetrics,
     }
 
     impl TestMetrics {
         fn new() -> Self {
-            Self {
-                seek_fulfillment_seconds: histogram("seek_fulfillment_seconds"),
-                frontier_check_seconds: histogram("frontier_check_seconds"),
-                error_scan_seconds: histogram("error_scan_seconds"),
-                cursor_setup_seconds: histogram("cursor_setup_seconds"),
-                row_iteration_seconds: histogram("row_iteration_seconds"),
-                row_iteration_rows: histogram("row_iteration_rows"),
-                result_sort_seconds: histogram("result_sort_seconds"),
-                result_sort_rows: histogram("result_sort_rows"),
-                row_collection_seconds: histogram("row_collection_seconds"),
-            }
+            let metrics =
+                ComputeMetrics::register_with(&MetricsRegistry::new(), ComputeRuntimeRole::Solo)
+                    .for_worker(0);
+            let walk = PeekWalkMetrics::new(&metrics);
+            Self { metrics, walk }
         }
 
         fn as_metrics(&self) -> IndexPeekMetrics<'_> {
             IndexPeekMetrics {
-                seek_fulfillment_seconds: &self.seek_fulfillment_seconds,
-                frontier_check_seconds: &self.frontier_check_seconds,
-                error_scan_seconds: &self.error_scan_seconds,
-                cursor_setup_seconds: &self.cursor_setup_seconds,
-                row_iteration_seconds: &self.row_iteration_seconds,
-                row_iteration_rows: &self.row_iteration_rows,
-                result_sort_seconds: &self.result_sort_seconds,
-                result_sort_rows: &self.result_sort_rows,
-                row_collection_seconds: &self.row_collection_seconds,
+                seek_fulfillment_seconds: &self.metrics.index_peek_seek_fulfillment_seconds,
+                frontier_check_seconds: &self.metrics.index_peek_frontier_check_seconds,
+                walk: &self.walk,
             }
         }
 
-        /// How often each histogram that `collect_finished_data` can observe into was observed.
+        /// How often each metric that `collect_finished_data` can observe into was observed.
         ///
         /// The two histograms the enclosing `seek_fulfillment` owns are left out, because the
         /// tests that read this call `collect_finished_data` directly.
         fn observations(&self) -> BTreeMap<&'static str, u64> {
+            let metrics = &self.metrics;
             BTreeMap::from([
+                ("walks_inline", metrics.index_peek_walks_inline.get()),
+                ("walks_offloaded", metrics.index_peek_walks_offloaded.get()),
                 (
                     "error_scan_seconds",
-                    self.error_scan_seconds.get_sample_count(),
+                    metrics.index_peek_error_scan_seconds.get_sample_count(),
                 ),
                 (
                     "cursor_setup_seconds",
-                    self.cursor_setup_seconds.get_sample_count(),
+                    metrics.index_peek_cursor_setup_seconds.get_sample_count(),
                 ),
                 (
                     "row_iteration_seconds",
-                    self.row_iteration_seconds.get_sample_count(),
+                    metrics.index_peek_row_iteration_seconds.get_sample_count(),
                 ),
                 (
                     "row_iteration_rows",
-                    self.row_iteration_rows.get_sample_count(),
+                    metrics.index_peek_row_iteration_rows.get_sample_count(),
                 ),
                 (
                     "result_sort_seconds",
-                    self.result_sort_seconds.get_sample_count(),
+                    metrics.index_peek_result_sort_seconds.get_sample_count(),
                 ),
-                ("result_sort_rows", self.result_sort_rows.get_sample_count()),
+                (
+                    "result_sort_rows",
+                    metrics.index_peek_result_sort_rows.get_sample_count(),
+                ),
                 (
                     "row_collection_seconds",
-                    self.row_collection_seconds.get_sample_count(),
+                    metrics.index_peek_row_collection_seconds.get_sample_count(),
                 ),
             ])
         }
     }
 
     /// The observation counts a driver call is expected to leave behind, named so that a failure
-    /// says which histogram moved.
+    /// says which metric moved.
+    ///
+    /// `walks_offloaded` is zero throughout, because these tests exercise the inline driver and a
+    /// walk it promotes is counted by the task that finishes it.
     fn expected_observations(
+        walks_inline: u64,
         error_scan: u64,
         cursor_setup: u64,
         rows: u64,
     ) -> BTreeMap<&'static str, u64> {
         BTreeMap::from([
+            ("walks_inline", walks_inline),
+            ("walks_offloaded", 0),
             ("error_scan_seconds", error_scan),
             ("cursor_setup_seconds", cursor_setup),
             ("row_iteration_seconds", rows),
@@ -2537,7 +2484,7 @@ pub(crate) mod index_peek_tests {
             Answer::from(answer),
             Answer::Ready(PeekResponse::Rows(vec![row_collection(0..6)]))
         );
-        assert_eq!(metrics.observations(), expected_observations(1, 1, 1));
+        assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 1));
     }
 
     /// A peek its error trace answers reports no phase timer at all, because it reached none of
@@ -2558,7 +2505,7 @@ pub(crate) mod index_peek_tests {
             Answer::from(answer),
             Answer::Ready(PeekResponse::Error(expected))
         );
-        assert_eq!(metrics.observations(), expected_observations(0, 0, 0));
+        assert_eq!(metrics.observations(), expected_observations(1, 0, 0, 0));
     }
 
     /// A peek whose accumulated rows fill a batch is diverted to the stash rather than answered
@@ -2579,7 +2526,7 @@ pub(crate) mod index_peek_tests {
         let answer = subject.collect_finished_data(u64::MAX, true, 0, None, &metrics.as_metrics());
 
         assert_eq!(Answer::from(answer), Answer::UsePeekStash);
-        assert_eq!(metrics.observations(), expected_observations(1, 1, 0));
+        assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 0));
     }
 
     /// A peek its ok walk fails is answered with that error, and reports the phases that walk
@@ -2617,6 +2564,6 @@ pub(crate) mod index_peek_tests {
                 ByteSize::b(max_result_size)
             ))))
         );
-        assert_eq!(metrics.observations(), expected_observations(1, 1, 0));
+        assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 0));
     }
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -82,7 +82,7 @@ mod peek_result_iterator;
 mod peek_scan;
 mod peek_stash;
 
-use self::peek_budget::InlineBudget;
+use self::peek_budget::{InlineBudget, InlineBudgetConfig};
 use self::peek_metrics::IndexPeekMetrics;
 use self::peek_metrics::PeekWalkMetrics;
 pub(crate) use self::peek_offload::PeekPermits;
@@ -292,6 +292,12 @@ pub struct ComputeState {
     /// the inline driver reads it on every activation of every pending peek.
     peek_walk_metrics: PeekWalkMetrics,
 
+    /// The parameters [`ComputeState::peek_budget`] is refilled from.
+    ///
+    /// Held rather than looked up, because a refill happens on every sweep of the pending peeks
+    /// and a sweep runs on every activation of the worker.
+    peek_budget_config: InlineBudgetConfig,
+
     /// What is left of what this activation may spend walking index peeks on the worker.
     ///
     /// Refilled at the top of each sweep of the pending peeks. A peek that arrives between two
@@ -346,9 +352,11 @@ impl ComputeState {
         peek_permits: Arc<PeekPermits>,
         storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
     ) -> Self {
+        let worker_config: Rc<ConfigSet> = mz_dyncfgs::all_dyncfgs().into();
         let traces = TraceManager::new(metrics.clone());
         let command_history = ComputeCommandHistory::new(metrics.for_history());
         let peek_walk_metrics = PeekWalkMetrics::new(&metrics);
+        let peek_budget_config = InlineBudgetConfig::new(&worker_config);
 
         Self {
             collections: Default::default(),
@@ -366,11 +374,12 @@ impl ComputeState {
             metrics,
             tracing_handle,
             context,
-            worker_config: mz_dyncfgs::all_dyncfgs().into(),
+            worker_config,
             metrics_registry,
             workers_per_process,
             peek_permits,
             peek_walk_metrics,
+            peek_budget_config,
             // The offload is off until a configuration arrives, and this is what off means.
             peek_budget: InlineBudget::Unbounded,
             peek_resume_at: None,
@@ -1470,8 +1479,7 @@ impl<'a> ActiveComputeState<'a> {
         let mut upper = Antichain::new();
         let mut pending_peeks = std::mem::take(&mut self.compute_state.pending_peeks);
 
-        self.compute_state.peek_budget =
-            InlineBudget::for_activation(&self.compute_state.worker_config);
+        self.compute_state.peek_budget = self.compute_state.peek_budget_config.for_activation();
 
         let mut order: Vec<Uuid> = pending_peeks.keys().copied().collect();
         if let Some(resume_at) = self.compute_state.peek_resume_at.take() {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1316,9 +1316,20 @@ impl<'a> ActiveComputeState<'a> {
                 // and the one way it does that is a cancellation that removed this entry, so an
                 // entry that is still here to be polled means the task died. Answering the peek is
                 // what keeps it from waiting forever on a walk nothing is running.
-                Err(oneshot::error::TryRecvError::Closed) => Some(PeekResponse::Error(
-                    PeekError::unstructured("offloaded peek walk failed"),
-                )),
+                //
+                // NOTE: a walk whose task is dropped by a shutting-down tokio runtime reaches here
+                // the same way a panicking one does. The worker is going away too in that case, so
+                // the log line is noise rather than a lost signal, and the alternative of staying
+                // silent would hide a panicked walk in the case that matters.
+                Err(oneshot::error::TryRecvError::Closed) => {
+                    soft_panic_or_log!(
+                        "offloaded walk of peek on {} ended without an outcome",
+                        offloaded.peek.target.id()
+                    );
+                    Some(PeekResponse::Error(PeekError::unstructured(
+                        "offloaded peek walk failed",
+                    )))
+                }
             },
             PendingPeek::Stash(stashing_peek) => {
                 let num_batches = PEEK_STASH_NUM_BATCHES.get(&self.compute_state.worker_config);

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1504,7 +1504,7 @@ impl<'a> ActiveComputeState<'a> {
     /// answered or promoted, and neither leaves an activation behind, so a worker with no dataflow
     /// to run would park with peeks waiting on nothing but their turn. Every path that defers a
     /// peek therefore calls this before it hands the worker back.
-    fn request_peek_activation(&mut self) {
+    fn request_peek_activation(&self) {
         match self.timely_worker.sync_activator_for([].into()).activate() {
             Ok(()) => {}
             Err(_) => debug!("unable to wake timely for peeks left waiting on their turn"),

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1486,15 +1486,26 @@ impl<'a> ActiveComputeState<'a> {
         let mut upper = Antichain::new();
         let mut pending_peeks = std::mem::take(&mut self.compute_state.pending_peeks);
 
-        let mut order: Vec<Uuid> = pending_peeks.keys().copied().collect();
-        if let Some(resume_at) = self.compute_state.peek_resume_at.take() {
-            let resume_from = order.partition_point(|uuid| *uuid < resume_at);
-            order.rotate_left(resume_from);
-        }
+        // Turning the ring costs a vector of the pending uuids and a lookup per peek, where taking
+        // the map in its own order costs neither. Only a sweep that passed a peek over leaves a
+        // resume point, and no peek is ever passed over while the offload is off, so the kill
+        // switch takes the second arm and pays exactly what the worker paid before.
+        match self.compute_state.peek_resume_at.take() {
+            Some(resume_at) => {
+                let mut order: Vec<Uuid> = pending_peeks.keys().copied().collect();
+                let resume_from = order.partition_point(|uuid| *uuid < resume_at);
+                order.rotate_left(resume_from);
 
-        for uuid in order {
-            let peek = pending_peeks.remove(&uuid).expect("taken from this map");
-            self.process_peek(&mut upper, peek);
+                for uuid in order {
+                    let peek = pending_peeks.remove(&uuid).expect("taken from this map");
+                    self.process_peek(&mut upper, peek);
+                }
+            }
+            None => {
+                for (_uuid, peek) in pending_peeks {
+                    self.process_peek(&mut upper, peek);
+                }
+            }
         }
 
         if self.compute_state.peek_resume_at.is_some() {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1476,6 +1476,12 @@ impl<'a> ActiveComputeState<'a> {
         // Returning before the map is walked, ordered, or taken keeps that case as cheap as the
         // kill switch path has to be.
         if self.compute_state.pending_peeks.is_empty() {
+            // A resume point names where in the uuid ordering the next sweep starts, and with
+            // nothing pending there is nothing for it to name. Cancellation and `reconcile` both
+            // empty the map without clearing it, and only a sweep consumes one, so a resume point
+            // left here would outlive every peek it could serve and make each later arrival ask
+            // for an activation with nothing to do.
+            self.compute_state.peek_resume_at = None;
             return;
         }
 
@@ -2422,6 +2428,24 @@ mod peek_sweep_tests {
         sweep(&mut state);
 
         assert_eq!(state.peek_budget.grant(), Some(INLINE_BUDGET));
+    }
+
+    /// An activation that finds nothing pending drops the resume point, which nothing else
+    /// consumes once the peek it names is gone.
+    ///
+    /// Cancellation removes a deferred peek from the map, and `reconcile` empties the map
+    /// wholesale, both without touching the resume point. Left set on a replica whose peeks all
+    /// answer inline, it would make `handle_peek` ask for an extra worker iteration for every peek
+    /// the replica ever serves.
+    #[mz_ore::test(tokio::test)]
+    async fn an_idle_activation_drops_the_resume_point() {
+        let mut state = compute_state_with_offload_on();
+        state.peek_resume_at = Some(Uuid::from_u128(1));
+        assert!(state.pending_peeks.is_empty());
+
+        sweep(&mut state);
+
+        assert_eq!(state.peek_resume_at, None);
     }
 }
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -82,7 +82,7 @@ mod peek_result_iterator;
 mod peek_scan;
 mod peek_stash;
 
-use self::peek_budget::{InlineBudget, InlineBudgetConfig};
+use self::peek_budget::InlineBudget;
 use self::peek_metrics::IndexPeekMetrics;
 use self::peek_metrics::PeekWalkMetrics;
 pub(crate) use self::peek_offload::PeekPermits;
@@ -292,17 +292,13 @@ pub struct ComputeState {
     /// the inline driver reads it on every activation of every pending peek.
     peek_walk_metrics: PeekWalkMetrics,
 
-    /// The parameters [`ComputeState::peek_budget`] is refilled from.
+    /// What this activation may spend walking index peeks on the worker, and what is left of it.
     ///
-    /// Held rather than looked up, because a refill happens on every activation of the worker.
-    peek_budget_config: InlineBudgetConfig,
-
-    /// What is left of what this activation may spend walking index peeks on the worker.
-    ///
-    /// Refilled at the top of every activation, before the pending peeks are looked at, because a
-    /// peek that arrives outside a sweep is granted out of this budget too. A peek that arrives
-    /// while others are pending draws from what the last sweep left, so a batch of arriving peeks
-    /// costs at most one more aggregate rather than one inline budget per peek in the batch.
+    /// The activation is begun at the top of every sweep and armed from the parameters by the
+    /// first peek that asks for a slice, which is not always a peek the sweep visits: a peek
+    /// arriving between two sweeps is granted its first slice where it arrives. Such a peek draws
+    /// from what the last sweep left, so a batch of arriving peeks costs at most one more
+    /// aggregate rather than one inline budget per peek in the batch.
     peek_budget: InlineBudget,
 
     /// The pending peek a sweep stopped at for want of budget, and where the next sweep starts.
@@ -356,7 +352,7 @@ impl ComputeState {
         let traces = TraceManager::new(metrics.clone());
         let command_history = ComputeCommandHistory::new(metrics.for_history());
         let peek_walk_metrics = PeekWalkMetrics::new(&metrics);
-        let peek_budget_config = InlineBudgetConfig::new(&worker_config);
+        let peek_budget = InlineBudget::new(&worker_config);
 
         Self {
             collections: Default::default(),
@@ -379,9 +375,7 @@ impl ComputeState {
             workers_per_process,
             peek_permits,
             peek_walk_metrics,
-            peek_budget_config,
-            // The offload is off until a configuration arrives, and this is what off means.
-            peek_budget: InlineBudget::Unbounded,
+            peek_budget,
             peek_resume_at: None,
             suspended_collections: Default::default(),
             server_maintenance_interval: Duration::ZERO,
@@ -1222,8 +1216,16 @@ impl<'a> ActiveComputeState<'a> {
     /// that is granted none of it is left pending untouched, to be served first on the next
     /// activation.
     fn process_peek(&mut self, upper: &mut Antichain<Timestamp>, mut peek: PendingPeek) {
+        // Asked for ahead of the match rather than in a guard on its arms, because the grant is
+        // what arms this activation's budget. Only an index peek draws on that budget, so a peek
+        // of any other kind must not arm it.
+        let granted = match &peek {
+            PendingPeek::Index(_) => self.compute_state.peek_budget.grant(),
+            _ => None,
+        };
+
         let response = match &mut peek {
-            PendingPeek::Index(peek) if self.compute_state.peek_budget.grant().is_none() => {
+            PendingPeek::Index(peek) if granted.is_none() => {
                 // This activation has spent what it may on peeks. Nothing about the peek has
                 // changed, because a scan is opened by the slice that walks it, so passing it over
                 // costs the peek an activation and nothing else.
@@ -1234,11 +1236,7 @@ impl<'a> ActiveComputeState<'a> {
             }
             PendingPeek::Index(peek) => {
                 let start = Instant::now();
-                let granted = self
-                    .compute_state
-                    .peek_budget
-                    .grant()
-                    .expect("guarded by the preceding arm");
+                let granted = granted.expect("guarded by the preceding arm");
 
                 let row_iteration_limit =
                     peek_row_iteration_limit(&self.compute_state.worker_config);
@@ -1463,13 +1461,13 @@ impl<'a> ActiveComputeState<'a> {
 
     /// Scan pending peeks and attempt to retire each.
     pub fn process_peeks(&mut self) {
-        // Refilled ahead of the early return below, because `handle_peek` grants an arriving peek
-        // out of this budget and no sweep runs on that path. A replica whose index peeks all
-        // answer inline never leaves one pending, so a refill that ran only where the sweep finds
-        // work would leave the budget at what the constructor set and nothing would ever be
-        // offloaded. The refill reads the parameters through handles and allocates nothing, which
-        // is what keeps it above the return.
-        self.compute_state.peek_budget = self.compute_state.peek_budget_config.for_activation();
+        // Begun ahead of the early return below, because the aggregate bounds an activation and
+        // this is the only place an activation begins. A replica whose index peeks all answer
+        // inline leaves none of them pending, so a sweep that began an activation only where it
+        // found work would let the aggregate drain across the arrivals such a replica serves and
+        // then pass every later arrival over. Beginning one costs a write of `None`, which is what
+        // keeps it above the return.
+        self.compute_state.peek_budget.start_activation();
 
         // What follows runs on every iteration of the worker loop, tens of thousands of times a
         // second on a busy worker, and the overwhelming majority of those find no pending peek.
@@ -2614,10 +2612,11 @@ mod peek_sweep_tests {
             None,
             "the peek must answer in one slice for what it charged to be the cost of a whole walk"
         );
-        let cost = match harness.state.peek_budget {
-            InlineBudget::Bounded { remaining, .. } => WIDE_AGGREGATE - remaining,
-            InlineBudget::Unbounded => panic!("the offload is on, so the budget is bounded"),
-        };
+        let remaining =
+            harness.state.peek_budget.remaining().expect(
+                "the offload is on and the sweep granted a slice, so the budget is bounded",
+            );
+        let cost = WIDE_AGGREGATE - remaining;
         // A driver that charged the fuel it granted rather than the fuel it spent would report a
         // cost equal to the grant, and a test sizing its aggregate from that measurement would
         // then agree with itself at the wrong number. A walk visits one position per key plus what
@@ -2631,21 +2630,65 @@ mod peek_sweep_tests {
         cost
     }
 
-    /// An activation that finds nothing pending still arms the budget, which is what a peek
-    /// arriving before the next sweep is granted out of.
+    /// A peek that arrives before any sweep has run is granted a bounded slice, so a walk that
+    /// outruns it leaves the worker.
+    ///
+    /// The commands a worker has queued are drained in full before it sweeps its pending peeks,
+    /// and `handle_peek` runs a peek's first slice as the peek arrives. On a fresh replica that
+    /// drain is the controller's whole history: the `CreateInstance` that builds this state, the
+    /// `UpdateConfiguration` that turns the offload on, and then every peek the controller
+    /// re-sends. A budget armed only where an activation begins would grant each of those peeks
+    /// unbounded fuel, and unbounded fuel never suspends, so each would walk to its answer on a
+    /// worker that is hydrating and holding the largest backlog it will ever hold.
+    #[mz_ore::test(tokio::test)]
+    async fn a_peek_arriving_before_any_sweep_is_granted_a_bounded_slice() {
+        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+
+        let mut harness = at_production_defaults();
+        harness
+            .state
+            .traces
+            .set(TARGET_ID, trace_bundle(&keys, cancelling_errors(0)));
+
+        harness
+            .active()
+            .handle_peek(index_peek_with_uuid(PEEK_A, None));
+
+        assert_eq!(
+            harness.pending(PEEK_A),
+            Some("offloaded"),
+            "a peek arriving before any sweep outran a bounded slice and was promoted"
+        );
+        assert_eq!(
+            harness.drain().await,
+            vec![(PEEK_A, whole_index_answer(&keys))]
+        );
+        assert_eq!(
+            harness.walks(),
+            (0, 1),
+            "the promoted driver ended the walk, so no slice of it ran on the worker"
+        );
+    }
+
+    /// An activation that finds nothing pending still begins one, which is what refills the
+    /// aggregate the peeks arriving before the next sweep are granted out of.
     ///
     /// A replica whose index peeks all answer inline leaves none of them pending, so no sweep of
-    /// its ever visits a peek. Were the budget armed only where the sweep finds work, every peek
-    /// on such a replica would be granted the unbounded fuel the state is constructed with, and
-    /// unbounded fuel cannot suspend, so nothing would be offloaded however the parameters are
-    /// set. That is the case the offload exists for: one expensive lookup among cheap ones.
+    /// its ever visits a peek. Were an activation begun only where the sweep finds work, the
+    /// aggregate would drain across the arrivals such a replica serves and then pass every later
+    /// arrival over, deferring peeks the worker had the budget to answer.
     #[mz_ore::test(tokio::test)]
-    async fn an_idle_activation_arms_the_budget() {
+    async fn an_idle_activation_refills_the_aggregate() {
         let mut harness = Harness::new(|updates| {
             updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
             updates.add(&INDEX_PEEK_INLINE_BUDGET, INLINE_BUDGET);
         });
         assert!(harness.state.pending_peeks.is_empty());
+
+        // Spend the aggregate, as the peeks an activation serves do.
+        assert_eq!(harness.state.peek_budget.grant(), Some(INLINE_BUDGET));
+        harness.state.peek_budget.charge(usize::MAX);
+        assert_eq!(harness.state.peek_budget.grant(), None);
 
         harness.sweep();
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -75,12 +75,14 @@ use crate::render::{LinearJoinSpec, StartSignal};
 use crate::server::{ComputeInstanceContext, ResponseSender};
 
 mod error_scan;
+mod peek_budget;
 mod peek_metrics;
 mod peek_offload;
 mod peek_result_iterator;
 mod peek_scan;
 mod peek_stash;
 
+use self::peek_budget::InlineBudget;
 use self::peek_metrics::IndexPeekMetrics;
 use self::peek_metrics::PeekWalkMetrics;
 pub(crate) use self::peek_offload::PeekPermits;
@@ -290,6 +292,22 @@ pub struct ComputeState {
     /// the inline driver reads it on every activation of every pending peek.
     peek_walk_metrics: PeekWalkMetrics,
 
+    /// What is left of what this activation may spend walking index peeks on the worker.
+    ///
+    /// Refilled at the top of each sweep of the pending peeks. A peek that arrives between two
+    /// sweeps draws from what the last sweep left, so a batch of arriving peeks costs at most one
+    /// more aggregate rather than one inline budget per peek in the batch.
+    peek_budget: InlineBudget,
+
+    /// The pending peek a sweep stopped at for want of budget, and where the next sweep starts.
+    ///
+    /// Serving the pending peeks in uuid order alone would let a peek that arrives with a lower
+    /// uuid take the turn of one an earlier sweep passed over. Resuming here makes the sweep a
+    /// ring, so a peek that was passed over is served before the peeks that were served ahead of
+    /// it. A stale entry is harmless: a uuid that has since been answered still names where in the
+    /// ordering to resume.
+    peek_resume_at: Option<Uuid>,
+
     /// Collections awaiting schedule instruction by the controller.
     ///
     /// Each entry stores a reference to a token that can be dropped to unsuspend the collection's
@@ -353,6 +371,9 @@ impl ComputeState {
             workers_per_process,
             peek_permits,
             peek_walk_metrics,
+            // The offload is off until a configuration arrives, and this is what off means.
+            peek_budget: InlineBudget::Unbounded,
+            peek_resume_at: None,
             suspended_collections: Default::default(),
             server_maintenance_interval: Duration::ZERO,
             init_system_time: mz_ore::now::SYSTEM_TIME(),
@@ -1178,10 +1199,28 @@ impl<'a> ActiveComputeState<'a> {
     }
 
     /// Either complete the peek (and send the response) or put it in the pending set.
+    ///
+    /// An index peek walks for as long as this activation's remaining budget allows, and a peek
+    /// that is granted none of it is left pending untouched, to be served first on the next
+    /// activation.
     fn process_peek(&mut self, upper: &mut Antichain<Timestamp>, mut peek: PendingPeek) {
         let response = match &mut peek {
+            PendingPeek::Index(peek) if self.compute_state.peek_budget.grant().is_none() => {
+                // This activation has spent what it may on peeks. Nothing about the peek has
+                // changed, because a scan is opened by the slice that walks it, so passing it over
+                // costs the peek an activation and nothing else.
+                self.compute_state
+                    .peek_resume_at
+                    .get_or_insert(peek.peek.uuid);
+                None
+            }
             PendingPeek::Index(peek) => {
                 let start = Instant::now();
+                let granted = self
+                    .compute_state
+                    .peek_budget
+                    .grant()
+                    .expect("guarded by the preceding arm");
 
                 let row_iteration_limit =
                     peek_row_iteration_limit(&self.compute_state.worker_config);
@@ -1216,14 +1255,21 @@ impl<'a> ActiveComputeState<'a> {
                     walk: &self.compute_state.peek_walk_metrics,
                 };
 
+                let mut fuel = granted;
                 let status = peek.seek_fulfillment(
                     upper,
                     self.compute_state.max_result_size,
                     peek_stash_enabled && peek_stash_eligible,
                     peek_stash_threshold_bytes,
                     row_iteration_limit,
+                    &mut fuel,
                     &metrics,
                 );
+
+                // Charged with what the slice walked rather than with what it was granted, so a
+                // peek that answers in three positions leaves the activation's budget to the peeks
+                // behind it.
+                self.compute_state.peek_budget.charge(granted - fuel);
 
                 self.compute_state
                     .metrics
@@ -1400,9 +1446,30 @@ impl<'a> ActiveComputeState<'a> {
     /// Scan pending peeks and attempt to retire each.
     pub fn process_peeks(&mut self) {
         let mut upper = Antichain::new();
-        let pending_peeks = std::mem::take(&mut self.compute_state.pending_peeks);
-        for (_uuid, peek) in pending_peeks {
+        let mut pending_peeks = std::mem::take(&mut self.compute_state.pending_peeks);
+
+        self.compute_state.peek_budget =
+            InlineBudget::for_activation(&self.compute_state.worker_config);
+
+        let mut order: Vec<Uuid> = pending_peeks.keys().copied().collect();
+        if let Some(resume_at) = self.compute_state.peek_resume_at.take() {
+            let resume_from = order.partition_point(|uuid| *uuid < resume_at);
+            order.rotate_left(resume_from);
+        }
+
+        for uuid in order {
+            let peek = pending_peeks.remove(&uuid).expect("taken from this map");
             self.process_peek(&mut upper, peek);
+        }
+
+        // Nothing else wakes a worker that passed a peek over. The peeks that spent the budget
+        // were answered or promoted, and neither leaves an activation behind, so a worker with no
+        // dataflow to run would park with peeks waiting on nothing but their turn.
+        if self.compute_state.peek_resume_at.is_some() {
+            match self.timely_worker.sync_activator_for([].into()).activate() {
+                Ok(()) => {}
+                Err(_) => debug!("unable to wake timely for peeks left waiting on their turn"),
+            }
         }
     }
 
@@ -1858,6 +1925,11 @@ impl IndexPeek {
     /// then for any time `t` less or equal to `peek.timestamp` it is
     /// not the case that `upper` is less or equal to that timestamp,
     /// and so the result cannot further evolve.
+    ///
+    /// `fuel` bounds how far the walk may go on this worker, in cursor positions, and is charged
+    /// for the positions it visits. A walk that exhausts it and still has work left is promoted
+    /// rather than continued here. A peek whose frontiers do not yet admit the read spends none of
+    /// it.
     fn seek_fulfillment(
         &mut self,
         upper: &mut Antichain<Timestamp>,
@@ -1865,6 +1937,7 @@ impl IndexPeek {
         peek_stash_eligible: bool,
         peek_stash_threshold_bytes: usize,
         row_iteration_limit: Option<usize>,
+        fuel: &mut usize,
         metrics: &IndexPeekMetrics<'_>,
     ) -> PeekStatus {
         let method_start = Instant::now();
@@ -1897,6 +1970,7 @@ impl IndexPeek {
             peek_stash_eligible,
             peek_stash_threshold_bytes,
             row_iteration_limit,
+            fuel,
             metrics,
         );
 
@@ -1907,18 +1981,18 @@ impl IndexPeek {
         result
     }
 
-    /// Answers the peek by scanning the traces that fulfil it.
+    /// Answers the peek by scanning the traces that fulfil it, for as long as `fuel` allows.
     ///
-    /// One call drives one scan to an answer and drops it, so nothing survives the call and a
-    /// second call repeats both walks from the start. That is what the peek path asks for: it
-    /// reaches this only once the frontiers admit the read, and every outcome retires the peek
-    /// from the index-peek path, either with a response or by handing it to the stash.
+    /// One call opens one scan and either answers from it or hands it on, so nothing survives the
+    /// call. A scan that runs out of fuel with work left leaves with the [`PeekStatus::Promote`]
+    /// that reports it, which is what keeps the positions it walked from being walked again.
     fn collect_finished_data(
         &mut self,
         max_result_size: u64,
         peek_stash_eligible: bool,
         peek_stash_threshold_bytes: usize,
         row_iteration_limit: Option<usize>,
+        fuel: &mut usize,
         metrics: &IndexPeekMetrics<'_>,
     ) -> PeekStatus {
         let peek = &self.peek;
@@ -1932,10 +2006,7 @@ impl IndexPeek {
             peek_stash_threshold_bytes,
         );
 
-        // No caller supplies a budget, so nothing stops the scan short of an answer but a full
-        // batch, and this driver has nowhere to write one.
-        let mut fuel = usize::MAX;
-        let outcome = scan.step(row_iteration_limit, &mut fuel);
+        let outcome = scan.step(row_iteration_limit, fuel);
 
         // A suspension the offload can resume is the one outcome that leaves the walk unfinished,
         // so it is the one outcome this driver reports nothing for. Everything else ends the walk
@@ -2413,6 +2484,12 @@ pub(crate) mod index_peek_tests {
         }
     }
 
+    /// The fuel the inline driver spends with the offload off, which is the amount that makes a
+    /// walk run to an outcome rather than suspend.
+    fn unbounded_fuel() -> usize {
+        usize::MAX
+    }
+
     /// The observation counts a driver call is expected to leave behind, named so that a failure
     /// says which metric moved.
     ///
@@ -2492,8 +2569,14 @@ pub(crate) mod index_peek_tests {
         );
         let metrics = TestMetrics::new();
 
-        let answer =
-            subject.collect_finished_data(u64::MAX, false, usize::MAX, None, &metrics.as_metrics());
+        let answer = subject.collect_finished_data(
+            u64::MAX,
+            false,
+            usize::MAX,
+            None,
+            &mut unbounded_fuel(),
+            &metrics.as_metrics(),
+        );
 
         assert_eq!(
             Answer::from(answer),
@@ -2513,8 +2596,14 @@ pub(crate) mod index_peek_tests {
         let mut subject = index_peek_over(index_peek(trivial_finishing(), None), &keys, errors);
         let metrics = TestMetrics::new();
 
-        let answer =
-            subject.collect_finished_data(u64::MAX, false, usize::MAX, None, &metrics.as_metrics());
+        let answer = subject.collect_finished_data(
+            u64::MAX,
+            false,
+            usize::MAX,
+            None,
+            &mut unbounded_fuel(),
+            &metrics.as_metrics(),
+        );
 
         assert_eq!(
             Answer::from(answer),
@@ -2538,10 +2627,53 @@ pub(crate) mod index_peek_tests {
 
         // A threshold of zero bytes is crossed by the first row, so the scan fills a batch well
         // before the trace runs out.
-        let answer = subject.collect_finished_data(u64::MAX, true, 0, None, &metrics.as_metrics());
+        let answer = subject.collect_finished_data(
+            u64::MAX,
+            true,
+            0,
+            None,
+            &mut unbounded_fuel(),
+            &metrics.as_metrics(),
+        );
 
         assert_eq!(Answer::from(answer), Answer::UsePeekStash);
         assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 0));
+    }
+
+    /// A peek whose walk outruns the fuel it was granted leaves the worker rather than being
+    /// answered or diverted, and the walk it leaves with reports nothing.
+    ///
+    /// Reporting here as well as in the driver that finishes the walk would count one walk twice,
+    /// on both substrates and in every phase histogram, and the numbers a scan carries are
+    /// cumulative precisely so that the driver which ends it can report all of them.
+    #[mz_ore::test]
+    fn a_scan_that_outruns_its_fuel_leaves_the_worker_reporting_nothing() {
+        let keys: Vec<Row> = (0..6).map(ok_row).collect();
+        let mut subject = index_peek_over(
+            index_peek(trivial_finishing(), None),
+            &keys,
+            cancelling_errors(0),
+        );
+        let metrics = TestMetrics::new();
+
+        // An empty error trace is walked out within a position or two, so this fuel is spent
+        // inside the ok walk with most of the six keys still ahead of it.
+        let mut fuel = 2;
+        let answer = subject.collect_finished_data(
+            u64::MAX,
+            false,
+            usize::MAX,
+            None,
+            &mut fuel,
+            &metrics.as_metrics(),
+        );
+
+        assert_eq!(Answer::from(answer), Answer::Promote);
+        assert_eq!(
+            fuel, 0,
+            "a promoted slice spent every position it was given"
+        );
+        assert_eq!(metrics.observations(), expected_observations(0, 0, 0, 0));
     }
 
     /// A peek its ok walk fails is answered with that error, and reports the phases that walk
@@ -2569,6 +2701,7 @@ pub(crate) mod index_peek_tests {
             false,
             usize::MAX,
             None,
+            &mut unbounded_fuel(),
             &metrics.as_metrics(),
         );
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -75,11 +75,14 @@ use crate::render::{LinearJoinSpec, StartSignal};
 use crate::server::{ComputeInstanceContext, ResponseSender};
 
 mod error_scan;
+mod peek_offload;
 mod peek_result_iterator;
 mod peek_scan;
 mod peek_stash;
 
-use self::peek_scan::{PeekScan, ScanOutcome};
+pub(crate) use self::peek_offload::PeekPermits;
+use self::peek_offload::{OffloadConfig, OffloadOutcome, OffloadedPeek};
+use self::peek_scan::{IndexPeekScan, PeekScan, ScanOutcome};
 
 /// Cheap handles on the dyncfgs that bound how many rows a peek may examine.
 ///
@@ -274,6 +277,10 @@ pub struct ComputeState {
     /// The number of timely workers per process.
     pub workers_per_process: usize,
 
+    /// Bounds how many promoted peek walks run at once, shared with every other worker in this
+    /// process.
+    pub peek_permits: Arc<PeekPermits>,
+
     /// Collections awaiting schedule instruction by the controller.
     ///
     /// Each entry stores a reference to a token that can be dropped to unsuspend the collection's
@@ -309,6 +316,7 @@ impl ComputeState {
         context: ComputeInstanceContext,
         metrics_registry: MetricsRegistry,
         workers_per_process: usize,
+        peek_permits: Arc<PeekPermits>,
         storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
     ) -> Self {
         let traces = TraceManager::new(metrics.clone());
@@ -333,6 +341,7 @@ impl ComputeState {
             worker_config: mz_dyncfgs::all_dyncfgs().into(),
             metrics_registry,
             workers_per_process,
+            peek_permits,
             suspended_collections: Default::default(),
             server_maintenance_interval: Duration::ZERO,
             init_system_time: mz_ore::now::SYSTEM_TIME(),
@@ -1228,30 +1237,42 @@ impl<'a> ActiveComputeState<'a> {
                 match status {
                     PeekStatus::Ready(result) => Some(result),
                     PeekStatus::NotReady => None,
-                    PeekStatus::UsePeekStash => {
+                    PeekStatus::Promote(scan) => {
                         let _span =
-                            span!(parent: &peek.span, Level::DEBUG, "process_stash_peek").entered();
+                            span!(parent: &peek.span, Level::DEBUG, "promote_index_peek").entered();
 
-                        // NOTE: The row iteration limit does not follow a peek into the stash. The
-                        // stash restarts the scan and produces in bounded bursts, so a stashed
-                        // peek may examine any number of rows.
-                        let peek_stash_batch_max_runs = PEEK_RESPONSE_STASH_BATCH_MAX_RUNS
-                            .get(&self.compute_state.worker_config);
-
-                        let stash_task = peek_stash::StashingPeek::start_upload(
-                            Arc::clone(&self.compute_state.persist_clients),
-                            self.compute_state
-                                .peek_stash_persist_location
-                                .as_ref()
-                                .expect("verified above"),
+                        let uuid = peek.peek.uuid;
+                        let permits = Arc::clone(&self.compute_state.peek_permits);
+                        let offloaded = OffloadedPeek::promote(
                             peek.peek.clone(),
                             peek.trace_bundle.clone(),
-                            peek_stash_batch_max_runs,
+                            scan,
+                            &permits,
+                            OffloadConfig::new(&self.compute_state.worker_config),
+                            self.compute_state
+                                .metrics
+                                .index_peek_walks_offloaded
+                                .clone(),
+                            self.timely_worker.sync_activator_for([].into()),
                         );
 
                         self.compute_state
                             .pending_peeks
-                            .insert(peek.peek.uuid, PendingPeek::Stash(stash_task));
+                            .insert(uuid, PendingPeek::Offloaded(offloaded));
+                        return;
+                    }
+                    PeekStatus::UsePeekStash => {
+                        let _span =
+                            span!(parent: &peek.span, Level::DEBUG, "process_stash_peek").entered();
+
+                        let uuid = peek.peek.uuid;
+                        let stash_task = self
+                            .start_stash_upload(peek.peek.clone(), peek.trace_bundle.clone())
+                            .expect("stash location established before diverting");
+
+                        self.compute_state
+                            .pending_peeks
+                            .insert(uuid, PendingPeek::Stash(stash_task));
                         return;
                     }
                 }
@@ -1263,6 +1284,42 @@ impl<'a> ActiveComputeState<'a> {
                     .observe(duration.as_secs_f64());
                 result
             }),
+            PendingPeek::Offloaded(offloaded) => match offloaded.result.try_recv() {
+                Ok((OffloadOutcome::Answered(response), duration)) => {
+                    trace!(?offloaded.peek, ?duration, "finished offloaded index peek walk");
+                    Some(response)
+                }
+                Ok((OffloadOutcome::NeedsStash, duration)) => {
+                    let _span = span!(parent: &offloaded.span, Level::DEBUG, "process_stash_peek")
+                        .entered();
+                    trace!(?offloaded.peek, ?duration, "handing offloaded index peek to the stash");
+
+                    let uuid = offloaded.peek.uuid;
+                    let stash_task = self
+                        .start_stash_upload(offloaded.peek.clone(), offloaded.trace_bundle.clone());
+
+                    match stash_task {
+                        Some(stash_task) => {
+                            self.compute_state
+                                .pending_peeks
+                                .insert(uuid, PendingPeek::Stash(stash_task));
+                            return;
+                        }
+                        None => Some(PeekResponse::Error(PeekError::unstructured(
+                            "peek result is too large to answer inline and this replica has no \
+                             peek stash location",
+                        ))),
+                    }
+                }
+                Err(oneshot::error::TryRecvError::Empty) => None,
+                // The task drops its sender without sending only when it stops without an outcome,
+                // and the one way it does that is a cancellation that removed this entry, so an
+                // entry that is still here to be polled means the task died. Answering the peek is
+                // what keeps it from waiting forever on a walk nothing is running.
+                Err(oneshot::error::TryRecvError::Closed) => Some(PeekResponse::Error(
+                    PeekError::unstructured("offloaded peek walk failed"),
+                )),
+            },
             PendingPeek::Stash(stashing_peek) => {
                 let num_batches = PEEK_STASH_NUM_BATCHES.get(&self.compute_state.worker_config);
                 let batch_size = PEEK_STASH_BATCH_SIZE.get(&self.compute_state.worker_config);
@@ -1289,6 +1346,36 @@ impl<'a> ActiveComputeState<'a> {
             let uuid = peek.peek().uuid;
             self.compute_state.pending_peeks.insert(uuid, peek);
         }
+    }
+
+    /// Starts a peek stash upload for `peek`, which walks the ok trace of `trace_bundle` and
+    /// writes the rows it produces to persist.
+    ///
+    /// The walk starts over: the stash reads the trace bundle itself, so rows a previous walk of
+    /// the same peek accumulated are produced again rather than carried across.
+    ///
+    /// Returns `None` when this replica has no stash location, which a caller must establish
+    /// before it decides to divert a peek here.
+    fn start_stash_upload(
+        &self,
+        peek: Peek,
+        trace_bundle: TraceBundle,
+    ) -> Option<peek_stash::StashingPeek> {
+        let persist_location = self.compute_state.peek_stash_persist_location.clone()?;
+
+        // NOTE: The row iteration limit does not follow a peek into the stash. The stash restarts
+        // the scan and produces in bounded bursts, so a stashed peek may examine any number of
+        // rows.
+        let batch_max_runs =
+            PEEK_RESPONSE_STASH_BATCH_MAX_RUNS.get(&self.compute_state.worker_config);
+
+        Some(peek_stash::StashingPeek::start_upload(
+            Arc::clone(&self.compute_state.persist_clients),
+            &persist_location,
+            peek,
+            trace_bundle,
+            batch_max_runs,
+        ))
     }
 
     /// Scan pending peeks and attempt to retire each.
@@ -1444,6 +1531,9 @@ pub enum PendingPeek {
     /// A peek against an index that is being stashed in the peek stash by an
     /// async background task.
     Stash(peek_stash::StashingPeek),
+    /// A peek against an index whose walk was promoted off the worker and is running as an async
+    /// task.
+    Offloaded(OffloadedPeek),
 }
 
 impl PendingPeek {
@@ -1567,6 +1657,7 @@ impl PendingPeek {
             PendingPeek::Index(p) => &p.span,
             PendingPeek::Persist(p) => &p.span,
             PendingPeek::Stash(p) => &p.span,
+            PendingPeek::Offloaded(p) => &p.span,
         }
     }
 
@@ -1575,6 +1666,7 @@ impl PendingPeek {
             PendingPeek::Index(p) => &p.peek,
             PendingPeek::Persist(p) => &p.peek,
             PendingPeek::Stash(p) => &p.peek,
+            PendingPeek::Offloaded(p) => &p.peek,
         }
     }
 }
@@ -1856,18 +1948,16 @@ impl IndexPeek {
         let rows = match outcome {
             ScanOutcome::Complete(rows) => rows,
             ScanOutcome::Failed(error) => return PeekStatus::Ready(PeekResponse::Error(error)),
+            // A scan that suspends without a batch has work left and rows it is still allowed to
+            // accumulate, so it is resumed rather than disposed of. Every position it has walked
+            // travels with it, which is what makes the promotion cost one hand-off instead of a
+            // second walk.
+            ScanOutcome::Suspended if !scan.batch_ready() => return PeekStatus::Promote(scan),
             // Diversion is sound only for a scan whose error walk is over. The stash answers the
             // peek from a walk of the ok trace alone and never reads the error trace, so a peek
             // diverted with its error trace half-read would return rows where it must report an
-            // error. Unbounded fuel is what keeps that out of reach here, because a full batch is
-            // then the only thing that stops the scan, and only the ok walk accumulates rows. A
-            // driver that gives the scan a bounded budget makes an error-phase suspension
-            // reachable and owns resuming the scan rather than diverting it.
-            //
-            // The batch is taken and dropped rather than left to the scan's own drop, because
-            // discarding it is this driver's decision: the stash's own walk supersedes it. It is
-            // taken only once diversion is established, so that no path disposes of rows it has
-            // not first earned the right to discard.
+            // error. Only the ok walk accumulates rows, so a scan holding a full batch has read
+            // the error trace out, and the guard states that rather than assuming it.
             ScanOutcome::Suspended => {
                 if !scan.error_trace_clean() {
                     soft_panic_or_log!(
@@ -1878,12 +1968,10 @@ impl IndexPeek {
                         "peek suspended before its error trace was read out",
                     )));
                 }
-                if scan.take_batch().is_none() {
-                    soft_panic_or_log!(
-                        "peek on {} suspended with no batch to hand over",
-                        self.peek.target.id()
-                    );
-                }
+                // The batch is taken and dropped rather than left to the scan's own drop, because
+                // discarding it is this driver's decision: the stash walks the ok trace again from
+                // the trace bundle and produces these rows a second time.
+                let _batch = scan.take_batch();
                 return PeekStatus::UsePeekStash;
             }
         };
@@ -1927,6 +2015,9 @@ enum PeekStatus {
     /// The result size is above the configured threshold and the peek is
     /// eligible for using the peek result stash.
     UsePeekStash,
+    /// The walk stopped with work left and nothing to hand over, so it is finished away from the
+    /// worker. Carries the scan, which resumes from the cursor positions it stopped on.
+    Promote(IndexPeekScan),
     /// The peek result is ready.
     Ready(PeekResponse),
 }
@@ -2381,6 +2472,7 @@ pub(crate) mod index_peek_tests {
     enum Answer {
         NotReady,
         UsePeekStash,
+        Promote,
         Ready(PeekResponse),
     }
 
@@ -2389,6 +2481,9 @@ pub(crate) mod index_peek_tests {
             match status {
                 PeekStatus::NotReady => Answer::NotReady,
                 PeekStatus::UsePeekStash => Answer::UsePeekStash,
+                // The scan a promotion carries has no comparison of its own. What is comparable
+                // is that the walk left this driver rather than answering here.
+                PeekStatus::Promote(_) => Answer::Promote,
                 PeekStatus::Ready(response) => Answer::Ready(response),
             }
         }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -959,6 +959,15 @@ impl<'a> ActiveComputeState<'a> {
         }
 
         self.process_peek(&mut Antichain::new(), pending);
+
+        // `process_peek` may leave this peek waiting for budget, and no sweep of the pending peeks
+        // follows on this path. `reconcile` applies the peeks a reconnecting controller re-sends
+        // and then returns into the worker loop, which parks before its next sweep, so a peek
+        // deferred here would wait on an activation that nothing else produces. The park is
+        // unbounded when the maintenance interval is zero, which is a supported setting.
+        if self.compute_state.peek_resume_at.is_some() {
+            self.request_peek_activation();
+        }
     }
 
     fn handle_cancel_peek(&mut self, uuid: Uuid) {
@@ -1462,14 +1471,22 @@ impl<'a> ActiveComputeState<'a> {
             self.process_peek(&mut upper, peek);
         }
 
-        // Nothing else wakes a worker that passed a peek over. The peeks that spent the budget
-        // were answered or promoted, and neither leaves an activation behind, so a worker with no
-        // dataflow to run would park with peeks waiting on nothing but their turn.
         if self.compute_state.peek_resume_at.is_some() {
-            match self.timely_worker.sync_activator_for([].into()).activate() {
-                Ok(()) => {}
-                Err(_) => debug!("unable to wake timely for peeks left waiting on their turn"),
-            }
+            self.request_peek_activation();
+        }
+    }
+
+    /// Asks timely to activate this worker again, so that a peek passed over for want of budget
+    /// gets its turn.
+    ///
+    /// Nothing else wakes a worker that passed a peek over. The peeks that spent the budget were
+    /// answered or promoted, and neither leaves an activation behind, so a worker with no dataflow
+    /// to run would park with peeks waiting on nothing but their turn. Every path that defers a
+    /// peek therefore calls this before it hands the worker back.
+    fn request_peek_activation(&mut self) {
+        match self.timely_worker.sync_activator_for([].into()).activate() {
+            Ok(()) => {}
+            Err(_) => debug!("unable to wake timely for peeks left waiting on their turn"),
         }
     }
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -2888,7 +2888,7 @@ mod peek_sweep_tests {
     /// Charging the grant instead would spend the whole aggregate on the first peek whatever it
     /// walked, which is the difference between an activation serving a burst of point lookups and
     /// serving one of them. Comparing this run against an unbudgeted one would not catch it, since
-    /// both would answer the same rows; the assertion is against the budget this test supplied.
+    /// both would answer the same rows. The assertion is against the budget this test supplied.
     #[mz_ore::test(tokio::test)]
     async fn the_aggregate_is_charged_what_the_slices_walked() {
         let keys = wide_ok_rows(SMALL_INDEX_KEYS);

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -2340,11 +2340,13 @@ impl CollectionState {
 /// Tests of the sweep that drives the pending index peeks.
 ///
 /// Built over a live [`ComputeState`] and a real timely worker rather than over the budget alone,
-/// because what the sweep is pinned on here is where it arms the budget relative to the return it
-/// takes when nothing is pending.
+/// because what these pin is where a peek's walk runs, which is decided by the sweep and observed
+/// through the metrics a driver leaves behind.
 #[cfg(test)]
 mod peek_sweep_tests {
-    use mz_compute_types::dyncfgs::{ENABLE_INDEX_PEEK_OFFLOAD, INDEX_PEEK_INLINE_BUDGET};
+    use mz_compute_types::dyncfgs::{
+        ENABLE_INDEX_PEEK_OFFLOAD, INDEX_PEEK_ACTIVATION_BUDGET, INDEX_PEEK_INLINE_BUDGET,
+    };
     use mz_dyncfg::ConfigUpdates;
     use mz_persist_client::cache::PersistClientCache;
     use mz_secrets::InMemorySecretsController;
@@ -2356,60 +2358,262 @@ mod peek_sweep_tests {
     use crate::metrics::ComputeMetrics;
     use crate::server::ComputeRuntimeRole;
 
+    use super::index_peek_tests::{
+        TARGET_ID, cancelling_errors, index_peek_with_uuid, rows_answer, trace_bundle, wide_ok_rows,
+    };
     use super::*;
 
-    /// The per-peek budget these tests configure. Distinct from both the unbounded grant and the
-    /// parameter's default, so that an assertion on it says the configured value was read.
+    /// The per-peek budget the budget-arming tests configure. Distinct from both the unbounded
+    /// grant and the parameter's default, so that an assertion on it says the configured value was
+    /// read.
     const INLINE_BUDGET: usize = 12_345;
 
-    /// A compute state as `CreateInstance` leaves one, with the offload configured on.
-    fn compute_state_with_offload_on() -> ComputeState {
-        let metrics_registry = MetricsRegistry::new();
-        let metrics = ComputeMetrics::register_with(&metrics_registry, ComputeRuntimeRole::Solo)
-            .for_worker(0);
-        let context = ComputeInstanceContext {
-            scratch_directory: None,
-            worker_core_affinity: false,
-            connection_context: ConnectionContext::for_tests(Arc::new(
-                InMemorySecretsController::new(),
-            )),
-        };
+    /// How many keys the index the placement-policy tests peek holds.
+    ///
+    /// More positions than the production inline budget, so a walk of the whole index cannot
+    /// finish on the worker while a walk that seeks to one key finishes there comfortably. The two
+    /// halves of the policy are the same index at the same budget, differing only in what the peek
+    /// asks for.
+    const WIDE_INDEX_KEYS: u64 = 2_000;
 
-        let state = ComputeState::new(
-            Arc::new(PersistClientCache::new_no_metrics()),
-            TxnsContext::default(),
-            metrics,
-            Arc::new(TracingHandle::disabled()),
-            context,
-            metrics_registry,
-            1,
-            Arc::new(PeekPermits::new(1)),
-            None,
-        );
+    /// How many keys the index the budget tests peek holds. Small, because what those tests turn
+    /// on is how many peeks got a turn rather than how far each one walked.
+    const SMALL_INDEX_KEYS: u64 = 6;
 
-        // The worker applies these through `UpdateConfiguration`, which reaches the budget through
-        // the handles it holds rather than through any state the command touches.
-        let mut updates = ConfigUpdates::default();
-        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
-        updates.add(&INDEX_PEEK_INLINE_BUDGET, INLINE_BUDGET);
-        updates.apply(&state.worker_config);
+    /// How many activations a test drives before it declares a peek stuck.
+    ///
+    /// A promoted walk over these traces needs one slice, and a peek passed over for want of
+    /// budget needs one activation per peek ahead of it, so a sweep that makes progress finishes
+    /// far inside this bound and one that does not fails rather than hanging the suite.
+    const SWEEP_BOUND: usize = 200;
 
-        state
+    /// Peek uuids, named in the order they sort, because which peek a sweep serves first turns on
+    /// that order.
+    const PEEK_A: Uuid = Uuid::from_u128(1);
+    const PEEK_B: Uuid = Uuid::from_u128(2);
+    const PEEK_C: Uuid = Uuid::from_u128(3);
+    const PEEK_D: Uuid = Uuid::from_u128(4);
+
+    /// The compute state, the timely worker, and the response channel one activation runs against,
+    /// held together across activations.
+    ///
+    /// A promoted walk outlives the sweep that promoted it, so the worker whose activator it wakes,
+    /// the responses it eventually produces, and the state it stays pending in all have to survive
+    /// the call that started it.
+    struct Harness {
+        state: ComputeState,
+        timely_worker: TimelyWorker,
+        response_tx: ResponseSender,
+        responses: mpsc::UnboundedReceiver<(ComputeResponse, Uuid)>,
     }
 
-    /// Runs one sweep over `state`, as an activation of the worker does.
-    fn sweep(state: &mut ComputeState) {
-        let allocator = Allocator::Thread(Default::default());
-        let mut timely_worker = TimelyWorker::new(WorkerConfig::default(), allocator, None);
-        let (response_tx, _response_rx) = mpsc::unbounded_channel();
-        let mut response_tx = ResponseSender::new(response_tx, 0);
+    impl Harness {
+        /// A harness as `CreateInstance` leaves one, with `configure` applied to the worker
+        /// configuration as `UpdateConfiguration` applies a change.
+        fn new(configure: impl FnOnce(&mut ConfigUpdates)) -> Self {
+            let metrics_registry = MetricsRegistry::new();
+            let metrics =
+                ComputeMetrics::register_with(&metrics_registry, ComputeRuntimeRole::Solo)
+                    .for_worker(0);
+            let context = ComputeInstanceContext {
+                scratch_directory: None,
+                worker_core_affinity: false,
+                connection_context: ConnectionContext::for_tests(Arc::new(
+                    InMemorySecretsController::new(),
+                )),
+            };
 
-        ActiveComputeState {
-            timely_worker: &mut timely_worker,
-            compute_state: state,
-            response_tx: &mut response_tx,
+            let state = ComputeState::new(
+                Arc::new(PersistClientCache::new_no_metrics()),
+                TxnsContext::default(),
+                metrics,
+                Arc::new(TracingHandle::disabled()),
+                context,
+                metrics_registry,
+                1,
+                Arc::new(PeekPermits::new(1)),
+                None,
+            );
+
+            // The worker applies these through `UpdateConfiguration`, which reaches the budget
+            // through the handles it holds rather than through any state the command touches.
+            let mut updates = ConfigUpdates::default();
+            configure(&mut updates);
+            updates.apply(&state.worker_config);
+
+            // The worker is given a timer, because a worker without one reports work waiting
+            // whatever its activations hold, which would make `Harness::park_for` vacuous.
+            let timely_worker = TimelyWorker::new(
+                WorkerConfig::default(),
+                Allocator::Thread(Default::default()),
+                Some(Instant::now()),
+            );
+
+            let (response_tx, responses) = mpsc::unbounded_channel();
+            let mut response_tx = ResponseSender::new(response_tx, 0);
+            response_tx.set_nonce(Uuid::nil());
+
+            Self {
+                state,
+                timely_worker,
+                response_tx,
+                responses,
+            }
         }
-        .process_peeks();
+
+        fn active(&mut self) -> ActiveComputeState<'_> {
+            ActiveComputeState {
+                timely_worker: &mut self.timely_worker,
+                compute_state: &mut self.state,
+                response_tx: &mut self.response_tx,
+            }
+        }
+
+        /// Runs one sweep over the pending peeks, as an activation of the worker does.
+        fn sweep(&mut self) {
+            self.active().process_peeks();
+        }
+
+        /// Makes `peek` pending over `bundle`, as a peek whose frontiers were not yet ready is
+        /// left pending.
+        fn add_pending(&mut self, peek: Peek, bundle: TraceBundle) {
+            let pending = PendingPeek::index(peek, bundle);
+            let uuid = pending.peek().uuid;
+            let replaced = self.state.pending_peeks.insert(uuid, pending);
+            assert!(replaced.is_none(), "each pending peek needs its own uuid");
+        }
+
+        /// Which kind of pending peek `uuid` names, or `None` when no peek is pending under it.
+        ///
+        /// Named rather than matched, so that a test says which driver holds the peek and a
+        /// failure says which one holds it instead.
+        fn pending(&self, uuid: Uuid) -> Option<&'static str> {
+            self.state.pending_peeks.get(&uuid).map(|peek| match peek {
+                PendingPeek::Index(_) => "index",
+                PendingPeek::Persist(_) => "persist",
+                PendingPeek::Stash(_) => "stash",
+                PendingPeek::Offloaded(_) => "offloaded",
+            })
+        }
+
+        /// The uuids of the peeks still pending, in the order the sweep takes them.
+        fn pending_uuids(&self) -> Vec<Uuid> {
+            self.state.pending_peeks.keys().copied().collect()
+        }
+
+        /// The peek responses sent since this was last called, in the order they were sent.
+        fn peek_responses(&mut self) -> Vec<(Uuid, PeekResponse)> {
+            let mut responses = Vec::new();
+            while let Ok((response, _nonce)) = self.responses.try_recv() {
+                match response {
+                    ComputeResponse::PeekResponse(uuid, response, _otel_ctx) => {
+                        responses.push((uuid, response))
+                    }
+                    other => panic!("a peek sweep sent {other:?}"),
+                }
+            }
+            responses
+        }
+
+        /// The walks each substrate has driven to an outcome, as `(inline, offloaded)`.
+        fn walks(&self) -> (u64, u64) {
+            (
+                self.state.metrics.index_peek_walks_inline.get(),
+                self.state.metrics.index_peek_walks_offloaded.get(),
+            )
+        }
+
+        /// How long the worker would park before its next activation, as `step_or_park` reads it.
+        ///
+        /// `None` is an indefinite park, which is what a worker with no dataflow and no pending
+        /// activation does.
+        fn park_for(&self) -> Option<Duration> {
+            let activations = self.timely_worker.activations();
+            let mut activations = activations.borrow_mut();
+            activations.advance();
+            activations.empty_for()
+        }
+
+        /// Runs activations until nothing is pending, and reports the responses they produced.
+        ///
+        /// Bounded, so a peek that never answers fails here rather than hanging the suite. The
+        /// yield between activations is what lets a promoted walk's task run, which on a
+        /// single-threaded runtime happens nowhere else.
+        async fn drain(&mut self) -> Vec<(Uuid, PeekResponse)> {
+            let mut responses = Vec::new();
+            for _ in 0..SWEEP_BOUND {
+                self.sweep();
+                responses.extend(self.peek_responses());
+                if self.state.pending_peeks.is_empty() {
+                    return responses;
+                }
+                tokio::task::yield_now().await;
+            }
+            panic!("peeks were still pending after {SWEEP_BOUND} activations");
+        }
+    }
+
+    /// A harness with the offload on and every budget at its production default, which is the
+    /// configuration the placement policy is sized for.
+    fn at_production_defaults() -> Harness {
+        Harness::new(|updates| {
+            updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        })
+    }
+
+    /// A harness with the offload on and the per-activation aggregate set to `aggregate`.
+    fn with_activation_budget(aggregate: usize) -> Harness {
+        Harness::new(move |updates| {
+            updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+            updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, aggregate);
+        })
+    }
+
+    /// The answer a peek of the whole index holding `keys` gives.
+    ///
+    /// Both the promoted walk and the inline walk are compared against this rather than against
+    /// each other, so each test states the answer it expects instead of two runs agreeing on
+    /// whatever they produced.
+    fn whole_index_answer(keys: &[Row]) -> PeekResponse {
+        rows_answer(keys.iter().cloned())
+    }
+
+    /// The positions one peek of the index holding `keys` spends, measured by letting a sweep
+    /// spend an aggregate wide enough that nothing bounds it and reading what it charged.
+    ///
+    /// Measured rather than assumed, so that a test which configures the aggregate in multiples of
+    /// a walk states its budget in the unit the code charges. A constant here would let a change
+    /// to what a walk costs turn the test into one that asserts nothing.
+    fn walk_cost(keys: &[Row]) -> usize {
+        const WIDE_AGGREGATE: usize = 1_000_000;
+
+        let mut harness = with_activation_budget(WIDE_AGGREGATE);
+        harness.add_pending(
+            index_peek_with_uuid(PEEK_A, None),
+            trace_bundle(keys, cancelling_errors(0)),
+        );
+        harness.sweep();
+
+        assert_eq!(
+            harness.pending(PEEK_A),
+            None,
+            "the peek must answer in one slice for what it charged to be the cost of a whole walk"
+        );
+        let cost = match harness.state.peek_budget {
+            InlineBudget::Bounded { remaining, .. } => WIDE_AGGREGATE - remaining,
+            InlineBudget::Unbounded => panic!("the offload is on, so the budget is bounded"),
+        };
+        // A driver that charged the fuel it granted rather than the fuel it spent would report a
+        // cost equal to the grant, and a test sizing its aggregate from that measurement would
+        // then agree with itself at the wrong number. A walk visits one position per key plus what
+        // the error walk spends reaching the end of an empty trace, which is nothing like the
+        // per-peek budget the walk was granted.
+        assert!(
+            (keys.len()..*INDEX_PEEK_INLINE_BUDGET.default()).contains(&cost),
+            "a walk of {} keys charged {cost} positions, which is not what such a walk visits",
+            keys.len()
+        );
+        cost
     }
 
     /// An activation that finds nothing pending still arms the budget, which is what a peek
@@ -2422,12 +2626,15 @@ mod peek_sweep_tests {
     /// set. That is the case the offload exists for: one expensive lookup among cheap ones.
     #[mz_ore::test(tokio::test)]
     async fn an_idle_activation_arms_the_budget() {
-        let mut state = compute_state_with_offload_on();
-        assert!(state.pending_peeks.is_empty());
+        let mut harness = Harness::new(|updates| {
+            updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+            updates.add(&INDEX_PEEK_INLINE_BUDGET, INLINE_BUDGET);
+        });
+        assert!(harness.state.pending_peeks.is_empty());
 
-        sweep(&mut state);
+        harness.sweep();
 
-        assert_eq!(state.peek_budget.grant(), Some(INLINE_BUDGET));
+        assert_eq!(harness.state.peek_budget.grant(), Some(INLINE_BUDGET));
     }
 
     /// An activation that finds nothing pending drops the resume point, which nothing else
@@ -2439,13 +2646,393 @@ mod peek_sweep_tests {
     /// the replica ever serves.
     #[mz_ore::test(tokio::test)]
     async fn an_idle_activation_drops_the_resume_point() {
-        let mut state = compute_state_with_offload_on();
-        state.peek_resume_at = Some(Uuid::from_u128(1));
-        assert!(state.pending_peeks.is_empty());
+        let mut harness = Harness::new(|updates| {
+            updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+            updates.add(&INDEX_PEEK_INLINE_BUDGET, INLINE_BUDGET);
+        });
+        harness.state.peek_resume_at = Some(PEEK_A);
+        assert!(harness.state.pending_peeks.is_empty());
 
-        sweep(&mut state);
+        harness.sweep();
 
-        assert_eq!(state.peek_resume_at, None);
+        assert_eq!(harness.state.peek_resume_at, None);
+    }
+
+    /// A peek whose walk outruns the production inline budget leaves the worker, and the driver
+    /// that finished the walk counts it as offloaded.
+    ///
+    /// This is what says a peek is promoted at all. The rows a promoted walk answers with are the
+    /// rows an inline walk answers with, so a suite comparing only answers would pass with the
+    /// whole mechanism inert.
+    #[mz_ore::test(tokio::test)]
+    async fn a_scan_that_outruns_the_production_budget_is_promoted() {
+        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+        assert!(
+            u64::cast_from(*INDEX_PEEK_INLINE_BUDGET.default()) < WIDE_INDEX_KEYS,
+            "the index must hold more positions than the production budget lets a peek walk inline"
+        );
+
+        let mut harness = at_production_defaults();
+        harness.add_pending(
+            index_peek_with_uuid(PEEK_A, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+
+        harness.sweep();
+
+        assert_eq!(
+            harness.pending(PEEK_A),
+            Some("offloaded"),
+            "a walk that outran its inline budget belongs to the promoted driver"
+        );
+        assert_eq!(
+            harness.walks(),
+            (0, 0),
+            "promotion is not a terminal outcome, so neither driver has counted the walk yet"
+        );
+
+        assert_eq!(
+            harness.drain().await,
+            vec![(PEEK_A, whole_index_answer(&keys))]
+        );
+        assert_eq!(
+            harness.walks(),
+            (0, 1),
+            "the promoted driver ended the walk and counted it"
+        );
+    }
+
+    /// A point lookup at the production inline budget is answered on the worker, over the very
+    /// index whose full walk is promoted.
+    ///
+    /// This is the half of the placement policy that a layer promoting everything would still
+    /// pass every equivalence test while destroying. The budget is sized for point lookups and
+    /// nothing else, and what makes that true is measured here rather than argued.
+    #[mz_ore::test(tokio::test)]
+    async fn a_point_lookup_at_the_production_budget_stays_inline() {
+        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+        let literal = keys[7].clone();
+
+        let mut harness = at_production_defaults();
+        harness.add_pending(
+            index_peek_with_uuid(PEEK_A, Some(vec![literal.clone()])),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+
+        harness.sweep();
+
+        assert_eq!(
+            harness.peek_responses(),
+            vec![(PEEK_A, rows_answer([literal]))]
+        );
+        assert_eq!(
+            harness.pending(PEEK_A),
+            None,
+            "a peek answered inline leaves nothing pending"
+        );
+        assert_eq!(
+            harness.walks(),
+            (1, 0),
+            "a point lookup finishes inside the inline budget and is never promoted"
+        );
+    }
+
+    /// With the kill switch off, the peek that the production budget promotes instead walks to its
+    /// answer on the worker, and that answer is the one the promoted walk gives.
+    ///
+    /// Both this and the promoted run are compared against [`whole_index_answer`], so the
+    /// equivalence promotion owes is stated rather than inferred from two runs agreeing.
+    #[mz_ore::test(tokio::test)]
+    async fn the_kill_switch_answers_the_same_scan_inline() {
+        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+
+        // No configuration at all, which is the kill switch in the position production ships it.
+        let mut harness = Harness::new(|_updates| ());
+        harness.add_pending(
+            index_peek_with_uuid(PEEK_A, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+
+        harness.sweep();
+
+        assert_eq!(
+            harness.peek_responses(),
+            vec![(PEEK_A, whole_index_answer(&keys))]
+        );
+        assert_eq!(
+            harness.pending(PEEK_A),
+            None,
+            "an unbounded slice walks to the answer without suspending"
+        );
+        assert_eq!(
+            harness.walks(),
+            (1, 0),
+            "the kill switch promotes nothing, however far a peek walks"
+        );
+    }
+
+    /// One activation serves what the per-activation aggregate allows and passes the rest over,
+    /// however many peeks are pending.
+    ///
+    /// The sweep visits every pending peek, so a per-peek budget with no aggregate would let a
+    /// burst of N peeks cost N inline budgets in one pass, unbounded in N.
+    #[mz_ore::test(tokio::test)]
+    async fn the_activation_budget_bounds_a_burst() {
+        let keys = wide_ok_rows(SMALL_INDEX_KEYS);
+
+        let mut harness = with_activation_budget(1);
+        for uuid in [PEEK_A, PEEK_B, PEEK_C, PEEK_D] {
+            harness.add_pending(
+                index_peek_with_uuid(uuid, None),
+                trace_bundle(&keys, cancelling_errors(0)),
+            );
+        }
+
+        harness.sweep();
+
+        assert_eq!(
+            harness.peek_responses(),
+            vec![(PEEK_A, whole_index_answer(&keys))],
+            "an aggregate of one position serves one peek per activation"
+        );
+        assert_eq!(
+            harness.pending_uuids(),
+            vec![PEEK_B, PEEK_C, PEEK_D],
+            "the peeks that got no turn are left untouched"
+        );
+        assert_eq!(harness.state.peek_resume_at, Some(PEEK_B));
+
+        // The burst drains rather than wedging, one peek per activation.
+        assert_eq!(
+            harness.drain().await,
+            vec![
+                (PEEK_B, whole_index_answer(&keys)),
+                (PEEK_C, whole_index_answer(&keys)),
+                (PEEK_D, whole_index_answer(&keys)),
+            ]
+        );
+    }
+
+    /// The aggregate is charged what a slice walked rather than what it was granted, so an
+    /// activation serves as many peeks as their walks fit into.
+    ///
+    /// Charging the grant instead would spend the whole aggregate on the first peek whatever it
+    /// walked, which is the difference between an activation serving a burst of point lookups and
+    /// serving one of them. Comparing this run against an unbudgeted one would not catch it, since
+    /// both would answer the same rows; the assertion is against the budget this test supplied.
+    #[mz_ore::test(tokio::test)]
+    async fn the_aggregate_is_charged_what_the_slices_walked() {
+        let keys = wide_ok_rows(SMALL_INDEX_KEYS);
+        let cost = walk_cost(&keys);
+
+        // Room for two walks of this index and no more. The per-peek budget is left at its
+        // production default, which is far above one walk, so nothing here is promoted and what
+        // decides how many peeks got a turn is the aggregate alone.
+        let mut harness = with_activation_budget(2 * cost);
+        for uuid in [PEEK_A, PEEK_B, PEEK_C, PEEK_D] {
+            harness.add_pending(
+                index_peek_with_uuid(uuid, None),
+                trace_bundle(&keys, cancelling_errors(0)),
+            );
+        }
+
+        harness.sweep();
+
+        assert_eq!(
+            harness.peek_responses(),
+            vec![
+                (PEEK_A, whole_index_answer(&keys)),
+                (PEEK_B, whole_index_answer(&keys)),
+            ],
+            "an aggregate of two walks serves two peeks and passes the rest over"
+        );
+        assert_eq!(harness.pending_uuids(), vec![PEEK_C, PEEK_D]);
+        assert_eq!(harness.walks(), (2, 0), "neither served peek was promoted");
+    }
+
+    /// A peek passed over for want of budget is served before a peek that arrived after it, even
+    /// one whose uuid sorts ahead of it.
+    ///
+    /// The pending peeks are a map keyed by uuid, so a sweep taking them in map order alone would
+    /// let a newly arrived peek take the turn of one that has already waited an activation, and it
+    /// would do so again on every activation.
+    #[mz_ore::test(tokio::test)]
+    async fn a_passed_over_peek_is_served_before_one_that_arrived_later() {
+        let keys = wide_ok_rows(SMALL_INDEX_KEYS);
+        let answer = whole_index_answer(&keys);
+
+        let mut harness = with_activation_budget(1);
+        for uuid in [PEEK_B, PEEK_C] {
+            harness.add_pending(
+                index_peek_with_uuid(uuid, None),
+                trace_bundle(&keys, cancelling_errors(0)),
+            );
+        }
+
+        harness.sweep();
+
+        assert_eq!(harness.peek_responses(), vec![(PEEK_B, answer.clone())]);
+        assert_eq!(harness.state.peek_resume_at, Some(PEEK_C));
+
+        // A peek arrives whose uuid sorts ahead of the one that was passed over.
+        harness.add_pending(
+            index_peek_with_uuid(PEEK_A, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+
+        harness.sweep();
+
+        assert_eq!(
+            harness.peek_responses(),
+            vec![(PEEK_C, answer)],
+            "the peek that waited an activation takes the next turn"
+        );
+    }
+
+    /// A peek deferred as it arrives leaves an activation behind, so a worker with nothing else to
+    /// do does not park on it.
+    ///
+    /// `handle_peek` runs a peek's first slice as the peek arrives, and a peek that finds the
+    /// activation's budget spent is left pending there with no sweep to follow. `run_client` parks
+    /// after its maintenance tick, indefinitely at a zero maintenance interval, and nothing else
+    /// would wake it: the peeks that spent the budget were answered or promoted, and neither
+    /// leaves an activation behind.
+    #[mz_ore::test(tokio::test)]
+    async fn a_peek_deferred_as_it_arrives_leaves_an_activation_behind() {
+        let keys = wide_ok_rows(SMALL_INDEX_KEYS);
+
+        let mut harness = with_activation_budget(1);
+        harness
+            .state
+            .traces
+            .set(TARGET_ID, trace_bundle(&keys, cancelling_errors(0)));
+
+        // One peek spends this activation's whole aggregate.
+        harness.add_pending(
+            index_peek_with_uuid(PEEK_A, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+        harness.sweep();
+        assert_eq!(
+            harness.pending(PEEK_A),
+            None,
+            "the first peek answered and spent the aggregate"
+        );
+        assert_eq!(
+            harness.park_for(),
+            None,
+            "with nothing deferred the worker has nothing to wake for"
+        );
+
+        harness
+            .active()
+            .handle_peek(index_peek_with_uuid(PEEK_B, None));
+
+        assert_eq!(
+            harness.state.peek_resume_at,
+            Some(PEEK_B),
+            "the arriving peek found no budget and was deferred"
+        );
+        assert_eq!(
+            harness.park_for(),
+            Some(Duration::ZERO),
+            "a peek deferred outside a sweep leaves the worker something to wake for"
+        );
+    }
+
+    /// Cancelling a promoted peek answers it once, as cancelled, and the walk it left behind
+    /// answers nothing of its own.
+    ///
+    /// The walk holds the sending end of a channel whose receiver goes with the pending peek that
+    /// was removed, so a walk that reached an outcome after the cancellation has nowhere to put
+    /// it. Later activations must not produce a second response for the same peek.
+    #[mz_ore::test(tokio::test)]
+    async fn a_cancelled_promoted_peek_is_answered_once() {
+        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+
+        let mut harness = at_production_defaults();
+        harness.add_pending(
+            index_peek_with_uuid(PEEK_A, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+
+        harness.sweep();
+        assert_eq!(harness.pending(PEEK_A), Some("offloaded"));
+
+        harness.active().handle_cancel_peek(PEEK_A);
+
+        assert_eq!(
+            harness.peek_responses(),
+            vec![(PEEK_A, PeekResponse::Canceled)]
+        );
+        assert_eq!(harness.pending(PEEK_A), None);
+
+        for _ in 0..SWEEP_BOUND {
+            tokio::task::yield_now().await;
+            harness.sweep();
+        }
+        assert_eq!(
+            harness.peek_responses(),
+            vec![],
+            "a cancelled peek is answered once and never again"
+        );
+        assert_eq!(
+            harness.walks(),
+            (0, 0),
+            "a cancelled walk reaches no outcome and counts on neither substrate"
+        );
+    }
+
+    /// A promoted walk that hands back reaches the worker, which answers the peek rather than
+    /// leaving it pending on a walk that has stopped.
+    ///
+    /// The stash location is cleared between the promotion and the hand-back, so that the hand-back
+    /// takes the arm with nowhere to write the rows. That is the arm a replica configured without
+    /// a stash location takes, and reaching it any other way means driving a real upload to
+    /// persist, which the peek stash owns rather than this driver.
+    #[mz_ore::test(tokio::test)]
+    async fn a_promoted_hand_back_answers_when_there_is_nowhere_to_write() {
+        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+        let row_size = keys[0].byte_len() + size_of::<NonZeroUsize>();
+        // Above what the inline slice can accumulate within the production budget and below what
+        // the whole index holds, so the walk crosses the threshold after it has been promoted.
+        let threshold = 1_500 * row_size;
+        assert!(
+            *INDEX_PEEK_INLINE_BUDGET.default() * row_size < threshold,
+            "the inline slice must promote a scan that still has room"
+        );
+
+        let mut harness = Harness::new(move |updates| {
+            updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+            updates.add(&ENABLE_PEEK_RESPONSE_STASH, true);
+            updates.add(&PEEK_RESPONSE_STASH_THRESHOLD_BYTES, threshold);
+        });
+        harness.state.peek_stash_persist_location = Some(PersistLocation::new_in_mem());
+        harness.add_pending(
+            index_peek_with_uuid(PEEK_A, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+
+        harness.sweep();
+        assert_eq!(harness.pending(PEEK_A), Some("offloaded"));
+
+        harness.state.peek_stash_persist_location = None;
+
+        assert_eq!(
+            harness.drain().await,
+            vec![(
+                PEEK_A,
+                PeekResponse::Error(PeekError::unstructured(
+                    "peek result is too large to answer inline and this replica has no peek stash \
+                     location"
+                ))
+            )]
+        );
+        assert_eq!(
+            harness.walks(),
+            (0, 1),
+            "a hand-back is a terminal outcome of the promoted walk"
+        );
     }
 }
 
@@ -2581,6 +3168,14 @@ pub(crate) mod index_peek_tests {
             map_filter_project,
             otel_ctx: OpenTelemetryContext::empty(),
         }
+    }
+
+    /// A peek of [`TARGET_ID`] carrying `uuid`, so that a test with several pending peeks can say
+    /// which one a response answered.
+    pub(crate) fn index_peek_with_uuid(uuid: Uuid, literal_constraints: Option<Vec<Row>>) -> Peek {
+        let mut peek = index_peek(trivial_finishing(), literal_constraints);
+        peek.uuid = uuid;
+        peek
     }
 
     /// The keys of an index holding `count` distinct rows, in the order the ok walk visits them.

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1278,30 +1278,45 @@ impl<'a> ActiveComputeState<'a> {
                 result
             }),
             PendingPeek::Offloaded(offloaded) => match offloaded.result.try_recv() {
-                Ok((OffloadOutcome::Answered(response), duration)) => {
-                    trace!(?offloaded.peek, ?duration, "finished offloaded index peek walk");
-                    Some(response)
-                }
-                Ok((OffloadOutcome::NeedsStash, duration)) => {
-                    let _span = span!(parent: &offloaded.span, Level::DEBUG, "process_stash_peek")
-                        .entered();
-                    trace!(?offloaded.peek, ?duration, "handing offloaded index peek to the stash");
+                Ok((outcome, duration)) => {
+                    // Both outcomes are timed, because both measure the same thing: how long the
+                    // peek was away from the worker, the wait for a permit included. A walk that
+                    // hands back is the expensive case rather than an aborted one.
+                    self.compute_state
+                        .metrics
+                        .index_peek_offload_seconds
+                        .observe(duration.as_secs_f64());
 
-                    let uuid = offloaded.peek.uuid;
-                    let stash_task = self
-                        .start_stash_upload(offloaded.peek.clone(), offloaded.trace_bundle.clone());
-
-                    match stash_task {
-                        Some(stash_task) => {
-                            self.compute_state
-                                .pending_peeks
-                                .insert(uuid, PendingPeek::Stash(stash_task));
-                            return;
+                    match outcome {
+                        OffloadOutcome::Answered(response) => {
+                            trace!(?offloaded.peek, ?duration, "finished offloaded index peek walk");
+                            Some(response)
                         }
-                        None => Some(PeekResponse::Error(PeekError::unstructured(
-                            "peek result is too large to answer inline and this replica has no \
-                             peek stash location",
-                        ))),
+                        OffloadOutcome::NeedsStash => {
+                            let _span =
+                                span!(parent: &offloaded.span, Level::DEBUG, "process_stash_peek")
+                                    .entered();
+                            trace!(?offloaded.peek, ?duration, "handing offloaded index peek to the stash");
+
+                            let uuid = offloaded.peek.uuid;
+                            let stash_task = self.start_stash_upload(
+                                offloaded.peek.clone(),
+                                offloaded.trace_bundle.clone(),
+                            );
+
+                            match stash_task {
+                                Some(stash_task) => {
+                                    self.compute_state
+                                        .pending_peeks
+                                        .insert(uuid, PendingPeek::Stash(stash_task));
+                                    return;
+                                }
+                                None => Some(PeekResponse::Error(PeekError::unstructured(
+                                    "peek result is too large to answer inline and this replica \
+                                     has no peek stash location",
+                                ))),
+                            }
+                        }
                     }
                 }
                 Err(oneshot::error::TryRecvError::Empty) => None,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -294,15 +294,15 @@ pub struct ComputeState {
 
     /// The parameters [`ComputeState::peek_budget`] is refilled from.
     ///
-    /// Held rather than looked up, because a refill happens on every sweep of the pending peeks
-    /// and a sweep runs on every activation of the worker.
+    /// Held rather than looked up, because a refill happens on every activation of the worker.
     peek_budget_config: InlineBudgetConfig,
 
     /// What is left of what this activation may spend walking index peeks on the worker.
     ///
-    /// Refilled at the top of each sweep of the pending peeks. A peek that arrives between two
-    /// sweeps draws from what the last sweep left, so a batch of arriving peeks costs at most one
-    /// more aggregate rather than one inline budget per peek in the batch.
+    /// Refilled at the top of every activation, before the pending peeks are looked at, because a
+    /// peek that arrives outside a sweep is granted out of this budget too. A peek that arrives
+    /// while others are pending draws from what the last sweep left, so a batch of arriving peeks
+    /// costs at most one more aggregate rather than one inline budget per peek in the batch.
     peek_budget: InlineBudget,
 
     /// The pending peek a sweep stopped at for want of budget, and where the next sweep starts.
@@ -1463,23 +1463,24 @@ impl<'a> ActiveComputeState<'a> {
 
     /// Scan pending peeks and attempt to retire each.
     pub fn process_peeks(&mut self) {
-        // This runs on every iteration of the worker loop, tens of thousands of times a second on
-        // a busy worker, and the overwhelming majority of those find no pending peek. Returning
-        // before anything is read or allocated keeps that case as cheap as it was before peeks had
-        // budgets, which is also what the kill switch has to restore.
-        //
-        // A `peek_resume_at` left set here cannot strand a peek: with no pending peek there is
-        // nothing to serve, and a resume point names a position in the uuid ordering rather than
-        // an entry, so the sweep that follows the next peek's arrival rotates correctly whether or
-        // not the peek it names still exists.
+        // Refilled ahead of the early return below, because `handle_peek` grants an arriving peek
+        // out of this budget and no sweep runs on that path. A replica whose index peeks all
+        // answer inline never leaves one pending, so a refill that ran only where the sweep finds
+        // work would leave the budget at what the constructor set and nothing would ever be
+        // offloaded. The refill reads the parameters through handles and allocates nothing, which
+        // is what keeps it above the return.
+        self.compute_state.peek_budget = self.compute_state.peek_budget_config.for_activation();
+
+        // What follows runs on every iteration of the worker loop, tens of thousands of times a
+        // second on a busy worker, and the overwhelming majority of those find no pending peek.
+        // Returning before the map is walked, ordered, or taken keeps that case as cheap as the
+        // kill switch path has to be.
         if self.compute_state.pending_peeks.is_empty() {
             return;
         }
 
         let mut upper = Antichain::new();
         let mut pending_peeks = std::mem::take(&mut self.compute_state.pending_peeks);
-
-        self.compute_state.peek_budget = self.compute_state.peek_budget_config.for_activation();
 
         let mut order: Vec<Uuid> = pending_peeks.keys().copied().collect();
         if let Some(resume_at) = self.compute_state.peek_resume_at.take() {
@@ -2327,6 +2328,100 @@ impl CollectionState {
             "allowing writes for dataflow",
         );
         let _ = self.read_only_tx.send(false);
+    }
+}
+
+/// Tests of the sweep that drives the pending index peeks.
+///
+/// Built over a live [`ComputeState`] and a real timely worker rather than over the budget alone,
+/// because what the sweep is pinned on here is where it arms the budget relative to the return it
+/// takes when nothing is pending.
+#[cfg(test)]
+mod peek_sweep_tests {
+    use mz_compute_types::dyncfgs::{ENABLE_INDEX_PEEK_OFFLOAD, INDEX_PEEK_INLINE_BUDGET};
+    use mz_dyncfg::ConfigUpdates;
+    use mz_persist_client::cache::PersistClientCache;
+    use mz_secrets::InMemorySecretsController;
+    use mz_storage_types::connections::ConnectionContext;
+    use timely::WorkerConfig;
+    use timely::communication::Allocator;
+    use tokio::sync::mpsc;
+
+    use crate::metrics::ComputeMetrics;
+    use crate::server::ComputeRuntimeRole;
+
+    use super::*;
+
+    /// The per-peek budget these tests configure. Distinct from both the unbounded grant and the
+    /// parameter's default, so that an assertion on it says the configured value was read.
+    const INLINE_BUDGET: usize = 12_345;
+
+    /// A compute state as `CreateInstance` leaves one, with the offload configured on.
+    fn compute_state_with_offload_on() -> ComputeState {
+        let metrics_registry = MetricsRegistry::new();
+        let metrics = ComputeMetrics::register_with(&metrics_registry, ComputeRuntimeRole::Solo)
+            .for_worker(0);
+        let context = ComputeInstanceContext {
+            scratch_directory: None,
+            worker_core_affinity: false,
+            connection_context: ConnectionContext::for_tests(Arc::new(
+                InMemorySecretsController::new(),
+            )),
+        };
+
+        let state = ComputeState::new(
+            Arc::new(PersistClientCache::new_no_metrics()),
+            TxnsContext::default(),
+            metrics,
+            Arc::new(TracingHandle::disabled()),
+            context,
+            metrics_registry,
+            1,
+            Arc::new(PeekPermits::new(1)),
+            None,
+        );
+
+        // The worker applies these through `UpdateConfiguration`, which reaches the budget through
+        // the handles it holds rather than through any state the command touches.
+        let mut updates = ConfigUpdates::default();
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        updates.add(&INDEX_PEEK_INLINE_BUDGET, INLINE_BUDGET);
+        updates.apply(&state.worker_config);
+
+        state
+    }
+
+    /// Runs one sweep over `state`, as an activation of the worker does.
+    fn sweep(state: &mut ComputeState) {
+        let allocator = Allocator::Thread(Default::default());
+        let mut timely_worker = TimelyWorker::new(WorkerConfig::default(), allocator, None);
+        let (response_tx, _response_rx) = mpsc::unbounded_channel();
+        let mut response_tx = ResponseSender::new(response_tx, 0);
+
+        ActiveComputeState {
+            timely_worker: &mut timely_worker,
+            compute_state: state,
+            response_tx: &mut response_tx,
+        }
+        .process_peeks();
+    }
+
+    /// An activation that finds nothing pending still arms the budget, which is what a peek
+    /// arriving before the next sweep is granted out of.
+    ///
+    /// A replica whose index peeks all answer inline leaves none of them pending, so no sweep of
+    /// its ever visits a peek. Were the budget armed only where the sweep finds work, every peek
+    /// on such a replica would be granted the unbounded fuel the state is constructed with, and
+    /// unbounded fuel cannot suspend, so nothing would be offloaded however the parameters are
+    /// set. That is the case the offload exists for: one expensive lookup among cheap ones.
+    #[mz_ore::test(tokio::test)]
+    async fn an_idle_activation_arms_the_budget() {
+        let mut state = compute_state_with_offload_on();
+        assert!(state.pending_peeks.is_empty());
+
+        sweep(&mut state);
+
+        assert_eq!(state.peek_budget.grant(), Some(INLINE_BUDGET));
     }
 }
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -2575,6 +2575,25 @@ mod peek_sweep_tests {
             }
             panic!("peeks were still pending after {SWEEP_BOUND} activations");
         }
+
+        /// Runs the runtime until the two substrates have counted `walks` walks between them,
+        /// without sweeping.
+        ///
+        /// Bounded, so a walk that never reaches an outcome fails here rather than hanging the
+        /// suite. No sweep runs, so a promoted walk that finishes here leaves its outcome sitting
+        /// in the channel that carries it back, which the worker has not yet read.
+        async fn drive_until_walks(&self, walks: (u64, u64)) {
+            for _ in 0..SWEEP_BOUND {
+                if self.walks() == walks {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+            panic!(
+                "the substrates counted {:?} rather than {walks:?} within {SWEEP_BOUND} yields",
+                self.walks()
+            );
+        }
     }
 
     /// A harness with the offload on and every budget at its production default, which is the
@@ -2958,6 +2977,110 @@ mod peek_sweep_tests {
         );
     }
 
+    /// A resume point naming a peek that has since been cancelled still names where the next sweep
+    /// starts.
+    ///
+    /// The peek a caller cancels is disproportionately one that was passed over for want of
+    /// budget, because that is the peek that has been waiting, and cancellation removes it from
+    /// the map without touching the resume point. What the resume point names is a position in the
+    /// uuid ordering rather than a peek, so the sweep resumes at the first surviving peek that
+    /// sorts at or after it and the peeks that were served ahead of it still go last.
+    #[mz_ore::test(tokio::test)]
+    async fn a_resume_point_outliving_its_peek_still_names_where_to_resume() {
+        let keys = wide_ok_rows(SMALL_INDEX_KEYS);
+        let answer = whole_index_answer(&keys);
+
+        let mut harness = with_activation_budget(1);
+        for uuid in [PEEK_B, PEEK_C] {
+            harness.add_pending(
+                index_peek_with_uuid(uuid, None),
+                trace_bundle(&keys, cancelling_errors(0)),
+            );
+        }
+
+        harness.sweep();
+
+        assert_eq!(harness.peek_responses(), vec![(PEEK_B, answer.clone())]);
+        assert_eq!(harness.state.peek_resume_at, Some(PEEK_C));
+
+        harness.active().handle_cancel_peek(PEEK_C);
+
+        assert_eq!(
+            harness.peek_responses(),
+            vec![(PEEK_C, PeekResponse::Canceled)]
+        );
+        assert_eq!(
+            harness.state.peek_resume_at,
+            Some(PEEK_C),
+            "cancelling a peek leaves the resume point naming it"
+        );
+
+        // Peeks arrive on both sides of the cancelled one in the uuid ordering.
+        for uuid in [PEEK_A, PEEK_D] {
+            harness.add_pending(
+                index_peek_with_uuid(uuid, None),
+                trace_bundle(&keys, cancelling_errors(0)),
+            );
+        }
+
+        harness.sweep();
+
+        assert_eq!(
+            harness.peek_responses(),
+            vec![(PEEK_D, answer)],
+            "the sweep resumes at the first peek sorting after the cancelled one"
+        );
+        assert_eq!(harness.state.peek_resume_at, Some(PEEK_A));
+    }
+
+    /// A resume point sorting past every pending peek starts the next sweep at the first of them,
+    /// which is where a ring wraps to.
+    ///
+    /// This is the end of the ordering, where the rotation is by the whole length of it. Rotating
+    /// a sweep's peeks by their own count leaves them where they were, and where they were is the
+    /// wrap the ring owes the peeks that sort ahead of the resume point.
+    #[mz_ore::test(tokio::test)]
+    async fn a_resume_point_past_every_pending_peek_wraps_to_the_first() {
+        let keys = wide_ok_rows(SMALL_INDEX_KEYS);
+        let answer = whole_index_answer(&keys);
+
+        let mut harness = with_activation_budget(1);
+        for uuid in [PEEK_C, PEEK_D] {
+            harness.add_pending(
+                index_peek_with_uuid(uuid, None),
+                trace_bundle(&keys, cancelling_errors(0)),
+            );
+        }
+
+        harness.sweep();
+
+        assert_eq!(harness.peek_responses(), vec![(PEEK_C, answer.clone())]);
+        assert_eq!(harness.state.peek_resume_at, Some(PEEK_D));
+
+        harness.active().handle_cancel_peek(PEEK_D);
+        assert_eq!(
+            harness.peek_responses(),
+            vec![(PEEK_D, PeekResponse::Canceled)]
+        );
+
+        // Every peek that survives the cancellation sorts ahead of the resume point.
+        for uuid in [PEEK_A, PEEK_B] {
+            harness.add_pending(
+                index_peek_with_uuid(uuid, None),
+                trace_bundle(&keys, cancelling_errors(0)),
+            );
+        }
+
+        harness.sweep();
+
+        assert_eq!(
+            harness.peek_responses(),
+            vec![(PEEK_A, answer)],
+            "a resume point past every pending peek wraps to the first of them"
+        );
+        assert_eq!(harness.state.peek_resume_at, Some(PEEK_B));
+    }
+
     /// A peek deferred as it arrives leaves an activation behind, so a worker with nothing else to
     /// do does not park on it.
     ///
@@ -3018,7 +3141,9 @@ mod peek_sweep_tests {
     /// a walk that never reached an outcome. The cancellation lands before the promoted task has
     /// been polled, because nothing here awaits between the sweep that promoted it and the
     /// cancellation. What a walk that was already running does with a cancellation is pinned by
-    /// `peek_offload::tests::a_walk_cancelled_while_running_reports_no_outcome`.
+    /// `peek_offload::tests::a_walk_cancelled_while_running_reports_no_outcome`, and what one that
+    /// had already reached an outcome does by
+    /// [`a_walk_cancelled_with_its_outcome_in_flight_is_counted`].
     #[mz_ore::test(tokio::test)]
     async fn a_cancelled_promoted_peek_is_answered_once() {
         let keys = wide_ok_rows(WIDE_INDEX_KEYS);
@@ -3053,6 +3178,58 @@ mod peek_sweep_tests {
             harness.walks(),
             (0, 0),
             "a cancelled walk reaches no outcome and counts on neither substrate"
+        );
+    }
+
+    /// Cancelling a promoted peek whose walk has already reached its outcome answers it as
+    /// cancelled and counts the walk as offloaded.
+    ///
+    /// This is the case the walk counters are documented with: a walk is counted where it reached
+    /// an outcome, and a cancellation that lands after that point does not take the count away.
+    /// The window is the one between the task sending its outcome and the worker's next sweep
+    /// reading it, which is as long as the worker takes to come back around, so a replica under
+    /// load spends real time in it. The counters would otherwise have to be read as a lower bound
+    /// on the walks each substrate finished rather than as the count of them.
+    #[mz_ore::test(tokio::test)]
+    async fn a_walk_cancelled_with_its_outcome_in_flight_is_counted() {
+        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+
+        let mut harness = at_production_defaults();
+        harness.add_pending(
+            index_peek_with_uuid(PEEK_A, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+
+        harness.sweep();
+        assert_eq!(harness.pending(PEEK_A), Some("offloaded"));
+
+        // The walk runs to its outcome while no sweep collects it, which leaves the outcome in
+        // flight between the task and the worker.
+        harness.drive_until_walks((0, 1)).await;
+        assert_eq!(
+            harness.peek_responses(),
+            vec![],
+            "no sweep has read the outcome, so the peek is unanswered"
+        );
+
+        harness.active().handle_cancel_peek(PEEK_A);
+
+        assert_eq!(
+            harness.peek_responses(),
+            vec![(PEEK_A, PeekResponse::Canceled)],
+            "the cancellation answers the peek rather than the outcome in flight"
+        );
+        assert_eq!(
+            harness.walks(),
+            (0, 1),
+            "a walk that reached its outcome stays counted on the substrate that ended it"
+        );
+
+        harness.sweep();
+        assert_eq!(
+            harness.peek_responses(),
+            vec![],
+            "the outcome in flight is dropped with the peek rather than answered after it"
         );
     }
 

--- a/src/compute/src/compute_state/peek_budget.rs
+++ b/src/compute/src/compute_state/peek_budget.rs
@@ -50,7 +50,11 @@ impl InlineBudget {
 
         Self::Bounded {
             per_peek: INDEX_PEEK_INLINE_BUDGET.get(config),
-            remaining: INDEX_PEEK_ACTIVATION_BUDGET.get(config),
+            // An aggregate of zero would pass every peek over on every activation, and the
+            // activation a passed-over peek asks for would arrive to find the same empty budget,
+            // so no peek would ever be answered. One position keeps the parameter monotone down
+            // to its floor instead of wedging at it.
+            remaining: INDEX_PEEK_ACTIVATION_BUDGET.get(config).max(1),
         }
     }
 
@@ -128,6 +132,24 @@ mod tests {
         budget.charge(100);
         assert_eq!(budget.grant(), Some(100));
         budget.charge(100);
+        assert_eq!(budget.grant(), Some(100));
+        budget.charge(100);
+        assert_eq!(budget.grant(), None);
+    }
+
+    /// An aggregate of zero still serves one peek per activation. Without that, every peek would
+    /// be passed over on every activation and none would ever be answered.
+    #[mz_ore::test]
+    fn a_zero_aggregate_still_serves_one_peek() {
+        let config = mz_dyncfgs::all_dyncfgs();
+        let mut updates = ConfigUpdates::default();
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        updates.add(&INDEX_PEEK_INLINE_BUDGET, 100);
+        updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, 0);
+        updates.apply(&config);
+
+        let mut budget = InlineBudget::for_activation(&config);
+
         assert_eq!(budget.grant(), Some(100));
         budget.charge(100);
         assert_eq!(budget.grant(), None);

--- a/src/compute/src/compute_state/peek_budget.rs
+++ b/src/compute/src/compute_state/peek_budget.rs
@@ -1,0 +1,153 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! What a worker activation may spend walking index peeks before it hands the worker back.
+
+use mz_compute_types::dyncfgs::{
+    ENABLE_INDEX_PEEK_OFFLOAD, INDEX_PEEK_ACTIVATION_BUDGET, INDEX_PEEK_INLINE_BUDGET,
+};
+use mz_dyncfg::ConfigSet;
+
+/// The fuel an activation may spend walking index peeks on the worker, and what one peek may take
+/// of it.
+///
+/// Two counters rather than one, and the second is not optional. The per-peek budget is the
+/// placement policy: a peek that outruns it has been measured to be expensive and moves off the
+/// worker, which is what lets a point lookup over a skewed hot key offload without being
+/// special-cased. The aggregate bounds how long one activation withholds the worker from
+/// everything else it serves, because the peek path visits every pending peek on every activation,
+/// so a per-peek budget alone would let N pending peeks cost N times that budget in a single pass,
+/// unbounded in N.
+///
+/// Both are counted in cursor positions visited rather than rows returned, matching the unit the
+/// scan charges: a selective filter steps the cursor without returning anything, so a row-counted
+/// budget is one such a peek never spends.
+pub(super) enum InlineBudget {
+    /// Every peek walks to completion where it started, and nothing is promoted or passed over.
+    ///
+    /// This is what the kill switch restores, and it has to be what the worker did before the
+    /// offload existed rather than an approximation of it. Unbounded fuel is also what makes
+    /// promotion unreachable: the scan suspends only when its fuel runs out or when it holds a
+    /// full batch, and the first cannot happen here, so the only suspension left is the one that
+    /// goes to the peek stash exactly as it did before.
+    Unbounded,
+    /// A peek may spend `per_peek` before it is promoted, and all peeks together may spend
+    /// `remaining` before the rest of this activation's work gets the worker back.
+    Bounded { per_peek: usize, remaining: usize },
+}
+
+impl InlineBudget {
+    /// Reads the budget in effect now.
+    ///
+    /// Read once per activation rather than held, so a configuration change reaches the next
+    /// activation without disturbing the one under way.
+    pub(super) fn for_activation(config: &ConfigSet) -> Self {
+        if !ENABLE_INDEX_PEEK_OFFLOAD.get(config) {
+            return Self::Unbounded;
+        }
+
+        Self::Bounded {
+            per_peek: INDEX_PEEK_INLINE_BUDGET.get(config),
+            remaining: INDEX_PEEK_ACTIVATION_BUDGET.get(config),
+        }
+    }
+
+    /// The fuel one peek's slice may spend, or `None` when this activation has none left to give.
+    ///
+    /// A peek is granted its whole per-peek budget or nothing at all, so promotion keeps meaning
+    /// that the peek outran that budget rather than that it arrived late in an activation. The
+    /// aggregate is therefore overrun by at most one per-peek budget, which is also what keeps an
+    /// inline budget configured above the aggregate from passing over every peek forever.
+    ///
+    /// A peek granted nothing is passed over rather than stepped with an empty budget. A scan
+    /// stepped with no fuel suspends without walking anything, which would promote a peek that
+    /// never had its inline turn.
+    pub(super) fn grant(&self) -> Option<usize> {
+        match self {
+            Self::Unbounded => Some(usize::MAX),
+            Self::Bounded {
+                per_peek,
+                remaining,
+            } => (*remaining > 0).then_some(*per_peek),
+        }
+    }
+
+    /// Charges the activation for the positions a slice walked.
+    pub(super) fn charge(&mut self, spent: usize) {
+        match self {
+            Self::Unbounded => {}
+            Self::Bounded { remaining, .. } => *remaining = remaining.saturating_sub(spent),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_dyncfg::ConfigUpdates;
+
+    use super::*;
+
+    /// With the offload off, every peek is granted unbounded fuel however much the peeks before it
+    /// spent, which is what makes the kill switch restore the worker's old behaviour rather than
+    /// approximate it.
+    #[mz_ore::test]
+    fn the_kill_switch_grants_every_peek_an_unbounded_slice() {
+        let config = mz_dyncfgs::all_dyncfgs();
+        let mut budget = InlineBudget::for_activation(&config);
+
+        for _ in 0..3 {
+            assert_eq!(budget.grant(), Some(usize::MAX));
+            budget.charge(usize::MAX);
+        }
+    }
+
+    /// The aggregate is spent by what the peeks walked, not by what they were granted, so cheap
+    /// peeks keep getting turns and expensive ones drain it.
+    #[mz_ore::test]
+    fn the_aggregate_is_spent_by_what_the_peeks_walk() {
+        let config = mz_dyncfgs::all_dyncfgs();
+        let mut updates = ConfigUpdates::default();
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        updates.add(&INDEX_PEEK_INLINE_BUDGET, 100);
+        updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, 250);
+        updates.apply(&config);
+
+        let mut budget = InlineBudget::for_activation(&config);
+
+        // Point-lookup-sized slices barely touch the aggregate.
+        for _ in 0..10 {
+            assert_eq!(budget.grant(), Some(100));
+            budget.charge(2);
+        }
+
+        // Slices that spend the whole per-peek budget drain it, and the peeks behind them are
+        // passed over rather than served with a partial slice.
+        assert_eq!(budget.grant(), Some(100));
+        budget.charge(100);
+        assert_eq!(budget.grant(), Some(100));
+        budget.charge(100);
+        assert_eq!(budget.grant(), Some(100));
+        budget.charge(100);
+        assert_eq!(budget.grant(), None);
+    }
+
+    /// An inline budget larger than the aggregate still serves one peek per activation. Without
+    /// that, no peek would ever be granted a slice and every peek would hang.
+    #[mz_ore::test]
+    fn an_inline_budget_above_the_aggregate_still_serves_one_peek() {
+        let config = mz_dyncfgs::all_dyncfgs();
+        let mut updates = ConfigUpdates::default();
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        updates.add(&INDEX_PEEK_INLINE_BUDGET, 1_000_000_000);
+        updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, 1);
+        updates.apply(&config);
+
+        let mut budget = InlineBudget::for_activation(&config);
+
+        assert_eq!(budget.grant(), Some(1_000_000_000));
+        budget.charge(1_000_000_000);
+        assert_eq!(budget.grant(), None);
+    }
+}

--- a/src/compute/src/compute_state/peek_budget.rs
+++ b/src/compute/src/compute_state/peek_budget.rs
@@ -8,7 +8,49 @@
 use mz_compute_types::dyncfgs::{
     ENABLE_INDEX_PEEK_OFFLOAD, INDEX_PEEK_ACTIVATION_BUDGET, INDEX_PEEK_INLINE_BUDGET,
 };
-use mz_dyncfg::ConfigSet;
+use mz_dyncfg::{ConfigSet, ConfigValHandle};
+
+/// The parameters an [`InlineBudget`] is read from, each as a handle rather than as a value.
+///
+/// A budget is built for every sweep of the pending peeks, and a sweep runs on every activation of
+/// the worker, so reading the parameters by name would put three lookups against the whole
+/// configuration set on the worker's loop. Handles give the property the parameters are documented
+/// with at a fraction of that cost: a configuration change reaches the next sweep, and so the walks
+/// that sweep grants a slice to, without discarding the positions earlier sweeps walked.
+pub(super) struct InlineBudgetConfig {
+    enabled: ConfigValHandle<bool>,
+    per_peek: ConfigValHandle<usize>,
+    aggregate: ConfigValHandle<usize>,
+}
+
+impl InlineBudgetConfig {
+    pub(super) fn new(config: &ConfigSet) -> Self {
+        Self {
+            enabled: ENABLE_INDEX_PEEK_OFFLOAD.handle(config),
+            per_peek: INDEX_PEEK_INLINE_BUDGET.handle(config),
+            aggregate: INDEX_PEEK_ACTIVATION_BUDGET.handle(config),
+        }
+    }
+
+    /// Reads the budget in effect now.
+    ///
+    /// Read once per activation rather than held, so a configuration change reaches the next
+    /// activation without disturbing the one under way.
+    pub(super) fn for_activation(&self) -> InlineBudget {
+        if !self.enabled.get() {
+            return InlineBudget::Unbounded;
+        }
+
+        InlineBudget::Bounded {
+            per_peek: self.per_peek.get(),
+            // An aggregate of zero would pass every peek over on every activation, and the
+            // activation a passed-over peek asks for would arrive to find the same empty budget,
+            // so no peek would ever be answered. One position keeps the parameter monotone down
+            // to its floor instead of wedging at it.
+            remaining: self.aggregate.get().max(1),
+        }
+    }
+}
 
 /// The fuel an activation may spend walking index peeks on the worker, and what one peek may take
 /// of it.
@@ -39,25 +81,6 @@ pub(super) enum InlineBudget {
 }
 
 impl InlineBudget {
-    /// Reads the budget in effect now.
-    ///
-    /// Read once per activation rather than held, so a configuration change reaches the next
-    /// activation without disturbing the one under way.
-    pub(super) fn for_activation(config: &ConfigSet) -> Self {
-        if !ENABLE_INDEX_PEEK_OFFLOAD.get(config) {
-            return Self::Unbounded;
-        }
-
-        Self::Bounded {
-            per_peek: INDEX_PEEK_INLINE_BUDGET.get(config),
-            // An aggregate of zero would pass every peek over on every activation, and the
-            // activation a passed-over peek asks for would arrive to find the same empty budget,
-            // so no peek would ever be answered. One position keeps the parameter monotone down
-            // to its floor instead of wedging at it.
-            remaining: INDEX_PEEK_ACTIVATION_BUDGET.get(config).max(1),
-        }
-    }
-
     /// The fuel one peek's slice may spend, or `None` when this activation has none left to give.
     ///
     /// A peek is granted its whole per-peek budget or nothing at all, so promotion keeps meaning
@@ -99,7 +122,7 @@ mod tests {
     #[mz_ore::test]
     fn the_kill_switch_grants_every_peek_an_unbounded_slice() {
         let config = mz_dyncfgs::all_dyncfgs();
-        let mut budget = InlineBudget::for_activation(&config);
+        let mut budget = InlineBudgetConfig::new(&config).for_activation();
 
         for _ in 0..3 {
             assert_eq!(budget.grant(), Some(usize::MAX));
@@ -118,7 +141,7 @@ mod tests {
         updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, 250);
         updates.apply(&config);
 
-        let mut budget = InlineBudget::for_activation(&config);
+        let mut budget = InlineBudgetConfig::new(&config).for_activation();
 
         // Point-lookup-sized slices barely touch the aggregate.
         for _ in 0..10 {
@@ -137,6 +160,26 @@ mod tests {
         assert_eq!(budget.grant(), None);
     }
 
+    /// A configuration change reaches the sweep that follows it through the handles the budget
+    /// holds, which is what keeps a parameter change from waiting on a restart.
+    #[mz_ore::test]
+    fn a_parameter_change_reaches_the_next_activation() {
+        let config = mz_dyncfgs::all_dyncfgs();
+        let budget_config = InlineBudgetConfig::new(&config);
+
+        assert!(matches!(
+            budget_config.for_activation(),
+            InlineBudget::Unbounded
+        ));
+
+        let mut updates = ConfigUpdates::default();
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        updates.add(&INDEX_PEEK_INLINE_BUDGET, 100);
+        updates.apply(&config);
+
+        assert_eq!(budget_config.for_activation().grant(), Some(100));
+    }
+
     /// An aggregate of zero still serves one peek per activation. Without that, every peek would
     /// be passed over on every activation and none would ever be answered.
     #[mz_ore::test]
@@ -148,7 +191,7 @@ mod tests {
         updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, 0);
         updates.apply(&config);
 
-        let mut budget = InlineBudget::for_activation(&config);
+        let mut budget = InlineBudgetConfig::new(&config).for_activation();
 
         assert_eq!(budget.grant(), Some(100));
         budget.charge(100);
@@ -166,7 +209,7 @@ mod tests {
         updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, 1);
         updates.apply(&config);
 
-        let mut budget = InlineBudget::for_activation(&config);
+        let mut budget = InlineBudgetConfig::new(&config).for_activation();
 
         assert_eq!(budget.grant(), Some(1_000_000_000));
         budget.charge(1_000_000_000);

--- a/src/compute/src/compute_state/peek_budget.rs
+++ b/src/compute/src/compute_state/peek_budget.rs
@@ -42,7 +42,13 @@ impl InlineBudgetConfig {
         }
 
         InlineBudget::Bounded {
-            per_peek: self.per_peek.get(),
+            // A per-peek budget of zero would suspend every scan before it walked a position, and
+            // a suspension that holds no full batch is a promotion, so every point lookup would
+            // cost a task, a permit, and a trace bundle clone while walking nothing. The aggregate
+            // is untouched by such a peek, so this is a waste rather than a wedge, but it is also
+            // exactly what granting a peek an empty slice is documented to avoid. One position
+            // keeps the parameter monotone down to its floor.
+            per_peek: self.per_peek.get().max(1),
             // An aggregate of zero would pass every peek over on every activation, and the
             // activation a passed-over peek asks for would arrive to find the same empty budget,
             // so no peek would ever be answered. One position keeps the parameter monotone down
@@ -178,6 +184,22 @@ mod tests {
         updates.apply(&config);
 
         assert_eq!(budget_config.for_activation().grant(), Some(100));
+    }
+
+    /// A per-peek budget of zero still walks one position. Without that, every peek would be
+    /// promoted having walked nothing, which spends a task and a permit on a point lookup the
+    /// worker would have answered outright.
+    #[mz_ore::test]
+    fn a_zero_per_peek_budget_still_walks_one_position() {
+        let config = mz_dyncfgs::all_dyncfgs();
+        let mut updates = ConfigUpdates::default();
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        updates.add(&INDEX_PEEK_INLINE_BUDGET, 0);
+        updates.apply(&config);
+
+        let budget = InlineBudgetConfig::new(&config).for_activation();
+
+        assert_eq!(budget.grant(), Some(1));
     }
 
     /// An aggregate of zero still serves one peek per activation. Without that, every peek would

--- a/src/compute/src/compute_state/peek_budget.rs
+++ b/src/compute/src/compute_state/peek_budget.rs
@@ -12,19 +12,19 @@ use mz_dyncfg::{ConfigSet, ConfigValHandle};
 
 /// The parameters an [`InlineBudget`] is read from, each as a handle rather than as a value.
 ///
-/// A budget is built on every activation of the worker, so reading the parameters by name would put
-/// three lookups against the whole configuration set on the worker's loop. Handles give the property
-/// the parameters are documented with at a fraction of that cost: a configuration change reaches the
+/// An activation's fuel is read afresh, so reading the parameters by name would put three lookups
+/// against the whole configuration set on the worker's loop. Handles give the property the
+/// parameters are documented with at a fraction of that cost: a configuration change reaches the
 /// next activation, and so the walks it grants a slice to, without discarding the positions earlier
 /// sweeps walked.
-pub(super) struct InlineBudgetConfig {
+struct InlineBudgetConfig {
     enabled: ConfigValHandle<bool>,
     per_peek: ConfigValHandle<usize>,
     aggregate: ConfigValHandle<usize>,
 }
 
 impl InlineBudgetConfig {
-    pub(super) fn new(config: &ConfigSet) -> Self {
+    fn new(config: &ConfigSet) -> Self {
         Self {
             enabled: ENABLE_INDEX_PEEK_OFFLOAD.handle(config),
             per_peek: INDEX_PEEK_INLINE_BUDGET.handle(config),
@@ -32,16 +32,13 @@ impl InlineBudgetConfig {
         }
     }
 
-    /// Reads the budget in effect now.
-    ///
-    /// Read once per activation rather than held, so a configuration change reaches the next
-    /// activation without disturbing the one under way.
-    pub(super) fn for_activation(&self) -> InlineBudget {
+    /// Reads the parameters in effect now into the fuel of one activation.
+    fn arm(&self) -> ActivationBudget {
         if !self.enabled.get() {
-            return InlineBudget::Unbounded;
+            return ActivationBudget::Unbounded;
         }
 
-        InlineBudget::Bounded {
+        ActivationBudget::Bounded {
             // A per-peek budget of zero would suspend every scan before it walked a position, and
             // a suspension that holds no full batch is a promotion, so every point lookup would
             // cost a task, a permit, and a trace bundle clone while walking nothing. The aggregate
@@ -72,7 +69,7 @@ impl InlineBudgetConfig {
 /// Both are counted in cursor positions visited rather than rows returned, matching the unit the
 /// scan charges: a selective filter steps the cursor without returning anything, so a row-counted
 /// budget is one such a peek never spends.
-pub(super) enum InlineBudget {
+enum ActivationBudget {
     /// Every peek walks to completion where it started, and nothing is promoted or passed over.
     ///
     /// This is what the kill switch restores, and it has to be what the worker did before the
@@ -86,7 +83,46 @@ pub(super) enum InlineBudget {
     Bounded { per_peek: usize, remaining: usize },
 }
 
+/// The fuel of the activation under way, armed from the parameters by the first peek that asks for
+/// a slice of it.
+///
+/// Arming is by demand rather than by a caller refilling ahead of one, because the callers that
+/// grant a slice are not only the sweep. Commands are drained in full before any sweep runs, and a
+/// peek arriving on that path is granted its first slice as it arrives, so a budget that only a
+/// sweep armed would hand every peek of a reconnecting controller's re-sent backlog an unbounded
+/// slice. Arming at the grant leaves one place that can be wrong and makes a future caller of
+/// [`InlineBudget::grant`] bounded by construction.
+///
+/// Arming cannot happen where the state is built either. `CreateInstance` is followed by the
+/// `UpdateConfiguration` that carries the parameters, so a budget armed in the constructor would
+/// snapshot the code defaults and hold them for the life of the activation.
+pub(super) struct InlineBudget {
+    config: InlineBudgetConfig,
+    /// The fuel of the activation under way, or `None` while no peek has asked for a slice since
+    /// the activation began.
+    activation: Option<ActivationBudget>,
+}
+
 impl InlineBudget {
+    /// A budget reading `config`, whose first grant arms the first activation.
+    pub(super) fn new(config: &ConfigSet) -> Self {
+        Self {
+            config: InlineBudgetConfig::new(config),
+            activation: None,
+        }
+    }
+
+    /// Begins an activation, discarding what the previous one left.
+    ///
+    /// This is what keeps the aggregate a bound per activation rather than per process. Arming is
+    /// lazy, so nothing else ever refills the fuel: a budget armed once and never begun again
+    /// would let the first activation's aggregate bound every peek the replica goes on to serve.
+    /// The parameters are read at the grant that follows rather than here, so a configuration
+    /// change reaches this activation without disturbing the one it interrupted.
+    pub(super) fn start_activation(&mut self) {
+        self.activation = None;
+    }
+
     /// The fuel one peek's slice may spend, or `None` when this activation has none left to give.
     ///
     /// A peek is granted its whole per-peek budget or nothing at all, so promotion keeps meaning
@@ -97,10 +133,11 @@ impl InlineBudget {
     /// A peek granted nothing is passed over rather than stepped with an empty budget. A scan
     /// stepped with no fuel suspends without walking anything, which would promote a peek that
     /// never had its inline turn.
-    pub(super) fn grant(&self) -> Option<usize> {
-        match self {
-            Self::Unbounded => Some(usize::MAX),
-            Self::Bounded {
+    pub(super) fn grant(&mut self) -> Option<usize> {
+        let Self { config, activation } = self;
+        match activation.get_or_insert_with(|| config.arm()) {
+            ActivationBudget::Unbounded => Some(usize::MAX),
+            ActivationBudget::Bounded {
                 per_peek,
                 remaining,
             } => (*remaining > 0).then_some(*per_peek),
@@ -108,10 +145,25 @@ impl InlineBudget {
     }
 
     /// Charges the activation for the positions a slice walked.
+    ///
+    /// A charge without a grant ahead of it is nothing to charge for, because a slice is only ever
+    /// walked out of fuel this granted.
     pub(super) fn charge(&mut self, spent: usize) {
-        match self {
-            Self::Unbounded => {}
-            Self::Bounded { remaining, .. } => *remaining = remaining.saturating_sub(spent),
+        match &mut self.activation {
+            Some(ActivationBudget::Bounded { remaining, .. }) => {
+                *remaining = remaining.saturating_sub(spent)
+            }
+            Some(ActivationBudget::Unbounded) | None => {}
+        }
+    }
+
+    /// What is left of this activation's aggregate, or `None` when the activation is unarmed or
+    /// unbounded.
+    #[cfg(test)]
+    pub(super) fn remaining(&self) -> Option<usize> {
+        match &self.activation {
+            Some(ActivationBudget::Bounded { remaining, .. }) => Some(*remaining),
+            Some(ActivationBudget::Unbounded) | None => None,
         }
     }
 }
@@ -122,13 +174,58 @@ mod tests {
 
     use super::*;
 
+    /// The configuration the budget tests read, with the offload on, a per-peek budget of
+    /// `per_peek` and an aggregate of `aggregate`.
+    fn config(per_peek: usize, aggregate: usize) -> ConfigSet {
+        let config = mz_dyncfgs::all_dyncfgs();
+        let mut updates = ConfigUpdates::default();
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        updates.add(&INDEX_PEEK_INLINE_BUDGET, per_peek);
+        updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, aggregate);
+        updates.apply(&config);
+        config
+    }
+
+    /// A budget that no activation has begun still grants a bounded slice, because the grant is
+    /// what arms it.
+    ///
+    /// The worker drains the commands it has queued before it sweeps its pending peeks, and a peek
+    /// arriving on that path is granted a slice as it arrives. A budget armed only where an
+    /// activation begins would grant that peek the unbounded fuel of a budget that had never been
+    /// read, and unbounded fuel never suspends, so the peek would walk to its answer on the worker
+    /// however the parameters are set.
+    #[mz_ore::test]
+    fn the_first_grant_arms_the_budget() {
+        let config = config(100, 250);
+        let mut budget = InlineBudget::new(&config);
+
+        assert_eq!(budget.grant(), Some(100));
+    }
+
+    /// Beginning an activation refills the aggregate, which is what makes it a bound on one
+    /// activation rather than on the process.
+    #[mz_ore::test]
+    fn beginning_an_activation_refills_the_aggregate() {
+        let config = config(100, 250);
+        let mut budget = InlineBudget::new(&config);
+
+        assert_eq!(budget.grant(), Some(100));
+        budget.charge(250);
+        assert_eq!(budget.grant(), None);
+
+        budget.start_activation();
+
+        assert_eq!(budget.grant(), Some(100));
+        assert_eq!(budget.remaining(), Some(250));
+    }
+
     /// With the offload off, every peek is granted unbounded fuel however much the peeks before it
     /// spent, which is what makes the kill switch restore the worker's old behaviour rather than
     /// approximate it.
     #[mz_ore::test]
     fn the_kill_switch_grants_every_peek_an_unbounded_slice() {
         let config = mz_dyncfgs::all_dyncfgs();
-        let mut budget = InlineBudgetConfig::new(&config).for_activation();
+        let mut budget = InlineBudget::new(&config);
 
         for _ in 0..3 {
             assert_eq!(budget.grant(), Some(usize::MAX));
@@ -140,14 +237,8 @@ mod tests {
     /// peeks keep getting turns and expensive ones drain it.
     #[mz_ore::test]
     fn the_aggregate_is_spent_by_what_the_peeks_walk() {
-        let config = mz_dyncfgs::all_dyncfgs();
-        let mut updates = ConfigUpdates::default();
-        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
-        updates.add(&INDEX_PEEK_INLINE_BUDGET, 100);
-        updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, 250);
-        updates.apply(&config);
-
-        let mut budget = InlineBudgetConfig::new(&config).for_activation();
+        let config = config(100, 250);
+        let mut budget = InlineBudget::new(&config);
 
         // Point-lookup-sized slices barely touch the aggregate.
         for _ in 0..10 {
@@ -166,24 +257,26 @@ mod tests {
         assert_eq!(budget.grant(), None);
     }
 
-    /// A configuration change reaches the sweep that follows it through the handles the budget
-    /// holds, which is what keeps a parameter change from waiting on a restart.
+    /// A configuration change reaches the activation that follows it through the handles the
+    /// budget holds, which is what keeps a parameter change from waiting on a restart. The
+    /// activation under way when the change lands keeps the fuel it was armed with.
     #[mz_ore::test]
     fn a_parameter_change_reaches_the_next_activation() {
         let config = mz_dyncfgs::all_dyncfgs();
-        let budget_config = InlineBudgetConfig::new(&config);
+        let mut budget = InlineBudget::new(&config);
 
-        assert!(matches!(
-            budget_config.for_activation(),
-            InlineBudget::Unbounded
-        ));
+        assert_eq!(budget.grant(), Some(usize::MAX));
 
         let mut updates = ConfigUpdates::default();
         updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
         updates.add(&INDEX_PEEK_INLINE_BUDGET, 100);
         updates.apply(&config);
 
-        assert_eq!(budget_config.for_activation().grant(), Some(100));
+        assert_eq!(budget.grant(), Some(usize::MAX));
+
+        budget.start_activation();
+
+        assert_eq!(budget.grant(), Some(100));
     }
 
     /// A per-peek budget of zero still walks one position. Without that, every peek would be
@@ -191,13 +284,8 @@ mod tests {
     /// worker would have answered outright.
     #[mz_ore::test]
     fn a_zero_per_peek_budget_still_walks_one_position() {
-        let config = mz_dyncfgs::all_dyncfgs();
-        let mut updates = ConfigUpdates::default();
-        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
-        updates.add(&INDEX_PEEK_INLINE_BUDGET, 0);
-        updates.apply(&config);
-
-        let budget = InlineBudgetConfig::new(&config).for_activation();
+        let config = config(0, *INDEX_PEEK_ACTIVATION_BUDGET.default());
+        let mut budget = InlineBudget::new(&config);
 
         assert_eq!(budget.grant(), Some(1));
     }
@@ -206,14 +294,8 @@ mod tests {
     /// be passed over on every activation and none would ever be answered.
     #[mz_ore::test]
     fn a_zero_aggregate_still_serves_one_peek() {
-        let config = mz_dyncfgs::all_dyncfgs();
-        let mut updates = ConfigUpdates::default();
-        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
-        updates.add(&INDEX_PEEK_INLINE_BUDGET, 100);
-        updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, 0);
-        updates.apply(&config);
-
-        let mut budget = InlineBudgetConfig::new(&config).for_activation();
+        let config = config(100, 0);
+        let mut budget = InlineBudget::new(&config);
 
         assert_eq!(budget.grant(), Some(100));
         budget.charge(100);
@@ -224,14 +306,8 @@ mod tests {
     /// that, no peek would ever be granted a slice and every peek would hang.
     #[mz_ore::test]
     fn an_inline_budget_above_the_aggregate_still_serves_one_peek() {
-        let config = mz_dyncfgs::all_dyncfgs();
-        let mut updates = ConfigUpdates::default();
-        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
-        updates.add(&INDEX_PEEK_INLINE_BUDGET, 1_000_000_000);
-        updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, 1);
-        updates.apply(&config);
-
-        let mut budget = InlineBudgetConfig::new(&config).for_activation();
+        let config = config(1_000_000_000, 1);
+        let mut budget = InlineBudget::new(&config);
 
         assert_eq!(budget.grant(), Some(1_000_000_000));
         budget.charge(1_000_000_000);

--- a/src/compute/src/compute_state/peek_budget.rs
+++ b/src/compute/src/compute_state/peek_budget.rs
@@ -12,11 +12,11 @@ use mz_dyncfg::{ConfigSet, ConfigValHandle};
 
 /// The parameters an [`InlineBudget`] is read from, each as a handle rather than as a value.
 ///
-/// A budget is built for every sweep of the pending peeks, and a sweep runs on every activation of
-/// the worker, so reading the parameters by name would put three lookups against the whole
-/// configuration set on the worker's loop. Handles give the property the parameters are documented
-/// with at a fraction of that cost: a configuration change reaches the next sweep, and so the walks
-/// that sweep grants a slice to, without discarding the positions earlier sweeps walked.
+/// A budget is built on every activation of the worker, so reading the parameters by name would put
+/// three lookups against the whole configuration set on the worker's loop. Handles give the property
+/// the parameters are documented with at a fraction of that cost: a configuration change reaches the
+/// next activation, and so the walks it grants a slice to, without discarding the positions earlier
+/// sweeps walked.
 pub(super) struct InlineBudgetConfig {
     enabled: ConfigValHandle<bool>,
     per_peek: ConfigValHandle<usize>,

--- a/src/compute/src/compute_state/peek_metrics.rs
+++ b/src/compute/src/compute_state/peek_metrics.rs
@@ -24,6 +24,7 @@ use mz_compute_client::protocol::response::PeekResponse;
 use mz_expr::ColumnOrder;
 use mz_expr::row::RowCollection;
 use mz_ore::cast::CastLossy;
+use mz_ore::metrics::UIntGauge;
 use prometheus::{Histogram, IntCounter};
 
 use crate::compute_state::peek_scan::{RowBatch, WalkPhases};
@@ -45,6 +46,11 @@ pub(super) struct PeekWalkMetrics {
     result_sort_seconds: Histogram,
     result_sort_rows: Histogram,
     row_collection_seconds: Histogram,
+    /// How many promoted walks are waiting for a permit. Reported by the promoted driver alone,
+    /// which is the only one that queues.
+    permit_queue_depth: UIntGauge,
+    /// How long a promoted walk waited for its permit. Reported by the promoted driver alone.
+    permit_wait_seconds: Histogram,
 }
 
 impl PeekWalkMetrics {
@@ -59,6 +65,23 @@ impl PeekWalkMetrics {
             result_sort_seconds: metrics.index_peek_result_sort_seconds.clone(),
             result_sort_rows: metrics.index_peek_result_sort_rows.clone(),
             row_collection_seconds: metrics.index_peek_row_collection_seconds.clone(),
+            permit_queue_depth: metrics.index_peek_permit_queue_depth.clone(),
+            permit_wait_seconds: metrics.index_peek_permit_wait_seconds.clone(),
+        }
+    }
+
+    /// Accounts for a promoted walk joining the queue for a permit.
+    ///
+    /// The queue is the drain-rate signal the permit bound is watched through, and it has no
+    /// second bound, so both numbers have to come from the walks themselves. The returned guard
+    /// leaves the queue however the wait ends, a cancellation and an abort included, which is what
+    /// keeps the depth from drifting up over a process's life.
+    pub(super) fn queued_for_permit(&self) -> PermitWait {
+        self.permit_queue_depth.inc();
+        PermitWait {
+            queue_depth: self.permit_queue_depth.clone(),
+            wait_seconds: self.permit_wait_seconds.clone(),
+            since: Instant::now(),
         }
     }
 
@@ -131,6 +154,33 @@ impl PeekWalkMetrics {
             .observe(start.elapsed().as_secs_f64());
 
         PeekResponse::Rows(vec![collection])
+    }
+}
+
+/// A promoted walk's place in the queue for a permit, for as long as it holds one.
+///
+/// Leaving the queue is a drop rather than a call, so a walk that is cancelled or aborted while it
+/// waits leaves the queue as surely as one that is admitted.
+pub(super) struct PermitWait {
+    queue_depth: UIntGauge,
+    wait_seconds: Histogram,
+    since: Instant,
+}
+
+impl PermitWait {
+    /// Reports the wait of a walk that was admitted.
+    ///
+    /// A walk that leaves the queue any other way reports nothing, so the histogram describes
+    /// waits that ended in a permit rather than waits that ended.
+    pub(super) fn admitted(self) {
+        self.wait_seconds
+            .observe(self.since.elapsed().as_secs_f64());
+    }
+}
+
+impl Drop for PermitWait {
+    fn drop(&mut self) {
+        self.queue_depth.dec();
     }
 }
 

--- a/src/compute/src/compute_state/peek_metrics.rs
+++ b/src/compute/src/compute_state/peek_metrics.rs
@@ -1,0 +1,146 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! What an index peek reports about the walk that answers it.
+//!
+//! A walk is run by one driver or by two: the inline slice runs on the timely worker, and a
+//! promoted walk finishes what that slice started. The numbers a [`PeekScan`] carries are
+//! cumulative over every slice, whichever driver ran it, so the rule that keeps each histogram
+//! observed exactly once per walk is that **the driver which produces the walk's terminal outcome
+//! reports it**. Promotion is not a terminal outcome, so an inline slice that promotes reports
+//! nothing and the task that finishes the walk reports the whole set.
+//!
+//! A walk that is cancelled reports nothing, which is why the substrate counters count walks that
+//! ended rather than walks that started.
+//!
+//! [`PeekScan`]: super::peek_scan::PeekScan
+
+use std::num::NonZeroUsize;
+use std::time::Instant;
+
+use mz_compute_client::protocol::response::PeekResponse;
+use mz_expr::ColumnOrder;
+use mz_expr::row::RowCollection;
+use mz_ore::cast::CastLossy;
+use prometheus::{Histogram, IntCounter};
+
+use crate::compute_state::peek_scan::{RowBatch, WalkPhases};
+use crate::metrics::WorkerMetrics;
+
+/// The metrics an index peek walk reports, on either substrate.
+///
+/// Cloned into a promoted walk's task, so that a walk reports the same phases wherever it ran.
+#[derive(Clone, Debug)]
+pub(super) struct PeekWalkMetrics {
+    /// Counts walks that ended on the timely worker.
+    walks_inline: IntCounter,
+    /// Counts walks that ended away from the timely worker.
+    walks_offloaded: IntCounter,
+    error_scan_seconds: Histogram,
+    cursor_setup_seconds: Histogram,
+    row_iteration_seconds: Histogram,
+    row_iteration_rows: Histogram,
+    result_sort_seconds: Histogram,
+    result_sort_rows: Histogram,
+    row_collection_seconds: Histogram,
+}
+
+impl PeekWalkMetrics {
+    pub(super) fn new(metrics: &WorkerMetrics) -> Self {
+        Self {
+            walks_inline: metrics.index_peek_walks_inline.clone(),
+            walks_offloaded: metrics.index_peek_walks_offloaded.clone(),
+            error_scan_seconds: metrics.index_peek_error_scan_seconds.clone(),
+            cursor_setup_seconds: metrics.index_peek_cursor_setup_seconds.clone(),
+            row_iteration_seconds: metrics.index_peek_row_iteration_seconds.clone(),
+            row_iteration_rows: metrics.index_peek_row_iteration_rows.clone(),
+            result_sort_seconds: metrics.index_peek_result_sort_seconds.clone(),
+            result_sort_rows: metrics.index_peek_result_sort_rows.clone(),
+            row_collection_seconds: metrics.index_peek_row_collection_seconds.clone(),
+        }
+    }
+
+    /// Counts a walk that the timely worker drove to an outcome.
+    ///
+    /// A peek that reaches the peek stash counts here, because the walk that decided that ran on
+    /// the worker. The stash's own walk of the same trace counts on neither substrate.
+    pub(super) fn walked_inline(&self) {
+        self.walks_inline.inc();
+    }
+
+    /// Counts a walk that was promoted and admitted, whatever it goes on to report.
+    ///
+    /// A walk cancelled while queued for a permit counts on neither substrate, since it never ran
+    /// anywhere but on the inline slice that promoted it.
+    pub(super) fn walked_offloaded(&self) {
+        self.walks_offloaded.inc();
+    }
+
+    /// Reports the phases that precede the walk over the ok trace.
+    ///
+    /// Reported for every terminal outcome, including a walk that hands its rows to the peek
+    /// stash, because both phases are over by then whatever the walk does next.
+    pub(super) fn observe_error_phase(&self, phases: &WalkPhases) {
+        // A peek that its error trace answered reports neither number: that walk stopped where the
+        // error was rather than at the end of the trace, and the cursor the second number times
+        // was never used.
+        if !phases.error_trace_clean {
+            return;
+        }
+
+        self.error_scan_seconds
+            .observe(phases.error_scan.as_secs_f64());
+        self.cursor_setup_seconds
+            .observe(phases.cursor_setup.as_secs_f64());
+    }
+
+    /// Reports the walk over the ok trace, for a walk that completed it.
+    ///
+    /// A walk that ends any other way reports nothing here, because the rows it examined are not
+    /// the rows an answer took.
+    pub(super) fn observe_ok_phase(&self, phases: &WalkPhases) {
+        self.row_iteration_seconds
+            .observe(phases.row_iteration.as_secs_f64());
+        self.row_iteration_rows
+            .observe(f64::cast_lossy(phases.rows_processed));
+        self.result_sort_seconds
+            .observe(phases.result_sort.as_secs_f64());
+        self.result_sort_rows
+            .observe(f64::cast_lossy(phases.rows_sorted));
+    }
+
+    /// Builds the peek's answer out of the rows a completed walk produced.
+    ///
+    /// Both drivers build the answer here, and the build is timed here, so the time is reported
+    /// wherever the walk finished rather than only where it started.
+    pub(super) fn rows_response(&self, rows: RowBatch, order_by: &[ColumnOrder]) -> PeekResponse {
+        let start = Instant::now();
+
+        let rows = rows
+            .into_iter()
+            .map(|(row, copies)| {
+                let copies = NonZeroUsize::try_from(copies).expect("fits into usize");
+                (row, copies)
+            })
+            .collect();
+        let collection = RowCollection::new(rows, order_by);
+
+        self.row_collection_seconds
+            .observe(start.elapsed().as_secs_f64());
+
+        PeekResponse::Rows(vec![collection])
+    }
+}
+
+/// The metrics an index peek reports from the worker that owns it.
+///
+/// The two histograms here time the worker's own handling of a peek, which no promoted walk
+/// repeats, so unlike the walk's own metrics they have a single observer by construction.
+pub(super) struct IndexPeekMetrics<'a> {
+    pub seek_fulfillment_seconds: &'a Histogram,
+    pub frontier_check_seconds: &'a Histogram,
+    /// The metrics of the walk itself, which a promoted walk reports too.
+    pub walk: &'a PeekWalkMetrics,
+}

--- a/src/compute/src/compute_state/peek_metrics.rs
+++ b/src/compute/src/compute_state/peek_metrics.rs
@@ -93,10 +93,11 @@ impl PeekWalkMetrics {
         self.walks_inline.inc();
     }
 
-    /// Counts a walk that was promoted and admitted, whatever it goes on to report.
+    /// Counts a walk that a promoted task drove to an outcome, whatever that outcome is.
     ///
-    /// A walk cancelled while queued for a permit counts on neither substrate, since it never ran
-    /// anywhere but on the inline slice that promoted it.
+    /// A walk cancelled while queued for a permit or while running counts on neither substrate,
+    /// which is what makes the two substrates sum to the walks that ended. How many walks were
+    /// admitted is a different question, and one the permit queue's own metrics answer.
     pub(super) fn walked_offloaded(&self) {
         self.walks_offloaded.inc();
     }

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -1,0 +1,300 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! Driving an index peek's walk away from the timely worker that owns it.
+//!
+//! A promoted walk runs as an async task that spends one slice of fuel between yields, so the
+//! worker it left keeps serving everything else while it runs. The task owns both the scan and the
+//! permit that admitted it, which is what ties the bound on concurrent walks to the memory those
+//! walks retain: every way the task ends, including a panic, drops the two together.
+//!
+//! Only the worker performs IO on this path. The task walks traces and accumulates rows, and a
+//! walk whose rows outgrow an inline answer stops and hands back rather than writing them.
+
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use mz_compute_client::protocol::command::Peek;
+use mz_compute_client::protocol::response::PeekResponse;
+use mz_compute_types::dyncfgs::{INDEX_PEEK_PERMITS, INDEX_PEEK_YIELD_GRANULARITY};
+use mz_dyncfg::{ConfigSet, ConfigValHandle};
+use mz_expr::ColumnOrder;
+use mz_expr::row::RowCollection;
+use mz_ore::task::AbortOnDropHandle;
+use prometheus::IntCounter;
+use timely::scheduling::SyncActivator;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, oneshot};
+use tracing::debug;
+
+use crate::arrangement::manager::TraceBundle;
+use crate::compute_state::PeekRowIterationConfig;
+use crate::compute_state::peek_scan::{IndexPeekScan, ScanOutcome};
+
+/// The bound on how many promoted peek walks run at once in this process.
+///
+/// One instance is shared by every worker the process runs, because the resource it protects is
+/// the process's CPU rather than any one worker's. A per-worker bound would admit its count on
+/// each worker and over-admit by the worker count, and a bound sized for the whole replica would
+/// do the same across the processes a replica is spread over.
+pub struct PeekPermits {
+    semaphore: Arc<Semaphore>,
+    /// The permits the semaphore holds, changed only under this lock. Without the lock two
+    /// resizes would compute their deltas against the same stale count and apply both.
+    granted: Mutex<usize>,
+    /// The count in effect while the configured count leaves the choice to the process.
+    default_permits: usize,
+}
+
+impl PeekPermits {
+    /// Creates a bound that admits `default_permits` walks at once until it is configured
+    /// otherwise.
+    pub fn new(default_permits: usize) -> Self {
+        let default_permits = default_permits.min(Semaphore::MAX_PERMITS);
+        Self {
+            semaphore: Arc::new(Semaphore::new(default_permits)),
+            granted: Mutex::new(default_permits),
+            default_permits,
+        }
+    }
+
+    /// Resizes the bound to `configured`, where zero asks for the default, and returns the
+    /// semaphore a walk waits on.
+    ///
+    /// The count is applied when a walk asks to run rather than when the process starts, so a
+    /// change reaches every walk that has not been admitted yet.
+    ///
+    /// Lowering it takes back only the permits that are free at this moment. The rest stay with
+    /// the walks holding them, which is what keeps a configuration change from interrupting a walk
+    /// already under way, and the next call takes back what it can of the remainder.
+    fn queue(&self, configured: usize) -> Arc<Semaphore> {
+        let target = if configured == 0 {
+            self.default_permits
+        } else {
+            configured.min(Semaphore::MAX_PERMITS)
+        };
+
+        let mut granted = self.granted.lock().expect("lock poisoned");
+        if target > *granted {
+            self.semaphore.add_permits(target - *granted);
+            *granted = target;
+        } else if target < *granted {
+            *granted -= self.semaphore.forget_permits(*granted - target);
+        }
+
+        Arc::clone(&self.semaphore)
+    }
+}
+
+/// The parameters a promoted walk reads, each as a handle rather than a value.
+///
+/// `UpdateConfiguration` applies to walks that are already under way, so a walk reads what is in
+/// effect at each slice boundary rather than what was in effect when it was promoted. That way a
+/// change reaches it without discarding the cursor positions it has already visited.
+#[derive(Clone, Debug)]
+pub(super) struct OffloadConfig {
+    permits: ConfigValHandle<usize>,
+    yield_granularity: ConfigValHandle<usize>,
+    row_iteration: PeekRowIterationConfig,
+}
+
+impl OffloadConfig {
+    pub(super) fn new(config: &ConfigSet) -> Self {
+        Self {
+            permits: INDEX_PEEK_PERMITS.handle(config),
+            yield_granularity: INDEX_PEEK_YIELD_GRANULARITY.handle(config),
+            row_iteration: PeekRowIterationConfig::new(config),
+        }
+    }
+}
+
+/// What a promoted walk hands back to the worker that promoted it.
+pub enum OffloadOutcome {
+    /// The walk answered the peek.
+    Answered(PeekResponse),
+    /// The walk accumulated more rows than the peek may answer with inline, and answering it needs
+    /// them written to the peek stash. This driver performs no IO, so the walk stops here and the
+    /// worker takes the peek to the stash instead.
+    NeedsStash,
+}
+
+/// An index peek whose walk is running away from the worker that owns it.
+///
+/// Note that `OffloadedPeek` intentionally does not implement or derive `Clone`, as each one is
+/// meant to be dropped once it has been responded to.
+pub struct OffloadedPeek {
+    pub(crate) peek: Peek,
+    /// The traces the walk reads.
+    ///
+    /// Retained so that the peek stash can walk the ok trace again from here when the walk hands
+    /// back. The compaction hold this bundle carries is what keeps that second walk able to read
+    /// at the peek's timestamp.
+    pub(crate) trace_bundle: TraceBundle,
+    /// The outcome of the walk, eventually.
+    pub(crate) result: oneshot::Receiver<(OffloadOutcome, Duration)>,
+    /// The `tracing::Span` tracking this peek's operation.
+    pub(crate) span: tracing::Span,
+    /// The task driving the walk. Dropping this aborts it, which drops the scan, the cursors it
+    /// holds, and the permit that admitted it.
+    _abort_handle: AbortOnDropHandle<()>,
+}
+
+impl OffloadedPeek {
+    /// Promotes `scan` to a task that finishes the walk away from the worker.
+    ///
+    /// `peek` and `trace_bundle` stay with the worker rather than moving into the task, because
+    /// the bundle is what the stash restarts the walk from if the walk hands back.
+    ///
+    /// The scan must not already hold a full batch. Such a scan has nothing left to do here: its
+    /// first step reports that it needs the stash, so promoting it costs a permit and a hand-off
+    /// for a peek the worker could have diverted itself.
+    ///
+    /// `activator` wakes the worker once the outcome is ready, because nothing else the worker
+    /// waits on is disturbed by this task finishing.
+    pub(super) fn promote(
+        peek: Peek,
+        trace_bundle: TraceBundle,
+        scan: IndexPeekScan,
+        permits: &PeekPermits,
+        config: OffloadConfig,
+        walks_offloaded: IntCounter,
+        activator: SyncActivator,
+    ) -> Self {
+        let (mut result_tx, result_rx) = oneshot::channel();
+        let semaphore = permits.queue(config.permits.get());
+
+        let peek_uuid = peek.uuid;
+        let order_by = peek.finishing.order_by.clone();
+
+        let task_handle = mz_ore::task::spawn(
+            || format!("peek_offload::walk({peek_uuid})"),
+            async move {
+                let start = Instant::now();
+
+                let permit = tokio::select! {
+                    permit = semaphore.acquire_owned() => {
+                        permit.expect("peek permits are never closed")
+                    }
+                    // Cancellation while the walk waits its turn drops the receiving end of the
+                    // result channel. The scan leaves the queue with this task, releasing the
+                    // cursors and the accumulated rows it was holding, and never takes a permit.
+                    () = result_tx.closed() => return,
+                };
+
+                walks_offloaded.inc();
+
+                let Some(outcome) = Self::walk(permit, scan, &config, &order_by, &result_tx).await
+                else {
+                    return;
+                };
+
+                match result_tx.send((outcome, start.elapsed())) {
+                    Ok(()) => {}
+                    Err((_outcome, elapsed)) => {
+                        debug!(duration = ?elapsed, "dropping result for cancelled peek {peek_uuid}")
+                    }
+                }
+
+                match activator.activate() {
+                    Ok(()) => {}
+                    Err(_) => debug!("unable to wake timely after offloaded peek {peek_uuid}"),
+                }
+            },
+        );
+
+        Self {
+            peek,
+            trace_bundle,
+            result: result_rx,
+            span: tracing::Span::current(),
+            _abort_handle: task_handle.abort_on_drop(),
+        }
+    }
+
+    /// Drives `scan` to an outcome, yielding between slices.
+    ///
+    /// Returns `None` for a peek that was cancelled, which is the one way the walk ends without an
+    /// outcome to report.
+    ///
+    /// The permit is taken by value so that it lives exactly as long as the walk it admits. Every
+    /// way out of here drops it, an early return and an unwind alike. It is declared ahead of the
+    /// scan because parameters drop in reverse, so the permit stops accounting for the batches
+    /// only once the scan holding them is gone.
+    async fn walk(
+        _permit: OwnedSemaphorePermit,
+        mut scan: IndexPeekScan,
+        config: &OffloadConfig,
+        order_by: &[ColumnOrder],
+        result_tx: &oneshot::Sender<(OffloadOutcome, Duration)>,
+    ) -> Option<OffloadOutcome> {
+        loop {
+            // Cancellation removes the pending peek, which drops the receiving end of this
+            // channel, so a closed channel is the walk's cancellation signal and needs no
+            // mechanism of its own. The permit goes with this task rather than with the entry that
+            // was removed, so it is still accounting for these batches right up to here.
+            if result_tx.is_closed() {
+                return None;
+            }
+
+            // A granularity of zero would spend no fuel, and a scan stepped with no fuel makes no
+            // progress, so the walk would spin without ever reaching an outcome.
+            let mut fuel = config.yield_granularity.get().max(1);
+            let row_iteration_limit = config.row_iteration.current_limit();
+
+            match scan.step(row_iteration_limit, &mut fuel) {
+                ScanOutcome::Complete(rows) => {
+                    let rows = rows
+                        .into_iter()
+                        .map(|(row, copies)| {
+                            let copies = NonZeroUsize::try_from(copies).expect("fits into usize");
+                            (row, copies)
+                        })
+                        .collect();
+                    let collection = RowCollection::new(rows, order_by);
+                    return Some(OffloadOutcome::Answered(PeekResponse::Rows(vec![
+                        collection,
+                    ])));
+                }
+                ScanOutcome::Failed(error) => {
+                    return Some(OffloadOutcome::Answered(PeekResponse::Error(error)));
+                }
+                // A suspension holding a full batch is not one this walk can resume. The scan
+                // stops growing its prefix once the batch is full, so stepping it again spends no
+                // fuel and advances no cursor until a driver that writes rows takes the batch, and
+                // this one cannot. Rows accumulated so far are dropped, which is sound because the
+                // stash walks the ok trace again from the trace bundle and re-produces them.
+                ScanOutcome::Suspended if scan.batch_ready() => {
+                    return Some(OffloadOutcome::NeedsStash);
+                }
+                ScanOutcome::Suspended => tokio::task::yield_now().await,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn permits_resize_around_the_walks_holding_them() {
+        let permits = PeekPermits::new(4);
+
+        // Zero asks for the count the process chose.
+        assert_eq!(permits.queue(0).available_permits(), 4);
+        assert_eq!(permits.queue(6).available_permits(), 6);
+        assert_eq!(permits.queue(2).available_permits(), 2);
+
+        // A walk already under way keeps its permit through a lower count, so the shrink takes
+        // back only what is free right now, and the rest as that walk returns it.
+        let held = permits
+            .queue(2)
+            .try_acquire_owned()
+            .expect("a permit is free");
+        assert_eq!(permits.queue(1).available_permits(), 0);
+        drop(held);
+        assert_eq!(permits.queue(1).available_permits(), 1);
+    }
+}

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -293,7 +293,429 @@ impl OffloadedPeek {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+
+    use mz_dyncfg::ConfigUpdates;
+    use mz_ore::metrics::MetricsRegistry;
+    use mz_repr::Row;
+    use timely::WorkerConfig;
+    use timely::communication::Allocator;
+    use timely::worker::Worker as TimelyWorker;
+
+    use crate::compute_state::index_peek_tests::{
+        cancelling_errors, index_peek, ok_row, rows_answer, trace_bundle, trivial_finishing,
+        wide_ok_rows,
+    };
+    use crate::compute_state::peek_scan::PeekScan;
+    use crate::metrics::{ComputeMetrics, WorkerMetrics};
+    use crate::server::ComputeRuntimeRole;
+
     use super::*;
+
+    /// How many times a test lets the runtime run a promoted walk before it declares the walk
+    /// stuck.
+    ///
+    /// A walk over the traces here needs a handful of slices at the granularities these tests
+    /// configure, so a walk that advances finishes far inside this bound, and one that yields
+    /// without advancing fails the test rather than hanging the suite.
+    const DRIVE_BOUND: usize = 200;
+
+    /// How many keys the index a cancellation test walks holds.
+    ///
+    /// Large enough that a walk cut into one-position slices is still under way after the yields
+    /// such a test spends before it cancels.
+    const LONG_WALK_KEYS: u64 = 2_000;
+
+    /// The metrics a promoted walk reports into, registered into a registry the test owns so it
+    /// can read them back.
+    fn worker_metrics() -> WorkerMetrics {
+        ComputeMetrics::register_with(&MetricsRegistry::new(), ComputeRuntimeRole::Solo)
+            .for_worker(0)
+    }
+
+    /// The size the scan accounts a single-column row at.
+    fn row_size() -> usize {
+        ok_row(0).byte_len() + size_of::<NonZeroUsize>()
+    }
+
+    /// Opens a scan of `peek` over `bundle`, the way the peek path opens one.
+    ///
+    /// `stash_threshold_bytes` both makes the peek eligible for the stash and sets the size its
+    /// accumulated rows become a full batch at. `None` is a peek that may not use the stash at
+    /// all, whose accumulated rows therefore never become one.
+    fn open(
+        bundle: &mut TraceBundle,
+        peek: &Peek,
+        stash_threshold_bytes: Option<usize>,
+    ) -> IndexPeekScan {
+        let (oks, errs) = bundle.oks_errs_mut();
+        PeekScan::new(
+            peek,
+            errs,
+            oks,
+            u64::MAX,
+            stash_threshold_bytes.is_some(),
+            stash_threshold_bytes.unwrap_or(usize::MAX),
+        )
+    }
+
+    /// The configuration a promoted walk reads, with the yield granularity set to
+    /// `yield_granularity` so a test can choose how many slices a walk is cut into.
+    fn offload_config(yield_granularity: usize) -> OffloadConfig {
+        let config = mz_dyncfgs::all_dyncfgs();
+        let mut updates = ConfigUpdates::default();
+        updates.add(&INDEX_PEEK_YIELD_GRANULARITY, yield_granularity);
+        updates.apply(&config);
+        OffloadConfig::new(&config)
+    }
+
+    /// A timely worker whose activator a promoted walk wakes when its outcome is ready.
+    ///
+    /// A test holds one for as long as its walk runs, because an activator whose worker is gone
+    /// reports a failure the walk only logs, which would leave the test asserting against a
+    /// weaker path than the one the worker takes.
+    fn worker() -> TimelyWorker {
+        TimelyWorker::new(
+            WorkerConfig::default(),
+            Allocator::Thread(Default::default()),
+            None,
+        )
+    }
+
+    /// What a promoted walk handed back, in a form a test can compare whole.
+    ///
+    /// Mirrors [`OffloadOutcome`], which carries no comparison of its own because nothing on the
+    /// peek path compares one.
+    #[derive(Debug, PartialEq)]
+    enum HandBack {
+        Answered(PeekResponse),
+        NeedsStash,
+    }
+
+    impl From<OffloadOutcome> for HandBack {
+        fn from(outcome: OffloadOutcome) -> Self {
+            match outcome {
+                OffloadOutcome::Answered(response) => HandBack::Answered(response),
+                OffloadOutcome::NeedsStash => HandBack::NeedsStash,
+            }
+        }
+    }
+
+    /// Runs the runtime until `promoted`'s walk hands something back, and reports what.
+    ///
+    /// Bounded, so a walk that yields without ever reaching an outcome fails here rather than
+    /// hanging the suite. That is the failure a scan holding a full batch produces, which is the
+    /// case this driver's batch-ready arm exists to avoid.
+    async fn hand_back(promoted: &mut OffloadedPeek) -> HandBack {
+        for _ in 0..DRIVE_BOUND {
+            match promoted.result.try_recv() {
+                Ok((outcome, _elapsed)) => return HandBack::from(outcome),
+                Err(oneshot::error::TryRecvError::Empty) => tokio::task::yield_now().await,
+                Err(oneshot::error::TryRecvError::Closed) => {
+                    panic!("the promoted walk ended without handing anything back")
+                }
+            }
+        }
+        panic!("the promoted walk handed nothing back within {DRIVE_BOUND} yields");
+    }
+
+    /// Runs the runtime until `condition` holds, where `what` names what the test is waiting for.
+    ///
+    /// Bounded, so a condition that never holds fails here rather than hanging the suite.
+    async fn wait_until(mut condition: impl FnMut() -> bool, what: &str) {
+        for _ in 0..DRIVE_BOUND {
+            if condition() {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("{what} did not happen within {DRIVE_BOUND} yields");
+    }
+
+    /// A promoted walk finishes the walk the inline slice started, resuming from the cursor
+    /// positions that slice stopped on, and answers the whole peek.
+    ///
+    /// The counter is asserted rather than inferred from the configuration, because a peek
+    /// answered inline and a peek answered by a promoted task give the same rows.
+    #[mz_ore::test(tokio::test)]
+    async fn a_promoted_walk_finishes_the_answer_the_inline_slice_started() {
+        let keys: Vec<Row> = (0..6).map(ok_row).collect();
+        let peek = index_peek(trivial_finishing(), None);
+        let mut bundle = trace_bundle(&keys, cancelling_errors(2));
+        let mut scan = open(&mut bundle, &peek, None);
+
+        // Two positions leave the walk suspended with nothing to hand over, which is the state
+        // the worker promotes and the only one it promotes.
+        let mut fuel = 2;
+        assert_eq!(scan.step(None, &mut fuel), ScanOutcome::Suspended);
+        assert!(
+            !scan.batch_ready(),
+            "a scan holding a full batch is diverted rather than promoted"
+        );
+
+        let metrics = worker_metrics();
+        let worker = worker();
+        let permits = PeekPermits::new(1);
+        let mut promoted = OffloadedPeek::promote(
+            peek.clone(),
+            bundle,
+            scan,
+            &permits,
+            offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+            PeekWalkMetrics::new(&metrics),
+            worker.sync_activator_for([].into()),
+        );
+
+        assert_eq!(
+            hand_back(&mut promoted).await,
+            HandBack::Answered(rows_answer((0..6).map(ok_row))),
+        );
+        assert_eq!(
+            metrics.index_peek_walks_offloaded.get(),
+            1,
+            "the driver that ended the walk counts it"
+        );
+        assert_eq!(
+            metrics.index_peek_walks_inline.get(),
+            0,
+            "the slice that promoted the walk reports nothing"
+        );
+    }
+
+    /// A promoted walk whose accumulated rows grow into a full batch hands the peek back rather
+    /// than stepping a scan that cannot advance.
+    ///
+    /// A scan holding a full batch spends no fuel and moves no cursor when stepped, and this
+    /// driver has nowhere to write the batch, so a driver that treated the suspension as resumable
+    /// would yield forever without ever reaching an outcome. The bound in [`hand_back`] is what
+    /// turns that into a failure rather than a hang.
+    #[mz_ore::test(tokio::test)]
+    async fn a_promoted_walk_that_fills_a_batch_hands_back_rather_than_spinning() {
+        let keys: Vec<Row> = (0..6).map(ok_row).collect();
+        let peek = index_peek(trivial_finishing(), None);
+        let mut bundle = trace_bundle(&keys, cancelling_errors(0));
+        // Two rows fit under the threshold and the third crosses it, so the slice below promotes
+        // a scan with room left and the promoted walk is the one that fills the batch.
+        let mut scan = open(&mut bundle, &peek, Some(2 * row_size()));
+
+        let mut fuel = 2;
+        assert_eq!(scan.step(None, &mut fuel), ScanOutcome::Suspended);
+        assert!(
+            !scan.batch_ready(),
+            "the inline slice must promote a scan that still has room"
+        );
+
+        let metrics = worker_metrics();
+        let worker = worker();
+        let permits = PeekPermits::new(1);
+        let mut promoted = OffloadedPeek::promote(
+            peek.clone(),
+            bundle,
+            scan,
+            &permits,
+            offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+            PeekWalkMetrics::new(&metrics),
+            worker.sync_activator_for([].into()),
+        );
+
+        assert_eq!(hand_back(&mut promoted).await, HandBack::NeedsStash);
+        assert_eq!(
+            metrics.index_peek_walks_offloaded.get(),
+            1,
+            "a hand-back is a terminal outcome of the promoted walk"
+        );
+    }
+
+    /// A walk cancelled while it queues for a permit leaves the queue without ever taking one.
+    ///
+    /// The permit accounts for the batches a running walk retains, so a queued walk that took one
+    /// on its way out would report capacity the process does not have. The queue depth is a gauge
+    /// rather than a counter, so a walk that failed to leave it would drift the depth up over the
+    /// life of a process.
+    #[mz_ore::test(tokio::test)]
+    async fn a_walk_cancelled_while_queued_never_takes_a_permit() {
+        let keys: Vec<Row> = (0..6).map(ok_row).collect();
+        let peek = index_peek(trivial_finishing(), None);
+        let mut bundle = trace_bundle(&keys, cancelling_errors(2));
+        let scan = open(&mut bundle, &peek, None);
+
+        let metrics = worker_metrics();
+        let worker = worker();
+        let permits = PeekPermits::new(1);
+        // The one permit is held here, so the walk below queues rather than running.
+        let semaphore = permits.resize(0);
+        let held = Arc::clone(&semaphore)
+            .try_acquire_owned()
+            .expect("a permit is free");
+
+        let promoted = OffloadedPeek::promote(
+            peek.clone(),
+            bundle,
+            scan,
+            &permits,
+            offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+            PeekWalkMetrics::new(&metrics),
+            worker.sync_activator_for([].into()),
+        );
+
+        wait_until(
+            || metrics.index_peek_permit_queue_depth.get() == 1,
+            "the promoted walk joining the queue for a permit",
+        )
+        .await;
+
+        // Cancellation removes the pending peek, and dropping the entry is what ends the walk.
+        drop(promoted);
+
+        wait_until(
+            || metrics.index_peek_permit_queue_depth.get() == 0,
+            "the cancelled walk leaving the queue for a permit",
+        )
+        .await;
+        assert_eq!(
+            metrics.index_peek_permit_wait_seconds.get_sample_count(),
+            0,
+            "a walk cancelled while queued was never admitted"
+        );
+        assert_eq!(
+            metrics.index_peek_walks_offloaded.get(),
+            0,
+            "a cancelled walk reaches no outcome and counts on neither substrate"
+        );
+        assert_eq!(
+            semaphore.available_permits(),
+            0,
+            "the permit this test holds must not be handed back by the cancelled walk"
+        );
+
+        drop(held);
+        assert_eq!(semaphore.available_permits(), 1);
+    }
+
+    /// A walk cancelled while it runs stops at its next slice boundary, reports no outcome, and
+    /// releases the permit that admitted it.
+    ///
+    /// Cancellation drops the receiving end of the result channel and nothing else, so a closed
+    /// channel is the whole signal. The permit travels with the task rather than with the pending
+    /// peek that was removed, which is what makes its release coincide with the release of the
+    /// batches it accounts for.
+    #[mz_ore::test(tokio::test)]
+    async fn a_walk_cancelled_while_running_reports_no_outcome() {
+        let keys = wide_ok_rows(LONG_WALK_KEYS);
+        let peek = index_peek(trivial_finishing(), None);
+        let mut bundle = trace_bundle(&keys, cancelling_errors(0));
+        let scan = open(&mut bundle, &peek, None);
+
+        let metrics = worker_metrics();
+        let walk_metrics = PeekWalkMetrics::new(&metrics);
+        let permits = PeekPermits::new(1);
+        let semaphore = permits.resize(0);
+        let permit = Arc::clone(&semaphore)
+            .try_acquire_owned()
+            .expect("a permit is free");
+
+        let (result_tx, result_rx) = oneshot::channel();
+        // One position per slice over an index of `LONG_WALK_KEYS` positions, so the walk is
+        // still far from its answer after the yields this test spends before it cancels.
+        let config = offload_config(1);
+        let order_by = peek.finishing.order_by.clone();
+        let walk = mz_ore::task::spawn(|| "peek_offload_test::walk", async move {
+            OffloadedPeek::walk(permit, scan, &config, &walk_metrics, &order_by, &result_tx)
+                .await
+                .is_some()
+        });
+
+        for _ in 0..DRIVE_BOUND {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !walk.is_finished(),
+            "the walk must still be under way when it is cancelled"
+        );
+        assert_eq!(
+            semaphore.available_permits(),
+            0,
+            "a running walk holds the permit that admitted it"
+        );
+
+        drop(result_rx);
+
+        wait_until(|| walk.is_finished(), "the cancelled walk stopping").await;
+        assert_eq!(walk.await, false, "a cancelled walk reports no outcome");
+        assert_eq!(
+            semaphore.available_permits(),
+            1,
+            "a cancelled walk releases the permit that admitted it"
+        );
+        assert_eq!(
+            metrics.index_peek_row_iteration_seconds.get_sample_count(),
+            0,
+            "a walk that never completed reports no ok phase"
+        );
+    }
+
+    /// A promoted walk waits for a permit while another holds it, and runs once it is released.
+    ///
+    /// Excess walks queue rather than running, which is the whole of the concurrency bound. A
+    /// serial test that never has two walks outstanding would exercise a semaphore that is never
+    /// contended.
+    #[mz_ore::test(tokio::test)]
+    async fn a_walk_waits_for_a_permit_another_walk_holds() {
+        let keys: Vec<Row> = (0..6).map(ok_row).collect();
+        let peek = index_peek(trivial_finishing(), None);
+        let mut bundle = trace_bundle(&keys, cancelling_errors(2));
+        let scan = open(&mut bundle, &peek, None);
+
+        let metrics = worker_metrics();
+        let worker = worker();
+        let permits = PeekPermits::new(1);
+        let semaphore = permits.resize(0);
+        let held = Arc::clone(&semaphore)
+            .try_acquire_owned()
+            .expect("a permit is free");
+
+        let mut promoted = OffloadedPeek::promote(
+            peek.clone(),
+            bundle,
+            scan,
+            &permits,
+            offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+            PeekWalkMetrics::new(&metrics),
+            worker.sync_activator_for([].into()),
+        );
+
+        // Every chance to run, and it must not answer while the permit is elsewhere.
+        for _ in 0..DRIVE_BOUND {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            promoted.result.try_recv().err(),
+            Some(oneshot::error::TryRecvError::Empty),
+            "a walk that has not been admitted must not answer"
+        );
+        assert_eq!(
+            metrics.index_peek_permit_queue_depth.get(),
+            1,
+            "a walk waiting for a permit is counted in the queue"
+        );
+
+        drop(held);
+
+        assert_eq!(
+            hand_back(&mut promoted).await,
+            HandBack::Answered(rows_answer((0..6).map(ok_row))),
+        );
+        assert_eq!(
+            metrics.index_peek_permit_wait_seconds.get_sample_count(),
+            1,
+            "a wait that ended in a permit is observed"
+        );
+        assert_eq!(
+            metrics.index_peek_permit_queue_depth.get(),
+            0,
+            "an admitted walk leaves the queue"
+        );
+    }
 
     #[mz_ore::test]
     fn permits_resize_around_the_walks_holding_them() {

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -194,13 +194,17 @@ impl OffloadedPeek {
                 };
                 queued.admitted();
 
-                metrics.walked_offloaded();
-
                 let Some(outcome) =
                     Self::walk(permit, scan, &config, &metrics, &order_by, &result_tx).await
                 else {
                     return;
                 };
+
+                // Counted here rather than at the permit, so that the two substrate counters both
+                // count walks that ended. A walk cancelled while running took a permit and never
+                // reaches an outcome, so counting admissions would leave the pair summing to
+                // something other than the walks that ended.
+                metrics.walked_offloaded();
 
                 match result_tx.send((outcome, start.elapsed())) {
                     Ok(()) => {}

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -10,8 +10,9 @@
 //! permit that admitted it, which is what ties the bound on concurrent walks to the memory those
 //! walks retain: every way the task ends, including a panic, drops the two together.
 //!
-//! Only the worker performs IO on this path. The task walks traces and accumulates rows, and a
-//! walk whose rows outgrow an inline answer stops and hands back rather than writing them.
+//! This driver performs no IO of its own. The task walks traces and accumulates rows, and a walk
+//! whose rows outgrow an inline answer stops and hands back rather than writing them, which leaves
+//! the writing to the worker.
 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -67,7 +68,11 @@ impl PeekPermits {
     ///
     /// Lowering it takes back only the permits that are free at this moment. The rest stay with
     /// the walks holding them, which is what keeps a configuration change from interrupting a walk
-    /// already under way, and the next call takes back what it can of the remainder.
+    /// already under way, and the next call takes back what it can of the remainder. Until it
+    /// does, the count in effect is above the one configured and never below it, so the error a
+    /// lowering leaves behind is only ever a bound too loose. That is what makes applying it this
+    /// way safe: no walk is refused a permit the configuration allows it, and the excess drains as
+    /// the walks holding it finish.
     fn resize(&self, configured: usize) -> Arc<Semaphore> {
         let target = if configured == 0 {
             self.default_permits

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -296,6 +296,8 @@ mod tests {
     use std::num::NonZeroUsize;
 
     use mz_dyncfg::ConfigUpdates;
+    use mz_expr::RowSetFinishing;
+    use mz_expr::row::RowCollection;
     use mz_ore::metrics::MetricsRegistry;
     use mz_repr::Row;
     use timely::WorkerConfig;
@@ -380,6 +382,36 @@ mod tests {
             Allocator::Thread(Default::default()),
             None,
         )
+    }
+
+    /// A finishing that orders the peek's one column descending, which is the reverse of the order
+    /// the trace holds its keys in.
+    ///
+    /// A peek carrying an order is never eligible for the peek stash, because `is_streamable`
+    /// requires an empty `order_by`, so a promoted walk of one answers rather than handing back.
+    fn descending_finishing() -> RowSetFinishing {
+        let mut finishing = trivial_finishing();
+        finishing.order_by = vec![ColumnOrder {
+            column: 0,
+            desc: true,
+            nulls_last: true,
+        }];
+        finishing
+    }
+
+    /// The answer a walk gives when it produces `rows` in exactly that order, each at a
+    /// multiplicity of one.
+    ///
+    /// The collection is built in the order given rather than sorted by the comparator the walk
+    /// sorts with, so the order a test expects is the test's own statement.
+    fn ordered_rows_answer(rows: impl IntoIterator<Item = Row>) -> PeekResponse {
+        let rows: Vec<Row> = rows.into_iter().collect();
+        let byte_len = rows.iter().map(|row| row.data_len()).sum();
+        let mut builder = RowCollection::builder(byte_len, rows.len());
+        for row in &rows {
+            builder.push(row.as_row_ref(), NonZeroUsize::new(1).expect("non-zero"));
+        }
+        PeekResponse::Rows(vec![builder.build()])
     }
 
     /// What a promoted walk handed back, in a form a test can compare whole.
@@ -479,6 +511,40 @@ mod tests {
             metrics.index_peek_walks_inline.get(),
             0,
             "the slice that promoted the walk reports nothing"
+        );
+    }
+
+    /// A promoted walk answers with its rows in the order the peek asked for.
+    ///
+    /// The order travels from the peek into the task, which is the only place a promoted walk can
+    /// read it: the finishing stays with the worker. A driver that dropped it would answer in the
+    /// order the trace happens to hold, which every other peek here asks for.
+    #[mz_ore::test(tokio::test)]
+    async fn a_promoted_walk_answers_in_the_order_the_peek_asked_for() {
+        let keys: Vec<Row> = (0..6).map(ok_row).collect();
+        let peek = index_peek(descending_finishing(), None);
+        let mut bundle = trace_bundle(&keys, cancelling_errors(2));
+        let mut scan = open(&mut bundle, &peek, None);
+
+        let mut fuel = 2;
+        assert_eq!(scan.step(None, &mut fuel), ScanOutcome::Suspended);
+
+        let metrics = worker_metrics();
+        let worker = worker();
+        let permits = PeekPermits::new(1);
+        let mut promoted = OffloadedPeek::promote(
+            peek.clone(),
+            bundle,
+            scan,
+            &permits,
+            offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+            PeekWalkMetrics::new(&metrics),
+            worker.sync_activator_for([].into()),
+        );
+
+        assert_eq!(
+            hand_back(&mut promoted).await,
+            HandBack::Answered(ordered_rows_answer((0..6).rev().map(ok_row))),
         );
     }
 

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -13,7 +13,6 @@
 //! Only the worker performs IO on this path. The task walks traces and accumulates rows, and a
 //! walk whose rows outgrow an inline answer stops and hands back rather than writing them.
 
-use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -22,15 +21,14 @@ use mz_compute_client::protocol::response::PeekResponse;
 use mz_compute_types::dyncfgs::{INDEX_PEEK_PERMITS, INDEX_PEEK_YIELD_GRANULARITY};
 use mz_dyncfg::{ConfigSet, ConfigValHandle};
 use mz_expr::ColumnOrder;
-use mz_expr::row::RowCollection;
 use mz_ore::task::AbortOnDropHandle;
-use prometheus::IntCounter;
 use timely::scheduling::SyncActivator;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, oneshot};
 use tracing::debug;
 
 use crate::arrangement::manager::TraceBundle;
 use crate::compute_state::PeekRowIterationConfig;
+use crate::compute_state::peek_metrics::PeekWalkMetrics;
 use crate::compute_state::peek_scan::{IndexPeekScan, ScanOutcome};
 
 /// The bound on how many promoted peek walks run at once.
@@ -165,7 +163,7 @@ impl OffloadedPeek {
         scan: IndexPeekScan,
         permits: &PeekPermits,
         config: OffloadConfig,
-        walks_offloaded: IntCounter,
+        metrics: PeekWalkMetrics,
         activator: SyncActivator,
     ) -> Self {
         debug_assert!(
@@ -194,9 +192,10 @@ impl OffloadedPeek {
                     () = result_tx.closed() => return,
                 };
 
-                walks_offloaded.inc();
+                metrics.walked_offloaded();
 
-                let Some(outcome) = Self::walk(permit, scan, &config, &order_by, &result_tx).await
+                let Some(outcome) =
+                    Self::walk(permit, scan, &config, &metrics, &order_by, &result_tx).await
                 else {
                     return;
                 };
@@ -237,6 +236,7 @@ impl OffloadedPeek {
         _permit: OwnedSemaphorePermit,
         mut scan: IndexPeekScan,
         config: &OffloadConfig,
+        metrics: &PeekWalkMetrics,
         order_by: &[ColumnOrder],
         result_tx: &oneshot::Sender<(OffloadOutcome, Duration)>,
     ) -> Option<OffloadOutcome> {
@@ -254,21 +254,20 @@ impl OffloadedPeek {
             let mut fuel = config.yield_granularity.get().max(1);
             let row_iteration_limit = config.row_iteration.current_limit();
 
+            // This driver finishes the walk the worker started, so it reports every phase of it,
+            // including the slices that ran on the worker before the promotion. The worker
+            // reported none of them, exactly because it did not finish the walk.
             match scan.step(row_iteration_limit, &mut fuel) {
                 ScanOutcome::Complete(rows) => {
-                    let rows = rows
-                        .into_iter()
-                        .map(|(row, copies)| {
-                            let copies = NonZeroUsize::try_from(copies).expect("fits into usize");
-                            (row, copies)
-                        })
-                        .collect();
-                    let collection = RowCollection::new(rows, order_by);
-                    return Some(OffloadOutcome::Answered(PeekResponse::Rows(vec![
-                        collection,
-                    ])));
+                    let phases = scan.phases();
+                    metrics.observe_error_phase(&phases);
+                    metrics.observe_ok_phase(&phases);
+                    return Some(OffloadOutcome::Answered(
+                        metrics.rows_response(rows, order_by),
+                    ));
                 }
                 ScanOutcome::Failed(error) => {
+                    metrics.observe_error_phase(&scan.phases());
                     return Some(OffloadOutcome::Answered(PeekResponse::Error(error)));
                 }
                 // A suspension holding a full batch is not one this walk can resume. The scan
@@ -277,6 +276,7 @@ impl OffloadedPeek {
                 // this one cannot. Rows accumulated so far are dropped, which is sound because the
                 // stash walks the ok trace again from the trace bundle and re-produces them.
                 ScanOutcome::Suspended if scan.batch_ready() => {
+                    metrics.observe_error_phase(&scan.phases());
                     return Some(OffloadOutcome::NeedsStash);
                 }
                 ScanOutcome::Suspended => tokio::task::yield_now().await,

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -33,12 +33,13 @@ use crate::arrangement::manager::TraceBundle;
 use crate::compute_state::PeekRowIterationConfig;
 use crate::compute_state::peek_scan::{IndexPeekScan, ScanOutcome};
 
-/// The bound on how many promoted peek walks run at once in this process.
+/// The bound on how many promoted peek walks run at once.
 ///
-/// One instance is shared by every worker the process runs, because the resource it protects is
-/// the process's CPU rather than any one worker's. A per-worker bound would admit its count on
-/// each worker and over-admit by the worker count, and a bound sized for the whole replica would
-/// do the same across the processes a replica is spread over.
+/// The resource it protects is CPU rather than any one worker's thread, so one instance covers
+/// every worker that shares it. A per-worker bound would admit its count on each worker and
+/// over-admit by the worker count, and a bound sized for the whole replica would do the same
+/// across the processes a replica is spread over. How far one instance reaches is decided where it
+/// is constructed, and stated there.
 pub struct PeekPermits {
     semaphore: Arc<Semaphore>,
     /// The permits the semaphore holds, changed only under this lock. Without the lock two
@@ -60,7 +61,7 @@ impl PeekPermits {
         }
     }
 
-    /// Resizes the bound to `configured`, where zero asks for the default, and returns the
+    /// Resizes the bound to `configured`, where zero asks for the default, and hands back the
     /// semaphore a walk waits on.
     ///
     /// The count is applied when a walk asks to run rather than when the process starts, so a
@@ -69,7 +70,7 @@ impl PeekPermits {
     /// Lowering it takes back only the permits that are free at this moment. The rest stay with
     /// the walks holding them, which is what keeps a configuration change from interrupting a walk
     /// already under way, and the next call takes back what it can of the remainder.
-    fn queue(&self, configured: usize) -> Arc<Semaphore> {
+    fn resize(&self, configured: usize) -> Arc<Semaphore> {
         let target = if configured == 0 {
             self.default_permits
         } else {
@@ -91,8 +92,11 @@ impl PeekPermits {
 /// The parameters a promoted walk reads, each as a handle rather than a value.
 ///
 /// `UpdateConfiguration` applies to walks that are already under way, so a walk reads what is in
-/// effect at each slice boundary rather than what was in effect when it was promoted. That way a
-/// change reaches it without discarding the cursor positions it has already visited.
+/// effect when it reads rather than what was in effect when it was promoted, and a change reaches
+/// it without discarding the cursor positions it has already visited. The yield granularity and
+/// the row iteration limit are read at every slice boundary. The permit count is read once, on the
+/// worker, because it sizes the bound the walk then queues on rather than anything the walk does
+/// between slices.
 #[derive(Clone, Debug)]
 pub(super) struct OffloadConfig {
     permits: ConfigValHandle<usize>,
@@ -149,7 +153,9 @@ impl OffloadedPeek {
     ///
     /// The scan must not already hold a full batch. Such a scan has nothing left to do here: its
     /// first step reports that it needs the stash, so promoting it costs a permit and a hand-off
-    /// for a peek the worker could have diverted itself.
+    /// for a peek the worker could have diverted itself. The precondition is checked rather than
+    /// assumed, because such a scan holds a permit for the length of a hand-off and produces
+    /// nothing in return.
     ///
     /// `activator` wakes the worker once the outcome is ready, because nothing else the worker
     /// waits on is disturbed by this task finishing.
@@ -162,8 +168,13 @@ impl OffloadedPeek {
         walks_offloaded: IntCounter,
         activator: SyncActivator,
     ) -> Self {
+        debug_assert!(
+            !scan.batch_ready(),
+            "promoted a peek scan that already holds a full batch"
+        );
+
         let (mut result_tx, result_rx) = oneshot::channel();
-        let semaphore = permits.queue(config.permits.get());
+        let semaphore = permits.resize(config.permits.get());
 
         let peek_uuid = peek.uuid;
         let order_by = peek.finishing.order_by.clone();
@@ -283,18 +294,18 @@ mod tests {
         let permits = PeekPermits::new(4);
 
         // Zero asks for the count the process chose.
-        assert_eq!(permits.queue(0).available_permits(), 4);
-        assert_eq!(permits.queue(6).available_permits(), 6);
-        assert_eq!(permits.queue(2).available_permits(), 2);
+        assert_eq!(permits.resize(0).available_permits(), 4);
+        assert_eq!(permits.resize(6).available_permits(), 6);
+        assert_eq!(permits.resize(2).available_permits(), 2);
 
         // A walk already under way keeps its permit through a lower count, so the shrink takes
         // back only what is free right now, and the rest as that walk returns it.
         let held = permits
-            .queue(2)
+            .resize(2)
             .try_acquire_owned()
             .expect("a permit is free");
-        assert_eq!(permits.queue(1).available_permits(), 0);
+        assert_eq!(permits.resize(1).available_permits(), 0);
         drop(held);
-        assert_eq!(permits.queue(1).available_permits(), 1);
+        assert_eq!(permits.resize(1).available_permits(), 1);
     }
 }

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -182,6 +182,7 @@ impl OffloadedPeek {
             async move {
                 let start = Instant::now();
 
+                let queued = metrics.queued_for_permit();
                 let permit = tokio::select! {
                     permit = semaphore.acquire_owned() => {
                         permit.expect("peek permits are never closed")
@@ -191,6 +192,7 @@ impl OffloadedPeek {
                     // cursors and the accumulated rows it was holding, and never takes a permit.
                     () = result_tx.closed() => return,
                 };
+                queued.admitted();
 
                 metrics.walked_offloaded();
 

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -592,12 +592,16 @@ mod tests {
         );
     }
 
-    /// A walk cancelled while it queues for a permit leaves the queue without ever taking one.
+    /// A walk cancelled while it queues for a permit observes the cancellation and leaves the
+    /// queue without ever taking one.
     ///
     /// The permit accounts for the batches a running walk retains, so a queued walk that took one
     /// on its way out would report capacity the process does not have. The queue depth is a gauge
     /// rather than a counter, so a walk that failed to leave it would drift the depth up over the
     /// life of a process.
+    ///
+    /// The task's handle is kept for the length of the test, so what ends the walk is the walk
+    /// itself seeing the closed channel rather than an abort.
     #[mz_ore::test(tokio::test)]
     async fn a_walk_cancelled_while_queued_never_takes_a_permit() {
         let keys: Vec<Row> = (0..6).map(ok_row).collect();
@@ -630,8 +634,11 @@ mod tests {
         )
         .await;
 
-        // Cancellation removes the pending peek, and dropping the entry is what ends the walk.
-        drop(promoted);
+        // Only the receiving end of the result channel is dropped, which is the signal a queued
+        // walk has to observe on its own. Dropping the whole entry would abort the task as well,
+        // and an aborted task returns the queue depth to zero whether or not the walk ever looks
+        // at the cancellation.
+        drop(promoted.result);
 
         wait_until(
             || metrics.index_peek_permit_queue_depth.get() == 0,
@@ -720,13 +727,15 @@ mod tests {
         );
     }
 
-    /// A promoted walk waits for a permit while another holds it, and runs once it is released.
+    /// A promoted walk waits while the only permit is held elsewhere, and runs once it is
+    /// released.
     ///
-    /// Excess walks queue rather than running, which is the whole of the concurrency bound. A
-    /// serial test that never has two walks outstanding would exercise a semaphore that is never
-    /// contended.
+    /// Excess walks queue rather than running, which is the whole of the concurrency bound. The
+    /// permit is held by the test rather than by a second walk, so what is pinned is that a walk
+    /// which cannot take one neither answers nor leaves the queue. Two promoted walks contending
+    /// would assert the same thing over a scheduler that runs them one after the other anyway.
     #[mz_ore::test(tokio::test)]
-    async fn a_walk_waits_for_a_permit_another_walk_holds() {
+    async fn a_walk_waits_for_a_permit_held_elsewhere() {
         let keys: Vec<Row> = (0..6).map(ok_row).collect();
         let peek = index_peek(trivial_finishing(), None);
         let mut bundle = trace_bundle(&keys, cancelling_errors(2));

--- a/src/compute/src/compute_state/peek_scan.rs
+++ b/src/compute/src/compute_state/peek_scan.rs
@@ -53,6 +53,30 @@ pub(super) type RowBatch = Vec<(Row, NonZeroI64)>;
 /// The byte size of a row's count, as an answer built from a [`RowBatch`] stores it.
 const COUNT_BYTE_SIZE: usize = size_of::<NonZeroUsize>();
 
+/// What a walk has spent, in the phases the peek metrics report.
+///
+/// A snapshot rather than a view. Every number is cumulative over the slices the walk was cut
+/// into, wherever those slices ran, so the driver that ends the walk reads a complete account of
+/// it and the driver that promoted it reads nothing.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct WalkPhases {
+    /// Worker time the error walk spent.
+    pub error_scan: Duration,
+    /// Worker time spent opening the ok cursor.
+    pub cursor_setup: Duration,
+    /// Whether the error walk ended without finding an error, which is what makes the two numbers
+    /// above describe a phase that finished rather than one that was cut short.
+    pub error_trace_clean: bool,
+    /// Worker time the ok walk spent, including the time thinning spent sorting.
+    pub row_iteration: Duration,
+    /// Cursor positions the ok walk evaluated.
+    pub rows_processed: usize,
+    /// Worker time thinning spent sorting.
+    pub result_sort: Duration,
+    /// Rows handed to a sort, summed over the times thinning ran.
+    pub rows_sorted: usize,
+}
+
 /// The outcome of a fueled [`PeekScan::step`].
 #[derive(Debug, PartialEq)]
 pub(super) enum ScanOutcome {
@@ -279,30 +303,17 @@ where
         self.oks.rows_processed()
     }
 
-    /// Worker time the error walk spent, summed over the slices it was cut into.
-    pub(super) fn error_scan_time(&self) -> Duration {
-        self.error_scan_time
-    }
-
-    /// Worker time spent opening the ok cursor.
-    pub(super) fn cursor_setup_time(&self) -> Duration {
-        self.cursor_setup_time
-    }
-
-    /// Worker time the ok walk spent, summed over the slices it was cut into. Includes the time
-    /// thinning spent sorting.
-    pub(super) fn row_iteration_time(&self) -> Duration {
-        self.row_iteration_time
-    }
-
-    /// Worker time thinning spent sorting, summed over the times it ran.
-    pub(super) fn result_sort_time(&self) -> Duration {
-        self.result_sort_time
-    }
-
-    /// Rows handed to a sort, summed over the times thinning ran.
-    pub(super) fn rows_sorted(&self) -> usize {
-        self.rows_sorted
+    /// What the walk has spent so far, in the phases the peek metrics report.
+    pub(super) fn phases(&self) -> WalkPhases {
+        WalkPhases {
+            error_scan: self.error_scan_time,
+            cursor_setup: self.cursor_setup_time,
+            error_trace_clean: self.error_trace_clean(),
+            row_iteration: self.row_iteration_time,
+            rows_processed: self.rows_processed(),
+            result_sort: self.result_sort_time,
+            rows_sorted: self.rows_sorted,
+        }
     }
 
     /// Whether the walk over the error trace has ended without finding an error, which is the only

--- a/src/compute/src/compute_state/peek_scan.rs
+++ b/src/compute/src/compute_state/peek_scan.rs
@@ -29,16 +29,17 @@ use timely::order::PartialOrder;
 use super::error_scan::{ErrorScan, ErrorScanStep, ErrsHandle};
 use super::peek_result_iterator::{PeekResultIterator, Step};
 
+/// The scan an index peek builds, over the ok trace of the arrangement that answers it.
+pub(super) type IndexPeekScan = PeekScan<
+    crate::arrangement::manager::PaddedTrace<crate::typedefs::RowRowAgent<Timestamp, Diff>>,
+>;
+
 // A scan is driven wherever its driver runs, which includes a runtime that may move a task
 // between threads, so the concrete scan an index peek builds has to cross threads. Asserting it
 // here fails the build if a field is added that does not.
 const _: () = {
     const fn assert_send<T: Send>() {}
-    assert_send::<
-        PeekScan<
-            crate::arrangement::manager::PaddedTrace<crate::typedefs::RowRowAgent<Timestamp, Diff>>,
-        >,
-    >();
+    assert_send::<IndexPeekScan>();
 };
 
 /// Rows a scan hands to its driver, in the order the scan produced them.

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -42,9 +42,8 @@ pub struct StashingPeek {
     /// Iterator for the results. The worker thread has to continually pump
     /// results from this to the `rows_tx` channel.
     peek_iterator: Option<PeekResultIterator<PaddedTrace<RowRowAgent<Timestamp, Diff>>>>,
-    /// We can't give a PeekResultIterator to our async upload task because the
-    /// underlying trace reader is not Send/Sync. So we need to use a channel to
-    /// send result rows from the worker thread to the async background task.
+    /// Carries result rows from the worker thread, which owns the walk, to the async upload task.
+    /// The upload makes progress only while the worker keeps pumping into this.
     rows_tx: Option<tokio::sync::mpsc::Sender<Result<Vec<(Row, NonZeroI64)>, PeekError>>>,
     /// The result of the background task, eventually.
     pub result: oneshot::Receiver<(PeekResponse, Duration)>,

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -73,6 +73,9 @@ pub struct ComputeMetrics {
     index_peek_frontier_check_seconds: Histogram,
     index_peek_row_collection_seconds: Histogram,
     index_peek_walks_total: raw::IntCounterVec,
+    index_peek_permit_queue_depth: UIntGauge,
+    index_peek_permit_wait_seconds: Histogram,
+    index_peek_offload_seconds: Histogram,
 
     // memory usage
     shared_row_heap_capacity_bytes: raw::UIntGaugeVec,
@@ -271,6 +274,20 @@ impl ComputeMetrics {
                 help: "The number of index peek walks, by the substrate they ran on: `inline` on the timely worker, `offloaded` away from it. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.",
                 var_labels: ["substrate"],
             ), role)),
+            index_peek_permit_queue_depth: registry.register(with_role(metric!(
+                name: "mz_index_peek_permit_queue_depth",
+                help: "The number of offloaded index peek walks waiting for a permit to run. The queue is a signal rather than a bound: it is drained rather than capped, so sustained growth here is what says the drain rate is too low.",
+            ), role)),
+            index_peek_permit_wait_seconds: registry.register(with_role(metric!(
+                name: "mz_index_peek_permit_wait_seconds",
+                help: "Time an offloaded index peek walk waited for a permit before it started running. Only walks that were admitted are observed, so a walk cancelled while waiting is absent rather than reported as a long wait.",
+                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
+            ), role)),
+            index_peek_offload_seconds: registry.register(with_role(metric!(
+                name: "mz_index_peek_offload_seconds",
+                help: "Time an offloaded index peek walk spent away from the timely worker, from the promotion to the outcome, including the wait for a permit.",
+                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
+            ), role)),
             replica_expiration_timestamp_seconds: registry.register(with_role(metric!(
                 name: "mz_dataflow_replica_expiration_timestamp_seconds",
                 help: "The replica expiration timestamp in seconds since epoch.",
@@ -330,6 +347,9 @@ impl ComputeMetrics {
         let index_peek_walks_offloaded = self
             .index_peek_walks_total
             .with_label_values(&["offloaded"]);
+        let index_peek_permit_queue_depth = self.index_peek_permit_queue_depth.clone();
+        let index_peek_permit_wait_seconds = self.index_peek_permit_wait_seconds.clone();
+        let index_peek_offload_seconds = self.index_peek_offload_seconds.clone();
         let replica_expiration_timestamp_seconds = self
             .replica_expiration_timestamp_seconds
             .with_label_values(&[&worker]);
@@ -361,6 +381,9 @@ impl ComputeMetrics {
             index_peek_row_collection_seconds,
             index_peek_walks_inline,
             index_peek_walks_offloaded,
+            index_peek_permit_queue_depth,
+            index_peek_permit_wait_seconds,
+            index_peek_offload_seconds,
             replica_expiration_timestamp_seconds,
             replica_expiration_remaining_seconds,
             shared_row_heap_capacity_bytes,
@@ -419,6 +442,12 @@ pub struct WorkerMetrics {
     pub(crate) index_peek_walks_inline: IntCounter,
     /// Counts index peek walks that ran away from the timely worker.
     pub(crate) index_peek_walks_offloaded: IntCounter,
+    /// How many offloaded index peek walks are waiting for a permit.
+    pub(crate) index_peek_permit_queue_depth: UIntGauge,
+    /// Histogram of how long an offloaded index peek walk waited for its permit.
+    pub(crate) index_peek_permit_wait_seconds: Histogram,
+    /// Histogram of how long an offloaded index peek walk was away from the worker.
+    pub(crate) index_peek_offload_seconds: Histogram,
     /// The timestamp of replica expiration.
     pub(crate) replica_expiration_timestamp_seconds: UIntGauge,
     /// Remaining seconds until replica expiration.

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -221,7 +221,7 @@ impl ComputeMetrics {
             ), role)),
             index_peek_total_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_total_seconds",
-                help: "Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek polled repeatedly or walked in several slices contributes several observations. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.",
+                help: "Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk's end either promotes it or diverts it to the peek stash. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_seek_fulfillment_seconds: registry.register(with_role(metric!(
@@ -271,7 +271,7 @@ impl ComputeMetrics {
             ), role)),
             index_peek_walks_total: registry.register(with_role(metric!(
                 name: "mz_index_peek_walks_total",
-                help: "The number of index peek walks that reached an outcome, by the substrate they ended on: `inline` on the timely worker, `offloaded` away from it. A cancelled walk reaches no outcome and is counted on neither. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.",
+                help: "The number of index peek walks that reached an outcome, by the substrate they ended on: `inline` on the timely worker, `offloaded` away from it. A walk cancelled before it reaches an outcome is counted on neither. An offloaded walk cancelled after that, while its result is on its way back to the worker, counts as `offloaded`. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.",
                 var_labels: ["substrate"],
             ), role)),
             index_peek_permit_queue_depth: registry.register(with_role(metric!(

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -221,7 +221,7 @@ impl ComputeMetrics {
             ), role)),
             index_peek_total_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_total_seconds",
-                help: "Total time processing index peeks, from process_peek entry to response. Excluding peeks that use the peek response stash.",
+                help: "Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek polled repeatedly or walked in several slices contributes several observations. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_seek_fulfillment_seconds: registry.register(with_role(metric!(
@@ -231,17 +231,17 @@ impl ComputeMetrics {
             ), role)),
             index_peek_error_scan_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_error_scan_seconds",
-                help: "Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.",
+                help: "Time scanning the error trace for errors. Sums the time of the calls the scan was sliced into, so it excludes the gaps between them. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker. Only scans that find no error are observed.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_cursor_setup_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_cursor_setup_seconds",
-                help: "Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.",
+                help: "Time opening the trace cursor and sorting the literal constraints. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker. Excludes seeking the cursor to the literals, which is part of row iteration.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_row_iteration_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_row_iteration_seconds",
-                help: "Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.",
+                help: "Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the time of the calls the walk was sliced into, so it excludes the gaps between them. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_row_iteration_rows: registry.register(with_role(metric!(
@@ -251,7 +251,7 @@ impl ComputeMetrics {
             ), role)),
             index_peek_result_sort_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_result_sort_seconds",
-                help: "Time sorting intermediate results during peek collection.",
+                help: "Time sorting intermediate results during peek collection. A walk that was offloaded mixes timely worker time with the offloaded task's, because the slices before the promotion ran on the worker.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_result_sort_rows: registry.register(with_role(metric!(
@@ -271,7 +271,7 @@ impl ComputeMetrics {
             ), role)),
             index_peek_walks_total: registry.register(with_role(metric!(
                 name: "mz_index_peek_walks_total",
-                help: "The number of index peek walks, by the substrate they ran on: `inline` on the timely worker, `offloaded` away from it. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.",
+                help: "The number of index peek walks that reached an outcome, by the substrate they ended on: `inline` on the timely worker, `offloaded` away from it. A cancelled walk reaches no outcome and is counted on neither. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.",
                 var_labels: ["substrate"],
             ), role)),
             index_peek_permit_queue_depth: registry.register(with_role(metric!(

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -416,10 +416,6 @@ pub struct WorkerMetrics {
     /// before its first walk. An absent series and a series stuck at zero read the same in a graph,
     /// and only the latter distinguishes an offload that never engaged from one that engaged
     /// without changing latency.
-    ///
-    /// TODO: Drop the `dead_code` allowance on the inline counter once the peek driver increments
-    /// it.
-    #[allow(dead_code)]
     pub(crate) index_peek_walks_inline: IntCounter,
     /// Counts index peek walks that ran away from the timely worker.
     pub(crate) index_peek_walks_offloaded: IntCounter,

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -417,12 +417,11 @@ pub struct WorkerMetrics {
     /// and only the latter distinguishes an offload that never engaged from one that engaged
     /// without changing latency.
     ///
-    /// TODO: Drop the `dead_code` allowances on both substrate counters once the peek driver
-    /// increments them.
+    /// TODO: Drop the `dead_code` allowance on the inline counter once the peek driver increments
+    /// it.
     #[allow(dead_code)]
     pub(crate) index_peek_walks_inline: IntCounter,
     /// Counts index peek walks that ran away from the timely worker.
-    #[allow(dead_code)]
     pub(crate) index_peek_walks_offloaded: IntCounter,
     /// The timestamp of replica expiration.
     pub(crate) replica_expiration_timestamp_seconds: UIntGauge,

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -72,6 +72,7 @@ pub struct ComputeMetrics {
     index_peek_result_sort_rows: Histogram,
     index_peek_frontier_check_seconds: Histogram,
     index_peek_row_collection_seconds: Histogram,
+    index_peek_walks_total: raw::IntCounterVec,
 
     // memory usage
     shared_row_heap_capacity_bytes: raw::UIntGaugeVec,
@@ -265,6 +266,11 @@ impl ComputeMetrics {
                 help: "Time constructing RowCollection from peek results, including converting the row counts the scan produced.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
+            index_peek_walks_total: registry.register(with_role(metric!(
+                name: "mz_index_peek_walks_total",
+                help: "The number of index peek walks, by the substrate they ran on: `inline` on the timely worker, `offloaded` away from it. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.",
+                var_labels: ["substrate"],
+            ), role)),
             replica_expiration_timestamp_seconds: registry.register(with_role(metric!(
                 name: "mz_dataflow_replica_expiration_timestamp_seconds",
                 help: "The replica expiration timestamp in seconds since epoch.",
@@ -320,6 +326,10 @@ impl ComputeMetrics {
         let index_peek_result_sort_rows = self.index_peek_result_sort_rows.clone();
         let index_peek_frontier_check_seconds = self.index_peek_frontier_check_seconds.clone();
         let index_peek_row_collection_seconds = self.index_peek_row_collection_seconds.clone();
+        let index_peek_walks_inline = self.index_peek_walks_total.with_label_values(&["inline"]);
+        let index_peek_walks_offloaded = self
+            .index_peek_walks_total
+            .with_label_values(&["offloaded"]);
         let replica_expiration_timestamp_seconds = self
             .replica_expiration_timestamp_seconds
             .with_label_values(&[&worker]);
@@ -349,6 +359,8 @@ impl ComputeMetrics {
             index_peek_result_sort_rows,
             index_peek_frontier_check_seconds,
             index_peek_row_collection_seconds,
+            index_peek_walks_inline,
+            index_peek_walks_offloaded,
             replica_expiration_timestamp_seconds,
             replica_expiration_remaining_seconds,
             shared_row_heap_capacity_bytes,
@@ -398,6 +410,20 @@ pub struct WorkerMetrics {
     pub(crate) index_peek_frontier_check_seconds: Histogram,
     /// Histogram of index peek row collection construction durations.
     pub(crate) index_peek_row_collection_seconds: Histogram,
+    /// Counts index peek walks that ran on the timely worker.
+    ///
+    /// Both substrate series are resolved when the worker's metrics are built, so each reports zero
+    /// before its first walk. An absent series and a series stuck at zero read the same in a graph,
+    /// and only the latter distinguishes an offload that never engaged from one that engaged
+    /// without changing latency.
+    ///
+    /// TODO: Drop the `dead_code` allowances on both substrate counters once the peek driver
+    /// increments them.
+    #[allow(dead_code)]
+    pub(crate) index_peek_walks_inline: IntCounter,
+    /// Counts index peek walks that ran away from the timely worker.
+    #[allow(dead_code)]
+    pub(crate) index_peek_walks_offloaded: IntCounter,
     /// The timestamp of replica expiration.
     pub(crate) replica_expiration_timestamp_seconds: UIntGauge,
     /// Remaining seconds until replica expiration.

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -41,7 +41,7 @@ use tracing::{info, trace, warn};
 use uuid::Uuid;
 
 use crate::command_channel;
-use crate::compute_state::{ActiveComputeState, ComputeState, ReportedFrontier};
+use crate::compute_state::{ActiveComputeState, ComputeState, PeekPermits, ReportedFrontier};
 use crate::metrics::{ComputeMetrics, WorkerMetrics};
 
 /// Caller-provided configuration for compute.
@@ -141,6 +141,8 @@ struct Config {
     pub metrics_registry: MetricsRegistry,
     /// The number of timely workers per process.
     pub workers_per_process: usize,
+    /// Bounds how many promoted peek walks run at once, shared by every worker this server runs.
+    pub peek_permits: Arc<PeekPermits>,
     /// A reader for each storage worker in this process.
     pub storage_log_readers: Arc<Mutex<Vec<Option<StorageTimelyLogReader>>>>,
 }
@@ -180,6 +182,10 @@ pub async fn serve(
         context,
         metrics_registry: metrics_registry.clone(),
         workers_per_process,
+        // A walk that runs on its worker occupies one core, so peek CPU is capped today at one
+        // core per worker. Admitting one promoted walk per worker preserves that ceiling once
+        // promotion breaks the coupling that enforced it.
+        peek_permits: Arc::new(PeekPermits::new(workers_per_process)),
         storage_log_readers: Arc::new(Mutex::new(storage_log_readers)),
     };
     let tokio_executor = tokio::runtime::Handle::current();
@@ -314,6 +320,8 @@ struct Worker<'w> {
     metrics_registry: MetricsRegistry,
     /// The number of timely workers per process.
     workers_per_process: usize,
+    /// Bounds how many promoted peek walks run at once, shared by every worker in this process.
+    peek_permits: Arc<PeekPermits>,
     /// Reader for storage timely logging events.
     storage_log_reader: Option<StorageTimelyLogReader>,
 }
@@ -366,6 +374,7 @@ impl ClusterSpec for Config {
             tracing_handle: Arc::clone(&self.tracing_handle),
             metrics_registry: self.metrics_registry.clone(),
             workers_per_process: self.workers_per_process,
+            peek_permits: Arc::clone(&self.peek_permits),
             storage_log_reader,
         }
         .run()
@@ -504,6 +513,7 @@ impl<'w> Worker<'w> {
                 self.context.clone(),
                 self.metrics_registry.clone(),
                 self.workers_per_process,
+                Arc::clone(&self.peek_permits),
                 self.storage_log_reader.take(),
             ));
         }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -287,7 +287,7 @@ impl ResponseSender {
     }
 
     /// Set the cluster protocol nonce.
-    fn set_nonce(&mut self, nonce: Uuid) {
+    pub(crate) fn set_nonce(&mut self, nonce: Uuid) {
         self.nonce = Some(nonce);
     }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -185,6 +185,11 @@ pub async fn serve(
         // A walk that runs on its worker occupies one core, so peek CPU is capped today at one
         // core per worker. Admitting one promoted walk per worker preserves that ceiling once
         // promotion breaks the coupling that enforced it.
+        //
+        // NOTE: this bound covers the workers of one `serve` call, not those of the OS process. A
+        // process that runs a maintenance and an interactive runtime side by side calls `serve`
+        // twice, so those two roles share a persist cache and a metrics registry but not a peek
+        // permit, and the process admits this count once per role.
         peek_permits: Arc::new(PeekPermits::new(workers_per_process)),
         storage_log_readers: Arc::new(Mutex::new(storage_log_readers)),
     };

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -275,7 +275,10 @@ pub(crate) struct ResponseSender {
 }
 
 impl ResponseSender {
-    fn new(inner: mpsc::UnboundedSender<(ComputeResponse, Uuid)>, worker_id: usize) -> Self {
+    pub(crate) fn new(
+        inner: mpsc::UnboundedSender<(ComputeResponse, Uuid)>,
+        worker_id: usize,
+    ) -> Self {
         Self {
             inner,
             worker_id,

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -21,7 +21,9 @@ use std::process::ExitCode;
 use chrono::Utc;
 use clap::ArgAction;
 use mz_adapter_types::dyncfgs::ENABLE_BACKGROUND_ALTER_CLUSTER;
-use mz_compute_types::dyncfgs::{ENABLE_PEEK_ROW_ITERATION_LIMIT, PEEK_ROW_ITERATION_LIMIT};
+use mz_compute_types::dyncfgs::{
+    ENABLE_INDEX_PEEK_OFFLOAD, ENABLE_PEEK_ROW_ITERATION_LIMIT, PEEK_ROW_ITERATION_LIMIT,
+};
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_ore::cli::{self, CliConfig, KeyValueArg};
 use mz_ore::metrics::MetricsRegistry;
@@ -187,10 +189,13 @@ async fn main() -> ExitCode {
         .entry(ENABLE_BACKGROUND_ALTER_CLUSTER.name().to_string())
         .or_insert_with(|| "true".to_string());
 
-    // Keep the guard enabled in the suite without constraining normal test queries.
+    // Keep the guard enabled in the suite without constraining normal test queries, and exercise
+    // the peek offload path, which defaults off in production. The offload's budgets stay at their
+    // code defaults so the suite hits the placement decisions production makes.
     for (name, value) in [
         (ENABLE_PEEK_ROW_ITERATION_LIMIT.name(), "true"),
         (PEEK_ROW_ITERATION_LIMIT.name(), "1000000000"),
+        (ENABLE_INDEX_PEEK_OFFLOAD.name(), "true"),
     ] {
         system_parameter_defaults
             .entry(name.to_string())

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -210,6 +210,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     compute_flat_map_fuel
     compute_index_peek_activation_budget
     compute_index_peek_inline_budget
+    compute_index_peek_permits
     compute_index_peek_yield_granularity
     compute_logical_backpressure_max_retained_capabilities
     compute_mv_sink_advance_persist_frontiers

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -208,6 +208,9 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     compute_correction_v2_chain_proportionality
     compute_correction_v2_chunk_size
     compute_flat_map_fuel
+    compute_index_peek_activation_budget
+    compute_index_peek_inline_budget
+    compute_index_peek_yield_granularity
     compute_logical_backpressure_max_retained_capabilities
     compute_mv_sink_advance_persist_frontiers
     compute_peek_row_iteration_limit
@@ -242,6 +245,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_binary_date_bin
     enable_coalesce_case_transform
     enable_compute_half_join2
+    enable_compute_index_peek_offload
     enable_compute_peek_row_iteration_limit
     enable_compute_render_fueled_as_specific_collection
     enable_date_bin_hopping


### PR DESCRIPTION
Moves an expensive fast-path index peek's walk off the timely worker that received it, so a long scan no longer delays the peeks queued behind it. This is the layer the ones beneath it were built for.

A peek runs its first slice inline under a small budget, sized so point lookups finish there and nothing else does. If it completes, the peek never leaves the worker. If it outruns the budget it is promoted to an async task that yields, holding a permit from a process-wide semaphore. Cost is measured rather than predicted, so a skewed point lookup over a hot key needs no special case: it enters as a point lookup, overruns, and offloads.

Promotion is for a scan that suspended with its budget spent, never for one holding a full batch. A promoted task has nowhere to write a batch until the stash becomes a state transition of the same scan, and stepping a batch-ready scan returns without spending fuel or advancing, so promoting one would spin. A scan that fills a batch while promoted hands back and the worker starts the existing stash walk.

The permit is owned by the running task rather than by the pending peek, so releasing it coincides with releasing the batches it accounts for. Permits default to this process's worker count, which preserves the ceiling that exists today: a peek blocking its worker already costs one core per worker. Excess scans queue in the semaphore, so a peek storm costs queue entries rather than threads.

Cancellation needs no new mechanism at any stage. Removing the pending peek drops the result channel's receiver, and the task observes a closed sender at its next slice boundary; a scan still waiting for a permit leaves the queue the same way. Permits release on drop, including on panic.

A per-activation aggregate bounds what all peeks together spend in one sweep, since the worker visits every pending peek on every activation. A peek that gets no turn is served first on the next one.

Off by default in production and on in the test configuration. With the switch off nothing is promoted and placement is unchanged.

Both substrate counters are pre-resolved, so `mz_index_peek_walks_total{substrate="offloaded"}` reads zero rather than being absent, which keeps "the offload changed nothing" distinguishable from "the offload never engaged".

Reading `mz_index_peek_total_seconds` across the flag is misleading: a promoted peek contributes only its inline slice, which the inline budget bounds, so the expensive peeks leave a bounded sample where they used to leave the whole walk. `mz_index_peek_offload_seconds` and the per-phase histograms are the honest pairing.

🤖 Opened by [Claude Code](https://claude.com/claude-code) on behalf of @antiguru