### PR TITLE
Require read privileges for CREATE TABLE ... FROM SOURCE

### DIFF
--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -31,7 +31,8 @@ use crate::names::{
 };
 use crate::plan::{self, PlanKind};
 use crate::plan::{
-    DataSourceDesc, Explainee, MutationKind, Plan, SideEffectingFunc, UpdatePrivilege,
+    DataSourceDesc, Explainee, MutationKind, Plan, SideEffectingFunc, TableDataSource,
+    UpdatePrivilege,
 };
 use crate::session::metadata::SessionMetadata;
 use crate::session::user::{MZ_SUPPORT_ROLE_ID, MZ_SYSTEM_ROLE_ID, SUPPORT_USER, SYSTEM_USER};
@@ -635,17 +636,33 @@ fn generate_rbac_requirements(
         }
         Plan::CreateTable(plan::CreateTablePlan {
             name,
-            table: _,
+            table,
             if_not_exists: _,
-        }) => RbacRequirements {
-            privileges: vec![(
+        }) => {
+            let mut privileges = vec![(
                 SystemObjectId::Object(name.qualifiers.clone().into()),
                 AclMode::CREATE,
                 role_id,
-            )],
-            item_usage: &CREATE_ITEM_USAGE,
-            ..Default::default()
-        },
+            )];
+            // `CREATE TABLE ... FROM SOURCE` reads the source's data, so it
+            // requires `SELECT` on the source.
+            if let TableDataSource::DataSource {
+                desc: DataSourceDesc::IngestionExport { ingestion_id, .. },
+                timeline: _,
+            } = &table.data_source
+            {
+                privileges.extend(generate_read_privileges(
+                    catalog,
+                    iter::once(*ingestion_id),
+                    role_id,
+                ));
+            }
+            RbacRequirements {
+                privileges,
+                item_usage: &CREATE_ITEM_USAGE,
+                ..Default::default()
+            }
+        }
         Plan::CreateView(plan::CreateViewPlan {
             name,
             view: _,

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -694,6 +694,7 @@ def compileFastSltConfig() -> SltRunConfig:
         "test/sqllogictest/quote_ident.slt",
         "test/sqllogictest/quoting.slt",
         "test/sqllogictest/range.slt",
+        "test/sqllogictest/rbac_create_table_from_source.slt",
         "test/sqllogictest/rbac_enabled.slt",
         "test/sqllogictest/record.slt",
         "test/sqllogictest/recursion_limit.slt",

--- a/test/sqllogictest/rbac_create_table_from_source.slt
+++ b/test/sqllogictest/rbac_create_table_from_source.slt
@@ -1,0 +1,167 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# `CREATE TABLE ... FROM SOURCE` reads the source's data, so it requires the
+# same read privileges as reading the source directly: `SELECT` on the source
+# and `USAGE` on its schema.
+
+mode cockroach
+
+reset-server
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_rbac_checks TO true;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE attacker;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SCHEMA attacker_schema;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE, CREATE ON SCHEMA attacker_schema TO attacker;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON DATABASE materialize TO attacker;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON CLUSTER quickstart TO attacker;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SCHEMA victim_schema;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SOURCE victim_schema.victim_auction FROM LOAD GENERATOR AUCTION (AS OF 300, UP TO 301) FOR ALL TABLES;
+----
+COMPLETE 0
+
+# The attacker can name the objects but holds no read privilege on the source.
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA victim_schema TO attacker;
+----
+COMPLETE 0
+
+# Reading an export directly is denied.
+
+simple conn=attacker,user=attacker
+SELECT count(*) FROM victim_schema.users;
+----
+db error: ERROR: permission denied for SOURCE "materialize.victim_schema.users"
+DETAIL: The 'attacker' role needs SELECT privileges on SOURCE "materialize.victim_schema.users"
+
+# Attaching a reference to an attacker-owned table is denied for the same
+# reason: it reads the source's data.
+
+simple conn=attacker,user=attacker
+CREATE TABLE attacker_schema.laundered FROM SOURCE victim_schema.victim_auction (REFERENCE "auction"."users");
+----
+db error: ERROR: permission denied for SOURCE "materialize.victim_schema.victim_auction"
+DETAIL: The 'attacker' role needs SELECT privileges on SOURCE "materialize.victim_schema.victim_auction"
+
+# `CREATE` on the destination schema alone is not enough even when the source
+# is readable, so both halves of the requirement are pinned.
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE no_create;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON DATABASE materialize TO no_create;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA victim_schema, attacker_schema TO no_create;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON victim_schema.victim_auction TO no_create;
+----
+COMPLETE 0
+
+simple conn=no_create,user=no_create
+CREATE TABLE attacker_schema.nope FROM SOURCE victim_schema.victim_auction (REFERENCE "auction"."users");
+----
+db error: ERROR: permission denied for SCHEMA "materialize.attacker_schema"
+DETAIL: The 'no_create' role needs CREATE privileges on SCHEMA "materialize.attacker_schema"
+
+# With `SELECT` on the source, the attach is allowed, so the check denies the
+# attack without blocking legitimate attachment.
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON victim_schema.victim_auction TO attacker;
+----
+COMPLETE 0
+
+simple conn=attacker,user=attacker
+CREATE TABLE attacker_schema.authorized FROM SOURCE victim_schema.victim_auction (REFERENCE "auction"."users");
+----
+COMPLETE 0
+
+# The outcome does not depend on unrelated catalog state. A second role with the
+# same grants can attach the same reference even though another team's table now
+# exports it too, and nothing another team does to its own tables can revoke
+# this role's ability to run the same statement.
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE other_team;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SCHEMA other_team_schema;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE, CREATE ON SCHEMA other_team_schema TO other_team;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON DATABASE materialize TO other_team;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON CLUSTER quickstart TO other_team;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA victim_schema TO other_team;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON victim_schema.victim_auction TO other_team;
+----
+COMPLETE 0
+
+simple conn=other_team,user=other_team
+CREATE TABLE other_team_schema.mine FROM SOURCE victim_schema.victim_auction (REFERENCE "auction"."users");
+----
+COMPLETE 0


### PR DESCRIPTION
Require read privileges for CREATE TABLE ... FROM SOURCE

Fixes [SQL-655](https://linear.app/materializeinc/issue/SQL-655) (2026 Refactor penetration test, finding H02, High).

### Motivation

`CREATE TABLE ... FROM SOURCE` bypassed source authorization: it required only
`CREATE` on the destination schema, and nothing about the source it reads.
Because the new table is owned by whoever creates it, `CREATE` on any schema a
role controls was enough to read a source that role had been explicitly denied.

The assessment read 4,076 rows from an Auction load generator through an
attached table while direct reads of the same export stayed denied. The
behaviour has been reachable by default since v26.25.0 and was still present in
v26.35.0.

### Description

`CREATE TABLE ... FROM SOURCE` now requires `SELECT` on the source and `USAGE`
on its schema, the same read privileges `CREATE SINK` requires on the relation
it reads.

**The source is the authorization boundary.** `SELECT` on a source permits
attaching any reference that source ingests, including references that have no
table yet, and including columns some existing table omitted. If a reference
should not be reachable, it should not be in the source's publication or topic
set.

Pentest remediation item 2 (additionally requiring `SELECT` on an existing table
for the same reference) is intentionally not implemented: making the outcome
depend on which other tables happen to exist would let one team's migration
revoke another team's ability to run an unchanged statement. Per-column
granularity belongs in column-level grants.

### User-visible effect

This tightens an existing privilege requirement, and
`enable_create_table_from_source` is on by default, so it applies to everyone on
upgrade. A role that previously needed only `CREATE` on its own schema plus
`USAGE` on the source's schema now also needs `SELECT` on the source.

Deployments where a platform team owns sources and application teams attach
tables into their own schemas will need those `SELECT` grants added. The
user-facing privileges include for `CREATE TABLE` is updated in a follow-up PR,
kept separate so this fix is not gated on a second CODEOWNERS scope.

### Verification

New `test/sqllogictest/rbac_create_table_from_source.slt`: a direct read is
denied; the attach is denied without `SELECT` on the source; the attach is
denied for a role that has `SELECT` on the source but no `CREATE` on the
destination schema; it succeeds with both; and a second role with the same
grants can attach the same reference after another team has already attached it.

Registered in `tests_without_views` alongside the other RBAC suites, since
`--auto-index-selects` view-wrapping would change privilege semantics.

### Residual, not fixed here

Purification runs before authorization, and its gate covers secrets, connections
and types but not sources. The upstream connection also comes from the source's
own definition rather than the statement, so an unauthorized role can still
cause an outbound connection to the source's upstream using the source owner's
credentials, and use purification errors as an upstream existence and
column-name oracle. Shared with `CREATE SOURCE` and `CREATE SINK` rather than
introduced here; closing it needs a pre-purification privilege gate. Filed
separately.

