### PR TITLE
sql: accept WITH (WAIT ...) on ALTER CLUSTER unconditionally

### DIFF
--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -177,10 +177,6 @@ by default), Materialize rolls back the resize and the cluster keeps its current
 size. To customize the timeout behavior, use the `WAIT UNTIL READY` or `WAIT FOR` options.
 The resize still proceeds in the background.
 
-{{< private-preview >}}
-Customizing the resize timeout with `WAIT UNTIL READY` or `WAIT FOR`
-{{< /private-preview >}}
-
 - `WAIT UNTIL READY (TIMEOUT = ..., ON TIMEOUT = ...)` sets the timeout for the
   resize. On timeout, `ON TIMEOUT` selects whether to `COMMIT` (retire the old
   replicas and proceed with the not-yet-hydrated new ones, which can cause
@@ -227,7 +223,6 @@ current size. Materialize drops the pending replicas and keeps the current
 configuration.
 
 #### Downtime considerations for v26.34 or before
-{{< private-preview />}}
 
 You can use the `WAIT UNTIL READY` option to perform a zero-downtime resizing,
 which incurs **no downtime**. Instead of restarting the cluster, this approach

--- a/doc/user/data/examples/alter_cluster.yml
+++ b/doc/user/data/examples/alter_cluster.yml
@@ -96,8 +96,8 @@
         The following `<with_option>`s are supported:
         | Option  | Description |
         |--------|-------------|
-        | `WAIT UNTIL READY(...)`    | ***Private preview.** This option has known performance or stability issues and is under active development.* {{< include-from-yaml data="examples/alter_cluster" name="wait-until-ready-cmd-option" >}} |
-        | `WAIT FOR` |  ***Private preview.** This option has known performance or stability issues and is under active development.* Equivalent to `WAIT UNTIL READY` with `ON TIMEOUT = 'ROLLBACK'`. Materialize cuts over once the new replicas hydrate. When Materialize processes an expired timeout, it rolls back the resize and keeps the current size if the target replicas are still unhydrated.|
+        | `WAIT UNTIL READY(...)`    | {{< include-from-yaml data="examples/alter_cluster" name="wait-until-ready-cmd-option" >}} |
+        | `WAIT FOR` | Equivalent to `WAIT UNTIL READY` with `ON TIMEOUT = 'ROLLBACK'`. Materialize cuts over once the new replicas hydrate. When Materialize processes an expired timeout, it rolls back the resize and keeps the current size if the target replicas are still unhydrated.|
 
 - name: "syntax-reset-to-default"
   code: |

--- a/misc/python/materialize/checks/all_checks/cluster.py
+++ b/misc/python/materialize/checks/all_checks/cluster.py
@@ -152,9 +152,6 @@ class AlterClusterGracefulReconfiguration(Check):
 
     def initialize(self) -> Testdrive:
         return Testdrive(dedent("""
-            $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}
-            ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true
-
             $ postgres-execute connection=postgres://postgres:postgres@postgres
             CREATE USER graceful_reconfig WITH SUPERUSER PASSWORD 'postgres';
             ALTER USER graceful_reconfig WITH replication;

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -167,6 +167,14 @@ def get_minimal_system_parameters(
             "true" if version >= MzVersion.parse_mz("v26.29.0-dev") else "false"
         )
 
+    # The `WITH (WAIT ...)` graceful-reconfiguration surface. Always accepted
+    # from v26.41 on. Older binaries still gate it behind this feature flag, so
+    # pin it on for them: the tests that use the surface no longer enable it
+    # themselves, and in a mixed-version run some of their phases execute
+    # against the old binary.
+    if version < MzVersion.parse_mz("v26.41.0-dev"):
+        config["enable_zero_downtime_cluster_reconfiguration"] = "true"
+
     return config
 
 

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -168,10 +168,6 @@ def run(
         system_exe.execute("ALTER SYSTEM SET max_sql_server_connections = 1000000")
         system_exe.execute("ALTER SYSTEM SET max_kafka_connections = 1000000")
         system_exe.execute("ALTER SYSTEM SET idle_in_transaction_session_timeout = 0")
-        # Gates the WITH (WAIT ...) clause used by ReconfigureClusterAction.
-        system_exe.execute(
-            "ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true"
-        )
         # Most queries should not fail because of privileges
         for object_type in [
             "TABLES",

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -6736,15 +6736,6 @@ pub fn plan_alter_cluster(
                         );
                     }
 
-                    match alter_strategy {
-                        AlterClusterPlanStrategy::None => {}
-                        _ => {
-                            scx.require_feature_flag(
-                                &crate::session::vars::ENABLE_ZERO_DOWNTIME_CLUSTER_RECONFIGURATION,
-                            )?;
-                        }
-                    }
-
                     if replica_defs.is_some() {
                         sql_bail!("REPLICAS not supported for managed clusters");
                     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2254,12 +2254,6 @@ feature_flags!(
         enable_for_item_parsing: false,
     },
     {
-        name: enable_zero_downtime_cluster_reconfiguration,
-        desc: "Enable zero-downtime reconfiguration for alter cluster",
-        default: false,
-        enable_for_item_parsing: false,
-    },
-    {
         name: enable_network_policies,
         desc: "ENABLE NETWORK POLICIES",
         default: true,

--- a/test/cloudtest/test_managed_cluster.py
+++ b/test/cloudtest/test_managed_cluster.py
@@ -146,7 +146,6 @@ def test_zero_downtime_reconfiguration(mz: MaterializeApplication) -> None:
     # within the short poll loops below.
     mz.environmentd.sql(
         """
-        ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
         ALTER SYSTEM SET cluster_controller_tick_interval = '5ms';
         """,
         port="internal",

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -6318,7 +6318,6 @@ def workflow_test_zero_downtime_reconfigure(
             key${kafka-ingest.iteration}:value${kafka-ingest.iteration}
 
             $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-            ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
             CREATE CLUSTER cluster1 ( SIZE = 'scale=1,workers=1');
             GRANT ALL ON CLUSTER cluster1 TO materialize;
 
@@ -6435,13 +6434,6 @@ def workflow_test_zero_downtime_reconfigure(
             > SELECT count(*) FROM kafka_tbl
             1000
             """))
-        c.sql(
-            """
-            ALTER SYSTEM RESET enable_zero_downtime_cluster_reconfiguration;
-            """,
-            port=6877,
-            user="mz_system",
-        )
 
 
 def workflow_test_pending_replica_audit_events(
@@ -6457,11 +6449,10 @@ def workflow_test_pending_replica_audit_events(
     """
     c.up("materialized")
 
-    # Enable the WAIT surface and drive the controller tick down so the (empty)
-    # cluster's reconfiguration converges quickly.
+    # Drive the controller tick down so the (empty) cluster's reconfiguration
+    # converges quickly.
     c.sql(
         """
-        ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
         ALTER SYSTEM SET cluster_controller_tick_interval = '5ms';
         CREATE CLUSTER test_audit (SIZE = 'scale=1,workers=1');
         GRANT ALL ON CLUSTER test_audit TO materialize;
@@ -6556,7 +6547,6 @@ def workflow_test_pending_replica_audit_events(
     c.sql(
         """
         DROP CLUSTER test_audit CASCADE;
-        ALTER SYSTEM RESET enable_zero_downtime_cluster_reconfiguration;
         """,
         port=6877,
         user="mz_system",

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -480,6 +480,7 @@ KNOWN_STALE_LD_FLAGS: set[str] = set("""
     enable_repr_typecheck
     enable_unified_cluster_arrangment
     enable_yugabyte_connection
+    enable_zero_downtime_cluster_reconfiguration
     kafka_default_metadata_fetch_interval
     mysql_offset_known_interval
     persist_enable_arrow_lgalloc_noncc_sizes
@@ -516,7 +517,6 @@ INTENTIONAL_LD_OVERRIDES: set[str] = {
     "enable_lgalloc",
     "enable_timely_zero_copy_lgalloc",
     "enable_upsert_paged_spill",
-    "enable_zero_downtime_cluster_reconfiguration",
     "kafka_client_id_enrichment_rules",
     "kafka_progress_record_fetch_timeout",
     "kafka_socket_timeout",

--- a/test/pg-cdc/cluster-graceful-reconfiguration.td
+++ b/test/pg-cdc/cluster-graceful-reconfiguration.td
@@ -16,12 +16,6 @@
 # new replica until cut-over drops the old one. Readiness must therefore not
 # wait for the source to hydrate on the target, but must still wait for the
 # target's processes to come online before cutting over.
-#
-# The background flag is pinned explicitly so the test does not depend on the
-# harness defaults.
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true
 
 > CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -309,11 +309,6 @@ CREATE CLUSTER foo SIZE invalid_size, REPLICATION FACTOR 0
 statement error creating cluster replica would violate max_replicas_per_cluster limit \(desired: 9999999, limit: 5, current: 0\)
 CREATE CLUSTER foo SIZE 'scale=1,workers=1', replication factor 9999999;
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true;
-----
-COMPLETE 0
-
 statement ok
 CREATE CLUSTER foo (SIZE 'scale=1,workers=1')
 

--- a/test/testdrive/cluster-controller.td
+++ b/test/testdrive/cluster-controller.td
@@ -24,11 +24,9 @@ $ set-sql-timeout duration=120s
 
 # Drive the tick interval down so the controller ticks ~hundreds of times across
 # the waits below. It is re-read each tick, so the flip takes effect without a
-# restart. The graceful cases use the WITH (WAIT ...) surface, whose planner
-# acceptance is gated on enable_zero_downtime.
+# restart.
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET cluster_controller_tick_interval = '5ms'
-ALTER SYSTEM SET enable_zero_downtime_cluster_reconfiguration = true
 
 # ----- Baseline reconcile is a no-op -----
 #
@@ -1432,7 +1430,6 @@ scale=1,workers=2 0
 # Restore pristine server state (including the tick-interval override).
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM RESET cluster_controller_tick_interval
-ALTER SYSTEM RESET enable_zero_downtime_cluster_reconfiguration
 ALTER SYSTEM RESET enable_background_alter_cluster
 ALTER SYSTEM RESET enable_auto_scaling_strategy
 ALTER SYSTEM RESET enable_hydration_burst


### PR DESCRIPTION
### Motivation

The `WAIT FOR` and `WAIT UNTIL READY` options on `ALTER CLUSTER` are still gated by `enable_zero_downtime_cluster_reconfiguration` and documented as private preview. Graceful reconfiguration is now the standard path for managed cluster shape changes, so the gate only controls whether users can customize its deadline and timeout behavior.

### Description

Accept `ALTER CLUSTER ... WITH (WAIT ...)` unconditionally and remove the feature flag. The existing validation remains in place for `WAIT` on unmanaged clusters and for `WAIT` without a replica shape change.

Remove the private-preview labels from the `ALTER CLUSTER` documentation and remove explicit flag setup from tests and workloads. LaunchDarkly may retain the removed flag temporarily, so the consistency test marks it as stale.

Mixed-version tests can execute `WAIT` statements against older binaries that still enforce the gate. `get_minimal_system_parameters` therefore pins the flag on for binaries before v26.41.

### Verification

Existing sqllogictest, testdrive, cloudtest, platform-check, parallel-workload, and cluster mzcompose coverage now exercises the syntax without enabling the feature flag. The mixed-version system-parameter boundary is covered by the shared mzcompose configuration.
