### PR TITLE
parallel-benchmark: a peek isolation scenario driven by peeks alone

### DIFF
--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -1497,3 +1497,93 @@ class ReadIsolationUnderHydration(Scenario):
             conn_pool_size=1000,
             conn_pool_setup=["SET TRANSACTION_ISOLATION TO 'SERIALIZABLE'"],
         )
+
+
+class PeekIsolationUnderExpensivePeeks(Scenario):
+    r"""Measures whether a cheap peek stays fast while expensive peeks occupy the
+    same workers.
+
+    Every query is a fast-path index peek, so nothing renders a dataflow during
+    the load phase. That is what separates this from
+    `ReadIsolationUnderHydration`, whose contention is dataflow maintenance and
+    one of whose measured queries is an aggregate.
+
+    The expensive query filters on a non-key column, so it walks every position
+    of the index and returns nothing: its cost is the walk, which keeps result
+    size and the peek response stash out of the measurement. The cheap query is
+    a literal lookup on the key, and its p99 is what this reports.
+
+    Three things the numbers depend on, none of which the output would reveal if
+    they stopped holding:
+
+    * The expensive loop has to leave the worker idle between walks, or the
+      lookups queue without bound and the percentiles report the length of the
+      load phase. The measured cluster is one worker, since `Materialized` boots
+      at the `bootstrap` replica size and `--size` does not reach it, so the rate
+      is set against one walk: at 100ns to 1us per position, 100,000 positions
+      is 10ms to 100ms, and 2/s of those is 2% to 20% of that worker. Raising
+      the rate or the row count means redoing this.
+    * The loops are pooled and the pool is far larger than the ~3 connections
+      they hold. Waiting for a connection is timed like waiting for the replica,
+      and `ReuseConnQuery` would cap concurrency at one and report a client-side
+      backlog instead.
+    * The pool is SERIALIZABLE. Under STRICT SERIALIZABLE a peek waits for the
+      index's frontier, which is work on the same worker the walks occupy, so
+      the tail would include frontier lag that no change to peek placement
+      shortens.
+
+    Check `queries` on both sides before comparing percentiles: a query that
+    raises is dropped from the sample rather than recorded as slow.
+
+    To A/B a change that claims to improve peek isolation, run the scenario
+    twice with the flag that gates it and compare the lookup p50/p99:
+
+        bin/mzcompose --find parallel-benchmark run default \
+            --scenario PeekIsolationUnderExpensivePeeks \
+            --this-params <flag>=true
+        bin/mzcompose --find parallel-benchmark run default \
+            --scenario PeekIsolationUnderExpensivePeeks \
+            --this-params <flag>=false
+    """
+
+    def __init__(self, c: Composition, conn_infos: dict[str, PgConnInfo]):
+        self.init(
+            [
+                TdPhase("""
+                    > DROP TABLE IF EXISTS hot CASCADE
+
+                    # Sized so one full walk is long enough to delay what is
+                    # queued behind it and short enough to leave the worker idle
+                    # between walks. The class docstring has the arithmetic.
+                    > CREATE TABLE hot (k int, v int)
+                    > INSERT INTO hot SELECT n, n * 2 FROM generate_series(1, 100000) AS n
+                    > CREATE INDEX hot_k ON hot (k)
+
+                    # Wait for the index to hydrate before measuring.
+                    > SELECT v FROM hot WHERE k = 42
+                    84
+                    """),
+                LoadPhase(
+                    duration=120,
+                    actions=[
+                        # Measured: a literal lookup on the key, which is the
+                        # peek that has to stay fast.
+                        OpenLoop(
+                            action=PooledQuery("SELECT v FROM hot WHERE k = 42"),
+                            dist=Periodic(per_second=50),
+                            report_regressions=False,
+                        ),
+                        # Contention: a full walk of the same index. `v` is
+                        # always even and positive, so the filter matches
+                        # nothing and every position is examined for no rows.
+                        OpenLoop(
+                            action=PooledQuery("SELECT v FROM hot WHERE v = -1"),
+                            dist=Periodic(per_second=2),
+                            report_regressions=False,
+                        ),
+                    ],
+                ),
+            ],
+            conn_pool_size=100,
+            conn_pool_setup=["SET TRANSACTION_ISOLATION TO 'SERIALIZABLE'"],
+        )


### PR DESCRIPTION
`ReadIsolationUnderHydration` contends reads against dataflow maintenance, which is the right shape for a change that separates those two. It does not measure whether one peek delays another: its contention renders dataflows, and one of its two measured queries is an aggregate, so that query builds a dataflow of its own rather than taking the fast path.

`PeekIsolationUnderExpensivePeeks` puts only fast-path index peeks on the replica. The expensive query filters on a non-key column, so it walks every position of the index and matches nothing, which keeps its cost in the walk rather than in its result and leaves result size, the peek response stash, and the client out of the measurement. The cheap query is a literal lookup on the key. A walk that holds the worker for its whole scan delays the lookups queued behind it, so the lookup's p99 is what this reports.

The rates are calibrated rather than guessed. The measured cluster is one worker — `Materialized` boots at the `bootstrap` replica size, which is `scale=1,workers=1`, and `--size` does not reach it — so the offered rate is set against a single walk's cost, and the docstring carries the arithmetic. Raising the rate or the row count without redoing it turns this back into a saturation measurement, which reads the same on both sides of an A/B.

Plan shapes were confirmed with `EXPLAIN`: `WHERE k = 42` is a fast-path index lookup, `WHERE v = -1` a fast-path full scan with the filter in the map-filter-project, and `count(*) ... WHERE k &lt; 500` a `Reduce` dataflow.

### Measured

Two local runs, `--no-guarantees`, one worker, no offload on this branch:

| | 30s phase | 60s phase |
|---|---:|---:|
| lookup queries | 1500 / 1500 | 3000 / 3000 |
| lookup p50 | 3.21 ms | 3.36 ms |
| lookup p95 | 4.62 ms | 4.72 ms |
| lookup p99 | **23.72 ms** | **24.07 ms** |
| walk queries | 60 / 60 | 120 / 120 |
| walk avg | 23.98 ms | 24.57 ms |

Every offered query is accounted for, so the percentiles cover the whole distribution, and in-flight is 0.23 connections against 100 — nothing here is the client's queue. Halving the load phase leaves the percentiles alone, which is the property that was broken in nightly 18171, where p50 scaled with the phase because the backlog never drained.

The walk costs 240-246 ns per position, inside the 100 ns to 1 µs the docstring assumes, putting the worker at 4.9% utilization — inside the 2% to 20% band it claims. The tail is the walk: p99 24.07 ms against a walk of 24.57 ms, with the median untouched. That holds quantitatively: a walk occupies the worker 4.9% of the time, so ~4.9% of lookups collide and wait a uniform slice of it, which puts p95 just below the boundary and predicts p99 at ≈0.8 × 24.57 + 3.4 ≈ 23 ms against the 24.07 ms measured.

So an expensive peek inflates a cheap peek's tail 7× while leaving its median alone. That is the baseline a peek-placement change has to move.

🤖 Opened by [Claude Code](https://claude.com/claude-code) on behalf of @antiguru