### PR TITLE
compute: walk an expensive index peek off the serving worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7063,6 +7063,7 @@ dependencies = [
  "mz-proto",
  "mz-repr",
  "mz-row-spine",
+ "mz-secrets",
  "mz-storage-operators",
  "mz-storage-types",
  "mz-timely-util",

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -987,31 +987,31 @@ metrics:
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_cursor_setup_seconds_bucket
-  help: Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.
+  help: Time opening the trace cursor and sorting the literal constraints, excluding the seek to those literals.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_cursor_setup_seconds_count
-  help: Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.
+  help: Time opening the trace cursor and sorting the literal constraints, excluding the seek to those literals.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_cursor_setup_seconds_sum
-  help: Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.
+  help: Time opening the trace cursor and sorting the literal constraints, excluding the seek to those literals.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_error_scan_seconds_bucket
-  help: Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.
+  help: Time scanning the error trace for errors, summed over the slices the scan was cut into and observed only for scans that find no error.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_error_scan_seconds_count
-  help: Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.
+  help: Time scanning the error trace for errors, summed over the slices the scan was cut into and observed only for scans that find no error.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_error_scan_seconds_sum
-  help: Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.
+  help: Time scanning the error trace for errors, summed over the slices the scan was cut into and observed only for scans that find no error.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_frontier_check_seconds_bucket
@@ -1026,6 +1026,38 @@ metrics:
   visibility: internal
 - name: mz_index_peek_frontier_check_seconds_sum
   help: Time checking trace frontiers.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_offload_seconds_bucket
+  help: Wall-clock time an offloaded index peek walk spent away from the timely worker, including the wait for a permit.
+  labels:
+  - le
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_offload_seconds_count
+  help: Wall-clock time an offloaded index peek walk spent away from the timely worker, including the wait for a permit.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_offload_seconds_sum
+  help: Wall-clock time an offloaded index peek walk spent away from the timely worker, including the wait for a permit.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_permit_queue_depth
+  help: The number of offloaded index peek walks waiting for a permit to run.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_permit_wait_seconds_bucket
+  help: Time an offloaded index peek walk waited for a permit, observed only for walks that were admitted.
+  labels:
+  - le
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_permit_wait_seconds_count
+  help: Time an offloaded index peek walk waited for a permit, observed only for walks that were admitted.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_permit_wait_seconds_sum
+  help: Time an offloaded index peek walk waited for a permit, observed only for walks that were admitted.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_result_sort_rows_bucket
@@ -1085,17 +1117,17 @@ metrics:
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_bucket
-  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP, summed over the slices the walk was cut into.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_count
-  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP, summed over the slices the walk was cut into.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_iteration_seconds_sum
-  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.
+  help: Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP, summed over the slices the walk was cut into.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_seek_fulfillment_seconds_bucket
@@ -1113,17 +1145,23 @@ metrics:
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_total_seconds_bucket
-  help: Total time processing index peeks, from process_peek entry to response. Excluding peeks that use the peek response stash.
+  help: Time one visit to an index peek spent on the timely worker. A peek whose walk was offloaded contributes only the inline slice that offloaded it, and its time away from the worker is `mz_index_peek_offload_seconds`.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_total_seconds_count
-  help: Total time processing index peeks, from process_peek entry to response. Excluding peeks that use the peek response stash.
+  help: Time one visit to an index peek spent on the timely worker. A peek whose walk was offloaded contributes only the inline slice that offloaded it, and its time away from the worker is `mz_index_peek_offload_seconds`.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_total_seconds_sum
-  help: Total time processing index peeks, from process_peek entry to response. Excluding peeks that use the peek response stash.
+  help: Time one visit to an index peek spent on the timely worker. A peek whose walk was offloaded contributes only the inline slice that offloaded it, and its time away from the worker is `mz_index_peek_offload_seconds`.
+  source: src/compute/src/metrics.rs
+  visibility: internal
+- name: mz_index_peek_walks_total
+  help: 'The number of index peek walks that reached an outcome, by the substrate they ended on: `inline` on the timely worker, `offloaded` away from it.'
+  labels:
+  - substrate
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_kafka_partition_offset_max

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -144,6 +144,11 @@ def get_minimal_system_parameters(
         config["compute_peek_row_iteration_limit"] = "1000000000"
         config["enable_compute_peek_row_iteration_limit"] = "true"
 
+        # Exercise the peek offload path in tests while it defaults off in
+        # production. The budgets stay at their code defaults so tests make the
+        # same placement decisions production makes.
+        config["enable_compute_index_peek_offload"] = "true"
+
     if version < MzVersion.parse_mz("v0.163.0-dev"):
         config["enable_compute_active_dataflow_cancelation"] = "true"
 
@@ -819,6 +824,12 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "mz_metrics_rusage_refresh_interval",
     "mz_metrics_usage_refresh_interval",
     "compute_peek_response_stash_batch_max_runs",
+    # The offload's budgets, left at their code defaults so tests exercise the
+    # placement decisions production makes. parallel-workload varies them.
+    "compute_index_peek_inline_budget",
+    "compute_index_peek_activation_budget",
+    "compute_index_peek_yield_granularity",
+    "compute_index_peek_permit_fraction",
     "compute_peek_response_stash_read_batch_size_bytes",
     "compute_peek_response_stash_read_memory_budget_bytes",
     "compute_peek_stash_num_batches",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3067,6 +3067,40 @@ class FlipFlagsAction(Action):
             BOOLEAN_FLAG_VALUES
         )
         self.flags_with_values["compute_peek_row_iteration_limit"] = ["1000000000"]
+        self.flags_with_values["enable_compute_index_peek_offload"] = (
+            BOOLEAN_FLAG_VALUES
+        )
+        # The production default, a value that offloads all but the shortest
+        # peeks, and one that keeps every peek inline.
+        self.flags_with_values["compute_index_peek_inline_budget"] = [
+            "1024",
+            "1",
+            "1000000000",
+        ]
+        # The production default, a value that lets one activation serve a
+        # single position across all peeks, and one that lifts the aggregate
+        # so every pending peek spends its full inline budget in one pass.
+        self.flags_with_values["compute_index_peek_activation_budget"] = [
+            "8192",
+            "1",
+            "1000000000",
+        ]
+        # The production default, a value that checks for cancellation after
+        # every position, and one that checks once per walk of any arrangement
+        # this workload builds.
+        self.flags_with_values["compute_index_peek_yield_granularity"] = [
+            "10000",
+            "1",
+            "100000",
+        ]
+        # One permit per worker (the default), a bound that serializes every
+        # offloaded walk, and one that never queues. A fraction of the process's
+        # worker count, floored at one permit, so any tiny fraction serializes.
+        self.flags_with_values["compute_index_peek_permit_fraction"] = [
+            "1.0",
+            "0.0001",
+            "1000.0",
+        ]
         self.flags_with_values["compute_peek_response_stash_threshold_bytes"] = [
             "0",  # "force enabled"
             "1048576",  # 1 MiB, an in-between value

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -659,6 +659,90 @@ pub const PEEK_ROW_ITERATION_LIMIT: Config<usize> = Config::new(
     ParameterScope::Environment,
 );
 
+/// Whether a fast-path index peek may move its walk off the timely worker.
+///
+/// Off, a peek walks to completion on the worker that owns it, delaying every other message that
+/// worker serves. On, a peek that outruns [`INDEX_PEEK_INLINE_BUDGET`] finishes away from it.
+///
+/// The kill switch for the whole mechanism.
+pub const ENABLE_INDEX_PEEK_OFFLOAD: Config<bool> = Config::new(
+    "enable_compute_index_peek_offload",
+    false,
+    "Whether a fast-path index peek may move its walk off the timely worker.",
+    ParameterScope::Replica,
+);
+
+/// How far one peek may walk on the worker before it is offloaded, in consumed cursor positions.
+///
+/// A peek that exceeds it has been measured expensive, not predicted to be, so a point lookup over
+/// a skewed hot key offloads without a special case.
+///
+/// Counted in cursor positions, not rows returned: the result iterator steps the cursor without
+/// returning anything whenever the MFP rejects a row, so a selective filter over a large
+/// arrangement would never spend a row-counted budget. No wall-clock component, since under memory
+/// pressure a time bound anti-correlates with progress, one major fault consuming a whole slice.
+///
+/// Zero walks one position, not none: a peek granted no fuel would suspend having walked nowhere
+/// and be offloaded for it.
+pub const INDEX_PEEK_INLINE_BUDGET: Config<usize> = Config::new(
+    "compute_index_peek_inline_budget",
+    1024,
+    "How far one index peek may walk on the timely worker, in consumed cursor positions, before it is offloaded.",
+    ParameterScope::Replica,
+);
+
+/// What all peeks together may spend in one worker activation, in consumed cursor positions.
+///
+/// Every activation visits every pending peek, so a per-peek budget with no aggregate lets N
+/// pending peeks cost N times [`INDEX_PEEK_INLINE_BUDGET`] in one pass, unbounded in N. Peeks that
+/// get no turn are served first on the next activation.
+///
+/// Raising the ratio to the inline budget drains a burst in fewer activations, lowering it caps
+/// how long one activation withholds the worker.
+pub const INDEX_PEEK_ACTIVATION_BUDGET: Config<usize> = Config::new(
+    "compute_index_peek_activation_budget",
+    8 * 1024,
+    "What all index peeks together may spend in one timely worker activation, in consumed cursor positions.",
+    ParameterScope::Replica,
+);
+
+/// How often an offloaded scan checks for cancellation and re-reads its configuration, in
+/// consumed cursor positions.
+///
+/// At a plausible 100ns to 1us per position this bounds cancellation latency to single-digit
+/// milliseconds. Larger than [`INDEX_PEEK_INLINE_BUDGET`] because an offloaded scan is off the
+/// worker's critical path, so its slices answer to cancellation latency rather than to the
+/// worker's availability. A check is a few loads and no hand-off, so a finer granularity costs
+/// little.
+pub const INDEX_PEEK_YIELD_GRANULARITY: Config<usize> = Config::new(
+    "compute_index_peek_yield_granularity",
+    10000,
+    "How often an offloaded index peek scan checks for cancellation, in consumed cursor positions.",
+    ParameterScope::Replica,
+);
+
+/// How many offloaded index peek scans may run at once, as a fraction of the timely workers a
+/// compute runtime runs.
+///
+/// A fraction so the bound scales with the replica instead of being retuned per size. `1.0` admits
+/// one scan per worker, `0.5` one per two workers, and the bound is never below one scan. One per
+/// worker is the default because a peek walking on its worker occupies one core, so peek CPU is
+/// already capped at one core per worker today.
+///
+/// Per compute runtime, not global: a process running a maintenance and an interactive runtime
+/// admits it once per runtime.
+///
+/// This bounds running scans only. Scans that do not fit queue, costing a queue entry holding a
+/// suspended scan instead of a thread. Queue depth is a signal to alert on, not a second bound,
+/// since capping it would mean failing peeks.
+pub const INDEX_PEEK_PERMIT_FRACTION: Config<f64> = Config::new(
+    "compute_index_peek_permit_fraction",
+    1.0,
+    "How many offloaded index peek scans may run at once in one compute runtime, as a fraction of \
+     the timely workers it runs. Never below one scan.",
+    ParameterScope::Replica,
+);
+
 /// The collection interval for the Prometheus metrics introspection source.
 ///
 /// Set to zero to disable scraping and retract any existing data.
@@ -746,6 +830,11 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&PEEK_STASH_BATCH_SIZE)
         .add(&ENABLE_PEEK_ROW_ITERATION_LIMIT)
         .add(&PEEK_ROW_ITERATION_LIMIT)
+        .add(&ENABLE_INDEX_PEEK_OFFLOAD)
+        .add(&INDEX_PEEK_INLINE_BUDGET)
+        .add(&INDEX_PEEK_ACTIVATION_BUDGET)
+        .add(&INDEX_PEEK_YIELD_GRANULARITY)
+        .add(&INDEX_PEEK_PERMIT_FRACTION)
         .add(&COMPUTE_PROMETHEUS_INTROSPECTION_SCRAPE_INTERVAL)
         .add(&SUBSCRIBE_SNAPSHOT_OPTIMIZATION)
         .add(&MV_SINK_ADVANCE_PERSIST_FRONTIERS)

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -57,6 +57,7 @@ core_affinity = "0.8.3"
 
 [dev-dependencies]
 criterion.workspace = true
+mz-secrets = { path = "../secrets" }
 mz-storage-types = { path = "../storage-types", features = ["proptest"] }
 proptest.workspace = true
 rand.workspace = true

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -8,7 +8,7 @@
 use std::any::Any;
 use std::cell::RefCell;
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::num::NonZeroUsize;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -67,7 +67,13 @@ use tracing::{Level, debug, error, info, span, trace, warn};
 use uuid::Uuid;
 
 use crate::arrangement::manager::{TraceBundle, TraceManager};
-use crate::compute_state::peek_scan::{PeekScan, ScanOutcome, entry_byte_len};
+use crate::compute_state::peek_budget::InlineBudget;
+use crate::compute_state::peek_metrics::{IndexPeekMetrics, PeekWalkMetrics};
+pub(crate) use crate::compute_state::peek_offload::PeekPermits;
+use crate::compute_state::peek_offload::{OffloadConfig, OffloadOutcome, OffloadedPeek};
+use crate::compute_state::peek_scan::{
+    IndexPeekScan, PeekScan, ScanOutcome, entry_byte_len, rows_response,
+};
 use crate::logging;
 use crate::logging::compute::{CollectionLogging, ComputeEvent, PeekEvent};
 use crate::logging::initialize::LoggingTraces;
@@ -76,6 +82,9 @@ use crate::render::{LinearJoinSpec, StartSignal};
 use crate::server::{ComputeInstanceContext, ResponseSender};
 
 mod error_scan;
+mod peek_budget;
+mod peek_metrics;
+mod peek_offload;
 mod peek_result_iterator;
 mod peek_scan;
 mod peek_stash;
@@ -189,8 +198,17 @@ pub struct ComputeState {
     /// The entries are pairs of sink identifier (to identify the s3 oneshot instance)
     /// and the response itself.
     pub copy_to_response_buffer: Rc<RefCell<Vec<(GlobalId, CopyToResponse)>>>,
-    /// Peek commands that are awaiting fulfillment.
-    pub pending_peeks: BTreeMap<Uuid, PendingPeek>,
+    /// Index peeks awaiting their turn on the worker, in the order the sweep serves them.
+    ///
+    /// A sweep takes from the front and returns what it could not retire to the back, so a peek
+    /// it passed over is served before the peeks it served ahead of it, and a peek that arrives
+    /// later queues behind both. Keeping the order here spares the sweep a resume point.
+    pub queued_peeks: VecDeque<IndexPeek>,
+    /// Peeks a driver has taken over, awaiting the outcome that driver hands back.
+    ///
+    /// These are polled on every sweep and draw no budget, because the work they are waiting on is
+    /// not running on the worker.
+    pub pending_peeks: VecDeque<PendingPeek>,
     /// The persist location where we can stash large peek results.
     pub peek_stash_persist_location: Option<PersistLocation>,
     /// The logger, from Timely's logging framework, if logs are enabled.
@@ -233,6 +251,29 @@ pub struct ComputeState {
     /// The number of timely workers per process.
     pub workers_per_process: usize,
 
+    /// Bounds how many offloaded peek walks run at once, shared with the other workers of the same
+    /// `serve` call. A process running two compute runtime roles has one of these per role.
+    pub peek_permits: Arc<PeekPermits>,
+
+    /// The metrics an index peek walk reports, whichever driver runs it.
+    ///
+    /// Held here rather than assembled per peek, because an offload clones it into the task and
+    /// the inline driver reads it on every activation of every pending peek.
+    peek_walk_metrics: PeekWalkMetrics,
+
+    /// What this activation may spend walking index peeks on the worker, and what is left of it.
+    ///
+    /// Begun at the top of every sweep, but armed by the first peek that asks for a slice, which
+    /// may be one arriving between two sweeps. Such a peek draws from what the last sweep left, so
+    /// a batch of arrivals costs at most one more aggregate rather than one per peek.
+    peek_budget: InlineBudget,
+
+    /// Whether the last sweep passed a peek over for want of budget.
+    ///
+    /// Says only that such a peek exists, because [`ComputeState::queued_peeks`] already says
+    /// which one it is: the sweep left it at the front of the queue.
+    peek_passed_over: bool,
+
     /// Collections awaiting schedule instruction by the controller.
     ///
     /// Each entry stores a reference to a token that can be dropped to unsuspend the collection's
@@ -259,6 +300,14 @@ pub struct ComputeState {
 }
 
 impl ComputeState {
+    /// Whether a peek is waiting on nothing but its next turn in the sweep.
+    ///
+    /// Read by the worker loop before it parks. The sweep that serves such a peek runs on the same
+    /// thread, so the loop steps without parking rather than waking itself.
+    pub(crate) fn peeks_awaiting_turn(&self) -> bool {
+        self.peek_passed_over
+    }
+
     /// Construct a new `ComputeState`.
     pub fn new(
         persist_clients: Arc<PersistClientCache>,
@@ -268,16 +317,21 @@ impl ComputeState {
         context: ComputeInstanceContext,
         metrics_registry: MetricsRegistry,
         workers_per_process: usize,
+        peek_permits: Arc<PeekPermits>,
         storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
     ) -> Self {
+        let worker_config: Rc<ConfigSet> = mz_dyncfgs::all_dyncfgs().into();
         let traces = TraceManager::new(metrics.clone());
         let command_history = ComputeCommandHistory::new(metrics.for_history());
+        let peek_walk_metrics = PeekWalkMetrics::new(&metrics);
+        let peek_budget = InlineBudget::new(&worker_config);
 
         Self {
             collections: Default::default(),
             traces,
             subscribe_response_buffer: Default::default(),
             copy_to_response_buffer: Default::default(),
+            queued_peeks: Default::default(),
             pending_peeks: Default::default(),
             peek_stash_persist_location: None,
             compute_logger: None,
@@ -289,9 +343,13 @@ impl ComputeState {
             metrics,
             tracing_handle,
             context,
-            worker_config: mz_dyncfgs::all_dyncfgs().into(),
+            worker_config,
             metrics_registry,
             workers_per_process,
+            peek_permits,
+            peek_walk_metrics,
+            peek_budget,
+            peek_passed_over: false,
             suspended_collections: Default::default(),
             server_maintenance_interval: Duration::ZERO,
             init_system_time: mz_ore::now::SYSTEM_TIME(),
@@ -882,13 +940,26 @@ impl<'a> ActiveComputeState<'a> {
             logger.log(&pending.as_log_event(true));
         }
 
-        self.process_peek(&mut Antichain::new(), pending);
+        match pending {
+            PendingPeek::Index(peek) => self.serve_index_peek(&mut Antichain::new(), peek),
+            pending => self.poll_pending_peek(pending),
+        }
     }
 
     fn handle_cancel_peek(&mut self, uuid: Uuid) {
-        if let Some(peek) = self.compute_state.pending_peeks.remove(&uuid) {
-            self.send_peek_response(peek, PeekResponse::Canceled);
+        let queued = &mut self.compute_state.queued_peeks;
+        if let Some(index) = queued.iter().position(|peek| peek.peek.uuid == uuid) {
+            let peek = queued.remove(index).expect("found above");
+            self.send_peek_response(PendingPeek::Index(peek), PeekResponse::Canceled);
+            return;
         }
+
+        let pending = &mut self.compute_state.pending_peeks;
+        let Some(index) = pending.iter().position(|peek| peek.peek().uuid == uuid) else {
+            return;
+        };
+        let peek = pending.remove(index).expect("found above");
+        self.send_peek_response(peek, PeekResponse::Canceled);
     }
 
     fn handle_allow_writes(&mut self, id: GlobalId) {
@@ -1122,104 +1193,139 @@ impl<'a> ActiveComputeState<'a> {
         }
     }
 
-    /// Either complete the peek (and send the response) or put it in the pending set.
-    fn process_peek(&mut self, upper: &mut Antichain<Timestamp>, mut peek: PendingPeek) {
-        let response = match &mut peek {
-            PendingPeek::Index(peek) => {
-                let start = Instant::now();
+    /// Gives `peek` a turn on the worker if this activation's budget has one left, and queues it
+    /// for a later activation otherwise.
+    fn serve_index_peek(&mut self, upper: &mut Antichain<Timestamp>, peek: IndexPeek) {
+        match self.compute_state.peek_budget.grant() {
+            Some(fuel) => self.walk_index_peek(upper, peek, fuel),
+            None => {
+                // A scan is opened by the slice that walks it, so passing a peek over costs it an
+                // activation and nothing else.
+                self.compute_state.peek_passed_over = true;
+                self.compute_state.queued_peeks.push_back(peek);
+            }
+        }
+    }
 
-                let row_iteration_limit =
-                    peek_row_iteration_limit(&self.compute_state.worker_config);
+    /// Walks `peek` for up to `fuel` cursor positions and either answers it, hands it to a driver
+    /// that finishes it, or returns it to the queue for another turn.
+    fn walk_index_peek(
+        &mut self,
+        upper: &mut Antichain<Timestamp>,
+        mut peek: IndexPeek,
+        fuel: usize,
+    ) {
+        let start = Instant::now();
 
-                let peek_stash_eligible = peek
-                    .peek
-                    .finishing
-                    .is_streamable(peek.peek.result_desc.arity());
+        let row_iteration_limit = peek_row_iteration_limit(&self.compute_state.worker_config);
 
-                let peek_stash_enabled = {
-                    let enabled = ENABLE_PEEK_RESPONSE_STASH.get(&self.compute_state.worker_config);
-                    let peek_persist_stash_available =
-                        self.compute_state.peek_stash_persist_location.is_some();
-                    if !peek_persist_stash_available && enabled {
-                        error!("missing peek_stash_persist_location but peek stash is enabled");
-                    }
-                    enabled && peek_persist_stash_available
-                };
+        let peek_stash_eligible = peek
+            .peek
+            .finishing
+            .is_streamable(peek.peek.result_desc.arity());
 
-                let peek_stash_threshold_bytes =
-                    PEEK_RESPONSE_STASH_THRESHOLD_BYTES.get(&self.compute_state.worker_config);
+        let peek_stash_enabled = {
+            let enabled = ENABLE_PEEK_RESPONSE_STASH.get(&self.compute_state.worker_config);
+            let peek_persist_stash_available =
+                self.compute_state.peek_stash_persist_location.is_some();
+            if !peek_persist_stash_available && enabled {
+                error!("missing peek_stash_persist_location but peek stash is enabled");
+            }
+            enabled && peek_persist_stash_available
+        };
 
-                let metrics = IndexPeekMetrics {
-                    seek_fulfillment_seconds: &self
-                        .compute_state
-                        .metrics
-                        .index_peek_seek_fulfillment_seconds,
-                    frontier_check_seconds: &self
-                        .compute_state
-                        .metrics
-                        .index_peek_frontier_check_seconds,
-                    error_scan_seconds: &self.compute_state.metrics.index_peek_error_scan_seconds,
-                    cursor_setup_seconds: &self
-                        .compute_state
-                        .metrics
-                        .index_peek_cursor_setup_seconds,
-                    row_iteration_seconds: &self
-                        .compute_state
-                        .metrics
-                        .index_peek_row_iteration_seconds,
-                    row_iteration_rows: &self.compute_state.metrics.index_peek_row_iteration_rows,
-                    result_sort_seconds: &self.compute_state.metrics.index_peek_result_sort_seconds,
-                    result_sort_rows: &self.compute_state.metrics.index_peek_result_sort_rows,
-                    row_collection_seconds: &self
-                        .compute_state
-                        .metrics
-                        .index_peek_row_collection_seconds,
-                };
+        let peek_stash_threshold_bytes =
+            PEEK_RESPONSE_STASH_THRESHOLD_BYTES.get(&self.compute_state.worker_config);
 
-                let status = peek.seek_fulfillment(
-                    upper,
-                    self.compute_state.max_result_size,
-                    peek_stash_enabled && peek_stash_eligible,
-                    peek_stash_threshold_bytes,
-                    row_iteration_limit,
-                    &metrics,
+        let metrics = IndexPeekMetrics {
+            seek_fulfillment_seconds: &self
+                .compute_state
+                .metrics
+                .index_peek_seek_fulfillment_seconds,
+            frontier_check_seconds: &self.compute_state.metrics.index_peek_frontier_check_seconds,
+            walk: &self.compute_state.peek_walk_metrics,
+        };
+
+        let mut unspent = fuel;
+        let status = peek.seek_fulfillment(
+            upper,
+            self.compute_state.max_result_size,
+            peek_stash_enabled && peek_stash_eligible,
+            peek_stash_threshold_bytes,
+            row_iteration_limit,
+            &mut unspent,
+            &metrics,
+        );
+
+        // Charged with what the slice walked rather than with what it was granted, so a peek that
+        // answers in three positions leaves the activation's budget to the peeks behind it.
+        self.compute_state
+            .peek_budget
+            .charge(fuel.saturating_sub(unspent));
+
+        self.compute_state
+            .metrics
+            .index_peek_total_seconds
+            .observe(start.elapsed().as_secs_f64());
+
+        match status {
+            PeekStatus::Ready(response) => {
+                let _span =
+                    span!(parent: &peek.span, Level::DEBUG, "process_peek_response").entered();
+                self.send_peek_response(PendingPeek::Index(peek), response);
+            }
+            PeekStatus::NotReady => self.compute_state.queued_peeks.push_back(peek),
+            PeekStatus::Offload(scan) => {
+                let _span = span!(parent: &peek.span, Level::DEBUG, "offload_index_peek").entered();
+
+                let permits = Arc::clone(&self.compute_state.peek_permits);
+                let config = OffloadConfig::new(&self.compute_state.worker_config);
+                let walk_metrics = self.compute_state.peek_walk_metrics.clone();
+                let worker = std::thread::current();
+
+                let offloaded = OffloadedPeek::start(
+                    peek.peek,
+                    peek.trace_bundle,
+                    scan,
+                    permits,
+                    config,
+                    walk_metrics,
+                    worker,
                 );
 
                 self.compute_state
-                    .metrics
-                    .index_peek_total_seconds
-                    .observe(start.elapsed().as_secs_f64());
+                    .pending_peeks
+                    .push_back(PendingPeek::Offloaded(offloaded));
+            }
+            PeekStatus::UsePeekStash => {
+                let _span = span!(parent: &peek.span, Level::DEBUG, "process_stash_peek").entered();
 
-                match status {
-                    PeekStatus::Ready(result) => Some(result),
-                    PeekStatus::NotReady => None,
-                    PeekStatus::UsePeekStash => {
-                        let _span =
-                            span!(parent: &peek.span, Level::DEBUG, "process_stash_peek").entered();
+                let location = self
+                    .compute_state
+                    .peek_stash_persist_location
+                    .clone()
+                    .expect("stash location established before diverting");
+                let stash_task = self.start_stash_upload(&location, peek.peek, peek.trace_bundle);
 
-                        // NOTE: The row iteration limit does not follow a peek into the stash. The
-                        // stash restarts the scan and produces in bounded bursts, so a stashed
-                        // peek may examine any number of rows.
-                        let peek_stash_batch_max_runs = PEEK_RESPONSE_STASH_BATCH_MAX_RUNS
-                            .get(&self.compute_state.worker_config);
+                self.compute_state
+                    .pending_peeks
+                    .push_back(PendingPeek::Stash(stash_task));
+            }
+        }
+    }
 
-                        let stash_task = peek_stash::StashingPeek::start_upload(
-                            Arc::clone(&self.compute_state.persist_clients),
-                            self.compute_state
-                                .peek_stash_persist_location
-                                .as_ref()
-                                .expect("verified above"),
-                            peek.peek.clone(),
-                            peek.trace_bundle.clone(),
-                            peek_stash_batch_max_runs,
-                        );
-
-                        self.compute_state
-                            .pending_peeks
-                            .insert(peek.peek.uuid, PendingPeek::Stash(stash_task));
-                        return;
-                    }
-                }
+    /// Asks the driver that has taken `pending` over for its outcome, and sends the response when
+    /// one is ready.
+    fn poll_pending_peek(&mut self, mut pending: PendingPeek) {
+        let response = match &mut pending {
+            // An index peek reaches a driver only by leaving the queue, and the driver that takes
+            // it over replaces it with a variant of its own.
+            PendingPeek::Index(peek) => {
+                soft_panic_or_log!(
+                    "index peek on {} polled as if a driver had taken it over",
+                    peek.peek.target.id()
+                );
+                None
             }
             PendingPeek::Persist(peek) => peek.result.try_recv().ok().map(|(result, duration)| {
                 self.compute_state
@@ -1228,6 +1334,66 @@ impl<'a> ActiveComputeState<'a> {
                     .observe(duration.as_secs_f64());
                 result
             }),
+            PendingPeek::Offloaded(offloaded) => match offloaded.result.try_recv() {
+                Ok((outcome, duration)) => {
+                    // Both outcomes are timed, because a walk that hands back is the expensive
+                    // case rather than an aborted one.
+                    self.compute_state
+                        .metrics
+                        .index_peek_offload_seconds
+                        .observe(duration.as_secs_f64());
+
+                    match outcome {
+                        OffloadOutcome::Answered(response) => {
+                            trace!(?offloaded.peek, ?duration, "finished offloaded index peek walk");
+                            Some(response)
+                        }
+                        OffloadOutcome::NeedsStash => {
+                            let _span =
+                                span!(parent: &offloaded.span, Level::DEBUG, "process_stash_peek")
+                                    .entered();
+                            trace!(?offloaded.peek, ?duration, "handing offloaded index peek to the stash");
+
+                            match self.compute_state.peek_stash_persist_location.clone() {
+                                Some(location) => {
+                                    let PendingPeek::Offloaded(offloaded) = pending else {
+                                        unreachable!("matched as an offloaded peek")
+                                    };
+                                    let stash_task = self.start_stash_upload(
+                                        &location,
+                                        offloaded.peek,
+                                        offloaded.trace_bundle,
+                                    );
+                                    self.compute_state
+                                        .pending_peeks
+                                        .push_back(PendingPeek::Stash(stash_task));
+                                    return;
+                                }
+                                None => Some(PeekResponse::Error(PeekError::unstructured(
+                                    "peek result is too large to answer inline and this replica \
+                                     has no peek stash location",
+                                ))),
+                            }
+                        }
+                    }
+                }
+                Err(oneshot::error::TryRecvError::Empty) => None,
+                // The task drops its sender without sending only on a cancellation, which removes
+                // this entry, so an entry still here to be polled means the task died. Answering
+                // keeps the peek from waiting forever on a walk nothing is running.
+                //
+                // NOTE: a walk dropped by a shutting-down tokio runtime arrives here the same way.
+                // The worker is going away too, so the log line is noise rather than a lost signal.
+                Err(oneshot::error::TryRecvError::Closed) => {
+                    soft_panic_or_log!(
+                        "offloaded walk of peek on {} ended without an outcome",
+                        offloaded.peek.target.id()
+                    );
+                    Some(PeekResponse::Error(PeekError::unstructured(
+                        "offloaded peek walk failed",
+                    )))
+                }
+            },
             PendingPeek::Stash(stashing_peek) => {
                 let num_batches = PEEK_STASH_NUM_BATCHES.get(&self.compute_state.worker_config);
                 let batch_size = PEEK_STASH_BATCH_SIZE.get(&self.compute_state.worker_config);
@@ -1248,21 +1414,88 @@ impl<'a> ActiveComputeState<'a> {
         };
 
         if let Some(response) = response {
-            let _span = span!(parent: peek.span(), Level::DEBUG, "process_peek_response").entered();
-            self.send_peek_response(peek, response)
+            let _span =
+                span!(parent: pending.span(), Level::DEBUG, "process_peek_response").entered();
+            self.send_peek_response(pending, response)
         } else {
-            let uuid = peek.peek().uuid;
-            self.compute_state.pending_peeks.insert(uuid, peek);
+            self.compute_state.pending_peeks.push_back(pending);
         }
     }
 
-    /// Scan pending peeks and attempt to retire each.
+    /// Starts a peek stash upload for `peek`, which walks the ok trace of `trace_bundle` and
+    /// writes the rows it produces to persist.
+    ///
+    /// The walk starts over, so rows a previous walk of the same peek accumulated are produced
+    /// again rather than carried across.
+    fn start_stash_upload(
+        &self,
+        persist_location: &PersistLocation,
+        peek: Peek,
+        trace_bundle: TraceBundle,
+    ) -> peek_stash::StashingPeek {
+        // NOTE: The row iteration limit does not follow a peek into the stash. The stash restarts
+        // the scan and produces in bounded bursts, so a stashed peek may examine any number of
+        // rows.
+        let batch_max_runs =
+            PEEK_RESPONSE_STASH_BATCH_MAX_RUNS.get(&self.compute_state.worker_config);
+
+        peek_stash::StashingPeek::start_upload(
+            Arc::clone(&self.compute_state.persist_clients),
+            persist_location,
+            peek,
+            trace_bundle,
+            batch_max_runs,
+        )
+    }
+
+    /// Scan the peeks a driver is finishing and the peeks awaiting a turn, and attempt to retire
+    /// each.
+    ///
+    /// The queue of peeks awaiting a turn is served from the front and each peek it cannot retire
+    /// is returned to the back, so the next sweep resumes where this one ran out of budget without
+    /// either of them recording where that was.
     pub fn process_peeks(&mut self) {
-        let mut upper = Antichain::new();
-        let pending_peeks = std::mem::take(&mut self.compute_state.pending_peeks);
-        for (_uuid, peek) in pending_peeks {
-            self.process_peek(&mut upper, peek);
+        // Above the early return because this is the only place an activation begins. A replica
+        // whose peeks all answer inline leaves none pending, and beginning an activation only
+        // where there is work would let the aggregate drain across its arrivals.
+        self.compute_state.peek_budget.start_activation();
+
+        // Says what this sweep found, so it is cleared before the sweep rather than carried in
+        // from the last one. A peek cancelled or dropped between two sweeps would otherwise leave
+        // the worker spinning on a turn nothing is waiting for.
+        self.compute_state.peek_passed_over = false;
+
+        // Runs on every iteration of the worker loop, and almost every one finds no peek at all.
+        if self.compute_state.pending_peeks.is_empty() && self.compute_state.queued_peeks.is_empty()
+        {
+            return;
         }
+
+        let mut upper = Antichain::new();
+
+        // Both queues are taken out of the state for the sweep, because serving a peek borrows
+        // `self` mutably. A peek the sweep returns for another turn lands in the emptied queue.
+        let mut pending_peeks = std::mem::take(&mut self.compute_state.pending_peeks);
+        while let Some(peek) = pending_peeks.pop_front() {
+            self.poll_pending_peek(peek);
+        }
+
+        // The aggregate does not refill within an activation, so the first peek the budget cannot
+        // serve is also the last: every peek behind it would be passed over for the same reason.
+        let mut queued_peeks = std::mem::take(&mut self.compute_state.queued_peeks);
+        while let Some(peek) = queued_peeks.pop_front() {
+            let Some(fuel) = self.compute_state.peek_budget.grant() else {
+                queued_peeks.push_front(peek);
+                break;
+            };
+            self.walk_index_peek(&mut upper, peek, fuel);
+        }
+
+        // A peek the sweep never reached keeps its place ahead of the peeks it served, so the
+        // queue rotates instead of starving its tail.
+        self.compute_state.peek_passed_over = !queued_peeks.is_empty();
+        let served = std::mem::replace(&mut self.compute_state.queued_peeks, queued_peeks);
+        self.compute_state.queued_peeks.extend(served);
     }
 
     /// Sends a response for this peek's resolution to the coordinator.
@@ -1409,6 +1642,9 @@ pub enum PendingPeek {
     /// A peek against an index that is being stashed in the peek stash by an
     /// async background task.
     Stash(peek_stash::StashingPeek),
+    /// A peek against an index whose walk was offloaded from the worker and is running as an async
+    /// task.
+    Offloaded(OffloadedPeek),
 }
 
 impl PendingPeek {
@@ -1532,6 +1768,7 @@ impl PendingPeek {
             PendingPeek::Index(p) => &p.span,
             PendingPeek::Persist(p) => &p.span,
             PendingPeek::Stash(p) => &p.span,
+            PendingPeek::Offloaded(p) => &p.span,
         }
     }
 
@@ -1540,6 +1777,7 @@ impl PendingPeek {
             PendingPeek::Index(p) => &p.peek,
             PendingPeek::Persist(p) => &p.peek,
             PendingPeek::Stash(p) => &p.peek,
+            PendingPeek::Offloaded(p) => &p.peek,
         }
     }
 }
@@ -1697,22 +1935,6 @@ pub struct IndexPeek {
     span: tracing::Span,
 }
 
-/// Histogram metrics for index peek phases.
-///
-/// This struct bundles references to the various histogram metrics used to
-/// instrument the index peek processing pipeline.
-pub(crate) struct IndexPeekMetrics<'a> {
-    pub seek_fulfillment_seconds: &'a prometheus::Histogram,
-    pub frontier_check_seconds: &'a prometheus::Histogram,
-    pub error_scan_seconds: &'a prometheus::Histogram,
-    pub cursor_setup_seconds: &'a prometheus::Histogram,
-    pub row_iteration_seconds: &'a prometheus::Histogram,
-    pub row_iteration_rows: &'a prometheus::Histogram,
-    pub result_sort_seconds: &'a prometheus::Histogram,
-    pub result_sort_rows: &'a prometheus::Histogram,
-    pub row_collection_seconds: &'a prometheus::Histogram,
-}
-
 impl IndexPeek {
     /// Attempts to fulfill the peek and reports success.
     ///
@@ -1726,6 +1948,10 @@ impl IndexPeek {
     /// then for any time `t` less or equal to `peek.timestamp` it is
     /// not the case that `upper` is less or equal to that timestamp,
     /// and so the result cannot further evolve.
+    ///
+    /// `fuel` bounds how far the walk may go on this worker, in cursor positions, and is charged
+    /// for the positions it visits. A walk that exhausts it with work left is offloaded rather than
+    /// continued here, and a peek whose frontiers do not admit the read yet spends none of it.
     fn seek_fulfillment(
         &mut self,
         upper: &mut Antichain<Timestamp>,
@@ -1733,6 +1959,7 @@ impl IndexPeek {
         peek_stash_eligible: bool,
         peek_stash_threshold_bytes: usize,
         row_iteration_limit: Option<usize>,
+        fuel: &mut usize,
         metrics: &IndexPeekMetrics<'_>,
     ) -> PeekStatus {
         let method_start = Instant::now();
@@ -1765,6 +1992,7 @@ impl IndexPeek {
             peek_stash_eligible,
             peek_stash_threshold_bytes,
             row_iteration_limit,
+            fuel,
             metrics,
         );
 
@@ -1775,18 +2003,18 @@ impl IndexPeek {
         result
     }
 
-    /// Answers the peek by scanning the traces that fulfil it.
+    /// Answers the peek by scanning the traces that fulfil it, for as long as `fuel` allows.
     ///
-    /// One call drives one scan to an answer and drops it, so nothing survives the call and a
-    /// second call repeats both walks from the start. That is what the peek path asks for: it
-    /// reaches this only once the frontiers admit the read, and every outcome retires the peek
-    /// from the index-peek path, either with a response or by handing it to the stash.
+    /// One call opens one scan and either answers from it or hands it on, so nothing survives the
+    /// call. A scan that runs out of fuel with work left leaves with the [`PeekStatus::Offload`]
+    /// that reports it, so the positions it walked are not walked again.
     fn collect_finished_data(
         &mut self,
         max_result_size: u64,
         peek_stash_eligible: bool,
         peek_stash_threshold_bytes: usize,
         row_iteration_limit: Option<usize>,
+        fuel: &mut usize,
         metrics: &IndexPeekMetrics<'_>,
     ) -> PeekStatus {
         let peek = &self.peek;
@@ -1800,20 +2028,16 @@ impl IndexPeek {
             peek_stash_threshold_bytes,
         );
 
-        // No caller supplies a budget, so nothing stops the scan short of an answer but a full
-        // batch, and this driver has nowhere to write one.
-        let mut fuel = usize::MAX;
-        let outcome = scan.step(row_iteration_limit, &mut fuel);
+        let outcome = scan.step(row_iteration_limit, fuel);
 
-        // Both phases that precede the ok walk are reported only for a peek that reached that
-        // walk, so a peek answered by its error trace reports neither.
-        if scan.error_trace_clean() {
-            metrics
-                .error_scan_seconds
-                .observe(scan.error_scan_time.as_secs_f64());
-            metrics
-                .cursor_setup_seconds
-                .observe(scan.cursor_setup_time.as_secs_f64());
+        // A suspension the offload can resume is the one outcome that leaves the walk unfinished,
+        // so it is the one outcome this driver reports nothing for. Everything else ends the walk
+        // here, and this driver is the one that accounts for it.
+        let offloaded = matches!(outcome, ScanOutcome::Suspended) && !scan.batch_ready();
+        let phases = scan.phases();
+        if !offloaded {
+            metrics.walk.walked_inline();
+            metrics.walk.observe_error_phase(&phases);
         }
 
         let rows = match outcome {
@@ -1821,15 +2045,15 @@ impl IndexPeek {
             ScanOutcome::Finished(Err(error)) => {
                 return PeekStatus::Ready(PeekResponse::Error(error));
             }
+            // A scan that suspends without a batch has work left and rows it may still
+            // accumulate, so it travels to the offloaded walk with its positions and their cost.
+            // The offload costs one hand-off rather than a second walk.
+            ScanOutcome::Suspended if !scan.batch_ready() => return PeekStatus::Offload(scan),
             // Diversion is sound only for a scan whose error walk is over. The stash answers the
             // peek from a walk of the ok trace alone and never reads the error trace, so a peek
             // diverted with its error trace half-read would return rows where it must report an
-            // error.
-            //
-            // The batch is taken and dropped rather than left to the scan's own drop, because
-            // discarding it is this driver's decision: the stash's own walk supersedes it. It is
-            // taken only once diversion is established, so that no path disposes of rows it has
-            // not first earned the right to discard.
+            // error. Only the ok walk accumulates rows, so a scan holding a full batch has read
+            // the error trace out, and the guard states that rather than assuming it.
             ScanOutcome::Suspended => {
                 if !scan.error_trace_clean() {
                     soft_panic_or_log!(
@@ -1840,43 +2064,20 @@ impl IndexPeek {
                         "peek suspended before its error trace was read out",
                     )));
                 }
-                if scan.take_batch().is_none() {
-                    soft_panic_or_log!(
-                        "peek on {} suspended with no batch to hand over",
-                        self.peek.target.id()
-                    );
-                }
+                // Dropped here rather than with the scan, because discarding it is this driver's
+                // decision: the stash walks the ok trace again and produces these rows a second
+                // time.
+                let _batch = scan.take_batch();
                 return PeekStatus::UsePeekStash;
             }
         };
 
-        metrics
-            .row_iteration_seconds
-            .observe(scan.row_iteration_time.as_secs_f64());
-        metrics
-            .row_iteration_rows
-            .observe(f64::cast_lossy(scan.rows_processed()));
-        metrics
-            .result_sort_seconds
-            .observe(scan.result_sort_time.as_secs_f64());
-        metrics
-            .result_sort_rows
-            .observe(f64::cast_lossy(scan.rows_sorted));
+        metrics.walk.observe_ok_phase(&phases);
 
-        let row_collection_start = Instant::now();
-        let rows = rows
-            .into_iter()
-            .map(|(row, copies)| {
-                let copies = NonZeroUsize::try_from(copies).expect("fits into usize");
-                (row, copies)
-            })
-            .collect();
-        let collection = RowCollection::new(rows, &self.peek.finishing.order_by);
-        metrics
-            .row_collection_seconds
-            .observe(row_collection_start.elapsed().as_secs_f64());
-
-        PeekStatus::Ready(PeekResponse::Rows(vec![collection]))
+        let start = Instant::now();
+        let response = rows_response(rows, &self.peek.finishing.order_by);
+        metrics.walk.observe_row_collection(start.elapsed());
+        PeekStatus::Ready(response)
     }
 }
 
@@ -1889,6 +2090,9 @@ enum PeekStatus {
     /// The result size is above the configured threshold and the peek is
     /// eligible for using the peek result stash.
     UsePeekStash,
+    /// The walk stopped with work left and nothing to hand over, so it is finished away from the
+    /// worker. Carries the scan, which resumes from the cursor positions it stopped on.
+    Offload(IndexPeekScan),
     /// The peek result is ready.
     Ready(PeekResponse),
 }
@@ -2113,9 +2317,10 @@ impl CollectionState {
 #[cfg(test)]
 mod tests;
 
-/// Tests of the inline index-peek driver, and the fixtures a peek scan is tested over.
-///
-/// The fixtures are shared with [`peek_scan`]'s own tests, which build a scan from the same
-/// [`TraceBundle`] this driver hands one.
+/// Tests of the inline index-peek driver, and the fixtures [`peek_scan`]'s tests share with it.
 #[cfg(test)]
 pub(crate) mod index_peek_tests;
+
+/// Tests of the sweep that drives the pending index peeks.
+#[cfg(test)]
+mod peek_sweep_tests;

--- a/src/compute/src/compute_state/index_peek_tests.rs
+++ b/src/compute/src/compute_state/index_peek_tests.rs
@@ -13,12 +13,14 @@ use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::trace::{Batcher, Builder, Trace};
 use mz_expr::RowSetFinishing;
 use mz_ore::cast::CastFrom;
-use mz_repr::{Datum, Diff, RelationDesc};
+use mz_repr::{Datum, Diff, RelationDesc, SqlScalarType};
 use mz_row_spine::{RowRowBatcher, RowRowBuilder, RowRowSpine};
 use mz_timely_util::columnation::ColumnationStack;
 use timely::container::PushInto;
 use timely::dataflow::operators::generic::OperatorInfo;
 
+use crate::metrics::ComputeMetrics;
+use crate::server::ComputeRuntimeRole;
 use crate::typedefs::{ErrAgent, ErrSpine, RowRowAgent};
 
 use super::error_scan::tests::{
@@ -45,8 +47,11 @@ where
 }
 
 /// A row holding `value` as its only datum, as the ok trace's keys hold it.
-pub(crate) fn ok_row(value: u8) -> Row {
-    Row::pack_slice(&[Datum::UInt8(value)])
+///
+/// The datum type matches the column [`index_peek`] declares, because that description is the
+/// schema a peek taken to the stash writes its rows under.
+pub(crate) fn ok_row(value: u64) -> Row {
+    Row::pack_slice(&[Datum::UInt64(value)])
 }
 
 /// A finishing that asks for every row, in the order the walk produced them.
@@ -106,6 +111,10 @@ pub(crate) fn answering_errors(count: usize) -> (ErrorUpdates, PeekError) {
 /// one without return rows of the same shape: the cursor's key is one datum, the values are
 /// empty, and a literal constraint contributes a second datum that a join in a dataflow would
 /// have added.
+///
+/// The result description carries that one column, because its arity is what decides whether
+/// the peek's finishing streams, and a finishing that streams is what makes a peek eligible
+/// for the peek stash.
 pub(crate) fn index_peek(
     finishing: RowSetFinishing,
     literal_constraints: Option<Vec<Row>>,
@@ -117,9 +126,12 @@ pub(crate) fn index_peek(
         .expect("valid plan")
         .into_nontemporal()
         .expect("non-temporal plan");
+    let result_desc = RelationDesc::builder()
+        .with_column("value", SqlScalarType::UInt64.nullable(false))
+        .finish();
     Peek {
         target: PeekTarget::Index { id: TARGET_ID },
-        result_desc: RelationDesc::empty(),
+        result_desc,
         literal_constraints,
         uuid: Uuid::nil(),
         timestamp: PEEK_TIMESTAMP,
@@ -129,96 +141,110 @@ pub(crate) fn index_peek(
     }
 }
 
-/// The histograms an index peek observes into, owned by the test that reads them back.
-struct TestMetrics {
-    seek_fulfillment_seconds: prometheus::Histogram,
-    frontier_check_seconds: prometheus::Histogram,
-    error_scan_seconds: prometheus::Histogram,
-    cursor_setup_seconds: prometheus::Histogram,
-    row_iteration_seconds: prometheus::Histogram,
-    row_iteration_rows: prometheus::Histogram,
-    result_sort_seconds: prometheus::Histogram,
-    result_sort_rows: prometheus::Histogram,
-    row_collection_seconds: prometheus::Histogram,
+/// A peek of [`TARGET_ID`] carrying `uuid`, so that a test with several pending peeks can say
+/// which one a response answered.
+pub(crate) fn index_peek_with_uuid(uuid: Uuid, literal_constraints: Option<Vec<Row>>) -> Peek {
+    let mut peek = index_peek(trivial_finishing(), literal_constraints);
+    peek.uuid = uuid;
+    peek
 }
 
-fn histogram(name: &str) -> prometheus::Histogram {
-    prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(name, name))
-        .expect("valid histogram")
+/// The keys of an index holding `count` distinct rows, in the order the ok walk visits them.
+///
+/// Sorted here rather than assumed, because the trace holds its keys in [`Row`] order and the
+/// answer a full walk gives is that order. Used where an index needs more positions than the
+/// production inline budget lets a peek walk on the worker.
+pub(crate) fn wide_ok_rows(count: u64) -> Vec<Row> {
+    let mut keys: Vec<Row> = (0..count).map(ok_row).collect();
+    keys.sort();
+    keys
+}
+
+/// The metrics an index peek observes into, registered into a registry the test owns so it
+/// can read them back.
+struct TestMetrics {
+    metrics: WorkerMetrics,
+    walk: PeekWalkMetrics,
 }
 
 impl TestMetrics {
     fn new() -> Self {
-        Self {
-            seek_fulfillment_seconds: histogram("seek_fulfillment_seconds"),
-            frontier_check_seconds: histogram("frontier_check_seconds"),
-            error_scan_seconds: histogram("error_scan_seconds"),
-            cursor_setup_seconds: histogram("cursor_setup_seconds"),
-            row_iteration_seconds: histogram("row_iteration_seconds"),
-            row_iteration_rows: histogram("row_iteration_rows"),
-            result_sort_seconds: histogram("result_sort_seconds"),
-            result_sort_rows: histogram("result_sort_rows"),
-            row_collection_seconds: histogram("row_collection_seconds"),
-        }
+        let metrics =
+            ComputeMetrics::register_with(&MetricsRegistry::new(), ComputeRuntimeRole::Solo)
+                .for_worker(0);
+        let walk = PeekWalkMetrics::new(&metrics);
+        Self { metrics, walk }
     }
 
     fn as_metrics(&self) -> IndexPeekMetrics<'_> {
         IndexPeekMetrics {
-            seek_fulfillment_seconds: &self.seek_fulfillment_seconds,
-            frontier_check_seconds: &self.frontier_check_seconds,
-            error_scan_seconds: &self.error_scan_seconds,
-            cursor_setup_seconds: &self.cursor_setup_seconds,
-            row_iteration_seconds: &self.row_iteration_seconds,
-            row_iteration_rows: &self.row_iteration_rows,
-            result_sort_seconds: &self.result_sort_seconds,
-            result_sort_rows: &self.result_sort_rows,
-            row_collection_seconds: &self.row_collection_seconds,
+            seek_fulfillment_seconds: &self.metrics.index_peek_seek_fulfillment_seconds,
+            frontier_check_seconds: &self.metrics.index_peek_frontier_check_seconds,
+            walk: &self.walk,
         }
     }
 
-    /// How often each histogram that `collect_finished_data` can observe into was observed.
+    /// How often each metric that `collect_finished_data` can observe into was observed.
     ///
     /// The two histograms the enclosing `seek_fulfillment` owns are left out, because the
     /// tests that read this call `collect_finished_data` directly.
     fn observations(&self) -> BTreeMap<&'static str, u64> {
+        let metrics = &self.metrics;
         BTreeMap::from([
+            ("walks_inline", metrics.index_peek_walks_inline.get()),
+            ("walks_offloaded", metrics.index_peek_walks_offloaded.get()),
             (
                 "error_scan_seconds",
-                self.error_scan_seconds.get_sample_count(),
+                metrics.index_peek_error_scan_seconds.get_sample_count(),
             ),
             (
                 "cursor_setup_seconds",
-                self.cursor_setup_seconds.get_sample_count(),
+                metrics.index_peek_cursor_setup_seconds.get_sample_count(),
             ),
             (
                 "row_iteration_seconds",
-                self.row_iteration_seconds.get_sample_count(),
+                metrics.index_peek_row_iteration_seconds.get_sample_count(),
             ),
             (
                 "row_iteration_rows",
-                self.row_iteration_rows.get_sample_count(),
+                metrics.index_peek_row_iteration_rows.get_sample_count(),
             ),
             (
                 "result_sort_seconds",
-                self.result_sort_seconds.get_sample_count(),
+                metrics.index_peek_result_sort_seconds.get_sample_count(),
             ),
-            ("result_sort_rows", self.result_sort_rows.get_sample_count()),
+            (
+                "result_sort_rows",
+                metrics.index_peek_result_sort_rows.get_sample_count(),
+            ),
             (
                 "row_collection_seconds",
-                self.row_collection_seconds.get_sample_count(),
+                metrics.index_peek_row_collection_seconds.get_sample_count(),
             ),
         ])
     }
 }
 
+/// The fuel the inline driver spends with the offload off, which is the amount that makes a
+/// walk run to an outcome rather than suspend.
+fn unbounded_fuel() -> usize {
+    usize::MAX
+}
+
 /// The observation counts a driver call is expected to leave behind, named so that a failure
-/// says which histogram moved.
+/// says which metric moved.
+///
+/// `walks_offloaded` is zero throughout, because these tests exercise the inline driver and a
+/// walk it offloads is counted by the task that finishes it.
 fn expected_observations(
+    walks_inline: u64,
     error_scan: u64,
     cursor_setup: u64,
     rows: u64,
 ) -> BTreeMap<&'static str, u64> {
     BTreeMap::from([
+        ("walks_inline", walks_inline),
+        ("walks_offloaded", 0),
         ("error_scan_seconds", error_scan),
         ("cursor_setup_seconds", cursor_setup),
         ("row_iteration_seconds", rows),
@@ -237,6 +263,7 @@ fn expected_observations(
 enum Answer {
     NotReady,
     UsePeekStash,
+    Offload,
     Ready(PeekResponse),
 }
 
@@ -245,6 +272,9 @@ impl From<PeekStatus> for Answer {
         match status {
             PeekStatus::NotReady => Answer::NotReady,
             PeekStatus::UsePeekStash => Answer::UsePeekStash,
+            // The scan an offload carries has no comparison of its own. What is comparable
+            // is that the walk left this driver rather than answering here.
+            PeekStatus::Offload(_) => Answer::Offload,
             PeekStatus::Ready(response) => Answer::Ready(response),
         }
     }
@@ -259,13 +289,19 @@ fn index_peek_over(peek: Peek, keys: &[Row], errors: ErrorUpdates) -> IndexPeek 
     }
 }
 
-/// The rows a completed peek over `values` answers with.
-fn row_collection(values: impl IntoIterator<Item = u8>) -> RowCollection {
-    let rows = values
+/// The rows a completed peek answers with, each at a multiplicity of one and in the order the
+/// walk produced them.
+pub(crate) fn row_collection(rows: impl IntoIterator<Item = Row>) -> RowCollection {
+    let rows = rows
         .into_iter()
-        .map(|value| (ok_row(value), NonZeroUsize::new(1).expect("non-zero")))
+        .map(|row| (row, NonZeroUsize::new(1).expect("non-zero")))
         .collect();
     RowCollection::new(rows, &[])
+}
+
+/// The answer a peek gives when its walk completes over `rows`.
+pub(crate) fn rows_answer(rows: impl IntoIterator<Item = Row>) -> PeekResponse {
+    PeekResponse::Rows(vec![row_collection(rows)])
 }
 
 /// A peek whose scan runs to completion is answered with the rows it accumulated, and reports
@@ -280,14 +316,20 @@ fn a_completed_scan_answers_with_rows_and_reports_every_phase() {
     );
     let metrics = TestMetrics::new();
 
-    let answer =
-        subject.collect_finished_data(u64::MAX, false, usize::MAX, None, &metrics.as_metrics());
+    let answer = subject.collect_finished_data(
+        u64::MAX,
+        false,
+        usize::MAX,
+        None,
+        &mut unbounded_fuel(),
+        &metrics.as_metrics(),
+    );
 
     assert_eq!(
         Answer::from(answer),
-        Answer::Ready(PeekResponse::Rows(vec![row_collection(0..6)]))
+        Answer::Ready(rows_answer((0..6).map(ok_row)))
     );
-    assert_eq!(metrics.observations(), expected_observations(1, 1, 1));
+    assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 1));
 }
 
 /// A peek its error trace answers reports no phase timer at all, because it reached none of
@@ -301,14 +343,20 @@ fn an_error_answered_peek_reports_no_phase_timers() {
     let mut subject = index_peek_over(index_peek(trivial_finishing(), None), &keys, errors);
     let metrics = TestMetrics::new();
 
-    let answer =
-        subject.collect_finished_data(u64::MAX, false, usize::MAX, None, &metrics.as_metrics());
+    let answer = subject.collect_finished_data(
+        u64::MAX,
+        false,
+        usize::MAX,
+        None,
+        &mut unbounded_fuel(),
+        &metrics.as_metrics(),
+    );
 
     assert_eq!(
         Answer::from(answer),
         Answer::Ready(PeekResponse::Error(expected))
     );
-    assert_eq!(metrics.observations(), expected_observations(0, 0, 0));
+    assert_eq!(metrics.observations(), expected_observations(1, 0, 0, 0));
 }
 
 /// A peek whose accumulated rows fill a batch is diverted to the stash rather than answered
@@ -326,10 +374,82 @@ fn a_scan_that_fills_a_batch_diverts_the_peek_to_the_stash() {
 
     // A threshold of zero bytes is crossed by the first row, so the scan fills a batch well
     // before the trace runs out.
-    let answer = subject.collect_finished_data(u64::MAX, true, 0, None, &metrics.as_metrics());
+    let answer = subject.collect_finished_data(
+        u64::MAX,
+        true,
+        0,
+        None,
+        &mut unbounded_fuel(),
+        &metrics.as_metrics(),
+    );
 
     assert_eq!(Answer::from(answer), Answer::UsePeekStash);
-    assert_eq!(metrics.observations(), expected_observations(1, 1, 0));
+    assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 0));
+}
+
+/// A peek whose walk both fills a batch and runs out of fuel is diverted to the stash rather
+/// than offloaded, and the driver that diverted it accounts for the walk.
+///
+/// This is the livelock the placement policy is built around. An offloaded scan holding a full
+/// batch has nowhere to write it, so stepping it spends no fuel and advances no cursor, and a
+/// driver that resumed it would yield forever. The two causes of a suspension coincide here,
+/// which is the case an offload condition written as "the fuel ran out" would get wrong.
+#[mz_ore::test]
+fn a_batch_ready_suspension_is_diverted_rather_than_offloaded() {
+    let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    let mut subject = index_peek_over(
+        index_peek(trivial_finishing(), None),
+        &keys,
+        cancelling_errors(0),
+    );
+    let metrics = TestMetrics::new();
+
+    // A threshold of zero bytes is crossed by the first row the ok walk produces. The empty
+    // error trace costs no position, so that one row is all the budget buys, and the scan
+    // suspends holding a full batch and out of fuel, with both causes of a suspension in force
+    // at once.
+    let mut fuel = 1;
+    let answer =
+        subject.collect_finished_data(u64::MAX, true, 0, None, &mut fuel, &metrics.as_metrics());
+    assert_eq!(Answer::from(answer), Answer::UsePeekStash);
+    assert_eq!(fuel, 0, "the slice spent every position it was given");
+    assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 0));
+}
+
+/// A peek whose walk outruns the fuel it was granted leaves the worker rather than being
+/// answered or diverted, and the walk it leaves with reports nothing.
+///
+/// Reporting here as well as in the driver that finishes the walk would count one walk twice,
+/// on both substrates and in every phase histogram, and the numbers a scan carries are
+/// cumulative precisely so that the driver which ends it can report all of them.
+#[mz_ore::test]
+fn a_scan_that_outruns_its_fuel_leaves_the_worker_reporting_nothing() {
+    let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    let mut subject = index_peek_over(
+        index_peek(trivial_finishing(), None),
+        &keys,
+        cancelling_errors(0),
+    );
+    let metrics = TestMetrics::new();
+
+    // An empty error trace is walked out within a position or two, so this fuel is spent
+    // inside the ok walk with most of the six keys still ahead of it.
+    let mut fuel = 2;
+    let answer = subject.collect_finished_data(
+        u64::MAX,
+        false,
+        usize::MAX,
+        None,
+        &mut fuel,
+        &metrics.as_metrics(),
+    );
+
+    assert_eq!(Answer::from(answer), Answer::Offload);
+    assert_eq!(
+        fuel, 0,
+        "an offloaded slice spent every position it was given"
+    );
+    assert_eq!(metrics.observations(), expected_observations(0, 0, 0, 0));
 }
 
 /// A peek its ok walk fails is answered with that error, and reports the phases that walk
@@ -357,6 +477,7 @@ fn an_ok_phase_failure_reports_the_phases_the_walk_reached() {
         false,
         usize::MAX,
         None,
+        &mut unbounded_fuel(),
         &metrics.as_metrics(),
     );
 
@@ -366,5 +487,5 @@ fn an_ok_phase_failure_reports_the_phases_the_walk_reached() {
             max_result_size: usize::cast_from(max_result_size),
         }))
     );
-    assert_eq!(metrics.observations(), expected_observations(1, 1, 0));
+    assert_eq!(metrics.observations(), expected_observations(1, 1, 1, 0));
 }

--- a/src/compute/src/compute_state/peek_budget.rs
+++ b/src/compute/src/compute_state/peek_budget.rs
@@ -1,0 +1,140 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! What a worker activation may spend walking index peeks before it hands the worker back.
+
+use mz_compute_types::dyncfgs::{
+    ENABLE_INDEX_PEEK_OFFLOAD, INDEX_PEEK_ACTIVATION_BUDGET, INDEX_PEEK_INLINE_BUDGET,
+};
+use mz_dyncfg::{ConfigSet, ConfigValHandle};
+
+/// The parameters an [`InlineBudget`] is read from, as handles: every activation reads them, and
+/// by-name lookups would put three searches of the configuration set on the worker's loop.
+struct InlineBudgetConfig {
+    enabled: ConfigValHandle<bool>,
+    per_peek: ConfigValHandle<usize>,
+    aggregate: ConfigValHandle<usize>,
+}
+
+impl InlineBudgetConfig {
+    fn new(config: &ConfigSet) -> Self {
+        Self {
+            enabled: ENABLE_INDEX_PEEK_OFFLOAD.handle(config),
+            per_peek: INDEX_PEEK_INLINE_BUDGET.handle(config),
+            aggregate: INDEX_PEEK_ACTIVATION_BUDGET.handle(config),
+        }
+    }
+
+    /// Reads the parameters in effect now into the fuel of one activation.
+    fn arm(&self) -> ActivationBudget {
+        if !self.enabled.get() {
+            return ActivationBudget::Unbounded;
+        }
+
+        // Both floors keep the parameters monotone down to zero rather than wedging there. A
+        // per-peek budget of zero suspends every scan before it walks a position, and a suspension
+        // holding no full batch is an offload, so every point lookup would pay for a task and a
+        // permit to walk nothing. An aggregate of zero passes every peek over on every activation,
+        // and the activation a passed-over peek asks for finds the same empty budget.
+        ActivationBudget::Bounded {
+            per_peek: self.per_peek.get().max(1),
+            remaining: self.aggregate.get().max(1),
+        }
+    }
+}
+
+/// The fuel an activation may spend walking index peeks on the worker, and what one peek may take
+/// of it.
+///
+/// The per-peek budget decides placement: a peek that outruns it moves off the worker. The
+/// aggregate exists because the sweep visits every pending peek, so a per-peek budget alone would
+/// let N peeks cost N times that budget in one pass.
+///
+/// Both count cursor positions, the unit the scan charges.
+enum ActivationBudget {
+    /// Every peek walks to completion where it started, and nothing is offloaded or passed over.
+    ///
+    /// What the kill switch restores. A scan suspends only out of fuel or holding a full batch,
+    /// so unbounded fuel leaves the batch as the only suspension and the peek takes the stash.
+    Unbounded,
+    /// A peek may spend `per_peek` before it is offloaded, and all peeks together may spend
+    /// `remaining` before the rest of this activation's work gets the worker back.
+    Bounded { per_peek: usize, remaining: usize },
+}
+
+/// The fuel of the activation under way, armed from the parameters by the first peek that asks for
+/// a slice of it.
+///
+/// Arming at the grant is what reads the parameters as late as anything can. Commands drain in
+/// full before the sweep that begins an activation, so a peek arriving on that path is granted a
+/// slice before any activation has begun, and a budget that only an activation's start armed would
+/// hand that peek whatever the last one left. The constructor cannot arm it either: `ConfigSet`
+/// handles read the live value, but a value read there is read before `handle_create_instance`
+/// applies the controller's snapshot, and an empty snapshot leaves the defaults in place until the
+/// first `UpdateConfiguration`. Since the offload's own flag defaults off, an eagerly armed budget
+/// is an unbounded one, and it would go to every peek in a reconnecting controller's backlog.
+pub(super) struct InlineBudget {
+    config: InlineBudgetConfig,
+    /// The fuel of the activation under way, or `None` while no peek has asked for a slice since
+    /// the activation began.
+    activation: Option<ActivationBudget>,
+}
+
+impl InlineBudget {
+    /// A budget reading `config`, whose first grant arms the first activation.
+    pub(super) fn new(config: &ConfigSet) -> Self {
+        Self {
+            config: InlineBudgetConfig::new(config),
+            activation: None,
+        }
+    }
+
+    /// Begins an activation, discarding what the previous one left. Nothing else refills the fuel.
+    pub(super) fn start_activation(&mut self) {
+        self.activation = None;
+    }
+
+    /// The fuel one peek's slice may spend, or `None` when this activation has none left to give.
+    ///
+    /// A peek gets its whole per-peek budget or nothing, so the aggregate can overrun by one
+    /// budget.
+    ///
+    /// A caller granted `None` must pass the peek over. Stepping with no fuel suspends the scan
+    /// without walking anything, offloading a peek that never had its inline turn.
+    pub(super) fn grant(&mut self) -> Option<usize> {
+        let Self { config, activation } = self;
+        match activation.get_or_insert_with(|| config.arm()) {
+            ActivationBudget::Unbounded => Some(usize::MAX),
+            ActivationBudget::Bounded {
+                per_peek,
+                remaining,
+            } => (*remaining > 0).then_some(*per_peek),
+        }
+    }
+
+    /// Charges the activation for the positions a slice walked. An unarmed budget has nothing to
+    /// charge, since a slice is only ever walked out of fuel this granted.
+    pub(super) fn charge(&mut self, spent: usize) {
+        match &mut self.activation {
+            Some(ActivationBudget::Bounded { remaining, .. }) => {
+                *remaining = remaining.saturating_sub(spent)
+            }
+            Some(ActivationBudget::Unbounded) | None => {}
+        }
+    }
+
+    /// What is left of this activation's aggregate, or `None` when the activation is unarmed or
+    /// unbounded.
+    #[cfg(test)]
+    pub(super) fn remaining(&self) -> Option<usize> {
+        match &self.activation {
+            Some(ActivationBudget::Bounded { remaining, .. }) => Some(*remaining),
+            Some(ActivationBudget::Unbounded) | None => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/compute/src/compute_state/peek_budget/tests.rs
+++ b/src/compute/src/compute_state/peek_budget/tests.rs
@@ -1,0 +1,154 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Tests of the fuel an activation may spend walking index peeks.
+
+use mz_dyncfg::ConfigUpdates;
+
+use super::*;
+
+/// The configuration the budget tests read, with the offload on, a per-peek budget of
+/// `per_peek` and an aggregate of `aggregate`.
+fn config(per_peek: usize, aggregate: usize) -> ConfigSet {
+    let config = mz_dyncfgs::all_dyncfgs();
+    let mut updates = ConfigUpdates::default();
+    updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+    updates.add(&INDEX_PEEK_INLINE_BUDGET, per_peek);
+    updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, aggregate);
+    updates.apply(&config);
+    config
+}
+
+/// A budget that no activation has begun still grants a bounded slice, because the grant is
+/// what arms it.
+///
+/// The worker drains the commands it has queued before it sweeps its pending peeks, and a peek
+/// arriving on that path is granted a slice as it arrives. A budget armed only where an
+/// activation begins would grant that peek the unbounded fuel of a budget that had never been
+/// read, and unbounded fuel never suspends, so the peek would walk to its answer on the worker
+/// however the parameters are set.
+#[mz_ore::test]
+fn the_first_grant_arms_the_budget() {
+    let config = config(100, 250);
+    let mut budget = InlineBudget::new(&config);
+
+    assert_eq!(budget.grant(), Some(100));
+}
+
+/// Beginning an activation refills the aggregate, which is what makes it a bound on one
+/// activation rather than on the process.
+#[mz_ore::test]
+fn beginning_an_activation_refills_the_aggregate() {
+    let config = config(100, 250);
+    let mut budget = InlineBudget::new(&config);
+
+    assert_eq!(budget.grant(), Some(100));
+    budget.charge(250);
+    assert_eq!(budget.grant(), None);
+
+    budget.start_activation();
+
+    assert_eq!(budget.grant(), Some(100));
+    assert_eq!(budget.remaining(), Some(250));
+}
+
+/// With the offload off, every peek is granted unbounded fuel however much the peeks before it
+/// spent, which is what makes the kill switch restore the worker's old behaviour rather than
+/// approximate it.
+#[mz_ore::test]
+fn the_kill_switch_grants_every_peek_an_unbounded_slice() {
+    let config = mz_dyncfgs::all_dyncfgs();
+    let mut budget = InlineBudget::new(&config);
+
+    for _ in 0..3 {
+        assert_eq!(budget.grant(), Some(usize::MAX));
+        budget.charge(usize::MAX);
+    }
+}
+
+/// The aggregate is spent by what the peeks walked, not by what they were granted, so cheap
+/// peeks keep getting turns and expensive ones drain it.
+#[mz_ore::test]
+fn the_aggregate_is_spent_by_what_the_peeks_walk() {
+    let config = config(100, 250);
+    let mut budget = InlineBudget::new(&config);
+
+    // Point-lookup-sized slices barely touch the aggregate.
+    for _ in 0..10 {
+        assert_eq!(budget.grant(), Some(100));
+        budget.charge(2);
+    }
+
+    // Slices that spend the whole per-peek budget drain it, and the peeks behind them are
+    // passed over rather than served with a partial slice.
+    assert_eq!(budget.grant(), Some(100));
+    budget.charge(100);
+    assert_eq!(budget.grant(), Some(100));
+    budget.charge(100);
+    assert_eq!(budget.grant(), Some(100));
+    budget.charge(100);
+    assert_eq!(budget.grant(), None);
+}
+
+/// A configuration change reaches the activation that follows it through the handles the
+/// budget holds, which is what keeps a parameter change from waiting on a restart. The
+/// activation under way when the change lands keeps the fuel it was armed with.
+#[mz_ore::test]
+fn a_parameter_change_reaches_the_next_activation() {
+    let config = mz_dyncfgs::all_dyncfgs();
+    let mut budget = InlineBudget::new(&config);
+
+    assert_eq!(budget.grant(), Some(usize::MAX));
+
+    let mut updates = ConfigUpdates::default();
+    updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+    updates.add(&INDEX_PEEK_INLINE_BUDGET, 100);
+    updates.apply(&config);
+
+    assert_eq!(budget.grant(), Some(usize::MAX));
+
+    budget.start_activation();
+
+    assert_eq!(budget.grant(), Some(100));
+}
+
+/// A per-peek budget of zero still walks one position. Without that, every peek would be
+/// offloaded having walked nothing, which spends a task and a permit on a point lookup the
+/// worker would have answered outright.
+#[mz_ore::test]
+fn a_zero_per_peek_budget_still_walks_one_position() {
+    let config = config(0, *INDEX_PEEK_ACTIVATION_BUDGET.default());
+    let mut budget = InlineBudget::new(&config);
+
+    assert_eq!(budget.grant(), Some(1));
+}
+
+/// An aggregate of zero still serves one peek per activation. Without that, every peek would
+/// be passed over on every activation and none would ever be answered.
+#[mz_ore::test]
+fn a_zero_aggregate_still_serves_one_peek() {
+    let config = config(100, 0);
+    let mut budget = InlineBudget::new(&config);
+
+    assert_eq!(budget.grant(), Some(100));
+    budget.charge(100);
+    assert_eq!(budget.grant(), None);
+}
+
+/// An inline budget larger than the aggregate still serves one peek per activation. Without
+/// that, no peek would ever be granted a slice and every peek would hang.
+#[mz_ore::test]
+fn an_inline_budget_above_the_aggregate_still_serves_one_peek() {
+    let config = config(1_000_000_000, 1);
+    let mut budget = InlineBudget::new(&config);
+
+    assert_eq!(budget.grant(), Some(1_000_000_000));
+    budget.charge(1_000_000_000);
+    assert_eq!(budget.grant(), None);
+}

--- a/src/compute/src/compute_state/peek_metrics.rs
+++ b/src/compute/src/compute_state/peek_metrics.rs
@@ -1,0 +1,164 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! What an index peek reports about the walk that answers it.
+//!
+//! A walk runs on one driver or two, and the numbers a [`PeekScan`] carries are cumulative over
+//! every slice either drove. Each histogram is observed once per walk, by the driver that produces
+//! the terminal outcome. An offload is not terminal, so a slice that offloads reports nothing and
+//! the task that finishes reports the whole set. A cancelled walk reports nothing, so the substrate
+//! counters count walks that ended.
+//!
+//! [`PeekScan`]: super::peek_scan::PeekScan
+
+use std::time::{Duration, Instant};
+
+use mz_ore::cast::CastLossy;
+use mz_ore::metrics::UIntGauge;
+use prometheus::{Histogram, IntCounter};
+
+use crate::compute_state::peek_scan::WalkPhases;
+use crate::metrics::WorkerMetrics;
+
+/// The metrics an index peek walk reports, on either substrate.
+///
+/// Cloned into an offloaded walk's task, so that a walk reports the same phases wherever it ran.
+#[derive(Clone, Debug)]
+pub(super) struct PeekWalkMetrics {
+    /// Counts walks that ended on the timely worker.
+    walks_inline: IntCounter,
+    /// Counts walks that ended away from the timely worker.
+    walks_offloaded: IntCounter,
+    error_scan_seconds: Histogram,
+    cursor_setup_seconds: Histogram,
+    row_iteration_seconds: Histogram,
+    row_iteration_rows: Histogram,
+    result_sort_seconds: Histogram,
+    result_sort_rows: Histogram,
+    row_collection_seconds: Histogram,
+    /// How many offloaded walks are waiting for a permit. Reported by the offloaded driver alone,
+    /// which is the only one that queues.
+    permit_queue_depth: UIntGauge,
+    /// How long an offloaded walk waited for its permit. Reported by the offloaded driver alone.
+    permit_wait_seconds: Histogram,
+}
+
+impl PeekWalkMetrics {
+    pub(super) fn new(metrics: &WorkerMetrics) -> Self {
+        Self {
+            walks_inline: metrics.index_peek_walks_inline.clone(),
+            walks_offloaded: metrics.index_peek_walks_offloaded.clone(),
+            error_scan_seconds: metrics.index_peek_error_scan_seconds.clone(),
+            cursor_setup_seconds: metrics.index_peek_cursor_setup_seconds.clone(),
+            row_iteration_seconds: metrics.index_peek_row_iteration_seconds.clone(),
+            row_iteration_rows: metrics.index_peek_row_iteration_rows.clone(),
+            result_sort_seconds: metrics.index_peek_result_sort_seconds.clone(),
+            result_sort_rows: metrics.index_peek_result_sort_rows.clone(),
+            row_collection_seconds: metrics.index_peek_row_collection_seconds.clone(),
+            permit_queue_depth: metrics.index_peek_permit_queue_depth.clone(),
+            permit_wait_seconds: metrics.index_peek_permit_wait_seconds.clone(),
+        }
+    }
+
+    /// Accounts for an offloaded walk joining the queue for a permit.
+    ///
+    /// The returned guard leaves the queue however the wait ends, a cancellation and an abort
+    /// included, so the depth cannot drift up over a process's life.
+    pub(super) fn queued_for_permit(&self) -> PermitWait {
+        self.permit_queue_depth.inc();
+        PermitWait {
+            queue_depth: self.permit_queue_depth.clone(),
+            wait_seconds: self.permit_wait_seconds.clone(),
+            since: Instant::now(),
+        }
+    }
+
+    /// Counts a walk that the timely worker drove to an outcome.
+    ///
+    /// A peek diverted to the peek stash counts here, because the walk that decided that ran on
+    /// the worker. The stash's own walk of the same trace counts on neither substrate.
+    pub(super) fn walked_inline(&self) {
+        self.walks_inline.inc();
+    }
+
+    /// Counts a walk that an offloaded task drove to an outcome, whatever that outcome is.
+    ///
+    /// A walk cancelled while queued or while running counts on neither substrate, so the two sum
+    /// to the walks that ended rather than to the walks that were admitted.
+    pub(super) fn walked_offloaded(&self) {
+        self.walks_offloaded.inc();
+    }
+
+    /// Reports the phases that precede the walk over the ok trace.
+    ///
+    /// Reported for every terminal outcome, a hand-off to the peek stash included, because both
+    /// phases are over by then whatever the walk does next.
+    pub(super) fn observe_error_phase(&self, phases: &WalkPhases) {
+        // A peek its error trace answered reports neither number: that walk stopped where the
+        // error was, and the cursor the second number times was never used.
+        if !phases.error_trace_clean {
+            return;
+        }
+
+        self.error_scan_seconds
+            .observe(phases.error_scan.as_secs_f64());
+        self.cursor_setup_seconds
+            .observe(phases.cursor_setup.as_secs_f64());
+    }
+
+    /// Reports the walk over the ok trace, for a walk that completed it. A walk that ends any
+    /// other way reports nothing here: the rows it examined are not the rows an answer took.
+    pub(super) fn observe_ok_phase(&self, phases: &WalkPhases) {
+        self.row_iteration_seconds
+            .observe(phases.row_iteration.as_secs_f64());
+        self.row_iteration_rows
+            .observe(f64::cast_lossy(phases.rows_processed));
+        self.result_sort_seconds
+            .observe(phases.result_sort.as_secs_f64());
+        self.result_sort_rows
+            .observe(f64::cast_lossy(phases.rows_sorted));
+    }
+
+    /// Reports the time [`rows_response`](super::peek_scan::rows_response) took.
+    pub(super) fn observe_row_collection(&self, elapsed: Duration) {
+        self.row_collection_seconds.observe(elapsed.as_secs_f64());
+    }
+}
+
+/// An offloaded walk's place in the queue for a permit, for as long as it holds one.
+///
+/// Leaving the queue is a drop rather than a call, so a cancelled or aborted walk leaves it as
+/// surely as an admitted one.
+pub(super) struct PermitWait {
+    queue_depth: UIntGauge,
+    wait_seconds: Histogram,
+    since: Instant,
+}
+
+impl PermitWait {
+    /// Reports the wait of a walk that was admitted. A walk that leaves the queue any other way
+    /// reports nothing, so the histogram describes waits that ended in a permit.
+    pub(super) fn admitted(self) {
+        self.wait_seconds
+            .observe(self.since.elapsed().as_secs_f64());
+    }
+}
+
+impl Drop for PermitWait {
+    fn drop(&mut self) {
+        self.queue_depth.dec();
+    }
+}
+
+/// The metrics an index peek reports from the worker that owns it.
+///
+/// These time the worker's own handling of a peek, which no offloaded walk repeats, so unlike the
+/// walk's metrics they have a single observer by construction.
+pub(super) struct IndexPeekMetrics<'a> {
+    pub seek_fulfillment_seconds: &'a Histogram,
+    pub frontier_check_seconds: &'a Histogram,
+    /// The metrics of the walk itself, which an offloaded walk reports too.
+    pub walk: &'a PeekWalkMetrics,
+}

--- a/src/compute/src/compute_state/peek_offload.rs
+++ b/src/compute/src/compute_state/peek_offload.rs
@@ -1,0 +1,440 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! Driving an index peek's walk away from the timely worker that owns it.
+//!
+//! An offloaded walk steps its scan on the blocking pool, so neither the timely worker nor an
+//! async one carries it. It returns to its async task only to answer, and checks for cancellation
+//! every `yield_granularity` positions in between. The scan and the permit that admitted it travel
+//! together, and every way the walk ends, including a panic, drops the two together.
+//!
+//! The permit bounds the walks that run, and nothing else. An offloaded walk that has not been
+//! admitted queues holding its scan, which retains its accumulated rows and pins the batches its
+//! cursors were opened over, so retained memory grows with offloaded walks rather than running
+//! ones.
+//!
+//! This driver performs no IO. A walk whose rows outgrow an inline answer hands back rather than
+//! writing them, which leaves the writing to the worker.
+
+use std::sync::{Arc, Mutex};
+use std::thread::Thread;
+use std::time::{Duration, Instant};
+
+use mz_compute_client::protocol::command::Peek;
+use mz_compute_client::protocol::response::{PeekError, PeekResponse};
+use mz_compute_types::dyncfgs::{INDEX_PEEK_PERMIT_FRACTION, INDEX_PEEK_YIELD_GRANULARITY};
+use mz_dyncfg::{ConfigSet, ConfigValHandle};
+use mz_expr::ColumnOrder;
+use mz_ore::cast::CastLossy;
+use mz_ore::soft_panic_or_log;
+use mz_ore::task::AbortOnDropHandle;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, oneshot};
+use tracing::debug;
+
+use crate::arrangement::manager::TraceBundle;
+use crate::compute_state::PeekRowIterationConfig;
+use crate::compute_state::peek_metrics::PeekWalkMetrics;
+use crate::compute_state::peek_scan::{IndexPeekScan, ScanOutcome, rows_response};
+
+/// The bound on how many offloaded peek walks run at once.
+///
+/// The resource it protects is CPU rather than any one worker's thread, so one instance covers
+/// every worker that shares it.
+pub struct PeekPermits {
+    semaphore: Arc<Semaphore>,
+    /// Under one lock, so a resize computing its delta and a release deciding whether to return
+    /// its permit see one state.
+    bound: Mutex<Bound>,
+    /// The workers the configured fraction is a fraction of.
+    workers: usize,
+}
+
+/// How many permits the semaphore has issued, and how many it should have.
+struct Bound {
+    /// Permits issued and not forgotten: the ones the semaphore holds plus the ones walks hold.
+    granted: usize,
+    /// What the last resize asked for. Below `granted` while a shrink is still being absorbed.
+    target: usize,
+}
+
+/// The permit an offloaded walk holds while it runs, released on drop.
+///
+/// A release owed to a shrink that found every permit held is forgotten rather than returned.
+/// That is how a lowered bound converges without interrupting a walk: a permit released while a
+/// walk is queued goes straight to that walk and never becomes available, so taking free permits
+/// back at the next resize would leave the bound where it was for as long as anything queued.
+pub(super) struct WalkPermit {
+    permit: Option<OwnedSemaphorePermit>,
+    permits: Arc<PeekPermits>,
+}
+
+impl Drop for WalkPermit {
+    fn drop(&mut self) {
+        let Some(permit) = self.permit.take() else {
+            return;
+        };
+        if self.permits.absorb_release() {
+            permit.forget();
+        }
+    }
+}
+
+impl PeekPermits {
+    /// Creates a bound over the `workers` a process runs, admitting one walk per worker until it
+    /// is configured otherwise.
+    pub fn new(workers: usize) -> Self {
+        let permits = Self::permits_for(workers, 1.0);
+        Self {
+            semaphore: Arc::new(Semaphore::new(permits)),
+            bound: Mutex::new(Bound {
+                granted: permits,
+                target: permits,
+            }),
+            workers,
+        }
+    }
+
+    /// Waits for a permit.
+    async fn acquire(self: &Arc<Self>) -> WalkPermit {
+        let permit = Arc::clone(&self.semaphore)
+            .acquire_owned()
+            .await
+            .expect("peek permits are never closed");
+        WalkPermit {
+            permit: Some(permit),
+            permits: Arc::clone(self),
+        }
+    }
+
+    /// Whether the permit about to be released is owed to a shrink, in which case the caller
+    /// forgets it instead of returning it.
+    fn absorb_release(&self) -> bool {
+        let mut bound = self.bound.lock().expect("lock poisoned");
+        if bound.granted > bound.target {
+            bound.granted -= 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// The permits `fraction` asks for over `workers`, at least one and at most what a semaphore
+    /// can hold.
+    ///
+    /// A `fraction` that is negative or NaN lands on the floor of one rather than being rejected,
+    /// because a misconfigured bound should pace the offload rather than stop it.
+    fn permits_for(workers: usize, fraction: f64) -> usize {
+        let scaled = f64::cast_lossy(workers) * fraction;
+        if scaled < 1.0 || scaled.is_nan() {
+            return 1;
+        }
+        usize::cast_lossy(scaled).clamp(1, Semaphore::MAX_PERMITS)
+    }
+
+    /// Resizes the bound to what `fraction` asks for.
+    ///
+    /// Raising it takes effect at once. Lowering it interrupts no walk: the permits free right now
+    /// go, and the rest go as the walks holding them finish, see [`WalkPermit`].
+    fn resize(&self, fraction: f64) {
+        let target = Self::permits_for(self.workers, fraction);
+
+        let mut bound = self.bound.lock().expect("lock poisoned");
+        bound.target = target;
+        if target > bound.granted {
+            self.semaphore.add_permits(target - bound.granted);
+            bound.granted = target;
+        } else if target < bound.granted {
+            bound.granted -= self.semaphore.forget_permits(bound.granted - target);
+        }
+    }
+
+    /// The permits no walk holds.
+    #[cfg(test)]
+    fn available_permits(&self) -> usize {
+        self.semaphore.available_permits()
+    }
+
+    /// Takes a permit if one is free.
+    #[cfg(test)]
+    fn try_acquire(self: &Arc<Self>) -> Option<WalkPermit> {
+        let permit = Arc::clone(&self.semaphore).try_acquire_owned().ok()?;
+        Some(WalkPermit {
+            permit: Some(permit),
+            permits: Arc::clone(self),
+        })
+    }
+}
+
+/// The parameters an offloaded walk reads, each as a handle rather than a value.
+///
+/// A handle lets a configuration change reach a walk already under way without discarding the
+/// positions it has visited. The granularity and the row limit are read at every slice boundary,
+/// the permit fraction once on the worker, since it sizes the bound the walk queues on.
+#[derive(Clone, Debug)]
+pub(super) struct OffloadConfig {
+    permit_fraction: ConfigValHandle<f64>,
+    yield_granularity: ConfigValHandle<usize>,
+    row_iteration: PeekRowIterationConfig,
+}
+
+impl OffloadConfig {
+    pub(super) fn new(config: &ConfigSet) -> Self {
+        Self {
+            permit_fraction: INDEX_PEEK_PERMIT_FRACTION.handle(config),
+            yield_granularity: INDEX_PEEK_YIELD_GRANULARITY.handle(config),
+            row_iteration: PeekRowIterationConfig::new(config),
+        }
+    }
+}
+
+/// What an offloaded walk hands back to the worker that offloaded it.
+pub enum OffloadOutcome {
+    /// The walk answered the peek.
+    Answered(PeekResponse),
+    /// The walk accumulated more rows than the peek may answer with inline, and answering it needs
+    /// them written to the peek stash. This driver performs no IO, so the walk stops here and the
+    /// worker takes the peek to the stash instead.
+    NeedsStash,
+}
+
+/// An index peek whose walk is running away from the worker that owns it.
+///
+/// Note that `OffloadedPeek` intentionally does not implement or derive `Clone`, as each one is
+/// meant to be dropped once it has been responded to.
+pub struct OffloadedPeek {
+    pub(crate) peek: Peek,
+    /// The traces the walk reads. Retained so the stash can walk the ok trace again from here
+    /// when the walk hands back, under the compaction hold this bundle carries.
+    pub(crate) trace_bundle: TraceBundle,
+    /// The outcome of the walk, eventually.
+    pub(crate) result: oneshot::Receiver<(OffloadOutcome, Duration)>,
+    /// The `tracing::Span` tracking this peek's operation.
+    pub(crate) span: tracing::Span,
+    /// The task driving the walk. Dropping this aborts it. The blocking thread stepping the scan
+    /// stops at its next cancellation check, and the scan, the cursors it holds, and the permit
+    /// that admitted it drop there.
+    _abort_handle: AbortOnDropHandle<()>,
+}
+
+impl OffloadedPeek {
+    /// Offloads `scan` to a task that finishes the walk away from the worker, waking `worker`
+    /// once the outcome is ready.
+    ///
+    /// `peek` and `trace_bundle` stay with the worker, because the bundle is what the stash
+    /// restarts the walk from if the walk hands back.
+    ///
+    /// The scan must not already hold a full batch: its first step would report that it needs the
+    /// stash, costing a permit and a hand-off for a peek the worker could have diverted itself.
+    /// The `debug_assert` below catches that in CI, not in an optimized build.
+    pub(super) fn start(
+        peek: Peek,
+        trace_bundle: TraceBundle,
+        scan: IndexPeekScan,
+        permits: Arc<PeekPermits>,
+        config: OffloadConfig,
+        metrics: PeekWalkMetrics,
+        worker: Thread,
+    ) -> Self {
+        debug_assert!(
+            !scan.batch_ready(),
+            "offloaded a peek scan that already holds a full batch"
+        );
+
+        let (mut result_tx, result_rx) = oneshot::channel();
+        permits.resize(config.permit_fraction.get());
+
+        let peek_uuid = peek.uuid;
+        // Shared rather than copied per use: the answer arm needs it owned, because it builds
+        // the response on the blocking pool, and a walk whose rows went to the stash never looks
+        // at it at all.
+        let order_by: Arc<[ColumnOrder]> = peek.finishing.order_by.as_slice().into();
+
+        let task_handle = mz_ore::task::spawn(
+            || format!("peek_offload::walk({peek_uuid})"),
+            async move {
+                // Wall clock from the hand-off rather than the walk's own time. The wait for a
+                // permit is in here, because that is what the peek's latency is made of.
+                let start = Instant::now();
+
+                let queued = metrics.queued_for_permit();
+                let permit = tokio::select! {
+                    permit = permits.acquire() => permit,
+                    // Cancellation while the walk waits its turn drops the receiving end of the
+                    // result channel. The scan leaves the queue with this task, releasing the
+                    // cursors and the accumulated rows it was holding, and never takes a permit.
+                    () = result_tx.closed() => return,
+                };
+                queued.admitted();
+
+                let state = WalkState {
+                    scan,
+                    _permit: permit,
+                    result_tx,
+                };
+                let (state, outcome) = Self::walk(state, &config, &metrics, order_by).await;
+                let Some(outcome) = outcome else {
+                    return;
+                };
+                let result_tx = state.result_tx;
+
+                // Past the walk rather than at the permit, so a walk that took a permit and was
+                // then cancelled is not counted, as `walked_offloaded` states.
+                metrics.walked_offloaded();
+
+                match result_tx.send((outcome, start.elapsed())) {
+                    Ok(()) => {}
+                    Err((_outcome, elapsed)) => {
+                        debug!(duration = ?elapsed, "dropping result for cancelled peek {peek_uuid}")
+                    }
+                }
+
+                // Unparked rather than activated: the sweep polls this peek anyway, and a
+                // root-path activation would also mark the worker's dataflows schedulable. An
+                // unpark landing before the park is remembered, so the wake cannot be missed.
+                worker.unpark();
+            },
+        );
+
+        Self {
+            peek,
+            trace_bundle,
+            result: result_rx,
+            span: tracing::Span::current(),
+            _abort_handle: task_handle.abort_on_drop(),
+        }
+    }
+
+    /// Drives the scan in `state` to an outcome. `None` means the peek was cancelled, which is the
+    /// one way the walk ends without an outcome.
+    async fn walk(
+        mut state: WalkState,
+        config: &OffloadConfig,
+        metrics: &PeekWalkMetrics,
+        order_by: Arc<[ColumnOrder]>,
+    ) -> (WalkState, Option<OffloadOutcome>) {
+        loop {
+            // Stepped on the blocking pool, because the walk is CPU-bound for its whole length and
+            // would otherwise hold an async worker there. Not `block_in_place`, which parks a core
+            // for the same span. The scan crosses to the pool and back, which it can because it
+            // owns `Arc`-backed batch snapshots and holds no trace handle.
+            let config = config.clone();
+            let (stepped, outcome) = mz_ore::task::spawn_blocking(
+                || "peek_offload::walk",
+                move || state.step_until_blocked(&config),
+            )
+            .await;
+            state = stepped;
+            let scan = &mut state.scan;
+
+            let Some(outcome) = outcome else {
+                return (state, None);
+            };
+
+            // This driver finishes the walk the worker started, so it reports every phase of it,
+            // the slices that ran on the worker included. The worker reported none of them.
+            match outcome {
+                ScanOutcome::Finished(Ok(rows)) => {
+                    let phases = scan.phases();
+                    metrics.observe_error_phase(&phases);
+                    metrics.observe_ok_phase(&phases);
+                    // Onto the blocking pool for the same reason a slice goes there: building
+                    // the answer sorts and copies the whole row set, and a finishing that
+                    // carries an order accumulates the whole result before it can.
+                    let order_by = Arc::clone(&order_by);
+                    let (response, elapsed) = mz_ore::task::spawn_blocking(
+                        || "peek_offload::answer",
+                        move || {
+                            let start = Instant::now();
+                            (rows_response(rows, &order_by), start.elapsed())
+                        },
+                    )
+                    .await;
+                    metrics.observe_row_collection(elapsed);
+                    return (state, Some(OffloadOutcome::Answered(response)));
+                }
+                ScanOutcome::Finished(Err(error)) => {
+                    metrics.observe_error_phase(&scan.phases());
+                    return (
+                        state,
+                        Some(OffloadOutcome::Answered(PeekResponse::Error(error))),
+                    );
+                }
+                // A suspension holding a full batch is not one this walk can resume: the scan
+                // stops advancing until a driver that writes rows takes the batch, and this one
+                // cannot. The accumulated rows are dropped, which is sound because the stash walks
+                // the ok trace again from the trace bundle.
+                ScanOutcome::Suspended if scan.batch_ready() => {
+                    metrics.observe_error_phase(&scan.phases());
+                    // The stash answers from the ok trace alone, so a peek diverted with its
+                    // error trace half-read would return rows where it owes an error. Only the ok
+                    // walk accumulates, so a full batch implies the error walk is over, and the
+                    // guard states that rather than assuming it, as the inline driver does.
+                    if !scan.error_trace_clean() {
+                        soft_panic_or_log!(
+                            "peek on {} suspended before its error trace was read out",
+                            scan.target_id()
+                        );
+                        return (
+                            state,
+                            Some(OffloadOutcome::Answered(PeekResponse::Error(
+                                PeekError::unstructured(
+                                    "peek suspended before its error trace was read out",
+                                ),
+                            ))),
+                        );
+                    }
+                    return (state, Some(OffloadOutcome::NeedsStash));
+                }
+                // `step_until_blocked` returns a suspension only with a batch, so this arm is not
+                // reached, and going back to the pool is the right thing if it ever is.
+                ScanOutcome::Suspended => {}
+            }
+        }
+    }
+}
+
+/// What an offloaded walk carries between its async task and the blocking pool.
+///
+/// The three travel together so that an aborted task cannot separate them: the scan is stepped
+/// on a blocking thread that an abort cannot interrupt, and the permit accounts for that thread
+/// until the scan leaves it. Fields drop in declaration order, so the scan and its batches go
+/// before the permit that accounts for them.
+struct WalkState {
+    scan: IndexPeekScan,
+    _permit: WalkPermit,
+    /// The sending end of the peek's result channel. Its receiver is dropped by cancellation and
+    /// by nothing else, so a closed channel is the cancellation signal.
+    result_tx: oneshot::Sender<(OffloadOutcome, Duration)>,
+}
+
+impl WalkState {
+    /// Steps the scan until it ends, offers a batch, or the peek is cancelled, whichever comes
+    /// first. `None` is the cancellation.
+    ///
+    /// Runs on a blocking thread, and reads the configuration and checks for cancellation every
+    /// `yield_granularity` positions rather than returning to the async task, which costs a
+    /// round trip through the runtime that a walk with nothing to await has no use for.
+    fn step_until_blocked(mut self, config: &OffloadConfig) -> (Self, Option<ScanOutcome>) {
+        loop {
+            if self.result_tx.is_closed() {
+                return (self, None);
+            }
+
+            // A granularity of zero would spend no fuel, and a scan stepped with no fuel makes no
+            // progress, so the walk would spin without ever reaching an outcome.
+            let mut fuel = config.yield_granularity.get().max(1);
+            let row_iteration_limit = config.row_iteration.current_limit();
+
+            match self.scan.step(row_iteration_limit, &mut fuel) {
+                // Out of fuel with nothing to hand over: a cancellation check, not a stop.
+                ScanOutcome::Suspended if !self.scan.batch_ready() => {}
+                outcome => return (self, Some(outcome)),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/compute/src/compute_state/peek_offload/tests.rs
+++ b/src/compute/src/compute_state/peek_offload/tests.rs
@@ -1,0 +1,630 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Tests of the task that finishes an offloaded index peek walk.
+
+use std::num::NonZeroUsize;
+
+use mz_dyncfg::ConfigUpdates;
+use mz_expr::RowSetFinishing;
+use mz_expr::row::RowCollection;
+use mz_ore::metrics::MetricsRegistry;
+use mz_repr::Row;
+
+use crate::compute_state::index_peek_tests::{
+    cancelling_errors, index_peek, ok_row, rows_answer, trace_bundle, trivial_finishing,
+    wide_ok_rows,
+};
+use crate::compute_state::peek_scan::PeekScan;
+use crate::metrics::{ComputeMetrics, WorkerMetrics};
+use crate::server::ComputeRuntimeRole;
+
+use super::*;
+
+/// How many times a test lets the runtime run an offloaded walk before it declares the walk
+/// stuck.
+///
+/// A walk over the traces here needs a handful of slices at the granularities these tests
+/// configure, so a walk that advances finishes far inside this bound, and one that makes no
+/// progress fails the test rather than hanging the suite.
+///
+/// Wall clock, not yields: a walk steps its scan on the blocking pool, so waiting for one means
+/// waiting for another thread and not for this runtime to come back around.
+const DRIVE_BOUND: Duration = Duration::from_secs(30);
+
+/// How long a bounded wait sleeps between checks.
+const DRIVE_POLL: Duration = Duration::from_millis(1);
+
+/// How long a test gives a walk that must NOT reach an outcome, before asserting it has not.
+///
+/// Long enough for a walk that was going to advance to have done so, short enough that a walk over
+/// [`LONG_WALK_KEYS`] positions cannot finish inside it.
+const DRIVE_PAUSE: Duration = Duration::from_millis(2);
+
+/// How many keys the index a cancellation test walks holds.
+///
+/// Large enough that a walk checking for cancellation at every position is still under way after
+/// [`DRIVE_PAUSE`]. The margin is wall clock and wants to stay wide.
+const LONG_WALK_KEYS: u64 = 500_000;
+
+/// The metrics an offloaded walk reports into, registered into a registry the test owns so it
+/// can read them back.
+fn worker_metrics() -> WorkerMetrics {
+    ComputeMetrics::register_with(&MetricsRegistry::new(), ComputeRuntimeRole::Solo).for_worker(0)
+}
+
+/// The size the scan accounts a single-column row at.
+fn row_size() -> usize {
+    ok_row(0).byte_len() + size_of::<NonZeroUsize>()
+}
+
+/// Opens a scan of `peek` over `bundle`, the way the peek path opens one.
+///
+/// `stash_threshold_bytes` both makes the peek eligible for the stash and sets the size its
+/// accumulated rows become a full batch at. `None` is a peek that may not use the stash at
+/// all, whose accumulated rows therefore never become one.
+fn open(
+    bundle: &mut TraceBundle,
+    peek: &Peek,
+    stash_threshold_bytes: Option<usize>,
+) -> IndexPeekScan {
+    let (oks, errs) = bundle.oks_errs_mut();
+    PeekScan::new(
+        peek,
+        errs,
+        oks,
+        u64::MAX,
+        stash_threshold_bytes.is_some(),
+        stash_threshold_bytes.unwrap_or(usize::MAX),
+    )
+}
+
+/// The configuration an offloaded walk reads, with the yield granularity set to
+/// `yield_granularity` so a test can choose how many slices a walk is cut into.
+fn offload_config(yield_granularity: usize) -> OffloadConfig {
+    let config = mz_dyncfgs::all_dyncfgs();
+    let mut updates = ConfigUpdates::default();
+    updates.add(&INDEX_PEEK_YIELD_GRANULARITY, yield_granularity);
+    updates.apply(&config);
+    OffloadConfig::new(&config)
+}
+
+/// A finishing that orders the peek's one column descending, which is the reverse of the order
+/// the trace holds its keys in.
+///
+/// A peek carrying an order is never eligible for the peek stash, because `is_streamable`
+/// requires an empty `order_by`, so an offloaded walk of one answers rather than handing back.
+fn descending_finishing() -> RowSetFinishing {
+    let mut finishing = trivial_finishing();
+    finishing.order_by = vec![ColumnOrder {
+        column: 0,
+        desc: true,
+        nulls_last: true,
+    }];
+    finishing
+}
+
+/// The answer a walk gives when it produces `rows` in exactly that order, each at a
+/// multiplicity of one.
+///
+/// The collection is built in the order given rather than sorted by the comparator the walk
+/// sorts with, so the order a test expects is the test's own statement.
+fn ordered_rows_answer(rows: impl IntoIterator<Item = Row>) -> PeekResponse {
+    let rows: Vec<Row> = rows.into_iter().collect();
+    let byte_len = rows.iter().map(|row| row.data_len()).sum();
+    let mut builder = RowCollection::builder(byte_len, rows.len());
+    for row in &rows {
+        builder.push(row.as_row_ref(), NonZeroUsize::new(1).expect("non-zero"));
+    }
+    PeekResponse::Rows(vec![builder.build()])
+}
+
+/// What an offloaded walk handed back, in a form a test can compare whole.
+///
+/// Mirrors [`OffloadOutcome`], which carries no comparison of its own because nothing on the
+/// peek path compares one.
+#[derive(Debug, PartialEq)]
+enum HandBack {
+    Answered(PeekResponse),
+    NeedsStash,
+}
+
+impl From<OffloadOutcome> for HandBack {
+    fn from(outcome: OffloadOutcome) -> Self {
+        match outcome {
+            OffloadOutcome::Answered(response) => HandBack::Answered(response),
+            OffloadOutcome::NeedsStash => HandBack::NeedsStash,
+        }
+    }
+}
+
+/// Runs the runtime until `offloaded`'s walk hands something back, and reports what.
+///
+/// Bounded, so a walk that yields without ever reaching an outcome fails here rather than
+/// hanging the suite. That is the failure a scan holding a full batch produces, which is the
+/// case this driver's batch-ready arm exists to avoid.
+async fn hand_back(offloaded: &mut OffloadedPeek) -> HandBack {
+    let Ok(handed_back) = tokio::time::timeout(DRIVE_BOUND, &mut offloaded.result).await else {
+        panic!("the offloaded walk handed nothing back within {DRIVE_BOUND:?}");
+    };
+    let (outcome, _elapsed) =
+        handed_back.expect("the offloaded walk ended without handing anything back");
+    HandBack::from(outcome)
+}
+
+/// Runs the runtime until `condition` holds, where `what` names what the test is waiting for.
+///
+/// Bounded, so a condition that never holds fails here rather than hanging the suite.
+async fn wait_until(mut condition: impl FnMut() -> bool, what: &str) {
+    let deadline = Instant::now() + DRIVE_BOUND;
+    while Instant::now() < deadline {
+        if condition() {
+            return;
+        }
+        tokio::time::sleep(DRIVE_POLL).await;
+    }
+    panic!("{what} did not happen within {DRIVE_BOUND:?}");
+}
+
+/// An offloaded walk finishes the walk the inline slice started, resuming from the cursor
+/// positions that slice stopped on, and answers the whole peek.
+///
+/// The counter is asserted rather than inferred from the configuration, because a peek
+/// answered inline and a peek answered by an offloaded task give the same rows.
+#[mz_ore::test(tokio::test)]
+async fn an_offloaded_walk_finishes_the_answer_the_inline_slice_started() {
+    let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    let peek = index_peek(trivial_finishing(), None);
+    let mut bundle = trace_bundle(&keys, cancelling_errors(2));
+    let mut scan = open(&mut bundle, &peek, None);
+
+    // Two positions leave the walk suspended with nothing to hand over, which is the state
+    // the worker offloads and the only one it offloads.
+    let mut fuel = 2;
+    assert_eq!(scan.step(None, &mut fuel), ScanOutcome::Suspended);
+    assert!(
+        !scan.batch_ready(),
+        "a scan holding a full batch is diverted rather than offloaded"
+    );
+
+    let metrics = worker_metrics();
+    let permits = Arc::new(PeekPermits::new(1));
+    let mut offloaded = OffloadedPeek::start(
+        peek.clone(),
+        bundle,
+        scan,
+        Arc::clone(&permits),
+        offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+        PeekWalkMetrics::new(&metrics),
+        std::thread::current(),
+    );
+
+    assert_eq!(
+        hand_back(&mut offloaded).await,
+        HandBack::Answered(rows_answer((0..6).map(ok_row))),
+    );
+    assert_eq!(
+        metrics.index_peek_walks_offloaded.get(),
+        1,
+        "the driver that ended the walk counts it"
+    );
+    assert_eq!(
+        metrics.index_peek_walks_inline.get(),
+        0,
+        "the slice that offloaded the walk reports nothing"
+    );
+}
+
+/// An offloaded walk answers with its rows in the order the peek asked for.
+///
+/// The order travels from the peek into the task, which is the only place an offloaded walk can
+/// read it: the finishing stays with the worker. A driver that dropped it would answer in the
+/// order the trace happens to hold, which every other peek here asks for.
+#[mz_ore::test(tokio::test)]
+async fn an_offloaded_walk_answers_in_the_order_the_peek_asked_for() {
+    let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    let peek = index_peek(descending_finishing(), None);
+    let mut bundle = trace_bundle(&keys, cancelling_errors(2));
+    let mut scan = open(&mut bundle, &peek, None);
+
+    let mut fuel = 2;
+    assert_eq!(scan.step(None, &mut fuel), ScanOutcome::Suspended);
+
+    let metrics = worker_metrics();
+    let permits = Arc::new(PeekPermits::new(1));
+    let mut offloaded = OffloadedPeek::start(
+        peek.clone(),
+        bundle,
+        scan,
+        Arc::clone(&permits),
+        offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+        PeekWalkMetrics::new(&metrics),
+        std::thread::current(),
+    );
+
+    assert_eq!(
+        hand_back(&mut offloaded).await,
+        HandBack::Answered(ordered_rows_answer((0..6).rev().map(ok_row))),
+    );
+}
+
+/// An offloaded walk whose accumulated rows grow into a full batch hands the peek back rather
+/// than stepping a scan that cannot advance.
+///
+/// A scan holding a full batch spends no fuel and moves no cursor when stepped, and this
+/// driver has nowhere to write the batch, so a driver that treated the suspension as resumable
+/// would yield forever without ever reaching an outcome. The bound in [`hand_back`] is what
+/// turns that into a failure rather than a hang.
+#[mz_ore::test(tokio::test)]
+async fn an_offloaded_walk_that_fills_a_batch_hands_back_rather_than_spinning() {
+    let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    let peek = index_peek(trivial_finishing(), None);
+    let mut bundle = trace_bundle(&keys, cancelling_errors(0));
+    // Two rows fit under the threshold and the third crosses it, so the slice below offloads
+    // a scan with room left and the offloaded walk is the one that fills the batch.
+    let mut scan = open(&mut bundle, &peek, Some(2 * row_size()));
+
+    let mut fuel = 2;
+    assert_eq!(scan.step(None, &mut fuel), ScanOutcome::Suspended);
+    assert!(
+        !scan.batch_ready(),
+        "the inline slice must offload a scan that still has room"
+    );
+
+    let metrics = worker_metrics();
+    let permits = Arc::new(PeekPermits::new(1));
+    let mut offloaded = OffloadedPeek::start(
+        peek.clone(),
+        bundle,
+        scan,
+        Arc::clone(&permits),
+        offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+        PeekWalkMetrics::new(&metrics),
+        std::thread::current(),
+    );
+
+    assert_eq!(hand_back(&mut offloaded).await, HandBack::NeedsStash);
+    assert_eq!(
+        metrics.index_peek_walks_offloaded.get(),
+        1,
+        "a hand-back is a terminal outcome of the offloaded walk"
+    );
+}
+
+/// A walk cancelled while it queues for a permit observes the cancellation and leaves the
+/// queue without ever taking one.
+///
+/// The permit accounts for the batches a running walk retains, so a queued walk that took one
+/// on its way out would report capacity the process does not have. The queue depth is a gauge
+/// rather than a counter, so a walk that failed to leave it would drift the depth up over the
+/// life of a process.
+///
+/// The task's handle is kept for the length of the test, so what ends the walk is the walk
+/// itself seeing the closed channel rather than an abort.
+#[mz_ore::test(tokio::test)]
+async fn a_walk_cancelled_while_queued_never_takes_a_permit() {
+    let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    let peek = index_peek(trivial_finishing(), None);
+    let mut bundle = trace_bundle(&keys, cancelling_errors(2));
+    let scan = open(&mut bundle, &peek, None);
+
+    let metrics = worker_metrics();
+    let permits = Arc::new(PeekPermits::new(1));
+    // The one permit is held here, so the walk below queues rather than running.
+    permits.resize(1.0);
+    let held = permits.try_acquire().expect("a permit is free");
+
+    let offloaded = OffloadedPeek::start(
+        peek.clone(),
+        bundle,
+        scan,
+        Arc::clone(&permits),
+        offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+        PeekWalkMetrics::new(&metrics),
+        std::thread::current(),
+    );
+
+    wait_until(
+        || metrics.index_peek_permit_queue_depth.get() == 1,
+        "the offloaded walk joining the queue for a permit",
+    )
+    .await;
+
+    // Only the receiving end of the result channel is dropped, which is the signal a queued
+    // walk has to observe on its own. Dropping the whole entry would abort the task as well,
+    // and an aborted task returns the queue depth to zero whether or not the walk ever looks
+    // at the cancellation.
+    drop(offloaded.result);
+
+    wait_until(
+        || metrics.index_peek_permit_queue_depth.get() == 0,
+        "the cancelled walk leaving the queue for a permit",
+    )
+    .await;
+    assert_eq!(
+        metrics.index_peek_permit_wait_seconds.get_sample_count(),
+        0,
+        "a walk cancelled while queued was never admitted"
+    );
+    assert_eq!(
+        metrics.index_peek_walks_offloaded.get(),
+        0,
+        "a cancelled walk reaches no outcome and counts on neither substrate"
+    );
+    assert_eq!(
+        permits.available_permits(),
+        0,
+        "the permit this test holds must not be handed back by the cancelled walk"
+    );
+
+    drop(held);
+    assert_eq!(permits.available_permits(), 1);
+}
+
+/// A walk cancelled while it runs stops at its next slice boundary, reports no outcome, and
+/// releases the permit that admitted it.
+///
+/// Cancellation drops the receiving end of the result channel and nothing else, so a closed
+/// channel is the whole signal. The permit travels with the task rather than with the pending
+/// peek that was removed, which is what makes its release coincide with the release of the
+/// batches it accounts for.
+#[mz_ore::test(tokio::test)]
+async fn a_walk_cancelled_while_running_reports_no_outcome() {
+    let keys = wide_ok_rows(LONG_WALK_KEYS);
+    let peek = index_peek(trivial_finishing(), None);
+    let mut bundle = trace_bundle(&keys, cancelling_errors(0));
+    let scan = open(&mut bundle, &peek, None);
+
+    let metrics = worker_metrics();
+    let walk_metrics = PeekWalkMetrics::new(&metrics);
+    let permits = Arc::new(PeekPermits::new(1));
+    permits.resize(1.0);
+    let permit = permits.try_acquire().expect("a permit is free");
+
+    let (result_tx, result_rx) = oneshot::channel();
+    // One position per slice over an index of `LONG_WALK_KEYS` positions, so the walk is still
+    // far from its answer after `DRIVE_PAUSE`.
+    let config = offload_config(1);
+    let order_by: Arc<[ColumnOrder]> = peek.finishing.order_by.as_slice().into();
+    let walk = mz_ore::task::spawn(|| "peek_offload_test::walk", async move {
+        let state = WalkState {
+            scan,
+            _permit: permit,
+            result_tx,
+        };
+        let (_state, outcome) = OffloadedPeek::walk(state, &config, &walk_metrics, order_by).await;
+        outcome.is_some()
+    });
+
+    tokio::time::sleep(DRIVE_PAUSE).await;
+    assert!(
+        !walk.is_finished(),
+        "the walk must still be under way when it is cancelled"
+    );
+    assert_eq!(
+        permits.available_permits(),
+        0,
+        "a running walk holds the permit that admitted it"
+    );
+
+    drop(result_rx);
+
+    wait_until(|| walk.is_finished(), "the cancelled walk stopping").await;
+    assert_eq!(walk.await, false, "a cancelled walk reports no outcome");
+    assert_eq!(
+        permits.available_permits(),
+        1,
+        "a cancelled walk releases the permit that admitted it"
+    );
+    assert_eq!(
+        metrics.index_peek_row_iteration_seconds.get_sample_count(),
+        0,
+        "a walk that never completed reports no ok phase"
+    );
+}
+
+/// An offloaded walk waits while the only permit is held elsewhere, and runs once it is
+/// released.
+///
+/// Excess walks queue rather than running, which is the whole of the concurrency bound. The
+/// permit is held by the test rather than by a second walk, so what is pinned is that a walk
+/// which cannot take one neither answers nor leaves the queue. Two offloaded walks contending
+/// would assert the same thing over a scheduler that runs them one after the other anyway.
+#[mz_ore::test(tokio::test)]
+async fn a_walk_waits_for_a_permit_held_elsewhere() {
+    let keys: Vec<Row> = (0..6).map(ok_row).collect();
+    let peek = index_peek(trivial_finishing(), None);
+    let mut bundle = trace_bundle(&keys, cancelling_errors(2));
+    let scan = open(&mut bundle, &peek, None);
+
+    let metrics = worker_metrics();
+    let permits = Arc::new(PeekPermits::new(1));
+    permits.resize(1.0);
+    let held = permits.try_acquire().expect("a permit is free");
+
+    let mut offloaded = OffloadedPeek::start(
+        peek.clone(),
+        bundle,
+        scan,
+        Arc::clone(&permits),
+        offload_config(*INDEX_PEEK_YIELD_GRANULARITY.default()),
+        PeekWalkMetrics::new(&metrics),
+        std::thread::current(),
+    );
+
+    // Every chance to run, and it must not answer while the permit is elsewhere.
+    tokio::time::sleep(DRIVE_PAUSE).await;
+    assert_eq!(
+        offloaded.result.try_recv().err(),
+        Some(oneshot::error::TryRecvError::Empty),
+        "a walk that has not been admitted must not answer"
+    );
+    assert_eq!(
+        metrics.index_peek_permit_queue_depth.get(),
+        1,
+        "a walk waiting for a permit is counted in the queue"
+    );
+
+    drop(held);
+
+    assert_eq!(
+        hand_back(&mut offloaded).await,
+        HandBack::Answered(rows_answer((0..6).map(ok_row))),
+    );
+    assert_eq!(
+        metrics.index_peek_permit_wait_seconds.get_sample_count(),
+        1,
+        "a wait that ended in a permit is observed"
+    );
+    assert_eq!(
+        metrics.index_peek_permit_queue_depth.get(),
+        0,
+        "an admitted walk leaves the queue"
+    );
+    // A walk that answers has to give its permit back, or the bound would shrink by one per
+    // peek until the replica offloaded nothing ever again.
+    wait_until(
+        || permits.available_permits() == 1,
+        "the answered walk returning its permit",
+    )
+    .await;
+}
+
+/// Dropping an offloaded peek cancels the walk it left with, rather than leaving a thread walking
+/// traces nothing is waiting on.
+///
+/// The receiving end of the result channel goes with the peek, and that is the whole signal: the
+/// blocking thread stepping the scan sees the channel closed at its next check and stops, and the
+/// permit is released there. The task's abort handle ends only the task's own awaiting.
+#[mz_ore::test(tokio::test)]
+async fn dropping_an_offloaded_peek_cancels_its_walk() {
+    let keys = wide_ok_rows(LONG_WALK_KEYS);
+    let peek = index_peek(trivial_finishing(), None);
+    let mut bundle = trace_bundle(&keys, cancelling_errors(0));
+    let scan = open(&mut bundle, &peek, None);
+
+    let metrics = worker_metrics();
+    let permits = Arc::new(PeekPermits::new(1));
+    permits.resize(1.0);
+
+    let offloaded = OffloadedPeek::start(
+        peek.clone(),
+        bundle,
+        scan,
+        Arc::clone(&permits),
+        offload_config(1),
+        PeekWalkMetrics::new(&metrics),
+        std::thread::current(),
+    );
+
+    // A cancellation check at every position over a long index, so the walk is still under way
+    // here.
+    wait_until(
+        || permits.available_permits() == 0,
+        "the walk being admitted",
+    )
+    .await;
+
+    drop(offloaded);
+
+    wait_until(
+        || permits.available_permits() == 1,
+        "the cancelled walk releasing its permit",
+    )
+    .await;
+    assert_eq!(
+        metrics.index_peek_walks_offloaded.get(),
+        0,
+        "a cancelled walk reaches no outcome"
+    );
+}
+
+/// The fraction is read against the workers the process runs, so the same value means a
+/// proportionally larger bound on a larger replica and needs no retuning per size.
+#[mz_ore::test]
+fn the_permit_fraction_scales_with_the_worker_count() {
+    let resized = |workers, fraction| {
+        let permits = PeekPermits::new(workers);
+        permits.resize(fraction);
+        permits.available_permits()
+    };
+    assert_eq!(resized(1, 1.0), 1);
+    assert_eq!(resized(4, 1.0), 4);
+    assert_eq!(resized(16, 1.0), 16);
+
+    // Fractions of a worker round down, and the bound never reaches zero: a fraction that asks
+    // for less than one walk would stop every offloaded peek rather than pacing it.
+    assert_eq!(resized(4, 0.5), 2);
+    assert_eq!(resized(4, 0.3), 1);
+    assert_eq!(resized(4, 0.0), 1);
+    assert_eq!(resized(4, -1.0), 1);
+    assert_eq!(resized(4, f64::NAN), 1);
+
+    // Above one the bound is a multiple of the worker count, and a fraction too large to hold is
+    // clamped to what a semaphore can take rather than wrapping to a tiny bound.
+    assert_eq!(resized(4, 2.0), 8);
+    assert_eq!(resized(4, f64::INFINITY), Semaphore::MAX_PERMITS);
+}
+
+#[mz_ore::test]
+fn permits_resize_around_the_walks_holding_them() {
+    let permits = Arc::new(PeekPermits::new(4));
+
+    permits.resize(1.0);
+    assert_eq!(permits.available_permits(), 4);
+    permits.resize(0.5);
+    assert_eq!(permits.available_permits(), 2);
+
+    // A walk already under way keeps its permit through a lower count, so the shrink takes
+    // back only what is free right now, and the rest as that walk returns it.
+    let held = permits.try_acquire().expect("a permit is free");
+    permits.resize(0.25);
+    assert_eq!(permits.available_permits(), 0);
+    drop(held);
+    assert_eq!(permits.available_permits(), 1);
+}
+
+/// A shrink that finds every permit held lands as the walks holding them finish, with a walk
+/// queued for a permit the whole time.
+///
+/// The queued walk is what makes this case its own: a permit released while a walk is queued
+/// goes to that walk and never shows as available, so a shrink that only took back available
+/// permits would never land while anything queued.
+#[mz_ore::test(tokio::test)]
+async fn a_shrink_that_finds_every_permit_held_lands_as_walks_finish() {
+    let permits = Arc::new(PeekPermits::new(2));
+    permits.resize(1.0);
+    let first = permits.try_acquire().expect("a permit is free");
+    let second = permits.try_acquire().expect("a permit is free");
+
+    let queued = mz_ore::task::spawn(|| "peek_offload_test::queued", {
+        let permits = Arc::clone(&permits);
+        async move { permits.acquire().await }
+    });
+    tokio::time::sleep(DRIVE_PAUSE).await;
+    assert!(!queued.is_finished(), "the third walk must be queued");
+
+    permits.resize(0.5);
+    assert_eq!(permits.available_permits(), 0);
+
+    // The first release is owed to the shrink, so the queued walk stays queued.
+    drop(first);
+    tokio::time::sleep(DRIVE_PAUSE).await;
+    assert!(
+        !queued.is_finished(),
+        "a release owed to the shrink must not admit the queued walk"
+    );
+
+    // The second release is not, so it admits the queued walk and the bound is one.
+    drop(second);
+    let third = queued.await;
+    assert_eq!(permits.available_permits(), 0);
+    drop(third);
+    assert_eq!(permits.available_permits(), 1);
+}

--- a/src/compute/src/compute_state/peek_scan.rs
+++ b/src/compute/src/compute_state/peek_scan.rs
@@ -18,8 +18,9 @@ use differential_dataflow::trace::cursor::BatchCursor;
 use differential_dataflow::trace::implementations::BatchContainer;
 use differential_dataflow::trace::{Cursor, Navigable, TraceReader};
 use mz_compute_client::protocol::command::Peek;
-use mz_compute_client::protocol::response::PeekError;
-use mz_expr::RowComparator;
+use mz_compute_client::protocol::response::{PeekError, PeekResponse};
+use mz_expr::row::RowCollection;
+use mz_expr::{ColumnOrder, RowComparator};
 use mz_ore::cast::CastFrom;
 use mz_ore::soft_panic_or_log;
 use mz_repr::fixed_length::ExtendDatums;
@@ -29,11 +30,28 @@ use timely::order::PartialOrder;
 use crate::compute_state::error_scan::{ErrorScan, ErrorScanStep, ErrsHandle};
 use crate::compute_state::peek_result_iterator::{PeekResultIterator, Step};
 
+/// The scan an index peek builds, over the ok trace of the arrangement that answers it.
+pub(super) type IndexPeekScan = PeekScan<
+    crate::arrangement::manager::PaddedTrace<crate::typedefs::RowRowAgent<Timestamp, Diff>>,
+>;
+
 /// Rows a scan hands to its driver, in the order the scan produced them.
 ///
 /// The form [`PeekResultIterator`] yields and the form the peek stash carries, so the path that
 /// moves large volumes never converts.
 pub(super) type RowBatch = Vec<(Row, NonZeroI64)>;
+
+/// Builds the peek's answer out of the rows a completed walk produced, sorted by `order_by`.
+pub(super) fn rows_response(rows: RowBatch, order_by: &[ColumnOrder]) -> PeekResponse {
+    let rows = rows
+        .into_iter()
+        .map(|(row, copies)| {
+            let copies = NonZeroUsize::try_from(copies).expect("fits into usize");
+            (row, copies)
+        })
+        .collect();
+    PeekResponse::Rows(vec![RowCollection::new(rows, order_by)])
+}
 
 /// The byte size of a row's count, as an answer built from a [`RowBatch`] stores it.
 const COUNT_BYTE_SIZE: usize = size_of::<NonZeroUsize>();
@@ -51,6 +69,28 @@ pub(super) fn entry_byte_len(row: &Row) -> usize {
     row.data_len()
         .saturating_add(OFFSET_BYTE_SIZE)
         .saturating_add(COUNT_BYTE_SIZE)
+}
+
+/// What a walk has spent, in the phases the peek metrics report.
+///
+/// Every number is cumulative over the slices the walk was cut into, wherever those slices ran.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct WalkPhases {
+    /// Worker time the error walk spent.
+    pub error_scan: Duration,
+    /// Worker time spent opening the ok cursor.
+    pub cursor_setup: Duration,
+    /// Whether the error walk ended without finding an error. The two numbers above describe a
+    /// finished phase only when it did.
+    pub error_trace_clean: bool,
+    /// Worker time the ok walk spent, including the time thinning spent sorting.
+    pub row_iteration: Duration,
+    /// Cursor positions the ok walk evaluated.
+    pub rows_processed: usize,
+    /// Worker time thinning spent sorting.
+    pub result_sort: Duration,
+    /// Rows handed to a sort, summed over the times thinning ran.
+    pub rows_sorted: usize,
 }
 
 /// The outcome of a fueled [`PeekScan::step`].
@@ -256,9 +296,27 @@ where
         Some(self.take_results())
     }
 
+    /// The collection this scan reads.
+    pub(super) fn target_id(&self) -> GlobalId {
+        self.target_id
+    }
+
     /// The number of cursor positions the ok walk has evaluated.
     pub(super) fn rows_processed(&self) -> usize {
         self.oks.rows_processed()
+    }
+
+    /// What the walk has spent so far, in the phases the peek metrics report.
+    pub(super) fn phases(&self) -> WalkPhases {
+        WalkPhases {
+            error_scan: self.error_scan_time,
+            cursor_setup: self.cursor_setup_time,
+            error_trace_clean: self.error_trace_clean(),
+            row_iteration: self.row_iteration_time,
+            rows_processed: self.rows_processed(),
+            result_sort: self.result_sort_time,
+            rows_sorted: self.rows_sorted,
+        }
     }
 
     /// Whether the walk over the error trace has ended without finding an error, which is the only

--- a/src/compute/src/compute_state/peek_scan/tests.rs
+++ b/src/compute/src/compute_state/peek_scan/tests.rs
@@ -42,7 +42,7 @@ type OksHandle = PaddedTrace<RowRowAgent<Timestamp, Diff>>;
 const RESUMPTION_BOUND: usize = 100;
 
 /// The rows `value` values yield, in the order the ok walk produces them.
-fn rows(values: impl IntoIterator<Item = u8>) -> Vec<Row> {
+fn rows(values: impl IntoIterator<Item = u64>) -> Vec<Row> {
     values.into_iter().map(row).collect()
 }
 
@@ -57,7 +57,7 @@ fn row_size() -> usize {
 }
 
 /// The rows and counts a completed scan over `values` hands back.
-fn expected(values: impl IntoIterator<Item = u8>) -> RowBatch {
+fn expected(values: impl IntoIterator<Item = u64>) -> RowBatch {
     values
         .into_iter()
         .map(|value| (row(value), NonZeroI64::new(1).expect("non-zero")))

--- a/src/compute/src/compute_state/peek_stash.rs
+++ b/src/compute/src/compute_state/peek_stash.rs
@@ -42,9 +42,9 @@ pub struct StashingPeek {
     /// Iterator for the results. The worker thread has to continually pump
     /// results from this to the `rows_tx` channel.
     peek_iterator: Option<PeekResultIterator<PaddedTrace<RowRowAgent<Timestamp, Diff>>>>,
-    /// We can't give a PeekResultIterator to our async upload task because the
-    /// underlying trace reader is not Send/Sync. So we need to use a channel to
-    /// send result rows from the worker thread to the async background task.
+    /// Carries result rows from the worker thread, which owns the walk, to the async upload task.
+    /// The walk stays on the worker because the upload is what the task is for, so the rows have
+    /// to cross threads and the upload makes progress only while the worker keeps pumping.
     rows_tx: Option<tokio::sync::mpsc::Sender<Result<Vec<(Row, NonZeroI64)>, PeekError>>>,
     /// The result of the background task, eventually.
     pub result: oneshot::Receiver<(PeekResponse, Duration)>,

--- a/src/compute/src/compute_state/peek_sweep_tests.rs
+++ b/src/compute/src/compute_state/peek_sweep_tests.rs
@@ -1,0 +1,1047 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Tests of the sweep that drives the pending index peeks.
+
+use mz_compute_types::dyncfgs::{
+    ENABLE_INDEX_PEEK_OFFLOAD, INDEX_PEEK_ACTIVATION_BUDGET, INDEX_PEEK_INLINE_BUDGET,
+    PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES,
+};
+use mz_dyncfg::ConfigUpdates;
+use mz_persist_client::Schemas;
+use mz_persist_client::cache::PersistClientCache;
+use mz_secrets::InMemorySecretsController;
+use mz_storage_types::connections::ConnectionContext;
+use timely::WorkerConfig;
+use timely::communication::Allocator;
+use tokio::sync::mpsc;
+
+use crate::metrics::ComputeMetrics;
+use crate::server::ComputeRuntimeRole;
+
+use super::index_peek_tests::{
+    TARGET_ID, cancelling_errors, index_peek_with_uuid, rows_answer, trace_bundle, wide_ok_rows,
+};
+use super::*;
+
+/// The per-peek budget the budget-arming tests configure. Distinct from both the unbounded
+/// grant and the parameter's default, so that an assertion on it says the configured value was
+/// read.
+const INLINE_BUDGET: usize = 12_345;
+
+/// How many keys the index the placement-policy tests peek holds.
+///
+/// More positions than the production inline budget, so a walk of the whole index cannot
+/// finish on the worker while a walk that seeks to one key finishes there comfortably. The two
+/// halves of the policy are the same index at the same budget, differing only in what the peek
+/// asks for.
+const WIDE_INDEX_KEYS: u64 = 2_000;
+
+/// How many keys the index the budget tests peek holds. Small, because what those tests turn
+/// on is how many peeks got a turn rather than how far each one walked.
+const SMALL_INDEX_KEYS: u64 = 6;
+
+/// How many rows a walk accumulates before its batch is full, in the tests that drive a
+/// hand-back.
+///
+/// More than the inline slice can accumulate within the production budget and fewer than the
+/// wide index holds, which is what puts the crossing after the offload rather than before it
+/// or never.
+const HAND_BACK_AT_ROWS: u64 = 1_500;
+
+/// How many activations a test drives before it declares a peek stuck.
+///
+/// An offloaded walk over these traces needs one slice, and a peek passed over for want of
+/// budget needs one activation per peek ahead of it, so a sweep that makes progress finishes
+/// far inside this bound and one that does not fails rather than hanging the suite.
+const SWEEP_BOUND: usize = 200;
+
+/// How long a bounded wait sleeps between activations.
+///
+/// A sleep and not a yield: an offloaded walk steps its scan on the blocking pool and a stashed
+/// peek waits on an upload, so both need another thread to run. Yielding would spin against them
+/// and turn the bound into a measure of how fast the machine runs the spin.
+const SWEEP_POLL: Duration = Duration::from_millis(1);
+
+/// Peek uuids, named in the order they sort, because which peek a sweep serves first turns on
+/// that order.
+const PEEK_A: Uuid = Uuid::from_u128(1);
+const PEEK_B: Uuid = Uuid::from_u128(2);
+const PEEK_C: Uuid = Uuid::from_u128(3);
+const PEEK_D: Uuid = Uuid::from_u128(4);
+
+/// The compute state, the timely worker, and the response channel one activation runs against,
+/// held together across activations.
+///
+/// An offloaded walk outlives the sweep that offloaded it, so the worker whose activator it wakes,
+/// the responses it eventually produces, and the state it stays pending in all have to survive
+/// the call that started it.
+struct Harness {
+    state: ComputeState,
+    timely_worker: TimelyWorker,
+    response_tx: ResponseSender,
+    responses: mpsc::UnboundedReceiver<(ComputeResponse, Uuid)>,
+}
+
+impl Harness {
+    /// A harness as `CreateInstance` leaves one, with `configure` applied to the worker
+    /// configuration as `UpdateConfiguration` applies a change.
+    fn new(configure: impl FnOnce(&mut ConfigUpdates)) -> Self {
+        let metrics_registry = MetricsRegistry::new();
+        let metrics = ComputeMetrics::register_with(&metrics_registry, ComputeRuntimeRole::Solo)
+            .for_worker(0);
+        let context = ComputeInstanceContext {
+            scratch_directory: None,
+            worker_core_affinity: false,
+            connection_context: ConnectionContext::for_tests(Arc::new(
+                InMemorySecretsController::new(),
+            )),
+        };
+
+        let state = ComputeState::new(
+            Arc::new(PersistClientCache::new_no_metrics()),
+            TxnsContext::default(),
+            metrics,
+            Arc::new(TracingHandle::disabled()),
+            context,
+            metrics_registry,
+            1,
+            Arc::new(PeekPermits::new(1)),
+            None,
+        );
+
+        // The worker applies these through `UpdateConfiguration`, which reaches the budget
+        // through the handles it holds rather than through any state the command touches.
+        let mut updates = ConfigUpdates::default();
+        configure(&mut updates);
+        updates.apply(&state.worker_config);
+
+        let timely_worker = TimelyWorker::new(
+            WorkerConfig::default(),
+            Allocator::Thread(Default::default()),
+            Some(Instant::now()),
+        );
+
+        let (response_tx, responses) = mpsc::unbounded_channel();
+        let mut response_tx = ResponseSender::new(response_tx, 0);
+        response_tx.set_nonce(Uuid::nil());
+
+        Self {
+            state,
+            timely_worker,
+            response_tx,
+            responses,
+        }
+    }
+
+    fn active(&mut self) -> ActiveComputeState<'_> {
+        ActiveComputeState {
+            timely_worker: &mut self.timely_worker,
+            compute_state: &mut self.state,
+            response_tx: &mut self.response_tx,
+        }
+    }
+
+    /// Runs one sweep over the pending peeks, as an activation of the worker does.
+    fn sweep(&mut self) {
+        self.active().process_peeks();
+    }
+
+    /// Queues `peek` over `bundle`, as a peek whose frontiers were not yet ready is queued.
+    fn add_pending(&mut self, peek: Peek, bundle: TraceBundle) {
+        let PendingPeek::Index(pending) = PendingPeek::index(peek, bundle) else {
+            unreachable!("built as an index peek")
+        };
+        let uuid = pending.peek.uuid;
+        assert!(
+            !self.queued_uuids().contains(&uuid),
+            "each queued peek needs its own uuid",
+        );
+        self.state.queued_peeks.push_back(pending);
+    }
+
+    /// Which kind of peek `uuid` names, or `None` when no peek is outstanding under it.
+    ///
+    /// Named rather than matched, so that a test says which driver holds the peek and a
+    /// failure says which one holds it instead.
+    fn pending(&self, uuid: Uuid) -> Option<&'static str> {
+        if self.state.queued_peeks.iter().any(|p| p.peek.uuid == uuid) {
+            return Some("index");
+        }
+        let peek = self
+            .state
+            .pending_peeks
+            .iter()
+            .find(|peek| peek.peek().uuid == uuid)?;
+        Some(match peek {
+            PendingPeek::Index(_) => "index",
+            PendingPeek::Persist(_) => "persist",
+            PendingPeek::Stash(_) => "stash",
+            PendingPeek::Offloaded(_) => "offloaded",
+        })
+    }
+
+    /// The uuids of the peeks awaiting a turn, in the order the sweep takes them.
+    fn queued_uuids(&self) -> Vec<Uuid> {
+        self.state
+            .queued_peeks
+            .iter()
+            .map(|peek| peek.peek.uuid)
+            .collect()
+    }
+
+    /// Whether any peek is outstanding, queued or in the hands of a driver.
+    fn nothing_outstanding(&self) -> bool {
+        self.state.queued_peeks.is_empty() && self.state.pending_peeks.is_empty()
+    }
+
+    /// The peek responses sent since this was last called, in the order they were sent.
+    fn peek_responses(&mut self) -> Vec<(Uuid, PeekResponse)> {
+        let mut responses = Vec::new();
+        while let Ok((response, _nonce)) = self.responses.try_recv() {
+            match response {
+                ComputeResponse::PeekResponse(uuid, response, _otel_ctx) => {
+                    responses.push((uuid, response))
+                }
+                other => panic!("a peek sweep sent {other:?}"),
+            }
+        }
+        responses
+    }
+
+    /// The walks each substrate has driven to an outcome, as `(inline, offloaded)`.
+    fn walks(&self) -> (u64, u64) {
+        (
+            self.state.metrics.index_peek_walks_inline.get(),
+            self.state.metrics.index_peek_walks_offloaded.get(),
+        )
+    }
+
+    /// Runs activations until nothing is pending, and reports the responses they produced.
+    ///
+    /// Bounded, so a peek that never answers fails here rather than hanging the suite. The
+    /// pause between activations is what lets an offloaded walk's task run, which on a
+    /// single-threaded runtime happens nowhere else.
+    ///
+    /// Paced by [`SWEEP_POLL`], because the work a sweep waits on does not run on this runtime.
+    async fn drain(&mut self) -> Vec<(Uuid, PeekResponse)> {
+        let mut responses = Vec::new();
+        for _ in 0..SWEEP_BOUND {
+            self.sweep();
+            responses.extend(self.peek_responses());
+            if self.nothing_outstanding() {
+                return responses;
+            }
+            tokio::time::sleep(SWEEP_POLL).await;
+        }
+        panic!("peeks were still pending after {SWEEP_BOUND} activations");
+    }
+
+    /// Runs the runtime until the two substrates have counted `walks` walks between them,
+    /// without sweeping.
+    ///
+    /// Bounded, so a walk that never reaches an outcome fails here rather than hanging the
+    /// suite. No sweep runs, so an offloaded walk that finishes here leaves its outcome sitting
+    /// in the channel that carries it back, which the worker has not yet read.
+    async fn drive_until_walks(&self, walks: (u64, u64)) {
+        for _ in 0..SWEEP_BOUND {
+            if self.walks() == walks {
+                return;
+            }
+            tokio::time::sleep(SWEEP_POLL).await;
+        }
+        panic!(
+            "the substrates counted {:?} rather than {walks:?} within {SWEEP_BOUND} activations",
+            self.walks()
+        );
+    }
+}
+
+/// A harness with the offload on and every budget at its production default, which is the
+/// configuration the placement policy is sized for.
+fn at_production_defaults() -> Harness {
+    Harness::new(|updates| {
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+    })
+}
+
+/// A harness with the offload on and the per-activation aggregate set to `aggregate`.
+fn with_activation_budget(aggregate: usize) -> Harness {
+    Harness::new(move |updates| {
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        updates.add(&INDEX_PEEK_ACTIVATION_BUDGET, aggregate);
+    })
+}
+
+/// The answer a peek of the whole index holding `keys` gives.
+///
+/// Both the offloaded walk and the inline walk are compared against this rather than against
+/// each other, so each test states the answer it expects instead of two runs agreeing on
+/// whatever they produced.
+fn whole_index_answer(keys: &[Row]) -> PeekResponse {
+    rows_answer(keys.iter().cloned())
+}
+
+/// The positions one peek of the index holding `keys` spends, measured by letting a sweep
+/// spend an aggregate wide enough that nothing bounds it and reading what it charged.
+///
+/// Measured rather than assumed, so that a test which configures the aggregate in multiples of
+/// a walk states its budget in the unit the code charges. A constant here would let a change
+/// to what a walk costs turn the test into one that asserts nothing.
+fn walk_cost(keys: &[Row]) -> usize {
+    const WIDE_AGGREGATE: usize = 1_000_000;
+
+    let mut harness = with_activation_budget(WIDE_AGGREGATE);
+    harness.add_pending(
+        index_peek_with_uuid(PEEK_A, None),
+        trace_bundle(keys, cancelling_errors(0)),
+    );
+    harness.sweep();
+
+    assert_eq!(
+        harness.pending(PEEK_A),
+        None,
+        "the peek must answer in one slice for what it charged to be the cost of a whole walk"
+    );
+    let remaining = harness
+        .state
+        .peek_budget
+        .remaining()
+        .expect("the offload is on and the sweep granted a slice, so the budget is bounded");
+    let cost = WIDE_AGGREGATE - remaining;
+    // A driver that charged the fuel it granted rather than the fuel it spent would report a
+    // cost equal to the grant, and a test sizing its aggregate from that measurement would
+    // then agree with itself at the wrong number. A walk visits one position per key plus what
+    // the error walk spends reaching the end of an empty trace, which is nothing like the
+    // per-peek budget the walk was granted.
+    assert!(
+        (keys.len()..*INDEX_PEEK_INLINE_BUDGET.default()).contains(&cost),
+        "a walk of {} keys charged {cost} positions, which is not what such a walk visits",
+        keys.len()
+    );
+    cost
+}
+
+/// A peek that arrives before any sweep has run is granted a bounded slice, so a walk that
+/// outruns it leaves the worker.
+///
+/// The commands a worker has queued are drained in full before it sweeps its pending peeks,
+/// and `handle_peek` runs a peek's first slice as the peek arrives. On a fresh replica that
+/// drain is the controller's whole history: the `CreateInstance` that builds this state, the
+/// `UpdateConfiguration` that turns the offload on, and then every peek the controller
+/// re-sends. A budget armed only where an activation begins would grant each of those peeks
+/// unbounded fuel, and unbounded fuel never suspends, so each would walk to its answer on a
+/// worker that is hydrating and holding the largest backlog it will ever hold.
+#[mz_ore::test(tokio::test)]
+async fn a_peek_arriving_before_any_sweep_is_granted_a_bounded_slice() {
+    let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+
+    let mut harness = at_production_defaults();
+    harness
+        .state
+        .traces
+        .set(TARGET_ID, trace_bundle(&keys, cancelling_errors(0)));
+
+    harness
+        .active()
+        .handle_peek(index_peek_with_uuid(PEEK_A, None));
+
+    assert_eq!(
+        harness.pending(PEEK_A),
+        Some("offloaded"),
+        "a peek arriving before any sweep outran a bounded slice and was offloaded"
+    );
+    assert_eq!(
+        harness.drain().await,
+        vec![(PEEK_A, whole_index_answer(&keys))]
+    );
+    assert_eq!(
+        harness.walks(),
+        (0, 1),
+        "the offloaded driver ended the walk, so no slice of it ran on the worker"
+    );
+}
+
+/// An activation that finds nothing pending still begins one, which is what refills the
+/// aggregate the peeks arriving before the next sweep are granted out of.
+///
+/// A replica whose index peeks all answer inline leaves none of them pending, so no sweep of
+/// its ever visits a peek. Were an activation begun only where the sweep finds work, the
+/// aggregate would drain across the arrivals such a replica serves and then pass every later
+/// arrival over, deferring peeks the worker had the budget to answer.
+#[mz_ore::test(tokio::test)]
+async fn an_idle_activation_refills_the_aggregate() {
+    let mut harness = Harness::new(|updates| {
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        updates.add(&INDEX_PEEK_INLINE_BUDGET, INLINE_BUDGET);
+    });
+    assert!(harness.nothing_outstanding());
+
+    // Spend the aggregate, as the peeks an activation serves do.
+    assert_eq!(harness.state.peek_budget.grant(), Some(INLINE_BUDGET));
+    harness.state.peek_budget.charge(usize::MAX);
+    assert_eq!(harness.state.peek_budget.grant(), None);
+
+    harness.sweep();
+
+    assert_eq!(harness.state.peek_budget.grant(), Some(INLINE_BUDGET));
+}
+
+/// An activation that finds nothing pending reports no peek awaiting a turn.
+///
+/// Cancellation removes a deferred peek from the queue, and `reconcile` empties the queue
+/// wholesale. Left set on a replica whose peeks all answer inline, the flag would make the
+/// worker ask for an extra iteration for every peek the replica ever serves.
+#[mz_ore::test(tokio::test)]
+async fn an_idle_activation_reports_no_peek_awaiting_a_turn() {
+    let mut harness = Harness::new(|updates| {
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        updates.add(&INDEX_PEEK_INLINE_BUDGET, INLINE_BUDGET);
+    });
+    harness.state.peek_passed_over = true;
+    assert!(harness.nothing_outstanding());
+
+    harness.sweep();
+
+    assert!(!harness.state.peek_passed_over);
+}
+
+/// A peek whose walk outruns the production inline budget leaves the worker, and the driver
+/// that finished the walk counts it as offloaded.
+///
+/// This is what says a peek is offloaded at all. The rows an offloaded walk answers with are the
+/// rows an inline walk answers with, so a suite comparing only answers would pass with the
+/// whole mechanism inert.
+#[mz_ore::test(tokio::test)]
+async fn a_scan_that_outruns_the_production_budget_is_offloaded() {
+    let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+    assert!(
+        u64::cast_from(*INDEX_PEEK_INLINE_BUDGET.default()) < WIDE_INDEX_KEYS,
+        "the index must hold more positions than the production budget lets a peek walk inline"
+    );
+
+    let mut harness = at_production_defaults();
+    harness.add_pending(
+        index_peek_with_uuid(PEEK_A, None),
+        trace_bundle(&keys, cancelling_errors(0)),
+    );
+
+    harness.sweep();
+
+    assert_eq!(
+        harness.pending(PEEK_A),
+        Some("offloaded"),
+        "a walk that outran its inline budget belongs to the offloaded driver"
+    );
+    assert_eq!(
+        harness.walks(),
+        (0, 0),
+        "an offload is not a terminal outcome, so neither driver has counted the walk yet"
+    );
+
+    assert_eq!(
+        harness.drain().await,
+        vec![(PEEK_A, whole_index_answer(&keys))]
+    );
+    assert_eq!(
+        harness.walks(),
+        (0, 1),
+        "the offloaded driver ended the walk and counted it"
+    );
+}
+
+/// A point lookup at the production inline budget is answered on the worker, over the very
+/// index whose full walk is offloaded.
+///
+/// This is the half of the placement policy that a layer offloading everything would still
+/// pass every equivalence test while destroying. The budget is sized for point lookups and
+/// nothing else, and what makes that true is measured here rather than argued.
+#[mz_ore::test(tokio::test)]
+async fn a_point_lookup_at_the_production_budget_stays_inline() {
+    let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+    let literal = keys[7].clone();
+
+    let mut harness = at_production_defaults();
+    harness.add_pending(
+        index_peek_with_uuid(PEEK_A, Some(vec![literal.clone()])),
+        trace_bundle(&keys, cancelling_errors(0)),
+    );
+
+    harness.sweep();
+
+    assert_eq!(
+        harness.peek_responses(),
+        vec![(PEEK_A, rows_answer([literal]))]
+    );
+    assert_eq!(
+        harness.pending(PEEK_A),
+        None,
+        "a peek answered inline leaves nothing pending"
+    );
+    assert_eq!(
+        harness.walks(),
+        (1, 0),
+        "a point lookup finishes inside the inline budget and is never offloaded"
+    );
+}
+
+/// With the kill switch off, the peek that the production budget offloads instead walks to its
+/// answer on the worker, and that answer is the one the offloaded walk gives.
+///
+/// Both this and the offloaded run are compared against [`whole_index_answer`], so the
+/// equivalence the offload owes is stated rather than inferred from two runs agreeing.
+#[mz_ore::test(tokio::test)]
+async fn the_kill_switch_answers_the_same_scan_inline() {
+    let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+
+    // No configuration at all, which is the kill switch in the position production ships it.
+    let mut harness = Harness::new(|_updates| ());
+    harness.add_pending(
+        index_peek_with_uuid(PEEK_A, None),
+        trace_bundle(&keys, cancelling_errors(0)),
+    );
+
+    harness.sweep();
+
+    assert_eq!(
+        harness.peek_responses(),
+        vec![(PEEK_A, whole_index_answer(&keys))]
+    );
+    assert_eq!(
+        harness.pending(PEEK_A),
+        None,
+        "an unbounded slice walks to the answer without suspending"
+    );
+    assert_eq!(
+        harness.walks(),
+        (1, 0),
+        "the kill switch offloads nothing, however far a peek walks"
+    );
+}
+
+/// One activation serves what the per-activation aggregate allows and passes the rest over,
+/// however many peeks are pending.
+///
+/// The sweep visits every pending peek, so a per-peek budget with no aggregate would let a
+/// burst of N peeks cost N inline budgets in one pass, unbounded in N.
+#[mz_ore::test(tokio::test)]
+async fn the_activation_budget_bounds_a_burst() {
+    let keys = wide_ok_rows(SMALL_INDEX_KEYS);
+
+    let mut harness = with_activation_budget(1);
+    for uuid in [PEEK_A, PEEK_B, PEEK_C, PEEK_D] {
+        harness.add_pending(
+            index_peek_with_uuid(uuid, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+    }
+
+    harness.sweep();
+
+    assert_eq!(
+        harness.peek_responses(),
+        vec![(PEEK_A, whole_index_answer(&keys))],
+        "an aggregate of one position serves one peek per activation"
+    );
+    assert_eq!(
+        harness.queued_uuids(),
+        vec![PEEK_B, PEEK_C, PEEK_D],
+        "the peeks that got no turn are left untouched"
+    );
+    assert!(harness.state.peek_passed_over);
+
+    // The burst drains rather than wedging, one peek per activation.
+    assert_eq!(
+        harness.drain().await,
+        vec![
+            (PEEK_B, whole_index_answer(&keys)),
+            (PEEK_C, whole_index_answer(&keys)),
+            (PEEK_D, whole_index_answer(&keys)),
+        ]
+    );
+}
+
+/// The aggregate is charged what a slice walked rather than what it was granted, so an
+/// activation serves as many peeks as their walks fit into.
+///
+/// Charging the grant instead would spend the whole aggregate on the first peek whatever it
+/// walked, which is the difference between an activation serving a burst of point lookups and
+/// serving one of them. Comparing this run against an unbudgeted one would not catch it, since
+/// both would answer the same rows. The assertion is against the budget this test supplied.
+#[mz_ore::test(tokio::test)]
+async fn the_aggregate_is_charged_what_the_slices_walked() {
+    let keys = wide_ok_rows(SMALL_INDEX_KEYS);
+    let cost = walk_cost(&keys);
+
+    // Room for two walks of this index and no more. The per-peek budget is left at its
+    // production default, which is far above one walk, so nothing here is offloaded and what
+    // decides how many peeks got a turn is the aggregate alone.
+    let mut harness = with_activation_budget(2 * cost);
+    for uuid in [PEEK_A, PEEK_B, PEEK_C, PEEK_D] {
+        harness.add_pending(
+            index_peek_with_uuid(uuid, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+    }
+
+    harness.sweep();
+
+    assert_eq!(
+        harness.peek_responses(),
+        vec![
+            (PEEK_A, whole_index_answer(&keys)),
+            (PEEK_B, whole_index_answer(&keys)),
+        ],
+        "an aggregate of two walks serves two peeks and passes the rest over"
+    );
+    assert_eq!(harness.queued_uuids(), vec![PEEK_C, PEEK_D]);
+    assert_eq!(harness.walks(), (2, 0), "neither served peek was offloaded");
+}
+
+/// A peek passed over for want of budget is served before a peek that arrived after it, even
+/// one whose uuid sorts ahead of it.
+///
+/// A sweep that took the pending peeks in any order of its own would let a newly arrived peek
+/// take the turn of one that has already waited an activation, and would do so again on every
+/// activation.
+#[mz_ore::test(tokio::test)]
+async fn a_passed_over_peek_is_served_before_one_that_arrived_later() {
+    let keys = wide_ok_rows(SMALL_INDEX_KEYS);
+    let answer = whole_index_answer(&keys);
+
+    let mut harness = with_activation_budget(1);
+    for uuid in [PEEK_B, PEEK_C] {
+        harness.add_pending(
+            index_peek_with_uuid(uuid, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+    }
+
+    harness.sweep();
+
+    assert_eq!(harness.peek_responses(), vec![(PEEK_B, answer.clone())]);
+    assert!(harness.state.peek_passed_over);
+
+    // A peek arrives whose uuid sorts ahead of the one that was passed over.
+    harness.add_pending(
+        index_peek_with_uuid(PEEK_A, None),
+        trace_bundle(&keys, cancelling_errors(0)),
+    );
+
+    harness.sweep();
+
+    assert_eq!(
+        harness.peek_responses(),
+        vec![(PEEK_C, answer)],
+        "the peek that waited an activation takes the next turn"
+    );
+}
+
+/// Cancelling the peek a sweep passed over leaves the peeks behind it in turn.
+///
+/// The peek a caller cancels is disproportionately one that was passed over for want of budget,
+/// because that is the peek that has been waiting. Taking it out of the queue has to leave the
+/// rest in the order the sweep returned them to it, and a peek arriving afterwards still queues
+/// behind them however its uuid sorts.
+#[mz_ore::test(tokio::test)]
+async fn cancelling_a_passed_over_peek_leaves_the_rest_in_turn() {
+    let keys = wide_ok_rows(SMALL_INDEX_KEYS);
+    let answer = whole_index_answer(&keys);
+
+    let mut harness = with_activation_budget(1);
+    for uuid in [PEEK_B, PEEK_C, PEEK_D] {
+        harness.add_pending(
+            index_peek_with_uuid(uuid, None),
+            trace_bundle(&keys, cancelling_errors(0)),
+        );
+    }
+
+    harness.sweep();
+
+    assert_eq!(harness.peek_responses(), vec![(PEEK_B, answer.clone())]);
+    assert_eq!(harness.queued_uuids(), vec![PEEK_C, PEEK_D]);
+    assert!(harness.state.peek_passed_over);
+
+    harness.active().handle_cancel_peek(PEEK_C);
+
+    assert_eq!(
+        harness.peek_responses(),
+        vec![(PEEK_C, PeekResponse::Canceled)]
+    );
+    assert_eq!(
+        harness.queued_uuids(),
+        vec![PEEK_D],
+        "cancelling the peek at the front must not disturb the one behind it",
+    );
+
+    // Arrives after the cancellation, and sorts ahead of the waiting peek by uuid.
+    harness.add_pending(
+        index_peek_with_uuid(PEEK_A, None),
+        trace_bundle(&keys, cancelling_errors(0)),
+    );
+    assert_eq!(harness.queued_uuids(), vec![PEEK_D, PEEK_A]);
+
+    harness.sweep();
+
+    assert_eq!(
+        harness.peek_responses(),
+        vec![(PEEK_D, answer)],
+        "the peek that waited through the cancellation takes the next turn"
+    );
+    assert!(harness.state.peek_passed_over);
+}
+
+/// A peek deferred as it arrives reports that it is waiting on its turn, which is what keeps the
+/// worker from parking on it.
+///
+/// `handle_peek` runs a peek's first slice as the peek arrives, and a peek that finds the
+/// activation's budget spent is left pending there with no sweep to follow. `run_client` reads
+/// this before it parks, and would otherwise park indefinitely at a zero maintenance interval:
+/// the peeks that spent the budget were answered or offloaded, and neither leaves an activation
+/// behind.
+#[mz_ore::test(tokio::test)]
+async fn a_peek_deferred_as_it_arrives_asks_the_worker_not_to_park() {
+    let keys = wide_ok_rows(SMALL_INDEX_KEYS);
+
+    let mut harness = with_activation_budget(1);
+    harness
+        .state
+        .traces
+        .set(TARGET_ID, trace_bundle(&keys, cancelling_errors(0)));
+
+    // One peek spends this activation's whole aggregate.
+    harness.add_pending(
+        index_peek_with_uuid(PEEK_A, None),
+        trace_bundle(&keys, cancelling_errors(0)),
+    );
+    harness.sweep();
+    assert_eq!(
+        harness.pending(PEEK_A),
+        None,
+        "the first peek answered and spent the aggregate"
+    );
+    assert!(
+        !harness.state.peeks_awaiting_turn(),
+        "with nothing deferred the worker is free to park"
+    );
+
+    harness
+        .active()
+        .handle_peek(index_peek_with_uuid(PEEK_B, None));
+
+    assert_eq!(
+        harness.queued_uuids(),
+        vec![PEEK_B],
+        "the arriving peek found no budget and was deferred"
+    );
+    assert!(
+        harness.state.peeks_awaiting_turn(),
+        "a peek deferred outside a sweep has to keep the worker from parking"
+    );
+}
+
+/// Cancelling an offloaded peek answers it once, as cancelled, and no later activation answers
+/// it again.
+///
+/// This is the worker's half of a cancellation. The entry the cancellation removes owns the
+/// handle to the walk, so removing it aborts the walk, and what the activations that follow
+/// have to produce is nothing at all: no second response, and no count on either substrate for
+/// a walk that never reached an outcome. The cancellation lands before the offloaded task has
+/// been polled, because nothing here awaits between the sweep that offloaded it and the
+/// cancellation. What a walk that was already running does with a cancellation is pinned by
+/// `peek_offload::tests::a_walk_cancelled_while_running_reports_no_outcome`, and what one that
+/// had already reached an outcome does by
+/// [`a_walk_cancelled_with_its_outcome_in_flight_is_counted`].
+#[mz_ore::test(tokio::test)]
+async fn a_cancelled_offloaded_peek_is_answered_once() {
+    let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+
+    let mut harness = at_production_defaults();
+    harness.add_pending(
+        index_peek_with_uuid(PEEK_A, None),
+        trace_bundle(&keys, cancelling_errors(0)),
+    );
+
+    harness.sweep();
+    assert_eq!(harness.pending(PEEK_A), Some("offloaded"));
+
+    harness.active().handle_cancel_peek(PEEK_A);
+
+    assert_eq!(
+        harness.peek_responses(),
+        vec![(PEEK_A, PeekResponse::Canceled)]
+    );
+    assert_eq!(harness.pending(PEEK_A), None);
+
+    for _ in 0..SWEEP_BOUND {
+        tokio::time::sleep(SWEEP_POLL).await;
+        harness.sweep();
+    }
+    assert_eq!(
+        harness.peek_responses(),
+        vec![],
+        "a cancelled peek is answered once and never again"
+    );
+    assert_eq!(
+        harness.walks(),
+        (0, 0),
+        "a cancelled walk reaches no outcome and counts on neither substrate"
+    );
+}
+
+/// Cancelling an offloaded peek whose walk has already reached its outcome answers it as
+/// cancelled and counts the walk as offloaded.
+///
+/// This is the case the walk counters are documented with: a walk is counted where it reached
+/// an outcome, and a cancellation that lands after that point does not take the count away.
+/// The window is the one between the task sending its outcome and the worker's next sweep
+/// reading it, which is as long as the worker takes to come back around, so a replica under
+/// load spends real time in it. The counters would otherwise have to be read as a lower bound
+/// on the walks each substrate finished rather than as the count of them.
+#[mz_ore::test(tokio::test)]
+async fn a_walk_cancelled_with_its_outcome_in_flight_is_counted() {
+    let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+
+    let mut harness = at_production_defaults();
+    harness.add_pending(
+        index_peek_with_uuid(PEEK_A, None),
+        trace_bundle(&keys, cancelling_errors(0)),
+    );
+
+    harness.sweep();
+    assert_eq!(harness.pending(PEEK_A), Some("offloaded"));
+
+    // The walk runs to its outcome while no sweep collects it, which leaves the outcome in
+    // flight between the task and the worker.
+    harness.drive_until_walks((0, 1)).await;
+    assert_eq!(
+        harness.peek_responses(),
+        vec![],
+        "no sweep has read the outcome, so the peek is unanswered"
+    );
+
+    harness.active().handle_cancel_peek(PEEK_A);
+
+    assert_eq!(
+        harness.peek_responses(),
+        vec![(PEEK_A, PeekResponse::Canceled)],
+        "the cancellation answers the peek rather than the outcome in flight"
+    );
+    assert_eq!(
+        harness.walks(),
+        (0, 1),
+        "a walk that reached its outcome stays counted on the substrate that ended it"
+    );
+
+    harness.sweep();
+    assert_eq!(
+        harness.peek_responses(),
+        vec![],
+        "the outcome in flight is dropped with the peek rather than answered after it"
+    );
+}
+
+/// A harness whose peek of the whole wide index is offloaded and whose offloaded walk then
+/// crosses the stash threshold, swept once so that the peek is already offloaded.
+///
+/// `location` is the replica's peek stash location, which has to be present here whatever the
+/// hand-back is meant to find: a replica without one makes no scan stash-eligible, so its
+/// walks never fill a batch and never hand back at all.
+fn offloaded_walk_that_hands_back(keys: &[Row], location: PersistLocation) -> Harness {
+    assert!(
+        u64::cast_from(*INDEX_PEEK_INLINE_BUDGET.default()) < HAND_BACK_AT_ROWS
+            && HAND_BACK_AT_ROWS < WIDE_INDEX_KEYS,
+        "the walk must cross the stash threshold after it is offloaded and before it ends"
+    );
+    // The threshold is a size rather than a count, because the size of what a scan has
+    // accumulated is what it compares against. Summed over the rows it is meant to admit,
+    // rather than multiplied out, because a row's packed width follows the value it holds.
+    let threshold: usize = keys
+        .iter()
+        .take(usize::cast_from(HAND_BACK_AT_ROWS))
+        .map(peek_scan::entry_byte_len)
+        .sum();
+
+    let mut harness = Harness::new(move |updates| {
+        updates.add(&ENABLE_INDEX_PEEK_OFFLOAD, true);
+        updates.add(&ENABLE_PEEK_RESPONSE_STASH, true);
+        updates.add(&PEEK_RESPONSE_STASH_THRESHOLD_BYTES, threshold);
+    });
+    harness.state.peek_stash_persist_location = Some(location);
+    harness.add_pending(
+        index_peek_with_uuid(PEEK_A, None),
+        trace_bundle(keys, cancelling_errors(0)),
+    );
+
+    harness.sweep();
+    assert_eq!(
+        harness.pending(PEEK_A),
+        Some("offloaded"),
+        "the walk must leave the worker before it crosses the threshold"
+    );
+    harness
+}
+
+/// Runs activations until the offloaded walk of `PEEK_A` has handed back.
+///
+/// Bounded, so a walk that never hands back fails here rather than hanging the suite. The pause
+/// between activations is what lets the offloaded walk run.
+async fn sweep_until_handed_back(harness: &mut Harness) {
+    for _ in 0..SWEEP_BOUND {
+        if harness.pending(PEEK_A) != Some("offloaded") {
+            return;
+        }
+        tokio::time::sleep(SWEEP_POLL).await;
+        harness.sweep();
+    }
+    panic!("the offloaded walk had not handed back after {SWEEP_BOUND} activations");
+}
+
+/// The rows a stashed peek response holds, read back out of `location` the way the coordinator
+/// reads one, in [`Row`] order.
+///
+/// A stashed response names a persist batch rather than carrying the answer, so what the peek
+/// owes its caller is only visible from the batch. The batch is ordered as persist consolidates
+/// it rather than as the peek would have answered, and the coordinator orders what it reads
+/// back, so the rows are sorted here and compared as the set they are.
+async fn stashed_rows(
+    harness: &Harness,
+    location: &PersistLocation,
+    response: PeekResponse,
+) -> Vec<Row> {
+    let PeekResponse::Stashed(stashed) = response else {
+        panic!("a peek taken to the stash answers with a stashed response, not {response:?}");
+    };
+
+    // Opened out of the harness's own cache, because two `PersistLocation`s naming the same
+    // in-memory URI reach the same blob only through the cache that opened them.
+    let mut client = harness
+        .state
+        .persist_clients
+        .open(location.clone())
+        .await
+        .expect("the in-memory location opens");
+
+    let shard_id = stashed.shard_id;
+    let batches = stashed
+        .batches
+        .into_iter()
+        .map(|batch| client.batch_from_transmittable_batch(&shard_id, batch))
+        .collect();
+    let read_schemas: Schemas<SourceData, ()> = Schemas {
+        id: None,
+        key: Arc::new(stashed.relation_desc),
+        val: Arc::new(UnitSchema),
+    };
+    let mut cursor = client
+        .read_batches_consolidated::<_, _, _, i64>(
+            shard_id,
+            Antichain::from_elem(Timestamp::default()),
+            read_schemas,
+            batches,
+            |_stats| true,
+            *PEEK_RESPONSE_STASH_READ_MEMORY_BUDGET_BYTES.default(),
+        )
+        .await
+        .expect("the batches are readable at the timestamp they were written at");
+
+    let mut rows = Vec::new();
+    while let Some(updates) = cursor.next().await {
+        for ((key, _val), _time, diff) in updates {
+            assert_eq!(diff, 1, "the index holds each key once");
+            rows.push(key.0.expect("the peek stash holds no errors"));
+        }
+    }
+    rows.sort();
+
+    // Deleted as the coordinator deletes them once it has read them. A batch dropped without
+    // this leaves its blob keys behind and says so in a warning.
+    for batch in cursor.into_lease() {
+        batch.delete().await;
+    }
+    rows
+}
+
+/// An offloaded walk that hands back with a stash location present takes the peek to the stash,
+/// which answers it with the rows the peek would have answered with inline.
+///
+/// This is the arm every hand-back in production takes, because a replica's stash location is
+/// set once at instance creation and nothing clears it. The peek has to become pending on the
+/// stash rather than be answered where the hand-back arrives: the rows are produced by a
+/// second walk that the worker pumps over the activations that follow, and answering here
+/// would drop them.
+#[mz_ore::test(tokio::test)]
+async fn an_offloaded_hand_back_takes_the_peek_to_the_stash() {
+    // The wide keys carry the `UInt64` the peek's result description declares, which is the
+    // schema the stash writes its batch under. The narrow fixture rows do not.
+    let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+    let location = PersistLocation::new_in_mem();
+    let mut harness = offloaded_walk_that_hands_back(&keys, location.clone());
+
+    sweep_until_handed_back(&mut harness).await;
+
+    assert_eq!(
+        harness.pending(PEEK_A),
+        Some("stash"),
+        "the hand-back starts a stash upload and leaves the peek waiting on it"
+    );
+    assert_eq!(
+        harness.peek_responses(),
+        vec![],
+        "a peek handed to the stash is not answered where the hand-back arrives"
+    );
+    assert_eq!(
+        harness.walks(),
+        (0, 1),
+        "a hand-back is a terminal outcome of the offloaded walk"
+    );
+
+    let mut responses = harness.drain().await;
+    assert_eq!(responses.len(), 1, "the stashed peek answers once");
+    let (uuid, response) = responses.pop().expect("length checked");
+    assert_eq!(uuid, PEEK_A);
+    assert_eq!(
+        stashed_rows(&harness, &location, response).await,
+        keys,
+        "the stash holds the rows the peek would have answered with inline"
+    );
+}
+
+/// An offloaded walk that hands back with nowhere to write the rows answers the peek with an
+/// error rather than leaving it pending on a walk that has stopped.
+///
+/// This arm is defensive only. Reaching it takes a replica that loses its stash location
+/// between the offload and the hand-back, which nothing does, and the location is cleared
+/// here to stand in for that: `handle_create_instance` sets it and nothing clears it, while a
+/// replica that never had one makes no scan stash-eligible, so none of its walks fills a batch
+/// and hands back in the first place. The arm production takes is
+/// [`an_offloaded_hand_back_takes_the_peek_to_the_stash`]'s.
+#[mz_ore::test(tokio::test)]
+async fn an_offloaded_hand_back_answers_when_there_is_nowhere_to_write() {
+    let keys = wide_ok_rows(WIDE_INDEX_KEYS);
+    let mut harness = offloaded_walk_that_hands_back(&keys, PersistLocation::new_in_mem());
+
+    harness.state.peek_stash_persist_location = None;
+
+    assert_eq!(
+        harness.drain().await,
+        vec![(
+            PEEK_A,
+            PeekResponse::Error(PeekError::unstructured(
+                "peek result is too large to answer inline and this replica has no peek stash \
+                 location"
+            ))
+        )]
+    );
+    assert_eq!(
+        harness.walks(),
+        (0, 1),
+        "a hand-back is a terminal outcome of the offloaded walk"
+    );
+}

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -72,6 +72,10 @@ pub struct ComputeMetrics {
     index_peek_result_sort_rows: Histogram,
     index_peek_frontier_check_seconds: Histogram,
     index_peek_row_collection_seconds: Histogram,
+    index_peek_walks_total: raw::IntCounterVec,
+    index_peek_permit_queue_depth: UIntGauge,
+    index_peek_permit_wait_seconds: Histogram,
+    index_peek_offload_seconds: Histogram,
 
     // memory usage
     shared_row_heap_capacity_bytes: raw::UIntGaugeVec,
@@ -217,7 +221,7 @@ impl ComputeMetrics {
             ), role)),
             index_peek_total_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_total_seconds",
-                help: "Total time processing index peeks, from process_peek entry to response. Excluding peeks that use the peek response stash.",
+                help: "Time one visit to an index peek spent on the timely worker. A peek whose walk was offloaded contributes only the inline slice that offloaded it, and its time away from the worker is `mz_index_peek_offload_seconds`.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_seek_fulfillment_seconds: registry.register(with_role(metric!(
@@ -227,17 +231,17 @@ impl ComputeMetrics {
             ), role)),
             index_peek_error_scan_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_error_scan_seconds",
-                help: "Time scanning the error trace for errors. Sums the worker time of the calls the scan was sliced into, so it excludes the gaps between them. Only scans that find no error are observed.",
+                help: "Time scanning the error trace for errors, summed over the slices the scan was cut into and observed only for scans that find no error.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_cursor_setup_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_cursor_setup_seconds",
-                help: "Time opening the trace cursor and sorting the literal constraints. Excludes seeking the cursor to the literals, which is part of row iteration.",
+                help: "Time opening the trace cursor and sorting the literal constraints, excluding the seek to those literals.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_row_iteration_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_row_iteration_seconds",
-                help: "Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP. Sums the worker time of the calls the walk was sliced into, so it excludes the gaps between them.",
+                help: "Time iterating rows, seeking the cursor to the literal constraints, and evaluating MFP, summed over the slices the walk was cut into.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_row_iteration_rows: registry.register(with_role(metric!(
@@ -263,6 +267,25 @@ impl ComputeMetrics {
             index_peek_row_collection_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_row_collection_seconds",
                 help: "Time constructing RowCollection from peek results, including converting the row counts the scan produced.",
+                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
+            ), role)),
+            index_peek_walks_total: registry.register(with_role(metric!(
+                name: "mz_index_peek_walks_total",
+                help: "The number of index peek walks that reached an outcome, by the substrate they ended on: `inline` on the timely worker, `offloaded` away from it.",
+                var_labels: ["substrate"],
+            ), role)),
+            index_peek_permit_queue_depth: registry.register(with_role(metric!(
+                name: "mz_index_peek_permit_queue_depth",
+                help: "The number of offloaded index peek walks waiting for a permit to run.",
+            ), role)),
+            index_peek_permit_wait_seconds: registry.register(with_role(metric!(
+                name: "mz_index_peek_permit_wait_seconds",
+                help: "Time an offloaded index peek walk waited for a permit, observed only for walks that were admitted.",
+                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
+            ), role)),
+            index_peek_offload_seconds: registry.register(with_role(metric!(
+                name: "mz_index_peek_offload_seconds",
+                help: "Wall-clock time an offloaded index peek walk spent away from the timely worker, including the wait for a permit.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             replica_expiration_timestamp_seconds: registry.register(with_role(metric!(
@@ -320,6 +343,13 @@ impl ComputeMetrics {
         let index_peek_result_sort_rows = self.index_peek_result_sort_rows.clone();
         let index_peek_frontier_check_seconds = self.index_peek_frontier_check_seconds.clone();
         let index_peek_row_collection_seconds = self.index_peek_row_collection_seconds.clone();
+        let index_peek_walks_inline = self.index_peek_walks_total.with_label_values(&["inline"]);
+        let index_peek_walks_offloaded = self
+            .index_peek_walks_total
+            .with_label_values(&["offloaded"]);
+        let index_peek_permit_queue_depth = self.index_peek_permit_queue_depth.clone();
+        let index_peek_permit_wait_seconds = self.index_peek_permit_wait_seconds.clone();
+        let index_peek_offload_seconds = self.index_peek_offload_seconds.clone();
         let replica_expiration_timestamp_seconds = self
             .replica_expiration_timestamp_seconds
             .with_label_values(&[&worker]);
@@ -349,6 +379,11 @@ impl ComputeMetrics {
             index_peek_result_sort_rows,
             index_peek_frontier_check_seconds,
             index_peek_row_collection_seconds,
+            index_peek_walks_inline,
+            index_peek_walks_offloaded,
+            index_peek_permit_queue_depth,
+            index_peek_permit_wait_seconds,
+            index_peek_offload_seconds,
             replica_expiration_timestamp_seconds,
             replica_expiration_remaining_seconds,
             shared_row_heap_capacity_bytes,
@@ -398,6 +433,20 @@ pub struct WorkerMetrics {
     pub(crate) index_peek_frontier_check_seconds: Histogram,
     /// Histogram of index peek row collection construction durations.
     pub(crate) index_peek_row_collection_seconds: Histogram,
+    /// Counts index peek walks that ran on the timely worker.
+    ///
+    /// Both substrate series are resolved when the worker's metrics are built, so each exists at
+    /// zero before its first walk. A series at zero says the offload never engaged, where an absent
+    /// series says nothing.
+    pub(crate) index_peek_walks_inline: IntCounter,
+    /// Counts index peek walks that ran away from the timely worker.
+    pub(crate) index_peek_walks_offloaded: IntCounter,
+    /// How many offloaded index peek walks are waiting for a permit.
+    pub(crate) index_peek_permit_queue_depth: UIntGauge,
+    /// Histogram of how long an offloaded index peek walk waited for its permit.
+    pub(crate) index_peek_permit_wait_seconds: Histogram,
+    /// Histogram of how long an offloaded index peek walk was away from the worker.
+    pub(crate) index_peek_offload_seconds: Histogram,
     /// The timestamp of replica expiration.
     pub(crate) replica_expiration_timestamp_seconds: UIntGauge,
     /// Remaining seconds until replica expiration.

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -41,7 +41,9 @@ use tracing::{info, trace, warn};
 use uuid::Uuid;
 
 use crate::command_channel;
-use crate::compute_state::{ActiveComputeState, ComputeState, ReportedFrontier};
+use crate::compute_state::{
+    ActiveComputeState, ComputeState, PeekPermits, PendingPeek, ReportedFrontier,
+};
 use crate::metrics::{ComputeMetrics, WorkerMetrics};
 
 /// Caller-provided configuration for compute.
@@ -141,6 +143,8 @@ struct Config {
     pub metrics_registry: MetricsRegistry,
     /// The number of timely workers per process.
     pub workers_per_process: usize,
+    /// Bounds how many offloaded peek walks run at once, shared by every worker this server runs.
+    pub peek_permits: Arc<PeekPermits>,
     /// A reader for each storage worker in this process.
     pub storage_log_readers: Arc<Mutex<Vec<Option<StorageTimelyLogReader>>>>,
 }
@@ -180,6 +184,9 @@ pub async fn serve(
         context,
         metrics_registry: metrics_registry.clone(),
         workers_per_process,
+        // NOTE: per compute runtime, not global. A process running a maintenance and an
+        // interactive runtime calls `serve` twice and admits the bound once per call.
+        peek_permits: Arc::new(PeekPermits::new(workers_per_process)),
         storage_log_readers: Arc::new(Mutex::new(storage_log_readers)),
     };
     let tokio_executor = tokio::runtime::Handle::current();
@@ -264,7 +271,11 @@ pub(crate) struct ResponseSender {
 }
 
 impl ResponseSender {
-    fn new(inner: mpsc::UnboundedSender<(ComputeResponse, Uuid)>, worker_id: usize) -> Self {
+    /// `pub(crate)` rather than private so the peek tests can build the sender a worker holds.
+    pub(crate) fn new(
+        inner: mpsc::UnboundedSender<(ComputeResponse, Uuid)>,
+        worker_id: usize,
+    ) -> Self {
         Self {
             inner,
             worker_id,
@@ -273,7 +284,7 @@ impl ResponseSender {
     }
 
     /// Set the cluster protocol nonce.
-    fn set_nonce(&mut self, nonce: Uuid) {
+    pub(crate) fn set_nonce(&mut self, nonce: Uuid) {
         self.nonce = Some(nonce);
     }
 
@@ -314,6 +325,9 @@ struct Worker<'w> {
     metrics_registry: MetricsRegistry,
     /// The number of timely workers per process.
     workers_per_process: usize,
+    /// Bounds how many offloaded peek walks run at once, shared by the workers of one `serve`
+    /// call rather than by the process.
+    peek_permits: Arc<PeekPermits>,
     /// Reader for storage timely logging events.
     storage_log_reader: Option<StorageTimelyLogReader>,
 }
@@ -366,6 +380,7 @@ impl ClusterSpec for Config {
             tracing_handle: Arc::clone(&self.tracing_handle),
             metrics_registry: self.metrics_registry.clone(),
             workers_per_process: self.workers_per_process,
+            peek_permits: Arc::clone(&self.peek_permits),
             storage_log_reader,
         }
         .run()
@@ -472,6 +487,13 @@ impl<'w> Worker<'w> {
                 sleep_duration = Some(next_maintenance.saturating_duration_since(now))
             };
 
+            // Do not sleep while a peek waits for its turn. Only the sweep below gives it one,
+            // and nothing else leaves an activation behind to end the park.
+            let sleep_duration = match &self.compute_state {
+                Some(state) if state.peeks_awaiting_turn() => Some(Duration::ZERO),
+                _ => sleep_duration,
+            };
+
             // Step the timely worker, recording the time taken.
             let timer = self.metrics.timely_step_duration_seconds.start_timer();
             self.timely_worker.step_or_park(sleep_duration);
@@ -504,6 +526,7 @@ impl<'w> Worker<'w> {
                 self.context.clone(),
                 self.metrics_registry.clone(),
                 self.workers_per_process,
+                Arc::clone(&self.peek_permits),
                 self.storage_log_reader.take(),
             ));
         }
@@ -747,8 +770,10 @@ impl<'w> Worker<'w> {
             // All re-used dataflows should roll back any believed communicated information (e.g. frontiers)
             // so that they recommunicate that information as if from scratch.
 
-            // Remove all pending peeks.
-            for (_, peek) in std::mem::take(&mut compute_state.pending_peeks) {
+            // Remove all peeks, whether they have started or are still awaiting a turn.
+            let queued = std::mem::take(&mut compute_state.queued_peeks);
+            let pending = std::mem::take(&mut compute_state.pending_peeks);
+            for peek in queued.into_iter().map(PendingPeek::Index).chain(pending) {
                 // Log dropping the peek request.
                 if let Some(logger) = compute_state.compute_logger.as_mut() {
                     logger.log(&peek.as_log_event(false));

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -208,6 +208,10 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     compute_correction_v2_chain_proportionality
     compute_correction_v2_chunk_size
     compute_flat_map_fuel
+    compute_index_peek_activation_budget
+    compute_index_peek_inline_budget
+    compute_index_peek_permit_fraction
+    compute_index_peek_yield_granularity
     compute_logical_backpressure_max_retained_capabilities
     compute_mv_sink_advance_persist_frontiers
     compute_peek_row_iteration_limit
@@ -244,6 +248,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_coalesce_case_transform
     enable_columnar_merge_batcher
     enable_compute_half_join2
+    enable_compute_index_peek_offload
     enable_compute_peek_row_iteration_limit
     enable_compute_render_fueled_as_specific_collection
     enable_date_bin_hopping

--- a/test/sqllogictest/index_peek_offload.slt
+++ b/test/sqllogictest/index_peek_offload.slt
@@ -1,0 +1,192 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# ---------------------------------------------------------
+# Offloading a fast-path index peek's walk.
+#
+# A peek that outruns its inline budget finishes its walk away from the timely
+# worker. Placement is all that changes, so every query below has to answer
+# exactly as it does with the offload off, and each is run both ways.
+#
+# The queries have to be served from an arrangement to reach the walk at all,
+# which is what the indexes below are for. An aggregate would build a dataflow
+# instead and never reach it.
+# ---------------------------------------------------------
+
+mode cockroach
+
+statement ok
+CREATE TABLE t (a int, b text)
+
+statement ok
+INSERT INTO t SELECT g, 'row-' || g::text FROM generate_series(1, 200) g
+
+statement ok
+CREATE INDEX t_a_idx ON t (a)
+
+# The offload is on in the test configuration, so the baseline has to turn it
+# off rather than inherit it. Without this the queries below run offloaded and
+# the file compares the offloaded walk against itself.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_compute_index_peek_offload TO false;
+----
+COMPLETE 0
+
+# A full scan, a literal constraint on the key, a filter the MFP rejects most
+# rows for, and a finishing that orders and truncates. With the offload off
+# these establish the answers the offloaded walk has to reproduce.
+
+query IT
+SELECT a, b FROM t WHERE b = 'row-137'
+----
+137  row-137
+
+query IT
+SELECT a, b FROM t WHERE a = 42
+----
+42  row-42
+
+query IT rowsort
+SELECT a, b FROM t WHERE a > 197
+----
+198  row-198
+199  row-199
+200  row-200
+
+query I
+SELECT a FROM t ORDER BY a DESC LIMIT 3
+----
+200
+199
+198
+
+# An error in the collection is answered from the error trace, which the walk
+# reads before it reads any rows. This one is found at the first position, so
+# the walk ends there and is answered on the worker however the budget is set.
+# What it covers is that arming the offload leaves that path alone.
+
+statement ok
+CREATE TABLE z (a int)
+
+statement ok
+INSERT INTO z VALUES (1), (0)
+
+statement ok
+CREATE VIEW z_div AS SELECT 100 / a AS x FROM z
+
+statement ok
+CREATE DEFAULT INDEX ON z_div
+
+query error division by zero
+SELECT x FROM z_div
+
+# Now the same queries with the walk offloaded. A budget of one position
+# promotes every walk here rather than only the long ones, and a granularity of
+# one makes a promoted walk yield between positions rather than running to its
+# answer in a single slice.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_compute_index_peek_offload TO true;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET compute_index_peek_inline_budget TO 1;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET compute_index_peek_yield_granularity TO 1;
+----
+COMPLETE 0
+
+query IT
+SELECT a, b FROM t WHERE b = 'row-137'
+----
+137  row-137
+
+query IT
+SELECT a, b FROM t WHERE a = 42
+----
+42  row-42
+
+query IT rowsort
+SELECT a, b FROM t WHERE a > 197
+----
+198  row-198
+199  row-199
+200  row-200
+
+query I
+SELECT a FROM t ORDER BY a DESC LIMIT 3
+----
+200
+199
+198
+
+query error division by zero
+SELECT x FROM z_div
+
+# The aggregate bounds what all peeks together spend in one activation, so a
+# value below one peek's budget passes peeks over rather than answering them.
+# Such a peek is served on a later activation, which is a delay rather than a
+# different answer.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET compute_index_peek_activation_budget TO 1;
+----
+COMPLETE 0
+
+query IT rowsort
+SELECT a, b FROM t WHERE a > 197
+----
+198  row-198
+199  row-199
+200  row-200
+
+# A fraction below one worker's share still admits one walk, so promotion is
+# paced rather than stopped.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET compute_index_peek_permit_fraction TO 0.01;
+----
+COMPLETE 0
+
+query I
+SELECT a FROM t ORDER BY a DESC LIMIT 3
+----
+200
+199
+198
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET compute_index_peek_permit_fraction;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET compute_index_peek_activation_budget;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET compute_index_peek_yield_granularity;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET compute_index_peek_inline_budget;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET enable_compute_index_peek_offload;
+----
+COMPLETE 0


### PR DESCRIPTION
Moves an expensive fast-path index peek's walk off the timely worker that received it, so a long scan no longer delays the peeks queued behind it. This is the layer the ones beneath it were built for.

A peek runs its first slice inline under a small budget, sized so point lookups finish there and nothing else does. If it completes, the peek never leaves the worker. If it outruns the budget it is offloaded to a task that walks the rest on the blocking pool, holding a permit from a process-wide semaphore. The walk stays on its blocking thread, checking for cancellation every few thousand positions, and returns to the runtime only to answer: a round trip per slice costs two thread wakes, which is more than the slice itself on a small machine. Cost is measured rather than predicted, so a skewed point lookup over a hot key needs no special case: it enters as a point lookup, overruns, and offloads.

The offload is for a scan that suspended with its budget spent, never for one holding a full batch. An offloaded task has nowhere to write a batch until the stash becomes a state transition of the same scan, and stepping a batch-ready scan returns without spending fuel or advancing, so offloading one would spin. A scan that fills a batch while offloaded hands back and the worker starts the existing stash walk.

The permit travels with the scan rather than with the pending peek, so releasing it coincides with releasing the batches it accounts for. Permits default to this runtime's worker count, which preserves the ceiling that exists today: a peek blocking its worker already costs one core per worker. Excess scans queue in the semaphore, so a peek storm costs queue entries rather than threads.

Cancellation needs no new mechanism at any stage. Removing the pending peek drops the result channel's receiver, and the walk observes a closed sender at its next cancellation check; a scan still waiting for a permit leaves the queue the same way. Permits release on drop, including on panic.

The peeks awaiting a turn on the worker and the peeks a driver has taken over sit in separate queues, because they need opposite treatment. The former all draw on one per-activation aggregate that does not refill within an activation, so the sweep serves them from the front and stops at the first peek the budget cannot serve: every peek behind it would be passed over for the same reason. The latter draw no budget, since their work is not on the worker, so the sweep polls all of them. A peek that gets no turn keeps its place and is served first on the next activation.

Off by default in production and on in the test configuration. With the switch off nothing is offloaded and placement is unchanged.

Both substrate counters are pre-resolved, so `mz_index_peek_walks_total{substrate="offloaded"}` reads zero rather than being absent, which keeps "the offload changed nothing" distinguishable from "the offload never engaged".

Reading `mz_index_peek_total_seconds` across the flag is misleading: an offloaded peek contributes only its inline slice, which the inline budget bounds, so the expensive peeks leave a bounded sample where they used to leave the whole walk. `mz_index_peek_offload_seconds` and the per-phase histograms are the honest pairing. `mz_index_peek_offload_seconds` is wall clock away from the worker, so it counts the wait for a permit, not the walk's own time.

🤖 Opened by [Claude Code](https://claude.com/claude-code) on behalf of @antiguru


Replaces #38478, which GitHub closed when the design document moved from the bottom of the stack to the top and its branch was force-pushed past these commits. Same content, new base.
