### PR TITLE
sql-parser: handle EXPLAIN TIMESTAMP AS DOT instead of panicking

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -9478,6 +9478,7 @@ impl<'a> Parser<'a> {
             match self.parse_one_of_keywords(&[TEXT, JSON, DOT]) {
                 Some(TEXT) => Some(ExplainFormat::Text),
                 Some(JSON) => Some(ExplainFormat::Json),
+                Some(DOT) => Some(ExplainFormat::Dot),
                 None => return Err(ParserError::new(self.index, "expected a format")),
                 _ => unreachable!(),
             }

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -195,6 +195,13 @@ EXPLAIN TIMESTAMP AS JSON FOR SELECT 1
 ExplainTimestamp(ExplainTimestampStatement { format: Some(Json), select: SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None } })
 
 parse-statement
+EXPLAIN TIMESTAMP AS DOT FOR SELECT 1
+----
+EXPLAIN TIMESTAMP AS DOT FOR SELECT 1
+=>
+ExplainTimestamp(ExplainTimestampStatement { format: Some(Dot), select: SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, qualify: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None } })
+
+parse-statement
 EXPLAIN AS JSON SELECT * FROM foo
 ----
 EXPLAIN AS JSON SELECT * FROM foo


### PR DESCRIPTION
### Motivation

`EXPLAIN TIMESTAMP AS DOT FOR <query>` panics the parser (`unreachable!()` at `src/sql-parser/src/parser.rs`), and since the parse path is not wrapped in `catch_unwind` and the panic hook calls `process::abort()`, it crashes environmentd. Post-authentication, so any role that can run SQL can take the environment down with one statement. Verified on the v26.39.0 emulator (SIGABRT, exit 134). Found while reviewing the `EXPLAIN TIMESTAMP` docs page.

Closes: [SQL-665](https://linear.app/materializeinc/issue/SQL-665)

### Description

`parse_explain_timestamp` accepts `DOT` in `parse_one_of_keywords(&[TEXT, JSON, DOT])` but had no `Some(DOT)` arm, so `AS DOT` fell through to `_ => unreachable!()`. Added `Some(DOT) => Some(ExplainFormat::Dot)`, matching `parse_explain_plan`. The statement now parses and reaches the sequencer's existing `AdapterError::Unsupported("EXPLAIN TIMESTAMP AS DOT")` (`src/adapter/src/coord/sequencer/inner/explain_timestamp.rs`) instead of panicking.

### Verification

Added a `parse-statement` regression case for `EXPLAIN TIMESTAMP AS DOT FOR SELECT 1` to `src/sql-parser/tests/testdata/explain`.
