### PR TITLE
docs: rename generated skill from materialize-docs to mz-docs (CDX-11)

### DIFF
--- a/bin/gen-claude-skill
+++ b/bin/gen-claude-skill
@@ -16,7 +16,7 @@
 #
 # Arguments: OUTPUT_DIR  Directory to output the skill files. The OUTPUT_DIR
 #   directory is cleaned before generation.
-#   Default: .agents/skills/materialize-docs.
+#   Default: .agents/skills/mz-docs.
 #   For publishing to the website,
 #   we will output to doc/user/public/markdown-docs directory.
 #
@@ -30,7 +30,7 @@ cd "$(dirname "$0")/.."
 
 # For publishing to the website, we will output to doc/user/public/markdown-docs
 # directory. The OUTPUT_DIR directory is cleaned before generation.
-OUTPUT_DIR="${1:-.agents/skills/materialize-docs}"
+OUTPUT_DIR="${1:-.agents/skills/mz-docs}"
 
 # Ensure output directory exists
 mkdir -p "$OUTPUT_DIR"

--- a/doc/user/layouts/index.skill.md
+++ b/doc/user/layouts/index.skill.md
@@ -1,6 +1,6 @@
 {{- /* Home page template - generates SKILL.md for Claude */ -}}
 ---
-name: materialize-docs
+name: mz-docs
 description: Materialize documentation for SQL syntax, data ingestion, concepts, and best practices. Use when users ask about Materialize queries, sources, sinks, views, or clusters.
 ---
 


### PR DESCRIPTION
Renames the generated Claude docs skill from `materialize-docs` to `mz-docs` to match the `mz-` prefix standard ([CDX-11](https://linear.app/materializeinc/issue/CDX-11)). Pairs with MaterializeInc/agent-skills#53 and needs to land in the same window, otherwise the twice-daily skill regen writes a `name` that mismatches the skill directory; also depends on the `mz-*` vs `mz-materialize-*` naming decision on that PR.