### PR TITLE
compute: limit the heap size of a query's dataflow

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -766,6 +766,12 @@ metrics:
   - instance_id
   source: src/compute-client/src/metrics.rs
   visibility: internal
+- name: mz_compute_heap_size_limits_exceeded_total
+  help: The total number of queries failed for exceeding their heap size limit.
+  labels:
+  - instance_id
+  source: src/compute-client/src/metrics.rs
+  visibility: internal
 - name: mz_compute_peek_duration_seconds_bucket
   help: A histogram of peek durations since restart.
   labels:

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -649,6 +649,11 @@ def get_default_system_parameters(
 # all. Only add it in UNINTERESTING_SYSTEM_PARAMETERS if none of the above
 # apply.
 UNINTERESTING_SYSTEM_PARAMETERS = [
+    # Not varied fleet-wide: turning it on adds the watchdog's operators, and the
+    # logging channels feeding them, to every replica's logging dataflow, which
+    # introspection goldens enumerate. test/testdrive/query_heap_size.td turns it
+    # on for clusters of its own instead.
+    "enable_compute_heap_size_limit",
     "enable_compute_half_join2",
     "enable_mz_join_core",
     "linear_join_yielding",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2941,6 +2941,7 @@ class FlipFlagsAction(Action):
             BOOLEAN_FLAG_VALUES
         )
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_compute_heap_size_limit"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_public_metrics_endpoint"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [
             "0",

--- a/src/adapter/src/active_compute_sink.rs
+++ b/src/adapter/src/active_compute_sink.rs
@@ -15,7 +15,7 @@ use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 
 use mz_adapter_types::connection::ConnectionId;
-use mz_compute_client::protocol::response::SubscribeBatch;
+use mz_compute_client::protocol::response::{SubscribeBatch, SubscribeError};
 use mz_controller_types::ClusterId;
 use mz_expr::row::RowCollection;
 use mz_expr::{RowComparator, compare_columns};
@@ -278,11 +278,16 @@ impl ActiveSubscribe {
                 );
                 mz_ore::iter::consolidate_update_iter(merged)
             }
-            Err(s) => {
-                self.send(
-                    PeekResponseUnary::Error(AdapterError::Unstructured(anyhow::Error::msg(s))),
-                    0,
-                );
+            Err(error) => {
+                let error = match error {
+                    SubscribeError::Unstructured(error) => {
+                        AdapterError::Unstructured(anyhow::Error::msg(error))
+                    }
+                    SubscribeError::HeapSizeLimitExceeded { heap_size, limit } => {
+                        AdapterError::QueryHeapSizeLimitExceeded { heap_size, limit }
+                    }
+                };
+                self.send(PeekResponseUnary::Error(error), 0);
                 return true;
             }
         };

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -36,7 +36,7 @@ use derivative::Derivative;
 use mz_adapter_types::dyncfgs::ENABLE_INTROSPECTION_SUBSCRIBES;
 use mz_cluster_client::ReplicaId;
 use mz_compute_client::controller::error::ERROR_TARGET_REPLICA_FAILED;
-use mz_compute_client::protocol::response::SubscribeBatch;
+use mz_compute_client::protocol::response::{SubscribeBatch, SubscribeError};
 use mz_controller_types::ClusterId;
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_panic_or_log;
@@ -447,7 +447,7 @@ impl Coordinator {
         let updates = match batch.updates {
             Ok(updates) if updates.is_empty() => return,
             Ok(updates) => updates,
-            Err(error) if error == ERROR_TARGET_REPLICA_FAILED => {
+            Err(SubscribeError::Unstructured(error)) if error == ERROR_TARGET_REPLICA_FAILED => {
                 // The target replica disconnected, reinstall the subscribe.
                 self.reinstall_introspection_subscribe(id).await;
                 return;

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -137,7 +137,7 @@ impl Coordinator {
                 target_cluster,
                 None,
                 explain_ctx,
-                max_query_result_size
+                max_query_result_size,
             ),
             ctx
         );
@@ -766,11 +766,17 @@ impl Coordinator {
             );
         }
 
+        let max_query_heap_size = ctx.session().vars().max_query_heap_size();
+
         let session = ctx.session_mut();
         let conn_id = session.conn_id().clone();
 
-        let (peek_plan, df_meta, typ) = global_lir_plan.unapply();
+        let (mut peek_plan, df_meta, typ) = global_lir_plan.unapply();
         let source_arity = typ.arity();
+
+        if let peek::PeekPlan::SlowPath(PeekDataflowPlan { desc, .. }) = &mut peek_plan {
+            desc.heap_size_limit = max_query_heap_size;
+        }
 
         emit_optimizer_notices(&*self.catalog, &*session, &df_meta.optimizer_notices);
 

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -504,7 +504,8 @@ impl Coordinator {
             replica_id,
         }: SubscribeFinish,
     ) -> Result<StageResult<Box<SubscribeStage>>, AdapterError> {
-        let (df_desc, df_meta) = global_lir_plan.unapply();
+        let (mut df_desc, df_meta) = global_lir_plan.unapply();
+        df_desc.heap_size_limit = ctx.session().vars().max_query_heap_size();
         emit_optimizer_notices(&*self.catalog, ctx.session(), &df_meta.optimizer_notices);
         let conn_id = ctx.session.conn_id().clone();
         let session_uuid = ctx.session().uuid();

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -208,6 +208,13 @@ pub enum AdapterError {
         /// The configured per-worker limit.
         limit: usize,
     },
+    /// A query's dataflow exceeded the `max_query_heap_size` limit.
+    QueryHeapSizeLimitExceeded {
+        /// The heap size observed, in bytes. A lower bound on what the query actually used.
+        heap_size: u64,
+        /// The limit that was in effect, in bytes.
+        limit: u64,
+    },
     /// The specified feature is not permitted in safe mode.
     SafeModeViolation(String),
     /// The current transaction had the wrong set of write locks.
@@ -615,6 +622,11 @@ impl AdapterError {
                  worker. This limit prevents long-running SELECT queries from delaying other \
                  work on the cluster."
             )),
+            AdapterError::QueryHeapSizeLimitExceeded { heap_size, .. } => Some(format!(
+                "The query's dataflow was observed holding at least {heap_size} bytes across the \
+                 cluster replica. The measurement covers the dataflow's internal state and is \
+                 taken periodically, so the query may have grown past the limit by more than this."
+            )),
             AdapterError::SafeModeViolation(_) => Some(
                 "The Materialize server you are connected to is running in \
                  safe mode, which limits the features that are available."
@@ -867,6 +879,12 @@ impl AdapterError {
                  `compute_peek_row_iteration_limit`."
                     .into(),
             ),
+            AdapterError::QueryHeapSizeLimitExceeded { .. } => Some(
+                "Reduce the amount of data the query keeps in memory, for example by filtering \
+                 earlier or querying an index. To permit this query, raise the \
+                 `max_query_heap_size` session variable."
+                    .into(),
+            ),
             AdapterError::PlanError(e) => e.hint(),
             AdapterError::UnallowedOnCluster { cluster, .. } => {
                 (cluster != MZ_CATALOG_SERVER_CLUSTER.name).then(||
@@ -1011,6 +1029,7 @@ impl AdapterError {
             AdapterError::ResultSize(_) => SqlState::OUT_OF_MEMORY,
             AdapterError::SubscribeFellBehind { .. } => SqlState::OUT_OF_MEMORY,
             AdapterError::PeekRowIterationLimitExceeded { .. } => SqlState::PROGRAM_LIMIT_EXCEEDED,
+            AdapterError::QueryHeapSizeLimitExceeded { .. } => SqlState::OUT_OF_MEMORY,
             AdapterError::SafeModeViolation(_) => SqlState::INTERNAL_ERROR,
             AdapterError::SubscribeOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::Optimizer(e) => match e {
@@ -1323,6 +1342,12 @@ impl fmt::Display for AdapterError {
                 write!(
                     f,
                     "query exceeded the configured row iteration limit of {limit} rows"
+                )
+            }
+            AdapterError::QueryHeapSizeLimitExceeded { limit, .. } => {
+                write!(
+                    f,
+                    "query exceeded the max_query_heap_size limit of {limit} bytes"
                 )
             }
             AdapterError::ReplaceMaterializedViewSealed { name } => {
@@ -1682,6 +1707,9 @@ impl From<mz_compute_client::protocol::response::PeekError> for AdapterError {
             PeekError::RowIterationLimitExceeded { limit } => {
                 AdapterError::PeekRowIterationLimitExceeded { limit }
             }
+            PeekError::HeapSizeLimitExceeded { heap_size, limit } => {
+                AdapterError::QueryHeapSizeLimitExceeded { heap_size, limit }
+            }
         }
     }
 }
@@ -1848,6 +1876,29 @@ mod tests {
                 .hint
                 .as_deref()
                 .is_some_and(|hint| hint.contains("compute_peek_row_iteration_limit"))
+        );
+    }
+
+    #[mz_ore::test]
+    fn heap_size_limit_error_is_not_an_internal_error() {
+        use mz_compute_client::protocol::response::PeekError;
+
+        let response = AdapterError::from(PeekError::HeapSizeLimitExceeded {
+            heap_size: 2048,
+            limit: 1024,
+        })
+        .into_response(Severity::Error);
+
+        assert_eq!(response.code, SqlState::OUT_OF_MEMORY);
+        assert_eq!(
+            response.message,
+            "query exceeded the max_query_heap_size limit of 1024 bytes"
+        );
+        assert!(
+            response
+                .hint
+                .as_deref()
+                .is_some_and(|hint| hint.contains("max_query_heap_size"))
         );
     }
 

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -1314,10 +1314,12 @@ impl PeekClient {
                         )
                         .await?
                     }
-                    PeekPlan::SlowPath(dataflow_plan) => {
+                    PeekPlan::SlowPath(mut dataflow_plan) => {
                         if let Some(logging_id) = logging.id() {
                             self.log_set_transient_index_id(logging_id, dataflow_plan.id);
                         }
+
+                        dataflow_plan.desc.heap_size_limit = session.vars().max_query_heap_size();
 
                         let response = self
                             .call_coordinator(|tx| Command::ExecuteSlowPathPeek {
@@ -1371,10 +1373,12 @@ impl PeekClient {
             }
             Execution::Subscribe {
                 subscribe_plan,
-                df_desc,
+                mut df_desc,
                 df_meta,
                 optimization_finished_at: _optimization_finished_at,
             } => {
+                df_desc.heap_size_limit = session.vars().max_query_heap_size();
+
                 if df_desc.as_of.as_ref().expect("as of set") == &df_desc.until {
                     session.add_notice(AdapterNotice::EqualSubscribeBounds {
                         bound: *df_desc.until.as_option().expect("as of set"),

--- a/src/clusterd-test-driver/src/dataflow.rs
+++ b/src/clusterd-test-driver/src/dataflow.rs
@@ -713,6 +713,7 @@ fn augment(
         refresh_schedule: lowered.refresh_schedule,
         debug_name: lowered.debug_name,
         time_dependence: lowered.time_dependence,
+        heap_size_limit: lowered.heap_size_limit,
     })
 }
 

--- a/src/clusterd-test-driver/src/responses.rs
+++ b/src/clusterd-test-driver/src/responses.rs
@@ -158,7 +158,7 @@ impl Responses {
                             // path replaces the updates with a message.
                             Err(e) => {
                                 if state.error.is_none() {
-                                    state.error = Some(e);
+                                    state.error = Some(e.to_string());
                                 }
                             }
                         }

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -1147,6 +1147,7 @@ mod tests {
             refresh_schedule: Default::default(),
             debug_name: Default::default(),
             time_dependence: None,
+            heap_size_limit: None,
         }
     }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -64,8 +64,9 @@ use crate::protocol::command::{
 };
 use crate::protocol::history::ComputeCommandHistory;
 use crate::protocol::response::{
-    ComputeResponse, CopyToResponse, FrontiersResponse, PeekError as ProtocolPeekError,
-    PeekResponse, StatusResponse, SubscribeBatch, SubscribeResponse,
+    ComputeResponse, CopyToResponse, FrontiersResponse, HeapSizeLimitStatus,
+    PeekError as ProtocolPeekError, PeekResponse, StatusResponse, SubscribeBatch, SubscribeError,
+    SubscribeResponse,
 };
 
 #[derive(Error, Debug)]
@@ -1599,6 +1600,7 @@ impl Instance {
             refresh_schedule: dataflow.refresh_schedule,
             debug_name: dataflow.debug_name,
             time_dependence: dataflow.time_dependence,
+            heap_size_limit: dataflow.heap_size_limit,
         };
 
         if augmented_dataflow.is_transient() {
@@ -2301,9 +2303,87 @@ impl Instance {
         }
     }
 
-    fn handle_status_response(&self, response: StatusResponse, _replica_id: ReplicaId) {
+    fn handle_status_response(&mut self, response: StatusResponse, replica_id: ReplicaId) {
         match response {
-            StatusResponse::Placeholder => {}
+            StatusResponse::HeapSizeLimitExceeded(status) => {
+                self.handle_heap_size_limit_exceeded(status, replica_id)
+            }
+        }
+    }
+
+    /// Fails the query served by the dataflow that exceeded its heap size limit.
+    ///
+    /// Limits are only ever set on transient dataflows, so the collection identifies either a
+    /// subscribe or a peek.
+    fn handle_heap_size_limit_exceeded(
+        &mut self,
+        status: HeapSizeLimitStatus,
+        replica_id: ReplicaId,
+    ) {
+        let HeapSizeLimitStatus {
+            collection_id,
+            heap_size,
+            heap_size_limit,
+        } = status;
+        tracing::debug!(
+            %replica_id, %collection_id, %heap_size, %heap_size_limit,
+            "dataflow exceeded its heap size limit",
+        );
+
+        if self.subscribes.contains_key(&collection_id) {
+            self.metrics.heap_size_limits_exceeded_total.inc();
+            let frontier = self.subscribes[&collection_id].frontier.clone();
+            self.deliver_response(ComputeControllerResponse::SubscribeResponse(
+                collection_id,
+                SubscribeBatch {
+                    lower: frontier.clone(),
+                    upper: frontier,
+                    updates: Err(SubscribeError::HeapSizeLimitExceeded {
+                        heap_size,
+                        limit: heap_size_limit,
+                    }),
+                },
+            ));
+            return;
+        }
+
+        // Peeks are keyed by UUID, so find the one reading from this collection. A peek's read
+        // hold is on the collection its dataflow exports, which is what the replica reports.
+        let peek = self
+            .peeks
+            .iter()
+            .find(|(_, peek)| peek.read_hold.id() == collection_id)
+            .map(|(uuid, peek)| (*uuid, peek.otel_ctx.clone()));
+
+        match peek {
+            // Routing through `handle_peek_response` keeps the metrics, the peek notification,
+            // and the `CancelPeek` command consistent with a replica-reported peek error, and
+            // applies the replica-targeting filter for targeted peeks.
+            Some((uuid, otel_ctx)) => {
+                self.metrics.heap_size_limits_exceeded_total.inc();
+                self.handle_peek_response(
+                    uuid,
+                    PeekResponse::Error(ProtocolPeekError::HeapSizeLimitExceeded {
+                        heap_size,
+                        limit: heap_size_limit,
+                    }),
+                    otel_ctx,
+                    replica_id,
+                )
+            }
+            // A collection the controller does not know at all means the replica is running a
+            // dataflow the controller never installed.
+            None if !self.collections.contains_key(&collection_id) => soft_panic_or_log!(
+                "heap size limit exceeded for an unknown collection \
+                 (collection_id={collection_id}, replica_id={replica_id})",
+            ),
+            // Every replica running the dataflow reports independently, and the first report
+            // finishes the query, so later ones legitimately find nothing left to fail.
+            None => tracing::debug!(
+                %replica_id,
+                %collection_id,
+                "heap size limit exceeded for a collection that is no longer being read",
+            ),
         }
     }
 

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -63,6 +63,7 @@ pub struct ComputeControllerMetrics {
 
     // peeks
     peeks_total: IntCounterVec,
+    heap_size_limits_exceeded_total: IntCounterVec,
     peek_duration_seconds: HistogramVec,
 
     // replica connections
@@ -167,6 +168,11 @@ impl ComputeControllerMetrics {
                 help: "The total number of peeks served.",
                 var_labels: ["instance_id", "result"],
             )),
+            heap_size_limits_exceeded_total: metrics_registry.register(metric!(
+                name: "mz_compute_heap_size_limits_exceeded_total",
+                help: "The total number of queries failed for exceeding their heap size limit.",
+                var_labels: ["instance_id"],
+            )),
             peek_duration_seconds: metrics_registry.register(metric!(
                 name: "mz_compute_peek_duration_seconds",
                 help: "A histogram of peek durations since restart.",
@@ -231,6 +237,9 @@ impl ComputeControllerMetrics {
         let response_recv_count = self
             .response_recv_count
             .get_delete_on_drop_metric(labels.clone());
+        let heap_size_limits_exceeded_total = self
+            .heap_size_limits_exceeded_total
+            .get_delete_on_drop_metric(labels.clone());
         let connected_replica_count = self
             .connected_replica_count
             .get_delete_on_drop_metric(labels);
@@ -248,6 +257,7 @@ impl ComputeControllerMetrics {
             history_dataflow_count,
             peeks_total,
             peek_duration_seconds,
+            heap_size_limits_exceeded_total,
             response_send_count,
             response_recv_count,
             connected_replica_count,
@@ -281,6 +291,12 @@ pub struct InstanceMetrics {
     pub peeks_total: PeekMetrics<IntCounter>,
     /// Histogram tracking peek durations.
     pub peek_duration_seconds: PeekMetrics<Histogram>,
+    /// Counter tracking the number of queries failed for exceeding their heap size limit.
+    ///
+    /// Incremented once per report that names a peek or subscribe the controller is still
+    /// tracking, so the reports every other replica running the same dataflow sends do not
+    /// inflate it.
+    pub heap_size_limits_exceeded_total: IntCounter,
     /// Counter tracking the number of sends on the compute response queue.
     pub response_send_count: IntCounter,
     /// Counter tracking the number of receives on the compute response queue.

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -222,9 +222,9 @@ impl PeekResponse {
 /// The error of an unsuccessful peek.
 ///
 /// The variant decides what the user sees: a `Dataflow` error keeps the structure the dataflow
-/// produced and so gets the same SQLSTATE constant folding would have assigned, a
-/// `RowIterationLimitExceeded` names a limit the user can raise, and an `Unstructured` error is
-/// reported as an internal error. Prefer the structured variants whenever the source has one.
+/// produced and so gets the same SQLSTATE constant folding would have assigned, the limit
+/// variants name a limit the user can raise, and an `Unstructured` error is reported as an
+/// internal error. Prefer the structured variants whenever the source has one.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum PeekError {
     /// An error produced while executing the dataflow, for example evaluating an expression over
@@ -236,6 +236,13 @@ pub enum PeekError {
     RowIterationLimitExceeded {
         /// The limit that was in effect, in rows.
         limit: usize,
+    },
+    /// The dataflow serving the peek reached its `max_query_heap_size` limit.
+    HeapSizeLimitExceeded {
+        /// The heap size observed, in bytes. A lower bound, see [`HeapSizeLimitStatus::heap_size`].
+        heap_size: u64,
+        /// The limit that was in effect, in bytes.
+        limit: u64,
     },
 }
 
@@ -254,6 +261,11 @@ impl fmt::Display for PeekError {
             Self::RowIterationLimitExceeded { limit } => write!(
                 f,
                 "query exceeded the configured row iteration limit of {limit} rows"
+            ),
+            Self::HeapSizeLimitExceeded { heap_size, limit } => write!(
+                f,
+                "query exceeded the max_query_heap_size limit of {limit} bytes; \
+                 it was using at least {heap_size} bytes"
             ),
         }
     }
@@ -359,7 +371,7 @@ pub struct SubscribeBatch {
     /// may aggregate different batches together later as we combine results from different workers.
     ///
     /// An `Err` variant can be used to indicate e.g. that the size of the updates exceeds internal limits.
-    pub updates: Result<Vec<UpdateCollection>, String>,
+    pub updates: Result<Vec<UpdateCollection>, SubscribeError>,
 }
 
 impl SubscribeBatch {
@@ -372,18 +384,74 @@ impl SubscribeBatch {
                 self.updates = Err(format!(
                     "result exceeds max size of {}",
                     ByteSize::b(u64::cast_from(max_result_size))
-                ));
+                )
+                .into());
             }
         }
+    }
+}
+
+/// The error of a failed subscribe.
+///
+/// As with [`PeekError`], an `Unstructured` error is reported to the user as an internal error,
+/// so a condition the user can act on belongs in a variant of its own.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SubscribeError {
+    /// An error with no structured form.
+    Unstructured(String),
+    /// The dataflow serving the subscribe reached its `max_query_heap_size` limit.
+    HeapSizeLimitExceeded {
+        /// The heap size observed, in bytes. A lower bound, see [`HeapSizeLimitStatus::heap_size`].
+        heap_size: u64,
+        /// The limit that was in effect, in bytes.
+        limit: u64,
+    },
+}
+
+impl fmt::Display for SubscribeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unstructured(error) => f.write_str(error),
+            Self::HeapSizeLimitExceeded { heap_size, limit } => write!(
+                f,
+                "query exceeded the max_query_heap_size limit of {limit} bytes; \
+                 it was using at least {heap_size} bytes"
+            ),
+        }
+    }
+}
+
+impl From<String> for SubscribeError {
+    fn from(error: String) -> Self {
+        Self::Unstructured(error)
+    }
+}
+
+impl From<&str> for SubscribeError {
+    fn from(error: &str) -> Self {
+        Self::Unstructured(error.into())
     }
 }
 
 /// Status updates replicas can report to the controller.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum StatusResponse {
-    /// No status responses are implemented currently, but we're leaving the infrastructure around
-    /// in anticipation of materialize#31246.
-    Placeholder,
+    /// Reports that a dataflow exceeded its heap size limit.
+    HeapSizeLimitExceeded(HeapSizeLimitStatus),
+}
+
+/// An update reporting that a dataflow exceeded its heap size limit.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HeapSizeLimitStatus {
+    /// The ID of the compute collection exported by the dataflow.
+    pub collection_id: GlobalId,
+    /// The heap size the dataflow was observed to occupy, in bytes.
+    ///
+    /// Summed across the replica's workers, and covering only instrumented allocations, so it is
+    /// a lower bound on the dataflow's actual memory use.
+    pub heap_size: u64,
+    /// The limit the dataflow exceeded, in bytes.
+    pub heap_size_limit: u64,
 }
 
 #[cfg(test)]

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 use crate::protocol::command::ComputeCommand;
 use crate::protocol::response::{
     ComputeResponse, CopyToResponse, FrontiersResponse, PeekError, PeekResponse,
-    StashedPeekResponse, SubscribeBatch, SubscribeResponse,
+    StashedPeekResponse, SubscribeBatch, SubscribeError, SubscribeResponse,
 };
 
 /// A client to a compute server.
@@ -506,7 +506,7 @@ struct PendingSubscribe {
     /// The subscribe frontiers of the partitioned shards.
     frontiers: MutableAntichain<Timestamp>,
     /// The updates we are holding back until their timestamps are complete.
-    stashed_updates: Result<Vec<UpdateCollection>, String>,
+    stashed_updates: Result<Vec<UpdateCollection>, SubscribeError>,
     /// The row size of stashed updates, for `max_result_size` checking.
     stashed_result_size: usize,
     /// Whether we have already emitted a `DroppedAt` response for this subscribe.
@@ -534,7 +534,11 @@ impl PendingSubscribe {
     ///
     /// This also implements the short-circuit behavior of error responses, and performs
     /// `max_result_size` checking.
-    fn stash(&mut self, new_updates: Result<Vec<UpdateCollection>, String>, max_result_size: u64) {
+    fn stash(
+        &mut self,
+        new_updates: Result<Vec<UpdateCollection>, SubscribeError>,
+        max_result_size: u64,
+    ) {
         match (&mut self.stashed_updates, new_updates) {
             (Err(_), _) => {
                 // Subscribe is borked; nothing to do.
@@ -551,7 +555,8 @@ impl PendingSubscribe {
                     self.stashed_updates = Err(format!(
                         "total result exceeds max size of {}",
                         ByteSize::b(max_result_size)
-                    ));
+                    )
+                    .into());
                 } else {
                     stashed.extend(new);
                 }

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -67,6 +67,15 @@ pub struct DataflowDescription<P, S: 'static = ()> {
     pub debug_name: String,
     /// Description of how the dataflow's progress relates to wall-clock time. None for unknown.
     pub time_dependence: Option<TimeDependence>,
+    /// The maximum heap size in bytes the dataflow may occupy, if any.
+    ///
+    /// Only set on transient dataflows, because exceeding the limit fails the query the dataflow
+    /// serves. A query served without a dataflow of its own, such as a fast-path peek reading an
+    /// existing arrangement, has nothing to charge and so carries no limit.
+    ///
+    /// Enforcement is approximate: the replica observes instrumented allocations with a delay, so
+    /// a dataflow can exceed the limit before the controller learns about it.
+    pub heap_size_limit: Option<u64>,
 }
 
 impl<P, S> DataflowDescription<P, S> {
@@ -270,6 +279,7 @@ impl<P, S> DataflowDescription<P, S> {
             refresh_schedule: None,
             debug_name: name,
             time_dependence: None,
+            heap_size_limit: None,
         }
     }
 
@@ -597,6 +607,7 @@ where
             refresh_schedule: self.refresh_schedule.clone(),
             debug_name: self.debug_name.clone(),
             time_dependence: self.time_dependence.clone(),
+            heap_size_limit: self.heap_size_limit,
         }
     }
 }

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -697,9 +697,26 @@ pub const MV_SINK_ADVANCE_PERSIST_FRONTIERS: Config<bool> = Config::new(
     ParameterScope::Environment,
 );
 
+/// Enables the watchdog dataflow that reports dataflows exceeding their heap size limit.
+///
+/// Rendering the watchdog costs a small amount of steady-state work per replica, so it is gated
+/// separately from the `max_query_heap_size` session variable that supplies the limits.
+///
+/// The two directions are not symmetric. A replica decides whether to render the watchdog once,
+/// when it initializes its logging dataflow, so enabling this only takes effect on replicas
+/// created afterwards. Disabling it takes effect immediately, because a replica also consults it
+/// when it installs a dataflow's limit, and a limit that is never installed is never enforced.
+pub const ENABLE_COMPUTE_HEAP_SIZE_LIMIT: Config<bool> = Config::new(
+    "enable_compute_heap_size_limit",
+    false,
+    "Whether to render the watchdog dataflow that enforces per-dataflow heap size limits.",
+    ParameterScope::Replica,
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
+        .add(&ENABLE_COMPUTE_HEAP_SIZE_LIMIT)
         .add(&ENABLE_HALF_JOIN2)
         .add(&ENABLE_ERROR_DISTINCT)
         .add(&ENABLE_MZ_JOIN_CORE)

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -202,6 +202,7 @@ impl Context {
             refresh_schedule: desc.refresh_schedule,
             debug_name: desc.debug_name,
             time_dependence: desc.time_dependence,
+            heap_size_limit: desc.heap_size_limit,
         };
 
         // Refining: identify the common parts in the MFPs pushed onto a

--- a/src/compute/src/command_channel.rs
+++ b/src/compute/src/command_channel.rs
@@ -193,6 +193,7 @@ fn split_command(
                     initial_storage_as_of: dataflow.initial_storage_as_of.clone(),
                     refresh_schedule: dataflow.refresh_schedule.clone(),
                     time_dependence: dataflow.time_dependence.clone(),
+                    heap_size_limit: dataflow.heap_size_limit,
                 })
                 .map(Box::new)
                 .map(ComputeCommand::CreateDataflow);

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -26,11 +26,12 @@ use mz_compute_client::protocol::command::{
 };
 use mz_compute_client::protocol::history::ComputeCommandHistory;
 use mz_compute_client::protocol::response::{
-    ComputeResponse, CopyToResponse, FrontiersResponse, PeekError, PeekResponse, SubscribeResponse,
+    ComputeResponse, CopyToResponse, FrontiersResponse, HeapSizeLimitStatus, PeekError,
+    PeekResponse, StatusResponse, SubscribeResponse,
 };
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::dyncfgs::{
-    ENABLE_PEEK_RESPONSE_STASH, ENABLE_PEEK_ROW_ITERATION_LIMIT,
+    ENABLE_COMPUTE_HEAP_SIZE_LIMIT, ENABLE_PEEK_RESPONSE_STASH, ENABLE_PEEK_ROW_ITERATION_LIMIT,
     PEEK_RESPONSE_STASH_BATCH_MAX_RUNS, PEEK_RESPONSE_STASH_THRESHOLD_BYTES,
     PEEK_ROW_ITERATION_LIMIT, PEEK_STASH_BATCH_SIZE, PEEK_STASH_NUM_BATCHES,
 };
@@ -247,6 +248,17 @@ pub struct ComputeState {
 
     /// The storage worker forwards its introspection logs to the compute worker.
     pub storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
+
+    /// Heap size limit in bytes, keyed by Timely dataflow index.
+    ///
+    /// Shared with the watchdog logging fragment, which reads it to decide whether a dataflow's
+    /// observed heap size is over budget. Only dataflows that carry a limit appear here.
+    heap_size_limits: Rc<RefCell<BTreeMap<usize, u64>>>,
+    /// Timely dataflow indices the watchdog reported as over their heap size limit, along with
+    /// the heap size it observed.
+    ///
+    /// Written by the watchdog fragment, drained by [`ActiveComputeState::process_heap_size_limits`].
+    dataflows_exceeding_heap_size_limit: Rc<RefCell<BTreeMap<usize, u64>>>,
 }
 
 impl ComputeState {
@@ -288,6 +300,8 @@ impl ComputeState {
             init_system_time: mz_ore::now::SYSTEM_TIME(),
             replica_expiration: Antichain::default(),
             storage_log_reader,
+            heap_size_limits: Default::default(),
+            dataflows_exceeding_heap_size_limit: Default::default(),
         }
     }
 
@@ -732,6 +746,7 @@ impl<'a> ActiveComputeState<'a> {
                     .map(|t| mz_ore::now::to_datetime(t.into())),
                 plan_until = ?dataflow.until.elements(),
                 until = ?until.elements(),
+                heap_size_limit = ?dataflow.heap_size_limit,
                 "creating dataflow",
             );
         } else {
@@ -747,6 +762,7 @@ impl<'a> ActiveComputeState<'a> {
                     .map(|t| mz_ore::now::to_datetime(t.into())),
                 plan_until = ?dataflow.until.elements(),
                 until = ?until.elements(),
+                heap_size_limit = ?dataflow.heap_size_limit,
                 "creating dataflow",
             );
         };
@@ -808,6 +824,26 @@ impl<'a> ActiveComputeState<'a> {
             self.compute_state
                 .suspended_collections
                 .insert(id, Rc::clone(&suspension_token));
+        }
+
+        // The gate is read here as well as at logging initialization, so that turning the feature
+        // off keeps this map empty rather than filling it for a watchdog that is not running.
+        if let Some(limit) = dataflow.heap_size_limit {
+            // Exceeding a limit fails the query the dataflow serves, and there is no such query
+            // behind an index or a materialized view, so the controller only ever sets a limit on
+            // a transient dataflow. Enforcing one here anyway would fail nothing and hide the bug.
+            if !dataflow.is_transient() {
+                soft_panic_or_log!(
+                    "heap size limit on a non-transient dataflow \
+                     (name={}, limit={limit})",
+                    dataflow.debug_name,
+                );
+            } else if ENABLE_COMPUTE_HEAP_SIZE_LIMIT.get(&self.compute_state.worker_config) {
+                self.compute_state
+                    .heap_size_limits
+                    .borrow_mut()
+                    .insert(*dataflow_index, limit);
+            }
         }
 
         crate::render::build_compute_dataflow(
@@ -910,6 +946,10 @@ impl<'a> ActiveComputeState<'a> {
 
         // Drop the dataflow, if all its exports have been dropped.
         if let Ok(index) = Rc::try_unwrap(collection.dataflow_index) {
+            self.compute_state
+                .heap_size_limits
+                .borrow_mut()
+                .remove(&index);
             self.timely_worker.drop_dataflow(index);
         }
 
@@ -955,6 +995,8 @@ impl<'a> ActiveComputeState<'a> {
             Rc::clone(&self.compute_state.worker_config),
             self.compute_state.workers_per_process,
             storage_log_reader,
+            Rc::clone(&self.compute_state.heap_size_limits),
+            Rc::clone(&self.compute_state.dataflows_exceeding_heap_size_limit),
         );
 
         let dataflow_index = Rc::new(dataflow_index);
@@ -1322,6 +1364,51 @@ impl<'a> ActiveComputeState<'a> {
         let mut responses = self.compute_state.copy_to_response_buffer.borrow_mut();
         for (sink_id, response) in responses.drain(..) {
             self.send_compute_response(ComputeResponse::CopyToResponse(sink_id, response));
+        }
+    }
+
+    /// Reports dataflows the watchdog found to be over their heap size limit.
+    ///
+    /// The report names the collection rather than the Timely dataflow, because the dataflow index
+    /// is a replica-local detail the controller does not track. A dataflow with a limit is
+    /// transient and therefore exports exactly one collection, but the scan tolerates more.
+    ///
+    /// Reporting is all this does. The replica never drops the offending dataflow on its own
+    /// judgement, because the controller owns which dataflows a replica runs and a self-inflicted
+    /// drop would leave the replica's dataflow set disagreeing with the command history the
+    /// controller reconciles against. The heap size is summed across all of a replica's workers,
+    /// so in a multi-process replica the verdict is reached in one process and there is no
+    /// protocol to carry it to the others. The price is a command round trip before the memory is
+    /// released, which the approximate accounting already concedes.
+    pub fn process_heap_size_limits(&self) {
+        let exceeded = std::mem::take(
+            &mut *self
+                .compute_state
+                .dataflows_exceeding_heap_size_limit
+                .borrow_mut(),
+        );
+        if exceeded.is_empty() {
+            return;
+        }
+
+        let limits = self.compute_state.heap_size_limits.borrow();
+        for (&collection_id, state) in self.compute_state.collections.iter() {
+            let Some(&heap_size) = exceeded.get(&*state.dataflow_index) else {
+                continue;
+            };
+            // The limit is dropped along with the dataflow, so a report that raced the drop has
+            // nothing left to fail.
+            let Some(&heap_size_limit) = limits.get(&*state.dataflow_index) else {
+                continue;
+            };
+            let status = HeapSizeLimitStatus {
+                collection_id,
+                heap_size,
+                heap_size_limit,
+            };
+            self.send_compute_response(ComputeResponse::Status(
+                StatusResponse::HeapSizeLimitExceeded(status),
+            ));
         }
     }
 

--- a/src/compute/src/logging.rs
+++ b/src/compute/src/logging.rs
@@ -16,6 +16,7 @@ mod prometheus;
 mod reachability;
 mod resource_usage;
 mod timely;
+mod watchdog;
 
 use std::any::Any;
 use std::collections::BTreeMap;

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -29,10 +29,10 @@ use mz_timely_util::columnar::builder::ColumnBuilder;
 use mz_timely_util::columnar::{Col2ValBatcher, Column, columnar_exchange};
 use mz_timely_util::replay::MzReplay;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
-use timely::dataflow::operators::Operator;
 use timely::dataflow::operators::generic::OutputBuilder;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::operator::empty;
+use timely::dataflow::operators::{Leave, Operator};
 use timely::dataflow::{Scope, StreamVec};
 use timely::scheduling::activate::{Activations, Activator};
 use tracing::error;
@@ -40,8 +40,8 @@ use uuid::Uuid;
 
 use crate::extensions::arrange::MzArrangeCore;
 use crate::logging::{
-    ComputeLog, EventQueue, LogCollection, LogVariant, OutputSessionColumnar, PermutedRowPacker,
-    SharedLoggingState, Update,
+    ComputeLog, EventQueue, LogCollection, LogVariant, OutputSessionColumnar, OutputSessionVec,
+    PermutedRowPacker, SharedLoggingState, Update,
 };
 use crate::typedefs::RowRowSpine;
 use mz_row_spine::RowRowBuilder;
@@ -298,9 +298,20 @@ impl LirMetadata {
 }
 
 /// The return type of the [`construct`] function.
-pub(super) struct Return {
+pub(super) struct Return<'scope> {
     /// Collections returned by [`construct`].
     pub collections: BTreeMap<LogVariant, LogCollection>,
+    /// Per-operator arrangement heap size deltas, in bytes carried in the diff field.
+    ///
+    /// Unlike the `ArrangementHeapSize` log collection this stream is keyed by operator ID rather
+    /// than packed into rows, so the watchdog can aggregate it without re-parsing datums. `None`
+    /// unless the caller asked for it, so that a replica that enforces no heap size limits pays
+    /// for neither the output nor the channel leaving the logging scope.
+    pub arrangement_heap_size: Option<StreamVec<'scope, Timestamp, Update<(usize, ())>>>,
+    /// Maps each arrangement operator to the dataflow hosting it, for as long as it exists.
+    ///
+    /// `None` under the same condition as [`Return::arrangement_heap_size`].
+    pub arrangement_dataflows: Option<StreamVec<'scope, Timestamp, Update<(usize, usize)>>>,
 }
 
 /// Constructs the logging dataflow fragment for compute logs.
@@ -312,15 +323,18 @@ pub(super) struct Return {
 /// * `event_queue`: The source to read compute log events from.
 /// * `compute_event_streams`: Additional compute event streams to absorb.
 /// * `shared_state`: Shared state between logging dataflow fragments.
+/// * `heap_size_watchdog`: Whether to produce the streams the watchdog fragment consumes.
 pub(super) fn construct<'scope>(
     scope: Scope<'scope, Timestamp>,
     activations: Rc<RefCell<Activations>>,
     config: &mz_compute_client::logging::LoggingConfig,
     event_queue: EventQueue<Column<(Duration, ComputeEvent)>>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
-) -> Return {
+    heap_size_watchdog: bool,
+) -> Return<'scope> {
     let logging_interval_ms = std::cmp::max(1, config.interval.as_millis());
 
+    let outer = scope;
     scope.scoped("compute logging", move |scope| {
         let enable_logging = config.enable_logging;
         let (logs, token) = if enable_logging {
@@ -366,6 +380,13 @@ pub(super) fn construct<'scope>(
         let mut lir_mapping_out = OutputBuilder::from(lir_mapping_out);
         let (dataflow_global_ids_out, dataflow_global_ids) = demux.new_output();
         let mut dataflow_global_ids_out = OutputBuilder::from(dataflow_global_ids_out);
+        let (arrangement_heap_size_bytes_out, arrangement_heap_size_bytes) =
+            heap_size_watchdog.then(|| demux.new_output()).unzip();
+        let mut arrangement_heap_size_bytes_out =
+            arrangement_heap_size_bytes_out.map(OutputBuilder::from);
+        let (arrangement_dataflows_out, arrangement_dataflows) =
+            heap_size_watchdog.then(|| demux.new_output()).unzip();
+        let mut arrangement_dataflows_out = arrangement_dataflows_out.map(OutputBuilder::from);
 
         let mut demux_state = DemuxState::new(activations, scope.index());
         demux.build(move |_capability| {
@@ -383,6 +404,11 @@ pub(super) fn construct<'scope>(
                 let mut operator_hydration_status = operator_hydration_status_out.activate();
                 let mut lir_mapping = lir_mapping_out.activate();
                 let mut dataflow_global_ids = dataflow_global_ids_out.activate();
+                let mut arrangement_heap_size_bytes = arrangement_heap_size_bytes_out
+                    .as_mut()
+                    .map(|out| out.activate());
+                let mut arrangement_dataflows =
+                    arrangement_dataflows_out.as_mut().map(|out| out.activate());
 
                 input.for_each(|cap, data| {
                     let mut output_sessions = DemuxOutput {
@@ -402,6 +428,12 @@ pub(super) fn construct<'scope>(
                             .session_with_builder(&cap),
                         lir_mapping: lir_mapping.session_with_builder(&cap),
                         dataflow_global_ids: dataflow_global_ids.session_with_builder(&cap),
+                        arrangement_heap_size_bytes: arrangement_heap_size_bytes
+                            .as_mut()
+                            .map(|out| out.session_with_builder(&cap)),
+                        arrangement_dataflows: arrangement_dataflows
+                            .as_mut()
+                            .map(|out| out.session_with_builder(&cap)),
                     };
 
                     let shared_state = &mut shared_state.borrow_mut();
@@ -461,7 +493,11 @@ pub(super) fn construct<'scope>(
             }
         }
 
-        Return { collections }
+        Return {
+            collections,
+            arrangement_heap_size: arrangement_heap_size_bytes.map(|stream| stream.leave(outer)),
+            arrangement_dataflows: arrangement_dataflows.map(|stream| stream.leave(outer)),
+        }
     })
 }
 
@@ -819,8 +855,11 @@ impl ExportState {
 }
 
 /// State for tracking arrangement sizes.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 struct ArrangementSizeState {
+    /// The Timely dataflow hosting the arrangement, taken from the first element of the
+    /// arrangement operator's address.
+    dataflow_id: usize,
     size: isize,
     capacity: isize,
     count: isize,
@@ -841,6 +880,8 @@ struct DemuxOutput<'a, 'b> {
     error_count: OutputSessionColumnar<'a, 'b, Update<(Row, Row)>>,
     lir_mapping: OutputSessionColumnar<'a, 'b, Update<(Row, Row)>>,
     dataflow_global_ids: OutputSessionColumnar<'a, 'b, Update<(Row, Row)>>,
+    arrangement_heap_size_bytes: Option<OutputSessionVec<'a, 'b, Update<(usize, ())>>>,
+    arrangement_dataflows: Option<OutputSessionVec<'a, 'b, Update<(usize, usize)>>>,
 }
 
 /// Event handler of the demux operator.
@@ -1269,6 +1310,9 @@ impl DemuxHandler<'_, '_, '_> {
         let datum = self.state.pack_arrangement_heap_size_update(operator_id);
         let diff = Diff::cast_from(delta_size);
         self.output.arrangement_heap_size.give((datum, ts, diff));
+        if let Some(output) = &mut self.output.arrangement_heap_size_bytes {
+            output.give(((operator_id, ()), ts, diff));
+        }
     }
 
     /// Update the allocation capacity for an arrangement.
@@ -1327,16 +1371,27 @@ impl DemuxHandler<'_, '_, '_> {
             address,
         }: Ref<'_, ArrangementHeapSizeOperator>,
     ) {
-        let activator = Activator::new(
-            address.into_iter().collect(),
-            Rc::clone(&self.state.activations),
-        );
-        let existing = self
-            .state
-            .arrangement_size
-            .insert(operator_id, Default::default());
+        let address: Rc<[usize]> = address.into_iter().collect();
+        // An operator's address starts at the dataflow that hosts it, so its first element names
+        // the Timely dataflow index the compute controller knows the collection by.
+        let Some(&dataflow_id) = address.first() else {
+            error!(%operator_id, "arrangement size operator has an empty address");
+            return;
+        };
+        let activator = Activator::new(address, Rc::clone(&self.state.activations));
+        let state = ArrangementSizeState {
+            dataflow_id,
+            size: 0,
+            capacity: 0,
+            count: 0,
+        };
+        let existing = self.state.arrangement_size.insert(operator_id, state);
         if existing.is_some() {
             error!(%operator_id, "arrangement size operator already registered");
+        }
+        let ts = self.ts();
+        if let Some(output) = &mut self.output.arrangement_dataflows {
+            output.give(((operator_id, dataflow_id), ts, Diff::ONE));
         }
         let existing = self
             .shared_state
@@ -1374,6 +1429,13 @@ impl DemuxHandler<'_, '_, '_> {
             let size = self.state.pack_arrangement_heap_size_update(operator_id);
             let diff = -Diff::cast_from(state.size);
             self.output.arrangement_heap_size.give((size, ts, diff));
+            if let Some(output) = &mut self.output.arrangement_heap_size_bytes {
+                output.give(((operator_id, ()), ts, diff));
+            }
+
+            if let Some(output) = &mut self.output.arrangement_dataflows {
+                output.give(((operator_id, state.dataflow_id), ts, Diff::MINUS_ONE));
+            }
         }
         self.shared_state
             .arrangement_size_activators

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -26,25 +26,32 @@ use mz_timely_util::columnar::{Col2ValBatcher, columnar_exchange};
 use mz_timely_util::columnation::ColumnationChunker;
 use mz_timely_util::replay::MzReplay;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
-use timely::dataflow::operators::InputCapability;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::operator::empty;
 use timely::dataflow::operators::generic::{OutputBuilder, Session};
+use timely::dataflow::operators::{InputCapability, Leave};
 use timely::dataflow::{Scope, StreamVec};
 
 use crate::extensions::arrange::MzArrangeCore;
 use crate::logging::compute::{ArrangementHeapSizeOperatorDrop, ComputeEvent};
 use crate::logging::{
-    DifferentialLog, EventQueue, LogCollection, LogVariant, SharedLoggingState,
+    DifferentialLog, EventQueue, LogCollection, LogVariant, SharedLoggingState, Update,
     consolidate_and_pack,
 };
 use crate::typedefs::{KeyBatcher, RowRowSpine};
 use mz_row_spine::RowRowBuilder;
 
 /// The return type of [`construct`].
-pub(super) struct Return {
+pub(super) struct Return<'scope> {
     /// Collections to export.
     pub collections: BTreeMap<LogVariant, LogCollection>,
+    /// Per-operator merge batcher heap size deltas, in bytes carried in the diff field.
+    ///
+    /// A batcher is logged under the global ID of the arrangement operator that owns it, so this
+    /// stream shares a key space with the compute logging fragment's arrangement heap sizes.
+    /// `None` unless the caller asked for it, so that a replica that enforces no heap size limits
+    /// pays for neither the output nor the channel leaving the logging scope.
+    pub batcher_heap_size: Option<StreamVec<'scope, Timestamp, Update<(usize, ())>>>,
 }
 
 /// Constructs the logging dataflow fragment for differential logs.
@@ -54,14 +61,17 @@ pub(super) struct Return {
 /// * `config`: Logging configuration
 /// * `event_queue`: The source to read log events from.
 /// * `shared_state`: Shared state across all logging dataflow fragments.
-pub(super) fn construct(
-    scope: Scope<'_, Timestamp>,
+/// * `batcher_heap_size`: Whether to produce the [`Return::batcher_heap_size`] stream.
+pub(super) fn construct<'scope>(
+    scope: Scope<'scope, Timestamp>,
     config: &mz_compute_client::logging::LoggingConfig,
     event_queue: EventQueue<Vec<(Duration, DifferentialEvent)>>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
-) -> Return {
+    batcher_heap_size: bool,
+) -> Return<'scope> {
     let logging_interval_ms = std::cmp::max(1, config.interval.as_millis());
 
+    let outer = scope;
     scope.scoped("differential logging", move |scope| {
         let enable_logging = config.enable_logging;
         let (logs, token) = if enable_logging {
@@ -88,6 +98,8 @@ pub(super) fn construct(
         let (batcher_size_out, batcher_size) = demux.new_output();
         let (batcher_capacity_out, batcher_capacity) = demux.new_output();
         let (batcher_allocations_out, batcher_allocations) = demux.new_output();
+        let (batcher_heap_size_out, batcher_heap_size) =
+            batcher_heap_size.then(|| demux.new_output()).unzip();
 
         let mut batches_out = OutputBuilder::from(batches_out);
         let mut records_out = OutputBuilder::from(records_out);
@@ -96,6 +108,7 @@ pub(super) fn construct(
         let mut batcher_size_out = OutputBuilder::from(batcher_size_out);
         let mut batcher_capacity_out = OutputBuilder::from(batcher_capacity_out);
         let mut batcher_allocations_out = OutputBuilder::from(batcher_allocations_out);
+        let mut batcher_heap_size_out = batcher_heap_size_out.map(OutputBuilder::from);
 
         let mut demux_state = Default::default();
         demux.build(move |_capability| {
@@ -107,6 +120,8 @@ pub(super) fn construct(
                 let mut batcher_size = batcher_size_out.activate();
                 let mut batcher_capacity = batcher_capacity_out.activate();
                 let mut batcher_allocations = batcher_allocations_out.activate();
+                let mut batcher_heap_size =
+                    batcher_heap_size_out.as_mut().map(|out| out.activate());
 
                 input.for_each_time(|cap, data| {
                     let mut output_buffers = DemuxOutput {
@@ -117,6 +132,9 @@ pub(super) fn construct(
                         batcher_size: batcher_size.session_with_builder(&cap),
                         batcher_capacity: batcher_capacity.session_with_builder(&cap),
                         batcher_allocations: batcher_allocations.session_with_builder(&cap),
+                        batcher_heap_size: batcher_heap_size
+                            .as_mut()
+                            .map(|out| out.session_with_builder(&cap)),
                     };
 
                     for (time, event) in data.flat_map(|data: &mut Vec<_>| data.drain(..)) {
@@ -209,7 +227,10 @@ pub(super) fn construct(
             }
         }
 
-        Return { collections }
+        Return {
+            collections,
+            batcher_heap_size: batcher_heap_size.map(|stream| stream.leave(outer)),
+        }
     })
 }
 
@@ -230,6 +251,10 @@ struct DemuxOutput<'a, 'b> {
     batcher_size: OutputSession<'a, 'b, (usize, ())>,
     batcher_capacity: OutputSession<'a, 'b, (usize, ())>,
     batcher_allocations: OutputSession<'a, 'b, (usize, ())>,
+    /// Duplicates `batcher_size` for the watchdog, which consumes it unpacked. A second demux
+    /// output is cheaper than teeing the stream, which would clone every container. Absent unless
+    /// the watchdog is rendered.
+    batcher_heap_size: Option<OutputSession<'a, 'b, (usize, ())>>,
 }
 
 /// State maintained by the demux operator.
@@ -353,6 +378,9 @@ impl DemuxHandler<'_, '_, '_> {
         self.output
             .batcher_size
             .give(((operator_id, ()), ts, size_diff));
+        if let Some(output) = &mut self.output.batcher_heap_size {
+            output.give(((operator_id, ()), ts, size_diff));
+        }
         self.output
             .batcher_capacity
             .give(((operator_id, ()), ts, capacity_diff));

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -14,6 +14,7 @@ use differential_dataflow::VecCollection;
 use differential_dataflow::dynamic::pointstamp::PointStamp;
 use differential_dataflow::logging::{DifferentialEvent, DifferentialEventBuilder};
 use mz_compute_client::logging::{LogVariant, LoggingConfig};
+use mz_compute_types::dyncfgs::ENABLE_COMPUTE_HEAP_SIZE_LIMIT;
 use mz_dyncfg::ConfigSet;
 use mz_ore::metrics::MetricsRegistry;
 use mz_repr::{Diff, Timestamp};
@@ -48,6 +49,8 @@ pub fn initialize(
     worker_config: Rc<ConfigSet>,
     workers_per_process: usize,
     storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
+    heap_size_limits: Rc<RefCell<BTreeMap<usize, u64>>>,
+    dataflows_exceeding_heap_size_limit: Rc<RefCell<BTreeMap<usize, u64>>>,
 ) -> LoggingTraces {
     let interval_ms = std::cmp::max(1, config.interval.as_millis());
 
@@ -74,6 +77,8 @@ pub fn initialize(
         worker_config,
         workers_per_process,
         storage_log_reader,
+        heap_size_limits,
+        dataflows_exceeding_heap_size_limit,
     };
 
     // Depending on whether we should log the creation of the logging dataflows, we register the
@@ -114,6 +119,10 @@ struct LoggingContext<'a> {
     workers_per_process: usize,
     /// Optional reader for storage timely logging events.
     storage_log_reader: Option<crate::server::StorageTimelyLogReader>,
+    /// Heap size limit in bytes per Timely dataflow index, maintained by the compute state.
+    heap_size_limits: Rc<RefCell<BTreeMap<usize, u64>>>,
+    /// Timely dataflow indices the watchdog found to be over their heap size limit.
+    dataflows_exceeding_heap_size_limit: Rc<RefCell<BTreeMap<usize, u64>>>,
 }
 
 pub(crate) struct LoggingTraces {
@@ -148,26 +157,58 @@ impl LoggingContext<'_> {
             } = super::reachability::construct(scope, self.config, self.r_event_queue.clone());
             collections.extend(reachability_collections);
 
+            // Read once here so the compute and differential fragments agree on whether to
+            // produce the watchdog's inputs at all. Their demux outputs and the channels leaving
+            // the logging scope cost every replica, not just one enforcing a limit.
+            let heap_size_watchdog = ENABLE_COMPUTE_HEAP_SIZE_LIMIT.get(&self.worker_config);
+
             let super::differential::Return {
                 collections: differential_collections,
+                batcher_heap_size,
             } = super::differential::construct(
                 scope,
                 self.config,
                 self.d_event_queue.clone(),
                 Rc::clone(&self.shared_state),
+                heap_size_watchdog,
             );
             collections.extend(differential_collections);
 
             let super::compute::Return {
                 collections: compute_collections,
+                arrangement_heap_size,
+                arrangement_dataflows,
             } = super::compute::construct(
                 scope.clone(),
                 scope.activations(),
                 self.config,
                 self.c_event_queue.clone(),
                 Rc::clone(&self.shared_state),
+                heap_size_watchdog,
             );
             collections.extend(compute_collections);
+
+            if let (
+                Some(arrangement_heap_size),
+                Some(batcher_heap_size),
+                Some(arrangement_dataflows),
+            ) = (
+                arrangement_heap_size,
+                batcher_heap_size,
+                arrangement_dataflows,
+            ) {
+                let inputs = super::watchdog::Inputs {
+                    arrangement_heap_size,
+                    batcher_heap_size,
+                    arrangement_dataflows,
+                };
+                super::watchdog::construct(
+                    scope,
+                    inputs,
+                    Rc::clone(&self.heap_size_limits),
+                    Rc::clone(&self.dataflows_exceeding_heap_size_limit),
+                );
+            }
 
             let super::prometheus::Return {
                 collections: prometheus_collections,

--- a/src/compute/src/logging/watchdog.rs
+++ b/src/compute/src/logging/watchdog.rs
@@ -1,0 +1,168 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A dataflow fragment that reports dataflows exceeding their heap size limit.
+//!
+//! The fragment consumes the heap sizes the logging fragments already collect, attributes them to
+//! the dataflow hosting the reporting operator, and compares the per-dataflow total against the
+//! limit the controller installed for that dataflow.
+//!
+//! Accounting is approximate by construction. Only instrumented allocations are visible, and they
+//! are reported once per logging interval, so a dataflow can exceed its limit for up to an
+//! interval before the fragment notices. The design accepts that: the limit exists to stop
+//! runaway queries, not to bound memory exactly.
+
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
+
+use mz_ore::cast::CastFrom;
+use mz_repr::{Diff, Timestamp};
+use mz_timely_util::columnation::ColumnationChunker;
+use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::operators::Concatenate;
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use timely::dataflow::{Scope, StreamVec};
+
+use crate::extensions::arrange::MzArrangeCore;
+use crate::logging::Update;
+use crate::typedefs::spines::{ColKeyBatcher, ColKeyBuilder, ColValBatcher, ColValBuilder};
+use crate::typedefs::{KeySpine, KeyValSpine};
+
+/// The logging streams the watchdog derives its verdict from.
+pub(super) struct Inputs<'scope> {
+    /// Per-operator arrangement heap size deltas, in bytes carried in the diff field.
+    pub arrangement_heap_size: StreamVec<'scope, Timestamp, Update<(usize, ())>>,
+    /// Per-operator merge batcher heap size deltas, in bytes carried in the diff field.
+    pub batcher_heap_size: StreamVec<'scope, Timestamp, Update<(usize, ())>>,
+    /// Maps each arrangement operator to the dataflow hosting it, for as long as it exists.
+    pub arrangement_dataflows: StreamVec<'scope, Timestamp, Update<(usize, usize)>>,
+}
+
+/// Renders the watchdog fragment.
+///
+/// `limits` maps a Timely dataflow index to the heap size limit in bytes the controller set for
+/// it, and is maintained by the compute state as dataflows come and go. A dataflow whose total
+/// heap size reaches its limit is recorded in `exceeded`, together with the size observed, which
+/// the worker's main loop drains and turns into controller responses.
+pub(super) fn construct<'scope>(
+    scope: Scope<'scope, Timestamp>,
+    inputs: Inputs<'scope>,
+    limits: Rc<RefCell<BTreeMap<usize, u64>>>,
+    exceeded: Rc<RefCell<BTreeMap<usize, u64>>>,
+) {
+    let Inputs {
+        arrangement_heap_size,
+        batcher_heap_size,
+        arrangement_dataflows,
+    } = inputs;
+
+    // Both size streams are keyed by the global ID of the arrangement operator: Differential logs
+    // a merge batcher under the ID of the operator that owns it.
+    let operator_heap_size = scope.concatenate([arrangement_heap_size, batcher_heap_size]);
+
+    // Arrange worker-locally. Every worker sees the same operator-to-dataflow mapping, so
+    // exchanging it would inflate the mapping's multiplicity by the worker count, and the join's
+    // diff multiplication would inflate the byte counts along with it.
+    let operator_heap_size = operator_heap_size.mz_arrange_core::<
+        _,
+        ColumnationChunker<_>,
+        ColKeyBatcher<_, _, _>,
+        ColKeyBuilder<_, _, _>,
+        KeySpine<usize, Timestamp, Diff>,
+    >(Pipeline, "Arrange watchdog operator heap size");
+    let arrangement_dataflows = arrangement_dataflows.mz_arrange_core::<
+        _,
+        ColumnationChunker<_>,
+        ColValBatcher<_, _, _, _>,
+        ColValBuilder<_, _, _, _>,
+        KeyValSpine<usize, usize, Timestamp, Diff>,
+    >(Pipeline, "Arrange watchdog operator dataflows");
+
+    let dataflow_heap_size = operator_heap_size
+        .join_core(arrangement_dataflows, |_operator, &(), &dataflow| {
+            Some((dataflow, ()))
+        });
+
+    // Summing across workers happens here, in the exchange: every worker's subtotal for a given
+    // dataflow lands on the same worker, which is the only one that can see the replica-wide
+    // total and hence the only one that reports.
+    let pact = Exchange::new(|((dataflow, ()), _time, _diff): &Update<(usize, ())>| {
+        u64::cast_from(*dataflow)
+    });
+
+    let mut builder = OperatorBuilder::new("Watchdog: heap size limits".to_string(), scope);
+    let mut input = builder.new_input(dataflow_heap_size.inner, pact);
+
+    builder.build(move |_capabilities| {
+        // Heap size deltas that the input frontier has not yet closed out. Folding them into the
+        // totals early would let a transient over-count fail a query that never exceeded its
+        // limit, because a retraction and the addition it cancels can arrive out of order across
+        // workers.
+        let mut pending: BTreeMap<Timestamp, Vec<(usize, Diff)>> = BTreeMap::new();
+        let mut totals: BTreeMap<usize, Diff> = BTreeMap::new();
+        // Dataflows already reported. The controller acts on the first report by failing the
+        // query, so repeating it for every subsequent size change is noise.
+        let mut reported: BTreeSet<usize> = BTreeSet::new();
+
+        move |frontiers| {
+            input.for_each_time(|_cap, data| {
+                for ((dataflow, ()), time, diff) in
+                    data.flat_map(|data: &mut Vec<_>| data.drain(..))
+                {
+                    pending.entry(time).or_default().push((dataflow, diff));
+                }
+            });
+
+            let limits = limits.borrow();
+
+            let frontier = &frontiers[0];
+            let mut touched = BTreeSet::new();
+            while let Some(entry) = pending.first_entry() {
+                if frontier.less_equal(entry.key()) {
+                    break;
+                }
+                for (dataflow, diff) in entry.remove() {
+                    // A dataflow's limit is installed before it is rendered, so anything absent
+                    // here will never gain a limit and is not worth accounting for.
+                    if !limits.contains_key(&dataflow) {
+                        continue;
+                    }
+                    *totals.entry(dataflow).or_default() += diff;
+                    touched.insert(dataflow);
+                }
+            }
+
+            // A dataflow's limit is dropped along with the dataflow, which is the signal that its
+            // accounting can go too. The size updates do balance out to zero on their own, but
+            // only once the drop has worked its way through the logging streams.
+            totals.retain(|dataflow, _| limits.contains_key(dataflow));
+            reported.retain(|dataflow| limits.contains_key(dataflow));
+
+            if touched.is_empty() {
+                return;
+            }
+
+            let mut exceeded = exceeded.borrow_mut();
+            for dataflow in touched {
+                let Some(&total) = totals.get(&dataflow) else {
+                    continue;
+                };
+                let Ok(heap_size) = u64::try_from(total.into_inner()) else {
+                    continue;
+                };
+                let limit = limits[&dataflow];
+                // Strictly greater: a dataflow that lands exactly on its limit is within it.
+                if heap_size > limit && reported.insert(dataflow) {
+                    exceeded.insert(dataflow, heap_size);
+                }
+            }
+        }
+    });
+}

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -483,6 +483,7 @@ impl<'w> Worker<'w> {
                 compute_state.process_peeks();
                 compute_state.process_subscribes();
                 compute_state.process_copy_tos();
+                compute_state.process_heap_size_limits();
             }
         }
     }

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -256,13 +256,13 @@ impl SubscribeProtocol {
         let updates = match (&self.poison, ship_errors.first()) {
             (Some(error), _) => {
                 // The subscribe is poisoned; keep sending the same error.
-                Err(error.clone())
+                Err(error.clone().into())
             }
             (None, Some((_, error, _))) => {
                 // The subscribe encountered its first error; poison it.
                 let error = error.to_string();
                 self.poison = Some(error.clone());
-                Err(error)
+                Err(error.into())
             }
             (None, None) => {
                 // No error encountered so for; ship the rows we have!

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -933,6 +933,17 @@ impl SessionVars {
             .as_bytes()
     }
 
+    /// Returns the value of the `max_query_heap_size` configuration parameter.
+    ///
+    /// Zero reads as no limit, the same as an unset value, because a query that may occupy no
+    /// heap at all cannot run.
+    pub fn max_query_heap_size(&self) -> Option<u64> {
+        self.expect_value::<Option<ByteSize>>(&MAX_QUERY_HEAP_SIZE)
+            .as_ref()
+            .map(ByteSize::as_bytes)
+            .filter(|size| *size > 0)
+    }
+
     /// Sets the internal metadata associated with the user.
     pub fn set_internal_user_metadata(&mut self, metadata: InternalUserMetadata) {
         self.user.internal_metadata = Some(metadata);
@@ -2526,6 +2537,7 @@ static SESSION_SYSTEM_VARS: LazyLock<BTreeMap<&'static UncasedStr, &'static VarD
             &TIMEZONE,
             &TRANSACTION_ISOLATION,
             &MAX_QUERY_RESULT_SIZE,
+            &MAX_QUERY_HEAP_SIZE,
         ]
         .into_iter()
         .map(|var| (UncasedStr::new(var.name()), var))

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -604,6 +604,13 @@ pub static MAX_QUERY_RESULT_SIZE: VarDefinition = VarDefinition::new(
     true,
 );
 
+pub static MAX_QUERY_HEAP_SIZE: VarDefinition = VarDefinition::new(
+    "max_query_heap_size",
+    value!(Option<ByteSize>; None),
+    "The maximum heap size in bytes that a single query's dataflow may occupy (Materialize).",
+    true,
+);
+
 pub static MAX_COPY_FROM_ROW_SIZE: VarDefinition = VarDefinition::new(
     "max_copy_from_row_size",
     value!(ByteSize; ByteSize::mb(128)),

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -158,6 +158,7 @@ SESSION_VARIABLES = {
     "idle_in_transaction_session_timeout",
     "timezone",
     "transaction_isolation",
+    "max_query_heap_size",
     "max_query_result_size",
     # Pseudo-variables added by SessionVars::iter.
     "mz_version",

--- a/test/testdrive/query_heap_size.td
+++ b/test/testdrive/query_heap_size.td
@@ -1,0 +1,147 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test the `max_query_heap_size` session variable.
+
+$ set-regex match=\d{13,20} replacement=<TIMESTAMP>
+
+# The watchdog that enforces the limit is rendered when a replica initializes its logging dataflow,
+# so the flag has to be set before the clusters below are created.
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET enable_compute_heap_size_limit = true
+
+# Two workers, so that the per-dataflow subtotals are exchanged and summed across workers rather
+# than read off a single one.
+#
+# The introspection interval bounds how quickly the watchdog can observe a dataflow, and the two
+# clusters want opposite things from it. A subscribe delivers its snapshot from the `as_of` the
+# coordinator picked before the dataflow existed, so a long interval makes "snapshot first, error
+# second" deterministic. A peek's dataflow lives only as long as the peek, so a short interval is
+# what gives the watchdog a chance to see it at all.
+
+> CREATE CLUSTER heap_limit_subscribe (SIZE 'scale=1,workers=2', INTROSPECTION INTERVAL '5s')
+
+> CREATE CLUSTER heap_limit_peek (SIZE 'scale=1,workers=2', INTROSPECTION INTERVAL '10ms')
+
+> CREATE TABLE t (a int4, b text)
+
+> INSERT INTO t SELECT generate_series, repeat('a', 100) FROM generate_series(1, 50000)
+
+> SHOW max_query_heap_size
+""
+
+> SET cluster = heap_limit_subscribe
+
+# Without a limit the subscribe keeps running.
+
+> BEGIN
+
+> DECLARE c CURSOR FOR SUBSCRIBE (SELECT count(*) FROM (SELECT a, max(b) FROM t GROUP BY a))
+
+> FETCH 1 c
+<TIMESTAMP> 1 50000
+
+> FETCH 1 c WITH (TIMEOUT = '2s')
+
+> ROLLBACK
+
+# A limit the dataflow stays well below does not disturb it either.
+
+> SET max_query_heap_size = '512MB'
+
+> BEGIN
+
+> DECLARE c CURSOR FOR SUBSCRIBE (SELECT count(*) FROM (SELECT a, max(b) FROM t GROUP BY a))
+
+> FETCH 1 c
+<TIMESTAMP> 1 50000
+
+> FETCH 1 c WITH (TIMEOUT = '2s')
+
+> ROLLBACK
+
+# A limit the dataflow cannot meet fails the subscribe. The grouped subquery arranges a row per
+# key, which puts it well above the limit set here.
+
+> SET max_query_heap_size = '1kB'
+
+> BEGIN
+
+> DECLARE c CURSOR FOR SUBSCRIBE (SELECT count(*) FROM (SELECT a, max(b) FROM t GROUP BY a))
+
+> FETCH 1 c
+<TIMESTAMP> 1 50000
+
+# The timeout bounds a regression: without it a fetch that never errors blocks the whole run rather
+# than failing it.
+! FETCH 1 c WITH (TIMEOUT = '60s')
+contains:query exceeded the max_query_heap_size limit
+
+> ROLLBACK
+
+# Zero reads as no limit, so the same subscribe runs again.
+
+> SET max_query_heap_size = 0
+
+> BEGIN
+
+> DECLARE c CURSOR FOR SUBSCRIBE (SELECT count(*) FROM (SELECT a, max(b) FROM t GROUP BY a))
+
+> FETCH 1 c
+<TIMESTAMP> 1 50000
+
+> FETCH 1 c WITH (TIMEOUT = '2s')
+
+> ROLLBACK
+
+> RESET max_query_heap_size
+
+> SHOW max_query_heap_size
+""
+
+# The same limit applies to a slow-path peek, which renders a dataflow of its own and fails through
+# the peek response path rather than the subscribe one.
+#
+# NOTE: unlike the subscribe above, this is not ordering-proof. Whichever of the watchdog's report
+# and the replica's own peek response reaches the controller first wins, because the first one
+# retires the peek. The 10ms introspection interval on this cluster buys a wide margin over a
+# reduce across 50k rows, but if it ever proves too narrow, the lever is a larger or deliberately
+# slower input rather than a shorter interval.
+
+> SET cluster = heap_limit_peek
+
+> SELECT count(*) FROM (SELECT a, max(b) FROM t GROUP BY a)
+50000
+
+> SET max_query_heap_size = '1kB'
+
+! SELECT count(*) FROM (SELECT a, max(b) FROM t GROUP BY a)
+contains:query exceeded the max_query_heap_size limit
+
+# A fast-path peek reads an existing arrangement rather than rendering a dataflow, so it carries no
+# limit and is unaffected.
+
+> CREATE INDEX t_a ON t (a)
+
+> SELECT a FROM t WHERE a = 1
+1
+
+> RESET max_query_heap_size
+
+> RESET cluster
+
+> DROP TABLE t CASCADE
+
+> DROP CLUSTER heap_limit_subscribe
+
+> DROP CLUSTER heap_limit_peek
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM RESET enable_compute_heap_size_limit

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -52,6 +52,7 @@ max_mysql_connections                    1000                    "The maximum nu
 max_network_policies                     25                      "The maximum number of network policies in the region."
 max_objects_per_schema                   1000                    "The maximum number of objects in a schema (Materialize)."
 max_postgres_connections                 1000                    "The maximum number of PostgreSQL connections in the region, across all schemas (Materialize)."
+max_query_heap_size                      ""                      "The maximum heap size in bytes that a single query's dataflow may occupy (Materialize)."
 max_query_result_size                    "1GB"                   "The maximum size in bytes for a single query's result (Materialize)."
 max_replicas_per_cluster                 5                       "The maximum number of replicas of a single cluster (Materialize)."
 max_result_size                          "1GB"                   "The maximum size in bytes for an internal query result (Materialize)."


### PR DESCRIPTION
Adds a `max_query_heap_size` session variable that bounds the heap a transient
dataflow may occupy. Peeks and subscribes carry the limit on their
`DataflowDescription`; a replica observes the heap sizes its logging fragments
already collect and reports a dataflow that reaches its limit back to the
controller, which fails the query.

The accounting lives in a new watchdog logging fragment. It joins arrangement
and merge batcher heap sizes against the dataflow that hosts the reporting
operator, sums the result across the replica's workers, and compares the total
against the limit the compute state installed when it created the dataflow.
Accounting is approximate: only instrumented allocations are visible, and they
surface once per logging interval, so a dataflow can exceed its limit briefly
before the fragment notices.

Exceeding the limit is a user-facing condition, so it travels as a variant of
its own on both response paths. `PeekError::HeapSizeLimitExceeded` and the new
`SubscribeError::HeapSizeLimitExceeded` become
`AdapterError::QueryHeapSizeLimitExceeded`, which reports `OUT_OF_MEMORY` with a
hint naming the session variable. Other subscribe errors stay unstructured, so
`SubscribeError` starts with the two variants it needs rather than a full
classification of what a subscribe can fail with.

Everything the feature costs is gated behind the replica-scoped
`enable_compute_heap_size_limit` dyncfg, which is off in production: the
watchdog fragment, the demux outputs feeding it, and the channels those leave
the logging scope through. A replica that enforces no limits runs exactly the
dataflow it ran before, which is why this branch leaves the introspection
goldens untouched. The two directions of the flag are not symmetric. A replica
decides whether to render the watchdog once, when it initializes logging, so
enabling only takes effect on replicas created afterwards; disabling takes
effect immediately, because a replica also consults the flag when it installs a
dataflow's limit.

`mz_compute_heap_size_limits_exceeded_total` counts the queries failed this way,
per instance.

### Relation to #31246

This supersedes #31246, which was written against a tree from March 2025. The
replica-side code is a rewrite rather than a rebase: the compute protocol has
since dropped protobuf, and the logging fragments were rebuilt on the current
Timely and Differential APIs. `StatusResponse::Placeholder`, which main carries
"in anticipation of materialize#31246", becomes the real variant here.

Behavioral differences from that revision, beyond the port:

* Per-worker relations are arranged with `Pipeline` rather than an exchange.
  Every worker produces the same operator-to-dataflow mapping and the same
  per-dataflow limit, so exchanging them multiplied each relation's multiplicity
  by the worker count, and the joins multiplied the observed byte counts along
  with it.
* The limits reach the fragment through shared state rather than a Timely input
  handle, which removes the per-iteration handle advancement that derived a
  logging timestamp from `SYSTEM_TIME`.
* The dyncfg gates the fragment and its inputs. Previously it gated only the
  limit bookkeeping, so every replica paid for the fragment's arrangements
  whether or not the feature was in use.
* A dataflow is reported once rather than on every subsequent size change.
* Over-limit peeks are failed through the same path as a replica-reported peek
  error, so they are neither counted nor notified as user cancellations, and a
  replica that is not a targeted peek's target does not fail it.
* `Bifurcate`, a general-purpose two-output operator added to `mz-timely-util`
  to tap the logging streams, is gone. The streams are demux outputs, which is
  how the logging fragments produce them anyway.

### Review comments from #31246

* Bundling the limits into a `QueryResourceLimits` (teskje, frankmcsherry,
  ParkMyCar): moot. `peek_finish` reads the variable from the session the way
  `subscribe_finish` already did, so the parameter never crosses the peek stages
  and `coord.rs` is untouched.
* Enforcing the limit for `INSERT/UPDATE ... SELECT` (teskje, ParkMyCar): the
  limit now applies there, for the same reason. `max_query_result_size` stays
  unset on that path, since it bounds a result the user does not see.
* Reporting which limit was exceeded (teskje): the status is
  `HeapSizeLimitExceeded`, carries the observed size and the limit, and the
  error names `max_query_heap_size`.
* Reporting a collection that is neither a peek nor a subscribe (teskje): a
  collection the controller does not know is a soft panic. A known collection
  with no reader left is expected, because every replica reports independently
  and the first report finishes the query.
* `SET max_query_heap_size = 0` and `RESET max_query_heap_size` (ParkMyCar):
  both read as no limit, and the test covers both.

Not addressed: `COPY TO` dataflows still carry no limit. User documentation is
in #38554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)