### PR TITLE
parallel-benchmark: a read isolation scenario under hydration churn

### DIFF
--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -1274,3 +1274,121 @@ class StagingBench(Scenario):
             ],
             conn_pool_size=100,
         )
+
+
+class HydrationChurn(Action):
+    """Continuously builds a heavy maintained materialized view, forces it to
+    hydrate, then drops it, keeping the replica's maintenance workers busy.
+
+    `SELECT count(*)` blocks until the view has hydrated, so each iteration does
+    real hydration work before the drop. Runs in a `ClosedLoop`, which is
+    single-threaded, so a fixed view name is safe.
+    """
+
+    def __init__(self, conn_info: PgConnInfo, name: str, view_sql: str):
+        self.conn_info = conn_info
+        self.name = name
+        self.view_sql = view_sql
+        self.conn = conn_info.connect()
+        self.conn.autocommit = True
+        self.cur = self.conn.cursor()
+
+    def _run(self, conns: queue.Queue):
+        self.cur.execute(
+            f"CREATE MATERIALIZED VIEW {self.name} AS {self.view_sql}".encode()
+        )
+        # Force hydration to complete before we drop, so the replica actually
+        # does the build work rather than cancelling it immediately.
+        self.cur.execute(f"SELECT count(*) FROM {self.name}".encode())
+        self.cur.fetchall()
+        self.cur.execute(f"DROP MATERIALIZED VIEW {self.name}".encode())
+
+    def __str__(self) -> str:
+        return f"hydration churn {self.name}"
+
+
+class ReadIsolationUnderHydration(Scenario):
+    r"""Measures whether peeks stay fast while the replica's maintenance workers
+    are saturated by continuous dataflow hydration.
+
+    Reads and dataflow maintenance share a replica's workers, so a build that
+    monopolizes them delays the peeks issued against already hydrated
+    collections. This scenario puts both on one replica and reports what the
+    reads experience.
+
+    The peeks run open-loop at a fixed rate, so a replica that cannot keep up
+    under contention accumulates queue-wait latency the reported p50/p99
+    capture. That backlog is the signal: it is what a user issuing reads at a
+    steady rate experiences when maintenance steals the serving capacity.
+
+    To A/B a change that claims to improve read isolation, run the scenario
+    twice with the flag that gates it and compare the SELECT p50/p99/qps:
+
+        bin/mzcompose --find parallel-benchmark run default \
+            --scenario ReadIsolationUnderHydration \
+            --this-params <flag>=true
+        bin/mzcompose --find parallel-benchmark run default \
+            --scenario ReadIsolationUnderHydration \
+            --this-params <flag>=false
+    """
+
+    def __init__(self, c: Composition, conn_infos: dict[str, PgConnInfo]):
+        mz = conn_infos["materialized"]
+        # Heavy enough that one build takes real CPU, small enough that two
+        # concurrent churn loops do not exhaust memory.
+        churn_view_sql = "SELECT a, count(*) AS c FROM big GROUP BY a"
+        self.init(
+            [
+                TdPhase("""
+                    > DROP TABLE IF EXISTS hot CASCADE
+                    > DROP TABLE IF EXISTS big CASCADE
+
+                    # The peek target: a small indexed table, pre-hydrated.
+                    > CREATE TABLE hot (k int, v int)
+                    > INSERT INTO hot SELECT n, n * 2 FROM generate_series(1, 100000) AS n
+                    > CREATE INDEX hot_k ON hot (k)
+
+                    # The contention source: a large table churned into heavy MVs.
+                    > CREATE TABLE big (a int, b int)
+                    > INSERT INTO big SELECT n, n % 1000 FROM generate_series(1, 1000000) AS n
+
+                    # Wait for the hot index to hydrate before measuring.
+                    > SELECT v FROM hot WHERE k = 42
+                    84
+                    """),
+                LoadPhase(
+                    duration=120,
+                    actions=[
+                        # Measured: fast-path index point lookup.
+                        OpenLoop(
+                            action=ReuseConnQuery(
+                                "SELECT v FROM hot WHERE k = 42",
+                                mz,
+                                strict_serializable=False,
+                            ),
+                            dist=Periodic(per_second=50),
+                            report_regressions=False,
+                        ),
+                        # Measured: slow-path range scan + reduce peek (more
+                        # sensitive to contention on the replica).
+                        OpenLoop(
+                            action=ReuseConnQuery(
+                                "SELECT count(*) FROM hot WHERE k < 50000",
+                                mz,
+                                strict_serializable=False,
+                            ),
+                            dist=Periodic(per_second=12),
+                            report_regressions=False,
+                        ),
+                    ]
+                    + [
+                        # Contention: continuous hydration churn on the same replica.
+                        ClosedLoop(
+                            action=HydrationChurn(mz, f"churn_{i}", churn_view_sql),
+                            report_regressions=False,
+                        )
+                        for i in range(2)
+                    ],
+                ),
+            ],
+        )


### PR DESCRIPTION
Reads and dataflow maintenance share a replica's workers, so a build that monopolizes them delays peeks against already hydrated collections. `ReadIsolationUnderHydration` puts both on one replica and reports what the reads experience. Two closed loops create, hydrate, and drop a heavy materialized view over a million-row table, while two open loops issue a point lookup and a range scan against a small pre-hydrated index at fixed rates.

The peeks run open-loop, so a replica that cannot keep up under contention accumulates queue-wait latency in the reported p50 and p99. That backlog is the measurement, since it is what a user reading at a steady rate sees when maintenance takes the serving capacity. Neither loop reports regressions and the scenario declares no guarantees, so it records a series without gating CI.

A change that claims to improve read isolation is A/B'd by running the scenario twice with the flag that gates it, comparing the SELECT p50, p99, and qps between the two runs.

The change is a new scenario in `misc/python/materialize/parallel_benchmark/scenarios.py`, plus the `HydrationChurn` action it drives the contention with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
