### PR TITLE
sql: Transparent `Debug` impl for `StableRow` to avoid noise in debug output

### DIFF
--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -361,7 +361,6 @@ impl Ord for Row {
 /// `SourceData`, and `row.proto` is covered by the buf breaking lint.
 #[derive(
     Clone,
-    Debug,
     Default,
     Eq,
     PartialEq,
@@ -384,6 +383,12 @@ impl Deref for StableRow {
 
     fn deref(&self) -> &Row {
         &self.0
+    }
+}
+
+impl Debug for StableRow {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/test/sqllogictest/distinct_arrangements.slt
+++ b/test/sqllogictest/distinct_arrangements.slt
@@ -978,8 +978,8 @@ Arrange errors
 ArrangeAccumulable [val: empty]
 ArrangeAccumulable [val: empty]
 ArrangeAccumulable [val: empty]
-ArrangeBy[[CallBinary(ModInt64(ModInt64), Column(0, "data"), Literal(Ok(StableRow(Row{[Int64(2)]})), ReprColumnType { scalar_type: Int64, nullable: false }))]]
-ArrangeBy[[CallBinary(ModInt64(ModInt64), Column(0, "data"), Literal(Ok(StableRow(Row{[Int64(2)]})), ReprColumnType { scalar_type: Int64, nullable: false }))]]-errors
+ArrangeBy[[CallBinary(ModInt64(ModInt64), Column(0, "data"), Literal(Ok(Row{[Int64(2)]}), ReprColumnType { scalar_type: Int64, nullable: false }))]]
+ArrangeBy[[CallBinary(ModInt64(ModInt64), Column(0, "data"), Literal(Ok(Row{[Int64(2)]}), ReprColumnType { scalar_type: Int64, nullable: false }))]]-errors
 ArrangeBy[[CallUnary(CastInt32ToInt64(CastInt32ToInt64), Column(0, "id"))]]
 ArrangeBy[[Column(0)]]
 ArrangeBy[[Column(0, "data")]]
@@ -1017,7 +1017,7 @@ Distinct errors
 Distinct errors
 Distinct errors
 Distinct errors
-Distinct errors[[CallBinary(ModInt64(ModInt64), Column(0, "data"), Literal(Ok(StableRow(Row{[Int64(2)]})), ReprColumnType { scalar_type: Int64, nullable: false }))]]
+Distinct errors[[CallBinary(ModInt64(ModInt64), Column(0, "data"), Literal(Ok(Row{[Int64(2)]}), ReprColumnType { scalar_type: Int64, nullable: false }))]]
 Distinct errors[[Column(0)]]
 Distinct errors[[Column(0)]]
 Distinct errors[[]]


### PR DESCRIPTION
### Motivation

Closes [SQL-646](https://linear.app/materializeinc/issue/SQL-646).
https://github.com/MaterializeInc/materialize/pull/37814#issuecomment-5366410023

### Description

The `StableRow` newtype struct derived `Debug`, which added the struct name as chatter. This PR removes it, per @antiguru's review.

### Verification

Tests pass.