### PR TITLE
persist: make Pending cancel safe

### DIFF
--- a/src/persist-client/src/internal/merge.rs
+++ b/src/persist-client/src/internal/merge.rs
@@ -163,7 +163,6 @@ impl<T> DerefMut for MergeTree<T> {
 #[derive(Debug)]
 pub enum Pending<T> {
     Writing(JoinHandle<T>),
-    Blocking,
     Finished(T),
 }
 
@@ -176,25 +175,38 @@ impl<T: Send + 'static> Pending<T> {
         matches!(self, Self::Finished(_))
     }
 
+    /// Wait for the value, consuming `self`.
     pub async fn into_result(self) -> T {
         match self {
             Pending::Writing(h) => h.await,
-            Pending::Blocking => panic!("block_until_ready cancelled?"),
             Pending::Finished(t) => t,
         }
     }
 
+    /// Wait for the value and store it, so that later calls resolve without waiting.
+    ///
+    /// Cancel safe: the spawned task keeps running and the handle is retained, so a `Pending`
+    /// whose `block_until_ready` was dropped mid-await still yields its value from a later
+    /// `block_until_ready` or `into_result`.
     pub async fn block_until_ready(&mut self) {
-        let pending = mem::replace(self, Self::Blocking);
-        let value = pending.into_result().await;
+        let value = match self {
+            // Await through the borrow rather than taking the handle out: taking it would have to
+            // leave a placeholder behind, and cancellation at this await point would make that
+            // placeholder permanent.
+            Pending::Writing(handle) => handle.await,
+            Pending::Finished(_) => return,
+        };
         *self = Pending::Finished(value);
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use futures::poll;
     use mz_ore::cast::CastLossy;
+    use tokio::sync::oneshot;
+
+    use super::*;
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // too slow
@@ -259,5 +271,28 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A `Pending` whose `block_until_ready` is cancelled mid-await still resolves later. Callers
+    /// reach that await through ordinary cancellable futures, and the value must survive it.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `epoll_create1`
+    async fn test_pending_survives_cancellation() {
+        let (tx, rx) = oneshot::channel();
+        let mut pending = Pending::new(mz_ore::task::spawn(|| "pending-test", async move {
+            rx.await.expect("sender not dropped")
+        }));
+
+        // The task cannot complete before the send below, so this poll is guaranteed to suspend at
+        // the await inside `block_until_ready`. Dropping the future there is the cancellation.
+        {
+            let mut blocked = Box::pin(pending.block_until_ready());
+            assert!(poll!(&mut blocked).is_pending());
+        }
+
+        tx.send(42).expect("receiver not dropped");
+        pending.block_until_ready().await;
+        assert!(pending.is_finished());
+        assert_eq!(pending.into_result().await, 42);
     }
 }


### PR DESCRIPTION
`Pending::block_until_ready` replaced the state with a `Blocking` placeholder before awaiting the write handle. Dropping the future at that await left the placeholder in place permanently, and every later `into_result` on that `Pending` panicked with "block_until_ready cancelled?".

`BatchBuilder` reaches that await in its ordinary write path, in the loop that bounds outstanding part writes, and `finish` reaches `into_result` through the run-completion paths. A caller who drove `BatchBuilder::add` inside a cancellable future and then called `finish`, for example to obtain a `Batch` it could `delete()`, hit an unconditional panic. Since `install_enhanced_handler` aborts the process for any panic outside a catch, that lost the whole process rather than the batch. The window is not narrow: for a large batch on object storage the part writes are the bottleneck, so a builder past a few parts spends most of its wall time inside exactly that await.

The fix awaits the handle through the borrow instead of taking it out. Nothing is removed from the state, so there is no placeholder to leave behind and the `Blocking` variant disappears along with its panic. The spawned task keeps running across the cancellation, so a later `block_until_ready` or `into_result` still yields the value.

Two items from [PER-70](https://linear.app/materializeinc/issue/PER-70) stay open and are not part of this change: a `BatchBuilder` teardown that surrenders the parts already written without flushing the buffered one, and removing the `ore_catch_unwind` workaround that #38482 wraps around its peek-stash blob cleanup, which this fix makes unnecessary.

Adds `test_pending_survives_cancellation`, which cancels a `block_until_ready` at its await point and then reads the value; it fails with the original panic before the fix.

Closes: [PER-70](https://linear.app/materializeinc/issue/PER-70)

🤖 Generated with [Claude Code](https://claude.com/claude-code)