### PR TITLE
transform: typecheck scalar expressions iteratively

### DIFF
--- a/src/expr/src/visit.rs
+++ b/src/expr/src/visit.rs
@@ -110,14 +110,26 @@ pub trait VisitChildren<T> {
 ///
 /// All methods provided by this trait are iterative.
 ///
+/// The immutable visitors hand the callback references borrowed for the whole
+/// lifetime of `&self`, so a callback may keep them: accumulate them, or embed
+/// them in its error type. This is what lets a bottom-up fold report an error
+/// that points at the offending node.
+///
+/// The mutable visitors deliberately do not do this. Their callbacks are
+/// higher-ranked over the reference lifetime, which prevents a callback from
+/// retaining what it is handed. Retaining were it permitted would produce
+/// aliasing `&mut` references to a parent and its child, because a parent's
+/// pointer stays on the traversal stack while its children are visited. See
+/// [`VisitMutAction`] for the full argument.
+///
 /// NB that any visitor with mutable post-traversal uses unsafe code. It is critical
 /// that `VisitChildren::children_mut` be written using safe code, i.e., no aliasing
 /// of children or access to parents.
 pub trait Visit {
     /// Post-order immutable infallible visitor for `self`.
-    fn visit_post<F>(&self, f: &mut F)
+    fn visit_post<'a, F>(&'a self, f: &mut F)
     where
-        F: FnMut(&Self);
+        F: FnMut(&'a Self);
 
     /// Post-order mutable infallible visitor for `self`.
     fn visit_mut_post<F>(&mut self, f: &mut F)
@@ -125,9 +137,9 @@ pub trait Visit {
         F: FnMut(&mut Self);
 
     /// Post-order immutable fallible visitor for `self`.
-    fn try_visit_post<F, E>(&self, f: &mut F) -> Result<(), E>
+    fn try_visit_post<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
     where
-        F: FnMut(&Self) -> Result<(), E>;
+        F: FnMut(&'a Self) -> Result<(), E>;
 
     /// Post-order mutable fallible visitor for `self`.
     fn try_visit_mut_post<F, E>(&mut self, f: &mut F) -> Result<(), E>
@@ -135,9 +147,9 @@ pub trait Visit {
         F: FnMut(&mut Self) -> Result<(), E>;
 
     /// Pre-order immutable infallible visitor for `self`.
-    fn visit_pre<F>(&self, f: &mut F)
+    fn visit_pre<'a, F>(&'a self, f: &mut F)
     where
-        F: FnMut(&Self);
+        F: FnMut(&'a Self);
 
     /// Pre-order immutable infallible visitor for `self`, which also accumulates context
     /// information along the path from the root to the current node's parent.
@@ -150,15 +162,15 @@ pub trait Visit {
     /// When using it on a `MirRelationExpr`, one has to be mindful that `Let` bindings are not
     /// followed, i.e., the context won't include what happens with a `Let` binding in some other
     /// `MirRelationExpr` where the binding occurs in a `Get`.
-    fn visit_pre_with_context<Context, AccFun, Visitor>(
-        &self,
+    fn visit_pre_with_context<'a, Context, AccFun, Visitor>(
+        &'a self,
         init: Context,
         acc_fun: &mut AccFun,
         visitor: &mut Visitor,
     ) where
         Context: Clone,
-        AccFun: FnMut(Context, &Self) -> Context,
-        Visitor: FnMut(&Context, &Self);
+        AccFun: FnMut(Context, &'a Self) -> Context,
+        Visitor: FnMut(&Context, &'a Self);
 
     /// Pre-order mutable infallible visitor for `self`.
     fn visit_mut_pre<F>(&mut self, f: &mut F)
@@ -166,9 +178,9 @@ pub trait Visit {
         F: FnMut(&mut Self);
 
     /// Pre-order immutable fallible visitor for `self`.
-    fn try_visit_pre<F, E>(&self, f: &mut F) -> Result<(), E>
+    fn try_visit_pre<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
     where
-        F: FnMut(&Self) -> Result<(), E>;
+        F: FnMut(&'a Self) -> Result<(), E>;
 
     /// Pre-order mutable fallible visitor for `self`.
     fn try_visit_mut_pre<F, E>(&mut self, f: &mut F) -> Result<(), E>
@@ -182,10 +194,10 @@ pub trait Visit {
     ///
     /// Optionally, `pre` can return which children, if any, should be visited
     /// (default is to visit all children).
-    fn visit_pre_post<F1, F2>(&self, pre: &mut F1, post: &mut F2)
+    fn visit_pre_post<'a, F1, F2>(&'a self, pre: &mut F1, post: &mut F2)
     where
-        F1: FnMut(&Self) -> Option<Vec<&Self>>,
-        F2: FnMut(&Self);
+        F1: FnMut(&'a Self) -> Option<Vec<&'a Self>>,
+        F2: FnMut(&'a Self);
 
     /// A generalization of [`Visit::visit_mut_pre`] and [`Visit::visit_mut_post`].
     ///
@@ -241,9 +253,9 @@ enum VisitMutAction<T> {
 }
 
 impl<T: VisitChildren<T>> Visit for T {
-    fn visit_post<F>(&self, f: &mut F)
+    fn visit_post<'a, F>(&'a self, f: &mut F)
     where
-        F: FnMut(&Self),
+        F: FnMut(&'a Self),
     {
         use VisitAction::*;
         let mut stack = vec![Enter(self)];
@@ -287,9 +299,9 @@ impl<T: VisitChildren<T>> Visit for T {
         }
     }
 
-    fn try_visit_post<F, E>(&self, f: &mut F) -> Result<(), E>
+    fn try_visit_post<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
     where
-        F: FnMut(&Self) -> Result<(), E>,
+        F: FnMut(&'a Self) -> Result<(), E>,
     {
         use VisitAction::*;
         let mut stack = vec![Enter(self)];
@@ -337,9 +349,9 @@ impl<T: VisitChildren<T>> Visit for T {
         Ok(())
     }
 
-    fn visit_pre<F>(&self, f: &mut F)
+    fn visit_pre<'a, F>(&'a self, f: &mut F)
     where
-        F: FnMut(&Self),
+        F: FnMut(&'a Self),
     {
         let mut stack = vec![self];
         while let Some(elt) = stack.pop() {
@@ -349,15 +361,15 @@ impl<T: VisitChildren<T>> Visit for T {
         }
     }
 
-    fn visit_pre_with_context<Context, AccFun, Visitor>(
-        &self,
+    fn visit_pre_with_context<'a, Context, AccFun, Visitor>(
+        &'a self,
         init: Context,
         acc_fun: &mut AccFun,
         visitor: &mut Visitor,
     ) where
         Context: Clone,
-        AccFun: FnMut(Context, &Self) -> Context,
-        Visitor: FnMut(&Context, &Self),
+        AccFun: FnMut(Context, &'a Self) -> Context,
+        Visitor: FnMut(&Context, &'a Self),
     {
         let mut stack = vec![(self, init)];
         while let Some((elt, ctx)) = stack.pop() {
@@ -380,9 +392,9 @@ impl<T: VisitChildren<T>> Visit for T {
         }
     }
 
-    fn try_visit_pre<F, E>(&self, f: &mut F) -> Result<(), E>
+    fn try_visit_pre<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
     where
-        F: FnMut(&Self) -> Result<(), E>,
+        F: FnMut(&'a Self) -> Result<(), E>,
     {
         let mut stack = vec![self];
         while let Some(elt) = stack.pop() {
@@ -407,10 +419,10 @@ impl<T: VisitChildren<T>> Visit for T {
 
         Ok(())
     }
-    fn visit_pre_post<F1, F2>(&self, pre: &mut F1, post: &mut F2)
+    fn visit_pre_post<'a, F1, F2>(&'a self, pre: &mut F1, post: &mut F2)
     where
-        F1: FnMut(&Self) -> Option<Vec<&Self>>,
-        F2: FnMut(&Self),
+        F1: FnMut(&'a Self) -> Option<Vec<&'a Self>>,
+        F2: FnMut(&'a Self),
     {
         use VisitAction::*;
         let mut stack = vec![Enter(self)];

--- a/src/expr/src/visit.rs
+++ b/src/expr/src/visit.rs
@@ -117,10 +117,14 @@ pub trait VisitChildren<T> {
 ///
 /// The mutable visitors deliberately do not do this. Their callbacks are
 /// higher-ranked over the reference lifetime, which prevents a callback from
-/// retaining what it is handed. Retaining were it permitted would produce
-/// aliasing `&mut` references to a parent and its child, because a parent's
-/// pointer stays on the traversal stack while its children are visited. See
-/// [`VisitMutAction`] for the full argument.
+/// retaining what it is handed. For the post-order and pre-post visitors that
+/// is load-bearing: they rebuild `&mut Self` from raw pointers while a parent's
+/// pointer stays on the traversal stack, so retaining a child reference, were
+/// that permitted, would alias `&mut` references to a parent and its child.
+/// See `VisitMutAction` for the full argument. The pre-order visitors keep
+/// plain `&mut Self` on their stack and consume a parent before visiting its
+/// children, so for them the borrow checker would reject the generalization
+/// rather than accept unsound code.
 ///
 /// NB that any visitor with mutable post-traversal uses unsafe code. It is critical
 /// that `VisitChildren::children_mut` be written using safe code, i.e., no aliasing

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -15,6 +15,7 @@ use std::sync::{Arc, Mutex};
 
 use itertools::Itertools;
 use mz_expr::explain::{HumanizedExplain, HumanizerMode};
+use mz_expr::visit::Visit;
 use mz_expr::{
     AggregateExpr, ColumnOrder, Id, JoinImplementation, LocalId, MirRelationExpr, MirScalarExpr,
     RECURSION_LIMIT, non_nullable_columns,
@@ -1475,6 +1476,13 @@ impl Typecheck {
         })
     }
 
+    /// Typecheck a `MirScalarExpr`.
+    ///
+    /// The walk is iterative, so it is safe at any expression depth. `types`
+    /// carries the results of already-visited subexpressions: post-order
+    /// guarantees that a node with `n` children finds their types as the top
+    /// `n` entries, so each arm drains that many and pushes its own result.
+    /// One entry remains when the walk finishes, and it is the answer.
     fn typecheck_scalar<'a>(
         &self,
         expr: &'a MirScalarExpr,
@@ -1483,84 +1491,103 @@ impl Typecheck {
     ) -> Result<ReprColumnType, TypeError<'a>> {
         use MirScalarExpr::*;
 
-        self.checked_recur(|tc| match expr {
-            Column(i, _) => match column_types.get(*i) {
-                Some(ty) => Ok(ty.clone()),
-                None => Err(TypeError::NoSuchColumn {
-                    source,
-                    expr,
-                    col: *i,
-                }),
-            },
-            Literal(row, typ) => {
-                let typ = typ.clone();
-                if let Ok(row) = row {
-                    let datums = row.unpack();
+        let mut types = Vec::<ReprColumnType>::new();
 
-                    row_difference_with_column_types(source, &datums, std::slice::from_ref(&typ))?;
+        expr.try_visit_post(&mut |e: &'a MirScalarExpr| -> Result<(), TypeError<'a>> {
+            let typ = match e {
+                Column(i, _) => match column_types.get(*i) {
+                    Some(ty) => ty.clone(),
+                    None => {
+                        return Err(TypeError::NoSuchColumn {
+                            source,
+                            expr: e,
+                            col: *i,
+                        });
+                    }
+                },
+                Literal(row, typ) => {
+                    let typ = typ.clone();
+                    if let Ok(row) = row {
+                        let datums = row.unpack();
+
+                        row_difference_with_column_types(
+                            source,
+                            &datums,
+                            std::slice::from_ref(&typ),
+                        )?;
+                    }
+
+                    typ
                 }
-
-                Ok(typ)
-            }
-            CallUnmaterializable(func) => Ok(func.output_type()),
-            CallUnary { expr, func } => {
-                let typ_in = tc.typecheck_scalar(expr, source, column_types)?;
-                let typ_out = func.output_type(typ_in);
-                Ok(typ_out)
-            }
-            CallBinary { expr1, expr2, func } => {
-                let typ_in1 = tc.typecheck_scalar(expr1, source, column_types)?;
-                let typ_in2 = tc.typecheck_scalar(expr2, source, column_types)?;
-                let typ_out = func.output_type(&[typ_in1, typ_in2]);
-                Ok(typ_out)
-            }
-            CallVariadic { exprs, func } => Ok(func.output_type(
-                exprs
-                    .iter()
-                    .map(|e| tc.typecheck_scalar(e, source, column_types))
-                    .collect::<Result<Vec<_>, TypeError>>()?,
-            )),
-            If { cond, then, els } => {
-                let cond_type = tc.typecheck_scalar(cond, source, column_types)?;
-
-                // condition must be boolean
-                // ignoring nullability: null is treated as false
-                // NB this behavior is slightly different from columns_match (for which we would set nullable to false in the expected type)
-                if cond_type.scalar_type != ReprScalarType::Bool {
-                    let sub = cond_type.scalar_type.clone();
-
-                    return Err(TypeError::MismatchColumn {
-                        source,
-                        got: cond_type,
-                        expected: ReprColumnType {
-                            scalar_type: ReprScalarType::Bool,
-                            nullable: true,
-                        },
-                        diffs: vec![ReprColumnTypeDifference::NotSubtype {
-                            sub,
-                            sup: ReprScalarType::Bool,
-                        }],
-                        message: "expected boolean condition".to_string(),
-                    });
+                CallUnmaterializable(func) => func.output_type(),
+                CallUnary { expr: _, func } => {
+                    let typ_in = types.pop().expect("CallUnary child");
+                    func.output_type(typ_in)
                 }
-
-                let mut then_type = tc.typecheck_scalar(then, source, column_types)?;
-                let else_type = tc.typecheck_scalar(els, source, column_types)?;
-
-                let diffs = column_union(&mut then_type, &else_type);
-                if !diffs.is_empty() {
-                    return Err(TypeError::MismatchColumn {
-                        source,
-                        got: then_type,
-                        expected: else_type,
-                        diffs,
-                        message: "couldn't compute union of column types for If".to_string(),
-                    });
+                CallBinary {
+                    expr1: _,
+                    expr2: _,
+                    func,
+                } => {
+                    let typ_in2 = types.pop().expect("CallBinary children");
+                    let typ_in1 = types.pop().expect("CallBinary children");
+                    func.output_type(&[typ_in1, typ_in2])
                 }
+                CallVariadic { exprs, func } => {
+                    assert!(types.len() >= exprs.len(), "CallVariadic children");
+                    let typ_in = types.split_off(types.len() - exprs.len());
+                    func.output_type(typ_in)
+                }
+                If {
+                    cond: _,
+                    then: _,
+                    els: _,
+                } => {
+                    let else_type = types.pop().expect("If children");
+                    let mut then_type = types.pop().expect("If children");
+                    let cond_type = types.pop().expect("If children");
 
-                Ok(then_type)
-            }
-        })
+                    // condition must be boolean
+                    // ignoring nullability: null is treated as false
+                    // NB this behavior is slightly different from columns_match (for which we would set nullable to false in the expected type)
+                    if cond_type.scalar_type != ReprScalarType::Bool {
+                        let sub = cond_type.scalar_type.clone();
+
+                        return Err(TypeError::MismatchColumn {
+                            source,
+                            got: cond_type,
+                            expected: ReprColumnType {
+                                scalar_type: ReprScalarType::Bool,
+                                nullable: true,
+                            },
+                            diffs: vec![ReprColumnTypeDifference::NotSubtype {
+                                sub,
+                                sup: ReprScalarType::Bool,
+                            }],
+                            message: "expected boolean condition".to_string(),
+                        });
+                    }
+
+                    let diffs = column_union(&mut then_type, &else_type);
+                    if !diffs.is_empty() {
+                        return Err(TypeError::MismatchColumn {
+                            source,
+                            got: then_type,
+                            expected: else_type,
+                            diffs,
+                            message: "couldn't compute union of column types for If".to_string(),
+                        });
+                    }
+
+                    then_type
+                }
+            };
+
+            types.push(typ);
+            Ok(())
+        })?;
+
+        Ok(types.pop().expect("root type"))
     }
 
     /// Typecheck an `AggregateExpr`
@@ -1570,13 +1597,11 @@ impl Typecheck {
         source: &'a MirRelationExpr,
         column_types: &[ReprColumnType],
     ) -> Result<ReprColumnType, TypeError<'a>> {
-        self.checked_recur(|tc| {
-            let t_in = tc.typecheck_scalar(&expr.expr, source, column_types)?;
+        let t_in = self.typecheck_scalar(&expr.expr, source, column_types)?;
 
-            // TODO check that t_in is actually acceptable for `func`
+        // TODO check that t_in is actually acceptable for `func`
 
-            Ok(expr.func.output_type(t_in))
-        })
+        Ok(expr.func.output_type(t_in))
     }
 }
 
@@ -2154,5 +2179,53 @@ mod tests {
         assert!(!datum.is_instance_of(&typ));
         let diff = datum_difference_with_column_type(&datum, &typ);
         assert_err!(diff);
+    }
+    /// A scalar expression far deeper than `RECURSION_LIMIT` typechecks, on a
+    /// thread whose stack is far smaller than `mz_ore::stack::STACK_RED_ZONE`.
+    /// The walk keeps its worklist on the heap, so neither the recursion guard
+    /// nor the native stack bounds the depth it accepts.
+    ///
+    /// `MirScalarExpr`'s `Drop` is recursive, which shapes the rest of the test:
+    /// the expression is built and dismantled with loops, and the outcome is
+    /// reduced to shallow values before anything can panic. An assertion that
+    /// unwound past a `DEPTH`-deep expression would overflow this thread while
+    /// dropping it and report that instead of the failure it caught.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer`
+    fn deep_scalar_typechecks_without_recursing() {
+        const DEPTH: usize = 20 * RECURSION_LIMIT;
+        const THREAD_STACK_SIZE: usize = 256 << 10;
+
+        std::thread::Builder::new()
+            .stack_size(THREAD_STACK_SIZE)
+            .spawn(|| {
+                let mut expr = MirScalarExpr::column(0);
+                for _ in 0..DEPTH {
+                    expr = expr.not();
+                }
+
+                let source = MirRelationExpr::constant(vec![], ReprRelationType::empty());
+                let column_types = vec![ReprColumnType {
+                    scalar_type: ReprScalarType::Bool,
+                    nullable: false,
+                }];
+
+                let outcome = Typecheck::new(empty_typechecking_context())
+                    .typecheck_scalar(&expr, &source, &column_types)
+                    .map(|typ| typ.scalar_type)
+                    .map_err(|err| match err {
+                        TypeError::Recursion { .. } => "recursion limit",
+                        _ => "type error",
+                    });
+
+                while let MirScalarExpr::CallUnary { expr: inner, .. } = expr {
+                    expr = *inner;
+                }
+
+                assert_eq!(outcome, Ok(ReprScalarType::Bool));
+            })
+            .expect("spawn")
+            .join()
+            .expect("deep scalar typecheck must not overflow the stack");
     }
 }

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -1508,11 +1508,10 @@ impl Typecheck {
                 Literal(row, typ) => {
                     let typ = typ.clone();
                     if let Ok(row) = row {
-                        // A literal's row holds exactly one datum.
-                        let datum = row.unpack_first();
+                        let datums = row.unpack();
                         row_difference_with_column_types(
                             source,
-                            &[datum],
+                            &datums,
                             std::slice::from_ref(&typ),
                         )?;
                     }

--- a/src/transform/src/typecheck.rs
+++ b/src/transform/src/typecheck.rs
@@ -787,7 +787,7 @@ fn datum_difference_with_column_type(
 
 fn row_difference_with_column_types<'a>(
     source: &'a MirRelationExpr,
-    datums: &Vec<Datum<'_>>,
+    datums: &[Datum<'_>],
     column_types: &[ReprColumnType],
 ) -> Result<(), TypeError<'a>> {
     // correct length
@@ -1508,11 +1508,11 @@ impl Typecheck {
                 Literal(row, typ) => {
                     let typ = typ.clone();
                     if let Ok(row) = row {
-                        let datums = row.unpack();
-
+                        // A literal's row holds exactly one datum.
+                        let datum = row.unpack_first();
                         row_difference_with_column_types(
                             source,
-                            &datums,
+                            &[datum],
                             std::slice::from_ref(&typ),
                         )?;
                     }
@@ -1587,7 +1587,13 @@ impl Typecheck {
             Ok(())
         })?;
 
-        Ok(types.pop().expect("root type"))
+        let typ = types.pop().expect("root type");
+        assert!(
+            types.is_empty(),
+            "typecheck_scalar left {} types unconsumed",
+            types.len()
+        );
+        Ok(typ)
     }
 
     /// Typecheck an `AggregateExpr`
@@ -2181,17 +2187,19 @@ mod tests {
         assert_err!(diff);
     }
     /// A scalar expression far deeper than `RECURSION_LIMIT` typechecks, on a
-    /// thread whose stack is far smaller than `mz_ore::stack::STACK_RED_ZONE`.
-    /// The walk keeps its worklist on the heap, so neither the recursion guard
-    /// nor the native stack bounds the depth it accepts.
+    /// thread whose stack could not hold one frame per node. The walk keeps its
+    /// worklist on the heap, so neither the recursion guard nor the native stack
+    /// bounds the depth it accepts.
     ///
     /// `MirScalarExpr`'s `Drop` is recursive, which shapes the rest of the test:
     /// the expression is built and dismantled with loops, and the outcome is
     /// reduced to shallow values before anything can panic. An assertion that
     /// unwound past a `DEPTH`-deep expression would overflow this thread while
-    /// dropping it and report that instead of the failure it caught.
+    /// dropping it and report that instead of the failure it caught. A stack
+    /// overflow aborts the process rather than unwinding, so the `join` below
+    /// can only ever report a panic inside the thread.
     #[mz_ore::test]
-    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer`
+    #[cfg_attr(miri, ignore)] // the 40k-node walk is slow under Miri
     fn deep_scalar_typechecks_without_recursing() {
         const DEPTH: usize = 20 * RECURSION_LIMIT;
         const THREAD_STACK_SIZE: usize = 256 << 10;
@@ -2226,6 +2234,6 @@ mod tests {
             })
             .expect("spawn")
             .join()
-            .expect("deep scalar typecheck must not overflow the stack");
+            .expect("deep scalar typecheck panicked");
     }
 }


### PR DESCRIPTION
Makes `Typecheck::typecheck_scalar` iterative, and generalizes the lifetimes on
`Visit`'s immutable methods so that it can be.

This is deliberately the small end of a larger question, and I would like input
on how much further to take it. The survey and reasoning behind that question
are at the bottom.

## The change

`typecheck_scalar` recursed once per `MirScalarExpr` node under `checked_recur`,
so a deep enough scalar expression failed typechecking with a recursion-limit
error rather than a type. That limit is also shared with the relation-level
walk, through the single `RecursionGuard` on `Typecheck`, so scalar depth ate
into the budget available to relation depth.

It now walks with `Visit::try_visit_post` and accumulates results in a vector,
the shape `column_knowledge::optimize` already uses. Post-order means a node
with `n` children finds their types as the top `n` entries, so each arm drains
that many and pushes its own. Scalar depth is bounded by the heap, and the
recursion guard belongs entirely to the relation walk.

`typecheck_aggregate`'s `checked_recur` goes with it: it only wrapped a call
into `typecheck_scalar` and no longer guards any recursion.

### The lifetime generalization

`TypeError<'a>` stores references into the plan, so the fold wants to hand the
visited node straight into the error. That did not compile. `Visit`'s immutable
methods took `F: FnMut(&Self)`, which desugars to a higher-ranked bound over the
reference lifetime, so `E` is fixed before that lifetime is instantiated and can
never mention it.

Six immutable methods now take `&'a self` with `F: FnMut(&'a Self)`. The
worklists in the impls already held `&'a T`, so only the signatures change: no
impl body and no call site does. The bound got weaker, so every existing closure
still satisfies it.

The four mutable methods keep the higher-ranked bound, and I added a trait-level
comment saying why, because the asymmetry otherwise reads as an oversight. There
it is load-bearing for soundness: those callbacks receive `&mut Self` rebuilt
from raw pointers whose parents are still on the traversal stack, and
quantifying the lifetime per call is what stops a callback from retaining a
child reference alongside its parent's. Generalizing them lets a callback hoard
aliasing `&mut` references to a parent and its child, which I checked by
building it.

## Behavior change

The `If` arm used to reject a non-boolean condition before typechecking `then`
and `els`. Post-order visits all three subtrees first, so an error inside a
branch now preempts a condition-type error. Nothing in `src/` or `test/` asserts
on either message, and this is an internal consistency pass, so I took the
simpler traversal. Easy to restore the old precedence if reviewers would rather.

## Tests

Adds `deep_scalar_typechecks_without_recursing`, which typechecks an expression
twenty times deeper than `RECURSION_LIMIT` on a thread whose stack is far
smaller than `STACK_RED_ZONE`. Against the recursive version it fails with
`left: Err("recursion limit")`.

The test builds and dismantles the expression with loops, and reduces the
outcome to shallow values before asserting. `MirScalarExpr`'s `Drop` is
recursive, so an assertion unwinding past a deep expression overflows the thread
while dropping it and reports that instead of the failure it caught. This bit me
while writing the test. `transform_hir.rs` works around the same thing by hand.

## The larger question

This started as a sweep for `mz_ore::stack` uses that could become worklists
instead. There are 18 `maybe_grow` and 30 `checked_recur` sites, and most of
them are not worth converting. Ranking them by likelihood of ever being the
thing that fails, rather than by how tidy the conversion looks, the picture is:

Query-structure depth is not bounded by the syntactic limits. The parser caps
nesting at 128 and flat chains at 1024, and the planner at 1024, but those bound
the SQL text, and planning and normalization turn width into depth:
`NormalizeLets` floats every binding into one `Let` chain at the root, `CASE`
arms become a chain of `If` nodes, and a join chain nests one level per join.
Each of those has tripped a recursion limit or overflowed a stack in practice
([SQL-547](https://linear.app/materializeinc/issue/SQL-547), [SQL-492](https://linear.app/materializeinc/issue/SQL-492), [SQL-508](https://linear.app/materializeinc/issue/SQL-508), [SQL-509](https://linear.app/materializeinc/issue/SQL-509)), and two of the `test/limits` caps
(`database-issues#2626`, `#2628`) were set when exactly these paths overflowed,
so they are not evidence that depth stays small. The 2048 guard in the MIR
transforms is reachable.

Even so, converting the eleven transform walkers that share it would be eleven
bespoke refactors of transform cores, and it would not remove the need for a
limit: a runaway transform that keeps growing a plan would exhaust memory
instead of the stack. The direction the team has settled on is a uniform depth
check in the transform infrastructure, applied around every transform, with
`maybe_grow` inside the walkers. I do not think we should convert those walkers.
This PR is a case where the conversion happened to be cheap.

Two things do look worth it, because a check around the transforms would not
cover them:

1. `eq` and `hash` for `DatumList`, `DatumMap`, and `DatumNested`. [SQL-515](https://linear.app/materializeinc/issue/SQL-515) added
   `maybe_grow` to `cmp` on those three types and left `eq` and `hash` recursive
   next door, and SQL `=` reaches `Datum::eq` directly (`func.rs:1789` is
   `a == b`). Same repro as the incident, different operator, on a worker rather
   than environmentd. Depth here is data, not query structure, so no parser or
   planner limit gates it. Making all three iterative would also let us drop the
   three `maybe_grow` calls from a hot `#[inline(always)]` comparison path.

2. `DataflowBuilder::import_into_dataflow`. Recursion depth is the view
   dependency chain, on the coordinator thread, with nothing capping how many
   views you chain. This is the same shape as [SQL-426](https://linear.app/materializeinc/issue/SQL-426), where dependency
   validation recursed over a view chain and overflowed the coordinator stack.

Separately, and not a `mz_ore::stack` site at all: `EXPR_CHAIN_LIMIT = 1024`
exists partly so that ASTs stay shallow enough for the recursive `Drop`,
`Display`, and visit paths (`parser.rs:53`). That is a limit on user queries
standing in for a fixable implementation detail.

Happy to stop here, take just the two items above, or drop the follow-ups
entirely. Mostly I want to know which of those the team thinks is worth the
churn.

### Release notes

None. Both changes are internal, and the recursion limit this lifts was not
reachable through a single statement.

