### PR TITLE
workload-replay: authenticate the captured-workloads fetch on a warm agent

### DIFF
--- a/misc/python/materialize/workload_replay/util.py
+++ b/misc/python/materialize/workload_replay/util.py
@@ -203,39 +203,44 @@ def update_captured_workloads_repo() -> None:
     public_url = "https://github.com/MaterializeInc/captured-workloads"
 
     used_token = False
-    if not (path / ".git").is_dir():
-        path.mkdir(exist_ok=True)
-        if ui.env_is_truthy("CI"):
-            github_token = os.environ.get(
-                "GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN"
-            ) or os.getenv("GITHUB_TOKEN")
-            assert (
-                github_token
-            ), "GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN or GITHUB_TOKEN must be set in CI"
+    if ui.env_is_truthy("CI"):
+        github_token = os.environ.get(
+            "GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN"
+        ) or os.getenv("GITHUB_TOKEN")
+        assert (
+            github_token
+        ), "GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN or GITHUB_TOKEN must be set in CI"
+        auth_url = f"https://materializebot:{urllib.parse.quote(github_token, safe='')}@github.com/MaterializeInc/captured-workloads"
+        # Anything carrying the token goes through subprocess.run, not
+        # spawn.runv, so it is not echoed into the build log.
+        if not (path / ".git").is_dir():
+            path.mkdir(exist_ok=True)
             # check=True so a failed clone fails here, not later as a confusing
             # "no workload files found".
+            subprocess.run(["git", "clone", auth_url, str(path)], check=True)
+        else:
+            # The checkout is already here from an earlier run on this agent,
+            # which reset the remote to the credential-less public URL below.
+            # captured-workloads is an internal repository, so fetching from
+            # that URL can never authenticate - re-point it before fetching.
             subprocess.run(
+                ["git", "-C", str(path), "remote", "set-url", "origin", auth_url],
+                check=True,
+            )
+        used_token = True
+    elif not (path / ".git").is_dir():
+        path.mkdir(exist_ok=True)
+        try:
+            spawn.runv(["git", "clone", public_url, str(path)])
+        except:
+            spawn.runv(
                 [
                     "git",
                     "clone",
-                    f"https://materializebot:{urllib.parse.quote(github_token, safe='')}@github.com/MaterializeInc/captured-workloads",
+                    "git@github.com:MaterializeInc/captured-workloads",
                     str(path),
-                ],
-                check=True,
+                ]
             )
-            used_token = True
-        else:
-            try:
-                spawn.runv(["git", "clone", public_url, str(path)])
-            except:
-                spawn.runv(
-                    [
-                        "git",
-                        "clone",
-                        "git@github.com:MaterializeInc/captured-workloads",
-                        str(path),
-                    ]
-                )
 
     spawn.runv(["git", "-C", str(path), "fetch"])
     spawn.runv(["git", "-C", str(path), "checkout", commit])


### PR DESCRIPTION
### Motivation

[nightly #18101](https://buildkite.com/materialize/nightly/builds/18101) failed two Workload Replay shards with:

```
error: RPC failed; HTTP 401 curl 22 The requested URL returned error: 401
fatal: expected flush after ref listing
subprocess.CalledProcessError: Command '['git', '-C', '.../captured-workloads', 'fetch']' returned non-zero exit status 128
```

`update_captured_workloads_repo` clones `captured-workloads` with a token when the checkout is absent, then resets the remote to the credential-less public URL so the token is not left in `.git/config`. But the `git fetch` that follows sits **outside** that `if not (path / ".git").is_dir()` guard.

So on the second and subsequent runs on the same agent the clone is skipped, `used_token` stays `False`, and the fetch runs against the public URL with no credentials. `captured-workloads` is an `internal` repository, so that fetch can never authenticate — it is a deterministic failure on any warm agent workspace, not a flake.

### Description

Restructure so the CI branch owns both cases: build the authenticated URL once, clone with it when the checkout is cold, and `git remote set-url` to it when the checkout is warm. The closing reset to the public URL is unchanged, so the token still does not persist between runs.

Verified locally that git does store URL userinfo in `remote.origin.url`:

```
$ git clone "https://materializebot:FAKETOKEN123@github.com/MaterializeInc/sqllogictest" repo
$ git -C repo config --get remote.origin.url
https://materializebot:FAKETOKEN123@github.com/MaterializeInc/sqllogictest
```

That is why the cold path already worked, and it is what makes the warm-path re-point sufficient.

The non-CI branch is unchanged in behaviour (public URL, SSH fallback); it just moves into an `elif` so the CI branch can handle warm checkouts.

### Tips for reviewer

Everything carrying the token still goes through `subprocess.run` rather than `spawn.runv`, so it is not echoed into the build log — that was deliberate in the original and is preserved, including for the new `remote set-url`.

`bin/lint` reports one failure on this branch, `check-zizmor.sh`, flagging unpinned actions in `.github/workflows/slack_notify_sql_parser.yml`. It is pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
