### PR TITLE
mz-deploy: reconcile comments

### DIFF
--- a/src/mz-deploy/src/cli/commands.rs
+++ b/src/mz-deploy/src/cli/commands.rs
@@ -63,6 +63,7 @@ pub mod apply_sources;
 pub mod apply_tables;
 pub mod clean;
 pub mod clusters;
+pub mod comments;
 pub mod compile;
 pub mod debug;
 pub mod delete;

--- a/src/mz-deploy/src/cli/commands/apply_connections.rs
+++ b/src/mz-deploy/src/cli/commands/apply_connections.rs
@@ -16,7 +16,7 @@ use crate::cli::executor::ObjectAction;
 use crate::cli::executor::{
     ApplyPlan, ApplyResult, DeploymentExecutor, ObjectResult, compile_apply_project_and_connect,
 };
-use crate::client::Client;
+use crate::client::{Client, ObjectComment};
 use crate::config::Settings;
 use crate::project;
 use crate::project::ast::Statement;
@@ -54,6 +54,7 @@ impl Connections {
         executor: &DeploymentExecutor<'_>,
         obj_id: &ObjectId,
         typed_obj: &compiled::DatabaseObject,
+        current_comments: &[ObjectComment],
         live_sql: Option<&str>,
     ) -> Result<ObjectAction, CliError> {
         let Statement::CreateConnection(ref create_stmt) = typed_obj.stmt else {
@@ -108,6 +109,7 @@ impl Connections {
             obj_id,
             typed_obj,
             OBJECT_KIND,
+            current_comments,
         )
         .await?;
 
@@ -120,6 +122,7 @@ impl Connections {
         executor: &DeploymentExecutor<'_>,
         obj_id: &ObjectId,
         typed_obj: &compiled::DatabaseObject,
+        current_comments: &[ObjectComment],
     ) -> Result<ObjectAction, CliError> {
         let resolved_stmt = match self
             .resolver
@@ -138,6 +141,7 @@ impl Connections {
             obj_id,
             typed_obj,
             OBJECT_KIND,
+            current_comments,
         )
         .await?;
 
@@ -174,6 +178,11 @@ pub async fn plan(
         .check_catalog_objects_exist(&target_ids, OBJECT_KIND.catalog_table())
         .await
         .map_err(CliError::Connection)?;
+    let current_comments = client
+        .introspection()
+        .get_database_object_comments(&existing, OBJECT_KIND.catalog_object_type())
+        .await
+        .map_err(CliError::Connection)?;
     let live_sqls = client
         .introspection()
         .get_connection_create_sqls(&existing)
@@ -205,12 +214,19 @@ pub async fn plan(
                     executor,
                     &obj_id,
                     typed_obj,
+                    current_comments.get(&obj_id).map_or(&[], Vec::as_slice),
                     live_sqls.get(&obj_id).map(String::as_str),
                 )
                 .await?
         } else {
             connections
-                .handle_new(client, executor, &obj_id, typed_obj)
+                .handle_new(
+                    client,
+                    executor,
+                    &obj_id,
+                    typed_obj,
+                    current_comments.get(&obj_id).map_or(&[], Vec::as_slice),
+                )
                 .await?
         };
         results.push(ObjectResult {

--- a/src/mz-deploy/src/cli/commands/apply_network_policies.rs
+++ b/src/mz-deploy/src/cli/commands/apply_network_policies.rs
@@ -10,15 +10,17 @@
 //! Network policies apply command - converge live network policy state to match definitions.
 
 use crate::cli::CliError;
-use crate::cli::commands::grants;
 use crate::cli::commands::reconcile::{ObjectKind, ReconcileTarget};
+use crate::cli::commands::{comments, grants};
 use crate::cli::executor::{
     ApplyPlan, ApplyResult, DeploymentExecutor, ObjectAction, ObjectResult, connect_apply_client,
 };
-use crate::client::Client;
+use crate::client::{Client, ObjectComment};
 use crate::config::Settings;
 use crate::project::network_policies::{self, NetworkPolicyDefinition};
 use mz_sql_parser::ast::AlterNetworkPolicyStatement;
+
+const OBJECT_KIND: ObjectKind = ObjectKind::NetworkPolicy;
 
 /// Plan network policy changes without executing or printing.
 pub async fn plan(
@@ -40,16 +42,23 @@ pub async fn plan(
     }
 
     let names: Vec<&str> = definitions.iter().map(|def| def.name.as_str()).collect();
-    let existing = client
-        .introspection()
-        .existing_network_policies(&names)
-        .await
-        .map_err(CliError::Connection)?;
+    let introspection = client.introspection();
+    let (existing, current_comments) = futures::try_join!(
+        introspection.existing_network_policies(&names),
+        introspection.get_named_object_comments(OBJECT_KIND.catalog_table(), &names),
+    )
+    .map_err(CliError::Connection)?;
 
     let mut object_results = Vec::new();
     for def in &definitions {
-        let obj_result =
-            plan_network_policy(client, executor, def, existing.contains(&def.name)).await?;
+        let obj_result = plan_network_policy(
+            client,
+            executor,
+            def,
+            existing.contains(&def.name),
+            current_comments.get(&def.name).map_or(&[], Vec::as_slice),
+        )
+        .await?;
         object_results.push(obj_result);
     }
 
@@ -81,6 +90,7 @@ async fn plan_network_policy(
     executor: &DeploymentExecutor<'_>,
     def: &NetworkPolicyDefinition,
     exists: bool,
+    current_comments: &[ObjectComment],
 ) -> Result<ObjectResult, CliError> {
     let policy_name = &def.name;
 
@@ -100,19 +110,9 @@ async fn plan_network_policy(
         ObjectAction::Created
     };
 
-    // Reconcile grants
-    grants::reconcile(
-        client,
-        executor,
-        &ReconcileTarget::named(ObjectKind::NetworkPolicy, policy_name),
-        &def.grants,
-    )
-    .await?;
-
-    // Execute COMMENT statements
-    for comment in &def.comments {
-        executor.execute_sql(comment).await?;
-    }
+    let target = ReconcileTarget::named(OBJECT_KIND, policy_name);
+    grants::reconcile(client, executor, &target, &def.grants).await?;
+    comments::reconcile(executor, &target, &def.comments, current_comments).await?;
 
     Ok(ObjectResult {
         object: policy_name.clone(),

--- a/src/mz-deploy/src/cli/commands/apply_objects.rs
+++ b/src/mz-deploy/src/cli/commands/apply_objects.rs
@@ -7,33 +7,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Shared helpers for apply commands that reconcile grants/comments on database objects.
+//! Shared helpers for apply commands that reconcile grants and comments on
+//! database objects.
 
 use crate::cli::CliError;
-use crate::cli::commands::grants;
 use crate::cli::commands::reconcile::{ObjectKind, ReconcileTarget};
+use crate::cli::commands::{comments, grants};
 use crate::cli::executor::DeploymentExecutor;
-use crate::client::Client;
+use crate::client::{Client, ObjectComment};
 use crate::project::ir::compiled;
 use crate::project::ir::object_id::ObjectId;
 
-/// Reconcile grants and execute comment statements for one database object.
+/// Reconcile grants and comments for one database object against `current_comments`,
+/// the comments the catalog holds for it.
 pub async fn reconcile_grants_and_comments(
     client: &Client,
     executor: &DeploymentExecutor<'_>,
     obj_id: &ObjectId,
     typed_obj: &compiled::DatabaseObject,
     kind: ObjectKind,
+    current_comments: &[ObjectComment],
 ) -> Result<(), CliError> {
-    grants::reconcile(
-        client,
-        executor,
-        &ReconcileTarget::item(kind, obj_id),
-        &typed_obj.grants,
-    )
-    .await?;
-    for comment in &typed_obj.comments {
-        executor.execute_sql(comment).await?;
-    }
-    Ok(())
+    let target = ReconcileTarget::item(kind, obj_id);
+    grants::reconcile(client, executor, &target, &typed_obj.grants).await?;
+    comments::reconcile(executor, &target, &typed_obj.comments, current_comments).await
 }

--- a/src/mz-deploy/src/cli/commands/apply_secrets.rs
+++ b/src/mz-deploy/src/cli/commands/apply_secrets.rs
@@ -16,7 +16,7 @@ use crate::cli::executor::ObjectAction;
 use crate::cli::executor::{
     ApplyPlan, ApplyResult, DeploymentExecutor, ObjectResult, compile_apply_project_and_connect,
 };
-use crate::client::Client;
+use crate::client::{Client, ObjectComment};
 use crate::config::Settings;
 use crate::project;
 use crate::project::ast::Statement;
@@ -50,6 +50,7 @@ impl Secrets {
         executor: &DeploymentExecutor<'_>,
         obj_id: &ObjectId,
         typed_obj: &compiled::DatabaseObject,
+        current_comments: &[ObjectComment],
     ) -> Result<(ObjectAction, Vec<String>), CliError> {
         let Statement::CreateSecret(ref create_stmt) = typed_obj.stmt else {
             unreachable!("filtered for CreateSecret");
@@ -68,6 +69,7 @@ impl Secrets {
             obj_id,
             typed_obj,
             OBJECT_KIND,
+            current_comments,
         )
         .await?;
 
@@ -80,6 +82,7 @@ impl Secrets {
         executor: &DeploymentExecutor<'_>,
         obj_id: &ObjectId,
         typed_obj: &compiled::DatabaseObject,
+        current_comments: &[ObjectComment],
     ) -> Result<(ObjectAction, Vec<String>), CliError> {
         let Statement::CreateSecret(ref create_stmt) = typed_obj.stmt else {
             unreachable!("filtered for CreateSecret");
@@ -93,6 +96,7 @@ impl Secrets {
             obj_id,
             typed_obj,
             OBJECT_KIND,
+            current_comments,
         )
         .await?;
 
@@ -129,6 +133,11 @@ pub async fn plan(
         .check_catalog_objects_exist(&target_ids, OBJECT_KIND.catalog_table())
         .await
         .map_err(CliError::Connection)?;
+    let current_comments = client
+        .introspection()
+        .get_database_object_comments(&existing, OBJECT_KIND.catalog_object_type())
+        .await
+        .map_err(CliError::Connection)?;
 
     let schemas: BTreeSet<_> = target_objects
         .iter()
@@ -150,11 +159,23 @@ pub async fn plan(
         executor.take_statements();
         let (action, redacted_statements) = if existing.contains(&obj_id) {
             secrets
-                .handle_existing(client, executor, &obj_id, typed_obj)
+                .handle_existing(
+                    client,
+                    executor,
+                    &obj_id,
+                    typed_obj,
+                    current_comments.get(&obj_id).map_or(&[], Vec::as_slice),
+                )
                 .await?
         } else {
             secrets
-                .handle_new(client, executor, &obj_id, typed_obj)
+                .handle_new(
+                    client,
+                    executor,
+                    &obj_id,
+                    typed_obj,
+                    current_comments.get(&obj_id).map_or(&[], Vec::as_slice),
+                )
                 .await?
         };
         results.push(ObjectResult {

--- a/src/mz-deploy/src/cli/commands/apply_sources.rs
+++ b/src/mz-deploy/src/cli/commands/apply_sources.rs
@@ -57,6 +57,11 @@ pub async fn plan(
         .check_catalog_objects_exist(&target_ids, OBJECT_KIND.catalog_table())
         .await
         .map_err(CliError::Connection)?;
+    let current_comments = client
+        .introspection()
+        .get_database_object_comments(&existing, OBJECT_KIND.catalog_object_type())
+        .await
+        .map_err(CliError::Connection)?;
 
     let schemas: BTreeSet<_> = target_objects
         .iter()
@@ -84,6 +89,7 @@ pub async fn plan(
                 &obj_id,
                 typed_obj,
                 OBJECT_KIND,
+                current_comments.get(&obj_id).map_or(&[], Vec::as_slice),
             )
             .await?;
             ObjectAction::UpToDate
@@ -98,6 +104,7 @@ pub async fn plan(
                 &obj_id,
                 typed_obj,
                 OBJECT_KIND,
+                current_comments.get(&obj_id).map_or(&[], Vec::as_slice),
             )
             .await?;
             ObjectAction::Created

--- a/src/mz-deploy/src/cli/commands/apply_tables.rs
+++ b/src/mz-deploy/src/cli/commands/apply_tables.rs
@@ -61,6 +61,11 @@ pub async fn plan(
         .check_catalog_objects_exist(&target_ids, OBJECT_KIND.catalog_table())
         .await
         .map_err(CliError::Connection)?;
+    let current_comments = client
+        .introspection()
+        .get_database_object_comments(&existing, OBJECT_KIND.catalog_object_type())
+        .await
+        .map_err(CliError::Connection)?;
 
     let to_create: BTreeSet<_> = target_ids.difference(&existing).cloned().collect();
     client
@@ -94,6 +99,7 @@ pub async fn plan(
                 &obj_id,
                 typed_obj,
                 OBJECT_KIND,
+                current_comments.get(&obj_id).map_or(&[], Vec::as_slice),
             )
             .await?;
             results.push(ObjectResult {
@@ -119,6 +125,7 @@ pub async fn plan(
             &obj_id,
             typed_obj,
             OBJECT_KIND,
+            current_comments.get(&obj_id).map_or(&[], Vec::as_slice),
         )
         .await?;
         let post_statements = executor.take_statements();

--- a/src/mz-deploy/src/cli/commands/clusters.rs
+++ b/src/mz-deploy/src/cli/commands/clusters.rs
@@ -12,12 +12,12 @@
 use std::collections::BTreeMap;
 
 use crate::cli::CliError;
-use crate::cli::commands::grants;
 use crate::cli::commands::reconcile::{ObjectKind, ReconcileTarget};
+use crate::cli::commands::{comments, grants};
 use crate::cli::executor::{
     ApplyPlan, ApplyResult, DeploymentExecutor, ObjectAction, ObjectResult, connect_apply_client,
 };
-use crate::client::{Client, parse_create_cluster, quote_identifier};
+use crate::client::{Client, ObjectComment, parse_create_cluster, quote_identifier};
 use crate::config::Settings;
 use crate::project::clusters::{self, ClusterDefinition};
 use mz_repr::adt::interval::Interval;
@@ -26,6 +26,8 @@ use mz_sql_parser::ast::visit_mut::VisitMut;
 use mz_sql_parser::ast::{
     ClusterOption, ClusterOptionName, CreateClusterStatement, Raw, Value, WithOptionValue,
 };
+
+const OBJECT_KIND: ObjectKind = ObjectKind::Cluster;
 
 /// Plan cluster changes without executing or printing.
 pub async fn plan(
@@ -51,19 +53,35 @@ pub async fn plan(
     }
 
     let names: Vec<&str> = definitions.iter().map(|def| def.name.as_str()).collect();
-    let (live, default_replication_factor) =
-        futures::try_join!(live_clusters(client, &names), async {
+    let (live, current_comments, default_replication_factor) = futures::try_join!(
+        live_clusters(client, &names),
+        async {
+            client
+                .introspection()
+                .get_named_object_comments(OBJECT_KIND.catalog_table(), &names)
+                .await
+                .map_err(CliError::Connection)
+        },
+        async {
             client
                 .default_cluster_replication_factor()
                 .await
                 .map_err(CliError::Connection)
-        })?;
+        },
+    )?;
     let defaults = default_options(default_replication_factor);
 
     let mut object_results = Vec::new();
     for def in &definitions {
-        let obj_result =
-            plan_cluster(client, executor, def, live.get(&def.name), &defaults).await?;
+        let obj_result = plan_cluster(
+            client,
+            executor,
+            def,
+            live.get(&def.name),
+            &defaults,
+            current_comments.get(&def.name).map_or(&[], Vec::as_slice),
+        )
+        .await?;
         object_results.push(obj_result);
     }
 
@@ -96,6 +114,7 @@ async fn plan_cluster(
     def: &ClusterDefinition,
     live: Option<&CreateClusterStatement<Raw>>,
     defaults: &BTreeMap<ClusterOptionName, WithOptionValue<Raw>>,
+    current_comments: &[ObjectComment],
 ) -> Result<ObjectResult, CliError> {
     let cluster_name = &def.name;
 
@@ -142,19 +161,9 @@ async fn plan_cluster(
         }
     };
 
-    // Reconcile grants
-    grants::reconcile(
-        client,
-        executor,
-        &ReconcileTarget::named(ObjectKind::Cluster, cluster_name),
-        &def.grants,
-    )
-    .await?;
-
-    // Execute COMMENT statements
-    for comment in &def.comments {
-        executor.execute_sql(comment).await?;
-    }
+    let target = ReconcileTarget::named(OBJECT_KIND, cluster_name);
+    grants::reconcile(client, executor, &target, &def.grants).await?;
+    comments::reconcile(executor, &target, &def.comments, current_comments).await?;
 
     Ok(ObjectResult {
         object: cluster_name.clone(),

--- a/src/mz-deploy/src/cli/commands/comments.rs
+++ b/src/mz-deploy/src/cli/commands/comments.rs
@@ -1,0 +1,294 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Shared helpers for comment reconciliation across apply commands.
+//!
+//! Mirrors [`super::grants`]: read the comments recorded in the catalog, then
+//! emit only the `COMMENT ON` statements that close the gap between them and
+//! what the project declares. A comment the project no longer declares is
+//! cleared with `COMMENT ON ... IS NULL`, so the project is the source of truth
+//! for comments on the objects it manages.
+
+use crate::cli::CliError;
+use crate::cli::commands::reconcile::ReconcileTarget;
+use crate::cli::executor::DeploymentExecutor;
+use crate::client::ObjectComment;
+use crate::info;
+use mz_sql_parser::ast::{CommentObjectType, CommentStatement, Raw};
+use owo_colors::{OwoColorize, Stream, Style};
+use std::collections::BTreeMap;
+
+/// What a comment attaches to within one object.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CommentTarget {
+    /// The object itself.
+    Object,
+    /// One of the object's columns, by name.
+    ///
+    /// Column names are compared verbatim: the parser has already folded
+    /// unquoted identifiers to the casing the catalog stores.
+    Column(String),
+}
+
+/// Reconcile comments on one object: set what differs, clear what the project
+/// no longer declares.
+pub async fn reconcile(
+    executor: &DeploymentExecutor<'_>,
+    object: &ReconcileTarget<'_>,
+    comments: &[CommentStatement<Raw>],
+    current: &[ObjectComment],
+) -> Result<(), CliError> {
+    let desired = desired_comments(comments);
+    let changes = comment_changes(&desired, current, object);
+
+    let dash_style = Style::new().red().bold();
+    for stmt in &changes {
+        if stmt.comment.is_none() && !executor.is_dry_run() {
+            info!(
+                "  {} Clearing stale comment on {} '{}'",
+                "-".if_supports_color(Stream::Stderr, |t| dash_style.style(t)),
+                object.kind().label(),
+                object.display_name(),
+            );
+        }
+        executor.execute_sql(stmt).await?;
+    }
+    Ok(())
+}
+
+/// Extract the comment text each target should carry.
+///
+/// An authored `COMMENT ON ... IS NULL` declares the absence of a comment, so it
+/// is left out here and handled by the same path that clears stale comments.
+/// When a project declares the same target twice, the last statement wins, which
+/// matches the order the server would have applied them in.
+pub fn desired_comments(comments: &[CommentStatement<Raw>]) -> BTreeMap<CommentTarget, String> {
+    let mut desired = BTreeMap::new();
+    for stmt in comments {
+        let target = match &stmt.object {
+            CommentObjectType::Column { name } => {
+                CommentTarget::Column(name.column.as_str().to_string())
+            }
+            _ => CommentTarget::Object,
+        };
+        match &stmt.comment {
+            Some(comment) => {
+                desired.insert(target, comment.clone());
+            }
+            None => {
+                desired.remove(&target);
+            }
+        }
+    }
+    desired
+}
+
+/// Compute the `COMMENT ON` statements that close the gap between `desired` and
+/// `current`.
+///
+/// Emits a statement for every target whose text differs from what the catalog
+/// holds, then clears every target the catalog holds that `desired` does not
+/// declare.
+pub fn comment_changes(
+    desired: &BTreeMap<CommentTarget, String>,
+    current: &[ObjectComment],
+    object: &ReconcileTarget<'_>,
+) -> Vec<CommentStatement<Raw>> {
+    let stored: BTreeMap<CommentTarget, &str> = current
+        .iter()
+        .map(|c| {
+            let target = match &c.column {
+                Some(column) => CommentTarget::Column(column.clone()),
+                None => CommentTarget::Object,
+            };
+            (target, c.comment.as_str())
+        })
+        .collect();
+
+    let mut changes = Vec::new();
+    for (target, comment) in desired {
+        if stored.get(target).is_some_and(|held| *held == comment) {
+            continue;
+        }
+        changes.push(object.comment_statement(target, Some(comment.clone())));
+    }
+    for target in stored.keys() {
+        if !desired.contains_key(target) {
+            changes.push(object.comment_statement(target, None));
+        }
+    }
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::commands::reconcile::ObjectKind;
+    use crate::project::ir::object_id::ObjectId;
+    use mz_sql_parser::ast::Statement;
+    use mz_sql_parser::parser::parse_statements;
+
+    /// Parse a COMMENT SQL string into a `CommentStatement`.
+    fn parse_comment(sql: &str) -> CommentStatement<Raw> {
+        let stmts = parse_statements(sql).unwrap();
+        match stmts.into_iter().next().unwrap().ast {
+            Statement::Comment(c) => c,
+            other => panic!("expected COMMENT, got: {}", other),
+        }
+    }
+
+    fn stored(column: Option<&str>, comment: &str) -> ObjectComment {
+        ObjectComment {
+            column: column.map(str::to_string),
+            comment: comment.to_string(),
+        }
+    }
+
+    fn obj_id() -> ObjectId {
+        ObjectId::new("db".to_string(), "public".to_string(), "t".to_string())
+    }
+
+    fn changes(desired: &[CommentStatement<Raw>], current: &[ObjectComment]) -> Vec<String> {
+        let id = obj_id();
+        let object = ReconcileTarget::item(ObjectKind::Table, &id);
+        comment_changes(&desired_comments(desired), current, &object)
+            .iter()
+            .map(|c| c.to_string())
+            .collect()
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function 'rust_psm_stack_pointer'
+    fn test_desired_comments_object_and_column() {
+        let desired = desired_comments(&[
+            parse_comment("COMMENT ON TABLE db.public.t IS 'the table'"),
+            parse_comment("COMMENT ON COLUMN db.public.t.id IS 'the key'"),
+        ]);
+        assert_eq!(desired.len(), 2);
+        assert_eq!(desired[&CommentTarget::Object], "the table");
+        assert_eq!(desired[&CommentTarget::Column("id".to_string())], "the key");
+    }
+
+    /// An authored `IS NULL` declares absence, so it drops out of the desired
+    /// set and is handled by the stale-clearing path instead.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function 'rust_psm_stack_pointer'
+    fn test_desired_comments_explicit_null_declares_absence() {
+        let desired = desired_comments(&[
+            parse_comment("COMMENT ON TABLE db.public.t IS 'the table'"),
+            parse_comment("COMMENT ON TABLE db.public.t IS NULL"),
+        ]);
+        assert!(desired.is_empty());
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function 'rust_psm_stack_pointer'
+    fn test_desired_comments_last_statement_wins() {
+        let desired = desired_comments(&[
+            parse_comment("COMMENT ON TABLE db.public.t IS 'first'"),
+            parse_comment("COMMENT ON TABLE db.public.t IS 'second'"),
+        ]);
+        assert_eq!(desired[&CommentTarget::Object], "second");
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function 'rust_psm_stack_pointer'
+    fn test_comment_changes_already_matching() {
+        let desired = vec![
+            parse_comment("COMMENT ON TABLE db.public.t IS 'the table'"),
+            parse_comment("COMMENT ON COLUMN db.public.t.id IS 'the key'"),
+        ];
+        let current = vec![stored(None, "the table"), stored(Some("id"), "the key")];
+        assert!(changes(&desired, &current).is_empty());
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function 'rust_psm_stack_pointer'
+    fn test_comment_changes_missing_comment_is_set() {
+        let desired = vec![parse_comment("COMMENT ON TABLE db.public.t IS 'the table'")];
+        assert_eq!(
+            changes(&desired, &[]),
+            vec!["COMMENT ON TABLE db.public.t IS 'the table'"]
+        );
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function 'rust_psm_stack_pointer'
+    fn test_comment_changes_only_the_drifted_target() {
+        let desired = vec![
+            parse_comment("COMMENT ON TABLE db.public.t IS 'the table'"),
+            parse_comment("COMMENT ON COLUMN db.public.t.id IS 'the new key'"),
+        ];
+        let current = vec![stored(None, "the table"), stored(Some("id"), "the old key")];
+        assert_eq!(
+            changes(&desired, &current),
+            vec!["COMMENT ON COLUMN db.public.t.id IS 'the new key'"]
+        );
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function 'rust_psm_stack_pointer'
+    fn test_comment_changes_clears_stale_object_comment() {
+        assert_eq!(
+            changes(&[], &[stored(None, "left over")]),
+            vec!["COMMENT ON TABLE db.public.t IS NULL"]
+        );
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function 'rust_psm_stack_pointer'
+    fn test_comment_changes_clears_stale_column_comment() {
+        let desired = vec![parse_comment("COMMENT ON TABLE db.public.t IS 'the table'")];
+        let current = vec![stored(None, "the table"), stored(Some("id"), "left over")];
+        assert_eq!(
+            changes(&desired, &current),
+            vec!["COMMENT ON COLUMN db.public.t.id IS NULL"]
+        );
+    }
+
+    /// Sets come before clears, and each group is ordered by target.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function 'rust_psm_stack_pointer'
+    fn test_comment_changes_sets_then_clears() {
+        let desired = vec![parse_comment(
+            "COMMENT ON COLUMN db.public.t.id IS 'the key'",
+        )];
+        let current = vec![stored(None, "left over")];
+        assert_eq!(
+            changes(&desired, &current),
+            vec![
+                "COMMENT ON COLUMN db.public.t.id IS 'the key'",
+                "COMMENT ON TABLE db.public.t IS NULL",
+            ]
+        );
+    }
+
+    /// Named objects render their own keyword, not `TABLE`.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function 'rust_psm_stack_pointer'
+    fn test_comment_changes_named_object_keywords() {
+        let desired = desired_comments(&[parse_comment("COMMENT ON CLUSTER c IS 'the cluster'")]);
+        let cluster = ReconcileTarget::named(ObjectKind::Cluster, "c");
+        let rendered: Vec<String> = comment_changes(&desired, &[], &cluster)
+            .iter()
+            .map(|c| c.to_string())
+            .collect();
+        assert_eq!(rendered, vec!["COMMENT ON CLUSTER c IS 'the cluster'"]);
+
+        let cleared: Vec<String> = comment_changes(
+            &BTreeMap::new(),
+            &[stored(None, "left over")],
+            &ReconcileTarget::named(ObjectKind::Role, "r"),
+        )
+        .iter()
+        .map(|c| c.to_string())
+        .collect();
+        assert_eq!(cleared, vec!["COMMENT ON ROLE r IS NULL"]);
+    }
+}

--- a/src/mz-deploy/src/cli/commands/reconcile.rs
+++ b/src/mz-deploy/src/cli/commands/reconcile.rs
@@ -10,9 +10,12 @@
 //! Shared object metadata for catalog reconciliation.
 
 use mz_sql_parser::ast::{
-    GrantTargetSpecification, GrantTargetSpecificationInner, Ident, ObjectType, Raw,
-    UnresolvedItemName, UnresolvedObjectName,
+    ColumnName, CommentObjectType, CommentStatement, GrantTargetSpecification,
+    GrantTargetSpecificationInner, Ident, ObjectType, Raw, RawClusterName, RawItemName,
+    RawNetworkPolicyName, UnresolvedItemName, UnresolvedObjectName,
 };
+
+use crate::cli::commands::comments::CommentTarget;
 
 use crate::project::ir::object_id::ObjectId;
 
@@ -24,6 +27,7 @@ pub enum ObjectKind {
     Secret,
     Connection,
     Cluster,
+    Role,
     NetworkPolicy,
 }
 
@@ -36,7 +40,19 @@ impl ObjectKind {
             Self::Secret => "mz_secrets",
             Self::Connection => "mz_connections",
             Self::Cluster => "mz_clusters",
+            Self::Role => "mz_roles",
             Self::NetworkPolicy => "mz_network_policies",
+        }
+    }
+
+    /// The object type stored in `mz_objects`.
+    pub fn catalog_object_type(self) -> &'static str {
+        match self {
+            Self::Table => "table",
+            Self::Source => "source",
+            Self::Secret => "secret",
+            Self::Connection => "connection",
+            _ => unreachable!("{} is not stored in mz_objects", self.label()),
         }
     }
 
@@ -48,6 +64,7 @@ impl ObjectKind {
             Self::Connection => "connection",
             Self::Cluster => "cluster",
             Self::NetworkPolicy => "network policy",
+            Self::Role => unreachable!("a role has no default privileges"),
         }
     }
 
@@ -58,6 +75,7 @@ impl ObjectKind {
             Self::Source => &["SELECT"],
             Self::Secret | Self::Connection | Self::NetworkPolicy => &["USAGE"],
             Self::Cluster => &["USAGE", "CREATE"],
+            Self::Role => &[],
         }
     }
 
@@ -69,6 +87,7 @@ impl ObjectKind {
             Self::Connection => ObjectType::Connection,
             Self::Cluster => ObjectType::Cluster,
             Self::NetworkPolicy => ObjectType::NetworkPolicy,
+            Self::Role => unreachable!("a role has no grant target"),
         }
     }
 
@@ -80,6 +99,7 @@ impl ObjectKind {
             Self::Secret => "secret",
             Self::Connection => "connection",
             Self::Cluster => "cluster",
+            Self::Role => "role",
             Self::NetworkPolicy => "network policy",
         }
     }
@@ -107,7 +127,7 @@ impl<'a> ReconcileTarget<'a> {
     pub fn named(kind: ObjectKind, name: &'a str) -> Self {
         debug_assert!(matches!(
             kind,
-            ObjectKind::Cluster | ObjectKind::NetworkPolicy
+            ObjectKind::Cluster | ObjectKind::Role | ObjectKind::NetworkPolicy
         ));
         Self::Named { kind, name }
     }
@@ -153,4 +173,82 @@ impl<'a> ReconcileTarget<'a> {
             object_spec_inner: GrantTargetSpecificationInner::Objects { names: vec![name] },
         }
     }
+
+    /// Build a statement that sets or clears one comment target.
+    pub fn comment_statement(
+        &self,
+        target: &CommentTarget,
+        comment: Option<String>,
+    ) -> CommentStatement<Raw> {
+        let object = match target {
+            CommentTarget::Column(column) => {
+                let Self::Item { id, .. } = self else {
+                    unreachable!("a {} cannot carry a column comment", self.kind().label());
+                };
+                CommentObjectType::Column {
+                    name: ColumnName {
+                        relation: item_name(id),
+                        column: Ident::new_unchecked(column),
+                    },
+                }
+            }
+            CommentTarget::Object => match self {
+                Self::Item {
+                    kind: ObjectKind::Table,
+                    id,
+                } => CommentObjectType::Table {
+                    name: item_name(id),
+                },
+                Self::Item {
+                    kind: ObjectKind::Source,
+                    id,
+                } => CommentObjectType::Source {
+                    name: item_name(id),
+                },
+                Self::Item {
+                    kind: ObjectKind::Secret,
+                    id,
+                } => CommentObjectType::Secret {
+                    name: item_name(id),
+                },
+                Self::Item {
+                    kind: ObjectKind::Connection,
+                    id,
+                } => CommentObjectType::Connection {
+                    name: item_name(id),
+                },
+                Self::Named {
+                    kind: ObjectKind::Cluster,
+                    name,
+                } => CommentObjectType::Cluster {
+                    name: RawClusterName::Unresolved(Ident::new_unchecked(*name)),
+                },
+                Self::Named {
+                    kind: ObjectKind::Role,
+                    name,
+                } => CommentObjectType::Role {
+                    name: Ident::new_unchecked(*name),
+                },
+                Self::Named {
+                    kind: ObjectKind::NetworkPolicy,
+                    name,
+                } => CommentObjectType::NetworkPolicy {
+                    name: RawNetworkPolicyName::Unresolved(Ident::new_unchecked(*name)),
+                },
+                Self::Item { kind, .. } | Self::Named { kind, .. } => {
+                    unreachable!("invalid {} target identity", kind.label())
+                }
+            },
+        };
+        CommentStatement { object, comment }
+    }
+}
+
+/// The fully-qualified name of a schema-qualified object.
+fn item_name(id: &ObjectId) -> RawItemName {
+    RawItemName::Name(UnresolvedItemName::qualified(&[
+        Ident::new_unchecked(id.expect_database()),
+        Ident::new_unchecked(id.schema()),
+        Ident::new_unchecked(id.object()),
+    ]))
 }

--- a/src/mz-deploy/src/cli/commands/roles.rs
+++ b/src/mz-deploy/src/cli/commands/roles.rs
@@ -10,17 +10,21 @@
 //! Roles apply command - converge live role state to match definitions.
 
 use crate::cli::CliError;
+use crate::cli::commands::comments;
+use crate::cli::commands::reconcile::{ObjectKind, ReconcileTarget};
 use crate::cli::executor::{
     ApplyPlan, ApplyResult, DeploymentExecutor, ObjectAction, ObjectResult, connect_apply_client,
 };
-use crate::client::Client;
 use crate::client::quote_identifier;
+use crate::client::{Client, ObjectComment};
 use crate::config::Settings;
 use crate::project::roles::{self, RoleDefinition};
 use itertools::Itertools;
 use mz_sql_parser::ast::AlterRoleOption;
 use mz_sql_parser::ast::SetRoleVar;
 use std::collections::BTreeSet;
+
+const OBJECT_KIND: ObjectKind = ObjectKind::Role;
 
 /// Plan role changes without executing or printing.
 pub async fn plan(
@@ -42,10 +46,11 @@ pub async fn plan(
 
     let names: Vec<&str> = definitions.iter().map(|def| def.name.as_str()).collect();
     let introspection = client.introspection();
-    let (existing, members, parameters) = futures::try_join!(
+    let (existing, members, parameters, current_comments) = futures::try_join!(
         introspection.existing_roles(&names),
         introspection.get_role_members(&names),
         introspection.get_role_parameters(&names),
+        introspection.get_named_object_comments(OBJECT_KIND.catalog_table(), &names),
     )
     .map_err(CliError::Connection)?;
 
@@ -71,6 +76,7 @@ pub async fn plan(
             def,
             members.get(&def.name).map_or(&[], Vec::as_slice),
             parameters.get(&def.name).map_or(&[], Vec::as_slice),
+            current_comments.get(&def.name).map_or(&[], Vec::as_slice),
         )
         .await?;
         let mut statements = create_stmts;
@@ -112,6 +118,7 @@ async fn configure_role(
     def: &RoleDefinition,
     current_members: &[String],
     current_params: &[String],
+    current_comments: &[ObjectComment],
 ) -> Result<(), CliError> {
     let role_name = &def.name;
 
@@ -125,10 +132,13 @@ async fn configure_role(
         executor.execute_sql(grant).await?;
     }
 
-    // Execute COMMENT statements
-    for comment in &def.comments {
-        executor.execute_sql(comment).await?;
-    }
+    comments::reconcile(
+        executor,
+        &ReconcileTarget::named(OBJECT_KIND, role_name),
+        &def.comments,
+        current_comments,
+    )
+    .await?;
 
     // Revoke stale grants
     let desired_members: BTreeSet<String> = def

--- a/src/mz-deploy/src/client.rs
+++ b/src/mz-deploy/src/client.rs
@@ -143,6 +143,6 @@ pub use introspection::DependentSink;
 pub use models::{
     ApplyState, Cluster, ClusterConfig, ClusterReplica, ConflictRecord, DeploymentDetails,
     DeploymentHistoryEntry, DeploymentKind, DeploymentMetadata, DeploymentMode,
-    DeploymentObjectRecord, ObjectGrant, PendingStatement, ProductionClusterRecord,
+    DeploymentObjectRecord, ObjectComment, ObjectGrant, PendingStatement, ProductionClusterRecord,
     ReplacementMvRecord, SchemaDeploymentRecord, StagingDeployment,
 };

--- a/src/mz-deploy/src/client/introspection.rs
+++ b/src/mz-deploy/src/client/introspection.rs
@@ -16,7 +16,7 @@
 
 use crate::client::connection::{Client, IntrospectionClient};
 use crate::client::errors::ConnectionError;
-use crate::client::models::{Cluster, ClusterConfig, ClusterReplica, ObjectGrant};
+use crate::client::models::{Cluster, ClusterConfig, ClusterReplica, ObjectComment, ObjectGrant};
 use crate::client::sql_placeholders;
 use crate::client::staging_suffix_like_pattern;
 use crate::client::{parse_create_cluster, quote_identifier};
@@ -42,6 +42,35 @@ pub struct DependentSink {
     pub dependency_type: String,
 }
 
+/// A `target` CTE holding the `(database, schema, object)` name triples a bulk
+/// catalog read is restricted to.
+///
+/// The triples arrive as three parallel arrays bound to `$1`, `$2`, and `$3` by
+/// [`array_literal`], and are zipped back into rows server-side. The statement
+/// text is therefore identical however many objects a project manages, and a
+/// query that needs parameters of its own numbers them from `$4` on.
+///
+/// The three name components are matched separately rather than against a
+/// concatenated fully-qualified name. A concatenation would have to agree with
+/// the catalog on when an identifier needs quoting, and a name containing a `.`
+/// would make it ambiguous.
+const TARGET_OBJECTS_CTE: &str = "\
+    target AS (
+        SELECT
+            ($1::text::text[])[i] AS database,
+            ($2::text::text[])[i] AS schema,
+            ($3::text::text[])[i] AS object
+        FROM generate_series(1, array_length($1::text::text[], 1)) AS g(i)
+    )";
+
+/// A `target` CTE holding the names a bulk read over a named-object catalog
+/// table is restricted to.
+///
+/// Names arrive as one array bound to `$1` by [`array_literal`], so a query that
+/// needs parameters of its own numbers them from `$2` on.
+const TARGET_NAMES_CTE: &str = "\
+    target AS (SELECT name FROM unnest($1::text::text[]) AS u(name))";
+
 /// Encode `values` as a Postgres text array literal.
 ///
 /// Materialize's pgwire cannot decode an array bind parameter, so a query that
@@ -66,6 +95,34 @@ fn array_literal<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
     }
     literal.push('}');
     literal
+}
+
+/// The three parallel name arrays [`TARGET_OBJECTS_CTE`] zips back together,
+/// each encoded by [`array_literal`].
+fn target_object_arrays(objects: &BTreeSet<ObjectId>) -> [String; 3] {
+    [
+        array_literal(objects.iter().map(ObjectId::expect_database)),
+        array_literal(objects.iter().map(ObjectId::schema)),
+        array_literal(objects.iter().map(ObjectId::object)),
+    ]
+}
+
+/// Group rows carrying the `database`, `schema`, and `object` columns of
+/// [`TARGET_OBJECTS_CTE`] by the object they describe.
+///
+/// An object the catalog holds no rows for is absent from the map rather than
+/// present with an empty vector, so callers must treat a miss as "nothing
+/// recorded".
+fn group_by_object<T>(
+    rows: &[Row],
+    mut value: impl FnMut(&Row) -> T,
+) -> BTreeMap<ObjectId, Vec<T>> {
+    let mut grouped: BTreeMap<ObjectId, Vec<T>> = BTreeMap::new();
+    for row in rows {
+        let id = ObjectId::new(row.get("database"), row.get("schema"), row.get("object"));
+        grouped.entry(id).or_default().push(value(row));
+    }
+    grouped
 }
 
 /// Group rows by their `name` column, preserving the query's row order within
@@ -1239,6 +1296,92 @@ pub(super) async fn get_connection_create_sqls(
         .collect())
 }
 
+/// Get every comment recorded on `objects` and their columns, keyed by object.
+pub(super) async fn get_database_object_comments(
+    client: &Client,
+    objects: &BTreeSet<ObjectId>,
+    object_type: &str,
+) -> Result<BTreeMap<ObjectId, Vec<ObjectComment>>, ConnectionError> {
+    if objects.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let query = format!(
+        r#"
+        -- `object_sub_id` is NULL for a comment on the object itself and the
+        -- 1-based column position otherwise, so the LEFT JOIN resolves it to a
+        -- column name and leaves object-level comments with a NULL column.
+        WITH {}
+        SELECT
+            target.database,
+            target.schema,
+            target.object,
+            col.name AS column_name,
+            c.comment
+        FROM mz_internal.mz_comments c
+        JOIN mz_objects o ON c.id = o.id
+        JOIN mz_schemas s ON o.schema_id = s.id
+        JOIN mz_databases d ON s.database_id = d.id
+        JOIN target
+            ON target.database = d.name
+           AND target.schema = s.name
+           AND target.object = o.name
+        LEFT JOIN mz_columns col
+            ON col.id = c.id AND col.position::int4 = c.object_sub_id
+        WHERE o.type = $4
+        ORDER BY target.database, target.schema, target.object, c.object_sub_id
+        "#,
+        TARGET_OBJECTS_CTE
+    );
+
+    let [databases, schemas, names] = target_object_arrays(objects);
+    let rows = client
+        .query(&query, &[&databases, &schemas, &names, &object_type])
+        .await?;
+
+    Ok(group_by_object(&rows, |row| ObjectComment {
+        column: row.get("column_name"),
+        comment: row.get("comment"),
+    }))
+}
+
+/// Get the comments recorded on each of `names` in `catalog_table`, keyed by
+/// name.
+///
+/// A globally named object carries no column comments, so only object-level
+/// rows are read.
+pub(super) async fn get_named_object_comments(
+    client: &Client,
+    catalog_table: &str,
+    names: &[&str],
+) -> Result<BTreeMap<String, Vec<ObjectComment>>, ConnectionError> {
+    if names.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let query = format!(
+        r#"
+        WITH {}
+        SELECT target.name, c.comment
+        FROM mz_internal.mz_comments c
+        JOIN {} o ON c.id = o.id
+        JOIN target ON target.name = o.name
+        WHERE c.object_sub_id IS NULL
+        ORDER BY target.name
+        "#,
+        TARGET_NAMES_CTE, catalog_table
+    );
+
+    let rows = client
+        .query(&query, &[&array_literal(names.iter().copied())])
+        .await?;
+
+    Ok(group_by_name(&rows, |row| ObjectComment {
+        column: None,
+        comment: row.get("comment"),
+    }))
+}
+
 impl IntrospectionClient<'_> {
     /// Get the current Materialize user/role.
     pub async fn get_current_user(&self) -> Result<String, ConnectionError> {
@@ -1401,6 +1544,26 @@ impl IntrospectionClient<'_> {
         schema_exists(self.client, database, schema).await
     }
 
+    /// Get every comment recorded on `objects` and their columns, keyed by
+    /// object.
+    pub async fn get_database_object_comments(
+        &self,
+        objects: &BTreeSet<ObjectId>,
+        object_type: &str,
+    ) -> Result<BTreeMap<ObjectId, Vec<ObjectComment>>, ConnectionError> {
+        get_database_object_comments(self.client, objects, object_type).await
+    }
+
+    /// Get the comments recorded on each of `names` in `catalog_table`, keyed
+    /// by name.
+    pub async fn get_named_object_comments(
+        &self,
+        catalog_table: &str,
+        names: &[&str],
+    ) -> Result<BTreeMap<String, Vec<ObjectComment>>, ConnectionError> {
+        get_named_object_comments(self.client, catalog_table, names).await
+    }
+
     /// The subset of `names` that exist as network policies.
     pub async fn existing_network_policies(
         &self,
@@ -1547,7 +1710,9 @@ impl IntrospectionClient<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::array_literal;
+    use super::{array_literal, target_object_arrays};
+    use crate::project::ir::object_id::ObjectId;
+    use std::collections::BTreeSet;
 
     #[mz_ore::test]
     fn test_array_literal_quotes_every_element() {
@@ -1574,5 +1739,24 @@ mod tests {
         assert_eq!(array_literal([r#"say "hi""#]), r#"{"say \"hi\""}"#);
         assert_eq!(array_literal([r"back\slash"]), r#"{"back\\slash"}"#);
         assert_eq!(array_literal([r#"\""#]), r#"{"\\\""}"#);
+    }
+
+    /// The three arrays are parallel: index `i` of each names one component of
+    /// the same object, in the set's iteration order.
+    #[mz_ore::test]
+    fn test_target_object_arrays_stay_parallel() {
+        let objects = BTreeSet::from([
+            ObjectId::new("db1".into(), "s1".into(), "t1".into()),
+            ObjectId::new("db2".into(), "s2".into(), "t2".into()),
+        ]);
+
+        assert_eq!(
+            target_object_arrays(&objects),
+            [
+                r#"{"db1","db2"}"#.to_string(),
+                r#"{"s1","s2"}"#.to_string(),
+                r#"{"t1","t2"}"#.to_string(),
+            ]
+        );
     }
 }

--- a/src/mz-deploy/src/client/models.rs
+++ b/src/mz-deploy/src/client/models.rs
@@ -125,6 +125,16 @@ pub struct ObjectGrant {
     pub privilege_type: String,
 }
 
+/// One comment recorded against an object or one of its columns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectComment {
+    /// `None` for a comment on the object itself, `Some(name)` for a comment on
+    /// one of its columns.
+    pub column: Option<String>,
+    /// The comment text.
+    pub comment: String,
+}
+
 /// Configuration for creating a cluster (managed or unmanaged).
 ///
 /// This captures all the information needed to clone a cluster's configuration


### PR DESCRIPTION
A project's comments were replayed on every apply: each `COMMENT ON` it declared was executed unconditionally, and a comment the project stopped declaring stayed on the object forever. This makes comments declared state. Each apply phase reads the comments the catalog holds for the objects it manages, emits only the statements that close the gap, and clears with `COMMENT ON ... IS NULL` anything the project no longer declares.

Two authoring details fall out of treating comments as state:

- An authored `COMMENT ON ... IS NULL` declares the *absence* of a comment rather than a comment whose text is null, so it drops out of the desired set and is served by the same path that clears stale ones.
- Where a project declares the same target twice, the last statement wins, matching the order the server would have applied them in.

## Reads

Comments are read in bulk per phase, one query for database objects and one for globally named ones, so this adds a single round trip to a phase rather than one per object. Both restrict themselves through a `target` CTE built from text array literals, since Materialize's pgwire cannot decode an array bind parameter (the encoding landed in #38548).

The object query matches the three name components separately rather than against a concatenated fully-qualified name. A concatenation would have to agree with the catalog on when an identifier needs quoting, and a name containing a `.` would make it ambiguous.

## Types

`ObjectKind` gains `Role`, which carries comments but has no grant target or default privileges, and `ReconcileTarget` gains `comment_statement` so each kind renders its own `COMMENT ON` keyword.

## Tests

Adds unit tests for the desired-comment extraction (object and column targets, explicit `IS NULL`, last-wins), the diff against catalog state (already matching, missing, only-the-drifted target, stale object and column comments, set-before-clear ordering), and the keyword each object kind renders. Plus a test that the object query's three name arrays stay parallel.

## Stack

Third in a stack, based on #38549. Review #38548 and #38549 first; the diff here is only the third commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)