### PR TITLE
adapter: add the first curated metric sinks (sizes and errors) (SQL-556)

### DIFF
--- a/misc/python/materialize/checks/all_checks/metric_sink.py
+++ b/misc/python/materialize/checks/all_checks/metric_sink.py
@@ -96,9 +96,19 @@ class MetricSink(Check):
 
                 > SET cluster_replica = ${replica-name}
 
+                # Three user sinks came back. Exclude the curated sinks, which the
+                # coordinator installs on every replica labeled by name not id.
                 > SELECT count(DISTINCT labels -> 'sink') FROM mz_introspection.mz_cluster_prometheus_metrics
                   WHERE metric_name = 'mz_compute_metric_sink_frontier_ms'
+                    AND labels -> 'sink' NOT IN ('mz_metric_arrangement_sizes', 'mz_metric_dataflow_errors')
                 3
+
+                # The curated sinks come back too, re-installed from the static list
+                # rather than re-parsed from a catalog item.
+                > SELECT count(DISTINCT labels -> 'sink') FROM mz_introspection.mz_cluster_prometheus_metrics
+                  WHERE metric_name = 'mz_compute_metric_sink_frontier_ms'
+                    AND labels -> 'sink' IN ('mz_metric_arrangement_sizes', 'mz_metric_dataflow_errors')
+                2
 
                 > RESET cluster_replica
                 """))

--- a/src/adapter/src/coord/metric_sink.rs
+++ b/src/adapter/src/coord/metric_sink.rs
@@ -84,7 +84,71 @@ pub(super) struct CuratedMetricSink {
 }
 
 /// The curated metric sinks, installed on every replica.
-const CURATED: &[CuratedMetricSink] = &[];
+///
+/// Sources read the raw `..._raw` logging relations, never the derived builtin views like
+/// `mz_dataflow_arrangement_sizes`, which re-aggregate expensively and churn even on static data (a
+/// per-dataflow size metric off the derived view measured ~30x the raw form).
+///
+/// Every family sums across workers, so a series carries no `worker_id`, and a multi-process replica
+/// reports one number per grouping key rather than one per process. The size families emit one series
+/// per dataflow, the errors family one per export.
+const CURATED: &[CuratedMetricSink] = &[
+    CuratedMetricSink {
+        name: "mz_metric_arrangement_sizes",
+        prefix: "mz_metric_sink_",
+        // Key on the exported object's `GlobalId`, not the timely dataflow id, which is re-minted on
+        // every re-render and joins to nothing. The size logs are per operator, so map operator ->
+        // dataflow -> global id. A dataflow can export several objects, so collapse them to one
+        // representative id (`min(global_id)`) to keep one series per dataflow instead of fanning out.
+        // A dataflow with no export (a transient peek) has no global id, so bucket its arrangements
+        // under an `unattributable` sentinel rather than dropping their bytes from the total.
+        source_sql: "
+SELECT 'arrangement_size_bytes'::text AS metric_name, 'gauge'::text AS metric_type,
+       map_build(LIST[ROW('id', COALESCE(gid.global_id, 'unattributable'))])::map[text=>text] AS labels,
+       count(*)::double precision AS value, 'arrangement heap size in bytes'::text AS help
+FROM mz_introspection.mz_arrangement_heap_size_raw r
+JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
+LEFT JOIN (SELECT id, min(global_id) AS global_id FROM mz_introspection.mz_dataflow_global_ids GROUP BY id) gid
+  ON gid.id = dod.dataflow_id
+GROUP BY COALESCE(gid.global_id, 'unattributable')
+UNION ALL
+SELECT 'arrangement_records'::text AS metric_name, 'gauge'::text AS metric_type,
+       map_build(LIST[ROW('id', COALESCE(gid.global_id, 'unattributable'))])::map[text=>text] AS labels,
+       count(*)::double precision AS value, 'number of records in arrangement heaps'::text AS help
+FROM mz_introspection.mz_arrangement_records_raw r
+JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
+LEFT JOIN (SELECT id, min(global_id) AS global_id FROM mz_introspection.mz_dataflow_global_ids GROUP BY id) gid
+  ON gid.id = dod.dataflow_id
+GROUP BY COALESCE(gid.global_id, 'unattributable')
+UNION ALL
+SELECT 'arrangement_batches'::text AS metric_name, 'gauge'::text AS metric_type,
+       map_build(LIST[ROW('id', COALESCE(gid.global_id, 'unattributable'))])::map[text=>text] AS labels,
+       count(*)::double precision AS value, 'number of batches in arrangements'::text AS help
+FROM mz_introspection.mz_arrangement_batches_raw r
+JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
+LEFT JOIN (SELECT id, min(global_id) AS global_id FROM mz_introspection.mz_dataflow_global_ids GROUP BY id) gid
+  ON gid.id = dod.dataflow_id
+GROUP BY COALESCE(gid.global_id, 'unattributable')",
+    },
+    CuratedMetricSink {
+        name: "mz_metric_dataflow_errors",
+        prefix: "mz_metric_sink_",
+        // Raw log, not the `mz_compute_error_counts` view: the view joins the storage-managed
+        // `mz_internal.mz_compute_dependencies`, which `ensure_reads_only_logs` rejects. `count` is
+        // per-worker, so sum per export. `HAVING` drops the healthy ones.
+        //
+        // NOTE: direct errors only. The raw log attributes an error to the export that raised it. The
+        // view also forwards counts onto index-reuse exports, so a broken reuse-index reads 0 here and
+        // its errors show under the underlying export, undercounting against the view.
+        source_sql: "
+SELECT 'dataflow_error_count'::text AS metric_name, 'gauge'::text AS metric_type,
+       map_build(LIST[ROW('id', export_id::text)])::map[text=>text] AS labels,
+       sum(count)::double precision AS value, 'count of errors in the dataflow'::text AS help
+FROM mz_introspection.mz_compute_error_counts_raw
+GROUP BY export_id
+HAVING sum(count) > 0",
+    },
+];
 
 /// A [`CuratedMetricSink`] installed on one replica.
 #[derive(Debug)]
@@ -211,8 +275,9 @@ impl Coordinator {
         //
         // NOTE: This checks only the prefix format, not collisions. A curated prefix is not checked
         // against user sinks (`ensure_metric_sink_prefix_is_free` cannot see a non-catalog item) nor
-        // against other curated definitions, yet both share the `mz_metric_sink_` lane and could
-        // overlap. Deferred until `CURATED` is populated.
+        // against other curated definitions, which all share the `mz_metric_sink_` lane. Today's
+        // definitions stay disjoint by publishing distinct `metric_name`s within that lane, so no
+        // series collide; a definition reusing another's family would need a real check here.
         if let Err(err) = validate_metric_sink_prefix(definition.prefix) {
             soft_panic_or_log!(
                 "invalid curated metric sink prefix (name={}): {err}",
@@ -379,11 +444,11 @@ impl Coordinator {
         let read_holds = self.acquire_read_holds(&id_bundle);
         df_desc.set_as_of(read_holds.least_valid_read());
 
-        // Record the install now that the dataflow is about to ship, so a definition that fails to
-        // plan or optimize leaves no entry behind. `drop_metric_sinks` uses this entry to release the
-        // sink's instance-global collection state when the replica is dropped. Recording after the
-        // ship (an introspection subscribe records before sequencing) is safe: validity was rechecked
-        // at this stage and nothing awaits before the ship, so no replica drop can interleave.
+        // Record the install just before shipping. A failed plan or optimize returns earlier, so it
+        // leaves no entry behind. `drop_metric_sinks` reads this entry to release the sink's
+        // instance-global collection state on replica drop. Recording before the ship is safe because
+        // the coordinator runs one message at a time with no await between the two, so no replica drop
+        // sees an entry whose dataflow has not shipped.
         let install = InstalledMetricSink {
             cluster_id,
             sink_id,
@@ -425,7 +490,7 @@ impl Coordinator {
             info!(%sink_id, %replica_id, name, "dropping metric sink");
             self.metric_sinks.remove(&(replica_id, name));
 
-            // The collection exists (the entry is recorded only after the dataflow ships), so this
+            // The entry exists only for a shipped dataflow, so its collection is present and this
             // drop succeeds. Result ignored: a failure during replica teardown is not worth a panic.
             let _ = self
                 .controller
@@ -450,9 +515,7 @@ fn metric_sinks_on_replica(
 }
 
 /// Enforces the introspection-only contract from [`CuratedMetricSink::source_sql`]: every relation
-/// the definition reads, walking views transitively, must be a log collection. A storage-backed
-/// read would put envd's write frontier on the sink's emission path, the coupling these sinks exist
-/// to avoid.
+/// the definition reads, walking views transitively, must be a log collection.
 ///
 /// Checked here against what the definition reads rather than by import kind after optimization: the
 /// import split (storage vs index) depends on which indexes the target cluster happens to have, so
@@ -650,23 +713,31 @@ mod tests {
         }
     }
 
-    /// Every curated definition must plan against the system catalog. A definition that does not
-    /// would soft-panic at boot, so catch it here as a failing test instead. `CURATED` is empty
-    /// today, so this iterates nothing until the first definition lands.
+    /// Runs the two checks `plan_metric_sink` does at boot, where a failure soft-panics (a hard panic
+    /// under debug assertions, so a CI boot crash-loop). The gate is the load-bearing one: a source
+    /// can plan cleanly yet still read a storage-backed relation transitively (a builtin view joining
+    /// in an introspection source), which only `ensure_reads_only_logs` catches.
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method`
     async fn curated_definitions_plan() {
         Catalog::with_debug(|catalog| async move {
             let session_catalog = catalog.for_system_session();
             for definition in CURATED {
-                definition
-                    .plan_source(&session_catalog)
-                    .unwrap_or_else(|err| {
-                        panic!(
-                            "curated metric sink {:?} does not plan: {err}",
-                            definition.name
-                        )
-                    });
+                let (_, _, dependencies) =
+                    definition
+                        .plan_source(&session_catalog)
+                        .unwrap_or_else(|err| {
+                            panic!(
+                                "curated metric sink {:?} does not plan: {err}",
+                                definition.name
+                            )
+                        });
+                ensure_reads_only_logs(&catalog, &dependencies).unwrap_or_else(|err| {
+                    panic!(
+                        "curated metric sink {:?} reads a non-introspection relation: {err}",
+                        definition.name
+                    )
+                });
             }
         })
         .await

--- a/src/adapter/src/coord/metric_sink.rs
+++ b/src/adapter/src/coord/metric_sink.rs
@@ -20,18 +20,10 @@
 //! cluster, and the cost scales with `CURATED`. `coord::introspection` already accepts this for its
 //! subscribes.
 //!
-//! # Lifecycle
-//!
-//! * After a new replica is created, the coordinator calls `install_metric_sinks` to install every
-//!   definition on it. `bootstrap_metric_sinks` does the same for the replicas that already exist
-//!   when the coordinator starts.
-//! * Before a replica is dropped, the coordinator calls `drop_metric_sinks` to drop the sinks
-//!   installed on it.
-//! * A replica that disconnects and reconnects (a crash, an OOM) has its dataflows re-rendered from
-//!   the controller's state, so unlike an introspection subscribe there is nothing to reinstall.
-//!
-//! This mirrors [`crate::coord::introspection`], which installs introspection subscribes on the
-//! same triggers.
+//! `install_metric_sinks` installs every definition on a newly created replica
+//! (`bootstrap_metric_sinks` covers the replicas already present at startup), and
+//! `drop_metric_sinks` drops them before a replica is dropped. This mirrors
+//! [`crate::coord::introspection`], which installs introspection subscribes on the same triggers.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -45,8 +37,8 @@ use mz_repr::optimize::OverrideFrom;
 use mz_repr::{CatalogItemId, GlobalId, RelationDesc};
 use mz_sql::catalog::SessionCatalog;
 use mz_sql::plan::{
-    HirRelationExpr, Params, Plan, SubscribeFrom, SubscribePlan, validate_metric_sink_desc,
-    validate_metric_sink_prefix,
+    HirRelationExpr, METRIC_SINK_CURATED_PREFIX_MARKER, Params, Plan, SubscribeFrom, SubscribePlan,
+    validate_metric_sink_desc, validate_metric_sink_prefix,
 };
 use mz_sql::session::user::{MZ_SYSTEM_ROLE_ID, RoleMetadata};
 use mz_sql::session::vars::ENABLE_METRIC_SINK;
@@ -78,16 +70,19 @@ pub(super) struct CuratedMetricSink {
     /// with it.
     source_sql: &'static str,
     /// Prepended to every row's `metric_name` to form the published name, exactly as a user's
-    /// `CREATE METRIC SINK ... WITH (PREFIX = ...)`. Must start with `mz_metric_sink_` so the
-    /// published families land in the reserved lane (see `validate_metric_sink_prefix`).
+    /// `CREATE METRIC SINK ... WITH (PREFIX = ...)`. Every definition in [`CURATED`] uses
+    /// [`METRIC_SINK_CURATED_PREFIX_MARKER`], which user sinks are barred from, so nothing a user
+    /// publishes can collide with a curated family.
     prefix: &'static str,
 }
 
 /// The curated metric sinks, installed on every replica.
 ///
-/// Sources read the raw `..._raw` logging relations, never the derived builtin views like
-/// `mz_dataflow_arrangement_sizes`, which re-aggregate expensively and churn even on static data (a
-/// per-dataflow size metric off the derived view measured ~30x the raw form).
+/// Sources take their measurements from the raw `..._raw` logging relations, never from a derived
+/// view that re-aggregates them, like `mz_dataflow_arrangement_sizes`: those churn even on static
+/// data, and a per-dataflow size metric off the derived view measured ~30x the raw form. Cheap
+/// mapping views over the same logs, `mz_dataflow_operator_dataflows` and `mz_compute_exports`,
+/// carry no aggregation and are read freely.
 ///
 /// Every family sums across workers, so a series carries no `worker_id`, and a multi-process replica
 /// reports one number per grouping key rather than one per process. The size families emit one series
@@ -95,44 +90,55 @@ pub(super) struct CuratedMetricSink {
 const CURATED: &[CuratedMetricSink] = &[
     CuratedMetricSink {
         name: "mz_metric_arrangement_sizes",
-        prefix: "mz_metric_sink_",
-        // Key on the exported object's `GlobalId`, not the timely dataflow id, which is re-minted on
-        // every re-render and joins to nothing. The size logs are per operator, so map operator ->
-        // dataflow -> global id. A dataflow can export several objects, so collapse them to one
-        // representative id (`min(global_id)`) to keep one series per dataflow instead of fanning out.
-        // A dataflow with no export (a transient peek) has no global id, so bucket its arrangements
-        // under an `unattributable` sentinel rather than dropping their bytes from the total.
+        prefix: METRIC_SINK_CURATED_PREFIX_MARKER,
+        // Key on the export id from `mz_compute_exports`, not `mz_dataflow_global_ids`: a
+        // materialized view builds under a transient view id and appears only as an export, so a
+        // global-id label names a `t<N>` that maps to no catalog object and churns on every
+        // re-render.
+        //
+        // Logs are per operator, so map operator -> dataflow -> export id. `min(export_id)`
+        // collapses a multi-export dataflow to one series (lexicographic, so `min('u10', 'u2')` is
+        // `'u10'`: arbitrary but stable). The group-size hint stops that `min` from rendering the
+        // 8-level hierarchy, which would otherwise show up as tuning advice for the sink's own
+        // dataflow in `mz_expected_group_size_advice`.
+        //
+        // Transient exports (subscribes, peeks, metric sinks) and operators with no worker-0
+        // mapping fall through to an `unattributable` sentinel, so their bytes still count without a
+        // churning `t<N>` label growing series without bound.
         source_sql: "
+WITH ex AS (
+    SELECT dataflow_id, min(export_id) AS export_id
+    FROM mz_introspection.mz_compute_exports
+    WHERE export_id NOT LIKE 't%'
+    GROUP BY dataflow_id OPTIONS (AGGREGATE INPUT GROUP SIZE = 1)
+)
 SELECT 'arrangement_size_bytes'::text AS metric_name, 'gauge'::text AS metric_type,
-       map_build(LIST[ROW('id', COALESCE(gid.global_id, 'unattributable'))])::map[text=>text] AS labels,
+       map_build(LIST[ROW('id', COALESCE(ex.export_id, 'unattributable'))])::map[text=>text] AS labels,
        count(*)::double precision AS value, 'arrangement heap size in bytes'::text AS help
 FROM mz_introspection.mz_arrangement_heap_size_raw r
-JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
-LEFT JOIN (SELECT id, min(global_id) AS global_id FROM mz_introspection.mz_dataflow_global_ids GROUP BY id) gid
-  ON gid.id = dod.dataflow_id
-GROUP BY COALESCE(gid.global_id, 'unattributable')
+LEFT JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
+LEFT JOIN ex ON ex.dataflow_id = dod.dataflow_id
+GROUP BY COALESCE(ex.export_id, 'unattributable')
 UNION ALL
 SELECT 'arrangement_records'::text AS metric_name, 'gauge'::text AS metric_type,
-       map_build(LIST[ROW('id', COALESCE(gid.global_id, 'unattributable'))])::map[text=>text] AS labels,
+       map_build(LIST[ROW('id', COALESCE(ex.export_id, 'unattributable'))])::map[text=>text] AS labels,
        count(*)::double precision AS value, 'number of records in arrangement heaps'::text AS help
 FROM mz_introspection.mz_arrangement_records_raw r
-JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
-LEFT JOIN (SELECT id, min(global_id) AS global_id FROM mz_introspection.mz_dataflow_global_ids GROUP BY id) gid
-  ON gid.id = dod.dataflow_id
-GROUP BY COALESCE(gid.global_id, 'unattributable')
+LEFT JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
+LEFT JOIN ex ON ex.dataflow_id = dod.dataflow_id
+GROUP BY COALESCE(ex.export_id, 'unattributable')
 UNION ALL
 SELECT 'arrangement_batches'::text AS metric_name, 'gauge'::text AS metric_type,
-       map_build(LIST[ROW('id', COALESCE(gid.global_id, 'unattributable'))])::map[text=>text] AS labels,
+       map_build(LIST[ROW('id', COALESCE(ex.export_id, 'unattributable'))])::map[text=>text] AS labels,
        count(*)::double precision AS value, 'number of batches in arrangements'::text AS help
 FROM mz_introspection.mz_arrangement_batches_raw r
-JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
-LEFT JOIN (SELECT id, min(global_id) AS global_id FROM mz_introspection.mz_dataflow_global_ids GROUP BY id) gid
-  ON gid.id = dod.dataflow_id
-GROUP BY COALESCE(gid.global_id, 'unattributable')",
+LEFT JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
+LEFT JOIN ex ON ex.dataflow_id = dod.dataflow_id
+GROUP BY COALESCE(ex.export_id, 'unattributable')",
     },
     CuratedMetricSink {
         name: "mz_metric_dataflow_errors",
-        prefix: "mz_metric_sink_",
+        prefix: METRIC_SINK_CURATED_PREFIX_MARKER,
         // Raw log, not the `mz_compute_error_counts` view: the view joins the storage-managed
         // `mz_internal.mz_compute_dependencies`, which `ensure_reads_only_logs` rejects. `count` is
         // per-worker, so sum per export. `HAVING` drops the healthy ones.
@@ -173,8 +179,6 @@ pub(super) struct PlannedMetricSink {
 
 impl Coordinator {
     /// Installs the curated metric sinks on all existing replicas.
-    ///
-    /// Meant to be invoked during coordinator bootstrapping.
     pub(super) async fn bootstrap_metric_sinks(&mut self) {
         for (cluster_id, replica_id) in self.all_cluster_replicas() {
             self.install_metric_sinks(cluster_id, replica_id).await;
@@ -269,15 +273,12 @@ impl Coordinator {
         }
 
         // A user sink's prefix is validated at plan time; a curated one has no such gate, so enforce
-        // the same contract here. The prefix keeps published families in the reserved lane and
-        // supplies the leading character the row shaping's name validation needs. A failure is a bug
-        // in our own definition, hence `soft_panic_or_log!`.
+        // the same contract here. A failure is a bug in our own definition, hence
+        // `soft_panic_or_log!`. User-vs-curated collisions need no check: the curated prefix is
+        // reserved against user sinks in `validate_user_metric_sink_prefix`.
         //
-        // NOTE: This checks only the prefix format, not collisions. A curated prefix is not checked
-        // against user sinks (`ensure_metric_sink_prefix_is_free` cannot see a non-catalog item) nor
-        // against other curated definitions, which all share the `mz_metric_sink_` lane. Today's
-        // definitions stay disjoint by publishing distinct `metric_name`s within that lane, so no
-        // series collide; a definition reusing another's family would need a real check here.
+        // NOTE: curated definitions are not checked against each other; they stay disjoint by
+        // publishing distinct `metric_name`s under the shared curated prefix.
         if let Err(err) = validate_metric_sink_prefix(definition.prefix) {
             soft_panic_or_log!(
                 "invalid curated metric sink prefix (name={}): {err}",
@@ -633,7 +634,10 @@ mod tests {
     use mz_cluster_client::ReplicaId;
     use mz_controller_types::ClusterId;
     use mz_repr::GlobalId;
-    use mz_sql::plan::validate_metric_sink_prefix;
+    use mz_sql::plan::{
+        METRIC_SINK_CURATED_PREFIX_MARKER, validate_metric_sink_prefix,
+        validate_user_metric_sink_prefix,
+    };
 
     use crate::catalog::Catalog;
     use crate::coord::metric_sink::{
@@ -683,9 +687,6 @@ mod tests {
         assert!(metric_sinks_on_replica(&sinks, r(5)).is_empty());
     }
 
-    /// Every curated definition's prefix must satisfy the same contract a user's `PREFIX` does.
-    /// Unlike the user path, nothing validates a curated prefix at runtime before this guards it,
-    /// so a malformed one would escape the reserved lane or break the shaping's name validation.
     #[mz_ore::test]
     fn curated_prefixes_are_valid() {
         for definition in CURATED {
@@ -695,6 +696,26 @@ mod tests {
                     definition.name, definition.prefix
                 )
             });
+        }
+    }
+
+    #[mz_ore::test]
+    fn curated_prefixes_are_reserved_against_user_sinks() {
+        for definition in CURATED {
+            assert!(
+                definition
+                    .prefix
+                    .starts_with(METRIC_SINK_CURATED_PREFIX_MARKER),
+                "curated metric sink {:?} does not use the reserved curated prefix: {:?}",
+                definition.name,
+                definition.prefix
+            );
+            assert!(
+                validate_user_metric_sink_prefix(definition.prefix).is_err(),
+                "a user could claim curated metric sink {:?}'s prefix {:?}",
+                definition.name,
+                definition.prefix
+            );
         }
     }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -116,9 +116,10 @@ pub use query::{ExprContext, QueryContext, QueryLifetime};
 pub use scope::Scope;
 pub use side_effecting_func::SideEffectingFunc;
 pub use statement::ddl::{
-    AlterSourceAddSubsourceOptionExtracted, MySqlConfigOptionExtracted, PgConfigOptionExtracted,
-    PlannedAlterRoleOption, PlannedRoleAttributes, PlannedRoleVariable,
-    SqlServerConfigOptionExtracted, validate_metric_sink_desc, validate_metric_sink_prefix,
+    AlterSourceAddSubsourceOptionExtracted, METRIC_SINK_CURATED_PREFIX_MARKER,
+    MySqlConfigOptionExtracted, PgConfigOptionExtracted, PlannedAlterRoleOption,
+    PlannedRoleAttributes, PlannedRoleVariable, SqlServerConfigOptionExtracted,
+    validate_metric_sink_desc, validate_metric_sink_prefix, validate_user_metric_sink_prefix,
 };
 pub use statement::{
     StatementClassification, StatementContext, StatementDesc, describe, plan, plan_copy_from,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4258,16 +4258,14 @@ generate_extracted_config!(CreateMetricSinkOption, (Prefix, String));
 /// rot as new platform collectors are added.
 const METRIC_SINK_PREFIX_MARKER: &str = "mz_metric_sink_";
 
-/// Rejects a prefix that could not start a Prometheus metric name, or that escapes the reserved
-/// `mz_metric_sink_` lane (see `METRIC_SINK_PREFIX_MARKER`).
-///
-/// The sink prepends this to every name it publishes, so `prefix + name` must stay a legal
-/// family name (`[a-zA-Z_:][a-zA-Z0-9_:]*`, the same grammar the runtime checks each row's
-/// `metric_name` against). The prefix must therefore be at least one character long.
-///
-/// Enforced for a user's `CREATE METRIC SINK` at plan time, and for a coordinator-installed curated
-/// sink at install time. Both paths depend on the guarantees this gives the row shaping: the
-/// reserved leading character is what lets a bare `metric_name` start with a digit or be empty.
+/// The prefix reserved for the curated sinks (`mz_adapter::coord::metric_sink::CURATED`);
+/// [`validate_user_metric_sink_prefix`] keeps user prefixes clear of it.
+pub const METRIC_SINK_CURATED_PREFIX_MARKER: &str = "mz_metric_sink_curated_";
+
+/// Rejects a prefix that is not a legal start of a Prometheus metric name, or that escapes the
+/// reserved `mz_metric_sink_` lane (`METRIC_SINK_PREFIX_MARKER`). The reserved leading character
+/// is what lets a row's bare `metric_name` start with a digit or be empty. User sinks use
+/// [`validate_user_metric_sink_prefix`], which adds the curated reservation.
 pub fn validate_metric_sink_prefix(prefix: &str) -> Result<(), PlanError> {
     if prefix.is_empty() {
         return Err(sql_err!("metric sink prefix must not be empty"));
@@ -4290,6 +4288,28 @@ pub fn validate_metric_sink_prefix(prefix: &str) -> Result<(), PlanError> {
             "metric sink prefix {:?} must start with {:?}",
             prefix,
             METRIC_SINK_PREFIX_MARKER
+        ));
+    }
+    Ok(())
+}
+
+/// [`validate_metric_sink_prefix`] plus the reservation that keeps user sinks clear of the curated
+/// families ([`METRIC_SINK_CURATED_PREFIX_MARKER`]).
+///
+/// The check runs both ways so it is total: a prefix that starts with the curated prefix is
+/// rejected, and so is one the curated prefix starts with (a bare `mz_metric_sink_` plus a
+/// `curated_...` row would otherwise publish a curated family, which Prometheus merges silently).
+/// It is static rather than a catalog scan like `Coordinator::ensure_metric_sink_prefix_is_free`,
+/// because curated sinks are not catalog items.
+pub fn validate_user_metric_sink_prefix(prefix: &str) -> Result<(), PlanError> {
+    validate_metric_sink_prefix(prefix)?;
+    if prefix.starts_with(METRIC_SINK_CURATED_PREFIX_MARKER)
+        || METRIC_SINK_CURATED_PREFIX_MARKER.starts_with(prefix)
+    {
+        return Err(sql_err!(
+            "metric sink prefix {:?} overlaps {:?}, which is reserved for the built-in metric sinks",
+            prefix,
+            METRIC_SINK_CURATED_PREFIX_MARKER
         ));
     }
     Ok(())
@@ -4344,7 +4364,7 @@ pub fn plan_create_metric_sink(
     let Some(prefix) = prefix else {
         sql_bail!("CREATE METRIC SINK requires a PREFIX option");
     };
-    validate_metric_sink_prefix(&prefix)?;
+    validate_user_metric_sink_prefix(&prefix)?;
     let name = scx.allocate_qualified_name(normalize::unresolved_item_name(name.clone())?)?;
     let full_name = scx.catalog.resolve_full_name(&name);
     let partial_name = PartialItemName::from(full_name.clone());
@@ -8597,5 +8617,30 @@ fn ensure_cluster_is_not_managed(
         })
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        METRIC_SINK_CURATED_PREFIX_MARKER, METRIC_SINK_PREFIX_MARKER,
+        validate_user_metric_sink_prefix,
+    };
+
+    #[mz_ore::test]
+    fn user_metric_sink_prefix_cannot_reach_the_curated_prefix() {
+        // Starts with the curated prefix.
+        assert!(validate_user_metric_sink_prefix(METRIC_SINK_CURATED_PREFIX_MARKER).is_err());
+        assert!(validate_user_metric_sink_prefix("mz_metric_sink_curated_x").is_err());
+        // A proper prefix of the curated prefix, which a `curated_...` row would complete.
+        assert!(validate_user_metric_sink_prefix(METRIC_SINK_PREFIX_MARKER).is_err());
+        assert!(validate_user_metric_sink_prefix("mz_metric_sink_cur").is_err());
+        // Still outside the reserved lane entirely.
+        assert!(validate_user_metric_sink_prefix("myapp_").is_err());
+        // A prefix that diverges from the curated prefix is fine, including one that merely contains
+        // the marker further along.
+        assert!(validate_user_metric_sink_prefix("mz_metric_sink_myapp_").is_ok());
+        assert!(validate_user_metric_sink_prefix("mz_metric_sink_curatex_").is_ok());
+        assert!(validate_user_metric_sink_prefix("mz_metric_sink_my_curated_").is_ok());
     }
 }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -326,6 +326,15 @@ def workflow_test_github_4443(c: Composition) -> None:
             user="mz_system",
         )
 
+        # Curated metric sinks install a dataflow on every replica, which would
+        # inflate the dataflow counts asserted below. Disable them before the
+        # cluster is created so its replica carries only this test's dataflows.
+        c.sql(
+            "ALTER SYSTEM SET enable_metric_sink = false;",
+            port=6877,
+            user="mz_system",
+        )
+
         # Set up a cluster with an indexed table and an unindexed one.
         c.sql("""
             CREATE CLUSTER cluster1 REPLICAS (replica1 (

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -326,15 +326,6 @@ def workflow_test_github_4443(c: Composition) -> None:
             user="mz_system",
         )
 
-        # Curated metric sinks install a dataflow on every replica, which would
-        # inflate the dataflow counts asserted below. Disable them before the
-        # cluster is created so its replica carries only this test's dataflows.
-        c.sql(
-            "ALTER SYSTEM SET enable_metric_sink = false;",
-            port=6877,
-            user="mz_system",
-        )
-
         # Set up a cluster with an indexed table and an unindexed one.
         c.sql("""
             CREATE CLUSTER cluster1 REPLICAS (replica1 (
@@ -369,19 +360,34 @@ def workflow_test_github_4443(c: Composition) -> None:
             replica_command_count,
             replica_dataflow_count,
         ) = find_command_history_metrics(c)
+
+        # Curated metric sinks install one dataflow per definition on every replica,
+        # so they add to the aggregate history dataflow counts above. That metric
+        # carries no per-dataflow label to filter on, so subtract the live count of
+        # curated sink dataflows rather than hardcoding it, keeping the bounds
+        # correct as the CURATED set grows. Read the count off cluster1's own
+        # replica, the one whose history the metrics above describe.
+        with c.sql_cursor() as cursor:
+            cursor.execute(b"SET cluster = cluster1")
+            cursor.execute(
+                b"SELECT count(*) FROM mz_introspection.mz_dataflows"
+                b" WHERE name LIKE '%metric-sink-%'"
+            )
+            metric_sink_dataflows = int(cursor.fetchall()[0][0])
+
         assert controller_command_count > 0, "controller history cannot be empty"
         assert (
             controller_dataflow_count > 0
         ), "at least one dataflow expected in controller history"
         assert (
-            controller_dataflow_count < 6
+            controller_dataflow_count - metric_sink_dataflows < 6
         ), "more dataflows than expected in controller history"
         assert replica_command_count > 0, "replica history cannot be empty"
         assert (
             replica_dataflow_count > 0
         ), "at least one dataflow expected in replica history"
         assert (
-            replica_dataflow_count < 6
+            replica_dataflow_count - metric_sink_dataflows < 6
         ), "more dataflows than expected in replica history"
 
         # execute 400 fast- and slow-path peeks
@@ -427,7 +433,7 @@ def workflow_test_github_4443(c: Composition) -> None:
             controller_dataflow_count > 0
         ), f"at least one dataflow expected in controller history, got {controller_dataflow_count}"
         assert (
-            controller_dataflow_count < 6
+            controller_dataflow_count - metric_sink_dataflows < 6
         ), f"more dataflows than expected in controller history, got {controller_dataflow_count}"
         assert (
             replica_command_count < 100
@@ -436,7 +442,7 @@ def workflow_test_github_4443(c: Composition) -> None:
             replica_dataflow_count > 0
         ), f"at least one dataflow expected in replica history, got {replica_dataflow_count}"
         assert (
-            replica_dataflow_count < 6
+            replica_dataflow_count - metric_sink_dataflows < 6
         ), f"more dataflows than expected in replica history, got {replica_dataflow_count}"
 
 

--- a/test/sqllogictest/metric_sink.slt
+++ b/test/sqllogictest/metric_sink.slt
@@ -125,6 +125,38 @@ CREATE METRIC SINK ms_bad_prefix FROM shaped WITH (PREFIX = '')
 statement error metric sink prefix "app_" must start with "mz_metric_sink_"
 CREATE METRIC SINK ms_unmarked FROM shaped WITH (PREFIX = 'app_')
 
+# `mz_metric_sink_curated_` is reserved for the built-in sinks. The reservation is
+# bidirectional: a user prefix may neither start with it nor be one it starts with,
+# since the published name appends an arbitrary `metric_name`. `mz_metric_sink_` plus
+# a row named `curated_arrangement_size_bytes` is exactly the second case.
+
+statement error metric sink prefix "mz_metric_sink_curated_" overlaps "mz_metric_sink_curated_", which is reserved for the built-in metric sinks
+CREATE METRIC SINK ms_curated FROM shaped WITH (PREFIX = 'mz_metric_sink_curated_')
+
+statement error metric sink prefix "mz_metric_sink_curated_mine_" overlaps "mz_metric_sink_curated_", which is reserved for the built-in metric sinks
+CREATE METRIC SINK ms_curated_mine FROM shaped WITH (PREFIX = 'mz_metric_sink_curated_mine_')
+
+statement error metric sink prefix "mz_metric_sink_" overlaps "mz_metric_sink_curated_", which is reserved for the built-in metric sinks
+CREATE METRIC SINK ms_bare FROM shaped WITH (PREFIX = 'mz_metric_sink_')
+
+statement error metric sink prefix "mz_metric_sink_cur" overlaps "mz_metric_sink_curated_", which is reserved for the built-in metric sinks
+CREATE METRIC SINK ms_cur FROM shaped WITH (PREFIX = 'mz_metric_sink_cur')
+
+# A prefix that diverges from the curated prefix is fine, and so is one that merely
+# contains the marker further along.
+
+statement ok
+CREATE METRIC SINK ms_curatex FROM shaped WITH (PREFIX = 'mz_metric_sink_curatex_')
+
+statement ok
+DROP METRIC SINK ms_curatex
+
+statement ok
+CREATE METRIC SINK ms_my_curated FROM shaped WITH (PREFIX = 'mz_metric_sink_my_curated_')
+
+statement ok
+DROP METRIC SINK ms_my_curated
+
 # Prefixes on one cluster have to be prefix-free, not merely distinct: `app_`
 # plus a row named `svc_x` publishes exactly what `app_svc_` plus a row named
 # `x` does, and the Prometheus registry merges same-named families silently.

--- a/test/testdrive/dataflow-cleanup.td
+++ b/test/testdrive/dataflow-cleanup.td
@@ -17,9 +17,12 @@
 # Filter them out so test assertions only see compute operators.
 $ set storage-id-offset=281474976710656
 
-# Introspection subscribes add noise to the introspection sources, so disable them.
+# Introspection subscribes and curated metric sinks both install dataflows on
+# every replica, adding noise to the introspection sources, so disable them
+# before creating the cluster below.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_introspection_subscribes = false
+ALTER SYSTEM SET enable_metric_sink = false
 
 # Create a clean replica to inspect dataflow state on.
 

--- a/test/testdrive/divergent-dataflow-cancellation.td
+++ b/test/testdrive/divergent-dataflow-cancellation.td
@@ -18,9 +18,12 @@
 # Filter them out so test assertions only see compute operators.
 $ set storage-id-offset=281474976710656
 
-# Introspection subscribes add noise to the introspection sources, so disable them.
+# Introspection subscribes and curated metric sinks both install dataflows on
+# every replica, adding noise to the introspection sources, so disable them
+# before creating the cluster below.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_introspection_subscribes = false
+ALTER SYSTEM SET enable_metric_sink = false
 
 > CREATE CLUSTER test SIZE 'scale=1,workers=1';
 > SET cluster = test;

--- a/test/testdrive/divergent-dataflow-cancellation.td
+++ b/test/testdrive/divergent-dataflow-cancellation.td
@@ -18,15 +18,53 @@
 # Filter them out so test assertions only see compute operators.
 $ set storage-id-offset=281474976710656
 
-# Introspection subscribes and curated metric sinks both install dataflows on
-# every replica, adding noise to the introspection sources, so disable them
-# before creating the cluster below.
+# Introspection subscribes add noise to the introspection sources, so disable them.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_introspection_subscribes = false
-ALTER SYSTEM SET enable_metric_sink = false
+
+# Curated metric sinks install one dataflow per definition on every replica. CI
+# runs with the feature on, so the assertions at the end filter them out instead
+# of disabling it and leaving the shipping path untested. The default cluster's
+# replica has run the same set since boot, so read the count from there rather
+# than hardcoding it.
+> SELECT count(*) > 0 FROM mz_introspection.mz_dataflows
+  WHERE name LIKE '%metric-sink-%'
+true
+
+$ set-from-sql var=metric-sink-dataflows
+SELECT count(*)::text FROM mz_introspection.mz_dataflows WHERE name LIKE '%metric-sink-%'
 
 > CREATE CLUSTER test SIZE 'scale=1,workers=1';
 > SET cluster = test;
+
+# Sink install is async; wait for all of them before capturing the baselines
+# below, or one landing later looks like a cancelled dataflow that never cleaned up.
+> SELECT count(*) = ${metric-sink-dataflows} FROM mz_introspection.mz_dataflows
+  WHERE name LIKE '%metric-sink-%'
+true
+
+# Capture the sinks' footprint now, while they are the only dataflows here, to
+# subtract from the expect-empty assertions at the end. Export ids have no useful
+# order, so list them.
+$ set-from-sql var=baseline-exports
+SELECT string_agg(DISTINCT '''' || export_id || '''', ',')
+FROM mz_introspection.mz_compute_exports_per_worker
+WHERE export_id NOT LIKE 'si%'
+
+# Operator and channel ids share one monotonic Timely counter, so a single
+# high-water mark separates the sinks from what this test installs next; channels
+# show up in mz_dataflow_addresses_per_worker too, so it covers both. Exclude
+# storage ids, or the mark exceeds STORAGE_ID_OFFSET and the assertions go vacuous.
+#
+# NOTE: qualify the ORDER BY column so it sorts the numeric id, not the ::text
+# projection (which ranks 999 above 1000). Keep the query fast-path, or it
+# allocates ids above the mark it reports.
+$ set-from-sql var=baseline-max-id
+SELECT id::text AS max_id
+FROM mz_introspection.mz_dataflow_addresses_per_worker
+WHERE id < ${storage-id-offset}
+ORDER BY mz_dataflow_addresses_per_worker.id DESC
+LIMIT 1
 
 > CREATE VIEW divergent AS
   WITH MUTUALLY RECURSIVE
@@ -44,6 +82,13 @@ ALTER SYSTEM SET enable_metric_sink = false
   FROM mz_introspection.mz_dataflows
   WHERE name LIKE '%divergent%'
 2
+
+# The dataflows just installed have to sit above the mark, or the assertions at
+# the end filter away everything they are meant to catch.
+> SELECT count(*) > 0
+  FROM mz_introspection.mz_dataflow_operators_per_worker
+  WHERE id > ${baseline-max-id} AND id < ${storage-id-offset}
+true
 
 # Drop the installed dataflows
 
@@ -74,33 +119,36 @@ contains: canceling statement due to statement timeout
 
 > COMMIT
 
-# Confirm that all dataflows are now cancelled.
+# Confirm that all dataflows are now cancelled. The curated metric sinks are
+# still running, so each query excludes their baseline rather than expecting a
+# bare empty replica: an id above the high-water mark, or an export outside the
+# captured list, belongs to a dataflow this test installed and cancelled.
 #
 # NOTE: It is important that the below queries are all fast-path queries.
 # Otherwise they'd introduce new dataflows, confusing the results.
 # For `_raw` relations, add a limit to protect against huge results.
 
-> SELECT * FROM mz_introspection.mz_arrangement_batches_raw LIMIT 10
-> SELECT * FROM mz_introspection.mz_arrangement_records_raw LIMIT 10
-> SELECT * FROM mz_introspection.mz_arrangement_sharing_raw LIMIT 10
-> SELECT * FROM mz_introspection.mz_compute_error_counts_raw LIMIT 10
+> SELECT * FROM mz_introspection.mz_arrangement_batches_raw WHERE operator_id > ${baseline-max-id} LIMIT 10
+> SELECT * FROM mz_introspection.mz_arrangement_records_raw WHERE operator_id > ${baseline-max-id} LIMIT 10
+> SELECT * FROM mz_introspection.mz_arrangement_sharing_raw WHERE operator_id > ${baseline-max-id} LIMIT 10
+> SELECT * FROM mz_introspection.mz_compute_error_counts_raw WHERE export_id NOT IN (${baseline-exports}) LIMIT 10
 > SELECT *
   FROM mz_introspection.mz_compute_exports_per_worker
-  WHERE export_id NOT LIKE 'si%'
+  WHERE export_id NOT LIKE 'si%' AND export_id NOT IN (${baseline-exports})
 > SELECT *
   FROM mz_introspection.mz_compute_frontiers_per_worker
-  WHERE export_id NOT LIKE 'si%'
+  WHERE export_id NOT LIKE 'si%' AND export_id NOT IN (${baseline-exports})
 > SELECT *
   FROM mz_introspection.mz_compute_import_frontiers_per_worker
-  WHERE export_id NOT LIKE 'si%'
-> SELECT * FROM mz_introspection.mz_compute_operator_durations_histogram_raw WHERE id < ${storage-id-offset} LIMIT 10
-> SELECT id, worker_id, address::text FROM mz_introspection.mz_dataflow_addresses_per_worker WHERE id < ${storage-id-offset}
-> SELECT * FROM mz_introspection.mz_dataflow_channels_per_worker WHERE id < ${storage-id-offset}
-> SELECT * FROM mz_introspection.mz_dataflow_operator_reachability_raw WHERE id < ${storage-id-offset} LIMIT 10
-> SELECT * FROM mz_introspection.mz_dataflow_operators_per_worker WHERE id < ${storage-id-offset}
-> SELECT * FROM mz_introspection.mz_message_counts_received_raw WHERE channel_id < ${storage-id-offset} LIMIT 10
-> SELECT * FROM mz_introspection.mz_message_counts_sent_raw WHERE channel_id < ${storage-id-offset} LIMIT 10
-> SELECT * FROM mz_introspection.mz_scheduling_elapsed_raw WHERE id < ${storage-id-offset} LIMIT 10
+  WHERE export_id NOT LIKE 'si%' AND export_id NOT IN (${baseline-exports})
+> SELECT * FROM mz_introspection.mz_compute_operator_durations_histogram_raw WHERE id > ${baseline-max-id} AND id < ${storage-id-offset} LIMIT 10
+> SELECT id, worker_id, address::text FROM mz_introspection.mz_dataflow_addresses_per_worker WHERE id > ${baseline-max-id} AND id < ${storage-id-offset}
+> SELECT * FROM mz_introspection.mz_dataflow_channels_per_worker WHERE id > ${baseline-max-id} AND id < ${storage-id-offset}
+> SELECT * FROM mz_introspection.mz_dataflow_operator_reachability_raw WHERE id > ${baseline-max-id} AND id < ${storage-id-offset} LIMIT 10
+> SELECT * FROM mz_introspection.mz_dataflow_operators_per_worker WHERE id > ${baseline-max-id} AND id < ${storage-id-offset}
+> SELECT * FROM mz_introspection.mz_message_counts_received_raw WHERE channel_id > ${baseline-max-id} AND channel_id < ${storage-id-offset} LIMIT 10
+> SELECT * FROM mz_introspection.mz_message_counts_sent_raw WHERE channel_id > ${baseline-max-id} AND channel_id < ${storage-id-offset} LIMIT 10
+> SELECT * FROM mz_introspection.mz_scheduling_elapsed_raw WHERE id > ${baseline-max-id} AND id < ${storage-id-offset} LIMIT 10
 
 # Cleanup.
 > DROP CLUSTER test CASCADE

--- a/test/testdrive/expected_group_size_tuning.td
+++ b/test/testdrive/expected_group_size_tuning.td
@@ -9,8 +9,12 @@
 
 $ set-sql-timeout duration=240s
 
-# This test uses introspection queries that need to be targeted to a replica
-> SET cluster_replica = r1
+# The curated metric sinks read arrangement introspection on every replica, which
+# perturbs the arrangement sizes the group-size advice below is computed from and
+# leaves it empty. Turn them off so the views run on a replica that boots without
+# them.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_metric_sink = false
 
 # Start from a TPC-H load generator source with small data.
 > CREATE CLUSTER lgtpch_cluster_tuning SIZE 'scale=1,workers=1';
@@ -26,6 +30,13 @@ $ set-sql-timeout duration=240s
 > CREATE TABLE region FROM SOURCE lgtpch (REFERENCE region);
 > CREATE TABLE supplier FROM SOURCE lgtpch (REFERENCE supplier);
 > COMMIT
+
+# Run the views on a dedicated cluster created after the setting above, so its
+# replica boots without the metric sinks. This test's introspection queries target
+# this replica.
+> CREATE CLUSTER lgtpch_compute_tuning SIZE '${arg.default-replica-size}';
+> SET cluster = lgtpch_compute_tuning
+> SET cluster_replica = r1
 
 # Create a set of materialized views for testing based on the TPC-H schema.
 > CREATE MATERIALIZED VIEW lineitem_by_orderkey AS

--- a/test/testdrive/expected_group_size_tuning.td
+++ b/test/testdrive/expected_group_size_tuning.td
@@ -9,12 +9,8 @@
 
 $ set-sql-timeout duration=240s
 
-# The curated metric sinks read arrangement introspection on every replica, which
-# perturbs the arrangement sizes the group-size advice below is computed from and
-# leaves it empty. Turn them off so the views run on a replica that boots without
-# them.
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_metric_sink = false
+# This test uses introspection queries that need to be targeted to a replica
+> SET cluster_replica = r1
 
 # Start from a TPC-H load generator source with small data.
 > CREATE CLUSTER lgtpch_cluster_tuning SIZE 'scale=1,workers=1';
@@ -30,13 +26,6 @@ ALTER SYSTEM SET enable_metric_sink = false
 > CREATE TABLE region FROM SOURCE lgtpch (REFERENCE region);
 > CREATE TABLE supplier FROM SOURCE lgtpch (REFERENCE supplier);
 > COMMIT
-
-# Run the views on a dedicated cluster created after the setting above, so its
-# replica boots without the metric sinks. This test's introspection queries target
-# this replica.
-> CREATE CLUSTER lgtpch_compute_tuning SIZE '${arg.default-replica-size}';
-> SET cluster = lgtpch_compute_tuning
-> SET cluster_replica = r1
 
 # Create a set of materialized views for testing based on the TPC-H schema.
 > CREATE MATERIALIZED VIEW lineitem_by_orderkey AS
@@ -125,6 +114,15 @@ ALTER SYSTEM SET enable_metric_sink = false
 "Dataflow: materialize.public.lineitem_by_partkey" TopK 8 6 255
 "Dataflow: materialize.public.lineitem_by_suppkey" ReduceHierarchical 8 5 4095
 "Dataflow: materialize.public.lineitem_by_suppkey" TopK 8 5 4095
+
+# The curated metric sinks run on this replica too, and this view has no
+# internal-dataflow filter. Their `min` aggregate carries a group-size hint, so it
+# renders one reduce stage and offers nothing to cut. Without the hint each sink
+# dataflow would add a row here, in a view users are pointed at for tuning advice.
+> SELECT count(*)
+  FROM mz_introspection.mz_expected_group_size_advice
+  WHERE dataflow_name LIKE '%metric-sink-%';
+0
 
 # Validate the reported memory savings for the entries above. The `savings` column
 # sums arrangement heap sizes (mz_arrangement_sizes.size), which are logged

--- a/test/testdrive/github-6335.td
+++ b/test/testdrive/github-6335.td
@@ -51,5 +51,6 @@ $ set-sql-timeout duration=360s
   JOIN mz_introspection.mz_dataflows d ON d.id = e.dataflow_id
   WHERE e.export_id LIKE 't%' AND
         d.name NOT LIKE '%introspection-subscribe%' AND
-        d.name NOT LIKE '%oneshot-select%'
+        d.name NOT LIKE '%oneshot-select%' AND
+        d.name NOT LIKE '%metric-sink%'
 0

--- a/test/testdrive/metric-sink.td
+++ b/test/testdrive/metric-sink.td
@@ -95,12 +95,17 @@ true
 2
 
 # Read the sink's id off the companion gauge it stamps with a `sink` label.
-# `LIMIT 1` guards the single-row contract of `set-from-sql`: today `s` is the
-# only metric sink, but a second one (user or builtin) sharing this scrape
-# window would otherwise make the capture fail.
+# The curated metric sinks (installed on every replica) stamp this gauge with
+# their names too, so exclude those to isolate `s`, the only user sink here.
+# `LIMIT 1` guards the single-row contract of `set-from-sql`.
+#
+# NOTE: `CURATED` in src/adapter/src/coord/metric_sink.rs is the source of truth
+# for these names. The same exclusion list is repeated later in this file and in
+# checks/all_checks/metric_sink.py, so a new curated sink means updating them all.
 $ set-from-sql var=sink-id
 SELECT labels -> 'sink' FROM mz_introspection.mz_cluster_prometheus_metrics
 WHERE metric_name = 'mz_compute_metric_sink_frontier_ms'
+  AND labels -> 'sink' NOT IN ('mz_metric_arrangement_sizes', 'mz_metric_dataflow_errors')
 LIMIT 1
 
 # The companion gauges exist, are labeled with this sink's id, and read healthy
@@ -216,10 +221,11 @@ contains:still depended upon by metric sink "s"
 > CREATE METRIC SINK s_skip IN CLUSTER quickstart FROM lv WITH (PREFIX = 'mz_metric_sink_skip_')
 
 # Both rows are skipped and stay distinct (a null value is not the same identity as an empty one),
-# so the gauge reads 2, not 1. This retrying read also waits for the scrape to observe the sink;
-# `s_skip` is the only metric sink here, so no `sink`-label filter is needed.
+# so the gauge reads 2, not 1. This retrying read also waits for the scrape to observe the sink.
+# `s_skip` is the only user sink here, but the curated sinks stamp this gauge too, so exclude them.
 > SELECT value FROM mz_introspection.mz_cluster_prometheus_metrics
   WHERE metric_name = 'mz_compute_metric_sink_skipped'
+    AND labels -> 'sink' NOT IN ('mz_metric_arrangement_sizes', 'mz_metric_dataflow_errors')
 2
 
 # Neither row publishes a series under the sink's metric name.
@@ -229,12 +235,125 @@ contains:still depended upon by metric sink "s"
 
 > DROP TABLE lt CASCADE
 
+#
+# Curated metric sinks. The coordinator installs these on every replica (not via
+# CREATE METRIC SINK), so with `enable_metric_sink` on they run on quickstart's r1
+# from boot. Reads target r1 (cluster_replica, set at the top of the file).
+#
+
+# An index gives the sizes sink a dataflow arrangement to measure.
+> CREATE TABLE arr_t (k text NOT NULL, v int)
+
+> INSERT INTO arr_t VALUES ('a', 1), ('b', 2)
+
+> CREATE INDEX arr_idx ON arr_t (k)
+
+# Each size family publishes one gauge series per dataflow, tagged with a
+# representative exported object's global id, or `unattributable` for a dataflow
+# that exports nothing. Values churn, so assert shape rather than magnitude.
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes'
+    AND metric_type = 'gauge' AND labels -> 'id' IS NOT NULL
+true
+
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_arrangement_records'
+    AND metric_type = 'gauge' AND labels -> 'id' IS NOT NULL
+true
+
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_arrangement_batches'
+    AND metric_type = 'gauge' AND labels -> 'id' IS NOT NULL
+true
+
+# The attributable path: the index above is keyed by its object's global id.
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes'
+    AND labels -> 'id' LIKE 'u%'
+true
+
+# The sentinel path: the replica's own introspection-subscribe dataflows export no
+# catalog object, so their arrangements bucket under `unattributable` instead of
+# dropping. These run on every replica, so the bucket is always present.
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes'
+    AND labels -> 'id' = 'unattributable'
+true
+
+# Series count equals the sink's own operator -> dataflow -> id mapping over the raw
+# heap-size log, the global id when the dataflow exports one and the sentinel when it
+# does not. Also confirms the per-worker rows collapsed.
+> SELECT
+    (SELECT count(*) FROM mz_introspection.mz_cluster_prometheus_metrics
+       WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes')
+    =
+    (SELECT count(DISTINCT COALESCE(gid.global_id, 'unattributable'))
+       FROM mz_introspection.mz_arrangement_heap_size_raw r
+       JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
+       LEFT JOIN (SELECT id, min(global_id) AS global_id
+               FROM mz_introspection.mz_dataflow_global_ids GROUP BY id) gid
+         ON gid.id = dod.dataflow_id)
+true
+
+# Both curated sinks report healthy companion gauges: frontier advancing, no errors.
+> SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_frontier_ms'
+    AND labels -> 'sink' = 'mz_metric_arrangement_sizes'
+true
+
+> SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_frontier_ms'
+    AND labels -> 'sink' = 'mz_metric_dataflow_errors'
+true
+
+> SELECT value = 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_errors'
+    AND labels -> 'sink' = 'mz_metric_arrangement_sizes'
+true
+
+> SELECT value = 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_errors'
+    AND labels -> 'sink' = 'mz_metric_dataflow_errors'
+true
+
+# The errors sink's HAVING drops zero-error exports, so a healthy cluster
+# publishes no error series.
+> SELECT count(*) FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_dataflow_error_count'
+0
+
+# A divide-by-zero materialized view errors in its dataflow, so the raw error
+# log gains a row and the errors sink publishes a series for it.
+> CREATE TABLE err_t (x int)
+
+> INSERT INTO err_t VALUES (0)
+
+> CREATE MATERIALIZED VIEW err_mv IN CLUSTER quickstart AS SELECT 1 / x AS v FROM err_t
+
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_dataflow_error_count'
+    AND metric_type = 'gauge' AND labels -> 'id' IS NOT NULL
+true
+
+# Once the erroring dataflow is gone the error series is retracted.
+> DROP MATERIALIZED VIEW err_mv
+
+> SELECT count(*) FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_dataflow_error_count'
+0
+
+> DROP INDEX arr_idx
+
+> DROP TABLE arr_t
+
+> DROP TABLE err_t
+
 # Replica churn drives the coordinator's curated metric-sink install and
-# teardown (`install_metric_sinks` / `drop_metric_sinks`). The curated list is
-# empty, so there is no curated series to assert on: what is under test is that
-# both hooks run over an empty list without erroring, and that a replica added
-# and removed under a live sink leaves that sink publishing on the replica that
-# remains.
+# teardown (`install_metric_sinks` / `drop_metric_sinks`): the curated sinks
+# install on churn_c's added replica and are torn down when it is dropped. The
+# curated series themselves are asserted on quickstart above; here the focus is
+# that a user sink added and removed under replica churn keeps publishing on the
+# replica that remains, while the curated install/teardown runs on each change.
 #
 # On its own cluster, so the churn does not disturb the replica serving the rest
 # of this file. `quickstart` is a managed cluster anyway, which rejects
@@ -286,3 +405,129 @@ contains:still depended upon by metric sink "s"
 > DROP CLUSTER churn_c CASCADE
 
 > DROP TABLE churn_t CASCADE
+
+#
+# Curated sinks across a multi-cluster, multi-replica topology. The coordinator
+# installs the curated set on every replica of every cluster, so a regression that
+# skipped a replica, or only worked on quickstart, leaves one of the four replicas
+# below with no curated series. Each read targets one replica by name, so a missing
+# install shows as a mismatch rather than being masked by another replica's series.
+#
+> CREATE CLUSTER ma_c (SIZE '${arg.default-replica-size}', REPLICATION FACTOR 2)
+
+> CREATE CLUSTER mb_c (SIZE '${arg.default-replica-size}', REPLICATION FACTOR 2)
+
+> CREATE TABLE mrep_t (x int)
+
+> INSERT INTO mrep_t VALUES (0), (1), (2)
+
+# An arrangement (index) and an erroring dataflow (divide by zero) on each cluster.
+> CREATE INDEX mrep_ix_a IN CLUSTER ma_c ON mrep_t (x)
+
+> CREATE MATERIALIZED VIEW mrep_mv_a IN CLUSTER ma_c AS SELECT 1 / x AS v FROM mrep_t
+
+> CREATE INDEX mrep_ix_b IN CLUSTER mb_c ON mrep_t (x)
+
+> CREATE MATERIALIZED VIEW mrep_mv_b IN CLUSTER mb_c AS SELECT 1 / x AS v FROM mrep_t
+
+# Every replica of both clusters publishes the size family, the error family (the
+# erroring MV), and both curated sinks' health frontier gauges.
+> SET cluster = ma_c
+
+> SET cluster_replica = r1
+
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
+true
+
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_dataflow_error_count' AND labels -> 'id' IS NOT NULL
+true
+
+> SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_frontier_ms' AND labels -> 'sink' = 'mz_metric_arrangement_sizes'
+true
+
+> SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_frontier_ms' AND labels -> 'sink' = 'mz_metric_dataflow_errors'
+true
+
+# One series per dataflow, not per worker: holds for any worker count, and under
+# a multi-worker config it is the assertion that the per-worker raw log collapsed.
+> SELECT
+    (SELECT count(*) FROM mz_introspection.mz_cluster_prometheus_metrics
+       WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes')
+    =
+    (SELECT count(DISTINCT COALESCE(gid.global_id, 'unattributable'))
+       FROM mz_introspection.mz_arrangement_heap_size_raw r
+       JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
+       LEFT JOIN (SELECT id, min(global_id) AS global_id
+               FROM mz_introspection.mz_dataflow_global_ids GROUP BY id) gid
+         ON gid.id = dod.dataflow_id)
+true
+
+> SET cluster_replica = r2
+
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
+true
+
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_dataflow_error_count' AND labels -> 'id' IS NOT NULL
+true
+
+> SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_frontier_ms' AND labels -> 'sink' = 'mz_metric_arrangement_sizes'
+true
+
+> SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_frontier_ms' AND labels -> 'sink' = 'mz_metric_dataflow_errors'
+true
+
+> SET cluster = mb_c
+
+> SET cluster_replica = r1
+
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
+true
+
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_dataflow_error_count' AND labels -> 'id' IS NOT NULL
+true
+
+> SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_frontier_ms' AND labels -> 'sink' = 'mz_metric_arrangement_sizes'
+true
+
+> SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_frontier_ms' AND labels -> 'sink' = 'mz_metric_dataflow_errors'
+true
+
+> SET cluster_replica = r2
+
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
+true
+
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_dataflow_error_count' AND labels -> 'id' IS NOT NULL
+true
+
+> SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_frontier_ms' AND labels -> 'sink' = 'mz_metric_arrangement_sizes'
+true
+
+> SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_compute_metric_sink_frontier_ms' AND labels -> 'sink' = 'mz_metric_dataflow_errors'
+true
+
+> RESET cluster_replica
+
+> RESET cluster
+
+> DROP CLUSTER ma_c CASCADE
+
+> DROP CLUSTER mb_c CASCADE
+
+> DROP TABLE mrep_t CASCADE

--- a/test/testdrive/metric-sink.td
+++ b/test/testdrive/metric-sink.td
@@ -249,50 +249,76 @@ contains:still depended upon by metric sink "s"
 > CREATE INDEX arr_idx ON arr_t (k)
 
 # Each size family publishes one gauge series per dataflow, tagged with a
-# representative exported object's global id, or `unattributable` for a dataflow
-# that exports nothing. Values churn, so assert shape rather than magnitude.
+# representative exported object's catalog id, or `unattributable` for a dataflow
+# that exports no catalog object. Values churn, so assert shape rather than magnitude.
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes'
+  WHERE metric_name = 'mz_metric_sink_curated_arrangement_size_bytes'
     AND metric_type = 'gauge' AND labels -> 'id' IS NOT NULL
 true
 
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_arrangement_records'
+  WHERE metric_name = 'mz_metric_sink_curated_arrangement_records'
     AND metric_type = 'gauge' AND labels -> 'id' IS NOT NULL
 true
 
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_arrangement_batches'
+  WHERE metric_name = 'mz_metric_sink_curated_arrangement_batches'
     AND metric_type = 'gauge' AND labels -> 'id' IS NOT NULL
 true
 
-# The attributable path: the index above is keyed by its object's global id.
+# The attributable path, on the index's own catalog id rather than any `u%` label:
+# an index is a dataflow export, so its arrangement bytes carry its id.
+$ set-from-sql var=arr-idx-id
+SELECT id FROM mz_catalog.mz_indexes WHERE name = 'arr_idx'
+
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes'
-    AND labels -> 'id' LIKE 'u%'
+  WHERE metric_name = 'mz_metric_sink_curated_arrangement_size_bytes'
+    AND labels -> 'id' = '${arr-idx-id}'
 true
 
-# The sentinel path: the replica's own introspection-subscribe dataflows export no
-# catalog object, so their arrangements bucket under `unattributable` instead of
-# dropping. These run on every replica, so the bucket is always present.
+# A materialized view is only an export of its dataflow: what the dataflow *builds* is a
+# transient internal view, so an id read off the build list would label these bytes with a
+# `t<N>` that resolves to no catalog object. The reduce gives the view an arrangement to
+# measure.
+> CREATE MATERIALIZED VIEW arr_mv AS SELECT k, count(*) AS n FROM arr_t GROUP BY k
+
+$ set-from-sql var=arr-mv-id
+SELECT id FROM mz_catalog.mz_materialized_views WHERE name = 'arr_mv'
+
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes'
+  WHERE metric_name = 'mz_metric_sink_curated_arrangement_size_bytes'
+    AND labels -> 'id' = '${arr-mv-id}'
+true
+
+# The sentinel path: the replica's own introspection subscribes and metric sinks export
+# only transient ids, which are folded into the sentinel rather than labelled, so their
+# arrangements still count. These run on every replica, so the bucket is always present.
+> SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_curated_arrangement_size_bytes'
     AND labels -> 'id' = 'unattributable'
 true
 
-# Series count equals the sink's own operator -> dataflow -> id mapping over the raw
-# heap-size log, the global id when the dataflow exports one and the sentinel when it
-# does not. Also confirms the per-worker rows collapsed.
+# No series carries a transient id. Those are re-minted on every re-render, so labelling
+# them would grow the sink's series set without bound.
+> SELECT count(*) FROM mz_introspection.mz_cluster_prometheus_metrics
+  WHERE metric_name = 'mz_metric_sink_curated_arrangement_size_bytes'
+    AND labels -> 'id' LIKE 't%'
+0
+
+# Series count equals the sink's own operator -> dataflow -> export id mapping over the
+# raw heap-size log, the export id when the dataflow exports a catalog object and the
+# sentinel when it does not. Also confirms the per-worker rows collapsed.
 > SELECT
     (SELECT count(*) FROM mz_introspection.mz_cluster_prometheus_metrics
-       WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes')
+       WHERE metric_name = 'mz_metric_sink_curated_arrangement_size_bytes')
     =
-    (SELECT count(DISTINCT COALESCE(gid.global_id, 'unattributable'))
+    (SELECT count(DISTINCT COALESCE(ex.export_id, 'unattributable'))
        FROM mz_introspection.mz_arrangement_heap_size_raw r
-       JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
-       LEFT JOIN (SELECT id, min(global_id) AS global_id
-               FROM mz_introspection.mz_dataflow_global_ids GROUP BY id) gid
-         ON gid.id = dod.dataflow_id)
+       LEFT JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
+       LEFT JOIN (SELECT dataflow_id, min(export_id) AS export_id
+               FROM mz_introspection.mz_compute_exports
+               WHERE export_id NOT LIKE 't%' GROUP BY dataflow_id) ex
+         ON ex.dataflow_id = dod.dataflow_id)
 true
 
 # Both curated sinks report healthy companion gauges: frontier advancing, no errors.
@@ -319,7 +345,7 @@ true
 # The errors sink's HAVING drops zero-error exports, so a healthy cluster
 # publishes no error series.
 > SELECT count(*) FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_dataflow_error_count'
+  WHERE metric_name = 'mz_metric_sink_curated_dataflow_error_count'
 0
 
 # A divide-by-zero materialized view errors in its dataflow, so the raw error
@@ -331,7 +357,7 @@ true
 > CREATE MATERIALIZED VIEW err_mv IN CLUSTER quickstart AS SELECT 1 / x AS v FROM err_t
 
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_dataflow_error_count'
+  WHERE metric_name = 'mz_metric_sink_curated_dataflow_error_count'
     AND metric_type = 'gauge' AND labels -> 'id' IS NOT NULL
 true
 
@@ -339,10 +365,12 @@ true
 > DROP MATERIALIZED VIEW err_mv
 
 > SELECT count(*) FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_dataflow_error_count'
+  WHERE metric_name = 'mz_metric_sink_curated_dataflow_error_count'
 0
 
 > DROP INDEX arr_idx
+
+> DROP MATERIALIZED VIEW arr_mv
 
 > DROP TABLE arr_t
 
@@ -437,11 +465,11 @@ true
 > SET cluster_replica = r1
 
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
+  WHERE metric_name = 'mz_metric_sink_curated_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
 true
 
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_dataflow_error_count' AND labels -> 'id' IS NOT NULL
+  WHERE metric_name = 'mz_metric_sink_curated_dataflow_error_count' AND labels -> 'id' IS NOT NULL
 true
 
 > SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
@@ -456,24 +484,25 @@ true
 # a multi-worker config it is the assertion that the per-worker raw log collapsed.
 > SELECT
     (SELECT count(*) FROM mz_introspection.mz_cluster_prometheus_metrics
-       WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes')
+       WHERE metric_name = 'mz_metric_sink_curated_arrangement_size_bytes')
     =
-    (SELECT count(DISTINCT COALESCE(gid.global_id, 'unattributable'))
+    (SELECT count(DISTINCT COALESCE(ex.export_id, 'unattributable'))
        FROM mz_introspection.mz_arrangement_heap_size_raw r
-       JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
-       LEFT JOIN (SELECT id, min(global_id) AS global_id
-               FROM mz_introspection.mz_dataflow_global_ids GROUP BY id) gid
-         ON gid.id = dod.dataflow_id)
+       LEFT JOIN mz_introspection.mz_dataflow_operator_dataflows dod ON r.operator_id = dod.id
+       LEFT JOIN (SELECT dataflow_id, min(export_id) AS export_id
+               FROM mz_introspection.mz_compute_exports
+               WHERE export_id NOT LIKE 't%' GROUP BY dataflow_id) ex
+         ON ex.dataflow_id = dod.dataflow_id)
 true
 
 > SET cluster_replica = r2
 
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
+  WHERE metric_name = 'mz_metric_sink_curated_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
 true
 
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_dataflow_error_count' AND labels -> 'id' IS NOT NULL
+  WHERE metric_name = 'mz_metric_sink_curated_dataflow_error_count' AND labels -> 'id' IS NOT NULL
 true
 
 > SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
@@ -489,11 +518,11 @@ true
 > SET cluster_replica = r1
 
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
+  WHERE metric_name = 'mz_metric_sink_curated_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
 true
 
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_dataflow_error_count' AND labels -> 'id' IS NOT NULL
+  WHERE metric_name = 'mz_metric_sink_curated_dataflow_error_count' AND labels -> 'id' IS NOT NULL
 true
 
 > SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
@@ -507,11 +536,11 @@ true
 > SET cluster_replica = r2
 
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
+  WHERE metric_name = 'mz_metric_sink_curated_arrangement_size_bytes' AND labels -> 'id' IS NOT NULL
 true
 
 > SELECT count(*) > 0 FROM mz_introspection.mz_cluster_prometheus_metrics
-  WHERE metric_name = 'mz_metric_sink_dataflow_error_count' AND labels -> 'id' IS NOT NULL
+  WHERE metric_name = 'mz_metric_sink_curated_dataflow_error_count' AND labels -> 'id' IS NOT NULL
 true
 
 > SELECT value > 0 FROM mz_introspection.mz_cluster_prometheus_metrics


### PR DESCRIPTION
[SQL-555](https://linear.app/materializeinc/issue/SQL-555) landed the machinery to install curated metric sinks on every
replica, but `CURATED` was empty, so nothing ran at boot.

Solution:

Add the two v1 definitions: `mz_metric_arrangement_sizes` (three gauge
families) and `mz_metric_dataflow_errors` (one gauge). Both read the raw
`..._raw` logs, not the derived views, which re-aggregate expensively.

The sizes sink labels each series with the exported object's `GlobalId`, not the
timely dataflow id, which churns across re-renders. A dataflow with no export,
like a subscribe, falls back to an `unattributable` bucket so its bytes still count.

The errors sink reads the raw log rather than `mz_compute_error_counts`
because that view joins in `mz_compute_dependencies`, a storage-managed
source that `ensure_reads_only_logs` rejects: reading it would couple the
sink's frontier to envd. Elapsed stays out of v1, its log churns
continuously and cost 14% of a 2-worker replica even raw-sourced.

`curated_definitions_plan` only called `plan_source`, so a definition that
broke the log-only contract still passed the test but crash-looped the
coordinator at boot. It now runs `ensure_reads_only_logs` too.

Testing:

- Unit tests plan each definition and run the log-only gate.
- metric-sink.td gains a curated section and a multi-cluster,
multi-replica section.
- metric-sink.td covers both the attributable and `unattributable` id paths.
- The MetricSink platform check now asserts the curated sinks survive a boot,
which covers restart, upgrade, and zero-downtime.