### PR TITLE
AGENTS.md: add comment deduplication rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,4 +157,27 @@ works goes in an inline `//` at the decision point, or in a module-level `//!`
 when it is about how the pieces fit together. Document a struct field only when
 its meaning is subtle.
 
+Every fact gets exactly one owning comment: the decision point for reasoning,
+the mechanism for mechanism docs, the public setter or constant for config
+semantics. Everywhere else either points at the owner or says nothing. The
+tell is the same clause appearing near-verbatim in a module doc, a struct doc,
+and an inline comment; when that happens, pick the owner and cut the rest. In
+particular: don't restate a callee's documented contract at its call sites,
+don't narrate in one function's doc what a sibling's doc already owns, and
+don't duplicate an assert message in a comment on the same line.
+
+Budget doc-comment paragraphs by decisions: each paragraph should carry a
+distinct decision or invariant, not re-argue one documented elsewhere or
+enumerate the item's callers or fields. Skip speculative comments about what
+a future implementation could do (one `TODO` at the owning seam is enough),
+and skip comments explaining an absence when the surrounding docs already
+imply it. No ASCII section-divider banners (`// ----- helpers -----`); item
+placement carries the structure. Performance claims in comments should state
+a constraint or a measured number, not unverifiable color ("the compiler can
+autovectorize this").
+
+The same economy applies to tests: a test whose name and assert messages
+state the property needs no doc comment. Keep test docs for non-obvious
+setup, fixtures whose shape encodes the scenario, and multi-phase protocols.
+
 Mark counterintuitive gotchas with `NOTE:` and future work with `TODO:`.


### PR DESCRIPTION
Extends the existing "Code comments" section of AGENTS.md with three rules distilled from a comment audit of `mz_ore::pool` and `mz_timely_util::columnar` (cleanup in #38434):

* **One owning comment per fact.** Reasoning lives at the decision point, mechanism docs at the mechanism, config semantics on the public setter or constant; other sites point at the owner or say nothing. Covers the common failure of the same clause appearing near-verbatim in a module doc, a struct doc, and an inline comment, plus its corollaries: don't restate a callee's contract at call sites, and don't duplicate an assert message in a comment.
* **Budget doc-comment paragraphs by decisions.** No re-arguing a decision documented elsewhere, no enumerating callers or fields, no speculative future-implementation notes, no absence-narration, no ASCII section-divider banners, no unverifiable performance color.
* **Test-doc economy.** A test whose name and assert messages state the property needs no doc comment; test docs are for non-obvious setup, scenario-encoding fixtures, and multi-phase protocols.

The existing rules in the section (fluff, body narration, chronology, NOTE/TODO) are untouched; the additions only cover what the section didn't already say.

Generated with [Claude Code](https://claude.com/claude-code)