### PR TITLE
adapter: invalidate expression cache on MV replacement apply

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -5036,6 +5036,20 @@ impl Coordinator {
             "finishing materialized view replacement application",
         );
 
+        // The durable expression cache is keyed by GlobalId and relies on the
+        // invariant that the definition behind a GlobalId never changes.
+        // Applying a replacement violates that for the target's existing
+        // GlobalIds: the item retains them as prior versions while its
+        // definition becomes the replacement's. Invalidate their cached
+        // expressions, and await the invalidation before the catalog
+        // transaction commits, so no subsequent bootstrap can pair the new
+        // definition with a stale cached expression whose dependencies may
+        // since have been dropped.
+        let invalidate_ids = self.catalog().get_entry(&id).global_ids().collect();
+        self.catalog()
+            .update_expression_cache(Vec::new(), Vec::new(), invalidate_ids)
+            .await;
+
         let ops = vec![catalog::Op::AlterMaterializedViewApplyReplacement { id, replacement_id }];
         match self
             .catalog_transact(Some(ctx.ctx().session_mut()), ops)

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -4436,6 +4436,61 @@ fn test_durable_oids() {
     }
 }
 
+// Applying a materialized view replacement retains the target's existing
+// GlobalIds as prior versions while swapping in the replacement's definition.
+// The durable expression cache is keyed by GlobalId under the invariant that
+// the definition behind a GlobalId never changes, so the apply must invalidate
+// the cached expressions of the retained GlobalIds. If it doesn't, the next
+// bootstrap installs the stale optimized expression for the item, and if the
+// old definition's dependencies have since been dropped, timeline resolution
+// panics with "catalog out of sync" on every startup.
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // too slow
+#[allow(clippy::disallowed_methods)]
+fn test_replacement_materialized_view_invalidates_expression_cache() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let harness = test_util::TestHarness::default()
+        .data_directory(data_dir.path())
+        .with_system_parameter_default(
+            "enable_replacement_materialized_views".to_string(),
+            "true".to_string(),
+        );
+
+    {
+        let server = harness.clone().start_blocking();
+        let mut client = server.connect(postgres::NoTls).unwrap();
+        client.batch_execute("CREATE TABLE t1 (a int)").unwrap();
+        client.batch_execute("INSERT INTO t1 VALUES (1)").unwrap();
+        client
+            .batch_execute("CREATE VIEW v1 AS SELECT a FROM t1")
+            .unwrap();
+        client
+            .batch_execute("CREATE MATERIALIZED VIEW mv AS SELECT a FROM v1")
+            .unwrap();
+        client.batch_execute("CREATE TABLE t2 (a int)").unwrap();
+        client.batch_execute("INSERT INTO t2 VALUES (2)").unwrap();
+        client
+            .batch_execute("CREATE VIEW v2 AS SELECT a FROM t2")
+            .unwrap();
+        client
+            .batch_execute("CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv AS SELECT a FROM v2")
+            .unwrap();
+        client
+            .batch_execute("ALTER MATERIALIZED VIEW mv APPLY REPLACEMENT rp")
+            .unwrap();
+        client.batch_execute("DROP VIEW v1").unwrap();
+        let row = client.query_one("SELECT a FROM mv", &[]).unwrap();
+        assert_eq!(row.get::<_, i32>(0), 2, "pre-restart");
+    }
+
+    {
+        let server = harness.start_blocking();
+        let mut client = server.connect(postgres::NoTls).unwrap();
+        let row = client.query_one("SELECT a FROM mv", &[]).unwrap();
+        assert_eq!(row.get::<_, i32>(0), 2);
+    }
+}
+
 #[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // too slow
 #[allow(clippy::disallowed_methods)]


### PR DESCRIPTION
### Motivation

Root cause of a production incident: after an `ALTER MATERIALIZED VIEW ... APPLY REPLACEMENT` followed by dropping the old definition's dependencies, `environmentd` entered a deterministic crash loop, panicking on every boot with `catalog out of sync, missing id User(...)` in `Coordinator::bootstrap`.

The durable expression cache is keyed by `GlobalId` and relies on the invariant that the definition behind a `GlobalId` never changes. Applying a replacement violates that invariant: the target item retains its existing `GlobalId`s as prior versions (the root version stays the durable item's primary `global_id`) while its definition becomes the replacement's, and nothing invalidated the cached expressions under the retained ids.

On the next restart of the same build version, `parse_item` hits the stale cache entry under the retained root `GlobalId` and installs the old optimized expression alongside the new `create_sql`. Consequences:

* If any dependency of the old definition has since been dropped, timeline resolution during bootstrap panics, before the server can serve queries. Restarting cannot self-heal.
* Even when the old dependencies still exist, the stale local MIR is live in catalog state. If the MV's global plan also misses the cache on that boot (for example after an imported index was dropped), `bootstrap_dataflow_plans` re-optimizes from the stale local MIR and renders the old query.

### Description

Invalidate the target's cached expressions (all of its `GlobalId`s) when finishing the replacement apply, awaited before the catalog transaction commits, so no subsequent bootstrap can observe the new definition paired with a stale cached expression. If the transaction fails after the invalidation, the only cost is a re-optimization at the next boot. The `invalidate_ids` parameter of `update_expression_cache` already existed but had no callers.

Environments that applied a replacement before this fix hold stale entries until a version upgrade regenerates the cache (entries are keyed per build version). An environment that hits the panic before upgrading can be recovered by booting with `enable_expression_cache=false`.

### Verification

Added `test_replacement_materialized_view_invalidates_expression_cache` to the environmentd server tests: it applies a replacement, drops the old dependency, and restarts against the same data directory. Without the fix the restart reproduces the bootstrap panic; with the fix it boots and serves the replacement's output.

---

Generated with [Claude Code](https://claude.com/claude-code)
