### PR TITLE
sqllogictest: disable flaky statement_timeout test in cockroach/set.slt

### DIFF
--- a/test/sqllogictest/cockroach/set.slt
+++ b/test/sqllogictest/cockroach/set.slt
@@ -410,8 +410,10 @@ onlyif cockroach
 statement ok
 SET application_name = current_timestamp()::string
 
-# Commented out: Materialize's statement_timeout is currently broken, see
-# https://github.com/MaterializeInc/database-issues/issues/9947
+# TODO(database-issues#9947): Uncomment when statement_timeout works for plain
+# SELECTs. For peeks it currently only bounds the optimization phase (see
+# src/adapter/src/frontend_peek.rs), so the 1 ms timeout sometimes fails to
+# fire and the record then fails with UnexpectedPlanSuccess.
 ## Test statement_timeout on a long-running query.
 #statement ok
 #SET statement_timeout = 1

--- a/test/sqllogictest/cockroach/set.slt
+++ b/test/sqllogictest/cockroach/set.slt
@@ -410,12 +410,14 @@ onlyif cockroach
 statement ok
 SET application_name = current_timestamp()::string
 
-# Test statement_timeout on a long-running query.
-statement ok
-SET statement_timeout = 1
-
-statement error canceling statement due to statement timeout
-SELECT * FROM generate_series(1,1000000)
+# Commented out: Materialize's statement_timeout is currently broken, see
+# https://github.com/MaterializeInc/database-issues/issues/9947
+## Test statement_timeout on a long-running query.
+#statement ok
+#SET statement_timeout = 1
+#
+#statement error canceling statement due to statement timeout
+#SELECT * FROM generate_series(1,1000000)
 
 # Test that statement_timeout can be set with an interval string.
 statement ok


### PR DESCRIPTION
Comments out the `statement error canceling statement due to statement timeout` test at `test/sqllogictest/cockroach/set.slt:418`.

**Why**
- Materialize's `statement_timeout` is currently broken, see [database-issues#9947](https://github.com/MaterializeInc/database-issues/issues/9947). For a plain `SELECT` it only bounds the optimization phase (`src/adapter/src/frontend_peek.rs`), so the test's 1 ms timeout sometimes fails to fire and the query succeeds, which fails the record with `UnexpectedPlanSuccess`.
- CI flake: 5 `SLT 3` failures since the file was imported on 2026-07-19, most recently https://buildkite.com/materialize/test/builds/133285#01a05c4c-1024-4ead-a3cc-7a5d6a829683.

The block is commented out rather than deleted so it can be restored once the timeout works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
