### PR TITLE
`storage-controller`: update stale comments about multiple replicas

### DIFF
--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -47,11 +47,10 @@ use crate::history::CommandHistory;
 ///
 /// Encapsulates communication with replicas in this instance, and their rehydration.
 ///
-/// Note that storage objects (sources and sinks) don't currently support replication (database-issues#5051).
-/// An instance can have multiple replicas connected, but only if it has no storage objects
-/// installed. Attempting to install storage objects on multi-replica instances, or attempting to
-/// add more than one replica to instances that have storage objects installed, is illegal and will
-/// lead to panics.
+/// An instance can have any number of replicas. Objects that must run on one replica (ingestions
+/// whose connection reports `SourceConnection::prefers_single_replica`, such as OLTP sources, and
+/// all sinks) are scheduled on the replica with the lowest `ReplicaId` and move only when that
+/// replica goes away; all other objects run on every replica. See `update_scheduling`.
 #[derive(Debug)]
 pub(crate) struct Instance {
     /// The workload class of this instance.
@@ -156,8 +155,7 @@ impl Instance {
 
     /// Adds a new replica to this storage instance.
     pub fn add_replica(&mut self, id: ReplicaId, config: ReplicaConfig) {
-        // Reduce the history to limit the amount of commands sent to the new replica, and to
-        // enable the `objects_installed` assert below.
+        // Reduce the history to limit the amount of commands sent to the new replica.
         self.history.reduce();
 
         let metrics = self.metrics.for_replica(id);


### PR DESCRIPTION
### Motivation

The doc comment on `storage_controller::instance::Instance` says storage objects do not support replication and that installing them on a multi-replica instance, or adding a second replica to an instance with storage objects, "is illegal and will lead to panics". That describes the state before [database-issues#5051](https://github.com/MaterializeInc/database-issues/issues/5051) (closed 2025-07-01); today `update_scheduling` in the same file handles both cases. A reader who trusts the comment gets the wrong model of what the controller does on a multi-replica cluster.

### Description

- `Instance` doc comment: an instance can have any number of replicas; objects that must run on one replica (ingestions whose connection prefers a single replica, that is PostgreSQL, MySQL and SQL Server, and every sink) are scheduled on the replica with the lowest `ReplicaId` and move only when that replica goes away; all other objects (Kafka and load-generator ingestions) run on every replica. Points at `update_scheduling`, which owns the details.
- `add_replica`: its comment justified the history reduction partly by an `objects_installed` assert that no longer exists; only the remaining reason stays.

### Verification

Comment-only change. Checked against `update_scheduling` (`instance.rs:505-606`) and the `prefers_single_replica` implementations in `src/storage-types/src/sources/*.rs`.

