### PR TITLE
Document the read privileges CREATE TABLE ... FROM SOURCE requires

### DIFF
--- a/doc/user/content/headless/sql-command-privileges/create-table.md
+++ b/doc/user/content/headless/sql-command-privileges/create-table.md
@@ -5,3 +5,7 @@ headless: true
 - `USAGE` privileges on all types used in the table definition.
 - `USAGE` privileges on the schemas that all types in the statement are
   contained in.
+- For `CREATE TABLE ... FROM SOURCE`, `SELECT` privileges on the source and
+  `USAGE` privileges on its schema. `SELECT` on a source permits attaching any
+  reference that source ingests, so grant it only to roles that should be able
+  to read all of the source's data.


### PR DESCRIPTION
Document the read privileges CREATE TABLE ... FROM SOURCE requires

### Motivation

`CREATE TABLE ... FROM SOURCE` populates the new table from an existing
ingestion, so creating it reads that source's data.
MaterializeInc/materialize#38480 makes the privilege requirements match that,
fixing a case where `CREATE` on the destination schema alone was enough to read
a source the role had been denied ([SQL-655](https://linear.app/materializeinc/issue/SQL-655), 2026 penetration test finding H02).

The privileges include for `CREATE TABLE` still lists only the schema and type
requirements, so it understates what the statement needs.

### Description

Add the read requirement to `create-table.md`, the single include used by all
five `CREATE TABLE` pages and by the generated privileges appendix: `SELECT` on
the source plus `USAGE` on its schema.

The note about scope is the part worth reading. The source is the authorization
boundary, so `SELECT` on it permits attaching any reference that source ingests,
including references with no existing table and columns some existing table
omitted. An admin deciding whether to grant it needs that sentence.

Split out from #38480 so that fix, which is an urgent security finding, is not
gated on a second CODEOWNERS scope. It is accurate to merge this either before
or after #38480: before, it documents a requirement that is about to exist;
after, it closes a gap where the docs understate what is enforced.

### Verification

Prose only. Rendering is unchanged in shape, four bullets where there were three.

