### PR TITLE
adapter: authorize source access before purification

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1623,6 +1623,14 @@ impl Coordinator {
                     ) {
                         return ctx.retire(Err(e.into()));
                     }
+                    if let Err(e) = rbac::check_purification_source_access(
+                        &conn_catalog,
+                        ctx.session(),
+                        &stmt,
+                        &resolved_ids,
+                    ) {
+                        return ctx.retire(Err(e.into()));
+                    }
 
                     let (result, cluster_id) = mz_sql::pure::purify_statement(
                         conn_catalog,

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -19,7 +19,7 @@ use mz_ore::str::StrExt;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::role_id::RoleId;
 use mz_repr::{CatalogItemId, RelationVersionSelector};
-use mz_sql_parser::ast::{Ident, QualifiedReplica};
+use mz_sql_parser::ast::{Ident, QualifiedReplica, Statement};
 use mz_storage_types::sources::SourceExportDetails;
 use tracing::debug;
 
@@ -27,7 +27,7 @@ use crate::catalog::{
     CatalogItemType, ErrorMessageObjectDescription, ObjectType, SessionCatalog, SystemObjectType,
 };
 use crate::names::{
-    CommentObjectId, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds,
+    Aug, CommentObjectId, ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds,
     SchemaSpecifier, SystemObjectId,
 };
 use crate::plan::{self, PlanKind};
@@ -395,6 +395,54 @@ pub fn check_usage(
         role_membership,
         session.role_metadata().current_role,
     )?;
+
+    Ok(())
+}
+
+/// Checks if a session may use the sources a statement names during
+/// purification. If not, an error is returned.
+///
+/// Purification borrows a named source's connection to contact its upstream,
+/// and that connection is not in the resolved ids [`check_usage`] covers. The
+/// privileges required here are a subset of what planning requires later.
+pub fn check_purification_source_access(
+    catalog: &impl SessionCatalog,
+    session: &dyn SessionMetadata,
+    stmt: &Statement<Aug>,
+    resolved_ids: &ResolvedIds,
+) -> Result<(), UnauthorizedError> {
+    rbac_check_preamble(catalog, session)?;
+
+    let role_id = session.role_metadata().current_role;
+    let sources = resolved_ids.items().filter(|id| {
+        catalog
+            .try_get_item(id)
+            .is_some_and(|item| item.item_type() == CatalogItemType::Source)
+    });
+
+    let mut requirements = RbacRequirements::empty();
+    match stmt {
+        Statement::AlterSource(_) => {
+            requirements.ownership = sources.map(|id| ObjectId::Item(*id)).collect();
+        }
+        _ => {
+            let role_membership = catalog.collect_role_membership(&role_id);
+            let not_owned = sources
+                .filter(|id| !check_owner_roles(&ObjectId::Item(**id), &role_membership, catalog))
+                .copied();
+            requirements.privileges = generate_read_privileges(catalog, not_owned, role_id);
+        }
+    }
+    let requirements = filter_requirements(catalog, session, requirements);
+
+    let role_membership = catalog.collect_role_membership(&role_id);
+    let unheld_ownership = requirements
+        .ownership
+        .into_iter()
+        .filter(|id| !check_owner_roles(id, &role_membership, catalog))
+        .collect();
+    ownership_err(unheld_ownership, catalog)?;
+    check_object_privileges(catalog, requirements.privileges, role_membership, role_id)?;
 
     Ok(())
 }

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -16,10 +16,11 @@ use maplit::btreeset;
 use mz_controller_types::ClusterId;
 use mz_expr::CollectionPlan;
 use mz_ore::str::StrExt;
-use mz_repr::CatalogItemId;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::role_id::RoleId;
+use mz_repr::{CatalogItemId, RelationVersionSelector};
 use mz_sql_parser::ast::{Ident, QualifiedReplica};
+use mz_storage_types::sources::SourceExportDetails;
 use tracing::debug;
 
 use crate::catalog::{
@@ -31,7 +32,8 @@ use crate::names::{
 };
 use crate::plan::{self, PlanKind};
 use crate::plan::{
-    DataSourceDesc, Explainee, MutationKind, Plan, SideEffectingFunc, UpdatePrivilege,
+    DataSourceDesc, Explainee, MutationKind, Plan, SideEffectingFunc, TableDataSource,
+    UpdatePrivilege,
 };
 use crate::session::metadata::SessionMetadata;
 use crate::session::user::{MZ_SUPPORT_ROLE_ID, MZ_SYSTEM_ROLE_ID, SUPPORT_USER, SYSTEM_USER};
@@ -635,17 +637,147 @@ fn generate_rbac_requirements(
         }
         Plan::CreateTable(plan::CreateTablePlan {
             name,
-            table: _,
+            table,
             if_not_exists: _,
-        }) => RbacRequirements {
-            privileges: vec![(
+        }) => {
+            let mut ownership = Vec::new();
+            let mut privileges = vec![(
                 SystemObjectId::Object(name.qualifiers.clone().into()),
                 AclMode::CREATE,
                 role_id,
-            )],
-            item_usage: &CREATE_ITEM_USAGE,
-            ..Default::default()
-        },
+            )];
+            // `CREATE TABLE ... FROM SOURCE` populates the new table from an
+            // existing ingestion, and the table is owned by whoever creates it.
+            // Without a read check here, `CREATE` on any schema the role
+            // controls is enough to read a source the role cannot read.
+            //
+            // The safe rule is: the role may attach a reference only if it can
+            // already read every column the new table would expose. It can, if
+            // it owns the source, or if it can read an existing export of the
+            // reference that projects at least those columns. When neither
+            // holds, the attach opens a new or wider read path to upstream
+            // data, which is what `ALTER SOURCE ... ADD SUBSOURCE` does, so it
+            // requires ownership of the source.
+            //
+            // Keying on column coverage rather than on the set of exports is
+            // what makes this both not over-strict (a sibling table exporting
+            // the same reference does not lock other roles out) and not
+            // under-strict (an export created with `EXCLUDE COLUMNS` does not
+            // authorize a wider table for the same reference).
+            //
+            // Column *names* are only a proxy for what data a table exposes
+            // where the names come from the upstream schema: postgres, mysql,
+            // sql_server, and multi-output load generators reject
+            // caller-supplied names, so equal names mean the same upstream
+            // column and thus the same data.
+            //
+            // On Kafka the caller picks `FORMAT`/`ENVELOPE`/`INCLUDE` and then
+            // renames the resulting columns, so equal names can hide raw
+            // payload bytes, headers, and partition metadata the covering
+            // export never projected. Kafka references therefore do not take
+            // the coverage path and require ownership instead.
+            //
+            // Single-output load generators also allow caller-supplied names
+            // and let format/envelope reshape the schema, so names are not
+            // authoritative there either. They stay on the coverage path
+            // anyway: the data is synthetic with no credential-gated upstream,
+            // so there is nothing confidential to escalate to, and the subset
+            // check below still prevents widening the projection. Do not extend
+            // this reasoning to a connector that reads a real upstream.
+            if let TableDataSource::DataSource {
+                desc:
+                    DataSourceDesc::IngestionExport {
+                        ingestion_id,
+                        external_reference,
+                        ..
+                    },
+                timeline: _,
+            } = &table.data_source
+            {
+                let role_membership = catalog.collect_role_membership(&role_id);
+                let owns_source =
+                    check_owner_roles(&ObjectId::Item(*ingestion_id), &role_membership, catalog);
+                if !owns_source {
+                    let planned_columns: BTreeSet<_> =
+                        table.desc.latest().iter_names().cloned().collect();
+                    // Exports of this reference that project at least the
+                    // columns the new table would. An export that projects
+                    // fewer (e.g. one created with `EXCLUDE COLUMNS`) does not
+                    // authorize the wider table.
+                    let covering_exports: Vec<_> = catalog
+                        .get_item(ingestion_id)
+                        .used_by()
+                        .iter()
+                        .filter(|id| {
+                            catalog.get_item(id).source_export_details().is_some_and(
+                                |(parent, reference, details, _)| {
+                                    parent == *ingestion_id
+                                        && reference == external_reference
+                                        // Kafka column names are caller-chosen
+                                        // and do not identify the underlying
+                                        // data, so a name match is not a read
+                                        // proxy; require ownership instead.
+                                        && !matches!(details, SourceExportDetails::Kafka(_))
+                                },
+                            )
+                        })
+                        .filter(|id| {
+                            catalog
+                                .get_item(id)
+                                .at_version(RelationVersionSelector::Latest)
+                                .relation_desc()
+                                .is_some_and(|desc| {
+                                    let export_columns: BTreeSet<_> =
+                                        desc.iter_names().cloned().collect();
+                                    planned_columns.is_subset(&export_columns)
+                                })
+                        })
+                        .copied()
+                        .collect();
+                    if covering_exports.is_empty() {
+                        // No existing export covers these columns, so the attach
+                        // opens a new or wider read path to upstream data.
+                        // `ALTER SOURCE ... ADD SUBSOURCE` requires ownership for
+                        // the same reason.
+                        ownership.push(ObjectId::Item(*ingestion_id));
+                    } else {
+                        // Reading the data requires `SELECT` on the source and on
+                        // a covering export, plus `USAGE` on their schemas.
+                        // Prefer a covering export the role can already read so
+                        // the requirement is satisfiable when it should be; when
+                        // none is readable, name one anyway so the denial points
+                        // at a grant that would authorize the attach rather than
+                        // at ownership.
+                        let chosen_export = covering_exports
+                            .iter()
+                            .copied()
+                            .find(|export_id| {
+                                role_holds_privileges(
+                                    catalog,
+                                    &generate_read_privileges(
+                                        catalog,
+                                        [*ingestion_id, *export_id].into_iter(),
+                                        role_id,
+                                    ),
+                                    &role_membership,
+                                )
+                            })
+                            .unwrap_or(covering_exports[0]);
+                        privileges.extend(generate_read_privileges(
+                            catalog,
+                            [*ingestion_id, chosen_export].into_iter(),
+                            role_id,
+                        ));
+                    }
+                }
+            }
+            RbacRequirements {
+                ownership,
+                privileges,
+                item_usage: &CREATE_ITEM_USAGE,
+                ..Default::default()
+            }
+        }
         Plan::CreateView(plan::CreateViewPlan {
             name,
             view: _,
@@ -1763,6 +1895,36 @@ fn generate_required_source_privileges(
 /// that view has all of the privileges required to execute the query within the view.
 ///
 /// For more details see: <https://www.postgresql.org/docs/15/rules-privileges.html>
+/// Reports whether `role_membership` already satisfies every privilege in
+/// `required`. Used to collapse a disjunctive requirement ("read via any one of
+/// these objects") into a concrete decision at requirement-generation time,
+/// which the conjunctive [`RbacRequirements`] cannot express directly.
+fn role_holds_privileges(
+    catalog: &impl SessionCatalog,
+    required: &[(SystemObjectId, AclMode, RoleId)],
+    role_membership: &BTreeSet<RoleId>,
+) -> bool {
+    required.iter().all(|(object_id, acl_mode, _)| {
+        // Users implicitly hold all privileges on their own temp schema, which
+        // may not exist yet. Mirror `check_object_privileges`.
+        if matches!(
+            object_id,
+            SystemObjectId::Object(ObjectId::Schema((_, SchemaSpecifier::Temporary)))
+        ) {
+            return true;
+        }
+        let Some(object_privileges) = catalog.get_privileges(object_id) else {
+            return false;
+        };
+        let held = role_membership
+            .iter()
+            .flat_map(|role_id| object_privileges.get_acl_items_for_grantee(role_id))
+            .map(|mz_acl_item| mz_acl_item.acl_mode)
+            .fold(AclMode::empty(), |accum, acl_mode| accum.union(acl_mode));
+        held.contains(*acl_mode)
+    })
+}
+
 fn generate_read_privileges(
     catalog: &impl SessionCatalog,
     ids: impl Iterator<Item = CatalogItemId>,

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -694,6 +694,7 @@ def compileFastSltConfig() -> SltRunConfig:
         "test/sqllogictest/quote_ident.slt",
         "test/sqllogictest/quoting.slt",
         "test/sqllogictest/range.slt",
+        "test/sqllogictest/rbac_create_table_from_source.slt",
         "test/sqllogictest/rbac_enabled.slt",
         "test/sqllogictest/record.slt",
         "test/sqllogictest/recursion_limit.slt",

--- a/test/sqllogictest/rbac_create_table_from_source.slt
+++ b/test/sqllogictest/rbac_create_table_from_source.slt
@@ -187,6 +187,15 @@ CREATE SOURCE victim_schema.unexported FROM LOAD GENERATOR AUCTION (AS OF 300, U
 ----
 COMPLETE 0
 
+# Without SELECT the pre-purification gate rejects the statement. The plan-time
+# check alone would report missing ownership instead.
+
+simple conn=attacker,user=attacker
+CREATE TABLE attacker_schema.first_attach FROM SOURCE victim_schema.unexported (REFERENCE "auction"."users");
+----
+db error: ERROR: permission denied for SOURCE "materialize.victim_schema.unexported"
+DETAIL: The 'attacker' role needs SELECT privileges on SOURCE "materialize.victim_schema.unexported"
+
 simple conn=mz_system,user=mz_system
 GRANT SELECT ON victim_schema.unexported TO attacker;
 ----

--- a/test/sqllogictest/rbac_create_table_from_source.slt
+++ b/test/sqllogictest/rbac_create_table_from_source.slt
@@ -1,0 +1,210 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# `CREATE TABLE ... FROM SOURCE` must require the same read privileges as
+# reading the source data directly.
+#
+# The statement plans to a generic `Plan::CreateTable`, so its RBAC arm has to
+# inspect `table.data_source` to notice that the new table is populated from an
+# existing ingestion. The table is owned by whoever creates it, so without that
+# check `CREATE` on any schema the role controls is enough to read a source it
+# has been denied.
+#
+# The rule is column coverage: a role may attach a reference only if it can
+# already read every column the new table would expose, either by owning the
+# source or by reading an existing export that projects at least those columns.
+#
+# The column-restricted case (an export created with `EXCLUDE COLUMNS`, which a
+# wider table for the same reference must not be authorized by) is only reachable
+# on the postgres, mysql, and sql_server connectors, which sqllogictest cannot
+# drive. It is covered by the coverage logic in `generate_rbac_requirements` and
+# should get a testdrive case against a network connector. What follows exercises
+# the load-generator paths: parent-plus-export requirement, the no-existing-export
+# ownership fallback, and that a sibling table exporting the same reference does
+# not lock other roles out.
+#
+# When nothing has exported the reference yet there is no such export, and no
+# existing item's privileges say who may read it. Attaching it is creating a new
+# read path to upstream data, so it requires ownership of the source, matching
+# `ALTER SOURCE ... ADD SUBSOURCE`.
+
+mode cockroach
+
+reset-server
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_rbac_checks TO true;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE attacker;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SCHEMA attacker_schema;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE, CREATE ON SCHEMA attacker_schema TO attacker;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON DATABASE materialize TO attacker;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON CLUSTER quickstart TO attacker;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SCHEMA victim_schema;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SOURCE victim_schema.victim_auction FROM LOAD GENERATOR AUCTION (AS OF 300, UP TO 301) FOR ALL TABLES;
+----
+COMPLETE 0
+
+# The attacker can name the objects but holds no read privilege on either.
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA victim_schema TO attacker;
+----
+COMPLETE 0
+
+# Reading the export directly is denied.
+
+simple conn=attacker,user=attacker
+SELECT count(*) FROM victim_schema.users;
+----
+db error: ERROR: permission denied for SOURCE "materialize.victim_schema.users"
+DETAIL: The 'attacker' role needs SELECT privileges on SOURCE "materialize.victim_schema.users"
+
+# Attaching the same reference to an attacker-owned table must be denied for the
+# same reason. The parent ingestion is reported first.
+
+simple conn=attacker,user=attacker
+CREATE TABLE attacker_schema.laundered FROM SOURCE victim_schema.victim_auction (REFERENCE "auction"."users");
+----
+db error: ERROR: permission denied for SOURCE "materialize.victim_schema.victim_auction"
+DETAIL: The 'attacker' role needs SELECT privileges on SOURCE "materialize.victim_schema.victim_auction"
+
+# `SELECT` on the parent alone is not enough: for a source with exports, the
+# rows live in the export, which carries its own privileges.
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON victim_schema.victim_auction TO attacker;
+----
+COMPLETE 0
+
+simple conn=attacker,user=attacker
+CREATE TABLE attacker_schema.laundered FROM SOURCE victim_schema.victim_auction (REFERENCE "auction"."users");
+----
+db error: ERROR: permission denied for SOURCE "materialize.victim_schema.users"
+DETAIL: The 'attacker' role needs SELECT privileges on SOURCE "materialize.victim_schema.users"
+
+# With the complete read privilege set, the same statement is allowed, so the
+# check denies the attack without blocking legitimate attachment.
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON victim_schema.users TO attacker;
+----
+COMPLETE 0
+
+simple conn=attacker,user=attacker
+CREATE TABLE attacker_schema.authorized FROM SOURCE victim_schema.victim_auction (REFERENCE "auction"."users");
+----
+COMPLETE 0
+
+# A second role with the same grants can attach the same reference, even though
+# `attacker_schema.authorized` now exports it too. The requirement is a covering
+# export the role can read (the `users` subsource), not read on every export, so
+# one team's private table does not lock another team out.
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE other_team;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE SCHEMA other_team_schema;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE, CREATE ON SCHEMA other_team_schema TO other_team;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON DATABASE materialize TO other_team;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON CLUSTER quickstart TO other_team;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA victim_schema TO other_team;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON victim_schema.victim_auction TO other_team;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON victim_schema.users TO other_team;
+----
+COMPLETE 0
+
+simple conn=other_team,user=other_team
+CREATE TABLE other_team_schema.mine FROM SOURCE victim_schema.victim_auction (REFERENCE "auction"."users");
+----
+COMPLETE 0
+
+# A source with no exports. Attaching a reference to it is a first attach, so
+# `SELECT` on the parent is not enough: ownership is required.
+
+simple conn=mz_system,user=mz_system
+CREATE SOURCE victim_schema.unexported FROM LOAD GENERATOR AUCTION (AS OF 300, UP TO 301);
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+GRANT SELECT ON victim_schema.unexported TO attacker;
+----
+COMPLETE 0
+
+simple conn=attacker,user=attacker
+CREATE TABLE attacker_schema.first_attach FROM SOURCE victim_schema.unexported (REFERENCE "auction"."users");
+----
+db error: ERROR: must be owner of SOURCE materialize.victim_schema.unexported
+
+# The owner may attach it, so the rule gates the caller rather than the syntax.
+
+simple conn=mz_system,user=mz_system
+ALTER SOURCE victim_schema.unexported OWNER TO attacker;
+----
+COMPLETE 0
+
+simple conn=attacker,user=attacker
+CREATE TABLE attacker_schema.first_attach FROM SOURCE victim_schema.unexported (REFERENCE "auction"."users");
+----
+COMPLETE 0


### PR DESCRIPTION
Stacked on #38480. Review only the top commit until that merges; the base will be retargeted to `main` afterwards.

### Motivation

#38480 closes the plan-time bug in [SQL-655](https://linear.app/materializeinc/issue/SQL-655) but leaves a residual it calls out: purification runs before planning, and `must_spawn_purification` only authorizes the secrets, connections, and types in the statement's resolved ids. `CREATE TABLE ... FROM SOURCE` and `ALTER SOURCE` take the upstream connection from the *named source's* own `source_desc()`, which is not in the resolved ids, so a role the plan would reject can still make Materialize open an outbound connection to the upstream using the source owner's credentials, and read purification errors as an upstream existence and column-name oracle.

`CREATE SOURCE ... FROM CONNECTION` and `CREATE SINK ... INTO` are not affected: the connection they use is in their resolved ids and the existing `check_usage(CREATE_ITEM_USAGE)` call already gates it before purification. No new privilege is needed.

### Description

Add `rbac::check_purification_source_access` and call it next to the existing `check_usage` in the purification task. For every `Source` item the statement names it requires:

* `ALTER SOURCE`: ownership of the source.
* every other purified statement: `SELECT` on the source (with schema `USAGE`), or ownership.

Each is a necessary condition of the corresponding plan-time requirement (`ALTER SOURCE` requires ownership; `CREATE TABLE ... FROM SOURCE` after #38480 requires `SELECT` on the parent or ownership; `CREATE SINK FROM` requires read on its input), so no statement the plan would accept is rejected here. Superuser and RBAC-off sessions are unaffected through the usual `filter_requirements`.

This is a necessary-condition gate, not a duplicate of the plan-time check. The column-coverage rule in #38480 needs the purified schema and stays where it is.

### User-visible effect

A role without `SELECT` on a source now gets a `SELECT` denial from `CREATE TABLE ... FROM SOURCE` instead of an ownership denial, and gets it before any upstream I/O. No previously permitted statement becomes denied.

### Verification

Extends `test/sqllogictest/rbac_create_table_from_source.slt` with the one case the gate is observable on: a non-owner with no `SELECT` on a never-exported source is denied for `SELECT` rather than for ownership. Confirmed the assertion fails without the `command_handler.rs` call and passes with it.

Part of [SQL-655](https://linear.app/materializeinc/issue/SQL-655).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
