### PR TITLE
catalog: document the source and sink statuses the code produces

### DIFF
--- a/doc/user/content/reference/system-catalog/mz_internal.md
+++ b/doc/user/content/reference/system-catalog/mz_internal.md
@@ -1280,7 +1280,7 @@ debugging.
 | `name`                   | [`text`]                        | The name of the sink.                                                                                            |
 | `type`                   | [`text`]                        | The type of the sink.                                                                                            |
 | `last_status_change_at`  | [`timestamp with time zone`]    | Wall-clock timestamp of the sink status change.                                                                  |
-| `status`                 | [`text`]                        | The status of the sink: one of `created`, `starting`, `running`, `stalled`, `failed`, or `dropped`.              |
+| `status`                 | [`text`]                        | The status of the sink: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.              |
 | `error`                  | [`text`]                        | If the sink is in an error state, the error message.                                                             |
 | `details`                | [`jsonb`]                       | Additional metadata provided by the sink. In case of error, may contain a `hint` field with helpful suggestions. |
 
@@ -1295,7 +1295,7 @@ messages and additional metadata helpful for debugging.
 | -------------- | ------------------------------- | --------                                                                                                         |
 | `occurred_at`  | [`timestamp with time zone`]    | Wall-clock timestamp of the sink status change.                                                                  |
 | `sink_id`      | [`text`]                        | The ID of the sink. Corresponds to [`mz_catalog.mz_sinks.id`](../mz_catalog#mz_sinks).                           |
-| `status`       | [`text`]                        | The status of the sink: one of `created`, `starting`, `running`, `stalled`, `failed`, or `dropped`.              |
+| `status`       | [`text`]                        | The status of the sink: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.              |
 | `error`        | [`text`]                        | If the sink is in an error state, the error message.                                                             |
 | `details`      | [`jsonb`]                       | Additional metadata provided by the sink. In case of error, may contain a `hint` field with helpful suggestions. |
 | `replica_id`   | [`text`]                        | The ID of the replica that an instance of a sink is running on.                                                  |
@@ -1402,7 +1402,7 @@ debugging.
 | `name`                   | [`text`]                        | The name of the source.                                                                                            |
 | `type`                   | [`text`]                        | The type of the source.                                                                                            |
 | `last_status_change_at`  | [`timestamp with time zone`]    | Wall-clock timestamp of the source status change.                                                                  |
-| `status`                 | [`text`]                        | The status of the source: one of `created`, `starting`, `running`, `paused`, `stalled`, `failed`, or `dropped`.    |
+| `status`                 | [`text`]                        | The status of the source: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.              |
 | `error`                  | [`text`]                        | If the source is in an error state, the error message.                                                             |
 | `details`                | [`jsonb`]                       | Additional metadata provided by the source. In case of error, may contain a `hint` field with helpful suggestions. |
 
@@ -1417,7 +1417,7 @@ messages and additional metadata helpful for debugging.
 | -------------- | ------------------------------- | --------                                                                                                           |
 | `occurred_at`  | [`timestamp with time zone`]    | Wall-clock timestamp of the source status change.                                                                  |
 | `source_id`    | [`text`]                        | The ID of the source. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources).                       |
-| `status`       | [`text`]                        | The status of the source: one of `created`, `starting`, `running`, `paused`, `stalled`, `failed`, or `dropped`.    |
+| `status`       | [`text`]                        | The status of the source: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.              |
 | `error`        | [`text`]                        | If the source is in an error state, the error message.                                                             |
 | `details`      | [`jsonb`]                       | Additional metadata provided by the source. In case of error, may contain a `hint` field with helpful suggestions. |
 | `replica_id`   | [`text`]                        | The ID of the replica that an instance of a source is running on.                                                  |

--- a/doc/user/content/reference/system-catalog/mz_internal.md
+++ b/doc/user/content/reference/system-catalog/mz_internal.md
@@ -1295,7 +1295,7 @@ messages and additional metadata helpful for debugging.
 | -------------- | ------------------------------- | --------                                                                                                         |
 | `occurred_at`  | [`timestamp with time zone`]    | Wall-clock timestamp of the sink status change.                                                                  |
 | `sink_id`      | [`text`]                        | The ID of the sink. Corresponds to [`mz_catalog.mz_sinks.id`](../mz_catalog#mz_sinks).                           |
-| `status`       | [`text`]                        | The status of the sink: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.              |
+| `status`       | [`text`]                        | The status of the sink: one of `starting`, `running`, `paused`, `stalled`, or `dropped`.                         |
 | `error`        | [`text`]                        | If the sink is in an error state, the error message.                                                             |
 | `details`      | [`jsonb`]                       | Additional metadata provided by the sink. In case of error, may contain a `hint` field with helpful suggestions. |
 | `replica_id`   | [`text`]                        | The ID of the replica that an instance of a sink is running on.                                                  |
@@ -1417,7 +1417,7 @@ messages and additional metadata helpful for debugging.
 | -------------- | ------------------------------- | --------                                                                                                           |
 | `occurred_at`  | [`timestamp with time zone`]    | Wall-clock timestamp of the source status change.                                                                  |
 | `source_id`    | [`text`]                        | The ID of the source. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources).                       |
-| `status`       | [`text`]                        | The status of the source: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.              |
+| `status`       | [`text`]                        | The status of the source: one of `starting`, `running`, `paused`, `stalled`, or `dropped`.                         |
 | `error`        | [`text`]                        | If the source is in an error state, the error message.                                                             |
 | `details`      | [`jsonb`]                       | Additional metadata provided by the source. In case of error, may contain a `hint` field with helpful suggestions. |
 | `replica_id`   | [`text`]                        | The ID of the replica that an instance of a source is running on.                                                  |

--- a/doc/user/content/serve-results/sink/sink-troubleshooting.md
+++ b/doc/user/content/serve-results/sink/sink-troubleshooting.md
@@ -21,8 +21,8 @@ SELECT * FROM mz_internal.mz_sink_statuses
 WHERE name = <SINK_NAME>;
 ```
 
-If your sink reports a status of `stalled` or `failed`, you likely have a
-configuration issue. The returned `error` field will provide details.
+If your sink reports a status of `stalled`, you likely have a configuration
+issue. The returned `error` field will provide details.
 
 If your sink reports a status of `starting` for more than a few minutes,
 [contact support](/support).

--- a/src/catalog/src/builtin/mz_internal.rs
+++ b/src/catalog/src/builtin/mz_internal.rs
@@ -1318,7 +1318,7 @@ pub static MZ_SOURCE_STATUS_HISTORY: LazyLock<BuiltinSource> = LazyLock::new(|| 
         ),
         (
             "status",
-            "The status of the source: one of `created`, `starting`, `running`, `paused`, `stalled`, `failed`, or `dropped`.",
+            "The status of the source: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.",
         ),
         (
             "error",
@@ -2169,7 +2169,7 @@ pub static MZ_SOURCE_STATUSES: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinV
         ),
         (
             "status",
-            "The status of the source: one of `created`, `starting`, `running`, `paused`, `stalled`, `failed`, or `dropped`.",
+            "The status of the source: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.",
         ),
         (
             "error",
@@ -2368,7 +2368,7 @@ pub static MZ_SINK_STATUS_HISTORY: LazyLock<BuiltinSource> = LazyLock::new(|| Bu
         ),
         (
             "status",
-            "The status of the sink: one of `created`, `starting`, `running`, `stalled`, `failed`, or `dropped`.",
+            "The status of the sink: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.",
         ),
         (
             "error",
@@ -2451,7 +2451,7 @@ pub static MZ_SINK_STATUSES: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinVie
         ),
         (
             "status",
-            "The status of the sink: one of `created`, `starting`, `running`, `stalled`, `failed`, or `dropped`.",
+            "The status of the sink: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.",
         ),
         (
             "error",

--- a/src/catalog/src/builtin/mz_internal.rs
+++ b/src/catalog/src/builtin/mz_internal.rs
@@ -1318,7 +1318,7 @@ pub static MZ_SOURCE_STATUS_HISTORY: LazyLock<BuiltinSource> = LazyLock::new(|| 
         ),
         (
             "status",
-            "The status of the source: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.",
+            "The status of the source: one of `starting`, `running`, `paused`, `stalled`, or `dropped`.",
         ),
         (
             "error",
@@ -2368,7 +2368,7 @@ pub static MZ_SINK_STATUS_HISTORY: LazyLock<BuiltinSource> = LazyLock::new(|| Bu
         ),
         (
             "status",
-            "The status of the sink: one of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`.",
+            "The status of the sink: one of `starting`, `running`, `paused`, `stalled`, or `dropped`.",
         ),
         (
             "error",

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -683,7 +683,7 @@ id  text  The␠ID␠of␠the␠sink.␠Corresponds␠to␠`mz_catalog.mz_sinks.
 name  text  The␠name␠of␠the␠sink.
 type  text  The␠type␠of␠the␠sink.
 last_status_change_at  timestamp␠with␠time␠zone  Wall-clock␠timestamp␠of␠the␠sink␠status␠change.
-status  text  The␠status␠of␠the␠sink:␠one␠of␠`created`,␠`starting`,␠`running`,␠`stalled`,␠`failed`,␠or␠`dropped`.
+status  text  The␠status␠of␠the␠sink:␠one␠of␠`created`,␠`starting`,␠`running`,␠`paused`,␠`stalled`,␠or␠`dropped`.
 error  text  If␠the␠sink␠is␠in␠an␠error␠state,␠the␠error␠message.
 details  jsonb  Additional␠metadata␠provided␠by␠the␠sink.␠In␠case␠of␠error,␠may␠contain␠a␠`hint`␠field␠with␠helpful␠suggestions.
 
@@ -692,7 +692,7 @@ SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object 
 ----
 occurred_at  timestamp␠with␠time␠zone  Wall-clock␠timestamp␠of␠the␠sink␠status␠change.
 sink_id  text  The␠ID␠of␠the␠sink.␠Corresponds␠to␠`mz_catalog.mz_sinks.id`.
-status  text  The␠status␠of␠the␠sink:␠one␠of␠`created`,␠`starting`,␠`running`,␠`stalled`,␠`failed`,␠or␠`dropped`.
+status  text  The␠status␠of␠the␠sink:␠one␠of␠`created`,␠`starting`,␠`running`,␠`paused`,␠`stalled`,␠or␠`dropped`.
 error  text  If␠the␠sink␠is␠in␠an␠error␠state,␠the␠error␠message.
 details  jsonb  Additional␠metadata␠provided␠by␠the␠sink.␠In␠case␠of␠error,␠may␠contain␠a␠`hint`␠field␠with␠helpful␠suggestions.
 replica_id  text  The␠ID␠of␠the␠replica␠that␠an␠instance␠of␠a␠sink␠is␠running␠on.
@@ -722,7 +722,7 @@ id  text  The␠ID␠of␠the␠source.␠Corresponds␠to␠`mz_catalog.mz_sour
 name  text  The␠name␠of␠the␠source.
 type  text  The␠type␠of␠the␠source.
 last_status_change_at  timestamp␠with␠time␠zone  Wall-clock␠timestamp␠of␠the␠source␠status␠change.
-status  text  The␠status␠of␠the␠source:␠one␠of␠`created`,␠`starting`,␠`running`,␠`paused`,␠`stalled`,␠`failed`,␠or␠`dropped`.
+status  text  The␠status␠of␠the␠source:␠one␠of␠`created`,␠`starting`,␠`running`,␠`paused`,␠`stalled`,␠or␠`dropped`.
 error  text  If␠the␠source␠is␠in␠an␠error␠state,␠the␠error␠message.
 details  jsonb  Additional␠metadata␠provided␠by␠the␠source.␠In␠case␠of␠error,␠may␠contain␠a␠`hint`␠field␠with␠helpful␠suggestions.
 
@@ -731,7 +731,7 @@ SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object 
 ----
 occurred_at  timestamp␠with␠time␠zone  Wall-clock␠timestamp␠of␠the␠source␠status␠change.
 source_id  text  The␠ID␠of␠the␠source.␠Corresponds␠to␠`mz_catalog.mz_sources.id`.
-status  text  The␠status␠of␠the␠source:␠one␠of␠`created`,␠`starting`,␠`running`,␠`paused`,␠`stalled`,␠`failed`,␠or␠`dropped`.
+status  text  The␠status␠of␠the␠source:␠one␠of␠`created`,␠`starting`,␠`running`,␠`paused`,␠`stalled`,␠or␠`dropped`.
 error  text  If␠the␠source␠is␠in␠an␠error␠state,␠the␠error␠message.
 details  jsonb  Additional␠metadata␠provided␠by␠the␠source.␠In␠case␠of␠error,␠may␠contain␠a␠`hint`␠field␠with␠helpful␠suggestions.
 replica_id  text  The␠ID␠of␠the␠replica␠that␠an␠instance␠of␠a␠source␠is␠running␠on.

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -692,7 +692,7 @@ SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object 
 ----
 occurred_at  timestamp␠with␠time␠zone  Wall-clock␠timestamp␠of␠the␠sink␠status␠change.
 sink_id  text  The␠ID␠of␠the␠sink.␠Corresponds␠to␠`mz_catalog.mz_sinks.id`.
-status  text  The␠status␠of␠the␠sink:␠one␠of␠`created`,␠`starting`,␠`running`,␠`paused`,␠`stalled`,␠or␠`dropped`.
+status  text  The␠status␠of␠the␠sink:␠one␠of␠`starting`,␠`running`,␠`paused`,␠`stalled`,␠or␠`dropped`.
 error  text  If␠the␠sink␠is␠in␠an␠error␠state,␠the␠error␠message.
 details  jsonb  Additional␠metadata␠provided␠by␠the␠sink.␠In␠case␠of␠error,␠may␠contain␠a␠`hint`␠field␠with␠helpful␠suggestions.
 replica_id  text  The␠ID␠of␠the␠replica␠that␠an␠instance␠of␠a␠sink␠is␠running␠on.
@@ -731,7 +731,7 @@ SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object 
 ----
 occurred_at  timestamp␠with␠time␠zone  Wall-clock␠timestamp␠of␠the␠source␠status␠change.
 source_id  text  The␠ID␠of␠the␠source.␠Corresponds␠to␠`mz_catalog.mz_sources.id`.
-status  text  The␠status␠of␠the␠source:␠one␠of␠`created`,␠`starting`,␠`running`,␠`paused`,␠`stalled`,␠or␠`dropped`.
+status  text  The␠status␠of␠the␠source:␠one␠of␠`starting`,␠`running`,␠`paused`,␠`stalled`,␠or␠`dropped`.
 error  text  If␠the␠source␠is␠in␠an␠error␠state,␠the␠error␠message.
 details  jsonb  Additional␠metadata␠provided␠by␠the␠source.␠In␠case␠of␠error,␠may␠contain␠a␠`hint`␠field␠with␠helpful␠suggestions.
 replica_id  text  The␠ID␠of␠the␠replica␠that␠an␠instance␠of␠a␠source␠is␠running␠on.


### PR DESCRIPTION
### Motivation

The `status` column comments of `mz_source_statuses`, `mz_sink_statuses`, `mz_source_status_history` and `mz_sink_status_history`, and the docs rows generated from them, list `failed`, which nothing produces, and leave out `paused` for sinks, which the controller does produce. Found while writing agent guidance that keys off these statuses.

### Description

- `failed` removed from all four comments and docs rows: the storage `Status` enum (`src/storage-client/src/client.rs:168`) has `starting`, `running`, `paused`, `stalled`, `ceased` (unused) and `dropped`, its `FromStr` rejects any other string, and no writer emits `failed`.
- `paused` added to the two sink relations: `update_paused_statuses` (`src/storage-controller/src/instance.rs:306`) and the replica-dropped path (`src/storage-controller/src/lib.rs:640`) write `paused` for sinks as well as sources.
- `created` stays in `mz_source_statuses` and `mz_sink_statuses`, which synthesize it for objects with no status row yet (`COALESCE(status, 'created')`), and is dropped from the two history relations, which only hold statuses the controller wrote.
- `sink-troubleshooting.md` also told users to look for `failed`. It now names only `stalled`.
- `test/sqllogictest/autogenerated/mz_internal.slt` regenerated with `ci/test/lint-docs-catalog.sh --rewrite`.

### Verification

`ci/test/lint-docs-catalog.sh` passes; the regenerated SLT asserts the docs text against the live column comments in CI.


