### PR TITLE
adapter: skip introspection-disabled replicas when installing per-replica features

### DIFF
--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -114,6 +114,25 @@ impl Coordinator {
             .collect()
     }
 
+    /// Whether `replica_id` on `cluster_id` has replica introspection (logging) enabled.
+    ///
+    /// A replica created with `INTROSPECTION INTERVAL 0` still installs its logging dataflows, but
+    /// they replay empty, so a per-replica feature reading those log relations only ever sees a
+    /// dead source. Both the introspection-subscribe and curated-metric-sink installs skip such
+    /// replicas.
+    ///
+    /// Returns `false` for a replica or cluster not in the catalog, so a caller racing a replica
+    /// drop installs nothing.
+    pub(super) fn replica_introspection_enabled(
+        &self,
+        cluster_id: ClusterId,
+        replica_id: ReplicaId,
+    ) -> bool {
+        self.catalog
+            .try_get_cluster_replica(cluster_id, replica_id)
+            .is_some_and(|replica| replica.config.compute.logging.enabled())
+    }
+
     /// Installs introspection subscribes on all existing replicas.
     ///
     /// Meant to be invoked during coordinator bootstrapping.
@@ -132,6 +151,10 @@ impl Coordinator {
     ) {
         let dyncfgs = self.catalog().system_config().dyncfgs();
         if !ENABLE_INTROSPECTION_SUBSCRIBES.get(dyncfgs) {
+            return;
+        }
+
+        if !self.replica_introspection_enabled(cluster_id, replica_id) {
             return;
         }
 

--- a/src/adapter/src/coord/metric_sink.rs
+++ b/src/adapter/src/coord/metric_sink.rs
@@ -132,13 +132,10 @@ impl Coordinator {
             return;
         }
 
-        // TODO: Skip replicas created with introspection disabled. Their logging dataflows never
-        // run, so a `source_sql` reading introspection relations there never advances. That is not
-        // just wasted work: the sink publishes its input frontier as its write frontier, so a
-        // never-advancing input stalls the sink's frontier at its as-of and pins the read holds it
-        // takes on those collections for the replica's whole life (replica-local, released on
-        // drop). `coord::introspection` installs subscribes on the same triggers and has the same
-        // gap.
+        if !self.replica_introspection_enabled(cluster_id, replica_id) {
+            return;
+        }
+
         for definition in CURATED {
             self.install_metric_sink(cluster_id, replica_id, definition)
                 .await;

--- a/src/compute-types/src/config.rs
+++ b/src/compute-types/src/config.rs
@@ -52,3 +52,23 @@ impl ComputeReplicaLogging {
         self.interval.is_some()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::ComputeReplicaLogging;
+
+    /// Two per-replica install paths (introspection subscribes, curated metric sinks) skip a
+    /// replica on this predicate, so pin what it means.
+    #[mz_ore::test]
+    fn logging_is_enabled_exactly_when_an_interval_is_set() {
+        let logging = |interval| ComputeReplicaLogging {
+            log_logging: false,
+            interval,
+        };
+
+        assert!(logging(Some(Duration::from_secs(1))).enabled());
+        assert!(!logging(None).enabled());
+    }
+}

--- a/test/testdrive/unified-compute-introspection.td
+++ b/test/testdrive/unified-compute-introspection.td
@@ -149,5 +149,35 @@ idx_div_by_zero r1 1
   JOIN mz_cluster_replicas r ON c.replica_id = r.id
   WHERE c.count != 0
 
+# Test that no introspection subscribes are installed on a replica created with
+# introspection disabled. Its logging dataflows never run, so a subscribe there
+# would never advance and would pin the read holds it takes for the replica's
+# whole life.
+#
+# The subscribes are transient dataflows targeted at a single replica, so they
+# show up as `t%` object IDs in `mz_cluster_replica_frontiers`.
+
+> CREATE CLUSTER introspection_off (SIZE '${arg.default-replica-size}', INTROSPECTION INTERVAL 0)
+> CREATE CLUSTER introspection_on (SIZE '${arg.default-replica-size}')
+
+# The positive control is created last, so by the time its subscribes are
+# visible the ones for `introspection_off` would be too.
+> SELECT count(*) > 0
+  FROM mz_cluster_replica_frontiers f
+  JOIN mz_cluster_replicas r ON r.id = f.replica_id
+  JOIN mz_clusters c ON c.id = r.cluster_id
+  WHERE c.name = 'introspection_on' AND f.object_id LIKE 't%'
+true
+
+> SELECT count(*)
+  FROM mz_cluster_replica_frontiers f
+  JOIN mz_cluster_replicas r ON r.id = f.replica_id
+  JOIN mz_clusters c ON c.id = r.cluster_id
+  WHERE c.name = 'introspection_off' AND f.object_id LIKE 't%'
+0
+
+> DROP CLUSTER introspection_on
+> DROP CLUSTER introspection_off
+
 # Clean up.
 > DROP CLUSTER test


### PR DESCRIPTION
Problem:
A replica created with `INTROSPECTION INTERVAL 0` runs no logging
dataflows, so a per-replica feature reading introspection relations there never
advances.

Solution:

Add `Coordinator::replica_introspection_enabled` next to
`all_cluster_replicas` and consult it from both install paths: the
curated-metric-sink install and the introspection-subscribe install, which had
the same gap and gated only on the global dyncfg.

Testing:

A testdrive asserts no introspection subscribes appear in
`mz_cluster_replica_frontiers` for an introspection-disabled replica, with a
positive control on a later cluster so a merely-slow subscribe can't pass the
check by accident.

A unit test pins the `logging.enabled()` predicate both install paths gate on.