### PR TITLE
docs: refresh stale EXPLAIN samples and fix invalid examples in the optimization and index pages

### DIFF
--- a/doc/user/content/headless/index-ordering.md
+++ b/doc/user/content/headless/index-ordering.md
@@ -13,4 +13,6 @@ As such, indexes in Materialize currently do not provide optimizations for:
   quantity > 10`,  `price >= 10 AND price <= 50`, and `WHERE quantity
   BETWEEN 10 AND 20`).
 
-- `GROUP BY`, `ORDER BY` and `LIMIT` clauses.
+- `GROUP BY` and `ORDER BY` clauses. (A `LIMIT` without an `ORDER BY` is an
+  exception: see the `fast path limit` index usage type in
+  [Optimization](/transform-data/optimization/#use-explain-to-verify-index-usage).)

--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -1,6 +1,6 @@
 ---
 title: "CREATE INDEX"
-description: "`CREATE INDEX` creates an in-memory index on a source, view, or materialized view."
+description: "`CREATE INDEX` creates an in-memory index on a table, source, view, or materialized view."
 menu:
   # This should also have a "non-content entry" under Reference, which is
   # configured in doc/user/config.toml
@@ -8,7 +8,7 @@ menu:
     parent: 'commands'
 ---
 
-`CREATE INDEX` creates an in-memory [index](/concepts/indexes/) on a source, view, or materialized view.
+`CREATE INDEX` creates an in-memory [index](/concepts/indexes/) on a table, source, view, or materialized view.
 
 In Materialize, indexes store query results in memory within a specific [cluster](/concepts/clusters/), and keep these results **incrementally updated** as new data arrives. This ensures that indexed data remains [fresh](/concepts/reaction-time), reflecting the latest changes with minimal latency.
 
@@ -124,7 +124,7 @@ join keys are the key columns in an index.
 CREATE MATERIALIZED VIEW active_customers AS
     SELECT guid, geo_id, last_active_on
     FROM customer_source
-    WHERE last_active_on > now() - INTERVAL '30' DAYS;
+    WHERE mz_now() < last_active_on + INTERVAL '30' DAYS;
 
 CREATE INDEX active_customers_geo_idx ON active_customers (geo_id);
 
@@ -154,8 +154,7 @@ If you commonly filter by a certain column being equal to a literal value, you c
 ```mzsql
 CREATE MATERIALIZED VIEW active_customers AS
     SELECT guid, geo_id, last_active_on
-    FROM customer_source
-    GROUP BY geo_id;
+    FROM customer_source;
 
 CREATE INDEX active_customers_idx ON active_customers (guid);
 
@@ -175,7 +174,7 @@ Create an index with an expression to improve query performance over a frequentl
 avoid building downstream views to apply the function like the one used in the example: `upper()`.
 Take into account that aggregations like `count()` cannot be used as indexed expressions.
 
-For more details on using indexes to optimize queries, see [Optimization](../../ops/optimization/).
+For more details on using indexes to optimize queries, see [Optimization](/transform-data/optimization/).
 
 ## Privileges
 

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -160,9 +160,6 @@ non-indexed, and so on."
 
 {{% include-headless "/headless/replacement-views/public-preview-annotation" %}}
 
-{{% include-from-yaml file="examples/create_materialized_view"
-name="replacement-view-syntax-details" %}}
-
 {{% include-example file="examples/create_materialized_view"
 example="example-create-replacement-materialized-view" %}}
 

--- a/doc/user/content/transform-data/optimization.md
+++ b/doc/user/content/transform-data/optimization.md
@@ -195,23 +195,27 @@ CREATE INDEX ON foo (x, y);
 EXPLAIN SELECT * FROM foo WHERE x = 42 AND y = 50;
 ```
 
-In the [`EXPLAIN`](/sql/explain-plan/) output, check for `lookup_value` after
+In the [`EXPLAIN`](/sql/explain-plan/) output, check for a `Lookup values:` line after
 the index name to confirm that Materialize will use a point lookup; i.e., that
 Materialize will only read the matching records from the index instead of
 scanning the entire index:
 
 ```
- Explained Query (fast path):
-   Project (#0{x}, #1{y})
-     ReadIndex on=materialize.public.foo foo_x_y_idx=[lookup value=(42, 50)]
+Explained Query (fast path):
+  →Map/Filter/Project
+    Project: #0, #1
+    →Index Lookup on materialize.public.foo (using materialize.public.foo_x_y_idx)
+      Lookup values: (42, 50)
 
- Used Indexes:
-   - materialize.public.foo_x_y_idx (lookup)
+Used Indexes:
+  - materialize.public.foo_x_y_idx (lookup)
+
+Target cluster: quickstart
 ```
 
 ### `JOIN`
 
-In general, you can [improve the performance of your joins](https://materialize.com/blog/maintaining-joins-using-few-resources) by creating indexes on the columns occurring in join keys. (When a relation is joined with different relations on different keys, then separate indexes should be created for these keys.) This comes at the cost of additional memory usage. Materialize's in-memory [arrangements](/overview/arrangements) (the internal data structure of indexes) allow the system to share indexes across queries: **for multiple queries, an index is a fixed upfront cost with memory savings for each new query that uses it.**
+In general, you can [improve the performance of your joins](https://materialize.com/blog/maintaining-joins-using-few-resources) by creating indexes on the columns occurring in join keys. (When a relation is joined with different relations on different keys, then separate indexes should be created for these keys.) This comes at the cost of additional memory usage. Materialize's in-memory [arrangements](/get-started/arrangements/#arrangements) (the internal data structure of indexes) allow the system to share indexes across queries: **for multiple queries, an index is a fixed upfront cost with memory savings for each new query that uses it.**
 
 Let's create a few tables to work through examples.
 
@@ -301,27 +305,28 @@ CREATE INDEX sections_fk_courses ON sections (course_id);
 ```
 
 ```mzsql
-EXPLAIN SELECT * FROM course_schedule;
+EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM course_schedule;
 ```
 
 ```
-Optimized Plan
 Explained Query:
-  Project (#1, #5, #7)
-    Filter (#0) IS NOT NULL AND (#4) IS NOT NULL
-      Join on=(#0 = #3 AND #4 = #6) type=delta                 <---------- Delta join
-        ArrangeBy keys=[[#0]]
-          ReadIndex on=teachers pk_teachers=[delta join 1st input (full scan)]
-        ArrangeBy keys=[[#1], [#2]]
-          ReadIndex on=sections sections_fk_teachers=[delta join lookup] sections_fk_courses=[delta join lookup]
-        ArrangeBy keys=[[#0]]
-          ReadIndex on=courses pk_courses=[delta join lookup]
+  Project (#1{name}, #5{schedule}, #7{name}) // { arity: 3 }
+    Filter (#0{id}) IS NOT NULL AND (#4{course_id}) IS NOT NULL // { arity: 8 }
+      Join on=(#0{id} = #3{teacher_id} AND #4{course_id} = #6{id}) type=delta // { arity: 8 }   <---------- Delta join
+        ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+          ReadIndex on=teachers pk_teachers=[delta join 1st input (full scan)] // { arity: 2 }
+        ArrangeBy keys=[[#1{teacher_id}], [#2{course_id}]] // { arity: 4 }
+          ReadIndex on=sections sections_fk_teachers=[delta join lookup] sections_fk_courses=[delta join lookup] // { arity: 4 }
+        ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+          ReadIndex on=courses pk_courses=[delta join lookup] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.pk_teachers (delta join 1st input (full scan))
   - materialize.public.sections_fk_teachers (delta join lookup)
   - materialize.public.pk_courses (delta join lookup)
   - materialize.public.sections_fk_courses (delta join lookup)
+
+Target cluster: quickstart
 ```
 
 For [ad hoc `SELECT` queries](/sql/select/#ad-hoc-queries) with a delta join, place the smallest input (taking into account predicates that filter from it) first in the `FROM` clause. (This is only relevant for joins with more than two inputs, because two-input joins are always Differential joins.)
@@ -404,7 +409,7 @@ CREATE INDEX sections_fk_teachers ON sections (teacher_id);
 CREATE INDEX pk_courses ON courses (id);
 CREATE INDEX sections_fk_courses ON sections (course_id);
 
-EXPLAIN
+EXPLAIN OPTIMIZED PLAN FOR
   SELECT
       t.name AS teacher_name,
       s.schedule,
@@ -416,35 +421,38 @@ EXPLAIN
 ```
 
 ```
-                                                  Optimized Plan
-------------------------------------------------------------------------------------------------------------------
- Explained Query:                                                                                                +
-   Project (#1, #6, #8)                                                                                          +
-     Filter (#0) IS NOT NULL AND (#5) IS NOT NULL                                                                +
-       Join on=(#0 = #4 AND #5 = #7) type=delta                                                                  +
-         ArrangeBy keys=[[#0]]                                                                                   +
-           ReadIndex on=materialize.public.teachers teachers_name=[lookup value=("Escalante")]                   +
-         ArrangeBy keys=[[#1], [#2]]                                                                             +
-           ReadIndex on=sections sections_fk_teachers=[delta join lookup] sections_fk_courses=[delta join lookup]+
-         ArrangeBy keys=[[#0]]                                                                                   +
-           ReadIndex on=courses pk_courses=[delta join lookup]                                                   +
-                                                                                                                 +
- Used Indexes:                                                                                                   +
-   - materialize.public.teachers_name (lookup)                                                                   +
-   - materialize.public.sections_fk_teachers (delta join lookup)                                                 +
-   - materialize.public.pk_courses (delta join lookup)                                                           +
-   - materialize.public.sections_fk_courses (delta join lookup)                                                  +
+Explained Query:
+  Project (#1{name}, #6{schedule}, #8{name}) // { arity: 3 }
+    Filter (#0{id}) IS NOT NULL AND (#5{course_id}) IS NOT NULL // { arity: 9 }
+      Join on=(#0{id} = #4{teacher_id} AND #5{course_id} = #7{id}) type=delta // { arity: 9 }
+        ArrangeBy keys=[[#0{id}]] // { arity: 3 }
+          ReadIndex on=materialize.public.teachers teachers_name=[lookup value=("Escalante")] // { arity: 3 }
+        ArrangeBy keys=[[#1{teacher_id}], [#2{course_id}]] // { arity: 4 }
+          ReadIndex on=sections sections_fk_teachers=[delta join lookup] sections_fk_courses=[delta join lookup] // { arity: 4 }
+        ArrangeBy keys=[[#0{id}]] // { arity: 2 }
+          ReadIndex on=courses pk_courses=[delta join lookup] // { arity: 2 }
+
+Used Indexes:
+  - materialize.public.teachers_name (lookup)
+  - materialize.public.sections_fk_teachers (delta join lookup)
+  - materialize.public.pk_courses (delta join lookup)
+  - materialize.public.sections_fk_courses (delta join lookup)
+
+Target cluster: quickstart
 ```
 
 You can see in the above `EXPLAIN` printout that the system will use `teachers_name` for a point lookup, and use three other indexes for the execution of the delta join. Note that the `pk_teachers` index is not used, as explained [above](#joins-with-filters).
 
-The following are the possible index usage types:
+The most common index usage types are:
 - `*** full scan ***`: Materialize will read the entire index.
 - `lookup`: Materialize will look up only specific keys in the index.
 - `differential join`: Materialize will use the index to perform a _differential join_. For a differential join between two relations, the amount of memory required is proportional to the sum of the sizes of each of the input relations that are **not** indexed. In other words, if an input is already indexed, then the size of that input won't affect the memory usage of a differential join between two relations. For a join between more than two relations, we recommend aiming for a delta join instead of a differential join, as explained [above](#optimize-multi-way-joins-with-delta-joins). A differential join between more than two relations will perform a series of binary differential joins on top of each other, and each of these binary joins (except the first one) will use memory proportional to the size of the intermediate data that is fed into the join.
 - `delta join 1st input (full scan)`: Materialize will use the index for the first input of a [delta join](#optimize-multi-way-joins-with-delta-joins). Note that the first input of a delta join is always fully scanned. However, executing the join won't require additional memory if the input is indexed.
 - `delta join lookup`: Materialize will use the index for a non-first input of a [delta join](#optimize-multi-way-joins-with-delta-joins). This means that, in an ad hoc query, the join will perform only lookups into the index.
 - `fast path limit`: When a [fast path](/sql/explain-plan/#fast-path-queries) query has a `LIMIT` clause but no `ORDER BY` clause, then Materialize will read from the index only as many records as required to satisfy the `LIMIT` (plus `OFFSET`) clause.
+- `plan root (no new arrangement)`: The query's result is already arranged as needed, so Materialize reads the existing arrangement instead of building a new one.
+- `sink export`: The index is read to feed a sink, for example a `SUBSCRIBE`.
+- `index export`: The index is read to build another index.
 
 ### Limitations
 
@@ -632,7 +640,7 @@ WHERE mz_now() <= floor(extract(epoch FROM event_ts)) * 1000 + 86400000
 [arrangements]: /get-started/arrangements/#arrangements
 [`MIN`]: /sql/functions/#min
 [`MAX`]: /sql/functions/#max
-[Top K]: /transform-data/patterns/top-k
+[Top K]: /transform-data/idiomatic-materialize-sql/top-k/
 [`mz_introspection.mz_expected_group_size_advice`]: /reference/system-catalog/mz_introspection/#mz_expected_group_size_advice
 [dataflows]: /get-started/arrangements/#dataflows
 [`SELECT` syntax]: /sql/select/#syntax

--- a/doc/user/data/examples/create_index.yml
+++ b/doc/user/data/examples/create_index.yml
@@ -14,12 +14,12 @@
         specified, defaults to the active cluster.
     - name: "`<obj_name>`"
       description: |
-        The name of the source, view, or materialized view on which you want
+        The name of the table, source, view, or materialized view on which you want
         to create an index.
     - name: "`USING <method>`"
       description: |
         The name of the index method to use. The only supported method is
-        [`arrangement`](/overview/arrangements).
+        [`arrangement`](/get-started/arrangements/).
     - name: "`(<col_expr>, ...)`"
       description: |
         The expressions to use as the key for the index.
@@ -43,12 +43,12 @@
         specified, defaults to the active cluster.
     - name: "`<obj_name>`"
       description: |
-        The name of the source, view, or materialized view on which you want
+        The name of the table, source, view, or materialized view on which you want
         to create an index.
     - name: "`USING <method>`"
       description: |
         The name of the index method to use. The only supported method is
-        [`arrangement`](/overview/arrangements).
+        [`arrangement`](/get-started/arrangements/).
     - name: "`WITH (<with_option>[,...])`"
       description: |
         The following `<with_option>` is supported:


### PR DESCRIPTION
### Motivation

`EXPLAIN` has defaulted to the **physical** plan since [#33448](https://github.com/MaterializeInc/materialize/pull/33448) (2025-06), but the optimization page still shows a bare `EXPLAIN` producing "Optimized Plan" MIR output. Separately, two `CREATE INDEX` examples fail if you run them, and the shared index-limitations note contradicts the same page. Everything below was checked against a v26.39.0 emulator or the code.

### Description

**`transform-data/optimization.md` — three plan samples regenerated verbatim from v26.39.0:**

- The point-lookup sample showed MIR (`ReadIndex on=… foo_x_y_idx=[lookup value=(42, 50)]`). A bare `EXPLAIN` prints the fast-path arrow form, so the sample is now the real output (`→Index Lookup on … / Lookup values: (42, 50)`), and the surrounding prose no longer tells readers to look for `lookup_value`.
- The two delta-join samples are reachable only via `EXPLAIN OPTIMIZED PLAN FOR`, so the commands say that. The regenerated output adds what a release build actually prints: humanized column names (`#0{id}`), `// { arity: N }` annotations, and the `Target cluster:` footer. The `<---------- Delta join` teaching callout is kept.

  (Using `OPTIMIZED PLAN` rather than switching the samples to the physical plan is deliberate: a bare `EXPLAIN` over a `SELECT` renders `One-Shot Delta Join`, a one-shot form that the index or materialized view the section is about would not use.)

**Index usage types** — the list omitted three variants that `IndexUsageType` renders (`src/repr/src/explain.rs`): `plan root (no new arrangement)`, `sink export`, `index export`. Added, and the lead-in now says "most common" rather than "all possible".

**`headless/index-ordering.md`** (rendered on this page and on `concepts/indexes`) said indexes provide no optimization for `LIMIT`, contradicting the `fast path limit` usage type documented a few lines above it. Now carves out that exception.

**`sql/create-index.md`:**

- "creates an in-memory index on a source, view, or materialized view" — the planner also accepts tables. Fixed in the page and in the two rendered syntax entries in `data/examples/create_index.yml`.
- The `active_customers` example used `now()`, which cannot be materialized (`cannot materialize call to current_timestamp`, with a hint pointing at `mz_now()`); rewritten as the temporal filter `mz_now() < last_active_on + INTERVAL '30' DAYS`.
- The "Speed up filtering" example had `GROUP BY geo_id` with two ungrouped columns, which fails to plan; the clause is dropped (the example only needs the columns).

**`sql/create-materialized-view.md`** — a duplicate `include-from-yaml` used the wrong parameter (`file=` instead of `data=`) and a name that does not exist, so it silently rendered nothing; the correct include is already a few lines above. Removed.

**Retired links** — `../../ops/optimization/`, `/overview/arrangements` (×3), and the old Top K path now point at their current locations.

### Verification

Prose and samples only. `hugo` builds cleanly. All three plan samples were captured from a v26.39.0 emulator using this page's own schema, and both failing `CREATE INDEX` examples were confirmed to error before the fix.
