### PR TITLE
Fix clippy warnings on newer Rust toolchains

### DIFF
--- a/src/adapter/src/catalog/open/builtin_schema_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_schema_migration.rs
@@ -1400,7 +1400,7 @@ async fn read_migration_shard<P>(
     predicate: P,
 ) -> Option<Vec<(migration_shard::Key, ShardId)>>
 where
-    P: for<'a> Fn(&migration_shard::Key) -> bool,
+    P: Fn(&migration_shard::Key) -> bool,
 {
     let as_of = Antichain::from_elem(read_ts);
     let updates = persist_read.snapshot_and_fetch(as_of).await.ok()?;

--- a/src/avro/src/util.rs
+++ b/src/avro/src/util.rs
@@ -21,7 +21,6 @@
 // The original source code is subject to the terms of the MIT license, a copy
 // of which can be found in the LICENSE file at the root of this repository.
 
-use std::i64;
 use std::io::Read;
 
 use serde_json::{Map, Value};
@@ -73,7 +72,7 @@ pub fn zig_i64(n: i64, buffer: &mut Vec<u8>) {
 
 pub fn zag_i32<R: Read>(reader: &mut R) -> Result<i32, AvroError> {
     let i = zag_i64(reader)?;
-    if i < i64::from(i32::min_value()) || i > i64::from(i32::max_value()) {
+    if i < i64::from(i32::MIN) || i > i64::from(i32::MAX) {
         Err(AvroError::Decode(DecodeError::I32OutOfRange(i)))
     } else {
         Ok(i as i32)

--- a/src/ccsr/tests/client.rs
+++ b/src/ccsr/tests/client.rs
@@ -268,7 +268,7 @@ async fn test_client_errors() -> Result<(), anyhow::Error> {
     let client = mz_ccsr::ClientConfig::new(SCHEMA_REGISTRY_URL.clone()).build()?;
 
     // Get-by-id-specific errors.
-    match client.get_schema_by_id(i32::max_value()).await {
+    match client.get_schema_by_id(i32::MAX).await {
         Err(GetByIdError::SchemaNotFound) => (),
         res => panic!("expected GetError::SchemaNotFound, got {:?}", res),
     }

--- a/src/compute/src/logging.rs
+++ b/src/compute/src/logging.rs
@@ -306,7 +306,7 @@ where
     B::Output: Clone,
     CB: ContainerBuilder,
     L: Into<LogVariant>,
-    F: for<'a> FnMut(B::Output, &mut PermutedRowPacker, &mut OutputSession<CB>) + 'static,
+    F: FnMut(B::Output, &mut PermutedRowPacker, &mut OutputSession<CB>) + 'static,
 {
     let log = log.into();
     // TODO: Use something other than the debug representation of the log variant as a name.

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -145,7 +145,7 @@ pub trait MzData:
 impl<T> MzData for T
 where
     T: columnation::Columnation,
-    T: for<'a> columnar::Columnar<Container: Clone + Send>,
+    T: columnar::Columnar<Container: Clone + Send>,
     for<'a> Ref<'a, T>: Copy + Ord,
 {
 }

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -977,7 +977,7 @@ impl<E: OptimizableExpr> MapFilterProject<E> {
     pub fn optimize(&mut self) {
         // Track sizes and iterate as long as they decrease.
         let mut prev_size = None;
-        let mut self_size = usize::max_value();
+        let mut self_size = usize::MAX;
         // Continue as long as strict improvements occur.
         while prev_size.map(|p| self_size < p).unwrap_or(true) {
             // Lock in current size.

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3295,7 +3295,6 @@ fn mz_render_typmod(oid: u32, typmod: i32) -> String {
 
 #[cfg(test)]
 mod test {
-    use chrono::prelude::*;
     use mz_repr::PropDatum;
     use proptest::prelude::*;
 

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -388,7 +388,7 @@ impl<'de> Deserialize<'de> for CpuLimit {
         // Note -- we just round off any precision beyond 0.001 here.
         let float = f64::deserialize(deserializer)?;
         let millicpus = (float * 1000.).round();
-        if millicpus < 0. || millicpus > (std::usize::MAX as f64) {
+        if millicpus < 0. || millicpus > (usize::MAX as f64) {
             use serde::de::Error;
             Err(D::Error::invalid_value(
                 Unexpected::Float(float),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -9538,7 +9538,7 @@ impl<'a> Parser<'a> {
             let err = parser_err!(
                 self,
                 self.peek_prev_pos(),
-                format!("WITH HOLD is unsupported for cursors")
+                "WITH HOLD is unsupported for cursors"
             )
             .map_parser_err(StatementKind::Declare);
             self.expect_keyword(HOLD)
@@ -10254,7 +10254,7 @@ impl<'a> Parser<'a> {
             return parser_err!(
                 self,
                 self.peek_prev_pos(),
-                format!("For object type MATERIALIZED VIEWS, you must specify 'TABLES'")
+                "For object type MATERIALIZED VIEWS, you must specify 'TABLES'"
             );
         }
 
@@ -10297,7 +10297,7 @@ impl<'a> Parser<'a> {
             return parser_err!(
                 self,
                 self.peek_prev_pos(),
-                format!("For object type MATERIALIZED VIEWS, you must specify 'TABLES'")
+                "For object type MATERIALIZED VIEWS, you must specify 'TABLES'"
             );
         }
 

--- a/src/timely-util/src/columnar/merge_batcher.rs
+++ b/src/timely-util/src/columnar/merge_batcher.rs
@@ -667,7 +667,6 @@ mod tests {
     use std::sync::Arc;
 
     use columnar::Index;
-    use timely::container::PushInto as _;
 
     use super::*;
     use crate::column_pager::{PageDecision, PageEvent, PageHint, PagingPolicy};


### PR DESCRIPTION
CI derives its toolchain from the `rust-version` field in the root `Cargo.toml`, which pins 1.97.1. Warnings that newer toolchains introduce therefore go unreported until someone builds locally. This change clears everything that Rust 1.98 reports, plus the deprecations that the current nightly adds on top.

Rust 1.98 extends `clippy::extra_unused_lifetimes` to higher-ranked binders in where-clauses, which flags three `for<'a>` binders whose lifetime never appears in the bound they introduce. Removing the binder leaves the bounds unchanged, because the parenthesized `Fn` sugar already introduces a fresh lifetime for each elided reference. The same toolchain also reports two unused imports and three `clippy::useless_format` calls. `parser_err!` calls `to_string` on a single-expression argument, so passing the literal directly still produces an owned `String`.

Nightly additionally deprecates the legacy numeric constants and constructors. `max_value` and `min_value` become the `MAX` and `MIN` associated constants, and `std::usize::MAX` becomes `usize::MAX`. Dropping the `use std::i64` import in the Avro decoder is what silences the two warnings on `i64::MAX` and `i64::MIN`, because that import made the path resolve to the deprecated module instead of the primitive type.

Two groups of nightly warnings are left alone. The `fetch_update` to `try_update` rename is too recent to use while CI builds with 1.97.1, and the `overflow evaluating the requirement` notices come from the new trait solver hitting its recursion limit rather than from a defect in this code.

Note that this change does not close the gap that hid these warnings. CI keeps building with 1.97.1, so the next lint a newer toolchain adds will go unreported the same way. Bumping `rust-version` rebuilds the CI builder image and raises the declared minimum supported version, which belongs in its own change.

### Release notes

No user-visible changes.

🤖 Posted by [Claude Code](https://claude.com/claude-code)