### PR TITLE
repr: canonicalize ranges from the declared element type, not the Datum tag

### DIFF
--- a/src/arrow-util/src/reader.rs
+++ b/src/arrow-util/src/reader.rs
@@ -492,6 +492,7 @@ fn scalar_type_and_array_to_reader(
             let upper_nulls = upper_array.nulls().cloned();
 
             Ok(ColReader::Range {
+                element_type: (**element_type).clone(),
                 lower: Box::new(lower_reader),
                 lower_nulls,
                 upper: Box::new(upper_reader),
@@ -641,6 +642,9 @@ enum ColReader {
     },
 
     Range {
+        /// Declared element type, which canonicalization needs to size its
+        /// discrete step.
+        element_type: SqlScalarType,
         lower: Box<ColReader>,
         lower_nulls: Option<NullBuffer>,
         upper: Box<ColReader>,
@@ -1112,6 +1116,7 @@ impl ColReader {
                 return Ok(());
             }
             ColReader::Range {
+                element_type,
                 lower,
                 lower_nulls,
                 upper,
@@ -1168,15 +1173,15 @@ impl ColReader {
                     bound: upper_row.as_ref().map(|row| row.unpack_first()),
                 };
 
-                // Use `push_range` (not `push_range_with`) so the range is
-                // canonicalized before being packed. Parquet files authored by
-                // external engines may encode discrete ranges in non-canonical
-                // form (e.g. `[1,10]` for int4range, which MZ stores as
-                // `[1,11)`); without canonicalization those rows would not
-                // compare or hash equal to MZ-constructed values.
-                packer
-                    .push_range(Range::new(Some((lower_bound, upper_bound))))
-                    .context("pack range")?;
+                // Parquet files authored by external engines may encode discrete
+                // ranges in non-canonical form, e.g. `[1,10]` for an int4range,
+                // which MZ stores as `[1,11)`. Without canonicalization those rows
+                // would not compare or hash equal to MZ-constructed values.
+                let mut range = Range::new(Some((lower_bound, upper_bound)));
+                range
+                    .canonicalize(element_type)
+                    .context("canonicalize range")?;
+                packer.push_range(range).context("pack range")?;
 
                 return Ok(());
             }
@@ -1671,8 +1676,8 @@ mod tests {
                     bound: Some(Datum::Int32(1)),
                 },
                 RangeUpperBound {
-                    inclusive: true,
-                    bound: Some(Datum::Int32(10)),
+                    inclusive: false,
+                    bound: Some(Datum::Int32(11)),
                 },
             ))))
             .unwrap();
@@ -1685,8 +1690,8 @@ mod tests {
         want.packer()
             .push_range(Range::new(Some((
                 RangeLowerBound {
-                    inclusive: false,
-                    bound: Some(Datum::Int32(5)),
+                    inclusive: true,
+                    bound: Some(Datum::Int32(6)),
                 },
                 RangeUpperBound {
                     inclusive: false,
@@ -1695,5 +1700,101 @@ mod tests {
             ))))
             .unwrap();
         assert_eq!(got, want, "row 1: (5,15) should canonicalize to [6,15)");
+    }
+
+    /// The step's width comes from the column's declared element type, so an
+    /// inclusive upper bound at `i32::MAX` overflows for an `int4range` where the
+    /// same value in an `int8range` does not.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
+    fn range_step_width_follows_declared_element_type() {
+        use arrow::array::ArrayRef;
+        use arrow::datatypes::DataType;
+        use mz_repr::adt::range::{Range, RangeLowerBound, RangeUpperBound};
+
+        fn read_int_range(
+            element_type: SqlScalarType,
+            arrow_type: DataType,
+            lower: ArrayRef,
+            upper: ArrayRef,
+        ) -> Result<Row, anyhow::Error> {
+            let desc = RelationDesc::builder()
+                .with_column(
+                    "r",
+                    SqlScalarType::Range {
+                        element_type: Box::new(element_type),
+                    }
+                    .nullable(true),
+                )
+                .finish();
+
+            #[allow(clippy::as_conversions)]
+            let range_fields: Vec<(Arc<Field>, ArrayRef)> = vec![
+                (
+                    Arc::new(Field::new("lower", arrow_type.clone(), true)),
+                    lower,
+                ),
+                (Arc::new(Field::new("upper", arrow_type, true)), upper),
+                (
+                    Arc::new(Field::new("lower_inclusive", DataType::Boolean, false)),
+                    Arc::new(BooleanArray::from(vec![true])) as ArrayRef,
+                ),
+                (
+                    Arc::new(Field::new("upper_inclusive", DataType::Boolean, false)),
+                    Arc::new(BooleanArray::from(vec![true])) as ArrayRef,
+                ),
+                (
+                    Arc::new(Field::new("empty", DataType::Boolean, false)),
+                    Arc::new(BooleanArray::from(vec![false])) as ArrayRef,
+                ),
+            ];
+            let range_struct = StructArray::from(range_fields);
+            #[allow(clippy::as_conversions)]
+            let batch = StructArray::from(vec![(
+                Arc::new(Field::new("r", range_struct.data_type().clone(), true)),
+                Arc::new(range_struct) as ArrayRef,
+            )]);
+
+            let reader = ArrowReader::new(&desc, batch)?;
+            let mut got = Row::default();
+            reader.read(0, &mut got)?;
+            Ok(got)
+        }
+
+        #[allow(clippy::as_conversions)]
+        let err = read_int_range(
+            SqlScalarType::Int32,
+            DataType::Int32,
+            Arc::new(Int32Array::from(vec![Some(1)])) as ArrayRef,
+            Arc::new(Int32Array::from(vec![Some(i32::MAX)])) as ArrayRef,
+        )
+        .expect_err("int4 step at i32::MAX overflows");
+        assert!(
+            format!("{err:#}").contains("integer out of range"),
+            "unexpected error: {err:#}"
+        );
+
+        #[allow(clippy::as_conversions)]
+        let got = read_int_range(
+            SqlScalarType::Int64,
+            DataType::Int64,
+            Arc::new(Int64Array::from(vec![Some(1)])) as ArrayRef,
+            Arc::new(Int64Array::from(vec![Some(i64::from(i32::MAX))])) as ArrayRef,
+        )
+        .expect("int8 step at i32::MAX is in range");
+        let mut want = Row::default();
+        want.packer()
+            .push_range(Range::new(Some((
+                RangeLowerBound {
+                    inclusive: true,
+                    bound: Some(Datum::Int64(1)),
+                },
+                RangeUpperBound {
+                    inclusive: false,
+                    bound: Some(Datum::Int64(i64::from(i32::MAX) + 1)),
+                },
+            ))))
+            .unwrap();
+        assert_eq!(got, want);
     }
 }

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -784,7 +784,7 @@ impl<E: Eval> LazyUnaryFunc for CastStringToRange<E> {
                 .eval(&[Datum::String(elem_text)], temp_storage)
         })?;
 
-        range.canonicalize()?;
+        range.canonicalize(self.return_ty.unwrap_range_element_type())?;
 
         Ok(temp_storage.make_datum(|packer| {
             packer

--- a/src/expr/src/scalar/func/variadic.rs
+++ b/src/expr/src/scalar/func/variadic.rs
@@ -623,7 +623,7 @@ impl EagerVariadicFunc for RangeCreate {
             RangeBound::new(upper, upper_inclusive),
         )));
 
-        range.canonicalize()?;
+        range.canonicalize(&self.elem_type)?;
 
         Ok(temp_storage.make_datum(|row| {
             row.push_range(range).expect("errors already handled");

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -327,7 +327,11 @@ impl Value {
                     Type::Range { element_type } => &*element_type,
                     _ => panic!("Value::Range should have type Type::Range. Found {:?}", typ),
                 };
-                let range = range.try_into_bounds(|elem| elem.into_datum(buf, elem_pg_type))?;
+                let elem_type = SqlScalarType::try_from(&**elem_pg_type)?;
+                let mut range = range.try_into_bounds(|elem| elem.into_datum(buf, elem_pg_type))?;
+                // A client is free to send a range in whatever form it likes, so
+                // this is where a range built from wire bounds gets canonicalized.
+                range.canonicalize(&elem_type)?;
                 buf.try_make_datum(|packer| packer.push_range(range).map_err(IntoDatumError::from))?
             }
             Value::MzAclItem(mz_acl_item) => Datum::MzAclItem(mz_acl_item),
@@ -868,8 +872,15 @@ impl Value {
                 // TODO: We should be able to push ranges without scratch space, but that requires
                 // a different `push_range` API.
                 let buf = RowArena::new();
-                let range = range
+                let mut range = range
                     .try_into_bounds(|elem| elem.into_datum(&buf, element_type))
+                    .map_err(Box::<dyn Error + Sync + Send>::from)?;
+                // The text form is whatever the client wrote, e.g. `[1,10]` for an
+                // `int4range`, so it has to be canonicalized to `[1,11)` here.
+                let elem_type = SqlScalarType::try_from(&**element_type)
+                    .map_err(Box::<dyn Error + Sync + Send>::from)?;
+                range
+                    .canonicalize(&elem_type)
                     .map_err(Box::<dyn Error + Sync + Send>::from)?;
                 packer
                     .push_range(range)
@@ -1120,10 +1131,42 @@ pub fn values_from_row(row: &RowRef, typ: &SqlRelationType) -> Vec<Option<Value>
 
 #[cfg(test)]
 mod tests {
-    use mz_repr::arb_datum_for_scalar;
+    use mz_repr::{Row, arb_datum_for_scalar};
     use proptest::prelude::*;
 
     use super::*;
+
+    /// A range's text form is whatever the client wrote, so it is canonicalized
+    /// on the way in, and the step's width comes from the declared element type.
+    /// The same inclusive upper bound overflows an `int4range` and is fine in an
+    /// `int8range`.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // numeric/decimal contexts unsupported under miri
+    fn decode_text_range_canonicalizes_at_element_width() {
+        fn decode(elem: Type, text: &str) -> Result<Row, String> {
+            let ty = Type::Range {
+                element_type: Box::new(elem),
+            };
+            let mut row = Row::default();
+            let mut packer = row.packer();
+            Value::decode_text_into_row(&ty, text, &mut packer).map_err(|e| e.to_string())?;
+            drop(packer);
+            Ok(row)
+        }
+
+        let err = decode(Type::Int4, "[1,2147483647]")
+            .expect_err("int4 step at i32::MAX overflows");
+        assert!(err.contains("integer out of range"), "unexpected error: {err}");
+
+        let row = decode(Type::Int8, "[1,2147483647]").expect("int8 step is in range");
+        assert_eq!(row.unpack_first().to_string(), "[1,2147483648)");
+
+        // `[0,0]` steps its upper bound to `1`, `[0,0)` collapses to empty.
+        let row = decode(Type::Int4, "[0,0]").expect("valid range");
+        assert_eq!(row.unpack_first().to_string(), "[0,1)");
+        let row = decode(Type::Int4, "[0,0)").expect("valid range");
+        assert_eq!(row.unpack_first().to_string(), "empty");
+    }
 
     /// Property test: [`Value::binary_encoding_error`] agrees with the actual
     /// behavior of [`Value::encode_binary`] for every `(SqlScalarType, Datum)`

--- a/src/pgrepr/src/value/error.rs
+++ b/src/pgrepr/src/value/error.rs
@@ -16,6 +16,8 @@ use std::fmt;
 use mz_repr::adt::array::InvalidArrayError;
 use mz_repr::adt::range::InvalidRangeError;
 
+use crate::types::TypeConversionError;
+
 /// Error returned when a decoded text value contains a NUL character, which
 /// PostgreSQL-compatible text values must never contain.
 #[derive(Debug)]
@@ -37,6 +39,9 @@ pub enum IntoDatumError {
     Range(InvalidRangeError),
     /// Invalid array (e.g. wrong cardinality or too many dimensions).
     Array(InvalidArrayError),
+    /// A type with no `SqlScalarType` equivalent (e.g. a range whose element
+    /// type carries an invalid numeric constraint).
+    Type(TypeConversionError),
 }
 
 impl fmt::Display for IntoDatumError {
@@ -44,6 +49,7 @@ impl fmt::Display for IntoDatumError {
         match self {
             IntoDatumError::Range(e) => e.fmt(f),
             IntoDatumError::Array(e) => e.fmt(f),
+            IntoDatumError::Type(e) => e.fmt(f),
         }
     }
 }
@@ -53,6 +59,7 @@ impl Error for IntoDatumError {
         match self {
             IntoDatumError::Range(e) => Some(e),
             IntoDatumError::Array(e) => Some(e),
+            IntoDatumError::Type(e) => Some(e),
         }
     }
 }
@@ -66,5 +73,11 @@ impl From<InvalidRangeError> for IntoDatumError {
 impl From<InvalidArrayError> for IntoDatumError {
     fn from(e: InvalidArrayError) -> Self {
         IntoDatumError::Array(e)
+    }
+}
+
+impl From<TypeConversionError> for IntoDatumError {
+    fn from(e: TypeConversionError) -> Self {
+        IntoDatumError::Type(e)
     }
 }

--- a/src/repr/fuzz/fuzz_targets/range_ops.rs
+++ b/src/repr/fuzz/fuzz_targets/range_ops.rs
@@ -27,8 +27,8 @@
 
 use libfuzzer_sys::arbitrary::{self, Unstructured};
 use libfuzzer_sys::fuzz_target;
-use mz_repr::Datum;
 use mz_repr::adt::range::{Range, RangeBound};
+use mz_repr::{Datum, SqlScalarType};
 
 // None = infinite bound. Some((inclusive, value)) = finite bound.
 type BoundSpec = Option<(bool, i32)>;
@@ -54,7 +54,7 @@ fn make_range(spec: RangeSpec) -> Range<Datum<'static>> {
 /// (misordered bounds, etc.).
 fn canonical(spec: RangeSpec) -> Option<Range<Datum<'static>>> {
     let mut r = make_range(spec);
-    r.canonicalize().ok()?;
+    r.canonicalize(&SqlScalarType::Int32).ok()?;
     Some(r)
 }
 

--- a/src/repr/fuzz/fuzz_targets/row_arrow_roundtrip.rs
+++ b/src/repr/fuzz/fuzz_targets/row_arrow_roundtrip.rs
@@ -400,7 +400,7 @@ fn gen_scalar_datum<'a>(u: &mut Unstructured, ty: &SqlScalarType) -> arbitrary::
 /// Push a `Range` of the given discrete element type. Each bound is
 /// independently infinite (`Datum::Null` => infinite via `RangeBound::new`) or
 /// a finite element value, and independently inclusive/exclusive. Empty ranges
-/// are reached when `push_range`'s canonicalization collapses the bounds.
+/// are reached when canonicalization collapses the bounds.
 fn push_range(
     packer: &mut mz_repr::RowPacker,
     u: &mut Unstructured,
@@ -425,7 +425,12 @@ fn push_range(
     let upper: RangeUpperBound<Datum> = RangeBound::new(upper_d, bool::arbitrary(u)?);
     // An out-of-order range (lower > upper) is an `InvalidRangeError`. On
     // failure just fall back to the empty range so the column stays valid.
-    if packer.push_range(Range::new(Some((lower, upper)))).is_err() {
+    let mut range = Range::new(Some((lower, upper)));
+    if range.canonicalize(element_type).is_err() {
+        let _ = packer.push_range(Range { inner: None });
+        return Ok(());
+    }
+    if packer.push_range(range).is_err() {
         let _ = packer.push_range(Range { inner: None });
     }
     Ok(())

--- a/src/repr/src/adt/range.rs
+++ b/src/repr/src/adt/range.rs
@@ -501,7 +501,11 @@ impl<'a, B: Copy + Ord> Range<B> {
 
         let mut r = r.into_bounds(Datum::from);
 
-        r.canonicalize()?;
+        // Both arms build the result's bounds out of the operands' canonical
+        // bounds, flipping inclusivity, which lands on canonical inclusivity
+        // again. There is no step left to apply, so the element type is not
+        // needed here.
+        r.canonicalize_without_step()?;
 
         Ok(r)
     }
@@ -516,9 +520,47 @@ impl<'a> Range<Datum<'a>> {
     /// - Ranges are empty if lower >= upper after prev. step unless range type
     ///   does not have step and both bounds are inclusive
     ///
+    /// `elem_type` is the range's declared element type. It determines the width
+    /// of the discrete step, which is load-bearing at the element type's
+    /// boundary: an `int4range` bound at `i32::MAX` must overflow on the step,
+    /// where the same value in an `int8range` must not. The declared type is the
+    /// only sound source for that width, as a bound's `Datum` does not
+    /// necessarily distinguish the widths.
+    ///
     /// # Panics
     /// - If the upper and lower bounds are finite and of different types.
-    pub fn canonicalize(&mut self) -> Result<(), InvalidRangeError> {
+    pub fn canonicalize(&mut self, elem_type: &SqlScalarType) -> Result<(), InvalidRangeError> {
+        self.canonicalize_inner(Some(elem_type))
+    }
+
+    /// Canonicalize a range whose bounds are derived from already-canonical
+    /// bounds, and so need no discrete step rewrite.
+    ///
+    /// The step rewrite only ever fires on a lower bound that is exclusive or an
+    /// upper bound that is inclusive. A caller that assembles its bounds out of
+    /// canonical ones, where lower bounds are already inclusive and upper bounds
+    /// already exclusive, has nothing left for the step to do and therefore does
+    /// not need the element type. Everything else canonicalization does, namely
+    /// forcing infinite bounds exclusive, rejecting misordered bounds, and
+    /// collapsing to the empty range, is independent of the element type.
+    pub(crate) fn canonicalize_without_step(&mut self) -> Result<(), InvalidRangeError> {
+        self.canonicalize_inner(None)
+    }
+
+    /// Whether the range is canonical, so far as that can be told without the
+    /// element type. The step rewrite is invisible to this check. An infinite
+    /// bound left inclusive, or an empty range left uncollapsed, is not.
+    pub(crate) fn is_canonical_without_step(&self) -> bool {
+        let mut probe = *self;
+        probe.canonicalize_without_step().is_ok() && probe == *self
+    }
+
+    /// `elem_type` of `None` skips the discrete step rewrite. See
+    /// [`Range::canonicalize_without_step`] for when that is sound.
+    fn canonicalize_inner(
+        &mut self,
+        elem_type: Option<&SqlScalarType>,
+    ) -> Result<(), InvalidRangeError> {
         let (lower, upper) = match &mut self.inner {
             Some(inner) => (&mut inner.lower, &mut inner.upper),
             None => return Ok(()),
@@ -538,8 +580,8 @@ impl<'a> Range<Datum<'a>> {
             _ => {}
         };
 
-        lower.canonicalize()?;
-        upper.canonicalize()?;
+        lower.canonicalize(elem_type)?;
+        upper.canonicalize(elem_type)?;
 
         // The only way that you have two inclusive bounds with equal value are
         // if type does not have step.
@@ -733,18 +775,23 @@ impl<'a, const UPPER: bool> RangeBound<Datum<'a>, UPPER> {
     /// Rewrite the bounds to the consistent format. This is absolutely
     /// necessary to perform the correct equality/comparison operations on
     /// types.
-    fn canonicalize(&mut self) -> Result<(), InvalidRangeError> {
-        Ok(match self.bound {
-            None => {
+    fn canonicalize(&mut self, elem_type: Option<&SqlScalarType>) -> Result<(), InvalidRangeError> {
+        Ok(match (self.bound, elem_type) {
+            (None, _) => {
                 self.inclusive = false;
             }
-            // Valid range types are defined in typeconv.rs:validate_range_element_type
-            Some(value) => match value {
-                d @ Datum::Int32(_) => self.canonicalize_inner::<i32>(d)?,
-                d @ Datum::Int64(_) => self.canonicalize_inner::<i64>(d)?,
-                d @ Datum::Date(_) => self.canonicalize_inner::<Date>(d)?,
-                Datum::Numeric(..) | Datum::Timestamp(..) | Datum::TimestampTz(..) => {}
-                d => unreachable!("{d:?} not yet supported in ranges"),
+            (Some(_), None) => {}
+            // Valid range element types are defined in
+            // typeconv.rs:validate_range_element_type. The step's width comes from
+            // the declared element type, never from the bound's `Datum`.
+            (Some(d), Some(elem_type)) => match elem_type {
+                SqlScalarType::Int32 => self.canonicalize_inner::<i32>(d)?,
+                SqlScalarType::Int64 => self.canonicalize_inner::<i64>(d)?,
+                SqlScalarType::Date => self.canonicalize_inner::<Date>(d)?,
+                SqlScalarType::Numeric { .. }
+                | SqlScalarType::Timestamp { .. }
+                | SqlScalarType::TimestampTz { .. } => {}
+                other => unreachable!("{other:?} is not a valid range element type"),
             },
         })
     }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -2769,6 +2769,11 @@ impl RowPacker<'_> {
 
     /// Pushes a `Datum::Range` derived from the `Range<Datum<'a>`.
     ///
+    /// The range must already be canonical. Canonicalization needs the range's
+    /// declared element type to size the discrete step, which a `Row` has no
+    /// access to, so it belongs to whoever builds the range out of its bounds.
+    /// Call [`Range::canonicalize`] there.
+    ///
     /// # Panics
     /// - If lower and upper express finite values and they are datums of
     ///   different types.
@@ -2777,13 +2782,13 @@ impl RowPacker<'_> {
     ///   [`RangeBound::new`].
     ///
     /// # Notes
-    /// - This function canonicalizes the range before pushing it to the row.
-    /// - Prefer this function over `push_range_with` because of its
-    ///   canonicaliztion.
     /// - Prefer creating [`RangeBound`]s using [`RangeBound::new`], which
     ///   handles `Datum::Null` in a SQL-friendly way.
-    pub fn push_range<'a>(&mut self, mut range: Range<Datum<'a>>) -> Result<(), InvalidRangeError> {
-        range.canonicalize()?;
+    pub fn push_range<'a>(&mut self, range: Range<Datum<'a>>) -> Result<(), InvalidRangeError> {
+        debug_assert!(
+            range.is_canonical_without_step(),
+            "push_range requires a canonical range, got {range}"
+        );
         match range.inner {
             None => {
                 self.row.data.push(Tag::Range.into());
@@ -2813,9 +2818,9 @@ impl RowPacker<'_> {
     /// Pushes a `DatumRange` built from the specified arguments.
     ///
     /// # Warning
-    /// Unlike `push_range`, `push_range_with` _does not_ canonicalize its
-    /// inputs. Consequentially, this means it's possible to generate ranges
-    /// that will not reflect the proper ordering and equality.
+    /// The bounds must already be canonical, as neither this nor `push_range`
+    /// canonicalizes. Non-canonical bounds do not reflect the proper ordering
+    /// and equality.
     ///
     /// # Panics
     /// - If lower or upper expresses a finite value and does not push exactly
@@ -4334,12 +4339,12 @@ mod tests {
             Datum::JsonNull,
             Datum::Range(Range { inner: None }),
             arena.make_datum(|packer| {
-                packer
-                    .push_range(Range::new(Some((
-                        RangeLowerBound::new(Datum::Int32(-1), true),
-                        RangeUpperBound::new(Datum::Int32(1), true),
-                    ))))
-                    .unwrap();
+                let mut range = Range::new(Some((
+                    RangeLowerBound::new(Datum::Int32(-1), true),
+                    RangeUpperBound::new(Datum::Int32(1), true),
+                )));
+                range.canonicalize(&SqlScalarType::Int32).unwrap();
+                packer.push_range(range).unwrap();
             }),
         ];
         for value in values_of_interest {

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -5417,9 +5417,7 @@ pub fn arb_datum(allow_dummy: bool) -> BoxedStrategy<PropDatum> {
         any::<[u8; 16]>()
             .prop_map(|x| PropDatum::Uuid(Uuid::from_bytes(x)))
             .boxed(),
-        arb_range(arb_range_data())
-            .prop_map(PropDatum::Range)
-            .boxed(),
+        arb_range_any().prop_map(PropDatum::Range).boxed(),
     ];
 
     if allow_dummy {
@@ -5519,9 +5517,11 @@ pub fn arb_datum_for_scalar(scalar_type: SqlScalarType) -> impl Strategy<Value =
         SqlScalarType::Range { element_type } => {
             let data_strat = (
                 arb_datum_for_scalar(*element_type.clone()),
-                arb_datum_for_scalar(*element_type),
+                arb_datum_for_scalar(*element_type.clone()),
             );
-            arb_range(data_strat).prop_map(PropDatum::Range).boxed()
+            arb_range(*element_type, data_strat)
+                .prop_map(PropDatum::Range)
+                .boxed()
         }
         SqlScalarType::List { element_type, .. } => arb_list(arb_datum_for_scalar(*element_type))
             .prop_map(PropDatum::List)
@@ -5707,29 +5707,37 @@ pub fn arb_range_type() -> Union<BoxedStrategy<SqlScalarType>> {
     ])
 }
 
+/// A range over each of the discrete range element types.
 #[cfg(any(test, feature = "proptest"))]
-fn arb_range_data() -> Union<BoxedStrategy<(PropDatum, PropDatum)>> {
+fn arb_range_any() -> Union<BoxedStrategy<PropRange>> {
     Union::new(vec![
-        (
-            any::<i32>().prop_map(PropDatum::Int32),
-            any::<i32>().prop_map(PropDatum::Int32),
-        )
-            .boxed(),
-        (
-            any::<i64>().prop_map(PropDatum::Int64),
-            any::<i64>().prop_map(PropDatum::Int64),
-        )
-            .boxed(),
-        (
-            arb_date().prop_map(PropDatum::Date),
-            arb_date().prop_map(PropDatum::Date),
-        )
-            .boxed(),
+        arb_range(
+            SqlScalarType::Int32,
+            (
+                any::<i32>().prop_map(PropDatum::Int32),
+                any::<i32>().prop_map(PropDatum::Int32),
+            ),
+        ),
+        arb_range(
+            SqlScalarType::Int64,
+            (
+                any::<i64>().prop_map(PropDatum::Int64),
+                any::<i64>().prop_map(PropDatum::Int64),
+            ),
+        ),
+        arb_range(
+            SqlScalarType::Date,
+            (
+                arb_date().prop_map(PropDatum::Date),
+                arb_date().prop_map(PropDatum::Date),
+            ),
+        ),
     ])
 }
 
 #[cfg(any(test, feature = "proptest"))]
 fn arb_range(
+    elem_type: SqlScalarType,
     data: impl Strategy<Value = (PropDatum, PropDatum)> + 'static,
 ) -> BoxedStrategy<PropRange> {
     (
@@ -5741,7 +5749,7 @@ fn arb_range(
         data,
     )
         .prop_map(
-            |(split, lower_inf, lower_inc, upper_inf, upper_inc, (a, b))| {
+            move |(split, lower_inf, lower_inc, upper_inf, upper_inc, (a, b))| {
                 let mut row = Row::default();
                 let mut packer = row.packer();
                 let r = if split % 32 == 0 {
@@ -5772,7 +5780,7 @@ fn arb_range(
                         },
                     )));
 
-                    range.canonicalize().unwrap();
+                    range.canonicalize(&elem_type).unwrap();
 
                     // Extract canonicalized state; pretend the range was empty
                     // if the bounds are rewritten.
@@ -6175,7 +6183,7 @@ mod tests {
 
         #[mz_ore::test]
         #[cfg_attr(miri, ignore)] // too slow
-        fn range_packing_unpacks_correctly(range in arb_range(arb_range_data())) {
+        fn range_packing_unpacks_correctly(range in arb_range_any()) {
             let PropRange(row, prop_range) = range;
             let row = row.unpack_first();
             let d = row.unwrap_range();

--- a/src/storage-types/src/sources/casts.rs
+++ b/src/storage-types/src/sources/casts.rs
@@ -367,7 +367,7 @@ impl CastFunc {
                 }))
             }
             CastFunc::CastStringToRange {
-                return_ty: _,
+                return_ty,
                 cast_expr,
             } => {
                 let mut range = strconv::parse_range(a, |elem_text| {
@@ -377,7 +377,7 @@ impl CastFunc {
                     };
                     cast_expr.eval(&[Datum::String(elem_text)], arena)
                 })?;
-                range.canonicalize()?;
+                range.canonicalize(return_ty.unwrap_range_element_type())?;
                 Ok(arena.make_datum(|packer| {
                     packer
                         .push_range(range)

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -472,11 +472,15 @@ impl SourceTimestamp for KafkaTimestamp {
         };
         assert_eq!(lower_inclusive, upper_inclusive, "invalid range {self}");
 
+        let mut range = range::Range::new(Some((
+            range::RangeBound::new(lower, lower_inclusive),
+            range::RangeBound::new(upper, upper_inclusive),
+        )));
+        range
+            .canonicalize(&SqlScalarType::Numeric { max_scale: None })
+            .expect("partition intervals are valid ranges");
         packer
-            .push_range(range::Range::new(Some((
-                range::RangeBound::new(lower, lower_inclusive),
-                range::RangeBound::new(upper, upper_inclusive),
-            ))))
+            .push_range(range)
             .expect("pushing range must not generate errors");
 
         packer.push(Datum::UInt64(self.timestamp().offset));
@@ -488,9 +492,9 @@ impl SourceTimestamp for KafkaTimestamp {
 
         match (datums.next(), datums.next(), datums.next()) {
             (Some(Datum::Range(range)), Some(Datum::UInt64(offset)), None) => {
-                let mut range = range.into_bounds(|b| b.datum());
-                //XXX: why do we have to canonicalize on read?
-                range.canonicalize().expect("ranges must be valid");
+                // No canonicalization on read. The row was written canonical, and
+                // a numeric range has no discrete step to rewrite anyway.
+                let range = range.into_bounds(|b| b.datum());
                 let range = range.inner.expect("empty range");
 
                 let lower = range.lower.bound.map(|row| {

--- a/src/storage/fuzz/fuzz_targets/upsert_consolidate.rs
+++ b/src/storage/fuzz/fuzz_targets/upsert_consolidate.rs
@@ -50,7 +50,7 @@ use mz_repr::adt::numeric::Numeric;
 use mz_repr::adt::range::{Range, RangeBound, RangeInner};
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::role_id::RoleId;
-use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
+use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, SqlScalarType, Timestamp};
 use mz_storage::fuzz_exports::{StateValue, UpsertValue, upsert_bincode_opts};
 use mz_storage_types::errors::{
     DecodeError, DecodeErrorKind, UpsertError, UpsertNullKeyError, UpsertValueError,
@@ -197,9 +197,13 @@ fn push_range(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result
             None
         },
     };
-    let range = Range {
+    let mut range = Range {
         inner: Some(RangeInner { lower, upper }),
     };
+    if range.canonicalize(&SqlScalarType::Int32).is_err() {
+        packer.push(Datum::Int32(lo));
+        return Ok(());
+    }
     if packer.push_range(range).is_err() {
         packer.push(Datum::Int32(lo));
     }

--- a/src/storage/fuzz/fuzz_targets/upsert_runtime.rs
+++ b/src/storage/fuzz/fuzz_targets/upsert_runtime.rs
@@ -57,7 +57,7 @@ use mz_repr::adt::numeric::Numeric;
 use mz_repr::adt::range::{Range, RangeBound, RangeInner};
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::role_id::RoleId;
-use mz_repr::{Datum, Diff, Row, RowPacker, Timestamp};
+use mz_repr::{Datum, Diff, Row, RowPacker, SqlScalarType, Timestamp};
 use mz_storage::fuzz_exports::{FuzzUpsertParts, UpsertKey, UpsertValue, fuzz_drain_staged_input};
 use mz_storage::source::SourceExportCreationConfig;
 use mz_storage_types::errors::{
@@ -225,9 +225,13 @@ fn push_range(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result
             None
         },
     };
-    let range = Range {
+    let mut range = Range {
         inner: Some(RangeInner { lower, upper }),
     };
+    if range.canonicalize(&SqlScalarType::Int32).is_err() {
+        packer.push(Datum::Int32(lo));
+        return Ok(());
+    }
     if packer.push_range(range).is_err() {
         packer.push(Datum::Int32(lo));
     }

--- a/src/storage/fuzz/fuzz_targets/upsert_state_consolidate.rs
+++ b/src/storage/fuzz/fuzz_targets/upsert_state_consolidate.rs
@@ -47,7 +47,7 @@ use mz_repr::adt::numeric::Numeric;
 use mz_repr::adt::range::{Range, RangeBound, RangeInner};
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::role_id::RoleId;
-use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
+use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, SqlScalarType, Timestamp};
 use mz_storage::fuzz_exports::{
     FuzzUpsertParts, UpsertKey, UpsertValue, UpsertValueAndSize, upsert_bincode_opts,
 };
@@ -204,9 +204,13 @@ fn push_range(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result
             None
         },
     };
-    let range = Range {
+    let mut range = Range {
         inner: Some(RangeInner { lower, upper }),
     };
+    if range.canonicalize(&SqlScalarType::Int32).is_err() {
+        packer.push(Datum::Int32(lo));
+        return Ok(());
+    }
     if packer.push_range(range).is_err() {
         packer.push(Datum::Int32(lo));
     }

--- a/src/storage/fuzz/fuzz_targets/upsert_value_roundtrip_v2.rs
+++ b/src/storage/fuzz/fuzz_targets/upsert_value_roundtrip_v2.rs
@@ -51,7 +51,7 @@ use mz_repr::adt::numeric::Numeric;
 use mz_repr::adt::range::{Range, RangeBound, RangeInner};
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::role_id::RoleId;
-use mz_repr::{Datum, Row, RowPacker, Timestamp};
+use mz_repr::{Datum, Row, RowPacker, SqlScalarType, Timestamp};
 use mz_row_spine::DatumContainer;
 use mz_storage::fuzz_exports::{UpsertValue, datum_seq_to_upsert_value, upsert_value_to_row};
 use mz_storage_types::errors::{
@@ -272,11 +272,15 @@ fn push_range(packer: &mut RowPacker, u: &mut Unstructured) -> arbitrary::Result
             None
         },
     };
-    let range = Range {
+    let mut range = Range {
         inner: Some(RangeInner { lower, upper }),
     };
-    // `push_range` canonicalizes and may reject (e.g. a degenerate empty range).
+    // Canonicalization may reject the bounds (e.g. a step that overflows int4).
     // On rejection just push a plain scalar so the row is still valid.
+    if range.canonicalize(&SqlScalarType::Int32).is_err() {
+        packer.push(Datum::Int32(lo));
+        return Ok(());
+    }
     if packer.push_range(range).is_err() {
         packer.push(Datum::Int32(lo));
     }

--- a/test/pgtest/copy-from-range.pt
+++ b/test/pgtest/copy-from-range.pt
@@ -108,3 +108,74 @@ ReadyForQuery
 ----
 ErrorResponse {"fields":[]}
 ReadyForQuery {"status":"I"}
+
+#
+# Negative: a discrete step that overflows the element type is an error
+#
+
+send
+Query {"query": "COPY copy_range_t FROM STDIN"}
+----
+
+until
+CopyIn
+----
+CopyIn {"format":"text","column_formats":["text"]}
+
+send
+CopyData "[1,2147483647]\n"
+CopyDone
+----
+
+until no_error_fields
+ReadyForQuery
+----
+ErrorResponse {"fields":[]}
+ReadyForQuery {"status":"I"}
+
+#
+# The step's width comes from the declared element type, so the bound that
+# overflows an int4range is fine in an int8range.
+#
+
+send
+Query {"query": "CREATE TABLE copy_range_t8 (r int8range)"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "COPY copy_range_t8 FROM STDIN"}
+----
+
+until
+CopyIn
+----
+CopyIn {"format":"text","column_formats":["text"]}
+
+send
+CopyData "[1,2147483647]\n"
+CopyDone
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"COPY 1"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "SELECT r FROM copy_range_t8"}
+----
+
+until
+ReadyForQuery
+----
+RowDescription {"fields":[{"name":"r"}]}
+DataRow {"fields":["[1,2147483648)"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Supersedes #37264, which took a narrower cut at this and left the interesting half open. That PR is closed in favor of this one rather than force-pushed, because its description's call-site analysis turns out to be wrong in a way that matters, and reading it first is a net negative. Both review comments there are addressed here, not deferred: antiguru's is resolved by there being no remaining tag-sniffing callers to migrate, and ggevay's dangling `RANGE_CANON_ANALYSIS.md` reference is gone along with the doc comment that carried it.

## What

Range canonicalization decided the width of the discrete step by matching on the bound's **`Datum` tag**:

```rust
d @ Datum::Int32(_) => self.canonicalize_inner::<i32>(d)?,
d @ Datum::Int64(_) => self.canonicalize_inner::<i64>(d)?,
d @ Datum::Date(_)  => self.canonicalize_inner::<Date>(d)?,
```

`canonicalize_inner::<T>` calls `T::step()`, so the runtime tag of the value chose which `step()` ran. Reading an `i32` out of a `Datum` is data extraction and is fine. Selecting a code path from the variant you find is control flow, and that is what this removes.

The width is load-bearing, not cosmetic. PG canonicalizes discrete ranges to `[lo, hi)`, and the `+1` has to be checked at the element's own width:

* `'[2,2147483647]'::int4range` must fail with `integer out of range`
* the same bound in an `int8range` must succeed as `[2,2147483648)`

Same value, opposite outcomes. On `main` the tag happens to carry the right width, because an `int4range` stores `Int32` bounds, but nothing enforces that agreement. #37262 removes it: with `Int32`/`Int64` collapsed into one `Datum::Int` a tag cannot tell an `int4range` from an `int8range`, which is why that PR carries a `SPIKE FORCING-FUNCTION` stub canonicalizing everything at `i64`.

## The rule this settles

Canonicalize once, where a range is built out of bounds that are not already canonical, using the declared element type. Everything downstream trusts.

There are seven such sites and every one of them already has the declared element type in hand:

| Site | Element type from |
|---|---|
| `variadic.rs` `RangeCreate` | `self.elem_type` |
| `impls/string.rs` `CastStringToRange` | `return_ty` |
| `storage-types/casts.rs` `CastStringToRange` | `return_ty` |
| `pgrepr/value.rs` `into_datum`, binary `Value::Range` | `elem_pg_type` |
| `pgrepr/value.rs` `decode_text_into_row`, text | `element_type` |
| `arrow-util/reader.rs` range column | new `element_type` on `ColReader::Range` |
| `kafka.rs` progress row | statically `numeric` |

The bottom four are the ones worth a close look. They are ingress paths, where a range arrives in whatever form a client or a foreign Parquet writer chose, and they relied entirely on `Row::push_range` to canonicalize:

* binary `Value::Range` backs bind parameters and CSV/oneshot `COPY`
* `decode_text_into_row` backs `COPY ... FROM STDIN`
* `arrow-util/reader.rs` already carried a comment saying foreign Parquet may encode an `int4range` as `[1,10]` and must be canonicalized to `[1,11)`

Under a width-blind step each of those silently stores `[1,2147483648)` in an `int4range` column instead of raising an error.

## What stops canonicalizing

**`Row::push_range`.** A `Row` has no declared element type, so it could only ever guess the width, and canonicalization is not packing. Its contract is now that the range arrives canonical, checked in debug builds as far as is possible without the element type: infinite bounds exclusive, empty collapsed, bounds ordered. The step rewrite is the only part that check cannot see. `push_range_with`'s warning is updated, since neither function canonicalizes now.

**`Range::difference`.** Both of its non-trivial arms build the result's bounds out of the operands' canonical bounds, flipping inclusivity, which lands back on canonical inclusivity. The step rewrite only fires on an exclusive lower or inclusive upper bound, so it cannot fire here, and everything else canonicalization does is width-independent. It calls a crate-private `canonicalize_without_step` and needs no element type. This is what antiguru asked to see tracked, and it is cheaper than making `range_difference` a stateful `BinaryFunc`.

**`kafka.rs::decode_row`,** which carried `//XXX: why do we have to canonicalize on read?`. Answered by deletion: it re-canonicalized a numeric range read out of a canonical row, and numeric has no step.

Three sites needed nothing. `Range::{union,intersection}` take min/max of canonical bounds and so preserve canonicality; `OutputDatumType for Range` packs their results into a `Datum::Range` without canonicalizing at all, which independently confirms as much; and `row/encode.rs` decodes persisted bytes through `push_range_with`, which never canonicalized.

`grep 'Datum::' src/repr/src/adt/range.rs` now returns only `Datum::from` conversions and the `Datum::Null`-means-infinite convention in `RangeBound::new`. The one remaining tag use is validation rather than dispatch, the `assert_eq!(DatumKind::from(l), DatumKind::from(u))` guarding against mixed bound types, which keeps compiling under unification and merely gets weaker.

## Behavior

Behavior-preserving on `main`: wherever a bound is unwrapped today, its tag and the declared type agree. No release note.

Two things a reviewer should confirm anyway. The three ingress paths now surface `CanonicalizationOverflow` and `MisorderedRangeBounds` from `canonicalize` rather than from `push_range`, so the same error reaches the user one call earlier. And `IntoDatumError` gains a `Type` variant, because `SqlScalarType::try_from(&Type)` is fallible for a numeric element type with a bad typmod, which the `value_decode_text` fuzz target generates deliberately.

## Tests

* New `pgrepr` unit test over `decode_text_into_row`: `[1,2147483647]` is an error for `int4range` and `[1,2147483648)` for `int8range`, `[0,0]` becomes `[0,1)`, `[0,0)` collapses to `empty`.
* New `arrow-util` unit test putting the same int4-vs-int8 pair through the Parquet range reader.
* New cases in `test/pgtest/copy-from-range.pt` for the same pair over `COPY ... FROM STDIN`.
* `range_canonicalizes_noncanonical_input` gets stronger. Its `want` was built by pushing the non-canonical form and letting `push_range` rewrite it, so both sides went through the same code and it would have passed against a reader that did nothing. `want` is now the canonical form written out.
* `arb_range` and the range fuzz targets canonicalize with an explicit element type, which is where the boundary-overflow behavior actually gets exercised.

## For #37262

The spike's `adt/range.rs` diff goes to zero. There is no `Datum` arm left in canonicalization to stub out, so its remaining known-incomplete items are mechanical rather than semantic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
