### PR TITLE
metrics: add dyncfg-driven export filter for environmentd metrics

### DIFF
--- a/doc/developer/design/20260902_metrics_export_filter.md
+++ b/doc/developer/design/20260902_metrics_export_filter.md
@@ -1,0 +1,210 @@
+# Runtime control of environmentd metric cardinality
+
+- Associated: [DB-199](https://linear.app/materializeinc/issue/DB-199), [INC-1252](https://app.incident.io/materializeinc/incidents/1252), [#38616](https://github.com/MaterializeInc/materialize/pull/38616)
+
+## The Problem
+
+environmentd exposes one `/metrics` endpoint whose sample count is proportional
+to catalog size: many families carry one series per catalog object, persist
+shard, replica or cluster. The AMP scraper rejects any response over 50 MiB,
+which is not configurable on our side. In INC-1252 the largest environment in
+the fleet (about 14k catalog objects) returned about 58 MB and 450k samples
+across 531 families, so every scrape failed with `body size limit exceeded`
+and every environmentd metric for the environment disappeared for hours,
+twice. Recovery was coincidental, when the sample count dipped back under the
+limit. The environment is growing, so it will cross the limit again.
+
+Until now there was no runtime control over which families or which scopes
+environmentd exports. The only levers were a code change and a rollout.
+
+The largest families on the affected endpoint, from the incident channel:
+
+| Family | Samples | Labels |
+|---|---|---|
+| `mz_dataflow_wallclock_lag_seconds{,_sum,_count}` | 61,548 | instance_id, replica_id, collection_id |
+| `mz_time_to_first_row_seconds` | 52,080 | instance_id, isolation_level, strategy, application_name |
+| `mz_timestamp_difference_for_strict_serializable_ms` | 34,125 | compute_instance |
+| `mz_compute_peek_duration_seconds` | 31,176 | instance_id, result |
+| `mz_object_info` | 14,488 | one per catalog object |
+
+Of the 173 labeled metric families in environmentd-side crates, 92 scale with
+objects, replicas or clusters: 43 per persist shard (Persist), 3 per
+collection per replica and 29 per replica or per cluster in the compute and
+storage controllers (Cluster), 5 per catalog object and 2 per unbounded
+`application_name` in the adapter (SQL).
+
+## Success Criteria
+
+- An operator can shed environmentd samples at runtime through `ALTER SYSTEM`,
+  with no restart, and get well under the scrape limit.
+- The shedding can be scoped: per-replica or per-object detail can be kept for
+  named clusters or replicas while dropped elsewhere. Per-replica metrics are
+  used daily to compare old and new generation replicas during rollouts and to
+  track OOM-looping replicas, so all-or-nothing is not acceptable.
+- Under growth, one family degrades at a time rather than the whole endpoint.
+- Payload size and per-family sample counts are observable before the limit is
+  reached.
+- Every knob defaults to current behavior.
+
+## Out of Scope
+
+- What clusterd exposes. clusterd endpoints were not near the limit.
+- Changes to the metrics pipeline (compression, remote-write batching). These
+  are tracked on the Cloud side as INC-1252 follow-ups.
+- Deciding which families to delete outright. That is a per-team audit;
+  [#38614](https://github.com/MaterializeInc/materialize/pull/38614) is the
+  first instance.
+
+## Solution Proposal
+
+Two layers. Layer 1 is one chokepoint owned by one team and is the incident
+fix, implemented in #38616. Layer 2 is per-owner work that removes the cost at
+the source.
+
+### Layer 1: export-side filter at the registry chokepoint
+
+`mz_ore::metrics::MetricsRegistry::gather` runs a list of postprocessors over
+the gathered families. The compute controller already uses one to add a
+`workload_class` label to every series carrying `instance_id`. The export
+filter (`mz_metrics::export_filter`) is a second postprocessor, installed once
+per environmentd instance from `mz_environmentd::serve`, that drops families
+and series before encoding according to four dyncfgs. All are
+`ParameterScope::Environment` and default to no filtering.
+
+| dyncfg | Type | Default | Effect |
+|---|---|---|---|
+| `metrics_export_disabled_families` | comma list, trailing `*` glob | `""` | Families whose name matches are removed. |
+| `metrics_export_cluster_allowlist` | comma list of cluster IDs | `""` (all) | Series carrying `instance_id`, `cluster_id` or `compute_instance` are kept only for the listed clusters. Series without such a label, or with an empty value, are unaffected. |
+| `metrics_export_replica_allowlist` | comma list of replica IDs | `""` (all) | The same for `replica_id`. |
+| `metrics_export_max_series_per_family` | usize | `0` (unlimited) | A family with more exported samples than this is dropped whole and counted in a self-metric. |
+
+Semantics as predicates over the output of one gather, for every retained
+family `f` not named with the `mz_metrics_export_` prefix, with `S(f)` its
+series and `samples(f)` the number of text-format lines it encodes to:
+
+- `not glob_match(disabled_families, f.name)`
+- `for all s in S(f) with a cluster label: cluster_allowlist is empty or label value is empty or label value in cluster_allowlist`
+- `for all s in S(f) with a replica label: replica_allowlist is empty or label value is empty or label value in replica_allowlist`
+- `max == 0 or samples(f) <= max`
+- `S(f)` is non-empty
+
+Design decisions:
+
+- **Samples, not label sets.** The cap and the series gauge count what the
+  text encoder emits. A histogram series expands to one line per bucket plus
+  `+Inf`, `_count` and `_sum`, so counting label sets would undercount
+  histogram-heavy families by an order of magnitude, and those are exactly the
+  families that dominated the incident.
+- **Whole-family drop at the cap, never truncation.** A truncated family is an
+  arbitrary subset that looks complete on a dashboard. An absent family is
+  visibly absent, and the `*_info` dashboards already fall back when a family
+  is missing.
+- **Self-metrics are exempt.** The filter's own families are never filtered,
+  so a small cap or a broad prefix cannot hide the metrics that explain what
+  was dropped.
+- **Configuration is read from the live system dyncfg set.** environmentd
+  already holds an `Arc<ConfigSet>` built from every dyncfg that the storage
+  controller updates on every system-config change. The filter reads the four
+  raw values at each gather and re-parses only when they change, so there is
+  no catalog round-trip per scrape, no process-global state, and no separate
+  update hook to keep in sync. The parsed configuration is shared through an
+  `Arc` swapped under a short mutex hold, so a coordinator config update never
+  waits on an in-flight filter pass.
+- **Per-instance, not per-process.** The test harness starts several
+  environmentd instances in one process, each with its own registry, so the
+  filter is installed from `serve` rather than from the binary's `main`.
+- **Where it applies.** The postprocessor filters every consumer of
+  `gather()`. `/metrics/public` gathers environmentd's own families through it
+  and then merges clusterd-sourced series it fetches separately, so the filter
+  governs environmentd's own series only. That is the intended scope.
+
+Self-metrics, registered by the filter:
+
+| Metric | Labels | Purpose |
+|---|---|---|
+| `mz_metrics_export_series` (gauge) | `family` | Samples exported per family at the previous gather, after filtering. This is the leading indicator we lacked during the incident. |
+| `mz_metrics_export_dropped_series_total` (counter) | `family`, `reason` in {`disabled_family`, `cluster_allowlist`, `replica_allowlist`, `over_cap`} | What the filter is doing. |
+| `mz_metrics_export_encoded_bytes` (gauge) | none | Size of the most recently encoded internal `/metrics` response. |
+
+Suggested alert: `mz_metrics_export_encoded_bytes > 30 MiB` fleet-wide, well
+under the 50 MiB limit. `topk(10, mz_metrics_export_series)` gives the
+reduction candidates per environment.
+
+Cost: gather still materializes every registered series before the filter
+runs. The filter fixes the payload and the scrape, not the process-side CPU
+and memory of maintaining the series. That is Layer 2.
+
+### Layer 2: emission-side gating per owner
+
+Each per-object family gets a dyncfg that stops series from being created, so
+the process stops paying for them and leaks are bounded. Ordered by sample
+contribution in the incident environment.
+
+- **Cluster: `mz_dataflow_wallclock_lag_seconds{,_sum,_count}`.** Created per
+  collection per replica by `wallclock_lag_metrics` in `mz_cluster_client`,
+  from the compute controller and the storage controller. Proposal: dyncfg
+  `wallclock_lag_metrics_scope` with values `all` (default), `replica`
+  (aggregate over collections into a per-replica family), `none`.
+  Per-collection lag remains queryable through
+  `mz_internal.mz_wallclock_global_lag_history`.
+- **SQL: the `application_name` label** on `mz_time_to_first_row_seconds` and
+  `mz_adapter_commands`. The label is client-controlled and unbounded, and a
+  histogram multiplies it by about 19 buckets. Proposal: dyncfg
+  `adapter_metrics_application_name_label` with values `full` (default),
+  `allowlist` (names not in a configured list collapse to `other`), `off`.
+- **Persist: `ShardsMetrics`.** 43 families with one series per shard.
+  Proposal: dyncfg `persist_shard_metrics_enabled` in `PersistConfig`. When
+  false, `ShardMetrics::new` builds unregistered local metric instances so
+  call sites keep working with no branching.
+- **SQL: the `*_info` families.** A zero
+  `catalog_info_metrics_reconcile_interval` stops reconciliation but leaves
+  existing series in place. Change: zero also clears the series.
+- **Cluster: per-replica and per-cluster controller metrics.** Bounded by
+  replica and cluster count rather than object count. Cover with Layer 1
+  allowlists first.
+
+### Cross-cutting: declare cardinality class at the definition
+
+`metric!` accepts `tags:` and `visibility:` as documentation-only metadata
+consumed by `bin/gen-metrics-catalog`. Add a `scales_with:` field with values
+`Object`, `Shard`, `Collection`, `Replica`, `Cluster`, `Client`, keep a
+name-to-class map in the registry at registration, and let
+`metrics_export_disabled_families` accept `class:per_object` in addition to
+family names. A metrics-catalog lint that fails CI when a metric has a
+scaling label and no class keeps the inventory above from rotting.
+
+## Minimal Viable Prototype
+
+#38616 implements Layer 1 in full: the four dyncfgs, the postprocessor, the
+self-metrics, unit tests for every rule, and an environmentd integration test
+that flips each dyncfg through `ALTER SYSTEM` and scrapes `/metrics`. CI
+system-parameter defaults run the filter path with a non-existent probe family
+and a high cap so the postprocessor executes in every mzcompose-based test
+without changing what tests observe. The drop branches themselves are covered
+by the unit and integration tests, not by the CI defaults.
+
+## Alternatives
+
+- **Emission-side gating only.** Fixes process cost as well as payload, but
+  needs a change in each owning crate and gives no single lever during an
+  incident. It is Layer 2, sequenced after the chokepoint.
+- **Gzip on the endpoint.** About 10x smaller payload, but AMP's limit is
+  checked against the decoded body in practice and compression does not
+  reduce sample count. Tracked on the Cloud side as a complementary
+  mitigation.
+- **Truncating an over-cap family** instead of dropping it. Rejected because a
+  partial family is indistinguishable from a complete one on a dashboard.
+- **A process-global filter updated through `mz_metrics::update_dyncfg`.**
+  The first implementation. Rejected because the test harness runs several
+  environmentd instances per process and the coordinator's config update
+  would have contended with an in-flight filter pass.
+
+## Open questions
+
+1. Should `/metrics/public` also filter the clusterd-sourced series it merges
+   in? The current scope is environmentd's own series only.
+2. Is per-collection wallclock lag as a Prometheus metric load-bearing for any
+   alert, or is `mz_wallclock_global_lag_history` sufficient? Decides whether
+   the `replica` aggregate in Layer 2 is needed or `none` is enough.
+3. Should the cap default to a non-zero value in production once the
+   self-metrics have a few weeks of data?

--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -1228,6 +1228,23 @@ metrics:
   help: The current VmSwap metric.
   source: src/compute/src/memory_limiter.rs
   visibility: internal
+- name: mz_metrics_export_dropped_series_total
+  help: Samples removed from the exported metrics by the export filter.
+  labels:
+  - family
+  - reason
+  source: src/metrics/src/export_filter.rs
+  visibility: internal
+- name: mz_metrics_export_encoded_bytes
+  help: Size in bytes of the most recently encoded internal metrics response.
+  source: src/metrics/src/export_filter.rs
+  visibility: internal
+- name: mz_metrics_export_series
+  help: Number of samples exported per metric family at the previous gather, after filtering.
+  labels:
+  - family
+  source: src/metrics/src/export_filter.rs
+  visibility: internal
 - name: mz_metrics_lgalloc_allocations_total
   help: Number of region allocations in size class
   labels:

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -213,6 +213,19 @@ def get_variable_system_parameters(
             "100ms",
             ["10ms", "100ms", "1s", "10s"],
         ),
+        # Exercise the metrics export filter without changing what tests
+        # observe: the disabled family does not exist and the cap is far above
+        # any real family's series count.
+        VariableSystemParameter(
+            "metrics_export_disabled_families",
+            "mz_export_filter_ci_probe_*",
+            ["", "mz_export_filter_ci_probe_*"],
+        ),
+        VariableSystemParameter(
+            "metrics_export_max_series_per_family",
+            "1000000",
+            ["0", "1000000"],
+        ),
         VariableSystemParameter(
             "persist_next_listen_batch_retryer_fixed_sleep",
             "1200ms",
@@ -818,6 +831,8 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "mz_metrics_lgalloc_refresh_interval",
     "mz_metrics_rusage_refresh_interval",
     "mz_metrics_usage_refresh_interval",
+    "metrics_export_cluster_allowlist",
+    "metrics_export_replica_allowlist",
     "compute_peek_response_stash_batch_max_runs",
     "compute_peek_response_stash_read_batch_size_bytes",
     "compute_peek_response_stash_read_memory_budget_bytes",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2942,6 +2942,14 @@ class FlipFlagsAction(Action):
         )
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_public_metrics_endpoint"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["metrics_export_disabled_families"] = [
+            "''",
+            "'mz_export_filter_ci_probe_*'",
+        ]
+        self.flags_with_values["metrics_export_max_series_per_family"] = [
+            "0",
+            "1000000",
+        ]
         self.flags_with_values["persist_batch_structured_key_lower_len"] = [
             "0",
             "1",
@@ -3394,6 +3402,8 @@ class FlipFlagsAction(Action):
             "mz_metrics_lgalloc_refresh_interval",
             "mz_metrics_rusage_refresh_interval",
             "mz_metrics_usage_refresh_interval",
+            "metrics_export_cluster_allowlist",
+            "metrics_export_replica_allowlist",
             "compute_peek_stash_num_batches",
             "compute_peek_stash_batch_size",
             "compute_peek_response_stash_batch_max_runs",

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -182,6 +182,8 @@ pub struct HttpConfig {
     pub dyncfgs: Arc<ConfigSet>,
     pub metrics: Metrics,
     pub metrics_registry: MetricsRegistry,
+    /// Records the encoded size of `/metrics` responses.
+    pub metrics_export_filter: mz_metrics::ExportFilter,
     pub mcp_metrics: mcp_metrics::McpMetrics,
     pub oauth_metadata_metrics: oauth_metadata::OauthMetadataMetrics,
     pub internal_route_config: Arc<InternalRouteConfig>,
@@ -242,6 +244,7 @@ impl HttpServer {
             dyncfgs,
             metrics,
             metrics_registry,
+            metrics_export_filter,
             mcp_metrics,
             oauth_metadata_metrics,
             internal_route_config,
@@ -487,8 +490,11 @@ impl HttpServer {
                 .route(
                     "/metrics",
                     routing::get(move |headers: HeaderMap| async move {
-                        mz_http_util::handle_prometheus(&metrics_registry_for_handler, headers)
-                            .await
+                        mz_http_util::handle_prometheus_with(
+                            &metrics_registry_for_handler,
+                            headers,
+                            |bytes| metrics_export_filter.record_encoded_bytes(bytes),
+                        )
                     }),
                 )
                 .route(

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -415,6 +415,10 @@ impl Listeners {
         let adapter_client_rx = adapter_client_rx.shared();
 
         let metrics_registry = config.metrics_registry.clone();
+        let metrics_export_filter = mz_metrics::ExportFilter::install(
+            &metrics_registry,
+            Arc::clone(&config.system_dyncfgs),
+        );
         let metrics = http::Metrics::register_into(&metrics_registry, "mz_http");
         let mcp_metrics = http::mcp_metrics::McpMetrics::register_into(&metrics_registry);
         let oauth_metadata_metrics =
@@ -445,6 +449,7 @@ impl Listeners {
                 dyncfgs: Arc::clone(&config.system_dyncfgs),
                 metrics: metrics.clone(),
                 metrics_registry: metrics_registry.clone(),
+                metrics_export_filter: metrics_export_filter.clone(),
                 mcp_metrics: mcp_metrics.clone(),
                 oauth_metadata_metrics: oauth_metadata_metrics.clone(),
                 internal_route_config: Arc::clone(&internal_route_config),

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2211,6 +2211,110 @@ fn test_internal_console_proxy() {
 
 #[mz_ore::test]
 #[allow(clippy::disallowed_methods)]
+fn test_metrics_export_filter() {
+    let server = test_util::TestHarness::default().start_blocking();
+    let mut internal_client = server.connect_internal(postgres::NoTls).unwrap();
+
+    let url = Url::parse(&format!(
+        "http://{}/metrics",
+        server.internal_http_local_addr()
+    ))
+    .unwrap();
+    let scrape = || {
+        let res = Client::new().get(url.clone()).send().unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        res.text().unwrap()
+    };
+    // Dyncfg updates reach the filter asynchronously; poll the scrape until
+    // `check` holds.
+    let wait_for = |what: &str, check: &dyn Fn(&str) -> bool| {
+        Retry::default()
+            .max_duration(Duration::from_secs(30))
+            .retry(|_| {
+                if check(&scrape()) {
+                    Ok(())
+                } else {
+                    Err(format!("{what} not yet observed in /metrics"))
+                }
+            })
+            .unwrap();
+    };
+
+    // The system clusters give `mz_compute_controller_replica_count` one
+    // series per cluster, labeled by `instance_id`.
+    let per_cluster = "mz_compute_controller_replica_count{";
+    let s1 = "mz_compute_controller_replica_count{instance_id=\"s1\"";
+    let s2 = "mz_compute_controller_replica_count{instance_id=\"s2\"";
+    wait_for("system cluster series", &|body| {
+        body.contains(s1) && body.contains(s2)
+    });
+
+    // Disabling a family by exact name removes it and nothing else.
+    internal_client
+        .batch_execute(
+            "ALTER SYSTEM SET metrics_export_disabled_families = 'mz_compute_controller_replica_count'",
+        )
+        .unwrap();
+    wait_for("disabled family", &|body| {
+        !body.contains(per_cluster) && body.contains("mz_compute_controller_collection_count{")
+    });
+
+    // A trailing `*` disables every family with the prefix.
+    internal_client
+        .batch_execute(
+            "ALTER SYSTEM SET metrics_export_disabled_families = 'mz_compute_controller_*'",
+        )
+        .unwrap();
+    // The filter's own `mz_metrics_export_*` families stay exported and name
+    // the dropped families in their labels, so look for sample lines rather
+    // than any occurrence of the prefix.
+    wait_for("disabled prefix", &|body| {
+        !body.contains("\nmz_compute_controller_")
+            && body.contains(
+                "mz_metrics_export_dropped_series_total{family=\"mz_compute_controller_replica_count\",reason=\"disabled_family\"}",
+            )
+    });
+
+    // Resetting restores the families with their current values.
+    internal_client
+        .batch_execute("ALTER SYSTEM RESET metrics_export_disabled_families")
+        .unwrap();
+    wait_for("families restored", &|body| {
+        body.contains(s1) && body.contains(s2)
+    });
+
+    // A cluster allowlist keeps only the listed cluster's series.
+    internal_client
+        .batch_execute("ALTER SYSTEM SET metrics_export_cluster_allowlist = 's1'")
+        .unwrap();
+    wait_for("cluster allowlist", &|body| {
+        body.contains(s1) && !body.contains(s2) && !body.contains("instance_id=\"s2\"")
+    });
+    internal_client
+        .batch_execute("ALTER SYSTEM RESET metrics_export_cluster_allowlist")
+        .unwrap();
+    wait_for("allowlist reset", &|body| body.contains(s2));
+
+    // The series cap drops a multi-series family whole and leaves single-series
+    // families in place.
+    internal_client
+        .batch_execute("ALTER SYSTEM SET metrics_export_max_series_per_family = 1")
+        .unwrap();
+    wait_for("series cap", &|body| {
+        !body.contains(per_cluster)
+            && body.contains("mz_metrics_export_encoded_bytes ")
+            && body.contains(
+                "mz_metrics_export_dropped_series_total{family=\"mz_compute_controller_replica_count\",reason=\"over_cap\"}",
+            )
+    });
+    internal_client
+        .batch_execute("ALTER SYSTEM RESET metrics_export_max_series_per_family")
+        .unwrap();
+    wait_for("cap reset", &|body| body.contains(s1) && body.contains(s2));
+}
+
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
 fn test_metrics_public_endpoint() {
     let server = test_util::TestHarness::default()
         .with_system_parameter_default(

--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -139,6 +139,16 @@ pub async fn handle_prometheus(
     registry: &MetricsRegistry,
     headers: HeaderMap,
 ) -> Result<Response, (StatusCode, String)> {
+    handle_prometheus_with(registry, headers, |_| ())
+}
+
+/// Like [`handle_prometheus`], additionally passing the encoded response size
+/// in bytes to `on_encoded` before the response is returned.
+pub fn handle_prometheus_with(
+    registry: &MetricsRegistry,
+    headers: HeaderMap,
+    on_encoded: impl FnOnce(usize),
+) -> Result<Response, (StatusCode, String)> {
     let families = registry.gather();
     let mut buf = Vec::new();
     let content_type = if wants_prometheus_protobuf(&headers) {
@@ -158,6 +168,7 @@ pub async fn handle_prometheus(
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
         ContentType::text()
     };
+    on_encoded(buf.len());
 
     Ok((TypedHeader(content_type), buf).into_response())
 }

--- a/src/metrics/src/dyncfgs.rs
+++ b/src/metrics/src/dyncfgs.rs
@@ -50,6 +50,59 @@ pub(crate) const MZ_METRICS_USAGE_REFRESH_INTERVAL: Config<Duration> = Config::n
     ParameterScope::Replica,
 );
 
+/// Metric families removed from this process's exported metrics.
+///
+/// Comma-separated family names. A trailing `*` matches any family with that
+/// prefix. See `export_filter` for the export-time semantics shared by all
+/// `metrics_export_*` configs.
+pub(crate) const METRICS_EXPORT_DISABLED_FAMILIES: Config<&str> = Config::new(
+    "metrics_export_disabled_families",
+    "",
+    "Comma-separated metric family names (trailing `*` matches a prefix) removed from the \
+     exported metrics.",
+    ParameterScope::Environment,
+);
+
+/// Clusters whose per-cluster series are exported.
+///
+/// Comma-separated cluster IDs. When non-empty, exported series carrying an
+/// `instance_id` or `cluster_id` label are kept only for the listed clusters.
+/// Series without either label, or with an empty value, are unaffected.
+pub(crate) const METRICS_EXPORT_CLUSTER_ALLOWLIST: Config<&str> = Config::new(
+    "metrics_export_cluster_allowlist",
+    "",
+    "Comma-separated cluster IDs. When non-empty, series with an `instance_id` or `cluster_id` \
+     label are exported only for these clusters.",
+    ParameterScope::Environment,
+);
+
+/// Replicas whose per-replica series are exported.
+///
+/// Comma-separated replica IDs. When non-empty, exported series carrying a
+/// `replica_id` label are kept only for the listed replicas.
+pub(crate) const METRICS_EXPORT_REPLICA_ALLOWLIST: Config<&str> = Config::new(
+    "metrics_export_replica_allowlist",
+    "",
+    "Comma-separated replica IDs. When non-empty, series with a `replica_id` label are \
+     exported only for these replicas.",
+    ParameterScope::Environment,
+);
+
+/// Upper bound on the samples exported for any one family.
+///
+/// Counted as the text encoder emits them, so a histogram series counts once
+/// per bucket plus its `+Inf`, `_count` and `_sum` lines. A family exceeding
+/// the bound is dropped whole rather than truncated, so a dashboard sees an
+/// absent family instead of a partial one that looks complete. Zero disables
+/// the bound.
+pub(crate) const METRICS_EXPORT_MAX_SERIES_PER_FAMILY: Config<usize> = Config::new(
+    "metrics_export_max_series_per_family",
+    0,
+    "Metric families with more exported samples than this are not exported. Zero disables the \
+     bound.",
+    ParameterScope::Environment,
+);
+
 /// Adds the full set of all storage `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -57,4 +110,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&MZ_METRICS_LGALLOC_REFRESH_INTERVAL)
         .add(&MZ_METRICS_RUSAGE_REFRESH_INTERVAL)
         .add(&MZ_METRICS_USAGE_REFRESH_INTERVAL)
+        .add(&METRICS_EXPORT_DISABLED_FAMILIES)
+        .add(&METRICS_EXPORT_CLUSTER_ALLOWLIST)
+        .add(&METRICS_EXPORT_REPLICA_ALLOWLIST)
+        .add(&METRICS_EXPORT_MAX_SERIES_PER_FAMILY)
 }

--- a/src/metrics/src/export_filter.rs
+++ b/src/metrics/src/export_filter.rs
@@ -1,0 +1,715 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Runtime filtering of the metrics a process exports.
+//!
+//! Many metric families carry one series per catalog object, persist shard,
+//! replica or cluster, so a single `/metrics` response grows with the catalog.
+//! Scrapers reject oversized responses outright, which loses every metric of
+//! the process at once. The export filter is a gather-time postprocessor on
+//! the [`MetricsRegistry`] that drops families and scopes series by cluster or
+//! replica according to the `metrics_export_*` dyncfgs, so an operator can
+//! shed cardinality at runtime without a restart.
+//!
+//! The filter changes what is exported, not what is recorded. Filtered series
+//! still exist in the registry, so re-enabling a family restores its current
+//! values, and the process still pays the cost of maintaining them.
+//!
+//! The filter's own metrics are registered in the same registry it filters
+//! and are exempt from filtering, so an operator can always see what was
+//! dropped. The registry gathers them before the postprocessor runs, so each
+//! scrape reports the filter's view of the previous scrape.
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
+
+use mz_dyncfg::ConfigSet;
+use mz_ore::cast::CastFrom;
+use mz_ore::metric;
+use mz_ore::metrics::raw::{IntCounterVec, UIntGaugeVec};
+use mz_ore::metrics::{MetricsRegistry, UIntGauge};
+use prometheus::proto::{LabelPair, Metric, MetricFamily};
+
+use crate::dyncfgs::{
+    METRICS_EXPORT_CLUSTER_ALLOWLIST, METRICS_EXPORT_DISABLED_FAMILIES,
+    METRICS_EXPORT_MAX_SERIES_PER_FAMILY, METRICS_EXPORT_REPLICA_ALLOWLIST,
+};
+
+/// Labels whose value identifies a cluster.
+const CLUSTER_LABELS: &[&str] = &["instance_id", "cluster_id", "compute_instance"];
+/// Labels whose value identifies a replica.
+const REPLICA_LABELS: &[&str] = &["replica_id"];
+/// Name prefix of the filter's own metrics, which are never filtered.
+const SELF_METRIC_PREFIX: &str = "mz_metrics_export_";
+
+/// A family name pattern from `metrics_export_disabled_families`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FamilyPattern {
+    Exact(String),
+    Prefix(String),
+}
+
+impl FamilyPattern {
+    fn parse(s: &str) -> Self {
+        match s.strip_suffix('*') {
+            Some(prefix) => FamilyPattern::Prefix(prefix.to_owned()),
+            None => FamilyPattern::Exact(s.to_owned()),
+        }
+    }
+
+    fn matches(&self, name: &str) -> bool {
+        match self {
+            FamilyPattern::Exact(exact) => name == exact,
+            FamilyPattern::Prefix(prefix) => name.starts_with(prefix),
+        }
+    }
+}
+
+/// Why a series or family was removed from the export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DropReason {
+    DisabledFamily,
+    ClusterAllowlist,
+    ReplicaAllowlist,
+    OverCap,
+}
+
+impl DropReason {
+    fn label(self) -> &'static str {
+        match self {
+            DropReason::DisabledFamily => "disabled_family",
+            DropReason::ClusterAllowlist => "cluster_allowlist",
+            DropReason::ReplicaAllowlist => "replica_allowlist",
+            DropReason::OverCap => "over_cap",
+        }
+    }
+}
+
+/// The raw dyncfg values the filter is configured from, kept so a gather can
+/// detect a change without re-parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RawConfig {
+    disabled_families: String,
+    cluster_allowlist: String,
+    replica_allowlist: String,
+    max_samples_per_family: usize,
+}
+
+impl RawConfig {
+    fn read(config_set: &ConfigSet) -> Self {
+        RawConfig {
+            disabled_families: METRICS_EXPORT_DISABLED_FAMILIES.get(config_set),
+            cluster_allowlist: METRICS_EXPORT_CLUSTER_ALLOWLIST.get(config_set),
+            replica_allowlist: METRICS_EXPORT_REPLICA_ALLOWLIST.get(config_set),
+            max_samples_per_family: METRICS_EXPORT_MAX_SERIES_PER_FAMILY.get(config_set),
+        }
+    }
+}
+
+/// The parsed form of the export filter dyncfgs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ExportFilterConfig {
+    disabled_families: Vec<FamilyPattern>,
+    cluster_allowlist: BTreeSet<String>,
+    replica_allowlist: BTreeSet<String>,
+    max_samples_per_family: usize,
+}
+
+impl ExportFilterConfig {
+    fn parse(raw: &RawConfig) -> Self {
+        Self::new(
+            &raw.disabled_families,
+            &raw.cluster_allowlist,
+            &raw.replica_allowlist,
+            raw.max_samples_per_family,
+        )
+    }
+
+    fn new(
+        disabled_families: &str,
+        cluster_allowlist: &str,
+        replica_allowlist: &str,
+        max_samples_per_family: usize,
+    ) -> Self {
+        ExportFilterConfig {
+            disabled_families: parse_list(disabled_families)
+                .map(FamilyPattern::parse)
+                .collect(),
+            cluster_allowlist: parse_list(cluster_allowlist).map(str::to_owned).collect(),
+            replica_allowlist: parse_list(replica_allowlist).map(str::to_owned).collect(),
+            max_samples_per_family,
+        }
+    }
+
+    fn family_disabled(&self, name: &str) -> bool {
+        self.disabled_families.iter().any(|p| p.matches(name))
+    }
+
+    /// Returns why a series with these labels is excluded, if it is.
+    ///
+    /// A series is excluded when it carries a scoping label with a non-empty
+    /// value that is not in the corresponding non-empty allowlist. Series
+    /// without the label, or with an empty value, are kept.
+    fn series_drop_reason(&self, labels: &[LabelPair]) -> Option<DropReason> {
+        let excluded = |allowlist: &BTreeSet<String>, names: &[&str]| {
+            !allowlist.is_empty()
+                && labels.iter().any(|l| {
+                    names.contains(&l.name())
+                        && !l.value().is_empty()
+                        && !allowlist.contains(l.value())
+                })
+        };
+        if excluded(&self.cluster_allowlist, CLUSTER_LABELS) {
+            Some(DropReason::ClusterAllowlist)
+        } else if excluded(&self.replica_allowlist, REPLICA_LABELS) {
+            Some(DropReason::ReplicaAllowlist)
+        } else {
+            None
+        }
+    }
+}
+
+fn parse_list(s: &str) -> impl Iterator<Item = &str> {
+    s.split(',').map(str::trim).filter(|s| !s.is_empty())
+}
+
+/// The number of samples the text encoder emits for one series.
+///
+/// A histogram expands to one line per bucket plus the implicit `+Inf`
+/// bucket, `_count` and `_sum`. A summary expands to one line per quantile
+/// plus `_count` and `_sum`. Everything else is one line. Scraper limits are
+/// on samples, not label sets, so this is the unit the cap and the series
+/// gauge use.
+fn exported_samples(series: &Metric) -> usize {
+    if let Some(histogram) = series.histogram.as_ref() {
+        histogram.bucket.len() + 3
+    } else if let Some(summary) = series.summary.as_ref() {
+        summary.quantile.len() + 2
+    } else {
+        1
+    }
+}
+
+/// Metrics describing what the filter exported and dropped.
+#[derive(Debug)]
+struct ExportFilterMetrics {
+    samples: UIntGaugeVec,
+    dropped_samples: IntCounterVec,
+    encoded_bytes: UIntGauge,
+    /// Families the `samples` gauge currently has a child for, so children of
+    /// families that stop being exported can be removed. Updating children in
+    /// place rather than resetting the gauge keeps a concurrent gather from
+    /// observing an empty gauge.
+    reported_families: Mutex<BTreeSet<String>>,
+}
+
+impl ExportFilterMetrics {
+    fn register_into(registry: &MetricsRegistry) -> Self {
+        ExportFilterMetrics {
+            samples: registry.register(metric!(
+                name: "mz_metrics_export_series",
+                help: "Number of samples exported per metric family at the previous gather, after filtering.",
+                var_labels: ["family"],
+            )),
+            dropped_samples: registry.register(metric!(
+                name: "mz_metrics_export_dropped_series_total",
+                help: "Samples removed from the exported metrics by the export filter.",
+                var_labels: ["family", "reason"],
+            )),
+            encoded_bytes: registry.register(metric!(
+                name: "mz_metrics_export_encoded_bytes",
+                help: "Size in bytes of the most recently encoded internal metrics response.",
+            )),
+            reported_families: Mutex::new(BTreeSet::new()),
+        }
+    }
+
+    fn record_dropped(&self, family: &str, reason: DropReason, samples: usize) {
+        if samples > 0 {
+            self.dropped_samples
+                .with_label_values(&[family, reason.label()])
+                .inc_by(u64::cast_from(samples));
+        }
+    }
+
+    /// Sets the per-family sample gauge to `exported` and removes children for
+    /// families no longer exported.
+    fn record_exported(&self, exported: &[(&str, usize)]) {
+        let mut reported = self.reported_families.lock().expect("lock poisoned");
+        let mut still_reported = BTreeSet::new();
+        for (family, samples) in exported {
+            self.samples
+                .with_label_values(&[family])
+                .set(u64::cast_from(*samples));
+            still_reported.insert((*family).to_owned());
+        }
+        for stale in reported.difference(&still_reported) {
+            // The child may already be gone if the gauge was reset elsewhere.
+            let _ = self.samples.remove_label_values(&[stale]);
+        }
+        *reported = still_reported;
+    }
+}
+
+/// Applies `config` to gathered `families` in place, recording the outcome in
+/// `metrics`.
+///
+/// Postconditions on every retained family not named with
+/// [`SELF_METRIC_PREFIX`]: it matches no disabled pattern, none of its series
+/// carries a scoping label value outside a non-empty allowlist, its sample
+/// count does not exceed the cap when the cap is non-zero, and it is not
+/// empty.
+fn apply(
+    config: &ExportFilterConfig,
+    families: &mut Vec<MetricFamily>,
+    metrics: &ExportFilterMetrics,
+) {
+    families.retain_mut(|family| {
+        // Taken out so the series can be filtered while `name` borrows the
+        // family; put back only when the family is retained.
+        let mut series = std::mem::take(&mut family.metric);
+        let name = family.name();
+        if name.starts_with(SELF_METRIC_PREFIX) {
+            family.metric = series;
+            return true;
+        }
+        if config.family_disabled(name) {
+            let samples = series.iter().map(exported_samples).sum();
+            metrics.record_dropped(name, DropReason::DisabledFamily, samples);
+            return false;
+        }
+        let mut dropped_cluster = 0;
+        let mut dropped_replica = 0;
+        let mut kept = 0;
+        series.retain(|series| match config.series_drop_reason(&series.label) {
+            None => {
+                kept += exported_samples(series);
+                true
+            }
+            Some(DropReason::ClusterAllowlist) => {
+                dropped_cluster += exported_samples(series);
+                false
+            }
+            Some(_) => {
+                dropped_replica += exported_samples(series);
+                false
+            }
+        });
+        metrics.record_dropped(name, DropReason::ClusterAllowlist, dropped_cluster);
+        metrics.record_dropped(name, DropReason::ReplicaAllowlist, dropped_replica);
+        if kept == 0 {
+            return false;
+        }
+        if config.max_samples_per_family > 0 && kept > config.max_samples_per_family {
+            metrics.record_dropped(name, DropReason::OverCap, kept);
+            return false;
+        }
+        family.metric = series;
+        true
+    });
+    let exported: Vec<(&str, usize)> = families
+        .iter()
+        .filter(|family| !family.name().starts_with(SELF_METRIC_PREFIX))
+        .map(|family| {
+            (
+                family.name(),
+                family.metric.iter().map(exported_samples).sum(),
+            )
+        })
+        .collect();
+    metrics.record_exported(&exported);
+}
+
+/// The filter's state, shared between the registry postprocessor and the
+/// [`ExportFilter`] handles.
+#[derive(Debug)]
+struct Inner {
+    dyncfgs: Arc<ConfigSet>,
+    /// The last configuration read from `dyncfgs`, re-parsed only when the raw
+    /// values change.
+    cached: Mutex<(RawConfig, Arc<ExportFilterConfig>)>,
+    metrics: ExportFilterMetrics,
+}
+
+impl Inner {
+    /// Returns the current configuration, re-parsing it if the dyncfgs changed
+    /// since the previous gather.
+    fn config(&self) -> Arc<ExportFilterConfig> {
+        let raw = RawConfig::read(&self.dyncfgs);
+        let mut cached = self.cached.lock().expect("lock poisoned");
+        if cached.0 != raw {
+            let parsed = Arc::new(ExportFilterConfig::parse(&raw));
+            tracing::info!(?parsed, "metrics export filter updated");
+            *cached = (raw, parsed);
+        }
+        Arc::clone(&cached.1)
+    }
+}
+
+/// A handle to the export filter installed on a [`MetricsRegistry`].
+#[derive(Debug, Clone)]
+pub struct ExportFilter {
+    inner: Arc<Inner>,
+}
+
+impl ExportFilter {
+    /// Installs the filter as a postprocessor on `registry`.
+    ///
+    /// `dyncfgs` must contain the `metrics_export_*` configs (see
+    /// [`crate::all_dyncfgs`]) and is read at every gather, so it must be the
+    /// set that receives live configuration updates. Install at most once per
+    /// registry.
+    pub fn install(registry: &MetricsRegistry, dyncfgs: Arc<ConfigSet>) -> Self {
+        let raw = RawConfig::read(&dyncfgs);
+        let parsed = Arc::new(ExportFilterConfig::parse(&raw));
+        let inner = Arc::new(Inner {
+            dyncfgs,
+            cached: Mutex::new((raw, parsed)),
+            metrics: ExportFilterMetrics::register_into(registry),
+        });
+        registry.register_postprocessor({
+            let inner = Arc::clone(&inner);
+            move |families| {
+                let config = inner.config();
+                apply(&config, families, &inner.metrics);
+            }
+        });
+        ExportFilter { inner }
+    }
+
+    /// Records the encoded size of a metrics response in
+    /// `mz_metrics_export_encoded_bytes`.
+    pub fn record_encoded_bytes(&self, bytes: usize) {
+        self.inner.metrics.encoded_bytes.set(u64::cast_from(bytes));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_dyncfg::{ConfigUpdates, ConfigVal};
+    use mz_ore::metrics::IntGauge;
+    use mz_ore::metrics::raw::{HistogramVec, IntGaugeVec as RawIntGaugeVec};
+    use prometheus::core::Collector;
+
+    use super::*;
+
+    fn registry_with_series() -> (MetricsRegistry, ExportFilterMetrics) {
+        let registry = MetricsRegistry::new();
+        let per_replica: RawIntGaugeVec = registry.register(metric!(
+            name: "test_per_replica",
+            help: "per replica",
+            var_labels: ["instance_id", "replica_id"],
+        ));
+        per_replica.with_label_values(&["u1", "u10"]).set(1);
+        per_replica.with_label_values(&["u1", "u11"]).set(1);
+        per_replica.with_label_values(&["u2", "u20"]).set(1);
+        let per_cluster: RawIntGaugeVec = registry.register(metric!(
+            name: "test_per_cluster",
+            help: "per cluster",
+            var_labels: ["cluster_id"],
+        ));
+        per_cluster.with_label_values(&["u1"]).set(1);
+        per_cluster.with_label_values(&["u2"]).set(1);
+        per_cluster.with_label_values(&[""]).set(1);
+        let plain: IntGauge = registry.register(metric!(
+            name: "test_plain",
+            help: "no labels",
+        ));
+        plain.set(1);
+        let other: IntGauge = registry.register(metric!(
+            name: "other_plain",
+            help: "no labels",
+        ));
+        other.set(1);
+        // Register the filter's metrics into a separate registry so they do
+        // not appear in the gathered output under test.
+        let metrics = ExportFilterMetrics::register_into(&MetricsRegistry::new());
+        (registry, metrics)
+    }
+
+    fn names_and_counts(families: &[MetricFamily]) -> Vec<(&str, usize)> {
+        families
+            .iter()
+            .map(|f| (f.name(), f.metric.len()))
+            .collect()
+    }
+
+    fn dropped(metrics: &ExportFilterMetrics, family: &str, reason: &str) -> u64 {
+        metrics
+            .dropped_samples
+            .with_label_values(&[family, reason])
+            .get()
+    }
+
+    fn gauge_families(metrics: &ExportFilterMetrics) -> Vec<String> {
+        metrics
+            .samples
+            .collect()
+            .into_iter()
+            .flat_map(|f| f.metric.into_iter())
+            .map(|m| m.label[0].value().to_owned())
+            .collect()
+    }
+
+    #[mz_ore::test]
+    fn parse_config() {
+        let config = ExportFilterConfig::new(" a, b* ,,", "u1 , u2", "", 5);
+        assert_eq!(
+            config.disabled_families,
+            vec![
+                FamilyPattern::Exact("a".into()),
+                FamilyPattern::Prefix("b".into())
+            ]
+        );
+        assert_eq!(
+            config.cluster_allowlist,
+            ["u1", "u2"].into_iter().map(String::from).collect()
+        );
+        assert!(config.replica_allowlist.is_empty());
+        assert_eq!(config.max_samples_per_family, 5);
+        assert_eq!(
+            ExportFilterConfig::new("", "", "", 0),
+            ExportFilterConfig::default()
+        );
+    }
+
+    #[mz_ore::test]
+    fn default_config_changes_nothing_but_still_counts() {
+        let (registry, metrics) = registry_with_series();
+        let before = registry.gather();
+        let mut after = before.clone();
+        apply(&ExportFilterConfig::default(), &mut after, &metrics);
+        assert_eq!(names_and_counts(&before), names_and_counts(&after));
+        assert_eq!(
+            metrics
+                .samples
+                .with_label_values(&["test_per_replica"])
+                .get(),
+            3
+        );
+    }
+
+    #[mz_ore::test]
+    fn disabled_families_exact_and_prefix() {
+        let (registry, metrics) = registry_with_series();
+        let mut families = registry.gather();
+        let config = ExportFilterConfig::new("test_plain,test_per_*", "", "", 0);
+        apply(&config, &mut families, &metrics);
+        assert_eq!(names_and_counts(&families), vec![("other_plain", 1)]);
+        assert_eq!(dropped(&metrics, "test_per_replica", "disabled_family"), 3);
+        assert_eq!(dropped(&metrics, "test_per_cluster", "disabled_family"), 3);
+        assert_eq!(dropped(&metrics, "test_plain", "disabled_family"), 1);
+    }
+
+    #[mz_ore::test]
+    fn cluster_allowlist_scopes_both_label_names_and_keeps_empty_values() {
+        let (registry, metrics) = registry_with_series();
+        let mut families = registry.gather();
+        let config = ExportFilterConfig::new("", "u2", "", 0);
+        apply(&config, &mut families, &metrics);
+        assert_eq!(
+            names_and_counts(&families),
+            vec![
+                ("other_plain", 1),
+                ("test_per_cluster", 2),
+                ("test_per_replica", 1),
+                ("test_plain", 1),
+            ]
+        );
+        for series in &families[1].metric {
+            assert!(series.label[0].value() == "u2" || series.label[0].value().is_empty());
+        }
+        assert_eq!(
+            dropped(&metrics, "test_per_replica", "cluster_allowlist"),
+            2
+        );
+        assert_eq!(
+            dropped(&metrics, "test_per_cluster", "cluster_allowlist"),
+            1
+        );
+    }
+
+    #[mz_ore::test]
+    fn replica_allowlist_and_empty_family_removal() {
+        let (registry, metrics) = registry_with_series();
+        let mut families = registry.gather();
+        let config = ExportFilterConfig::new("", "", "u99", 0);
+        apply(&config, &mut families, &metrics);
+        assert_eq!(
+            names_and_counts(&families),
+            vec![
+                ("other_plain", 1),
+                ("test_per_cluster", 3),
+                ("test_plain", 1)
+            ]
+        );
+        assert_eq!(
+            dropped(&metrics, "test_per_replica", "replica_allowlist"),
+            3
+        );
+    }
+
+    #[mz_ore::test]
+    fn cap_drops_whole_family_after_scoping() {
+        let (registry, metrics) = registry_with_series();
+        let mut families = registry.gather();
+        let config = ExportFilterConfig::new("", "", "", 2);
+        apply(&config, &mut families, &metrics);
+        assert_eq!(
+            names_and_counts(&families),
+            vec![("other_plain", 1), ("test_plain", 1)]
+        );
+        assert_eq!(dropped(&metrics, "test_per_replica", "over_cap"), 3);
+        assert_eq!(dropped(&metrics, "test_per_cluster", "over_cap"), 3);
+
+        // Scoping runs before the cap, so a family that fits once scoped stays.
+        let mut families = registry.gather();
+        let config = ExportFilterConfig::new("", "u1", "", 2);
+        apply(&config, &mut families, &metrics);
+        assert_eq!(
+            names_and_counts(&families),
+            vec![
+                ("other_plain", 1),
+                ("test_per_cluster", 2),
+                ("test_per_replica", 2),
+                ("test_plain", 1),
+            ]
+        );
+    }
+
+    #[mz_ore::test]
+    fn histograms_count_exported_samples() {
+        let registry = MetricsRegistry::new();
+        let histogram: HistogramVec = registry.register(metric!(
+            name: "test_histogram",
+            help: "histogram",
+            var_labels: ["instance_id"],
+            buckets: vec![1.0, 2.0],
+        ));
+        histogram.with_label_values(&["u1"]).observe(1.0);
+        histogram.with_label_values(&["u2"]).observe(1.0);
+        let metrics = ExportFilterMetrics::register_into(&MetricsRegistry::new());
+
+        // Two series, each two buckets plus +Inf, _count and _sum.
+        let mut families = registry.gather();
+        apply(&ExportFilterConfig::default(), &mut families, &metrics);
+        assert_eq!(
+            metrics.samples.with_label_values(&["test_histogram"]).get(),
+            10
+        );
+
+        // A cap between the label-set count and the sample count still drops it.
+        let mut families = registry.gather();
+        apply(
+            &ExportFilterConfig::new("", "", "", 5),
+            &mut families,
+            &metrics,
+        );
+        assert!(families.is_empty());
+        assert_eq!(dropped(&metrics, "test_histogram", "over_cap"), 10);
+
+        let mut families = registry.gather();
+        apply(
+            &ExportFilterConfig::new("", "u1", "", 5),
+            &mut families,
+            &metrics,
+        );
+        assert_eq!(names_and_counts(&families), vec![("test_histogram", 1)]);
+        assert_eq!(dropped(&metrics, "test_histogram", "cluster_allowlist"), 5);
+    }
+
+    #[mz_ore::test]
+    fn series_gauge_tracks_retained_families_only() {
+        let (registry, metrics) = registry_with_series();
+        let mut families = registry.gather();
+        apply(
+            &ExportFilterConfig::new("", "", "", 0),
+            &mut families,
+            &metrics,
+        );
+        assert_eq!(
+            metrics
+                .samples
+                .with_label_values(&["test_per_replica"])
+                .get(),
+            3
+        );
+
+        let mut families = registry.gather();
+        apply(
+            &ExportFilterConfig::new("test_per_replica", "", "", 0),
+            &mut families,
+            &metrics,
+        );
+        let reported = gauge_families(&metrics);
+        assert!(!reported.contains(&"test_per_replica".to_owned()));
+        assert!(reported.contains(&"test_plain".to_owned()));
+    }
+
+    #[mz_ore::test]
+    fn self_metrics_are_exempt() {
+        let (registry, metrics) = registry_with_series();
+        // Register the filter's own families into the registry under test and
+        // give one of them more series than the cap allows.
+        let own = ExportFilterMetrics::register_into(&registry);
+        own.samples.with_label_values(&["a"]).set(1);
+        own.samples.with_label_values(&["b"]).set(1);
+        let mut families = registry.gather();
+        let config = ExportFilterConfig::new("mz_*", "", "", 1);
+        apply(&config, &mut families, &metrics);
+        assert_eq!(
+            names_and_counts(&families),
+            vec![
+                ("mz_metrics_export_encoded_bytes", 1),
+                ("mz_metrics_export_series", 2),
+                ("other_plain", 1),
+                ("test_plain", 1),
+            ]
+        );
+        assert!(!gauge_families(&metrics).contains(&"mz_metrics_export_series".to_owned()));
+    }
+
+    #[mz_ore::test]
+    fn installed_filter_follows_live_dyncfgs() {
+        let registry = MetricsRegistry::new();
+        let gauge: RawIntGaugeVec = registry.register(metric!(
+            name: "test_gauge",
+            help: "test",
+            var_labels: ["instance_id"],
+        ));
+        gauge.with_label_values(&["u1"]).set(1);
+        let dyncfgs = Arc::new(crate::all_dyncfgs(ConfigSet::default()));
+        let filter = ExportFilter::install(&registry, Arc::clone(&dyncfgs));
+        assert!(registry.gather().iter().any(|f| f.name() == "test_gauge"));
+
+        let mut updates = ConfigUpdates::default();
+        updates.add_dynamic(
+            "metrics_export_disabled_families",
+            ConfigVal::String("test_gauge".into()),
+        );
+        updates.apply(&dyncfgs);
+        assert!(!registry.gather().iter().any(|f| f.name() == "test_gauge"));
+
+        let mut updates = ConfigUpdates::default();
+        updates.add_dynamic(
+            "metrics_export_disabled_families",
+            ConfigVal::String("".into()),
+        );
+        updates.apply(&dyncfgs);
+        assert!(registry.gather().iter().any(|f| f.name() == "test_gauge"));
+
+        filter.record_encoded_bytes(42);
+        let bytes = registry
+            .gather()
+            .into_iter()
+            .find(|f| f.name() == "mz_metrics_export_encoded_bytes")
+            .expect("registered");
+        assert_eq!(bytes.metric[0].gauge.value(), 42.0);
+    }
+}

--- a/src/metrics/src/lib.rs
+++ b/src/metrics/src/lib.rs
@@ -25,8 +25,10 @@ use mz_ore::metrics::MetricsRegistry;
 use tokio::time::Interval;
 
 pub use dyncfgs::all_dyncfgs;
+pub use export_filter::ExportFilter;
 
 mod dyncfgs;
+mod export_filter;
 pub mod lgalloc;
 pub mod rusage;
 pub mod usage;

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -317,6 +317,10 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     mcp_max_response_size
     mcp_request_timeout
     memory_limiter_usage_bias
+    metrics_export_cluster_allowlist
+    metrics_export_disabled_families
+    metrics_export_max_series_per_family
+    metrics_export_replica_allowlist
     mysql_replication_heartbeat_interval
     mysql_source_connect_timeout
     mysql_source_snapshot_lock_wait_timeout


### PR DESCRIPTION
### Motivation

In [INC-1252](https://app.incident.io/materializeinc/incidents/1252) a single environmentd `/metrics` response (~58 MB, ~450k samples) exceeded the AMP scraper's 50 MiB body-size limit, so every scrape failed and all environmentd metrics for the environment disappeared for hours, twice. Many families carry one series per catalog object, persist shard, replica or cluster, so the response grows with the catalog, and until now the only lever was a code change and a rollout.

Tracking issue: [DB-199](https://linear.app/materializeinc/issue/DB-199/reduce-environmentd-metric-cardinality-dyncfg-gating-for-per-object). Design: `doc/developer/design/20260902_metrics_export_filter.md` in this PR.

### Description

Adds a gather-time postprocessor on the metrics registry, installed once per environmentd instance from `mz_environmentd::serve`, that drops families and scopes series at export time according to four new dyncfgs. All default to no filtering.

| dyncfg | Effect |
|---|---|
| `metrics_export_disabled_families` | Comma-separated family names, trailing `*` matches a prefix. Matching families are removed. |
| `metrics_export_cluster_allowlist` | When set, series carrying `instance_id`, `cluster_id` or `compute_instance` are exported only for the listed clusters. |
| `metrics_export_replica_allowlist` | Same for `replica_id`. |
| `metrics_export_max_series_per_family` | A family with more exported samples than this is dropped whole rather than truncated, so a dashboard sees an absent family instead of a partial one that looks complete. Zero disables. |

The filter records what it did in `mz_metrics_export_series{family}`, `mz_metrics_export_dropped_series_total{family,reason}` and `mz_metrics_export_encoded_bytes`. Its own families are exempt from filtering so the operator can always see what was dropped. The per-family sample gauge and the encoded-bytes gauge are the leading indicators we lacked during the incident.

Design notes:

* Counts are exported samples, as the text encoder emits them, not label sets. A histogram series expands to one line per bucket plus `+Inf`, `_count` and `_sum`, and histogram-heavy families dominated the incident.
* Configuration is read from the live system dyncfg set that environmentd already holds and the storage controller already updates on every system-config change, so there is no catalog round-trip per scrape, no process-global state, and no separate update hook. Raw values are re-parsed only when they change.
* Filtering is export-side only. Filtered series still exist in the registry, so re-enabling a family restores its current values, and the process still pays for maintaining them. Emission-side gating per family (persist shard metrics, per-collection wallclock lag, the `application_name` label) is follow-up work in [DB-199](https://linear.app/materializeinc/issue/DB-199).
* clusterd does not install the filter, so clusterd exports are unaffected. `/metrics/public` gathers environmentd's own families through the filter and then merges clusterd-sourced series it fetches separately, so the filter governs environmentd's own series only.

### Tests

* Unit tests in `mz_metrics::export_filter` for list parsing, each rule, the cap, histogram sample counting, self-metric exemption, stale gauge children, and live dyncfg updates.
* `test_metrics_export_filter` in `src/environmentd/tests/server.rs` flips each dyncfg via `ALTER SYSTEM` on a running environmentd and scrapes `/metrics`.
* CI system-parameter defaults run the filter path with a non-existent probe family and a high cap, so the postprocessor executes in every mzcompose-based test without changing what tests observe. The drop branches are covered by the unit and integration tests, not by the CI defaults.

### Tips for reviewer

Start with `src/metrics/src/export_filter.rs`; everything else is wiring. The design doc covers the alternatives considered, including the process-global variant this PR replaced.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label.
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
