### PR TITLE
Fix MZ_USERNAME name and warn that MZ_HOST selects the connection mode

### DIFF
--- a/doc/user/content/manage/terraform/get-started.md
+++ b/doc/user/content/manage/terraform/get-started.md
@@ -153,11 +153,15 @@ export MZ_HOST=<host>
 ```
 
 {{< warning >}}
-`MZ_HOST` does more than supply a value. The provider connects to self-managed
-Materialize whenever a host is set, including when it comes from `MZ_HOST`. If you
-leave `MZ_HOST` exported and then run Terraform against Materialize Cloud, the
-provider uses your self-managed settings instead, which usually fails with an
-`invalid password` error. Unset it before working with Materialize Cloud.
+`MZ_HOST` is intended for use with Self-Managed Materialize. If `MZ_HOST` is set,
+the provider connects directly to that host, using `MZ_USERNAME` and
+`MZ_PASSWORD`, instead of connecting through Materialize Cloud.
+
+If you leave `MZ_HOST` exported and then run Terraform against Materialize
+Cloud, the provider uses your self-managed settings instead, which usually
+results in an `invalid password` error.
+
+Unset `MZ_HOST` before working with Materialize Cloud.
 {{< /warning >}}
 
 ```hcl

--- a/doc/user/content/manage/terraform/get-started.md
+++ b/doc/user/content/manage/terraform/get-started.md
@@ -152,9 +152,17 @@ export MZ_PASSWORD=<password>
 export MZ_HOST=<host>
 ```
 
+{{< warning >}}
+`MZ_HOST` does more than supply a value. The provider connects to self-managed
+Materialize whenever a host is set, including when it comes from `MZ_HOST`. If you
+leave `MZ_HOST` exported and then run Terraform against Materialize Cloud, the
+provider uses your self-managed settings instead, which usually fails with an
+`invalid password` error. Unset it before working with Materialize Cloud.
+{{< /warning >}}
+
 ```hcl
 provider "materialize" {
-  # Configuration will be read from MZ_HOST, MZ_PORT, MZ_USER,
+  # Configuration will be read from MZ_HOST, MZ_PORT, MZ_USERNAME,
   # MZ_DATABASE, MZ_PASSWORD, MZ_SSLMODE environment variables
 }
 ```
@@ -189,7 +197,7 @@ provider "materialize" {
 |-----------|-------------|---------------------|---------|
 | `host` | Materialize host address | `MZ_HOST` | - |
 | `port` | Materialize port | `MZ_PORT` | `6875` |
-| `username` | Database username | `MZ_USER` | `materialize` |
+| `username` | Database username | `MZ_USERNAME` | `materialize` |
 | `database` | Database name | `MZ_DATABASE` | `materialize` |
 | `password` | Database password | `MZ_PASSWORD` | - |
 | `sslmode` | SSL mode (`disable`, `require`, `verify-ca`, `verify-full`) | `MZ_SSLMODE` | `require` |


### PR DESCRIPTION
The Terraform guide documents the username environment variable as `MZ_USER`, but the provider only reads `MZ_USERNAME`, so following the table has no effect. Also adds a warning that setting `MZ_HOST` does not only supply a value, it makes the provider talk to self-managed Materialize, which surprised a customer whose leftover `MZ_HOST` silently redirected their Materialize Cloud project and failed with an invalid password error.