### PR TITLE
compute: record the export type in mz_compute_exports

### DIFF
--- a/doc/user/content/reference/system-catalog/mz_introspection.md
+++ b/doc/user/content/reference/system-catalog/mz_introspection.md
@@ -109,6 +109,7 @@ The `mz_compute_exports` view describes the objects exported by [dataflows][data
 | -------------- |-----------| --------                                                                                                                                                                                                                                                                                       |
 | `export_id`    | [`text`]  | The ID of the index, materialized view, or subscription exported by the dataflow. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), or [`mz_internal.mz_subscriptions.id`](../mz_internal#mz_subscriptions). |
 | `dataflow_id`  | [`uint8`] | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).                                                                                                                                                                                                               |
+| `export_type`  | [`text`]  | The type of the export: `index`, `materialized_view`, `subscribe`, `copy_to_s3_oneshot`, or `metric_sink`. Only a `materialized_view` writes its results back to storage.                                                                                                                 |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_exports_per_worker -->
 

--- a/src/catalog/src/builtin/mz_introspection.rs
+++ b/src/catalog/src/builtin/mz_introspection.rs
@@ -868,6 +868,7 @@ pub static MZ_COMPUTE_EXPORTS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinV
     desc: RelationDesc::builder()
         .with_column("export_id", SqlScalarType::String.nullable(false))
         .with_column("dataflow_id", SqlScalarType::UInt64.nullable(false))
+        .with_column("export_type", SqlScalarType::String.nullable(false))
         .with_key(vec![0])
         .finish(),
     column_comments: BTreeMap::from_iter([
@@ -879,9 +880,13 @@ pub static MZ_COMPUTE_EXPORTS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinV
             "dataflow_id",
             "The ID of the dataflow. Corresponds to `mz_dataflows.id`.",
         ),
+        (
+            "export_type",
+            "The type of the export: `index`, `materialized_view`, `subscribe`, `copy_to_s3_oneshot`, or `metric_sink`. Only a `materialized_view` writes its results back to storage.",
+        ),
     ]),
     sql: "
-SELECT export_id, dataflow_id
+SELECT export_id, dataflow_id, export_type
 FROM mz_introspection.mz_compute_exports_per_worker
 WHERE worker_id = 0::uint8",
     access: vec![PUBLIC_SELECT],

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -313,6 +313,7 @@ impl LogVariant {
                 .with_column("export_id", SqlScalarType::String.nullable(false))
                 .with_column("worker_id", SqlScalarType::UInt64.nullable(false))
                 .with_column("dataflow_id", SqlScalarType::UInt64.nullable(false))
+                .with_column("export_type", SqlScalarType::String.nullable(false))
                 .with_key(vec![0, 1])
                 .finish(),
 

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -330,6 +330,20 @@ impl<P, S> DataflowDescription<P, S> {
         self.exported_index_ids().chain(self.exported_sink_ids())
     }
 
+    /// Identifiers of exported objects, each paired with the name of its export type.
+    ///
+    /// The name is `index` for index exports and [`ComputeSinkConnection::name`] for sink
+    /// exports. Only the `materialized_view` type maintains a persist sink, so consumers can use
+    /// the name to tell which exports are expected to write to storage.
+    pub fn export_types(&self) -> impl Iterator<Item = (GlobalId, &'static str)> + '_ {
+        let indexes = self.exported_index_ids().map(|id| (id, "index"));
+        let sinks = self
+            .sink_exports
+            .iter()
+            .map(|(id, desc)| (*id, desc.connection.name()));
+        indexes.chain(sinks)
+    }
+
     /// Identifiers of exported indexes.
     pub fn exported_index_ids(&self) -> impl Iterator<Item = GlobalId> + Clone + '_ {
         self.index_exports.keys().copied()

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -767,7 +767,7 @@ impl<'a> ActiveComputeState<'a> {
         let starts_immediately = dataflow.import_ids().next().is_none();
 
         // Initialize compute and logging state for each object.
-        for object_id in dataflow.export_ids() {
+        for (object_id, export_type) in dataflow.export_types() {
             let is_subscribe_or_copy = subscribe_copy_ids.contains(&object_id);
             let metrics = self.compute_state.metrics.for_collection(object_id);
             let mut collection = CollectionState::new(
@@ -782,6 +782,7 @@ impl<'a> ActiveComputeState<'a> {
                     object_id,
                     logger,
                     *dataflow_index,
+                    export_type,
                     dataflow.import_ids(),
                 );
                 if starts_immediately {
@@ -977,8 +978,13 @@ impl<'a> ActiveComputeState<'a> {
                 metrics,
             );
 
-            let logging =
-                CollectionLogging::new(id, logger.clone(), *dataflow_index, std::iter::empty());
+            let logging = CollectionLogging::new(
+                id,
+                logger.clone(),
+                *dataflow_index,
+                "index",
+                std::iter::empty(),
+            );
             // Log collections are never suspended and the controller marks them scheduled
             // implicitly, so no `Schedule` command ever arrives for them. Record their hydration
             // start here, or they would sit permanently in the illegal state of being hydrated

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -57,6 +57,8 @@ pub struct Export {
     pub export_id: GlobalId,
     /// Timely worker index of the exporting dataflow.
     pub dataflow_index: usize,
+    /// Name of the export's type, as produced by `DataflowDescription::export_types`.
+    pub export_type: String,
 }
 
 /// The export for a global id was dropped.
@@ -628,16 +630,18 @@ impl DemuxState {
         ])
     }
 
-    /// Pack an export update key-value for the given export ID and dataflow index.
+    /// Pack an export update key-value for the given export ID, dataflow index, and export type.
     fn pack_export_update(
         &mut self,
         export_id: GlobalId,
         dataflow_index: usize,
+        export_type: &str,
     ) -> (&RowRef, &RowRef) {
         self.export_packer.pack_slice(&[
             make_string_datum(export_id, &mut self.scratch_string_a),
             Datum::UInt64(u64::cast_from(self.worker_id)),
             Datum::UInt64(u64::cast_from(dataflow_index)),
+            Datum::String(export_type),
         ])
     }
 
@@ -782,6 +786,10 @@ struct HydrationTimestamps {
 struct ExportState {
     /// The ID of the dataflow maintaining this export.
     dataflow_index: usize,
+    /// Name of the export's type.
+    ///
+    /// Retained so the drop of the export can retract the row it inserted.
+    export_type: String,
     /// Number of errors in this export.
     ///
     /// This must be a signed integer, since per-worker error counts can be negative, only the
@@ -802,9 +810,10 @@ struct ExportState {
 }
 
 impl ExportState {
-    fn new(dataflow_index: usize, installed_at: Duration) -> Self {
+    fn new(dataflow_index: usize, export_type: String, installed_at: Duration) -> Self {
         Self {
             dataflow_index,
+            export_type,
             error_count: Diff::ZERO,
             created_at: Instant::now(),
             hydration_time_ns: None,
@@ -899,21 +908,25 @@ impl DemuxHandler<'_, '_, '_> {
         ExportReference {
             export_id,
             dataflow_index,
+            export_type,
         }: Ref<'_, Export>,
     ) {
         let export_id = Columnar::into_owned(export_id);
+        let export_type: String = Columnar::into_owned(export_type);
         let ts = self.ts();
-        let datum = self.state.pack_export_update(export_id, dataflow_index);
+        let datum = self
+            .state
+            .pack_export_update(export_id, dataflow_index, &export_type);
         self.output.export.give((datum, ts, Diff::ONE));
 
         // Stamp the event time, not `ts`, which is rounded up to the logging interval. The rounding
         // then only delays when an update becomes visible, rather than skewing recorded instants.
         let installed_at = self.time;
 
-        let existing = self
-            .state
-            .exports
-            .insert(export_id, ExportState::new(dataflow_index, installed_at));
+        let existing = self.state.exports.insert(
+            export_id,
+            ExportState::new(dataflow_index, export_type, installed_at),
+        );
         if existing.is_some() {
             error!(%export_id, "export already registered");
         }
@@ -943,7 +956,9 @@ impl DemuxHandler<'_, '_, '_> {
         let ts = self.ts();
         let dataflow_index = export.dataflow_index;
 
-        let datum = self.state.pack_export_update(export_id, dataflow_index);
+        let datum = self
+            .state
+            .pack_export_update(export_id, dataflow_index, &export.export_type);
         self.output.export.give((datum, ts, Diff::MINUS_ONE));
 
         // Remove error count logging for this export.
@@ -1454,11 +1469,13 @@ impl CollectionLogging {
         export_id: GlobalId,
         logger: Logger,
         dataflow_index: usize,
+        export_type: &str,
         import_ids: impl Iterator<Item = GlobalId>,
     ) -> Self {
         logger.log(&ComputeEvent::Export(Export {
             export_id,
             dataflow_index,
+            export_type: export_type.to_string(),
         }));
 
         let mut self_ = Self {

--- a/test/sqllogictest/autogenerated/mz_introspection.slt
+++ b/test/sqllogictest/autogenerated/mz_introspection.slt
@@ -70,6 +70,7 @@ SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND ob
 ----
 export_id  text  The␠ID␠of␠the␠index,␠materialized␠view,␠or␠subscription␠exported␠by␠the␠dataflow.␠Corresponds␠to␠`mz_catalog.mz_indexes.id`,␠`mz_catalog.mz_materialized_views.id`,␠or␠`mz_internal.mz_subscriptions.id`.
 dataflow_id  uint8  The␠ID␠of␠the␠dataflow.␠Corresponds␠to␠`mz_dataflows.id`.
+export_type  text  The␠type␠of␠the␠export:␠`index`,␠`materialized_view`,␠`subscribe`,␠`copy_to_s3_oneshot`,␠or␠`metric_sink`.␠Only␠a␠`materialized_view`␠writes␠its␠results␠back␠to␠storage.
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_frontiers' ORDER BY position

--- a/test/sqllogictest/catalog_server_explain.slt
+++ b/test/sqllogictest/catalog_server_explain.slt
@@ -14206,7 +14206,7 @@ EXPLAIN SELECT * FROM "mz_introspection"."mz_compute_exports";
 ----
 Explained Query (fast path):
   →Map/Filter/Project
-    Project: #0, #2
+    Project: #0, #2, #3
     Filter: (#1{worker_id} = 0)
       →Indexed mz_introspection.mz_compute_exports_per_worker (using mz_introspection.mz_compute_exports_per_worker_s2_primary_idx)
 

--- a/test/sqllogictest/mz_catalog_server_index_accounting.slt
+++ b/test/sqllogictest/mz_catalog_server_index_accounting.slt
@@ -350,6 +350,7 @@ mz_compute_error_counts_raw  export_id
 mz_compute_error_counts_raw  worker_id
 mz_compute_exports_per_worker  dataflow_id
 mz_compute_exports_per_worker  export_id
+mz_compute_exports_per_worker  export_type
 mz_compute_exports_per_worker  worker_id
 mz_compute_frontiers_per_worker  export_id
 mz_compute_frontiers_per_worker  time

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -146,6 +146,35 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
     df.name LIKE '%my_unique_mv_name%'
 1
 
+# Test that mz_compute_exports reports the type of each export.
+
+> CREATE INDEX my_unique_index_name ON t (a)
+
+> SELECT exp.export_type
+  FROM mz_indexes idx
+  JOIN mz_internal.mz_object_global_ids gid ON gid.id = idx.id
+  JOIN mz_introspection.mz_compute_exports exp ON exp.export_id = gid.global_id
+  WHERE idx.name = 'my_unique_index_name'
+index
+
+> SELECT exp.export_type
+  FROM mz_materialized_views mv
+  JOIN mz_internal.mz_object_global_ids gid ON gid.id = mv.id
+  JOIN mz_introspection.mz_compute_exports exp ON exp.export_id = gid.global_id
+  WHERE mv.name = 'my_unique_mv_name'
+materialized_view
+
+> DROP INDEX my_unique_index_name
+
+> BEGIN
+> DECLARE c CURSOR FOR SUBSCRIBE (
+  SELECT true
+  FROM mz_introspection.mz_compute_exports e, mz_internal.mz_subscriptions s
+  WHERE e.export_id = s.id AND e.export_type = 'subscribe')
+> FETCH 1 c WITH (timeout='20s')
+<TIMESTAMP> 1 true
+> COMMIT
+
 # Test that each operator has at most one parent
 
 > SELECT max(count) FROM (


### PR DESCRIPTION
Add an `export_type` column to `mz_introspection.mz_compute_exports_per_worker` and to the derived `mz_introspection.mz_compute_exports`. The column carries `index` for index exports and the sink connection name for sink exports, so `materialized_view`, `subscribe`, `copy_to_s3_oneshot`, or `metric_sink`.

A consumer asking whether every export on a replica has finished its work needs to know which exports write to storage, because only those reach a write stage. Without the type on the export relation, the only source for that fact is a catalog join through `mz_internal.mz_object_global_ids` to `mz_catalog.mz_materialized_views`. That leaves `mz_introspection` for a fact the replica already has, and it names one catalog type rather than the property that matters, so any other persist-sink-backed export would read as never-writing. The replica knows the type precisely, and `ComputeSinkConnection::name()` already renders the variants.

`DataflowDescription::export_types` pairs each export with its type name and becomes the single owner of the vocabulary. The demux keeps the name in `ExportState` so dropping an export retracts the row it inserted. The column is not part of the key, which stays `(export_id, worker_id)`, so `index_by` and the index arity are unchanged. That leaves the per-replica index column positions, the `unnest(indkey)` rows, and the `mz_indexes` counts alone; what moves is the column listing in `mz_catalog_server_index_accounting.slt`, the autogenerated `mz_introspection.slt`, and the fast-path projection in `catalog_server_explain.slt`.

Extends `test/testdrive/introspection-sources.td` with assertions that an index reports `index`, a materialized view reports `materialized_view`, and a live subscribe reports `subscribe`.

### Release notes

This release will add an `export_type` column to `mz_introspection.mz_compute_exports` and `mz_introspection.mz_compute_exports_per_worker`, reporting whether a dataflow export is an index, a materialized view, a subscribe, a copy to S3, or a metric sink.

Closes: [CPU-233](https://linear.app/materializeinc/issue/CPU-233)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
