### PR TITLE
Hard-cap snapshot partition prefix probes at 5000 per table

### DIFF
--- a/src/mysql-util/src/probe.rs
+++ b/src/mysql-util/src/probe.rs
@@ -25,6 +25,10 @@ pub const MAX_KEY_LENGTH: u32 = 768;
 /// Probes a string primary key column. Only supports `utf8mb4_bin` against CHAR/VARCHAR
 /// columns up to 768 characters. Enforcement is deferred to the caller. There may be
 /// other collations we can support, but we should do more validation.
+///
+/// NOTE: The partitioning walk's local bookkeeping scales quadratically with the
+/// number of probes. Local benchmarking of 5k probes over 5k entries was fast
+/// (under a second of CPU), so exceed that budget at your own risk.
 pub struct KeyProber<'a, 't> {
     tx: &'a mut Transaction<'t>,
     /// Quoted `` `schema`.`table` `` for SQL interpolation.

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -255,7 +255,8 @@ pub static MYSQL_SOURCE_SNAPSHOT_PARTITION_PROBED_PREFIXES_PER_BILLION_ROWS: Con
         "mysql_source_snapshot_partition_probed_prefixes_per_billion_rows",
         1_000,
         "Cap on MySQL snapshot PK-prefix partitioning probed prefixes per table, per billion \
-     estimated rows; when exhausted, splitting stops early with coarser partition boundaries.",
+     estimated rows; when exhausted, splitting stops early with coarser partition boundaries. \
+     The per-table budget is additionally hard-capped at 5000.",
         ParameterScope::Replica,
     );
 

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -236,6 +236,7 @@ fn worker_pk_range(
 const SUPPORTED_PK_COLLATION: &str = "utf8mb4_bin";
 const SUPPORTED_PK_CHARSET: &str = "utf8mb4";
 const MIN_PROBED_PREFIXES: u64 = 64;
+const MAX_PROBED_PREFIXES: u64 = 5_000;
 
 /// Partitioning configuration settings bundled to avoid accidental mixing.
 struct PartitionSettings {
@@ -277,7 +278,7 @@ async fn compute_sampled_splits(
     // that can take hours to snapshot.
     let max_probed_prefixes = (row_count.saturating_mul(settings.probed_prefixes_per_billion_rows)
         / 1_000_000_000)
-        .max(MIN_PROBED_PREFIXES);
+        .clamp(MIN_PROBED_PREFIXES, MAX_PROBED_PREFIXES);
     let params = mz_mysql_util::PartitionParams {
         num_workers: worker_count,
         estimated_row_count: row_count,


### PR DESCRIPTION
### Motivation
There's a little O(depth*prefixes) algorithm going on. I think it can kind of be viewed as O(probes^2). Anyways, I did a little testing locally that confirmed it would be fast even up to 5k iterations over 5k prefixes and told folks I'd implement a cap. I just realized I never actually set that hard 5k cap.

### Description
Implement a hard cap on probes to address some light concerns we had with the way we select prefixes.

