### PR TITLE
sql-669: drop promsql queries superseded by the info metrics

### DIFF
--- a/src/environmentd/src/http/prometheus.rs
+++ b/src/environmentd/src/http/prometheus.rs
@@ -133,29 +133,6 @@ pub(crate) static USAGE_METRIC_QUERIES: &[PrometheusSqlQuery] = &[
         per_replica: false,
     },
     PrometheusSqlQuery {
-        metric_name: "mz_clusters_count",
-        help: "Number of active clusters in the instance.",
-        query: "select
-                count(id) as clusters
-            from mz_clusters
-            where id like 'u%'",
-        value_column_name: "clusters",
-        per_replica: false,
-    },
-    PrometheusSqlQuery {
-        metric_name: "mz_cluster_reps_count",
-        help: "Number of active cluster replicas in the instance, by replica size.",
-        // `mz_cluster_replicas.size` is NULL for unmanaged replicas. Coalesce
-        // to an empty string so the resulting Prometheus label is a string.
-        query: "select COALESCE(size, '') as size
-                , count(id) as replicas
-            from mz_cluster_replicas
-            where cluster_id like 'u%'
-            group by size",
-        value_column_name: "replicas",
-        per_replica: false,
-    },
-    PrometheusSqlQuery {
         metric_name: "mz_indexes_count",
         help: "Number of active indexes in the instance, by the type of relation on which the index is built.",
         query: "select
@@ -188,27 +165,6 @@ pub(crate) static USAGE_METRIC_QUERIES: &[PrometheusSqlQuery] = &[
         per_replica: false,
     },
     PrometheusSqlQuery {
-        metric_name: "mz_views_count",
-        help: "Number of active views in the instance.",
-        query: "select count(id) as views from mz_views where id like 'u%'",
-        value_column_name: "views",
-        per_replica: false,
-    },
-    PrometheusSqlQuery {
-        metric_name: "mz_mzd_views_count",
-        help: "Number of active materialized views in the instance.",
-        query: "select count(id) as mzd_views from mz_materialized_views where id like 'u%'",
-        value_column_name: "mzd_views",
-        per_replica: false,
-    },
-    PrometheusSqlQuery {
-        metric_name: "mz_secrets_count",
-        help: "Number of active secrets in the instance.",
-        query: "select count(id) as secrets from mz_secrets where id like 'u%'",
-        value_column_name: "secrets",
-        per_replica: false,
-    },
-    PrometheusSqlQuery {
         metric_name: "mz_sinks_count",
         help: "Number of active sinks in the instance, by type, envelope type, and size.",
         query: "SELECT
@@ -234,40 +190,6 @@ pub(crate) static USAGE_METRIC_QUERIES: &[PrometheusSqlQuery] = &[
             where id like 'u%'
             group by type",
         value_column_name: "connections",
-        per_replica: false,
-    },
-    PrometheusSqlQuery {
-        metric_name: "mz_tables_count",
-        help: "Number of active tables in the instance.",
-        query: "select count(id) as tables from mz_tables where id like 'u%'",
-        value_column_name: "tables",
-        per_replica: false,
-    },
-    PrometheusSqlQuery {
-        metric_name: "mz_catalog_items",
-        help: "Mapping internal id for catalog item.",
-        query: "SELECT
-                concat(d.name, '.', s.name, '.', o.name) AS label,
-                0 AS value
-            FROM mz_objects o
-            JOIN mz_schemas s ON (o.schema_id = s.id)
-            JOIN mz_databases d ON (s.database_id = d.id)
-            WHERE o.id LIKE 'u%'",
-        value_column_name: "value",
-        per_replica: false,
-    },
-    PrometheusSqlQuery {
-        metric_name: "mz_object_id",
-        help: "Mapping external name for catalog item.",
-        query: "SELECT
-                o.id AS label1,
-                concat(d.name, '.', s.name, '.', o.name) AS label2,
-                0 AS value
-            FROM mz_objects o
-            JOIN mz_schemas s ON (o.schema_id = s.id)
-            JOIN mz_databases d ON (s.database_id = d.id)
-            WHERE o.id LIKE 'u%'",
-        value_column_name: "value",
         per_replica: false,
     },
 ];

--- a/test/cloudtest/test_metrics.py
+++ b/test/cloudtest/test_metrics.py
@@ -65,7 +65,7 @@ def test_prometheus_sql_metrics(mz: MaterializeApplication) -> None:
         assert found, "could not read metrics"
 
     check_metrics("mz_frontier", "mz_read_frontier")
-    check_metrics("mz_usage", "mz_clusters_count")
+    check_metrics("mz_usage", "mz_compute_cluster_status")
     check_metrics("mz_compute", "mz_compute_replica_park_duration_seconds_total")
     check_metrics("mz_storage", "mz_storage_objects")
 


### PR DESCRIPTION
The coordinator exports catalog identity and counts directly as mz_object_info, mz_cluster_info, and mz_replica_info, so the SQL-backed equivalents on /metrics/mz_usage are redundant. Drop the eight that those metrics express exactly:
```
  mz_catalog_items, mz_object_id
      -> mz_object_info
  mz_clusters_count
      -> count(max by (cluster_id) (mz_cluster_info{cluster_id=~"u.*"}))
  mz_cluster_reps_count
      -> count by (size) (max by (replica_id, size) (mz_replica_info{cluster_id=~"u.*"}))
  mz_views_count
      -> count(max by (object_id) (mz_object_info{type="view", object_id=~"u.*"}))
  mz_mzd_views_count
      -> count(max by (object_id) (mz_object_info{type="materialized-view", object_id=~"u.*"}))
  mz_tables_count
      -> count(max by (object_id) (mz_object_info{type="table", object_id=~"u.*"}))
  mz_secrets_count
      -> count(max by (object_id) (mz_object_info{type="secret", object_id=~"u.*"}))
```