### PR TITLE
docs: note MySQL parallel snapshotting in v26.39 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -25,6 +25,7 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 
 ### Improvements {#v26.39-improvements}
 - **Improved connect modal in the console**: We've updated the UI to make it easier to connect coding agents to our MCP servers, and connect applications to Materialize.
+- **Parallel MySQL table snapshotting** {{< private-preview-inline />}}: Materialize can now split the initial snapshot of a single MySQL table across all the workers of the cluster hosting the source, so a source dominated by one very large table benefits from a larger cluster. Tables are eligible when they have a single-column `CHAR` or `VARCHAR` primary key using the `utf8mb4` character set with the `utf8mb4_bin` collation. For more information, see [MySQL snapshot parallelism](/ingest-data/mysql/snapshot-parallelism/).
 
 ### Agent Skills {#v26.39-agent-skills}
 - **mz-ontology-design**: A new skill that structures a Materialize SQL code base as a canonical ontology — a shared `raw` database, a shared `core` database, and one database per use case — with rules for semantic object grain and identity, temporal semantics, and a machine-readable relationship registry.

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -25,7 +25,7 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 
 ### Improvements {#v26.39-improvements}
 - **Improved connect modal in the console**: We've updated the UI to make it easier to connect coding agents to our MCP servers, and connect applications to Materialize.
-- **Parallel MySQL table snapshotting** {{< private-preview-inline />}}: Materialize can now split the initial snapshot of a single MySQL table across all the workers of the cluster hosting the source, so a source dominated by one very large table benefits from a larger cluster. Tables are eligible when they have a single-column `CHAR` or `VARCHAR` primary key using the `utf8mb4` character set with the `utf8mb4_bin` collation. For more information, see [MySQL snapshot parallelism](/ingest-data/mysql/snapshot-parallelism/).
+- **Faster MySQL table snapshots** {{< private-preview-inline />}}: Initial snapshots for MySQL tables are now parallelized. We saw speedups of up to 80%. When we tested a snapshot of a 2bn row table (2.45TB), previously the snapshot completed in 220 minutes. With the new parallelization, the snapshot completed in 43 minutes. Tables are eligible for parallel snapshots when they have a single-column `CHAR` or `VARCHAR` primary key using the `utf8mb4` character set with the `utf8mb4_bin` collation. For more information, see [MySQL snapshot parallelism](/ingest-data/mysql/snapshot-parallelism/).
 
 ### Agent Skills {#v26.39-agent-skills}
 - **mz-ontology-design**: A new skill that structures a Materialize SQL code base as a canonical ontology — a shared `raw` database, a shared `core` database, and one database per use case — with rules for semantic object grain and identity, temporal semantics, and a machine-readable relationship registry.


### PR DESCRIPTION
### Motivation

The v26.39 release notes did not mention that Materialize can now split the initial snapshot of a single MySQL table across the workers of the cluster hosting the source. The feature is documented under [MySQL snapshot parallelism](https://materialize.com/docs/ingest-data/mysql/snapshot-parallelism/) but had no release-notes entry, so users reading the release notes would not learn about it.

### Description

Adds one bullet to the v26.39 improvements list in `doc/user/content/releases/_index.md`. The bullet is marked with the `private-preview-inline` shortcode, matching how the feature is labelled on the MySQL ingestion pages, summarizes the eligibility requirements (single-column `CHAR`/`VARCHAR` primary key on `utf8mb4` with the `utf8mb4_bin` collation), and links to the snapshot parallelism page for the details.

Docs-only change; no code or tests were touched.

### Verification

Reviewed the rendered Markdown source against the surrounding improvements bullets and confirmed the `private-preview-inline` shortcode and the `/ingest-data/mysql/snapshot-parallelism/` link path match existing usage elsewhere in the docs tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6PChVTyFzUFaAgUrVnwFZ)_