### PR TITLE
console: host the Ory login flow instead of Ory's bundled UI

### DIFF
--- a/console/.gitignore
+++ b/console/.gitignore
@@ -31,3 +31,5 @@ yarn-error.log
 
 # Test logs
 /log
+.env.local
+.certs

--- a/console/package.json
+++ b/console/package.json
@@ -50,6 +50,7 @@
     "@lezer/highlight": "^1.0.0",
     "@materializeinc/sql-lexer": "^26.16.0",
     "@materializeinc/sql-pretty": "^26.16.0",
+    "@ory/client-fetch": "1.22.22",
     "@rehookify/datepicker": "^6.6.7",
     "@segment/analytics-next": "^1.82.0",
     "@sentry/react": "^10.45.0",
@@ -324,6 +325,12 @@
                 "@frontegg/*"
               ],
               "message": "Import from src/external-library-wrappers/frontegg.ts instead. This is to control mocking of the Frontegg library."
+            },
+            {
+              "group": [
+                "@ory/*"
+              ],
+              "message": "Import from src/external-library-wrappers/ory.ts instead. This is to control mocking of the Ory library."
             }
           ]
         }

--- a/console/src/api/materialize/consoleConfig.test.ts
+++ b/console/src/api/materialize/consoleConfig.test.ts
@@ -1,0 +1,81 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { fetchConsoleConfig, resetConsoleConfig } from "./consoleConfig";
+
+const respondWith = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("fetchConsoleConfig", () => {
+  beforeEach(() => {
+    resetConsoleConfig();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads one request for the whole page load", async () => {
+    const fetchMock = vi.fn(async () =>
+      respondWith({
+        oidc_issuer: "https://issuer.example.com",
+        console_oidc_client_id: "client-id",
+        console_oidc_scopes: "openid email",
+        console_ory_sdk_url: "https://ory.example.com",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const [first, second] = await Promise.all([
+      fetchConsoleConfig(),
+      fetchConsoleConfig(),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(second);
+    expect(first.oryUrl).toBe("https://ory.example.com");
+  });
+
+  // environmentd serves this endpoint only once it is up, so a console loaded a
+  // moment too early must not be stuck on that failure until someone reloads.
+  it("does not remember a failure", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("", { status: 503 }))
+      .mockResolvedValue(
+        respondWith({ console_ory_sdk_url: "https://ory.example.com" }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchConsoleConfig()).rejects.toThrow(/still be starting up/);
+
+    await expect(fetchConsoleConfig()).resolves.toMatchObject({
+      oryUrl: "https://ory.example.com",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  // A deployment that does not run Ory leaves the parameter unset, and the
+  // console has to read that as "plain OIDC" rather than as missing data.
+  it("reports an absent parameter as empty rather than undefined", async () => {
+    vi.stubGlobal("fetch", async () =>
+      respondWith({ console_oidc_client_id: "client-id" }),
+    );
+
+    await expect(fetchConsoleConfig()).resolves.toEqual({
+      issuer: "",
+      oidcClientId: "client-id",
+      oidcScopes: "",
+      oryUrl: "",
+    });
+  });
+});

--- a/console/src/api/materialize/consoleConfig.ts
+++ b/console/src/api/materialize/consoleConfig.ts
@@ -1,0 +1,73 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/**
+ * The system parameters environmentd publishes so the console can sign users
+ * in. Field names mirror the parameters themselves.
+ */
+interface ConsoleConfigResponse {
+  oidc_issuer?: string;
+  console_oidc_client_id?: string;
+  console_oidc_scopes?: string;
+  console_ory_sdk_url?: string;
+}
+
+export interface ConsoleConfig {
+  issuer: string;
+  oidcClientId: string;
+  oidcScopes: string;
+  /**
+   * Where Ory's APIs are served, when the deployment runs Ory and lets the
+   * console host its login flow. Empty otherwise: the console is then a plain
+   * OIDC client and the issuer serves its own login pages.
+   */
+  oryUrl: string;
+}
+
+let configPromise: Promise<ConsoleConfig> | undefined;
+
+/**
+ * Configuration environmentd holds and the console cannot derive. Memoized: the
+ * OIDC client and any Ory flow both need it on the same page load, and it does
+ * not change while the tab is open.
+ *
+ * A rejection is not cached. The endpoint is unavailable whenever environmentd
+ * is still starting, and remembering that failure would strand the console on
+ * an error until the page is reloaded.
+ */
+export function fetchConsoleConfig(): Promise<ConsoleConfig> {
+  if (!configPromise) {
+    configPromise = requestConsoleConfig().catch((error) => {
+      configPromise = undefined;
+      throw error;
+    });
+  }
+  return configPromise;
+}
+
+async function requestConsoleConfig(): Promise<ConsoleConfig> {
+  const response = await fetch("/api/console/config");
+  if (!response.ok) {
+    throw new Error(
+      "Could not read this environment's sign-in configuration. It may still be starting up.",
+    );
+  }
+  const data: ConsoleConfigResponse = await response.json();
+  return {
+    issuer: data.oidc_issuer ?? "",
+    oidcClientId: data.console_oidc_client_id ?? "",
+    oidcScopes: data.console_oidc_scopes ?? "",
+    oryUrl: data.console_ory_sdk_url ?? "",
+  };
+}
+
+/** Discards the memoized config. Exported for tests. */
+export function resetConsoleConfig() {
+  configPromise = undefined;
+}

--- a/console/src/external-library-wrappers/__mocks__/oidc.ts
+++ b/console/src/external-library-wrappers/__mocks__/oidc.ts
@@ -19,6 +19,11 @@ export const AuthProvider = ({ children }: React.PropsWithChildren) => children;
 
 export const hasAuthParams = vi.fn(() => false);
 
+export const useOidcManagerQuery = vi.fn(() => ({
+  data: undefined as { getIdToken: () => string | undefined } | undefined,
+  isLoading: false,
+}));
+
 export class MzOidcUserManager {
   getIdToken = vi.fn(() => undefined);
   getUserManager = vi.fn();

--- a/console/src/external-library-wrappers/__mocks__/ory.ts
+++ b/console/src/external-library-wrappers/__mocks__/ory.ts
@@ -1,0 +1,179 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import type { LoginFlow } from "~/external-library-wrappers/ory";
+
+export {
+  Configuration,
+  type LoginFlow,
+  ResponseError,
+  type UiNode,
+} from "~/external-library-wrappers/ory";
+
+export const MOCK_FLOW_ID = "00000000-0000-0000-0000-000000000001";
+export const MOCK_CSRF_TOKEN = "mock-csrf-token";
+
+// The SSO-only shape Materialize deploys: one provider button plus the flow
+// state that has to be replayed on submit.
+export const dummyLoginFlow = {
+  id: MOCK_FLOW_ID,
+  type: "browser",
+  expires_at: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+  issued_at: new Date().toISOString(),
+  request_url: "https://auth.example.com/self-service/login/browser",
+  ui: {
+    action: `https://auth.example.com/self-service/login?flow=${MOCK_FLOW_ID}`,
+    method: "POST",
+    nodes: [
+      {
+        type: "input",
+        group: "oidc",
+        attributes: {
+          name: "provider",
+          type: "submit",
+          value: "auth0",
+          disabled: false,
+          node_type: "input",
+        },
+        messages: [],
+        meta: {
+          label: { id: 1010002, text: "Sign in with Auth0", type: "info" },
+        },
+      },
+      {
+        type: "input",
+        group: "default",
+        attributes: {
+          name: "csrf_token",
+          type: "hidden",
+          value: MOCK_CSRF_TOKEN,
+          required: true,
+          disabled: false,
+          node_type: "input",
+        },
+        messages: [],
+        meta: {},
+      },
+    ],
+  },
+} as unknown as LoginFlow;
+
+// Two providers, so the chooser is a real choice and the page renders it
+// instead of redirecting. Also covers the node iteration: nothing about the
+// renderer may be specific to one provider.
+export const dummyMultiProviderLoginFlow = {
+  ...dummyLoginFlow,
+  ui: {
+    ...dummyLoginFlow.ui,
+    nodes: [
+      dummyLoginFlow.ui.nodes[0],
+      {
+        type: "input",
+        group: "oidc",
+        attributes: {
+          name: "provider",
+          type: "submit",
+          value: "okta",
+          disabled: false,
+          node_type: "input",
+        },
+        messages: [],
+        meta: {
+          label: { id: 1010002, text: "Sign in with Okta", type: "info" },
+        },
+      },
+      dummyLoginFlow.ui.nodes[1],
+    ],
+  },
+} as unknown as LoginFlow;
+
+// Step one of an identifier-first flow: Kratos asks who you are before it will
+// say which providers can serve you.
+export const dummyIdentifierFirstLoginFlow = {
+  ...dummyLoginFlow,
+  ui: {
+    ...dummyLoginFlow.ui,
+    nodes: [
+      dummyLoginFlow.ui.nodes[1],
+      {
+        type: "input",
+        group: "identifier_first",
+        attributes: {
+          name: "identifier",
+          type: "text",
+          value: "",
+          required: true,
+          disabled: false,
+          node_type: "input",
+        },
+        messages: [],
+        meta: { label: { id: 1070004, text: "ID", type: "info" } },
+      },
+      {
+        type: "input",
+        group: "identifier_first",
+        attributes: {
+          name: "method",
+          type: "submit",
+          value: "identifier_first",
+          disabled: false,
+          node_type: "input",
+        },
+        messages: [],
+        meta: { label: { id: 1010001, text: "Continue", type: "info" } },
+      },
+    ],
+  },
+} as unknown as LoginFlow;
+
+// A password flow, which this deployment does not configure. Used to check that
+// an unrenderable method is reported rather than drawn as an empty form.
+export const dummyPasswordLoginFlow = {
+  ...dummyLoginFlow,
+  ui: {
+    ...dummyLoginFlow.ui,
+    nodes: [
+      {
+        type: "input",
+        group: "default",
+        attributes: {
+          name: "csrf_token",
+          type: "hidden",
+          value: MOCK_CSRF_TOKEN,
+          required: true,
+          disabled: false,
+          node_type: "input",
+        },
+        messages: [],
+        meta: {},
+      },
+      {
+        type: "input",
+        group: "password",
+        attributes: {
+          name: "password",
+          type: "password",
+          required: true,
+          disabled: false,
+          node_type: "input",
+        },
+        messages: [],
+        meta: { label: { id: 1070001, text: "Password", type: "info" } },
+      },
+    ],
+  },
+} as unknown as LoginFlow;
+
+export const createBrowserLoginFlow = vi.fn(async () => dummyLoginFlow);
+export const getLoginFlow = vi.fn(async () => dummyLoginFlow);
+
+export const FrontendApi = vi.fn(() => ({
+  createBrowserLoginFlow,
+  getLoginFlow,
+}));

--- a/console/src/external-library-wrappers/oidc.ts
+++ b/console/src/external-library-wrappers/oidc.ts
@@ -24,6 +24,7 @@ import { useQuery } from "@tanstack/react-query";
 import { User, UserManager, WebStorageStateStore } from "oidc-client-ts";
 
 import { apiClient } from "~/api/apiClient";
+import { fetchConsoleConfig } from "~/api/materialize/consoleConfig";
 import { useAppConfig } from "~/config/useAppConfig";
 
 export interface OidcConfig {
@@ -32,37 +33,24 @@ export interface OidcConfig {
   scopes: string;
 }
 
-interface ConsoleConfigResponse {
-  oidc_issuer: string;
-  console_oidc_client_id: string;
-  console_oidc_scopes: string;
-}
-
 async function fetchOidcConfig(): Promise<OidcConfig> {
-  const response = await fetch("/api/console/config");
-  if (!response.ok) {
-    throw new Error(`Failed to fetch OIDC config: ${response.status}`);
-  }
-  const data: ConsoleConfigResponse = await response.json();
+  const config = await fetchConsoleConfig();
 
-  if (!data.console_oidc_client_id) {
+  if (!config.oidcClientId) {
     throw new Error(
       "To use SSO, OIDC client ID must be set. Configure the console_oidc_client_id system parameter: https://materialize.com/docs/self-managed-deployments/configuration-system-parameters/",
     );
   }
-  if (
-    !data.console_oidc_scopes ||
-    !data.console_oidc_scopes.includes("openid")
-  ) {
+  if (!config.oidcScopes.includes("openid")) {
     throw new Error(
       "To use SSO, OIDC scopes must include at least 'openid'. Configure the console_oidc_scopes system parameter: https://materialize.com/docs/self-managed-deployments/configuration-system-parameters/",
     );
   }
 
   return {
-    issuer: data.oidc_issuer,
-    clientId: data.console_oidc_client_id,
-    scopes: data.console_oidc_scopes,
+    issuer: config.issuer,
+    clientId: config.oidcClientId,
+    scopes: config.oidcScopes,
   };
 }
 

--- a/console/src/external-library-wrappers/ory.ts
+++ b/console/src/external-library-wrappers/ory.ts
@@ -1,0 +1,27 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/* eslint-disable no-restricted-imports */
+/**
+ * This file is a facade for the @ory/client-fetch library.
+ * It is used primarily to mock the Ory client in tests via `vi.mock` in ~/vitest.setup.ts.
+ * Make sure anything you'd like to mock is updated in ./__mocks__/ory.ts
+ *
+ * We use @ory/client-fetch rather than @ory/client because it is maintained
+ * against the current Kratos and Hydra APIs, and its models describe a flow's
+ * UI nodes as a discriminated union, which is what lets a renderer narrow on
+ * `node_type` without casting.
+ */
+export {
+  Configuration,
+  FrontendApi,
+  type LoginFlow,
+  ResponseError,
+  type UiNode,
+} from "@ory/client-fetch";

--- a/console/src/platform/UnauthenticatedRoutes.test.tsx
+++ b/console/src/platform/UnauthenticatedRoutes.test.tsx
@@ -1,0 +1,71 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { screen } from "@testing-library/react";
+import React from "react";
+
+import { dummyLoginFlow } from "~/external-library-wrappers/__mocks__/ory";
+import { createBrowserLoginFlow } from "~/external-library-wrappers/__mocks__/ory";
+import {
+  type MzOidcUserManager,
+  useOidcManagerQuery,
+} from "~/external-library-wrappers/oidc";
+import { renderComponent } from "~/test/utils";
+
+import { LoginRoute } from "./UnauthenticatedRoutes";
+
+/** A live OIDC token is the cheapest way to look signed in: it skips the
+ * server probe the route otherwise makes for a password session cookie. */
+const signedIn = () =>
+  vi.mocked(useOidcManagerQuery).mockReturnValue({
+    data: { getIdToken: () => "a-token" } as unknown as MzOidcUserManager,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useOidcManagerQuery>);
+
+describe("LoginRoute", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_ORY_SDK_URL", "http://localhost:4000");
+    createBrowserLoginFlow.mockResolvedValue(dummyLoginFlow);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  // Hydra sends a signed-in user back here when an OAuth2 client asks for
+  // re-authentication. Redirecting them into the app strands that request with
+  // no way to finish, so the flow has to win over the signed-in shortcut.
+  it("renders the Ory flow for a challenge even when already signed in", async () => {
+    signedIn();
+
+    await renderComponent(<LoginRoute />, {
+      initialRouterEntries: ["/account/login?login_challenge=challenge-abc"],
+    });
+
+    // A regex, not the exact name: a single-provider flow submits itself, and
+    // Chakra's spinner adds a visually hidden "Loading..." to the button's name.
+    expect(
+      await screen.findByRole("button", { name: /Sign in with Auth0/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("sends a signed-in user to the app when no flow is in progress", async () => {
+    signedIn();
+
+    await renderComponent(<LoginRoute />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    expect(createBrowserLoginFlow).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: /Sign in with Auth0/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/console/src/platform/UnauthenticatedRoutes.tsx
+++ b/console/src/platform/UnauthenticatedRoutes.tsx
@@ -9,7 +9,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import React from "react";
-import { Navigate, Route } from "react-router-dom";
+import { Navigate, Route, useSearchParams } from "react-router-dom";
 
 import { hasActiveSession, LOGIN_PATH } from "~/api/materialize/auth";
 import { LaunchDarklyProvider } from "~/components/LaunchDarkly";
@@ -27,21 +27,36 @@ import { SentryRoutes } from "~/sentry";
 
 import { Login } from "./auth/Login";
 import { OidcCallback } from "./auth/OidcCallback";
+import { OryLoginPage } from "./auth/ory/OryLoginPage";
 
 // Redirect already-signed-in users off the login page. The password session
 // cookie is httpOnly, so probe the server; a live OIDC token skips the probe.
-const LoginRoute = () => {
+export const LoginRoute = () => {
+  const [searchParams] = useSearchParams();
+  // Ory marks a request it sent here to be authenticated: `flow` from Kratos,
+  // `login_challenge` from Hydra on behalf of an OAuth2 client. Either means
+  // this page is the identity provider's login UI for the duration of that
+  // request rather than the console's own front door.
+  const isOryFlow =
+    searchParams.has("flow") || searchParams.has("login_challenge");
+
   const { data: oidcManager } = useOidcManagerQuery();
   const hasOidcToken = Boolean(oidcManager?.getIdToken());
 
   const { data: hasCookieSession } = useQuery({
     queryKey: ["hasActiveSession"],
     queryFn: hasActiveSession,
-    enabled: !hasOidcToken,
+    enabled: !hasOidcToken && !isOryFlow,
     staleTime: Infinity,
     retry: false,
   });
 
+  // Checked before the signed-in redirect below: a client may ask someone who
+  // already has a session to re-authenticate, and sending them to the app
+  // instead would strand the flow with no way to finish.
+  if (isOryFlow) {
+    return <OryLoginPage />;
+  }
   if (hasOidcToken || hasCookieSession) {
     return <Navigate to="/" replace />;
   }

--- a/console/src/platform/auth/ory/OryLoginPage.test.tsx
+++ b/console/src/platform/auth/ory/OryLoginPage.test.tsx
@@ -1,0 +1,369 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+import {
+  createBrowserLoginFlow,
+  dummyIdentifierFirstLoginFlow,
+  dummyLoginFlow,
+  dummyMultiProviderLoginFlow,
+  dummyPasswordLoginFlow,
+  getLoginFlow,
+  MOCK_CSRF_TOKEN,
+  MOCK_FLOW_ID,
+} from "~/external-library-wrappers/__mocks__/ory";
+import { ResponseError } from "~/external-library-wrappers/ory";
+import { renderComponent } from "~/test/utils";
+
+import { resetOryClient } from "./oryConfig";
+import { OryLoginPage } from "./OryLoginPage";
+
+describe("OryLoginPage", () => {
+  let submitted: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.stubEnv("VITE_ORY_SDK_URL", "http://localhost:4000");
+    // The client is memoized across calls, so it has to be discarded or the
+    // first test's resolved URL leaks into every later one.
+    resetOryClient();
+    createBrowserLoginFlow.mockResolvedValue(dummyLoginFlow);
+    getLoginFlow.mockResolvedValue(dummyLoginFlow);
+    // jsdom does not navigate, so the submit is observed and cancelled.
+    submitted = vi.fn((e: SubmitEvent) => e.preventDefault());
+    window.addEventListener("submit", submitted);
+  });
+
+  afterEach(() => {
+    window.removeEventListener("submit", submitted);
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("renders a button per provider the flow offers", async () => {
+    createBrowserLoginFlow.mockResolvedValue(dummyMultiProviderLoginFlow);
+
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    const auth0 = await screen.findByRole("button", {
+      name: "Sign in with Auth0",
+    });
+    expect(auth0).toHaveAttribute("name", "provider");
+    expect(auth0).toHaveAttribute("value", "auth0");
+    // A federated button carries a mark, so it does not read as plain text.
+    expect(auth0.querySelector("svg")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "Sign in with Okta" }),
+    ).toHaveAttribute("value", "okta");
+  });
+
+  // Kratos answers the submit with a redirect to the provider, so the form has
+  // to post to Kratos itself rather than fetch in the background.
+  it("posts to the action Kratos supplied, replaying the CSRF token", async () => {
+    createBrowserLoginFlow.mockResolvedValue(dummyMultiProviderLoginFlow);
+
+    const { container } = await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    await screen.findByRole("button", { name: "Sign in with Auth0" });
+    const form = container.querySelector("form");
+    expect(form).toHaveAttribute("action", dummyLoginFlow.ui.action);
+    expect(form).toHaveAttribute("method", "POST");
+    expect(container.querySelector('input[name="csrf_token"]')).toHaveValue(
+      MOCK_CSRF_TOKEN,
+    );
+  });
+
+  it("reuses the flow already in the URL", async () => {
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: [`/account/login?flow=${MOCK_FLOW_ID}`],
+    });
+
+    await waitFor(() => expect(getLoginFlow).toHaveBeenCalled());
+    expect(createBrowserLoginFlow).not.toHaveBeenCalled();
+  });
+
+  it("forwards the Hydra login challenge so Kratos can accept it", async () => {
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login?login_challenge=challenge-abc"],
+    });
+
+    await waitFor(() =>
+      expect(createBrowserLoginFlow).toHaveBeenCalledWith(
+        expect.objectContaining({ loginChallenge: "challenge-abc" }),
+      ),
+    );
+  });
+
+  it("starts a new flow when the one in the URL has expired", async () => {
+    getLoginFlow.mockRejectedValueOnce(
+      new ResponseError(new Response(null, { status: 410 })),
+    );
+
+    const { container } = await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: [`/account/login?flow=${MOCK_FLOW_ID}`],
+    });
+
+    await waitFor(() => expect(createBrowserLoginFlow).toHaveBeenCalled());
+    expect(container.querySelector("form")).toHaveAttribute(
+      "action",
+      dummyLoginFlow.ui.action,
+    );
+  });
+
+  // Kratos returns a chooser even for one provider; clicking through it is
+  // friction an ordinary SSO sign-in does not have.
+  it("submits straight to the provider when the flow offers only one", async () => {
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    await waitFor(() => expect(submitted).toHaveBeenCalled());
+    expect(
+      (submitted.mock.calls[0][0].submitter as HTMLButtonElement).value,
+    ).toBe("auth0");
+  });
+
+  it("waits for the user when the flow carries a message", async () => {
+    createBrowserLoginFlow.mockResolvedValue({
+      ...dummyLoginFlow,
+      ui: {
+        ...dummyLoginFlow.ui,
+        messages: [
+          { id: 4000006, text: "The provider rejected you", type: "error" },
+        ],
+      },
+    });
+
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    expect(await screen.findByText("The provider rejected you")).toBeVisible();
+    expect(submitted).not.toHaveBeenCalled();
+  });
+
+  // Being signed in already is not a failure; Kratos wants the flow restarted
+  // as a refresh so the person reconfirms rather than being told they cannot.
+  it("retries as a refresh when a session already exists", async () => {
+    createBrowserLoginFlow.mockRejectedValueOnce(
+      new ResponseError(
+        new Response(
+          JSON.stringify({ error: { id: "session_already_available" } }),
+          { status: 400 },
+        ),
+      ),
+    );
+
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    await waitFor(() =>
+      expect(createBrowserLoginFlow).toHaveBeenLastCalledWith(
+        expect.objectContaining({ refresh: true }),
+      ),
+    );
+    expect(screen.queryByText(/valid session/)).not.toBeInTheDocument();
+    await waitFor(() => expect(submitted).toHaveBeenCalled());
+  });
+
+  // Hydra hands back a refresh flow whenever a Kratos session already exists.
+  // Stopping there would put a button in front of every OAuth2 sign-in, and
+  // pressing it verifies nothing the provider is not about to verify anyway.
+  it("continues through a refresh flow rather than stopping to confirm", async () => {
+    createBrowserLoginFlow.mockResolvedValue({
+      ...dummyLoginFlow,
+      refresh: true,
+      ui: {
+        ...dummyLoginFlow.ui,
+        messages: [
+          { id: 1010003, text: "Please confirm this action", type: "info" },
+        ],
+      },
+    });
+
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login?login_challenge=challenge-abc"],
+    });
+
+    await waitFor(() => expect(submitted).toHaveBeenCalled());
+  });
+
+  // Identifier-first asks for an email before naming a provider, so the form has
+  // to draw a text field and wait for it rather than redirecting.
+  it("draws the identifier field and waits for input", async () => {
+    createBrowserLoginFlow.mockResolvedValue(dummyIdentifierFirstLoginFlow);
+
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    const field = await screen.findByLabelText(/^ID/);
+    expect(field).toHaveAttribute("name", "identifier");
+    expect(field).toBeRequired();
+    expect(
+      screen.getByRole("button", { name: "Continue" }),
+    ).toBeInTheDocument();
+    expect(submitted).not.toHaveBeenCalled();
+  });
+
+  // Advancing the form and handing off to a provider are different actions, so
+  // they must not read as two equal choices.
+  it("ranks the step's own submit above the provider buttons", async () => {
+    createBrowserLoginFlow.mockResolvedValue({
+      ...dummyIdentifierFirstLoginFlow,
+      ui: {
+        ...dummyIdentifierFirstLoginFlow.ui,
+        nodes: [
+          ...dummyIdentifierFirstLoginFlow.ui.nodes,
+          dummyLoginFlow.ui.nodes[0],
+        ],
+      },
+    });
+
+    const { container } = await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    await screen.findByRole("button", { name: "Continue" });
+    // Scoped to the form: AuthLayout renders a copy button of its own.
+    const buttons = Array.from(container.querySelectorAll("form button"));
+    expect(buttons.map((b) => b.textContent)).toEqual([
+      "Continue",
+      "Sign in with Auth0",
+    ]);
+    expect(buttons[0].className).not.toEqual(buttons[1].className);
+    expect(screen.getByText("or")).toBeVisible();
+  });
+
+  // Kratos attaches a script node to flows that use WebAuthn. It decorates the
+  // flow; the method that needs it contributes its own input, which is what
+  // should decide whether this page can draw the form.
+  it("does not warn about presentational nodes it skips", async () => {
+    createBrowserLoginFlow.mockResolvedValue({
+      ...dummyLoginFlow,
+      ui: {
+        ...dummyLoginFlow.ui,
+        nodes: [
+          ...dummyLoginFlow.ui.nodes,
+          {
+            type: "script",
+            group: "webauthn",
+            attributes: {
+              id: "webauthn_script",
+              src: "https://example.com/webauthn.js",
+              type: "text/javascript",
+              async: true,
+              referrerpolicy: "no-referrer",
+              crossorigin: "anonymous",
+              integrity: "sha512-x",
+              nonce: "",
+              node_type: "script",
+            },
+            messages: [],
+            meta: {},
+          },
+        ],
+      },
+    });
+
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    // A regex, not the exact name: the button submits itself here, and Chakra's
+    // spinner adds a visually hidden "Loading..." to its accessible name.
+    await screen.findByRole("button", { name: /Sign in with Auth0/ });
+    expect(screen.queryByText(/does not support/)).not.toBeInTheDocument();
+  });
+
+  // An image carries something the user has to read, a TOTP QR code say, so
+  // dropping it leaves a form that cannot be completed.
+  it("warns when it skips a node the user needs to see", async () => {
+    createBrowserLoginFlow.mockResolvedValue({
+      ...dummyLoginFlow,
+      ui: {
+        ...dummyLoginFlow.ui,
+        nodes: [
+          ...dummyLoginFlow.ui.nodes,
+          {
+            type: "img",
+            group: "totp",
+            attributes: {
+              id: "totp_qr",
+              src: "data:image/png;base64,x",
+              width: 256,
+              height: 256,
+              node_type: "img",
+            },
+            messages: [],
+            meta: {},
+          },
+        ],
+      },
+    });
+
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    expect(await screen.findByText(/does not support/)).toBeVisible();
+  });
+
+  // Status codes are an implementation detail; the reader can do nothing with
+  // one, and CLAUDE.md rules them out of user-facing copy.
+  it("keeps the transport out of the message when Ory says nothing useful", async () => {
+    createBrowserLoginFlow.mockRejectedValueOnce(
+      new ResponseError(new Response("", { status: 500 })),
+    );
+
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    expect(
+      await screen.findByText(
+        "Sign-in could not be started. Please try again.",
+      ),
+    ).toBeVisible();
+    expect(screen.queryByText(/500/)).not.toBeInTheDocument();
+  });
+
+  it("reports a sign-in method it cannot render instead of drawing a dead form", async () => {
+    createBrowserLoginFlow.mockResolvedValue(dummyPasswordLoginFlow);
+
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    expect(
+      await screen.findByText(/sign-in method this page does not support/),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /sign in/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("surfaces an error when the flow cannot be started", async () => {
+    createBrowserLoginFlow.mockRejectedValueOnce(new Error("Ory unreachable"));
+
+    await renderComponent(<OryLoginPage />, {
+      initialRouterEntries: ["/account/login"],
+    });
+
+    await waitFor(async () =>
+      expect(await screen.findByText("Ory unreachable")).toBeVisible(),
+    );
+  });
+});

--- a/console/src/platform/auth/ory/OryLoginPage.tsx
+++ b/console/src/platform/auth/ory/OryLoginPage.tsx
@@ -1,0 +1,400 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Button,
+  Divider,
+  FormControl,
+  HStack,
+  Input,
+  Text,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
+import { useQuery } from "@tanstack/react-query";
+import React, { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import Alert from "~/components/Alert";
+import { LabeledInput } from "~/components/formComponentsV2";
+import { LoadingContainer } from "~/components/LoadingContainer";
+import { MaterializeLogo } from "~/components/MaterializeLogo";
+import {
+  type LoginFlow,
+  ResponseError,
+  type UiNode,
+} from "~/external-library-wrappers/ory";
+import { LockIcon } from "~/icons";
+import { AuthContentContainer, AuthLayout } from "~/layouts/AuthLayout";
+import { MaterializeTheme } from "~/theme";
+
+import { getOryClient } from "./oryConfig";
+
+/**
+ * Resolves the login flow for this page load.
+ *
+ * A `flow` in the URL means Ory redirected back to us and the flow already
+ * exists. A `login_challenge` means Hydra sent the user here to authenticate
+ * for an OAuth2 client, and forwarding it is what lets Kratos accept that
+ * challenge on our behalf.
+ */
+async function fetchLoginFlow({
+  flowId,
+  loginChallenge,
+  returnTo,
+}: {
+  flowId: string | null;
+  loginChallenge: string | null;
+  returnTo: string | null;
+}): Promise<LoginFlow> {
+  const api = await getOryClient();
+
+  if (flowId) {
+    try {
+      return await api.getLoginFlow({ id: flowId });
+    } catch (error) {
+      // A flow that has expired, been consumed, or never existed is recoverable
+      // by starting a fresh one. Anything else is a real failure.
+      if (
+        !(error instanceof ResponseError) ||
+        ![404, 410].includes(error.response.status)
+      ) {
+        throw error;
+      }
+    }
+  }
+
+  const params = {
+    ...(returnTo ? { returnTo } : {}),
+    ...(loginChallenge ? { loginChallenge } : {}),
+  };
+
+  try {
+    return await api.createBrowserLoginFlow(params);
+  } catch (error) {
+    // Kratos refuses to start a login for someone already signed in and asks
+    // for `refresh` instead, which re-authenticates the current session rather
+    // than replacing it. A returning user hitting this page wants that, not an
+    // error telling them they are logged in.
+    if ((await oryErrorId(error)) !== "session_already_available") throw error;
+    return api.createBrowserLoginFlow({ ...params, refresh: true });
+  }
+}
+
+/** The `error.id` Ory reported, or undefined when the failure isn't Ory's. */
+async function oryErrorId(error: unknown): Promise<string | undefined> {
+  if (!(error instanceof ResponseError)) return undefined;
+  const body: { error?: { id?: string } } = await error.response
+    .clone()
+    .json()
+    .catch(() => ({}));
+  return body.error?.id;
+}
+
+/**
+ * Ory states why a request failed in the response body. The thrown error itself
+ * carries only "Response returned an error code", so unwrap it or the page
+ * shows nothing a reader can act on.
+ */
+async function unwrapOryError(error: unknown): Promise<Error> {
+  if (!(error instanceof ResponseError)) {
+    return error instanceof Error
+      ? error
+      : new Error("Failed to start sign-in. Please try refreshing the page.");
+  }
+  const body: { error?: { message?: string; reason?: string } } =
+    await error.response
+      .clone()
+      .json()
+      .catch(() => ({}));
+  // `reason` and `message` are Ory's own prose. Its `id` is a machine code and
+  // the status an implementation detail, so neither is shown.
+  const { message, reason } = body.error ?? {};
+  return new Error(
+    reason ?? message ?? "Sign-in could not be started. Please try again.",
+  );
+}
+
+/** Input types the form draws. Anything else is reported, not skipped. */
+const RENDERABLE_FIELD_TYPES = ["text", "email", "password", "tel"];
+
+interface LoginFormNodes {
+  /** Flow state, most importantly the CSRF token, replayed on submit. */
+  hidden: { name: string; value: string }[];
+  /**
+   * Values the user types. Present on an identifier-first flow, which asks for
+   * an email before it will say which providers can serve it.
+   */
+  fields: {
+    name: string;
+    type: string;
+    label: string;
+    value: string;
+    required: boolean;
+    autocomplete?: string;
+  }[];
+  /** This step's own submit, such as Continue on an identifier-first flow. */
+  submits: { name: string; value: string; label: string }[];
+  /** One per configured identity provider. */
+  providers: { name: string; value: string; label: string }[];
+  /** Set when the flow asks for something this screen cannot draw. */
+  hasUnsupportedNode: boolean;
+}
+
+/**
+ * Kratos describes a flow as a list of UI nodes rather than a fixed form, so
+ * what a deployment configures is what a screen has to render. Anything this
+ * form cannot draw is reported rather than silently dropped, since a half-drawn
+ * form looks like a broken page instead of a misconfiguration.
+ */
+function collectNodes(nodes: UiNode[]): LoginFormNodes {
+  const hidden: LoginFormNodes["hidden"] = [];
+  const fields: LoginFormNodes["fields"] = [];
+  const submits: LoginFormNodes["submits"] = [];
+  const providers: LoginFormNodes["providers"] = [];
+  let hasUnsupportedNode = false;
+
+  for (const { attributes, group, meta } of nodes) {
+    if (attributes.node_type !== "input") {
+      // Scripts, text and links decorate a flow rather than carry it, and a
+      // method that genuinely needs one also contributes an input this loop
+      // rejects on its own. An image is different: a flow that shows one, a
+      // TOTP QR code say, cannot be completed without it.
+      if (attributes.node_type === "img") hasUnsupportedNode = true;
+      continue;
+    }
+    const value = String(attributes.value ?? "");
+    if (attributes.type === "hidden") {
+      hidden.push({ name: attributes.name, value });
+    } else if (attributes.type === "submit") {
+      // A federated button hands the user to another service; the step's own
+      // submit advances this form. Different actions, so they are ranked
+      // differently rather than stacked as equals.
+      const button = {
+        name: attributes.name,
+        value,
+        label: meta.label?.text ?? "Sign in",
+      };
+      (group === "oidc" || group === "saml" ? providers : submits).push(button);
+    } else if (RENDERABLE_FIELD_TYPES.includes(attributes.type)) {
+      fields.push({
+        name: attributes.name,
+        type: attributes.type,
+        // Kratos labels the identifier "ID", since it does not know whether a
+        // deployment identifies people by email, username or phone.
+        label: meta.label?.text ?? attributes.name,
+        value,
+        required: attributes.required ?? false,
+        autocomplete: attributes.autocomplete,
+      });
+    } else {
+      hasUnsupportedNode = true;
+    }
+  }
+
+  return { hidden, fields, submits, providers, hasUnsupportedNode };
+}
+
+const LoginFlowForm = ({ flow }: { flow: LoginFlow }) => {
+  const { hidden, fields, submits, providers, hasUnsupportedNode } =
+    collectNodes(flow.ui.nodes);
+  const { colors } = useTheme<MaterializeTheme>();
+  const providerRef = useRef<HTMLButtonElement>(null);
+  // Which button is mid-submit, so the one that was pressed shows it. Recorded
+  // on the form rather than in each handler, which puts the automatic submit
+  // below on the same path as a real press.
+  const [submittingValue, setSubmittingValue] = useState<string>();
+
+  // Kratos brokers any number of providers, so it always returns a chooser.
+  // Where a deployment configures exactly one, that chooser is a button the
+  // user has no decision to make about, and clicking through it is friction an
+  // ordinary SSO sign-in does not have.
+  //
+  // Held back whenever the flow reports an error: a rejected attempt returns as
+  // an error message on a fresh flow, and submitting that unattended would
+  // bounce between here and the provider indefinitely.
+  //
+  // `refresh` does not hold it back. On a login flow that only means an
+  // existing session is being re-authenticated, and reaching this page is
+  // already the request to do that. Pressing the button proves nothing either
+  // way: the provider is what verifies the person, and it still applies its own
+  // credential and MFA policy when the browser arrives.
+  const hasError = flow.ui.messages?.some((m) => m.type === "error") ?? false;
+  const autoSubmit =
+    providers.length === 1 &&
+    submits.length === 0 &&
+    fields.length === 0 &&
+    !hasUnsupportedNode &&
+    !hasError;
+
+  // Runs once: the form is keyed on the flow, so `autoSubmit` cannot change
+  // under a mounted instance. Pressing the button rather than submitting the
+  // form directly is what makes the browser include its name and value, which
+  // is how the flow says which provider was chosen.
+  useEffect(() => {
+    if (autoSubmit) providerRef.current?.click();
+  }, [autoSubmit]);
+
+  return (
+    // Submitting navigates rather than fetches: Kratos answers with a redirect
+    // to the identity provider, which only a top-level navigation can follow.
+    <form
+      action={flow.ui.action}
+      method={flow.ui.method}
+      onSubmit={(event) =>
+        setSubmittingValue(
+          (event.nativeEvent as SubmitEvent).submitter?.getAttribute("value") ??
+            undefined,
+        )
+      }
+    >
+      {hidden.map((input) => (
+        <input
+          key={input.name}
+          type="hidden"
+          name={input.name}
+          value={input.value}
+          readOnly
+        />
+      ))}
+      <VStack spacing="6" alignItems="stretch">
+        {flow.ui.messages?.map((message, index) => (
+          <Alert
+            key={`${message.id}:${index}`}
+            variant={message.type === "error" ? "error" : "info"}
+            minWidth="100%"
+            message={message.text}
+          />
+        ))}
+        {(hasUnsupportedNode || submits.length + providers.length === 0) && (
+          <Alert
+            variant="warning"
+            minWidth="100%"
+            message="This environment is configured with a sign-in method this page does not support."
+          />
+        )}
+        {fields.map((field) => (
+          // FormControl is what gives FormLabel its htmlFor, so the label is
+          // only tied to the input when one wraps them.
+          <FormControl key={field.name} isRequired={field.required}>
+            <LabeledInput label={field.label} variant="stretch">
+              <Input
+                name={field.name}
+                type={field.type}
+                defaultValue={field.value}
+                autoComplete={field.autocomplete}
+                size="lg"
+              />
+            </LabeledInput>
+          </FormControl>
+        ))}
+        {submits.map((submit) => (
+          <Button
+            key={`${submit.name}:${submit.value}`}
+            variant="primary"
+            size="lg"
+            width="100%"
+            type="submit"
+            name={submit.name}
+            value={submit.value}
+            isLoading={submittingValue === submit.value}
+            loadingText={submit.label}
+          >
+            {submit.label}
+          </Button>
+        ))}
+        {submits.length > 0 && providers.length > 0 && (
+          <HStack spacing="4" aria-hidden="true">
+            <Divider borderColor={colors.border.primary} />
+            <Text fontSize="sm" color={colors.foreground.secondary}>
+              or
+            </Text>
+            <Divider borderColor={colors.border.primary} />
+          </HStack>
+        )}
+        {providers.map((provider, index) => (
+          <Button
+            key={`${provider.name}:${provider.value}`}
+            ref={index === 0 ? providerRef : undefined}
+            variant={submits.length > 0 ? "secondary" : "primary"}
+            size="lg"
+            width="100%"
+            type="submit"
+            name={provider.name}
+            value={provider.value}
+            isLoading={submittingValue === provider.value}
+            loadingText={provider.label}
+            // One mark for every provider: an approximated brand logo is worse
+            // than none, and a deployment is free to name its provider
+            // anything, so most would have no logo to show.
+            leftIcon={<LockIcon />}
+            // LockIcon bakes in a stroke colour and a 24px box. Scoped here so
+            // the glyph tracks the label in both themes without changing the
+            // icon for every other screen that uses it.
+            sx={{
+              "& svg": { width: "4", height: "4" },
+              "& svg [stroke]": { stroke: "currentColor" },
+            }}
+          >
+            {provider.label}
+          </Button>
+        ))}
+      </VStack>
+    </form>
+  );
+};
+
+export const OryLoginPage = () => {
+  const [searchParams] = useSearchParams();
+  const flowId = searchParams.get("flow");
+  const loginChallenge = searchParams.get("login_challenge");
+  const returnTo = searchParams.get("return_to");
+
+  const {
+    data: flow,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["oryLoginFlow", flowId, loginChallenge, returnTo],
+    queryFn: async () => {
+      try {
+        return await fetchLoginFlow({ flowId, loginChallenge, returnTo });
+      } catch (flowError) {
+        throw await unwrapOryError(flowError);
+      }
+    },
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  return (
+    <AuthLayout>
+      <AuthContentContainer>
+        <VStack alignItems="stretch" width="100%" mx="12">
+          <HStack my={{ base: "8", lg: "0" }} paddingBottom="8">
+            <MaterializeLogo height="12" />
+          </HStack>
+          {error && (
+            <Alert
+              variant="error"
+              minWidth="100%"
+              message={error.message}
+              mb="4"
+            />
+          )}
+          {isLoading && <LoadingContainer />}
+          {/* Keyed so a new flow starts with fresh submit state: the effect
+              inside fires once per form, and an uncontrolled input keeps its
+              first value. */}
+          {flow && <LoginFlowForm key={flow.id} flow={flow} />}
+        </VStack>
+      </AuthContentContainer>
+    </AuthLayout>
+  );
+};

--- a/console/src/platform/auth/ory/oryConfig.ts
+++ b/console/src/platform/auth/ory/oryConfig.ts
@@ -1,0 +1,98 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { fetchConsoleConfig } from "~/api/materialize/consoleConfig";
+import { Configuration, FrontendApi } from "~/external-library-wrappers/ory";
+
+/**
+ * Ory has to be same-site with the console or the browser drops its CSRF and
+ * session cookies, and the flow then fails partway through with nothing that
+ * points at the cause. Warned about rather than rejected: a registrable domain
+ * cannot be derived from a hostname without a public suffix list, so comparing
+ * the last two labels misjudges a multi-part suffix such as `co.uk`.
+ */
+function warnIfCrossSite(sdkUrl: string) {
+  if (!import.meta.env.DEV) return;
+  const registrable = (host: string) => host.split(".").slice(-2).join(".");
+  try {
+    const oryHost = new URL(sdkUrl).hostname;
+    if (registrable(oryHost) !== registrable(window.location.hostname)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Ory is served from ${oryHost} but the console from ${window.location.hostname}. ` +
+          "Cookies are scoped to a registrable domain, so sign-in will fail unless the two share one.",
+      );
+    }
+  } catch {
+    // Not a URL at all. The client construction below reports that itself.
+  }
+}
+
+/**
+ * Where Ory lives is the operator's choice, so only environmentd knows it. An
+ * empty value means the deployment does not run Ory: the console is then a
+ * plain OIDC client and the issuer serves its own login pages.
+ */
+async function resolveOrySdkUrl(): Promise<string> {
+  // Development only. Self-managed ships one image to every deployment, so a
+  // build-time value baked into the bundle would silently override whatever
+  // each operator configured.
+  if (import.meta.env.DEV && import.meta.env.VITE_ORY_SDK_URL) {
+    return import.meta.env.VITE_ORY_SDK_URL;
+  }
+
+  const { oryUrl } = await fetchConsoleConfig();
+  if (!oryUrl) {
+    throw new Error(
+      "This environment is not configured to sign in through Ory. Set the " +
+        "console_ory_sdk_url system parameter.",
+    );
+  }
+  warnIfCrossSite(oryUrl);
+  return oryUrl;
+}
+
+let clientPromise: Promise<FrontendApi> | undefined;
+
+/**
+ * Shared Ory API client. Callers must not construct their own: a new instance
+ * changes the identity of any callback closing over it, which re-triggers
+ * flow-fetching effects in a loop.
+ *
+ * A rejection is not cached, so a console that loaded while environmentd was
+ * still starting recovers on the next attempt rather than needing a reload.
+ */
+export function getOryClient(): Promise<FrontendApi> {
+  if (!clientPromise) {
+    clientPromise = resolveOrySdkUrl()
+      .then(
+        (url) =>
+          new FrontendApi(
+            new Configuration({
+              basePath: url,
+              credentials: "include",
+              // Without an explicit JSON accept, Kratos treats a self-service
+              // flow request as a page load and 303s to its own hosted UI,
+              // which a cross-origin fetch cannot follow.
+              headers: { Accept: "application/json" },
+            }),
+          ),
+      )
+      .catch((error) => {
+        clientPromise = undefined;
+        throw error;
+      });
+  }
+  return clientPromise;
+}
+
+/** Discards the memoized client. Exported for tests. */
+export function resetOryClient() {
+  clientPromise = undefined;
+}

--- a/console/src/vitest.setup.ts
+++ b/console/src/vitest.setup.ts
@@ -41,9 +41,10 @@ configure({ asyncUtilTimeout: 10_000 });
 
 // Mocks
 
-// Mock the facades for the frontegg and oidc libraries
+// Mock the facades for the frontegg, oidc and ory libraries
 vi.mock("~/external-library-wrappers/frontegg");
 vi.mock("~/external-library-wrappers/oidc");
+vi.mock("~/external-library-wrappers/ory");
 vi.mock("~/hooks/useFlags", () => {
   return { useFlags: () => ({}) };
 });

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -7,10 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+import { readFileSync } from "node:fs";
+
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import react from "@vitejs/plugin-react";
 import browserslistToEsbuild from "browserslist-to-esbuild";
-import { defineConfig } from "vite";
+import { defineConfig, type ProxyOptions } from "vite";
 import { analyzer } from "vite-bundle-analyzer";
 import { createHtmlPlugin } from "vite-plugin-html";
 import svgr from "vite-plugin-svgr";
@@ -132,6 +134,33 @@ if (isProd) {
 
 const devServerProxyPort = process.env.DEV_SERVER_PROXY_PORT ?? 6876;
 
+const devServerTls =
+  process.env.DEV_SERVER_TLS_CERT && process.env.DEV_SERVER_TLS_KEY
+    ? {
+        cert: readFileSync(process.env.DEV_SERVER_TLS_CERT),
+        key: readFileSync(process.env.DEV_SERVER_TLS_KEY),
+      }
+    : undefined;
+
+/**
+ * Proxies Ory's self-service API through the dev server when ORY_KRATOS_URL is
+ * set, keeping the SDK same-origin so Kratos needs no CORS entry per laptop.
+ * Point VITE_ORY_SDK_URL at the dev server itself.
+ *
+ * Kratos scopes its CSRF and session cookies to its own registrable domain and
+ * marks them Secure, and an OIDC round trip returns through Kratos's own host.
+ * DEV_SERVER_HOST must therefore name a host under that same domain, served
+ * over TLS, or the browser drops those cookies partway through the flow.
+ */
+const oryTarget: ProxyOptions = {
+  target: process.env.ORY_KRATOS_URL,
+  changeOrigin: true,
+};
+
+const oryProxy: Record<string, ProxyOptions> = process.env.ORY_KRATOS_URL
+  ? { "/self-service/": oryTarget, "/sessions/": oryTarget }
+  : {};
+
 export default defineConfig({
   build: {
     // Converts browserslist format to explicit esbuild browser ranges
@@ -140,7 +169,8 @@ export default defineConfig({
   },
   define: buildDefinitions(),
   server: {
-    host: "local.dev.materialize.com",
+    host: process.env.DEV_SERVER_HOST ?? "local.dev.materialize.com",
+    https: devServerTls,
     port: 3000,
     /**
      * Proxy any requests from :3000 to environmentd/balancerd ports to avoid CORs issues.
@@ -149,6 +179,7 @@ export default defineConfig({
     proxy:
       process.env.DEV_SERVER_WITH_TLS_PROXY === "true"
         ? {
+            ...oryProxy,
             "/api/": {
               target: `https://127.0.0.1:${devServerProxyPort}`,
               secure: false,
@@ -165,6 +196,7 @@ export default defineConfig({
             },
           }
         : {
+            ...oryProxy,
             "/api/": {
               target: `http://127.0.0.1:${devServerProxyPort}`,
             },

--- a/console/yarn.lock
+++ b/console/yarn.lock
@@ -3244,6 +3244,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ory/client-fetch@npm:1.22.22":
+  version: 1.22.22
+  resolution: "@ory/client-fetch@npm:1.22.22"
+  checksum: 10c0/77f41a46cce8d9d587921554f46014d438d033555288f28d57d71187963c87e4344b030e0a860cfd2045554b9522c55fffbab220e468a058523a7a99a139f464
+  languageName: node
+  linkType: hard
+
 "@pkgr/core@npm:^0.1.0":
   version: 0.1.0
   resolution: "@pkgr/core@npm:0.1.0"
@@ -10888,6 +10895,7 @@ __metadata:
     "@lezer/highlight": "npm:^1.0.0"
     "@materializeinc/sql-lexer": "npm:^26.16.0"
     "@materializeinc/sql-pretty": "npm:^26.16.0"
+    "@ory/client-fetch": "npm:1.22.22"
     "@playwright/test": "npm:^1.61.0"
     "@rehookify/datepicker": "npm:^6.6.7"
     "@segment/analytics-next": "npm:^1.82.0"

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -347,6 +347,17 @@ pub const CONSOLE_OIDC_SCOPES: Config<&'static str> = Config::new(
     "Space-separated OIDC scopes requested by the web console.",
 );
 
+/// Base URL of the Ory APIs for the web console.
+///
+/// Only the operator knows where Ory was deployed, so the console cannot derive
+/// this. It must be same-site with the console or the browser drops Ory's CSRF
+/// and session cookies.
+pub const CONSOLE_ORY_SDK_URL: Config<&'static str> = Config::new(
+    "console_ory_sdk_url",
+    "",
+    "Base URL of the Ory APIs for the web console.",
+);
+
 /// Interval at which to collect per-object arrangement size snapshots for the history table.
 pub const ARRANGEMENT_SIZE_HISTORY_COLLECTION_INTERVAL: Config<Duration> = Config::new(
     "arrangement_size_history_collection_interval",
@@ -488,6 +499,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&GROUP_COMMIT_MAX_ATTEMPTS)
         .add(&CONSOLE_OIDC_CLIENT_ID)
         .add(&CONSOLE_OIDC_SCOPES)
+        .add(&CONSOLE_ORY_SDK_URL)
         .add(&ARRANGEMENT_SIZE_HISTORY_COLLECTION_INTERVAL)
         .add(&ARRANGEMENT_SIZE_HISTORY_RETENTION_PERIOD)
         .add(&CATALOG_INFO_METRICS_RECONCILE_INTERVAL)

--- a/src/environmentd/src/http/console.rs
+++ b/src/environmentd/src/http/console.rs
@@ -24,7 +24,9 @@ use hyper_tls::HttpsConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
-use mz_adapter_types::dyncfgs::{CONSOLE_OIDC_CLIENT_ID, CONSOLE_OIDC_SCOPES, OIDC_ISSUER};
+use mz_adapter_types::dyncfgs::{
+    CONSOLE_OIDC_CLIENT_ID, CONSOLE_OIDC_SCOPES, CONSOLE_ORY_SDK_URL, OIDC_ISSUER,
+};
 
 use crate::http::Delayed;
 
@@ -53,12 +55,13 @@ impl ConsoleProxyConfig {
     }
 }
 
-/// OIDC configuration values needed by the Console to initiate OIDC login.
-static CONSOLE_CONFIG_VAR_NAMES: LazyLock<[&'static str; 3]> = LazyLock::new(|| {
+/// Configuration values needed by the Console to initiate login.
+static CONSOLE_CONFIG_VAR_NAMES: LazyLock<[&'static str; 4]> = LazyLock::new(|| {
     [
         OIDC_ISSUER.name(),
         CONSOLE_OIDC_CLIENT_ID.name(),
         CONSOLE_OIDC_SCOPES.name(),
+        CONSOLE_ORY_SDK_URL.name(),
     ]
 });
 


### PR DESCRIPTION
Draft, for feedback on the shape before I split it for landing.

A self-managed deployment that runs Ory today sends users to Ory's own self-service UI, on an Ory hostname, to sign in. This lets the console render that flow itself so people stay on a Materialize page.

**Ory is not a new authentication mode.** Hydra is an OIDC issuer like any other: `authenticator_kind` stays `Oidc`, environmentd validates the same JWT against the same JWKS, and group-to-role sync is untouched. The only thing that changes is who draws the login screen.

### One login URL

`/account/login` renders the Kratos flow when the request carries a `flow` or `login_challenge`, and the console's own sign-in otherwise. Those parameters only ever appear when Ory sent the browser here, so a deployment using generic OIDC never takes that path and needs no configuration to opt out.

The check runs *before* the already-signed-in redirect. An OAuth2 client can ask someone who already has a session to re-authenticate, and sending them into the app instead would strand that request with no way to finish. Both directions are pinned by a test, because reordering them fails only in a browser.

### Rendering the flow

Kratos describes a flow as a list of UI nodes rather than a fixed form, so the page iterates them instead of hardcoding a provider:

- a second identity provider renders a second button with no code change
- an identifier-first flow renders its email step
- the step's own submit ranks above federated buttons, since advancing a form and handing off to another service are different actions
- a single provider with nothing to fill in submits itself, so an SSO-only deployment sees a redirect rather than a button it has no choice about
- anything the page cannot draw is reported rather than half-drawn, so a misconfiguration reads as one instead of as a broken page

### Configuration

environmentd publishes a new `console_ory_sdk_url` system parameter through `/api/console/config`. Only the operator knows where Ory was deployed, and it has to be same-site with the console or the browser drops Ory's CSRF and session cookies. Empty means the deployment does not run Ory.

Reading that endpoint moves into a single module. It was already fetched independently by the OIDC client, and would now have been fetched a second time for Ory, each with its own copy of the response type.

### Dev server

`DEV_SERVER_HOST`, `DEV_SERVER_TLS_CERT` and `DEV_SERVER_TLS_KEY`, plus a proxy for Kratos's self-service API when `ORY_KRATOS_URL` is set. Kratos scopes cookies to its own registrable domain and marks them `Secure`, so iterating against a real Ory stack means serving the console from a sibling host over TLS. All of it is inert unless set.

### Trying it

Two things have to be true, and neither is inferred: environmentd must publish where Ory lives, and Ory must send people to the console.

**1. Point Materialize at Hydra.** In the `materialize-terraform-self-managed` enterprise example this is already wired from the Ory module's outputs; the parameter added here is the new one:

```hcl
authenticator_kind = "Oidc"

system_parameters = {
  oidc_issuer               = module.ory.hydra_external_url
  oidc_audience             = jsonencode([module.ory.oauth2_client_id])
  oidc_authentication_claim = "email"
  console_oidc_client_id    = module.ory.oauth2_client_id
  console_oidc_scopes       = "openid email"
  console_ory_sdk_url       = module.ory.kratos_external_url
}
```

`oidc_audience` is the OAuth2 **client id**, not the client's `audience` field. They are different values and the plausible one produces tokens that fail validation with no useful error.

**2. Point Ory at the console.** Hydra and Kratos each keep their own login URL, and they are separate settings. Only Hydra's governs the OAuth2 chain, so changing just Kratos's leaves sign-in landing on Ory's UI:

```hcl
hydra_helm_values = { hydra = { config = { urls = {
  login = "https://<console-fqdn>/account/login"
} } } }

kratos_helm_values = { kratos = { config = { selfservice = {
  default_browser_return_url = "https://<console-fqdn>"
  flows = { login = { ui_url = "https://<console-fqdn>/account/login" } }
} } } }
```

Then sign in at `/account/login` → **Sign in with SSO**. The URL becomes `/account/login?login_challenge=…`, which is the tell that Hydra routed through the console rather than its own UI.

**Iterating on the console locally** needs the dev server to be same-site with Ory and served over TLS, because Kratos scopes its cookies to its own registrable domain and marks them `Secure`. Running on `localhost` cannot work. Point a hosts entry for the console's real hostname at `127.0.0.1`, issue a locally trusted certificate for it, and:

```
env ORY_KRATOS_URL=https://<kratos-fqdn> \
    DEV_SERVER_HOST=<console-fqdn> \
    DEV_SERVER_TLS_CERT=$PWD/.certs/console.pem \
    DEV_SERVER_TLS_KEY=$PWD/.certs/console-key.pem \
    yarn start
```

Set `VITE_ORY_SDK_URL` in `console/.env.local` to the dev server's own origin, **including the port** — the proxy above keeps the SDK same-origin so Kratos needs no CORS entry per laptop. That override is ignored outside development, so it cannot leak into a build.

Hydra matches redirect URIs exactly, so a dev server on a port needs that origin registered: `materialize_console_extra_fqdns = ["<console-fqdn>:3000"]`.

### Tests

- `OryLoginPage.test.tsx` — node rendering, provider ranking, the automatic submit and each of its guards, recovery from an expired flow, an existing session restarting as a refresh
- `UnauthenticatedRoutes.test.tsx` — both directions of the routing decision
- `consoleConfig.test.ts` — memoization, and that a failure is not remembered

### Known gaps

- **The session layer is not ported.** A token lands in storage and nothing consumes it, so completing a sign-in still leaves the console signed out. That is the next piece of work, not a defect in this one.
- **Logout and error screens are still Ory-branded.** The error screen is the one worth owning; it appears exactly when something has gone wrong.
- **This is ~1400 lines**, roughly three times the repo's guideline. Suggested split for landing: (1) the environmentd dyncfg, (2) the shared console-config module, which stands alone as a refactor, (3) the login page and its wiring.

### Release note

This release will add a `console_ory_sdk_url` system parameter, which lets a self-managed console render the login flow of a self-hosted Ory deployment rather than redirecting to Ory's own UI.
