### PR TITLE
[docs] generate llms.txt from front matter

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -6,6 +6,7 @@ disableKinds = ['taxonomy']
 
 [params]
 repo = "//github.com/MaterializeInc/materialize"
+canonicalHost = "https://materialize.com"
 bannerMessage = ""
 bannerLink = ""
 
@@ -122,6 +123,18 @@ weight = 55
   baseName = "index"
   isPlainText = true
   notAlternative = true
+
+#
+# Custom output format for the llms.txt docs index
+#
+[outputFormats.llmstxt]
+  mediaType = "text/plain"
+  baseName = "llms"
+  isPlainText = true
+  notAlternative = true
+
+[outputs]
+  home = ["HTML", "RSS", "llmstxt"]
 
 [markup.goldmark.renderer]
 # allow <a name="link-target">, the old syntax no longer works

--- a/doc/user/layouts/_default/list.html
+++ b/doc/user/layouts/_default/list.html
@@ -3,11 +3,7 @@
 {{ if not (.Params.disable_h1) }}
   <div class="title-row">
     <h1>{{.Title}}</h1>
-    {{- $basePath := (urls.Parse site.BaseURL).Path -}}
-    {{- if not (strings.HasSuffix $basePath "/") -}}{{- $basePath = printf "%s/" $basePath -}}{{- end -}}
-    {{- $pagePath := .RelPermalink | strings.TrimPrefix $basePath -}}
-    {{- $mdURL := printf "%smarkdown-docs/%sindex.md" $basePath $pagePath -}}
-    <a class="btn-ghost" href="{{ $mdURL }}">View as Markdown</a>
+    <a class="btn-ghost" href="{{ partial "markdown-url.html" (dict "page" .) }}">View as Markdown</a>
   </div>
 {{ end }}
 

--- a/doc/user/layouts/_default/single.html
+++ b/doc/user/layouts/_default/single.html
@@ -3,11 +3,7 @@
 {{ if not (.Params.disable_h1) }}
   <div class="title-row">
     <h1>{{.Title | markdownify}}</h1>
-    {{- $basePath := (urls.Parse site.BaseURL).Path -}}
-    {{- if not (strings.HasSuffix $basePath "/") -}}{{- $basePath = printf "%s/" $basePath -}}{{- end -}}
-    {{- $pagePath := .RelPermalink | strings.TrimPrefix $basePath -}}
-    {{- $mdURL := printf "%smarkdown-docs/%sindex.md" $basePath $pagePath -}}
-    <a class="btn-ghost" href="{{ $mdURL }}">View as Markdown</a>
+    <a class="btn-ghost" href="{{ partial "markdown-url.html" (dict "page" .) }}">View as Markdown</a>
   </div>
 {{ end }}
 

--- a/doc/user/layouts/index.llmstxt.txt
+++ b/doc/user/layouts/index.llmstxt.txt
@@ -1,0 +1,121 @@
+{{- /*
+  Renders /llms.txt, an index of every docs page for LLM and agent consumers.
+  Format per https://llmstxt.org/: an H1, a `>` summary blockquote, a short
+  orienting note, then one H2 per top-level docs section listing
+  "- [Title](url): description" entries.
+
+  Links point at each page's Markdown rendition rather than its HTML page, so a
+  consumer fetches prose instead of site chrome.
+
+  Only the HTML pass renders this file. config.skill.toml resets outputs.home to
+  ["skill"], and the rightmost --config file wins, so the Markdown pass emits
+  markdown-docs/index.md instead of a second copy of this index.
+
+  The output must be byte-stable: no dates, no build metadata, and no ranging
+  over maps. Every collection below is explicitly ordered.
+*/ -}}
+{{- $basePath := (urls.Parse site.BaseURL).Path -}}
+{{- /*
+  Only the main docs build produces the markdown-docs tree these links resolve
+  against; self-managed-docs/* branches build HTML alone. Emit nothing there
+  rather than publish an index of dead links.
+*/ -}}
+{{- if not (in $basePath "self-managed") -}}
+{{- $eligible := slice -}}
+{{- range site.Pages -}}
+  {{- $keep := true -}}
+  {{- /* The home page is this file. */ -}}
+  {{- if .IsHome -}}{{- $keep = false -}}{{- end -}}
+  {{- /* build.render=never leaves a page with no permalink to link to. */ -}}
+  {{- if not .RelPermalink -}}{{- $keep = false -}}{{- end -}}
+  {{- if .Params.headless -}}{{- $keep = false -}}{{- end -}}
+  {{- /*
+    Per-version release notes, filtered by path rather than permalink: the
+    older ones predate the render:never convention and still render, so the
+    permalink check above catches only part of the set. The /releases/ landing
+    page stays.
+  */ -}}
+  {{- if strings.HasPrefix .Path "/releases/v" -}}{{- $keep = false -}}{{- end -}}
+  {{- with .Params.robots -}}
+    {{- if in (lower .) "noindex" -}}{{- $keep = false -}}{{- end -}}
+  {{- end -}}
+  {{- if $keep -}}{{- $eligible = $eligible | append . -}}{{- end -}}
+{{- end -}}
+{{- /*
+  Group order follows the sidebar. A top-level menu entry names a group only
+  when it canonically stands for a top-level content section: either its page IS
+  that section's index page, or its identifier resolves to one. The first test
+  has to compare paths, not just .Section, because a nested page can register a
+  top-level nav entry (content/integrations/mcp-server/_index.md does, at weight
+  48) and would otherwise claim the whole integrations group at the wrong
+  position. The identifier test covers the header-only entries declared in
+  config.toml, which have no page at all.
+
+  A header whose children are root-level pages maps to the empty section, which
+  is how faqs/support/license reach the index.
+*/ -}}
+{{- $keys := slice -}}
+{{- $groups := slice -}}
+{{- range site.Menus.main.ByWeight -}}
+  {{- $key := "" -}}
+  {{- $found := false -}}
+  {{- with .Page -}}
+    {{- if eq .Path (printf "/%s" .Section) -}}
+      {{- $key = .Section -}}{{- $found = true -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not $found -}}
+    {{- with site.GetPage (printf "/%s" .Identifier) -}}
+      {{- if eq .Path (printf "/%s" .Section) -}}
+        {{- $key = .Section -}}{{- $found = true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if and (not $found) (not .Page) .HasChildren -}}
+    {{- range .Children.ByWeight -}}
+      {{- if not $found -}}
+        {{- with .Page -}}{{- $key = .Section -}}{{- $found = true -}}{{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if and $found (not (in $keys $key)) -}}
+    {{- $keys = $keys | append $key -}}
+    {{- $groups = $groups | append (dict "key" $key "title" .Name) -}}
+  {{- end -}}
+{{- end -}}
+{{- /*
+  Sections the nav never mentions, so nothing is dropped silently: two sections
+  spell the front matter key `menus:` and register no entry, concepts sits under
+  the Get started header, and administration has no entry at all.
+*/ -}}
+{{- range site.Home.Sections -}}
+  {{- if not (in $keys .Section) -}}
+    {{- $keys = $keys | append .Section -}}
+    {{- $groups = $groups | append (dict "key" .Section "title" .LinkTitle) -}}
+  {{- end -}}
+{{- end -}}
+{{- if not (in $keys "") -}}
+  {{- $groups = $groups | append (dict "key" "" "title" "Other") -}}
+{{- end -}}
+{{- /*
+  The summary is the same intro the docs home page and "What is Materialize?"
+  render, so the positioning here cannot drift from the site's own wording.
+*/ -}}
+{{- $intro := "" -}}
+{{- with site.GetPage "/headless/materialize-intro/intro" -}}
+  {{- $intro = trim (replaceRE `\s+` " " .RawContent) " " -}}
+{{- end -}}
+# {{ site.Title }}
+
+> {{ $intro }}
+
+Every link below points at the Markdown source of a documentation page. For the
+HTML page instead, drop `markdown-docs/` from the URL and drop the trailing
+`index.md`. Per-version release notes are not listed individually; see the
+Releases section.
+{{ range $groups }}{{ $items := sort (where $eligible "Section" .key) "RelPermalink" }}{{ if $items }}
+## {{ .title }}
+
+{{ range $items }}- [{{ .Title }}]({{ partial "markdown-url.html" (dict "page" . "absolute" true) }}){{ with .Description }}{{ $d := trim (replaceRE `\s+` " " .) " " }}{{ if $d }}: {{ $d }}{{ end }}{{ end }}
+{{ end }}{{ end }}{{ end -}}
+{{- end -}}

--- a/doc/user/layouts/index.llmstxt.txt
+++ b/doc/user/layouts/index.llmstxt.txt
@@ -1,4 +1,14 @@
 {{- /*
+  Copyright Materialize, Inc. and contributors. All rights reserved.
+
+  Use of this software is governed by the Business Source License
+  included in the LICENSE file at the root of this repository.
+
+  As of the Change Date specified in that file, in accordance with
+  the Business Source License, use of this software will be governed
+  by the Apache License, Version 2.0.
+*/ -}}
+{{- /*
   Renders /llms.txt, an index of every docs page for LLM and agent consumers.
   Format per https://llmstxt.org/: an H1, a `>` summary blockquote, a short
   orienting note, then one H2 per top-level docs section listing

--- a/doc/user/layouts/partials/markdown-url.html
+++ b/doc/user/layouts/partials/markdown-url.html
@@ -1,0 +1,34 @@
+{{- /*
+  Returns the URL of a page's Markdown rendition, the file the `skill` output
+  format writes into <baseURL>/markdown-docs/ on the second Hugo pass (see
+  ci/deploy_website/website.sh).
+
+  Arguments (dict):
+    page      (required) the Page to link to
+    absolute  (optional) prefix the URL with scheme://host
+
+  baseURL is a bare path in the production and preview builds ("/docs",
+  "/materialize/$PR"), so .Permalink cannot yield an absolute URL. When baseURL
+  carries no host of its own, fall back to params.canonicalHost, except under
+  `hugo --environment preview`, where the artifacts serve from
+  preview.materialize.com.
+
+  Usage:
+    {{ partial "markdown-url.html" (dict "page" .) }}
+    {{ partial "markdown-url.html" (dict "page" $p "absolute" true) }}
+*/ -}}
+{{- $basePath := (urls.Parse site.BaseURL).Path -}}
+{{- if not (strings.HasSuffix $basePath "/") -}}{{- $basePath = printf "%s/" $basePath -}}{{- end -}}
+{{- $pagePath := .page.RelPermalink | strings.TrimPrefix $basePath -}}
+{{- $url := printf "%smarkdown-docs/%sindex.md" $basePath $pagePath -}}
+{{- if .absolute -}}
+  {{- $parsed := urls.Parse site.BaseURL -}}
+  {{- $origin := site.Params.canonicalHost -}}
+  {{- if $parsed.Host -}}
+    {{- $origin = printf "%s://%s" $parsed.Scheme $parsed.Host -}}
+  {{- else if eq hugo.Environment "preview" -}}
+    {{- $origin = "https://preview.materialize.com" -}}
+  {{- end -}}
+  {{- $url = printf "%s%s" $origin $url -}}
+{{- end -}}
+{{- return $url -}}


### PR DESCRIPTION
Generates an llms.txt for materialize.com/docs. It contains the hero description and then a map of every page. The pages header is included as description. 

example
```txt
# Materialize Documentation

> Materialize is the live data layer for apps and AI agents. To keep results up-to-date as new data arrives, Materialize incrementally updates results as it ingests data rather than recalculating results from scratch.

Every link below points at the Markdown source of a documentation page. For the
HTML page instead, drop `markdown-docs/` from the URL and drop the trailing
`index.md`. Per-version release notes are not listed individually; see the
Releases section.

## Get started

- [What is Materialize?](https://materialize.com/docs/markdown-docs/get-started/index.md): Learn more about Materialize
- [Arrangements](https://materialize.com/docs/markdown-docs/get-started/arrangements/index.md): Understand how Materialize arrangements work.
- [Download and run Materialize Emulator](https://materialize.com/docs/markdown-docs/get-started/install-materialize-emulator/index.md): The Materialize Emulator is an all-in-one Docker image available on Docker Hub, offering the fastest way to get hands-on experience with Materialize in a local environment.
- [Install Self-Managed Materialize](https://materialize.com/docs/markdown-docs/get-started/install/index.md): Install Self-Managed Materialize.
- [Quickstart](https://materialize.com/docs/markdown-docs/get-started/quickstart/index.md): Learn the basics of Materialize.

## Self-Managed Deployments

- [Self-Managed Deployments](https://materialize.com/docs/markdown-docs/self-managed-deployments/index.md): Learn about the key components and architecture of self-managed Materialize deployments.
- [Appendix](https://materialize.com/docs/markdown-docs/self-managed-deployments/appendix/index.md)
```


### Motivation

Why does this change exist? Link to a GitHub issue, design doc, Slack
thread, or explain the problem in a sentence or two. A reviewer who has
no context should understand *why* after reading this section.

If this implements or addresses an existing issue, it's enough to link to that:
Closes <issue>
Fixes <bug>
etc.

### Description

What does this PR actually do? Focus on the approach and any non-obvious
decisions. The diff shows the code --- use this space to explain what the
diff *can't* tell a reviewer.

### Verification

How do you know this change is correct? Describe new or existing automated
tests, or manual steps you took.
