### PR TITLE
compute: gate the MV sink's read-back on the desired snapshot

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -314,6 +314,11 @@ def get_variable_system_parameters(
             ["true", "false"],
         ),
         VariableSystemParameter(
+            "compute_mv_sink_gate_readback_on_snapshot",
+            "true",
+            ["true", "false"],
+        ),
+        VariableSystemParameter(
             "enable_password_auth",
             "true",
             ["true", "false"],

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2941,6 +2941,9 @@ class FlipFlagsAction(Action):
             BOOLEAN_FLAG_VALUES
         )
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["compute_mv_sink_gate_readback_on_snapshot"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_public_metrics_endpoint"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [
             "0",

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -697,6 +697,16 @@ pub const MV_SINK_ADVANCE_PERSIST_FRONTIERS: Config<bool> = Config::new(
     ParameterScope::Environment,
 );
 
+/// Whether the MV sink withholds the read-back of its output shard until the `desired` snapshot
+/// has been absorbed.
+pub const MV_SINK_GATE_READBACK_ON_SNAPSHOT: Config<bool> = Config::new(
+    "compute_mv_sink_gate_readback_on_snapshot",
+    false,
+    "Whether the MV sink delays reading back its output shard until the desired snapshot has \
+     been absorbed into the correction buffer.",
+    ParameterScope::Environment,
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -749,6 +759,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COMPUTE_PROMETHEUS_INTROSPECTION_SCRAPE_INTERVAL)
         .add(&SUBSCRIBE_SNAPSHOT_OPTIMIZATION)
         .add(&MV_SINK_ADVANCE_PERSIST_FRONTIERS)
+        .add(&MV_SINK_GATE_READBACK_ON_SNAPSHOT)
         .add(&ENABLE_COLUMN_PAGED_BATCHER)
         .add(&ENABLE_COLUMNAR_MERGE_BATCHER)
         .add(&ENABLE_COLUMN_PAGED_BATCHER_SPILL)

--- a/src/compute/src/sink/materialized_view.rs
+++ b/src/compute/src/sink/materialized_view.rs
@@ -116,13 +116,16 @@
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::pin::pin;
+use std::future::Future;
+use std::pin::{Pin, pin};
 use std::rc::Rc;
 use std::sync::Arc;
 
 use differential_dataflow::{AsCollection, Hashable, VecCollection};
 use futures::StreamExt;
-use mz_compute_types::dyncfgs::MV_SINK_ADVANCE_PERSIST_FRONTIERS;
+use mz_compute_types::dyncfgs::{
+    MV_SINK_ADVANCE_PERSIST_FRONTIERS, MV_SINK_GATE_READBACK_ON_SNAPSHOT,
+};
 use mz_compute_types::sinks::{ComputeSinkDesc, MaterializedViewSinkConnection};
 use mz_dyncfg::ConfigSet;
 use mz_ore::cast::CastFrom;
@@ -158,6 +161,9 @@ use crate::render::sinks::SinkRender;
 use crate::sink::correction::{ChannelLogging, Correction, CorrectionLogger};
 use crate::sink::materialized_view_v2;
 use crate::sink::refresh::apply_refresh;
+
+#[cfg(test)]
+mod tests;
 
 impl<'scope> SinkRender<'scope> for MaterializedViewSinkConnection<CollectionMetadata> {
     fn render_sink(
@@ -261,9 +267,25 @@ where
     let scope = ok_collection.scope();
     let desired = OkErr::new(ok_collection.inner, err_collection.inner);
 
+    // Withhold the read-back until the `desired` snapshot has been absorbed, to keep the
+    // correction buffer from holding both snapshots at once. See `SnapshotGate`.
+    let (snapshot_signal, snapshot_token) =
+        if MV_SINK_GATE_READBACK_ON_SNAPSHOT.get(&compute_state.worker_config) {
+            let (signal, token) = StartSignal::new();
+            (Some(signal), Some(token))
+        } else {
+            (None, None)
+        };
+
     // Read back the persist shard.
-    let (persist, persist_token) =
-        persist_source(scope, sink_id, target.clone(), compute_state, start_signal);
+    let (persist, persist_token) = persist_source(
+        scope,
+        sink_id,
+        target.clone(),
+        compute_state,
+        start_signal,
+        snapshot_signal,
+    );
 
     let persist_api = PersistApi {
         persist_clients: Arc::clone(&compute_state.persist_clients),
@@ -288,6 +310,7 @@ where
         persist,
         descs.clone(),
         read_only_rx,
+        snapshot_token,
         Rc::clone(&compute_state.worker_config),
     );
 
@@ -347,6 +370,65 @@ pub(super) fn advance(
     }
 }
 
+/// Withholds the read-back of the sink's output shard until the `desired` snapshot has been
+/// absorbed into the correction buffer.
+///
+/// The correction buffer holds `desired - persist`. During hydration both sides of that
+/// subtraction are snapshots of the same collection, so they are the same size and cancel almost
+/// entirely. They do not cancel while they are being accumulated, though: the read-back is I/O
+/// bound and parallel while `desired` is CPU bound, so the read-back lands in full long before
+/// `desired` has produced enough updates to cancel against, and the buffer peaks at the sum of
+/// both snapshots. Withholding the read-back until `desired` is complete bounds the peak at one
+/// snapshot plus whatever the read-back accumulates between consolidations.
+///
+/// Holding the read-back back costs no progress. The `mint` operator emits its first batch
+/// description only once the `desired` frontier is ahead of the output shard's upper, which
+/// already requires the `desired` snapshot to be complete, and the `write` operator then waits
+/// for the read-back to reach that description's `lower` regardless. So the gate reorders two
+/// phases that could never have overlapped in a way that produced a write, and gives up
+/// wall-clock overlap only.
+///
+/// The gate relies on the `desired` frontier moving beyond the `as_of` to open. That happens
+/// before any write is possible: for a non-empty output collection the `as_of` is hard
+/// constrained to be strictly less than the shard's upper (see the storage-export constraint in
+/// `mz_compute_client::as_of_selection`), and for an empty one there is no snapshot to read back.
+///
+/// NOTE: For a sink following a refresh schedule the gate can open before the snapshot has been
+/// emitted. `apply_refresh` rounds frontiers up to the next refresh time, so a sink whose `as_of`
+/// falls between two refresh times reports a frontier beyond the `as_of` from the start. The gate
+/// then opens immediately and the read-back proceeds as it does without the gate, which costs the
+/// memory saving but nothing else.
+pub(super) struct SnapshotGate {
+    /// The sink's `as_of`. The gate opens once the `desired` frontier moves beyond it.
+    as_of: Antichain<Timestamp>,
+    /// Dropped to open the gate. `None` once the gate is open, or when it was never armed.
+    token: Option<Rc<dyn Any>>,
+}
+
+impl SnapshotGate {
+    /// Arm a gate on the given `token`, or return an already-open gate if `token` is `None`.
+    pub(super) fn new(as_of: &Antichain<Timestamp>, token: Option<Rc<dyn Any>>) -> Self {
+        let mut gate = Self {
+            as_of: as_of.clone(),
+            token,
+        };
+        // The empty antichain is the maximum, so no `desired` frontier can ever move beyond an
+        // empty `as_of` and the gate would never open. A sink with an empty `as_of` has nothing
+        // left to write, so open immediately rather than withholding the read-back forever.
+        if gate.as_of.is_empty() {
+            gate.token = None;
+        }
+        gate
+    }
+
+    /// Open the gate if the given `desired` frontier has moved beyond the `as_of`.
+    pub(super) fn observe(&mut self, desired_frontier: &Antichain<Timestamp>) {
+        if self.token.is_some() && PartialOrder::less_than(&self.as_of, desired_frontier) {
+            self.token = None;
+        }
+    }
+}
+
 /// A persist API specialized to a single collection.
 #[derive(Clone)]
 pub(super) struct PersistApi {
@@ -393,6 +475,7 @@ pub(super) fn persist_source<'s>(
     target: CollectionMetadata,
     compute_state: &ComputeState,
     start_signal: StartSignal,
+    snapshot_signal: Option<StartSignal>,
 ) -> (PersistStreams<'s>, Vec<PressOnDropButton>) {
     // There is no guarantee that the sink as-of is beyond the persist shard's since. If it isn't,
     // instantiating a `persist_source` with it would panic. So instead we leave it to
@@ -409,6 +492,21 @@ pub(super) fn persist_source<'s>(
     let until = Antichain::new();
     let map_filter_project = None;
 
+    // `shard_source` awaits the start signal only after it has opened its read handle, so
+    // chaining the snapshot signal here delays fetching without giving up the `since` hold on
+    // the output shard.
+    let start_signal = start_signal.into_send_future();
+    let start_signal: Pin<Box<dyn Future<Output = ()> + Send>> = match snapshot_signal {
+        Some(snapshot_signal) => {
+            let snapshot_signal = snapshot_signal.into_send_future();
+            Box::pin(async move {
+                start_signal.await;
+                snapshot_signal.await;
+            })
+        }
+        None => Box::pin(start_signal),
+    };
+
     let (ok_stream, err_stream, token) =
         mz_storage_operators::persist_source::persist_source::<DataflowErrorSer>(
             scope,
@@ -422,7 +520,7 @@ pub(super) fn persist_source<'s>(
             until,
             map_filter_project,
             compute_state.dataflow_max_inflight_bytes(),
-            start_signal.into_send_future(),
+            start_signal,
             ErrorHandler::Halt("compute persist sink"),
         );
 
@@ -775,6 +873,7 @@ mod write {
     ///  * `desired`: The ok/err streams that should be sinked to persist.
     ///  * `persist`: The ok/err streams read back from the output persist shard.
     ///  * `descs`: The stream of batch descriptions produced by the `mint` operator.
+    ///  * `snapshot_token`: The token of the read-back's `SnapshotGate`, if armed.
     pub fn render<'s>(
         sink_id: GlobalId,
         persist_api: PersistApi,
@@ -783,6 +882,7 @@ mod write {
         persist: PersistStreams<'s>,
         descs: DescsStream<'s>,
         mut read_only_rx: watch::Receiver<bool>,
+        snapshot_token: Option<Rc<dyn Any>>,
         worker_config: Rc<ConfigSet>,
     ) -> (BatchesStream<'s>, PressOnDropButton) {
         let scope = desired.ok.scope();
@@ -843,6 +943,7 @@ mod write {
                 channel_logging,
                 as_of,
                 read_only,
+                snapshot_token,
                 &worker_config,
             );
             let mut correction_logger = correction_logger;
@@ -972,6 +1073,8 @@ mod write {
         /// batches, so the batch-write path never sweeps `consolidate_before(upper)` forward; the
         /// forced consolidation stands in for it and is re-armed as long as this holds.
         read_only: bool,
+        /// Gate withholding the output shard's read-back until the `desired` snapshot is in.
+        snapshot_gate: SnapshotGate,
     }
 
     impl State {
@@ -983,6 +1086,7 @@ mod write {
             logging: Option<ChannelLogging>,
             as_of: Antichain<Timestamp>,
             read_only: bool,
+            snapshot_token: Option<Rc<dyn Any>>,
             worker_config: &ConfigSet,
         ) -> Self {
             let worker_metrics = metrics.for_worker(worker_id);
@@ -990,6 +1094,7 @@ mod write {
             // Force a consolidation of `corrections` after the snapshot updates have been fully
             // processed, to ensure we get rid of those as quickly as possible.
             let force_consolidation_after = Some(as_of.clone());
+            let snapshot_gate = SnapshotGate::new(&as_of, snapshot_token);
 
             let mut state = Self {
                 sink_id,
@@ -1009,6 +1114,7 @@ mod write {
                 batch_description: None,
                 force_consolidation_after,
                 read_only,
+                snapshot_gate,
             };
 
             // Immediately advance the persist frontier tracking to the `as_of`.
@@ -1068,6 +1174,10 @@ mod write {
 
         /// Apply the effects of a previous `desired` frontier advancement.
         fn apply_desired_frontier_advancement(&mut self) {
+            // The `desired` snapshot is complete once its frontier moves beyond the `as_of`, at
+            // which point there is nothing left to gain from withholding the read-back.
+            self.snapshot_gate
+                .observe(self.desired_frontiers.frontier());
             self.maybe_force_consolidation();
         }
 

--- a/src/compute/src/sink/materialized_view/tests.rs
+++ b/src/compute/src/sink/materialized_view/tests.rs
@@ -1,0 +1,76 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Tests for the MV sink's shared helpers.
+
+use std::any::Any;
+use std::rc::{Rc, Weak};
+
+use mz_repr::Timestamp;
+use timely::progress::Antichain;
+
+use super::SnapshotGate;
+
+/// Build a gate armed on a fresh token, returning a weak handle that reports whether the gate
+/// still holds the token.
+fn armed(as_of: &Antichain<Timestamp>) -> (SnapshotGate, Weak<dyn Any>) {
+    let token: Rc<dyn Any> = Rc::new(());
+    let held = Rc::downgrade(&token);
+    (SnapshotGate::new(as_of, Some(token)), held)
+}
+
+fn is_open(held: &Weak<dyn Any>) -> bool {
+    held.strong_count() == 0
+}
+
+fn frontier(ts: u64) -> Antichain<Timestamp> {
+    Antichain::from_elem(Timestamp::new(ts))
+}
+
+#[mz_ore::test]
+fn gate_stays_shut_until_desired_passes_as_of() {
+    let (mut gate, held) = armed(&frontier(10));
+    assert!(!is_open(&held));
+
+    // A frontier at the `as_of` means the snapshot updates at that time may still be arriving.
+    gate.observe(&frontier(10));
+    assert!(!is_open(&held));
+
+    // A frontier before the `as_of` must not open the gate either. The `write` operator clamps
+    // its tracked frontier upwards, but the gate compares against whatever it is handed.
+    gate.observe(&frontier(5));
+    assert!(!is_open(&held));
+
+    gate.observe(&frontier(11));
+    assert!(is_open(&held));
+}
+
+#[mz_ore::test]
+fn empty_desired_frontier_opens_the_gate() {
+    let (mut gate, held) = armed(&frontier(10));
+    gate.observe(&Antichain::new());
+    assert!(is_open(&held));
+}
+
+#[mz_ore::test]
+fn empty_as_of_opens_the_gate_immediately() {
+    // The empty antichain is the maximum, so no `desired` frontier can ever move beyond it.
+    // Withholding the read-back forever would wedge the sink, so the gate must start open.
+    let (_gate, held) = armed(&Antichain::new());
+    assert!(is_open(&held));
+}
+
+#[mz_ore::test]
+fn unarmed_gate_is_inert() {
+    let as_of = frontier(10);
+    let mut gate = SnapshotGate::new(&as_of, None);
+    // Observing frontiers on a gate that was never armed must not panic.
+    gate.observe(&frontier(5));
+    gate.observe(&frontier(11));
+}

--- a/src/compute/src/sink/materialized_view_v2.rs
+++ b/src/compute/src/sink/materialized_view_v2.rs
@@ -52,7 +52,9 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use differential_dataflow::{Hashable, VecCollection};
-use mz_compute_types::dyncfgs::MV_SINK_ADVANCE_PERSIST_FRONTIERS;
+use mz_compute_types::dyncfgs::{
+    MV_SINK_ADVANCE_PERSIST_FRONTIERS, MV_SINK_GATE_READBACK_ON_SNAPSHOT,
+};
 use mz_dyncfg::ConfigSet;
 use mz_ore::cast::CastFrom;
 use mz_persist_client::batch::{Batch, ProtoBatch};
@@ -77,7 +79,7 @@ use crate::render::errors::DataflowErrorSer;
 use crate::sink::correction::{ChannelLogging, Correction, CorrectionLogger};
 use crate::sink::materialized_view::{
     BatchDescription, BatchesStream, DescsStream, DesiredStreams, OkErr, PersistApi,
-    PersistStreams, SharedSinkFrontier, advance, operator_name, persist_source,
+    PersistStreams, SharedSinkFrontier, SnapshotGate, advance, operator_name, persist_source,
 };
 
 /// Renders an MV sink writing the given desired collection into the `target` persist collection.
@@ -96,9 +98,25 @@ pub(super) fn persist_sink<'s>(
     let scope = ok_collection.scope();
     let desired = OkErr::new(ok_collection.inner, err_collection.inner);
 
+    // Withhold the read-back until the `desired` snapshot has been absorbed, to keep the
+    // correction buffer from holding both snapshots at once. See `SnapshotGate`.
+    let (snapshot_signal, snapshot_token) =
+        if MV_SINK_GATE_READBACK_ON_SNAPSHOT.get(&compute_state.worker_config) {
+            let (signal, token) = StartSignal::new();
+            (Some(signal), Some(token))
+        } else {
+            (None, None)
+        };
+
     // Read back the persist shard.
-    let (persist, persist_token) =
-        persist_source(scope, sink_id, target.clone(), compute_state, start_signal);
+    let (persist, persist_token) = persist_source(
+        scope,
+        sink_id,
+        target.clone(),
+        compute_state,
+        start_signal,
+        snapshot_signal,
+    );
 
     let persist_api = PersistApi {
         persist_clients: Arc::clone(&compute_state.persist_clients),
@@ -128,6 +146,7 @@ pub(super) fn persist_sink<'s>(
         persist,
         descs.clone(),
         read_only_rx,
+        snapshot_token,
         Rc::clone(&compute_state.worker_config),
     );
 
@@ -569,6 +588,7 @@ mod write {
     ///  * `desired`: The ok/err streams that should be sinked to persist.
     ///  * `persist`: The ok/err streams read back from the output persist shard.
     ///  * `descs`: The stream of batch descriptions produced by the `mint` operator.
+    ///  * `snapshot_token`: The token of the read-back's `SnapshotGate`, if armed.
     pub fn render<'s>(
         sink_id: GlobalId,
         persist_api: PersistApi,
@@ -577,6 +597,7 @@ mod write {
         persist: PersistStreams<'s>,
         descs: DescsStream<'s>,
         mut read_only_rx: watch::Receiver<bool>,
+        snapshot_token: Option<Rc<dyn Any>>,
         worker_config: Rc<ConfigSet>,
     ) -> BatchesStream<'s> {
         let scope = desired.ok.scope();
@@ -728,6 +749,7 @@ mod write {
                 as_of,
                 advance_persist_frontiers_at_startup,
                 read_only,
+                snapshot_token,
             );
 
             // Whether a batch write is currently in flight in the Tokio task.
@@ -1027,6 +1049,8 @@ mod write {
         /// batches, so the `WriteBatch` path never sweeps `consolidate_before(upper)` forward;
         /// the forced consolidation stands in for it and is re-armed as long as this holds.
         read_only: bool,
+        /// Gate withholding the output shard's read-back until the `desired` snapshot is in.
+        snapshot_gate: SnapshotGate,
     }
 
     impl State {
@@ -1036,10 +1060,12 @@ mod write {
             as_of: Antichain<Timestamp>,
             advance_persist_frontiers_at_startup: bool,
             read_only: bool,
+            snapshot_token: Option<Rc<dyn Any>>,
         ) -> Self {
             // Force a consolidation of corrections after the snapshot updates have been fully
             // processed, to ensure we get rid of those as quickly as possible.
             let force_consolidation_after = Some(as_of.clone());
+            let snapshot_gate = SnapshotGate::new(&as_of, snapshot_token);
 
             let mut state = Self {
                 sink_id,
@@ -1049,6 +1075,7 @@ mod write {
                 batch_description: None,
                 force_consolidation_after,
                 read_only,
+                snapshot_gate,
             };
 
             // Immediately advance the persist frontier tracking to the `as_of`.
@@ -1086,12 +1113,16 @@ mod write {
 
         fn advance_desired_ok_frontier(&mut self, frontier: AntichainRef<Timestamp>) {
             if advance(&mut self.desired_frontiers.ok, frontier) {
+                self.snapshot_gate
+                    .observe(self.desired_frontiers.frontier());
                 self.trace("advanced `desired` ok frontier");
             }
         }
 
         fn advance_desired_err_frontier(&mut self, frontier: AntichainRef<Timestamp>) {
             if advance(&mut self.desired_frontiers.err, frontier) {
+                self.snapshot_gate
+                    .observe(self.desired_frontiers.frontier());
                 self.trace("advanced `desired` err frontier");
             }
         }

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -767,6 +767,36 @@ SCENARIOS = [
         clusterd_memory="3.5Gb",
     ),
     Scenario(
+        name="mv-sink-rehydration",
+        # A pass-through materialized view with no index: the dataflow holds no arrangements, so
+        # replica memory is dominated by the MV sink's correction buffer, which accumulates
+        # `desired - persist`. On rehydration both sides of that subtraction are snapshots of the
+        # same collection and the same size, so a sink that accumulates them concurrently peaks at
+        # twice the output while one that absorbs `desired` first peaks at roughly the output.
+        # `clusterd_memory` is set between those two peaks.
+        pre_restart=dedent(f"""
+            > SET statement_timeout = '600 s';
+
+            > CREATE TABLE t1 (key INTEGER, payload TEXT)
+
+            > CREATE MATERIALIZED VIEW v1 IN CLUSTER clusterd AS
+              SELECT key, payload FROM t1
+
+            > INSERT INTO t1 (key, payload)
+              SELECT generate_series, repeat('x', 250)
+              FROM generate_series(1, {REPEAT} * {ITERATIONS})
+
+            > SELECT COUNT(*) FROM v1;
+            {REPEAT * ITERATIONS}
+            """),
+        post_restart=dedent(f"""
+            > SELECT COUNT(*) FROM v1;
+            {REPEAT * ITERATIONS}
+            """),
+        materialized_memory="4.5Gb",
+        clusterd_memory="1.5Gb",
+    ),
+    Scenario(
         name="table-aggregate",
         pre_restart=dedent(f"""
             > SET statement_timeout = '600 s';

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -210,6 +210,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     compute_flat_map_fuel
     compute_logical_backpressure_max_retained_capabilities
     compute_mv_sink_advance_persist_frontiers
+    compute_mv_sink_gate_readback_on_snapshot
     compute_peek_row_iteration_limit
     compute_peek_response_stash_batch_max_runs
     compute_peek_response_stash_read_batch_size_bytes


### PR DESCRIPTION
### Motivation

The MV sink's correction buffer holds `desired - persist`, and the `write` operator fills it from both inputs concurrently. During hydration both sides of that subtraction are snapshots of the same collection, so they are the same size and cancel almost entirely once consolidated. They do not cancel while they are being accumulated: the read-back is I/O bound and parallel while `desired` is CPU bound, so the read-back lands in full long before `desired` has produced enough updates to cancel against. The buffer peaks at the sum of both snapshots.

Observed in a production environment on a 25cc replica: steady state 0.5 GiB, one snapshot 4.0 GiB, peak demand 8.3-10.8 GiB against a 7.6 GiB limit. The replica sat in a crash loop for 13 hours, 162 restarts, killed by the compute memory limiter (RSS + swap, exit 167, so `OOMKilled` never appears) partway through every rehydration attempt.

### Description

Withhold the read-back until the `desired` frontier has moved beyond the `as_of`, which is the point at which the `desired` snapshot is complete. With all of `desired` resident, each arriving read-back chunk cancels on its first merge, so the peak drops to one snapshot plus whatever the read-back accumulates between consolidations.

Ordering the two phases costs no progress. `mint` emits its first batch description only once the `desired` frontier is ahead of the output shard's upper, which already requires the `desired` snapshot to be complete, and `write` then waits for the read-back to reach that description's `lower` regardless. So no batch could have been written during the window the gate holds. Only wall-clock overlap between the two phases is given up, and lower memory pressure may well pay that back.

Mechanically this chains a second signal onto the `start_signal` the read-back's `persist_source` already takes. `shard_source` awaits that signal after opening its read handle, so fetching is delayed without giving up the `since` hold on the output shard. `write` owns the token and drops it where it already observes the `desired` frontier advance. No new operator and no extra data cloning. Both sink implementations are wired, including `materialized_view_v2`, which is the variant CI exercises by default.

Three notes a reviewer cannot get from the diff:

- I had also planned to harden `write` to require read-back completeness before its first batch, independent of frontier arithmetic. It reduces to a no-op: `mint`'s first `lower` is the shard upper, so the proposed condition is implied by the existing `desc.lower <= persist_frontier` in every case. The corner it was meant to protect (`as_of >= upper` with a non-empty shard) is unreachable, because `apply_downstream_storage_constraints` hard constrains a non-empty output collection to `as_of <= step_back(write_frontier)`. The invariant is documented on `SnapshotGate` rather than asserted.
- For a sink following a refresh schedule the gate can open before the snapshot is emitted, because `apply_refresh` rounds frontiers up and a sink whose `as_of` falls between refresh times reports a frontier beyond it from the start. That degrades to current behavior. Fixing it means feeding the gate the pre-`apply_refresh` frontier, which `render_sink` already probes for `compute_probe`.
- `HYDRATION_CONCURRENCY` is enforced controller-side by withholding `Schedule` until a dataflow reports hydration, so a gated sink reports hydration later by its read-back duration and a queue of MVs serializes slightly more. There is no cycle: the gate depends only on the dataflow's own inputs, which are already scheduled.

Gated on `compute_mv_sink_gate_readback_on_snapshot`, off in production and on in the test configuration.

### Verification

Adds unit tests for the gate's frontier threshold and both empty-antichain cases (an empty `as_of` is the maximum antichain, so the gate must open immediately or the sink wedges forever), and an `mv-sink-rehydration` bounded-memory scenario that rehydrates a pass-through materialized view under a cap set between the one-snapshot and two-snapshot peaks.

Draft because that scenario's `clusterd_memory` is not yet calibrated. The fix moves the peak from roughly 2x the output to roughly 1.33x, so the cap has to sit inside a narrow band, and the current value is a guess pending a measured run in each direction. Staging measurement of a real rehydration is also outstanding, and will decide whether 1.33x is good enough or whether the correction buffer also needs a re-arming forced consolidation while the read-back drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
