### PR TITLE
console: CNS-38 explain why an interrupted shell command needs a retry

### DIFF
--- a/console/src/platform/shell/CommandResult.tsx
+++ b/console/src/platform/shell/CommandResult.tsx
@@ -115,15 +115,21 @@ const CommandResult = ({
     ? `Returned in ${formatCommandDuration(timeTaken)}`
     : null;
 
-  // If the error comes from a query cancellation, we don't want to display it as
-  // an error
+  // A cancelled query and a dropped connection both surface as errors so that
+  // they get an explanation in the command block, but neither is a failure the
+  // server reported. Drop the "Error:" prefix for both.
   const errorOutputPropOverrides =
-    error && error.code === ErrorCode.QUERY_CANCELED
+    error &&
+    (error.code === ErrorCode.QUERY_CANCELED ||
+      error.code === ErrorCode.CONNECTION_FAILURE)
       ? {
           errorMessageOverride: capitalizeSentence(error.message, false),
         }
       : {};
 
+  // NOTE: this deliberately does not include CONNECTION_FAILURE. An
+  // interrupted command never receives an end timestamp, so `timeTakenStr` is
+  // null and the element these props apply to is not rendered at all.
   const codePropOverrides =
     error?.code === ErrorCode.QUERY_CANCELED
       ? {

--- a/console/src/platform/shell/HistoryOutput.test.tsx
+++ b/console/src/platform/shell/HistoryOutput.test.tsx
@@ -1,0 +1,114 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { screen } from "@testing-library/react";
+import { Setter } from "jotai";
+import mitt from "mitt";
+import React from "react";
+
+import {
+  defaultRegionId,
+  healthyEnvironment,
+  renderComponent,
+  setFakeEnvironment,
+} from "~/test/utils";
+
+import { COMMAND_INTERRUPTED_MESSAGE } from "./constants";
+import HistoryOutput from "./HistoryOutput";
+import { createInterruptedCommandError } from "./machines/webSocketFsm";
+import { CommandOutput, historyItemAtom, shellStateAtom } from "./store/shell";
+import {
+  ShellWebsocketContext,
+  ShellWebsocketContextType,
+  ShellWSEmitterEvents,
+} from "./useShellWebsocket";
+
+// The command echo reads Chakra's color mode, which the test providers do not
+// install. Nothing here asserts on syntax highlighting.
+vi.mock("./SyntaxHighlightedBlock", () => ({
+  default: ({ value }: { value: string }) => <pre>{value}</pre>,
+}));
+
+const HISTORY_ID = "1";
+
+const emitter = mitt<ShellWSEmitterEvents>();
+
+const websocketContext: ShellWebsocketContextType = {
+  send: vi.fn(),
+  commitToHistory: vi.fn(),
+  isSocketInitializing: false,
+  isSocketError: false,
+  isSocketAvailable: true,
+  cacheCommand: vi.fn(),
+  on: emitter.on,
+  off: emitter.off,
+};
+
+function commandOutput(overrides: Partial<CommandOutput> = {}): CommandOutput {
+  return {
+    kind: "command",
+    historyId: HISTORY_ID,
+    command: "SHOW MATERIALIZED VIEWS;",
+    statements: [{ query: "SHOW MATERIALIZED VIEWS;" }],
+    commandSentTimeMs: 0,
+    commandResults: [{ notices: [] }],
+    commandResultsDisplayStates: [
+      {
+        isSubscribeManager: false,
+        isFollowingSubscribeManager: true,
+        currentTablePage: 0,
+        currentSubscribeManagerTablePage: 0,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+async function renderHistoryOutput(historyItem: CommandOutput) {
+  return renderComponent(
+    <ShellWebsocketContext.Provider value={websocketContext}>
+      <HistoryOutput historyId={HISTORY_ID} />
+    </ShellWebsocketContext.Provider>,
+    {
+      initializeState: async ({ set }: { set: Setter }) => {
+        await setFakeEnvironment(set, defaultRegionId, healthyEnvironment);
+        // Retry is only enabled once the socket is idle again.
+        set(shellStateAtom, (prev) => ({
+          ...prev,
+          webSocketState: "readyForQuery",
+        }));
+        set(historyItemAtom(HISTORY_ID), historyItem);
+      },
+    },
+  );
+}
+
+describe("HistoryOutput", () => {
+  it("explains why an interrupted command needs to be retried", async () => {
+    await renderHistoryOutput(
+      commandOutput({
+        interrupted: true,
+        error: createInterruptedCommandError(),
+      }),
+    );
+
+    expect(screen.getByText(COMMAND_INTERRUPTED_MESSAGE)).toBeVisible();
+
+    const retry = screen.getByRole("button", { name: "Retry" });
+    expect(retry).toBeVisible();
+    expect(retry).toBeEnabled();
+  });
+
+  it("shows neither the message nor Retry for a command that was not interrupted", async () => {
+    await renderHistoryOutput(commandOutput());
+
+    expect(screen.queryByText(COMMAND_INTERRUPTED_MESSAGE)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+});

--- a/console/src/platform/shell/constants.ts
+++ b/console/src/platform/shell/constants.ts
@@ -19,3 +19,9 @@ export const TUTORIAL_WIDTH = "600px";
 
 export const CONNECTION_LOST_NOTICE_MESSAGE =
   "The connection was interrupted. Some session state may have been lost.";
+
+// Shown on a command that was in flight when the WebSocket closed. The socket
+// has no heartbeat, so a connection that died while idle is only discovered
+// when the next command is sent into it.
+export const COMMAND_INTERRUPTED_MESSAGE =
+  "The connection to Materialize was lost. This command may not have run. Press Retry to send it again.";

--- a/console/src/platform/shell/machines/webSocketFsm.test.ts
+++ b/console/src/platform/shell/machines/webSocketFsm.test.ts
@@ -12,7 +12,7 @@ import { interpret } from "@xstate/fsm";
 import { ErrorCode, MzDataType } from "~/api/materialize/types";
 
 import { createHistoryId } from "../historyId";
-import webSocketFsm from "./webSocketFsm";
+import webSocketFsm, { createInterruptedCommandError } from "./webSocketFsm";
 
 const MOCKED_HISTORY_ID = "1";
 
@@ -228,6 +228,55 @@ describe("webSocketFsm", () => {
       expect(
         machine.state.context.latestCommandOutput?.commandResults[0].notices[0],
       ).toEqual(notice);
+    });
+
+    it("connection closed while a command is in flight marks it interrupted and explains why", () => {
+      const machine = interpret(webSocketFsm);
+      machine.start();
+      machine.send("READY_FOR_QUERY");
+      machine.send({
+        type: "SEND",
+        command: "SELECT 5;",
+        statements: [{ query: "SELECT 5;" }],
+      });
+      machine.send("COMMAND_STARTING_HAS_ROWS");
+
+      machine.send({ type: "CONNECTION_CLOSED" });
+
+      expect(machine.state.matches("interrupted")).toBeTruthy();
+      expect(
+        machine.state.context.latestCommandOutput?.interrupted,
+      ).toBeTruthy();
+      expect(machine.state.context.latestCommandOutput?.error).toEqual(
+        createInterruptedCommandError(),
+      );
+    });
+
+    it("connection closed after a server error keeps the server error", () => {
+      const machine = interpret(webSocketFsm);
+      machine.start();
+      machine.send("READY_FOR_QUERY");
+      machine.send({
+        type: "SEND",
+        command: "SELECT nuke_materialize();",
+        statements: [{ query: "SELECT nuke_materialize();" }],
+      });
+      machine.send("COMMAND_STARTING_HAS_ROWS");
+
+      const error = {
+        message: "function nuke_materialize does not exist",
+        code: ErrorCode.UNDEFINED_FUNCTION,
+      };
+      machine.send({ type: "ERROR", error });
+
+      // The socket can close before READY_FOR_QUERY arrives, which leaves the
+      // machine in a state that still counts as processing.
+      machine.send({ type: "CONNECTION_CLOSED" });
+
+      expect(
+        machine.state.context.latestCommandOutput?.interrupted,
+      ).toBeTruthy();
+      expect(machine.state.context.latestCommandOutput?.error).toEqual(error);
     });
   });
 

--- a/console/src/platform/shell/machines/webSocketFsm.ts
+++ b/console/src/platform/shell/machines/webSocketFsm.ts
@@ -12,11 +12,13 @@ import { assign, createMachine, StateMachine } from "@xstate/fsm";
 import {
   Column,
   Error,
+  ErrorCode,
   ExtendedRequestItem,
   Notice,
 } from "~/api/materialize/types";
 import { assert } from "~/util";
 
+import { COMMAND_INTERRUPTED_MESSAGE } from "../constants";
 import {
   CommandOutput,
   CommandResult,
@@ -115,6 +117,19 @@ function getLatestCommandResult(latestCommandOutput?: CommandOutput) {
   return latestCommandResult;
 }
 
+/**
+ * The error a command carries when the connection dropped before it finished.
+ *
+ * Materialize never sends 08006 itself, so this code unambiguously marks an
+ * error the client synthesized rather than one the server reported.
+ */
+export function createInterruptedCommandError(): Error {
+  return {
+    message: COMMAND_INTERRUPTED_MESSAGE,
+    code: ErrorCode.CONNECTION_FAILURE,
+  };
+}
+
 const markCommandAsInterrupted = assign<
   WebSocketFsmContext,
   ConnectionClosedEvent
@@ -122,6 +137,9 @@ const markCommandAsInterrupted = assign<
   latestCommandOutput: ({ latestCommandOutput }) => {
     if (latestCommandOutput) {
       latestCommandOutput.interrupted = true;
+      if (!latestCommandOutput.error) {
+        latestCommandOutput.error = createInterruptedCommandError();
+      }
     }
     return latestCommandOutput;
   },


### PR DESCRIPTION
### Motivation

Fixes [CNS-38](https://linear.app/materializeinc/issue/CNS-38)

Instead of simply displaying "Retry" after a disconnection, add an error message.

### Description

Investigation revealed that we can mitigate the disconnection problem at its source. This UX improvement is a first step.
<img width="821" height="526" alt="Screenshot 2026-09-01 at 4 19 47 PM" src="https://github.com/user-attachments/assets/6ded122f-41ef-448a-80d9-ab8bb40f0c8b" />

### Verification

New test case asserting CONNECTION_CLOSED mid-command sets both interrupted and the error. This event had no coverage at all before.

Assert that an interrupted command renders the message and an enabled Retry button, and that a normal command renders neither.

Manually tested with a non-trivial bit of chicanery.