### PR TITLE
environmentd, ci: allow selecting console preview builds during impersonation

### DIFF
--- a/ci/test/console/vercel-preview-impersonation.sh
+++ b/ci/test/console/vercel-preview-impersonation.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Deploys an impersonation-flavored console preview for this branch. The build
+# can then be selected in a Teleport impersonation session via
+# /internal-console/?preview_build=<label>. See
+# console/doc/organization-impersonation.md.
+
+set -euo pipefail
+
+. misc/shlib/shlib.bash
+
+cd console
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+export VERCEL_ENVIRONMENT=preview
+export SENTRY_RELEASE="$BUILDKITE_COMMIT"
+corepack enable
+retry yarn install --immutable --network-timeout 30000
+
+# The deploy/internal-impersonation branch scope carries the impersonation
+# build settings, notably BASENAME=/internal-console.
+npx vercel@latest pull --yes \
+  --environment="$VERCEL_ENVIRONMENT" \
+  --git-branch=deploy/internal-impersonation \
+  --token="$VERCEL_TOKEN"
+bin/apply-vercel-csp.js --sentry-release="$SENTRY_RELEASE"
+npx vercel@latest build --token="$VERCEL_TOKEN"
+
+deployment_url="$(npx vercel@latest deploy --prebuilt --token="$VERCEL_TOKEN")"
+alias_url="$(node bin/vercel-preview-url.js "${BUILDKITE_BRANCH}" internal.console.materialize.com)"
+echo "Aliasing $deployment_url to $alias_url"
+npx vercel@latest alias --scope=materialize --token="$VERCEL_TOKEN" \
+  set "$deployment_url" "$alias_url"
+
+label="${alias_url%%.*}"
+printf "+++ Impersonation preview deployed. Select it in a Teleport session with ?preview_build=%s\n" "$label"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -828,6 +828,20 @@ steps:
         sanitizer: skip
         ci_glue_exempt: true
 
+      - id: console-vercel-preview-impersonation
+        label: ":vercel: Console Vercel preview (impersonation)"
+        command: bin/ci-builder run stable ci/test/console/vercel-preview-impersonation.sh
+        inputs:
+          - console/**
+        depends_on: []
+        timeout_in_minutes: 15
+        if: "build.pull_request.id != null"
+        agents:
+          queue: linux-x86_64
+        coverage: skip
+        sanitizer: skip
+        ci_glue_exempt: true
+
       - id: dataflow-visualizer
         label: Dataflow visualizer
         depends_on: build-x86_64

--- a/console/bin/vercel-preview-url.js
+++ b/console/bin/vercel-preview-url.js
@@ -25,7 +25,7 @@ function toKebabCase(input) {
     .replace(/^-+|-+$/g, ""); // Remove leading and trailing hyphens
 }
 
-function getPreviewUrl(identifier) {
+function getPreviewUrl(identifier, domain) {
   const sanitized = toKebabCase(identifier);
   let subdomain = `console-git-${sanitized}`;
   if (subdomain.length > MAX_SUBDOMAIN_LENGTH) {
@@ -36,9 +36,12 @@ function getPreviewUrl(identifier) {
       .substring(0, MAX_SUBDOMAIN_LENGTH)
       .replace(/-+$/g, "");
   }
-  const url = `${subdomain}.preview.console.materialize.com`;
+  const url = `${subdomain}.${domain}`;
   return url;
 }
 
-const previewUrl = getPreviewUrl(argv[2]);
+const previewUrl = getPreviewUrl(
+  argv[2],
+  argv[3] ?? "preview.console.materialize.com",
+);
 stdout.write(previewUrl + "\n");

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -444,11 +444,13 @@ impl HttpServer {
                 )
                 .route(
                     "/internal-console/{*path}",
-                    routing::get(console::handle_internal_console),
+                    routing::get(console::handle_internal_console)
+                        .post(console::handle_internal_console),
                 )
                 .route(
                     "/internal-console/",
-                    routing::get(console::handle_internal_console),
+                    routing::get(console::handle_internal_console)
+                        .post(console::handle_internal_console),
                 )
                 // Cluster HTTP proxy routes.
                 .route("/clusters", routing::get(cluster::handle_clusters))

--- a/src/environmentd/src/http/console.rs
+++ b/src/environmentd/src/http/console.rs
@@ -17,7 +17,7 @@ use axum::Json;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use axum::response::{IntoResponse, Response};
-use http::header::{CONTENT_TYPE, COOKIE, HOST, LOCATION, SET_COOKIE};
+use http::header::{CONTENT_TYPE, COOKIE, HOST, LOCATION, ORIGIN, SET_COOKIE};
 use http::{HeaderMap, HeaderValue, Method};
 use hyper::Uri;
 use hyper_tls::HttpsConnector;
@@ -202,11 +202,12 @@ pub(crate) async fn handle_internal_console(
 /// Handles the `?preview_build=<label>` selection parameter. A GET with a
 /// label renders a confirmation page whose form POSTs the selection back; the
 /// POST stores it in a cookie and redirects to the same path without the
-/// parameter. Requiring the POST means a cross-site navigation cannot change
-/// the served build, since `SameSite=Lax` session cookies accompany top-level
-/// GETs but not cross-site POSTs. Clearing (an empty label) is allowed on GET:
-/// it only ever restores the default build and is the recovery path for a
-/// broken selection. Returns `None` when the parameter is absent.
+/// parameter. The POST must additionally be same-origin (see
+/// [`is_same_origin`]), so a cross-site navigation cannot change the served
+/// build even if the fronting proxy's session cookie policy were to allow
+/// cross-site POSTs. Clearing (an empty label) is allowed on GET: it only
+/// ever restores the default build and is the recovery path for a broken
+/// selection. Returns `None` when the parameter is absent.
 fn preview_build_selection_response(
     console_config: &ConsoleProxyConfig,
     req: &Request<Body>,
@@ -224,6 +225,9 @@ fn preview_build_selection_response(
         }
     }
     let is_post = *req.method() == Method::POST;
+    if is_post && !is_same_origin(req) {
+        return Err(StatusCode::FORBIDDEN);
+    }
     let Some(label) = selection else {
         // The proxied upstream serves only static assets, so only selection
         // POSTs are accepted.
@@ -268,6 +272,32 @@ fn preview_build_selection_response(
         .body(Body::empty())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(Some(response))
+}
+
+/// True unless the request was initiated by another site. Browser-set
+/// `Sec-Fetch-Site` cannot be forged by page scripts; `Origin` is the
+/// fallback for browsers predating it. The fronting proxy's `SameSite=Lax`
+/// session cookie also keeps a cross-site POST unauthenticated today, but
+/// that is its configuration, not this code's, so the check here is the
+/// layer this proxy owns.
+fn is_same_origin(req: &Request<Body>) -> bool {
+    if let Some(site) = req
+        .headers()
+        .get("sec-fetch-site")
+        .and_then(|v| v.to_str().ok())
+    {
+        return site == "same-origin" || site == "none";
+    }
+    let (Some(origin), Some(host)) = (req.headers().get(ORIGIN), req.headers().get(HOST)) else {
+        // No `Origin` on a POST means it was not a cross-site form submission.
+        return true;
+    };
+    let (Ok(origin), Ok(host)) = (origin.to_str(), host.to_str()) else {
+        return false;
+    };
+    origin
+        .split_once("://")
+        .is_some_and(|(_, authority)| authority == host)
 }
 
 /// Confirmation page for a preview build selection. All interpolated values

--- a/src/environmentd/src/http/console.rs
+++ b/src/environmentd/src/http/console.rs
@@ -17,8 +17,8 @@ use axum::Json;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use axum::response::{IntoResponse, Response};
-use http::header::{COOKIE, HOST, LOCATION, SET_COOKIE};
-use http::{HeaderMap, HeaderValue};
+use http::header::{CONTENT_TYPE, COOKIE, HOST, LOCATION, SET_COOKIE};
+use http::{HeaderMap, HeaderValue, Method};
 use hyper::Uri;
 use hyper_tls::HttpsConnector;
 use hyper_util::client::legacy::Client;
@@ -87,14 +87,20 @@ impl ConsoleProxyConfig {
     }
 }
 
-/// A valid preview build label is a DNS label: 1-63 characters of lowercase
-/// ASCII alphanumerics and hyphens, not starting or ending with a hyphen.
+/// Prefix required of preview build labels. CI only creates preview aliases
+/// under this prefix, so requiring it keeps the reachable hosts to builds of
+/// console pull requests.
+const PREVIEW_BUILD_LABEL_PREFIX: &str = "console-git-";
+
+/// A valid preview build label is a DNS label (1-63 characters of lowercase
+/// ASCII alphanumerics and hyphens, not ending with a hyphen) starting with
+/// [`PREVIEW_BUILD_LABEL_PREFIX`].
 fn is_valid_preview_build_label(label: &str) -> bool {
-    (1..=63).contains(&label.len())
+    label.len() <= 63
+        && label.starts_with(PREVIEW_BUILD_LABEL_PREFIX)
         && label
             .bytes()
             .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
-        && !label.starts_with('-')
         && !label.ends_with('-')
 }
 
@@ -142,7 +148,9 @@ pub async fn handle_console_config(
 /// HTML, JS, and CSS static files.
 ///
 /// `?preview_build=<label>` selects a per-browser preview build served from a
-/// subdomain of the upstream host; an empty value returns to the default.
+/// subdomain of the upstream host; an empty value returns to the default. A
+/// GET only renders a confirmation page. The selection itself requires a POST,
+/// so that a cross-site link cannot change which build a browser is served.
 pub(crate) async fn handle_internal_console(
     console_config: Extension<Arc<ConsoleProxyConfig>>,
     mut req: Request<Body>,
@@ -151,9 +159,11 @@ pub(crate) async fn handle_internal_console(
         return Ok(response);
     }
 
-    let upstream_url = preview_build_from_cookie(req.headers())
-        .and_then(|label| console_config.preview_url(&label))
-        .unwrap_or_else(|| console_config.url.clone());
+    let preview_build = preview_build_from_cookie(req.headers())
+        .and_then(|label| console_config.preview_url(&label).map(|url| (label, url)));
+    let upstream_url = preview_build
+        .as_ref()
+        .map_or_else(|| console_config.url.clone(), |(_, url)| url.clone());
 
     let path = req.uri().path();
     let mut path_query = req
@@ -175,21 +185,28 @@ pub(crate) async fn handle_internal_console(
         .insert(HOST, HeaderValue::from_str(&host).unwrap());
 
     // Call this request against the upstream, return response directly.
-    Ok(console_config
-        .client
-        .request(req)
-        .await
-        .map_err(|err| {
+    match console_config.client.request(req).await {
+        Ok(response) => Ok(response.into_response()),
+        Err(err) => {
             tracing::warn!("Error retrieving console url: {}", err);
-            StatusCode::BAD_REQUEST
-        })?
-        .into_response())
+            // A broken preview selection would otherwise present as an opaque
+            // error until the cookie expires, so offer the way back.
+            match preview_build {
+                Some((label, _)) => Ok(preview_build_unavailable_response(&label)),
+                None => Err(StatusCode::BAD_REQUEST),
+            }
+        }
+    }
 }
 
-/// Handles the `?preview_build=<label>` selection parameter: stores the
-/// selection in a cookie and redirects back to the same path without the
-/// parameter, so subsequent asset requests carry the choice. Returns `None`
-/// when the parameter is absent.
+/// Handles the `?preview_build=<label>` selection parameter. A GET with a
+/// label renders a confirmation page whose form POSTs the selection back; the
+/// POST stores it in a cookie and redirects to the same path without the
+/// parameter. Requiring the POST means a cross-site navigation cannot change
+/// the served build, since `SameSite=Lax` session cookies accompany top-level
+/// GETs but not cross-site POSTs. Clearing (an empty label) is allowed on GET:
+/// it only ever restores the default build and is the recovery path for a
+/// broken selection. Returns `None` when the parameter is absent.
 fn preview_build_selection_response(
     console_config: &ConsoleProxyConfig,
     req: &Request<Body>,
@@ -206,7 +223,13 @@ fn preview_build_selection_response(
             any_remaining = true;
         }
     }
+    let is_post = *req.method() == Method::POST;
     let Some(label) = selection else {
+        // The proxied upstream serves only static assets, so only selection
+        // POSTs are accepted.
+        if is_post {
+            return Err(StatusCode::METHOD_NOT_ALLOWED);
+        }
         return Ok(None);
     };
 
@@ -215,11 +238,17 @@ fn preview_build_selection_response(
         console_config.route_prefix
     );
     let cookie = if label.is_empty() {
-        // An empty label clears the selection.
         format!("{PREVIEW_BUILD_COOKIE}=; Max-Age=0; {cookie_attributes}")
     } else {
-        if console_config.preview_url(&label).is_none() {
+        let Some(preview_url) = console_config.preview_url(&label) else {
             return Err(StatusCode::BAD_REQUEST);
+        };
+        if !is_post {
+            return Ok(Some(preview_build_confirmation_response(
+                console_config,
+                &label,
+                &preview_url,
+            )));
         }
         format!(
             "{PREVIEW_BUILD_COOKIE}={label}; \
@@ -239,6 +268,49 @@ fn preview_build_selection_response(
         .body(Body::empty())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(Some(response))
+}
+
+/// Confirmation page for a preview build selection. All interpolated values
+/// are validated or config-controlled, never raw request input.
+fn preview_build_confirmation_response(
+    console_config: &ConsoleProxyConfig,
+    label: &str,
+    preview_url: &str,
+) -> Response {
+    let route_prefix = &console_config.route_prefix;
+    let body = format!(
+        "<!DOCTYPE html>\n\
+         <html><head><title>Console preview build</title></head><body>\n\
+         <p>Serve console assets in this browser from <code>{preview_url}</code> \
+         for the next 24 hours?</p>\n\
+         <form method=\"post\"><button type=\"submit\">Use preview build {label}</button></form>\n\
+         <p><a href=\"{route_prefix}/\">Cancel</a></p>\n\
+         </body></html>\n"
+    );
+    (
+        StatusCode::OK,
+        [(CONTENT_TYPE, "text/html; charset=utf-8")],
+        body,
+    )
+        .into_response()
+}
+
+/// Error page served when the selected preview build cannot be fetched,
+/// linking back to the default build.
+fn preview_build_unavailable_response(label: &str) -> Response {
+    let body = format!(
+        "<!DOCTYPE html>\n\
+         <html><head><title>Console preview build unavailable</title></head><body>\n\
+         <p>Failed to load console preview build <code>{label}</code>.</p>\n\
+         <p><a href=\"?{PREVIEW_BUILD_PARAM}=\">Return to the default console build</a></p>\n\
+         </body></html>\n"
+    );
+    (
+        StatusCode::BAD_GATEWAY,
+        [(CONTENT_TYPE, "text/html; charset=utf-8")],
+        body,
+    )
+        .into_response()
 }
 
 /// Returns the preview build label from the request's cookies, if one is set

--- a/src/environmentd/src/http/console.rs
+++ b/src/environmentd/src/http/console.rs
@@ -17,8 +17,8 @@ use axum::Json;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use axum::response::{IntoResponse, Response};
-use http::HeaderValue;
-use http::header::HOST;
+use http::header::{COOKIE, HOST, LOCATION, SET_COOKIE};
+use http::{HeaderMap, HeaderValue};
 use hyper::Uri;
 use hyper_tls::HttpsConnector;
 use hyper_util::client::legacy::Client;
@@ -27,6 +27,17 @@ use hyper_util::rt::TokioExecutor;
 use mz_adapter_types::dyncfgs::{CONSOLE_OIDC_CLIENT_ID, CONSOLE_OIDC_SCOPES, OIDC_ISSUER};
 
 use crate::http::Delayed;
+
+/// Query parameter that selects (or, with an empty value, clears) the console
+/// preview build this proxy serves to the requesting browser.
+const PREVIEW_BUILD_PARAM: &str = "preview_build";
+
+/// Cookie storing the selected preview build label.
+const PREVIEW_BUILD_COOKIE: &str = "mz_console_preview_build";
+
+/// Preview selections expire after a day so stale cookies drift back to the
+/// default build.
+const PREVIEW_BUILD_COOKIE_MAX_AGE_SECS: u64 = 60 * 60 * 24;
 
 pub(crate) struct ConsoleProxyConfig {
     /// Hyper http client, supports https.
@@ -37,6 +48,10 @@ pub(crate) struct ConsoleProxyConfig {
 
     /// Route this is being served from (e.g. /internal-console).
     route_prefix: String,
+
+    /// Host of `url`, under which preview builds are served as subdomains
+    /// (e.g. `<label>.internal.console.materialize.com`).
+    preview_host_suffix: Option<String>,
 }
 
 impl ConsoleProxyConfig {
@@ -45,12 +60,42 @@ impl ConsoleProxyConfig {
         if let Some(new) = url.strip_suffix('/') {
             url = new.to_string();
         }
+        let preview_host_suffix = Uri::try_from(url.as_str())
+            .ok()
+            .and_then(|uri| uri.host().map(|host| host.to_string()));
         Self {
             client: Client::builder(TokioExecutor::new()).build(HttpsConnector::new()),
             url,
             route_prefix,
+            preview_host_suffix,
         }
     }
+
+    /// Returns the upstream URL serving the given preview build, or `None` if
+    /// the label is invalid or no preview host suffix could be derived.
+    ///
+    /// NOTE: This proxy runs inside the environment's network, so it must not
+    /// be usable for SSRF. Preview builds are only ever fetched over https
+    /// from a validated subdomain of the configured upstream host, never from
+    /// a caller-provided URL.
+    fn preview_url(&self, label: &str) -> Option<String> {
+        let suffix = self.preview_host_suffix.as_deref()?;
+        if !is_valid_preview_build_label(label) {
+            return None;
+        }
+        Some(format!("https://{label}.{suffix}"))
+    }
+}
+
+/// A valid preview build label is a DNS label: 1-63 characters of lowercase
+/// ASCII alphanumerics and hyphens, not starting or ending with a hyphen.
+fn is_valid_preview_build_label(label: &str) -> bool {
+    (1..=63).contains(&label.len())
+        && label
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        && !label.starts_with('-')
+        && !label.ends_with('-')
 }
 
 /// OIDC configuration values needed by the Console to initiate OIDC login.
@@ -95,10 +140,21 @@ pub async fn handle_console_config(
 /// To avoid CORS and serve the Console from the same host as the Teleport app,
 /// this route proxies the upstream Console to handle requests for
 /// HTML, JS, and CSS static files.
+///
+/// `?preview_build=<label>` selects a per-browser preview build served from a
+/// subdomain of the upstream host; an empty value returns to the default.
 pub(crate) async fn handle_internal_console(
     console_config: Extension<Arc<ConsoleProxyConfig>>,
     mut req: Request<Body>,
 ) -> Result<Response, StatusCode> {
+    if let Some(response) = preview_build_selection_response(&console_config, &req)? {
+        return Ok(response);
+    }
+
+    let upstream_url = preview_build_from_cookie(req.headers())
+        .and_then(|label| console_config.preview_url(&label))
+        .unwrap_or_else(|| console_config.url.clone());
+
     let path = req.uri().path();
     let mut path_query = req
         .uri()
@@ -109,7 +165,7 @@ pub(crate) async fn handle_internal_console(
         path_query = stripped_path_query;
     }
 
-    let uri = Uri::try_from(format!("{}{}", console_config.url, path_query)).unwrap();
+    let uri = Uri::try_from(format!("{}{}", upstream_url, path_query)).unwrap();
     let host = uri.host().unwrap().to_string();
     // Preserve the request, but update the URI to point upstream.
     *req.uri_mut() = uri;
@@ -128,4 +184,80 @@ pub(crate) async fn handle_internal_console(
             StatusCode::BAD_REQUEST
         })?
         .into_response())
+}
+
+/// Handles the `?preview_build=<label>` selection parameter: stores the
+/// selection in a cookie and redirects back to the same path without the
+/// parameter, so subsequent asset requests carry the choice. Returns `None`
+/// when the parameter is absent.
+fn preview_build_selection_response(
+    console_config: &ConsoleProxyConfig,
+    req: &Request<Body>,
+) -> Result<Option<Response>, StatusCode> {
+    let query = req.uri().query().unwrap_or("");
+    let mut selection = None;
+    let mut remaining_query = url::form_urlencoded::Serializer::new(String::new());
+    let mut any_remaining = false;
+    for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+        if key == PREVIEW_BUILD_PARAM {
+            selection = Some(value.into_owned());
+        } else {
+            remaining_query.append_pair(&key, &value);
+            any_remaining = true;
+        }
+    }
+    let Some(label) = selection else {
+        return Ok(None);
+    };
+
+    let cookie_attributes = format!(
+        "Path={}; Secure; HttpOnly; SameSite=Lax",
+        console_config.route_prefix
+    );
+    let cookie = if label.is_empty() {
+        // An empty label clears the selection.
+        format!("{PREVIEW_BUILD_COOKIE}=; Max-Age=0; {cookie_attributes}")
+    } else {
+        if console_config.preview_url(&label).is_none() {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+        format!(
+            "{PREVIEW_BUILD_COOKIE}={label}; \
+             Max-Age={PREVIEW_BUILD_COOKIE_MAX_AGE_SECS}; {cookie_attributes}"
+        )
+    };
+
+    let mut location = req.uri().path().to_string();
+    if any_remaining {
+        location.push('?');
+        location.push_str(&remaining_query.finish());
+    }
+    let response = Response::builder()
+        .status(StatusCode::SEE_OTHER)
+        .header(LOCATION, location)
+        .header(SET_COOKIE, cookie)
+        .body(Body::empty())
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Some(response))
+}
+
+/// Returns the preview build label from the request's cookies, if one is set
+/// and valid. Invalid values are ignored rather than rejected so a stale
+/// cookie can never break the default console.
+fn preview_build_from_cookie(headers: &HeaderMap) -> Option<String> {
+    for header in headers.get_all(COOKIE) {
+        let Ok(header) = header.to_str() else {
+            continue;
+        };
+        for pair in header.split(';') {
+            let mut parts = pair.trim().splitn(2, '=');
+            if parts.next() == Some(PREVIEW_BUILD_COOKIE) {
+                let label = parts.next().unwrap_or("");
+                if is_valid_preview_build_label(label) {
+                    return Some(label.to_string());
+                }
+            }
+        }
+    }
+    None
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -14,7 +14,7 @@
 use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Write;
-use std::io::Write as _;
+use std::io::{Read as _, Write as _};
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -61,7 +61,7 @@ use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
 use rdkafka_sys::RDKafkaErrorCode;
 use regex::Regex;
 use reqwest::blocking::Client;
-use reqwest::header::{CONTENT_ENCODING, CONTENT_TYPE};
+use reqwest::header::{CONTENT_ENCODING, CONTENT_TYPE, COOKIE, LOCATION, SET_COOKIE};
 use reqwest::{StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
@@ -2207,6 +2207,107 @@ fn test_internal_console_proxy() {
         res.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
         "text/html"
     );
+}
+
+/// Serves a canned HTTP response on a local port, counting requests. Stands in
+/// for the upstream console deployment in proxy tests.
+fn spawn_mock_console_upstream(body: &'static str) -> (String, Arc<AtomicUsize>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_clone = Arc::clone(&hits);
+    thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else {
+                continue;
+            };
+            hits_clone.fetch_add(1, Ordering::SeqCst);
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+    (format!("http://{}", addr), hits)
+}
+
+#[mz_ore::test]
+fn test_internal_console_proxy_preview_build() {
+    let (upstream_url, upstream_hits) = spawn_mock_console_upstream("default-build");
+    let server = test_util::TestHarness::default()
+        .with_internal_console_redirect_url(Some(upstream_url))
+        .start_blocking();
+
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let base = format!(
+        "http://{}/internal-console/",
+        server.internal_http_local_addr()
+    );
+
+    // Without a selection, the default upstream serves the request.
+    let res = client.get(Url::parse(&base).unwrap()).send().unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.text().unwrap(), "default-build");
+
+    // Selecting a preview build sets a cookie and redirects back to the same
+    // path, preserving unrelated query parameters.
+    let res = client
+        .get(Url::parse(&format!("{base}?preview_build=console-git-foo&x=1")).unwrap())
+        .send()
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        res.headers().get(LOCATION).unwrap().to_str().unwrap(),
+        "/internal-console/?x=1"
+    );
+    let cookie = res.headers().get(SET_COOKIE).unwrap().to_str().unwrap();
+    assert_contains!(cookie, "mz_console_preview_build=console-git-foo");
+    assert_contains!(cookie, "Path=/internal-console");
+
+    // An invalid label is rejected outright.
+    let res = client
+        .get(Url::parse(&format!("{base}?preview_build=Bad_Label")).unwrap())
+        .send()
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    // A selection cookie routes the request to the preview host instead of
+    // the default upstream. `https://console-git-foo.127.0.0.1` is
+    // unreachable, so the proxy errors rather than falling back.
+    let hits_before = upstream_hits.load(Ordering::SeqCst);
+    let res = client
+        .get(Url::parse(&base).unwrap())
+        .header(COOKIE, "mz_console_preview_build=console-git-foo")
+        .send()
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(upstream_hits.load(Ordering::SeqCst), hits_before);
+
+    // An invalid cookie value is ignored, serving the default build.
+    let res = client
+        .get(Url::parse(&base).unwrap())
+        .header(COOKIE, "mz_console_preview_build=NOT!VALID")
+        .send()
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.text().unwrap(), "default-build");
+
+    // An empty selection clears the cookie.
+    let res = client
+        .get(Url::parse(&format!("{base}?preview_build=")).unwrap())
+        .send()
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SEE_OTHER);
+    let cookie = res.headers().get(SET_COOKIE).unwrap().to_str().unwrap();
+    assert_contains!(cookie, "mz_console_preview_build=;");
+    assert_contains!(cookie, "Max-Age=0");
 }
 
 #[mz_ore::test]

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -61,7 +61,7 @@ use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
 use rdkafka_sys::RDKafkaErrorCode;
 use regex::Regex;
 use reqwest::blocking::Client;
-use reqwest::header::{CONTENT_ENCODING, CONTENT_TYPE, COOKIE, LOCATION, SET_COOKIE};
+use reqwest::header::{CONTENT_ENCODING, CONTENT_TYPE, COOKIE, LOCATION, ORIGIN, SET_COOKIE};
 use reqwest::{StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
@@ -2281,6 +2281,29 @@ fn test_internal_console_proxy_preview_build() {
     let cookie = res.headers().get(SET_COOKIE).unwrap().to_str().unwrap();
     assert_contains!(cookie, "mz_console_preview_build=console-git-foo");
     assert_contains!(cookie, "Path=/internal-console");
+
+    // A cross-site POST is rejected on its own provenance, independent of the
+    // fronting proxy's session cookie policy.
+    for (header, value) in [
+        ("sec-fetch-site", "cross-site"),
+        (ORIGIN.as_str(), "https://attacker.example"),
+    ] {
+        let res = client
+            .post(Url::parse(&format!("{base}?preview_build=console-git-foo")).unwrap())
+            .header(header, value)
+            .send()
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+        assert_eq!(res.headers().get(SET_COOKIE), None);
+    }
+
+    // A same-origin POST declaring its provenance still succeeds.
+    let res = client
+        .post(Url::parse(&format!("{base}?preview_build=console-git-foo")).unwrap())
+        .header("sec-fetch-site", "same-origin")
+        .send()
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SEE_OTHER);
 
     // An invalid label and a label without the console-git- prefix are
     // rejected outright.

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2256,10 +2256,21 @@ fn test_internal_console_proxy_preview_build() {
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().unwrap(), "default-build");
 
-    // Selecting a preview build sets a cookie and redirects back to the same
-    // path, preserving unrelated query parameters.
+    // A GET with a preview build label only renders the confirmation page.
     let res = client
         .get(Url::parse(&format!("{base}?preview_build=console-git-foo&x=1")).unwrap())
+        .send()
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.headers().get(SET_COOKIE), None);
+    let body = res.text().unwrap();
+    assert_contains!(body.as_str(), "console-git-foo.127.0.0.1");
+    assert_contains!(body.as_str(), "<form method=\"post\"");
+
+    // POSTing the selection sets the cookie and redirects back to the same
+    // path, preserving unrelated query parameters.
+    let res = client
+        .post(Url::parse(&format!("{base}?preview_build=console-git-foo&x=1")).unwrap())
         .send()
         .unwrap();
     assert_eq!(res.status(), StatusCode::SEE_OTHER);
@@ -2271,33 +2282,48 @@ fn test_internal_console_proxy_preview_build() {
     assert_contains!(cookie, "mz_console_preview_build=console-git-foo");
     assert_contains!(cookie, "Path=/internal-console");
 
-    // An invalid label is rejected outright.
-    let res = client
-        .get(Url::parse(&format!("{base}?preview_build=Bad_Label")).unwrap())
-        .send()
-        .unwrap();
-    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    // An invalid label and a label without the console-git- prefix are
+    // rejected outright.
+    for label in ["Bad_Label", "other-subdomain"] {
+        let res = client
+            .get(Url::parse(&format!("{base}?preview_build={label}")).unwrap())
+            .send()
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // A POST without a selection is not proxied.
+    let res = client.post(Url::parse(&base).unwrap()).send().unwrap();
+    assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
 
     // A selection cookie routes the request to the preview host instead of
     // the default upstream. `https://console-git-foo.127.0.0.1` is
-    // unreachable, so the proxy errors rather than falling back.
+    // unreachable, so the proxy serves the recovery page rather than falling
+    // back.
     let hits_before = upstream_hits.load(Ordering::SeqCst);
     let res = client
         .get(Url::parse(&base).unwrap())
         .header(COOKIE, "mz_console_preview_build=console-git-foo")
         .send()
         .unwrap();
-    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(res.status(), StatusCode::BAD_GATEWAY);
+    assert_contains!(res.text().unwrap(), "?preview_build=");
     assert_eq!(upstream_hits.load(Ordering::SeqCst), hits_before);
 
-    // An invalid cookie value is ignored, serving the default build.
-    let res = client
-        .get(Url::parse(&base).unwrap())
-        .header(COOKIE, "mz_console_preview_build=NOT!VALID")
-        .send()
-        .unwrap();
-    assert_eq!(res.status(), StatusCode::OK);
-    assert_eq!(res.text().unwrap(), "default-build");
+    // Invalid or non-prefixed cookie values are ignored, serving the default
+    // build.
+    for cookie in [
+        "mz_console_preview_build=NOT!VALID",
+        "mz_console_preview_build=other-subdomain",
+    ] {
+        let res = client
+            .get(Url::parse(&base).unwrap())
+            .header(COOKIE, cookie)
+            .send()
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().unwrap(), "default-build");
+    }
 
     // An empty selection clears the cookie.
     let res = client


### PR DESCRIPTION
### Motivation

Seeing a console PR's changes inside a customer environment (Teleport impersonation) currently requires re-aliasing `internal.console.materialize.com` globally, which switches every impersonation session, for everyone, to that build.

### Description

Two pieces:

* **CI**: each console PR now also deploys an impersonation-flavored build (`BASENAME=/internal-console`, pulled from the `deploy/internal-impersonation` Vercel env) aliased to `console-git-<branch>.internal.console.materialize.com`. The wildcard DNS, TLS, and Vercel team domain for this already exist.
* **environmentd**: the `/internal-console` proxy accepts `?preview_build=<label>`. A GET renders a confirmation page naming the target host; the selection itself requires the page's same-origin POST and is stored in a browser cookie (24h, `Path=/internal-console`), after which assets are served from `https://<label>.<upstream host>` instead of the default upstream. Labels must carry the `console-git-` prefix CI creates and are validated as DNS labels, only ever composed onto the configured upstream's host, so the proxy cannot be pointed at arbitrary URLs. An invalid cookie is ignored rather than rejected, and a preview that fails to load serves a recovery page linking back to the default build.

The selection is per-browser. Other impersonation sessions, including other people on the same environment, are unaffected.

### Verification

* New integration test `test_internal_console_proxy_preview_build` covers: a GET renders the confirmation page without setting state, the POST sets the cookie and redirects back (preserving other query params), invalid and non-prefixed labels are rejected, a valid cookie routes the proxy away from the default upstream, a failing preview serves the recovery page, invalid cookies are ignored, and an empty selection clears the cookie.
* Manually verified against the production Vercel project that a `console-git-*.internal.console.materialize.com` alias can be assigned from the console project, serves anonymously over TLS, and can be removed.

### Usage

1. Push a console PR. The `console-vercel-preview-impersonation` step prints the label (`console-git-<branch>`).
2. Open a customer environment through Teleport as usual, append `?preview_build=console-git-<branch>` to the `/internal-console/` URL, and confirm on the page that appears.
3. Browse normally; assets now come from the PR build. The selection expires after 24 hours, or visit `?preview_build=` (empty value) to return to the default build immediately.

Requires the environment to run an environmentd release that includes this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
