### PR TITLE
adapter: distinguish OCC retry metric callers

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -1500,15 +1500,20 @@ metrics:
 - name: mz_occ_read_then_write_retry_count_bucket
   help: Number of OCC retries per read-then-write operation.
   labels:
+  - caller
   - le
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_occ_read_then_write_retry_count_count
   help: Number of OCC retries per read-then-write operation.
+  labels:
+  - caller
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_occ_read_then_write_retry_count_sum
   help: Number of OCC retries per read-then-write operation.
+  labels:
+  - caller
   source: src/adapter/src/metrics.rs
   visibility: internal
 - name: mz_optimization_notices

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -163,6 +163,7 @@ use crate::coord::read_then_write::{DependencyPolicy, validate_read_then_write_d
 use crate::coord::timestamp_selection::TimestampProvider;
 use crate::coord::{Coordinator, TargetCluster};
 use crate::error::AdapterError;
+use crate::metrics::{OCC_CALLER_BACKGROUND, OCC_CALLER_SESSION};
 use crate::optimize::Optimize;
 use crate::optimize::dataflows::{ComputeInstanceSnapshot, EvalTime, ExprPrep, ExprPrepOneShot};
 use crate::peek_client::CoordinatorClient;
@@ -1068,9 +1069,14 @@ impl PeekClient {
             )
             .await;
 
+        let caller_label = match caller {
+            RtwCaller::Session => OCC_CALLER_SESSION,
+            RtwCaller::Background { .. } => OCC_CALLER_BACKGROUND,
+        };
         self.coordinator_client()
             .metrics()
             .occ_retry_count
+            .with_label_values(&[caller_label])
             .observe(f64::from(u32::try_from(retry_count).unwrap_or(u32::MAX)));
 
         // Finish the operation, including a blind write's submission, before

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -71,7 +71,7 @@ pub struct Metrics {
 
 impl Metrics {
     pub(crate) fn register_into(registry: &MetricsRegistry) -> Self {
-        let metrics = Self {
+        Self {
             query_total: registry.register(metric!(
                 name: "mz_query_total",
                 help: "The total number of queries issued of the given type since process start.",
@@ -323,11 +323,7 @@ impl Metrics {
                     0., 1., 2., 3., 5., 10., 25., 50., 100., 200., 300., 500., 750., 1000.,
                 ],
             )),
-        };
-        for caller in [OCC_CALLER_SESSION, OCC_CALLER_BACKGROUND] {
-            let _ = metrics.occ_retry_count.with_label_values(&[caller]);
         }
-        metrics
     }
 
     pub(crate) fn row_set_finishing_seconds(&self) -> Histogram {

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -16,6 +16,9 @@ use mz_sql_parser::ast::statement_kind_label_value;
 use prometheus::core::{AtomicU64, GenericCounter};
 use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec};
 
+pub(crate) const OCC_CALLER_SESSION: &str = "session";
+pub(crate) const OCC_CALLER_BACKGROUND: &str = "background";
+
 #[derive(Debug, Clone)]
 pub struct Metrics {
     pub query_total: IntCounterVec,
@@ -63,12 +66,12 @@ pub struct Metrics {
     pub catalog_transact_phase_seconds: HistogramVec,
     pub apply_catalog_implications_seconds: Histogram,
     pub group_commit_catalog_upper_seconds: Histogram,
-    pub occ_retry_count: Histogram,
+    pub occ_retry_count: HistogramVec,
 }
 
 impl Metrics {
     pub(crate) fn register_into(registry: &MetricsRegistry) -> Self {
-        Self {
+        let metrics = Self {
             query_total: registry.register(metric!(
                 name: "mz_query_total",
                 help: "The total number of queries issued of the given type since process start.",
@@ -315,11 +318,16 @@ impl Metrics {
             occ_retry_count: registry.register(metric!(
                 name: "mz_occ_read_then_write_retry_count",
                 help: "Number of OCC retries per read-then-write operation.",
+                var_labels: ["caller"],
                 buckets: vec![
                     0., 1., 2., 3., 5., 10., 25., 50., 100., 200., 300., 500., 750., 1000.,
                 ],
             )),
+        };
+        for caller in [OCC_CALLER_SESSION, OCC_CALLER_BACKGROUND] {
+            let _ = metrics.occ_retry_count.with_label_values(&[caller]);
         }
+        metrics
     }
 
     pub(crate) fn row_set_finishing_seconds(&self) -> Histogram {

--- a/src/environmentd/tests/read_then_write.rs
+++ b/src/environmentd/tests/read_then_write.rs
@@ -27,6 +27,7 @@ use mz_environmentd::test_util;
 use mz_ore::assert_contains;
 use mz_ore::error::ErrorExt;
 use mz_ore::retry::Retry;
+use prometheus::proto::{Histogram, MetricFamily};
 use tokio_postgres::error::SqlState;
 
 /// A harness with frontend OCC read-then-write enabled and nothing else.
@@ -48,6 +49,23 @@ fn server_error_message(err: &postgres::Error) -> String {
         Some(db_error) => db_error.message().to_string(),
         None => err.to_string(),
     }
+}
+
+fn session_occ_retry_histogram(metrics: &[MetricFamily]) -> &Histogram {
+    metrics
+        .iter()
+        .find(|family| family.name() == "mz_occ_read_then_write_retry_count")
+        .expect("mz_occ_read_then_write_retry_count metric should be registered")
+        .get_metric()
+        .iter()
+        .find(|metric| {
+            metric
+                .get_label()
+                .iter()
+                .any(|label| label.name() == "caller" && label.value() == "session")
+        })
+        .expect("session OCC retry histogram should be registered")
+        .get_histogram()
 }
 
 // `mz_query_total` feeds product telemetry, and DML the session task sequences
@@ -440,13 +458,7 @@ fn test_concurrent_updates_retry() {
     // contention essentially guarantees at least one observation lands above
     // the 0-retry bucket, so we assert that too.
     let metrics = server.metrics_registry().gather();
-    let retry_metric = metrics
-        .iter()
-        .find(|m| m.name() == "mz_occ_read_then_write_retry_count")
-        .expect("mz_occ_read_then_write_retry_count metric should be registered");
-    let metric = retry_metric.get_metric();
-    assert_eq!(metric.len(), 1, "expected a single histogram series");
-    let histogram = metric[0].get_histogram();
+    let histogram = session_occ_retry_histogram(&metrics);
 
     let total_updates = u64::try_from(NUM_WORKERS * UPDATES_PER_WORKER).unwrap();
     assert!(
@@ -574,13 +586,7 @@ fn test_concurrent_delete_does_not_over_delete() {
     // rows at once, at least one attempt must have found its read timestamp
     // passed and retried against fresh state.
     let metrics = server.metrics_registry().gather();
-    let retry_metric = metrics
-        .iter()
-        .find(|m| m.name() == "mz_occ_read_then_write_retry_count")
-        .expect("mz_occ_read_then_write_retry_count metric should be registered");
-    let metric = retry_metric.get_metric();
-    assert_eq!(metric.len(), 1, "expected a single histogram series");
-    let histogram = metric[0].get_histogram();
+    let histogram = session_occ_retry_histogram(&metrics);
     let zero_retry_bucket = histogram
         .get_bucket()
         .iter()
@@ -2069,15 +2075,7 @@ fn test_replica_expiration_spares_folded_selections() {
     // reach the histogram if the frontend sequenced them, and the coordinator's
     // lock path does not read subscribe frontiers at all.
     let metrics = server.metrics_registry().gather();
-    let observations = metrics
-        .iter()
-        .find(|m| m.name() == "mz_occ_read_then_write_retry_count")
-        .expect("mz_occ_read_then_write_retry_count metric should be registered")
-        .get_metric()
-        .first()
-        .expect("a single histogram series")
-        .get_histogram()
-        .get_sample_count();
+    let observations = session_occ_retry_histogram(&metrics).get_sample_count();
     assert!(
         observations >= 2,
         "the OCC path sequenced {observations} statements, so the INSERT and the \

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4877,8 +4877,8 @@ def workflow_test_occ_zero_row_write_linearization(c: Composition) -> None:
     disarm = f"SET failpoints = '{failpoint}=off'"
 
     def occ_writes() -> tuple[int, int]:
-        """Read-then-writes the OCC path sequenced, and how many of their write
-        attempts lost the race for their write timestamp."""
+        """Session read-then-writes sequenced through OCC, and how many of their
+        write attempts lost the race for their write timestamp."""
         metric = "mz_occ_read_then_write_retry_count"
         metrics = c.exec(
             "materialized", "curl", "localhost:6878/metrics", capture=True
@@ -4887,9 +4887,12 @@ def workflow_test_occ_zero_row_write_linearization(c: Composition) -> None:
         for suffix in ["count", "sum"]:
             prefix = f'{metric}_{suffix}{{caller="session"}} '
             values[suffix] = next(
-                int(float(line.split()[1]))
-                for line in metrics.splitlines()
-                if line.startswith(prefix)
+                (
+                    int(float(line.split()[1]))
+                    for line in metrics.splitlines()
+                    if line.startswith(prefix)
+                ),
+                0,
             )
         return values["count"], values["sum"]
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -4883,12 +4883,15 @@ def workflow_test_occ_zero_row_write_linearization(c: Composition) -> None:
         metrics = c.exec(
             "materialized", "curl", "localhost:6878/metrics", capture=True
         ).stdout
-        values = {
-            line.split()[0]: int(float(line.split()[1]))
-            for line in metrics.splitlines()
-            if line.startswith((f"{metric}_count ", f"{metric}_sum "))
-        }
-        return values[f"{metric}_count"], values[f"{metric}_sum"]
+        values = {}
+        for suffix in ["count", "sum"]:
+            prefix = f'{metric}_{suffix}{{caller="session"}} '
+            values[suffix] = next(
+                int(float(line.split()[1]))
+                for line in metrics.splitlines()
+                if line.startswith(prefix)
+            )
+        return values["count"], values["sum"]
 
     def guard_rows(cur: Cursor, key: int) -> int:
         """Rows of `guard` for `key`, which is what the UPDATE's selection reads."""
@@ -5117,7 +5120,9 @@ def workflow_test_occ_sealed_input_write_stands_alone(c: Composition) -> None:
             "materialized", "curl", "localhost:6878/metrics", capture=True
         ).stdout
         assert any(
-            line.startswith("mz_occ_read_then_write_retry_count_count ")
+            line.startswith(
+                'mz_occ_read_then_write_retry_count_count{caller="session"} '
+            )
             and float(line.split()[1]) > 0
             for line in metrics.splitlines()
         ), "no read-then-write went through the OCC path"

--- a/test/txn-wal-fencing/mzcompose.py
+++ b/test/txn-wal-fencing/mzcompose.py
@@ -336,9 +336,7 @@ def occ_sequenced_writes(c: Composition, service: str) -> int:
     for line in metrics.splitlines():
         if line.startswith(f'{OCC_METRIC}{{caller="session"}} '):
             return int(float(line.split()[1]))
-    # The histogram is registered unconditionally, so a missing line means the
-    # scrape itself did not land.
-    raise RuntimeError(f"{OCC_METRIC} not found in {service} metrics")
+    return 0
 
 
 def increment_counter(args: tuple[Composition, str, bool]) -> Increment:

--- a/test/txn-wal-fencing/mzcompose.py
+++ b/test/txn-wal-fencing/mzcompose.py
@@ -104,8 +104,8 @@ SERVICES = [
 # different values.
 OCC_FLAG = "enable_adapter_frontend_occ_read_then_write"
 
-# Observed once per read-then-write that the OCC path sequenced, so the
-# histogram's sample count identifies which path a process took.
+# Observed once per read-then-write that the OCC path sequenced. The `session`
+# caller's sample count identifies which path a process used for user DML.
 OCC_METRIC = "mz_occ_read_then_write_retry_count_count"
 
 
@@ -329,12 +329,12 @@ class Increment(Enum):
 
 
 def occ_sequenced_writes(c: Composition, service: str) -> int:
-    """How many read-then-writes `service` has sequenced through the OCC path."""
+    """How many session read-then-writes `service` sequenced through OCC."""
     metrics = c.exec(
         service, "curl", "--silent", "localhost:6878/metrics", capture=True
     ).stdout
     for line in metrics.splitlines():
-        if line.startswith(f"{OCC_METRIC} "):
+        if line.startswith(f'{OCC_METRIC}{{caller="session"}} '):
             return int(float(line.split()[1]))
     # The histogram is registered unconditionally, so a missing line means the
     # scrape itself did not land.


### PR DESCRIPTION
## Motivation

Hydration-history maintenance uses the OCC read-then-write implementation regardless of the session rollout flag. Its observations therefore incremented the same unlabeled retry histogram as session DML.

The mixed-mode fencing workflow uses that histogram to verify whether user DML took the session OCC path or the coordinator lock path. A hydration-history sweep on an instance configured for the lock path could make the workflow report that the instance had sequenced OCC writes, causing [SQL-673](https://linear.app/materializeinc/issue/SQL-673).

## Description

Add a bounded `caller` label to `mz_occ_read_then_write_retry_count` with `session` and `background` values. The shared OCC implementation records every operation against its caller. Series are emitted on their first observation, and scrape-based test consumers interpret an absent selected series as zero.

Update repository consumers that reason about user DML routing to select `caller="session"`. This keeps background retry observations available without letting maintenance work affect those assertions.

Closes: [SQL-673](https://linear.app/materializeinc/issue/SQL-673)

## Verification

Updated the existing Rust metric assertions and mzcompose metric consumers for the labeled series. CI provides runtime verification.
