### PR TITLE
clusterd-test-driver: pin `explain` renders to un-redacted

### DIFF
--- a/src/clusterd-test-driver/src/dataflow.rs
+++ b/src/clusterd-test-driver/src/dataflow.rs
@@ -460,11 +460,20 @@ impl DataflowBuilder {
     /// Honors [`Self::optimize`] exactly like [`Self::finish`], so the explained
     /// plan is the one that would be shipped. A no-catalog [`DummyHumanizer`]
     /// renders ids as `u123` and columns as `#n` — stable and matching the `.spec`
-    /// MIR vocabulary, with no catalog to thread in.
+    /// MIR vocabulary, with no catalog to thread in. Literals render verbatim,
+    /// independent of the build profile.
     pub fn explain(self) -> anyhow::Result<String> {
         let features = OptimizerFeatures::default();
         let mut lowered = Self::lower(self.mir, self.optimize, &features)?;
-        let config = ExplainConfig::default();
+        // `redacted` is pinned rather than taken from `ExplainConfig::default`, which
+        // derives it from the build's soft-assertion setting: a default-configured
+        // render would anonymize literals in the release-profile driver image and
+        // print them verbatim under `cargo test` or a `PROFILE=dev` local run. A
+        // golden must not depend on how the binary was built.
+        let config = ExplainConfig {
+            redacted: false,
+            ..ExplainConfig::default()
+        };
         let context = ExplainContext {
             config: &config,
             features: &features,


### PR DESCRIPTION
Follow-up to #37141, addressing def-'s review that landed after the merge.

`ExplainConfig::default()` derives `redacted` from `mz_ore::assert::soft_assertions_enabled()`, which follows `debug_assertions` unless `MZ_SOFT_ASSERTIONS` overrides it. The `HeadlessDriver` mzcompose service sets no such override and its image is a plain `cargo-build` pre-image at mzbuild's release-like profile, so `explain` rendered goldens with literals anonymized to a block character there, while `cargo test` and `run-local.py`'s default `PROFILE=dev` rendered them verbatim. A golden written under one would not match the other, and any plan carrying a literal would assert a redaction instead of the constant. Nothing differs today because `join.spec`'s plan holds only ids, `Arrange`/`Stream` nodes, and column keys.

Pinning `redacted: false` makes the render depend only on the plan and not on how the binary was built. Confirmed by hand: with the pin removed and `MZ_SOFT_ASSERTIONS=0`, a plan carrying a literal renders `map=(█)`.

No test covers this. Every configuration the crate's unit tests run in already has soft assertions on, so an assertion on the rendered text holds with or without the pin, and the only way to make one bite is to flip the process-global `SOFT_ASSERTIONS` atomic from inside the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)