### PR TITLE
console: correct the source status values in MaintainedObjectSourceStatus

### DIFF
--- a/console/src/platform/maintained-objects/queries.ts
+++ b/console/src/platform/maintained-objects/queries.ts
@@ -71,9 +71,9 @@ export interface MaintainedObjectLag {
  * initial snapshot.
  */
 export interface MaintainedObjectSourceStatus {
-  /** One of `created`, `starting`, `running`, `paused`, `stalled`, `failed`. */
+  /** One of `created`, `starting`, `running`, `paused`, `stalled`, or `dropped`. */
   status: string;
-  /** Populated when the source is `stalled` or `failed`. */
+  /** Populated when the source is `stalled`. */
   error: string | null;
   /** Null while no replica has reported statistics yet. */
   snapshotCommitted: boolean | null;


### PR DESCRIPTION
### Motivation

`MaintainedObjectSourceStatus` (`console/src/platform/maintained-objects/queries.ts`) documents the `status` and `error` fields that the hydration-aggregate feed delivers. That feed selects `status, error` from `mz_source_statuses` (`buildHydrationAggregateQuery`, filtered only by `type not in ('subsource','progress')`), and the two comments do not match what that relation can contain:

- `failed` is never reported. The storage `Status` enum (`src/storage-client/src/client.rs`) has no such variant, its `FromStr` rejects the string, and no writer emits it. [#38585](https://github.com/MaterializeInc/materialize/pull/38585) corrected the catalog comments and docs accordingly.
- `dropped` is missing from the list, though the relation reports it and this query does not filter it out.
- `error` is populated only for `stalled`; no other status carries one.

### Description

Comment-only change to the two JSDoc lines. No behaviour change.

### Not included, for the Console team to decide

While checking this I found that `failed` is not only a stale comment — it is a first-class value in the Console's source/sink status handling, for a status the database cannot produce:

- `ConnectorStatus` (`console/src/api/materialize/types.ts`) includes `"failed"`.
- `connectorStatusToHealth` (`console/src/platform/connectors/utils.ts`) maps it to `unhealthy`.
- `sourceStatusToColor` (`console/src/platform/clusters/format.ts`) gives it a colour.
- `StatusPill` renders it.
- `SOURCE_STATUS_BUCKETS` (`console/src/platform/maintained-objects/filters.ts`) exposes it as a **user-facing filter option labelled "Failed"**, which can never match a source or sink.

I left that alone deliberately: removing a union member touches exhaustive switches and a visible filter list, which is a UI decision and needs a typecheck run I can't do from here. Worth a look — as far as I can tell no released version ever produced `failed`, so this is not version-skew tolerance. Note `ConnectorStatus` is used only for sources and sinks; privatelink/SSH connection statuses are a separate set that legitimately includes `failed`.

Also not touched: `console/types/materialize.d.ts` still carries the old comment text in four places. It is kysely-codegen output ("do not edit it manually") and will correct itself on the next `yarn gen:types` against a build containing #38585.

### Verification

Comments only, no code paths touched.
