### PR TITLE
ci: Nightly fixes (2026-08-31)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6993,7 +6993,6 @@ dependencies = [
  "mz-storage-types",
  "mz-timely-util",
  "mz-txn-wal",
- "nix 0.31.3",
  "num_cpus",
  "rustls",
  "serde",

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -35,7 +35,6 @@ mz-storage = { path = "../storage" }
 mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 mz-txn-wal = { path = "../txn-wal" }
-nix.workspace = true
 num_cpus.workspace = true
 rustls.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Based on https://buildkite.com/materialize/nightly/builds/18177 and https://buildkite.com/materialize/nightly/builds/18176

### Motivation

`bin/unused-deps` has failed on every nightly since [#18169](https://buildkite.com/materialize/nightly/builds/18169), plus both v26.40.0 RC nightlies ([#18172](https://buildkite.com/materialize/nightly/builds/18172), [#18174](https://buildkite.com/materialize/nightly/builds/18174)), on a single finding:

```
Found 1 unused dependencies:

  src/clusterd/Cargo.toml
      nix
```

### Description

Remove `nix` from `src/clusterd`. #38250 moved the `nix::sys::statvfs` call out of `src/clusterd/src/usage_metrics.rs` and into `src/metrics/src/usage.rs`, which declares `nix` itself. That left the dependency stranded in the clusterd manifest: at the nightly commit there is no `nix` reference anywhere under `src/clusterd/`, so the rustc `unused_crate_dependencies` lint is correct and no `[package.metadata.unused-deps] ignore` entry is warranted.

### Verification

`bin/unused-deps` locally, which is the failing check itself:

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 28s
All dependencies are used.
```

plus `cargo check -p mz-clusterd --lib --bins`, clean. The `Cargo.lock` change is the corresponding one-line removal from the `mz-clusterd` dependency list.

### Tips for reviewer

The check runs only in the nightly ([`ci/nightly/pipeline.template.yml`](https://github.com/MaterializeInc/materialize/blob/main/ci/nightly/pipeline.template.yml)), not in `tests`, which is why #38250 could merge with the stranded dependency. That looks like a deliberate cost decision given it is a full-workspace `cargo check`, so nothing here changes it.

Unlike most PRs in this series this one carries a single fix; the other failures in those two builds are not mechanical (a Terraform provider constraint, handled separately, an SLT flake, and a Workload Replay benchmark regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)