### PR TITLE
docs: remove production-readiness warning from mz-deploy get-started

### DIFF
--- a/doc/user/content/manage/mz-deploy/get-started.md
+++ b/doc/user/content/manage/mz-deploy/get-started.md
@@ -9,10 +9,6 @@ menu:
     name: "Get started"
 ---
 
-{{< warning >}}
-`mz-deploy` is a v0.2 release and is not yet recommended for production use.
-{{< /warning >}}
-
 `mz-deploy` is a deployment tool that gives you compile-time validation, unit
 testing, and zero-downtime blue/green deployments for Materialize — all from
 plain SQL files in a git repository. This quickstart walks you through creating


### PR DESCRIPTION
### Motivation

[materialize.com/docs/manage/mz-deploy/get-started](https://materialize.com/docs/manage/mz-deploy/get-started/) still shows:

> `mz-deploy` is a v0.2 release and is not yet recommended for production use.

#38329 removed that warning from the mz-deploy landing page (`_index.md`) but the identical block on the Get started page was missed, so the page a new user is most likely to land on still says mz-deploy isn't fit for production.

Reported in [#deploy-tool](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1787685127502159).

### Description

Deletes the same four-line `{{< warning >}}` block from `doc/user/content/manage/mz-deploy/get-started.md`. This was the last remaining occurrence in `doc/` (`git grep "not yet recommended for production" -- doc/` is now empty).

### Verification

Docs-only change; no behavior. Diff is byte-identical to the removal in #38329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)