### PR TITLE
catalog: correct stale system-catalog column comments

### DIFF
--- a/doc/user/content/reference/system-catalog/mz_catalog.md
+++ b/doc/user/content/reference/system-catalog/mz_catalog.md
@@ -111,8 +111,8 @@ any kind of capacity planning.
 | `processes`            | [`uint8`]   | The number of processes in the replica.                                                                                                                      |
 | `workers`              | [`uint8`]   | The number of Timely Dataflow workers per process.                                                                                                           |
 | `cpu_nano_cores`       | [`uint8`]   | The CPU allocation per process, in billionths of a vCPU core.                                                                                                |
-| `memory_bytes`         | [`uint8`]   | The RAM allocation per process, in billionths of a vCPU core.                                                                                                |
-| `disk_bytes`           | [`uint8`]   | The disk allocation per process.                                                                                                                             |
+| `memory_bytes`         | [`uint8`]   | The RAM allocation per process, in bytes.                                                                                                |
+| `disk_bytes`           | [`uint8`]   | The disk allocation per process, in bytes. On sizes that use swap, this is the swap allowance rather than a filesystem disk.                                                                                                                             |
 | `credits_per_hour`     | [`numeric`] | The number of compute credits consumed per hour.                                                                                                             |
 
 ### `mz_cluster_replicas`
@@ -144,7 +144,7 @@ The `mz_clusters` table contains a row for each cluster in the system.
 | `managed`                 | [`boolean`]          | Whether the cluster is a [managed cluster](/sql/create-cluster/) with automatically managed replicas.                                    |
 | `size`                    | [`text`]             | If the cluster is managed, the desired size of the cluster's replicas. `NULL` for unmanaged clusters.                                    |
 | `replication_factor`      | [`uint4`]            | If the cluster is managed, the desired number of replicas of the cluster. `NULL` for unmanaged clusters.                                 |
-| `disk`                    | [`boolean`]          | **Unstable** If the cluster is managed, `true` if the replicas have the `DISK` option . `NULL` for unmanaged clusters.                   |
+| `disk`                    | [`boolean`]          | **Unstable** If the cluster is managed, `true` if the replicas use a local disk rather than swap. `NULL` for unmanaged clusters.                   |
 | `availability_zones`      | [`text list`]        | **Unstable** If the cluster is managed, the list of availability zones specified in `AVAILABILITY ZONES`. `NULL` for unmanaged clusters. |
 | `introspection_debugging` | [`boolean`]          | Whether introspection of the gathering of the introspection data is enabled.                                                             |
 | `introspection_interval`  | [`interval`]         | The interval at which to collect introspection data.                                                                                     |

--- a/doc/user/content/reference/system-catalog/mz_internal.md
+++ b/doc/user/content/reference/system-catalog/mz_internal.md
@@ -200,7 +200,7 @@ an autoscaling action is running.
 
 ## `mz_cluster_replica_metrics`
 
-The `mz_cluster_replica_metrics` view gives the last known CPU and RAM utilization statistics
+The `mz_cluster_replica_metrics` view gives the last known CPU, RAM, disk, and heap utilization statistics
 for all processes of all extant cluster replicas.
 
 At this time, we do not make any guarantees about the exactness or freshness of these numbers.
@@ -219,7 +219,7 @@ usage.
 | `process_id`        | [`uint8`]    | The ID of a process within the replica.
 | `cpu_nano_cores`    | [`uint8`]    | Approximate CPU usage, in billionths of a vCPU core.
 | `memory_bytes`      | [`uint8`]    | Approximate RAM usage, in bytes.
-| `disk_bytes`        | [`uint8`]    | Approximate disk usage, in bytes.
+| `disk_bytes`        | [`uint8`]    | Approximate disk usage, in bytes. On replicas whose disk is provided as swap, this includes swap usage.
 | `heap_bytes`        | [`uint8`]    | Approximate heap (RAM + swap) usage, in bytes.
 | `heap_limit`        | [`uint8`]    | Available heap (RAM + swap) space, in bytes.
 
@@ -242,8 +242,8 @@ history is retained across restarts.
 | `replica_id`     | [`text`]  | The ID of a cluster replica.
 | `process_id`     | [`uint8`] | The ID of a process within the replica.
 | `cpu_nano_cores` | [`uint8`] | Approximate CPU usage, in billionths of a vCPU core.
-| `memory_bytes`   | [`uint8`] | Approximate memory usage, in bytes.
-| `disk_bytes`     | [`uint8`] | Approximate disk usage, in bytes.
+| `memory_bytes`   | [`uint8`] | Approximate RAM usage, in bytes.
+| `disk_bytes`     | [`uint8`] | Approximate disk usage, in bytes. On replicas whose disk is provided as swap, this includes swap usage.
 | `occurred_at`    | [`timestamp with time zone`] | Wall-clock timestamp at which the event occurred.
 | `heap_bytes`     | [`uint8`] | Approximate heap (RAM + swap) usage, in bytes.
 | `heap_limit`     | [`uint8`] | Available heap (RAM + swap) space, in bytes.
@@ -279,7 +279,7 @@ for all processes of all extant cluster replicas.
 
 ## `mz_cluster_replica_utilization`
 
-The `mz_cluster_replica_utilization` view gives the last known CPU and RAM utilization statistics
+The `mz_cluster_replica_utilization` view gives the last known CPU, RAM, disk, and heap utilization statistics
 for all processes of all extant cluster replicas, as a percentage of the total resource allocation.
 
 At this time, we do not make any guarantees about the exactness or freshness of these numbers.
@@ -291,7 +291,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 | `process_id`     | [`uint8`]            | The ID of a process within the replica.
 | `cpu_percent`    | [`double precision`] | Approximate CPU usage, in percent of the total allocation.
 | `memory_percent` | [`double precision`] | Approximate RAM usage, in percent of the total allocation.
-| `disk_percent`   | [`double precision`] | Approximate disk usage, in percent of the total allocation.
+| `disk_percent`   | [`double precision`] | Approximate disk usage, in percent of the total allocation. On replicas whose disk is provided as swap, this includes swap usage.
 | `heap_percent`   | [`double precision`] | Approximate heap (RAM + swap) usage, in percent of the total allocation.
 
 ## `mz_cluster_replica_utilization_history`
@@ -309,7 +309,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 | `process_id`     | [`uint8`]            | The ID of a process within the replica.
 | `cpu_percent`    | [`double precision`] | Approximate CPU usage, in percent of the total allocation.
 | `memory_percent` | [`double precision`] | Approximate RAM usage, in percent of the total allocation.
-| `disk_percent`   | [`double precision`] | Approximate disk usage, in percent of the total allocation.
+| `disk_percent`   | [`double precision`] | Approximate disk usage, in percent of the total allocation. On replicas whose disk is provided as swap, this includes swap usage.
 | `heap_percent`   | [`double precision`] | Approximate heap (RAM + swap) usage, in percent of the total allocation.
 | `occurred_at`    | [`timestamp with time zone`] | Wall-clock timestamp at which the event occurred.
 
@@ -459,7 +459,7 @@ inputs.
 <!-- RELATION_SPEC mz_internal.mz_hydration_statuses -->
 | Field        | Type        | Meaning  |
 | -----------  | ----------- | -------- |
-| `object_id`  | [`text`]    | The ID of a dataflow-powered object. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_internal.mz_subscriptions`](#mz_subscriptions), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_sinks.id`](../mz_catalog#mz_sinks). |
+| `object_id`  | [`text`]    | The ID of a dataflow-powered object. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_sinks.id`](../mz_catalog#mz_sinks). |
 | `replica_id` | [`text`]    | The ID of a cluster replica. |
 | `hydrated`   | [`boolean`] | Whether the object is hydrated on the replica. |
 
@@ -536,7 +536,7 @@ SQL objects that don't exist in the dataflow layer (such as views) are omitted.
 <!-- RELATION_SPEC mz_internal.mz_materialization_dependencies -->
 | Field       | Type     | Meaning                                                                                                                                                                                                                                                                                            |
 | ----------- | -------- | --------                                                                                                                                                                                                                                                                                           |
-| `object_id`     | [`text`] | The ID of a materialization. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), or [`mz_catalog.mz_sinks.id`](#mz_subscriptions).                                                           |
+| `object_id`     | [`text`] | The ID of a materialization. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), or [`mz_catalog.mz_sinks.id`](../mz_catalog#mz_sinks).                                                           |
 | `dependency_id` | [`text`] | The ID of a dataflow dependency. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables). |
 
 ## `mz_materialization_lag`
@@ -1309,7 +1309,7 @@ The `mz_source_statistics` view contains statistics about each source.
 <!-- RELATION_SPEC mz_internal.mz_source_statistics -->
 | Field                     | Type         | Meaning |
 | --------------------------|--------------|---------|
-| `id`                      | [`text`]     | The ID of the source. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources). |
+| `id`                      | [`text`]     | The ID of the source or table for which statistics are reported. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources) or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables). |
 | `replica_id`              | [`text`]     | The ID of a replica running the source. Corresponds to [`mz_catalog.mz_cluster_replicas.id`](../mz_catalog#mz_cluster_replicas). |
 | `messages_received`       | [`uint8`]    | The number of messages the source has received from the external system. Messages are counted in a source type-specific manner. Messages do not correspond directly to updates: some messages produce multiple updates, while other messages may be coalesced into a single update. |
 | `bytes_received`          | [`uint8`]    | The number of bytes the source has read from the external system. Bytes are counted in a source type-specific manner and may or may not include protocol overhead. |
@@ -1485,7 +1485,7 @@ Wallclock lag measures how far behind real-world wall-clock time each
 | Field         | Type         | Meaning
 | --------------| -------------| --------
 | `object_id`   | [`text`]     | The ID of the table, source, materialized view, index, or sink. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects).
-| `lag`         | [`interval`] | The amount of time the object's write frontier lags behind wallclock time.
+| `lag`         | [`interval`] | The smallest wallclock lag observed for the object across its replicas during the most recent minute.
 
 ## `mz_wallclock_lag_history`
 
@@ -1497,7 +1497,7 @@ i.e., the [freshness](/concepts/reaction-time/#freshness), for each table, sourc
 | --------------| -------------| --------
 | `object_id`   | [`text`]     | The ID of the table, source, materialized view, index, or sink. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects).
 | `replica_id`  | [`text`]     | The ID of a replica computing the object, or `NULL` for persistent objects. Corresponds to [`mz_cluster_replicas.id`](../mz_catalog/#mz_cluster_replicas).
-| `lag`         | [`interval`] | The amount of time the object's write frontier lags behind wallclock time.
+| `lag`         | [`interval`] | The maximum time the object's write frontier lagged behind wallclock time during the recording interval (60 seconds by default), rounded down to whole seconds.
 | `occurred_at` | [`timestamp with time zone`] | Wall-clock timestamp at which the event occurred.
 
 ## `mz_wallclock_global_lag_history`

--- a/doc/user/content/reference/system-catalog/mz_introspection.md
+++ b/doc/user/content/reference/system-catalog/mz_introspection.md
@@ -27,7 +27,7 @@ Thus, in a multi-replica cluster, queries to these relations need to be directed
 Note that once this command is issued, all subsequent `SELECT` queries, for introspection relations or not, will be directed to the targeted replica.
 Replica targeting can be cancelled by issuing the command `RESET cluster_replica`.
 
-For each of the below introspection relations, there exists also a variant with a `_per_worker` name suffix.
+Most of the below introspection relations also have a variant with a `_per_worker` name suffix. The exceptions are `mz_cluster_prometheus_metrics`, `mz_cluster_replica_resource_usage`, `mz_dataflow_arrangement_sizes`, `mz_expected_group_size_advice`, and `mz_mappable_objects`, which have no per-worker variant, and `mz_dataflow_global_ids` and `mz_lir_mapping`, whose per-worker variants are named `mz_compute_dataflow_global_ids_per_worker` and `mz_compute_lir_mapping_per_worker`.
 Per-worker relations expose the same data as their global counterparts, but have an extra `worker_id` column that splits the information by Timely Dataflow worker.
 
 ## `mz_active_peeks`
@@ -52,7 +52,7 @@ The `mz_arrangement_sharing` view describes how many times each [arrangement] in
 | Field          | Type       | Meaning                                                                                                                   |
 | -------------- |------------| --------                                                                                                                  |
 | `operator_id`  | [`uint8`]  | The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
-| `count`        | [`bigint`] | The number of operators that share the arrangement.                                                                       |
+| `count`        | [`bigint`] | The number of live trace handles on the arrangement.                                                                       |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_sharing_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_sharing_raw -->
@@ -211,7 +211,7 @@ The `mz_dataflow_addresses` view describes how the [dataflow] channels and opera
 | Field        | Type            | Meaning                                                                                                                                                       |
 | ------------ |-----------------| --------                                                                                                                                                      |
 | `id`         | [`uint8`]       | The ID of the channel or operator. Corresponds to [`mz_dataflow_channels.id`](#mz_dataflow_channels) or [`mz_dataflow_operators.id`](#mz_dataflow_operators). |
-| `address`    | [`bigint list`] | A list of scope-local indexes indicating the path from the root to this channel or operator.                                                                  |
+| `address`    | [`uint8 list`] | A list of scope-local indexes indicating the path from the root to this channel or operator.                                                                  |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_addresses_per_worker -->
 
@@ -432,7 +432,7 @@ The `mz_records_per_dataflow_operator` view describes the number of records in e
 | `name`         | [`text`]   | The internal name of the operator.                                                           |
 | `dataflow_id`  | [`uint8`]  | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).                   |
 | `records`      | [`bigint`] | The number of records in the operator.                                                       |
-| `batches`      | [`bigint`] | The number of batches in the dataflow.                                                       |
+| `batches`      | [`bigint`] | The number of batches in the operator.                                                       |
 | `size`         | [`bigint`] | The utilized size in bytes of the arrangement.                                               |
 | `capacity`     | [`bigint`] | The capacity in bytes of the arrangement. Can be larger than the size.                       |
 | `allocations`  | [`bigint`] | The number of separate memory allocations backing the arrangement.                           |

--- a/src/catalog/src/builtin/mz_catalog.rs
+++ b/src/catalog/src/builtin/mz_catalog.rs
@@ -2468,7 +2468,7 @@ pub static MZ_CLUSTERS: LazyLock<BuiltinMaterializedView> = LazyLock::new(|| {
             ),
             (
                 "disk",
-                "**Unstable** If the cluster is managed, `true` if the replicas have the `DISK` option . `NULL` for unmanaged clusters.",
+                "**Unstable** If the cluster is managed, `true` if the replicas use a local disk rather than swap. `NULL` for unmanaged clusters.",
             ),
             (
                 "availability_zones",
@@ -2816,11 +2816,11 @@ pub static MZ_CLUSTER_REPLICA_SIZES: LazyLock<BuiltinTable> = LazyLock::new(|| B
             "cpu_nano_cores",
             "The CPU allocation per process, in billionths of a vCPU core.",
         ),
+        ("memory_bytes", "The RAM allocation per process, in bytes."),
         (
-            "memory_bytes",
-            "The RAM allocation per process, in billionths of a vCPU core.",
+            "disk_bytes",
+            "The disk allocation per process, in bytes. On sizes that use swap, this is the swap allowance rather than a filesystem disk.",
         ),
-        ("disk_bytes", "The disk allocation per process."),
         (
             "credits_per_hour",
             "The number of compute credits consumed per hour.",

--- a/src/catalog/src/builtin/mz_internal.rs
+++ b/src/catalog/src/builtin/mz_internal.rs
@@ -2766,8 +2766,8 @@ WHERE
     }
 });
 
-pub static MZ_CLUSTER_REPLICA_METRICS_HISTORY: LazyLock<BuiltinSource> =
-    LazyLock::new(|| BuiltinSource {
+pub static MZ_CLUSTER_REPLICA_METRICS_HISTORY: LazyLock<BuiltinSource> = LazyLock::new(|| {
+    BuiltinSource {
         name: "mz_cluster_replica_metrics_history",
         schema: MZ_INTERNAL_SCHEMA,
         oid: oid::SOURCE_MZ_CLUSTER_REPLICA_METRICS_HISTORY_OID,
@@ -2780,8 +2780,11 @@ pub static MZ_CLUSTER_REPLICA_METRICS_HISTORY: LazyLock<BuiltinSource> =
                 "cpu_nano_cores",
                 "Approximate CPU usage, in billionths of a vCPU core.",
             ),
-            ("memory_bytes", "Approximate memory usage, in bytes."),
-            ("disk_bytes", "Approximate disk usage, in bytes."),
+            ("memory_bytes", "Approximate RAM usage, in bytes."),
+            (
+                "disk_bytes",
+                "Approximate disk usage, in bytes. On replicas whose disk is provided as swap, this includes swap usage.",
+            ),
             (
                 "occurred_at",
                 "Wall-clock timestamp at which the event occurred.",
@@ -2795,7 +2798,8 @@ pub static MZ_CLUSTER_REPLICA_METRICS_HISTORY: LazyLock<BuiltinSource> =
         is_retained_metrics_object: false,
         access: vec![PUBLIC_SELECT],
         ontology: None,
-    });
+    }
+});
 
 pub static MZ_CLUSTER_REPLICA_METRICS: LazyLock<BuiltinView> = LazyLock::new(|| BuiltinView {
     name: "mz_cluster_replica_metrics",
@@ -2819,7 +2823,10 @@ pub static MZ_CLUSTER_REPLICA_METRICS: LazyLock<BuiltinView> = LazyLock::new(|| 
             "Approximate CPU usage, in billionths of a vCPU core.",
         ),
         ("memory_bytes", "Approximate RAM usage, in bytes."),
-        ("disk_bytes", "Approximate disk usage, in bytes."),
+        (
+            "disk_bytes",
+            "Approximate disk usage, in bytes. On replicas whose disk is provided as swap, this includes swap usage.",
+        ),
         (
             "heap_bytes",
             "Approximate heap (RAM + swap) usage, in bytes.",
@@ -2954,7 +2961,7 @@ pub static MZ_WALLCLOCK_LAG_HISTORY: LazyLock<BuiltinSource> = LazyLock::new(|| 
         ),
         (
             "lag",
-            "The amount of time the object's write frontier lags behind wallclock time.",
+            "The maximum time the object's write frontier lagged behind wallclock time during the recording interval (60 seconds by default), rounded down to whole seconds.",
         ),
         (
             "occurred_at",
@@ -3115,7 +3122,7 @@ pub static MZ_WALLCLOCK_GLOBAL_LAG: LazyLock<BuiltinView> = LazyLock::new(|| Bui
         ),
         (
             "lag",
-            "The amount of time the object's write frontier lags behind wallclock time.",
+            "The smallest wallclock lag observed for the object across its replicas during the most recent minute.",
         ),
     ]),
     sql: "
@@ -5383,7 +5390,7 @@ pub static MZ_CLUSTER_REPLICA_UTILIZATION: LazyLock<BuiltinView> = LazyLock::new
         ),
         (
             "disk_percent",
-            "Approximate disk usage, in percent of the total allocation.",
+            "Approximate disk usage, in percent of the total allocation. On replicas whose disk is provided as swap, this includes swap usage.",
         ),
         (
             "heap_percent",
@@ -5422,8 +5429,8 @@ FROM
     }),
 });
 
-pub static MZ_CLUSTER_REPLICA_UTILIZATION_HISTORY: LazyLock<BuiltinView> =
-    LazyLock::new(|| BuiltinView {
+pub static MZ_CLUSTER_REPLICA_UTILIZATION_HISTORY: LazyLock<BuiltinView> = LazyLock::new(|| {
+    BuiltinView {
         name: "mz_cluster_replica_utilization_history",
         schema: MZ_INTERNAL_SCHEMA,
         oid: oid::VIEW_MZ_CLUSTER_REPLICA_UTILIZATION_HISTORY_OID,
@@ -5452,7 +5459,7 @@ pub static MZ_CLUSTER_REPLICA_UTILIZATION_HISTORY: LazyLock<BuiltinView> =
             ),
             (
                 "disk_percent",
-                "Approximate disk usage, in percent of the total allocation.",
+                "Approximate disk usage, in percent of the total allocation. On replicas whose disk is provided as swap, this includes swap usage.",
             ),
             (
                 "heap_percent",
@@ -5478,7 +5485,8 @@ FROM
         JOIN mz_internal.mz_cluster_replica_metrics_history AS m ON m.replica_id = r.id",
         access: vec![PUBLIC_SELECT],
         ontology: None,
-    });
+    }
+});
 
 pub static MZ_INDEX_ADVICE: LazyLock<BuiltinView> = LazyLock::new(|| {
     BuiltinView {
@@ -7495,7 +7503,7 @@ pub static MZ_HYDRATION_STATUSES: LazyLock<BuiltinView> = LazyLock::new(|| Built
     column_comments: BTreeMap::from_iter([
         (
             "object_id",
-            "The ID of a dataflow-powered object. Corresponds to `mz_catalog.mz_indexes.id`, `mz_catalog.mz_materialized_views.id`, `mz_internal.mz_subscriptions`, `mz_catalog.mz_sources.id`, or `mz_catalog.mz_sinks.id`.",
+            "The ID of a dataflow-powered object. Corresponds to `mz_catalog.mz_indexes.id`, `mz_catalog.mz_materialized_views.id`, `mz_catalog.mz_sources.id`, or `mz_catalog.mz_sinks.id`.",
         ),
         ("replica_id", "The ID of a cluster replica."),
         ("hydrated", "Whether the object is hydrated on the replica."),
@@ -8768,7 +8776,7 @@ pub static MZ_SOURCE_STATISTICS: LazyLock<BuiltinView> = LazyLock::new(|| {
         column_comments: BTreeMap::from_iter([
             (
                 "id",
-                "The ID of the source. Corresponds to `mz_catalog.mz_sources.id`.",
+                "The ID of the source or table for which statistics are reported. Corresponds to `mz_catalog.mz_sources.id` or `mz_catalog.mz_tables.id`.",
             ),
             (
                 "replica_id",

--- a/src/catalog/src/builtin/mz_introspection.rs
+++ b/src/catalog/src/builtin/mz_introspection.rs
@@ -1215,7 +1215,7 @@ pub static MZ_RECORDS_PER_DATAFLOW_OPERATOR: LazyLock<BuiltinView> =
                 "The ID of the dataflow. Corresponds to `mz_dataflows.id`.",
             ),
             ("records", "The number of records in the operator."),
-            ("batches", "The number of batches in the dataflow."),
+            ("batches", "The number of batches in the operator."),
             ("size", "The utilized size in bytes of the arrangement."),
             (
                 "capacity",
@@ -2243,7 +2243,7 @@ pub static MZ_ARRANGEMENT_SHARING: LazyLock<BuiltinView> = LazyLock::new(|| Buil
         ),
         (
             "count",
-            "The number of operators that share the arrangement.",
+            "The number of live trace handles on the arrangement.",
         ),
     ]),
     sql: "

--- a/test/sqllogictest/autogenerated/mz_catalog.slt
+++ b/test/sqllogictest/autogenerated/mz_catalog.slt
@@ -76,8 +76,8 @@ size  text  The␠human-readable␠replica␠size.
 processes  uint8  The␠number␠of␠processes␠in␠the␠replica.
 workers  uint8  The␠number␠of␠Timely␠Dataflow␠workers␠per␠process.
 cpu_nano_cores  uint8  The␠CPU␠allocation␠per␠process,␠in␠billionths␠of␠a␠vCPU␠core.
-memory_bytes  uint8  The␠RAM␠allocation␠per␠process,␠in␠billionths␠of␠a␠vCPU␠core.
-disk_bytes  uint8  The␠disk␠allocation␠per␠process.
+memory_bytes  uint8  The␠RAM␠allocation␠per␠process,␠in␠bytes.
+disk_bytes  uint8  The␠disk␠allocation␠per␠process,␠in␠bytes.␠On␠sizes␠that␠use␠swap,␠this␠is␠the␠swap␠allowance␠rather␠than␠a␠filesystem␠disk.
 credits_per_hour  numeric  The␠number␠of␠compute␠credits␠consumed␠per␠hour.
 
 query TTT
@@ -101,7 +101,7 @@ privileges  mz_aclitem[]  The␠privileges␠belonging␠to␠the␠cluster.
 managed  boolean  Whether␠the␠cluster␠is␠a␠managed␠cluster␠with␠automatically␠managed␠replicas.
 size  text  If␠the␠cluster␠is␠managed,␠the␠desired␠size␠of␠the␠cluster's␠replicas.␠`NULL`␠for␠unmanaged␠clusters.
 replication_factor  uint4  If␠the␠cluster␠is␠managed,␠the␠desired␠number␠of␠replicas␠of␠the␠cluster.␠`NULL`␠for␠unmanaged␠clusters.
-disk  boolean  **Unstable**␠If␠the␠cluster␠is␠managed,␠`true`␠if␠the␠replicas␠have␠the␠`DISK`␠option␠.␠`NULL`␠for␠unmanaged␠clusters.
+disk  boolean  **Unstable**␠If␠the␠cluster␠is␠managed,␠`true`␠if␠the␠replicas␠use␠a␠local␠disk␠rather␠than␠swap.␠`NULL`␠for␠unmanaged␠clusters.
 availability_zones  list  **Unstable**␠If␠the␠cluster␠is␠managed,␠the␠list␠of␠availability␠zones␠specified␠in␠`AVAILABILITY␠ZONES`.␠`NULL`␠for␠unmanaged␠clusters.
 introspection_debugging  boolean  Whether␠introspection␠of␠the␠gathering␠of␠the␠introspection␠data␠is␠enabled.
 introspection_interval  interval  The␠interval␠at␠which␠to␠collect␠introspection␠data.

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -146,7 +146,7 @@ replica_id  text  The␠ID␠of␠a␠cluster␠replica.
 process_id  uint8  The␠ID␠of␠a␠process␠within␠the␠replica.
 cpu_nano_cores  uint8  Approximate␠CPU␠usage,␠in␠billionths␠of␠a␠vCPU␠core.
 memory_bytes  uint8  Approximate␠RAM␠usage,␠in␠bytes.
-disk_bytes  uint8  Approximate␠disk␠usage,␠in␠bytes.
+disk_bytes  uint8  Approximate␠disk␠usage,␠in␠bytes.␠On␠replicas␠whose␠disk␠is␠provided␠as␠swap,␠this␠includes␠swap␠usage.
 heap_bytes  uint8  Approximate␠heap␠(RAM␠+␠swap)␠usage,␠in␠bytes.
 heap_limit  uint8  Available␠heap␠(RAM␠+␠swap)␠space,␠in␠bytes.
 
@@ -156,8 +156,8 @@ SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object 
 replica_id  text  The␠ID␠of␠a␠cluster␠replica.
 process_id  uint8  The␠ID␠of␠a␠process␠within␠the␠replica.
 cpu_nano_cores  uint8  Approximate␠CPU␠usage,␠in␠billionths␠of␠a␠vCPU␠core.
-memory_bytes  uint8  Approximate␠memory␠usage,␠in␠bytes.
-disk_bytes  uint8  Approximate␠disk␠usage,␠in␠bytes.
+memory_bytes  uint8  Approximate␠RAM␠usage,␠in␠bytes.
+disk_bytes  uint8  Approximate␠disk␠usage,␠in␠bytes.␠On␠replicas␠whose␠disk␠is␠provided␠as␠swap,␠this␠includes␠swap␠usage.
 occurred_at  timestamp␠with␠time␠zone  Wall-clock␠timestamp␠at␠which␠the␠event␠occurred.
 heap_bytes  uint8  Approximate␠heap␠(RAM␠+␠swap)␠usage,␠in␠bytes.
 heap_limit  uint8  Available␠heap␠(RAM␠+␠swap)␠space,␠in␠bytes.
@@ -187,7 +187,7 @@ replica_id  text  The␠ID␠of␠a␠cluster␠replica.
 process_id  uint8  The␠ID␠of␠a␠process␠within␠the␠replica.
 cpu_percent  double␠precision  Approximate␠CPU␠usage,␠in␠percent␠of␠the␠total␠allocation.
 memory_percent  double␠precision  Approximate␠RAM␠usage,␠in␠percent␠of␠the␠total␠allocation.
-disk_percent  double␠precision  Approximate␠disk␠usage,␠in␠percent␠of␠the␠total␠allocation.
+disk_percent  double␠precision  Approximate␠disk␠usage,␠in␠percent␠of␠the␠total␠allocation.␠On␠replicas␠whose␠disk␠is␠provided␠as␠swap,␠this␠includes␠swap␠usage.
 heap_percent  double␠precision  Approximate␠heap␠(RAM␠+␠swap)␠usage,␠in␠percent␠of␠the␠total␠allocation.
 
 query TTT
@@ -197,7 +197,7 @@ replica_id  text  The␠ID␠of␠a␠cluster␠replica.
 process_id  uint8  The␠ID␠of␠a␠process␠within␠the␠replica.
 cpu_percent  double␠precision  Approximate␠CPU␠usage,␠in␠percent␠of␠the␠total␠allocation.
 memory_percent  double␠precision  Approximate␠RAM␠usage,␠in␠percent␠of␠the␠total␠allocation.
-disk_percent  double␠precision  Approximate␠disk␠usage,␠in␠percent␠of␠the␠total␠allocation.
+disk_percent  double␠precision  Approximate␠disk␠usage,␠in␠percent␠of␠the␠total␠allocation.␠On␠replicas␠whose␠disk␠is␠provided␠as␠swap,␠this␠includes␠swap␠usage.
 heap_percent  double␠precision  Approximate␠heap␠(RAM␠+␠swap)␠usage,␠in␠percent␠of␠the␠total␠allocation.
 occurred_at  timestamp␠with␠time␠zone  Wall-clock␠timestamp␠at␠which␠the␠event␠occurred.
 
@@ -278,7 +278,7 @@ value  jsonb  The␠value␠of␠the␠strategy.␠For␠`FOR`,␠is␠a␠numbe
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object = 'mz_hydration_statuses' ORDER BY position
 ----
-object_id  text  The␠ID␠of␠a␠dataflow-powered␠object.␠Corresponds␠to␠`mz_catalog.mz_indexes.id`,␠`mz_catalog.mz_materialized_views.id`,␠`mz_internal.mz_subscriptions`,␠`mz_catalog.mz_sources.id`,␠or␠`mz_catalog.mz_sinks.id`.
+object_id  text  The␠ID␠of␠a␠dataflow-powered␠object.␠Corresponds␠to␠`mz_catalog.mz_indexes.id`,␠`mz_catalog.mz_materialized_views.id`,␠`mz_catalog.mz_sources.id`,␠or␠`mz_catalog.mz_sinks.id`.
 replica_id  text  The␠ID␠of␠a␠cluster␠replica.
 hydrated  boolean  Whether␠the␠object␠is␠hydrated␠on␠the␠replica.
 
@@ -700,7 +700,7 @@ replica_id  text  The␠ID␠of␠the␠replica␠that␠an␠instance␠of␠a�
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object = 'mz_source_statistics' ORDER BY position
 ----
-id  text  The␠ID␠of␠the␠source.␠Corresponds␠to␠`mz_catalog.mz_sources.id`.
+id  text  The␠ID␠of␠the␠source␠or␠table␠for␠which␠statistics␠are␠reported.␠Corresponds␠to␠`mz_catalog.mz_sources.id`␠or␠`mz_catalog.mz_tables.id`.
 replica_id  text  The␠ID␠of␠a␠replica␠running␠the␠source.␠Corresponds␠to␠`mz_catalog.mz_cluster_replicas.id`.
 messages_received  uint8  The␠number␠of␠messages␠the␠source␠has␠received␠from␠the␠external␠system.␠Messages␠are␠counted␠in␠a␠source␠type-specific␠manner.␠Messages␠do␠not␠correspond␠directly␠to␠updates:␠some␠messages␠produce␠multiple␠updates,␠while␠other␠messages␠may␠be␠coalesced␠into␠a␠single␠update.
 bytes_received  uint8  The␠number␠of␠bytes␠the␠source␠has␠read␠from␠the␠external␠system.␠Bytes␠are␠counted␠in␠a␠source␠type-specific␠manner␠and␠may␠or␠may␠not␠include␠protocol␠overhead.
@@ -756,14 +756,14 @@ query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object = 'mz_wallclock_global_lag' ORDER BY position
 ----
 object_id  text  The␠ID␠of␠the␠table,␠source,␠materialized␠view,␠index,␠or␠sink.␠Corresponds␠to␠`mz_objects.id`.
-lag  interval  The␠amount␠of␠time␠the␠object's␠write␠frontier␠lags␠behind␠wallclock␠time.
+lag  interval  The␠smallest␠wallclock␠lag␠observed␠for␠the␠object␠across␠its␠replicas␠during␠the␠most␠recent␠minute.
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_internal' AND object = 'mz_wallclock_lag_history' ORDER BY position
 ----
 object_id  text  The␠ID␠of␠the␠table,␠source,␠materialized␠view,␠index,␠or␠sink.␠Corresponds␠to␠`mz_objects.id`.
 replica_id  text  The␠ID␠of␠a␠replica␠computing␠the␠object,␠or␠`NULL`␠for␠persistent␠objects.␠Corresponds␠to␠`mz_cluster_replicas.id`.
-lag  interval  The␠amount␠of␠time␠the␠object's␠write␠frontier␠lags␠behind␠wallclock␠time.
+lag  interval  The␠maximum␠time␠the␠object's␠write␠frontier␠lagged␠behind␠wallclock␠time␠during␠the␠recording␠interval␠(60␠seconds␠by␠default),␠rounded␠down␠to␠whole␠seconds.
 occurred_at  timestamp␠with␠time␠zone  Wall-clock␠timestamp␠at␠which␠the␠event␠occurred.
 
 query TTT

--- a/test/sqllogictest/autogenerated/mz_introspection.slt
+++ b/test/sqllogictest/autogenerated/mz_introspection.slt
@@ -47,7 +47,7 @@ query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_arrangement_sharing' ORDER BY position
 ----
 operator_id  uint8  The␠ID␠of␠the␠operator␠that␠created␠the␠arrangement.␠Corresponds␠to␠`mz_dataflow_operators.id`.
-count  bigint  The␠number␠of␠operators␠that␠share␠the␠arrangement.
+count  bigint  The␠number␠of␠live␠trace␠handles␠on␠the␠arrangement.
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_arrangement_sizes' ORDER BY position
@@ -241,7 +241,7 @@ id  uint8  The␠ID␠of␠the␠operator.␠Corresponds␠to␠`mz_dataflow_ope
 name  text  The␠internal␠name␠of␠the␠operator.
 dataflow_id  uint8  The␠ID␠of␠the␠dataflow.␠Corresponds␠to␠`mz_dataflows.id`.
 records  bigint  The␠number␠of␠records␠in␠the␠operator.
-batches  bigint  The␠number␠of␠batches␠in␠the␠dataflow.
+batches  bigint  The␠number␠of␠batches␠in␠the␠operator.
 size  bigint  The␠utilized␠size␠in␠bytes␠of␠the␠arrangement.
 capacity  bigint  The␠capacity␠in␠bytes␠of␠the␠arrangement.␠Can␠be␠larger␠than␠the␠size.
 allocations  bigint  The␠number␠of␠separate␠memory␠allocations␠backing␠the␠arrangement.


### PR DESCRIPTION
### Motivation

While reviewing the system-catalog reference pages I checked each column comment against the relation's own SQL (or its writer). The ones below no longer describe what the column holds. The docs rows in `doc/user/content/reference/system-catalog/*.md` are lint-coupled to these comments (`ci/test/lint-docs-catalog.sh`), so each fix changes the comment, its docs row, and the autogenerated SLT together.

### Description

Wrong units or plainly incorrect:

- `mz_cluster_replica_sizes.memory_bytes` said "in billionths of a vCPU core" — a verbatim copy of the `cpu_nano_cores` line above it. It is a byte count.
- `mz_clusters.disk` said `true` "if the replicas have the `DISK` option". The column is computed as `NOT swap_enabled AND disk_bytes != 0`, and the `DISK` option is a no-op on legacy sizes and rejected on modern ones ("DISK option not supported for modern cluster sizes"). Also drops a stray `option .`. (`mz_cluster_replicas.disk` was already accurate and is untouched.)
- `mz_records_per_dataflow_operator.batches` said "in the dataflow"; it is grouped per operator, like its `records` sibling. (`mz_records_per_dataflow.batches` legitimately says "dataflow" and is untouched.)
- `mz_arrangement_sharing.count` said "the number of operators that share the arrangement". The value is `count(*)` over a stream of signed `TraceShare` diffs, i.e. the number of live trace handles; one operator can hold several, and an arrangement nobody holds drops out of the view.
- `mz_hydration_statuses.object_id` listed `mz_internal.mz_subscriptions`; the view unions indexes, materialized views, sources and sinks only, and subscribe dataflows are transient and never catalog objects.
- `mz_source_statistics.id` said only "the ID of the source". The `report_paths` CTE also reports statistics for a table created from a source under the table's own id.

Swap-related, where the column measures something broader than its name:

- `mz_cluster_replica_sizes.disk_bytes`: for swap-enabled sizes this allocation is the swap allowance folded into the process heap limit, not a filesystem disk.
- `disk_bytes` / `disk_percent` on `mz_cluster_replica_metrics{,_history}` and `mz_cluster_replica_utilization{,_history}`: on Kubernetes the orchestrator sums disk and swap into `disk_bytes`. Only the `mz_cluster_replica_metrics` prose mentioned this; the four column comments now say so too.
- `mz_cluster_replica_metrics_history.memory_bytes` said "memory usage" where the view over it says "RAM usage" for the same column; aligned on "RAM" to keep it distinct from `heap_bytes` (RAM + swap).

Wallclock lag, where both comments described an instantaneous reading:

- `mz_wallclock_lag_history.lag` is the maximum observed during the recording interval (60 s by default, sampled once per second, floored to whole seconds).
- `mz_wallclock_global_lag.lag` is the *smallest* lag across the object's replicas in the most recent minute, since the underlying history bins by minute with `min(lag)`.

Docs-only:

- `mz_introspection.md`: the blanket "for each of the below relations there exists a `_per_worker` variant" is false — five have none and two are named differently; `mz_dataflow_addresses.address` was typed `bigint list` (the column is `uint8 list`, as its sibling rows say).
- `mz_internal.md`: the `mz_cluster_replica_metrics` / `mz_cluster_replica_utilization` intros said "CPU and RAM" though both relations also carry disk and heap columns; one `mz_catalog.mz_sinks.id` reference linked to `#mz_subscriptions`.

### Verification

`ci/test/lint-docs-catalog.sh` passes (3/3) with the regenerated SLTs, which assert the docs text against the live column comments in CI.

Deliberately left for separate changes: `mz_source_statistics_with_history` ships with no column comments at all, and several introspection ID columns documented as "Corresponds to `mz_catalog...id`" actually hold global IDs that need `mz_internal.mz_object_global_ids` to join.
