### PR TITLE
doc: design security barrier views [ WIP ]

### DIFF
--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -226,6 +226,54 @@ equivalence class is seeded only from leakproof or unconstrained predicates,
 since a derived qual carries no level; and **ordering**, where a levelled
 predicate must be evaluated after every lower-level one.
 
+### What a future transform has to know
+
+Mechanism B's residual risk is often stated as "every future transform that
+touches predicates has to preserve the level." That is too broad on two counts,
+and being precise about it matters, because the imprecise version is both
+unactionable and more alarming than the truth.
+
+**A new transform cannot fail to notice that levels exist.** There is no blanket
+conversion from an expression to a predicate, so constructing one requires
+naming a level: `Predicate::unconstrained` or `Predicate::at_level`. And `level`
+is private with `raise` as its only mutator, so no code can lower one. What a
+new author can miss is not the mechanism but the contract.
+
+**Reordering predicates within a plan is self-healing.** `MapFilterProject`
+sorts by level, so however much a transform shuffles predicates in the
+mid-level plan, the order is re-established when they fuse into one operator.
+The sort is a convergent enforcement point, not a step that can be skipped.
+
+That leaves three specific shapes, and they are the whole contract:
+
+1. **Relocating a predicate across operators.** The sort only helps when the
+   predicates end up in the same `MapFilterProject`. A transform that moves a
+   levelled predicate into an operator evaluated earlier than the one holding a
+   lower-level predicate breaks the guarantee. `PredicatePushdown` has an
+   explicit hold for this; a new relocating transform does not inherit it.
+2. **Deriving a predicate from a levelled one.** A derived predicate must
+   inherit the minimum level of its sources. The compiler forces the author to
+   name a level and cannot tell them which one is correct, and
+   `Predicate::unconstrained` is the natural thing to write. The two existing
+   derivation sites handle this by declining to seed an equivalence class from a
+   levelled non-leakproof predicate; a new site has no way to learn that rule.
+3. **A new place a predicate can live.** A new `MirRelationExpr` variant holding
+   predicates, or a new fused-operator representation.
+   `raise_security_level` walks `Filter` nodes and would not find it, and the
+   sort would not cover it.
+
+Shape 1 is mechanically closable. Because a descendant filter always evaluates
+before an ancestor filter on the same row, the requirement is a plan-tree
+invariant: for any `Filter` D that is a descendant of `Filter` A,
+`max_level(D) <= min_level(A)`. Levels below higher levels are correct; the
+violation is the reverse. `Typecheck` already runs between transforms validating
+plan invariants and is where this belongs, which would turn shape 1 from review
+discipline into a test failure.
+
+Shape 2 is the one that stays soft, and it is the line to put at the top of a
+risk register. Shape 3 is shared with mechanism A, whose `raise_security_level`
+equivalent has the same blind spot.
+
 ### Comparison
 
 The difference underneath every row below is that A rides a boundary Materialize
@@ -248,7 +296,7 @@ physical layer and the protocol that ships plans to compute.
 | What the optimizer may do across the view | the two plans stay distinct objects, so no transform sees both at once; leakproof predicates, column demand, and monotonicity still cross | the two plans merge into one, so every transform applies to both; only evaluation order is constrained |
 | Unit of the constraint | the whole view | one predicate relative to another |
 | Where the guarantee lives | structural: nothing from a consumer can enter a producer's plan | by rule, at each seam that moves, orders, or derives predicates |
-| Failure mode of a missed site | costs an optimization | silently produces an insecure plan |
+| Failure mode of a missed site | costs an optimization | silently produces an insecure plan, for the three shapes below |
 | Reaches LIR / compute protocol | no | yes, once `MapFilterProject` carries the level |
 | Perf, barrier views | view is not inlined: no cross-boundary folding, an extra collection and often an arrangement per boundary, no fast-path peek | inlining preserved; a related spike measured zero plan delta |
 | Perf, non-barrier views | none | none: every text plan in the `EXPLAIN` corpus is byte-identical |
@@ -292,9 +340,11 @@ unconstrained predicate or re-applying an existing one, because there is no
 blanket conversion from an expression to a predicate. That is what surfaced
 three real level-dropping bugs, in `into_map_filter_project`,
 `literal_constraints`, and `canonicalize_mfp`, each of which would have compiled
-silently under a blanket conversion. It is also the standing cost: the same
-discipline applies to every future transform that touches predicates, and
-nothing enforces it but the review.
+silently under a blanket conversion.
+
+So the existing tree is checked rather than assumed. What B carries instead is
+an obligation on code that does not exist yet, scoped in
+[What a future transform has to know](#what-a-future-transform-has-to-know).
 
 Two smaller costs specific to B: `Predicate` is 104 bytes against
 `MirScalarExpr`'s 96, and the serialized MIR nests `{expr, level}`, changing
@@ -589,9 +639,10 @@ for any future non-error channel.
   closed and confines the concept to two gates, but costs real performance on
   barrier views beyond the shared cost. B preserves that performance and is the
   mechanism row-level security would need, but puts the concept on the compute
-  protocol and carries a standing obligation: every future transform that
-  touches predicates has to preserve the level, and nothing enforces that but
-  review. This document deliberately does not pick.
+  protocol and carries an obligation on future code, scoped to three shapes in
+  [What a future transform has to know](#what-a-future-transform-has-to-know),
+  of which one is mechanically closable and one stays soft. This document
+  deliberately does not pick.
 - The default is settled in this document and the mechanism is not. If the team
   disagrees with opt-in, the argument to engage is in
   [The argument against](#the-argument-against-and-what-to-do-about-it), and the

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -433,6 +433,21 @@ joins, which is a narrower and better-defined thing to reason about.
 
 ### The case for opt-in
 
+**Default-on turns a query cost into an upgrade cost.** The expression cache is
+keyed on build version, so every plan is re-derived on every version bump. What
+makes that safe today is that the new version almost always arrives at the same
+plan, so a replica's memory requirement is the one it already met. Zero-downtime
+upgrade then runs both generations until the new one has re-hydrated, which
+commits the headroom that would absorb a change.
+
+Enabling barriers for every view would re-derive affected plans into ones that
+need more memory, per the example above, at the point in an environment's life
+when the least is spare. A replica that cannot fit the new plan cannot finish
+re-hydrating, and an upgrade whose new generation cannot finish re-hydrating does
+not cut over. That failure is not a slow query, it is an environment that cannot
+be upgraded, discovered during the upgrade. Opt-in avoids it by construction: an
+existing view's plan does not change unless somebody changes the view.
+
 **The cost has a recognizable shape.** It bites when a reader's predicate is
 fallible, selective, and sits above a join or an arrangement. That is a real
 pattern, not a corner case, and a user who hits it should be able to trace the

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -1,0 +1,326 @@
+# Security barrier views
+
+- Associated: (none yet)
+
+## The Problem
+
+Materialize tells users that `SELECT` on a view is what governs access to it:
+
+> To read from a views or a materialized views, you must have `SELECT`
+> privileges on the view/materialized views. That is, having `SELECT`
+> privileges on the underlying objects defining the view/materialized view is
+> insufficient.
+
+That statement is accurate about privilege checking, and it invites the
+PostgreSQL pattern of using a view as a row-level access control boundary:
+
+```sql
+CREATE VIEW my_orders AS SELECT * FROM orders WHERE tenant = current_user;
+GRANT SELECT ON my_orders TO tenant_role;
+```
+
+The privilege half of this works. `Plan::Select` requires read privileges only
+on the objects the query itself names, and `current_user` inside a view body is
+resolved against the *querying* session, so the view behaves like a PostgreSQL
+view with definer privileges and invoker identity.
+
+The optimizer half does not. A predicate supplied by the reader is pushed
+across the view boundary and evaluated *before* the view's own filter, so a
+reader can aim a fallible expression at rows they are not allowed to see and
+read the hidden values back out of the resulting error message.
+
+PostgreSQL solved this with `security_barrier` views. Materialize has no
+equivalent.
+
+### Current exposure
+
+This is not hypothetical. Modeling the situation directly against
+`optimize_dataflow_filters_inner`, with `#0` a secret column and `#1` the
+tenant column:
+
+| view   | plan                          |
+| ------ | ----------------------------- |
+| `mine` | `Filter (#1 = 7)` over `Get orders` |
+| `q`    | `Filter ((100 / #0) > 0)` over `Get mine` |
+
+produces:
+
+```
+--- `mine` after cross-view filter pushdown ---
+Filter (#1 = 7) AND ((100 / #0) > 0)
+  Get orders
+
+--- predicates propagated to the `orders` source import ---
+["(#1 = 7)", "((100 / #0) > 0)"]
+
+--- MFP evaluation order inside `mine` ---
+[ "@1: ((100 / #0) > 0)",
+  "@2: (#1 = 7)" ]
+```
+
+Three separate things go wrong:
+
+1. The reader's predicate is spliced into the view's own plan, becoming a
+   sibling of the tenant filter rather than staying above it.
+2. It propagates all the way to the `orders` source import, where it will be
+   handed to persist filter pushdown and evaluated against every row of the
+   base collection.
+3. Inside the resulting `MapFilterProject`, predicates are ordered by the
+   column position they first reference, so the reader's predicate on `#0` is
+   scheduled *ahead* of the tenant filter on `#1`.
+
+Two mechanisms perform the boundary crossing. `inline_views` rewrites a
+singly-referenced view into a `Let` binding, after which
+`PredicatePushdown::push_into_let_binding` moves the reader's predicate into
+the binding's value and deletes it from the consumer.
+`optimize_dataflow_filters_inner` performs the same propagation for views that
+survive inlining. Everywhere else, a global `Get` is opaque to predicate
+pushdown: the transform records predicates at a `Get` but explicitly cannot
+delete them from the enclosing `Filter`.
+
+Turning this into an oracle is easy, because Materialize's error messages embed
+the offending value:
+
+```
+invalid input syntax for type integer: "<the actual hidden value>"
+"<the actual hidden value>" bigint out of range
+```
+
+So `SELECT * FROM my_orders WHERE ssn::int > 0` exfiltrates a foreign tenant's
+`ssn` verbatim in a single query, and `WHERE 1 / (secret - 42) > 0` gives a
+clean binary-search oracle over any numeric column.
+
+Materializing the view is not an available mitigation. `ExprPrepMaintained`
+rejects unmaterializable functions, so a view whose predicate references
+`current_user` cannot be indexed or materialized. Exactly the views that need
+a barrier are the ones that are always inlined into the reader's dataflow.
+
+## Success Criteria
+
+1. A view can be marked such that no reader-supplied expression is evaluated
+   against a row the view's own filter would have excluded.
+2. The guarantee holds against the optimizer, not merely against the plans it
+   happens to produce today. A new transform that crosses the view boundary
+   should have to opt in rather than silently defeat the barrier.
+3. Predicates that cannot leak still cross the boundary, so the common
+   selective filters keep reaching persist pushdown and index lookups.
+4. The default behavior of existing views does not change.
+
+## Out of Scope
+
+- Row-level security policies attached to tables. This design covers views
+  only.
+- `security_invoker` views. Materialize's privilege model is already
+  definer-style and this design does not change it.
+- Timing and introspection side channels. A barrier view's base scan still
+  runs on the reader's cluster, and `mz_introspection` is `PUBLIC_SELECT`, so
+  operator-level record counts and query latency remain observable. PostgreSQL
+  has the same class of hole and does not address it either. See
+  [Open questions](#open-questions).
+- Making the barrier the default for all views.
+
+## Solution Proposal
+
+Adopt PostgreSQL's pre-9.5 model: mark the view, then decline to dissolve its
+boundary. Do not adopt PostgreSQL's later `RestrictInfo.security_level`
+machinery.
+
+That machinery exists so that quals originating at many different security
+levels can be interleaved at a single scan node, which is what row-level
+security requires. Materialize has no RLS, so every barrier is a whole-object
+boundary and a single bit per object suffices.
+
+### Syntax
+
+```sql
+CREATE VIEW my_orders WITH (SECURITY BARRIER) AS
+    SELECT * FROM orders WHERE tenant = current_user;
+```
+
+`WITH (SECURITY BARRIER = false)` is accepted and is the default. The option
+lands on `ViewDefinition` so it prints between the column list and `AS`,
+matching PostgreSQL and round-tripping through `SHOW CREATE VIEW` via
+`create_sql`.
+
+### Leakproofness
+
+PostgreSQL needs `LEAKPROOF` because it has user-defined functions that can
+leak through `RAISE NOTICE`, error text, or a dishonest `COST`. Marking a
+function `LEAKPROOF` is therefore a superuser trust decision recorded in
+`pg_proc`.
+
+Materialize has no user-defined functions, so every function in a predicate is
+a builtin, and the only value-dependent channel a builtin has is its error.
+Leakproof therefore reduces to infallible, and `MirScalarExpr::could_error()`
+already answers exactly that question. Its defaults are fail-safe:
+`LazyUnaryFunc::could_error` returns `true` unless a function overrides it, and
+`EagerUnaryFunc` derives it from whether the Rust signature returns a `Result`.
+
+This is a strictly better foundation than `pg_proc.proleakproof`. It is
+type-derived and compiler-checked rather than asserted by a human, and it
+cannot be subverted by a user defining their own function.
+
+The cost of the barrier is correspondingly small. `eq` is declared
+`fn eq(...) -> bool`, not `-> Result<...>`, so `=` is automatically leakproof,
+as are `<`, `>`, `AND`, `OR`, and `IS NULL`. Those are precisely the predicates
+that persist part-pruning and `LiteralConstraints` index lookups can exploit,
+so the pushdown that actually pays for itself still crosses the barrier. What
+stops at the boundary is fallible expressions, which pushdown would not have
+been able to use for pruning anyway.
+
+### Optimizer changes
+
+The barrier set is optimizer-only state, so it belongs on `TransformCtx`, the
+struct that already threads arguments through all transforms, rather than on
+`DataflowDescription`, which is part of the compute protocol.
+
+`DataflowBuilder` learns which imported views are barriers as it imports them,
+because `import_into_dataflow` already matches on the catalog entry. Callers
+hand that set to `TransformCtx::global`.
+
+Two gates then implement the barrier:
+
+- `inline_views` skips a barrier view, so it stays a distinct
+  `objects_to_build` entry referenced through a global `Get`. Every transform
+  that runs per-object then treats it as opaque for free, and no `Let` binding
+  is ever formed for `push_into_let_binding` to push into.
+- `optimize_dataflow_filters_inner` applies only leakproof predicates to a
+  barrier view. Non-leakproof predicates stay above the `Get` in the consumer,
+  and because they never enter the view's plan they also never propagate onward
+  to the view's own inputs.
+
+No other cross-object transform needs a gate. `optimize_dataflow_demand`
+prunes columns rather than rows, which is safe and which PostgreSQL also
+permits. Everything else in the pipeline operates within a single object.
+
+### What this fixes
+
+End to end, through the real optimizer. Given
+
+```sql
+CREATE TABLE orders (tenant text, secret text, amount int);
+CREATE VIEW plain_orders   AS SELECT * FROM orders WHERE tenant = 'alice';
+CREATE VIEW barrier_orders WITH (SECURITY BARRIER) AS
+    SELECT * FROM orders WHERE tenant = 'alice';
+```
+
+the unprotected view hands the reader's fallible expression to the base
+collection:
+
+```
+EXPLAIN SELECT * FROM plain_orders WHERE amount / (length(secret) - 3) > 0;
+
+Explained Query:
+  Filter (#0{tenant} = "alice") AND ((#2{amount} / (char_length(#1{secret}) - 3)) > 0)
+    ReadStorage materialize.public.orders
+
+Source materialize.public.orders
+  filter=((#0{tenant} = "alice") AND ((#2{amount} / (char_length(#1{secret}) - 3)) > 0))
+```
+
+The barrier view does not:
+
+```
+EXPLAIN SELECT * FROM barrier_orders WHERE amount / (length(secret) - 3) > 0;
+
+Explained Query:
+  Filter ((#2{amount} / (char_length(#1{secret}) - 3)) > 0)
+    ReadGlobalFromSameDataflow materialize.public.barrier_orders
+
+materialize.public.barrier_orders:
+  Filter (#0{tenant} = "alice")
+    ReadStorage materialize.public.orders
+
+Source materialize.public.orders
+  filter=((#0{tenant} = "alice"))
+```
+
+The view survives as its own object, read through
+`ReadGlobalFromSameDataflow`, the division sits above it, and the tenant filter
+is the only thing reaching `orders`.
+
+A leakproof predicate still crosses, and still reaches the source import where
+persist pruning can use it:
+
+```
+EXPLAIN SELECT * FROM barrier_orders WHERE amount = 42;
+
+Explained Query:
+  Filter (#2{amount} = 42)
+    ReadGlobalFromSameDataflow materialize.public.barrier_orders
+
+materialize.public.barrier_orders:
+  Filter (#0{tenant} = "alice") AND (#2{amount} = 42)
+    ReadStorage materialize.public.orders
+
+Source materialize.public.orders
+  filter=((#0{tenant} = "alice") AND (#2{amount} = 42))
+```
+
+## Minimal Viable Prototype
+
+Implemented on branch `security-barrier-views`, roughly 230 lines across 28
+files, most of it option plumbing. The optimizer change proper is two gates and
+one predicate in `src/transform/src/dataflow.rs`.
+
+- `src/transform/tests/test_security_barrier.rs` asserts all three behaviors
+  above at the `optimize_dataflow_filters_inner` seam, including a test that
+  pins the current exposure so a regression is visible.
+- `test/sqllogictest/security_barrier.slt` covers the SQL surface and the
+  `EXPLAIN` output quoted above.
+- The existing `EXPLAIN` and privilege suites pass unchanged (1530 assertions),
+  confirming that the default path is untouched.
+
+Deliberately left out of the prototype:
+
+- An `mz_views` catalog column reporting the flag. `SHOW CREATE VIEW` already
+  reflects it through `create_sql`.
+- `ALTER VIEW ... SET (SECURITY BARRIER)`.
+- Documentation under `doc/user/`.
+
+## Alternatives
+
+**Per-predicate security levels, as in PostgreSQL 9.5 and later.** Carrying a
+level on each predicate would let barrier views be inlined and still preserve
+ordering, recovering the fusion the object-level barrier gives up. It also
+generalizes to row-level security. It is a far larger change: `Filter`'s
+`predicates` field, `MapFilterProject`, and every transform that constructs or
+reorders predicates would have to carry and respect the level, and any transform
+that forgets silently produces an insecure plan. The object-level barrier gets
+the same guarantee from two gates and can be upgraded later if RLS arrives.
+
+**Make every view a barrier.** Correct by default and immune to a user
+forgetting the option, but it would remove cross-view predicate pushdown from
+every workload in order to protect the small fraction of views used for access
+control. Not viable.
+
+**Document that views are not a security boundary.** Legitimate, and strictly
+cheaper. It is the right answer if we conclude that view-based row filtering is
+not a pattern we intend to support. It conflicts with what the RBAC
+documentation currently implies, so if we choose it we should say so
+explicitly rather than by omission.
+
+**Reject fallible expressions in predicates over any view.** Blocks the error
+channel without any optimizer changes, but it breaks a large amount of
+legitimate SQL (`::int` casts, division) and still leaves the ordering problem
+for any future non-error channel.
+
+## Open questions
+
+- Do we want to support view-based row-level access control at all? The whole
+  design is contingent on that. If yes, this is table stakes and the current
+  behavior is a security bug. If no, the honest move is to document that views
+  are not a security boundary and close this out.
+- `MirScalarExpr::could_error` is currently maintained to keep persist filter
+  pushdown correct. Promoting it to a security boundary means a wrong
+  `could_error = false` becomes a vulnerability rather than a performance bug.
+  Do we want an explicit policy and a test that pins the classification, or is
+  the type-derived default sufficient?
+- Timing and `mz_introspection` remain oracles for the cardinality of the
+  pre-filter scan, since a barrier view is still inlined into a dataflow on the
+  reader's cluster. Is that acceptable, as it is in PostgreSQL, or does a
+  serious answer require running the view on a cluster the reader does not have
+  introspection access to?
+- Should a barrier view be allowed to depend on a non-barrier view that reads
+  the same protected table? Nothing prevents it, and it is a plausible way to
+  build a barrier that does not actually protect anything.

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -120,7 +120,8 @@ a barrier are the ones that are always inlined into the reader's dataflow.
   operator-level record counts and query latency remain observable. PostgreSQL
   has the same class of hole and does not address it either. See
   [Open questions](#open-questions).
-- Making the barrier the default for all views.
+- Making the barrier the default for all views. Considered and rejected; see
+  [Why the option is opt-in](#why-the-option-is-opt-in).
 
 ## Solution Proposal
 
@@ -392,24 +393,115 @@ Deliberately left out of both:
 - `ALTER VIEW ... SET (SECURITY BARRIER)`.
 - Documentation under `doc/user/`.
 
+## Why the option is opt-in
+
+The option defaults off. That is a recommendation this document does make, and
+it is independent of which mechanism is chosen: both pay the cost below, and
+neither can avoid it.
+
+### A plan that a barrier makes more expensive
+
+Put the security filter and the reader's predicate on different tables, so that
+the reader's predicate would otherwise be pushed into a scan the security filter
+does not cover.
+
+```sql
+CREATE TABLE acct (tenant text, id int);
+CREATE TABLE det  (id int, secret text);
+
+CREATE VIEW my_det AS
+  SELECT det.id, det.secret
+  FROM acct JOIN det ON acct.id = det.id
+  WHERE acct.tenant = current_user;
+
+SELECT * FROM my_det WHERE secret::int > 0;
+```
+
+Without a barrier the cast is applied at the read of `det`:
+
+```
+Source materialize.public.det
+  filter=((#0{id}) IS NOT NULL AND (text_to_integer(#1{secret}) > 0))
+```
+
+so the arrangement on `det` only ever receives rows that passed it. With a
+barrier the cast moves into the join's per-match closure and leaves the source
+filter:
+
+```
+Join::Linear
+  linear_stage[0]
+    closure
+      filter=((text_to_integer(#1{secret}) > 0))
+...
+Source materialize.public.det
+  filter=((#0{id}) IS NOT NULL)
+```
+
+`det` is now arranged in full rather than pre-filtered. Arrangement size is the
+dominant memory cost in a Materialize dataflow, so the penalty is the
+selectivity of the reader's predicate: a cast that admits one row in a hundred
+costs roughly a hundredfold on that arrangement.
+
+Two things about this example are worth stating plainly.
+
+**The cost is inherent, not an artifact of either mechanism.** Filtering `det`
+by the reader's cast before the join would evaluate that cast against rows
+belonging to every tenant, which is exactly the disclosure the barrier exists to
+prevent. There is no correct plan that filters `det` early. The cheap plan is
+cheap because it is wrong. Mechanism A pays the same cost and adds to it, since
+it also declines to inline.
+
+**It is not a scan-volume cost.** Persist filter pushdown already treats a
+fallible expression conservatively, because it must not discard a part whose
+interior rows would error, so such a predicate was never driving much part
+pruning. What a barrier gives up is early filtering ahead of arrangements and
+joins, which is a narrower and better-defined thing to reason about.
+
+### The case for opt-in
+
+**The cost has a recognizable shape.** It bites when a reader's predicate is
+fallible, selective, and sits above a join or an arrangement. That is a real
+pattern, not a corner case, and a user who hits it should be able to trace the
+regression to a decision somebody made rather than to a property the system
+applies invisibly.
+
+**Attribution matters more than the average.** Applying barriers to every user
+view changes nothing in the `EXPLAIN` corpus, so the average cost may well be
+near zero. But the corpus does not contain the shape above, and an average is
+the wrong statistic for a cost that is concentrated. A query that silently loses
+early filtering because a cast happened to land above a join is very hard to
+explain to the person who wrote it.
+
+**The marker means something beyond the optimizer.** It records which views are
+access-control boundaries, which is information a reader of the schema wants and
+which no amount of default-on behaviour supplies. It also scopes what we have to
+defend: "declared views enforce ordering" is a claim we can state and test,
+where "no view ever evaluates a reader's fallible predicate early" is a
+whole-system property about every view, forever.
+
+**PostgreSQL has kept it opt-in since 9.2**, and its stated reason is the same
+category of cost. Their version is worse, because a non-leakproof qual cannot
+become an index qual and a row store then falls back to a sequential scan, which
+Materialize's streaming filters do not have an analogue for. But the direction
+of their conclusion survives the difference.
+
+### The argument against, and what to do about it
+
+The failure modes are not symmetric. Forgetting the option is silent data
+disclosure. Enabling it unnecessarily is a slower query. Anyone arguing for
+default-on is making a sound argument, and the measurements above do not refute
+it.
+
+The answer to that is not to pay the cost everywhere, but to make forgetting
+detectable. A view is being used as an access boundary exactly when some role
+holds `SELECT` on it and lacks `SELECT` on what it reads. That is a catalog
+query, not an optimizer change, and it can back a warning, a linting view, or an
+`mz_internal` relation listing views that look like boundaries but are not
+barriers. That closes the asymmetry at a fraction of the cost of default-on, and
+it is worth doing whichever mechanism is chosen.
+
 ## When to enable a barrier
-
-The option defaults off, so this is guidance a user needs in order to make the
-choice. The costs below are mechanism A's; under mechanism B most of them do not
-arise. Two measurements frame it.
-
-The cost of a barrier comes almost entirely from declining to inline the view,
-not from blocking predicates. Applying barriers to every user view and
-re-running the `EXPLAIN` corpus changes 8 files and 327 lines. Running the same
-experiment with the predicate gate disabled, leaving only the inlining gate,
-produces a byte-identical diff. On that corpus the security property itself is
-free and the mechanism is what costs.
-
-The second measurement is that the cost is zero for views that are already
-materialized. `import_into_dataflow` resolves an index or a materialized view
-before it ever considers a view plan, so neither gate fires.
-
-That yields a straightforward rule.
 
 **Enable it when the view is the access boundary**: the reader holds `SELECT`
 on the view and not on what it reads, and the rows it filters out are rows the
@@ -417,16 +509,19 @@ reader must not learn about. That is the only case the feature is for. A view
 that merely tidies up a query the reader could have written themselves does not
 need one.
 
-**The barrier is close to free when** the view is indexed on every cluster its
-readers use, or is a materialized view, since neither gate fires. It is also
-cheap when readers filter with comparisons, because `=`, `<`, `>`, `AND`, and
-`IS NULL` are all infallible and still cross.
+**The barrier is free when** the view is a materialized view, or is indexed on
+every cluster its readers use, because `import_into_dataflow` resolves an index
+or a materialized view before it ever considers a view plan and so no mechanism
+engages at all. It is also cheap whenever readers filter with comparisons: `=`,
+`<`, `>`, `AND`, and `IS NULL` are all infallible, so they are leakproof and
+cross the barrier untouched.
 
-**The barrier is expensive when** the view sits partway up a stack of other
-views, because the whole stack above and below it loses joint optimization, or
-when readers issue point lookups, because a barrier view occupies
-`objects_to_build[0]` and disqualifies the fast-path peek. A dataflow that would
-have folded to a constant will instead be built and run.
+**The barrier is expensive when** a reader's fallible predicate is selective and
+sits above a join or an arrangement, per the example above. Under mechanism A it
+is additionally expensive when the view sits partway up a stack of other views,
+because the whole stack loses joint optimization, and when readers issue point
+lookups, because a barrier view occupies `objects_to_build[0]` and disqualifies
+the fast-path peek.
 
 **Materializing is not a substitute**, for three reasons. An index only helps on
 the cluster that holds it, and a reader chooses their own cluster, so an
@@ -445,11 +540,12 @@ they are in [Mechanisms](#mechanisms). What follows are approaches rejected
 before either was prototyped.
 
 **Make every view a barrier.** Correct by default and immune to a user
-forgetting the option. Under mechanism A this changes 327 lines of the `EXPLAIN`
-corpus, measured with barriers restricted to user views so that builtin catalog
-views keep their plans. Under mechanism B it would be close to free, which is
-the reason B was explored. Whether a safe default is reachable therefore depends
-entirely on which mechanism is chosen.
+forgetting the option. Rejected, for the reasons in
+[Why the option is opt-in](#why-the-option-is-opt-in): the cost is concentrated
+rather than average, so applying it everywhere makes a real regression
+unattributable. The measurements are there too, including that mechanism A moves
+327 lines of the `EXPLAIN` corpus under this default while B moves none, which
+is what motivated exploring B in the first place.
 
 **Wrap the predicate in an opaque marker instead of carrying a level.** A
 `SecurityFence` unary function that the optimizer refuses to move. Prototyped:
@@ -480,12 +576,16 @@ for any future non-error channel.
   behavior is a security bug. If no, the honest move is to document that views
   are not a security boundary and close this out.
 - Which mechanism? Both prototypes work and close the same exposure. A fails
-  closed and confines the concept to two gates, but forecloses a safe default
-  and costs real performance on barrier views. B preserves performance and is
-  the mechanism row-level security would need, but puts the concept on the
-  compute protocol and carries a standing obligation: every future transform
-  that touches predicates has to preserve the level, and nothing enforces that
-  but review. This document deliberately does not pick.
+  closed and confines the concept to two gates, but costs real performance on
+  barrier views beyond the shared cost. B preserves that performance and is the
+  mechanism row-level security would need, but puts the concept on the compute
+  protocol and carries a standing obligation: every future transform that
+  touches predicates has to preserve the level, and nothing enforces that but
+  review. This document deliberately does not pick.
+- The default is settled in this document and the mechanism is not. If the team
+  disagrees with opt-in, the argument to engage is in
+  [The argument against](#the-argument-against-and-what-to-do-about-it), and the
+  detection idea there is the part worth keeping either way.
 - `MirScalarExpr::could_error` is currently maintained to keep persist filter
   pushdown correct. Promoting it to a security boundary means a wrong
   `could_error = false` becomes a vulnerability rather than a performance bug.

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -1,6 +1,6 @@
 # Security barrier views
 
-- Associated: (none yet)
+- Associated: [#38562](https://github.com/MaterializeInc/materialize/pull/38562) (prototype)
 
 ## The Problem
 
@@ -259,9 +259,9 @@ Source materialize.public.orders
 
 ## Minimal Viable Prototype
 
-Implemented on branch `security-barrier-views`, roughly 230 lines across 28
-files, most of it option plumbing. The optimizer change proper is two gates and
-one predicate in `src/transform/src/dataflow.rs`.
+Implemented in [#38562](https://github.com/MaterializeInc/materialize/pull/38562),
+roughly 230 lines across 28 files, most of it option plumbing. The optimizer
+change proper is two gates and one predicate in `src/transform/src/dataflow.rs`.
 
 - `src/transform/tests/test_security_barrier.rs` asserts all three behaviors
   above at the `optimize_dataflow_filters_inner` seam, including a test that

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -198,6 +198,16 @@ Two gates, both in `optimize_dataflow`. Nothing else in the pipeline needs to
 know the concept exists, because the boundary is between dataflow objects and
 the optimizer already respects those.
 
+Worth being precise about what "the boundary holds" means here, because it is
+not isolation. The view and its consumer remain two objects in one dataflow, and
+`optimize_dataflow_relations` runs the whole transform pipeline over each
+object separately, so no transform ever sees both plans at once. Three
+cross-object passes still run: `optimize_dataflow_filters`, which the gate
+restricts to leakproof predicates, and `optimize_dataflow_demand` and
+`optimize_dataflow_monotonic`, which are not gated at all. Column pruning and
+monotonicity therefore cross a barrier freely, which is safe because neither
+decides whether a row is produced.
+
 ### B. Security levels on predicates
 
 Prototype: [#38566](https://github.com/MaterializeInc/materialize/pull/38566).
@@ -235,7 +245,7 @@ physical layer and the protocol that ships plans to compute.
 
 | | A. Object gates | B. Levels |
 | --- | --- | --- |
-| What the optimizer may do across the view | nothing but leakproof predicates; the view and the query are planned separately | everything; the view is planned as part of the query, and only evaluation order is constrained |
+| What the optimizer may do across the view | the two plans stay distinct objects, so no transform sees both at once; leakproof predicates, column demand, and monotonicity still cross | the two plans merge into one, so every transform applies to both; only evaluation order is constrained |
 | Unit of the constraint | the whole view | one predicate relative to another |
 | Where the guarantee lives | structural: nothing from a consumer can enter a producer's plan | by rule, at each seam that moves, orders, or derives predicates |
 | Failure mode of a missed site | costs an optimization | silently produces an insecure plan |

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -1,9 +1,9 @@
 # Security barrier views
 
-- Associated: [#38562](https://github.com/MaterializeInc/materialize/pull/38562)
-  (prototype, object-level gates),
-  [#38566](https://github.com/MaterializeInc/materialize/pull/38566)
-  (prototype, security levels)
+- Associated: [#38568](https://github.com/MaterializeInc/materialize/pull/38568)
+  (prototype),
+  [#38562](https://github.com/MaterializeInc/materialize/pull/38562)
+  (prototype of the rejected alternative)
 
 ## The Problem
 
@@ -125,10 +125,14 @@ a barrier are the ones that are always inlined into the reader's dataflow.
 
 ## Solution Proposal
 
-The SQL surface and the exposure analysis below are common to both candidate
-mechanisms. The mechanisms themselves are presented side by side under
-[Mechanisms](#mechanisms), with a prototype for each. This document does not
-pick between them: that is a call for the team that owns the optimizer.
+Mark the view, then carry a security level on each predicate and constrain
+movement and evaluation order by level. This is PostgreSQL 9.5 and later, and it
+is also the mechanism row-level security would need.
+
+The alternative considered and rejected was to refuse to inline a barrier view,
+which is PostgreSQL's pre-9.5 model. It closes the same exposure and is simpler,
+but it costs real performance and cannot generalize. See
+[Alternatives](#alternatives).
 
 ### Syntax
 
@@ -168,143 +172,67 @@ so the pushdown that actually pays for itself still crosses the barrier. What
 stops at the boundary is fallible expressions, which pushdown would not have
 been able to use for pruning anyway.
 
-## Mechanisms
+### How it works
 
-Two mechanisms implement the same surface and close the same exposure. They
-differ in where the guarantee lives, what it costs, and how they fail. Each has
-a prototype.
-
-Both need the barrier set at optimization time. It is optimizer-only state, so
+The barrier set is needed at optimization time. It is optimizer-only state, so
 it belongs on `TransformCtx`, the struct that already threads arguments through
 all transforms, rather than on `DataflowDescription`, which is part of the
-compute protocol. `DataflowBuilder` collects it during import, which is the only
-point at which the optimizer holds the catalog entry.
-
-### A. Object-level gates
-
-Prototype: [#38562](https://github.com/MaterializeInc/materialize/pull/38562).
-This is PostgreSQL's pre-9.5 model: mark the view, then decline to dissolve its
-boundary.
-
-`inline_views` skips a barrier view, so it stays a distinct `objects_to_build`
-entry referenced through a global `Get`. Every per-object transform already
-treats that as opaque, and no `Let` binding is formed for
-`PredicatePushdown::push_into_let_binding` to push into.
-`optimize_dataflow_filters_inner` then applies only leakproof predicates to a
-barrier. A blocked predicate never enters the view's plan, so it never
-propagates onward to the view's inputs either.
-
-Two gates, both in `optimize_dataflow`. Nothing else in the pipeline needs to
-know the concept exists, because the boundary is between dataflow objects and
-the optimizer already respects those.
-
-Worth being precise about what "the boundary holds" means here, because it is
-not isolation. The view and its consumer remain two objects in one dataflow, and
-`optimize_dataflow_relations` runs the whole transform pipeline over each
-object separately, so no transform ever sees both plans at once. Three
-cross-object passes still run: `optimize_dataflow_filters`, which the gate
-restricts to leakproof predicates, and `optimize_dataflow_demand` and
-`optimize_dataflow_monotonic`, which are not gated at all. Column pruning and
-monotonicity therefore cross a barrier freely, which is safe because neither
-decides whether a row is produced.
-
-#### A (risk)
-
-Mechanism A's guarantee rests on an architectural property that nothing states
-and no type enforces: a transform sees one object at a time. A new cross-object
-pass has to be gated by hand, the way `inline_views` and
-`optimize_dataflow_filters` are, and a new place predicates can live would
-escape `inline_views` unnoticed.
-
-### B. Security levels on predicates
-
-Prototype: [#38566](https://github.com/MaterializeInc/materialize/pull/38566).
-This is PostgreSQL 9.5 and later, and it is also the mechanism row-level
-security would need.
+compute protocol. `DataflowBuilder` collects it during import, the only point at
+which the optimizer holds the catalog entry.
 
 `Filter` carries `Vec<Predicate>`, an expression plus the level it was
 introduced at. `inline_views` raises the consumer's non-leakproof predicates a
-level before splicing a barrier in, so the view's body is optimized jointly with
-its consumer's while ordering stays constrained. Incrementing rather than
-assigning a fixed level is what makes nested barriers work.
+level before splicing a barrier in, so the view's body is still optimized jointly
+with its consumer's while ordering stays constrained. Incrementing rather than
+assigning a fixed level is what makes nested barriers compose: each inlining
+lifts everything already merged, so a barrier's own predicates stay below every
+predicate written above it.
 
-Three seams enforce it: **movement**, where a levelled predicate may not sink
-below a lower level nor be reported at a `Get`; **derivation**, where an
-equivalence class is seeded only from leakproof or unconstrained predicates,
-since a derived qual carries no level; and **ordering**, where a levelled
-predicate must be evaluated after every lower-level one.
+Three seams enforce it:
 
-#### B (risk)
+- **Movement.** A levelled predicate may not sink below a lower level, and may
+  not be reported at a `Get`, where the level would be lost crossing into
+  another object. `PredicatePushdown` splits levelled predicates into a `Filter`
+  it then leaves alone. Everything below that split sees only level-0
+  predicates, which is what makes it sound for the rest of the transform to keep
+  working in bare expressions.
+- **Ordering.** `MapFilterProject` sorts by level first. Evaluation walks its
+  predicate list in order and stops at the first failure, so list order is
+  evaluation order and the sort is where the constraint is discharged.
+- **Derivation.** An equivalence class is seeded only from predicates that are
+  leakproof or unconstrained, since a derived qual carries no level of its own.
 
-Mechanism B's residual risk lies entirely in code that does not exist yet. If a
-**new transform mishandles a level it may generate an insecure plan, and nothing
+Ordering has to be enforced inside a single `MapFilterProject` because LIR has no
+`Filter` operator and lowering asserts every filter was extracted into one. Two
+cheaper encodings were tried and both failed: putting the level in a predicate's
+position is unsound, since `memoize_expressions` indexes `expressions` by
+position, and declining to fuse across levels leaves a `Filter` that cannot
+lower. So `MapFilterProject` carries the level, which puts it in LIR and on the
+compute protocol. The runtime does not need it, because `SafeMfpPlan` already
+evaluates predicates in vector order. It crosses because `MapFilterProject` is
+one generic type shared by both plan levels.
+
+Two smaller costs: `Predicate` is 104 bytes against `MirScalarExpr`'s 96, and
+the serialized MIR nests `{expr, level}`, which changes `EXPLAIN AS JSON` and
+requires an expression-cache format bump.
+
+### Residual risk
+
+The residual risk lies entirely in code that does not exist yet. If a **new
+transform mishandles a level it may generate an insecure plan, and nothing
 reports it**. There is no blanket conversion from an expression to a predicate,
 so constructing one requires naming a level: `Predicate::unconstrained` or
 `Predicate::at_level`. And `level` is private with `raise` as its only mutator,
 so no code can lower one. What a new author can miss is therefore not the
 mechanism but the contract, which is recorded on the `mz_expr::predicate`
 module: where a levelled predicate may be relocated to, what level a derived
-predicate inherits, and what a new predicate-bearing operator owes. The first of
-those is expressible as a plan-tree invariant and belongs in `Typecheck`; the
-second has no mechanical check; the third applies to mechanism A equally.
-
-### Comparison
-
-The difference underneath every row below is that A rides a boundary Materialize
-already has, while B introduces a new one.
-
-A dataflow is already a set of objects that are optimized independently, and an
-object referenced from another is opaque by construction. A does not add a rule,
-it declines to dissolve a boundary that exists anyway, and because objects are a
-runtime concept that boundary is represented at every layer: the mid-level plan,
-the physical plan, and the running dataflow.
-
-B inlines the view, so the boundary is gone, and asserts in its place an
-invariant that exists only during planning. By the time a plan reaches the
-physical layer all filtering has been fused into one operator, so there is no
-filter left to order, which is why the ordering has to be pushed down into the
-physical layer and the protocol that ships plans to compute.
-
-| | A. Object gates | B. Levels |
-| --- | --- | --- |
-| What the optimizer may do across the view | the two plans stay distinct objects, so no transform sees both at once; leakproof predicates, column demand, and monotonicity still cross | the two plans merge into one, so every transform applies to both; only evaluation order is constrained |
-| Unit of the constraint | the whole view | one predicate relative to another |
-| Where the guarantee lives | structural: nothing from a consumer can enter a producer's plan | by rule, at each seam that moves, orders, or derives predicates |
-| Reaches LIR / compute protocol | no | yes, once `MapFilterProject` carries the level |
-| Perf, barrier views | view is not inlined: no cross-boundary folding, an extra collection and often an arrangement per boundary, no fast-path peek | inlining preserved; a related spike measured zero plan delta |
-| Perf, non-barrier views | none | none: every text plan in the `EXPLAIN` corpus is byte-identical |
-| Generalizes to row-level security | no | yes |
-
-The last row is why B was explored at all. Row-level security means a table's own
-policy predicates must be evaluated before the user's, and there is no object
-boundary at a table scan to hang that on, so A cannot express it at any price.
-B's per-predicate ordering is the shape row-level security needs.
-
-The measured perf gap is the whole reason B exists. Applying barriers to every
-user view under A changes 327 lines of the `EXPLAIN` corpus, and running the
-same experiment with A's predicate gate disabled produces a byte-identical diff,
-so all of that cost comes from declining to inline rather than from the security
-property. One case regresses from `Constant <empty>` to a full differential join
-with two arrangements over a base collection, to compute a provably empty result.
-
-B's cost lands in a different place. Ordering has to be enforced inside a single
-`MapFilterProject`, because LIR has no `Filter` operator and lowering asserts
-every filter was extracted into one. Two cheaper encodings were tried and both
-failed: putting the level in a predicate's position is unsound, since
-`memoize_expressions` indexes `expressions` by position, and declining to fuse
-across levels leaves a `Filter` that cannot lower. So `MapFilterProject` carries
-the level, which puts it in LIR and on the compute protocol. The runtime does
-not need it: `SafeMfpPlan` already evaluates predicates in vector order, so the
-sort discharges the constraint. It crosses because `MapFilterProject` is one
-generic type shared by both plan levels.
-
-Two smaller costs specific to B: `Predicate` is 104 bytes against
-`MirScalarExpr`'s 96, and the serialized MIR nests `{expr, level}`, changing
-`EXPLAIN AS JSON` and requiring an expression-cache format bump.
+predicate inherits, and what a new predicate-bearing operator owes. The first is
+expressible as a plan-tree invariant and belongs in `Typecheck`; the second has
+no mechanical check; the third would apply to any mechanism.
 
 ### What this fixes
 
-End to end, through the real optimizer, with mechanism A. Given
+End to end, through the real optimizer. Given
 
 ```sql
 CREATE TABLE orders (tenant text, secret text, amount int);
@@ -317,7 +245,7 @@ the unprotected view hands the reader's fallible expression to the base
 collection:
 
 ```
-EXPLAIN SELECT * FROM plain_orders WHERE amount / (length(secret) - 3) > 0;
+EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM plain_orders WHERE amount / (length(secret) - 3) > 0;
 
 Explained Query:
   Filter (#0{tenant} = "alice") AND ((#2{amount} / (char_length(#1{secret}) - 3)) > 0)
@@ -327,38 +255,41 @@ Source materialize.public.orders
   filter=((#0{tenant} = "alice") AND ((#2{amount} / (char_length(#1{secret}) - 3)) > 0))
 ```
 
-The barrier view does not:
+The barrier view does not. The view is still inlined, so there is one plan rather
+than two, and the levels are visible on the `Filter`:
 
 ```
-EXPLAIN SELECT * FROM barrier_orders WHERE amount / (length(secret) - 3) > 0;
+EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM barrier_orders WHERE amount / (length(secret) - 3) > 0;
 
 Explained Query:
-  Filter ((#2{amount} / (char_length(#1{secret}) - 3)) > 0)
-    ReadGlobalFromSameDataflow materialize.public.barrier_orders
-
-materialize.public.barrier_orders:
-  Filter (#0{tenant} = "alice")
+  Filter (#0{tenant} = "alice") AND ((#2{amount} / (char_length(#1{secret}) - 3)) > 0) [levels: [0, 1]]
     ReadStorage materialize.public.orders
 
 Source materialize.public.orders
   filter=((#0{tenant} = "alice"))
 ```
 
-The view survives as its own object, read through
-`ReadGlobalFromSameDataflow`, the division sits above it, and the tenant filter
-is the only thing reaching `orders`.
-
-A leakproof predicate still crosses, and still reaches the source import where
-persist pruning can use it:
+That plan shows movement being blocked: only the tenant filter reaches the
+source. Ordering shows up in the physical plan, where the two predicates fuse
+into one operator. Over a table whose column order would otherwise schedule the
+reader's cast first, `t(secret, tenant)`:
 
 ```
-EXPLAIN SELECT * FROM barrier_orders WHERE amount = 42;
+plain    filter=((text_to_integer(#0{secret}) > 0) AND (#1{tenant} = "alice"))
+barrier  filter=((#1{tenant} = "alice") AND (text_to_integer(#0{secret}) > 0))
+```
+
+Both are fully inlined, so the order is the only difference. `secret` is `#0`
+and `tenant` is `#1`, so position alone would evaluate the cast first. The level
+outranks position.
+
+A leakproof predicate carries no level, so it still crosses and still reaches
+the source import where persist pruning can use it:
+
+```
+EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM barrier_orders WHERE amount = 42;
 
 Explained Query:
-  Filter (#2{amount} = 42)
-    ReadGlobalFromSameDataflow materialize.public.barrier_orders
-
-materialize.public.barrier_orders:
   Filter (#0{tenant} = "alice") AND (#2{amount} = 42)
     ReadStorage materialize.public.orders
 
@@ -418,7 +349,7 @@ costs roughly a hundredfold on that arrangement.
 
 Two things about this example are worth stating plainly.
 
-**The cost is inherent, not an artifact of either mechanism.** Filtering `det`
+**The cost is inherent, not an artifact of the mechanism.** Filtering `det`
 by the reader's cast before the join would evaluate that cast against rows
 belonging to every tenant, which is exactly the disclosure the barrier exists to
 prevent. There is no correct plan that filters `det` early. The cheap plan is
@@ -506,11 +437,9 @@ engages at all. It is also cheap whenever readers filter with comparisons: `=`,
 cross the barrier untouched.
 
 **The barrier is expensive when** a reader's fallible predicate is selective and
-sits above a join or an arrangement, per the example above. Under mechanism A it
-is additionally expensive when the view sits partway up a stack of other views,
-because the whole stack loses joint optimization, and when readers issue point
-lookups, because a barrier view occupies `objects_to_build[0]` and disqualifies
-the fast-path peek.
+sits above a join or an arrangement, per the example above. That is the only
+case, because the view is still inlined and everything else about planning it is
+unchanged.
 
 **Materializing is not a substitute**, for three reasons. An index only helps on
 the cluster that holds it, and a reader chooses their own cluster, so an
@@ -524,37 +453,25 @@ runs.
 
 ## Minimal Viable Prototype
 
-Two prototypes, one per mechanism, so that they can be compared rather than
-argued about.
+[#38568](https://github.com/MaterializeInc/materialize/pull/38568) is complete
+and verified end to end. 1768 sqllogictest assertions pass across the `EXPLAIN`
+corpus, privileges, joins, subqueries, and the barrier tests, and no text plan in
+the `EXPLAIN` corpus changes: only the JSON goldens move, for the serialization
+shape.
 
-**A, object-level gates**
-([#38562](https://github.com/MaterializeInc/materialize/pull/38562)) is complete
-and verified end to end. The optimizer change proper is two gates and one
-predicate in `src/transform/src/dataflow.rs`; the rest is option plumbing.
-`src/transform/tests/test_security_barrier.rs` asserts the blocked, admitted,
-and unprotected cases at the `optimize_dataflow_filters_inner` seam, including a
-test that pins the current exposure so a regression is visible.
-`test/sqllogictest/security_barrier.slt` covers the SQL surface and the
-resulting `EXPLAIN` plans. The existing `EXPLAIN` and privilege suites pass
-unchanged, confirming the default path is untouched.
+The guarantee is pinned by the plans in
+[What this fixes](#what-this-fixes), including the physical-plan pair over a
+table whose column order would otherwise schedule the reader's cast first. The
+ordering rule is also stated once, declaratively, in
+`src/expr/tests/test_security_levels.rs` and checked against arbitrary predicate
+lists, verified red before green: removing the level from the sort key fails
+three of the five properties.
 
-**B, security levels**
-([#38566](https://github.com/MaterializeInc/materialize/pull/38566)) is also
-complete. 1768 sqllogictest assertions pass, and no text plan in the `EXPLAIN`
-corpus changes: only the JSON goldens move, for the serialization shape, which
-implies an expression-cache format bump. The guarantee is pinned by physical
-plans over a table whose column order would otherwise schedule the reader's
-fallible cast ahead of the tenant filter:
+The rejected alternative is prototyped separately at
+[#38562](https://github.com/MaterializeInc/materialize/pull/38562), so the two
+can be compared rather than argued about.
 
-```
-plain   filter=((text_to_integer(#0{secret}) > 0) AND (#1{tenant} = "alice"))
-barrier filter=((#1{tenant} = "alice") AND (text_to_integer(#0{secret}) > 0))
-```
-
-Both are fully inlined, so ordering is the only difference. B is built on A's
-branch, so it inherits the SQL surface and tests; only the mechanism differs.
-
-Deliberately left out of both:
+Deliberately left out:
 
 - An `mz_views` catalog column reporting the flag. `SHOW CREATE VIEW` already
   reflects it through `create_sql`.
@@ -563,31 +480,56 @@ Deliberately left out of both:
 
 ## Alternatives
 
-The two candidate mechanisms are not alternatives to each other in this section;
-they are in [Mechanisms](#mechanisms). What follows are approaches rejected
-before either was prototyped.
+**Object-level gates: refuse to inline a barrier view.** PostgreSQL's pre-9.5
+model, and the closest alternative. `inline_views` skips a barrier view so it
+stays a distinct `objects_to_build` entry referenced through a global `Get`,
+which every per-object transform already treats as opaque, and
+`optimize_dataflow_filters_inner` then applies only leakproof predicates to it.
+Two gates, both in `optimize_dataflow`, and nothing else in the pipeline needs to
+know the concept exists. Prototyped and complete at
+[#38562](https://github.com/MaterializeInc/materialize/pull/38562).
+
+It is the better mechanism on one axis: the guarantee is structural rather than
+by rule. A transform cannot reach across an object boundary because reaching
+across is not an operation a transform has, so forgetting costs an optimization
+rather than the guarantee. It also never reaches LIR or the compute protocol.
+
+It was rejected on two counts. **Performance:** applying barriers to every user
+view moves 327 lines of the `EXPLAIN` corpus, and running the same experiment
+with its predicate gate disabled produces a byte-identical diff, so all of that
+cost comes from declining to inline rather than from the security property. One
+case regresses from `Constant <empty>` to a full differential join with two
+arrangements over a base collection, to compute a provably empty result. Barrier
+views also lose cross-boundary folding, gain an extra collection and often an
+arrangement per boundary, and no longer qualify for the fast-path peek, since a
+barrier view occupies `objects_to_build[0]`.
+
+**Generality:** it cannot express row-level security at any price. RLS means a
+table's own policy predicates must be evaluated before the user's, and there is
+no object boundary at a table scan to hang a gate on. Per-predicate ordering is
+the shape RLS needs.
 
 **Make every view a barrier.** Correct by default and immune to a user
 forgetting the option. Rejected, for the reasons in
 [Why the option is opt-in](#why-the-option-is-opt-in): the cost is concentrated
 rather than average, so applying it everywhere makes a real regression
-unattributable. The measurements are there too, including that mechanism A moves
-327 lines of the `EXPLAIN` corpus under this default while B moves none, which
-is what motivated exploring B in the first place.
+unattributable. Note that the cost is concentrated under this proposal but
+pervasive under object-level gates, which move 327 lines of the `EXPLAIN` corpus
+under the same default.
 
 **Wrap the predicate in an opaque marker instead of carrying a level.** A
 `SecurityFence` unary function that the optimizer refuses to move. Prototyped:
-it recovers all of A's cost and needs only 7 files, because an unrecognized
+it recovers the same performance and needs only 7 files, because an unrecognized
 wrapper is inert by default rather than requiring every transform to opt in. It
 was abandoned because wrapping makes a predicate syntactically unrecognizable,
 which is fail-safe where a transform is optional but fail-stop where its output
 is required. Temporal filters break outright: `mz_now()` is non-leakproof, so it
 gets wrapped, and `MfpPlan` then rejects it as an unsupported temporal
-predicate. Carrying the level beside the expression, as B does, leaves the
-expression untouched and does not have this problem.
+predicate. Carrying the level beside the expression leaves the expression
+untouched and does not have this problem.
 
 **Document that views are not a security boundary.** Legitimate, and strictly
-cheaper than either mechanism. It is the right answer if we conclude that
+cheaper than any mechanism. It is the right answer if we conclude that
 view-based row filtering is not a pattern we intend to support. It conflicts
 with what the RBAC documentation currently implies, so if we choose it we should
 say so explicitly rather than by omission.
@@ -603,18 +545,15 @@ for any future non-error channel.
   design is contingent on that. If yes, this is table stakes and the current
   behavior is a security bug. If no, the honest move is to document that views
   are not a security boundary and close this out.
-- Which mechanism? Both prototypes work and close the same exposure. A fails
-  closed and confines the concept to two gates, but costs real performance on
-  barrier views beyond the shared cost. B preserves that performance and is the
-  mechanism row-level security would need, but puts the concept on the compute
-  protocol and carries an obligation on future code, scoped to three shapes in
-  [B (risk)](#b-risk),
-  of which one is mechanically closable and one stays soft. This document
-  deliberately does not pick.
-- The default is settled in this document and the mechanism is not. If the team
-  disagrees with opt-in, the argument to engage is in
-  [The argument against](#the-argument-against-and-what-to-do-about-it), and the
-  detection idea there is the part worth keeping either way.
+- Is the residual risk acceptable? This proposal trades a structural guarantee
+  for a rule-based one in exchange for performance and for a path to row-level
+  security. The obligation on future code is scoped in
+  [Residual risk](#residual-risk), and one of its three shapes is closable as a
+  `Typecheck` invariant. If the team would rather have the structural guarantee
+  and pay for it, the alternative is prototyped and ready.
+- Should the `Typecheck` invariant land with this, or after? It converts the
+  movement half of the residual risk from review discipline into a test failure,
+  and it is the single highest-value follow-up.
 - `MirScalarExpr::could_error` is currently maintained to keep persist filter
   pushdown correct. Promoting it to a security boundary means a wrong
   `could_error = false` becomes a vulnerability rather than a performance bug.

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -242,7 +242,7 @@ physical layer and the protocol that ships plans to compute.
 | Perf, barrier views | view is not inlined: no cross-boundary folding, an extra collection and often an arrangement per boundary, no fast-path peek | inlining preserved; a related spike measured zero plan delta |
 | Perf, non-barrier views | none | none: every text plan in the `EXPLAIN` corpus is byte-identical |
 | Generalizes to row-level security | no | yes |
-| Prototype status | complete and verified end to end | compiles and is inert without barriers; the barrier path does not yet plan |
+| Prototype status | complete and verified end to end | complete and verified end to end |
 
 Row four is the one that outlives this design. Under A the safe behavior is the
 default: a transform that has never heard of security barriers cannot reach
@@ -264,14 +264,26 @@ so all of that cost comes from declining to inline rather than from the security
 property. One case regresses from `Constant <empty>` to a full differential join
 with two arrangements over a base collection, to compute a provably empty result.
 
-The unresolved cost of B is symmetrical. Ordering has to be enforced inside a
-single `MapFilterProject`, because LIR has no `Filter` operator and lowering
-asserts every filter was extracted into one. Encoding the level in a predicate's
-position is unsound, since `memoize_expressions` indexes `expressions` by
-position. Declining to fuse across levels leaves a `Filter` that cannot lower.
-So `MapFilterProject` has to carry the level, which reaches LIR, `MfpPlan`, and
-the compute protocol: roughly 48 further sites beyond the ~40 the MIR type
-change already touches.
+B's cost lands in a different place. Ordering has to be enforced inside a single
+`MapFilterProject`, because LIR has no `Filter` operator and lowering asserts
+every filter was extracted into one. Two cheaper encodings were tried and both
+failed: putting the level in a predicate's position is unsound, since
+`memoize_expressions` indexes `expressions` by position, and declining to fuse
+across levels leaves a `Filter` that cannot lower. So `MapFilterProject` carries
+the level, which puts it in LIR and on the compute protocol. The runtime does
+not need it: `SafeMfpPlan` already evaluates predicates in vector order, so the
+sort discharges the constraint. It crosses because `MapFilterProject` is one
+generic type shared by both plan levels.
+
+The finished prototype touches ~90 sites across 24 files. Every one is a
+predicate conversion that had to state whether it was creating a new
+unconstrained predicate or re-applying an existing one, because there is no
+blanket conversion from an expression to a predicate. That is what surfaced
+three real level-dropping bugs, in `into_map_filter_project`,
+`literal_constraints`, and `canonicalize_mfp`, each of which would have compiled
+silently under a blanket conversion. It is also the standing cost: the same
+discipline applies to every future transform that touches predicates, and
+nothing enforces it but the review.
 
 Two smaller costs specific to B: `Predicate` is 104 bytes against
 `MirScalarExpr`'s 96, and the serialized MIR nests `{expr, level}`, changing
@@ -358,13 +370,20 @@ resulting `EXPLAIN` plans. The existing `EXPLAIN` and privilege suites pass
 unchanged, confirming the default path is untouched.
 
 **B, security levels**
-([#38566](https://github.com/MaterializeInc/materialize/pull/38566)) is
-incomplete. The type change and the movement, derivation, and canonicalization
-seams are in place, the workspace compiles, and the change is inert without
-barriers: every text plan in the `EXPLAIN` corpus is byte-identical. A query
-against a barrier view does not yet plan, for the `MapFilterProject` reason in
-[Comparison](#comparison). B is built on A's branch, so it inherits the SQL
-surface and tests; only the mechanism differs.
+([#38566](https://github.com/MaterializeInc/materialize/pull/38566)) is also
+complete. 1768 sqllogictest assertions pass, and no text plan in the `EXPLAIN`
+corpus changes: only the JSON goldens move, for the serialization shape, which
+implies an expression-cache format bump. The guarantee is pinned by physical
+plans over a table whose column order would otherwise schedule the reader's
+fallible cast ahead of the tenant filter:
+
+```
+plain   filter=((text_to_integer(#0{secret}) > 0) AND (#1{tenant} = "alice"))
+barrier filter=((#1{tenant} = "alice") AND (text_to_integer(#0{secret}) > 0))
+```
+
+Both are fully inlined, so ordering is the only difference. B is built on A's
+branch, so it inherits the SQL surface and tests; only the mechanism differs.
 
 Deliberately left out of both:
 
@@ -460,11 +479,13 @@ for any future non-error channel.
   design is contingent on that. If yes, this is table stakes and the current
   behavior is a security bug. If no, the honest move is to document that views
   are not a security boundary and close this out.
-- Which mechanism? A is complete, fails closed, and confines the concept to two
-  gates, but forecloses a safe default and costs real performance on barrier
-  views. B preserves performance and generalizes to row-level security, but
-  reaches the compute protocol and fails open at any seam that is missed. This
-  document deliberately does not pick.
+- Which mechanism? Both prototypes work and close the same exposure. A fails
+  closed and confines the concept to two gates, but forecloses a safe default
+  and costs real performance on barrier views. B preserves performance and is
+  the mechanism row-level security would need, but puts the concept on the
+  compute protocol and carries a standing obligation: every future transform
+  that touches predicates has to preserve the level, and nothing enforces that
+  but review. This document deliberately does not pick.
 - `MirScalarExpr::could_error` is currently maintained to keep persist filter
   pushdown correct. Promoting it to a security boundary means a wrong
   `could_error = false` becomes a vulnerability rather than a performance bug.

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -534,10 +534,52 @@ view-based row filtering is not a pattern we intend to support. It conflicts
 with what the RBAC documentation currently implies, so if we choose it we should
 say so explicitly rather than by omission.
 
-**Reject fallible expressions in predicates over any view.** Blocks the error
-channel without any optimizer changes, but it breaks a large amount of
-legitimate SQL (`::int` casts, division) and still leaves the ordering problem
-for any future non-error channel.
+**Remove the offending value from error messages.** The most frequently
+proposed fix, and the most intuitive: the message literally contains the SSN, so
+stop printing it. It does not work, because the channel is the error's
+*existence*, not its content.
+
+A predicate that fails conditionally turns any comparison into a one-bit oracle,
+and the message carries no data at all:
+
+```sql
+-- error means some hidden row matches
+SELECT * FROM my_orders
+WHERE CASE WHEN secret LIKE '123%' THEN 1/0 ELSE 1 END = 1;
+ERROR:  Evaluation error: division by zero
+
+-- a prefix that matches nothing returns normally
+SELECT * FROM my_orders
+WHERE CASE WHEN secret LIKE '555%' THEN 1/0 ELSE 1 END = 1;
+ secret | tenant
+--------+--------
+ 42     | alice
+```
+
+Prefix-search that and any hidden value comes out bit by bit, whatever its type,
+whether or not the type ever embeds its input in a message. Exclusion composes
+with it: adding `secret NOT IN (<values already recovered>)` moves the probe to
+the next hidden row, so the attack enumerates rather than samples.
+
+So sanitizing messages changes the cost of extraction from one query per value
+to a logarithmic number of queries per value. That is worth something
+operationally, since a drain becomes visible to rate limiting and to audit logs
+in a way a single query is not, and it is worth doing on its own merits. It is
+not a fix, and it carries a real cost of its own: an error that names the value
+that failed is genuinely useful for debugging, and PostgreSQL prints it for the
+same reason.
+
+The general form of the argument is why this design constrains ordering rather
+than output. Any fallible expression is an oracle over whatever rows it is
+allowed to observe, so the only place to intervene is which rows it observes.
+
+**Reject fallible expressions in predicates over any view.** The sound version
+of the previous entry: if an oracle needs a fallible expression, refuse the
+expression. It needs no optimizer changes and it does close the channel. It also
+breaks a large amount of ordinary SQL, since `::int` casts and division appear in
+predicates constantly, and it would reject them over every view rather than only
+the ones acting as an access boundary. It also leaves the ordering problem intact
+for any future channel that is not an error.
 
 ## Open questions
 

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -226,18 +226,6 @@ equivalence class is seeded only from leakproof or unconstrained predicates,
 since a derived qual carries no level; and **ordering**, where a levelled
 predicate must be evaluated after every lower-level one.
 
-### Residual risk
-
-#### A (risk)
-
-Mechanism A's guarantee rests on an architectural property rather than on a
-check: nothing crosses an object boundary because the transform pipeline runs
-over one object at a time. Nothing states that property, and no type enforces
-it. A new cross-object pass would have to be gated by hand the way
-`inline_views` and `optimize_dataflow_filters` are, and a new place predicates
-can live would escape `inline_views` unnoticed. The surface is small, four
-cross-object passes today, but it is guarded by convention.
-
 #### B (risk)
 
 Mechanism B's residual risk lies entirely in code that does not exist yet. If a
@@ -274,22 +262,12 @@ physical layer and the protocol that ships plans to compute.
 | What the optimizer may do across the view | the two plans stay distinct objects, so no transform sees both at once; leakproof predicates, column demand, and monotonicity still cross | the two plans merge into one, so every transform applies to both; only evaluation order is constrained |
 | Unit of the constraint | the whole view | one predicate relative to another |
 | Where the guarantee lives | structural: nothing from a consumer can enter a producer's plan | by rule, at each seam that moves, orders, or derives predicates |
-| Failure mode of a missed site | costs an optimization | silently produces an insecure plan, for the three shapes below |
 | Reaches LIR / compute protocol | no | yes, once `MapFilterProject` carries the level |
 | Perf, barrier views | view is not inlined: no cross-boundary folding, an extra collection and often an arrangement per boundary, no fast-path peek | inlining preserved; a related spike measured zero plan delta |
 | Perf, non-barrier views | none | none: every text plan in the `EXPLAIN` corpus is byte-identical |
 | Generalizes to row-level security | no | yes |
-| Prototype status | complete and verified end to end | complete and verified end to end |
 
-Row four is the one that outlives this design. Under A the safe behavior is the
-default: a transform that has never heard of security barriers cannot reach
-across an object boundary, because reaching across is not something a transform
-can do, so forgetting costs an optimization. Under B the optimizing behavior is
-the default: a transform that has never heard of levels moves predicates freely,
-because moving predicates is its job, so forgetting costs the guarantee and
-nothing reports it.
-
-Row eight is why B was explored at all. Row-level security means a table's own
+Row five is why B was explored at all. Row-level security means a table's own
 policy predicates must be evaluated before the user's, and there is no object
 boundary at a table scan to hang that on, so A cannot express it at any price.
 B's per-predicate ordering is the shape row-level security needs.
@@ -311,18 +289,6 @@ the level, which puts it in LIR and on the compute protocol. The runtime does
 not need it: `SafeMfpPlan` already evaluates predicates in vector order, so the
 sort discharges the constraint. It crosses because `MapFilterProject` is one
 generic type shared by both plan levels.
-
-The finished prototype touches ~90 sites across 24 files. Every one is a
-predicate conversion that had to state whether it was creating a new
-unconstrained predicate or re-applying an existing one, because there is no
-blanket conversion from an expression to a predicate. That is what surfaced
-three real level-dropping bugs, in `into_map_filter_project`,
-`literal_constraints`, and `canonicalize_mfp`, each of which would have compiled
-silently under a blanket conversion.
-
-So the existing tree is checked rather than assumed. What B carries instead is
-an obligation on code that does not exist yet, scoped in
-[What a future transform has to know](#what-a-future-transform-has-to-know).
 
 Two smaller costs specific to B: `Predicate` is 104 bytes against
 `MirScalarExpr`'s 96, and the serialized MIR nests `{expr, level}`, changing
@@ -391,45 +357,6 @@ materialize.public.barrier_orders:
 Source materialize.public.orders
   filter=((#0{tenant} = "alice") AND (#2{amount} = 42))
 ```
-
-## Minimal Viable Prototype
-
-Two prototypes, one per mechanism, so that they can be compared rather than
-argued about.
-
-**A, object-level gates**
-([#38562](https://github.com/MaterializeInc/materialize/pull/38562)) is complete
-and verified end to end. The optimizer change proper is two gates and one
-predicate in `src/transform/src/dataflow.rs`; the rest is option plumbing.
-`src/transform/tests/test_security_barrier.rs` asserts the blocked, admitted,
-and unprotected cases at the `optimize_dataflow_filters_inner` seam, including a
-test that pins the current exposure so a regression is visible.
-`test/sqllogictest/security_barrier.slt` covers the SQL surface and the
-resulting `EXPLAIN` plans. The existing `EXPLAIN` and privilege suites pass
-unchanged, confirming the default path is untouched.
-
-**B, security levels**
-([#38566](https://github.com/MaterializeInc/materialize/pull/38566)) is also
-complete. 1768 sqllogictest assertions pass, and no text plan in the `EXPLAIN`
-corpus changes: only the JSON goldens move, for the serialization shape, which
-implies an expression-cache format bump. The guarantee is pinned by physical
-plans over a table whose column order would otherwise schedule the reader's
-fallible cast ahead of the tenant filter:
-
-```
-plain   filter=((text_to_integer(#0{secret}) > 0) AND (#1{tenant} = "alice"))
-barrier filter=((#1{tenant} = "alice") AND (text_to_integer(#0{secret}) > 0))
-```
-
-Both are fully inlined, so ordering is the only difference. B is built on A's
-branch, so it inherits the SQL surface and tests; only the mechanism differs.
-
-Deliberately left out of both:
-
-- An `mz_views` catalog column reporting the flag. `SHOW CREATE VIEW` already
-  reflects it through `create_sql`.
-- `ALTER VIEW ... SET (SECURITY BARRIER)`.
-- Documentation under `doc/user/`.
 
 ## Why the option is opt-in
 
@@ -539,6 +466,7 @@ query, not an optimizer change, and it can back a warning, a linting view, or an
 barriers. That closes the asymmetry at a fraction of the cost of default-on, and
 it is worth doing whichever mechanism is chosen.
 
+
 ## When to enable a barrier
 
 **Enable it when the view is the access boundary**: the reader holds `SELECT`
@@ -570,6 +498,45 @@ predicate calls `current_user` can be neither indexed nor materialized, because
 `ExprPrepMaintained` rejects unmaterializable functions. What a barrier adds
 over materializing is that the guarantee stops depending on where the query
 runs.
+
+## Minimal Viable Prototype
+
+Two prototypes, one per mechanism, so that they can be compared rather than
+argued about.
+
+**A, object-level gates**
+([#38562](https://github.com/MaterializeInc/materialize/pull/38562)) is complete
+and verified end to end. The optimizer change proper is two gates and one
+predicate in `src/transform/src/dataflow.rs`; the rest is option plumbing.
+`src/transform/tests/test_security_barrier.rs` asserts the blocked, admitted,
+and unprotected cases at the `optimize_dataflow_filters_inner` seam, including a
+test that pins the current exposure so a regression is visible.
+`test/sqllogictest/security_barrier.slt` covers the SQL surface and the
+resulting `EXPLAIN` plans. The existing `EXPLAIN` and privilege suites pass
+unchanged, confirming the default path is untouched.
+
+**B, security levels**
+([#38566](https://github.com/MaterializeInc/materialize/pull/38566)) is also
+complete. 1768 sqllogictest assertions pass, and no text plan in the `EXPLAIN`
+corpus changes: only the JSON goldens move, for the serialization shape, which
+implies an expression-cache format bump. The guarantee is pinned by physical
+plans over a table whose column order would otherwise schedule the reader's
+fallible cast ahead of the tenant filter:
+
+```
+plain   filter=((text_to_integer(#0{secret}) > 0) AND (#1{tenant} = "alice"))
+barrier filter=((#1{tenant} = "alice") AND (text_to_integer(#0{secret}) > 0))
+```
+
+Both are fully inlined, so ordering is the only difference. B is built on A's
+branch, so it inherits the SQL surface and tests; only the mechanism differs.
+
+Deliberately left out of both:
+
+- An `mz_views` catalog column reporting the flag. `SHOW CREATE VIEW` already
+  reflects it through `create_sql`.
+- `ALTER VIEW ... SET (SECURITY BARRIER)`.
+- Documentation under `doc/user/`.
 
 ## Alternatives
 

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -208,6 +208,14 @@ restricts to leakproof predicates, and `optimize_dataflow_demand` and
 monotonicity therefore cross a barrier freely, which is safe because neither
 decides whether a row is produced.
 
+#### A (risk)
+
+Mechanism A's guarantee rests on an architectural property that nothing states
+and no type enforces: a transform sees one object at a time. A new cross-object
+pass has to be gated by hand, the way `inline_views` and
+`optimize_dataflow_filters` are, and a new place predicates can live would
+escape `inline_views` unnoticed.
+
 ### B. Security levels on predicates
 
 Prototype: [#38566](https://github.com/MaterializeInc/materialize/pull/38566).
@@ -267,7 +275,7 @@ physical layer and the protocol that ships plans to compute.
 | Perf, non-barrier views | none | none: every text plan in the `EXPLAIN` corpus is byte-identical |
 | Generalizes to row-level security | no | yes |
 
-Row five is why B was explored at all. Row-level security means a table's own
+The last row is why B was explored at all. Row-level security means a table's own
 policy predicates must be evaluated before the user's, and there is no object
 boundary at a table scan to hang that on, so A cannot express it at any price.
 B's per-predicate ordering is the shape row-level security needs.
@@ -585,7 +593,7 @@ for any future non-error channel.
   barrier views beyond the shared cost. B preserves that performance and is the
   mechanism row-level security would need, but puts the concept on the compute
   protocol and carries an obligation on future code, scoped to three shapes in
-  [What a future transform has to know](#what-a-future-transform-has-to-know),
+  [B (risk)](#b-risk),
   of which one is mechanically closable and one stays soft. This document
   deliberately does not pick.
 - The default is settled in this document and the mechanism is not. If the team

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -217,15 +217,45 @@ predicate must be evaluated after every lower-level one.
 
 ### Comparison
 
+The difference underneath every row below is that A rides a boundary Materialize
+already has, while B introduces a new one.
+
+A dataflow is already a set of objects that are optimized independently, and an
+object referenced from another is opaque by construction. A does not add a rule,
+it declines to dissolve a boundary that exists anyway, and because objects are a
+runtime concept that boundary is represented at every layer: the mid-level plan,
+the physical plan, and the running dataflow.
+
+B inlines the view, so the boundary is gone, and asserts in its place an
+invariant that exists only during planning. By the time a plan reaches the
+physical layer all filtering has been fused into one operator, so there is no
+filter left to order, which is why the ordering has to be pushed down into the
+physical layer and the protocol that ships plans to compute.
+
 | | A. Object gates | B. Levels |
 | --- | --- | --- |
+| What the optimizer may do across the view | nothing but leakproof predicates; the view and the query are planned separately | everything; the view is planned as part of the query, and only evaluation order is constrained |
+| Unit of the constraint | the whole view | one predicate relative to another |
 | Where the guarantee lives | structural: nothing from a consumer can enter a producer's plan | by rule, at each seam that moves, orders, or derives predicates |
+| Failure mode of a missed site | costs an optimization | silently produces an insecure plan |
 | Reaches LIR / compute protocol | no | yes, once `MapFilterProject` carries the level |
 | Perf, barrier views | view is not inlined: no cross-boundary folding, an extra collection and often an arrangement per boundary, no fast-path peek | inlining preserved; a related spike measured zero plan delta |
 | Perf, non-barrier views | none | none: every text plan in the `EXPLAIN` corpus is byte-identical |
 | Generalizes to row-level security | no | yes |
-| Failure mode of a missed site | costs an optimization | silently produces an insecure plan |
 | Prototype status | complete and verified end to end | compiles and is inert without barriers; the barrier path does not yet plan |
+
+Row four is the one that outlives this design. Under A the safe behavior is the
+default: a transform that has never heard of security barriers cannot reach
+across an object boundary, because reaching across is not something a transform
+can do, so forgetting costs an optimization. Under B the optimizing behavior is
+the default: a transform that has never heard of levels moves predicates freely,
+because moving predicates is its job, so forgetting costs the guarantee and
+nothing reports it.
+
+Row eight is why B was explored at all. Row-level security means a table's own
+policy predicates must be evaluated before the user's, and there is no object
+boundary at a table scan to hang that on, so A cannot express it at any price.
+B's per-predicate ordering is the shape row-level security needs.
 
 The measured perf gap is the whole reason B exists. Applying barriers to every
 user view under A changes 327 lines of the `EXPLAIN` corpus, and running the

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -1,6 +1,9 @@
 # Security barrier views
 
-- Associated: [#38562](https://github.com/MaterializeInc/materialize/pull/38562) (prototype)
+- Associated: [#38562](https://github.com/MaterializeInc/materialize/pull/38562)
+  (prototype, object-level gates),
+  [#38566](https://github.com/MaterializeInc/materialize/pull/38566)
+  (prototype, security levels)
 
 ## The Problem
 
@@ -121,14 +124,10 @@ a barrier are the ones that are always inlined into the reader's dataflow.
 
 ## Solution Proposal
 
-Adopt PostgreSQL's pre-9.5 model: mark the view, then decline to dissolve its
-boundary. Do not adopt PostgreSQL's later `RestrictInfo.security_level`
-machinery.
-
-That machinery exists so that quals originating at many different security
-levels can be interleaved at a single scan node, which is what row-level
-security requires. Materialize has no RLS, so every barrier is a whole-object
-boundary and a single bit per object suffices.
+The SQL surface and the exposure analysis below are common to both candidate
+mechanisms. The mechanisms themselves are presented side by side under
+[Mechanisms](#mechanisms), with a prototype for each. This document does not
+pick between them: that is a call for the team that owns the optimizer.
 
 ### Syntax
 
@@ -168,34 +167,89 @@ so the pushdown that actually pays for itself still crosses the barrier. What
 stops at the boundary is fallible expressions, which pushdown would not have
 been able to use for pruning anyway.
 
-### Optimizer changes
+## Mechanisms
 
-The barrier set is optimizer-only state, so it belongs on `TransformCtx`, the
-struct that already threads arguments through all transforms, rather than on
-`DataflowDescription`, which is part of the compute protocol.
+Two mechanisms implement the same surface and close the same exposure. They
+differ in where the guarantee lives, what it costs, and how they fail. Each has
+a prototype.
 
-`DataflowBuilder` learns which imported views are barriers as it imports them,
-because `import_into_dataflow` already matches on the catalog entry. Callers
-hand that set to `TransformCtx::global`.
+Both need the barrier set at optimization time. It is optimizer-only state, so
+it belongs on `TransformCtx`, the struct that already threads arguments through
+all transforms, rather than on `DataflowDescription`, which is part of the
+compute protocol. `DataflowBuilder` collects it during import, which is the only
+point at which the optimizer holds the catalog entry.
 
-Two gates then implement the barrier:
+### A. Object-level gates
 
-- `inline_views` skips a barrier view, so it stays a distinct
-  `objects_to_build` entry referenced through a global `Get`. Every transform
-  that runs per-object then treats it as opaque for free, and no `Let` binding
-  is ever formed for `push_into_let_binding` to push into.
-- `optimize_dataflow_filters_inner` applies only leakproof predicates to a
-  barrier view. Non-leakproof predicates stay above the `Get` in the consumer,
-  and because they never enter the view's plan they also never propagate onward
-  to the view's own inputs.
+Prototype: [#38562](https://github.com/MaterializeInc/materialize/pull/38562).
+This is PostgreSQL's pre-9.5 model: mark the view, then decline to dissolve its
+boundary.
 
-No other cross-object transform needs a gate. `optimize_dataflow_demand`
-prunes columns rather than rows, which is safe and which PostgreSQL also
-permits. Everything else in the pipeline operates within a single object.
+`inline_views` skips a barrier view, so it stays a distinct `objects_to_build`
+entry referenced through a global `Get`. Every per-object transform already
+treats that as opaque, and no `Let` binding is formed for
+`PredicatePushdown::push_into_let_binding` to push into.
+`optimize_dataflow_filters_inner` then applies only leakproof predicates to a
+barrier. A blocked predicate never enters the view's plan, so it never
+propagates onward to the view's inputs either.
+
+Two gates, both in `optimize_dataflow`. Nothing else in the pipeline needs to
+know the concept exists, because the boundary is between dataflow objects and
+the optimizer already respects those.
+
+### B. Security levels on predicates
+
+Prototype: [#38566](https://github.com/MaterializeInc/materialize/pull/38566).
+This is PostgreSQL 9.5 and later, and it is also the mechanism row-level
+security would need.
+
+`Filter` carries `Vec<Predicate>`, an expression plus the level it was
+introduced at. `inline_views` raises the consumer's non-leakproof predicates a
+level before splicing a barrier in, so the view's body is optimized jointly with
+its consumer's while ordering stays constrained. Incrementing rather than
+assigning a fixed level is what makes nested barriers work.
+
+Three seams enforce it: **movement**, where a levelled predicate may not sink
+below a lower level nor be reported at a `Get`; **derivation**, where an
+equivalence class is seeded only from leakproof or unconstrained predicates,
+since a derived qual carries no level; and **ordering**, where a levelled
+predicate must be evaluated after every lower-level one.
+
+### Comparison
+
+| | A. Object gates | B. Levels |
+| --- | --- | --- |
+| Where the guarantee lives | structural: nothing from a consumer can enter a producer's plan | by rule, at each seam that moves, orders, or derives predicates |
+| Reaches LIR / compute protocol | no | yes, once `MapFilterProject` carries the level |
+| Perf, barrier views | view is not inlined: no cross-boundary folding, an extra collection and often an arrangement per boundary, no fast-path peek | inlining preserved; a related spike measured zero plan delta |
+| Perf, non-barrier views | none | none: every text plan in the `EXPLAIN` corpus is byte-identical |
+| Generalizes to row-level security | no | yes |
+| Failure mode of a missed site | costs an optimization | silently produces an insecure plan |
+| Prototype status | complete and verified end to end | compiles and is inert without barriers; the barrier path does not yet plan |
+
+The measured perf gap is the whole reason B exists. Applying barriers to every
+user view under A changes 327 lines of the `EXPLAIN` corpus, and running the
+same experiment with A's predicate gate disabled produces a byte-identical diff,
+so all of that cost comes from declining to inline rather than from the security
+property. One case regresses from `Constant <empty>` to a full differential join
+with two arrangements over a base collection, to compute a provably empty result.
+
+The unresolved cost of B is symmetrical. Ordering has to be enforced inside a
+single `MapFilterProject`, because LIR has no `Filter` operator and lowering
+asserts every filter was extracted into one. Encoding the level in a predicate's
+position is unsound, since `memoize_expressions` indexes `expressions` by
+position. Declining to fuse across levels leaves a `Filter` that cannot lower.
+So `MapFilterProject` has to carry the level, which reaches LIR, `MfpPlan`, and
+the compute protocol: roughly 48 further sites beyond the ~40 the MIR type
+change already touches.
+
+Two smaller costs specific to B: `Predicate` is 104 bytes against
+`MirScalarExpr`'s 96, and the serialized MIR nests `{expr, level}`, changing
+`EXPLAIN AS JSON` and requiring an expression-cache format bump.
 
 ### What this fixes
 
-End to end, through the real optimizer. Given
+End to end, through the real optimizer, with mechanism A. Given
 
 ```sql
 CREATE TABLE orders (tenant text, secret text, amount int);
@@ -259,19 +313,30 @@ Source materialize.public.orders
 
 ## Minimal Viable Prototype
 
-Implemented in [#38562](https://github.com/MaterializeInc/materialize/pull/38562),
-roughly 230 lines across 28 files, most of it option plumbing. The optimizer
-change proper is two gates and one predicate in `src/transform/src/dataflow.rs`.
+Two prototypes, one per mechanism, so that they can be compared rather than
+argued about.
 
-- `src/transform/tests/test_security_barrier.rs` asserts all three behaviors
-  above at the `optimize_dataflow_filters_inner` seam, including a test that
-  pins the current exposure so a regression is visible.
-- `test/sqllogictest/security_barrier.slt` covers the SQL surface and the
-  `EXPLAIN` output quoted above.
-- The existing `EXPLAIN` and privilege suites pass unchanged (1530 assertions),
-  confirming that the default path is untouched.
+**A, object-level gates**
+([#38562](https://github.com/MaterializeInc/materialize/pull/38562)) is complete
+and verified end to end. The optimizer change proper is two gates and one
+predicate in `src/transform/src/dataflow.rs`; the rest is option plumbing.
+`src/transform/tests/test_security_barrier.rs` asserts the blocked, admitted,
+and unprotected cases at the `optimize_dataflow_filters_inner` seam, including a
+test that pins the current exposure so a regression is visible.
+`test/sqllogictest/security_barrier.slt` covers the SQL surface and the
+resulting `EXPLAIN` plans. The existing `EXPLAIN` and privilege suites pass
+unchanged, confirming the default path is untouched.
 
-Deliberately left out of the prototype:
+**B, security levels**
+([#38566](https://github.com/MaterializeInc/materialize/pull/38566)) is
+incomplete. The type change and the movement, derivation, and canonicalization
+seams are in place, the workspace compiles, and the change is inert without
+barriers: every text plan in the `EXPLAIN` corpus is byte-identical. A query
+against a barrier view does not yet plan, for the `MapFilterProject` reason in
+[Comparison](#comparison). B is built on A's branch, so it inherits the SQL
+surface and tests; only the mechanism differs.
+
+Deliberately left out of both:
 
 - An `mz_views` catalog column reporting the flag. `SHOW CREATE VIEW` already
   reflects it through `create_sql`.
@@ -281,7 +346,8 @@ Deliberately left out of the prototype:
 ## When to enable a barrier
 
 The option defaults off, so this is guidance a user needs in order to make the
-choice. Two measurements frame it.
+choice. The costs below are mechanism A's; under mechanism B most of them do not
+arise. Two measurements frame it.
 
 The cost of a barrier comes almost entirely from declining to inline the view,
 not from blocking predicates. Applying barriers to every user view and
@@ -325,38 +391,33 @@ runs.
 
 ## Alternatives
 
-**Per-predicate security levels, as in PostgreSQL 9.5 and later.** Carrying a
-level on each predicate lets a barrier view be inlined and still preserve
-ordering, which recovers all of the measured cost, since all of it comes from
-not inlining. It is the mechanism a safe default would need.
-
-It is also a much larger change, and its failure mode is worse. Twenty-two files
-in `mz-transform` construct or match on `MirRelationExpr::Filter`; each would
-have to carry the level through, and one that forgets produces an insecure plan
-silently, where the object-level gates fail closed. Whether that risk can be
-contained is the subject of a separate spike, which also considers designs
-PostgreSQL does not use.
-
-For an opt-in feature the object-level barrier is the right trade: the same
-guarantee from two gates, paid for only where it is asked for.
+The two candidate mechanisms are not alternatives to each other in this section;
+they are in [Mechanisms](#mechanisms). What follows are approaches rejected
+before either was prototyped.
 
 **Make every view a barrier.** Correct by default and immune to a user
-forgetting the option. Measured on the `EXPLAIN` corpus, restricted to user
-views so that builtin catalog views keep their current plans, it changes 327
-lines: an extra collection and often an arrangement at every view boundary, the
-loss of fast-path peeks, and the loss of cross-boundary folding. One case in the
-corpus regresses from `Constant <empty>` to a full differential join with two
-arrangements over a base collection, to compute a result that is provably empty.
+forgetting the option. Under mechanism A this changes 327 lines of the `EXPLAIN`
+corpus, measured with barriers restricted to user views so that builtin catalog
+views keep their plans. Under mechanism B it would be close to free, which is
+the reason B was explored. Whether a safe default is reachable therefore depends
+entirely on which mechanism is chosen.
 
-The A/B above shows this cost belongs to the inlining gate rather than to the
-security property. That makes the choice of mechanism, not the choice of
-default, the thing standing between us and a safe default. See the entry below.
+**Wrap the predicate in an opaque marker instead of carrying a level.** A
+`SecurityFence` unary function that the optimizer refuses to move. Prototyped:
+it recovers all of A's cost and needs only 7 files, because an unrecognized
+wrapper is inert by default rather than requiring every transform to opt in. It
+was abandoned because wrapping makes a predicate syntactically unrecognizable,
+which is fail-safe where a transform is optional but fail-stop where its output
+is required. Temporal filters break outright: `mz_now()` is non-leakproof, so it
+gets wrapped, and `MfpPlan` then rejects it as an unsupported temporal
+predicate. Carrying the level beside the expression, as B does, leaves the
+expression untouched and does not have this problem.
 
 **Document that views are not a security boundary.** Legitimate, and strictly
-cheaper. It is the right answer if we conclude that view-based row filtering is
-not a pattern we intend to support. It conflicts with what the RBAC
-documentation currently implies, so if we choose it we should say so
-explicitly rather than by omission.
+cheaper than either mechanism. It is the right answer if we conclude that
+view-based row filtering is not a pattern we intend to support. It conflicts
+with what the RBAC documentation currently implies, so if we choose it we should
+say so explicitly rather than by omission.
 
 **Reject fallible expressions in predicates over any view.** Blocks the error
 channel without any optimizer changes, but it breaks a large amount of
@@ -369,6 +430,11 @@ for any future non-error channel.
   design is contingent on that. If yes, this is table stakes and the current
   behavior is a security bug. If no, the honest move is to document that views
   are not a security boundary and close this out.
+- Which mechanism? A is complete, fails closed, and confines the concept to two
+  gates, but forecloses a safe default and costs real performance on barrier
+  views. B preserves performance and generalizes to row-level security, but
+  reaches the compute protocol and fails open at any seam that is missed. This
+  document deliberately does not pick.
 - `MirScalarExpr::could_error` is currently maintained to keep persist filter
   pushdown correct. Promoting it to a security boundary means a wrong
   `could_error = false` becomes a vulnerability rather than a performance bug.

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -226,52 +226,31 @@ equivalence class is seeded only from leakproof or unconstrained predicates,
 since a derived qual carries no level; and **ordering**, where a levelled
 predicate must be evaluated after every lower-level one.
 
-### What a future transform has to know
+### Residual risk
 
-Mechanism B's residual risk lies entirely in code that does not exist yet, and
-it is narrower than "a future transform has to preserve the level" for two
-reasons.
+#### A (risk)
 
-**A new transform cannot fail to notice that levels exist.** There is no blanket
-conversion from an expression to a predicate, so constructing one requires
-naming a level: `Predicate::unconstrained` or `Predicate::at_level`. And `level`
-is private with `raise` as its only mutator, so no code can lower one. What a
-new author can miss is not the mechanism but the contract.
+Mechanism A's guarantee rests on an architectural property rather than on a
+check: nothing crosses an object boundary because the transform pipeline runs
+over one object at a time. Nothing states that property, and no type enforces
+it. A new cross-object pass would have to be gated by hand the way
+`inline_views` and `optimize_dataflow_filters` are, and a new place predicates
+can live would escape `inline_views` unnoticed. The surface is small, four
+cross-object passes today, but it is guarded by convention.
 
-**Reordering predicates within a plan is self-healing.** `MapFilterProject`
-sorts by level, so however much a transform shuffles predicates in the
-mid-level plan, the order is re-established when they fuse into one operator.
-The sort is a convergent enforcement point, not a step that can be skipped.
+#### B (risk)
 
-Three shapes remain, and they are the whole contract:
-
-1. **Relocating a predicate across operators.** The sort only helps when the
-   predicates end up in the same `MapFilterProject`. A transform that moves a
-   levelled predicate into an operator evaluated earlier than the one holding a
-   lower-level predicate breaks the guarantee. `PredicatePushdown` has an
-   explicit hold for this; a new relocating transform does not inherit it.
-2. **Deriving a predicate from a levelled one.** A derived predicate must
-   inherit the minimum level of its sources. The compiler forces the author to
-   name a level and cannot tell them which one is correct, and
-   `Predicate::unconstrained` is the natural thing to write. The two existing
-   derivation sites handle this by declining to seed an equivalence class from a
-   levelled non-leakproof predicate; a new site has no way to learn that rule.
-3. **A new place a predicate can live.** A new `MirRelationExpr` variant holding
-   predicates, or a new fused-operator representation.
-   `raise_security_level` walks `Filter` nodes and would not find it, and the
-   sort would not cover it.
-
-Shape 1 is mechanically closable. Because a descendant filter always evaluates
-before an ancestor filter on the same row, the requirement is a plan-tree
-invariant: for any `Filter` D that is a descendant of `Filter` A,
-`max_level(D) <= min_level(A)`. Levels below higher levels are correct; the
-violation is the reverse. `Typecheck` already runs between transforms validating
-plan invariants and is where this belongs, which would turn shape 1 from review
-discipline into a test failure.
-
-Shape 2 is the one that stays soft, and it is the line to put at the top of a
-risk register. Shape 3 is shared with mechanism A, whose `raise_security_level`
-equivalent has the same blind spot.
+Mechanism B's residual risk lies entirely in code that does not exist yet. If a
+**new transform mishandles a level it may generate an insecure plan, and nothing
+reports it**. There is no blanket conversion from an expression to a predicate,
+so constructing one requires naming a level: `Predicate::unconstrained` or
+`Predicate::at_level`. And `level` is private with `raise` as its only mutator,
+so no code can lower one. What a new author can miss is therefore not the
+mechanism but the contract, which is recorded on the `mz_expr::predicate`
+module: where a levelled predicate may be relocated to, what level a derived
+predicate inherits, and what a new predicate-bearing operator owes. The first of
+those is expressible as a plan-tree invariant and belongs in `Typecheck`; the
+second has no mechanical check; the third applies to mechanism A equally.
 
 ### Comparison
 

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -228,10 +228,9 @@ predicate must be evaluated after every lower-level one.
 
 ### What a future transform has to know
 
-Mechanism B's residual risk is often stated as "every future transform that
-touches predicates has to preserve the level." That is too broad on two counts,
-and being precise about it matters, because the imprecise version is both
-unactionable and more alarming than the truth.
+Mechanism B's residual risk lies entirely in code that does not exist yet, and
+it is narrower than "a future transform has to preserve the level" for two
+reasons.
 
 **A new transform cannot fail to notice that levels exist.** There is no blanket
 conversion from an expression to a predicate, so constructing one requires
@@ -244,7 +243,7 @@ sorts by level, so however much a transform shuffles predicates in the
 mid-level plan, the order is re-established when they fuse into one operator.
 The sort is a convergent enforcement point, not a step that can be skipped.
 
-That leaves three specific shapes, and they are the whole contract:
+Three shapes remain, and they are the whole contract:
 
 1. **Relocating a predicate across operators.** The sort only helps when the
    predicates end up in the same `MapFilterProject`. A transform that moves a

--- a/doc/developer/design/20260828_security_barrier_views.md
+++ b/doc/developer/design/20260828_security_barrier_views.md
@@ -278,21 +278,79 @@ Deliberately left out of the prototype:
 - `ALTER VIEW ... SET (SECURITY BARRIER)`.
 - Documentation under `doc/user/`.
 
+## When to enable a barrier
+
+The option defaults off, so this is guidance a user needs in order to make the
+choice. Two measurements frame it.
+
+The cost of a barrier comes almost entirely from declining to inline the view,
+not from blocking predicates. Applying barriers to every user view and
+re-running the `EXPLAIN` corpus changes 8 files and 327 lines. Running the same
+experiment with the predicate gate disabled, leaving only the inlining gate,
+produces a byte-identical diff. On that corpus the security property itself is
+free and the mechanism is what costs.
+
+The second measurement is that the cost is zero for views that are already
+materialized. `import_into_dataflow` resolves an index or a materialized view
+before it ever considers a view plan, so neither gate fires.
+
+That yields a straightforward rule.
+
+**Enable it when the view is the access boundary**: the reader holds `SELECT`
+on the view and not on what it reads, and the rows it filters out are rows the
+reader must not learn about. That is the only case the feature is for. A view
+that merely tidies up a query the reader could have written themselves does not
+need one.
+
+**The barrier is close to free when** the view is indexed on every cluster its
+readers use, or is a materialized view, since neither gate fires. It is also
+cheap when readers filter with comparisons, because `=`, `<`, `>`, `AND`, and
+`IS NULL` are all infallible and still cross.
+
+**The barrier is expensive when** the view sits partway up a stack of other
+views, because the whole stack above and below it loses joint optimization, or
+when readers issue point lookups, because a barrier view occupies
+`objects_to_build[0]` and disqualifies the fast-path peek. A dataflow that would
+have folded to a constant will instead be built and run.
+
+**Materializing is not a substitute**, for three reasons. An index only helps on
+the cluster that holds it, and a reader chooses their own cluster, so an
+attacker runs the query somewhere the index is absent and the view is inlined
+again. A materialized view that is a replacement target is imported from its
+view definition rather than its shard, and is inlined. And a view whose
+predicate calls `current_user` can be neither indexed nor materialized, because
+`ExprPrepMaintained` rejects unmaterializable functions. What a barrier adds
+over materializing is that the guarantee stops depending on where the query
+runs.
+
 ## Alternatives
 
 **Per-predicate security levels, as in PostgreSQL 9.5 and later.** Carrying a
-level on each predicate would let barrier views be inlined and still preserve
-ordering, recovering the fusion the object-level barrier gives up. It also
-generalizes to row-level security. It is a far larger change: `Filter`'s
-`predicates` field, `MapFilterProject`, and every transform that constructs or
-reorders predicates would have to carry and respect the level, and any transform
-that forgets silently produces an insecure plan. The object-level barrier gets
-the same guarantee from two gates and can be upgraded later if RLS arrives.
+level on each predicate lets a barrier view be inlined and still preserve
+ordering, which recovers all of the measured cost, since all of it comes from
+not inlining. It is the mechanism a safe default would need.
+
+It is also a much larger change, and its failure mode is worse. Twenty-two files
+in `mz-transform` construct or match on `MirRelationExpr::Filter`; each would
+have to carry the level through, and one that forgets produces an insecure plan
+silently, where the object-level gates fail closed. Whether that risk can be
+contained is the subject of a separate spike, which also considers designs
+PostgreSQL does not use.
+
+For an opt-in feature the object-level barrier is the right trade: the same
+guarantee from two gates, paid for only where it is asked for.
 
 **Make every view a barrier.** Correct by default and immune to a user
-forgetting the option, but it would remove cross-view predicate pushdown from
-every workload in order to protect the small fraction of views used for access
-control. Not viable.
+forgetting the option. Measured on the `EXPLAIN` corpus, restricted to user
+views so that builtin catalog views keep their current plans, it changes 327
+lines: an extra collection and often an arrangement at every view boundary, the
+loss of fast-path peeks, and the loss of cross-boundary folding. One case in the
+corpus regresses from `Constant <empty>` to a full differential join with two
+arrangements over a base collection, to compute a result that is provably empty.
+
+The A/B above shows this cost belongs to the inlining gate rather than to the
+security property. That makes the choice of mechanism, not the choice of
+default, the thing standing between us and a safe default. See the entry below.
 
 **Document that views are not a security boundary.** Legitimate, and strictly
 cheaper. It is the right answer if we conclude that view-based row filtering is


### PR DESCRIPTION
### Motivation

Our RBAC documentation states that `SELECT` on a view is what governs access
to it, and that `SELECT` on the underlying objects is insufficient. That
invites the PostgreSQL pattern of using a view as a row-level access control
boundary:

```sql
CREATE VIEW my_orders AS SELECT * FROM orders WHERE tenant = current_user;
GRANT SELECT ON my_orders TO tenant_role;
```

The privilege half of that pattern works today. `Plan::Select` requires read
privileges only on the objects the query itself names, and `current_user` in a
view body resolves against the querying session, so the view behaves like a
PostgreSQL view with definer privileges and invoker identity.

The optimizer half does not. A predicate supplied by the reader crosses the
view boundary, reaches the base collection, and is scheduled ahead of the
view's own filter. Since our error messages embed the offending value
(`invalid input syntax for type integer: "<value>"`), a reader can aim a
fallible expression at rows the view excludes and read the hidden values back
out of the error. `SELECT * FROM my_orders WHERE ssn::int > 0` exfiltrates
another tenant's `ssn` in a single query.

### Description

This is the design doc only. It records the problem, the verified exposure,
and a proposal.

The proposal adopts PostgreSQL's pre-9.5 model, marking the view and declining
to dissolve its boundary, rather than PostgreSQL's later per-qual
`RestrictInfo.security_level` machinery. That machinery exists so quals from
many security levels can interleave at one scan node, which is what row-level
security requires; we have no RLS, so a single bit per object suffices and the
whole thing reduces to two gates in `optimize_dataflow`.

Two points worth a reviewer's attention:

- **Leakproofness is cheaper and better founded here than in PostgreSQL.** We
  have no user-defined functions, so every function in a predicate is a builtin
  whose only value-dependent channel is its error. Leakproof therefore reduces
  to infallible, which `could_error()` already answers, and its defaults are
  fail-safe and type-derived rather than a superuser assertion in `pg_proc`.
  `=`, `<`, `>`, and `AND` come out leakproof automatically, which are exactly
  the predicates persist pruning and index lookups can use, so the performance
  cost is much smaller than PostgreSQL's.
- **The open questions matter more than the mechanism.** The first one is
  whether we want to support view-based row-level access control at all. If we
  do, this is table stakes and current behavior is a security bug. If we do
  not, the cheaper and equally honest answer is to document that views are not
  a security boundary, which conflicts with what the RBAC docs currently imply.

Deliberately out of scope: table-level RLS policies, `security_invoker` views,
and the timing and `mz_introspection` side channels, which PostgreSQL also
does not address.

### Verification

Design doc only, no code. The exposure and the proposed fix are both
demonstrated end to end in the prototype, #38562, which asserts the blocked,
admitted, and unprotected cases at the optimizer seam and covers the SQL
surface and resulting `EXPLAIN` plans in sqllogictest.

---

**kept in draft until we can decide on a mechanism**


Prototypes:
- barrier #38562 
- levels: #38568


🤖 Generated with [Claude Code](https://claude.com/claude-code)

> **Reading order:** #38568 is the self-contained package (design + mechanism B + formal verification). #38562 is mechanism A. This PR is one part of that set.
