### PR TITLE
sql: add EXCLUDE CONSTRAINTS option to CREATE TABLE .. FROM SOURCE

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -102,6 +102,7 @@ def get_minimal_system_parameters(
         "enable_create_table_from_source": "true",
         "enable_eager_delta_joins": "true",
         "enable_envelope_debezium_in_subscribe": "true",
+        "enable_exclude_constraints_option": "true",
         "enable_expressions_in_limit_syntax": "true",
         "enable_fixed_correlated_cte_lowering": "true",
         "enable_introspection_subscribes": "true",

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -111,6 +111,7 @@ Confluent
 Connection
 Connections
 Constraint
+Constraints
 Copy
 Correlated
 Count

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1774,6 +1774,13 @@ pub enum TableFromSourceOptionName {
     TextColumns,
     /// Columns you want to exclude when ingesting data
     ExcludeColumns,
+    /// Upstream `PRIMARY KEY`/`UNIQUE` constraints, by name, that Materialize
+    /// should not record as keys, so that their later upstream drop is a
+    /// non-event.
+    ExcludeConstraints,
+    /// Record no upstream constraints at all: no keys, and every column
+    /// ingested as nullable.
+    ExcludeAllConstraints,
     /// Hex-encoded protobuf of a `ProtoSourceExportStatementDetails`
     /// message, which includes details necessary for planning this
     /// table as a Source Export
@@ -1789,6 +1796,8 @@ impl AstDisplay for TableFromSourceOptionName {
         f.write_str(match self {
             TableFromSourceOptionName::TextColumns => "TEXT COLUMNS",
             TableFromSourceOptionName::ExcludeColumns => "EXCLUDE COLUMNS",
+            TableFromSourceOptionName::ExcludeConstraints => "EXCLUDE CONSTRAINTS",
+            TableFromSourceOptionName::ExcludeAllConstraints => "EXCLUDE ALL CONSTRAINTS",
             TableFromSourceOptionName::Details => "DETAILS",
             TableFromSourceOptionName::PartitionBy => "PARTITION BY",
             TableFromSourceOptionName::RetainHistory => "RETAIN HISTORY",
@@ -1808,6 +1817,8 @@ impl WithOptionName for TableFromSourceOptionName {
             TableFromSourceOptionName::Details
             | TableFromSourceOptionName::TextColumns
             | TableFromSourceOptionName::ExcludeColumns
+            | TableFromSourceOptionName::ExcludeConstraints
+            | TableFromSourceOptionName::ExcludeAllConstraints
             | TableFromSourceOptionName::RetainHistory => false,
             // The value is an arbitrary user expression/literal that may embed
             // sensitive data, so redact it (mirrors `KafkaSinkConfigOptionName`).

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5359,7 +5359,7 @@ impl<'a> Parser<'a> {
         let option = match self
             .expect_one_of_keywords(&[TEXT, EXCLUDE, IGNORE, DETAILS, PARTITION, RETAIN])?
         {
-            ref keyword @ (TEXT | EXCLUDE) => {
+            TEXT => {
                 self.expect_keyword(COLUMNS)?;
 
                 let _ = self.consume_token(&Token::Eq);
@@ -5373,14 +5373,58 @@ impl<'a> Parser<'a> {
                     });
 
                 TableFromSourceOption {
-                    name: match *keyword {
-                        TEXT => TableFromSourceOptionName::TextColumns,
-                        EXCLUDE => TableFromSourceOptionName::ExcludeColumns,
-                        _ => unreachable!(),
-                    },
+                    name: TableFromSourceOptionName::TextColumns,
                     value,
                 }
             }
+            EXCLUDE => match self.expect_one_of_keywords(&[COLUMNS, CONSTRAINTS, ALL])? {
+                COLUMNS => {
+                    let _ = self.consume_token(&Token::Eq);
+
+                    let value =
+                        self.parse_option_sequence(Parser::parse_identifier)?
+                            .map(|inner| {
+                                WithOptionValue::Sequence(
+                                    inner.into_iter().map(WithOptionValue::Ident).collect_vec(),
+                                )
+                            });
+
+                    TableFromSourceOption {
+                        name: TableFromSourceOptionName::ExcludeColumns,
+                        value,
+                    }
+                }
+                CONSTRAINTS => {
+                    let _ = self.consume_token(&Token::Eq);
+
+                    // Constraint names are raw upstream identifiers whose case
+                    // must be preserved exactly, so they are string literals
+                    // rather than SQL identifiers.
+                    let value = self
+                        .parse_option_sequence(Parser::parse_literal_string)?
+                        .map(|inner| {
+                            WithOptionValue::Sequence(
+                                inner
+                                    .into_iter()
+                                    .map(|s| WithOptionValue::Value(Value::String(s)))
+                                    .collect_vec(),
+                            )
+                        });
+
+                    TableFromSourceOption {
+                        name: TableFromSourceOptionName::ExcludeConstraints,
+                        value,
+                    }
+                }
+                ALL => {
+                    self.expect_keyword(CONSTRAINTS)?;
+                    TableFromSourceOption {
+                        name: TableFromSourceOptionName::ExcludeAllConstraints,
+                        value: None,
+                    }
+                }
+                _ => unreachable!(),
+            },
             DETAILS => TableFromSourceOption {
                 name: TableFromSourceOptionName::Details,
                 value: self.parse_optional_option_value()?,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -337,6 +337,48 @@ CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (TEXT COLUMNS = (bam))
 CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("baz")])), with_options: [TableFromSourceOption { name: TextColumns, value: Some(Sequence([Ident(Ident("bam"))])) }], include_metadata: [], format: None, envelope: None })
 
 parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE CONSTRAINTS ('users_wallet_id_key', 'MixedCase'))
+----
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE CONSTRAINTS = ('users_wallet_id_key', 'MixedCase'))
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("baz")])), with_options: [TableFromSourceOption { name: ExcludeConstraints, value: Some(Sequence([Value(String("users_wallet_id_key")), Value(String("MixedCase"))])) }], include_metadata: [], format: None, envelope: None })
+
+parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE CONSTRAINTS = ())
+----
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE CONSTRAINTS = ())
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("baz")])), with_options: [TableFromSourceOption { name: ExcludeConstraints, value: Some(Sequence([])) }], include_metadata: [], format: None, envelope: None })
+
+parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE ALL CONSTRAINTS)
+----
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE ALL CONSTRAINTS)
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("baz")])), with_options: [TableFromSourceOption { name: ExcludeAllConstraints, value: None }], include_metadata: [], format: None, envelope: None })
+
+parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE COLUMNS (a), EXCLUDE CONSTRAINTS ('k'))
+----
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE COLUMNS = (a), EXCLUDE CONSTRAINTS = ('k'))
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: NotSpecified, constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: Some(UnresolvedItemName([Ident("baz")])), with_options: [TableFromSourceOption { name: ExcludeColumns, value: Some(Sequence([Ident(Ident("a"))])) }, TableFromSourceOption { name: ExcludeConstraints, value: Some(Sequence([Value(String("k"))])) }], include_metadata: [], format: None, envelope: None })
+
+parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE ALL COLUMNS)
+----
+error: Expected CONSTRAINTS, found COLUMNS
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE ALL COLUMNS)
+                                                                   ^
+
+parse-statement
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE CONSTRAINTS (foo))
+----
+error: Expected literal string, found identifier "foo"
+CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) WITH (EXCLUDE CONSTRAINTS (foo))
+                                                                            ^
+
+parse-statement
 CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "seed"}' MESSAGE 'Batch' VALUE SCHEMA '123' MESSAGE 'M' ENVELOPE UPSERT
 ----
 CREATE TABLE t FROM SOURCE foo (REFERENCE = baz) FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "seed"}' MESSAGE 'Batch' VALUE SCHEMA '123' MESSAGE 'M' ENVELOPE UPSERT

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1748,6 +1748,8 @@ generate_extracted_config!(
     TableFromSourceOption,
     (TextColumns, Vec::<Ident>, Default(vec![])),
     (ExcludeColumns, Vec::<Ident>, Default(vec![])),
+    (ExcludeConstraints, Vec::<String>, Default(vec![])),
+    (ExcludeAllConstraints, bool, Default(false)),
     (PartitionBy, Vec<Ident>),
     (RetainHistory, OptionalDuration),
     (Details, String)
@@ -1779,6 +1781,11 @@ pub fn plan_create_table_from_source(
     let TableFromSourceOptionExtracted {
         text_columns,
         exclude_columns,
+        // Exclusion of constraints happens during purification, where the
+        // upstream table descriptor stored in `details` is pruned; nothing is
+        // left to do at planning time.
+        exclude_constraints: _,
+        exclude_all_constraints: _,
         retain_history,
         partition_by,
         details,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1781,9 +1781,6 @@ pub fn plan_create_table_from_source(
     let TableFromSourceOptionExtracted {
         text_columns,
         exclude_columns,
-        // Exclusion of constraints happens during purification, where the
-        // upstream table descriptor stored in `details` is pruned; nothing is
-        // left to do at planning time.
         exclude_constraints: _,
         exclude_all_constraints: _,
         retain_history,

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -1167,6 +1167,8 @@ fn humanize_sql_for_show_create(
             stmt.with_options.retain_mut(|o| match o.name {
                 TableFromSourceOptionName::TextColumns => true,
                 TableFromSourceOptionName::ExcludeColumns => true,
+                TableFromSourceOptionName::ExcludeConstraints => true,
+                TableFromSourceOptionName::ExcludeAllConstraints => true,
                 // Drop details, which does not roundtrip.
                 TableFromSourceOptionName::Details => false,
                 TableFromSourceOptionName::PartitionBy => true,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -60,7 +60,8 @@ use mz_storage_types::sources::load_generator::LoadGeneratorOutput;
 use mz_storage_types::sources::mysql::MySqlSourceDetails;
 use mz_storage_types::sources::postgres::PostgresSourcePublicationDetails;
 use mz_storage_types::sources::{
-    GenericSourceConnection, SourceDesc, SourceExportStatementDetails, SqlServerSourceExtras,
+    GenericSourceConnection, SourceConnection, SourceDesc, SourceExportStatementDetails,
+    SqlServerSourceExtras,
 };
 use prost::Message;
 use protobuf_native::MessageLite;
@@ -951,6 +952,8 @@ async fn purify_create_source(
                 external_references,
                 text_columns,
                 exclude_columns,
+                &BTreeSet::new(),
+                false,
                 source_name,
                 &reference_policy,
             )
@@ -1512,6 +1515,8 @@ async fn purify_alter_source_add_subsources(
                 &Some(ExternalReferences::SubsetTables(external_references)),
                 text_columns,
                 exclude_columns,
+                &BTreeSet::new(),
+                false,
                 &unresolved_source_name,
                 &SourceReferencePolicy::Required,
             )
@@ -1805,6 +1810,8 @@ async fn purify_create_table_from_source(
     let crate::plan::statement::ddl::TableFromSourceOptionExtracted {
         text_columns,
         exclude_columns,
+        exclude_constraints,
+        exclude_all_constraints,
         retain_history: _,
         details,
         partition_by: _,
@@ -1813,6 +1820,14 @@ async fn purify_create_table_from_source(
     if details.is_some() {
         sql_bail!("DETAILS option cannot be explicitly set");
     }
+
+    if !exclude_constraints.is_empty() || exclude_all_constraints {
+        scx.require_feature_flag(&crate::session::vars::ENABLE_EXCLUDE_CONSTRAINTS_OPTION)?;
+    }
+    if !exclude_constraints.is_empty() && exclude_all_constraints {
+        sql_bail!("EXCLUDE ALL CONSTRAINTS cannot be combined with EXCLUDE CONSTRAINTS");
+    }
+    let exclude_constraints: BTreeSet<String> = exclude_constraints.into_iter().collect();
 
     // Our text column values are unqualified (just column names), but the purification methods below
     // expect to match the fully-qualified names against the full set of tables in upstream, so we
@@ -1852,6 +1867,17 @@ async fn purify_create_table_from_source(
         }])
     });
 
+    // Excluding constraints is only meaningful for sources whose upstream
+    // tables have constraints Materialize records as keys.
+    if (!exclude_constraints.is_empty() || exclude_all_constraints)
+        && !matches!(desc.connection, GenericSourceConnection::Postgres(_))
+    {
+        sql_bail!(
+            "EXCLUDE CONSTRAINTS is not supported for {} sources",
+            desc.connection.name()
+        );
+    }
+
     // Run purification work specific to each source type: resolve the external reference to
     // a fully qualified name and obtain the appropriate details for the source-export statement
     let purified_export = match desc.connection {
@@ -1882,6 +1908,8 @@ async fn purify_create_table_from_source(
                 &requested_references,
                 qualified_text_columns,
                 qualified_exclude_columns,
+                &exclude_constraints,
+                exclude_all_constraints,
                 &unresolved_source_name,
                 &SourceReferencePolicy::Required,
             )

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1867,8 +1867,6 @@ async fn purify_create_table_from_source(
         }])
     });
 
-    // Excluding constraints is only meaningful for sources whose upstream
-    // tables have constraints Materialize records as keys.
     if (!exclude_constraints.is_empty() || exclude_all_constraints)
         && !matches!(desc.connection, GenericSourceConnection::Postgres(_))
     {

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -48,6 +48,11 @@ pub enum PgSourcePurificationError {
     DanglingTextColumns { items: Vec<PartialItemName> },
     #[error("EXCLUDE COLUMNS refers to table not currently being added")]
     DanglingExcludeColumns { items: Vec<PartialItemName> },
+    #[error("EXCLUDE CONSTRAINTS refers to constraints that do not exist on table {table}")]
+    DanglingExcludeConstraints {
+        table: PartialItemName,
+        constraints: Vec<String>,
+    },
     #[error("duplicated column name references: {0:?}")]
     DuplicatedColumnNames(Vec<String>),
     #[error("referenced tables use unsupported types")]
@@ -66,6 +71,13 @@ impl PgSourcePurificationError {
             Self::DanglingTextColumns { items } => Some(format!(
                 "the following tables are referenced but not added: {}",
                 itertools::join(items, ", ")
+            )),
+            Self::DanglingExcludeConstraints {
+                table: _,
+                constraints,
+            } => Some(format!(
+                "the following constraints were not found: {}",
+                constraints.join(", ")
             )),
             Self::DatabaseMissingFilteredSchemas {
                 database: _,
@@ -122,6 +134,11 @@ impl PgSourcePurificationError {
                 "Remove the {} option, as no tables are being added.",
                 option
             )),
+            Self::DanglingExcludeConstraints { .. } => Some(
+                "Constraint names are matched exactly, including case, against the upstream \
+                 PRIMARY KEY and UNIQUE constraint names."
+                    .into(),
+            ),
             Self::BypassRLSRequired { .. } => Some("Add the BYPASSRLS attribute to the Materialize user".into()),
             Self::InvalidConnection(e) => e.hint(),
             _ => None,

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -49,7 +49,7 @@ pub enum PgSourcePurificationError {
     #[error("EXCLUDE COLUMNS refers to table not currently being added")]
     DanglingExcludeColumns { items: Vec<PartialItemName> },
     #[error("EXCLUDE CONSTRAINTS refers to constraints that do not exist on table {table}")]
-    DanglingExcludeConstraints {
+    ConstraintsNotFound {
         table: PartialItemName,
         constraints: Vec<String>,
     },
@@ -72,7 +72,7 @@ impl PgSourcePurificationError {
                 "the following tables are referenced but not added: {}",
                 itertools::join(items, ", ")
             )),
-            Self::DanglingExcludeConstraints {
+            Self::ConstraintsNotFound {
                 table: _,
                 constraints,
             } => Some(format!(
@@ -134,7 +134,7 @@ impl PgSourcePurificationError {
                 "Remove the {} option, as no tables are being added.",
                 option
             )),
-            Self::DanglingExcludeConstraints { .. } => Some(
+            Self::ConstraintsNotFound { .. } => Some(
                 "Constraint names are matched exactly, including case, against the upstream \
                  PRIMARY KEY and UNIQUE constraint names."
                     .into(),

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -371,6 +371,12 @@ pub(super) async fn purify_source_exports(
     requested_references: &Option<ExternalReferences>,
     mut text_columns: Vec<UnresolvedItemName>,
     mut exclude_columns: Vec<UnresolvedItemName>,
+    // NOTE: `exclude_constraints` and `exclude_all_constraints` are only ever
+    // non-empty/true for `CREATE TABLE .. FROM SOURCE`, which purifies exactly
+    // one export, so constraint names are validated against that single
+    // table's constraints.
+    exclude_constraints: &BTreeSet<String>,
+    exclude_all_constraints: bool,
     unresolved_source_name: &UnresolvedItemName,
     reference_policy: &SourceReferencePolicy,
 ) -> Result<PurifiedSourceExports, PlanError> {
@@ -457,6 +463,25 @@ pub(super) async fn purify_source_exports(
             let text_columns = text_column_map.remove(&desc.oid);
             let exclude_columns = exclude_column_map.remove(&desc.oid);
 
+            // Validate requested constraint names against the table's full,
+            // pre-pruning constraint set, so that a constraint whose columns
+            // are also excluded via EXCLUDE COLUMNS is still accepted.
+            let dangling_constraints: Vec<_> = exclude_constraints
+                .iter()
+                .filter(|n| !desc.keys.iter().any(|k| &&k.name == n))
+                .cloned()
+                .collect();
+            if !dangling_constraints.is_empty() {
+                return Err(PgSourcePurificationError::DanglingExcludeConstraints {
+                    table: PartialItemName {
+                        database: None,
+                        schema: Some(desc.namespace.clone()),
+                        item: desc.name.clone(),
+                    },
+                    constraints: dangling_constraints,
+                });
+            }
+
             if let Some(exclude_cols) = &exclude_columns {
                 let excluded_col_nums: BTreeSet<u16> = desc
                     .columns
@@ -472,6 +497,24 @@ pub(super) async fn purify_source_exports(
                 // incompatible schema change once the excluded column disappears.
                 desc.keys
                     .retain(|k| k.cols.iter().all(|c| !excluded_col_nums.contains(c)));
+            }
+
+            // An excluded constraint is never recorded as a key, so it neither
+            // becomes a Materialize relation key nor participates in the
+            // runtime schema compatibility check. Its later upstream drop is
+            // then a non-event.
+            desc.keys.retain(|k| !exclude_constraints.contains(&k.name));
+
+            if exclude_all_constraints {
+                // No keys, and every column ingested as nullable, so dropping
+                // any PRIMARY KEY, UNIQUE, or NOT NULL constraint upstream is
+                // a non-event. Nullability flows from the desc into both the
+                // generated column definitions and the runtime column casts,
+                // which then skip NOT NULL enforcement.
+                desc.keys.clear();
+                for c in &mut desc.columns {
+                    c.nullable = true;
+                }
             }
 
             if let (Some(text_cols), Some(exclude_cols)) = (&text_columns, &exclude_columns) {

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -496,18 +496,11 @@ pub(super) async fn purify_source_exports(
                     .retain(|k| k.cols.iter().all(|c| !excluded_col_nums.contains(c)));
             }
 
-            // An excluded constraint is never recorded as a key, so it neither
-            // becomes a Materialize relation key nor participates in the
-            // runtime schema compatibility check. Its later upstream drop is
-            // then a non-event.
             desc.keys.retain(|k| !exclude_constraints.contains(&k.name));
 
             if exclude_all_constraints {
-                // No keys, and every column ingested as nullable, so dropping
-                // any PRIMARY KEY, UNIQUE, or NOT NULL constraint upstream is
-                // a non-event. Nullability flows from the desc into both the
-                // generated column definitions and the runtime column casts,
-                // which then skip NOT NULL enforcement.
+                // Marking columns as nullable allows dropping (and adding) the
+                // NOT NULL constraint without an outage.
                 desc.keys.clear();
                 for c in &mut desc.columns {
                     c.nullable = true;

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -463,22 +463,19 @@ pub(super) async fn purify_source_exports(
             let text_columns = text_column_map.remove(&desc.oid);
             let exclude_columns = exclude_column_map.remove(&desc.oid);
 
-            // Validate requested constraint names against the table's full,
-            // pre-pruning constraint set, so that a constraint whose columns
-            // are also excluded via EXCLUDE COLUMNS is still accepted.
-            let dangling_constraints: Vec<_> = exclude_constraints
+            let missing_exclude_constraints: Vec<_> = exclude_constraints
                 .iter()
                 .filter(|n| !desc.keys.iter().any(|k| &&k.name == n))
                 .cloned()
                 .collect();
-            if !dangling_constraints.is_empty() {
-                return Err(PgSourcePurificationError::DanglingExcludeConstraints {
+            if !missing_exclude_constraints.is_empty() {
+                return Err(PgSourcePurificationError::ConstraintsNotFound {
                     table: PartialItemName {
                         database: None,
                         schema: Some(desc.namespace.clone()),
                         item: desc.name.clone(),
                     },
-                    constraints: dangling_constraints,
+                    constraints: missing_exclude_constraints,
                 });
             }
 

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2266,6 +2266,13 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
+        name: enable_exclude_constraints_option,
+        desc: "Whether to allow the EXCLUDE CONSTRAINTS / EXCLUDE ALL CONSTRAINTS options \
+               in CREATE TABLE .. FROM SOURCE.",
+        default: false,
+        enable_for_item_parsing: true,
+    },
+    {
         name: enable_join_prioritize_arranged,
         desc: "Whether join planning should prioritize already-arranged keys over keys with more fields.",
         default: false,


### PR DESCRIPTION
### Motivation

Part of: [SS-464](https://linear.app/materializeinc/issue/SS-464)

Dropping an upstream `UNIQUE` or `PRIMARY KEY` constraint permanently stalls the corresponding Materialize table today. We want to make it possible to change upstream constraints without causing downtime in Materialize.

### Description
Add options to ignore constraints (gated behind `enable_exclude_constraints_option`):
- `EXCLUDE CONSTRAINTS ('<constraint_name>', ... ): Given a list of constraint names, filter out constraints matching those names at purification.
- `EXCLUDE ALL CONSTRAINTS`: Exclude all constraints during purification.

For context, during purification we previously recorded the set of constraints present on the table, which we later use to identify constraint changes and produce a definite error if a constraint changes unexpectedly.

### Verification
Lack of regression validated by existing test suite. Feature-specific testing in follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
