### PR TITLE
compute: answer an index peek from one budgeted scan

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -1057,17 +1057,17 @@ metrics:
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_collection_seconds_bucket
-  help: Time constructing RowCollection from peek results.
+  help: Time constructing RowCollection from peek results, including converting the row counts the scan produced.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_collection_seconds_count
-  help: Time constructing RowCollection from peek results.
+  help: Time constructing RowCollection from peek results, including converting the row counts the scan produced.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_collection_seconds_sum
-  help: Time constructing RowCollection from peek results.
+  help: Time constructing RowCollection from peek results, including converting the row counts the scan produced.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_rows_bucket
@@ -1085,17 +1085,17 @@ metrics:
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_bucket
-  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_count
-  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_sum
-  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_seek_fulfillment_seconds_bucket

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -1682,6 +1682,9 @@ impl From<mz_compute_client::protocol::response::PeekError> for AdapterError {
             PeekError::RowIterationLimitExceeded { limit } => {
                 AdapterError::PeekRowIterationLimitExceeded { limit }
             }
+            error @ PeekError::ResultExceedsMaxSize { .. } => {
+                AdapterError::ResultSize(error.to_string())
+            }
         }
     }
 }

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -11,6 +11,7 @@
 
 use std::fmt;
 
+use bytesize::ByteSize;
 use mz_expr::EvalError;
 use mz_expr::row::RowCollection;
 use mz_ore::cast::CastFrom;
@@ -237,6 +238,11 @@ pub enum PeekError {
         /// The limit that was in effect, in rows.
         limit: usize,
     },
+    /// A worker accumulated more answer bytes than `max_result_size` allows.
+    ResultExceedsMaxSize {
+        /// The ceiling that was in effect, in bytes.
+        max_result_size: usize,
+    },
 }
 
 impl PeekError {
@@ -254,6 +260,11 @@ impl fmt::Display for PeekError {
             Self::RowIterationLimitExceeded { limit } => write!(
                 f,
                 "query exceeded the configured row iteration limit of {limit} rows"
+            ),
+            Self::ResultExceedsMaxSize { max_result_size } => write!(
+                f,
+                "result exceeds max size of {}",
+                ByteSize::b(u64::cast_from(*max_result_size))
             ),
         }
     }
@@ -365,7 +376,6 @@ pub struct SubscribeBatch {
 impl SubscribeBatch {
     /// Converts `self` to an error if a maximum size is exceeded.
     fn to_error_if_exceeds(&mut self, max_result_size: usize) {
-        use bytesize::ByteSize;
         if let Ok(updates) = &self.updates {
             let total_size: usize = updates.iter().map(|updates| updates.byte_len()).sum();
             if total_size > max_result_size {

--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -273,6 +273,20 @@ impl TraceBundle {
         &mut self.errs
     }
 
+    /// Returns mutable references to both traces.
+    ///
+    /// A reader of both, such as a peek that must rule out errors before it returns rows, cannot
+    /// take them one at a time, because each of [`TraceBundle::oks_mut`] and
+    /// [`TraceBundle::errs_mut`] borrows the whole bundle.
+    pub fn oks_errs_mut(
+        &mut self,
+    ) -> (
+        &mut PaddedTrace<RowRowAgent<Timestamp, Diff>>,
+        &mut PaddedTrace<ErrAgent<Timestamp, Diff>>,
+    ) {
+        (&mut self.oks, &mut self.errs)
+    }
+
     /// Returns a reference to the `to_drop` tokens.
     pub fn to_drop(&self) -> &Option<Rc<dyn Any>> {
         &self.to_drop

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -17,9 +17,7 @@ use std::time::{Duration, Instant};
 use bytesize::ByteSize;
 use differential_dataflow::Hashable;
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::trace::cursor::BatchCursor;
-use differential_dataflow::trace::implementations::BatchContainer;
-use differential_dataflow::trace::{Cursor, Navigable, TraceReader};
+use differential_dataflow::trace::TraceReader;
 use mz_compute_client::logging::LoggingConfig;
 use mz_compute_client::protocol::command::{
     ComputeCommand, ComputeParameters, InstanceConfig, Peek, PeekTarget,
@@ -36,8 +34,8 @@ use mz_compute_types::dyncfgs::{
 };
 use mz_compute_types::plan::render_plan::RenderPlan;
 use mz_dyncfg::{ConfigSet, ConfigValHandle};
+use mz_expr::SafeMfpPlan;
 use mz_expr::row::RowCollection;
-use mz_expr::{RowComparator, SafeMfpPlan};
 use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::{MetricsRegistry, UIntGauge};
@@ -51,8 +49,7 @@ use mz_persist_client::cfg::USE_CRITICAL_SINCE_SNAPSHOT;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_types::PersistLocation;
 use mz_persist_types::codec_impls::UnitSchema;
-use mz_repr::fixed_length::ExtendDatums;
-use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena, Timestamp};
+use mz_repr::{DatumVec, GlobalId, Row, RowArena, Timestamp};
 use mz_storage_operators::stats::StatsCursor;
 use mz_storage_types::StorageDiff;
 use mz_storage_types::controller::CollectionMetadata;
@@ -70,6 +67,7 @@ use tracing::{Level, debug, error, info, span, trace, warn};
 use uuid::Uuid;
 
 use crate::arrangement::manager::{TraceBundle, TraceManager};
+use crate::compute_state::peek_scan::{PeekScan, ScanOutcome, entry_byte_len};
 use crate::logging;
 use crate::logging::compute::{CollectionLogging, ComputeEvent, PeekEvent};
 use crate::logging::initialize::LoggingTraces;
@@ -79,9 +77,8 @@ use crate::server::{ComputeInstanceContext, ResponseSender};
 
 mod error_scan;
 mod peek_result_iterator;
+mod peek_scan;
 mod peek_stash;
-
-use self::error_scan::{ErrorScan, ErrorScanState, ErrorScanStep};
 
 /// Cheap handles on the dyncfgs that bound how many rows a peek may examine.
 ///
@@ -138,6 +135,14 @@ impl PeekRowIterationTracker {
 
     fn rows_iterated(&self) -> usize {
         self.rows_iterated
+    }
+
+    /// Adds rows examined by a walk that ran before this one.
+    ///
+    /// The limit bounds a peek rather than a single walk, so a walk that continues another one
+    /// starts from the count that one reached.
+    fn add_rows_iterated(&mut self, rows_iterated: usize) {
+        self.rows_iterated = self.rows_iterated.saturating_add(rows_iterated);
     }
 
     fn track_next(&mut self) -> Result<(), PeekError> {
@@ -1444,7 +1449,6 @@ impl PendingPeek {
             peek,
             trace_bundle,
             span: tracing::Span::current(),
-            error_scan: ErrorScanState::NotStarted,
         })
     }
 
@@ -1664,9 +1668,7 @@ impl PersistPeek {
                     .map(|row| row.cloned())
                     .map_err(PeekError::from)?;
                 if let Some(row) = eval_result {
-                    total_size = total_size
-                        .saturating_add(row.byte_len())
-                        .saturating_add(std::mem::size_of::<NonZeroUsize>());
+                    total_size = total_size.saturating_add(entry_byte_len(&row));
                     if total_size > max_result_size {
                         return Err(PeekError::unstructured(format!(
                             "result exceeds max size of {}",
@@ -1693,11 +1695,6 @@ pub struct IndexPeek {
     trace_bundle: TraceBundle,
     /// The `tracing::Span` tracking this peek's operation
     span: tracing::Span,
-    /// The state of the walk over the error trace.
-    ///
-    /// Only [`ErrorScanState::Scanning`] holds a cursor, so a peek that is not walking its error
-    /// trace pins no error batches.
-    error_scan: ErrorScanState,
 }
 
 /// Histogram metrics for index peek phases.
@@ -1778,7 +1775,12 @@ impl IndexPeek {
         result
     }
 
-    /// Collects data for a known-complete peek from the ok stream.
+    /// Answers the peek by scanning the traces that fulfil it.
+    ///
+    /// One call drives one scan to an answer and drops it, so nothing survives the call and a
+    /// second call repeats both walks from the start. That is what the peek path asks for: it
+    /// reaches this only once the frontiers admit the read, and every outcome retires the peek
+    /// from the index-peek path, either with a response or by handing it to the stash.
     fn collect_finished_data(
         &mut self,
         max_result_size: u64,
@@ -1787,252 +1789,93 @@ impl IndexPeek {
         row_iteration_limit: Option<usize>,
         metrics: &IndexPeekMetrics<'_>,
     ) -> PeekStatus {
-        // Check if there exist any errors and, if so, return whatever one we
-        // find first.
-        //
-        // No caller supplies a scan budget, so the walk runs to an answer in one step.
-        let mut fuel = usize::MAX;
-        let rows_iterated = match self.step_error_scan(row_iteration_limit, metrics, &mut fuel) {
-            ErrorScanStep::Finished(Ok(rows_iterated)) => rows_iterated,
-            ErrorScanStep::Finished(Err(error)) => {
-                return PeekStatus::Ready(PeekResponse::Error(error));
-            }
-            ErrorScanStep::OutOfFuel => unreachable!("stepped with unbounded fuel"),
-        };
-
-        Self::collect_ok_finished_data(
-            &self.peek,
-            self.trace_bundle.oks_mut(),
+        let peek = &self.peek;
+        let (oks, errs) = self.trace_bundle.oks_errs_mut();
+        let mut scan = PeekScan::new(
+            peek,
+            errs,
+            oks,
             max_result_size,
             peek_stash_eligible,
             peek_stash_threshold_bytes,
-            row_iteration_limit,
-            rows_iterated,
-            metrics,
-        )
-    }
-
-    /// Advances this peek's walk over its error trace, starting it if it has not started,
-    /// charging one unit of `fuel` per cursor position.
-    ///
-    /// The walk resumes where a previous call left off, so a caller must not treat
-    /// [`ErrorScanStep::OutOfFuel`] as an end of scan.
-    ///
-    /// Once the walk has reported [`ErrorScanStep::Finished`], every further call reports that
-    /// same outcome, spends no fuel, and reads no trace. A peek an error answers can therefore
-    /// never be sent on to return rows.
-    fn step_error_scan(
-        &mut self,
-        row_iteration_limit: Option<usize>,
-        metrics: &IndexPeekMetrics<'_>,
-        fuel: &mut usize,
-    ) -> ErrorScanStep {
-        match &self.error_scan {
-            ErrorScanState::NotStarted => {
-                self.error_scan =
-                    ErrorScanState::Scanning(ErrorScan::new(self.trace_bundle.errs_mut()));
-            }
-            ErrorScanState::Scanning(_) => {}
-            ErrorScanState::Finished(outcome) => return ErrorScanStep::Finished(outcome.clone()),
-        }
-
-        let ErrorScanState::Scanning(scan) = &mut self.error_scan else {
-            unreachable!("walk is under way");
-        };
-        // The limit bounds the peek, not the call, so a walk already under way adopts the limit
-        // that is in effect now rather than the one that was in effect when it started.
-        scan.set_row_iteration_limit(row_iteration_limit);
-        let outcome = scan.step(self.peek.timestamp, self.peek.target.id(), fuel);
-        let scan_time = scan.scan_time;
-
-        // Both terminal outcomes drop the walk, so that a peek pins error batches only while it
-        // is reading them.
-        match &outcome {
-            ErrorScanStep::Finished(result) => {
-                self.error_scan = ErrorScanState::Finished(result.clone());
-                if result.is_ok() {
-                    // Reached at most once per peek, because the stored outcome answers any
-                    // further call. A scan that answers with an error observes nothing.
-                    metrics.error_scan_seconds.observe(scan_time.as_secs_f64());
-                }
-            }
-            ErrorScanStep::OutOfFuel => {}
-        }
-
-        outcome
-    }
-
-    /// Collects data for a known-complete peek from the ok stream.
-    fn collect_ok_finished_data<Tr>(
-        peek: &Peek,
-        oks_handle: &mut Tr,
-        max_result_size: u64,
-        peek_stash_eligible: bool,
-        peek_stash_threshold_bytes: usize,
-        row_iteration_limit: Option<usize>,
-        rows_iterated: usize,
-        metrics: &IndexPeekMetrics<'_>,
-    ) -> PeekStatus
-    where
-        Tr: TraceReader<Batch: Navigable>,
-        for<'a> BatchCursor<Tr>: Cursor<
-                Key<'a>: ExtendDatums + Eq,
-                KeyContainer: BatchContainer<Owned = Row>,
-                Val<'a>: ExtendDatums,
-                TimeGat<'a>: PartialOrder<Timestamp>,
-                DiffGat<'a> = &'a Diff,
-            >,
-    {
-        let max_result_size = usize::cast_from(max_result_size);
-        let count_byte_size = size_of::<NonZeroUsize>();
-
-        // Cursor setup timing
-        let cursor_setup_start = Instant::now();
-
-        // We clone `literal_constraints` here because we don't want to move the constraints
-        // out of the peek struct, and don't want to modify in-place.
-        let mut peek_iterator = peek_result_iterator::PeekResultIterator::new(
-            peek.target.id().clone(),
-            peek.map_filter_project.clone(),
-            peek.timestamp,
-            peek.literal_constraints.clone().as_deref_mut(),
-            oks_handle,
-            row_iteration_limit,
-            rows_iterated,
         );
 
-        metrics
-            .cursor_setup_seconds
-            .observe(cursor_setup_start.elapsed().as_secs_f64());
+        // No caller supplies a budget, so nothing stops the scan short of an answer but a full
+        // batch, and this driver has nowhere to write one.
+        let mut fuel = usize::MAX;
+        let outcome = scan.step(row_iteration_limit, &mut fuel);
 
-        // Accumulated `Vec<(row, count)>` results that we are likely to return.
-        let mut results = Vec::new();
-        let mut total_size: usize = 0;
+        // Both phases that precede the ok walk are reported only for a peek that reached that
+        // walk, so a peek answered by its error trace reports neither.
+        if scan.error_trace_clean() {
+            metrics
+                .error_scan_seconds
+                .observe(scan.error_scan_time.as_secs_f64());
+            metrics
+                .cursor_setup_seconds
+                .observe(scan.cursor_setup_time.as_secs_f64());
+        }
 
-        // When set, a bound on the number of records we need to return.
-        // The requirements on the records are driven by the finishing's
-        // `order_by` field. Further limiting will happen when the results
-        // are collected, so we don't need to have exactly this many results,
-        // just at least those results that would have been returned.
-        let max_results = peek.finishing.num_rows_needed();
-
-        let comparator = RowComparator::new(peek.finishing.order_by.as_slice());
-
-        // Row iteration timing
-        let row_iteration_start = Instant::now();
-        let mut sort_time_accum = Duration::ZERO;
-        let mut rows_sorted = 0usize;
-
-        while let Some(row) = peek_iterator.next() {
-            let row: (Row, _) = match row {
-                Ok(row) => row,
-                Err(err) => return PeekStatus::Ready(PeekResponse::Error(err)),
-            };
-            let (row, copies) = row;
-            let copies: NonZeroUsize = NonZeroUsize::try_from(copies).expect("fits into usize");
-
-            total_size = total_size
-                .saturating_add(row.byte_len())
-                .saturating_add(count_byte_size);
-            if peek_stash_eligible && total_size > peek_stash_threshold_bytes {
+        let rows = match outcome {
+            ScanOutcome::Finished(Ok(rows)) => rows,
+            ScanOutcome::Finished(Err(error)) => {
+                return PeekStatus::Ready(PeekResponse::Error(error));
+            }
+            // Diversion is sound only for a scan whose error walk is over. The stash answers the
+            // peek from a walk of the ok trace alone and never reads the error trace, so a peek
+            // diverted with its error trace half-read would return rows where it must report an
+            // error.
+            //
+            // The batch is taken and dropped rather than left to the scan's own drop, because
+            // discarding it is this driver's decision: the stash's own walk supersedes it. It is
+            // taken only once diversion is established, so that no path disposes of rows it has
+            // not first earned the right to discard.
+            ScanOutcome::Suspended => {
+                if !scan.error_trace_clean() {
+                    soft_panic_or_log!(
+                        "peek on {} suspended before its error trace was read out",
+                        self.peek.target.id()
+                    );
+                    return PeekStatus::Ready(PeekResponse::Error(PeekError::unstructured(
+                        "peek suspended before its error trace was read out",
+                    )));
+                }
+                if scan.take_batch().is_none() {
+                    soft_panic_or_log!(
+                        "peek on {} suspended with no batch to hand over",
+                        self.peek.target.id()
+                    );
+                }
                 return PeekStatus::UsePeekStash;
             }
-            if total_size > max_result_size {
-                return PeekStatus::Ready(PeekResponse::Error(PeekError::unstructured(format!(
-                    "result exceeds max size of {}",
-                    ByteSize::b(u64::cast_from(max_result_size))
-                ))));
-            }
-
-            results.push((row, copies));
-
-            // If we hold many more than `max_results` records, we can thin down
-            // `results` using `self.finishing.ordering`.
-            if let Some(max_results) = max_results {
-                // We use a threshold twice what we intend, to amortize the work
-                // across all of the insertions. We could tighten this, but it
-                // works for the moment.
-                //
-                // `max_results` is `limit + offset`, so a `LIMIT` near
-                // `i64::MAX` makes the doubling overflow. We then hold fewer
-                // rows than the threshold no matter what, and never thin. That
-                // is the right answer: such a peek cannot accumulate that many
-                // rows anyway, the result size limit stops it long before.
-                // Wrapping instead would make the threshold tiny, and we would
-                // thin while holding almost nothing, dropping rows past the end
-                // of the buffer.
-                if max_results
-                    .checked_mul(2)
-                    .is_some_and(|threshold| results.len() >= threshold)
-                {
-                    if peek.finishing.order_by.is_empty() {
-                        results.truncate(max_results);
-                        metrics
-                            .row_iteration_seconds
-                            .observe(row_iteration_start.elapsed().as_secs_f64());
-                        metrics
-                            .row_iteration_rows
-                            .observe(f64::cast_lossy(peek_iterator.rows_processed()));
-                        metrics
-                            .result_sort_seconds
-                            .observe(sort_time_accum.as_secs_f64());
-                        metrics
-                            .result_sort_rows
-                            .observe(f64::cast_lossy(rows_sorted));
-                        let row_collection_start = Instant::now();
-                        let collection = RowCollection::new(results, &peek.finishing.order_by);
-                        metrics
-                            .row_collection_seconds
-                            .observe(row_collection_start.elapsed().as_secs_f64());
-                        return PeekStatus::Ready(PeekResponse::Rows(vec![collection]));
-                    } else {
-                        // We can sort `results` and then truncate to `max_results`.
-                        // This has an effect similar to a priority queue, without
-                        // its interactive dequeueing properties.
-                        // TODO: Had we left these as `Vec<Datum>` we would avoid
-                        // the unpacking; we should consider doing that, although
-                        // it will require a re-pivot of the code to branch on this
-                        // inner test (as we prefer not to maintain `Vec<Datum>`
-                        // in the other case).
-                        let sort_start = Instant::now();
-                        rows_sorted = rows_sorted.saturating_add(results.len());
-                        results.sort_by(|left, right| {
-                            comparator.compare_rows(&left.0, &right.0, || left.0.cmp(&right.0))
-                        });
-                        sort_time_accum += sort_start.elapsed();
-                        let dropped = results.drain(max_results..);
-                        let dropped_size =
-                            dropped
-                                .into_iter()
-                                .fold(0, |acc: usize, (row, _count): (Row, _)| {
-                                    acc.saturating_add(
-                                        row.byte_len().saturating_add(count_byte_size),
-                                    )
-                                });
-                        total_size = total_size.saturating_sub(dropped_size);
-                    }
-                }
-            }
-        }
+        };
 
         metrics
             .row_iteration_seconds
-            .observe(row_iteration_start.elapsed().as_secs_f64());
+            .observe(scan.row_iteration_time.as_secs_f64());
         metrics
             .row_iteration_rows
-            .observe(f64::cast_lossy(peek_iterator.rows_processed()));
+            .observe(f64::cast_lossy(scan.rows_processed()));
         metrics
             .result_sort_seconds
-            .observe(sort_time_accum.as_secs_f64());
+            .observe(scan.result_sort_time.as_secs_f64());
         metrics
             .result_sort_rows
-            .observe(f64::cast_lossy(rows_sorted));
+            .observe(f64::cast_lossy(scan.rows_sorted));
 
         let row_collection_start = Instant::now();
-        let collection = RowCollection::new(results, &peek.finishing.order_by);
+        let rows = rows
+            .into_iter()
+            .map(|(row, copies)| {
+                let copies = NonZeroUsize::try_from(copies).expect("fits into usize");
+                (row, copies)
+            })
+            .collect();
+        let collection = RowCollection::new(rows, &self.peek.finishing.order_by);
         metrics
             .row_collection_seconds
             .observe(row_collection_start.elapsed().as_secs_f64());
+
         PeekStatus::Ready(PeekResponse::Rows(vec![collection]))
     }
 }
@@ -2269,3 +2112,10 @@ impl CollectionState {
 
 #[cfg(test)]
 mod tests;
+
+/// Tests of the inline index-peek driver, and the fixtures a peek scan is tested over.
+///
+/// The fixtures are shared with [`peek_scan`]'s own tests, which build a scan from the same
+/// [`TraceBundle`] this driver hands one.
+#[cfg(test)]
+pub(crate) mod index_peek_tests;

--- a/src/compute/src/compute_state/error_scan.rs
+++ b/src/compute/src/compute_state/error_scan.rs
@@ -22,18 +22,6 @@ use crate::typedefs::ErrAgent;
 /// [`TraceBundle::errs_mut`](crate::arrangement::manager::TraceBundle::errs_mut) hands it out.
 pub(super) type ErrsHandle = PaddedTrace<ErrAgent<Timestamp, Diff>>;
 
-/// The state of an index peek's walk over its error trace.
-pub(super) enum ErrorScanState {
-    /// The walk has not started, and holds no cursor yet.
-    NotStarted,
-    /// The walk is under way, and resumes from the cursor position it stopped on.
-    Scanning(ErrorScan),
-    /// The walk is over, holding what it needs to report the same outcome again without a second
-    /// walk and without a cursor: the rows it examined reaching a trace with no error at the
-    /// peek's timestamp, or the error that answers the peek.
-    Finished(Result<usize, PeekError>),
-}
-
 /// A walk over an index peek's error trace, suspendable between cursor positions.
 ///
 /// Holds nothing of the ok trace or of the rows a peek returns. A peek reaches those only once
@@ -68,11 +56,21 @@ impl ErrorScan {
     pub(super) fn new(errs: &mut ErrsHandle) -> Self {
         let scan_start = Instant::now();
         let (cursor, storage) = errs.cursor();
+        let mut scan = Self::from_cursor(cursor, storage);
+        scan.scan_time = scan_start.elapsed();
+        scan
+    }
+
+    /// Opens a walk over an already-opened cursor.
+    pub(super) fn from_cursor(
+        cursor: peek_result_iterator::TraceCursor<ErrsHandle>,
+        storage: peek_result_iterator::TraceStorage<ErrsHandle>,
+    ) -> Self {
         Self {
             cursor,
             storage,
             row_iteration_tracker: PeekRowIterationTracker::new(None, 0),
-            scan_time: scan_start.elapsed(),
+            scan_time: Duration::ZERO,
         }
     }
 
@@ -92,8 +90,8 @@ impl ErrorScan {
     ///
     /// This walk does not remember that it ended, and stepping it again after it reported
     /// [`ErrorScanStep::Finished`] walks a spent cursor.
-    /// [`IndexPeek::step_error_scan`](super::IndexPeek::step_error_scan) remembers instead: it
-    /// keeps the outcome and drops the walk, so a finished peek stops pinning error batches.
+    /// [`PeekScan`](super::peek_scan::PeekScan)'s error phase remembers instead: it keeps the
+    /// outcome and drops the walk, so a finished peek stops pinning error batches.
     pub(super) fn step(
         &mut self,
         peek_timestamp: Timestamp,
@@ -149,4 +147,4 @@ impl ErrorScan {
 }
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/src/compute/src/compute_state/error_scan/tests.rs
+++ b/src/compute/src/compute_state/error_scan/tests.rs
@@ -17,27 +17,28 @@ use timely::container::PushInto;
 use timely::progress::Antichain;
 
 use crate::render::errors::DataflowErrorSer;
-use crate::typedefs::{ErrBatcher, ErrBuilder};
+use crate::typedefs::{ErrBatcher, ErrBuilder, ErrSpine};
 
 use super::*;
 
 /// The time at which the peeks in these tests read.
-const PEEK_TIMESTAMP: Timestamp = Timestamp::new(1);
+pub(crate) const PEEK_TIMESTAMP: Timestamp = Timestamp::new(1);
+
+/// The updates that make up an error trace, in the form its batcher takes them.
+pub(crate) type ErrorUpdates = Vec<((DataflowErrorSer, ()), Timestamp, Diff)>;
 
 /// A distinct error for `index`.
 ///
 /// The order of the serialized form does not follow `index`, so a test that cares where a
 /// key falls in the walk sorts the errors and picks by position.
-fn error(index: usize) -> DataflowErrorSer {
+pub(crate) fn error(index: usize) -> DataflowErrorSer {
     DataflowErrorSer::from(EvalError::Internal(format!("error {index}").into()))
 }
 
-/// Builds a walk over a single-batch error trace holding `updates`, bounded by
-/// `row_iteration_limit`.
-fn error_scan(
-    updates: Vec<((DataflowErrorSer, ()), Timestamp, Diff)>,
-    row_iteration_limit: Option<usize>,
-) -> ErrorScan {
+/// Builds a single batch holding `updates`, covering `[0, Timestamp::MAX)`.
+pub(crate) fn error_batch(
+    updates: ErrorUpdates,
+) -> <ErrSpine<Timestamp, Diff> as TraceReader>::Batch {
     let mut batcher = ErrBatcher::<Timestamp, Diff>::new(None, 0);
     let mut chunk = ColumnationStack::with_capacity(updates.len());
     for update in updates {
@@ -45,15 +46,17 @@ fn error_scan(
     }
     batcher.push_into(chunk);
     let (mut chain, description) = batcher.seal(Antichain::from_elem(Timestamp::MAX));
-    let batch = ErrBuilder::<Timestamp, Diff>::seal(&mut chain, description);
-    let storage = vec![batch];
+    ErrBuilder::<Timestamp, Diff>::seal(&mut chain, description)
+}
+
+/// Builds a walk over a single-batch error trace holding `updates`, bounded by
+/// `row_iteration_limit`.
+pub(crate) fn error_scan(updates: ErrorUpdates, row_iteration_limit: Option<usize>) -> ErrorScan {
+    let storage = vec![error_batch(updates)];
     let cursor = CursorList::new(vec![storage[0].cursor()], &storage);
-    ErrorScan {
-        cursor,
-        storage,
-        row_iteration_tracker: PeekRowIterationTracker::new(row_iteration_limit, 0),
-        scan_time: Duration::ZERO,
-    }
+    let mut scan = ErrorScan::from_cursor(cursor, storage);
+    scan.set_row_iteration_limit(row_iteration_limit);
+    scan
 }
 
 /// Updates that put `error` in the trace at a multiplicity that cancels to zero at
@@ -61,11 +64,17 @@ fn error_scan(
 ///
 /// The two updates sit at different times so that they survive consolidation: a key whose
 /// updates consolidate away is not in the trace at all, and the walk never sees it.
-fn cancelling(error: &DataflowErrorSer) -> Vec<((DataflowErrorSer, ()), Timestamp, Diff)> {
+pub(crate) fn cancelling(error: &DataflowErrorSer) -> ErrorUpdates {
     vec![
         ((error.clone(), ()), Timestamp::new(0), Diff::ONE),
         ((error.clone(), ()), PEEK_TIMESTAMP, Diff::MINUS_ONE),
     ]
+}
+
+/// Updates that put `error` in the trace at a multiplicity of one at [`PEEK_TIMESTAMP`], so
+/// that a walk reaching this key answers the peek with it.
+pub(crate) fn holding(error: &DataflowErrorSer) -> ErrorUpdates {
+    vec![((error.clone(), ()), Timestamp::new(0), Diff::ONE)]
 }
 
 /// Runs `scan` to an answer in slices of `fuel_per_step` units, and returns that answer, the

--- a/src/compute/src/compute_state/index_peek_tests.rs
+++ b/src/compute/src/compute_state/index_peek_tests.rs
@@ -1,0 +1,370 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Tests of the inline index-peek driver, and the fixtures a peek scan is tested over.
+
+use differential_dataflow::operators::arrange::TraceAgent;
+use differential_dataflow::trace::{Batcher, Builder, Trace};
+use mz_expr::RowSetFinishing;
+use mz_ore::cast::CastFrom;
+use mz_repr::{Datum, Diff, RelationDesc};
+use mz_row_spine::{RowRowBatcher, RowRowBuilder, RowRowSpine};
+use mz_timely_util::columnation::ColumnationStack;
+use timely::container::PushInto;
+use timely::dataflow::operators::generic::OperatorInfo;
+
+use crate::typedefs::{ErrAgent, ErrSpine, RowRowAgent};
+
+use super::error_scan::tests::{
+    ErrorUpdates, PEEK_TIMESTAMP, cancelling, error, error_batch, holding,
+};
+use super::*;
+
+/// The collection the peeks in these tests read.
+pub(crate) const TARGET_ID: GlobalId = GlobalId::User(1);
+
+/// A trace agent over a trace holding exactly `batch`.
+///
+/// The writer is dropped here, which seals the trace to the empty frontier. That is what lets
+/// `TraceReader::cursor` hand out a cursor covering every batch, which is the only way a peek
+/// reads a trace.
+fn agent<Tr>(batch: Tr::Batch) -> TraceAgent<Tr>
+where
+    Tr: Trace<Time = Timestamp> + 'static,
+{
+    let info = OperatorInfo::new(0, 0, [].into());
+    let (agent, mut writer) = TraceAgent::new(Tr::new(info.clone(), None, None), info, None);
+    writer.insert(batch, Some(Timestamp::MIN));
+    agent
+}
+
+/// A row holding `value` as its only datum, as the ok trace's keys hold it.
+pub(crate) fn ok_row(value: u8) -> Row {
+    Row::pack_slice(&[Datum::UInt8(value)])
+}
+
+/// A finishing that asks for every row, in the order the walk produced them.
+pub(crate) fn trivial_finishing() -> RowSetFinishing {
+    RowSetFinishing::trivial(1)
+}
+
+/// The ok trace of an index holding one update per key in `keys`, all at [`Timestamp::MIN`] so
+/// that every one of them is visible at [`PEEK_TIMESTAMP`]. The values are empty.
+fn oks_trace(keys: &[Row]) -> RowRowAgent<Timestamp, Diff> {
+    let mut chunk = ColumnationStack::with_capacity(keys.len());
+    for key in keys {
+        chunk.push_into(((key.clone(), Row::default()), Timestamp::MIN, Diff::ONE));
+    }
+    let mut batcher = RowRowBatcher::<Timestamp, Diff>::new(None, 0);
+    batcher.push_into(chunk);
+    let (mut chain, description) = batcher.seal(Antichain::from_elem(Timestamp::MAX));
+    let batch = RowRowBuilder::<Timestamp, Diff>::seal(&mut chain, description);
+    agent::<RowRowSpine<Timestamp, Diff>>(batch)
+}
+
+/// The error trace of an index holding `updates`.
+fn errs_trace(updates: ErrorUpdates) -> ErrAgent<Timestamp, Diff> {
+    agent::<ErrSpine<Timestamp, Diff>>(error_batch(updates))
+}
+
+/// The traces of an index whose ok side holds `keys` and whose error side holds `errors`.
+pub(crate) fn trace_bundle(keys: &[Row], errors: ErrorUpdates) -> TraceBundle {
+    TraceBundle::new(oks_trace(keys), errs_trace(errors))
+}
+
+/// Errors that a walk over them examines one by one and finds none of, because each cancels to
+/// zero at [`PEEK_TIMESTAMP`].
+pub(crate) fn cancelling_errors(count: usize) -> ErrorUpdates {
+    let errors: Vec<_> = (0..count).map(error).collect();
+    errors.iter().flat_map(cancelling).collect()
+}
+
+/// `count` errors that cancel to zero at [`PEEK_TIMESTAMP`] plus one that does not, and the
+/// answer a walk that reaches the latter gives.
+///
+/// The serialized order of an error does not follow its index, so the errors are sorted and
+/// the answering one taken from the end. A walk that visits keys in order therefore reaches it
+/// last, having examined all `count` of the others.
+pub(crate) fn answering_errors(count: usize) -> (ErrorUpdates, PeekError) {
+    let mut errors: Vec<_> = (0..count + 1).map(error).collect();
+    errors.sort();
+    let (answering, cancelled) = errors.split_last().expect("non-empty");
+    let mut updates: ErrorUpdates = cancelled.iter().flat_map(cancelling).collect();
+    updates.extend(holding(answering));
+    (updates, PeekError::from(answering.deserialize()))
+}
+
+/// A peek of [`TARGET_ID`] at [`PEEK_TIMESTAMP`].
+///
+/// The projection drops every column but the first, so a peek with a literal constraint and
+/// one without return rows of the same shape: the cursor's key is one datum, the values are
+/// empty, and a literal constraint contributes a second datum that a join in a dataflow would
+/// have added.
+pub(crate) fn index_peek(
+    finishing: RowSetFinishing,
+    literal_constraints: Option<Vec<Row>>,
+) -> Peek {
+    let arity = if literal_constraints.is_some() { 2 } else { 1 };
+    let map_filter_project = mz_expr::MapFilterProject::new(arity)
+        .project([0])
+        .into_plan()
+        .expect("valid plan")
+        .into_nontemporal()
+        .expect("non-temporal plan");
+    Peek {
+        target: PeekTarget::Index { id: TARGET_ID },
+        result_desc: RelationDesc::empty(),
+        literal_constraints,
+        uuid: Uuid::nil(),
+        timestamp: PEEK_TIMESTAMP,
+        finishing,
+        map_filter_project,
+        otel_ctx: OpenTelemetryContext::empty(),
+    }
+}
+
+/// The histograms an index peek observes into, owned by the test that reads them back.
+struct TestMetrics {
+    seek_fulfillment_seconds: prometheus::Histogram,
+    frontier_check_seconds: prometheus::Histogram,
+    error_scan_seconds: prometheus::Histogram,
+    cursor_setup_seconds: prometheus::Histogram,
+    row_iteration_seconds: prometheus::Histogram,
+    row_iteration_rows: prometheus::Histogram,
+    result_sort_seconds: prometheus::Histogram,
+    result_sort_rows: prometheus::Histogram,
+    row_collection_seconds: prometheus::Histogram,
+}
+
+fn histogram(name: &str) -> prometheus::Histogram {
+    prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(name, name))
+        .expect("valid histogram")
+}
+
+impl TestMetrics {
+    fn new() -> Self {
+        Self {
+            seek_fulfillment_seconds: histogram("seek_fulfillment_seconds"),
+            frontier_check_seconds: histogram("frontier_check_seconds"),
+            error_scan_seconds: histogram("error_scan_seconds"),
+            cursor_setup_seconds: histogram("cursor_setup_seconds"),
+            row_iteration_seconds: histogram("row_iteration_seconds"),
+            row_iteration_rows: histogram("row_iteration_rows"),
+            result_sort_seconds: histogram("result_sort_seconds"),
+            result_sort_rows: histogram("result_sort_rows"),
+            row_collection_seconds: histogram("row_collection_seconds"),
+        }
+    }
+
+    fn as_metrics(&self) -> IndexPeekMetrics<'_> {
+        IndexPeekMetrics {
+            seek_fulfillment_seconds: &self.seek_fulfillment_seconds,
+            frontier_check_seconds: &self.frontier_check_seconds,
+            error_scan_seconds: &self.error_scan_seconds,
+            cursor_setup_seconds: &self.cursor_setup_seconds,
+            row_iteration_seconds: &self.row_iteration_seconds,
+            row_iteration_rows: &self.row_iteration_rows,
+            result_sort_seconds: &self.result_sort_seconds,
+            result_sort_rows: &self.result_sort_rows,
+            row_collection_seconds: &self.row_collection_seconds,
+        }
+    }
+
+    /// How often each histogram that `collect_finished_data` can observe into was observed.
+    ///
+    /// The two histograms the enclosing `seek_fulfillment` owns are left out, because the
+    /// tests that read this call `collect_finished_data` directly.
+    fn observations(&self) -> BTreeMap<&'static str, u64> {
+        BTreeMap::from([
+            (
+                "error_scan_seconds",
+                self.error_scan_seconds.get_sample_count(),
+            ),
+            (
+                "cursor_setup_seconds",
+                self.cursor_setup_seconds.get_sample_count(),
+            ),
+            (
+                "row_iteration_seconds",
+                self.row_iteration_seconds.get_sample_count(),
+            ),
+            (
+                "row_iteration_rows",
+                self.row_iteration_rows.get_sample_count(),
+            ),
+            (
+                "result_sort_seconds",
+                self.result_sort_seconds.get_sample_count(),
+            ),
+            ("result_sort_rows", self.result_sort_rows.get_sample_count()),
+            (
+                "row_collection_seconds",
+                self.row_collection_seconds.get_sample_count(),
+            ),
+        ])
+    }
+}
+
+/// The observation counts a driver call is expected to leave behind, named so that a failure
+/// says which histogram moved.
+fn expected_observations(
+    error_scan: u64,
+    cursor_setup: u64,
+    rows: u64,
+) -> BTreeMap<&'static str, u64> {
+    BTreeMap::from([
+        ("error_scan_seconds", error_scan),
+        ("cursor_setup_seconds", cursor_setup),
+        ("row_iteration_seconds", rows),
+        ("row_iteration_rows", rows),
+        ("result_sort_seconds", rows),
+        ("result_sort_rows", rows),
+        ("row_collection_seconds", rows),
+    ])
+}
+
+/// What a driver call answered with, in a form a test can compare whole.
+///
+/// Mirrors [`PeekStatus`], which carries no comparison of its own because nothing on the peek
+/// path compares one.
+#[derive(Debug, PartialEq)]
+enum Answer {
+    NotReady,
+    UsePeekStash,
+    Ready(PeekResponse),
+}
+
+impl From<PeekStatus> for Answer {
+    fn from(status: PeekStatus) -> Self {
+        match status {
+            PeekStatus::NotReady => Answer::NotReady,
+            PeekStatus::UsePeekStash => Answer::UsePeekStash,
+            PeekStatus::Ready(response) => Answer::Ready(response),
+        }
+    }
+}
+
+/// An index peek of `peek` over an index holding `keys` and `errors`.
+fn index_peek_over(peek: Peek, keys: &[Row], errors: ErrorUpdates) -> IndexPeek {
+    IndexPeek {
+        peek,
+        trace_bundle: trace_bundle(keys, errors),
+        span: tracing::Span::none(),
+    }
+}
+
+/// The rows a completed peek over `values` answers with.
+fn row_collection(values: impl IntoIterator<Item = u8>) -> RowCollection {
+    let rows = values
+        .into_iter()
+        .map(|value| (ok_row(value), NonZeroUsize::new(1).expect("non-zero")))
+        .collect();
+    RowCollection::new(rows, &[])
+}
+
+/// A peek whose scan runs to completion is answered with the rows it accumulated, and reports
+/// every phase the walk passed through.
+#[mz_ore::test]
+fn a_completed_scan_answers_with_rows_and_reports_every_phase() {
+    let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    let mut subject = index_peek_over(
+        index_peek(trivial_finishing(), None),
+        &keys,
+        cancelling_errors(4),
+    );
+    let metrics = TestMetrics::new();
+
+    let answer =
+        subject.collect_finished_data(u64::MAX, false, usize::MAX, None, &metrics.as_metrics());
+
+    assert_eq!(
+        Answer::from(answer),
+        Answer::Ready(PeekResponse::Rows(vec![row_collection(0..6)]))
+    );
+    assert_eq!(metrics.observations(), expected_observations(1, 1, 1));
+}
+
+/// A peek its error trace answers reports no phase timer at all, because it reached none of
+/// the phases they measure: the error walk stopped short of the trace's end, and the ok walk
+/// never ran.
+#[mz_ore::test]
+fn an_error_answered_peek_reports_no_phase_timers() {
+    let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    let (errors, expected) = answering_errors(3);
+
+    let mut subject = index_peek_over(index_peek(trivial_finishing(), None), &keys, errors);
+    let metrics = TestMetrics::new();
+
+    let answer =
+        subject.collect_finished_data(u64::MAX, false, usize::MAX, None, &metrics.as_metrics());
+
+    assert_eq!(
+        Answer::from(answer),
+        Answer::Ready(PeekResponse::Error(expected))
+    );
+    assert_eq!(metrics.observations(), expected_observations(0, 0, 0));
+}
+
+/// A peek whose accumulated rows fill a batch is diverted to the stash rather than answered
+/// inline. The phases the walk did pass through are reported, and those only a peek answered
+/// inline reaches are not.
+#[mz_ore::test]
+fn a_scan_that_fills_a_batch_diverts_the_peek_to_the_stash() {
+    let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    let mut subject = index_peek_over(
+        index_peek(trivial_finishing(), None),
+        &keys,
+        cancelling_errors(4),
+    );
+    let metrics = TestMetrics::new();
+
+    // A threshold of zero bytes is crossed by the first row, so the scan fills a batch well
+    // before the trace runs out.
+    let answer = subject.collect_finished_data(u64::MAX, true, 0, None, &metrics.as_metrics());
+
+    assert_eq!(Answer::from(answer), Answer::UsePeekStash);
+    assert_eq!(metrics.observations(), expected_observations(1, 1, 0));
+}
+
+/// A peek its ok walk fails is answered with that error, and reports the phases that walk
+/// reached: the error scan and the cursor setup, both of which precede it, and none of the
+/// histograms an inline answer observes into.
+///
+/// The sqllogictest sweeps compare answers, so they say nothing about which histogram a
+/// failing peek moved. This is what says that the two timers a clean error walk earns are
+/// observed on the way to the failure rather than after it.
+#[mz_ore::test]
+fn an_ok_phase_failure_reports_the_phases_the_walk_reached() {
+    let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    let mut subject = index_peek_over(
+        index_peek(trivial_finishing(), None),
+        &keys,
+        cancelling_errors(4),
+    );
+    let metrics = TestMetrics::new();
+
+    // A ceiling of one byte is crossed by the first row the ok walk produces, so the peek
+    // fails inside that walk rather than in the error walk before it.
+    let max_result_size = 1;
+    let answer = subject.collect_finished_data(
+        max_result_size,
+        false,
+        usize::MAX,
+        None,
+        &metrics.as_metrics(),
+    );
+
+    assert_eq!(
+        Answer::from(answer),
+        Answer::Ready(PeekResponse::Error(PeekError::ResultExceedsMaxSize {
+            max_result_size: usize::cast_from(max_result_size),
+        }))
+    );
+    assert_eq!(metrics.observations(), expected_observations(1, 1, 0));
+}

--- a/src/compute/src/compute_state/peek_result_iterator.rs
+++ b/src/compute/src/compute_state/peek_result_iterator.rs
@@ -194,6 +194,29 @@ where
         rows_iterated: usize,
     ) -> Self {
         let (cursor, storage) = trace_reader.cursor();
+        Self::from_cursor(
+            target_id,
+            map_filter_project,
+            peek_timestamp,
+            literal_constraints,
+            cursor,
+            storage,
+            row_iteration_limit,
+            rows_iterated,
+        )
+    }
+
+    /// Builds an iterator over an already-opened cursor.
+    pub(super) fn from_cursor(
+        target_id: GlobalId,
+        map_filter_project: mz_expr::SafeMfpPlan,
+        peek_timestamp: mz_repr::Timestamp,
+        literal_constraints: Option<&mut [Row]>,
+        cursor: TraceCursor<Tr>,
+        storage: TraceStorage<Tr>,
+        row_iteration_limit: Option<usize>,
+        rows_iterated: usize,
+    ) -> Self {
         let literals = literal_constraints.map(Literals::new);
 
         Self {
@@ -214,6 +237,18 @@ where
     /// Returns the number of rows evaluated by the iterator.
     pub fn rows_processed(&self) -> usize {
         self.rows_processed
+    }
+
+    /// Adopts the row-iteration limit that is in effect, without forgetting the rows the walk has
+    /// already examined.
+    pub(super) fn set_row_iteration_limit(&mut self, limit: Option<usize>) {
+        self.row_iteration_tracker.set_limit(limit);
+    }
+
+    /// Adopts the rows a walk that ran before this one examined, so that the row-iteration limit
+    /// bounds the peek rather than either walk alone.
+    pub(super) fn add_rows_iterated(&mut self, rows_iterated: usize) {
+        self.row_iteration_tracker.add_rows_iterated(rows_iterated);
     }
 
     /// Returns `true` if the iterator has no more literals to process, or if there are no literals at all.

--- a/src/compute/src/compute_state/peek_result_iterator/tests.rs
+++ b/src/compute/src/compute_state/peek_result_iterator/tests.rs
@@ -123,8 +123,8 @@ fn literal_seek_is_fueled_and_resumable() {
 
 /// Builds an iterator over `keys`, constrained to `constraints`.
 ///
-/// Mirrors [`PeekResultIterator::new`], which cannot be used here because it takes a trace
-/// rather than a cursor over one.
+/// Goes through [`PeekResultIterator::from_cursor`], because [`PeekResultIterator::new`]
+/// takes a trace rather than a cursor over one.
 fn iterator(keys: &[Row], constraints: &mut [Row]) -> PeekResultIterator<TestTrace> {
     let (cursor, storage) = trace(keys);
     // The cursor's key and the literal each contribute one datum. The values are empty.
@@ -133,19 +133,16 @@ fn iterator(keys: &[Row], constraints: &mut [Row]) -> PeekResultIterator<TestTra
         .expect("valid plan")
         .into_nontemporal()
         .expect("non-temporal plan");
-    PeekResultIterator {
-        target_id: GlobalId::User(1),
+    PeekResultIterator::from_cursor(
+        GlobalId::User(1),
+        map_filter_project,
+        Timestamp::MIN,
+        Some(constraints),
         cursor,
         storage,
-        map_filter_project,
-        peek_timestamp: Timestamp::MIN,
-        row_builder: Row::default(),
-        datum_vec: DatumVec::new(),
-        literals: Some(Literals::new(constraints)),
-        rows_processed: 0,
-        row_iteration_tracker: PeekRowIterationTracker::new(None, 0),
-        exhausted: false,
-    }
+        None,
+        0,
+    )
 }
 
 /// Builds an iterator over `keys` with no literal constraints, filtered by `predicate`.
@@ -164,19 +161,16 @@ fn iterator_without_literals(
         .expect("valid plan")
         .into_nontemporal()
         .expect("non-temporal plan");
-    PeekResultIterator {
-        target_id: GlobalId::User(1),
+    PeekResultIterator::from_cursor(
+        GlobalId::User(1),
+        map_filter_project,
+        Timestamp::MIN,
+        None,
         cursor,
         storage,
-        map_filter_project,
-        peek_timestamp: Timestamp::MIN,
-        row_builder: Row::default(),
-        datum_vec: DatumVec::new(),
-        literals: None,
-        rows_processed: 0,
-        row_iteration_tracker: PeekRowIterationTracker::new(None, 0),
-        exhausted: false,
-    }
+        None,
+        0,
+    )
 }
 
 /// Fuel must be spent walking the rows a `map_filter_project` rejects, not only the rows it

--- a/src/compute/src/compute_state/peek_scan.rs
+++ b/src/compute/src/compute_state/peek_scan.rs
@@ -1,0 +1,447 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! An index peek's walk over the two traces that answer it, as one suspendable object.
+//!
+//! A [`PeekScan`] owns both cursors, the rows it has accumulated, and the accounting that bounds
+//! them, and it spends a single budget across both phases. It performs no IO and never awaits, so
+//! the same scan runs wherever its driver puts it, and a driver that stops it between two cursor
+//! positions picks it up again without repeating work.
+
+use std::mem;
+use std::num::{NonZeroI64, NonZeroUsize};
+use std::time::{Duration, Instant};
+
+use differential_dataflow::trace::cursor::BatchCursor;
+use differential_dataflow::trace::implementations::BatchContainer;
+use differential_dataflow::trace::{Cursor, Navigable, TraceReader};
+use mz_compute_client::protocol::command::Peek;
+use mz_compute_client::protocol::response::PeekError;
+use mz_expr::RowComparator;
+use mz_ore::cast::CastFrom;
+use mz_ore::soft_panic_or_log;
+use mz_repr::fixed_length::ExtendDatums;
+use mz_repr::{Diff, GlobalId, Row, Timestamp};
+use timely::order::PartialOrder;
+
+use crate::compute_state::error_scan::{ErrorScan, ErrorScanStep, ErrsHandle};
+use crate::compute_state::peek_result_iterator::{PeekResultIterator, Step};
+
+/// Rows a scan hands to its driver, in the order the scan produced them.
+///
+/// The form [`PeekResultIterator`] yields and the form the peek stash carries, so the path that
+/// moves large volumes never converts.
+pub(super) type RowBatch = Vec<(Row, NonZeroI64)>;
+
+/// The byte size of a row's count, as an answer built from a [`RowBatch`] stores it.
+const COUNT_BYTE_SIZE: usize = size_of::<NonZeroUsize>();
+
+/// The byte size of a row's offset into the answer's packed row data.
+const OFFSET_BYTE_SIZE: usize = size_of::<usize>();
+
+/// The bytes one `(row, count)` entry contributes to the answer it ends up in.
+///
+/// This is `RowCollection::byte_len` per entry, the ruler `max_result_size` is applied with
+/// wherever a result is measured against it: the row's packed data, its offset into that data,
+/// and its count. The `Row` struct's own bytes are not part of it, because no answer carries them,
+/// and charging them measures a narrow row at up to twice what the client receives.
+pub(super) fn entry_byte_len(row: &Row) -> usize {
+    row.data_len()
+        .saturating_add(OFFSET_BYTE_SIZE)
+        .saturating_add(COUNT_BYTE_SIZE)
+}
+
+/// The outcome of a fueled [`PeekScan::step`].
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum ScanOutcome {
+    /// Stopped with work left, because the budget ran out or because the accumulated rows have
+    /// grown into a full batch.
+    ///
+    /// The scan retains what it accumulated. A driver that can write rows collects them through
+    /// [`PeekScan::take_batch`], and one that cannot is never handed rows it would have to drop.
+    ///
+    /// A scan holding a full batch makes no progress when stepped, so a driver that declines a
+    /// batch has to ask [`PeekScan::batch_ready`] before it steps again or it spins forever.
+    Suspended,
+    /// The walk is over. `Ok` carries the rows accumulated since the last batch was taken, which
+    /// together with the batches already taken are the peek's answer. `Err` is the peek's answer
+    /// instead, and the scan has dropped the rows it had accumulated, since they are part of no
+    /// answer.
+    Finished(Result<RowBatch, PeekError>),
+}
+
+/// The state of a [`PeekScan`]'s walk over its error trace.
+///
+/// Both ended states drop the walk, so a peek pins error batches only while it reads them.
+enum ErrorPhase {
+    /// The walk is under way, and resumes from the cursor position it stopped on.
+    Scanning(ErrorScan),
+    /// The error trace holds no error at the peek's timestamp, which is the only way to the ok
+    /// trace. The rows the walk examined have been handed to the ok walk.
+    Clean,
+    /// The error trace answered the peek. The answer is the scan's latched outcome.
+    Failed,
+}
+
+/// An index peek's walk over its error trace and its ok trace.
+///
+/// The walk suspends between any two cursor positions. Both phases spend one budget: the ok walk
+/// gets what the error walk leaves.
+///
+/// A stash-eligible scan retains at most `peek_stash_threshold_bytes`, plus the row that crossed
+/// it. A scan that cannot use the stash fills no batch, and `max_result_size` alone bounds its
+/// prefix.
+pub(super) struct PeekScan<Tr>
+where
+    Tr: TraceReader<Batch: Navigable>,
+{
+    /// The time at which the error trace is read.
+    peek_timestamp: Timestamp,
+    /// The collection the peek reads, for logging.
+    target_id: GlobalId,
+    error_phase: ErrorPhase,
+    /// The walk over the ok trace, reached only once the error walk reports the error trace
+    /// clean. Its cursor is opened with the scan, and nothing advances it before then.
+    oks: PeekResultIterator<Tr>,
+    /// The outcome the scan ended with, or `None` while it can still be stepped. The `Ok` carries
+    /// no rows: those left with the [`ScanOutcome::Finished`] that reported the end.
+    ended: Option<ScanOutcome>,
+    /// Rows accumulated since the last batch was taken.
+    results: RowBatch,
+    /// The byte size of `results`, as an answer built from them would store them.
+    total_size: usize,
+    /// The ceiling on what the scan may hold, above which the peek fails.
+    max_result_size: usize,
+    /// Whether this peek may divert its rows to the peek stash.
+    peek_stash_eligible: bool,
+    peek_stash_threshold_bytes: usize,
+    /// A bound on the rows the peek's finishing needs, `limit + offset`.
+    ///
+    /// Further limiting happens when the results are collected, so the scan does not have to hold
+    /// exactly this many rows, just at least those that would have been returned.
+    max_results: Option<usize>,
+    /// Orders the rows that thinning keeps. `None` when the finishing imposes no ordering, in
+    /// which case thinning keeps any `max_results` of them.
+    comparator: Option<RowComparator>,
+    /// Worker time the error walk spent, summed over the slices it was cut into.
+    pub(super) error_scan_time: Duration,
+    /// Worker time spent opening the ok cursor.
+    pub(super) cursor_setup_time: Duration,
+    /// Worker time the ok walk spent, summed over the slices it was cut into. Includes the time
+    /// thinning spent sorting.
+    pub(super) row_iteration_time: Duration,
+    /// Worker time thinning spent sorting, summed over the times it ran.
+    pub(super) result_sort_time: Duration,
+    /// Rows handed to a sort, summed over the times thinning ran.
+    pub(super) rows_sorted: usize,
+}
+
+impl<Tr> PeekScan<Tr>
+where
+    Tr: TraceReader<Batch: Navigable>,
+    for<'a> BatchCursor<Tr>: Cursor<
+            Key<'a>: ExtendDatums + Eq,
+            KeyContainer: BatchContainer<Owned = Row>,
+            Val<'a>: ExtendDatums,
+            TimeGat<'a>: PartialOrder<Timestamp>,
+            DiffGat<'a> = &'a Diff,
+        >,
+{
+    /// Opens a scan of `peek` over the traces that answer it.
+    ///
+    /// Both cursors are opened here, so that the scan holds everything it reads and needs neither
+    /// trace handle again. The walks start without a row-iteration limit. The limit in effect is
+    /// the caller's to supply to each [`PeekScan::step`].
+    pub(super) fn new(
+        peek: &Peek,
+        errs_handle: &mut ErrsHandle,
+        oks_handle: &mut Tr,
+        max_result_size: u64,
+        peek_stash_eligible: bool,
+        peek_stash_threshold_bytes: usize,
+    ) -> Self {
+        let error_scan = ErrorScan::new(errs_handle);
+        let error_scan_time = error_scan.scan_time;
+
+        let cursor_setup_start = Instant::now();
+        // The literal constraints are cloned rather than moved out of the peek, which outlives
+        // this scan.
+        let oks = PeekResultIterator::new(
+            peek.target.id(),
+            peek.map_filter_project.clone(),
+            peek.timestamp,
+            peek.literal_constraints.clone().as_deref_mut(),
+            oks_handle,
+            None,
+            0,
+        );
+        let cursor_setup_time = cursor_setup_start.elapsed();
+
+        let comparator = (!peek.finishing.order_by.is_empty())
+            .then(|| RowComparator::new(peek.finishing.order_by.clone()));
+
+        Self {
+            peek_timestamp: peek.timestamp,
+            target_id: peek.target.id(),
+            error_phase: ErrorPhase::Scanning(error_scan),
+            oks,
+            ended: None,
+            results: Vec::new(),
+            total_size: 0,
+            max_result_size: usize::cast_from(max_result_size),
+            peek_stash_eligible,
+            peek_stash_threshold_bytes,
+            max_results: peek.finishing.num_rows_needed(),
+            comparator,
+            error_scan_time,
+            cursor_setup_time,
+            row_iteration_time: Duration::ZERO,
+            result_sort_time: Duration::ZERO,
+            rows_sorted: 0,
+        }
+    }
+
+    /// Advances the scan until it has an answer for the peek, the accumulated rows make a full
+    /// batch, or `fuel` runs out, whichever comes first. Decrements `fuel` by the number of cursor
+    /// positions visited, in either phase.
+    ///
+    /// `row_iteration_limit` is the limit in effect now rather than at the scan's start, and the
+    /// count it bounds spans both phases.
+    ///
+    /// [`ScanOutcome::Suspended`] is not an end of scan: stepping again resumes where this call
+    /// stopped. [`ScanOutcome::Finished`] is, and stepping past one is a defect in the driver.
+    pub(super) fn step(
+        &mut self,
+        row_iteration_limit: Option<usize>,
+        fuel: &mut usize,
+    ) -> ScanOutcome {
+        // The repeat is not the answer this scan gave: the rows left with the first `Finished`.
+        // Reporting it rather than panicking keeps a driver that loses track of its scan from
+        // taking the replica with it.
+        if let Some(ended) = &self.ended {
+            soft_panic_or_log!("index peek scan stepped after it ended");
+            return ended.clone();
+        }
+
+        let outcome = match self.step_error_phase(row_iteration_limit, fuel) {
+            Some(outcome) => outcome,
+            None => self.step_ok_phase(row_iteration_limit, fuel),
+        };
+
+        // Latched here rather than in the arms of either walk, so every way the scan can end
+        // passes one place.
+        match &outcome {
+            ScanOutcome::Suspended => {}
+            ScanOutcome::Finished(Ok(_)) => {
+                self.ended = Some(ScanOutcome::Finished(Ok(RowBatch::new())));
+            }
+            ScanOutcome::Finished(Err(error)) => {
+                self.ended = Some(ScanOutcome::Finished(Err(error.clone())));
+            }
+        }
+
+        outcome
+    }
+
+    /// Takes the accumulated rows once they have crossed the stash threshold.
+    ///
+    /// Returns `None` while they have not, and for a peek that cannot use the stash at all, so a
+    /// driver with nowhere to write rows is never handed any.
+    pub(super) fn take_batch(&mut self) -> Option<RowBatch> {
+        if !self.batch_ready() {
+            return None;
+        }
+        Some(self.take_results())
+    }
+
+    /// The number of cursor positions the ok walk has evaluated.
+    pub(super) fn rows_processed(&self) -> usize {
+        self.oks.rows_processed()
+    }
+
+    /// Whether the walk over the error trace has ended without finding an error, which is the only
+    /// way the ok walk runs at all.
+    ///
+    /// False while that walk is under way, and false once it has answered the peek.
+    pub(super) fn error_trace_clean(&self) -> bool {
+        matches!(self.error_phase, ErrorPhase::Clean)
+    }
+
+    /// Whether the accumulated rows have grown past what this peek may answer with inline, which
+    /// is when [`PeekScan::take_batch`] hands them over.
+    ///
+    /// This is how a driver tells a [`ScanOutcome::Suspended`] it can resume from one it cannot:
+    /// a scan holding a full batch stays where it stands until the batch is taken.
+    pub(super) fn batch_ready(&self) -> bool {
+        self.peek_stash_eligible && self.total_size > self.peek_stash_threshold_bytes
+    }
+
+    /// Takes the accumulated rows and the size accounted to them.
+    ///
+    /// Every path that hands rows out goes through here, so `total_size` stays an account of
+    /// `results`.
+    fn take_results(&mut self) -> RowBatch {
+        self.total_size = 0;
+        mem::take(&mut self.results)
+    }
+
+    /// Fails the peek with `error`, dropping the rows the scan had accumulated, so that
+    /// [`PeekScan::take_batch`] never hands a driver the prefix of an answer that will not be
+    /// given.
+    fn fail(&mut self, error: PeekError) -> ScanOutcome {
+        let _dropped = self.take_results();
+        ScanOutcome::Finished(Err(error))
+    }
+
+    /// Advances the walk over the error trace.
+    ///
+    /// Returns `None` once the error trace is known to hold no error at the peek's timestamp,
+    /// which is the only way to the ok trace.
+    fn step_error_phase(
+        &mut self,
+        row_iteration_limit: Option<usize>,
+        fuel: &mut usize,
+    ) -> Option<ScanOutcome> {
+        let scan = match &mut self.error_phase {
+            ErrorPhase::Scanning(scan) => scan,
+            // `step` reports an ended scan before it reaches here, so a failed phase is never
+            // seen here.
+            ErrorPhase::Clean | ErrorPhase::Failed => return None,
+        };
+
+        // The limit bounds the peek, not the call, so a walk already under way adopts the limit
+        // that is in effect now rather than the one that was in effect when it started.
+        scan.set_row_iteration_limit(row_iteration_limit);
+        let outcome = scan.step(self.peek_timestamp, self.target_id, fuel);
+        self.error_scan_time = scan.scan_time;
+
+        match outcome {
+            ErrorScanStep::Finished(Ok(rows_iterated)) => {
+                // The rows the error walk examined count against the peek's limit, so the ok walk
+                // continues that count. Runs once per scan, since `Clean` never steps the walk.
+                self.oks.add_rows_iterated(rows_iterated);
+                self.error_phase = ErrorPhase::Clean;
+                None
+            }
+            ErrorScanStep::Finished(Err(error)) => {
+                self.error_phase = ErrorPhase::Failed;
+                Some(self.fail(error))
+            }
+            ErrorScanStep::OutOfFuel => Some(ScanOutcome::Suspended),
+        }
+    }
+
+    /// Advances the walk over the ok trace, accumulating the rows it produces.
+    fn step_ok_phase(
+        &mut self,
+        row_iteration_limit: Option<usize>,
+        fuel: &mut usize,
+    ) -> ScanOutcome {
+        // A scan holding a full batch stays where it is until the batch is taken, so the bound on
+        // what one scan retains is the scan's own rather than a rule each driver keeps. Past the
+        // stash threshold the result-size ceiling no longer bounds that growth either.
+        if self.batch_ready() {
+            return ScanOutcome::Suspended;
+        }
+
+        self.oks.set_row_iteration_limit(row_iteration_limit);
+
+        let row_iteration_start = Instant::now();
+
+        let outcome = loop {
+            let (row, copies) = match self.oks.step(fuel) {
+                Step::Row(Ok(row)) => row,
+                Step::Row(Err(error)) => break self.fail(error),
+                Step::Done => break ScanOutcome::Finished(Ok(self.take_results())),
+                Step::OutOfFuel => break ScanOutcome::Suspended,
+            };
+
+            self.total_size = self.total_size.saturating_add(entry_byte_len(&row));
+            let batch_ready = self.batch_ready();
+
+            // Rows bound for the stash are answered by a handle rather than by themselves, so the
+            // ceiling on an inline answer does not apply to a prefix that has grown past the
+            // stash threshold.
+            if !batch_ready && self.total_size > self.max_result_size {
+                break self.fail(PeekError::ResultExceedsMaxSize {
+                    max_result_size: self.max_result_size,
+                });
+            }
+
+            self.results.push((row, copies));
+
+            // Ahead of thinning, so that a row which both fills a batch and completes a thinned
+            // answer leaves the peek to the stash rather than answering it from the prefix.
+            if batch_ready {
+                break ScanOutcome::Suspended;
+            }
+
+            if let Some(outcome) = self.thin() {
+                break outcome;
+            }
+        };
+
+        self.row_iteration_time += row_iteration_start.elapsed();
+
+        outcome
+    }
+
+    /// Thins the accumulated rows down towards the ones the peek's finishing needs, once the scan
+    /// holds many more than that.
+    ///
+    /// Returns the outcome that ends the scan if thinning has produced every row the finishing
+    /// can use.
+    fn thin(&mut self) -> Option<ScanOutcome> {
+        let max_results = self.max_results?;
+
+        // We use a threshold twice what we intend, to amortize the work across all of the
+        // insertions. We could tighten this, but it works for the moment.
+        //
+        // `max_results` is `limit + offset`, so a `LIMIT` near `i64::MAX` makes the doubling
+        // overflow. We then hold fewer rows than the threshold no matter what, and never thin.
+        // That is the right answer: such a peek cannot accumulate that many rows anyway, the
+        // result size limit stops it long before. Wrapping instead would make the threshold tiny,
+        // and we would thin while holding almost nothing, dropping rows past the end of the
+        // buffer.
+        let thin = max_results
+            .checked_mul(2)
+            .is_some_and(|threshold| self.results.len() >= threshold);
+        if !thin {
+            return None;
+        }
+
+        let Some(comparator) = &self.comparator else {
+            // Without an ordering, any `max_results` rows answer the peek, so the rows in hand are
+            // an answer and the rest of the trace does not have to be walked.
+            self.results.truncate(max_results);
+            return Some(ScanOutcome::Finished(Ok(self.take_results())));
+        };
+
+        // We can sort `results` and then truncate to `max_results`. This has an effect similar to
+        // a priority queue, without its interactive dequeueing properties.
+        // TODO: Had we left these as `Vec<Datum>` we would avoid the unpacking; we should consider
+        // doing that, although it will require a re-pivot of the code to branch on this inner test
+        // (as we prefer not to maintain `Vec<Datum>` in the other case).
+        let sort_start = Instant::now();
+        self.rows_sorted = self.rows_sorted.saturating_add(self.results.len());
+        self.results.sort_by(|left, right| {
+            comparator.compare_rows(&left.0, &right.0, || left.0.cmp(&right.0))
+        });
+        self.result_sort_time += sort_start.elapsed();
+
+        let dropped = self.results.drain(max_results..);
+        let dropped_size = dropped
+            .into_iter()
+            .fold(0, |acc: usize, (row, _count): (Row, _)| {
+                acc.saturating_add(entry_byte_len(&row))
+            });
+        self.total_size = self.total_size.saturating_sub(dropped_size);
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/compute/src/compute_state/peek_scan/tests.rs
+++ b/src/compute/src/compute_state/peek_scan/tests.rs
@@ -1,0 +1,808 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Tests of the budgeted scan that answers an index peek.
+
+use differential_dataflow::trace::cursor::CursorList;
+use differential_dataflow::trace::implementations::ord_neu::OrdValBatcher;
+use differential_dataflow::trace::{Batcher, Builder, Navigable};
+use mz_expr::row::RowCollection;
+use mz_expr::{ColumnOrder, RowSetFinishing};
+use mz_ore::num::NonNeg;
+use mz_repr::Datum;
+use mz_row_spine::{ArcOrdValBuilder, ArcOrdValSpine};
+use timely::container::PushInto;
+use timely::progress::Antichain;
+
+use crate::arrangement::manager::{PaddedTrace, TraceBundle};
+use crate::compute_state::error_scan::tests::PEEK_TIMESTAMP;
+use crate::compute_state::index_peek_tests::{
+    answering_errors, cancelling_errors, index_peek, ok_row as row, trace_bundle, trivial_finishing,
+};
+use crate::typedefs::RowRowAgent;
+
+use super::*;
+
+type TestTrace = ArcOrdValSpine<Row, Row, Timestamp, Diff>;
+
+/// The ok-trace handle a peek reads through, as [`TraceBundle::oks_errs_mut`] hands it out.
+type OksHandle = PaddedTrace<RowRowAgent<Timestamp, Diff>>;
+
+/// How many times a test resumes a suspended scan before it declares the scan stuck.
+///
+/// Far above what any trace in this module needs, so a scan that resumes where it stopped
+/// finishes well inside it, and one that restarts a walk on every resumption fails the test
+/// rather than hanging it.
+const RESUMPTION_BOUND: usize = 100;
+
+/// The rows `value` values yield, in the order the ok walk produces them.
+fn rows(values: impl IntoIterator<Item = u8>) -> Vec<Row> {
+    values.into_iter().map(row).collect()
+}
+
+/// The size the scan accounts one row of these fixtures at, taken as the widest of them.
+///
+/// `Datum::UInt8` packs into the fewest bytes that hold its value, so `Datum::UInt8(0)` is a
+/// byte narrower than every other value these fixtures use. Sizing by the widest row is what
+/// keeps `count * row_size()` a bound that `count` rows stay under and `count + 1` cross, for
+/// the first batch and for every batch the walk reaches after a prefix reset alike.
+fn row_size() -> usize {
+    entry_byte_len(&row(1))
+}
+
+/// The rows and counts a completed scan over `values` hands back.
+fn expected(values: impl IntoIterator<Item = u8>) -> RowBatch {
+    values
+        .into_iter()
+        .map(|value| (row(value), NonZeroI64::new(1).expect("non-zero")))
+        .collect()
+}
+
+/// A walk over an ok trace holding `keys`.
+fn ok_iterator(keys: &[Row]) -> PeekResultIterator<TestTrace> {
+    let updates: Vec<((Row, Row), Timestamp, Diff)> = keys
+        .iter()
+        .map(|key| ((key.clone(), Row::default()), Timestamp::MIN, Diff::ONE))
+        .collect();
+    let mut batcher = OrdValBatcher::<Row, Row, Timestamp, Diff>::new(None, 0);
+    batcher.push_into(updates);
+    let (mut chain, description) = batcher.seal(Antichain::from_elem(Timestamp::MAX));
+    let batch = ArcOrdValBuilder::<Row, Row, Timestamp, Diff>::seal(&mut chain, description);
+    let storage = vec![batch];
+    let cursor = CursorList::new(vec![storage[0].cursor()], &storage);
+    // The cursor's key is the only datum. The values are empty.
+    let map_filter_project = mz_expr::MapFilterProject::new(1)
+        .into_plan()
+        .expect("valid plan")
+        .into_nontemporal()
+        .expect("non-temporal plan");
+    PeekResultIterator::from_cursor(
+        GlobalId::User(1),
+        map_filter_project,
+        Timestamp::MIN,
+        None,
+        cursor,
+        storage,
+        None,
+        0,
+    )
+}
+
+/// A walk over an error trace holding `keys` errors that each cancel to zero at
+/// [`PEEK_TIMESTAMP`], so the walk examines every one of them and finds no error.
+fn clean_error_scan(keys: usize) -> ErrorScan {
+    crate::compute_state::error_scan::tests::error_scan(cancelling_errors(keys), None)
+}
+
+/// A scan over `keys` whose error phase is `error_phase`, bounded by nothing else.
+///
+/// Mirrors what [`PeekScan::new`] builds. Tests use this rather than `new` to hold a second
+/// cursor layout under test, and to start from an [`ErrorPhase`] that a fresh scan cannot be
+/// in.
+fn scan(error_phase: ErrorPhase, keys: &[Row]) -> PeekScan<TestTrace> {
+    PeekScan {
+        peek_timestamp: PEEK_TIMESTAMP,
+        target_id: GlobalId::User(1),
+        error_phase,
+        oks: ok_iterator(keys),
+        ended: None,
+        results: Vec::new(),
+        total_size: 0,
+        max_result_size: usize::MAX,
+        peek_stash_eligible: false,
+        peek_stash_threshold_bytes: usize::MAX,
+        max_results: None,
+        comparator: None,
+        error_scan_time: Duration::ZERO,
+        cursor_setup_time: Duration::ZERO,
+        row_iteration_time: Duration::ZERO,
+        result_sort_time: Duration::ZERO,
+        rows_sorted: 0,
+    }
+}
+
+/// An error the error trace holds answers the peek, and the ok trace stays unread, so a peek
+/// that must report an error can never return rows instead.
+#[mz_ore::test]
+fn an_error_answers_the_peek_without_reading_the_ok_trace() {
+    let (errors, error) = answering_errors(0);
+    let mut subject = scan(
+        ErrorPhase::Scanning(crate::compute_state::error_scan::tests::error_scan(
+            errors, None,
+        )),
+        &rows(0..4),
+    );
+
+    let mut fuel = 100;
+    assert_eq!(
+        subject.step(None, &mut fuel),
+        ScanOutcome::Finished(Err(error))
+    );
+    assert_eq!(subject.rows_processed(), 0);
+}
+
+/// A scan that has answered holds spent cursors, so stepping it again is a defect in the driver
+/// rather than a way to read the answer twice.
+#[mz_ore::test]
+#[should_panic(expected = "index peek scan stepped after it ended")]
+fn stepping_a_scan_that_has_answered_is_a_defect() {
+    let mut subject = scan(ErrorPhase::Clean, &rows(0..4));
+
+    let mut fuel = usize::MAX;
+    let first = subject.step(None, &mut fuel);
+    assert!(
+        matches!(first, ScanOutcome::Finished(Ok(_))),
+        "the scan must answer before the second step: {first:?}"
+    );
+
+    let mut fuel = usize::MAX;
+    let _defect = subject.step(None, &mut fuel);
+}
+
+/// One budget covers both phases: what the error walk leaves is what the ok walk gets, and
+/// slicing the scan neither repeats nor skips a cursor position in either of them. Matching
+/// rows alone would not catch that, since a scan that re-walks positions it has already
+/// visited can still land on the right answer.
+#[mz_ore::test]
+fn one_budget_spans_both_phases() {
+    let keys = rows(0..6);
+    // Every error key cancels, so the error walk visits all of them and then the position
+    // past the last, before the ok walk sees anything.
+    let error_keys = 4;
+
+    let mut subject = scan(ErrorPhase::Scanning(clean_error_scan(error_keys)), &keys);
+    let mut fuel = usize::MAX;
+    let unsliced = subject.step(None, &mut fuel);
+    let unsliced_fuel = usize::MAX - fuel;
+    assert_eq!(unsliced, ScanOutcome::Finished(Ok(expected(0..6))));
+    assert!(
+        unsliced_fuel > error_keys,
+        "the error walk must be charged for the keys it visits"
+    );
+
+    let mut subject = scan(ErrorPhase::Scanning(clean_error_scan(error_keys)), &keys);
+    let mut spent = 0;
+    let mut sliced = None;
+    // Bounded so that a scan which restarts a phase on each resumption fails the test instead
+    // of hanging it.
+    for _ in 0..RESUMPTION_BOUND {
+        let mut fuel = 2;
+        let outcome = subject.step(None, &mut fuel);
+        spent += 2 - fuel;
+        match outcome {
+            ScanOutcome::Suspended => continue,
+            outcome @ ScanOutcome::Finished(_) => {
+                sliced = Some(outcome);
+                break;
+            }
+        }
+    }
+    let sliced = sliced.expect("scan did not finish within 100 resumptions");
+
+    assert_eq!(sliced, unsliced);
+    assert_eq!(
+        spent, unsliced_fuel,
+        "slicing the scan must not repeat or skip cursor positions"
+    );
+}
+
+/// The row-iteration limit bounds the peek rather than either walk, so the ok walk continues
+/// the count the error walk accrued. A limit that the two together exceed fails the peek
+/// part-way through the ok trace.
+#[mz_ore::test]
+fn the_row_iteration_limit_spans_both_phases() {
+    let keys = rows(0..6);
+    let error_keys = 4;
+    // Two rows past what the error walk examines.
+    let limit = error_keys + 2;
+
+    let mut subject = scan(ErrorPhase::Scanning(clean_error_scan(error_keys)), &keys);
+    let mut fuel = usize::MAX;
+    assert_eq!(
+        subject.step(Some(limit), &mut fuel),
+        ScanOutcome::Finished(Err(PeekError::RowIterationLimitExceeded { limit }))
+    );
+    assert_eq!(
+        subject.rows_processed(),
+        2,
+        "the ok walk must start from the count the error walk reached"
+    );
+    assert!(subject.results.is_empty(), "a failed scan keeps no rows");
+
+    // The same scan under a limit that covers both phases returns every row.
+    let mut subject = scan(ErrorPhase::Scanning(clean_error_scan(error_keys)), &keys);
+    let mut fuel = usize::MAX;
+    assert_eq!(
+        subject.step(Some(error_keys + keys.len()), &mut fuel),
+        ScanOutcome::Finished(Ok(expected(0..6)))
+    );
+}
+
+/// A batch is offered only once the accumulated rows have crossed the stash threshold, and
+/// only to a peek that may use the stash. Rows the scan has not offered stay with it, so a
+/// driver that cannot write them is never the one holding them.
+#[mz_ore::test]
+fn take_batch_yields_only_past_the_stash_threshold() {
+    let keys = rows(0..8);
+    let mut subject = scan(ErrorPhase::Clean, &keys);
+    subject.peek_stash_eligible = true;
+    // Crossed by the fourth row, which leaves rows on either side of it.
+    subject.peek_stash_threshold_bytes = 3 * row_size();
+
+    let mut fuel = 2;
+    assert_eq!(subject.step(None, &mut fuel), ScanOutcome::Suspended);
+    assert_eq!(subject.take_batch(), None, "the threshold is not crossed");
+
+    let mut fuel = 2;
+    assert_eq!(subject.step(None, &mut fuel), ScanOutcome::Suspended);
+    assert_eq!(subject.take_batch(), Some(expected(0..4)));
+    assert_eq!(subject.total_size, 0);
+    assert_eq!(subject.take_batch(), None, "the rows have been taken");
+
+    // What the scan accumulates after a batch is taken is the next part of its answer, and it
+    // stops on that batch too rather than walking the trace out.
+    let mut fuel = usize::MAX;
+    assert_eq!(subject.step(None, &mut fuel), ScanOutcome::Suspended);
+    assert_eq!(subject.take_batch(), Some(expected(4..8)));
+
+    let mut fuel = usize::MAX;
+    assert_eq!(
+        subject.step(None, &mut fuel),
+        ScanOutcome::Finished(Ok(RowBatch::new()))
+    );
+}
+
+/// A scan holding a full batch stops where it stands until the batch is taken. Stepping it
+/// again pulls no row and grows no prefix, which is what bounds what one scan retains for a
+/// driver that steps in a loop and takes batches on a schedule of its own.
+#[mz_ore::test]
+fn a_batch_ready_scan_does_not_grow_when_stepped_again() {
+    let keys = rows(0..8);
+    let mut subject = scan(ErrorPhase::Clean, &keys);
+    subject.peek_stash_eligible = true;
+    // Crossed by the third row, which leaves rows behind it in the trace.
+    subject.peek_stash_threshold_bytes = 2 * row_size();
+
+    let mut fuel = usize::MAX;
+    assert_eq!(subject.step(None, &mut fuel), ScanOutcome::Suspended);
+    let retained = subject.results.clone();
+    let total_size = subject.total_size;
+    let rows_processed = subject.rows_processed();
+    assert_eq!(retained, expected(0..3));
+
+    // Four resumptions are enough to expose growth of a row per step, and the bound keeps a
+    // scan that walks its trace out from ending this loop on its own.
+    for _ in 0..4 {
+        let mut fuel = usize::MAX;
+        assert_eq!(
+            subject.step(None, &mut fuel),
+            ScanOutcome::Suspended,
+            "a scan holding a batch has nothing to report but the batch"
+        );
+        assert_eq!(
+            subject.results, retained,
+            "stepping a batch-ready scan must not grow its prefix"
+        );
+        assert_eq!(subject.total_size, total_size);
+        assert_eq!(
+            subject.rows_processed(),
+            rows_processed,
+            "stepping a batch-ready scan must not advance its cursor"
+        );
+        assert_eq!(fuel, usize::MAX, "a scan holding a batch spends no fuel");
+    }
+
+    // Taking the batch is what lets the walk go on.
+    assert_eq!(subject.take_batch(), Some(retained));
+    let mut fuel = usize::MAX;
+    assert_eq!(subject.step(None, &mut fuel), ScanOutcome::Suspended);
+    assert_eq!(subject.results, expected(3..6));
+}
+
+/// Both outcomes that end the ok walk end the scan, and neither of them leaves the cursor at
+/// the end of the trace, so a scan that resumed from one would answer the same peek with a
+/// different row set.
+#[mz_ore::test]
+fn both_outcomes_of_the_ok_walk_end_the_scan() {
+    let keys = rows(0..10);
+
+    // A finishing without an ordering is answered by the rows in hand, which leaves rows a
+    // resumed walk would go on to produce.
+    let mut subject = scan(ErrorPhase::Clean, &keys);
+    subject.max_results = Some(2);
+
+    let mut fuel = usize::MAX;
+    assert_eq!(
+        subject.step(None, &mut fuel),
+        ScanOutcome::Finished(Ok(expected(0..2)))
+    );
+    assert!(subject.ended.is_some(), "the scan must be over");
+
+    // The result-size ceiling fails the peek on the row that crosses it, which is the other
+    // way the walk ends short of the trace's end.
+    let mut subject = scan(ErrorPhase::Clean, &keys);
+    subject.max_result_size = 3 * row_size();
+
+    let mut fuel = usize::MAX;
+    let failure = subject.step(None, &mut fuel);
+    assert!(
+        matches!(failure, ScanOutcome::Finished(Err(_))),
+        "the ceiling must fail the peek: {failure:?}"
+    );
+    assert_eq!(subject.ended, Some(failure));
+}
+
+/// A peek that cannot use the stash is never offered a batch, however large its accumulation
+/// grows.
+#[mz_ore::test]
+fn take_batch_yields_nothing_without_the_stash() {
+    let keys = rows(0..8);
+    let mut subject = scan(ErrorPhase::Clean, &keys);
+    // Every row crosses a zero threshold, so eligibility is the only thing that can keep the
+    // scan from offering a batch.
+    assert!(!subject.peek_stash_eligible);
+    subject.peek_stash_threshold_bytes = 0;
+
+    let mut fuel = usize::MAX;
+    assert_eq!(
+        subject.step(None, &mut fuel),
+        ScanOutcome::Finished(Ok(expected(0..8)))
+    );
+    assert_eq!(subject.take_batch(), None);
+    assert_eq!(
+        subject.total_size, 0,
+        "the size accounted to rows that have left the scan must not stay behind"
+    );
+}
+
+/// A finishing that imposes no ordering is answered by any `max_results` rows, so thinning
+/// truncates and the scan stops rather than walking the rest of the trace.
+#[mz_ore::test]
+fn unordered_thinning_truncates_and_ends_the_scan() {
+    let keys = rows(0..10);
+    let mut subject = scan(ErrorPhase::Clean, &keys);
+    subject.max_results = Some(2);
+
+    let mut fuel = usize::MAX;
+    assert_eq!(
+        subject.step(None, &mut fuel),
+        ScanOutcome::Finished(Ok(expected(0..2)))
+    );
+    assert_eq!(
+        subject.rows_processed(),
+        4,
+        "the scan must stop at the threshold rather than walk the trace out"
+    );
+    assert_eq!(
+        subject.total_size, 0,
+        "the size accounted to rows that have left the scan must not stay behind"
+    );
+}
+
+/// A finishing that imposes an ordering keeps the rows that order ranks first, thinning down
+/// to `max_results` each time it holds twice that many.
+#[mz_ore::test]
+fn ordered_thinning_keeps_the_rows_the_ordering_ranks_first() {
+    let keys = rows(0..10);
+    let mut subject = scan(ErrorPhase::Clean, &keys);
+    subject.max_results = Some(2);
+    subject.comparator = Some(RowComparator::new(vec![ColumnOrder {
+        column: 0,
+        desc: true,
+        nulls_last: true,
+    }]));
+
+    let mut fuel = usize::MAX;
+    assert_eq!(
+        subject.step(None, &mut fuel),
+        ScanOutcome::Finished(Ok(expected([9, 8])))
+    );
+    assert_eq!(
+        subject.rows_processed(),
+        keys.len(),
+        "an ordering can be decided only by walking the whole trace"
+    );
+}
+
+/// Accumulation past the result-size ceiling fails the peek, and the row that crossed it is
+/// not part of what the scan holds.
+#[mz_ore::test]
+fn accumulation_past_the_result_size_ceiling_fails_the_peek() {
+    let keys = rows(0..8);
+    let max_result_size = 3 * row_size();
+    let mut subject = scan(ErrorPhase::Clean, &keys);
+    subject.max_result_size = max_result_size;
+
+    let mut fuel = usize::MAX;
+    assert_eq!(
+        subject.step(None, &mut fuel),
+        ScanOutcome::Finished(Err(PeekError::ResultExceedsMaxSize { max_result_size }))
+    );
+    // The rows it had accumulated are gone: they are the prefix of an answer that will never be
+    // given, and holding them would leave `total_size` accounting for rows the scan no longer
+    // has. The position the ceiling tripped on is where the count says it is: three rows fit,
+    // and the fourth is the one that did not.
+    assert!(subject.results.is_empty());
+    assert_eq!(subject.take_batch(), None);
+    assert_eq!(subject.rows_processed(), 4);
+}
+
+/// The result-size ceiling bounds an inline answer, which rows bound for the stash are not.
+/// A scan whose batches are taken therefore walks the whole trace with a ceiling below what it
+/// produces, rather than failing the peek.
+///
+/// Driven with unbounded fuel, so every suspension is a full batch, and a scan that grew its
+/// prefix past the threshold instead of stopping would fail on the ceiling.
+#[mz_ore::test]
+fn a_prefix_bound_for_the_stash_is_not_bound_by_the_result_size_ceiling() {
+    let keys = rows(0..8);
+    let mut subject = scan(ErrorPhase::Clean, &keys);
+    subject.max_result_size = 3 * row_size();
+    subject.peek_stash_eligible = true;
+    subject.peek_stash_threshold_bytes = 2 * row_size();
+
+    let mut collected = RowBatch::new();
+    let mut completed = false;
+    // Bounded so that a regression which restarts the ok walk on every resumption fails here
+    // rather than spinning.
+    for _ in 0..RESUMPTION_BOUND {
+        let mut fuel = usize::MAX;
+        match subject.step(None, &mut fuel) {
+            ScanOutcome::Suspended => {
+                collected.extend(subject.take_batch().expect("a full batch"));
+            }
+            ScanOutcome::Finished(Ok(rest)) => {
+                collected.extend(rest);
+                completed = true;
+                break;
+            }
+            ScanOutcome::Finished(Err(error)) => panic!("scan failed: {error:?}"),
+        }
+    }
+    assert!(
+        completed,
+        "scan did not answer within {RESUMPTION_BOUND} resumptions"
+    );
+
+    assert_eq!(collected, expected(0..8));
+}
+
+/// Opens a scan of `peek` over `bundle`, the way the peek path opens one: through
+/// [`PeekScan::new`], from the pair of handles [`TraceBundle::oks_errs_mut`] hands out.
+fn open(
+    bundle: &mut TraceBundle,
+    peek: &Peek,
+    max_result_size: u64,
+    peek_stash_eligible: bool,
+    peek_stash_threshold_bytes: usize,
+) -> PeekScan<OksHandle> {
+    let (oks, errs) = bundle.oks_errs_mut();
+    PeekScan::new(
+        peek,
+        errs,
+        oks,
+        max_result_size,
+        peek_stash_eligible,
+        peek_stash_threshold_bytes,
+    )
+}
+
+/// Runs `subject` to an answer in slices of `fuel_per_step` units, taking every batch it
+/// offers, and returns that answer, the batches taken in order, and the fuel spent in total.
+///
+/// A scan that has a batch to give away is emptied before it is stepped again, so the fuel
+/// this reports is comparable across runs that cross the stash threshold and runs that do
+/// not.
+fn run_sliced(
+    subject: &mut PeekScan<OksHandle>,
+    fuel_per_step: usize,
+    row_iteration_limit: Option<usize>,
+) -> (ScanOutcome, RowBatch, usize) {
+    let mut taken = RowBatch::new();
+    let mut spent = 0;
+    for _ in 0..RESUMPTION_BOUND {
+        let mut fuel = fuel_per_step;
+        let outcome = subject.step(row_iteration_limit, &mut fuel);
+        spent += fuel_per_step - fuel;
+        match outcome {
+            ScanOutcome::Suspended => {
+                if let Some(batch) = subject.take_batch() {
+                    taken.extend(batch);
+                }
+            }
+            outcome @ ScanOutcome::Finished(_) => return (outcome, taken, spent),
+        }
+    }
+    panic!("scan did not answer within {RESUMPTION_BOUND} resumptions");
+}
+
+/// Opening a scan opens both cursors and reads through neither: the ok walk has evaluated no
+/// cursor position, and the error walk has not yet reported the error trace clean.
+///
+/// This is what makes the eager open of the ok cursor safe. A scan that read an ok row before
+/// its error walk finished could return rows for a peek that owes an error.
+///
+/// The literal seek is deferred out of construction for the same reason, and that property is
+/// pinned by `peek_result_iterator::tests::literal_seek_is_fueled_and_resumable`, because a
+/// seek moves the cursor without evaluating a position and so is invisible here.
+#[mz_ore::test]
+fn opening_a_scan_advances_neither_cursor() {
+    let keys = rows(0..6);
+    let peek = index_peek(trivial_finishing(), None);
+    let mut bundle = trace_bundle(&keys, cancelling_errors(4));
+
+    let subject = open(&mut bundle, &peek, u64::MAX, false, usize::MAX);
+
+    assert_eq!(
+        subject.rows_processed(),
+        0,
+        "the ok cursor must not advance"
+    );
+    assert!(
+        !subject.error_trace_clean(),
+        "the error trace is clean only once the error walk says so",
+    );
+}
+
+/// An error the error trace holds answers the peek whether the scan runs in one call or is
+/// sliced a cursor position at a time, at the same cost either way, and in neither case does
+/// the scan read a row of the ok trace.
+#[mz_ore::test]
+fn an_error_answers_a_sliced_scan_without_reading_an_ok_row() {
+    let keys = rows(0..6);
+    let cancelling_keys = 7;
+    let (errors, error) = answering_errors(cancelling_keys);
+    let peek = index_peek(trivial_finishing(), None);
+
+    let mut bundle = trace_bundle(&keys, errors.clone());
+    let mut subject = open(&mut bundle, &peek, u64::MAX, false, usize::MAX);
+    let (unsliced, _, unsliced_fuel) = run_sliced(&mut subject, usize::MAX, None);
+    assert_eq!(unsliced, ScanOutcome::Finished(Err(error.clone())));
+    assert_eq!(
+        subject.rows_processed(),
+        0,
+        "a peek its error trace answers must not read an ok row",
+    );
+    assert_eq!(
+        unsliced_fuel,
+        cancelling_keys + 1,
+        "the error walk is charged for every key it visits, the answering one included",
+    );
+
+    let mut bundle = trace_bundle(&keys, errors);
+    let mut subject = open(&mut bundle, &peek, u64::MAX, false, usize::MAX);
+    let (sliced, _, sliced_fuel) = run_sliced(&mut subject, 1, None);
+    assert_eq!(sliced, ScanOutcome::Finished(Err(error.clone())));
+    assert_eq!(
+        subject.rows_processed(),
+        0,
+        "slicing the scan must not let it reach the ok trace",
+    );
+    assert_eq!(
+        sliced_fuel, unsliced_fuel,
+        "slicing the scan must not repeat or skip an error key",
+    );
+
+    assert_eq!(
+        subject.ended,
+        Some(ScanOutcome::Finished(Err(error))),
+        "the error must end the scan rather than leave it resumable",
+    );
+}
+
+/// One budget covers both phases of a scan over a real index: slicing it across the
+/// error-to-ok boundary changes neither the answer nor the number of cursor positions the
+/// scan visits. Matching rows alone would not say that, because a scan that re-walks
+/// positions it has already visited still lands on the right rows.
+#[mz_ore::test]
+fn one_budget_spans_both_phases_of_a_scan_over_an_index() {
+    let keys = rows(0..6);
+    let error_keys = 4;
+    let peek = index_peek(trivial_finishing(), None);
+
+    let mut bundle = trace_bundle(&keys, cancelling_errors(error_keys));
+    let mut subject = open(&mut bundle, &peek, u64::MAX, false, usize::MAX);
+    let (unsliced, _, unsliced_fuel) = run_sliced(&mut subject, usize::MAX, None);
+    assert_eq!(unsliced, ScanOutcome::Finished(Ok(expected(0..6))));
+    // Every key of the error walk and every position of the ok walk comes out of the one
+    // budget the caller supplied, and nothing else does: neither phase charges for the
+    // position on which it discovers it is done. A phase that spent a budget of its own would
+    // leave the caller's short of this, while still answering the peek and still costing the
+    // same when sliced.
+    assert_eq!(
+        unsliced_fuel,
+        error_keys + subject.rows_processed(),
+        "one budget must be charged for the positions of both walks",
+    );
+
+    // Two positions per call, so the scan suspends inside the error walk, at the phase
+    // boundary, and inside the ok walk.
+    let mut bundle = trace_bundle(&keys, cancelling_errors(error_keys));
+    let mut subject = open(&mut bundle, &peek, u64::MAX, false, usize::MAX);
+    let (sliced, _, sliced_fuel) = run_sliced(&mut subject, 2, None);
+    assert_eq!(sliced, unsliced);
+    assert_eq!(
+        sliced_fuel, unsliced_fuel,
+        "slicing the scan must not repeat or skip cursor positions",
+    );
+}
+
+/// The row-iteration limit bounds the peek rather than either walk, so a limit that trips in
+/// the ok phase counts the error phase's positions too. It trips at the same position whether
+/// the scan ran in one call or was sliced.
+#[mz_ore::test]
+fn the_row_iteration_limit_trips_at_the_same_position_sliced_or_not() {
+    let keys = rows(0..6);
+    let error_keys = 4;
+    // Two rows past what the error walk examines, so the limit trips inside the ok walk.
+    let limit = error_keys + 2;
+    let peek = index_peek(trivial_finishing(), None);
+    let expected_outcome =
+        || ScanOutcome::Finished(Err(PeekError::RowIterationLimitExceeded { limit }));
+
+    let mut bundle = trace_bundle(&keys, cancelling_errors(error_keys));
+    let mut subject = open(&mut bundle, &peek, u64::MAX, false, usize::MAX);
+    let (unsliced, _, unsliced_fuel) = run_sliced(&mut subject, usize::MAX, Some(limit));
+    assert_eq!(unsliced, expected_outcome());
+    assert_eq!(
+        subject.rows_processed(),
+        2,
+        "the ok walk must continue the count the error walk reached",
+    );
+    let unsliced_rows = subject.rows_processed();
+
+    let mut bundle = trace_bundle(&keys, cancelling_errors(error_keys));
+    let mut subject = open(&mut bundle, &peek, u64::MAX, false, usize::MAX);
+    let (sliced, _, sliced_fuel) = run_sliced(&mut subject, 2, Some(limit));
+    assert_eq!(sliced, expected_outcome());
+    assert_eq!(
+        subject.rows_processed(),
+        unsliced_rows,
+        "slicing the scan must not move the position the limit trips on",
+    );
+    assert!(subject.results.is_empty(), "a failed scan keeps no rows");
+    assert_eq!(sliced_fuel, unsliced_fuel);
+}
+
+/// A scan offers no batch before its accumulation crosses the stash threshold, offers one
+/// once it has, and the batches it gave away followed by the payload of its final
+/// [`ScanOutcome::Finished`] are the answer the same peek gets from a single unsliced walk,
+/// in the same order and at the same cost.
+#[mz_ore::test]
+fn taken_batches_and_the_final_payload_reassemble_the_unsliced_answer() {
+    let keys = rows(0..8);
+    let error_keys = 3;
+    let peek = index_peek(trivial_finishing(), None);
+
+    // The answer to reassemble towards: one walk, no stash, unbounded fuel.
+    let mut bundle = trace_bundle(&keys, cancelling_errors(error_keys));
+    let mut subject = open(&mut bundle, &peek, u64::MAX, false, usize::MAX);
+    let (whole, taken, whole_fuel) = run_sliced(&mut subject, usize::MAX, None);
+    assert_eq!(whole, ScanOutcome::Finished(Ok(expected(0..8))));
+    assert_eq!(
+        taken,
+        RowBatch::new(),
+        "a peek that cannot use the stash is offered no batch",
+    );
+
+    // The same peek, stash-eligible and sliced two cursor positions at a time.
+    let mut bundle = trace_bundle(&keys, cancelling_errors(error_keys));
+    let mut subject = open(&mut bundle, &peek, u64::MAX, true, 2 * row_size());
+    assert_eq!(
+        subject.take_batch(),
+        None,
+        "a scan that has walked nothing has nothing to offer",
+    );
+
+    let (rest, mut reassembled, sliced_fuel) = run_sliced(&mut subject, 2, None);
+    let ScanOutcome::Finished(Ok(tail)) = rest else {
+        panic!("the sliced scan did not complete: {rest:?}");
+    };
+    assert!(
+        !reassembled.is_empty(),
+        "the threshold must be crossed at least once for this to test anything",
+    );
+    reassembled.extend(tail);
+    assert_eq!(reassembled, expected(0..8));
+    assert_eq!(
+        sliced_fuel, whole_fuel,
+        "taking batches must not repeat or skip cursor positions",
+    );
+}
+
+/// The literal constraints a peek carries reach the ok walk, so a constrained peek is answered
+/// by a seek to its literals rather than by a scan of the whole index.
+#[mz_ore::test]
+fn a_scan_reads_only_the_literals_the_peek_names() {
+    let keys = rows(0..8);
+    let peek = index_peek(trivial_finishing(), Some(rows([2, 5])));
+    let mut bundle = trace_bundle(&keys, cancelling_errors(2));
+    let mut subject = open(&mut bundle, &peek, u64::MAX, false, usize::MAX);
+
+    let mut fuel = usize::MAX;
+    assert_eq!(
+        subject.step(None, &mut fuel),
+        ScanOutcome::Finished(Ok(expected([2, 5]))),
+    );
+    assert_eq!(
+        subject.rows_processed(),
+        2,
+        "a constrained peek must evaluate only the positions its literals name",
+    );
+}
+
+/// The finishing a peek carries reaches the scan, which stops once it holds every row the
+/// finishing can use and keeps the rows the finishing's ordering ranks first.
+#[mz_ore::test]
+fn a_scan_thins_towards_the_rows_the_peeks_finishing_needs() {
+    let keys = rows(0..10);
+    let finishing = RowSetFinishing {
+        // Descending, so the rows the ordering ranks first are the last the walk reaches. A
+        // scan that thinned without the ordering would keep the first two instead.
+        order_by: vec![ColumnOrder {
+            column: 0,
+            desc: true,
+            nulls_last: true,
+        }],
+        limit: Some(NonNeg::try_from(2).expect("non-negative")),
+        offset: 0,
+        project: vec![0],
+    };
+    let peek = index_peek(finishing, None);
+    let mut bundle = trace_bundle(&keys, cancelling_errors(2));
+    let mut subject = open(&mut bundle, &peek, u64::MAX, false, usize::MAX);
+
+    let mut fuel = usize::MAX;
+    assert_eq!(
+        subject.step(None, &mut fuel),
+        ScanOutcome::Finished(Ok(expected([9, 8]))),
+    );
+}
+
+/// `entry_byte_len` is the per-entry half of `RowCollection::byte_len`, which is what the
+/// finishing and the controller measure a result against. Both fast-path peek routes charge with
+/// it, so a drift here gives one route a different effective `max_result_size` than the other.
+#[mz_ore::test]
+fn the_entry_ruler_matches_what_an_answer_costs() {
+    let rows = vec![
+        Row::pack_slice(&[Datum::Int32(42)]),
+        Row::pack_slice(&[Datum::String(&"a".repeat(100))]),
+        Row::pack_slice(&[Datum::Int32(1), Datum::String("two")]),
+    ];
+
+    let charged: usize = rows.iter().map(entry_byte_len).sum();
+    let collection = RowCollection::new(
+        rows.into_iter()
+            .map(|row| (row, NonZeroUsize::new(1).expect("non-zero")))
+            .collect(),
+        &[],
+    );
+
+    assert_eq!(charged, collection.byte_len());
+}

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -237,7 +237,7 @@ impl ComputeMetrics {
             ), role)),
             index_peek_row_iteration_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_row_iteration_seconds",
-                help: "Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP.",
+                help: "Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_row_iteration_rows: registry.register(with_role(metric!(
@@ -262,7 +262,7 @@ impl ComputeMetrics {
             ), role)),
             index_peek_row_collection_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_row_collection_seconds",
-                help: "Time constructing RowCollection from peek results.",
+                help: "Time constructing RowCollection from peek results, including converting the row counts the scan produced.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             replica_expiration_timestamp_seconds: registry.register(with_role(metric!(


### PR DESCRIPTION
Makes one object own both phases of a fast-path index peek. `PeekScan` holds the errs cursor, the oks cursor, the literal state, the accumulated rows, and the size accounting, and spends a single budget across the error trace and the ok walk. It performs no IO and never awaits, so the same scan runs wherever a driver puts it, and a driver that stops it between two cursor positions picks it up again without repeating work.

Before this, each phase was individually suspendable but nothing spanned the boundary, so no caller could hold a partially finished peek.

`ScanOutcome::Suspended` carries no payload. The scan keeps its accumulated prefix and a driver pulls it with `take_batch`, which yields a batch only once accumulation crosses the stash threshold. Nothing is handed by value to a driver with no way to dispose of it, so "committed rows are never dropped" is a property of the interface rather than a rule each driver keeps.

This is a refactor. Every peek answers exactly as it did, including the diversion to the peek stash, which still restarts the walk. Two full sqllogictest sweeps pass, one ordinary and one with the stash threshold at zero so that every streamable peek takes the diversion.

One behaviour does change, deliberately: a scan whose accumulation crosses the stash threshold now suspends rather than continuing to accumulate. The result-size ceiling does not gate a stash-bound prefix, so without it an inline driver would hold an entire result in memory where it previously stopped at the threshold.

🤖 Opened by [Claude Code](https://claude.com/claude-code) on behalf of @antiguru


Replaces #38477, which GitHub closed when the design document moved from the bottom of the stack to the top and its branch was force-pushed past these commits. Same content, new base.
