### PR TITLE
sqllogictest: stop pinning peek parameters in the test binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8862,7 +8862,6 @@ dependencies = [
  "md-5 0.10.6",
  "mz-adapter-types",
  "mz-catalog",
- "mz-compute-types",
  "mz-controller",
  "mz-dyncfgs",
  "mz-environmentd",

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -23,7 +23,6 @@ maplit.workspace = true
 md-5.workspace = true
 mz-adapter-types = { path = "../adapter-types" }
 mz-catalog = { path = "../catalog" }
-mz-compute-types = { path = "../compute-types" }
 mz-controller = { path = "../controller" }
 mz-dyncfgs = { path = "../dyncfgs" }
 mz-environmentd = { path = "../environmentd", default-features = false }

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -21,7 +21,6 @@ use std::process::ExitCode;
 use chrono::Utc;
 use clap::ArgAction;
 use mz_adapter_types::dyncfgs::ENABLE_BACKGROUND_ALTER_CLUSTER;
-use mz_compute_types::dyncfgs::{ENABLE_PEEK_ROW_ITERATION_LIMIT, PEEK_ROW_ITERATION_LIMIT};
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_ore::cli::{self, CliConfig, KeyValueArg};
 use mz_ore::metrics::MetricsRegistry;
@@ -186,16 +185,6 @@ async fn main() -> ExitCode {
     system_parameter_defaults
         .entry(ENABLE_BACKGROUND_ALTER_CLUSTER.name().to_string())
         .or_insert_with(|| "true".to_string());
-
-    // Keep the guard enabled in the suite without constraining normal test queries.
-    for (name, value) in [
-        (ENABLE_PEEK_ROW_ITERATION_LIMIT.name(), "true"),
-        (PEEK_ROW_ITERATION_LIMIT.name(), "1000000000"),
-    ] {
-        system_parameter_defaults
-            .entry(name.to_string())
-            .or_insert_with(|| value.to_string());
-    }
 
     let config = RunConfig {
         stdout: &OutputStream::new(io::stdout(), args.timestamps),


### PR DESCRIPTION
Undoes the part of #38506 that pinned `enable_compute_peek_row_iteration_limit` and `compute_peek_row_iteration_limit` as system parameter defaults inside the sqllogictest binary. A test binary that hardcodes parameter values holds a second copy of the test configuration, invisible to any operator or workflow and free to drift from `get_minimal_system_parameters`, which is where the suite's values belong. `mz-compute-types` becomes unused by the crate and goes with them.

The guard defaults off in code, so no query the suite runs changes. What is lost is that the suite no longer exercises the row iteration limit: the composition passes the binary no `--system-parameter-default`, so the values in `get_minimal_system_parameters` never reach it. Wiring that through restores the coverage and is not part of this change.

The two sqllogictest files that exercise the limit set both parameters themselves and reset them afterwards, and neither runs a query between resetting the limit and disabling the guard.

🤖 Opened by [Claude Code](https://claude.com/claude-code) on behalf of @antiguru