### PR TITLE
compute: count in-progress merges in arrangement heap accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,8 +3328,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 [[package]]
 name = "differential-dataflow"
 version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2677690d1dfbf4d8427eef2fdcf350ab0b258d3be20d01dd37dca07ca6f50bcc"
+source = "git+https://github.com/antiguru/differential-dataflow.git?rev=26257c4a5c6a09fb29c5423c9ba656b221f3d2df#26257c4a5c6a09fb29c5423c9ba656b221f3d2df"
 dependencies = [
  "columnar",
  "columnation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -642,6 +642,11 @@ debug-assertions = true
 # merged), after which point it becomes impossible to build that historical
 # version of Materialize.
 [patch.crates-io]
+# Waiting on https://github.com/TimelyDataflow/differential-dataflow/pull/852, which adds
+# `Spine::map_mergers` and the merger `result` accessors that arrangement heap accounting needs to
+# see in-progress merges. Drop this once a release carries them.
+differential-dataflow = { git = "https://github.com/antiguru/differential-dataflow.git", rev = "26257c4a5c6a09fb29c5423c9ba656b221f3d2df" }
+
 # Waiting on https://github.com/sfackler/rust-postgres/pull/752.
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -20,7 +20,7 @@ use differential_dataflow::trace::{Batch, Batcher, Builder, Trace, TraceReader};
 use differential_dataflow::{Collection, Data, ExchangeData, Hashable, VecCollection};
 use mz_compute_types::dyncfgs::{ENABLE_COLUMN_PAGED_BATCHER, ENABLE_COLUMNAR_MERGE_BATCHER};
 use mz_dyncfg::ConfigSet;
-use mz_row_spine::ArcBatch;
+use mz_row_spine::{ArcBatch, ArcMerger};
 use timely::Container;
 use timely::container::{ContainerBuilder, PushInto};
 use timely::dataflow::Stream;
@@ -279,19 +279,23 @@ pub trait ArrangementSize {
 /// Helper for [`ArrangementSize`] to install a common operator holding on to a trace.
 ///
 /// * `arranged`: The arrangement to inspect.
-/// * `logic`: Closure that calculates the heap size/capacity/allocations for a batch. The return
-///    value are size and capacity in bytes, and number of allocations, all in absolute values.
+/// * `batch_logic`: Closure that calculates the heap size/capacity/allocations for a batch. The
+///    return value are size and capacity in bytes, and number of allocations, all in absolute
+///    values.
+/// * `merger_logic`: The same, for the partially assembled output that an in-progress merge holds.
 ///
 /// Batch-size logging identifies each batch by the address of its backing allocation and holds a
 /// weak reference to it, so it needs the `Arc` underlying the spine's [`ArcBatch<B>`] batches;
 /// `batch.0` reaches straight through the newtype to it.
-fn log_arrangement_size_inner<'scope, B, L>(
+fn log_arrangement_size_inner<'scope, B, LB, LM>(
     arranged: Arranged<'scope, TraceAgent<Spine<ArcBatch<B>>>>,
-    mut logic: L,
+    mut batch_logic: LB,
+    mut merger_logic: LM,
 ) -> Arranged<'scope, TraceAgent<Spine<ArcBatch<B>>>>
 where
     B: Batch + 'static,
-    L: FnMut(&B) -> (usize, usize, usize) + 'static,
+    LB: FnMut(&B) -> (usize, usize, usize) + 'static,
+    LM: FnMut(&ArcMerger<B>) -> (usize, usize, usize) + 'static,
 {
     let scope = arranged.stream.scope();
     let Some(logger) = scope
@@ -328,7 +332,7 @@ where
                     for batch in data.iter() {
                         batches
                             .entry(Arc::as_ptr(&batch.0))
-                            .or_insert_with(|| (Arc::downgrade(&batch.0), logic(&batch.0)));
+                            .or_insert_with(|| (Arc::downgrade(&batch.0), batch_logic(&batch.0)));
                     }
                     output.session(&time).give_container(data);
                 });
@@ -346,7 +350,7 @@ where
                 trace.borrow().trace().map_batches(|batch| {
                     batches
                         .entry(Arc::as_ptr(&batch.0))
-                        .or_insert_with(|| (Arc::downgrade(&batch.0), logic(&batch.0)));
+                        .or_insert_with(|| (Arc::downgrade(&batch.0), batch_logic(&batch.0)));
                 });
 
                 let (mut size, mut capacity, mut allocations) = (0, 0, 0);
@@ -358,6 +362,25 @@ where
                     } else {
                         false
                     }
+                });
+
+                // An in-progress merge holds a third allocation beyond its two input batches: the
+                // partially assembled output, which `map_batches` does not present and which no
+                // weak reference above reaches. Its containers are allocated at the merged
+                // capacity the moment the merge begins, so leaving it out understates a merging
+                // arrangement's resident bytes by close to the sum of its inputs. It can exceed
+                // that sum, because a container sizes its merged reservation from the inputs'
+                // record counts rather than from their own allocations.
+                //
+                // A merger's contents change as the merge proceeds, so unlike a sealed batch it
+                // cannot be measured once and cached; it is re-measured on every activation. The
+                // cost is bounded by the number of layers mid-merge, logarithmic in the
+                // arrangement's size.
+                trace.borrow().trace().map_mergers(|merger| {
+                    let (sz, c, a) = merger_logic(merger);
+                    size += sz;
+                    capacity += c;
+                    allocations += a;
                 });
 
                 let size = size.try_into().expect("must fit");
@@ -399,6 +422,50 @@ where
     }
 }
 
+/// Sums the heap size, capacity, and allocation count of the containers backing a key/value
+/// arrangement's storage.
+///
+/// A macro rather than a function generic over the layout: `heap_size` is an inherent method on
+/// each concrete container type, not a trait method, so a body abstract over the layout cannot
+/// call it. Both a sealed batch and an in-progress merge's partial output are this storage type,
+/// and both are measured here so that the two agree.
+macro_rules! val_storage_heap_size {
+    ($storage:expr) => {{
+        let storage = $storage;
+        let (mut size, mut capacity, mut allocations) = (0, 0, 0);
+        let mut callback = |siz, cap| {
+            size += siz;
+            capacity += cap;
+            allocations += usize::from(cap > 0);
+        };
+        storage.keys.heap_size(&mut callback);
+        storage.vals.offs.heap_size(&mut callback);
+        storage.vals.vals.heap_size(&mut callback);
+        storage.upds.offs.heap_size(&mut callback);
+        storage.upds.times.heap_size(&mut callback);
+        storage.upds.diffs.heap_size(&mut callback);
+        (size, capacity, allocations)
+    }};
+}
+
+/// The key-only counterpart of [`val_storage_heap_size`], for storage with no value layer.
+macro_rules! key_storage_heap_size {
+    ($storage:expr) => {{
+        let storage = $storage;
+        let (mut size, mut capacity, mut allocations) = (0, 0, 0);
+        let mut callback = |siz, cap| {
+            size += siz;
+            capacity += cap;
+            allocations += usize::from(cap > 0);
+        };
+        storage.keys.heap_size(&mut callback);
+        storage.upds.offs.heap_size(&mut callback);
+        storage.upds.times.heap_size(&mut callback);
+        storage.upds.diffs.heap_size(&mut callback);
+        (size, capacity, allocations)
+    }};
+}
+
 impl<'scope, T, K, V, R> ArrangementSize for Arranged<'scope, KeyValAgent<K, V, T, R>>
 where
     T: MzTimestamp,
@@ -407,21 +474,11 @@ where
     R: Semigroup + Ord + MzData + 'static,
 {
     fn log_arrangement_size(self) -> Self {
-        log_arrangement_size_inner(self, |batch| {
-            let (mut size, mut capacity, mut allocations) = (0, 0, 0);
-            let mut callback = |siz, cap| {
-                size += siz;
-                capacity += cap;
-                allocations += usize::from(cap > 0);
-            };
-            batch.storage.keys.heap_size(&mut callback);
-            batch.storage.vals.offs.heap_size(&mut callback);
-            batch.storage.vals.vals.heap_size(&mut callback);
-            batch.storage.upds.offs.heap_size(&mut callback);
-            batch.storage.upds.times.heap_size(&mut callback);
-            batch.storage.upds.diffs.heap_size(&mut callback);
-            (size, capacity, allocations)
-        })
+        log_arrangement_size_inner(
+            self,
+            |batch| val_storage_heap_size!(&batch.storage),
+            |merger| val_storage_heap_size!(merger.inner().result()),
+        )
     }
 }
 
@@ -432,19 +489,11 @@ where
     R: Semigroup + Ord + MzData + 'static,
 {
     fn log_arrangement_size(self) -> Self {
-        log_arrangement_size_inner(self, |batch| {
-            let (mut size, mut capacity, mut allocations) = (0, 0, 0);
-            let mut callback = |siz, cap| {
-                size += siz;
-                capacity += cap;
-                allocations += usize::from(cap > 0);
-            };
-            batch.storage.keys.heap_size(&mut callback);
-            batch.storage.upds.offs.heap_size(&mut callback);
-            batch.storage.upds.times.heap_size(&mut callback);
-            batch.storage.upds.diffs.heap_size(&mut callback);
-            (size, capacity, allocations)
-        })
+        log_arrangement_size_inner(
+            self,
+            |batch| key_storage_heap_size!(&batch.storage),
+            |merger| key_storage_heap_size!(merger.inner().result()),
+        )
     }
 }
 
@@ -455,21 +504,11 @@ where
     R: Semigroup + Ord + MzArrangeData + 'static,
 {
     fn log_arrangement_size(self) -> Self {
-        log_arrangement_size_inner(self, |batch| {
-            let (mut size, mut capacity, mut allocations) = (0, 0, 0);
-            let mut callback = |siz, cap| {
-                size += siz;
-                capacity += cap;
-                allocations += usize::from(cap > 0);
-            };
-            batch.storage.keys.heap_size(&mut callback);
-            batch.storage.vals.offs.heap_size(&mut callback);
-            batch.storage.vals.vals.heap_size(&mut callback);
-            batch.storage.upds.offs.heap_size(&mut callback);
-            batch.storage.upds.times.heap_size(&mut callback);
-            batch.storage.upds.diffs.heap_size(&mut callback);
-            (size, capacity, allocations)
-        })
+        log_arrangement_size_inner(
+            self,
+            |batch| val_storage_heap_size!(&batch.storage),
+            |merger| val_storage_heap_size!(merger.inner().result()),
+        )
     }
 }
 
@@ -479,21 +518,11 @@ where
     R: Semigroup + Ord + MzArrangeData + 'static,
 {
     fn log_arrangement_size(self) -> Self {
-        log_arrangement_size_inner(self, |batch| {
-            let (mut size, mut capacity, mut allocations) = (0, 0, 0);
-            let mut callback = |siz, cap| {
-                size += siz;
-                capacity += cap;
-                allocations += usize::from(cap > 0);
-            };
-            batch.storage.keys.heap_size(&mut callback);
-            batch.storage.vals.offs.heap_size(&mut callback);
-            batch.storage.vals.vals.heap_size(&mut callback);
-            batch.storage.upds.offs.heap_size(&mut callback);
-            batch.storage.upds.times.heap_size(&mut callback);
-            batch.storage.upds.diffs.heap_size(&mut callback);
-            (size, capacity, allocations)
-        })
+        log_arrangement_size_inner(
+            self,
+            |batch| val_storage_heap_size!(&batch.storage),
+            |merger| val_storage_heap_size!(merger.inner().result()),
+        )
     }
 }
 
@@ -503,18 +532,10 @@ where
     R: Semigroup + Ord + MzArrangeData + 'static,
 {
     fn log_arrangement_size(self) -> Self {
-        log_arrangement_size_inner(self, |batch| {
-            let (mut size, mut capacity, mut allocations) = (0, 0, 0);
-            let mut callback = |siz, cap| {
-                size += siz;
-                capacity += cap;
-                allocations += usize::from(cap > 0);
-            };
-            batch.storage.keys.heap_size(&mut callback);
-            batch.storage.upds.offs.heap_size(&mut callback);
-            batch.storage.upds.times.heap_size(&mut callback);
-            batch.storage.upds.diffs.heap_size(&mut callback);
-            (size, capacity, allocations)
-        })
+        log_arrangement_size_inner(
+            self,
+            |batch| key_storage_heap_size!(&batch.storage),
+            |merger| key_storage_heap_size!(merger.inner().result()),
+        )
     }
 }

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -288,10 +288,17 @@ impl DemuxHandler<'_, '_, '_> {
     }
 
     fn handle_merge(&mut self, event: MergeEvent) {
-        let Some(done) = event.complete else { return };
+        let operator_id = event.operator;
+
+        let Some(done) = event.complete else {
+            // A merge start changes no batch or record count, but it does allocate the merge's
+            // output at its full capacity, so the arrangement's footprint jumps here rather than
+            // at completion. Re-measure now, or the size stays understated for the whole merge.
+            self.notify_arrangement_size(operator_id);
+            return;
+        };
 
         let ts = self.ts();
-        let operator_id = event.operator;
         self.output
             .batches
             .give(((operator_id, ()), ts, Diff::MINUS_ONE));

--- a/src/row-spine/src/arc_batch.rs
+++ b/src/row-spine/src/arc_batch.rs
@@ -207,6 +207,13 @@ pub struct ArcMerger<B: Batch> {
     merger: B::Merger,
 }
 
+impl<B: Batch> ArcMerger<B> {
+    /// The inner batch's merger, which owns the merge's partially assembled output.
+    pub fn inner(&self) -> &B::Merger {
+        &self.merger
+    }
+}
+
 impl<B: Batch> Merger<ArcBatch<B>> for ArcMerger<B> {
     fn new(
         source1: &ArcBatch<B>,

--- a/src/row-spine/src/lib.rs
+++ b/src/row-spine/src/lib.rs
@@ -13,7 +13,7 @@
 //! allocations, as well as a `dictionary` encoding wrapper that is able to rewrite
 //! the byte slices to use spare tags in each column to reference common values.
 
-pub use self::arc_batch::{ArcBatch, ArcBuilder};
+pub use self::arc_batch::{ArcBatch, ArcBuilder, ArcMerger};
 pub use self::dictionary::DatumContainer;
 pub use self::dictionary::DatumSeq;
 pub use self::offset_opt::OffsetOptimized;

--- a/src/row-spine/tests/merge_accounting.rs
+++ b/src/row-spine/tests/merge_accounting.rs
@@ -1,0 +1,121 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Heap accounting over a spine has to include its in-progress merges.
+//!
+//! A spine mid-merge holds three allocations at the layer being merged: the two input batches and
+//! the merge's partially assembled output. Only the inputs are reachable through
+//! `TraceReader::map_batches`, and the output's containers are allocated at their full merged
+//! capacity the moment the merge begins, so an accounting built on `map_batches` alone understates
+//! a merging arrangement's resident bytes by close to a factor of two.
+//!
+//! This drives a real `RowRowSpine` into a state with a merge in flight and checks that
+//! `Spine::map_mergers` reaches the output and that the output is a large share of the total.
+//! `mz_compute`'s `ArrangementSize` operator sums exactly these two contributions.
+
+use std::rc::Rc;
+
+use differential_dataflow::trace::{Builder, Description, Trace, TraceReader};
+use mz_repr::{Datum, Diff, Row, Timestamp};
+use mz_row_spine::{RowRowBuilder, RowRowSpine};
+use timely::dataflow::operators::generic::OperatorInfo;
+use timely::progress::{Antichain, Timestamp as _};
+
+type Spine = RowRowSpine<Timestamp, Diff>;
+type SpineBatch = <Spine as TraceReader>::Batch;
+type SpineBuilder = RowRowBuilder<Timestamp, Diff>;
+
+/// Heap size, capacity, and allocation count of a key/value storage's containers.
+///
+/// Mirrors `mz_compute::extensions::arrange`'s accounting, which is what this test guards.
+macro_rules! val_storage_heap_size {
+    ($storage:expr) => {{
+        let storage = $storage;
+        let (mut size, mut capacity, mut allocations) = (0usize, 0usize, 0usize);
+        let mut callback = |siz, cap| {
+            size += siz;
+            capacity += cap;
+            allocations += usize::from(cap > 0);
+        };
+        storage.keys.heap_size(&mut callback);
+        storage.vals.offs.heap_size(&mut callback);
+        storage.vals.vals.heap_size(&mut callback);
+        storage.upds.offs.heap_size(&mut callback);
+        storage.upds.times.heap_size(&mut callback);
+        storage.upds.diffs.heap_size(&mut callback);
+        (size, capacity, allocations)
+    }};
+}
+
+/// Seals one batch covering `[time, time + 1)`, holding `keys` distinct key/value pairs.
+fn batch(time: u64, keys: std::ops::Range<u64>) -> SpineBatch {
+    let mut chunk = <SpineBuilder as Builder>::Input::default();
+    for k in keys {
+        let key = Row::pack_slice(&[Datum::UInt64(k)]);
+        let val = Row::pack_slice(&[Datum::UInt64(k), Datum::String("padding padding padding")]);
+        chunk.copy(&((key, val), Timestamp::from(time), Diff::ONE));
+    }
+    <SpineBuilder as Builder>::seal(
+        &mut vec![chunk],
+        Description::new(
+            Antichain::from_elem(Timestamp::from(time)),
+            Antichain::from_elem(Timestamp::from(time + 1)),
+            Antichain::from_elem(Timestamp::minimum()),
+        ),
+    )
+}
+
+/// The bytes a spine's batches account for, and the bytes only its mergers account for.
+fn measure(spine: &Spine) -> (usize, usize) {
+    let mut batch_capacity = 0;
+    spine.map_batches(|batch| {
+        let (_, capacity, _) = val_storage_heap_size!(&batch.storage);
+        batch_capacity += capacity;
+    });
+    let mut merger_capacity = 0;
+    spine.map_mergers(|merger| {
+        let (_, capacity, _) = val_storage_heap_size!(merger.inner().result());
+        merger_capacity += capacity;
+    });
+    (batch_capacity, merger_capacity)
+}
+
+#[mz_ore::test]
+fn in_progress_merges_hold_bytes_no_batch_accounts_for() {
+    let info = OperatorInfo::new(0, 0, Rc::from(&[0][..]));
+    let mut spine: Spine = Trace::new(info, None, None);
+
+    // Enough batches that the spine has layers of several different scales mid-merge at once.
+    let per_batch = 4_000;
+    let mut peak: Option<(usize, usize)> = None;
+    for step in 0..32u64 {
+        let lo = step * per_batch;
+        spine.insert(batch(step, lo..lo + per_batch));
+        spine.set_physical_compaction(Antichain::from_elem(Timestamp::from(step + 1)).borrow());
+        spine.set_logical_compaction(Antichain::from_elem(Timestamp::from(step + 1)).borrow());
+
+        let (batches, mergers) = measure(&spine);
+        if peak.is_none_or(|(_, best)| mergers > best) {
+            peak = Some((batches, mergers));
+        }
+    }
+
+    let (batches, mergers) = peak.expect("at least one observation");
+    assert!(
+        mergers > 0,
+        "no in-progress merge observed; the test never reached the state it means to cover"
+    );
+    // The share is not a tight bound, only evidence that what `map_batches` misses is a first-order
+    // term rather than bookkeeping noise. In practice a top-level merge roughly doubles the total.
+    assert!(
+        mergers * 4 > batches,
+        "merger bytes {mergers} are under a quarter of batch bytes {batches}; \
+         either merge_capacity stopped allocating up front or the measurement is wrong"
+    );
+}


### PR DESCRIPTION
The `ArrangementSize` operator sums each batch a spine holds, reaching them through `TraceReader::map_batches`. For a layer mid-merge, that method presents the merge's two input batches and stops, but the layer holds a third allocation: the merger's partially assembled output. Differential sizes that output's containers with `merge_capacity` when the merge begins, so the allocation is there in full from the merge's first step and stays invisible until it becomes a batch.

This walks the spine's mergers alongside its batches. A merger's contents change as the merge proceeds, so unlike a sealed batch it cannot be measured once and cached; it is re-measured on every activation. The cost is bounded by the number of layers mid-merge, logarithmic in the arrangement's size.

It also re-measures when a merge starts. `handle_merge` returned early for a merge start event, since a start changes neither the batch nor the record count, which meant the size operator was not activated at the one moment the footprint jumps. Without this, the corrected accounting would not be observed until the next batch arrival, drop, or merge completion for that operator.

### Magnitude

Measured on a one-million-row index over 87 observations, comparing the reported totals against the totals including mergers:

| true/reported | size | capacity |
| --- | --- | --- |
| median | 1.54x | 1.83x |
| p90 | 1.95x | 1.97x |
| max | 2.53x | 2.55x |

The undercount tracks merge progress, from a median 1.07x while the merge output is under a quarter full to 1.91x once it is over three quarters full. The accounting was therefore least accurate exactly when an arrangement's footprint peaks, since that is when the merge output is nearly built and both input batches are still resident. At the peak observation `mz_arrangement_heap_size` reported 30.3 MB against 59.0 MB actually written.

`size` is the figure that matters for resident memory: every container reports it from `len`, and only the capacity figure comes from `capacity()`. Ratios can exceed 2x because a container sizes its merged reservation from the inputs' record counts rather than from the inputs' own allocations.

`OffsetOptimized` is not a contributor, contrary to what one might expect from the offset representations: its `merge_capacity` allocates nothing, and every layout the compute layer arranges with uses it. The eager terms are `DatumContainer` for keys and values, and `ColumnationStack` for times and diffs.

### Blocked on a dependency, and on a policy question

This needs `Spine::map_mergers` and the merger `result` accessors, proposed upstream in TimelyDataflow/differential-dataflow#852. Until a differential release carries them, `Cargo.toml` pins a git rev.

**The pin currently points at `antiguru/differential-dataflow`, which `deny.toml` forbids.** `cargo deny check sources` fails, so `check-cargo.sh` is red. The policy wants git dependencies owned by MaterializeInc, and `MaterializeInc/differential-dataflow` is archived and read-only, so there is no compliant target today. Resolving this needs one of:

* unarchiving `MaterializeInc/differential-dataflow`, or creating a new fork under the org, and repointing the pin;
* waiting for the upstream PR to merge and a differential release to be cut, then dropping the patch entirely;
* splitting this PR so the merge-start activation fix and the macro refactor land against released differential now, leaving the merger walk for later.

I have deliberately not edited `deny.toml`, since its comment says to ask #eng-infra rather than add a non-MaterializeInc org.

### Refactor

The five near-identical per-layout size closures are replaced by two macros shared between the batch and merger paths. A function generic over the layout cannot serve here, because `heap_size` is an inherent method on each concrete container rather than a trait method.

### Tests

Adds `src/row-spine/tests/merge_accounting.rs`, which drives a `RowRowSpine` into a state with a merge in flight and asserts that the merger's storage is a first-order share of the total rather than bookkeeping noise.

`test/testdrive/introspection-sources.td` and `test/testdrive/arrangement-dictionary-compression.td` read `mz_arrangement_sizes`, but assert only on batch counts and `> 0` predicates, so this change cannot alter their outcomes.

### Release notes

This release will report arrangement memory usage accurately while arrangements are merging. `mz_arrangement_sizes`, and the `mz_arrangement_size_bytes` and `mz_arrangement_capacity_bytes` metrics, previously understated a merging arrangement by up to roughly a factor of two, and were least accurate when an arrangement's memory use was at its highest. Expect reported sizes to rise for objects whose arrangements merge often; the underlying memory use has not changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
