### PR TITLE
sql-499: print ids for types in DOC ON positions

### DIFF
--- a/misc/python/materialize/checks/all_checks/kafka_sink.py
+++ b/misc/python/materialize/checks/all_checks/kafka_sink.py
@@ -791,6 +791,80 @@ class KafkaSinkComments(Check):
             """))
 
 
+class KafkaSinkCommentsOnType(Check):
+    """An Avro sink over a relation with a commented custom-type column
+    records a dependency edge on the type. Purification injects a
+    `DOC ON TYPE` reference for every commented type the sinked relation
+    uses, and the persisted reference must keep resolving across restarts
+    and upgrades and stay visible to `mz_object_dependencies`."""
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(dedent("""
+                > CREATE TYPE sink_comments_point AS (x integer, y integer)
+                > COMMENT ON TYPE sink_comments_point IS 'comment on type sink_comments_point'
+                > CREATE TABLE sink_comments_type_tbl (a int)
+                > INSERT INTO sink_comments_type_tbl VALUES (1)
+                > CREATE MATERIALIZED VIEW sink_comments_type_view AS
+                  SELECT ROW(a, a)::sink_comments_point AS p, a FROM sink_comments_type_tbl
+
+                > CREATE SINK sink_comments_type1 FROM sink_comments_type_view
+                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-comments-type1')
+                  KEY (a) NOT ENFORCED
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE UPSERT
+                """))
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
+                GRANT SELECT ON sink_comments_type_view TO materialize
+                GRANT USAGE ON CONNECTION kafka_conn TO materialize
+                GRANT USAGE ON CONNECTION csr_conn TO materialize
+
+                > CREATE SINK sink_comments_type2 FROM sink_comments_type_view
+                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-comments-type2')
+                  KEY (a) NOT ENFORCED
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE UPSERT
+                """,
+                """
+                $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
+                GRANT SELECT ON sink_comments_type_view TO materialize
+                GRANT USAGE ON CONNECTION kafka_conn TO materialize
+                GRANT USAGE ON CONNECTION csr_conn TO materialize
+
+                > CREATE SINK sink_comments_type3 FROM sink_comments_type_view
+                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-comments-type3')
+                  KEY (a) NOT ENFORCED
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE UPSERT
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(dedent("""
+                # Every sink depends on the commented type its injected DOC ON
+                # reference names, including sinks whose create_sql predates
+                # types printing ids in DOC ON positions.
+                #
+                # NOTE: the version guard must name the first release that
+                # prints ids in DOC ON positions.
+                >[version>=2604100] SELECT s.name
+                  FROM mz_internal.mz_object_dependencies d
+                  JOIN mz_sinks s ON s.id = d.object_id
+                  WHERE d.referenced_object_id IN
+                      (SELECT id FROM mz_types WHERE name = 'sink_comments_point')
+                  ORDER BY 1
+                sink_comments_type1
+                sink_comments_type2
+                sink_comments_type3
+                """))
+
+
 @externally_idempotent(False)
 class KafkaSinkAutoCreatedTopicConfig(Check):
     """Check on a sink with auto-created topic configuration"""

--- a/misc/python/materialize/checks/all_checks/kafka_sink.py
+++ b/misc/python/materialize/checks/all_checks/kafka_sink.py
@@ -857,7 +857,7 @@ class KafkaSinkCommentsOnType(Check):
                 #
                 # NOTE: the version guard must name the first release that
                 # prints ids in DOC ON positions.
-                >[version>=2604100] SELECT s.name
+                >[version>=2604200] SELECT s.name
                   FROM mz_internal.mz_object_dependencies d
                   JOIN mz_sinks s ON s.id = d.object_id
                   WHERE d.referenced_object_id IN

--- a/misc/python/materialize/checks/all_checks/kafka_sink.py
+++ b/misc/python/materialize/checks/all_checks/kafka_sink.py
@@ -800,6 +800,10 @@ class KafkaSinkCommentsOnType(Check):
 
     def initialize(self) -> Testdrive:
         return Testdrive(dedent("""
+                # A secret sharing the type's name, created first:
+                # the DOC ON migration must bind the type, not
+                # whichever same-named item is older.
+                > CREATE SECRET sink_comments_point AS 'x'
                 > CREATE TYPE sink_comments_point AS (x integer, y integer)
                 > COMMENT ON TYPE sink_comments_point IS 'comment on type sink_comments_point'
                 > CREATE TABLE sink_comments_type_tbl (a int)

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -154,6 +154,7 @@ pub(crate) async fn migrate(
         ast_rewrite_create_sink_partition_strategy(stmt)?;
         ast_rewrite_sql_server_constraints(stmt)?;
         ast_rewrite_add_missing_index_ids(tx, stmt)?;
+        ast_rewrite_add_missing_doc_on_ids(tx, stmt)?;
         ast_rewrite_kafka_metadata_refresh_intervals(stmt)?;
         ast_rewrite_small_commit_intervals(stmt)?;
         ast_rewrite_strip_builtin_version_pins(stmt)?;
@@ -1042,6 +1043,88 @@ fn ast_rewrite_add_missing_index_ids(
     Ok(())
 }
 
+/// Add missing item IDs to `DOC ON` references in CREATE SINK statements.
+///
+/// `DOC ON TYPE x` and `DOC ON COLUMN x.c` used to persist a type reference
+/// as a bare qualified name, unlike a relation in the same position, because
+/// name resolution suppressed ids for types. Resolution now prints the id
+/// (see `NameResolver::resolve_doc_on_name`); this rewrites stored statements
+/// to match, so the reference survives renames and `create_sql` reference
+/// extraction (`mz_object_dependencies`) recovers the sink's edge to the
+/// type.
+///
+/// References that already carry an id are skipped, so this is idempotent and
+/// safe to run every boot. A name without a database part denotes an item in
+/// an ambient (system) schema; those are not durable items and builtin names
+/// are stable, so such references are left resolving by name.
+fn ast_rewrite_add_missing_doc_on_ids(
+    tx: &Transaction<'_>,
+    stmt: &mut Statement<Raw>,
+) -> Result<(), anyhow::Error> {
+    if !matches!(stmt, Statement::CreateSink(_)) {
+        return Ok(());
+    }
+    rewrite_doc_on_ids(stmt, |name| {
+        let parts = &name.0;
+        let (db_name, schema_name, item_name) = match parts.len() {
+            3 => (&parts[0], &parts[1], &parts[2]),
+            2 => return None,
+            _ => panic!("invalid doc on reference: {name:?}"),
+        };
+        let db = tx.get_databases().find(|db| db.name == db_name.as_str());
+        let db = db.unwrap_or_else(|| panic!("missing database in doc on reference: {name:?}"));
+        let schema = tx
+            .get_schemas()
+            .find(|s| s.name == schema_name.as_str() && s.database_id == Some(db.id));
+        let schema =
+            schema.unwrap_or_else(|| panic!("missing schema in doc on reference: {name:?}"));
+        let item = tx
+            .get_items()
+            .find(|i| i.name == item_name.as_str() && i.schema_id == schema.id);
+        let item = item.unwrap_or_else(|| panic!("missing item in doc on reference: {name:?}"));
+        Some(item.id.to_string())
+    });
+    Ok(())
+}
+
+/// Replaces every bare `DOC ON` reference in `stmt` for which `lookup`
+/// returns an id with the `[id AS name]` form. `None` leaves the reference as
+/// a name.
+fn rewrite_doc_on_ids(
+    stmt: &mut Statement<Raw>,
+    lookup: impl FnMut(&mz_sql::ast::UnresolvedItemName) -> Option<String>,
+) {
+    use mz_sql::ast::visit_mut::{VisitMut, VisitMutNode};
+    use mz_sql::ast::{ColumnName, DocOnIdentifier, RawItemName, UnresolvedItemName};
+
+    struct Rewriter<F> {
+        lookup: F,
+    }
+
+    impl<'ast, F> VisitMut<'ast, Raw> for Rewriter<F>
+    where
+        F: FnMut(&UnresolvedItemName) -> Option<String>,
+    {
+        fn visit_doc_on_identifier_mut(&mut self, node: &mut DocOnIdentifier<Raw>) {
+            let name = match node {
+                DocOnIdentifier::Type(name) => name,
+                DocOnIdentifier::Column(ColumnName {
+                    relation,
+                    column: _,
+                }) => relation,
+            };
+            if let RawItemName::Name(unresolved) = name {
+                if let Some(id) = (self.lookup)(unresolved) {
+                    let unresolved = unresolved.clone();
+                    *name = RawItemName::Id(id, unresolved, None);
+                }
+            }
+        }
+    }
+
+    stmt.visit_mut(&mut Rewriter { lookup });
+}
+
 /// Strips the `VERSION` qualifier from by-id references to non-user (builtin)
 /// items.
 ///
@@ -1229,5 +1312,61 @@ mod tests {
         );
         assert!(!out.contains("VERSION"), "unexpected version: {out}");
         assert!(out.contains("s518"), "reference dropped: {out}");
+    }
+
+    fn add_doc_on_ids(
+        sql: &str,
+        lookup: impl FnMut(&mz_sql::ast::UnresolvedItemName) -> Option<String>,
+    ) -> String {
+        let mut stmt = mz_sql::parse::parse(sql)
+            .expect("test sql parses")
+            .into_element()
+            .ast;
+        rewrite_doc_on_ids(&mut stmt, lookup);
+        stmt.to_ast_string_stable()
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` (SQL parser stack growth)
+    fn adds_ids_to_bare_doc_on_references() {
+        // The persisted shape of a sink from before types printed ids in DOC
+        // ON positions: relations carry ids, the type and its column carry
+        // bare names.
+        let out = add_doc_on_ids(
+            r#"CREATE SINK "materialize"."public"."s" FROM [u1 AS "materialize"."public"."t"] INTO KAFKA CONNECTION [u2 AS "materialize"."public"."kc"] (TOPIC = 'top') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION [u3 AS "materialize"."public"."csr"] (DOC ON TYPE "materialize"."public"."point" = 'p', DOC ON COLUMN "materialize"."public"."point"."x" = 'x', DOC ON TYPE "pg_catalog"."int4" = 'i') ENVELOPE UPSERT"#,
+            |name| match name.0.len() {
+                3 => {
+                    assert_eq!(name.0[2].as_str(), "point", "unexpected lookup: {name:?}");
+                    Some("u9".into())
+                }
+                _ => None,
+            },
+        );
+        assert!(
+            out.contains(r#"DOC ON TYPE [u9 AS "materialize"."public"."point"]"#),
+            "type reference not rewritten: {out}"
+        );
+        assert!(
+            out.contains(r#"DOC ON COLUMN [u9 AS "materialize"."public"."point"]."x""#),
+            "column reference not rewritten: {out}"
+        );
+        // An ambient-schema (builtin) reference keeps resolving by name.
+        assert!(
+            out.contains(r#"DOC ON TYPE "pg_catalog"."int4""#),
+            "ambient reference rewritten: {out}"
+        );
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` (SQL parser stack growth)
+    fn leaves_id_doc_on_references_untouched() {
+        let out = add_doc_on_ids(
+            r#"CREATE SINK "materialize"."public"."s" FROM [u1 AS "materialize"."public"."t"] INTO KAFKA CONNECTION [u2 AS "materialize"."public"."kc"] (TOPIC = 'top') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION [u3 AS "materialize"."public"."csr"] (DOC ON TYPE [u4 AS "materialize"."public"."point"] = 'p', DOC ON COLUMN [u1 AS "materialize"."public"."t"]."c1" = 'c') ENVELOPE UPSERT"#,
+            |name| panic!("id reference must not be resolved: {name:?}"),
+        );
+        assert!(
+            out.contains(r#"DOC ON TYPE [u4 AS "materialize"."public"."point"]"#),
+            "id reference altered: {out}"
+        );
     }
 }

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -1091,10 +1091,10 @@ fn ast_rewrite_add_missing_doc_on_ids(
         if let Some(item) = user_type {
             return Some(item.id.to_string());
         }
-        // There does exist a rare case where `mz_system` can `COMMENT ON` a builtin type (e.g.
-        // int4) and if a sink was created with reference to that type, then the sink's stored
-        // statement wouldn't contain the ID of that type. Thus we get the builtin type's ID from
-        // its GidMapping.
+        // A bare name in an ambient schema denotes a builtin type (an explicit
+        // `DOC ON TYPE int4`, or a DOC ON injected by purification after mz_system
+        // commented on one). Builtin types are not durable items, so the lookup
+        // above cannot find them; their ids live in the system object mappings.
         let builtin_type = tx.get_system_object_mappings().find(|m| {
             m.description.schema_name == schema.name
                 && m.description.object_type == CatalogItemType::Type

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -1049,14 +1049,11 @@ fn ast_rewrite_add_missing_index_ids(
 /// as a bare qualified name, unlike a relation in the same position, because
 /// name resolution suppressed ids for types. Resolution now prints the id
 /// (see `NameResolver::resolve_doc_on_name`); this rewrites stored statements
-/// to match, so the reference survives renames and `create_sql` reference
-/// extraction (`mz_object_dependencies`) recovers the sink's edge to the
-/// type.
+/// to match, so `create_sql` reference extraction (`mz_object_dependencies`)
+/// recovers the sink's edge to the type.
 ///
 /// References that already carry an id are skipped, so this is idempotent and
-/// safe to run every boot. A name without a database part denotes an item in
-/// an ambient (system) schema; those are not durable items and builtin names
-/// are stable, so such references are left resolving by name.
+/// safe to run every boot.
 fn ast_rewrite_add_missing_doc_on_ids(
     tx: &Transaction<'_>,
     stmt: &mut Statement<Raw>,
@@ -1067,22 +1064,45 @@ fn ast_rewrite_add_missing_doc_on_ids(
     rewrite_doc_on_ids(stmt, |name| {
         let parts = &name.0;
         let (db_name, schema_name, item_name) = match parts.len() {
-            3 => (&parts[0], &parts[1], &parts[2]),
-            2 => return None,
+            3 => (Some(&parts[0]), &parts[1], &parts[2]),
+            // Names in ambient schemas denote builtin types, which are resolved
+            // through the system object mappings.
+            2 => (None, &parts[0], &parts[1]),
             _ => panic!("invalid doc on reference: {name:?}"),
         };
-        let db = tx.get_databases().find(|db| db.name == db_name.as_str());
-        let db = db.unwrap_or_else(|| panic!("missing database in doc on reference: {name:?}"));
+        let db_id = db_name.map(|db_name| {
+            let db = tx.get_databases().find(|db| db.name == db_name.as_str());
+            let db = db.unwrap_or_else(|| panic!("missing database in doc on reference: {name:?}"));
+            db.id
+        });
         let schema = tx
             .get_schemas()
-            .find(|s| s.name == schema_name.as_str() && s.database_id == Some(db.id));
+            .find(|s| s.name == schema_name.as_str() && s.database_id == db_id);
         let schema =
             schema.unwrap_or_else(|| panic!("missing schema in doc on reference: {name:?}"));
-        let item = tx
-            .get_items()
-            .find(|i| i.name == item_name.as_str() && i.schema_id == schema.id);
-        let item = item.unwrap_or_else(|| panic!("missing item in doc on reference: {name:?}"));
-        Some(item.id.to_string())
+
+        let user_type = tx.get_items().find(|i| {
+            i.name == item_name.as_str()
+                && i.schema_id == schema.id
+                // A type may share its (schema, name) with a secret, connection, sink,
+                // or function, so explicitly filter on Type.
+                && i.item_type() == CatalogItemType::Type
+        });
+        if let Some(item) = user_type {
+            return Some(item.id.to_string());
+        }
+        // There does exist a rare case where `mz_system` can `COMMENT ON` a builtin type (e.g.
+        // int4) and if a sink was created with reference to that type, then the sink's stored
+        // statement wouldn't contain the ID of that type. Thus we get the builtin type's ID from
+        // its GidMapping.
+        let builtin_type = tx.get_system_object_mappings().find(|m| {
+            m.description.schema_name == schema.name
+                && m.description.object_type == CatalogItemType::Type
+                && m.description.object_name == item_name.as_str()
+        });
+        let builtin_type =
+            builtin_type.unwrap_or_else(|| panic!("missing type in doc on reference: {name:?}"));
+        Some(builtin_type.unique_identifier.catalog_id.to_string())
     });
     Ok(())
 }
@@ -1339,7 +1359,11 @@ mod tests {
                     assert_eq!(name.0[2].as_str(), "point", "unexpected lookup: {name:?}");
                     Some("u9".into())
                 }
-                _ => None,
+                2 => {
+                    assert_eq!(name.0[1].as_str(), "int4", "unexpected lookup: {name:?}");
+                    Some("s23".into())
+                }
+                _ => panic!("unexpected lookup: {name:?}"),
             },
         );
         assert!(
@@ -1350,10 +1374,9 @@ mod tests {
             out.contains(r#"DOC ON COLUMN [u9 AS "materialize"."public"."point"]."x""#),
             "column reference not rewritten: {out}"
         );
-        // An ambient-schema (builtin) reference keeps resolving by name.
         assert!(
-            out.contains(r#"DOC ON TYPE "pg_catalog"."int4""#),
-            "ambient reference rewritten: {out}"
+            out.contains(r#"DOC ON TYPE [s23 AS "pg_catalog"."int4"]"#),
+            "builtin type reference not rewritten: {out}"
         );
     }
 

--- a/src/sql-parser/src/ast/item_refs.rs
+++ b/src/sql-parser/src/ast/item_refs.rs
@@ -379,6 +379,25 @@ mod tests {
     }
 
     #[mz_ore::test]
+    fn doc_on_references() {
+        // DOC ON TYPE and DOC ON COLUMN references persist with ids, so a
+        // sink's dependency on a commented type is recovered from the ids
+        // bucket like any other id reference.
+        let refs = collect(
+            r#"CREATE SINK s
+               FROM [u1 AS "materialize"."public"."t"]
+               INTO KAFKA CONNECTION [u2 AS "materialize"."public"."kc"] (TOPIC 'top')
+               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION [u3 AS "materialize"."public"."csr"]
+               (DOC ON TYPE [u4 AS "materialize"."public"."point"] = 'point doc',
+                DOC ON COLUMN [u4 AS "materialize"."public"."point"].x = 'x doc')
+               ENVELOPE UPSERT"#,
+        );
+        assert_eq!(refs.ids, strings(&["u1", "u2", "u3", "u4"]));
+        assert!(refs.named_relations.is_empty());
+        assert!(refs.named_types.is_empty());
+    }
+
+    #[mz_ore::test]
     fn index_references() {
         let refs = collect(
             r#"CREATE INDEX i IN CLUSTER [u1] ON [u2 AS "materialize"."public"."t"] ("pg_catalog"."abs"(a))"#,

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1668,6 +1668,30 @@ impl<'a> NameResolver<'a> {
             version,
         }
     }
+
+    /// Resolves an item name in a `DOC ON` position (`DOC ON TYPE x`,
+    /// `DOC ON COLUMN x.c`), where the name may denote a type or a relation. Also used for `COMMENT
+    /// ON COLUMN`.
+    fn resolve_doc_on_name(&mut self, name: RawItemName) -> ResolvedItemName {
+        let mut name = self.resolve_item_name(
+            name,
+            // The name can refer to either a type or a relation.
+            //
+            // It's possible this will get simpler once database-issues#7142 is
+            // fixed. See the comment on `ItemResolutionConfig` for details.
+            ItemResolutionConfig {
+                functions: false,
+                types: true,
+                relations: true,
+            },
+        );
+        if let ResolvedItemName::Item { print_id, .. } = &mut name {
+            // These references persist in a sink's `create_sql`, so the resolved name must print
+            // its id, otherwise it can't recover it when recreating
+            *print_id = true;
+        }
+        name
+    }
 }
 
 impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
@@ -1798,14 +1822,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
     }
 
     fn fold_column_name(&mut self, column_name: ast::ColumnName<Raw>) -> ast::ColumnName<Aug> {
-        let item_name = self.resolve_item_name(
-            column_name.relation,
-            ItemResolutionConfig {
-                functions: false,
-                types: true,
-                relations: true,
-            },
-        );
+        let item_name = self.resolve_doc_on_name(column_name.relation);
 
         match &item_name {
             ResolvedItemName::Item {
@@ -2302,19 +2319,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
     fn fold_doc_on_identifier(&mut self, node: DocOnIdentifier<Raw>) -> DocOnIdentifier<Aug> {
         match node {
             DocOnIdentifier::Column(name) => DocOnIdentifier::Column(self.fold_column_name(name)),
-            DocOnIdentifier::Type(name) => DocOnIdentifier::Type(self.resolve_item_name(
-                name,
-                // In `DOC ON TYPE ...`, the type can refer to either a type or
-                // a relation.
-                //
-                // It's possible this will get simpler once database-issues#7142 is fixed. See
-                // the comment on `ItemResolutionConfig` for details.
-                ItemResolutionConfig {
-                    functions: false,
-                    types: true,
-                    relations: true,
-                },
-            )),
+            DocOnIdentifier::Type(name) => DocOnIdentifier::Type(self.resolve_doc_on_name(name)),
         }
     }
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -429,10 +429,7 @@ pub(crate) fn purify_create_sink_avro_doc_on_options(
                 id: *object_id,
                 qualifiers: item.name().qualifiers.clone(),
                 full_name: catalog.resolve_full_name(item.name()),
-                print_id: !matches!(
-                    item.item_type(),
-                    CatalogItemType::Func | CatalogItemType::Type
-                ),
+                print_id: !matches!(item.item_type(), CatalogItemType::Func),
                 version: RelationVersionSelector::Latest,
             };
 

--- a/test/testdrive/kafka-avro-sinks-doc-comments.td
+++ b/test/testdrive/kafka-avro-sinks-doc-comments.td
@@ -69,6 +69,21 @@ $ schema-registry-verify schema-type=avro subject=testdrive-sink1-${testdrive.se
 $ schema-registry-verify schema-type=avro subject=testdrive-sink1-${testdrive.seed}-key
 {"type":"record","name":"row","doc":"key doc on t","fields":[{"name":"c2","type":"string","doc":"key doc on t.c2"}]}
 
+# The sink's DOC ON references record dependency edges on the commented type
+# and on the sinked table. The type reference persists by id, so reference
+# extraction (mz_object_dependencies) recovers the edge; a bare name would
+# silently drop out. The guard names the first release that prints ids in
+# DOC ON positions
+>[version>=2604100] SELECT count(*) FROM mz_internal.mz_object_dependencies
+  WHERE object_id = (SELECT id FROM mz_sinks WHERE name = 'sink1')
+    AND referenced_object_id = (SELECT id FROM mz_types WHERE name = 'point');
+1
+
+> SELECT count(*) FROM mz_internal.mz_object_dependencies
+  WHERE object_id = (SELECT id FROM mz_sinks WHERE name = 'sink1')
+    AND referenced_object_id = (SELECT id FROM mz_tables WHERE name = 't');
+1
+
 > CREATE CLUSTER sink2_cluster SIZE '${arg.default-storage-size}';
 > CREATE SINK sink2
   IN CLUSTER sink2_cluster

--- a/test/testdrive/kafka-avro-sinks-doc-comments.td
+++ b/test/testdrive/kafka-avro-sinks-doc-comments.td
@@ -74,7 +74,7 @@ $ schema-registry-verify schema-type=avro subject=testdrive-sink1-${testdrive.se
 # extraction (mz_object_dependencies) recovers the edge; a bare name would
 # silently drop out. The guard names the first release that prints ids in
 # DOC ON positions
->[version>=2604100] SELECT count(*) FROM mz_internal.mz_object_dependencies
+>[version>=2604200] SELECT count(*) FROM mz_internal.mz_object_dependencies
   WHERE object_id = (SELECT id FROM mz_sinks WHERE name = 'sink1')
     AND referenced_object_id = (SELECT id FROM mz_types WHERE name = 'point');
 1


### PR DESCRIPTION
**Context:**
DOC ON TYPE x and DOC ON COLUMN x.c resolve a name that may denote a
type or a relation, and both spellings persist in the sink's create_sql.
A relation in these positions prints as [id AS name], but resolution
suppressed ids for types, so a type persisted as a bare qualified name.
A bare name hides the sink's dependency on the type from create_sql
reference extraction: mz_object_dependencies files the bare name under
named_relations, whose join excludes Type rows, so the edge silently
drops out of the view even though the in-memory dependency graph (which
blocks DROP TYPE) still records it. The id form would also keep the
reference valid if renames of types were ever added; today no rename
strands a bare name, since ALTER TYPE has no RENAME and ALTER SCHEMA
RENAME rewrites bare names too.

Force ids in the two places that construct DOC ON references: the name
resolver's DOC ON folds, and sink purification, which injects DOC ON
options for every commented item the sink references. An AST migration
rewrites existing catalogs to match. The migration binds bare names to
types only, since a type may share (schema, name) with a secret,
connection, sink, or function, and resolves builtin types through the
system object mappings.

### Motivation
Part of sql-499

### Verification

Added platform check to test the upgrade and modified a td to assert it.
The platform check creates a secret with the type's name first, so the
migration must bind the type rather than the older same-named item.
