### PR TITLE
compute: make the peek stash a state transition of one scan

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -3622,25 +3622,6 @@ metrics:
   - version
   source: src/environmentd/src/environmentd/main.rs
   visibility: internal
-- name: mz_stashed_peek_seconds_bucket
-  help: Time spent reading a peek result and stashing it in the peek result stash (aka. persist blob).
-  labels:
-  - le
-  - worker_id
-  source: src/compute/src/metrics.rs
-  visibility: internal
-- name: mz_stashed_peek_seconds_count
-  help: Time spent reading a peek result and stashing it in the peek result stash (aka. persist blob).
-  labels:
-  - worker_id
-  source: src/compute/src/metrics.rs
-  visibility: internal
-- name: mz_stashed_peek_seconds_sum
-  help: Time spent reading a peek result and stashing it in the peek result stash (aka. persist blob).
-  labels:
-  - worker_id
-  source: src/compute/src/metrics.rs
-  visibility: internal
 - name: mz_statement_logging_actual_bytes
   help: The total amount of SQL text that was logged by statement logging.
   source: src/adapter/src/metrics.rs

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -1113,18 +1113,22 @@ metrics:
   help: Time in seek_fulfillment method including frontier checks and data collection.
   source: src/compute/src/metrics.rs
   visibility: internal
+- name: mz_index_peek_stashed_total
+  help: The number of index peek walks that answered with a handle to the peek response stash. Always a subset of the `offloaded` substrate of `mz_index_peek_walks_total`, because the driver that writes to the stash is the promoted one. How long such a walk spent writing is not separable from the walk itself, since one loop does both, and `mz_index_peek_offload_seconds` bounds it.
+  source: src/compute/src/metrics.rs
+  visibility: internal
 - name: mz_index_peek_total_seconds_bucket
-  help: 'Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk''s end either promotes it or diverts it to the peek stash. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.'
+  help: 'Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk''s end promotes it. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. A peek bound for the peek response stash is included, because the slice that promoted it ran here like any other.'
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_total_seconds_count
-  help: 'Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk''s end either promotes it or diverts it to the peek stash. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.'
+  help: 'Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk''s end promotes it. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. A peek bound for the peek response stash is included, because the slice that promoted it ran here like any other.'
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_total_seconds_sum
-  help: 'Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk''s end either promotes it or diverts it to the peek stash. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.'
+  help: 'Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk''s end promotes it. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. A peek bound for the peek response stash is included, because the slice that promoted it ran here like any other.'
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_walks_total

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -776,7 +776,6 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "compute_index_peek_permits",
     "compute_peek_response_stash_read_batch_size_bytes",
     "compute_peek_response_stash_read_memory_budget_bytes",
-    "compute_peek_stash_batch_size",
     "storage_statistics_retention_duration",
     "enable_paused_cluster_readhold_downgrade",
     "kafka_retry_backoff",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -776,7 +776,6 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "compute_index_peek_permits",
     "compute_peek_response_stash_read_batch_size_bytes",
     "compute_peek_response_stash_read_memory_budget_bytes",
-    "compute_peek_stash_num_batches",
     "compute_peek_stash_batch_size",
     "storage_statistics_retention_duration",
     "enable_paused_cluster_readhold_downgrade",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3352,7 +3352,6 @@ class FlipFlagsAction(Action):
             "mz_metrics_lgalloc_map_refresh_interval",
             "mz_metrics_lgalloc_refresh_interval",
             "mz_metrics_rusage_refresh_interval",
-            "compute_peek_stash_batch_size",
             "compute_peek_response_stash_batch_max_runs",
             "compute_peek_response_stash_read_batch_size_bytes",
             "compute_peek_response_stash_read_memory_budget_bytes",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3352,7 +3352,6 @@ class FlipFlagsAction(Action):
             "mz_metrics_lgalloc_map_refresh_interval",
             "mz_metrics_lgalloc_refresh_interval",
             "mz_metrics_rusage_refresh_interval",
-            "compute_peek_stash_num_batches",
             "compute_peek_stash_batch_size",
             "compute_peek_response_stash_batch_max_runs",
             "compute_peek_response_stash_read_batch_size_bytes",

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -600,14 +600,6 @@ pub const PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES: Config<usize> = Config::
     ParameterScope::Environment,
 );
 
-/// The number of batches to pump from the peek result iterator when stashing peek responses.
-pub const PEEK_STASH_NUM_BATCHES: Config<usize> = Config::new(
-    "compute_peek_stash_num_batches",
-    100,
-    "The number of batches to pump from the peek result iterator (in one iteration through the worker loop) when stashing peek responses.",
-    ParameterScope::Environment,
-);
-
 /// The size of each batch, as number of rows, pumped from the peek result
 /// iterator when stashing peek responses.
 pub const PEEK_STASH_BATCH_SIZE: Config<usize> = Config::new(
@@ -857,7 +849,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&PEEK_RESPONSE_STASH_BATCH_MAX_RUNS)
         .add(&PEEK_RESPONSE_STASH_READ_BATCH_SIZE_BYTES)
         .add(&PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES)
-        .add(&PEEK_STASH_NUM_BATCHES)
         .add(&PEEK_STASH_BATCH_SIZE)
         .add(&ENABLE_PEEK_ROW_ITERATION_LIMIT)
         .add(&PEEK_ROW_ITERATION_LIMIT)

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -600,15 +600,6 @@ pub const PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES: Config<usize> = Config::
     ParameterScope::Environment,
 );
 
-/// The size of each batch, as number of rows, pumped from the peek result
-/// iterator when stashing peek responses.
-pub const PEEK_STASH_BATCH_SIZE: Config<usize> = Config::new(
-    "compute_peek_stash_batch_size",
-    100000,
-    "The size, as number of rows, of each batch pumped from the peek result iterator (in one iteration through the worker loop) when stashing peek responses.",
-    ParameterScope::Environment,
-);
-
 /// Whether compute should stop peeks that iterate over too many rows.
 pub const ENABLE_PEEK_ROW_ITERATION_LIMIT: Config<bool> = Config::new(
     "enable_compute_peek_row_iteration_limit",
@@ -849,7 +840,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&PEEK_RESPONSE_STASH_BATCH_MAX_RUNS)
         .add(&PEEK_RESPONSE_STASH_READ_BATCH_SIZE_BYTES)
         .add(&PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES)
-        .add(&PEEK_STASH_BATCH_SIZE)
         .add(&ENABLE_PEEK_ROW_ITERATION_LIMIT)
         .add(&PEEK_ROW_ITERATION_LIMIT)
         .add(&ENABLE_INDEX_PEEK_OFFLOAD)

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -626,10 +626,13 @@ pub const ENABLE_PEEK_ROW_ITERATION_LIMIT: Config<bool> = Config::new(
 );
 
 /// The maximum number of rows a peek may iterate over on each worker.
+///
+/// The count spans a peek's whole walk of its arrangement, rows written to the peek stash
+/// included, because a peek walks its arrangement once and the count travels with that walk.
 pub const PEEK_ROW_ITERATION_LIMIT: Config<usize> = Config::new(
     "compute_peek_row_iteration_limit",
     1000,
-    "The maximum number of rows a peek may iterate over on each worker when enable_compute_peek_row_iteration_limit is enabled. Does not apply once a peek's results move to the peek stash.",
+    "The maximum number of rows a peek may iterate over on each worker when enable_compute_peek_row_iteration_limit is enabled. The count spans the peek's whole walk, rows written to the peek stash included.",
     ParameterScope::Environment,
 );
 

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -633,14 +633,19 @@ pub const PEEK_ROW_ITERATION_LIMIT: Config<usize> = Config::new(
     ParameterScope::Environment,
 );
 
-/// Whether a fast-path index peek may move its walk off the timely worker.
+/// Whether a fast-path index peek may move its walk off the timely worker for latency.
 ///
-/// Off, a peek walks the arrangement to completion on the worker that owns it, so an expensive
+/// Off, a peek walks the arrangement on the worker that owns it until it answers, so an expensive
 /// peek delays every other message that worker serves. On, a peek that outruns
 /// [`INDEX_PEEK_INLINE_BUDGET`] is promoted and finishes away from the worker.
 ///
-/// The kill switch for the whole mechanism, and off by default so production placement is
-/// unchanged until the path earns trust.
+/// It gates promotion for latency and only that. A peek whose accumulated rows outgrow what it may
+/// answer with inline is promoted whichever way this is set, because the driver that writes to the
+/// peek stash is the promoted one and such a peek has no other route to an answer. Off therefore
+/// means an ordinary peek runs where it used to, not that no peek ever leaves the worker.
+///
+/// The kill switch for the placement, and off by default so production placement is unchanged
+/// until the path earns trust.
 ///
 /// Environment-scoped because it selects between two execution paths whose output-equivalence is
 /// an assumption rather than a guarantee. A peek is broadcast to every replica of its cluster and
@@ -676,8 +681,8 @@ pub const ENABLE_INDEX_PEEK_OFFLOAD: Config<bool> = Config::new(
 /// without discarding the positions they have walked.
 ///
 /// Zero walks one position rather than none. A peek granted no fuel suspends before it has walked
-/// anywhere, and a suspension holding no full batch is a promotion, so zero would promote every
-/// point lookup for a walk that visited nothing.
+/// anywhere, and a suspension is a promotion, so zero would promote every point lookup for a walk
+/// that visited nothing.
 ///
 /// Environment-scoped because the threshold decides which peeks leave the worker. A value that
 /// differs by replica selects a different execution path for the same peek exactly as

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -716,6 +716,11 @@ pub const INDEX_PEEK_ACTIVATION_BUDGET: Config<usize> = Config::new(
 /// Counted in the same unit as [`INDEX_PEEK_INLINE_BUDGET`], for the same reasons, and likewise
 /// read through a handle.
 ///
+/// An upper bound rather than a period. A walk whose rows are bound for the peek stash suspends
+/// once its accumulation crosses `peek_response_stash_threshold_bytes`, which at that threshold's
+/// default is by far the smaller trigger, so such a walk yields per batch and the fuel it did not
+/// spend is not carried into the next slice.
+///
 /// Replica-scoped, unlike the switch and the two budgets. It selects no execution path and changes
 /// no result. It only sets how often a walk that is already promoted yields and rechecks
 /// cancellation, which is the timing of the replica process's own execution. Divergence is safe

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -86,7 +86,7 @@ use self::peek_budget::InlineBudget;
 use self::peek_metrics::IndexPeekMetrics;
 use self::peek_metrics::PeekWalkMetrics;
 pub(crate) use self::peek_offload::PeekPermits;
-use self::peek_offload::{OffloadConfig, OffloadOutcome, OffloadedPeek};
+use self::peek_offload::{OffloadConfig, OffloadedPeek};
 use self::peek_scan::{IndexPeekScan, PeekScan, ScanOutcome};
 
 /// Cheap handles on the dyncfgs that bound how many rows a peek may examine.
@@ -1246,14 +1246,17 @@ impl<'a> ActiveComputeState<'a> {
                     .finishing
                     .is_streamable(peek.peek.result_desc.arity());
 
-                let peek_stash_enabled = {
+                // The location a diverted peek's rows go to, or `None` where this replica has none
+                // or the stash is off. Carried rather than reduced to a flag, because the walk
+                // that diverts writes there itself and so needs the location and not the answer
+                // to whether one exists.
+                let peek_stash_location = {
                     let enabled = ENABLE_PEEK_RESPONSE_STASH.get(&self.compute_state.worker_config);
-                    let peek_persist_stash_available =
-                        self.compute_state.peek_stash_persist_location.is_some();
-                    if !peek_persist_stash_available && enabled {
+                    let location = self.compute_state.peek_stash_persist_location.clone();
+                    if location.is_none() && enabled {
                         error!("missing peek_stash_persist_location but peek stash is enabled");
                     }
-                    enabled && peek_persist_stash_available
+                    enabled.then_some(location).flatten()
                 };
 
                 let peek_stash_threshold_bytes =
@@ -1275,7 +1278,7 @@ impl<'a> ActiveComputeState<'a> {
                 let status = peek.seek_fulfillment(
                     upper,
                     self.compute_state.max_result_size,
-                    peek_stash_enabled && peek_stash_eligible,
+                    peek_stash_eligible && peek_stash_location.is_some(),
                     peek_stash_threshold_bytes,
                     row_iteration_limit,
                     &mut fuel,
@@ -1301,10 +1304,22 @@ impl<'a> ActiveComputeState<'a> {
 
                         let uuid = peek.peek.uuid;
                         let permits = Arc::clone(&self.compute_state.peek_permits);
+                        // Built from the same two facts the scan's stash eligibility was, so a
+                        // walk that can offer a batch is a walk that has somewhere to write it.
+                        let stash =
+                            peek_stash_location
+                                .filter(|_| peek_stash_eligible)
+                                .map(|location| {
+                                    peek_stash::StashTarget::new(
+                                        &peek.peek,
+                                        Arc::clone(&self.compute_state.persist_clients),
+                                        location,
+                                    )
+                                });
                         let offloaded = OffloadedPeek::promote(
                             peek.peek.clone(),
-                            peek.trace_bundle.clone(),
                             scan,
+                            stash,
                             &permits,
                             OffloadConfig::new(&self.compute_state.worker_config),
                             self.compute_state.peek_walk_metrics.clone(),
@@ -1314,20 +1329,6 @@ impl<'a> ActiveComputeState<'a> {
                         self.compute_state
                             .pending_peeks
                             .insert(uuid, PendingPeek::Offloaded(offloaded));
-                        return;
-                    }
-                    PeekStatus::UsePeekStash => {
-                        let _span =
-                            span!(parent: &peek.span, Level::DEBUG, "process_stash_peek").entered();
-
-                        let uuid = peek.peek.uuid;
-                        let stash_task = self
-                            .start_stash_upload(peek.peek.clone(), peek.trace_bundle.clone())
-                            .expect("stash location established before diverting");
-
-                        self.compute_state
-                            .pending_peeks
-                            .insert(uuid, PendingPeek::Stash(stash_task));
                         return;
                     }
                 }
@@ -1340,46 +1341,16 @@ impl<'a> ActiveComputeState<'a> {
                 result
             }),
             PendingPeek::Offloaded(offloaded) => match offloaded.result.try_recv() {
-                Ok((outcome, duration)) => {
-                    // Both outcomes are timed, because both measure the same thing: how long the
-                    // peek was away from the worker, the wait for a permit included. A walk that
-                    // hands back is the expensive case rather than an aborted one.
+                Ok((response, duration)) => {
+                    // The duration covers how long the peek was away from the worker, the wait for
+                    // a permit and any writing to the peek stash included.
                     self.compute_state
                         .metrics
                         .index_peek_offload_seconds
                         .observe(duration.as_secs_f64());
 
-                    match outcome {
-                        OffloadOutcome::Answered(response) => {
-                            trace!(?offloaded.peek, ?duration, "finished offloaded index peek walk");
-                            Some(response)
-                        }
-                        OffloadOutcome::NeedsStash => {
-                            let _span =
-                                span!(parent: &offloaded.span, Level::DEBUG, "process_stash_peek")
-                                    .entered();
-                            trace!(?offloaded.peek, ?duration, "handing offloaded index peek to the stash");
-
-                            let uuid = offloaded.peek.uuid;
-                            let stash_task = self.start_stash_upload(
-                                offloaded.peek.clone(),
-                                offloaded.trace_bundle.clone(),
-                            );
-
-                            match stash_task {
-                                Some(stash_task) => {
-                                    self.compute_state
-                                        .pending_peeks
-                                        .insert(uuid, PendingPeek::Stash(stash_task));
-                                    return;
-                                }
-                                None => Some(PeekResponse::Error(PeekError::unstructured(
-                                    "peek result is too large to answer inline and this replica \
-                                     has no peek stash location",
-                                ))),
-                            }
-                        }
-                    }
+                    trace!(?offloaded.peek, ?duration, "finished offloaded index peek walk");
+                    Some(response)
                 }
                 Err(oneshot::error::TryRecvError::Empty) => None,
                 // The task drops its sender without sending only when it stops without an outcome,
@@ -1437,6 +1408,9 @@ impl<'a> ActiveComputeState<'a> {
     ///
     /// Returns `None` when this replica has no stash location, which a caller must establish
     /// before it decides to divert a peek here.
+    // A peek whose answer belongs in the stash is written there by the walk that produces it, so
+    // no caller reaches this.
+    #[allow(dead_code)]
     fn start_stash_upload(
         &self,
         peek: Peek,
@@ -1670,6 +1644,9 @@ pub enum PendingPeek {
     Persist(PersistPeek),
     /// A peek against an index that is being stashed in the peek stash by an
     /// async background task.
+    // A peek whose answer belongs in the stash is written there by the walk that produces it, so
+    // nothing puts a peek into this state.
+    #[allow(dead_code)]
     Stash(peek_stash::StashingPeek),
     /// A peek against an index whose walk was promoted off the worker and is running as an async
     /// task.
@@ -2062,10 +2039,10 @@ impl IndexPeek {
 
         let outcome = scan.step(row_iteration_limit, fuel);
 
-        // A suspension the offload can resume is the one outcome that leaves the walk unfinished,
-        // so it is the one outcome this driver reports nothing for. Everything else ends the walk
-        // here, and this driver is the one that accounts for it.
-        let promoted = matches!(outcome, ScanOutcome::Suspended) && !scan.batch_ready();
+        // A suspension is the one outcome that leaves the walk unfinished, so it is the one
+        // outcome this driver reports nothing for. Everything else ends the walk here, and this
+        // driver is the one that accounts for it.
+        let promoted = matches!(outcome, ScanOutcome::Suspended);
         let phases = scan.phases();
         if !promoted {
             metrics.walk.walked_inline();
@@ -2075,32 +2052,13 @@ impl IndexPeek {
         let rows = match outcome {
             ScanOutcome::Complete(rows) => rows,
             ScanOutcome::Failed(error) => return PeekStatus::Ready(PeekResponse::Error(error)),
-            // A scan that suspends without a batch has work left and rows it is still allowed to
-            // accumulate, so it is resumed rather than disposed of. Every position it has walked
-            // travels with it, and so does the account of what those positions cost, which is what
-            // makes the promotion cost one hand-off instead of a second walk.
-            ScanOutcome::Suspended if !scan.batch_ready() => return PeekStatus::Promote(scan),
-            // Diversion is sound only for a scan whose error walk is over. The stash answers the
-            // peek from a walk of the ok trace alone and never reads the error trace, so a peek
-            // diverted with its error trace half-read would return rows where it must report an
-            // error. Only the ok walk accumulates rows, so a scan holding a full batch has read
-            // the error trace out, and the guard states that rather than assuming it.
-            ScanOutcome::Suspended => {
-                if !scan.error_trace_clean() {
-                    soft_panic_or_log!(
-                        "peek on {} suspended before its error trace was read out",
-                        self.peek.target.id()
-                    );
-                    return PeekStatus::Ready(PeekResponse::Error(PeekError::unstructured(
-                        "peek suspended before its error trace was read out",
-                    )));
-                }
-                // The batch is taken and dropped rather than left to the scan's own drop, because
-                // discarding it is this driver's decision: the stash walks the ok trace again from
-                // the trace bundle and produces these rows a second time.
-                let _batch = scan.take_batch();
-                return PeekStatus::UsePeekStash;
-            }
+            // A scan suspends because its slice ran out of fuel or because its accumulated rows
+            // grew into a full batch, and this driver can carry on with neither: it walks under a
+            // budget the slice has spent, and it writes no rows, so a batch handed to it here
+            // would have to be dropped. Every position the scan has walked travels with it, and so
+            // does the account of what those positions cost, which is what makes a promotion cost
+            // one hand-off instead of a second walk.
+            ScanOutcome::Suspended => return PeekStatus::Promote(scan),
         };
 
         metrics.walk.observe_ok_phase(&phases);
@@ -2119,11 +2077,12 @@ enum PeekStatus {
     /// The frontiers of objects are not yet advanced enough, peek is still
     /// pending.
     NotReady,
-    /// The result size is above the configured threshold and the peek is
-    /// eligible for using the peek result stash.
-    UsePeekStash,
-    /// The walk stopped with work left and nothing to hand over, so it is finished away from the
-    /// worker. Carries the scan, which resumes from the cursor positions it stopped on.
+    /// The walk stopped with work left, so it is finished away from the worker. Carries the scan,
+    /// which resumes from the cursor positions it stopped on.
+    ///
+    /// A walk stops either because it spent the fuel this activation granted it or because its
+    /// accumulated rows grew into a batch bound for the peek stash. Both leave here, because the
+    /// driver that finishes a walk is also the one that writes to the stash.
     Promote(IndexPeekScan),
     /// The peek result is ready.
     Ready(PeekResponse),
@@ -2355,11 +2314,10 @@ impl CollectionState {
 mod peek_sweep_tests {
     use mz_compute_types::dyncfgs::{
         ENABLE_INDEX_PEEK_OFFLOAD, INDEX_PEEK_ACTIVATION_BUDGET, INDEX_PEEK_INLINE_BUDGET,
-        PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES,
     };
     use mz_dyncfg::ConfigUpdates;
-    use mz_persist_client::Schemas;
     use mz_persist_client::cache::PersistClientCache;
+    use mz_repr::{IntoRowIterator, RowIterator, RowRef};
     use mz_secrets::InMemorySecretsController;
     use mz_storage_types::connections::ConnectionContext;
     use timely::WorkerConfig;
@@ -2391,13 +2349,13 @@ mod peek_sweep_tests {
     /// on is how many peeks got a turn rather than how far each one walked.
     const SMALL_INDEX_KEYS: u64 = 6;
 
-    /// How many rows a walk accumulates before its batch is full, in the tests that drive a
-    /// hand-back.
+    /// How many rows a walk accumulates before its batch is full, in the tests that drive a peek
+    /// to the stash.
     ///
     /// More than the inline slice can accumulate within the production budget and fewer than the
     /// wide index holds, which is what puts the crossing after the promotion rather than before it
     /// or never.
-    const HAND_BACK_AT_ROWS: u64 = 1_500;
+    const DIVERT_AT_ROWS: u64 = 1_500;
 
     /// How many activations a test drives before it declares a peek stuck.
     ///
@@ -2855,8 +2813,50 @@ mod peek_sweep_tests {
         assert_eq!(
             harness.walks(),
             (1, 0),
-            "the kill switch promotes nothing, however far a peek walks"
+            "with nothing bound for the stash, the kill switch promotes nothing however far a \
+             peek walks"
         );
+    }
+
+    /// With the kill switch off, a peek whose accumulated rows belong in the stash still leaves
+    /// the worker, and is answered from the stash exactly as it is with the switch on.
+    ///
+    /// The switch gates promotion for latency, which is the placement it can revert. Promotion for
+    /// stashing is not: the driver that writes to the stash is the promoted one, so a worker that
+    /// kept such a peek would hold a scan that makes no progress until its batch is taken and
+    /// answer the peek never. What the switch guarantees is that an ordinary peek runs where it
+    /// used to, not that no peek ever leaves the worker.
+    #[mz_ore::test(tokio::test)]
+    async fn the_kill_switch_still_takes_a_stash_bound_peek_off_the_worker() {
+        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+        // The threshold is a size rather than a count, because the size of what a scan has
+        // accumulated is what it compares against.
+        let row_size = keys[0].byte_len() + size_of::<NonZeroUsize>();
+        let threshold = usize::cast_from(DIVERT_AT_ROWS) * row_size;
+
+        // The offload is left where production ships it, and only the stash is turned on.
+        let mut harness = Harness::new(move |updates| {
+            updates.add(&ENABLE_PEEK_RESPONSE_STASH, true);
+            updates.add(&PEEK_RESPONSE_STASH_THRESHOLD_BYTES, threshold);
+        });
+        harness.state.peek_stash_persist_location = Some(PersistLocation::new_in_mem());
+        harness.add_pending(
+            index_peek_with_uuid(PEEK_A, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+
+        harness.sweep();
+        assert_eq!(
+            harness.pending(PEEK_A),
+            Some("offloaded"),
+            "an unbounded slice walks until its rows belong in the stash, and then leaves"
+        );
+
+        let mut responses = harness.drain().await;
+        assert_eq!(responses.len(), 1, "the stashed peek answers once");
+        let (uuid, response) = responses.pop().expect("length checked");
+        assert_eq!(uuid, PEEK_A);
+        assert_eq!(stashed_rows(&harness, response).await, keys);
     }
 
     /// One activation serves what the per-activation aggregate allows and passes the rest over,
@@ -3236,19 +3236,22 @@ mod peek_sweep_tests {
     /// A harness whose peek of the whole wide index is promoted and whose promoted walk then
     /// crosses the stash threshold, swept once so that the peek is already promoted.
     ///
-    /// `location` is the replica's peek stash location, which has to be present here whatever the
-    /// hand-back is meant to find: a replica without one makes no scan stash-eligible, so its
-    /// walks never fill a batch and never hand back at all.
-    fn promoted_walk_that_hands_back(keys: &[Row], location: PersistLocation) -> Harness {
+    /// `location` is the replica's peek stash location, which has to be present: a replica without
+    /// one makes no scan stash-eligible, so its walks never fill a batch and never reach the stash
+    /// at all.
+    fn promoted_walk_that_crosses_the_threshold(
+        keys: &[Row],
+        location: PersistLocation,
+    ) -> Harness {
         assert!(
-            u64::cast_from(*INDEX_PEEK_INLINE_BUDGET.default()) < HAND_BACK_AT_ROWS
-                && HAND_BACK_AT_ROWS < WIDE_INDEX_KEYS,
+            u64::cast_from(*INDEX_PEEK_INLINE_BUDGET.default()) < DIVERT_AT_ROWS
+                && DIVERT_AT_ROWS < WIDE_INDEX_KEYS,
             "the walk must cross the stash threshold after it is promoted and before it ends"
         );
         // The threshold is a size rather than a count, because the size of what a scan has
         // accumulated is what it compares against.
         let row_size = keys[0].byte_len() + size_of::<NonZeroUsize>();
-        let threshold = usize::cast_from(HAND_BACK_AT_ROWS) * row_size;
+        let threshold = usize::cast_from(DIVERT_AT_ROWS) * row_size;
 
         let mut harness = Harness::new(move |updates| {
             updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
@@ -3270,161 +3273,67 @@ mod peek_sweep_tests {
         harness
     }
 
-    /// Runs activations until the promoted walk of `PEEK_A` has handed back.
+    /// The rows a stashed peek response holds, read back the way the coordinator reads one, in
+    /// [`Row`] order.
     ///
-    /// Bounded, so a walk that never hands back fails here rather than hanging the suite. The
-    /// yield between activations is what lets the promoted task run.
-    async fn sweep_until_handed_back(harness: &mut Harness) {
-        for _ in 0..SWEEP_BOUND {
-            if harness.pending(PEEK_A) != Some("offloaded") {
-                return;
-            }
-            tokio::task::yield_now().await;
-            harness.sweep();
-        }
-        panic!("the promoted walk had not handed back after {SWEEP_BOUND} activations");
-    }
-
-    /// The rows a stashed peek response holds, read back out of `location` the way the coordinator
-    /// reads one, in [`Row`] order.
-    ///
-    /// A stashed response names a persist batch rather than carrying the answer, so what the peek
-    /// owes its caller is only visible from the batch. The batch is ordered as persist consolidates
-    /// it rather than as the peek would have answered, and the coordinator orders what it reads
-    /// back, so the rows are sorted here and compared as the set they are.
-    async fn stashed_rows(
-        harness: &Harness,
-        location: &PersistLocation,
-        response: PeekResponse,
-    ) -> Vec<Row> {
+    /// A stashed response names a persist batch rather than carrying the whole answer, so what the
+    /// peek owes its caller is the batch plus the rows the response carries inline, and both halves
+    /// are here. The batch is ordered as persist consolidates it rather than as the peek would have
+    /// answered, and the coordinator orders what it reads back, so the rows are sorted here and
+    /// compared as the set they are.
+    async fn stashed_rows(harness: &Harness, response: PeekResponse) -> Vec<Row> {
         let PeekResponse::Stashed(stashed) = response else {
             panic!("a peek taken to the stash answers with a stashed response, not {response:?}");
         };
 
-        // Opened out of the harness's own cache, because two `PersistLocation`s naming the same
-        // in-memory URI reach the same blob only through the cache that opened them.
-        let mut client = harness
-            .state
-            .persist_clients
-            .open(location.clone())
-            .await
-            .expect("the in-memory location opens");
-
-        let shard_id = stashed.shard_id;
-        let batches = stashed
-            .batches
-            .into_iter()
-            .map(|batch| client.batch_from_transmittable_batch(&shard_id, batch))
+        let mut rows: Vec<Row> = stashed
+            .inline_rows
+            .iter()
+            .flat_map(|rows| rows.clone().into_row_iter().map(RowRef::to_owned))
             .collect();
-        let read_schemas: Schemas<SourceData, ()> = Schemas {
-            id: None,
-            key: Arc::new(stashed.relation_desc),
-            val: Arc::new(UnitSchema),
-        };
-        let mut cursor = client
-            .read_batches_consolidated::<_, _, _, i64>(
-                shard_id,
-                Antichain::from_elem(Timestamp::default()),
-                read_schemas,
-                batches,
-                |_stats| true,
-                *PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES.default(),
-            )
-            .await
-            .expect("the batches are readable at the timestamp they were written at");
-
-        let mut rows = Vec::new();
-        while let Some(updates) = cursor.next().await {
-            for ((key, _val), _time, diff) in updates {
-                assert_eq!(diff, 1, "the index holds each key once");
-                rows.push(key.0.expect("the peek stash holds no errors"));
-            }
-        }
+        rows.extend(
+            peek_stash::tests::stashed_rows(&harness.state.persist_clients, *stashed).await,
+        );
         rows.sort();
-
-        // Deleted as the coordinator deletes them once it has read them. A batch dropped without
-        // this leaves its blob keys behind and says so in a warning.
-        for batch in cursor.into_lease() {
-            batch.delete().await;
-        }
         rows
     }
 
-    /// A promoted walk that hands back with a stash location present takes the peek to the stash,
-    /// which answers it with the rows the peek would have answered with inline.
+    /// A promoted walk whose accumulated rows cross the stash threshold writes them to the stash
+    /// and answers the peek with the handle, without a second walk of the trace and without the
+    /// peek ever leaving the driver that promoted it.
     ///
-    /// This is the arm every hand-back in production takes, because a replica's stash location is
-    /// set once at instance creation and nothing clears it. The peek has to become pending on the
-    /// stash rather than be answered where the hand-back arrives: the rows are produced by a
-    /// second walk that the worker pumps over the activations that follow, and answering here
-    /// would drop them.
+    /// The rows the walk was still holding when the trace ran out ride along with the handle, so
+    /// the answer is both halves together and neither half alone.
     #[mz_ore::test(tokio::test)]
-    async fn a_promoted_hand_back_takes_the_peek_to_the_stash() {
+    async fn a_promoted_walk_that_crosses_the_threshold_answers_from_the_stash() {
         // The wide keys carry the `UInt64` the peek's result description declares, which is the
         // schema the stash writes its batch under. The narrow fixture rows do not.
         let keys = wide_ok_rows(WIDE_INDEX_KEYS);
         let location = PersistLocation::new_in_mem();
-        let mut harness = promoted_walk_that_hands_back(&keys, location.clone());
-
-        sweep_until_handed_back(&mut harness).await;
-
-        assert_eq!(
-            harness.pending(PEEK_A),
-            Some("stash"),
-            "the hand-back starts a stash upload and leaves the peek waiting on it"
-        );
-        assert_eq!(
-            harness.peek_responses(),
-            vec![],
-            "a peek handed to the stash is not answered where the hand-back arrives"
-        );
-        assert_eq!(
-            harness.walks(),
-            (0, 1),
-            "a hand-back is a terminal outcome of the promoted walk"
-        );
+        let mut harness = promoted_walk_that_crosses_the_threshold(&keys, location);
 
         let mut responses = harness.drain().await;
         assert_eq!(responses.len(), 1, "the stashed peek answers once");
         let (uuid, response) = responses.pop().expect("length checked");
         assert_eq!(uuid, PEEK_A);
+
+        let PeekResponse::Stashed(stashed) = &response else {
+            panic!("a peek taken to the stash answers with a handle, not {response:?}");
+        };
         assert_eq!(
-            stashed_rows(&harness, &location, response).await,
-            keys,
-            "the stash holds the rows the peek would have answered with inline"
+            stashed.num_rows_batches,
+            DIVERT_AT_ROWS + 1,
+            "the walk wrote every row it had accumulated when it crossed the threshold"
         );
-    }
-
-    /// A promoted walk that hands back with nowhere to write the rows answers the peek with an
-    /// error rather than leaving it pending on a walk that has stopped.
-    ///
-    /// This arm is defensive only. Reaching it takes a replica that loses its stash location
-    /// between the promotion and the hand-back, which nothing does, and the location is cleared
-    /// here to stand in for that: `handle_create_instance` sets it and nothing clears it, while a
-    /// replica that never had one makes no scan stash-eligible, so none of its walks fills a batch
-    /// and hands back in the first place. The arm production takes is
-    /// [`a_promoted_hand_back_takes_the_peek_to_the_stash`]'s.
-    #[mz_ore::test(tokio::test)]
-    async fn a_promoted_hand_back_answers_when_there_is_nowhere_to_write() {
-        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
-        let mut harness = promoted_walk_that_hands_back(&keys, PersistLocation::new_in_mem());
-
-        harness.state.peek_stash_persist_location = None;
-
         assert_eq!(
-            harness.drain().await,
-            vec![(
-                PEEK_A,
-                PeekResponse::Error(PeekError::unstructured(
-                    "peek result is too large to answer inline and this replica has no peek stash \
-                     location"
-                ))
-            )]
+            stashed_rows(&harness, response).await,
+            keys,
+            "the stash and the rows beside it are the answer the peek would have given inline"
         );
         assert_eq!(
             harness.walks(),
             (0, 1),
-            "a hand-back is a terminal outcome of the promoted walk"
+            "one promoted walk produced the whole answer"
         );
     }
 }
@@ -3687,7 +3596,6 @@ pub(crate) mod index_peek_tests {
     #[derive(Debug, PartialEq)]
     enum Answer {
         NotReady,
-        UsePeekStash,
         Promote,
         Ready(PeekResponse),
     }
@@ -3696,7 +3604,6 @@ pub(crate) mod index_peek_tests {
         fn from(status: PeekStatus) -> Self {
             match status {
                 PeekStatus::NotReady => Answer::NotReady,
-                PeekStatus::UsePeekStash => Answer::UsePeekStash,
                 // The scan a promotion carries has no comparison of its own. What is comparable
                 // is that the walk left this driver rather than answering here.
                 PeekStatus::Promote(_) => Answer::Promote,
@@ -3784,11 +3691,14 @@ pub(crate) mod index_peek_tests {
         assert_eq!(metrics.observations(), expected_observations(1, 0, 0, 0));
     }
 
-    /// A peek whose accumulated rows fill a batch is diverted to the stash rather than answered
-    /// inline. The phases the walk did pass through are reported, and those only a peek answered
-    /// inline reaches are not.
+    /// A peek whose accumulated rows fill a batch leaves the worker, however much fuel the slice
+    /// still had, and the walk it leaves with reports nothing.
+    ///
+    /// A batch-ready suspension is a promotion because the driver that finishes a walk is also the
+    /// one that writes to the peek stash. Withholding it here would strand the peek: the scan
+    /// makes no progress until its batch is taken, and this driver never takes one.
     #[mz_ore::test]
-    fn a_scan_that_fills_a_batch_diverts_the_peek_to_the_stash() {
+    fn a_scan_that_fills_a_batch_leaves_the_worker_with_fuel_to_spare() {
         let keys: Vec<Row> = (0..6).map(ok_row).collect();
         let mut subject = index_peek_over(
             index_peek(trivial_finishing(), None),
@@ -3798,29 +3708,26 @@ pub(crate) mod index_peek_tests {
         let metrics = TestMetrics::new();
 
         // A threshold of zero bytes is crossed by the first row, so the scan fills a batch well
-        // before the trace runs out.
+        // before the trace runs out and well before unbounded fuel could run out.
+        let mut fuel = unbounded_fuel();
         let answer = subject.collect_finished_data(
             u64::MAX,
             true,
             0,
             None,
-            &mut unbounded_fuel(),
+            &mut fuel,
             &metrics.as_metrics(),
         );
 
-        assert_eq!(Answer::from(answer), Answer::UsePeekStash);
-        assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 0));
+        assert_eq!(Answer::from(answer), Answer::Promote);
+        assert!(fuel > 0, "the slice stopped for the batch, not for fuel");
+        assert_eq!(metrics.observations(), expected_observations(0, 0, 0, 0));
     }
 
-    /// A peek whose walk both fills a batch and runs out of fuel is diverted to the stash rather
-    /// than promoted, and the driver that diverted it accounts for the walk.
-    ///
-    /// This is the livelock the placement policy is built around. A promoted scan holding a full
-    /// batch has nowhere to write it, so stepping it spends no fuel and advances no cursor, and a
-    /// driver that resumed it would yield forever. The two causes of a suspension coincide here,
-    /// which is the case a promotion condition written as "the fuel ran out" would get wrong.
+    /// A peek whose walk both fills a batch and runs out of fuel leaves the worker exactly as one
+    /// that did only the first, so the two causes of a suspension need no telling apart.
     #[mz_ore::test]
-    fn a_batch_ready_suspension_is_diverted_rather_than_promoted() {
+    fn a_batch_ready_suspension_out_of_fuel_is_promoted_too() {
         let keys: Vec<Row> = (0..6).map(ok_row).collect();
         let mut subject = index_peek_over(
             index_peek(trivial_finishing(), None),
@@ -3842,9 +3749,9 @@ pub(crate) mod index_peek_tests {
             &mut fuel,
             &metrics.as_metrics(),
         );
-        assert_eq!(Answer::from(answer), Answer::UsePeekStash);
+        assert_eq!(Answer::from(answer), Answer::Promote);
         assert_eq!(fuel, 0, "the slice spent every position it was given");
-        assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 0));
+        assert_eq!(metrics.observations(), expected_observations(0, 0, 0, 0));
     }
 
     /// A peek whose walk outruns the fuel it was granted leaves the worker rather than being

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -3467,6 +3467,7 @@ pub(crate) mod index_peek_tests {
             BTreeMap::from([
                 ("walks_inline", metrics.index_peek_walks_inline.get()),
                 ("walks_offloaded", metrics.index_peek_walks_offloaded.get()),
+                ("walks_stashed", metrics.index_peek_stashed_total.get()),
                 (
                     "error_scan_seconds",
                     metrics.index_peek_error_scan_seconds.get_sample_count(),
@@ -3519,6 +3520,7 @@ pub(crate) mod index_peek_tests {
         BTreeMap::from([
             ("walks_inline", walks_inline),
             ("walks_offloaded", 0),
+            ("walks_stashed", 0),
             ("error_scan_seconds", error_scan),
             ("cursor_setup_seconds", cursor_setup),
             ("row_iteration_seconds", rows),
@@ -3695,7 +3697,7 @@ pub(crate) mod index_peek_tests {
     }
 
     /// A peek whose walk outruns the fuel it was granted leaves the worker rather than being
-    /// answered or diverted, and the walk it leaves with reports nothing.
+    /// answered, and the walk it leaves with reports nothing.
     ///
     /// Reporting here as well as in the driver that finishes the walk would count one walk twice,
     /// on both substrates and in every phase histogram, and the numbers a scan carries are

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -2440,6 +2440,26 @@ mod peek_sweep_tests {
             )
         }
 
+        /// The walks the peek stash answered.
+        ///
+        /// A stashed answer and an inline answer carry the same rows, so this is what turns "the
+        /// stash path engaged" from an inference about the configuration into an assertion.
+        fn walks_stashed(&self) -> u64 {
+            self.state.metrics.index_peek_stashed_total.get()
+        }
+
+        /// The cursor positions the ok walks that ended here reported, and how many walks reported
+        /// them.
+        ///
+        /// A walk reports its positions once, wherever it ended, and the count is cumulative over
+        /// every slice it was cut into. A peek answered by two walks of the same trace would
+        /// report twice, or once at twice the positions, and would answer with the same rows
+        /// either way.
+        fn ok_walk_positions(&self) -> (u64, f64) {
+            let rows = &self.state.metrics.index_peek_row_iteration_rows;
+            (rows.get_sample_count(), rows.get_sample_sum())
+        }
+
         /// How long the worker would park before its next activation, as `step_or_park` reads it.
         ///
         /// `None` is an indefinite park, which is what a worker with no dataflow and no pending
@@ -2797,6 +2817,16 @@ mod peek_sweep_tests {
         let (uuid, response) = responses.pop().expect("length checked");
         assert_eq!(uuid, PEEK_A);
         assert_eq!(stashed_rows(&harness, response).await, keys);
+        assert_eq!(
+            harness.walks(),
+            (0, 1),
+            "the promoted driver is the one that writes to the stash, so it ended the walk"
+        );
+        assert_eq!(
+            harness.walks_stashed(),
+            1,
+            "the kill switch does not take the stash away from a peek that needs it"
+        );
     }
 
     /// One activation serves what the per-activation aggregate allows and passes the rest over,
@@ -3266,6 +3296,11 @@ mod peek_sweep_tests {
             "the walk wrote every row it had accumulated when it crossed the threshold"
         );
         assert_eq!(
+            inline_rows(stashed),
+            usize::cast_from(WIDE_INDEX_KEYS - (DIVERT_AT_ROWS + 1)),
+            "the rows the walk still held when the trace ran out ride along with the handle"
+        );
+        assert_eq!(
             stashed_rows(&harness, response).await,
             keys,
             "the stash and the rows beside it are the answer the peek would have given inline"
@@ -3274,6 +3309,66 @@ mod peek_sweep_tests {
             harness.walks(),
             (0, 1),
             "one promoted walk produced the whole answer"
+        );
+        assert_eq!(harness.walks_stashed(), 1, "the stash answered the peek");
+        // The answer alone says nothing here: a walk that gave up at the threshold and started
+        // over would produce these very rows. What says the trace was walked once is the count of
+        // cursor positions the walk that ended reported.
+        assert_eq!(
+            harness.ok_walk_positions(),
+            (1, f64::cast_lossy(keys.len())),
+            "one walk evaluated each cursor position of the index once"
+        );
+    }
+
+    /// The rows a stashed response carries beside its batches.
+    fn inline_rows(stashed: &mz_compute_client::protocol::response::StashedPeekResponse) -> usize {
+        stashed
+            .inline_rows
+            .iter()
+            .map(|rows| rows.clone().into_row_iter().count())
+            .sum()
+    }
+
+    /// Cancelling a promoted peek whose walk is feeding the stash answers it once, as cancelled,
+    /// and the walk's own outcome never reaches the caller behind it.
+    ///
+    /// A walk bound for the stash answers with a handle rather than with rows, and the handle is
+    /// built after the cancellation has already removed the peek. A worker that let that outcome
+    /// through would answer the same peek twice, the second time with a handle to a batch its
+    /// cancellation has scheduled for deletion.
+    #[mz_ore::test(tokio::test)]
+    async fn a_cancelled_stash_bound_peek_is_answered_once() {
+        let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+        let mut harness =
+            promoted_walk_that_crosses_the_threshold(&keys, PersistLocation::new_in_mem());
+
+        harness.active().handle_cancel_peek(PEEK_A);
+
+        assert_eq!(
+            harness.peek_responses(),
+            vec![(PEEK_A, PeekResponse::Canceled)]
+        );
+        assert_eq!(harness.pending(PEEK_A), None);
+
+        for _ in 0..SWEEP_BOUND {
+            tokio::task::yield_now().await;
+            harness.sweep();
+        }
+        assert_eq!(
+            harness.peek_responses(),
+            vec![],
+            "a cancelled peek is answered once and never again"
+        );
+        assert_eq!(
+            harness.walks_stashed(),
+            0,
+            "a cancelled walk answers from no stash"
+        );
+        assert_eq!(
+            harness.walks(),
+            (0, 0),
+            "a cancelled walk reaches no outcome and counts on neither substrate"
         );
     }
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -3330,13 +3330,13 @@ mod peek_sweep_tests {
             .sum()
     }
 
-    /// Cancelling a promoted peek whose walk is feeding the stash answers it once, as cancelled,
-    /// and the walk's own outcome never reaches the caller behind it.
+    /// Cancelling a promoted peek bound for the stash answers it once, as cancelled, and the walk
+    /// behind it produces no second answer.
     ///
-    /// A walk bound for the stash answers with a handle rather than with rows, and the handle is
-    /// built after the cancellation has already removed the peek. A worker that let that outcome
-    /// through would answer the same peek twice, the second time with a handle to a batch its
-    /// cancellation has scheduled for deletion.
+    /// Cancellation both removes the pending peek and aborts the walk, and it is the removal that
+    /// has to be paired with the abort: a cancellation that answered without stopping the walk
+    /// would answer the same peek again, the second time with a handle to a batch nothing will
+    /// read.
     #[mz_ore::test(tokio::test)]
     async fn a_cancelled_stash_bound_peek_is_answered_once() {
         let keys = wide_ok_rows(WIDE_INDEX_KEYS);

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -29,8 +29,7 @@ use mz_compute_client::protocol::response::{
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::{
     ENABLE_PEEK_RESPONSE_STASH, ENABLE_PEEK_ROW_ITERATION_LIMIT,
-    PEEK_RESPONSE_STASH_BATCH_MAX_RUNS, PEEK_RESPONSE_STASH_THRESHOLD_BYTES,
-    PEEK_ROW_ITERATION_LIMIT, PEEK_STASH_BATCH_SIZE, PEEK_STASH_NUM_BATCHES,
+    PEEK_RESPONSE_STASH_THRESHOLD_BYTES, PEEK_ROW_ITERATION_LIMIT,
 };
 use mz_compute_types::plan::render_plan::RenderPlan;
 use mz_dyncfg::{ConfigSet, ConfigValHandle};
@@ -1372,23 +1371,6 @@ impl<'a> ActiveComputeState<'a> {
                     )))
                 }
             },
-            PendingPeek::Stash(stashing_peek) => {
-                let num_batches = PEEK_STASH_NUM_BATCHES.get(&self.compute_state.worker_config);
-                let batch_size = PEEK_STASH_BATCH_SIZE.get(&self.compute_state.worker_config);
-                stashing_peek.pump_rows(num_batches, batch_size);
-
-                if let Ok((response, duration)) = stashing_peek.result.try_recv() {
-                    self.compute_state
-                        .metrics
-                        .stashed_peek_seconds
-                        .observe(duration.as_secs_f64());
-                    trace!(?stashing_peek.peek, ?duration, "finished stashing peek response in persist");
-
-                    Some(response)
-                } else {
-                    None
-                }
-            }
         };
 
         if let Some(response) = response {
@@ -1398,39 +1380,6 @@ impl<'a> ActiveComputeState<'a> {
             let uuid = peek.peek().uuid;
             self.compute_state.pending_peeks.insert(uuid, peek);
         }
-    }
-
-    /// Starts a peek stash upload for `peek`, which walks the ok trace of `trace_bundle` and
-    /// writes the rows it produces to persist.
-    ///
-    /// The walk starts over: the stash reads the trace bundle itself, so rows a previous walk of
-    /// the same peek accumulated are produced again rather than carried across.
-    ///
-    /// Returns `None` when this replica has no stash location, which a caller must establish
-    /// before it decides to divert a peek here.
-    // A peek whose answer belongs in the stash is written there by the walk that produces it, so
-    // no caller reaches this.
-    #[allow(dead_code)]
-    fn start_stash_upload(
-        &self,
-        peek: Peek,
-        trace_bundle: TraceBundle,
-    ) -> Option<peek_stash::StashingPeek> {
-        let persist_location = self.compute_state.peek_stash_persist_location.clone()?;
-
-        // NOTE: The row iteration limit does not follow a peek into the stash. The stash restarts
-        // the scan and produces in bounded bursts, so a stashed peek may examine any number of
-        // rows.
-        let batch_max_runs =
-            PEEK_RESPONSE_STASH_BATCH_MAX_RUNS.get(&self.compute_state.worker_config);
-
-        Some(peek_stash::StashingPeek::start_upload(
-            Arc::clone(&self.compute_state.persist_clients),
-            &persist_location,
-            peek,
-            trace_bundle,
-            batch_max_runs,
-        ))
     }
 
     /// Scan pending peeks and attempt to retire each.
@@ -1642,12 +1591,6 @@ pub enum PendingPeek {
     Index(IndexPeek),
     /// A peek against a Persist-backed collection.
     Persist(PersistPeek),
-    /// A peek against an index that is being stashed in the peek stash by an
-    /// async background task.
-    // A peek whose answer belongs in the stash is written there by the walk that produces it, so
-    // nothing puts a peek into this state.
-    #[allow(dead_code)]
-    Stash(peek_stash::StashingPeek),
     /// A peek against an index whose walk was promoted off the worker and is running as an async
     /// task.
     Offloaded(OffloadedPeek),
@@ -1773,7 +1716,6 @@ impl PendingPeek {
         match self {
             PendingPeek::Index(p) => &p.span,
             PendingPeek::Persist(p) => &p.span,
-            PendingPeek::Stash(p) => &p.span,
             PendingPeek::Offloaded(p) => &p.span,
         }
     }
@@ -1782,7 +1724,6 @@ impl PendingPeek {
         match self {
             PendingPeek::Index(p) => &p.peek,
             PendingPeek::Persist(p) => &p.peek,
-            PendingPeek::Stash(p) => &p.peek,
             PendingPeek::Offloaded(p) => &p.peek,
         }
     }
@@ -2468,7 +2409,6 @@ mod peek_sweep_tests {
             self.state.pending_peeks.get(&uuid).map(|peek| match peek {
                 PendingPeek::Index(_) => "index",
                 PendingPeek::Persist(_) => "persist",
-                PendingPeek::Stash(_) => "stash",
                 PendingPeek::Offloaded(_) => "offloaded",
             })
         }

--- a/src/compute/src/compute_state/peek_budget.rs
+++ b/src/compute/src/compute_state/peek_budget.rs
@@ -40,11 +40,11 @@ impl InlineBudgetConfig {
 
         ActivationBudget::Bounded {
             // A per-peek budget of zero would suspend every scan before it walked a position, and
-            // a suspension that holds no full batch is a promotion, so every point lookup would
-            // cost a task, a permit, and a trace bundle clone while walking nothing. The aggregate
-            // is untouched by such a peek, so this is a waste rather than a wedge, but it is also
-            // exactly what granting a peek an empty slice is documented to avoid. One position
-            // keeps the parameter monotone down to its floor.
+            // every suspension is a promotion, so every point lookup would cost a task and a
+            // permit while walking nothing. The aggregate is untouched by such a peek, so this is
+            // a waste rather than a wedge, but it is also exactly what granting a peek an empty
+            // slice is documented to avoid. One position keeps the parameter monotone down to its
+            // floor.
             per_peek: self.per_peek.get().max(1),
             // An aggregate of zero would pass every peek over on every activation, and the
             // activation a passed-over peek asks for would arrive to find the same empty budget,

--- a/src/compute/src/compute_state/peek_budget.rs
+++ b/src/compute/src/compute_state/peek_budget.rs
@@ -70,13 +70,17 @@ impl InlineBudgetConfig {
 /// scan charges: a selective filter steps the cursor without returning anything, so a row-counted
 /// budget is one such a peek never spends.
 enum ActivationBudget {
-    /// Every peek walks to completion where it started, and nothing is promoted or passed over.
+    /// Every peek walks on the worker until it answers or until its rows belong in the peek stash,
+    /// and nothing is passed over.
     ///
-    /// This is what the kill switch restores, and it has to be what the worker did before the
-    /// offload existed rather than an approximation of it. Unbounded fuel is also what makes
-    /// promotion unreachable: the scan suspends only when its fuel runs out or when it holds a
-    /// full batch, and the first cannot happen here, so the only suspension left is the one that
-    /// goes to the peek stash exactly as it did before.
+    /// This is what the kill switch restores, and it is what the worker does for a peek that
+    /// answers inline. Unbounded fuel makes promotion for latency unreachable, because a scan
+    /// suspends only when its fuel runs out or when it holds a batch bound for the stash, and the
+    /// first cannot happen here.
+    ///
+    /// The second still can, and such a peek is still promoted, because the driver that writes to
+    /// the stash is the promoted one. So what this restores is where an ordinary peek runs, not a
+    /// guarantee that no peek leaves the worker.
     Unbounded,
     /// A peek may spend `per_peek` before it is promoted, and all peeks together may spend
     /// `remaining` before the rest of this activation's work gets the worker back.
@@ -220,8 +224,9 @@ mod tests {
     }
 
     /// With the offload off, every peek is granted unbounded fuel however much the peeks before it
-    /// spent, which is what makes the kill switch restore the worker's old behaviour rather than
-    /// approximate it.
+    /// spent, which is how the kill switch keeps a peek that answers inline on the worker. It says
+    /// nothing about a peek whose rows belong in the stash, which suspends on its batch rather
+    /// than on its fuel and leaves the worker either way.
     #[mz_ore::test]
     fn the_kill_switch_grants_every_peek_an_unbounded_slice() {
         let config = mz_dyncfgs::all_dyncfgs();

--- a/src/compute/src/compute_state/peek_metrics.rs
+++ b/src/compute/src/compute_state/peek_metrics.rs
@@ -99,9 +99,11 @@ impl PeekWalkMetrics {
 
     /// Counts a walk that a promoted task drove to an outcome, whatever that outcome is.
     ///
-    /// A walk cancelled while queued for a permit or while running counts on neither substrate,
-    /// which is what makes the two substrates sum to the walks that ended. How many walks were
-    /// admitted is a different question, and one the permit queue's own metrics answer.
+    /// A walk cancelled while queued for a permit or while running counts on neither substrate, as
+    /// does one whose task died without an outcome, which the worker answers with an error of its
+    /// own. The two substrates therefore sum to the walks that reached an outcome rather than to
+    /// the peeks that were answered. How many walks were admitted is a different question, and one
+    /// the permit queue's own metrics answer.
     pub(super) fn walked_offloaded(&self) {
         self.walks_offloaded.inc();
     }

--- a/src/compute/src/compute_state/peek_metrics.rs
+++ b/src/compute/src/compute_state/peek_metrics.rs
@@ -39,6 +39,8 @@ pub(super) struct PeekWalkMetrics {
     walks_inline: IntCounter,
     /// Counts walks that ended away from the timely worker.
     walks_offloaded: IntCounter,
+    /// Counts walks that answered from the peek response stash.
+    walks_stashed: IntCounter,
     error_scan_seconds: Histogram,
     cursor_setup_seconds: Histogram,
     row_iteration_seconds: Histogram,
@@ -58,6 +60,7 @@ impl PeekWalkMetrics {
         Self {
             walks_inline: metrics.index_peek_walks_inline.clone(),
             walks_offloaded: metrics.index_peek_walks_offloaded.clone(),
+            walks_stashed: metrics.index_peek_stashed_total.clone(),
             error_scan_seconds: metrics.index_peek_error_scan_seconds.clone(),
             cursor_setup_seconds: metrics.index_peek_cursor_setup_seconds.clone(),
             row_iteration_seconds: metrics.index_peek_row_iteration_seconds.clone(),
@@ -87,8 +90,9 @@ impl PeekWalkMetrics {
 
     /// Counts a walk that the timely worker drove to an outcome.
     ///
-    /// A peek that reaches the peek stash counts here, because the walk that decided that ran on
-    /// the worker. The stash's own walk of the same trace counts on neither substrate.
+    /// A walk that suspends leaves the worker instead of finishing here, so a peek whose answer
+    /// goes to the peek stash never counts here: the driver that writes to the stash is the
+    /// promoted one.
     pub(super) fn walked_inline(&self) {
         self.walks_inline.inc();
     }
@@ -100,6 +104,15 @@ impl PeekWalkMetrics {
     /// admitted is a different question, and one the permit queue's own metrics answer.
     pub(super) fn walked_offloaded(&self) {
         self.walks_offloaded.inc();
+    }
+
+    /// Counts a walk that answered with a handle to the peek response stash.
+    ///
+    /// Counted alongside [`Self::walked_offloaded`] rather than instead of it, so the two
+    /// substrates still sum to the walks that ended while this reports how many of them the stash
+    /// answered.
+    pub(super) fn walked_to_stash(&self) {
+        self.walks_stashed.inc();
     }
 
     /// Reports the phases that precede the walk over the ok trace.

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -389,9 +389,11 @@ async fn stashed_answer(
 mod tests {
     use std::num::NonZeroUsize;
 
+    use mz_compute_types::dyncfgs::{ENABLE_PEEK_ROW_ITERATION_LIMIT, PEEK_ROW_ITERATION_LIMIT};
     use mz_dyncfg::ConfigUpdates;
     use mz_expr::RowSetFinishing;
     use mz_expr::row::RowCollection;
+    use mz_ore::cast::CastLossy;
     use mz_ore::metrics::MetricsRegistry;
     use mz_ore::num::NonNeg;
     use mz_persist_client::cache::PersistClientCache;
@@ -407,7 +409,7 @@ mod tests {
         wide_ok_rows,
     };
     use crate::compute_state::peek_scan::PeekScan;
-    use crate::compute_state::peek_stash::tests::stashed_rows;
+    use crate::compute_state::peek_stash::tests::{CountedBlob, stashed_rows};
     use crate::metrics::{ComputeMetrics, WorkerMetrics};
     use crate::server::ComputeRuntimeRole;
 
@@ -496,12 +498,36 @@ mod tests {
     /// The configuration a promoted walk reads, with the yield granularity set to
     /// `yield_granularity` so a test can choose how many slices a walk is cut into.
     fn offload_config(yield_granularity: usize) -> OffloadConfig {
+        offload_config_with(yield_granularity, |_updates| ())
+    }
+
+    /// The same, with `configure` applied on top, as `UpdateConfiguration` applies a change.
+    fn offload_config_with(
+        yield_granularity: usize,
+        configure: impl FnOnce(&mut ConfigUpdates),
+    ) -> OffloadConfig {
         let config = mz_dyncfgs::all_dyncfgs();
         let mut updates = ConfigUpdates::default();
         updates.add(&INDEX_PEEK_YIELD_GRANULARITY, yield_granularity);
+        configure(&mut updates);
         updates.apply(&config);
         OffloadConfig::new(&config)
     }
+
+    /// The configuration a walk whose blob traffic a test counts reads.
+    ///
+    /// A builder over the run limit merges its runs, which writes parts of its own and leaves the
+    /// parts it merged from behind, so a test counting what a walk wrote raises the limit past the
+    /// runs the walk produces.
+    fn counted_blob_config(yield_granularity: usize) -> OffloadConfig {
+        offload_config_with(yield_granularity, |updates| {
+            updates.add(&PEEK_RESPONSE_STASH_BATCH_MAX_RUNS, NO_RUN_MERGING);
+        })
+    }
+
+    /// A run limit above the parts any walk here writes, which is at most one per key of the
+    /// longest trace these tests hold.
+    const NO_RUN_MERGING: usize = 8_000;
 
     /// A timely worker whose activator a promoted walk wakes when its outcome is ready.
     ///
@@ -664,6 +690,10 @@ mod tests {
     /// through a batch of their own, and the two halves together are every row the peek owes. The
     /// count of stashed rows is asserted as well, because a driver that wrote the tail to both
     /// halves would still answer with the right set.
+    ///
+    /// What says the trace was walked once is the count of cursor positions the walk reported, not
+    /// the rows it answered with: a second walk of the same trace produces the same rows, so an
+    /// answer-only test passes against the very regression it is meant to catch.
     #[mz_ore::test(tokio::test)]
     async fn a_promoted_walk_writes_full_batches_to_the_stash_and_walks_on() {
         let keys = wide_ok_rows(8);
@@ -706,6 +736,21 @@ mod tests {
             metrics.index_peek_walks_offloaded.get(),
             1,
             "one walk produced the whole answer"
+        );
+        assert_eq!(
+            metrics.index_peek_stashed_total.get(),
+            1,
+            "the walk answered from the stash"
+        );
+        assert_eq!(
+            metrics.index_peek_row_iteration_rows.get_sample_count(),
+            1,
+            "one walk reports one ok phase, whatever it was cut into"
+        );
+        assert_eq!(
+            metrics.index_peek_row_iteration_rows.get_sample_sum(),
+            f64::cast_lossy(keys.len()),
+            "the walk evaluated each cursor position of the trace once"
         );
     }
 
@@ -991,6 +1036,192 @@ mod tests {
             metrics.index_peek_permit_queue_depth.get(),
             0,
             "an admitted walk leaves the queue"
+        );
+    }
+
+    /// A walk that is aborted after its upload has written parts leaves nothing in blob storage.
+    ///
+    /// This is the whole of the cleanup a cancellation gets. Cancelling a peek removes the pending
+    /// entry, which drops the handle to this task and aborts it, and an aborted task is dropped
+    /// rather than polled again, so nothing the walk would have called runs. What deletes the parts
+    /// is `Drop for StashUpload` spawning the deletion onto the runtime the upload captured when it
+    /// opened, and this is the one test that drives an abort into that drop into that spawn.
+    #[mz_ore::test(tokio::test)]
+    async fn an_aborted_walk_deletes_the_parts_its_upload_wrote() {
+        let keys = wide_ok_rows(LONG_WALK_KEYS);
+        let peek = index_peek(trivial_finishing(), None);
+        let mut bundle = trace_bundle(&keys, cancelling_errors(0));
+        // Crossed by the third row, so the walk opens an upload a few positions in and keeps
+        // feeding it for the rest of a trace it cannot reach the end of before it is aborted.
+        let scan = open(&mut bundle, &peek, Some(2 * wide_row_size()));
+
+        let metrics = worker_metrics();
+        let worker = worker();
+        let permits = PeekPermits::new(1);
+        let blob = CountedBlob::new();
+        let promoted = OffloadedPeek::promote(
+            peek.clone(),
+            scan,
+            Some(stash_target(&peek, blob.clients())),
+            &permits,
+            // One position per slice, so the walk is still far from the end of the trace when the
+            // first part reaches blob storage.
+            counted_blob_config(1),
+            PeekWalkMetrics::new(&metrics),
+            worker.sync_activator_for([].into()),
+        );
+
+        blob.wait_until_something_is_written("a walk past the stash threshold")
+            .await;
+
+        // Dropping the whole entry is what a cancellation does, and it is the abort rather than
+        // any signal the walk observes.
+        drop(promoted);
+
+        blob.wait_until_nothing_is_left("an aborted walk").await;
+        assert_eq!(
+            blob.deletes_of_nothing(),
+            0,
+            "the deletes must name the keys the upload wrote"
+        );
+        assert_eq!(
+            metrics.index_peek_walks_offloaded.get(),
+            0,
+            "an aborted walk reaches no outcome and counts on neither substrate"
+        );
+        assert_eq!(
+            metrics.index_peek_stashed_total.get(),
+            0,
+            "an aborted walk answers from no stash"
+        );
+    }
+
+    /// A walk that observes its cancellation while feeding an upload gives the upload up, which
+    /// deletes the parts it had written, and reports no outcome.
+    ///
+    /// This is the other half of a cancellation. An abort usually stops the walk first, but a
+    /// cancellation that lands between two slices is seen by the walk itself, and the branch that
+    /// sees it has to give the upload up rather than return past it.
+    ///
+    /// The task's handle is kept for the length of the test, so what ends the walk is the walk
+    /// itself seeing the closed channel rather than an abort.
+    #[mz_ore::test(tokio::test)]
+    async fn a_walk_cancelled_while_uploading_deletes_what_it_wrote() {
+        let keys = wide_ok_rows(LONG_WALK_KEYS);
+        let peek = index_peek(trivial_finishing(), None);
+        let mut bundle = trace_bundle(&keys, cancelling_errors(0));
+        let scan = open(&mut bundle, &peek, Some(2 * wide_row_size()));
+
+        let metrics = worker_metrics();
+        let walk_metrics = PeekWalkMetrics::new(&metrics);
+        let permits = PeekPermits::new(1);
+        let semaphore = permits.resize(0);
+        let permit = Arc::clone(&semaphore)
+            .try_acquire_owned()
+            .expect("a permit is free");
+
+        let blob = CountedBlob::new();
+        let stash = stash_target(&peek, blob.clients());
+        let (result_tx, result_rx) = oneshot::channel();
+        let config = counted_blob_config(1);
+        let order_by = peek.finishing.order_by.clone();
+        let walk = mz_ore::task::spawn(|| "peek_offload_test::walk", async move {
+            OffloadedPeek::walk(
+                permit,
+                Uuid::nil(),
+                scan,
+                Some(stash),
+                &config,
+                &walk_metrics,
+                &order_by,
+                &result_tx,
+            )
+            .await
+            .is_some()
+        });
+
+        blob.wait_until_something_is_written("a walk past the stash threshold")
+            .await;
+        assert!(
+            !walk.is_finished(),
+            "the walk must still be under way when it is cancelled"
+        );
+
+        drop(result_rx);
+
+        wait_until(|| walk.is_finished(), "the cancelled walk stopping").await;
+        assert_eq!(walk.await, false, "a cancelled walk reports no outcome");
+
+        blob.wait_until_nothing_is_left("a cancelled walk").await;
+        assert_eq!(
+            blob.deletes_of_nothing(),
+            0,
+            "the deletes must name the keys the upload wrote"
+        );
+        assert_eq!(
+            semaphore.available_permits(),
+            1,
+            "a cancelled walk releases the permit that admitted it"
+        );
+    }
+
+    /// A walk that fails after its upload has written parts answers with the failure and deletes
+    /// those parts, because nothing will ever read them.
+    ///
+    /// A failure reachable only once rows are already in the stash is what this driver created:
+    /// the walk that produces the rows is now the walk that writes them, so its own error arm has
+    /// an upload to answer for.
+    #[mz_ore::test(tokio::test)]
+    async fn a_walk_that_fails_after_writing_deletes_what_it_wrote() {
+        let keys = wide_ok_rows(20);
+        let peek = index_peek(trivial_finishing(), None);
+        let mut bundle = trace_bundle(&keys, cancelling_errors(0));
+        // Crossed by the third row, so two batches reach the stash before the limit below trips.
+        let scan = open(&mut bundle, &peek, Some(2 * wide_row_size()));
+
+        // Past the rows two batches hold and short of the trace, so the walk fails with an upload
+        // open and parts written.
+        let limit = 8;
+
+        let metrics = worker_metrics();
+        let worker = worker();
+        let permits = PeekPermits::new(1);
+        let blob = CountedBlob::new();
+        let mut promoted = OffloadedPeek::promote(
+            peek.clone(),
+            scan,
+            Some(stash_target(&peek, blob.clients())),
+            &permits,
+            offload_config_with(1, |updates| {
+                updates.add(&PEEK_RESPONSE_STASH_BATCH_MAX_RUNS, NO_RUN_MERGING);
+                updates.add(&ENABLE_PEEK_ROW_ITERATION_LIMIT, true);
+                updates.add(&PEEK_ROW_ITERATION_LIMIT, limit);
+            }),
+            PeekWalkMetrics::new(&metrics),
+            worker.sync_activator_for([].into()),
+        );
+
+        assert_eq!(
+            answer(&mut promoted).await,
+            PeekResponse::Error(PeekError::RowIterationLimitExceeded { limit }),
+            "the peek is answered with the failure rather than with the rows already written",
+        );
+
+        blob.wait_until_nothing_is_left("a failed walk").await;
+        assert_eq!(
+            blob.deletes_of_nothing(),
+            0,
+            "the deletes must name the keys the upload wrote"
+        );
+        assert_eq!(
+            metrics.index_peek_stashed_total.get(),
+            0,
+            "a walk answered with an error answered from no stash"
+        );
+        assert_eq!(
+            metrics.index_peek_walks_offloaded.get(),
+            1,
+            "a failure is a terminal outcome, so the driver that reached it counts the walk"
         );
     }
 

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -346,9 +346,7 @@ impl OffloadedPeek {
                                 // defect in the upload rather than a blip, and the query's error
                                 // is the only other place it shows.
                                 warn!(%peek_uuid, %error, "peek stash rejected a batch");
-                                if let Some(upload) = upload.take() {
-                                    upload.discard();
-                                }
+                                upload.take().expect("opened above").discard();
                                 return Some(PeekResponse::Error(PeekError::unstructured(error)));
                             }
                         }

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -33,6 +33,8 @@ use tracing::{debug, warn};
 use crate::compute_state::PeekRowIterationConfig;
 use crate::compute_state::peek_metrics::PeekWalkMetrics;
 use crate::compute_state::peek_scan::{IndexPeekScan, RowBatch, ScanOutcome};
+use uuid::Uuid;
+
 use crate::compute_state::peek_stash::{StashTarget, StashUpload, UploadDemand};
 
 /// The bound on how many promoted peek walks run at once.
@@ -193,7 +195,7 @@ impl OffloadedPeek {
                 queued.admitted();
 
                 let Some(response) = Self::walk(
-                    permit, scan, stash, &config, &metrics, &order_by, &result_tx,
+                    permit, peek_uuid, scan, stash, &config, &metrics, &order_by, &result_tx,
                 )
                 .await
                 else {
@@ -240,6 +242,7 @@ impl OffloadedPeek {
     /// only once the scan holding them is gone.
     async fn walk(
         _permit: OwnedSemaphorePermit,
+        peek_uuid: Uuid,
         mut scan: IndexPeekScan,
         stash: Option<StashTarget>,
         config: &OffloadConfig,
@@ -280,7 +283,7 @@ impl OffloadedPeek {
                     metrics.observe_ok_phase(&phases);
                     return Some(match upload {
                         None => metrics.rows_response(rows, order_by),
-                        Some(upload) => stashed_answer(upload, rows).await,
+                        Some(upload) => stashed_answer(peek_uuid, upload, rows).await,
                     });
                 }
                 // NOTE: a walk that fails after it has written to the stash abandons the upload,
@@ -305,6 +308,7 @@ impl OffloadedPeek {
                             match stash.open(config.batch_max_runs.get()).await {
                                 Ok(opened) => upload = Some(opened),
                                 Err(error) => {
+                                    warn!(%peek_uuid, %error, "peek stash failed to open a shard");
                                     return Some(PeekResponse::Error(PeekError::unstructured(
                                         error,
                                     )));
@@ -324,7 +328,9 @@ impl OffloadedPeek {
                                 // and only the phases that precede it are complete enough to.
                                 metrics.observe_error_phase(&scan.phases());
                                 let open = upload.take().expect("opened above");
-                                return Some(stashed_answer(open, RowBatch::new()).await);
+                                return Some(
+                                    stashed_answer(peek_uuid, open, RowBatch::new()).await,
+                                );
                             }
                             // NOTE: the upload is abandoned here, which leaves the parts already
                             // written in blob storage, the same way a cancellation does.
@@ -332,7 +338,7 @@ impl OffloadedPeek {
                                 // Persist rejects a batch it was handed wrongly, so this is a
                                 // defect in the upload rather than a blip, and the query's error
                                 // is the only other place it shows.
-                                warn!(%error, "peek stash rejected a batch");
+                                warn!(%peek_uuid, %error, "peek stash rejected a batch");
                                 return Some(PeekResponse::Error(PeekError::unstructured(error)));
                             }
                         }
@@ -347,7 +353,11 @@ impl OffloadedPeek {
 
 /// The answer a peek whose rows reached the stash gets, over `inline_rows`, the rows the walk was
 /// still holding when it ended.
-async fn stashed_answer(upload: StashUpload, inline_rows: RowBatch) -> PeekResponse {
+async fn stashed_answer(
+    peek_uuid: Uuid,
+    upload: StashUpload,
+    inline_rows: RowBatch,
+) -> PeekResponse {
     match upload.finish(inline_rows).await {
         Ok(response) => response,
         // NOTE: the upload is abandoned here, which leaves the parts already written in blob
@@ -355,7 +365,7 @@ async fn stashed_answer(upload: StashUpload, inline_rows: RowBatch) -> PeekRespo
         Err(error) => {
             // Persist rejects a batch it was handed wrongly, so this is a defect in the upload
             // rather than a blip, and the query's error is the only other place it shows.
-            warn!(%error, "peek stash failed to finish a batch");
+            warn!(%peek_uuid, %error, "peek stash failed to finish a batch");
             PeekResponse::Error(PeekError::unstructured(error))
         }
     }
@@ -867,6 +877,7 @@ mod tests {
         let walk = mz_ore::task::spawn(|| "peek_offload_test::walk", async move {
             OffloadedPeek::walk(
                 permit,
+                Uuid::nil(),
                 scan,
                 None,
                 &config,

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -313,6 +313,9 @@ impl OffloadedPeek {
                     // progress until it is taken.
                     if let Some(batch) = scan.take_batch() {
                         let Some(stash) = &stash else {
+                            // The ok walk stopped short of the trace, so it reports nothing, and
+                            // only the phases that precede it are complete enough to.
+                            metrics.observe_error_phase(&scan.phases());
                             return Some(PeekResponse::Error(PeekError::unstructured(
                                 NO_STASH_LOCATION,
                             )));
@@ -323,6 +326,7 @@ impl OffloadedPeek {
                                 Ok(opened) => upload = Some(opened),
                                 Err(error) => {
                                     warn!(%peek_uuid, %error, "peek stash failed to open a shard");
+                                    metrics.observe_error_phase(&scan.phases());
                                     return Some(PeekResponse::Error(PeekError::unstructured(
                                         error,
                                     )));
@@ -351,6 +355,7 @@ impl OffloadedPeek {
                                 // defect in the upload rather than a blip, and the query's error
                                 // is the only other place it shows.
                                 warn!(%peek_uuid, %error, "peek stash rejected a batch");
+                                metrics.observe_error_phase(&scan.phases());
                                 upload.take().expect("opened above").discard();
                                 return Some(PeekResponse::Error(PeekError::unstructured(error)));
                             }

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -28,7 +28,7 @@ use mz_expr::ColumnOrder;
 use mz_ore::task::AbortOnDropHandle;
 use timely::scheduling::SyncActivator;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, oneshot};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::compute_state::PeekRowIterationConfig;
 use crate::compute_state::peek_metrics::PeekWalkMetrics;
@@ -326,7 +326,13 @@ impl OffloadedPeek {
                                 let open = upload.take().expect("opened above");
                                 return Some(stashed_answer(open, RowBatch::new()).await);
                             }
+                            // NOTE: the upload is abandoned here, which leaves the parts already
+                            // written in blob storage, the same way a cancellation does.
                             Err(error) => {
+                                // Persist rejects a batch it was handed wrongly, so this is a
+                                // defect in the upload rather than a blip, and the query's error
+                                // is the only other place it shows.
+                                warn!(%error, "peek stash rejected a batch");
                                 return Some(PeekResponse::Error(PeekError::unstructured(error)));
                             }
                         }
@@ -344,7 +350,14 @@ impl OffloadedPeek {
 async fn stashed_answer(upload: StashUpload, inline_rows: RowBatch) -> PeekResponse {
     match upload.finish(inline_rows).await {
         Ok(response) => response,
-        Err(error) => PeekResponse::Error(PeekError::unstructured(error)),
+        // NOTE: the upload is abandoned here, which leaves the parts already written in blob
+        // storage, the same way a cancellation does.
+        Err(error) => {
+            // Persist rejects a batch it was handed wrongly, so this is a defect in the upload
+            // rather than a blip, and the query's error is the only other place it shows.
+            warn!(%error, "peek stash failed to finish a batch");
+            PeekResponse::Error(PeekError::unstructured(error))
+        }
     }
 }
 

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -10,16 +10,19 @@
 //! permit that admitted it, which is what ties the bound on concurrent walks to the memory those
 //! walks retain: every way the task ends, including a panic, drops the two together.
 //!
-//! This driver performs no IO of its own. The task walks traces and accumulates rows, and a walk
-//! whose rows outgrow an inline answer stops and hands back rather than writing them, which leaves
-//! the writing to the worker.
+//! This driver is the only one that performs IO, and that is what keeps the scan it drives free of
+//! async colouring. A walk whose accumulated rows outgrow an inline answer hands the driver a full
+//! batch, the driver writes it to the peek stash, and the same walk carries on from where it
+//! stopped rather than starting over.
 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use mz_compute_client::protocol::command::Peek;
-use mz_compute_client::protocol::response::PeekResponse;
-use mz_compute_types::dyncfgs::{INDEX_PEEK_PERMITS, INDEX_PEEK_YIELD_GRANULARITY};
+use mz_compute_client::protocol::response::{PeekError, PeekResponse};
+use mz_compute_types::dyncfgs::{
+    INDEX_PEEK_PERMITS, INDEX_PEEK_YIELD_GRANULARITY, PEEK_RESPONSE_STASH_BATCH_MAX_RUNS,
+};
 use mz_dyncfg::{ConfigSet, ConfigValHandle};
 use mz_expr::ColumnOrder;
 use mz_ore::task::AbortOnDropHandle;
@@ -27,10 +30,10 @@ use timely::scheduling::SyncActivator;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, oneshot};
 use tracing::debug;
 
-use crate::arrangement::manager::TraceBundle;
 use crate::compute_state::PeekRowIterationConfig;
 use crate::compute_state::peek_metrics::PeekWalkMetrics;
-use crate::compute_state::peek_scan::{IndexPeekScan, ScanOutcome};
+use crate::compute_state::peek_scan::{IndexPeekScan, RowBatch, ScanOutcome};
+use crate::compute_state::peek_stash::{StashTarget, StashUpload, UploadDemand};
 
 /// The bound on how many promoted peek walks run at once.
 ///
@@ -97,13 +100,14 @@ impl PeekPermits {
 /// `UpdateConfiguration` applies to walks that are already under way, so a walk reads what is in
 /// effect when it reads rather than what was in effect when it was promoted, and a change reaches
 /// it without discarding the cursor positions it has already visited. The yield granularity and
-/// the row iteration limit are read at every slice boundary. The permit count is read once, on the
-/// worker, because it sizes the bound the walk then queues on rather than anything the walk does
-/// between slices.
+/// the row iteration limit are read at every slice boundary, and the batch runs where the walk
+/// opens its upload. The permit count is read once, on the worker, because it sizes the bound the
+/// walk then queues on rather than anything the walk does between slices.
 #[derive(Clone, Debug)]
 pub(super) struct OffloadConfig {
     permits: ConfigValHandle<usize>,
     yield_granularity: ConfigValHandle<usize>,
+    batch_max_runs: ConfigValHandle<usize>,
     row_iteration: PeekRowIterationConfig,
 }
 
@@ -112,20 +116,21 @@ impl OffloadConfig {
         Self {
             permits: INDEX_PEEK_PERMITS.handle(config),
             yield_granularity: INDEX_PEEK_YIELD_GRANULARITY.handle(config),
+            batch_max_runs: PEEK_RESPONSE_STASH_BATCH_MAX_RUNS.handle(config),
             row_iteration: PeekRowIterationConfig::new(config),
         }
     }
 }
 
-/// What a promoted walk hands back to the worker that promoted it.
-pub enum OffloadOutcome {
-    /// The walk answered the peek.
-    Answered(PeekResponse),
-    /// The walk accumulated more rows than the peek may answer with inline, and answering it needs
-    /// them written to the peek stash. This driver performs no IO, so the walk stops here and the
-    /// worker takes the peek to the stash instead.
-    NeedsStash,
-}
+/// What a walk answers a peek with when it produced rows it may not answer with inline and has
+/// nowhere to write them.
+///
+/// Unreachable by construction: a walk is given a stash target exactly where its scan was opened
+/// stash-eligible, and a scan that is not stash-eligible offers no batch. It is answered rather
+/// than asserted because the alternative to an answer is a peek that waits forever on a walk that
+/// has stopped.
+const NO_STASH_LOCATION: &str =
+    "peek result is too large to answer inline and this replica has no peek stash location";
 
 /// An index peek whose walk is running away from the worker that owns it.
 ///
@@ -133,14 +138,8 @@ pub enum OffloadOutcome {
 /// meant to be dropped once it has been responded to.
 pub struct OffloadedPeek {
     pub(crate) peek: Peek,
-    /// The traces the walk reads.
-    ///
-    /// Retained so that the peek stash can walk the ok trace again from here when the walk hands
-    /// back. The compaction hold this bundle carries is what keeps that second walk able to read
-    /// at the peek's timestamp.
-    pub(crate) trace_bundle: TraceBundle,
-    /// The outcome of the walk, eventually.
-    pub(crate) result: oneshot::Receiver<(OffloadOutcome, Duration)>,
+    /// The peek's answer, eventually.
+    pub(crate) result: oneshot::Receiver<(PeekResponse, Duration)>,
     /// The `tracing::Span` tracking this peek's operation.
     pub(crate) span: tracing::Span,
     /// The task driving the walk. Dropping this aborts it, which drops the scan, the cursors it
@@ -151,31 +150,25 @@ pub struct OffloadedPeek {
 impl OffloadedPeek {
     /// Promotes `scan` to a task that finishes the walk away from the worker.
     ///
-    /// `peek` and `trace_bundle` stay with the worker rather than moving into the task, because
-    /// the bundle is what the stash restarts the walk from if the walk hands back.
+    /// `stash` is where the walk writes rows the peek may not answer with inline, and is `Some`
+    /// exactly where `scan` was opened stash-eligible. A walk whose scan offers a batch and holds
+    /// no target answers the peek with an error rather than stopping.
     ///
-    /// The scan must not already hold a full batch. Such a scan has nothing left to do here: its
-    /// first step reports that it needs the stash, so promoting it costs a permit and a hand-off
-    /// for a peek the worker could have diverted itself. The precondition is checked rather than
-    /// assumed, because such a scan holds a permit for the length of a hand-off and produces
-    /// nothing in return.
+    /// The scan may already hold a full batch. Such a scan makes no progress until the batch is
+    /// taken, and this driver is the one that takes it, so promoting it is how a peek whose answer
+    /// is too large to return inline reaches the stash at all.
     ///
-    /// `activator` wakes the worker once the outcome is ready, because nothing else the worker
+    /// `activator` wakes the worker once the answer is ready, because nothing else the worker
     /// waits on is disturbed by this task finishing.
     pub(super) fn promote(
         peek: Peek,
-        trace_bundle: TraceBundle,
         scan: IndexPeekScan,
+        stash: Option<StashTarget>,
         permits: &PeekPermits,
         config: OffloadConfig,
         metrics: PeekWalkMetrics,
         activator: SyncActivator,
     ) -> Self {
-        debug_assert!(
-            !scan.batch_ready(),
-            "promoted a peek scan that already holds a full batch"
-        );
-
         let (mut result_tx, result_rx) = oneshot::channel();
         let semaphore = permits.resize(config.permits.get());
 
@@ -199,8 +192,10 @@ impl OffloadedPeek {
                 };
                 queued.admitted();
 
-                let Some(outcome) =
-                    Self::walk(permit, scan, &config, &metrics, &order_by, &result_tx).await
+                let Some(response) = Self::walk(
+                    permit, scan, stash, &config, &metrics, &order_by, &result_tx,
+                )
+                .await
                 else {
                     return;
                 };
@@ -211,9 +206,9 @@ impl OffloadedPeek {
                 // something other than the walks that ended.
                 metrics.walked_offloaded();
 
-                match result_tx.send((outcome, start.elapsed())) {
+                match result_tx.send((response, start.elapsed())) {
                     Ok(()) => {}
-                    Err((_outcome, elapsed)) => {
+                    Err((_response, elapsed)) => {
                         debug!(duration = ?elapsed, "dropping result for cancelled peek {peek_uuid}")
                     }
                 }
@@ -227,17 +222,17 @@ impl OffloadedPeek {
 
         Self {
             peek,
-            trace_bundle,
             result: result_rx,
             span: tracing::Span::current(),
             _abort_handle: task_handle.abort_on_drop(),
         }
     }
 
-    /// Drives `scan` to an outcome, yielding between slices.
+    /// Drives `scan` to the peek's answer, writing what it may not answer with inline to `stash`
+    /// and yielding between slices.
     ///
     /// Returns `None` for a peek that was cancelled, which is the one way the walk ends without an
-    /// outcome to report.
+    /// answer to report.
     ///
     /// The permit is taken by value so that it lives exactly as long as the walk it admits. Every
     /// way out of here drops it, an early return and an unwind alike. It is declared ahead of the
@@ -246,22 +241,32 @@ impl OffloadedPeek {
     async fn walk(
         _permit: OwnedSemaphorePermit,
         mut scan: IndexPeekScan,
+        stash: Option<StashTarget>,
         config: &OffloadConfig,
         metrics: &PeekWalkMetrics,
         order_by: &[ColumnOrder],
-        result_tx: &oneshot::Sender<(OffloadOutcome, Duration)>,
-    ) -> Option<OffloadOutcome> {
+        result_tx: &oneshot::Sender<(PeekResponse, Duration)>,
+    ) -> Option<PeekResponse> {
+        // Opened by the first batch the scan hands over, so a walk that never crosses the stash
+        // threshold neither opens a shard nor writes a byte. Whether it is open is also what
+        // decides how the peek is answered: an upload answers with a handle, and no upload means
+        // every row the walk produced is still here to answer with.
+        let mut upload: Option<StashUpload> = None;
+
         loop {
             // Cancellation removes the pending peek, which drops the receiving end of this
             // channel, so a closed channel is the walk's cancellation signal and needs no
             // mechanism of its own. The permit goes with this task rather than with the entry that
             // was removed, so it is still accounting for these batches right up to here.
+            //
+            // NOTE: parts of an upload written before this point stay in blob storage. Deleting
+            // them is work this driver does not do.
             if result_tx.is_closed() {
                 return None;
             }
 
             // A granularity of zero would spend no fuel, and a scan stepped with no fuel makes no
-            // progress, so the walk would spin without ever reaching an outcome.
+            // progress, so the walk would spin without ever reaching an answer.
             let mut fuel = config.yield_granularity.get().max(1);
             let row_iteration_limit = config.row_iteration.current_limit();
 
@@ -273,26 +278,73 @@ impl OffloadedPeek {
                     let phases = scan.phases();
                     metrics.observe_error_phase(&phases);
                     metrics.observe_ok_phase(&phases);
-                    return Some(OffloadOutcome::Answered(
-                        metrics.rows_response(rows, order_by),
-                    ));
+                    return Some(match upload {
+                        None => metrics.rows_response(rows, order_by),
+                        Some(upload) => stashed_answer(upload, rows).await,
+                    });
                 }
+                // NOTE: a walk that fails after it has written to the stash abandons the upload,
+                // which leaves the parts already written in blob storage, the same way a
+                // cancellation does.
                 ScanOutcome::Failed(error) => {
                     metrics.observe_error_phase(&scan.phases());
-                    return Some(OffloadOutcome::Answered(PeekResponse::Error(error)));
+                    return Some(PeekResponse::Error(error));
                 }
-                // A suspension holding a full batch is not one this walk can resume. The scan
-                // stops growing its prefix once the batch is full, so stepping it again spends no
-                // fuel and advances no cursor until a driver that writes rows takes the batch, and
-                // this one cannot. Rows accumulated so far are dropped, which is sound because the
-                // stash walks the ok trace again from the trace bundle and re-produces them.
-                ScanOutcome::Suspended if scan.batch_ready() => {
-                    metrics.observe_error_phase(&scan.phases());
-                    return Some(OffloadOutcome::NeedsStash);
+                ScanOutcome::Suspended => {
+                    // A scan hands over a batch only once its accumulation has crossed the stash
+                    // threshold, which most walks never do, and a scan that has one makes no
+                    // progress until it is taken.
+                    if let Some(batch) = scan.take_batch() {
+                        let Some(stash) = &stash else {
+                            return Some(PeekResponse::Error(PeekError::unstructured(
+                                NO_STASH_LOCATION,
+                            )));
+                        };
+
+                        if upload.is_none() {
+                            match stash.open(config.batch_max_runs.get()).await {
+                                Ok(opened) => upload = Some(opened),
+                                Err(error) => {
+                                    return Some(PeekResponse::Error(PeekError::unstructured(
+                                        error,
+                                    )));
+                                }
+                            }
+                        }
+
+                        let open = upload.as_mut().expect("opened above");
+                        match open.push(batch).await {
+                            Ok(UploadDemand::Wants) => {}
+                            // The stash holds every row the peek's finishing can use, so walking
+                            // on would produce rows no answer built from this upload can contain.
+                            // Nothing is left to carry inline: the batch just written is
+                            // everything the scan was holding.
+                            Ok(UploadDemand::Satisfied) => {
+                                // The ok walk stopped short of the trace, so it reports nothing,
+                                // and only the phases that precede it are complete enough to.
+                                metrics.observe_error_phase(&scan.phases());
+                                let open = upload.take().expect("opened above");
+                                return Some(stashed_answer(open, RowBatch::new()).await);
+                            }
+                            Err(error) => {
+                                return Some(PeekResponse::Error(PeekError::unstructured(error)));
+                            }
+                        }
+                    }
+
+                    tokio::task::yield_now().await;
                 }
-                ScanOutcome::Suspended => tokio::task::yield_now().await,
             }
         }
+    }
+}
+
+/// The answer a peek whose rows reached the stash gets, over `inline_rows`, the rows the walk was
+/// still holding when it ended.
+async fn stashed_answer(upload: StashUpload, inline_rows: RowBatch) -> PeekResponse {
+    match upload.finish(inline_rows).await {
+        Ok(response) => response,
+        Err(error) => PeekResponse::Error(PeekError::unstructured(error)),
     }
 }
 
@@ -304,16 +356,21 @@ mod tests {
     use mz_expr::RowSetFinishing;
     use mz_expr::row::RowCollection;
     use mz_ore::metrics::MetricsRegistry;
-    use mz_repr::Row;
+    use mz_ore::num::NonNeg;
+    use mz_persist_client::cache::PersistClientCache;
+    use mz_persist_types::PersistLocation;
+    use mz_repr::{IntoRowIterator, Row, RowIterator, RowRef};
     use timely::WorkerConfig;
     use timely::communication::Allocator;
     use timely::worker::Worker as TimelyWorker;
 
+    use crate::arrangement::manager::TraceBundle;
     use crate::compute_state::index_peek_tests::{
         cancelling_errors, index_peek, ok_row, rows_answer, trace_bundle, trivial_finishing,
         wide_ok_rows,
     };
     use crate::compute_state::peek_scan::PeekScan;
+    use crate::compute_state::peek_stash::tests::stashed_rows;
     use crate::metrics::{ComputeMetrics, WorkerMetrics};
     use crate::server::ComputeRuntimeRole;
 
@@ -340,9 +397,42 @@ mod tests {
             .for_worker(0)
     }
 
-    /// The size the scan accounts a single-column row at.
-    fn row_size() -> usize {
-        ok_row(0).byte_len() + size_of::<NonZeroUsize>()
+    /// The size the scan accounts a row of [`wide_ok_rows`] at.
+    ///
+    /// Those rows carry the `UInt64` the peek's result description declares, which is the schema
+    /// the stash writes its batch under, so a test that reaches the stash walks them rather than
+    /// the narrower [`ok_row`].
+    fn wide_row_size() -> usize {
+        wide_ok_rows(1)[0].byte_len() + size_of::<NonZeroUsize>()
+    }
+
+    /// The stash `peek` writes to, over the in-memory location `clients` opens.
+    fn stash_target(peek: &Peek, clients: &Arc<PersistClientCache>) -> StashTarget {
+        StashTarget::new(peek, Arc::clone(clients), PersistLocation::new_in_mem())
+    }
+
+    /// The batches and the inline rows of a stashed response, as one sorted row set.
+    ///
+    /// A peek's answer is both halves together, so a test that compared only one of them would
+    /// pass on a driver that wrote the rows to the wrong half.
+    async fn stashed_answer_rows(
+        clients: &PersistClientCache,
+        response: PeekResponse,
+    ) -> (Vec<Row>, Vec<Row>) {
+        let PeekResponse::Stashed(stashed) = response else {
+            panic!(
+                "a walk that reached the stash answers with a stashed response, not {response:?}"
+            )
+        };
+
+        let mut inline: Vec<Row> = stashed
+            .inline_rows
+            .iter()
+            .flat_map(|rows| rows.clone().into_row_iter().map(RowRef::to_owned))
+            .collect();
+        inline.sort();
+
+        (stashed_rows(clients, *stashed).await, inline)
     }
 
     /// Opens a scan of `peek` over `bundle`, the way the peek path opens one.
@@ -393,7 +483,7 @@ mod tests {
     /// the trace holds its keys in.
     ///
     /// A peek carrying an order is never eligible for the peek stash, because `is_streamable`
-    /// requires an empty `order_by`, so a promoted walk of one answers rather than handing back.
+    /// requires an empty `order_by`, so a promoted walk of one answers with its rows.
     fn descending_finishing() -> RowSetFinishing {
         let mut finishing = trivial_finishing();
         finishing.order_by = vec![ColumnOrder {
@@ -419,41 +509,25 @@ mod tests {
         PeekResponse::Rows(vec![builder.build()])
     }
 
-    /// What a promoted walk handed back, in a form a test can compare whole.
+    /// Runs the runtime until `promoted`'s walk answers the peek, and reports the answer.
     ///
-    /// Mirrors [`OffloadOutcome`], which carries no comparison of its own because nothing on the
-    /// peek path compares one.
-    #[derive(Debug, PartialEq)]
-    enum HandBack {
-        Answered(PeekResponse),
-        NeedsStash,
-    }
-
-    impl From<OffloadOutcome> for HandBack {
-        fn from(outcome: OffloadOutcome) -> Self {
-            match outcome {
-                OffloadOutcome::Answered(response) => HandBack::Answered(response),
-                OffloadOutcome::NeedsStash => HandBack::NeedsStash,
-            }
-        }
-    }
-
-    /// Runs the runtime until `promoted`'s walk hands something back, and reports what.
-    ///
-    /// Bounded, so a walk that yields without ever reaching an outcome fails here rather than
-    /// hanging the suite. That is the failure a scan holding a full batch produces, which is the
-    /// case this driver's batch-ready arm exists to avoid.
-    async fn hand_back(promoted: &mut OffloadedPeek) -> HandBack {
+    /// Bounded, so a walk that never reaches an answer fails here rather than hanging the suite.
+    /// The pause between attempts is a sleep rather than a yield because a walk that reaches the
+    /// stash waits on persist, whose work does not all happen on this runtime, and a spin against
+    /// that would turn the bound into a measure of how fast the machine spins.
+    async fn answer(promoted: &mut OffloadedPeek) -> PeekResponse {
         for _ in 0..DRIVE_BOUND {
             match promoted.result.try_recv() {
-                Ok((outcome, _elapsed)) => return HandBack::from(outcome),
-                Err(oneshot::error::TryRecvError::Empty) => tokio::task::yield_now().await,
+                Ok((response, _elapsed)) => return response,
+                Err(oneshot::error::TryRecvError::Empty) => {
+                    tokio::time::sleep(Duration::from_millis(1)).await
+                }
                 Err(oneshot::error::TryRecvError::Closed) => {
-                    panic!("the promoted walk ended without handing anything back")
+                    panic!("the promoted walk ended without answering the peek")
                 }
             }
         }
-        panic!("the promoted walk handed nothing back within {DRIVE_BOUND} yields");
+        panic!("the promoted walk did not answer within {DRIVE_BOUND} attempts");
     }
 
     /// Runs the runtime until `condition` holds, where `what` names what the test is waiting for.
@@ -481,32 +555,25 @@ mod tests {
         let mut bundle = trace_bundle(&keys, cancelling_errors(2));
         let mut scan = open(&mut bundle, &peek, None);
 
-        // Two positions leave the walk suspended with nothing to hand over, which is the state
-        // the worker promotes and the only one it promotes.
+        // Two positions leave the walk suspended for want of fuel, with the rest of the trace
+        // ahead of it.
         let mut fuel = 2;
         assert_eq!(scan.step(None, &mut fuel), ScanOutcome::Suspended);
-        assert!(
-            !scan.batch_ready(),
-            "a scan holding a full batch is diverted rather than promoted"
-        );
 
         let metrics = worker_metrics();
         let worker = worker();
         let permits = PeekPermits::new(1);
         let mut promoted = OffloadedPeek::promote(
             peek.clone(),
-            bundle,
             scan,
+            None,
             &permits,
             offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
             PeekWalkMetrics::new(&metrics),
             worker.sync_activator_for([].into()),
         );
 
-        assert_eq!(
-            hand_back(&mut promoted).await,
-            HandBack::Answered(rows_answer((0..6).map(ok_row))),
-        );
+        assert_eq!(answer(&mut promoted).await, rows_answer((0..6).map(ok_row)),);
         assert_eq!(
             metrics.index_peek_walks_offloaded.get(),
             1,
@@ -539,8 +606,8 @@ mod tests {
         let permits = PeekPermits::new(1);
         let mut promoted = OffloadedPeek::promote(
             peek.clone(),
-            bundle,
             scan,
+            None,
             &permits,
             offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
             PeekWalkMetrics::new(&metrics),
@@ -548,52 +615,139 @@ mod tests {
         );
 
         assert_eq!(
-            hand_back(&mut promoted).await,
-            HandBack::Answered(ordered_rows_answer((0..6).rev().map(ok_row))),
+            answer(&mut promoted).await,
+            ordered_rows_answer((0..6).rev().map(ok_row)),
         );
     }
 
-    /// A promoted walk whose accumulated rows grow into a full batch hands the peek back rather
-    /// than stepping a scan that cannot advance.
+    /// A promoted walk whose accumulated rows grow into a full batch writes the batch to the stash
+    /// and carries on from where it stopped, so one walk produces the whole answer.
     ///
-    /// A scan holding a full batch spends no fuel and moves no cursor when stepped, and this
-    /// driver has nowhere to write the batch, so a driver that treated the suspension as resumable
-    /// would yield forever without ever reaching an outcome. The bound in [`hand_back`] is what
-    /// turns that into a failure rather than a hang.
+    /// The rows the walk was still holding when it ended travel with the response rather than
+    /// through a batch of their own, and the two halves together are every row the peek owes. The
+    /// count of stashed rows is asserted as well, because a driver that wrote the tail to both
+    /// halves would still answer with the right set.
     #[mz_ore::test(tokio::test)]
-    async fn a_promoted_walk_that_fills_a_batch_hands_back_rather_than_spinning() {
-        let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    async fn a_promoted_walk_writes_full_batches_to_the_stash_and_walks_on() {
+        let keys = wide_ok_rows(8);
         let peek = index_peek(trivial_finishing(), None);
         let mut bundle = trace_bundle(&keys, cancelling_errors(0));
-        // Two rows fit under the threshold and the third crosses it, so the slice below promotes
-        // a scan with room left and the promoted walk is the one that fills the batch.
-        let mut scan = open(&mut bundle, &peek, Some(2 * row_size()));
+        // Two rows fit under the threshold and the third crosses it, so the walk fills a batch
+        // twice over and holds the last two rows when the trace runs out.
+        let mut scan = open(&mut bundle, &peek, Some(2 * wide_row_size()));
 
         let mut fuel = 2;
         assert_eq!(scan.step(None, &mut fuel), ScanOutcome::Suspended);
-        assert!(
-            !scan.batch_ready(),
-            "the inline slice must promote a scan that still has room"
+
+        let metrics = worker_metrics();
+        let worker = worker();
+        let permits = PeekPermits::new(1);
+        let clients = Arc::new(PersistClientCache::new_no_metrics());
+        let mut promoted = OffloadedPeek::promote(
+            peek.clone(),
+            scan,
+            Some(stash_target(&peek, &clients)),
+            &permits,
+            offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+            PeekWalkMetrics::new(&metrics),
+            worker.sync_activator_for([].into()),
         );
+
+        let response = answer(&mut promoted).await;
+        let PeekResponse::Stashed(stashed) = &response else {
+            panic!("a walk that reached the stash answers with a handle, not {response:?}");
+        };
+        assert_eq!(
+            stashed.num_rows_batches, 6,
+            "the stashed row count covers the batches alone"
+        );
+
+        let (batched, inline) = stashed_answer_rows(&clients, response).await;
+        assert_eq!(batched, keys[..6]);
+        assert_eq!(inline, keys[6..]);
+        assert_eq!(
+            metrics.index_peek_walks_offloaded.get(),
+            1,
+            "one walk produced the whole answer"
+        );
+    }
+
+    /// A promoted walk stops once the stash holds every row the peek's finishing can use, rather
+    /// than walking the rest of a trace whose rows no answer could contain.
+    #[mz_ore::test(tokio::test)]
+    async fn a_promoted_walk_stops_where_the_finishing_has_what_it_needs() {
+        let keys = wide_ok_rows(8);
+        let mut finishing = trivial_finishing();
+        finishing.limit = Some(NonNeg::try_from(2).expect("non-negative"));
+        let peek = index_peek(finishing, None);
+        let mut bundle = trace_bundle(&keys, cancelling_errors(0));
+        // Crossed by the second row, so the first batch already holds what the limit asks for.
+        let mut scan = open(&mut bundle, &peek, Some(wide_row_size()));
+
+        let mut fuel = 1;
+        assert_eq!(scan.step(None, &mut fuel), ScanOutcome::Suspended);
+
+        let metrics = worker_metrics();
+        let worker = worker();
+        let permits = PeekPermits::new(1);
+        let clients = Arc::new(PersistClientCache::new_no_metrics());
+        let mut promoted = OffloadedPeek::promote(
+            peek.clone(),
+            scan,
+            Some(stash_target(&peek, &clients)),
+            &permits,
+            offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+            PeekWalkMetrics::new(&metrics),
+            worker.sync_activator_for([].into()),
+        );
+
+        let (batched, inline) = stashed_answer_rows(&clients, answer(&mut promoted).await).await;
+        assert_eq!(batched, keys[..2], "the walk wrote what the limit asks for");
+        assert_eq!(
+            inline,
+            Vec::<Row>::new(),
+            "the batch that satisfied the stash was everything the walk held"
+        );
+        assert_eq!(
+            metrics.index_peek_row_iteration_seconds.get_sample_count(),
+            0,
+            "a walk that stopped short of the trace reports no ok phase"
+        );
+    }
+
+    /// A promoted walk that fills a batch with nowhere to write it answers the peek with an error
+    /// rather than leaving it waiting on a walk that has stopped.
+    ///
+    /// Defensive only: a walk is given a stash target exactly where its scan was opened
+    /// stash-eligible, so this pairing does not arise on the peek path. The scan here is opened
+    /// eligible and the target withheld, which is the pairing itself rather than a way of reaching
+    /// it.
+    #[mz_ore::test(tokio::test)]
+    async fn a_promoted_walk_with_nowhere_to_write_answers_with_an_error() {
+        let keys = wide_ok_rows(8);
+        let peek = index_peek(trivial_finishing(), None);
+        let mut bundle = trace_bundle(&keys, cancelling_errors(0));
+        let mut scan = open(&mut bundle, &peek, Some(2 * wide_row_size()));
+
+        let mut fuel = 2;
+        assert_eq!(scan.step(None, &mut fuel), ScanOutcome::Suspended);
 
         let metrics = worker_metrics();
         let worker = worker();
         let permits = PeekPermits::new(1);
         let mut promoted = OffloadedPeek::promote(
             peek.clone(),
-            bundle,
             scan,
+            None,
             &permits,
             offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
             PeekWalkMetrics::new(&metrics),
             worker.sync_activator_for([].into()),
         );
 
-        assert_eq!(hand_back(&mut promoted).await, HandBack::NeedsStash);
         assert_eq!(
-            metrics.index_peek_walks_offloaded.get(),
-            1,
-            "a hand-back is a terminal outcome of the promoted walk"
+            answer(&mut promoted).await,
+            PeekResponse::Error(PeekError::unstructured(NO_STASH_LOCATION)),
         );
     }
 
@@ -625,8 +779,8 @@ mod tests {
 
         let promoted = OffloadedPeek::promote(
             peek.clone(),
-            bundle,
             scan,
+            None,
             &permits,
             offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
             PeekWalkMetrics::new(&metrics),
@@ -698,9 +852,17 @@ mod tests {
         let config = offload_config(1);
         let order_by = peek.finishing.order_by.clone();
         let walk = mz_ore::task::spawn(|| "peek_offload_test::walk", async move {
-            OffloadedPeek::walk(permit, scan, &config, &walk_metrics, &order_by, &result_tx)
-                .await
-                .is_some()
+            OffloadedPeek::walk(
+                permit,
+                scan,
+                None,
+                &config,
+                &walk_metrics,
+                &order_by,
+                &result_tx,
+            )
+            .await
+            .is_some()
         });
 
         for _ in 0..DRIVE_BOUND {
@@ -756,8 +918,8 @@ mod tests {
 
         let mut promoted = OffloadedPeek::promote(
             peek.clone(),
-            bundle,
             scan,
+            None,
             &permits,
             offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
             PeekWalkMetrics::new(&metrics),
@@ -781,10 +943,7 @@ mod tests {
 
         drop(held);
 
-        assert_eq!(
-            hand_back(&mut promoted).await,
-            HandBack::Answered(rows_answer((0..6).map(ok_row))),
-        );
+        assert_eq!(answer(&mut promoted).await, rows_answer((0..6).map(ok_row)));
         assert_eq!(
             metrics.index_peek_permit_wait_seconds.get_sample_count(),
             1,

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -207,6 +207,9 @@ impl OffloadedPeek {
                 // reaches an outcome, so counting admissions would leave the pair summing to
                 // something other than the walks that ended.
                 metrics.walked_offloaded();
+                if matches!(response, PeekResponse::Stashed(_)) {
+                    metrics.walked_to_stash();
+                }
 
                 match result_tx.send((response, start.elapsed())) {
                     Ok(()) => {}

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -213,6 +213,11 @@ impl OffloadedPeek {
 
                 match result_tx.send((response, start.elapsed())) {
                     Ok(()) => {}
+                    // TODO: a dropped stashed response leaves its parts in blob storage. The
+                    // upload's own cleanup cannot reach them, because a finished batch belongs to
+                    // the response rather than to the upload, and rebuilding a deletable batch
+                    // from what the response carries needs a `WriteHandle` this task does not
+                    // hold. A reader-side sweep or persist's own garbage collection covers it.
                     Err((_response, elapsed)) => {
                         debug!(duration = ?elapsed, "dropping result for cancelled peek {peek_uuid}")
                     }
@@ -368,8 +373,9 @@ async fn stashed_answer(
 ) -> PeekResponse {
     match upload.finish(inline_rows).await {
         Ok(response) => response,
-        // NOTE: a rejected finish is the one abandonment that leaves the parts behind, because
-        // persist keeps the builder it was asked to finish. `StashUpload::finish` says so.
+        // NOTE: a rejected finish leaves the parts behind, because persist keeps the builder it
+        // was asked to finish. `StashUpload::finish` says so, and says why the case is stated
+        // rather than expected.
         Err(error) => {
             // Persist rejects a batch it was handed wrongly, so this is a defect in the upload
             // rather than a blip, and the query's error is the only other place it shows.

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -265,9 +265,13 @@ impl OffloadedPeek {
             // mechanism of its own. The permit goes with this task rather than with the entry that
             // was removed, so it is still accounting for these batches right up to here.
             //
-            // NOTE: parts of an upload written before this point stay in blob storage. Deleting
-            // them is work this driver does not do.
+            // Removing the entry also aborts this task, so a cancellation usually stops the walk
+            // before it gets here and the upload is given up by its drop instead. Both reach the
+            // same deletion, which is why this one can be written as an ordinary return.
             if result_tx.is_closed() {
+                if let Some(upload) = upload.take() {
+                    upload.discard();
+                }
                 return None;
             }
 
@@ -289,11 +293,13 @@ impl OffloadedPeek {
                         Some(upload) => stashed_answer(peek_uuid, upload, rows).await,
                     });
                 }
-                // NOTE: a walk that fails after it has written to the stash abandons the upload,
-                // which leaves the parts already written in blob storage, the same way a
-                // cancellation does.
                 ScanOutcome::Failed(error) => {
                     metrics.observe_error_phase(&scan.phases());
+                    // The peek is answered with the error rather than with the rows written so
+                    // far, so nothing will ever read them.
+                    if let Some(upload) = upload.take() {
+                        upload.discard();
+                    }
                     return Some(PeekResponse::Error(error));
                 }
                 ScanOutcome::Suspended => {
@@ -335,13 +341,14 @@ impl OffloadedPeek {
                                     stashed_answer(peek_uuid, open, RowBatch::new()).await,
                                 );
                             }
-                            // NOTE: the upload is abandoned here, which leaves the parts already
-                            // written in blob storage, the same way a cancellation does.
                             Err(error) => {
                                 // Persist rejects a batch it was handed wrongly, so this is a
                                 // defect in the upload rather than a blip, and the query's error
                                 // is the only other place it shows.
                                 warn!(%peek_uuid, %error, "peek stash rejected a batch");
+                                if let Some(upload) = upload.take() {
+                                    upload.discard();
+                                }
                                 return Some(PeekResponse::Error(PeekError::unstructured(error)));
                             }
                         }
@@ -363,8 +370,8 @@ async fn stashed_answer(
 ) -> PeekResponse {
     match upload.finish(inline_rows).await {
         Ok(response) => response,
-        // NOTE: the upload is abandoned here, which leaves the parts already written in blob
-        // storage, the same way a cancellation does.
+        // NOTE: a rejected finish is the one abandonment that leaves the parts behind, because
+        // persist keeps the builder it was asked to finish. `StashUpload::finish` says so.
         Err(error) => {
             // Persist rejects a batch it was handed wrongly, so this is a defect in the upload
             // rather than a blip, and the query's error is the only other place it shows.

--- a/src/compute/src/compute_state/peek_scan.rs
+++ b/src/compute/src/compute_state/peek_scan.rs
@@ -156,7 +156,10 @@ where
     results: RowBatch,
     /// The byte size of `results`, as an answer built from them would store them.
     total_size: usize,
-    /// The ceiling on what the scan may hold, above which the peek fails.
+    /// The byte size of the batches already handed to a driver, which `total_size` no longer
+    /// counts. Together the two are the size of the answer the peek is building.
+    handed_off_size: usize,
+    /// The ceiling on the whole answer, above which the peek fails.
     max_result_size: usize,
     /// Whether this peek may divert its rows to the peek stash.
     peek_stash_eligible: bool,
@@ -235,6 +238,7 @@ where
             ok_walk_end: None,
             results: Vec::new(),
             total_size: 0,
+            handed_off_size: 0,
             max_result_size: usize::cast_from(max_result_size),
             peek_stash_eligible,
             peek_stash_threshold_bytes,
@@ -338,6 +342,9 @@ where
     /// and the stash threshold are read against, and rows that have left the scan are bounded by
     /// neither.
     fn take_results(&mut self) -> RowBatch {
+        // Carried rather than dropped, because `max_result_size` bounds the answer the peek
+        // returns and not the prefix the scan happens to be holding.
+        self.handed_off_size = self.handed_off_size.saturating_add(self.total_size);
         self.total_size = 0;
         mem::take(&mut self.results)
     }
@@ -430,10 +437,14 @@ where
                 .saturating_add(COUNT_BYTE_SIZE);
             let batch_ready = self.batch_ready();
 
-            // Rows bound for the stash are answered by a handle rather than by themselves, so the
-            // ceiling on an inline answer does not apply to a prefix that has grown past the
-            // stash threshold.
-            if !batch_ready && self.total_size > self.max_result_size {
+            // Measured against everything the answer will contain, the batches already handed off
+            // included, because a peek bound for the stash returns its rows to the client like any
+            // other. Checking only the retained prefix would stop bounding a stashed answer at
+            // all, since a prefix is handed away and reset well below the ceiling. Failing here
+            // rather than on the way out also spares the replica writing an answer to blob storage
+            // that nothing may read.
+            let answer_size = self.handed_off_size.saturating_add(self.total_size);
+            if answer_size > self.max_result_size {
                 break ScanOutcome::Failed(PeekError::unstructured(format!(
                     "result exceeds max size of {}",
                     ByteSize::b(u64::cast_from(self.max_result_size))
@@ -616,6 +627,7 @@ mod tests {
             ok_walk_end: None,
             results: Vec::new(),
             total_size: 0,
+            handed_off_size: 0,
             max_result_size: usize::MAX,
             peek_stash_eligible: false,
             peek_stash_threshold_bytes: usize::MAX,
@@ -948,24 +960,66 @@ mod tests {
         assert_eq!(subject.results, expected(0..3));
     }
 
-    /// The result-size ceiling bounds an inline answer, which rows bound for the stash are not.
-    /// A scan whose batches are taken therefore walks the whole trace with a ceiling below what it
-    /// produces, rather than failing the peek.
+    /// The result-size ceiling bounds the whole answer, the batches already handed off included,
+    /// so a peek bound for the stash fails on it like any other.
     ///
-    /// Driven with unbounded fuel, so every suspension is a full batch, and a scan that grew its
-    /// prefix past the threshold instead of stopping would fail on the ceiling.
+    /// The ceiling here sits above the stash threshold, so the scan hands off batches and only
+    /// their sum reaches it. A ceiling compared against the retained prefix alone would never be
+    /// reached, because a prefix is handed away and reset well below it, and the peek would return
+    /// an answer of any size at all.
+    ///
+    /// Driven with unbounded fuel, so every suspension is a full batch.
     #[mz_ore::test]
-    fn a_prefix_bound_for_the_stash_is_not_bound_by_the_result_size_ceiling() {
+    fn a_stashed_answer_is_bound_by_the_result_size_ceiling_across_its_batches() {
         let keys = rows(0..8);
         let mut subject = scan(ErrorPhase::Clean, &keys);
-        subject.max_result_size = 3 * row_size();
+        subject.max_result_size = 5 * row_size();
+        subject.peek_stash_eligible = true;
+        subject.peek_stash_threshold_bytes = 2 * row_size();
+
+        let mut collected = RowBatch::new();
+        let mut failure = None;
+        // Bounded so that a regression which restarts the ok walk on every resumption fails here
+        // rather than spinning.
+        for _ in 0..RESUMPTION_BOUND {
+            let mut fuel = usize::MAX;
+            match subject.step(None, &mut fuel) {
+                ScanOutcome::Suspended => {
+                    collected.extend(subject.take_batch().expect("a full batch"));
+                }
+                ScanOutcome::Complete(rest) => {
+                    collected.extend(rest);
+                    break;
+                }
+                ScanOutcome::Failed(error) => {
+                    failure = Some(error);
+                    break;
+                }
+            }
+        }
+
+        assert_eq!(
+            failure,
+            Some(PeekError::unstructured(format!(
+                "result exceeds max size of {}",
+                ByteSize::b(u64::cast_from(5 * row_size()))
+            ))),
+            "a stashed answer past the ceiling must fail rather than answer, having collected {collected:?}"
+        );
+    }
+
+    /// A peek whose whole answer stays under the ceiling still reaches the stash, so the bound
+    /// across batches does not cost the stash the results it exists for.
+    #[mz_ore::test]
+    fn a_stashed_answer_under_the_ceiling_still_walks_the_whole_trace() {
+        let keys = rows(0..8);
+        let mut subject = scan(ErrorPhase::Clean, &keys);
+        subject.max_result_size = 100 * row_size();
         subject.peek_stash_eligible = true;
         subject.peek_stash_threshold_bytes = 2 * row_size();
 
         let mut collected = RowBatch::new();
         let mut completed = false;
-        // Bounded so that a regression which restarts the ok walk on every resumption fails here
-        // rather than spinning.
         for _ in 0..RESUMPTION_BOUND {
             let mut fuel = usize::MAX;
             match subject.step(None, &mut fuel) {

--- a/src/compute/src/compute_state/peek_scan.rs
+++ b/src/compute/src/compute_state/peek_scan.rs
@@ -87,11 +87,10 @@ pub(super) enum ScanOutcome {
     /// rows collects them through [`PeekScan::take_batch`]. A driver that cannot is never handed
     /// rows it would have to drop.
     ///
-    /// The two causes coincide only for a driver that takes every batch it is offered, because
-    /// taking one is what lets the walk go on. A driver that cannot write batches has to ask
-    /// [`PeekScan::batch_ready`] before it steps again: a scan holding a full batch makes no
-    /// progress when stepped, spending no fuel and advancing no cursor, so a driver that steps it
-    /// in a loop spins forever.
+    /// A driver has to take every batch it is offered, because taking one is what lets the walk go
+    /// on: a scan holding a full batch makes no progress when stepped, spending no fuel and
+    /// advancing no cursor, so a driver that steps it again without taking spins forever. A driver
+    /// with nowhere to write a batch therefore cannot carry such a scan to an answer.
     Suspended,
     /// The walk is over. Carries the rows accumulated since the last batch was taken, which
     /// together with the batches already taken are the peek's answer.
@@ -327,8 +326,8 @@ where
     /// Whether the accumulated rows have grown past what this peek may answer with inline, which
     /// is when [`PeekScan::take_batch`] hands them over.
     ///
-    /// This is how a driver tells a [`ScanOutcome::Suspended`] it can resume from one it cannot:
-    /// a scan holding a full batch stays where it stands until the batch is taken.
+    /// A scan whose batch is ready stays where it stands until the batch is taken, so this is also
+    /// whether stepping the scan again can make progress.
     pub(super) fn batch_ready(&self) -> bool {
         self.peek_stash_eligible && self.total_size > self.peek_stash_threshold_bytes
     }

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -6,213 +6,24 @@
 //! For eligible peeks, we send the result back via the peek stash (aka persist
 //! blob), instead of inline in `ComputeResponse`.
 
-use std::num::{NonZeroI64, NonZeroU64, NonZeroUsize};
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use mz_compute_client::protocol::command::Peek;
-use mz_compute_client::protocol::response::{PeekError, PeekResponse, StashedPeekResponse};
+use mz_compute_client::protocol::response::{PeekResponse, StashedPeekResponse};
 use mz_expr::row::RowCollection;
 use mz_ore::cast::CastFrom;
-use mz_ore::task::AbortOnDropHandle;
 use mz_persist_client::Schemas;
 use mz_persist_client::batch::BatchBuilder;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::{PersistLocation, ShardId};
-use mz_repr::{Diff, RelationDesc, Row, Timestamp};
+use mz_repr::{RelationDesc, Timestamp};
 use mz_storage_types::sources::SourceData;
 use timely::progress::Antichain;
-use tokio::sync::oneshot;
-use tracing::debug;
 use uuid::Uuid;
 
-use crate::arrangement::manager::{PaddedTrace, TraceBundle};
-use crate::compute_state::peek_result_iterator;
-use crate::compute_state::peek_result_iterator::PeekResultIterator;
 use crate::compute_state::peek_scan::RowBatch;
-use crate::typedefs::RowRowAgent;
-
-/// An async task that stashes a peek response in persist and yields a handle to
-/// the batch in a [PeekResponse::Stashed].
-///
-/// Note that `StashingPeek` intentionally does not implement or derive
-/// `Clone`, as each `StashingPeek` is meant to be dropped after it's
-/// done or no longer needed.
-pub struct StashingPeek {
-    pub peek: Peek,
-    /// Iterator for the results. The worker thread has to continually pump
-    /// results from this to the `rows_tx` channel.
-    peek_iterator: Option<PeekResultIterator<PaddedTrace<RowRowAgent<Timestamp, Diff>>>>,
-    /// Carries result rows from the worker thread, which owns the walk, to the async upload task.
-    /// The upload makes progress only while the worker keeps pumping into this.
-    rows_tx: Option<tokio::sync::mpsc::Sender<Result<Vec<(Row, NonZeroI64)>, PeekError>>>,
-    /// The result of the background task, eventually.
-    pub result: oneshot::Receiver<(PeekResponse, Duration)>,
-    /// The `tracing::Span` tracking this peek's operation
-    pub span: tracing::Span,
-    /// A background task that's responsible for producing the peek results.
-    /// If we're no longer interested in the results, we abort the task.
-    _abort_handle: AbortOnDropHandle<()>,
-}
-
-// A peek whose answer belongs in the stash is written there by the walk that produces it, so
-// nothing opens an upload of its own here.
-#[allow(dead_code)]
-impl StashingPeek {
-    pub fn start_upload(
-        persist_clients: Arc<PersistClientCache>,
-        persist_location: &PersistLocation,
-        mut peek: Peek,
-        mut trace_bundle: TraceBundle,
-        batch_max_runs: usize,
-    ) -> Self {
-        let (rows_tx, rows_rx) = tokio::sync::mpsc::channel(10);
-        let (result_tx, result_rx) = oneshot::channel::<(PeekResponse, Duration)>();
-
-        let persist_clients = Arc::clone(&persist_clients);
-        let persist_location = persist_location.clone();
-
-        let peek_uuid = peek.uuid;
-        let relation_desc = peek.result_desc.clone();
-
-        let oks_handle = trace_bundle.oks_mut();
-
-        let peek_iterator = peek_result_iterator::PeekResultIterator::new(
-            peek.target.id(),
-            peek.map_filter_project.clone(),
-            peek.timestamp,
-            peek.literal_constraints.as_deref_mut(),
-            oks_handle,
-            None,
-            0,
-        );
-
-        let rows_needed_by_finishing = peek.finishing.num_rows_needed();
-
-        let task_handle = mz_ore::task::spawn(
-            || format!("peek_stash::stash_peek_response({peek_uuid})"),
-            async move {
-                let start = Instant::now();
-
-                let result = Self::do_upload(
-                    &persist_clients,
-                    persist_location,
-                    batch_max_runs,
-                    peek.uuid,
-                    relation_desc,
-                    rows_needed_by_finishing,
-                    rows_rx,
-                )
-                .await;
-
-                let result = match result {
-                    Ok(peek_response) => peek_response,
-                    Err(e) => PeekResponse::Error(PeekError::unstructured(e.to_string())),
-                };
-                match result_tx.send((result, start.elapsed())) {
-                    Ok(()) => {}
-                    Err((_result, elapsed)) => {
-                        debug!(duration = ?elapsed, "dropping result for cancelled peek {}", peek_uuid)
-                    }
-                }
-            },
-        );
-
-        Self {
-            peek,
-            peek_iterator: Some(peek_iterator),
-            rows_tx: Some(rows_tx),
-            result: result_rx,
-            span: tracing::Span::current(),
-            _abort_handle: task_handle.abort_on_drop(),
-        }
-    }
-
-    async fn do_upload(
-        persist_clients: &PersistClientCache,
-        persist_location: PersistLocation,
-        batch_max_runs: usize,
-        peek_uuid: Uuid,
-        relation_desc: RelationDesc,
-        max_rows: Option<usize>, // The number of rows needed by the RowSetFinishing's offset + limit
-        mut rows_rx: tokio::sync::mpsc::Receiver<Result<Vec<(Row, NonZeroI64)>, PeekError>>,
-    ) -> Result<PeekResponse, String> {
-        let mut upload = StashUpload::open(
-            persist_clients,
-            persist_location,
-            batch_max_runs,
-            peek_uuid,
-            relation_desc,
-            max_rows,
-        )
-        .await?;
-
-        loop {
-            let row = rows_rx.recv().await;
-            match row {
-                Some(Ok(rows)) => match upload.push(rows).await? {
-                    UploadDemand::Wants => {}
-                    UploadDemand::Satisfied => {
-                        // Drop the receiver so the producer's next
-                        // try_reserve() fails, stopping row production.
-                        drop(rows_rx);
-                        break;
-                    }
-                },
-                Some(Err(err)) => return Ok(PeekResponse::Error(err)),
-                None => {
-                    break;
-                }
-            }
-        }
-
-        upload.finish(RowBatch::new()).await
-    }
-
-    /// Pumps rows from the [PeekResultIterator] to the async task, via our
-    /// `rows_tx`. Will pump at most `batch_size` rows in one batch, and at most
-    /// the given `num_batches` batches.
-    pub fn pump_rows(&mut self, mut num_batches: usize, batch_size: usize) {
-        while num_batches > 0
-            && let Some(row_iter) = self.peek_iterator.as_mut()
-        {
-            // Try to reserve space in the channel before pulling rows from the
-            // iterator.
-            let permit = match self
-                .rows_tx
-                .as_mut()
-                .expect("missing rows_tx")
-                .try_reserve()
-            {
-                Ok(permit) => permit,
-                Err(_) => {
-                    // Channel is full, can't send more rows right now.
-                    break;
-                }
-            };
-
-            let rows: Result<Vec<_>, _> = row_iter.take(batch_size).collect();
-            match rows {
-                Ok(rows) if rows.is_empty() => {
-                    // Iterator is exhausted, we're done
-                    drop(permit);
-                    self.peek_iterator.take();
-                    self.rows_tx.take();
-                    break;
-                }
-                Ok(rows) => {
-                    permit.send(Ok(rows));
-                }
-                Err(e) => {
-                    permit.send(Err(e));
-                }
-            }
-
-            num_batches -= 1;
-        }
-    }
-}
 
 /// Whether a [`StashUpload`] has room for more rows.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -435,10 +246,12 @@ impl StashTarget {
 /// back the same way.
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::num::NonZeroI64;
+
     use mz_compute_types::dyncfgs::{
         PEEK_RESPONSE_STASH_BATCH_MAX_RUNS, PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES,
     };
-    use mz_repr::{Datum, SqlScalarType};
+    use mz_repr::{Datum, Row, SqlScalarType};
 
     use super::*;
 

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -288,9 +288,9 @@ impl StashUpload {
     /// walk's permit is released when the walk returns rather than when this finishes, so nothing
     /// bounds how many abandoned uploads carry a part at once.
     ///
-    /// TODO: persist could offer a builder teardown that surrenders the parts already written
-    /// without flushing the buffered one, which would make this cost a delete and nothing else,
-    /// and would remove the reason the finish below has to be caught.
+    /// TODO(PER-70): persist could offer a builder teardown that surrenders the parts already
+    /// written without flushing the buffered one, which would make this cost a delete and nothing
+    /// else, and would remove the reason the finish below has to be caught.
     fn abandon(&mut self) {
         let Some(batch_builder) = self.batch_builder.take() else {
             return;
@@ -314,11 +314,11 @@ impl StashUpload {
                 .spawn_named(|| format!("peek_stash::discard({shard_id})"), async move {
                     // A builder whose write was in flight when its walk was aborted holds a part
                     // that persist has already marked as being waited on, and finishing it panics
-                    // rather than returning. The panic has to be caught here: this replica installs
-                    // a handler that aborts the process for any panic outside a catch, so
-                    // reclaiming one query's blob storage would otherwise cost the whole replica.
-                    // Failing to reclaim is what this path already tolerates elsewhere, which makes
-                    // the leak the right outcome and the abort the wrong one.
+                    // rather than returning, which PER-70 tracks. The panic has to be caught here:
+                    // this replica installs a handler that aborts the process for any panic outside
+                    // a catch, so reclaiming one query's blob storage would otherwise cost the
+                    // whole replica. Failing to reclaim is what this path already tolerates
+                    // elsewhere, which makes the leak the right outcome and the abort the wrong one.
                     let finished = std::panic::AssertUnwindSafe(batch_builder.finish(upper))
                         .ore_catch_unwind()
                         .await;

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -16,6 +16,7 @@ use mz_expr::row::RowCollection;
 use mz_ore::cast::CastFrom;
 use mz_ore::task::AbortOnDropHandle;
 use mz_persist_client::Schemas;
+use mz_persist_client::batch::BatchBuilder;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::{PersistLocation, ShardId};
@@ -29,6 +30,7 @@ use uuid::Uuid;
 use crate::arrangement::manager::{PaddedTrace, TraceBundle};
 use crate::compute_state::peek_result_iterator;
 use crate::compute_state::peek_result_iterator::PeekResultIterator;
+use crate::compute_state::peek_scan::RowBatch;
 use crate::typedefs::RowRowAgent;
 
 /// An async task that stashes a peek response in persist and yields a handle to
@@ -133,64 +135,28 @@ impl StashingPeek {
         max_rows: Option<usize>, // The number of rows needed by the RowSetFinishing's offset + limit
         mut rows_rx: tokio::sync::mpsc::Receiver<Result<Vec<(Row, NonZeroI64)>, PeekError>>,
     ) -> Result<PeekResponse, String> {
-        let client = persist_clients
-            .open(persist_location)
-            .await
-            .map_err(|e| e.to_string())?;
+        let mut upload = StashUpload::open(
+            persist_clients,
+            persist_location,
+            batch_max_runs,
+            peek_uuid,
+            relation_desc,
+            max_rows,
+        )
+        .await?;
 
-        let shard_id = format!("s{}", peek_uuid);
-        let shard_id = ShardId::try_from(shard_id).expect("can parse");
-        let write_schemas: Schemas<SourceData, ()> = Schemas {
-            id: None,
-            key: Arc::new(relation_desc.clone()),
-            val: Arc::new(UnitSchema),
-        };
-
-        let result_ts = Timestamp::default();
-        let lower = Antichain::from_elem(result_ts);
-        let upper = Antichain::from_elem(result_ts.step_forward());
-
-        // We have to use SourceData, which is a wrapper around a Result<Row,
-        // DataflowError>, because the bare columnar Row encoder doesn't support
-        // encoding rows with zero columns.
-        //
-        // TODO: We _could_ work around the above by teaching the bare columnar
-        // Row encoder about zero-column rows.
-        let mut batch_builder = client
-            .batch_builder::<SourceData, (), Timestamp, i64>(
-                shard_id,
-                write_schemas,
-                lower,
-                Some(batch_max_runs),
-            )
-            .await;
-
-        let mut num_rows: u64 = 0;
-
-        'outer: loop {
+        loop {
             let row = rows_rx.recv().await;
             match row {
-                Some(Ok(rows)) => {
-                    for (row, diff) in rows {
-                        num_rows +=
-                            u64::from(NonZeroU64::try_from(diff).expect("diff fits into u64"));
-                        let diff: i64 = diff.into();
-
-                        batch_builder
-                            .add(&SourceData(Ok(row)), &(), &Timestamp::default(), &diff)
-                            .await
-                            .expect("invalid usage");
-
-                        if let Some(max_rows) = max_rows {
-                            if num_rows >= u64::cast_from(max_rows) {
-                                // Drop the receiver so the producer's next
-                                // try_reserve() fails, stopping row production.
-                                drop(rows_rx);
-                                break 'outer;
-                            }
-                        }
+                Some(Ok(rows)) => match upload.push(rows).await {
+                    UploadDemand::Wants => {}
+                    UploadDemand::Satisfied => {
+                        // Drop the receiver so the producer's next
+                        // try_reserve() fails, stopping row production.
+                        drop(rows_rx);
+                        break;
                     }
-                }
+                },
                 Some(Err(err)) => return Ok(PeekResponse::Error(err)),
                 None => {
                     break;
@@ -198,18 +164,7 @@ impl StashingPeek {
             }
         }
 
-        let batch = batch_builder.finish(upper).await.expect("invalid usage");
-
-        let stashed_response = StashedPeekResponse {
-            num_rows_batches: u64::cast_from(num_rows),
-            encoded_size_bytes: batch.encoded_size_bytes(),
-            relation_desc,
-            shard_id,
-            batches: vec![batch.into_transmittable_batch()],
-            inline_rows: vec![RowCollection::new(vec![], &[])],
-        };
-        let result = PeekResponse::Stashed(Box::new(stashed_response));
-        Ok(result)
+        Ok(upload.finish().await)
     }
 
     /// Pumps rows from the [PeekResultIterator] to the async task, via our
@@ -253,5 +208,320 @@ impl StashingPeek {
 
             num_batches -= 1;
         }
+    }
+}
+
+/// Whether a [`StashUpload`] has room for more rows.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum UploadDemand {
+    /// The upload wants more rows.
+    Wants,
+    /// The upload holds every row the peek's finishing can use. Rows pushed after this are
+    /// discarded, because they sit past the offset plus limit the finishing asks for and no answer
+    /// built from this upload can contain them.
+    Satisfied,
+}
+
+/// A peek's answer on its way to the peek stash, written to persist a batch of rows at a time.
+///
+/// The upload owns the IO the stash needs, so a walk that feeds it performs none: a driver that can
+/// await pushes the rows the walk produced and finishes the upload, and the walk itself neither
+/// opens a client nor writes a byte. That split is what keeps a walk drivable from a timely worker
+/// and from an async task alike.
+///
+/// The rows an upload is given are the rows it writes, in the order it is given them, up to the
+/// point where the peek's finishing has all it can use. An upload dropped without
+/// [`StashUpload::finish`] leaves the parts it has already written to blob storage behind.
+pub(super) struct StashUpload {
+    /// The description the stashed response reports, and the schema the batch is written under.
+    relation_desc: RelationDesc,
+    /// The shard the batch belongs to, derived from the peek's uuid so that a reader holding the
+    /// response can find it.
+    shard_id: ShardId,
+    batch_builder: BatchBuilder<SourceData, (), Timestamp, i64>,
+    /// The upper the batch is finished at, one step beyond the timestamp every row is written at.
+    upper: Antichain<Timestamp>,
+    /// The number of rows the peek's finishing can use, its offset plus its limit, or `None` for a
+    /// finishing that can use every row the peek produces.
+    max_rows: Option<usize>,
+    /// Rows written so far, counting a row with a diff of `n` as `n` rows, which is how the
+    /// finishing counts them.
+    num_rows: u64,
+}
+
+impl StashUpload {
+    /// Opens an upload for the peek `peek_uuid` identifies.
+    ///
+    /// Fails when the stash location does not open, in which case nothing has been written.
+    pub(super) async fn open(
+        persist_clients: &PersistClientCache,
+        persist_location: PersistLocation,
+        batch_max_runs: usize,
+        peek_uuid: Uuid,
+        relation_desc: RelationDesc,
+        max_rows: Option<usize>,
+    ) -> Result<Self, String> {
+        let client = persist_clients
+            .open(persist_location)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let shard_id = format!("s{}", peek_uuid);
+        let shard_id = ShardId::try_from(shard_id).expect("can parse");
+        let write_schemas: Schemas<SourceData, ()> = Schemas {
+            id: None,
+            key: Arc::new(relation_desc.clone()),
+            val: Arc::new(UnitSchema),
+        };
+
+        let result_ts = Timestamp::default();
+        let lower = Antichain::from_elem(result_ts);
+        let upper = Antichain::from_elem(result_ts.step_forward());
+
+        // We have to use SourceData, which is a wrapper around a Result<Row,
+        // DataflowError>, because the bare columnar Row encoder doesn't support
+        // encoding rows with zero columns.
+        //
+        // TODO: We _could_ work around the above by teaching the bare columnar
+        // Row encoder about zero-column rows.
+        let batch_builder = client
+            .batch_builder::<SourceData, (), Timestamp, i64>(
+                shard_id,
+                write_schemas,
+                lower,
+                Some(batch_max_runs),
+            )
+            .await;
+
+        Ok(Self {
+            relation_desc,
+            shard_id,
+            batch_builder,
+            upper,
+            max_rows,
+            num_rows: 0,
+        })
+    }
+
+    /// Writes `rows` to the stash and reports whether the upload wants more.
+    ///
+    /// An upload that reaches what the finishing can use stops there, part-way through `rows` if
+    /// that is where it lands, and discards the rest of them. A driver holding a walk that is still
+    /// producing rows learns from the [`UploadDemand::Satisfied`] this returns that it may stop the
+    /// walk rather than finish it.
+    pub(super) async fn push(&mut self, rows: RowBatch) -> UploadDemand {
+        for (row, diff) in rows {
+            if self.demand() == UploadDemand::Satisfied {
+                break;
+            }
+
+            self.num_rows += u64::from(NonZeroU64::try_from(diff).expect("diff fits into u64"));
+            let diff: i64 = diff.into();
+
+            self.batch_builder
+                .add(&SourceData(Ok(row)), &(), &Timestamp::default(), &diff)
+                .await
+                .expect("invalid usage");
+        }
+
+        self.demand()
+    }
+
+    /// Whether the upload still wants rows.
+    pub(super) fn demand(&self) -> UploadDemand {
+        match self.max_rows {
+            Some(max_rows) if self.num_rows >= u64::cast_from(max_rows) => UploadDemand::Satisfied,
+            _ => UploadDemand::Wants,
+        }
+    }
+
+    /// Finishes the batch and builds the response that names it.
+    pub(super) async fn finish(self) -> PeekResponse {
+        let batch = self
+            .batch_builder
+            .finish(self.upper)
+            .await
+            .expect("invalid usage");
+
+        let stashed_response = StashedPeekResponse {
+            num_rows_batches: self.num_rows,
+            encoded_size_bytes: batch.encoded_size_bytes(),
+            relation_desc: self.relation_desc,
+            shard_id: self.shard_id,
+            batches: vec![batch.into_transmittable_batch()],
+            inline_rows: vec![RowCollection::new(vec![], &[])],
+        };
+        PeekResponse::Stashed(Box::new(stashed_response))
+    }
+}
+
+/// Tests of the incremental stash upload, over the persist location a replica would write to.
+#[cfg(test)]
+mod tests {
+    use mz_compute_types::dyncfgs::{
+        PEEK_RESPONSE_STASH_BATCH_MAX_RUNS, PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES,
+    };
+    use mz_repr::{Datum, SqlScalarType};
+
+    use super::*;
+
+    /// The description of the single-column result every peek here asks for.
+    fn result_desc() -> RelationDesc {
+        RelationDesc::builder()
+            .with_column("value", SqlScalarType::UInt64.nullable(false))
+            .finish()
+    }
+
+    /// A batch of `values`, each carrying `diff` copies of itself.
+    fn batch(values: impl IntoIterator<Item = u64>, diff: i64) -> RowBatch {
+        let diff = NonZeroI64::new(diff).expect("a row carries a non-zero diff");
+        values
+            .into_iter()
+            .map(|value| (Row::pack_slice(&[Datum::UInt64(value)]), diff))
+            .collect()
+    }
+
+    /// An upload of a peek that can use `max_rows` rows, opened against `clients`.
+    async fn open_upload(clients: &PersistClientCache, max_rows: Option<usize>) -> StashUpload {
+        StashUpload::open(
+            clients,
+            PersistLocation::new_in_mem(),
+            *PEEK_RESPONSE_STASH_BATCH_MAX_RUNS.default(),
+            Uuid::new_v4(),
+            result_desc(),
+            max_rows,
+        )
+        .await
+        .expect("the in-memory location opens")
+    }
+
+    /// The values a finished upload holds, in ascending order, each repeated as often as the diff
+    /// it was written with.
+    ///
+    /// A stashed response names a persist batch rather than carrying rows, so what the upload wrote
+    /// is only visible from the batch. Persist consolidates a batch rather than preserving the
+    /// order it was written in, so the values are sorted here and compared as the multiset they
+    /// are.
+    async fn stashed_values(clients: &PersistClientCache, response: PeekResponse) -> Vec<u64> {
+        let PeekResponse::Stashed(stashed) = response else {
+            panic!("an upload finishes into a stashed response, not {response:?}");
+        };
+
+        // Opened out of the cache that opened the upload, because two `PersistLocation`s naming the
+        // same in-memory URI reach the same blob only through one cache.
+        let mut client = clients
+            .open(PersistLocation::new_in_mem())
+            .await
+            .expect("the in-memory location opens");
+
+        let shard_id = stashed.shard_id;
+        let batches = stashed
+            .batches
+            .into_iter()
+            .map(|batch| client.batch_from_transmittable_batch(&shard_id, batch))
+            .collect();
+        let read_schemas: Schemas<SourceData, ()> = Schemas {
+            id: None,
+            key: Arc::new(stashed.relation_desc),
+            val: Arc::new(UnitSchema),
+        };
+        let mut cursor = client
+            .read_batches_consolidated::<_, _, _, i64>(
+                shard_id,
+                Antichain::from_elem(Timestamp::default()),
+                read_schemas,
+                batches,
+                |_stats| true,
+                *PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES.default(),
+            )
+            .await
+            .expect("the batch is readable at the timestamp it was written at");
+
+        let mut values = Vec::new();
+        while let Some(updates) = cursor.next().await {
+            for ((key, _val), _time, diff) in updates {
+                let row = key.0.expect("the peek stash holds no errors");
+                let value = row.unpack_first().unwrap_uint64();
+                let copies = usize::try_from(diff).expect("a stashed row carries a positive diff");
+                values.extend(std::iter::repeat_n(value, copies));
+            }
+        }
+        values.sort();
+
+        // Deleted as the coordinator deletes them once it has read them. A batch dropped without
+        // this leaves its blob keys behind and says so in a warning.
+        for batch in cursor.into_lease() {
+            batch.delete().await;
+        }
+        values
+    }
+
+    /// An upload with no limit to reach holds every row pushed into it, over as many pushes as the
+    /// driver made.
+    #[mz_ore::test(tokio::test)]
+    async fn an_upload_holds_the_rows_pushed_into_it() {
+        let clients = PersistClientCache::new_no_metrics();
+        let mut upload = open_upload(&clients, None).await;
+
+        assert_eq!(upload.push(batch(0..3, 1)).await, UploadDemand::Wants);
+        assert_eq!(upload.push(batch(3..5, 1)).await, UploadDemand::Wants);
+
+        let response = upload.finish().await;
+        let PeekResponse::Stashed(stashed) = &response else {
+            panic!("an upload finishes into a stashed response, not {response:?}");
+        };
+        assert_eq!(
+            stashed.num_rows_batches, 5,
+            "the response counts the rows the upload wrote"
+        );
+        assert_eq!(
+            stashed_values(&clients, response).await,
+            vec![0, 1, 2, 3, 4]
+        );
+    }
+
+    /// An upload counts a row against the limit as often as its diff says the answer holds it,
+    /// rather than once.
+    #[mz_ore::test(tokio::test)]
+    async fn an_upload_counts_a_row_as_often_as_its_diff() {
+        let clients = PersistClientCache::new_no_metrics();
+        let mut upload = open_upload(&clients, Some(4)).await;
+
+        assert_eq!(
+            upload.push(batch(0..2, 3)).await,
+            UploadDemand::Satisfied,
+            "six copies of two rows is past a limit of four"
+        );
+        assert_eq!(
+            stashed_values(&clients, upload.finish().await).await,
+            vec![0, 0, 0, 1, 1, 1],
+            "the row that crossed the limit is written whole"
+        );
+    }
+
+    /// An upload that has all the rows the finishing can use stops there, part-way through the push
+    /// that took it past the limit, and discards what is pushed after.
+    #[mz_ore::test(tokio::test)]
+    async fn an_upload_stops_at_the_rows_the_finishing_can_use() {
+        let clients = PersistClientCache::new_no_metrics();
+        let mut upload = open_upload(&clients, Some(2)).await;
+
+        assert_eq!(
+            upload.demand(),
+            UploadDemand::Wants,
+            "an upload that has written nothing wants rows"
+        );
+        assert_eq!(upload.push(batch(0..4, 1)).await, UploadDemand::Satisfied);
+        assert_eq!(
+            upload.push(batch(4..8, 1)).await,
+            UploadDemand::Satisfied,
+            "a satisfied upload stays satisfied"
+        );
+
+        assert_eq!(
+            stashed_values(&clients, upload.finish().await).await,
+            vec![0, 1],
+            "the rows past the limit are discarded, in the push that crossed it and after it"
+        );
     }
 }

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -15,7 +15,7 @@ use mz_expr::row::RowCollection;
 use mz_ore::cast::CastFrom;
 use mz_ore::task::RuntimeExt;
 use mz_persist_client::Schemas;
-use mz_persist_client::batch::BatchBuilder;
+use mz_persist_client::batch::{Batch, BatchBuilder};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::{PersistLocation, ShardId};
@@ -23,6 +23,7 @@ use mz_repr::{RelationDesc, Timestamp};
 use mz_storage_types::sources::SourceData;
 use timely::progress::Antichain;
 use tokio::runtime::Handle;
+use tokio::sync::oneshot;
 use tracing::warn;
 use uuid::Uuid;
 
@@ -47,10 +48,11 @@ pub(super) enum UploadDemand {
 /// and from an async task alike.
 ///
 /// The rows an upload is given are the rows it writes, in the order it is given them, up to the
-/// point where the peek's finishing has all it can use. An upload that is never finished deletes
-/// the parts it has written, whether it is handed to [`StashUpload::discard`] or only dropped, so
-/// abandoning one costs blob storage nothing lasting. [`StashUpload::abandon`] states the one case
-/// that escapes.
+/// point where the peek's finishing has all it can use. An upload that does not reach a reader
+/// deletes what it wrote, whether it is handed to [`StashUpload::discard`], only dropped, or
+/// stopped part-way through finishing. A batch persist refuses to finish is the one escape, and
+/// [`StashUpload::finish`] says so; a replica that dies mid-upload is the other, and
+/// [`StashUpload::abandon`] says so.
 ///
 /// Nothing here bounds how large a stashed answer grows where the finishing has no limit to reach.
 /// `max_result_size` bounds the prefix a single scan retains between batches and never the sum
@@ -190,17 +192,11 @@ impl StashUpload {
     ///
     /// Fails where persist rejects the batch, in which case nothing that was written is readable.
     ///
-    /// A rejection also strands the parts: persist takes the builder to finish it and hands back
-    /// no handle to what it holds when it refuses, so the deletion an abandoned upload does has
-    /// nothing to reach and the parts stay in blob storage.
+    /// A rejection is the one abandonment that leaves the parts behind: persist takes the builder
+    /// to finish it and hands back no handle to what it holds when it refuses, so nothing can
+    /// reach them and they stay in blob storage.
     pub(super) async fn finish(mut self, inline_rows: RowBatch) -> Result<PeekResponse, String> {
-        let batch = self
-            .batch_builder
-            .take()
-            .expect(BUILDER_TAKEN)
-            .finish(self.upper.clone())
-            .await
-            .map_err(|err| err.to_string())?;
+        let batch = self.finish_batch().await?.take();
 
         let inline_rows = inline_rows
             .into_iter()
@@ -221,6 +217,39 @@ impl StashUpload {
         Ok(PeekResponse::Stashed(Box::new(stashed_response)))
     }
 
+    /// Finishes the batch as work of its own, and leaves the upload holding no parts.
+    ///
+    /// Flushing the buffered part and the part uploads still in flight is the longest await an
+    /// upload makes, so it is where a cancellation is most likely to land, and the builder is
+    /// already out of the upload by then. Handing the builder to a task the cancellation does not
+    /// reach is what keeps that window from stranding everything written so far: whoever ends up
+    /// holding the batch nobody will read deletes it.
+    async fn finish_batch(&mut self) -> Result<DeliveredBatch, String> {
+        let batch_builder = self.batch_builder.take().expect(BUILDER_TAKEN);
+        let upper = self.upper.clone();
+        let shard_id = self.shard_id;
+        let runtime = self.runtime.clone();
+
+        let (tx, rx) = oneshot::channel();
+        let _handle =
+            self.runtime
+                .spawn_named(|| format!("peek_stash::finish({shard_id})"), async move {
+                    let delivered = batch_builder
+                        .finish(upper)
+                        .await
+                        .map(|batch| DeliveredBatch::new(batch, runtime, shard_id))
+                        .map_err(|err| err.to_string());
+                    // A send that finds no receiver hands the delivery straight back, and dropping it
+                    // here deletes the batch. An error nobody is left to read is simply dropped.
+                    let _undelivered = tx.send(delivered);
+                });
+
+        // The task is detached rather than held, so it outlives this await and the only way the
+        // channel closes without a delivery is a runtime that is going away.
+        rx.await
+            .map_err(|_| "peek stash lost the task finishing its batch".to_string())?
+    }
+
     /// Deletes the parts this upload has already written, consuming it.
     ///
     /// A driver whose peek will be answered with something other than these rows calls this to say
@@ -234,9 +263,16 @@ impl StashUpload {
     /// none.
     ///
     /// Persist hands back a handle to the parts it has taken only by finishing the batch, so the
-    /// rows still buffered are written out before the delete removes them along with the rest, and
-    /// they stay in memory until it does. That is a part's worth of rows outliving the permit that
-    /// admitted the walk which produced them.
+    /// rows still buffered are written out before the delete removes them again.
+    ///
+    /// That write is not small. A builder flushes only once it holds `persist_blob_target_size`
+    /// bytes, 128 MiB by default, so abandoning an upload can put that much into blob storage for
+    /// no purpose beyond earning the handle that deletes it, and hold it in memory meanwhile. The
+    /// walk's permit is released when the walk returns rather than when this finishes, so nothing
+    /// bounds how many abandoned uploads carry a part at once.
+    ///
+    /// TODO: persist could offer a builder teardown that surrenders the parts already written
+    /// without flushing the buffered one, which would make this cost a delete and nothing else.
     fn abandon(&mut self) {
         let Some(batch_builder) = self.batch_builder.take() else {
             return;
@@ -273,6 +309,60 @@ impl Drop for StashUpload {
     /// [`StashUpload::discard`], which is the only cleanup a walk aborted mid-upload gets.
     fn drop(&mut self) {
         self.abandon();
+    }
+}
+
+/// A finished batch on its way to the response that will name it, deleted from blob storage if it
+/// never arrives.
+///
+/// A batch nobody takes out of a delivery is a batch no reader will ever be told how to find, so
+/// dropping one deletes it. That covers both ways a delivery goes unclaimed, the send that finds
+/// no receiver and the receiver dropped between the send and the take, which is what persist's own
+/// `Drop for Batch` does not: it logs the blob keys it is leaving behind and leaves them.
+struct DeliveredBatch {
+    /// Taken by [`DeliveredBatch::take`], and a `None` says the batch has an owner that will
+    /// answer for it.
+    batch: Option<Batch<SourceData, (), Timestamp, i64>>,
+    runtime: Handle,
+    shard_id: ShardId,
+}
+
+impl DeliveredBatch {
+    fn new(
+        batch: Batch<SourceData, (), Timestamp, i64>,
+        runtime: Handle,
+        shard_id: ShardId,
+    ) -> Self {
+        Self {
+            batch: Some(batch),
+            runtime,
+            shard_id,
+        }
+    }
+
+    /// Claims the batch, consuming the delivery.
+    ///
+    /// The caller owes persist what the delivery owed it: a batch it drops without transmitting or
+    /// deleting is a batch whose blobs stay behind.
+    fn take(mut self) -> Batch<SourceData, (), Timestamp, i64> {
+        self.batch
+            .take()
+            .expect("a delivery holds its batch until it is claimed")
+    }
+}
+
+impl Drop for DeliveredBatch {
+    fn drop(&mut self) {
+        let Some(batch) = self.batch.take() else {
+            return;
+        };
+
+        let shard_id = self.shard_id;
+        let _handle = self
+            .runtime
+            .spawn_named(|| format!("peek_stash::delete({shard_id})"), async move {
+                batch.delete().await
+            });
     }
 }
 

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -50,8 +50,11 @@ pub(super) enum UploadDemand {
 /// The rows an upload is given are the rows it writes, in the order it is given them, up to the
 /// point where the peek's finishing has all it can use. An upload that does not reach a reader
 /// deletes what it wrote, whether it is handed to [`StashUpload::discard`], only dropped, or
-/// stopped part-way through finishing. A batch persist refuses to finish is the one escape, and
-/// [`StashUpload::finish`] says so; a replica that dies mid-upload is the other, and
+/// stopped part-way through finishing.
+///
+/// That guarantee ends where the finished batch does. Once [`StashUpload::finish`] hands back a
+/// response, the parts belong to the response rather than to any upload, and a caller that drops
+/// one leaves them behind. A replica that dies mid-upload leaves them behind too, and
 /// [`StashUpload::abandon`] says so.
 ///
 /// Nothing here bounds how large a stashed answer grows where the finishing has no limit to reach.
@@ -191,13 +194,15 @@ impl StashUpload {
     /// sound because a peek reaches the stash only with an empty `order_by`.
     ///
     /// Fails where persist rejects the batch, in which case nothing that was written is readable.
-    ///
-    /// A rejection is the one abandonment that leaves the parts behind: persist takes the builder
-    /// to finish it and hands back no handle to what it holds when it refuses, so nothing can
-    /// reach them and they stay in blob storage.
+    /// A rejection takes the parts with it, because persist keeps the builder it was asked to
+    /// finish and hands back no handle to what it holds. Only a batch whose bounds do not admit
+    /// its own updates is refused, which this upload's fixed lower, upper and timestamp cannot
+    /// produce, so the case is stated rather than expected.
     pub(super) async fn finish(mut self, inline_rows: RowBatch) -> Result<PeekResponse, String> {
-        let batch = self.finish_batch().await?.take();
+        let delivered = self.finish_batch().await?;
 
+        // Built before the batch leaves its guard, so that an unwind here still deletes what was
+        // written rather than leaving it for nobody.
         let inline_rows = inline_rows
             .into_iter()
             .map(|(row, copies)| {
@@ -205,6 +210,8 @@ impl StashUpload {
                 (row, copies)
             })
             .collect();
+
+        let batch = delivered.take();
 
         let stashed_response = StashedPeekResponse {
             num_rows_batches: self.num_rows,

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -6,7 +6,7 @@
 //! For eligible peeks, we send the result back via the peek stash (aka persist
 //! blob), instead of inline in `ComputeResponse`.
 
-use std::num::{NonZeroI64, NonZeroU64};
+use std::num::{NonZeroI64, NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -56,6 +56,9 @@ pub struct StashingPeek {
     _abort_handle: AbortOnDropHandle<()>,
 }
 
+// A peek whose answer belongs in the stash is written there by the walk that produces it, so
+// nothing opens an upload of its own here.
+#[allow(dead_code)]
 impl StashingPeek {
     pub fn start_upload(
         persist_clients: Arc<PersistClientCache>,
@@ -148,7 +151,7 @@ impl StashingPeek {
         loop {
             let row = rows_rx.recv().await;
             match row {
-                Some(Ok(rows)) => match upload.push(rows).await {
+                Some(Ok(rows)) => match upload.push(rows).await? {
                     UploadDemand::Wants => {}
                     UploadDemand::Satisfied => {
                         // Drop the receiver so the producer's next
@@ -164,7 +167,7 @@ impl StashingPeek {
             }
         }
 
-        Ok(upload.finish().await)
+        upload.finish(RowBatch::new()).await
     }
 
     /// Pumps rows from the [PeekResultIterator] to the async task, via our
@@ -232,6 +235,10 @@ pub(super) enum UploadDemand {
 /// The rows an upload is given are the rows it writes, in the order it is given them, up to the
 /// point where the peek's finishing has all it can use. An upload dropped without
 /// [`StashUpload::finish`] leaves the parts it has already written to blob storage behind.
+///
+/// Every write reports its failure rather than raising it. The unit that fails is the peek, whose
+/// driver answers it with the error, so a rejected write costs one query its answer instead of
+/// costing the walk that produced it its task.
 pub(super) struct StashUpload {
     /// The description the stashed response reports, and the schema the batch is written under.
     relation_desc: RelationDesc,
@@ -309,7 +316,10 @@ impl StashUpload {
     /// that is where it lands, and discards the rest of them. A driver holding a walk that is still
     /// producing rows learns from the [`UploadDemand::Satisfied`] this returns that it may stop the
     /// walk rather than finish it.
-    pub(super) async fn push(&mut self, rows: RowBatch) -> UploadDemand {
+    ///
+    /// Fails where persist rejects the write, which leaves the upload unusable and the rows it
+    /// holds unanswerable.
+    pub(super) async fn push(&mut self, rows: RowBatch) -> Result<UploadDemand, String> {
         for (row, diff) in rows {
             if self.demand() == UploadDemand::Satisfied {
                 break;
@@ -321,10 +331,10 @@ impl StashUpload {
             self.batch_builder
                 .add(&SourceData(Ok(row)), &(), &Timestamp::default(), &diff)
                 .await
-                .expect("invalid usage");
+                .map_err(|err| err.to_string())?;
         }
 
-        self.demand()
+        Ok(self.demand())
     }
 
     /// Whether the upload still wants rows.
@@ -336,12 +346,27 @@ impl StashUpload {
     }
 
     /// Finishes the batch and builds the response that names it.
-    pub(super) async fn finish(self) -> PeekResponse {
+    ///
+    /// `inline_rows` are rows of the same answer that never reached the stash, which the response
+    /// carries beside the batch rather than paying a write for. They are outside the stashed row
+    /// count, which describes the batch alone, and outside the ordering the stash imposes, which is
+    /// sound because a peek reaches the stash only with an empty `order_by`.
+    ///
+    /// Fails where persist rejects the batch, in which case nothing that was written is readable.
+    pub(super) async fn finish(self, inline_rows: RowBatch) -> Result<PeekResponse, String> {
         let batch = self
             .batch_builder
             .finish(self.upper)
             .await
-            .expect("invalid usage");
+            .map_err(|err| err.to_string())?;
+
+        let inline_rows = inline_rows
+            .into_iter()
+            .map(|(row, copies)| {
+                let copies = NonZeroUsize::try_from(copies).expect("fits into usize");
+                (row, copies)
+            })
+            .collect();
 
         let stashed_response = StashedPeekResponse {
             num_rows_batches: self.num_rows,
@@ -349,15 +374,67 @@ impl StashUpload {
             relation_desc: self.relation_desc,
             shard_id: self.shard_id,
             batches: vec![batch.into_transmittable_batch()],
-            inline_rows: vec![RowCollection::new(vec![], &[])],
+            inline_rows: vec![RowCollection::new(inline_rows, &[])],
         };
-        PeekResponse::Stashed(Box::new(stashed_response))
+        Ok(PeekResponse::Stashed(Box::new(stashed_response)))
+    }
+}
+
+/// Where a peek's rows go when they may not be answered with inline, and what opening the upload
+/// that writes them takes.
+///
+/// A driver holds a target rather than an open upload, because a walk that never crosses the stash
+/// threshold must neither open a shard nor write a byte, and most walks never do. A driver is given
+/// one exactly when the scan it drives was opened stash-eligible, so a walk with no target is a
+/// walk whose scan offers no batch.
+pub(super) struct StashTarget {
+    persist_clients: Arc<PersistClientCache>,
+    persist_location: PersistLocation,
+    /// The peek's uuid, which the shard the batch belongs to is derived from.
+    peek_uuid: Uuid,
+    /// The description the rows are written under, and the one the response reports.
+    relation_desc: RelationDesc,
+    /// The number of rows the peek's finishing can use, its offset plus its limit, or `None` for a
+    /// finishing that can use every row the peek produces.
+    max_rows: Option<usize>,
+}
+
+impl StashTarget {
+    /// The stash `peek`'s rows go to, at `persist_location`.
+    pub(super) fn new(
+        peek: &Peek,
+        persist_clients: Arc<PersistClientCache>,
+        persist_location: PersistLocation,
+    ) -> Self {
+        Self {
+            persist_clients,
+            persist_location,
+            peek_uuid: peek.uuid,
+            relation_desc: peek.result_desc.clone(),
+            max_rows: peek.finishing.num_rows_needed(),
+        }
+    }
+
+    /// Opens the upload, whose batch builder holds at most `batch_max_runs` runs.
+    pub(super) async fn open(&self, batch_max_runs: usize) -> Result<StashUpload, String> {
+        StashUpload::open(
+            &self.persist_clients,
+            self.persist_location.clone(),
+            batch_max_runs,
+            self.peek_uuid,
+            self.relation_desc.clone(),
+            self.max_rows,
+        )
+        .await
     }
 }
 
 /// Tests of the incremental stash upload, over the persist location a replica would write to.
+///
+/// [`tests::stashed_rows`] is shared with the drivers that feed an upload, which read a response
+/// back the same way.
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use mz_compute_types::dyncfgs::{
         PEEK_RESPONSE_STASH_BATCH_MAX_RUNS, PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES,
     };
@@ -395,6 +472,19 @@ mod tests {
         .expect("the in-memory location opens")
     }
 
+    /// Writes `rows` to `upload`, which persist accepts for every batch built here.
+    async fn push(upload: &mut StashUpload, rows: RowBatch) -> UploadDemand {
+        upload.push(rows).await.expect("persist takes the rows")
+    }
+
+    /// Finishes `upload` beside `inline_rows`, which persist accepts for every batch built here.
+    async fn finish(upload: StashUpload, inline_rows: RowBatch) -> PeekResponse {
+        upload
+            .finish(inline_rows)
+            .await
+            .expect("persist finishes the batch")
+    }
+
     /// The values a finished upload holds, in ascending order, each repeated as often as the diff
     /// it was written with.
     ///
@@ -407,6 +497,24 @@ mod tests {
             panic!("an upload finishes into a stashed response, not {response:?}");
         };
 
+        stashed_rows(clients, *stashed)
+            .await
+            .into_iter()
+            .map(|row| row.unpack_first().unwrap_uint64())
+            .collect()
+    }
+
+    /// The rows the batches of `stashed` hold, in [`Row`] order, each repeated as often as the diff
+    /// it was written with.
+    ///
+    /// A stashed response names a persist batch rather than carrying rows, so what an upload wrote
+    /// is only visible from the batch. Read as the coordinator reads one, deletions included, and
+    /// sorted because persist consolidates a batch rather than preserving the order it was written
+    /// in. Rows the response carries in `inline_rows` are not here: they never reached a batch.
+    pub(crate) async fn stashed_rows(
+        clients: &PersistClientCache,
+        stashed: StashedPeekResponse,
+    ) -> Vec<Row> {
         // Opened out of the cache that opened the upload, because two `PersistLocation`s naming the
         // same in-memory URI reach the same blob only through one cache.
         let mut client = clients
@@ -437,23 +545,22 @@ mod tests {
             .await
             .expect("the batch is readable at the timestamp it was written at");
 
-        let mut values = Vec::new();
+        let mut rows = Vec::new();
         while let Some(updates) = cursor.next().await {
             for ((key, _val), _time, diff) in updates {
                 let row = key.0.expect("the peek stash holds no errors");
-                let value = row.unpack_first().unwrap_uint64();
                 let copies = usize::try_from(diff).expect("a stashed row carries a positive diff");
-                values.extend(std::iter::repeat_n(value, copies));
+                rows.extend(std::iter::repeat_n(row, copies));
             }
         }
-        values.sort();
+        rows.sort();
 
         // Deleted as the coordinator deletes them once it has read them. A batch dropped without
         // this leaves its blob keys behind and says so in a warning.
         for batch in cursor.into_lease() {
             batch.delete().await;
         }
-        values
+        rows
     }
 
     /// An upload with no limit to reach holds every row pushed into it, over as many pushes as the
@@ -463,10 +570,10 @@ mod tests {
         let clients = PersistClientCache::new_no_metrics();
         let mut upload = open_upload(&clients, None).await;
 
-        assert_eq!(upload.push(batch(0..3, 1)).await, UploadDemand::Wants);
-        assert_eq!(upload.push(batch(3..5, 1)).await, UploadDemand::Wants);
+        assert_eq!(push(&mut upload, batch(0..3, 1)).await, UploadDemand::Wants);
+        assert_eq!(push(&mut upload, batch(3..5, 1)).await, UploadDemand::Wants);
 
-        let response = upload.finish().await;
+        let response = finish(upload, RowBatch::new()).await;
         let PeekResponse::Stashed(stashed) = &response else {
             panic!("an upload finishes into a stashed response, not {response:?}");
         };
@@ -488,12 +595,12 @@ mod tests {
         let mut upload = open_upload(&clients, Some(4)).await;
 
         assert_eq!(
-            upload.push(batch(0..2, 3)).await,
+            push(&mut upload, batch(0..2, 3)).await,
             UploadDemand::Satisfied,
             "six copies of two rows is past a limit of four"
         );
         assert_eq!(
-            stashed_values(&clients, upload.finish().await).await,
+            stashed_values(&clients, finish(upload, RowBatch::new()).await).await,
             vec![0, 0, 0, 1, 1, 1],
             "the row that crossed the limit is written whole"
         );
@@ -511,17 +618,59 @@ mod tests {
             UploadDemand::Wants,
             "an upload that has written nothing wants rows"
         );
-        assert_eq!(upload.push(batch(0..4, 1)).await, UploadDemand::Satisfied);
         assert_eq!(
-            upload.push(batch(4..8, 1)).await,
+            push(&mut upload, batch(0..4, 1)).await,
+            UploadDemand::Satisfied
+        );
+        assert_eq!(
+            push(&mut upload, batch(4..8, 1)).await,
             UploadDemand::Satisfied,
             "a satisfied upload stays satisfied"
         );
 
         assert_eq!(
-            stashed_values(&clients, upload.finish().await).await,
+            stashed_values(&clients, finish(upload, RowBatch::new()).await).await,
             vec![0, 1],
             "the rows past the limit are discarded, in the push that crossed it and after it"
+        );
+    }
+
+    /// Rows a walk still held when it ended travel with the response rather than through the
+    /// batch, so a reader sees them beside the stashed rows and the stashed row count counts only
+    /// what the batch holds.
+    #[mz_ore::test(tokio::test)]
+    async fn rows_that_never_reached_the_stash_travel_inline() {
+        let clients = PersistClientCache::new_no_metrics();
+        let mut upload = open_upload(&clients, None).await;
+
+        assert_eq!(push(&mut upload, batch(0..3, 1)).await, UploadDemand::Wants);
+
+        let response = finish(upload, batch(3..5, 1)).await;
+        let PeekResponse::Stashed(stashed) = &response else {
+            panic!("an upload finishes into a stashed response, not {response:?}");
+        };
+        assert_eq!(
+            stashed.num_rows_batches, 3,
+            "the stashed row count describes the batch alone"
+        );
+        let expected: Vec<(Row, NonZeroUsize)> = batch(3..5, 1)
+            .into_iter()
+            .map(|(row, copies)| {
+                (
+                    row,
+                    NonZeroUsize::try_from(copies).expect("fits into usize"),
+                )
+            })
+            .collect();
+        assert_eq!(
+            stashed.inline_rows,
+            vec![RowCollection::new(expected, &[])],
+            "the rows the walk still held travel with the response"
+        );
+        assert_eq!(
+            stashed_values(&clients, response).await,
+            vec![0, 1, 2],
+            "the rows carried inline are not written to the batch as well"
         );
     }
 }

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -13,6 +13,7 @@ use mz_compute_client::protocol::command::Peek;
 use mz_compute_client::protocol::response::{PeekResponse, StashedPeekResponse};
 use mz_expr::row::RowCollection;
 use mz_ore::cast::CastFrom;
+use mz_ore::task::RuntimeExt;
 use mz_persist_client::Schemas;
 use mz_persist_client::batch::BatchBuilder;
 use mz_persist_client::cache::PersistClientCache;
@@ -21,6 +22,8 @@ use mz_persist_types::{PersistLocation, ShardId};
 use mz_repr::{RelationDesc, Timestamp};
 use mz_storage_types::sources::SourceData;
 use timely::progress::Antichain;
+use tokio::runtime::Handle;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::compute_state::peek_scan::RowBatch;
@@ -44,8 +47,17 @@ pub(super) enum UploadDemand {
 /// and from an async task alike.
 ///
 /// The rows an upload is given are the rows it writes, in the order it is given them, up to the
-/// point where the peek's finishing has all it can use. An upload dropped without
-/// [`StashUpload::finish`] leaves the parts it has already written to blob storage behind.
+/// point where the peek's finishing has all it can use. An upload that is never finished deletes
+/// the parts it has written, whether it is handed to [`StashUpload::discard`] or only dropped, so
+/// abandoning one costs blob storage nothing lasting. [`StashUpload::abandon`] states the one case
+/// that escapes.
+///
+/// Nothing here bounds how large a stashed answer grows where the finishing has no limit to reach.
+/// `max_result_size` bounds the prefix a single scan retains between batches and never the sum
+/// across them, so an upload writes as many rows as the walk feeding it produces. What keeps a
+/// reader from having to hold all of them at once is the reader's own budget, the dyncfgs
+/// `peek_stash_read_batch_size_bytes` and `peek_stash_read_memory_budget_bytes`, and nothing on
+/// this side.
 ///
 /// Every write reports its failure rather than raising it. The unit that fails is the peek, whose
 /// driver answers it with the error, so a rejected write costs one query its answer instead of
@@ -56,7 +68,10 @@ pub(super) struct StashUpload {
     /// The shard the batch belongs to, derived from the peek's uuid so that a reader holding the
     /// response can find it.
     shard_id: ShardId,
-    batch_builder: BatchBuilder<SourceData, (), Timestamp, i64>,
+    /// The parts persist has taken so far. Taken by whichever of [`StashUpload::finish`] and
+    /// [`StashUpload::abandon`] gets there first, and a `None` says the parts are accounted for
+    /// and nothing is left to delete.
+    batch_builder: Option<BatchBuilder<SourceData, (), Timestamp, i64>>,
     /// The upper the batch is finished at, one step beyond the timestamp every row is written at.
     upper: Antichain<Timestamp>,
     /// The number of rows the peek's finishing can use, its offset plus its limit, or `None` for a
@@ -65,7 +80,14 @@ pub(super) struct StashUpload {
     /// Rows written so far, counting a row with a diff of `n` as `n` rows, which is how the
     /// finishing counts them.
     num_rows: u64,
+    /// The runtime an abandoned upload's deletion is spawned on, held rather than taken from the
+    /// ambient context because [`StashUpload::abandon`] runs where there may be none.
+    runtime: Handle,
 }
+
+/// What a [`StashUpload`] whose builder is already gone would be: an upload past the one call that
+/// consumes it, which no caller holds.
+const BUILDER_TAKEN: &str = "an upload holds its builder until it is finished or abandoned";
 
 impl StashUpload {
     /// Opens an upload for the peek `peek_uuid` identifies.
@@ -114,10 +136,11 @@ impl StashUpload {
         Ok(Self {
             relation_desc,
             shard_id,
-            batch_builder,
+            batch_builder: Some(batch_builder),
             upper,
             max_rows,
             num_rows: 0,
+            runtime: Handle::current(),
         })
     }
 
@@ -140,6 +163,8 @@ impl StashUpload {
             let diff: i64 = diff.into();
 
             self.batch_builder
+                .as_mut()
+                .expect(BUILDER_TAKEN)
                 .add(&SourceData(Ok(row)), &(), &Timestamp::default(), &diff)
                 .await
                 .map_err(|err| err.to_string())?;
@@ -164,10 +189,16 @@ impl StashUpload {
     /// sound because a peek reaches the stash only with an empty `order_by`.
     ///
     /// Fails where persist rejects the batch, in which case nothing that was written is readable.
-    pub(super) async fn finish(self, inline_rows: RowBatch) -> Result<PeekResponse, String> {
+    ///
+    /// A rejection also strands the parts: persist takes the builder to finish it and hands back
+    /// no handle to what it holds when it refuses, so the deletion an abandoned upload does has
+    /// nothing to reach and the parts stay in blob storage.
+    pub(super) async fn finish(mut self, inline_rows: RowBatch) -> Result<PeekResponse, String> {
         let batch = self
             .batch_builder
-            .finish(self.upper)
+            .take()
+            .expect(BUILDER_TAKEN)
+            .finish(self.upper.clone())
             .await
             .map_err(|err| err.to_string())?;
 
@@ -182,12 +213,66 @@ impl StashUpload {
         let stashed_response = StashedPeekResponse {
             num_rows_batches: self.num_rows,
             encoded_size_bytes: batch.encoded_size_bytes(),
-            relation_desc: self.relation_desc,
+            relation_desc: self.relation_desc.clone(),
             shard_id: self.shard_id,
             batches: vec![batch.into_transmittable_batch()],
             inline_rows: vec![RowCollection::new(inline_rows, &[])],
         };
         Ok(PeekResponse::Stashed(Box::new(stashed_response)))
+    }
+
+    /// Deletes the parts this upload has already written, consuming it.
+    ///
+    /// A driver whose peek will be answered with something other than these rows calls this to say
+    /// so. The deletion is scheduled rather than performed here, so this returns before blob
+    /// storage has caught up and reports nothing about how it went.
+    pub(super) fn discard(mut self) {
+        self.abandon();
+    }
+
+    /// Schedules the deletion of whatever parts the upload still holds, and leaves it holding
+    /// none.
+    ///
+    /// Persist hands back a handle to the parts it has taken only by finishing the batch, so the
+    /// rows still buffered are written out before the delete removes them along with the rest, and
+    /// they stay in memory until it does. That is a part's worth of rows outliving the permit that
+    /// admitted the walk which produced them.
+    fn abandon(&mut self) {
+        let Some(batch_builder) = self.batch_builder.take() else {
+            return;
+        };
+
+        let upper = self.upper.clone();
+        let shard_id = self.shard_id;
+
+        // Scheduled rather than awaited because the caller that matters most cannot await at all.
+        // Cancelling a peek aborts the walk driving it, and an aborted task is dropped rather than
+        // polled again, so the deletion reaches blob storage only as work that does not belong to
+        // that task. Entering the runtime explicitly is what lets this run from a `Drop`, which is
+        // not guaranteed to run inside a runtime context.
+        //
+        // NOTE: this reaches only an upload that a live replica gives up on. A replica that dies
+        // mid-upload, or one whose runtime is already shutting down, leaves the parts in blob
+        // storage, and reclaiming those needs a reader-side sweep or persist's own garbage
+        // collection.
+        let _handle =
+            self.runtime
+                .spawn_named(|| format!("peek_stash::discard({shard_id})"), async move {
+                    match batch_builder.finish(upper).await {
+                        Ok(batch) => batch.delete().await,
+                        Err(error) => {
+                            warn!(%shard_id, %error, "peek stash cannot delete an abandoned batch")
+                        }
+                    }
+                });
+    }
+}
+
+impl Drop for StashUpload {
+    /// Deletes the parts of an upload that ends without [`StashUpload::finish`] or
+    /// [`StashUpload::discard`], which is the only cleanup a walk aborted mid-upload gets.
+    fn drop(&mut self) {
+        self.abandon();
     }
 }
 

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -13,6 +13,7 @@ use mz_compute_client::protocol::command::Peek;
 use mz_compute_client::protocol::response::{PeekResponse, StashedPeekResponse};
 use mz_expr::row::RowCollection;
 use mz_ore::cast::CastFrom;
+use mz_ore::future::OreFutureExt;
 use mz_ore::task::RuntimeExt;
 use mz_persist_client::Schemas;
 use mz_persist_client::batch::{Batch, BatchBuilder};
@@ -49,11 +50,19 @@ pub(super) enum UploadDemand {
 ///
 /// The rows an upload is given are the rows it writes, in the order it is given them, up to the
 /// point where the peek's finishing has all it can use. An upload that does not reach a reader
-/// deletes what it wrote, whether it is handed to [`StashUpload::discard`], only dropped, or
-/// stopped part-way through finishing.
+/// deletes the parts a finished batch can reach, whether it is handed to [`StashUpload::discard`],
+/// only dropped, or stopped part-way through finishing.
 ///
-/// That guarantee ends where the finished batch does. Once [`StashUpload::finish`] hands back a
-/// response, the parts belong to the response rather than to any upload, and a caller that drops
+/// What a finished batch reaches is not always everything that was written. Persist merges runs
+/// once a builder holds more than `peek_response_stash_batch_max_runs` of them, and a merge writes
+/// a fresh output and drops the inputs it read without entering them into shard state, so nothing
+/// on either side can address them again. Parts flush at `persist_blob_target_size`, so an upload
+/// small enough never to merge deletes all of what it wrote and a large one deletes the output of
+/// its last merge. A reader deleting a response it has finished with reaches exactly the same
+/// parts, so this is a property of the builder rather than of abandonment.
+///
+/// The guarantee also ends where the finished batch does. Once [`StashUpload::finish`] hands back
+/// a response, the parts belong to the response rather than to any upload, and a caller that drops
 /// one leaves them behind. A replica that dies mid-upload leaves them behind too, and
 /// [`StashUpload::abandon`] says so.
 ///
@@ -66,7 +75,8 @@ pub(super) enum UploadDemand {
 ///
 /// Every write reports its failure rather than raising it. The unit that fails is the peek, whose
 /// driver answers it with the error, so a rejected write costs one query its answer instead of
-/// costing the walk that produced it its task.
+/// costing the walk that produced it its task. Cleanup holds itself to the same rule by catching
+/// what persist raises, for the reason [`StashUpload::abandon`] gives.
 pub(super) struct StashUpload {
     /// The description the stashed response reports, and the schema the batch is written under.
     relation_desc: RelationDesc,
@@ -279,7 +289,8 @@ impl StashUpload {
     /// bounds how many abandoned uploads carry a part at once.
     ///
     /// TODO: persist could offer a builder teardown that surrenders the parts already written
-    /// without flushing the buffered one, which would make this cost a delete and nothing else.
+    /// without flushing the buffered one, which would make this cost a delete and nothing else,
+    /// and would remove the reason the finish below has to be caught.
     fn abandon(&mut self) {
         let Some(batch_builder) = self.batch_builder.take() else {
             return;
@@ -301,10 +312,26 @@ impl StashUpload {
         let _handle =
             self.runtime
                 .spawn_named(|| format!("peek_stash::discard({shard_id})"), async move {
-                    match batch_builder.finish(upper).await {
-                        Ok(batch) => batch.delete().await,
-                        Err(error) => {
+                    // A builder whose write was in flight when its walk was aborted holds a part
+                    // that persist has already marked as being waited on, and finishing it panics
+                    // rather than returning. The panic has to be caught here: this replica installs
+                    // a handler that aborts the process for any panic outside a catch, so
+                    // reclaiming one query's blob storage would otherwise cost the whole replica.
+                    // Failing to reclaim is what this path already tolerates elsewhere, which makes
+                    // the leak the right outcome and the abort the wrong one.
+                    let finished = std::panic::AssertUnwindSafe(batch_builder.finish(upper))
+                        .ore_catch_unwind()
+                        .await;
+                    match finished {
+                        Ok(Ok(batch)) => batch.delete().await,
+                        Ok(Err(error)) => {
                             warn!(%shard_id, %error, "peek stash cannot delete an abandoned batch")
+                        }
+                        Err(_panic) => {
+                            warn!(
+                                %shard_id,
+                                "peek stash cannot reclaim an abandoned batch interrupted mid-write"
+                            )
                         }
                     }
                 });
@@ -1022,13 +1049,10 @@ pub(crate) mod tests {
         );
     }
 
-    /// A batch persist rejects is reported rather than raised, and the upload that held it does
-    /// not go on to tear down a builder persist has already taken.
+    /// A batch persist rejects is reported rather than raised.
     ///
     /// A rejected finish leaves the parts behind, which [`StashUpload::finish`] states: persist
-    /// keeps the builder it was asked to finish and hands back no handle to what it holds. The
-    /// upload is dropped here all the same, because a second teardown of a builder that is already
-    /// gone is what the `expect` this arm replaced would have panicked on.
+    /// keeps the builder it was asked to finish and hands back no handle to what it holds.
     #[mz_ore::test(tokio::test)]
     async fn a_rejected_batch_is_reported_rather_than_raised() {
         let clients = PersistClientCache::new_no_metrics();
@@ -1046,10 +1070,5 @@ pub(crate) mod tests {
                 .is_err_and(|error| error.contains("beyond the expected batch upper")),
             "persist must reject the batch and the upload must report it: {rejection:?}",
         );
-
-        // Every chance for a teardown the rejection left behind to run and fail.
-        for _ in 0..BLOB_TURNS {
-            tokio::task::yield_now().await;
-        }
     }
 }

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -429,13 +429,165 @@ impl StashTarget {
 #[cfg(test)]
 pub(crate) mod tests {
     use std::num::NonZeroI64;
+    use std::time::Duration;
 
     use mz_compute_types::dyncfgs::{
         PEEK_RESPONSE_STASH_BATCH_MAX_RUNS, PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES,
     };
+    use mz_dyncfg::{ConfigUpdates, ConfigVal};
+    use mz_ore::cast::CastLossy;
+    use mz_ore::metrics::MetricsRegistry;
+    use mz_persist_client::cfg::PersistConfig;
+    use mz_persist_client::rpc::PubSubClientConnection;
     use mz_repr::{Datum, Row, SqlScalarType};
 
     use super::*;
+
+    /// How many turns a test gives blob storage to catch up before it declares a deletion lost.
+    ///
+    /// Deleting the parts of an abandoned upload is scheduled rather than awaited, and the write
+    /// that earns the handle to delete runs partly on persist's isolated runtime, so a test can
+    /// only wait for it. Bounded by turns rather than by a deadline, so a deletion that never
+    /// happens fails the test rather than hanging the suite.
+    const BLOB_TURNS: usize = 1_000;
+
+    /// A run limit above what any upload here produces, so that its builder never merges runs.
+    ///
+    /// A merge writes parts of its own and leaves the parts it merged from behind, both of which
+    /// are persist's business rather than the upload's. Raising the limit past the runs a test
+    /// produces is what makes the parts it counts the parts the upload is answerable for.
+    const NO_RUN_MERGING: usize = 64;
+
+    /// A persist client cache whose blob traffic a test can count.
+    ///
+    /// Configured so that every row an upload takes becomes a part in blob storage rather than
+    /// bytes inlined into shard state, which is what makes "the parts an upload wrote" something a
+    /// test can observe at all. The counts are read off the registry because persist keeps its own
+    /// metric handles private.
+    pub(crate) struct CountedBlob {
+        registry: MetricsRegistry,
+        clients: Arc<PersistClientCache>,
+    }
+
+    impl CountedBlob {
+        pub(crate) fn new() -> Self {
+            let cfg = PersistConfig::new_for_tests();
+
+            let mut updates = ConfigUpdates::default();
+            for (name, val) in [
+                // A part per row, so a walk that has pushed anything has put a key in blob
+                // storage.
+                ("persist_blob_target_size", ConfigVal::Usize(0)),
+                // Without this persist keeps a small part in shard state, where no blob counter
+                // sees it and no delete has anything to remove.
+                (
+                    "persist_inline_writes_single_max_bytes",
+                    ConfigVal::Usize(0),
+                ),
+                // A part per row means a builder that stalls waiting for its outstanding writes,
+                // and a task aborted inside that stall leaves persist's `Pending` in the
+                // `Blocking` state it panics on when the cleanup later finishes the batch. Raising
+                // the bound past the parts a test produces keeps the stall out of the way, so what
+                // an abort test measures is this module's cleanup rather than that hazard. See the
+                // finding recorded for this layer.
+                (
+                    "persist_batch_builder_max_outstanding_parts",
+                    ConfigVal::Usize(8_192),
+                ),
+            ] {
+                assert!(
+                    cfg.entry(name).is_some(),
+                    "persist no longer has a config named {name}"
+                );
+                updates.add_dynamic(name, val);
+            }
+            updates.apply(&cfg);
+
+            let registry = MetricsRegistry::new();
+            let clients = Arc::new(PersistClientCache::new(cfg, &registry, |_, _| {
+                PubSubClientConnection::noop()
+            }));
+            Self { registry, clients }
+        }
+
+        pub(crate) fn clients(&self) -> &Arc<PersistClientCache> {
+            &self.clients
+        }
+
+        /// Blob keys written.
+        pub(crate) fn written(&self) -> u64 {
+            self.succeeded("blob_set")
+        }
+
+        /// Blob keys deleted.
+        pub(crate) fn deleted(&self) -> u64 {
+            self.succeeded("blob_delete")
+        }
+
+        /// Deletes that found nothing to delete, which is how a delete of a key that was never
+        /// written shows up.
+        pub(crate) fn deletes_of_nothing(&self) -> u64 {
+            self.counter("mz_persist_external_blob_delete_noop_count", &[])
+        }
+
+        /// Waits until every key written has been deleted, which is what an upload that reaches no
+        /// reader owes.
+        pub(crate) async fn wait_until_nothing_is_left(&self, what: &str) {
+            for _ in 0..BLOB_TURNS {
+                let written = self.written();
+                if written > 0 && self.deleted() == written {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            panic!(
+                "{what} left {} of {} blob keys behind after {BLOB_TURNS} turns",
+                self.written() - self.deleted(),
+                self.written(),
+            );
+        }
+
+        /// Waits until at least one part has reached blob storage.
+        pub(crate) async fn wait_until_something_is_written(&self, what: &str) {
+            for _ in 0..BLOB_TURNS {
+                if self.written() > 0 {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            panic!("{what} wrote no blob key within {BLOB_TURNS} turns");
+        }
+
+        fn succeeded(&self, op: &str) -> u64 {
+            self.counter("mz_persist_external_succeeded_count", &[("op", op)])
+        }
+
+        /// Sums the counter series named `name` whose labels include all of `labels`, reading zero
+        /// for a series that has not been incremented yet.
+        fn counter(&self, name: &str, labels: &[(&str, &str)]) -> u64 {
+            let Some(family) = self
+                .registry
+                .gather()
+                .into_iter()
+                .find(|m| m.name() == name)
+            else {
+                return 0;
+            };
+            family
+                .get_metric()
+                .iter()
+                .filter(|metric| {
+                    labels.iter().all(|(name, value)| {
+                        metric
+                            .get_label()
+                            .iter()
+                            .any(|label| label.name() == *name && label.value() == *value)
+                    })
+                })
+                .map(|metric| u64::cast_lossy(metric.get_counter().value()))
+                .sum()
+        }
+    }
 
     /// The description of the single-column result every peek here asks for.
     fn result_desc() -> RelationDesc {
@@ -455,10 +607,28 @@ pub(crate) mod tests {
 
     /// An upload of a peek that can use `max_rows` rows, opened against `clients`.
     async fn open_upload(clients: &PersistClientCache, max_rows: Option<usize>) -> StashUpload {
+        open_upload_with_runs(
+            clients,
+            max_rows,
+            *PEEK_RESPONSE_STASH_BATCH_MAX_RUNS.default(),
+        )
+        .await
+    }
+
+    /// An upload whose batch builder holds at most `batch_max_runs` runs.
+    ///
+    /// A builder that has more runs than that merges them, which writes parts of its own and
+    /// leaves the parts it merged from behind. A test counting what an upload wrote raises the
+    /// limit above the runs it produces, so that the parts it counts are the parts the upload owns.
+    async fn open_upload_with_runs(
+        clients: &PersistClientCache,
+        max_rows: Option<usize>,
+        batch_max_runs: usize,
+    ) -> StashUpload {
         StashUpload::open(
             clients,
             PersistLocation::new_in_mem(),
-            *PEEK_RESPONSE_STASH_BATCH_MAX_RUNS.default(),
+            batch_max_runs,
             Uuid::new_v4(),
             result_desc(),
             max_rows,
@@ -667,5 +837,219 @@ pub(crate) mod tests {
             vec![0, 1, 2],
             "the rows carried inline are not written to the batch as well"
         );
+    }
+
+    /// An upload built by hand, so that a test can hold the bounds [`StashUpload::open`] never
+    /// produces.
+    ///
+    /// Opening fixes the lower, the upper and the timestamp every row is written at, and that
+    /// combination is one persist always accepts. The rejection arms exist all the same, because
+    /// the alternative to reporting a rejection is a panic in a promoted walk, which lands in the
+    /// dead-task arm and takes the worker down with it in a test build.
+    async fn upload_with_bounds(
+        clients: &PersistClientCache,
+        lower: Timestamp,
+        upper: Timestamp,
+    ) -> StashUpload {
+        let client = clients
+            .open(PersistLocation::new_in_mem())
+            .await
+            .expect("the in-memory location opens");
+        let shard_id = ShardId::try_from(format!("s{}", Uuid::new_v4())).expect("can parse");
+        let relation_desc = result_desc();
+        let write_schemas: Schemas<SourceData, ()> = Schemas {
+            id: None,
+            key: Arc::new(relation_desc.clone()),
+            val: Arc::new(UnitSchema),
+        };
+        let batch_builder = client
+            .batch_builder::<SourceData, (), Timestamp, i64>(
+                shard_id,
+                write_schemas,
+                Antichain::from_elem(lower),
+                Some(NO_RUN_MERGING),
+            )
+            .await;
+
+        StashUpload {
+            relation_desc,
+            shard_id,
+            batch_builder: Some(batch_builder),
+            upper: Antichain::from_elem(upper),
+            max_rows: None,
+            num_rows: 0,
+            runtime: Handle::current(),
+        }
+    }
+
+    /// An upload a driver gives up on deletes the parts it had already written.
+    ///
+    /// This is the path a walk takes when the peek is answered with something other than these
+    /// rows, an error from the walk itself or a cancellation the walk observed.
+    #[mz_ore::test(tokio::test)]
+    async fn a_discarded_upload_deletes_the_parts_it_wrote() {
+        let blob = CountedBlob::new();
+        let mut upload = open_upload_with_runs(blob.clients(), None, NO_RUN_MERGING).await;
+
+        assert_eq!(push(&mut upload, batch(0..4, 1)).await, UploadDemand::Wants);
+        blob.wait_until_something_is_written("an upload holding four rows")
+            .await;
+
+        upload.discard();
+
+        blob.wait_until_nothing_is_left("a discarded upload").await;
+        assert_eq!(
+            blob.deletes_of_nothing(),
+            0,
+            "the deletes must name the keys the upload wrote"
+        );
+    }
+
+    /// An upload that is only dropped deletes the parts it had already written, which is the whole
+    /// cleanup a walk aborted mid-upload gets: an aborted task is dropped rather than polled
+    /// again, so nothing it would have called runs.
+    #[mz_ore::test(tokio::test)]
+    async fn a_dropped_upload_deletes_the_parts_it_wrote() {
+        let blob = CountedBlob::new();
+        let mut upload = open_upload_with_runs(blob.clients(), None, NO_RUN_MERGING).await;
+
+        assert_eq!(push(&mut upload, batch(0..4, 1)).await, UploadDemand::Wants);
+        blob.wait_until_something_is_written("an upload holding four rows")
+            .await;
+
+        drop(upload);
+
+        blob.wait_until_nothing_is_left("a dropped upload").await;
+        assert_eq!(
+            blob.deletes_of_nothing(),
+            0,
+            "the deletes must name the keys the upload wrote"
+        );
+    }
+
+    /// A finished batch that never reaches the response naming it is deleted.
+    ///
+    /// This is the window between persist handing the batch over and the response taking it: a
+    /// cancellation that lands there leaves a batch no reader will ever be told how to find, and
+    /// persist's own `Drop for Batch` logs the keys and leaves them.
+    #[mz_ore::test(tokio::test)]
+    async fn a_finished_batch_that_reaches_no_response_is_deleted() {
+        let blob = CountedBlob::new();
+        let mut upload = open_upload_with_runs(blob.clients(), None, NO_RUN_MERGING).await;
+
+        assert_eq!(push(&mut upload, batch(0..4, 1)).await, UploadDemand::Wants);
+        let delivered = upload
+            .finish_batch()
+            .await
+            .expect("persist finishes the batch");
+        assert!(
+            blob.written() > 0,
+            "a finished batch has written the parts it holds"
+        );
+        assert_eq!(
+            blob.deleted(),
+            0,
+            "a batch still on its way to a response is not deleted"
+        );
+
+        drop(delivered);
+
+        blob.wait_until_nothing_is_left("an unclaimed delivery")
+            .await;
+        assert_eq!(
+            blob.deletes_of_nothing(),
+            0,
+            "the deletes must name the keys the batch wrote"
+        );
+    }
+
+    /// An upload that finishes into a response leaves its parts alone, because the response is
+    /// what a reader finds them by.
+    ///
+    /// The other tests here would all pass against an upload that deleted everything it wrote
+    /// unconditionally, which is the shape of cleanup that costs every stashed peek its answer.
+    #[mz_ore::test(tokio::test)]
+    async fn a_finished_upload_leaves_its_parts_for_the_response() {
+        let blob = CountedBlob::new();
+        let mut upload = open_upload_with_runs(blob.clients(), None, NO_RUN_MERGING).await;
+
+        assert_eq!(push(&mut upload, batch(0..4, 1)).await, UploadDemand::Wants);
+        let response = finish(upload, RowBatch::new()).await;
+
+        // Every chance for a deletion that should not happen to happen.
+        for _ in 0..BLOB_TURNS {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            blob.written() > 0,
+            "a finished upload has written the parts it holds"
+        );
+        assert_eq!(
+            blob.deleted(),
+            0,
+            "the parts of a finished upload belong to the response that names them"
+        );
+        assert_eq!(
+            stashed_values(blob.clients(), response).await,
+            vec![0, 1, 2, 3],
+            "the response must still name a readable batch"
+        );
+    }
+
+    /// A write persist rejects is reported rather than raised.
+    ///
+    /// The unit that fails is the peek, whose driver answers it with the error. A panic here would
+    /// instead end the task driving a promoted walk, and the worker reads a dead task as a defect.
+    #[mz_ore::test(tokio::test)]
+    async fn a_rejected_write_is_reported_rather_than_raised() {
+        let clients = PersistClientCache::new_no_metrics();
+        // A lower past the timestamp the upload writes its rows at, which is the one thing
+        // `BatchBuilder::add` refuses.
+        let mut upload = upload_with_bounds(
+            &clients,
+            Timestamp::default().step_forward(),
+            Timestamp::default().step_forward().step_forward(),
+        )
+        .await;
+
+        let rejection = upload.push(batch(0..2, 1)).await;
+
+        assert!(
+            rejection
+                .as_ref()
+                .is_err_and(|error| error.contains("not beyond batch lower")),
+            "persist must reject the write and the upload must report it: {rejection:?}",
+        );
+    }
+
+    /// A batch persist rejects is reported rather than raised, and the upload that held it does
+    /// not go on to tear down a builder persist has already taken.
+    ///
+    /// A rejected finish leaves the parts behind, which [`StashUpload::finish`] states: persist
+    /// keeps the builder it was asked to finish and hands back no handle to what it holds. The
+    /// upload is dropped here all the same, because a second teardown of a builder that is already
+    /// gone is what the `expect` this arm replaced would have panicked on.
+    #[mz_ore::test(tokio::test)]
+    async fn a_rejected_batch_is_reported_rather_than_raised() {
+        let clients = PersistClientCache::new_no_metrics();
+        // An upper the rows the upload holds are not below, which is the one thing
+        // `BatchBuilder::finish` refuses.
+        let mut upload =
+            upload_with_bounds(&clients, Timestamp::default(), Timestamp::default()).await;
+
+        assert_eq!(push(&mut upload, batch(0..2, 1)).await, UploadDemand::Wants);
+        let rejection = upload.finish(RowBatch::new()).await;
+
+        assert!(
+            rejection
+                .as_ref()
+                .is_err_and(|error| error.contains("beyond the expected batch upper")),
+            "persist must reject the batch and the upload must report it: {rejection:?}",
+        );
+
+        // Every chance for a teardown the rejection left behind to run and fail.
+        for _ in 0..BLOB_TURNS {
+            tokio::task::yield_now().await;
+        }
     }
 }

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -58,7 +58,6 @@ pub struct ComputeMetrics {
     // look at.
     timely_step_duration_seconds: HistogramVec,
     persist_peek_seconds: HistogramVec,
-    stashed_peek_seconds: HistogramVec,
     handle_command_duration_seconds: HistogramVec,
 
     // Index peek timing phases (per-cluster, no worker label)
@@ -206,12 +205,6 @@ impl ComputeMetrics {
                 var_labels: ["worker_id"],
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
-            stashed_peek_seconds: registry.register(with_role(metric!(
-                name: "mz_stashed_peek_seconds",
-                help: "Time spent reading a peek result and stashing it in the peek result stash (aka. persist blob).",
-                var_labels: ["worker_id"],
-                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
-            ), role)),
             handle_command_duration_seconds: registry.register(with_role(metric!(
                 name: "mz_cluster_handle_command_duration_seconds",
                 help: "Time spent in handling commands.",
@@ -328,7 +321,6 @@ impl ComputeMetrics {
             .timely_step_duration_seconds
             .with_label_values(&[&worker]);
         let persist_peek_seconds = self.persist_peek_seconds.with_label_values(&[&worker]);
-        let stashed_peek_seconds = self.stashed_peek_seconds.with_label_values(&[&worker]);
         let handle_command_duration_seconds = CommandMetrics::build(|typ| {
             self.handle_command_duration_seconds
                 .with_label_values(&[worker.as_ref(), typ])
@@ -367,7 +359,6 @@ impl ComputeMetrics {
             arrangement_maintenance_active_info,
             timely_step_duration_seconds,
             persist_peek_seconds,
-            stashed_peek_seconds,
             handle_command_duration_seconds,
             index_peek_total_seconds,
             index_peek_seek_fulfillment_seconds,
@@ -409,8 +400,6 @@ pub struct WorkerMetrics {
     pub(crate) timely_step_duration_seconds: Histogram,
     /// Histogram of persist peek durations.
     pub(crate) persist_peek_seconds: Histogram,
-    /// Histogram of stashed peek durations.
-    pub(crate) stashed_peek_seconds: Histogram,
     /// Histogram of command handling durations.
     pub(crate) handle_command_duration_seconds: CommandMetrics<Histogram>,
     /// Histogram of total index peek durations.

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -72,6 +72,7 @@ pub struct ComputeMetrics {
     index_peek_frontier_check_seconds: Histogram,
     index_peek_row_collection_seconds: Histogram,
     index_peek_walks_total: raw::IntCounterVec,
+    index_peek_stashed_total: IntCounter,
     index_peek_permit_queue_depth: UIntGauge,
     index_peek_permit_wait_seconds: Histogram,
     index_peek_offload_seconds: Histogram,
@@ -214,7 +215,7 @@ impl ComputeMetrics {
             ), role)),
             index_peek_total_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_total_seconds",
-                help: "Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk's end either promotes it or diverts it to the peek stash. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. Excluding peeks that use the peek response stash.",
+                help: "Time one visit to an index peek spent on the timely worker. Observed per visit rather than per peek, so a peek revisited while the frontiers it reads are behind its timestamp contributes an observation per visit. A walk itself takes at most one of those visits: a suspension that is not the walk's end promotes it. A peek whose walk was offloaded contributes only the inline slice that promoted it, which the inline budget bounds. Its time away from the worker is `mz_index_peek_offload_seconds`. A peek bound for the peek response stash is included, because the slice that promoted it ran here like any other.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_seek_fulfillment_seconds: registry.register(with_role(metric!(
@@ -266,6 +267,10 @@ impl ComputeMetrics {
                 name: "mz_index_peek_walks_total",
                 help: "The number of index peek walks that reached an outcome, by the substrate they ended on: `inline` on the timely worker, `offloaded` away from it. A walk cancelled before it reaches an outcome is counted on neither. An offloaded walk cancelled after that, while its result is on its way back to the worker, counts as `offloaded`. Reports whether the offload engaged at all, which a latency change on its own cannot distinguish from the offload never having been reached.",
                 var_labels: ["substrate"],
+            ), role)),
+            index_peek_stashed_total: registry.register(with_role(metric!(
+                name: "mz_index_peek_stashed_total",
+                help: "The number of index peek walks that answered with a handle to the peek response stash. Always a subset of the `offloaded` substrate of `mz_index_peek_walks_total`, because the driver that writes to the stash is the promoted one. How long such a walk spent writing is not separable from the walk itself, since one loop does both, and `mz_index_peek_offload_seconds` bounds it.",
             ), role)),
             index_peek_permit_queue_depth: registry.register(with_role(metric!(
                 name: "mz_index_peek_permit_queue_depth",
@@ -339,6 +344,7 @@ impl ComputeMetrics {
         let index_peek_walks_offloaded = self
             .index_peek_walks_total
             .with_label_values(&["offloaded"]);
+        let index_peek_stashed_total = self.index_peek_stashed_total.clone();
         let index_peek_permit_queue_depth = self.index_peek_permit_queue_depth.clone();
         let index_peek_permit_wait_seconds = self.index_peek_permit_wait_seconds.clone();
         let index_peek_offload_seconds = self.index_peek_offload_seconds.clone();
@@ -372,6 +378,7 @@ impl ComputeMetrics {
             index_peek_row_collection_seconds,
             index_peek_walks_inline,
             index_peek_walks_offloaded,
+            index_peek_stashed_total,
             index_peek_permit_queue_depth,
             index_peek_permit_wait_seconds,
             index_peek_offload_seconds,
@@ -431,6 +438,11 @@ pub struct WorkerMetrics {
     pub(crate) index_peek_walks_inline: IntCounter,
     /// Counts index peek walks that ran away from the timely worker.
     pub(crate) index_peek_walks_offloaded: IntCounter,
+    /// Counts index peek walks that answered from the peek response stash.
+    ///
+    /// Resolved when the worker's metrics are built, so it reports zero before the first stashed
+    /// answer rather than being absent. Whether a peek reached the stash has no other signal.
+    pub(crate) index_peek_stashed_total: IntCounter,
     /// How many offloaded index peek walks are waiting for a permit.
     pub(crate) index_peek_permit_queue_depth: UIntGauge,
     /// Histogram of how long an offloaded index peek walk waited for its permit.


### PR DESCRIPTION
Deletes the second walk a stashed peek used to cost. A peek whose accumulated rows crossed the stash threshold abandoned its walk, and a separate path re-read the trace bundle from the beginning to stream rows into persist. The promoted driver now writes each full batch as the walk produces it, so a peek walks its arrangement exactly once whatever its answer turns out to be. This is the layer that makes the one-path claim in the design document true.

The upload becomes a handle the driver feeds. `StashUpload` keeps everything about the persist interaction, the shard derived from the peek uuid, the schemas, the batch builder, the `max_rows` early exit, and takes rows through `push` instead of through a channel the worker pumps. `Complete` carries whatever the scan still holds, and the driver assembles the answer around it: a driver that never opened an upload answers with a row collection, and one that did finishes and answers with the stashed handle, whose `inline_rows` carry the rows that never reached the stash. The hand-back the layer below needed goes away, because the task now has somewhere to write.

`PendingPeek` ends with fewer index-peek states than it had before this work started, which is the trade the design says the effort is making. `PendingPeek::Stash`, `StashingPeek` and its worker-driven pump, `start_stash_upload`, and `PEEK_STASH_NUM_BATCHES` are all gone. `PEEK_STASH_BATCH_SIZE` goes too, against the plan: it counted rows, the upload cuts a batch on the byte threshold the scan already tracks, and nothing read it. A live tunable that does nothing is worse than an absent one, because an operator who reaches for it gets silence rather than an error.

Two consequences worth stating plainly rather than discovering later.

The kill switch no longer means no peek ever leaves the worker. With `UsePeekStash` gone, a large streamable peek would otherwise have no route to the stash at all, which is a functional regression rather than a placement change. The switch therefore gates budget-based promotion only: a scan that suspends because its prefix is batch-ready is handed to a task whichever way the switch is set, because that promotion is for stashing rather than for latency. With the switch off, ordinary peeks behave exactly as they do today.

The row iteration limit now follows a peek into the peek stash. #38158 stopped at the stash because a stashed peek restarted its scan and the restart charged the same rows twice. Deleting the restart is what this change does, so the count simply continues because the scan does. The dyncfg description said otherwise and no longer does.

Cancellation deletes what it wrote. A cancelled peek used to leave the parts already written in blob storage, since `impl Drop for Batch` only logs the dangling keys and the reader-side delete runs after a successful read that a cancelled peek never reaches. Cancellation aborts the promoted task rather than signalling it, so an await placed after the cancellation check would never run, and the obligation lives on the upload itself: dropping one spawns a `Batch::delete()` onto a runtime handle captured when it opened. A guard covers the window inside `finish`, where persist has taken the builder and no upload holds the parts any more.

Reclaiming those blobs must not cost more than it saves. A builder whose part write was in flight when its walk was aborted holds a write persist has already marked as waited on, and finishing it panics rather than returning; this replica aborts the process on any uncaught panic, so reclaiming one query's blob storage could take the replica with it. The panic is caught and the shard logged. Failing to reclaim is an outcome this path already tolerates for a replica that dies mid-upload, which makes a leak the right answer there and an abort the wrong one. A Linear issue tracks the persist-side fix that would remove the need for the catch.

`mz_index_peek_stashed_total` counts the walks the stash answered. It is incremented beside the offloaded substrate counter, so it is a strict subset by construction, and every inline-driver test asserts it stays at zero. `mz_stashed_peek_seconds` goes: its only observer was the deleted walk, and a registered histogram that never observes reports a flat zero, which reads worse in a graph than an absent series. The duration is deliberately not reconstructed, because one loop now walks and writes, so the write is not separable from the walk.

What an upload can delete is not always everything it wrote. Persist merges runs once a builder holds more than `peek_response_stash_batch_max_runs` of them, and a merge writes a fresh output and drops the inputs it read without entering them into shard state. Parts flush at `persist_blob_target_size`, so an upload small enough never to merge deletes all of what it wrote and a large one deletes the output of its last merge. A reader deleting a response it has finished with reaches exactly the same parts, so this is a property of the builder rather than of abandonment, and it is unchanged by this PR.

Nothing bounds the total size of a stashed answer, which is also true today. `max_result_size` bounds the prefix a single scan retains between batches and never the sum across them. The only ceiling is the reader's own budget.

Known gaps, none of which this PR closes:

* No sqllogictest or testdrive exercises a real stashed fast-path peek through the adapter reader. `inline_rows` was always empty from a worker on the old path and is now non-empty up to the threshold, and the adapter merges it across workers, so that merge has no coverage in CI.
* Nothing bounds how many abandoned uploads hold a part at once. Each can hold up to `persist_blob_target_size`, and the abandon task outlives the walk's permit.
* The caught persist panic is verified by construction rather than by a test, because the panic handler that turns it into an abort is not installed under `cargo test`.

🤖 Opened by [Claude Code](https://claude.com/claude-code) on behalf of @antiguru