### PR TITLE
parallel-benchmark: measure the replica's backlog, not the client's

### DIFF
--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -254,30 +254,59 @@ class ReuseConnQuery(Action):
         return f"{self.query} (reuse connection)"
 
 
+class PooledConn:
+    """A connection from the pool, together with the session setup it was built
+    with.
+
+    The setup travels with the connection because `PooledQuery` reopens one that
+    failed. Reopening without it would leave that connection on the server
+    defaults for the rest of the run, which changes what the affected queries
+    measure without changing anything visible in the output.
+    """
+
+    def __init__(self, conn_info: PgConnInfo, setup: list[str]):
+        self.conn_info = conn_info
+        self.setup = setup
+        self.conn = self._connect()
+
+    def _connect(self) -> psycopg.Connection:
+        conn = self.conn_info.connect()
+        conn.autocommit = True
+        for statement in self.setup:
+            with conn.cursor() as cur:
+                cur.execute(statement.encode())
+        return conn
+
+    def reconnect(self) -> None:
+        self.conn.close()
+        self.conn = self._connect()
+
+    def close(self) -> None:
+        self.conn.close()
+
+
 class PooledQuery(Action):
     def __init__(self, query: str, conn_info: PgConnInfo):
         self.query = query
         self.conn_info = conn_info
 
     def _run(self, conns: queue.Queue):
-        conn = conns.get()
+        pooled = conns.get()
         try:
             try:
-                with conn.cursor() as cur:
+                with pooled.conn.cursor() as cur:
                     execute_query(cur, self.query)
             except psycopg.OperationalError as e:
                 print(f"Connection failed on query '{self.query}', reconnecting: {e}")
-                conn.close()
-                conn = self.conn_info.connect()
-                conn.autocommit = True
-                with conn.cursor() as cur:
+                pooled.reconnect()
+                with pooled.conn.cursor() as cur:
                     execute_query(cur, self.query)
         finally:
             # Always return a slot to the pool, even if the retry also failed.
             # Otherwise repeated failures drain the pool and pooled actions
             # block forever on conns.get().
             conns.task_done()
-            conns.put(conn)
+            conns.put(pooled)
 
     def __str__(self) -> str:
         return f"{self.query} (pooled)"
@@ -462,6 +491,7 @@ class Scenario:
     phases: list[Phase]
     thread_pool_size: int
     conn_pool_size: int
+    conn_pool_setup: list[str]
     guarantees: dict[str, dict[str, float]]
     regression_thresholds: dict[str, dict[str, float]]
     jobs: queue.Queue
@@ -481,12 +511,14 @@ class Scenario:
         phases: list[Phase],
         thread_pool_size: int = 5000,
         conn_pool_size: int = 0,
+        conn_pool_setup: list[str] = [],
         guarantees: dict[str, dict[str, float]] = {},
         regression_thresholds: dict[str, dict[str, float]] = {},
     ):
         self.phases = phases
         self.thread_pool_size = thread_pool_size
         self.conn_pool_size = conn_pool_size
+        self.conn_pool_setup = conn_pool_setup
         self.guarantees = guarantees
         self.regression_thresholds = regression_thresholds
         self.jobs = queue.Queue()
@@ -500,11 +532,11 @@ class Scenario:
         ]
         for thread in self.thread_pool:
             thread.start()
-        # Start threads and have them wait for work from a queue
+        # Start threads and have them wait for work from a queue. The session
+        # setup runs once per connection here rather than in `PooledQuery._run`,
+        # where it would put a round trip inside every measured duration.
         for i in range(self.conn_pool_size):
-            conn = conn_info.connect()
-            conn.autocommit = True
-            self.conns.put(conn)
+            self.conns.put(PooledConn(conn_info, self.conn_pool_setup))
 
     def run(
         self,
@@ -516,8 +548,8 @@ class Scenario:
 
     def teardown(self) -> None:
         while not self.conns.empty():
-            conn = self.conns.get()
-            conn.close()
+            pooled = self.conns.get()
+            pooled.close()
             self.conns.task_done()
         for i in range(len(self.thread_pool)):
             # Indicate to every thread to stop working

--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -296,9 +296,14 @@ class PooledConn:
 
 
 class PooledQuery(Action):
-    def __init__(self, query: str, conn_info: PgConnInfo):
+    """Runs `query` on a connection from the scenario's pool.
+
+    Takes no `PgConnInfo`: the pool is built from the scenario's connection
+    info, and reconnecting a failed slot is the pool's own business.
+    """
+
+    def __init__(self, query: str):
         self.query = query
-        self.conn_info = conn_info
 
     def _run(self, conns: queue.Queue):
         pooled = conns.get()

--- a/misc/python/materialize/parallel_benchmark/framework.py
+++ b/misc/python/materialize/parallel_benchmark/framework.py
@@ -271,15 +271,25 @@ class PooledConn:
 
     def _connect(self) -> psycopg.Connection:
         conn = self.conn_info.connect()
-        conn.autocommit = True
-        for statement in self.setup:
-            with conn.cursor() as cur:
-                cur.execute(statement.encode())
+        try:
+            conn.autocommit = True
+            for statement in self.setup:
+                with conn.cursor() as cur:
+                    cur.execute(statement.encode())
+        except Exception:
+            # A half-built connection is not usable and nothing else holds a
+            # reference to it, so close it rather than leaking the session.
+            conn.close()
+            raise
         return conn
 
     def reconnect(self) -> None:
+        # Built before the old one is discarded, so a failure here leaves this
+        # slot holding a working connection rather than a closed one. The
+        # caller returns the slot to the pool however this ends.
+        conn = self._connect()
         self.conn.close()
-        self.conn = self._connect()
+        self.conn = conn
 
     def close(self) -> None:
         self.conn.close()
@@ -537,6 +547,12 @@ class Scenario:
         # where it would put a round trip inside every measured duration.
         for i in range(self.conn_pool_size):
             self.conns.put(PooledConn(conn_info, self.conn_pool_setup))
+        # A pool that came up short silently narrows the concurrency every
+        # pooled action gets, which shows up as latency rather than as an
+        # error, so state the count rather than discovering it in the numbers.
+        assert (
+            self.conns.qsize() == self.conn_pool_size
+        ), f"pool has {self.conns.qsize()} of {self.conn_pool_size} connections"
 
     def run(
         self,

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -17,12 +17,14 @@ from materialize.parallel_benchmark.framework import (
     Action,
     ClosedLoop,
     LoadPhase,
+    Measurement,
     OpenLoop,
     Periodic,
     PooledQuery,
     ReuseConnQuery,
     Scenario,
     StandaloneQuery,
+    State,
     TdAction,
     TdPhase,
     disabled,
@@ -1297,6 +1299,11 @@ class HydrationChurn(Action):
     cursor raises without a round trip and the loop spins, taking the
     measurement store's process-wide lock against the threads that record the
     measured reads.
+
+    A failed iteration records no measurement, so the count of this action in
+    the report is the number of hydrations that actually happened. Recording one
+    would report the backoff as though it were a fast hydration, and the count
+    would rise as the contention fell.
     """
 
     # Long enough that a persistently failing loop cannot crowd out the threads
@@ -1310,14 +1317,34 @@ class HydrationChurn(Action):
         self._connect()
 
     def _connect(self) -> None:
-        self.conn = self.conn_info.connect()
-        self.conn.autocommit = True
-        self.cur = self.conn.cursor()
+        conn = self.conn_info.connect()
+        conn.autocommit = True
+        cur = conn.cursor()
+        old = getattr(self, "conn", None)
+        self.conn = conn
+        self.cur = cur
+        if old is not None:
+            try:
+                old.close()
+            except Exception as e:
+                print(
+                    f"Hydration churn {self.name} could not close the old connection: {e}"
+                )
+
+    def run(self, start_time: float, conns: queue.Queue, state: State):
+        # `Action.run` records a measurement whenever `_run` returns. A failed
+        # iteration did no hydration and spent its time in the backoff, so it
+        # records nothing rather than entering the series as a fast one.
+        if not self._churn():
+            return
+        duration = time.time() - start_time
+        state.measurements.add(str(self), Measurement(duration, start_time))
 
     def _run(self, conns: queue.Queue):
-        # `IF NOT EXISTS` and `IF EXISTS` keep an iteration that failed after
-        # its CREATE from wedging every iteration after it. A view left behind
-        # is already hydrated, so the next iteration drops it and carries on.
+        raise NotImplementedError("run() drives the churn directly")
+
+    def _churn(self) -> bool:
+        """Builds, hydrates and drops the view once. False if the iteration failed."""
         try:
             execute_query(
                 self.cur,
@@ -1327,14 +1354,26 @@ class HydrationChurn(Action):
             # does the build work rather than cancelling it immediately.
             execute_query(self.cur, f"SELECT count(*) FROM {self.name}")
             self.cur.fetchall()
-            execute_query(self.cur, f"DROP MATERIALIZED VIEW IF EXISTS {self.name}")
         except Exception as e:
             print(f"Hydration churn {self.name} failed, retrying: {e}")
             time.sleep(self.RETRY_BACKOFF_SECONDS)
             try:
+                # Dropped before the next iteration, because a view left behind
+                # turns the next `CREATE IF NOT EXISTS` into a no-op. The loop
+                # would then keep running with no build work in it, which is
+                # this scenario's contention source disappearing silently.
                 self._connect()
+                execute_query(self.cur, f"DROP MATERIALIZED VIEW IF EXISTS {self.name}")
             except Exception as e:
-                print(f"Hydration churn {self.name} could not reconnect: {e}")
+                print(f"Hydration churn {self.name} could not recover: {e}")
+            return False
+
+        try:
+            execute_query(self.cur, f"DROP MATERIALIZED VIEW IF EXISTS {self.name}")
+        except Exception as e:
+            print(f"Hydration churn {self.name} could not drop its view: {e}")
+            return False
+        return True
 
     def __str__(self) -> str:
         return f"hydration churn {self.name}"
@@ -1354,7 +1393,15 @@ class ReadIsolationUnderHydration(Scenario):
     capture. That backlog is the signal: it is what a user issuing reads at a
     steady rate experiences when maintenance steals the serving capacity.
 
-    The measured loops are pooled so that the backlog is the replica's.
+    The measured loops are pooled so that the backlog is the replica's, and the
+    pool is sized well above what they hold. By Little's law a local run held
+    about 73 connections in flight across the two loops, so the 100 they
+    started with left no room: a slower replica blocks in `conns.get()`, the
+    offered rate stops reaching the replica, and the percentiles collapse back
+    into the arrival-schedule artifact at concurrency 100 instead of 1. The
+    slower side of an A/B is the one that would hit it, and nothing in the
+    output distinguishes a pool-capped run from a replica-limited one.
+
     `ReuseConnQuery` serializes an open loop on one connection behind one lock,
     so read concurrency is one however large the thread pool is, and any query
     slower than the inter-arrival time backs up in the client instead. The
@@ -1372,7 +1419,14 @@ class ReadIsolationUnderHydration(Scenario):
     Compare p50 and p99, not qps. An open loop offers a fixed number of
     queries, every one of them is drained before the run ends, and each is
     timestamped when it was scheduled rather than when it completed, so the
-    reported qps is the offered rate whatever the replica does:
+    reported qps is the offered rate whatever the replica does.
+
+    Check `queries` on both sides before comparing percentiles. A query that
+    raises is logged and dropped rather than recorded, so a run that lost
+    samples reports percentiles over the ones that survived, and the ones that
+    fail are the ones taken when the replica was worst.
+
+    To A/B a change that claims to improve read isolation:
 
         bin/mzcompose --find parallel-benchmark run default \
             --scenario ReadIsolationUnderHydration \
@@ -1435,6 +1489,6 @@ class ReadIsolationUnderHydration(Scenario):
                     ],
                 ),
             ],
-            conn_pool_size=100,
+            conn_pool_size=1000,
             conn_pool_setup=["SET TRANSACTION_ISOLATION TO 'SERIALIZABLE'"],
         )

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -1300,6 +1300,12 @@ class HydrationChurn(Action):
     measurement store's process-wide lock against the threads that record the
     measured reads.
 
+    Each iteration drops the view before it creates it, rather than trusting the
+    previous one to have cleaned up. An iteration whose own drop fails would
+    otherwise leave the view behind on a working session, and the next create
+    would find it already there, hydrate nothing, and record the milliseconds
+    that took as the fastest hydration of the run.
+
     A failed iteration records no measurement, so the count of this action in
     the report is the number of hydrations that actually happened. Recording one
     would report the backoff as though it were a fast hydration, and the count
@@ -1346,32 +1352,28 @@ class HydrationChurn(Action):
     def _churn(self) -> bool:
         """Builds, hydrates and drops the view once. False if the iteration failed."""
         try:
+            # Leading, so an iteration cleans up after whatever the last one
+            # left rather than depending on it. The create is deliberately not
+            # `IF NOT EXISTS`: a view that survived both this drop and the last
+            # one has to fail the iteration, not turn it into a no-op that
+            # records a hydration it never performed.
+            execute_query(self.cur, f"DROP MATERIALIZED VIEW IF EXISTS {self.name}")
             execute_query(
                 self.cur,
-                f"CREATE MATERIALIZED VIEW IF NOT EXISTS {self.name} AS {self.view_sql}",
+                f"CREATE MATERIALIZED VIEW {self.name} AS {self.view_sql}",
             )
             # Force hydration to complete before we drop, so the replica actually
             # does the build work rather than cancelling it immediately.
             execute_query(self.cur, f"SELECT count(*) FROM {self.name}")
             self.cur.fetchall()
+            execute_query(self.cur, f"DROP MATERIALIZED VIEW IF EXISTS {self.name}")
         except Exception as e:
             print(f"Hydration churn {self.name} failed, retrying: {e}")
             time.sleep(self.RETRY_BACKOFF_SECONDS)
             try:
-                # Dropped before the next iteration, because a view left behind
-                # turns the next `CREATE IF NOT EXISTS` into a no-op. The loop
-                # would then keep running with no build work in it, which is
-                # this scenario's contention source disappearing silently.
                 self._connect()
-                execute_query(self.cur, f"DROP MATERIALIZED VIEW IF EXISTS {self.name}")
             except Exception as e:
-                print(f"Hydration churn {self.name} could not recover: {e}")
-            return False
-
-        try:
-            execute_query(self.cur, f"DROP MATERIALIZED VIEW IF EXISTS {self.name}")
-        except Exception as e:
-            print(f"Hydration churn {self.name} could not drop its view: {e}")
+                print(f"Hydration churn {self.name} could not reconnect: {e}")
             return False
         return True
 

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -11,6 +11,8 @@ import queue
 import time
 from copy import deepcopy
 
+import psycopg
+
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.mysql import MySql
 from materialize.parallel_benchmark.framework import (
@@ -1320,13 +1322,14 @@ class HydrationChurn(Action):
         self.conn_info = conn_info
         self.name = name
         self.view_sql = view_sql
+        self.conn: psycopg.Connection | None = None
         self._connect()
 
     def _connect(self) -> None:
         conn = self.conn_info.connect()
         conn.autocommit = True
         cur = conn.cursor()
-        old = getattr(self, "conn", None)
+        old = self.conn
         self.conn = conn
         self.cur = cur
         if old is not None:
@@ -1490,6 +1493,14 @@ class ReadIsolationUnderHydration(Scenario):
                         for i in range(2)
                     ],
                 ),
+                # Nothing resets the services between scenarios when the
+                # benchmark runs against an existing environment, so the
+                # scenario that created these drops them. `big` takes the churn
+                # views with it if a load phase ended mid-iteration.
+                TdPhase("""
+                    > DROP TABLE IF EXISTS hot CASCADE
+                    > DROP TABLE IF EXISTS big CASCADE
+                    """),
             ],
             conn_pool_size=1000,
             conn_pool_setup=["SET TRANSACTION_ISOLATION TO 'SERIALIZABLE'"],

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -1283,6 +1283,13 @@ class HydrationChurn(Action):
     `SELECT count(*)` blocks until the view has hydrated, so each iteration does
     real hydration work before the drop. Runs in a `ClosedLoop`, which is
     single-threaded, so a fixed view name is safe.
+
+    An iteration that fails is logged and skipped rather than allowed to
+    propagate. `ClosedLoop.run` is the thread's whole body and has no handler,
+    so an escaping exception would remove the contention for the rest of the
+    load phase while the measured loops kept reporting against a replica with
+    nothing else to do, which reads as the change under test having fixed read
+    isolation.
     """
 
     def __init__(self, conn_info: PgConnInfo, name: str, view_sql: str):
@@ -1294,14 +1301,24 @@ class HydrationChurn(Action):
         self.cur = self.conn.cursor()
 
     def _run(self, conns: queue.Queue):
-        self.cur.execute(
-            f"CREATE MATERIALIZED VIEW {self.name} AS {self.view_sql}".encode()
-        )
-        # Force hydration to complete before we drop, so the replica actually
-        # does the build work rather than cancelling it immediately.
-        self.cur.execute(f"SELECT count(*) FROM {self.name}".encode())
-        self.cur.fetchall()
-        self.cur.execute(f"DROP MATERIALIZED VIEW {self.name}".encode())
+        # `IF NOT EXISTS` and `IF EXISTS` keep an iteration that failed after
+        # its CREATE from wedging every iteration after it.
+        try:
+            execute_query(
+                self.cur,
+                f"CREATE MATERIALIZED VIEW IF NOT EXISTS {self.name} AS {self.view_sql}",
+            )
+            # Force hydration to complete before we drop, so the replica actually
+            # does the build work rather than cancelling it immediately.
+            execute_query(self.cur, f"SELECT count(*) FROM {self.name}")
+            self.cur.fetchall()
+        except Exception as e:
+            print(f"Hydration churn {self.name} failed, skipping iteration: {e}")
+        finally:
+            try:
+                execute_query(self.cur, f"DROP MATERIALIZED VIEW IF EXISTS {self.name}")
+            except Exception as e:
+                print(f"Hydration churn {self.name} could not drop its view: {e}")
 
     def __str__(self) -> str:
         return f"hydration churn {self.name}"
@@ -1321,8 +1338,17 @@ class ReadIsolationUnderHydration(Scenario):
     capture. That backlog is the signal: it is what a user issuing reads at a
     steady rate experiences when maintenance steals the serving capacity.
 
-    To A/B a change that claims to improve read isolation, run the scenario
-    twice with the flag that gates it and compare the SELECT p50/p99/qps:
+    The measured loops are pooled so that the backlog is the replica's.
+    `ReuseConnQuery` serializes an open loop on one connection behind one lock,
+    so read concurrency is one however large the thread pool is, and any query
+    slower than the inter-arrival time backs up in the client instead. The
+    percentiles that come out of that scale with the length of the load phase
+    rather than with peek latency, which is the same on both sides of an A/B.
+
+    Compare p50 and p99, not qps. An open loop offers a fixed number of
+    queries, every one of them is drained before the run ends, and each is
+    timestamped when it was scheduled rather than when it completed, so the
+    reported qps is the offered rate whatever the replica does:
 
         bin/mzcompose --find parallel-benchmark run default \
             --scenario ReadIsolationUnderHydration \
@@ -1361,21 +1387,15 @@ class ReadIsolationUnderHydration(Scenario):
                     actions=[
                         # Measured: fast-path index point lookup.
                         OpenLoop(
-                            action=ReuseConnQuery(
-                                "SELECT v FROM hot WHERE k = 42",
-                                mz,
-                                strict_serializable=False,
-                            ),
+                            action=PooledQuery("SELECT v FROM hot WHERE k = 42", mz),
                             dist=Periodic(per_second=50),
                             report_regressions=False,
                         ),
                         # Measured: slow-path range scan + reduce peek (more
                         # sensitive to contention on the replica).
                         OpenLoop(
-                            action=ReuseConnQuery(
-                                "SELECT count(*) FROM hot WHERE k < 50000",
-                                mz,
-                                strict_serializable=False,
+                            action=PooledQuery(
+                                "SELECT count(*) FROM hot WHERE k < 50000", mz
                             ),
                             dist=Periodic(per_second=12),
                             report_regressions=False,
@@ -1391,4 +1411,5 @@ class ReadIsolationUnderHydration(Scenario):
                     ],
                 ),
             ],
+            conn_pool_size=100,
         )

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import queue
+import time
 from copy import deepcopy
 
 from materialize.mzcompose.composition import Composition
@@ -1290,19 +1291,33 @@ class HydrationChurn(Action):
     load phase while the measured loops kept reporting against a replica with
     nothing else to do, which reads as the change under test having fixed read
     isolation.
+
+    A closed loop calls back to back with no pause of its own, so a failure that
+    repeats is backed off and the connection reopened. Without both, an unusable
+    cursor raises without a round trip and the loop spins, taking the
+    measurement store's process-wide lock against the threads that record the
+    measured reads.
     """
+
+    # Long enough that a persistently failing loop cannot crowd out the threads
+    # recording the measured reads, short enough to lose little contention.
+    RETRY_BACKOFF_SECONDS = 1.0
 
     def __init__(self, conn_info: PgConnInfo, name: str, view_sql: str):
         self.conn_info = conn_info
         self.name = name
         self.view_sql = view_sql
-        self.conn = conn_info.connect()
+        self._connect()
+
+    def _connect(self) -> None:
+        self.conn = self.conn_info.connect()
         self.conn.autocommit = True
         self.cur = self.conn.cursor()
 
     def _run(self, conns: queue.Queue):
         # `IF NOT EXISTS` and `IF EXISTS` keep an iteration that failed after
-        # its CREATE from wedging every iteration after it.
+        # its CREATE from wedging every iteration after it. A view left behind
+        # is already hydrated, so the next iteration drops it and carries on.
         try:
             execute_query(
                 self.cur,
@@ -1312,13 +1327,14 @@ class HydrationChurn(Action):
             # does the build work rather than cancelling it immediately.
             execute_query(self.cur, f"SELECT count(*) FROM {self.name}")
             self.cur.fetchall()
+            execute_query(self.cur, f"DROP MATERIALIZED VIEW IF EXISTS {self.name}")
         except Exception as e:
-            print(f"Hydration churn {self.name} failed, skipping iteration: {e}")
-        finally:
+            print(f"Hydration churn {self.name} failed, retrying: {e}")
+            time.sleep(self.RETRY_BACKOFF_SECONDS)
             try:
-                execute_query(self.cur, f"DROP MATERIALIZED VIEW IF EXISTS {self.name}")
+                self._connect()
             except Exception as e:
-                print(f"Hydration churn {self.name} could not drop its view: {e}")
+                print(f"Hydration churn {self.name} could not reconnect: {e}")
 
     def __str__(self) -> str:
         return f"hydration churn {self.name}"
@@ -1344,6 +1360,14 @@ class ReadIsolationUnderHydration(Scenario):
     slower than the inter-arrival time backs up in the client instead. The
     percentiles that come out of that scale with the length of the load phase
     rather than with peek latency, which is the same on both sides of an A/B.
+
+    The pool is set to SERIALIZABLE. Under STRICT SERIALIZABLE a peek is pinned
+    to the timestamp oracle and cannot answer until the index's frontier on the
+    replica reaches it, and advancing that frontier is compute work on the very
+    workers the churn saturates. The measurement would then blend peek service
+    time with frontier lag, and a change that lets peeks overtake maintenance
+    does not advance the frontier any sooner, so it would report no improvement
+    where there was one.
 
     Compare p50 and p99, not qps. An open loop offers a fixed number of
     queries, every one of them is drained before the run ends, and each is
@@ -1412,4 +1436,5 @@ class ReadIsolationUnderHydration(Scenario):
                 ),
             ],
             conn_pool_size=100,
+            conn_pool_setup=["SET TRANSACTION_ISOLATION TO 'SERIALIZABLE'"],
         )

--- a/misc/python/materialize/parallel_benchmark/scenarios.py
+++ b/misc/python/materialize/parallel_benchmark/scenarios.py
@@ -338,9 +338,7 @@ class OpenIndexedSelects(Scenario):
                     duration=120,
                     actions=[
                         OpenLoop(
-                            action=PooledQuery(
-                                "SELECT * FROM t4", conn_info=conn_infos["materialized"]
-                            ),
+                            action=PooledQuery("SELECT * FROM t4"),
                             dist=Periodic(per_second=400),
                         ),
                     ],
@@ -450,9 +448,7 @@ class PoolRead(Scenario):
                     duration=120,
                     actions=[
                         OpenLoop(
-                            action=PooledQuery(
-                                "SELECT 1", conn_info=conn_infos["materialized"]
-                            ),
+                            action=PooledQuery("SELECT 1"),
                             dist=Periodic(per_second=100),
                             # dist=Gaussian(mean=0.01, stddev=0.05),
                         ),
@@ -572,9 +568,7 @@ class StatementLogging(Scenario):
                     duration=120,
                     actions=[
                         OpenLoop(
-                            action=PooledQuery(
-                                "SELECT 1", conn_info=conn_infos["materialized"]
-                            ),
+                            action=PooledQuery("SELECT 1"),
                             dist=Periodic(per_second=100),
                             # dist=Gaussian(mean=0.01, stddev=0.05),
                         ),
@@ -1227,9 +1221,7 @@ class StagingBench(Scenario):
                     duration=82800,
                     actions=[
                         OpenLoop(
-                            action=PooledQuery(
-                                "SELECT 1", conn_info=conn_infos["materialized"]
-                            ),
+                            action=PooledQuery("SELECT 1"),
                             dist=Periodic(per_second=500),
                         ),
                         ClosedLoop(
@@ -1470,7 +1462,7 @@ class ReadIsolationUnderHydration(Scenario):
                     actions=[
                         # Measured: fast-path index point lookup.
                         OpenLoop(
-                            action=PooledQuery("SELECT v FROM hot WHERE k = 42", mz),
+                            action=PooledQuery("SELECT v FROM hot WHERE k = 42"),
                             dist=Periodic(per_second=50),
                             report_regressions=False,
                         ),
@@ -1478,7 +1470,7 @@ class ReadIsolationUnderHydration(Scenario):
                         # sensitive to contention on the replica).
                         OpenLoop(
                             action=PooledQuery(
-                                "SELECT count(*) FROM hot WHERE k < 50000", mz
+                                "SELECT count(*) FROM hot WHERE k < 50000"
                             ),
                             dist=Periodic(per_second=12),
                             report_regressions=False,

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -529,10 +529,14 @@ def run_once(
                 periodic_dists={pd[0]: int(pd[1]) for pd in args.periodic_dist or []},
             )
             scenario = scenario_class(c, conn_infos)
-            scenario.setup(c, conn_infos)
             start_time = time.time()
             Path(MZ_ROOT / "plots").mkdir(parents=True, exist_ok=True)
             try:
+                # Inside the try because setup() is what starts the worker
+                # threads and builds the connection pool. A failure partway
+                # through leaves those threads parked on an empty job queue,
+                # and only teardown()'s sentinels release them.
+                scenario.setup(c, conn_infos)
                 if not args.benchmarking_env:
                     # Don't let the garbage collector interfere with our measurements
                     gc.disable()

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -529,6 +529,10 @@ def run_once(
                 periodic_dists={pd[0]: int(pd[1]) for pd in args.periodic_dist or []},
             )
             scenario = scenario_class(c, conn_infos)
+            # Bound before the try, because the finally reports against it and a
+            # setup() that raises would otherwise leave it unbound, replacing
+            # the failure with an UnboundLocalError.
+            start_time = time.time()
             Path(MZ_ROOT / "plots").mkdir(parents=True, exist_ok=True)
             try:
                 # Inside the try because setup() is what starts the worker

--- a/test/parallel-benchmark/mzcompose.py
+++ b/test/parallel-benchmark/mzcompose.py
@@ -529,7 +529,6 @@ def run_once(
                 periodic_dists={pd[0]: int(pd[1]) for pd in args.periodic_dist or []},
             )
             scenario = scenario_class(c, conn_infos)
-            start_time = time.time()
             Path(MZ_ROOT / "plots").mkdir(parents=True, exist_ok=True)
             try:
                 # Inside the try because setup() is what starts the worker
@@ -537,6 +536,11 @@ def run_once(
                 # through leaves those threads parked on an empty job queue,
                 # and only teardown()'s sentinels release them.
                 scenario.setup(c, conn_infos)
+                # After setup(), because this is the denominator of the reported
+                # qps. Starting the thread pool and opening the connections is
+                # harness time, and a scenario with a qps guarantee has less
+                # slack than that costs.
+                start_time = time.time()
                 if not args.benchmarking_env:
                     # Don't let the garbage collector interfere with our measurements
                     gc.disable()


### PR DESCRIPTION
Makes `ReadIsolationUnderHydration` measure the replica rather than the harness. Addresses the post-merge review of #38542 and three further review rounds on this PR.

**The measured loops backed up in the client.** `ReuseConnQuery._run` holds one lock across the whole round trip and an `OpenLoop` dispatches a single shared action instance, so read concurrency was one however large the thread pool. Any query slower than the inter-arrival time queued client-side, and `Periodic` binds the *scheduled* time into the measurement, so that wait landed in the reported latency. Nightly 18171: p50 83s and p99 105s against a 120s load phase, with both arms within 3% because both measured the same client queue. Both loops are pooled now.

**Pooling has to keep the isolation level.** A pooled connection takes the server default, which is STRICT SERIALIZABLE, and there the peek is pinned to the oracle read timestamp as a hard lower bound — it cannot answer until the index's frontier reaches that timestamp, and advancing the frontier is compute work on the very workers the churn saturates. That would blend frontier lag into a number meant to measure peek placement, and produce a false negative: a change that lets peeks overtake maintenance does not advance the frontier any sooner. `Scenario.init` takes a `conn_pool_setup` applied once per connection at pool build, and a `PooledConn` carries its setup so a reconnect restores it.

**The pool must not become the constraint itself.** By Little's law the two loops hold ~47-73 connections in flight, so the 100 they started with left no headroom, and a slower replica would block in `conns.get()` and reproduce the arrival-schedule artifact at concurrency 100 instead of 1. Now 1000.

**A failing churn must not look like a working one.** The churn ran its statements straight off the cursor, so an error propagated out of `ClosedLoop.run` — the thread's whole body, no handler — and the contention vanished for the rest of the phase while the reads kept reporting against an idle replica. Each iteration now drops before it creates, so it heals whatever the last one left rather than depending on it; the create does not tolerate a leftover; a failed iteration backs off, reopens the connection, and records nothing, so the reported count is the number of hydrations that actually happened.

**Smaller:** `Scenario.setup` moved inside the `try` that guarantees `teardown` (a partial pool build previously parked thousands of non-daemon threads and hung the run), with `start_time` bound before it and rebound after, so harness startup stays out of the qps denominator without leaving the variable unbound on the failure path. The docstring now says to check `queries` before comparing percentiles, since a query that raises is dropped from the sample rather than counted as slow.

### Measured

Local run, `--load-phase-duration 60 --no-guarantees`, one worker:

| | lookup | `count(*)` | churn 0 / 1 |
|---|---:|---:|---:|
| queries | 3000 / 3000 | 720 / 720 | 6 / 6 |
| p50 | 221.91 ms | 2160.22 ms | 10501 / 10582 ms |
| p99 | 1809.02 ms | 5703.33 ms | 10823 / 12494 ms |
| max | 2248.54 ms | 5954.83 ms | — |

Every offered query is accounted for and no failures were logged. In-flight is ~47 connections against 1000. The backlog is bounded: max 2.25s against a 60s phase, with a negative slope, where saturation looks like 18171's p99 of 105s against 120s. Against the uncontended 3.36 ms lookup measured by the sibling scenario, hydration churn inflates the median 65×, which is the effect this scenario exists to report.

🤖 Opened by [Claude Code](https://claude.com/claude-code) on behalf of @antiguru