### PR TITLE
release: bump to version v26.41.0-dev.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "mz-balancerd"
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6795,7 +6795,7 @@ dependencies = [
 
 [[package]]
 name = "mz-catalog-debug"
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6965,7 +6965,7 @@ dependencies = [
 
 [[package]]
 name = "mz-clusterd"
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -7337,7 +7337,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "mz-materialized"
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 dependencies = [
  "custom-labels",
  "mz-clusterd",
@@ -7960,7 +7960,7 @@ dependencies = [
 
 [[package]]
 name = "mz-orchestratord"
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8144,7 +8144,7 @@ dependencies = [
 
 [[package]]
 name = "mz-persist-client"
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.8",
@@ -9222,7 +9222,7 @@ dependencies = [
 
 [[package]]
 name = "mz-testdrive"
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 dependencies = [
  "anyhow",
  "arrow 58.4.0",

--- a/doc/user/content/releases/v26.41.md
+++ b/doc/user/content/releases/v26.41.md
@@ -1,0 +1,10 @@
+---
+title: Materialize v26.41
+date: 2026-09-09
+released: false
+patch: 0
+rc: 1
+publish_helm_chart: true
+build:
+  render: never
+---

--- a/doc/user/data/self_managed/materialize_operator_chart_parameter.yml
+++ b/doc/user/data/self_managed/materialize_operator_chart_parameter.yml
@@ -830,7 +830,7 @@
   type: string
   notationtype: ""
   autodefault: ""
-  default: '`"v26.38.1"`'
+  default: '`"v26.39.0"`'
   autodescription: The tag/version of the operator image to be used
   description: ""
   section: ""

--- a/misc/helm-charts/operator/Chart.yaml
+++ b/misc/helm-charts/operator/Chart.yaml
@@ -11,7 +11,7 @@ apiVersion: v2
 name: materialize-operator
 description: Materialize Kubernetes Operator Helm Chart
 type: application
-version: v26.40.0-dev.0
-appVersion: v26.40.0-dev.0
+version: v26.41.0-dev.0
+appVersion: v26.41.0-dev.0
 icon: https://materialize.com/favicon.ico
 home: https://materialize.com

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -1,6 +1,6 @@
 # Materialize Kubernetes Operator Helm Chart
 
-![Version: v26.40.0-dev.0](https://img.shields.io/badge/Version-v26.40.0--dev.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.40.0-dev.0](https://img.shields.io/badge/AppVersion-v26.40.0--dev.0-informational?style=flat-square)
+![Version: v26.41.0-dev.0](https://img.shields.io/badge/Version-v26.41.0--dev.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.41.0-dev.0](https://img.shields.io/badge/AppVersion-v26.41.0--dev.0-informational?style=flat-square)
 
 Materialize Kubernetes Operator Helm Chart
 
@@ -176,7 +176,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.clusters.swap_enabled` | Configure sizes such that the pod QoS class is not Guaranteed, as is required for swap to be enabled. Disk doesn't make much sense with swap, as swap performs better than lgalloc, so it also gets disabled. | ``true`` |
 | `operator.image.pullPolicy` | Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images | ``"IfNotPresent"`` |
 | `operator.image.repository` | The Docker repository for the operator image | ``"materialize/orchestratord"`` |
-| `operator.image.tag` | The tag/version of the operator image to be used | ``"v26.38.1"`` |
+| `operator.image.tag` | The tag/version of the operator image to be used | ``"v26.39.0"`` |
 | `operator.nodeSelector` | Node selector to use for the operator pod | ``{}`` |
 | `operator.podDisruptionBudget.enabled` | Whether to create a PodDisruptionBudget for the operator. Only created when `replicas` is greater than 1, since a budget over a single replica either blocks node drains or protects nothing. | ``true`` |
 | `operator.podDisruptionBudget.maxUnavailable` | Maximum number of operator pods that may be unavailable at once during voluntary disruptions. Expressed as a maximum rather than a minimum so that node drains are never blocked outright, they are only serialized. | ``1`` |
@@ -206,7 +206,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```shell
 helm install my-materialize-operator \
-  --set operator.image.tag=v26.40.0-dev.0 \
+  --set operator.image.tag=v26.41.0-dev.0 \
   materialize/materialize-operator
 ```
 
@@ -241,7 +241,7 @@ metadata:
   name: 12345678-1234-1234-1234-123456789012
   namespace: materialize-environment
 spec:
-  environmentdImageRef: materialize/environmentd:v26.40.0-dev.0
+  environmentdImageRef: materialize/environmentd:v26.41.0-dev.0
   backendSecretName: materialize-backend
   environmentdResourceRequirements:
     limits:

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
       of: Deployment
   - equal:
       path: spec.template.spec.containers[0].image
-      value: materialize/orchestratord:v26.38.1
+      value: materialize/orchestratord:v26.39.0
   - equal:
       path: spec.template.spec.containers[0].imagePullPolicy
       value: IfNotPresent

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -13,7 +13,7 @@ operator:
     # -- The Docker repository for the operator image
     repository: materialize/orchestratord
     # -- The tag/version of the operator image to be used
-    tag: v26.38.1
+    tag: v26.39.0
     # -- Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images
     pullPolicy: IfNotPresent
 

--- a/misc/helm-charts/testing/materialize.yaml
+++ b/misc/helm-charts/testing/materialize.yaml
@@ -29,7 +29,7 @@ metadata:
   name: 12345678-1234-1234-1234-123456789012
   namespace: materialize-environment
 spec:
-  environmentdImageRef: materialize/environmentd:v26.40.0-dev.0
+  environmentdImageRef: materialize/environmentd:v26.41.0-dev.0
   backendSecretName: materialize-backend
   authenticatorKind: None
   #balancerdExternalCertificateSpec:

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-balancerd"
 description = "Balancer service."
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-catalog-debug"
 description = "Durable metadata storage debug tool."
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-clusterd"
 description = "Materialize's cluster server."
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition.workspace = true

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-materialized"
 description = "Materialize's unified binary."
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/orchestratord/Cargo.toml
+++ b/src/orchestratord/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-orchestratord"
 description = "Kubernetes operator for Materialize regions"
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-testdrive"
 description = "Integration test driver for Materialize."
-version = "26.40.0-dev.0"
+version = "26.41.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
Restores the two commits that [`auto_cut_release.py`](https://github.com/MaterializeInc/materialize/blob/main/misc/python/materialize/release/auto_cut_release.py) produced but could not push when the v26.40 cut ran on 2026-08-28.

## What happened

The `Cut release` workflow in `MaterializeInc/release` runs `auto_cut_release.py`, which tags `vX.Y.0-rc.1` and then bumps `main` to `X.(Y+1).0-dev.0` in the same pass. On 2026-08-28 it failed five times; the last attempt ([run 33177989384](https://github.com/MaterializeInc/release/actions/runs/33177989384)) got the tag out and then lost the bump:

```
14:05:02  Pushing release tag (v26.40.0-rc.1) to origin...      ← succeeded
14:05:05  Bumping version on main to v26.41.0-dev.0...
14:05:12  Pushing to origin...
14:05:14  remote: error: GH006: Protected branch update failed for refs/heads/main.
14:05:14   ! [remote rejected]  main -> main (protected branch hook declined)
```

The four earlier attempts never reached the tag: three failed with `Bad credentials` retrieving the default branch, one with `API rate limit exceeded`.

So `v26.40.0-rc.1` and `-rc.2` are tagged and staging is running rc.2, while `main` has been left at `26.41.0-dev.0`'s predecessor since [`e60d5e153d`](https://github.com/MaterializeInc/materialize/commit/e60d5e153d) on 2026-08-21.

## What this PR does

Two commits, matching the shape of every previous weekly bump:

* **`release: bump to version v26.41.0-dev.0`** — the eight `src/*/Cargo.toml` versions, the corresponding `Cargo.lock` workspace entries, and the helm-chart files regenerated by `bin/helm-chart-version-bump` plus `helm-docs`. Same 15 files as [`e60d5e153d`](https://github.com/MaterializeInc/materialize/commit/e60d5e153d).
* **`release: create doc file for v26.41`** — `doc/user/content/releases/v26.41.md`, with the release date `2026-09-09` that the failed run computed.

Both were produced by running the same steps `bin/bump-version` runs, with `v26.40 v26.41 2026-09-09` — the exact arguments from the failed run's log.

## Notes for the reviewer

* `bin/bump-version` also runs `cargo run -p mz-cloud-resources --bin crd-writer` to regenerate `doc/user/data/self_managed/materialize_crd_descriptions_v1*.json`. Those files are unchanged by a dev-version bump — none of the last several bump commits touched them — so that step is a no-op here and was skipped rather than run through a cold build.
* The `test/legacy-upgrade/*current_source*` rename that `bin/bump-version` performs is also a no-op this cycle: the only two matching files are `*example*` files, which the script skips.
* `helm-docs` was run at the pinned version 1.14.2.
* This is a substitute for the automation, not a replacement for fixing it. The push failure — and whatever changed about the workflow's credentials — still needs addressing, or next Friday's cut will drop the bump again.

## Why it matters beyond the version string

While `main` sits at `26.40.0-dev.0` after the v26.40 branch has been cut, any builtin schema change that merges here follows [`builtin_schema_migration.rs`](https://github.com/MaterializeInc/materialize/blob/main/src/adapter/src/catalog/open/builtin_schema_migration.rs)'s instruction to pin its `MigrationStep` at the workspace's current dev version — `26.40.0-dev.0`. Such a change first ships in v26.41.0, and `26.40.0-dev.0` does not sort above `26.40.0`, so `plan_migration`'s `s.version > source_version` filter skips the step for every environment already on 26.40.0. Landing the bump closes that window. Tracked as [SQL-663](https://linear.app/materializeinc/issue/SQL-663).
