### PR TITLE
sql-427: Add unique key representation for optimizer

### DIFF
--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -40,6 +40,7 @@ pub use relation::func::{
     NaiveOneByOneAggr, OneByOneAggr, TableFunc,
 };
 pub use relation::join_input_mapper::JoinInputMapper;
+pub use relation::unique_keys::UniqueKeySets;
 pub use relation::{
     AccessStrategy, AggregateExpr, CollectionPlan, ColumnOrder, JoinImplementation,
     JoinInputCharacteristics, LetRecLimit, MirRelationExpr, RECURSION_LIMIT, RowComparator,

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -56,6 +56,7 @@ use crate::{
 pub mod canonicalize;
 pub mod func;
 pub mod join_input_mapper;
+pub mod unique_keys;
 
 /// A recursion limit to be used for stack-safe traversals of [`MirRelationExpr`] trees.
 ///

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -43,6 +43,7 @@ use serde::{Deserialize, Serialize};
 use crate::Id::Local;
 use crate::explain::{HumanizedExpr, HumanizerMode};
 use crate::relation::func::{AggregateFunc, LagLeadType, TableFunc};
+use crate::relation::unique_keys::UniqueKeySets;
 use crate::row::{RowCollection, RowCollectionIter};
 use crate::scalar::columns::Columns;
 use crate::scalar::func::variadic::{
@@ -340,8 +341,14 @@ impl MirRelationExpr {
     /// The relation type is computed incrementally with a recursive post-order
     /// traversal, that accumulates the input types for the relations yet to be
     /// visited in `type_stack`.
+    ///
+    /// Unique keys are threaded through the traversal as [`UniqueKeySets`], so
+    /// that column equivalences discovered at one operator strengthen key
+    /// inference at the operators above it. The returned type reports only the
+    /// canonical keys.
     pub fn typ(&self) -> ReprRelationType {
-        let mut type_stack = Vec::new();
+        let mut type_stack: Vec<(Vec<ReprColumnType>, UniqueKeySets)> = Vec::new();
+        let empty = || (Vec::new(), UniqueKeySets::none());
         self.visit_pre_post(
             &mut |e: &MirRelationExpr| -> Option<Vec<&MirRelationExpr>> {
                 match &e {
@@ -354,31 +361,36 @@ impl MirRelationExpr {
                 match e {
                     MirRelationExpr::Let { .. } => {
                         let body_typ = type_stack.pop().unwrap();
-                        // Insert a dummy relation type for the value, since `typ_with_input_types`
-                        // won't look at it, but expects the relation type of the body to be second.
-                        type_stack.push(ReprRelationType::empty());
+                        // Insert a dummy type for the value, since the methods
+                        // below won't look at it, but expect the type of the
+                        // body to be second.
+                        type_stack.push(empty());
                         type_stack.push(body_typ);
                     }
                     MirRelationExpr::LetRec { values, .. } => {
                         let body_typ = type_stack.pop().unwrap();
-                        type_stack.extend(
-                            std::iter::repeat(ReprRelationType::empty()).take(values.len()),
-                        );
-                        // Insert dummy relation types for the values, since `typ_with_input_types`
-                        // won't look at them, but expects the relation type of the body to be last.
+                        type_stack.extend(std::iter::repeat_with(empty).take(values.len()));
+                        // Insert dummy types for the values, since the methods
+                        // below won't look at them, but expect the type of the
+                        // body to be last.
                         type_stack.push(body_typ);
                     }
                     _ => {}
                 }
                 let num_inputs = e.num_inputs();
-                let relation_type =
-                    e.typ_with_input_types(&type_stack[type_stack.len() - num_inputs..]);
+                let inputs = &type_stack[type_stack.len() - num_inputs..];
+                let column_types = e.col_with_input_cols(inputs.iter().map(|(cols, _)| cols));
+                let keys = e.unique_keys_with_input_keys(
+                    inputs.iter().map(|(cols, _)| cols.len()),
+                    inputs.iter().map(|(_, keys)| keys),
+                );
                 type_stack.truncate(type_stack.len() - num_inputs);
-                type_stack.push(relation_type);
+                type_stack.push((column_types, keys));
             },
         );
         assert_eq!(type_stack.len(), 1);
-        type_stack.pop().unwrap()
+        let (column_types, keys) = type_stack.pop().unwrap();
+        ReprRelationType::new(column_types).with_keys(keys.into_keys())
     }
 
     /// Reports the repr schema of the relation given the repr schema of the input relations.
@@ -542,6 +554,25 @@ impl MirRelationExpr {
     /// Reports the unique keys of the relation given the arities and the unique
     /// keys of the input relations.
     ///
+    /// This is a convenience wrapper around `unique_keys_with_input_keys` for
+    /// callers that track keys as plain lists, for example as part of a
+    /// `ReprRelationType`. Column equivalences of the inputs are unknown in
+    /// that form, and the output reports only the canonical keys.
+    pub fn keys_with_input_keys<'a, I, J>(&self, input_arities: I, input_keys: J) -> Vec<Vec<usize>>
+    where
+        I: Iterator<Item = usize>,
+        J: Iterator<Item = &'a Vec<Vec<usize>>>,
+    {
+        let input_keys = input_keys
+            .map(|keys| UniqueKeySets::from_keys(keys.clone()))
+            .collect::<Vec<_>>();
+        self.unique_keys_with_input_keys(input_arities, input_keys.iter())
+            .into_keys()
+    }
+
+    /// Reports the unique keys of the relation given the arities and the unique
+    /// keys of the input relations.
+    ///
     /// `input_arities` and `input_keys` are required to contain the
     /// corresponding info for the input relations of
     /// the current relation in the same order as they are visited by `try_visit_children`
@@ -552,18 +583,18 @@ impl MirRelationExpr {
     ///
     /// It is meant to be used during post-order traversals to compute unique keys
     /// incrementally.
-    pub fn keys_with_input_keys<'a, I, J>(
+    pub fn unique_keys_with_input_keys<'a, I, J>(
         &self,
         mut input_arities: I,
         mut input_keys: J,
-    ) -> Vec<Vec<usize>>
+    ) -> UniqueKeySets
     where
         I: Iterator<Item = usize>,
-        J: Iterator<Item = &'a Vec<Vec<usize>>>,
+        J: Iterator<Item = &'a UniqueKeySets>,
     {
         use MirRelationExpr::*;
 
-        let mut keys = match self {
+        match self {
             Constant {
                 rows: Ok(rows),
                 typ,
@@ -584,23 +615,21 @@ impl MirRelationExpr {
                     }
                 }
                 if rows.len() == 0 || (rows.len() == 1 && rows[0].1 == Diff::ONE) {
-                    vec![vec![]]
+                    UniqueKeySets::at_most_one_row()
                 } else {
                     // XXX - Multi-column keys are not detected.
-                    typ.keys
-                        .iter()
-                        .cloned()
-                        .chain(
-                            unique_values_per_col
-                                .into_iter()
-                                .enumerate()
-                                .filter(|(_idx, unique_vals)| unique_vals.is_some())
-                                .map(|(idx, _)| vec![idx]),
-                        )
-                        .collect()
+                    let mut result = UniqueKeySets::from_keys(typ.keys.clone());
+                    for (idx, unique_vals) in unique_values_per_col.into_iter().enumerate() {
+                        if unique_vals.is_some() {
+                            result.add_key(vec![idx]);
+                        }
+                    }
+                    result
                 }
             }
-            Constant { rows: Err(_), typ } | Get { typ, .. } => typ.keys.clone(),
+            Constant { rows: Err(_), typ } | Get { typ, .. } => {
+                UniqueKeySets::from_keys(typ.keys.clone())
+            }
             Threshold { .. } | ArrangeBy { .. } => input_keys.next().unwrap().clone(),
             Let { .. } => {
                 // skip over the unique keys for value
@@ -610,31 +639,11 @@ impl MirRelationExpr {
                 // skip over the unique keys for value
                 input_keys.nth(values.len()).unwrap().clone()
             }
-            Project { outputs, .. } => {
-                let input = input_keys.next().unwrap();
-                input
-                    .iter()
-                    .filter_map(|key_set| {
-                        if key_set.iter().all(|k| outputs.contains(k)) {
-                            Some(
-                                key_set
-                                    .iter()
-                                    .map(|c| outputs.iter().position(|o| o == c).unwrap())
-                                    .collect(),
-                            )
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
-            }
+            Project { outputs, .. } => input_keys.next().unwrap().project(outputs),
             Map { scalars, .. } => {
-                let mut remappings = Vec::new();
                 let arity = input_arities.next().unwrap();
+                let mut result = input_keys.next().unwrap().clone();
                 for (column, scalar) in scalars.iter().enumerate() {
-                    // assess whether the scalar preserves uniqueness,
-                    // and could participate in a key!
-
                     fn uniqueness(expr: &MirScalarExpr) -> Option<usize> {
                         match expr {
                             MirScalarExpr::CallUnary { func, expr } => {
@@ -649,170 +658,62 @@ impl MirRelationExpr {
                         }
                     }
 
+                    // A column that is an injective function of another column
+                    // mutually determines it, and can substitute for it in any
+                    // key.
                     if let Some(c) = uniqueness(scalar) {
-                        remappings.push((c, column + arity));
+                        result.equate(c, arity + column);
                     }
-                }
-
-                let mut result = input_keys.next().unwrap().clone();
-                let mut new_keys = Vec::new();
-                // Any column in `remappings` could be replaced in a key
-                // by the corresponding c. This could lead to combinatorial
-                // explosion using our current representation, so we wont
-                // do that. Instead, we'll handle the case of one remapping.
-                if remappings.len() == 1 {
-                    let (old, new) = remappings.pop().unwrap();
-                    for key in &result {
-                        if key.contains(&old) {
-                            let mut new_key: Vec<usize> =
-                                key.iter().cloned().filter(|k| k != &old).collect();
-                            new_key.push(new);
-                            new_key.sort_unstable();
-                            new_keys.push(new_key);
-                        }
-                    }
-                    result.append(&mut new_keys);
                 }
                 result
             }
             FlatMap { .. } => {
                 // FlatMap can add duplicate rows, so input keys are no longer
-                // valid
-                vec![]
+                // valid, but the equivalences among the input's columns
+                // continue to hold.
+                input_keys.next().unwrap().equivalences_only()
             }
             Negate { .. } => {
                 // Although negate may have distinct records for each key,
                 // the multiplicity is -1 rather than 1. This breaks many
                 // of the optimization uses of "keys".
-                vec![]
+                input_keys.next().unwrap().equivalences_only()
             }
             Filter { predicates, .. } => {
-                // A filter inherits the keys of its input unless the filters
-                // have reduced the input to a single row, in which case the
-                // keys of the input are `()`.
-                let mut input = input_keys.next().unwrap().clone();
-
-                if !input.is_empty() {
-                    // Track columns equated to literals, which we can prune.
-                    let mut cols_equal_to_literal = BTreeSet::new();
-
-                    // Perform union find on `col1 = col2` to establish
-                    // connected components of equated columns. Absent any
-                    // equalities, this will be `0 .. #c` (where #c is the
-                    // greatest column referenced by a predicate), but each
-                    // equality will orient the root of the greater to the root
-                    // of the lesser.
-                    let mut union_find = Vec::new();
-
-                    for expr in predicates.iter() {
-                        if let MirScalarExpr::CallBinary {
-                            func: crate::BinaryFunc::Eq(_),
-                            expr1,
-                            expr2,
-                        } = expr
-                        {
-                            if let MirScalarExpr::Column(c, _name) = &**expr1 {
-                                if expr2.is_literal_ok() {
-                                    cols_equal_to_literal.insert(c);
-                                }
-                            }
-                            if let MirScalarExpr::Column(c, _name) = &**expr2 {
-                                if expr1.is_literal_ok() {
-                                    cols_equal_to_literal.insert(c);
-                                }
-                            }
-                            // Perform union-find to equate columns.
-                            if let (Some(c1), Some(c2)) = (expr1.as_column(), expr2.as_column()) {
-                                if c1 != c2 {
-                                    // Ensure union_find has entries up to
-                                    // max(c1, c2) by filling up missing
-                                    // positions with identity mappings.
-                                    while union_find.len() <= std::cmp::max(c1, c2) {
-                                        union_find.push(union_find.len());
-                                    }
-                                    let mut r1 = c1; // Find the representative column of [c1].
-                                    while r1 != union_find[r1] {
-                                        assert!(union_find[r1] < r1);
-                                        r1 = union_find[r1];
-                                    }
-                                    let mut r2 = c2; // Find the representative column of [c2].
-                                    while r2 != union_find[r2] {
-                                        assert!(union_find[r2] < r2);
-                                        r2 = union_find[r2];
-                                    }
-                                    // Union [c1] and [c2] by pointing the
-                                    // larger to the smaller representative (we
-                                    // update the remaining equivalence class
-                                    // members only once after this for-loop).
-                                    union_find[std::cmp::max(r1, r2)] = std::cmp::min(r1, r2);
-                                }
+                // A filter inherits the keys of its input, strengthened by the
+                // column equalities among its predicates.
+                let mut result = input_keys.next().unwrap().clone();
+                let mut literal_cols = Vec::new();
+                for expr in predicates.iter() {
+                    if let MirScalarExpr::CallBinary {
+                        func: crate::BinaryFunc::Eq(_),
+                        expr1,
+                        expr2,
+                    } = expr
+                    {
+                        if let MirScalarExpr::Column(c, _name) = &**expr1 {
+                            if expr2.is_literal_ok() {
+                                literal_cols.push(*c);
                             }
                         }
-                    }
-
-                    // Complete union-find by pointing each element at its representative column.
-                    for i in 0..union_find.len() {
-                        // Iteration not required, as each prior already references the right column.
-                        union_find[i] = union_find[union_find[i]];
-                    }
-
-                    // Remove columns bound to literals, and remap columns equated to earlier columns.
-                    // We will re-expand remapped columns in a moment, but this avoids exponential work.
-                    for key_set in &mut input {
-                        key_set.retain(|k| !cols_equal_to_literal.contains(&k));
-                        for col in key_set.iter_mut() {
-                            if let Some(equiv) = union_find.get(*col) {
-                                *col = *equiv;
+                        if let MirScalarExpr::Column(c, _name) = &**expr2 {
+                            if expr1.is_literal_ok() {
+                                literal_cols.push(*c);
                             }
                         }
-                        key_set.sort();
-                        key_set.dedup();
-                    }
-                    input.sort();
-                    input.dedup();
-
-                    // Expand out each key to each of its equivalent forms.
-                    // Each instance of `col` can be replaced by any equivalent column.
-                    // This has the potential to result in exponentially sized number of unique keys,
-                    // and in the future we should probably maintain unique keys modulo equivalence.
-
-                    // First, compute an inverse map from each representative
-                    // column `sub` to all other equivalent columns `col`.
-                    let mut subs = Vec::new();
-                    for (col, sub) in union_find.iter().enumerate() {
-                        if *sub != col {
-                            assert!(*sub < col);
-                            while subs.len() <= *sub {
-                                subs.push(Vec::new());
-                            }
-                            subs[*sub].push(col);
+                        if let (Some(c1), Some(c2)) = (expr1.as_column(), expr2.as_column()) {
+                            result.equate(c1, c2);
                         }
-                    }
-                    // For each column, substitute for it in each occurrence.
-                    let mut to_add = Vec::new();
-                    for (col, subs) in subs.iter().enumerate() {
-                        if !subs.is_empty() {
-                            for key_set in input.iter() {
-                                if key_set.contains(&col) {
-                                    let mut to_extend = key_set.clone();
-                                    to_extend.retain(|c| c != &col);
-                                    for sub in subs {
-                                        to_extend.push(*sub);
-                                        to_add.push(to_extend.clone());
-                                        to_extend.pop();
-                                    }
-                                }
-                            }
-                        }
-                        // No deduplication, as we cannot introduce duplicates.
-                        input.append(&mut to_add);
-                    }
-                    for key_set in input.iter_mut() {
-                        key_set.sort();
-                        key_set.dedup();
                     }
                 }
-                input
+                // A column equated to a literal is constant and drops out of
+                // every key. Apply these after all equalities are recorded, so
+                // the entire equivalence class of each such column drops out
+                // regardless of predicate order.
+                for col in literal_cols {
+                    result.remove_constant_column(col);
+                }
+                result
             }
             Join { equivalences, .. } => {
                 // It is important the `new_from_input_arities` constructor is
@@ -823,31 +724,38 @@ impl MirRelationExpr {
                 input_mapper.global_keys(input_keys, equivalences)
             }
             Reduce { group_key, .. } => {
-                // The group key should form a key, but we might already have
-                // keys that are subsets of the group key, and should retain
-                // those instead, if so.
-                let mut result = Vec::new();
-                for key_set in input_keys.next().unwrap() {
-                    if key_set
-                        .iter()
-                        .all(|k| group_key.contains(&MirScalarExpr::column(*k)))
-                    {
-                        result.push(
-                            key_set
-                                .iter()
-                                .map(|i| {
-                                    group_key
-                                        .iter()
-                                        .position(|k| k == &MirScalarExpr::column(*i))
-                                        .unwrap()
-                                })
-                                .collect::<Vec<_>>(),
-                        );
+                let input = input_keys.next().unwrap();
+                // Group key positions, indexed by the equivalence class
+                // representative of the input column they contain.
+                let mut positions_by_rep: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+                for (pos, expr) in group_key.iter().enumerate() {
+                    if let Some(col) = expr.as_column() {
+                        positions_by_rep
+                            .entry(input.rep(col))
+                            .or_default()
+                            .push(pos);
                     }
                 }
-                if result.is_empty() {
-                    result.push((0..group_key.len()).collect());
+                let mut result = UniqueKeySets::none();
+                // Group key positions holding equivalent columns remain
+                // equivalent among the distinct grouped values.
+                for positions in positions_by_rep.values() {
+                    for pair in positions.windows(2) {
+                        result.equate(pair[0], pair[1]);
+                    }
                 }
+                // The group key forms a key, and any input key expressible in
+                // group key positions is a smaller one.
+                for key in input.keys() {
+                    let translated = key
+                        .iter()
+                        .map(|col| positions_by_rep.get(col).map(|positions| positions[0]))
+                        .collect::<Option<Vec<_>>>();
+                    if let Some(key) = translated {
+                        result.add_key(key);
+                    }
+                }
+                result.add_key((0..group_key.len()).collect());
                 result
             }
             TopK {
@@ -857,7 +765,7 @@ impl MirRelationExpr {
                 // a unique key, as there will be only one record with that key.
                 let mut result = input_keys.next().unwrap().clone();
                 if limit.as_ref().and_then(|x| x.as_literal_int64()) == Some(1) {
-                    result.push(group_key.clone())
+                    result.add_key(group_key.clone());
                 }
                 result
             }
@@ -894,7 +802,7 @@ impl MirRelationExpr {
                         // with the project being all columns in the input in order.
                         ((0..arity).collect::<Vec<_>>(), &**base)
                     };
-                let mut result = Vec::new();
+                let mut result = UniqueKeySets::none();
                 if let MirRelationExpr::Get {
                     id: first_id,
                     typ: _,
@@ -913,20 +821,27 @@ impl MirRelationExpr {
                                         } = input
                                         {
                                             if first_id == second_id {
-                                                result.extend(
-                                                    input_keys
-                                                        .next()
-                                                        .unwrap()
-                                                        .into_iter()
-                                                        .filter(|key| {
-                                                            key.iter().all(|c| {
-                                                                outputs.get(*c) == Some(c)
-                                                                    && base_projection.get(*c)
-                                                                        == Some(c)
-                                                            })
+                                                let base_keys = input_keys.next().unwrap();
+                                                for key in base_keys.keys() {
+                                                    // Each key column must pass through both
+                                                    // projections unpermuted. Any equivalent
+                                                    // column that does so can stand in.
+                                                    let translated = key
+                                                        .iter()
+                                                        .map(|col| {
+                                                            base_keys.equivalent_columns(*col).find(
+                                                                |c| {
+                                                                    outputs.get(*c) == Some(c)
+                                                                        && base_projection.get(*c)
+                                                                            == Some(c)
+                                                                },
+                                                            )
                                                         })
-                                                        .cloned(),
-                                                );
+                                                        .collect::<Option<Vec<_>>>();
+                                                    if let Some(key) = translated {
+                                                        result.add_key(key);
+                                                    }
+                                                }
                                             }
                                         }
                                     }
@@ -935,13 +850,12 @@ impl MirRelationExpr {
                         }
                     }
                 }
-                // Important: do not inherit keys of either input, as not unique.
+                // Important: do not inherit keys of either input, as not
+                // unique. Equivalences do not survive either: rows of the
+                // other input need not respect the equivalences of the base.
                 result
             }
-        };
-        keys.sort();
-        keys.dedup();
-        keys
+        }
     }
 
     /// The number of columns in the relation.
@@ -4156,6 +4070,31 @@ mod tests {
 
         let r = finishing.finish_incremental_inner(batch, max_result_size);
         assert!(r.unwrap_err().contains("total result exceeds max size"));
+    }
+
+    /// Key inference on a filter with column equality predicates must not
+    /// enumerate all equivalent key variants. With a 128 column unique key and
+    /// 24 disjoint column equalities such an enumeration produces 2^24 keys,
+    /// which exhausts memory. The canonical representation reports the single
+    /// key with each equated column mapped to its representative.
+    #[mz_ore::test]
+    fn test_filter_key_inference_compact_under_column_equalities() {
+        use crate::func::Eq;
+
+        let arity = 128;
+        let equalities = 24;
+        let typ = ReprRelationType::new(vec![ReprScalarType::Int32.nullable(true); arity])
+            .with_key((0..arity).collect());
+        let get = MirRelationExpr::global_get(GlobalId::User(1), typ);
+        let predicates = (0..equalities).map(|i| {
+            MirScalarExpr::column(i).call_binary(MirScalarExpr::column(i + equalities), Eq)
+        });
+        let keys = get.filter(predicates).typ().keys;
+
+        let canonical: Vec<usize> = (0..arity)
+            .filter(|c| !(equalities..2 * equalities).contains(c))
+            .collect();
+        assert_eq!(keys, vec![canonical]);
     }
 }
 

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -13,6 +13,7 @@ use std::ops::Range;
 use itertools::Itertools;
 use mz_repr::ReprRelationType;
 
+use crate::relation::unique_keys::UniqueKeySets;
 use crate::scalar::columns::Columns;
 use crate::scalar::func::variadic::{And, Or};
 use crate::visit::Visit;
@@ -99,11 +100,11 @@ impl JoinInputMapper {
     /// can remain unique.
     pub fn global_keys<'a, I>(
         &self,
-        mut local_keys: I,
+        local_keys: I,
         equivalences: &[Vec<MirScalarExpr>],
-    ) -> Vec<Vec<usize>>
+    ) -> UniqueKeySets
     where
-        I: Iterator<Item = &'a Vec<Vec<usize>>>,
+        I: Iterator<Item = &'a UniqueKeySets>,
     {
         // A relation's uniqueness constraint holds if there is a
         // sequence of the other relations such that each one has
@@ -113,14 +114,34 @@ impl JoinInputMapper {
         // Currently, we only:
         // 1. test for whether the uniqueness constraints for the first input will hold
         // 2. try one sequence, namely the inputs in order
-        // 3. check that the column themselves are used in the join constraints
-        //    Technically uniqueness constraint would still hold if a 1-to-1
-        //    expression on a unique key is used in the join constraint.
+        // 3. check that the columns themselves, or columns equivalent to them,
+        //    are used in the join constraints
 
-        // for inputs `1..self.total_inputs()`, store a set of columns from that
-        // input that exist in join constraints that have expressions belonging to
-        // earlier inputs.
-        let mut column_with_prior_bound_by_input = vec![BTreeSet::new(); self.total_inputs() - 1];
+        // Embed each input's keys and equivalences into the global column
+        // space, and collect the equivalences of all inputs together with the
+        // column equalities imposed by the join constraints.
+        let inputs_global = local_keys
+            .enumerate()
+            .map(|(index, keys)| keys.offset_columns(self.prior_arities[index]))
+            .collect::<Vec<_>>();
+        let mut result = UniqueKeySets::none();
+        for input in &inputs_global {
+            result.merge(&input.equivalences_only());
+        }
+        for equivalence in equivalences {
+            let mut columns = equivalence.iter().filter_map(|expr| expr.as_column());
+            if let Some(first) = columns.next() {
+                for col in columns {
+                    result.equate(first, col);
+                }
+            }
+        }
+
+        // for inputs `1..self.total_inputs()`, store a set of global columns
+        // (as their representatives) from that input that exist in join
+        // constraints that have expressions belonging to earlier inputs.
+        let mut column_with_prior_bound_by_input =
+            vec![BTreeSet::new(); self.total_inputs().saturating_sub(1)];
         for equivalence in equivalences {
             // do a scan to find the first input represented in the constraint
             let min_bound_input = equivalence
@@ -132,9 +153,9 @@ impl JoinInputMapper {
                     // then store all columns in the constraint that don't come
                     // from the first input
                     if let MirScalarExpr::Column(c, _name) = expr {
-                        let (col, input) = self.map_column_to_local(*c);
+                        let (_col, input) = self.map_column_to_local(*c);
                         if input > min_bound_input {
-                            column_with_prior_bound_by_input[input - 1].insert(col);
+                            column_with_prior_bound_by_input[input - 1].insert(result.rep(*c));
                         }
                     }
                 }
@@ -142,22 +163,24 @@ impl JoinInputMapper {
         }
 
         if self.total_inputs() > 0 {
-            let first_input_keys = local_keys.next().unwrap().clone();
-            // for inputs `1..self.total_inputs()`, checks the keys belong to each
-            // input against the storage of columns that exist in join constraints
-            // that have expressions belonging to earlier inputs.
-            let remains_unique = local_keys.enumerate().all(|(index, keys)| {
-                keys.iter().any(|ks| {
-                    ks.iter()
-                        .all(|k| column_with_prior_bound_by_input[index].contains(k))
+            // for inputs `1..self.total_inputs()`, checks the keys belonging to
+            // each input against the storage of columns that exist in join
+            // constraints that have expressions belonging to earlier inputs.
+            let remains_unique = inputs_global[1..].iter().enumerate().all(|(index, keys)| {
+                keys.keys().iter().any(|key| {
+                    key.iter().all(|col| {
+                        column_with_prior_bound_by_input[index].contains(&result.rep(*col))
+                    })
                 })
             });
 
             if remains_unique {
-                return first_input_keys;
+                for key in inputs_global[0].keys() {
+                    result.add_key(key.clone());
+                }
             }
         }
-        vec![]
+        result
     }
 
     /// returns the arity for a particular input

--- a/src/expr/src/relation/unique_keys.rs
+++ b/src/expr/src/relation/unique_keys.rs
@@ -1,0 +1,449 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Unique keys of a relation, represented modulo column equivalences.
+
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// The unique keys of a relation, represented modulo column equivalences.
+///
+/// Two columns are recorded as equivalent when their values mutually determine
+/// each other in every row of the relation, for example columns equated by a
+/// filter predicate, or a column and an injective function of it introduced by
+/// a map. Any column of a unique key can be replaced by an equivalent column
+/// to obtain another unique key. A value of this type therefore describes the
+/// family of all column sets that contain some key obtained from a recorded
+/// key by substituting columns within their equivalence classes.
+///
+/// Keys are stored canonically, using only equivalence class representatives.
+/// This keeps the representation polynomial in size where an explicit
+/// enumeration of keys is exponential: a wide key combined with n disjoint
+/// column equalities describes 2^n distinct minimal keys.
+///
+/// Values are kept in a normal form: representatives are the least column of
+/// their class, keys contain only representatives, each key is sorted and
+/// deduplicated, no key contains another, and the key list is sorted. Equal
+/// values therefore describe equal families. The converse does not hold, as
+/// two values can describe the same family through different equivalences,
+/// for example when a class touches no key.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct UniqueKeySets {
+    /// Maps each column to the representative (least column) of its
+    /// equivalence class. Columns at or beyond `reps.len()` are their own
+    /// representative. Trailing identity entries are trimmed.
+    reps: Vec<usize>,
+    /// Minimal antichain of canonical keys.
+    keys: Vec<Vec<usize>>,
+}
+
+impl UniqueKeySets {
+    /// A relation with no known unique keys.
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// A relation with at most one row, whose unique key is the empty set of
+    /// columns. This is the greatest element of the key lattice.
+    pub fn at_most_one_row() -> Self {
+        Self {
+            reps: Vec::new(),
+            keys: vec![vec![]],
+        }
+    }
+
+    /// Constructs from a list of keys, for example `ReprRelationType::keys`,
+    /// with no known equivalences.
+    pub fn from_keys(keys: Vec<Vec<usize>>) -> Self {
+        let mut result = Self::default();
+        for key in keys {
+            result.add_key(key);
+        }
+        result
+    }
+
+    /// The canonical keys: a minimal antichain of sorted column sets, each
+    /// containing only equivalence class representatives.
+    pub fn keys(&self) -> &[Vec<usize>] {
+        &self.keys
+    }
+
+    /// Discards the equivalences and returns the canonical keys.
+    pub fn into_keys(self) -> Vec<Vec<usize>> {
+        self.keys
+    }
+
+    /// The representative of `col`'s equivalence class.
+    pub fn rep(&self, col: usize) -> usize {
+        self.reps.get(col).copied().unwrap_or(col)
+    }
+
+    /// All columns in `col`'s equivalence class, in increasing order.
+    pub fn equivalent_columns(&self, col: usize) -> impl Iterator<Item = usize> + '_ {
+        let rep = self.rep(col);
+        // A column with no recorded class is its own sole member. Recorded
+        // representatives always lie within `reps`, so exactly one of the two
+        // halves below yields anything.
+        let unrecorded = (rep >= self.reps.len()).then_some(col);
+        (0..self.reps.len())
+            .filter(move |c| self.reps[*c] == rep)
+            .chain(unrecorded)
+    }
+
+    /// True iff `cols` contains a unique key, in which case no two rows of the
+    /// relation agree on all of `cols`.
+    pub fn is_unique_on<I>(&self, cols: I) -> bool
+    where
+        I: IntoIterator<Item = usize>,
+    {
+        let reps: BTreeSet<usize> = cols.into_iter().map(|c| self.rep(c)).collect();
+        self.keys
+            .iter()
+            .any(|key| key.iter().all(|c| reps.contains(c)))
+    }
+
+    /// Records that columns `a` and `b` mutually determine each other, and
+    /// re-canonicalizes the keys.
+    pub fn equate(&mut self, a: usize, b: usize) {
+        let ra = self.rep(a);
+        let rb = self.rep(b);
+        if ra == rb {
+            return;
+        }
+        let lo = std::cmp::min(ra, rb);
+        let hi = std::cmp::max(ra, rb);
+        if self.reps.len() <= hi {
+            self.reps.extend(self.reps.len()..=hi);
+        }
+        for rep in self.reps.iter_mut() {
+            if *rep == hi {
+                *rep = lo;
+            }
+        }
+        self.normalize_keys();
+    }
+
+    /// Adds a key, canonicalizing it and keeping the antichain minimal.
+    pub fn add_key(&mut self, mut key: Vec<usize>) {
+        for col in key.iter_mut() {
+            *col = self.rep(*col);
+        }
+        key.sort_unstable();
+        key.dedup();
+        if self.keys.iter().any(|k| is_subset(k, &key)) {
+            return;
+        }
+        self.keys.retain(|k| !is_subset(&key, k));
+        if let Err(pos) = self.keys.binary_search(&key) {
+            self.keys.insert(pos, key);
+        }
+    }
+
+    /// Removes `col`'s entire equivalence class from every key.
+    ///
+    /// Sound only when `col` is constant across the relation, for example when
+    /// a filter equates it with a literal. Every column equivalent to a
+    /// constant column is itself constant, so the whole class contributes
+    /// nothing to uniqueness.
+    pub fn remove_constant_column(&mut self, col: usize) {
+        let rep = self.rep(col);
+        if !self.keys.iter().any(|key| key.contains(&rep)) {
+            return;
+        }
+        let keys = std::mem::take(&mut self.keys);
+        for mut key in keys {
+            key.retain(|c| *c != rep);
+            self.add_key(key);
+        }
+    }
+
+    /// The keys of the relation projected onto `outputs`, where output column
+    /// `i` is input column `outputs[i]`.
+    ///
+    /// A key survives when each of its columns has an equivalent column among
+    /// the outputs. Equivalences between surviving columns are retained.
+    pub fn project(&self, outputs: &[usize]) -> Self {
+        let mut positions_by_rep: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+        for (pos, col) in outputs.iter().enumerate() {
+            positions_by_rep
+                .entry(self.rep(*col))
+                .or_default()
+                .push(pos);
+        }
+        let mut result = Self::default();
+        for positions in positions_by_rep.values() {
+            for pair in positions.windows(2) {
+                result.equate(pair[0], pair[1]);
+            }
+        }
+        for key in &self.keys {
+            let translated = key
+                .iter()
+                .map(|c| positions_by_rep.get(c).map(|positions| positions[0]))
+                .collect::<Option<Vec<_>>>();
+            if let Some(key) = translated {
+                result.add_key(key);
+            }
+        }
+        result
+    }
+
+    /// The same value with all columns shifted up by `offset`, for embedding
+    /// an input relation into a join's global column space.
+    pub fn offset_columns(&self, offset: usize) -> Self {
+        let mut reps = Vec::new();
+        if !self.reps.is_empty() {
+            reps.extend(0..offset);
+            reps.extend(self.reps.iter().map(|r| r + offset));
+        }
+        let keys = self
+            .keys
+            .iter()
+            .map(|key| key.iter().map(|c| c + offset).collect())
+            .collect();
+        Self { reps, keys }
+    }
+
+    /// The same equivalences with no keys, for operators that preserve column
+    /// relationships but not uniqueness, such as row duplication.
+    pub fn equivalences_only(&self) -> Self {
+        Self {
+            reps: self.reps.clone(),
+            keys: Vec::new(),
+        }
+    }
+
+    /// Incorporates knowledge about the same relation from `other`.
+    ///
+    /// Both values must describe the same relation. The result records the
+    /// union of the equivalences and of the keys.
+    pub fn merge(&mut self, other: &Self) {
+        for col in 0..other.reps.len() {
+            let rep = other.reps[col];
+            if rep != col {
+                self.equate(col, rep);
+            }
+        }
+        for key in &other.keys {
+            self.add_key(key.clone());
+        }
+    }
+
+    /// The greatest lower bound of `self` and `other` in the key lattice: the
+    /// strongest value implied by each of them alone.
+    ///
+    /// Unlike `merge`, the two values need not describe the same relation.
+    /// Columns are equivalent in the result when equivalent in both inputs,
+    /// and each result key is the union of a key from each input.
+    pub fn meet(&self, other: &Self) -> Self {
+        // A value containing the empty key describes every column set, so the
+        // meet is exactly the other value.
+        if self.keys.first().is_some_and(|key| key.is_empty()) {
+            return other.clone();
+        }
+        if other.keys.first().is_some_and(|key| key.is_empty()) {
+            return self.clone();
+        }
+        let mut result = Self::default();
+        // Group columns by their pair of representatives. Columns sharing the
+        // pair are equivalent in both inputs, hence in the meet.
+        let len = std::cmp::max(self.reps.len(), other.reps.len());
+        let mut first_by_pair: BTreeMap<(usize, usize), usize> = BTreeMap::new();
+        for col in 0..len {
+            let pair = (self.rep(col), other.rep(col));
+            match first_by_pair.entry(pair) {
+                Entry::Vacant(entry) => {
+                    entry.insert(col);
+                }
+                Entry::Occupied(entry) => {
+                    result.equate(*entry.get(), col);
+                }
+            }
+        }
+        for key_a in &self.keys {
+            for key_b in &other.keys {
+                let union = key_a.iter().chain(key_b.iter()).copied().collect();
+                result.add_key(union);
+            }
+        }
+        // A key of one input that the other input also recognizes as a key,
+        // through its own equivalences, belongs to the meet as well.
+        for key in &self.keys {
+            if other.is_unique_on(key.iter().copied()) {
+                result.add_key(key.clone());
+            }
+        }
+        for key in &other.keys {
+            if self.is_unique_on(key.iter().copied()) {
+                result.add_key(key.clone());
+            }
+        }
+        result
+    }
+
+    /// Restores the normal form after equivalence classes have changed.
+    fn normalize_keys(&mut self) {
+        let keys = std::mem::take(&mut self.keys);
+        for key in keys {
+            self.add_key(key);
+        }
+        while self
+            .reps
+            .last()
+            .is_some_and(|rep| *rep == self.reps.len() - 1)
+        {
+            self.reps.pop();
+        }
+    }
+}
+
+/// True iff sorted slice `a` is a subset of sorted slice `b`.
+fn is_subset(a: &[usize], b: &[usize]) -> bool {
+    a.iter().all(|x| b.binary_search(x).is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn from_keys_minimizes_antichain() {
+        let keys = UniqueKeySets::from_keys(vec![vec![2, 0, 2], vec![0, 1, 2], vec![3]]);
+        assert_eq!(keys.keys(), &[vec![0, 2], vec![3]]);
+    }
+
+    #[mz_ore::test]
+    fn equate_canonicalizes_keys() {
+        let mut keys = UniqueKeySets::from_keys(vec![vec![1, 3], vec![2, 3]]);
+        keys.equate(1, 2);
+        assert_eq!(keys.keys(), &[vec![1, 3]]);
+        assert_eq!(keys.rep(2), 1);
+        assert_eq!(keys.equivalent_columns(2).collect::<Vec<_>>(), vec![1, 2]);
+    }
+
+    #[mz_ore::test]
+    fn is_unique_on_uses_equivalences() {
+        let mut keys = UniqueKeySets::from_keys(vec![vec![0, 1]]);
+        keys.equate(0, 5);
+        keys.equate(1, 6);
+        assert!(keys.is_unique_on([0, 1]));
+        assert!(keys.is_unique_on([5, 6]));
+        assert!(keys.is_unique_on([0, 6, 3]));
+        assert!(!keys.is_unique_on([5]));
+    }
+
+    /// The pathological case for an explicit enumeration: one wide key plus n
+    /// disjoint column equalities describes 2^n minimal keys, while this
+    /// representation stays at a single canonical key.
+    #[mz_ore::test]
+    fn exponential_family_stays_compact() {
+        let arity = 128;
+        let equalities = 24;
+        let mut keys = UniqueKeySets::from_keys(vec![(0..arity).collect()]);
+        for i in 0..equalities {
+            keys.equate(i, i + equalities);
+        }
+        assert_eq!(keys.keys().len(), 1);
+        let canonical: Vec<usize> = (0..arity)
+            .filter(|c| !(equalities..2 * equalities).contains(c))
+            .collect();
+        assert_eq!(keys.keys(), &[canonical]);
+        // Every variant is still recognized as a key.
+        assert!(keys.is_unique_on((equalities..arity).collect::<Vec<_>>()));
+    }
+
+    #[mz_ore::test]
+    fn remove_constant_column_drops_class() {
+        let mut keys = UniqueKeySets::from_keys(vec![vec![0, 1], vec![2]]);
+        keys.equate(0, 3);
+        // Column 3 is constant, so its class member 0 leaves the keys.
+        keys.remove_constant_column(3);
+        assert_eq!(keys.keys(), &[vec![1], vec![2]]);
+    }
+
+    #[mz_ore::test]
+    fn project_translates_through_equivalences() {
+        let mut keys = UniqueKeySets::from_keys(vec![vec![0, 1]]);
+        keys.equate(0, 2);
+        // Column 0 is dropped, but its equivalent column 2 survives.
+        let projected = keys.project(&[2, 1]);
+        assert_eq!(projected.keys(), &[vec![0, 1]]);
+        // Two surviving columns of one class stay equivalent.
+        let projected = keys.project(&[0, 2, 1]);
+        assert_eq!(projected.keys(), &[vec![0, 2]]);
+        assert_eq!(projected.rep(1), 0);
+        // No equivalent column survives, so the key is lost.
+        let projected = keys.project(&[1]);
+        assert!(projected.keys().is_empty());
+    }
+
+    #[mz_ore::test]
+    fn meet_intersects_equivalences_and_unions_keys() {
+        let mut a = UniqueKeySets::from_keys(vec![vec![0]]);
+        a.equate(0, 1);
+        a.equate(2, 3);
+        let mut b = UniqueKeySets::from_keys(vec![vec![1]]);
+        b.equate(0, 1);
+        let met = a.meet(&b);
+        // Only the equivalence present in both inputs remains.
+        assert_eq!(met.rep(1), 0);
+        assert_eq!(met.rep(3), 3);
+        // The key union {0} ∪ {1} canonicalizes to {0}.
+        assert_eq!(met.keys(), &[vec![0]]);
+    }
+
+    /// Meeting with the lattice top must preserve the other value exactly,
+    /// equivalences included. The LetRec fixpoint starts every binding at top,
+    /// so losing equivalences here would silently weaken all recursive key
+    /// inference.
+    #[mz_ore::test]
+    fn meet_with_top_preserves_the_other_value() {
+        let mut a = UniqueKeySets::from_keys(vec![vec![1]]);
+        a.equate(0, 1);
+        let top = UniqueKeySets::at_most_one_row();
+        assert_eq!(top.meet(&a), a);
+        assert_eq!(a.meet(&top), a);
+    }
+
+    #[mz_ore::test]
+    fn meet_keeps_keys_recognized_by_both_inputs() {
+        let a = UniqueKeySets::from_keys(vec![vec![1]]);
+        let mut b = UniqueKeySets::from_keys(vec![vec![0]]);
+        b.equate(0, 1);
+        // The pairwise union alone would report only {0, 1}, but a's key [1]
+        // is also a key of b through b's equivalence {0, 1}, so it survives.
+        let met = a.meet(&b);
+        assert_eq!(met.keys(), &[vec![1]]);
+        // The equivalence itself does not survive: it holds only in b.
+        assert_eq!(met.rep(1), 1);
+    }
+
+    #[mz_ore::test]
+    fn merge_unions_knowledge() {
+        let mut a = UniqueKeySets::from_keys(vec![vec![0, 1]]);
+        a.equate(0, 2);
+        let mut b = UniqueKeySets::from_keys(vec![vec![3]]);
+        b.equate(2, 4);
+        a.merge(&b);
+        // Equivalences union transitively: {0, 2} and {2, 4} give {0, 2, 4}.
+        assert_eq!(a.rep(4), 0);
+        assert_eq!(a.keys(), &[vec![0, 1], vec![3]]);
+        assert!(a.is_unique_on([4, 1]));
+    }
+
+    #[mz_ore::test]
+    fn offset_columns_shifts_everything() {
+        let mut keys = UniqueKeySets::from_keys(vec![vec![0, 1]]);
+        keys.equate(0, 2);
+        let shifted = keys.offset_columns(10);
+        assert_eq!(shifted.keys(), &[vec![10, 11]]);
+        assert_eq!(shifted.rep(12), 10);
+        assert_eq!(shifted.rep(5), 5);
+    }
+}

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -676,21 +676,19 @@ mod unique_keys {
 
     use super::arity::Arity;
     use super::{Analysis, Derived, DerivedBuilder, Lattice};
-    use mz_expr::MirRelationExpr;
+    use mz_expr::{MirRelationExpr, UniqueKeySets};
 
     /// Analysis that determines the unique keys of relation expressions.
     ///
-    /// The analysis value is a `Vec<Vec<usize>>`, which should be interpreted as a list
-    /// of sets of column identifiers, each set of which has the property that there is at
-    /// most one instance of each assignment of values to those columns.
-    ///
-    /// The sets are minimal, in that any superset of another set is removed from the list.
-    /// Any superset of unique key columns are also unique key columns.
+    /// The analysis value is a [`UniqueKeySets`]: a minimal antichain of
+    /// canonical unique keys together with the column equivalences under which
+    /// any key column can substitute for an equivalent one. Any superset of a
+    /// described key is also a unique key.
     #[derive(Debug)]
     pub struct UniqueKeys;
 
     impl Analysis for UniqueKeys {
-        type Value = Vec<Vec<usize>>;
+        type Value = UniqueKeySets;
 
         fn announce_dependencies(builder: &mut DerivedBuilder) {
             builder.require(Arity);
@@ -715,23 +713,19 @@ mod unique_keys {
                     ..
                 } => {
                     // We have information from `typ` and from the analysis.
-                    // We should "join" them, unioning and reducing the keys.
-                    let mut keys = typ.keys.clone();
+                    // Both describe the same collection, so we may take the
+                    // union of their knowledge.
+                    let mut keys = UniqueKeySets::from_keys(typ.keys.clone());
                     if let Some(o) = depends.bindings().get(i) {
                         if let Some(ks) = results.get(*o) {
-                            for k in ks.iter() {
-                                antichain_insert(&mut keys, k.clone());
-                            }
-                            keys.extend(ks.iter().cloned());
-                            keys.sort();
-                            keys.dedup();
+                            keys.merge(ks);
                         }
                     }
                     keys
                 }
                 _ => {
                     let arity = depends.results::<Arity>();
-                    expr.keys_with_input_keys(
+                    expr.unique_keys_with_input_keys(
                         offsets.iter().map(|o| arity[*o]),
                         offsets.iter().map(|o| &results[*o]),
                     )
@@ -744,42 +738,19 @@ mod unique_keys {
         }
     }
 
-    fn antichain_insert(into: &mut Vec<Vec<usize>>, item: Vec<usize>) {
-        // Insert only if there is not a dominating element of `into`.
-        if into.iter().all(|key| !key.iter().all(|k| item.contains(k))) {
-            into.retain(|key| !key.iter().all(|k| item.contains(k)));
-            into.push(item);
-        }
-    }
-
-    /// Lattice for sets of columns that define a unique key.
-    ///
-    /// An element `Vec<Vec<usize>>` describes all sets of columns `Vec<usize>` that are a
-    /// superset of some set of columns in the lattice element.
+    /// Lattice for unique keys, ordered by the family of column sets each
+    /// value describes.
     struct UKLattice;
 
-    impl Lattice<Vec<Vec<usize>>> for UKLattice {
-        fn top(&self) -> Vec<Vec<usize>> {
-            vec![vec![]]
+    impl Lattice<UniqueKeySets> for UKLattice {
+        fn top(&self) -> UniqueKeySets {
+            UniqueKeySets::at_most_one_row()
         }
-        fn meet_assign(&self, a: &mut Vec<Vec<usize>>, b: Vec<Vec<usize>>) -> bool {
-            a.sort();
-            a.dedup();
-            let mut c = Vec::new();
-            for cols_a in a.iter_mut() {
-                cols_a.sort();
-                cols_a.dedup();
-                for cols_b in b.iter() {
-                    let mut cols_c = cols_a.iter().chain(cols_b).cloned().collect::<Vec<_>>();
-                    cols_c.sort();
-                    cols_c.dedup();
-                    antichain_insert(&mut c, cols_c);
-                }
-            }
-            c.sort();
-            c.dedup();
-            std::mem::swap(a, &mut c);
-            a != &mut c
+        fn meet_assign(&self, a: &mut UniqueKeySets, b: UniqueKeySets) -> bool {
+            let met = a.meet(&b);
+            let changed = met != *a;
+            *a = met;
+            changed
         }
     }
 }
@@ -1349,7 +1320,7 @@ mod explain {
                     &*derived.results::<super::UniqueKeys>(),
                 ) {
                     let analyses = annotations.entry(expr).or_default();
-                    analyses.keys = Some(keys.clone());
+                    analyses.keys = Some(keys.keys().to_vec());
                 }
             }
 
@@ -1405,7 +1376,7 @@ mod cardinality {
 
     use mz_expr::{
         BinaryFunc, Id, JoinImplementation, MirRelationExpr, MirScalarExpr, TableFunc, UnaryFunc,
-        VariadicFunc,
+        UniqueKeySets, VariadicFunc,
     };
     use mz_ore::cast::{CastFrom, CastLossy, TryCastFrom};
     use mz_repr::GlobalId;
@@ -1710,14 +1681,14 @@ mod cardinality {
         fn filter(
             &self,
             predicates: &Vec<MirScalarExpr>,
-            keys: &Vec<Vec<usize>>,
+            keys: &UniqueKeySets,
             input: CardinalityEstimate,
         ) -> CardinalityEstimate {
             // TODO(mgree): should we try to do something for indices built on multiple columns?
             let mut unique_columns = BTreeSet::new();
-            for key in keys {
+            for key in keys.keys() {
                 if key.len() == 1 {
-                    unique_columns.insert(key[0]);
+                    unique_columns.extend(keys.equivalent_columns(key[0]));
                 }
             }
 
@@ -1920,27 +1891,37 @@ mod cardinality {
                     inputs,
                     ..
                 } => {
+                    // The offset walk visits children last-to-first, but the
+                    // global column offsets and the estimates handed to `join`
+                    // must follow input order, so collect the child indices
+                    // first and process them reversed.
+                    let mut child_indices = Vec::with_capacity(inputs.len());
+                    let mut offset = 1;
+                    for _ in 0..inputs.len() {
+                        child_indices.push(index - offset);
+                        offset += &sizes[index - offset];
+                    }
+                    child_indices.reverse();
+
                     let mut input_results = Vec::with_capacity(inputs.len());
 
                     // maps a column to the index in `inputs` that it belongs to
                     let mut unique_columns = BTreeMap::new();
                     let mut key_offset = 0;
 
-                    let mut offset = 1;
-                    for idx in 0..inputs.len() {
-                        let input = results[index - offset];
-                        input_results.push(input);
+                    for (idx, child) in child_indices.into_iter().enumerate() {
+                        input_results.push(results[child]);
 
-                        let arity = arity[index - offset];
-                        let keys = &keys[index - offset];
-                        for key in keys {
+                        let arity = arity[child];
+                        let keys = &keys[child];
+                        for key in keys.keys() {
                             if key.len() == 1 {
-                                unique_columns.insert(key_offset + key[0], idx);
+                                for col in keys.equivalent_columns(key[0]) {
+                                    unique_columns.insert(key_offset + col, idx);
+                                }
                             }
                         }
                         key_offset += arity;
-
-                        offset += &sizes[index - offset];
                     }
 
                     self.join(equivalences, implementation, unique_columns, input_results)

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -286,7 +286,8 @@ mod support {
                     let keys = view
                         .value::<UniqueKeys>()
                         .expect("UniqueKeys required")
-                        .clone();
+                        .keys()
+                        .to_vec();
                     types.insert(*id, ReprRelationType::new(repr_cols).with_keys(keys));
                 }
             }

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -78,10 +78,7 @@ impl ReduceElision {
                     .value::<UniqueKeys>()
                     .expect("UniqueKeys required");
 
-                if input_keys.iter().any(|keys| {
-                    keys.iter()
-                        .all(|k| group_key.iter().any(|gk| gk.as_column() == Some(*k)))
-                }) {
+                if input_keys.is_unique_on(group_key.iter().filter_map(|gk| gk.as_column())) {
                     let map_scalars = aggregates
                         .iter()
                         .map(|a| a.on_unique(input_type))

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -60,11 +60,26 @@ fn handle_explain(
     // Create OptimizerFeatures and override from the config overrides layer.
     let features = OptimizerFeatures::default().override_from(&config.features);
 
+    // Optional cardinality statistics, given as `stats=(<source>-<count>,...)`.
+    let mut cardinality_stats = std::collections::BTreeMap::new();
+    for stat in args.get("stats").map_or(&[][..], |stats| &stats[..]) {
+        let Some((name, count)) = stat.rsplit_once('-') else {
+            return format!("malformed `stats` entry: {stat}");
+        };
+        let Some((id, _, _)) = catalog.get(name) else {
+            return format!("unknown source in `stats` entry: {name}");
+        };
+        let Ok(count) = count.parse::<usize>() else {
+            return format!("malformed count in `stats` entry: {stat}");
+        };
+        cardinality_stats.insert(*id, count);
+    }
+
     let context = ExplainContext {
         config: &config,
         features: &features,
         humanizer: catalog,
-        cardinality_stats: Default::default(), // empty stats
+        cardinality_stats,
         used_indexes: Default::default(),
         finishing: Default::default(),
         duration: Default::default(),
@@ -327,6 +342,7 @@ fn apply_transforms(
 fn parse_explain_config(mut flags: BTreeSet<String>) -> Result<ExplainConfig, String> {
     let result = ExplainConfig {
         arity: flags.remove("arity"),
+        cardinality: flags.remove("cardinality"),
         humanized_exprs: flags.remove("humanized_exprs"),
         column_names: flags.remove("column_names"),
         keys: flags.remove("keys"),

--- a/src/transform/tests/test_transforms/cardinality.spec
+++ b/src/transform/tests/test_transforms/cardinality.spec
@@ -1,0 +1,60 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Source definitions
+# ------------------
+
+# Define t0 source
+define
+DefSource name=t0 keys=[[#0]]
+  - c0: bigint
+  - c1: bigint
+  - c2: bigint
+----
+Source defined as t0
+
+
+# A join on columns that are not unique on either side multiplies the input
+# estimates.
+explain with=cardinality stats=(t0-1000)
+Join on=(#1 = #4)
+  Get t0
+  Filter #0 = #2
+    Get t0
+----
+Join on=(#1 = #4) // { cardinality: "100000" }
+  Get t0 // { cardinality: "1000" }
+  Filter (#0 = #2) // { cardinality: "100" }
+    Get t0 // { cardinality: "1000" }
+
+# A join on a unique key column of one side is bounded by the other side.
+explain with=cardinality stats=(t0-1000)
+Join on=(#1 = #3)
+  Get t0
+  Filter #0 = #2
+    Get t0
+----
+Join on=(#1 = #3) // { cardinality: "1000" }
+  Get t0 // { cardinality: "1000" }
+  Filter (#0 = #2) // { cardinality: "100" }
+    Get t0 // { cardinality: "1000" }
+
+# A join on a column *equated* to a unique key column gets the same bound: the
+# rhs filter makes #5 equivalent to the key column #3, and the estimator
+# widens unique columns through the equivalence class.
+explain with=cardinality stats=(t0-1000)
+Join on=(#1 = #5)
+  Get t0
+  Filter #0 = #2
+    Get t0
+----
+Join on=(#1 = #5) // { cardinality: "1000" }
+  Get t0 // { cardinality: "1000" }
+  Filter (#0 = #2) // { cardinality: "100" }
+    Get t0 // { cardinality: "1000" }

--- a/src/transform/tests/test_transforms/keys.spec
+++ b/src/transform/tests/test_transforms/keys.spec
@@ -48,7 +48,7 @@ explain with=keys
 Filter #4 = #3 AND #1 = #0
   Get t1
 ----
-Filter (#4 = #3) AND (#1 = #0) // { keys: "([0, 2, 3], [0, 2, 4], [1, 2, 3], [1, 2, 4])" }
+Filter (#4 = #3) AND (#1 = #0) // { keys: "([0, 2, 3])" }
   Get t1 // { keys: "([0, 1, 2, 3, 4])" }
 
 # Project with equalities between key components and
@@ -57,8 +57,39 @@ explain with=keys
 Filter #0 = #1 AND #3 = 5
   Get t1
 ----
-Filter (#0 = #1) AND (#3 = 5) // { keys: "([0, 2, 4], [1, 2, 4])" }
+Filter (#0 = #1) AND (#3 = 5) // { keys: "([0, 2, 4])" }
   Get t1 // { keys: "([0, 1, 2, 3, 4])" }
+
+# A column equated to a literal is constant, and its entire equivalence class
+# drops out of every key, regardless of predicate order.
+explain with=keys
+Filter #3 = 5 AND #3 = #4
+  Get t1
+----
+Filter (#3 = 5) AND (#3 = #4) // { keys: "([0, 1, 2])" }
+  Get t1 // { keys: "([0, 1, 2, 3, 4])" }
+
+explain with=keys
+Filter #3 = #4 AND #3 = 5
+  Get t1
+----
+Filter (#3 = #4) AND (#3 = 5) // { keys: "([0, 1, 2])" }
+  Get t1 // { keys: "([0, 1, 2, 3, 4])" }
+
+# Join whose constraint binds the rhs key through an equivalent column. The
+# constraint references #4 rather than the rhs key column #3, but the rhs
+# filter makes the two equivalent, so the rhs key still counts as bound and
+# the lhs keys survive.
+explain with=keys
+Join on=(#0 = #4)
+  Get t0
+  Filter #0 = #1
+    Get t0
+----
+Join on=(#0 = #4) // { keys: "([0], [1])" }
+  Get t0 // { keys: "([0], [1])" }
+  Filter (#0 = #1) // { keys: "([0])" }
+    Get t0 // { keys: "([0], [1])" }
 
 
 ## Incomplete patterns

--- a/src/transform/tests/test_transforms/typ.spec
+++ b/src/transform/tests/test_transforms/typ.spec
@@ -113,7 +113,7 @@ Filter (#0 = #1)
   Distinct project=[#0, #2]
     Get x
 ----
-Filter (#0 = #1) // { types: "(r_int32, r_int32)", keys: "([0], [1])" }
+Filter (#0 = #1) // { types: "(r_int32, r_int32)", keys: "([0])" }
   Distinct project=[#0, #2] // { types: "(r_int32?, r_int32?)", keys: "([0, 1])" }
     Get x // { types: "(r_int32?, r_int64?, r_int32?)", keys: "()" }
 
@@ -129,7 +129,7 @@ explain with=(types, keys)
 Filter (#0 = #2)
   Get with_keys
 ----
-Filter (#0 = #2) // { types: "(r_int32, r_int32?, r_int32)", keys: "([0, 1], [1, 2])" }
+Filter (#0 = #2) // { types: "(r_int32, r_int32?, r_int32)", keys: "([0, 1])" }
   Get with_keys // { types: "(r_int32?, r_int32?, r_int32?)", keys: "([0, 1], [1, 2])" }
 
 define
@@ -145,7 +145,7 @@ explain with=(types, keys)
 Filter (#0 = #2)
   Get with_keys2
 ----
-Filter (#0 = #2) // { types: "(r_int32, r_int32?, r_int32, r_int32?)", keys: "([0, 1], [0, 3], [1, 2], [2, 3])" }
+Filter (#0 = #2) // { types: "(r_int32, r_int32?, r_int32, r_int32?)", keys: "([0, 1], [0, 3])" }
   Get with_keys2 // { types: "(r_int32?, r_int32?, r_int32?, r_int32?)", keys: "([0, 1], [2, 3])" }
 
 # Regression test for materialize#14146. The keys at the end should be [#0]

--- a/test/sqllogictest/attributes/mir_unique_keys.slt
+++ b/test/sqllogictest/attributes/mir_unique_keys.slt
@@ -84,8 +84,8 @@ Explained Query:
         Reduce group_by=[#1{b}] aggregates=[sum(#0{a})] // { keys: "([0])" }
           Filter (#1{b}) IS NOT NULL // { keys: "()" }
             ReadStorage materialize.public.t // { keys: "()" }
-      ArrangeBy keys=[[#1{d}]] // { keys: "([0], [1])" }
-        Filter (#0{c} = #1{d}) // { keys: "([0], [1])" }
+      ArrangeBy keys=[[#1{d}]] // { keys: "([0])" }
+        Filter (#0{c} = #1{d}) // { keys: "([0])" }
           ReadIndex on=v v_primary_idx=[*** full scan ***] // { keys: "([0, 1])" }
 
 Source materialize.public.t
@@ -116,7 +116,7 @@ Explained Query:
   Threshold // { keys: "()" }
     Union // { keys: "()" }
       Project (#1{a}, #2) // { keys: "([1])" }
-        Map (integer_to_double(#0{c})) // { keys: "([0], [2])" }
+        Map (integer_to_double(#0{c})) // { keys: "([0])" }
           TopK group_by=[#0{c}] limit=1 // { keys: "([0])" }
             Project (#0{c}, #1{a}) // { keys: "()" }
               Join on=(#0{c} = #2{b}) type=differential // { keys: "()" }
@@ -130,8 +130,8 @@ Explained Query:
                     ReadStorage materialize.public.t // { keys: "()" }
       Negate // { keys: "()" }
         Project (#0{c}, #2) // { keys: "([1])" }
-          Filter (#0{c} = 1) // { keys: "([1], [2])" }
-            Map (integer_to_double(#1{d})) // { keys: "([0, 1], [0, 2])" }
+          Filter (#0{c} = 1) // { keys: "([1])" }
+            Map (integer_to_double(#1{d})) // { keys: "([0, 1])" }
               ReadIndex on=v v_primary_idx=[*** full scan ***] // { keys: "([0, 1])" }
 
 Source materialize.public.t

--- a/test/sqllogictest/keys.slt
+++ b/test/sqllogictest/keys.slt
@@ -50,3 +50,132 @@ Explained Query:
 Target cluster: quickstart
 
 EOF
+
+# Key inference through a Filter whose predicates equate columns must not
+# enumerate all equivalent key variants. The DISTINCT provides a wide unique
+# key, the LIMIT keeps the predicates from being pushed below it, and each
+# equated column pair would otherwise double the number of inferred keys.
+# The filter reports the canonical key, with each equated column replaced by
+# its class representative.
+
+statement ok
+CREATE TABLE kt10 (c0 int, c1 int, c2 int, c3 int, c4 int, c5 int, c6 int, c7 int, c8 int, c9 int)
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(keys, no fast path, humanized expressions) AS VERBOSE TEXT FOR
+SELECT * FROM (SELECT DISTINCT * FROM kt10 LIMIT 9999999999) s WHERE c0 = c5 AND c1 = c6 AND c2 = c7 AND c3 = c8 AND c4 = c9
+----
+Explained Query:
+  Filter (#0{c0} = #5{c5}) AND (#1{c1} = #6{c6}) AND (#2{c2} = #7{c7}) AND (#3{c3} = #8{c8}) AND (#4{c4} = #9{c9}) // { keys: "([0, 1, 2, 3, 4])" }
+    TopK limit=9999999999 // { keys: "([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])" }
+      Distinct project=[#0{c0}..=#9{c9}] // { keys: "([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])" }
+        ReadStorage materialize.public.kt10 // { keys: "()" }
+
+Source materialize.public.kt10
+
+Target cluster: quickstart
+
+EOF
+
+# The full-size version of the pattern above. With an explicit enumeration of
+# key variants, planning this query materializes 2^24 keys and ~15GB of memory.
+
+statement ok
+CREATE TABLE kt48 (c0 int, c1 int, c2 int, c3 int, c4 int, c5 int, c6 int, c7 int, c8 int, c9 int, c10 int, c11 int, c12 int, c13 int, c14 int, c15 int, c16 int, c17 int, c18 int, c19 int, c20 int, c21 int, c22 int, c23 int, c24 int, c25 int, c26 int, c27 int, c28 int, c29 int, c30 int, c31 int, c32 int, c33 int, c34 int, c35 int, c36 int, c37 int, c38 int, c39 int, c40 int, c41 int, c42 int, c43 int, c44 int, c45 int, c46 int, c47 int)
+
+query I
+SELECT count(*) FROM (SELECT * FROM (SELECT DISTINCT * FROM kt48 LIMIT 9999999999) s WHERE c0 = c24 AND c1 = c25 AND c2 = c26 AND c3 = c27 AND c4 = c28 AND c5 = c29 AND c6 = c30 AND c7 = c31 AND c8 = c32 AND c9 = c33 AND c10 = c34 AND c11 = c35 AND c12 = c36 AND c13 = c37 AND c14 = c38 AND c15 = c39 AND c16 = c40 AND c17 = c41 AND c18 = c42 AND c19 = c43 AND c20 = c44 AND c21 = c45 AND c22 = c46 AND c23 = c47) z
+----
+0
+
+# ReduceElision must recognize key variants through equivalences: the inner
+# Reduce is keyed on column a, the filter equates a with the aggregate column,
+# and the outer DISTINCT groups by the aggregate column alone. The reported
+# canonical key names a, so the elision only fires if the consumer looks
+# through the equivalence class rather than scanning the reported key list.
+
+statement ok
+CREATE TABLE elide_t (a int, b int)
+
+statement ok
+INSERT INTO elide_t VALUES (1, 1), (1, 2), (2, 2), (3, 3)
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(keys, no fast path, humanized expressions) AS VERBOSE TEXT FOR
+SELECT DISTINCT mb FROM (SELECT a, max(b) AS mb FROM elide_t GROUP BY a) s WHERE a = mb
+----
+Explained Query:
+  Project (#1{max_b}) // { keys: "([0])" }
+    Filter (#0{a} = #1{max_b}) // { keys: "([0])" }
+      Reduce group_by=[#0{a}] aggregates=[max(#1{b})] // { keys: "([0])" }
+        ReadStorage materialize.public.elide_t // { keys: "()" }
+
+Source materialize.public.elide_t
+
+Target cluster: quickstart
+
+EOF
+
+query I rowsort
+SELECT DISTINCT mb FROM (SELECT a, max(b) AS mb FROM elide_t GROUP BY a) s WHERE a = mb
+----
+2
+3
+
+# Key inference on a recursive query must run the analysis fixpoint to
+# convergence: the recursive binding starts from the optimistic "at most one
+# row" guess and settles on the real key, and the equivalence introduced by
+# the filter above the recursive Get must survive the fixpoint's meet, or the
+# DISTINCT in the body would not be elided.
+
+statement ok
+CREATE TABLE wmr_t (a int, b int)
+
+statement ok
+INSERT INTO wmr_t VALUES (1, 1), (1, 2), (2, 2), (7, 8)
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(keys, no fast path, humanized expressions) AS VERBOSE TEXT FOR
+WITH MUTUALLY RECURSIVE
+  c (a int, b int) AS (
+    SELECT DISTINCT ON (a) a, b FROM (
+      SELECT a, b FROM wmr_t
+      UNION ALL
+      SELECT a + 1, b FROM c WHERE a < 5
+    ) ORDER BY a, b
+  )
+SELECT DISTINCT b FROM c WHERE a = b
+----
+Explained Query:
+  With Mutually Recursive
+    cte l0 =
+      TopK group_by=[#0{a}] order_by=[#1{b} asc nulls_last] limit=1 // { keys: "([0])" }
+        Union // { keys: "()" }
+          ReadStorage materialize.public.wmr_t // { keys: "()" }
+          Project (#2, #1) // { keys: "()" }
+            Filter (#0{a} < 5) // { keys: "([0])" }
+              Map ((#0{a} + 1)) // { keys: "([0])" }
+                Get l0 // { keys: "([0])" }
+  Return // { keys: "([0])" }
+    Project (#1{b}) // { keys: "([0])" }
+      Filter (#0{a} = #1{b}) // { keys: "([0])" }
+        Get l0 // { keys: "([0])" }
+
+Source materialize.public.wmr_t
+
+Target cluster: quickstart
+
+EOF
+
+query I
+WITH MUTUALLY RECURSIVE
+  c (a int, b int) AS (
+    SELECT DISTINCT ON (a) a, b FROM (
+      SELECT a, b FROM wmr_t
+      UNION ALL
+      SELECT a + 1, b FROM c WHERE a < 5
+    ) ORDER BY a, b
+  )
+SELECT DISTINCT b FROM c WHERE a = b
+----
+1


### PR DESCRIPTION
Unique keys are currently a plain list of column sets. Nothing in that form
records that two columns determine each other, so an operator that learns of
such a pair (a filter equating two columns, a map introducing an injective
function of one) can only enumerate the key variants the pair generates. A wide
key combined with n disjoint column equalities has 2^n minimal keys, so the
enumeration is exponential in the number of equalities.

Add `UniqueKeySets`, which carries the keys alongside the column equivalence
classes they are understood modulo. Keys are stored canonically, using only
class representatives, so the value stays polynomial in size while still
describing the whole family of variants: `is_unique_on` maps its argument
through the classes before testing it, and `equivalent_columns` enumerates a
class when a caller needs an actual substitute column.

The type also offers the lattice operations key inference needs: `merge` for
combining two views of the same relation, and `meet` for the greatest lower
bound of views of different relations, as the LetRec fixpoint requires.

Values are kept in a normal form (least column as class representative, keys a
sorted minimal antichain of representatives) so that equality of values is
usable as a fixpoint test.

The type is unused so far.Remove these sections if your commit already has a good description!

### Motivation

Why does this change exist? Link to a GitHub issue, design doc, Slack
thread, or explain the problem in a sentence or two. A reviewer who has
no context should understand *why* after reading this section.

If this implements or addresses an existing issue, it's enough to link to that:
Closes <issue>
Fixes <bug>
etc.

### Description

What does this PR actually do? Focus on the approach and any non-obvious
decisions. The diff shows the code --- use this space to explain what the
diff *can't* tell a reviewer.

### Verification

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
