### PR TITLE
docs: note app password expiration dates in v26.39 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -26,6 +26,7 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 ### Improvements {#v26.39-improvements}
 - **Improved connect modal in the console**: We've updated the UI to make it easier to connect coding agents to our MCP servers, and connect applications to Materialize.
 - **Faster MySQL table snapshots** (private preview): Initial snapshots for MySQL tables are now parallelized. We saw speedups of up to 80%. When we tested a snapshot of a 2bn row table (2.45TB), previously the snapshot completed in 220 minutes. With the new parallelization, the snapshot completed in 43 minutes. Tables are eligible for parallel snapshots when they have a single-column `CHAR` or `VARCHAR` primary key using the `utf8mb4` character set with the `utf8mb4_bin` collation. For more information, see [MySQL snapshot parallelism](/ingest-data/mysql/snapshot-parallelism/).
+- **App password expiration dates** (<red>*Materialize Cloud only*</red>): When creating an app password in the [Materialize Console](/console/), you can now set an optional expiration date, after which the app password is no longer valid.
 
 ### Agent Skills {#v26.39-agent-skills}
 - **mz-ontology-design**: A new skill that structures a Materialize SQL code base as a canonical ontology — a shared `raw` database, a shared `core` database, and one database per use case — with rules for semantic object grain and identity, temporal semantics, and a machine-readable relationship registry.

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -26,7 +26,7 @@ both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for deta
 ### Improvements {#v26.39-improvements}
 - **Improved connect modal in the console**: We've updated the UI to make it easier to connect coding agents to our MCP servers, and connect applications to Materialize.
 - **Faster MySQL table snapshots** (private preview): Initial snapshots for MySQL tables are now parallelized. We saw speedups of up to 80%. When we tested a snapshot of a 2bn row table (2.45TB), previously the snapshot completed in 220 minutes. With the new parallelization, the snapshot completed in 43 minutes. Tables are eligible for parallel snapshots when they have a single-column `CHAR` or `VARCHAR` primary key using the `utf8mb4` character set with the `utf8mb4_bin` collation. For more information, see [MySQL snapshot parallelism](/ingest-data/mysql/snapshot-parallelism/).
-- **App password expiration dates** (<red>*Materialize Cloud only*</red>): When creating an app password in the [Materialize Console](/console/), you can now set an optional expiration date, after which the app password is no longer valid.
+- **App password expiration** (<red>*Materialize Cloud only*</red>): When creating an app password in the [Materialize Console](/console/), you can now set an optional expiration, after which the app password is no longer valid.
 
 ### Agent Skills {#v26.39-agent-skills}
 - **mz-ontology-design**: A new skill that structures a Materialize SQL code base as a canonical ontology — a shared `raw` database, a shared `core` database, and one database per use case — with rules for semantic object grain and identity, temporal semantics, and a machine-readable relationship registry.


### PR DESCRIPTION
The v26.39 release notes now mention that app passwords on Materialize Cloud can include an optional expiration date, set when creating the app password in the Materialize Console.

### Motivation

This surfaces an already-shipped Console feature in the release notes. App passwords already support an optional expiration date in the Materialize Console, but the v26.39.0 "Improvements" section did not call it out.

Slack thread: https://materializeinc.slack.com/archives/C04PB3GAQCF/p1788181659844759?thread_ts=1787950269.169229&cid=C04PB3GAQCF

### Description

Adds a single bullet to the v26.39.0 "Improvements" section in `doc/user/content/releases/_index.md` noting that app passwords on Materialize Cloud can now include an optional expiration date, settable when creating an app password in the Materialize Console.

### Verification

Documentation-only change; no automated tests apply. Verified the edit renders in the correct v26.39.0 "Improvements" section.

---
_Generated by [Claude Code](https://claude.ai/code/session_015oUtGDkrAjz3aXxhSJkWQg)_