### PR TITLE
docs: name swap and heap_percent in the troubleshooting pages' memory-pressure advice

### DIFF
--- a/doc/user/content/transform-data/dataflow-troubleshooting.md
+++ b/doc/user/content/transform-data/dataflow-troubleshooting.md
@@ -338,7 +338,10 @@ materialized view `num_bids`.
 
 ## Why is Materialize using so much memory?
 
-[Arrangements](/overview/arrangements) take up most of Materialize's memory use.
+[Arrangements](/overview/arrangements) are typically the largest part of a
+busy cluster's memory use, and the part that the introspection views attribute
+to individual dataflows. The rest of a replica's memory, its process baseline,
+allocator overhead and buffers of data in flight, is not itemized per dataflow.
 Arrangements maintain indexes for data as it changes. These queries extract the
 numbers of records and the size of the arrangements. The reported records may
 exceed the number of logical records; the report reflects the uncompacted

--- a/doc/user/content/transform-data/freshness-troubleshooting.md
+++ b/doc/user/content/transform-data/freshness-troubleshooting.md
@@ -169,7 +169,7 @@ A cluster can become overloaded if:
   the cluster undersized.
 
 When a cluster is overloaded, this may manifest as high CPU utilization, high
-memory utilization forcing data to disk, or Out of Memory (OOM) crash loops.
+memory utilization spilling into swap, or Out of Memory (OOM) crash loops.
 
 ### Check the CPU or memory pressure
 
@@ -185,7 +185,8 @@ SELECT
     c.id as cluster_id,
     r.name AS replica_name,
     u.cpu_percent,
-    u.memory_percent
+    u.memory_percent,
+    u.heap_percent
 FROM mz_internal.mz_cluster_replica_utilization u
 JOIN mz_catalog.mz_cluster_replicas r ON u.replica_id = r.id
 JOIN mz_catalog.mz_clusters c ON r.cluster_id = c.id
@@ -202,7 +203,8 @@ SELECT
     c.id as cluster_id,
     r.name AS replica_name,
     u.cpu_percent,
-    u.memory_percent
+    u.memory_percent,
+    u.heap_percent
 FROM mz_internal.mz_cluster_replica_utilization u
 JOIN mz_catalog.mz_cluster_replicas r ON u.replica_id = r.id
 JOIN mz_catalog.mz_clusters c ON r.cluster_id = c.id
@@ -215,8 +217,11 @@ ORDER BY u.cpu_percent DESC;
 - If the returned `cpu_percent` is high, all objects on that cluster experience
   correlated freshness degradation.
 
-- If the returned `memory_percent` is high, Materialize may force data to disk,
-  which can slow down processing.
+- If the returned `memory_percent` is high, the replica is close to its RAM
+  allocation and further growth spills into swap, which can slow down
+  processing.
+  `heap_percent` (RAM plus swap) shows how close the replica is to being
+  OOM-killed.
 
 To resolve, scale the cluster up to a larger size ([`ALTER CLUSTER ... SET (SIZE
 = '<new size>')`](/sql/alter-cluster/)), and/or move enough objects to another


### PR DESCRIPTION
### Motivation

Two statements on the troubleshooting pages are imprecise about memory: `dataflow-troubleshooting.md` says arrangements take up most of Materialize's memory, and `freshness-troubleshooting.md` says a high `memory_percent` may force data to disk. Noticed while writing agent guidance for memory optimization, where the arrangement sum is routinely well below the replica's heap and the pressure signal is swap.

### Description

- `dataflow-troubleshooting.md`, "Why is Materialize using so much memory?": arrangements are the largest part of a busy cluster's memory that the introspection views attribute to individual dataflows; the process baseline, allocator overhead and buffers of data in flight make up the rest and are not itemized. (Measured on a fresh 1-worker replica: 375 MB before any user object, then +238 MB of RSS for an index reporting 131 MB of arrangements.)
- `freshness-troubleshooting.md`: the "may force data to disk" sentence now names the mechanism and the metric. Memory pressure on current replica sizes goes to swap (every enabled Cloud size, and `swap_enabled: true` is the self-managed operator default, `misc/helm-charts/operator/values.yaml:148`), which `heap_percent` (RAM plus swap, in `mz_cluster_replica_utilization` since v0.159.0) reports; the two utilization queries on the page return it as well. Not covered: a self-managed replica configured with disk instead of swap spills through lgalloc; `manage/monitor/replica-resource-usage` describes that case.

### Verification

Prose only. `hugo` builds the site cleanly with both pages rendering the new text.
