### PR TITLE
console: CNS-56 Add 'Create App Password' button to App Password page.

### DIFF
--- a/console/e2e-tests/platform.spec.ts
+++ b/console/e2e-tests/platform.spec.ts
@@ -96,12 +96,14 @@ for (const region of REGIONS) {
       name: "App Password",
       exact: true,
     });
-    // Clicking "Create new" opens a Chakra popover. Under WebKit in CI the
+    // Clicking "Create New" opens a Chakra popover. Under WebKit in CI the
     // click occasionally lands before the popover is wired up, so the menu
     // never opens and the "App Password" entry never appears. Retry clicking
     // until the popover is actually open.
     await expect(async () => {
-      await page.getByRole("button", { name: "Create new" }).click();
+      await page
+        .getByRole("button", { name: "Create New", exact: true })
+        .click();
       await expect(appPasswordLink).toBeVisible({ timeout: 2_000 });
     }).toPass({ timeout: 30_000 });
     await appPasswordLink.click();

--- a/console/e2e-tests/platform.spec.ts
+++ b/console/e2e-tests/platform.spec.ts
@@ -92,21 +92,7 @@ for (const region of REGIONS) {
     // Create api key
     await context.goto(`${CONSOLE_ADDR}/access`);
     console.log("Creating app password", apiKeyName);
-    const appPasswordLink = page.getByRole("link", {
-      name: "App Password",
-      exact: true,
-    });
-    // Clicking "Create New" opens a Chakra popover. Under WebKit in CI the
-    // click occasionally lands before the popover is wired up, so the menu
-    // never opens and the "App Password" entry never appears. Retry clicking
-    // until the popover is actually open.
-    await expect(async () => {
-      await page
-        .getByRole("button", { name: "Create New", exact: true })
-        .click();
-      await expect(appPasswordLink).toBeVisible({ timeout: 2_000 });
-    }).toPass({ timeout: 30_000 });
-    await appPasswordLink.click();
+    await page.getByRole("button", { name: "Create New App Password" }).click();
     await page.getByRole("dialog", { name: "New app password" }).waitFor();
     await page.getByRole("textbox", { name: "Name" }).fill(apiKeyName);
     await page.getByRole("button", { name: "Create password" }).click();

--- a/console/src/access/AppPasswordsPage.test.tsx
+++ b/console/src/access/AppPasswordsPage.test.tsx
@@ -14,8 +14,15 @@ import React from "react";
 
 import { UserApiToken } from "~/api/frontegg/types";
 import server from "~/api/mocks/server";
+import { CloudAppConfig } from "~/config/AppConfig";
+import { appConfigAtom } from "~/config/store";
 import { dummyValidUser } from "~/external-library-wrappers/__mocks__/frontegg";
-import { renderComponent } from "~/test/utils";
+import {
+  defaultRegionId,
+  healthyEnvironment,
+  renderComponent,
+  setFakeEnvironment,
+} from "~/test/utils";
 
 import AppPasswordsPage from "./AppPasswordsPage";
 
@@ -76,6 +83,23 @@ const renderPage = (openNewModal = false) =>
       ? [{ pathname: "/", state: { new: true } }]
       : ["/"],
   });
+
+const renderImpersonatedPage = () => {
+  // Flipping the flag after construction leaves the config's impersonation
+  // derived URLs alone, which keeps the mocked Frontegg endpoints matching.
+  const appConfig = new CloudAppConfig();
+  appConfig.isImpersonating = true;
+
+  return renderComponent(<AppPasswordsPage user={dummyValidUser} />, {
+    initialRouterEntries: ["/"],
+    initializeState: async ({ set }) => {
+      set(appConfigAtom, appConfig);
+      await setFakeEnvironment(set, defaultRegionId, healthyEnvironment);
+    },
+  });
+};
+
+const CREATE_BUTTON = "Create New App Password";
 
 const findRow = (description: string) =>
   screen.findByRole("row", { name: description });
@@ -164,6 +188,36 @@ describe("AppPasswordsPage", () => {
 
     await waitFor(() => expect(created.personal).toBeDefined());
     expect(created.personal).not.toHaveProperty("expiresInMinutes");
+  });
+
+  it("opens the new password modal from the page's create button", async () => {
+    mockFrontegg([]);
+    await renderPage();
+    const user = userEvent.setup();
+
+    expect(
+      screen.queryByRole("dialog", { name: "New app password" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      await screen.findByRole("button", { name: CREATE_BUTTON }),
+    );
+
+    expect(
+      await screen.findByRole("dialog", { name: "New app password" }),
+    ).toBeVisible();
+  });
+
+  it("hides the create button while impersonating", async () => {
+    mockFrontegg([buildToken({ description: "Personal laptop" })]);
+    await renderImpersonatedPage();
+
+    // Wait for the page itself, so the assertion can't pass on an unrendered
+    // page.
+    await findRow("Personal laptop");
+    expect(
+      screen.queryByRole("button", { name: CREATE_BUTTON }),
+    ).not.toBeInTheDocument();
   });
 
   it("sends the expiration on the service password endpoint too", async () => {

--- a/console/src/access/AppPasswordsPage.tsx
+++ b/console/src/access/AppPasswordsPage.tsx
@@ -60,6 +60,7 @@ import { LoadingContainer } from "~/components/LoadingContainer";
 import { Modal } from "~/components/Modal";
 import SimpleSelect from "~/components/SimpleSelect";
 import StatusPill from "~/components/StatusPill";
+import { useAppConfig } from "~/config/useAppConfig";
 import { User } from "~/external-library-wrappers/frontegg";
 import {
   MainContentContainer,
@@ -93,6 +94,10 @@ const EXPIRING_SOON_MS = 7 * 24 * 60 * 60 * 1000;
 const AppPasswordsPage = ({ user }: { user: User }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const location = useLocation();
+  const appConfig = useAppConfig();
+
+  const isImpersonating =
+    appConfig.mode === "cloud" && appConfig.isImpersonating;
 
   React.useEffect(() => {
     if (location.state && "new" in location.state && location.state.new) {
@@ -103,7 +108,14 @@ const AppPasswordsPage = ({ user }: { user: User }) => {
   return (
     <MainContentContainer>
       <PageHeader>
-        <PageHeading>App Passwords</PageHeading>
+        <HStack width="100%" justifyContent="space-between">
+          <PageHeading>App Passwords</PageHeading>
+          {!isImpersonating && (
+            <Button variant="primary" size="sm" onClick={onOpen}>
+              Create New App Password
+            </Button>
+          )}
+        </HStack>
       </PageHeader>
       <React.Suspense fallback={<LoadingContainer />}>
         <AppErrorBoundary>

--- a/console/src/layouts/NavBar/CreateObjectButton.test.tsx
+++ b/console/src/layouts/NavBar/CreateObjectButton.test.tsx
@@ -10,7 +10,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { Route, Routes, useLocation } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 
 import { CAN_CREATE_CLUSTERS_QUERY_KEY } from "~/api/materialize/cluster/useCanCreateCluster";
 import { USE_CAN_CREATE_OBJECTS_QUERY_KEY } from "~/api/materialize/useCanCreateObjects";
@@ -35,22 +35,9 @@ const renderComponent = () => {
           path="/regions/:region/clusters/new"
           element={<div>New cluster form</div>}
         />
-        <Route
-          path="/access/app-passwords"
-          element={
-            <div>
-              App passwords page <RouterState />
-            </div>
-          }
-        />
       </Routes>
     </Wrapper>,
   );
-};
-
-const RouterState = () => {
-  const location = useLocation();
-  return <div>{JSON.stringify(location.state)}</div>;
 };
 
 describe("CreateObjectButton", () => {
@@ -82,9 +69,6 @@ describe("CreateObjectButton", () => {
     await user.click(button);
     expect(await screen.findByRole("link", { name: "Cluster" })).toBeVisible();
     expect(await screen.findByRole("link", { name: "Source" })).toBeVisible();
-    expect(
-      await screen.findByRole("link", { name: "App Password" }),
-    ).toBeVisible();
   });
 
   it("Clicking cluster shows the new cluster form", async () => {
@@ -93,16 +77,5 @@ describe("CreateObjectButton", () => {
     await user.click(await screen.findByRole("button", { name: "Create New" }));
     await user.click(await screen.findByRole("link", { name: "Cluster" }));
     expect(await screen.findByText("New cluster form")).toBeVisible();
-  });
-
-  it("Clicking app password shows the app password form", async () => {
-    renderComponent();
-    const user = userEvent.setup();
-    await user.click(await screen.findByRole("button", { name: "Create New" }));
-    await user.click(await screen.findByRole("link", { name: "App Password" }));
-    expect(await screen.findByText("App passwords page")).toBeVisible();
-    // Since this form doesn't have a dedicated url, we can only test that the state was
-    // passed correctly.
-    expect(await screen.findByText(`{"new":true}`)).toBeVisible();
   });
 });

--- a/console/src/layouts/NavBar/CreateObjectButton.tsx
+++ b/console/src/layouts/NavBar/CreateObjectButton.tsx
@@ -25,7 +25,6 @@ import { Link, LinkProps } from "react-router-dom";
 import { useSegment } from "~/analytics/segment";
 import useCanCreateCluster from "~/api/materialize/cluster/useCanCreateCluster";
 import useCanCreateObjects from "~/api/materialize/useCanCreateObjects";
-import { AppConfigSwitch } from "~/config/AppConfigSwitch";
 import { regionPath } from "~/platform/routeHelpers";
 import { useRegionSlug } from "~/store/environments";
 import { PlusIcon } from "~/svg/PlusIcon";
@@ -132,18 +131,6 @@ export const CreateObjectButton = (props: CreateObjectButtonProps) => {
             >
               Source
             </CreateObjectLink>
-            <AppConfigSwitch
-              cloudConfigElement={({ runtimeConfig }) =>
-                runtimeConfig.isImpersonating ? null : (
-                  <CreateObjectLink
-                    state={{ new: true }}
-                    to="/access/app-passwords"
-                  >
-                    App Password
-                  </CreateObjectLink>
-                )
-              }
-            />
           </VStack>
         </PopoverContent>
       </Popover>


### PR DESCRIPTION


### Motivation

Add a button that launches the "Create App Password" modal. The trigger was previously hidden in the "Create New" menu, generating feedback from users who weren't able to find it.

Closes [CNS-56 ](https://linear.app/materializeinc/issue/CNS-56/missing-create-app-password-button-on-page)
### Description

Button is hidden for users in Impersonation mode.

<img width="1103" height="302" alt="Screenshot 2026-08-31 at 4 50 53 PM" src="https://github.com/user-attachments/assets/9dc85b86-10f5-411c-8727-be8c773b8e0b" />


### Verification

Added automated tests that confirm expected behavior and confirm that it is hidden for impersonation users.