### PR TITLE
adapter: validate BILLED AS against the replica size map

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -118,7 +118,7 @@ use mz_compute_types::ComputeInstanceId;
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::LirRelationExpr;
 use mz_controller::clusters::{
-    ClusterConfig, ClusterEvent, ClusterStatus, ProcessId, ReplicaLocation,
+    ClusterConfig, ClusterEvent, ClusterStatus, ManagedReplicaLocation, ProcessId, ReplicaLocation,
 };
 use mz_controller::{ControllerConfig, Readiness};
 use mz_controller_types::{ClusterId, ReplicaId, WatchSetId};
@@ -4849,18 +4849,31 @@ impl Coordinator {
             .user_cluster_replicas()
             .filter(|replica| Some(replica.cluster_id) != exclude_cluster)
             .filter_map(|replica| match &replica.config.location {
-                ReplicaLocation::Managed(location) => Some(location.size_for_billing()),
+                ReplicaLocation::Managed(location) => Some(self.replica_credits_per_hour(location)),
                 ReplicaLocation::Unmanaged(_) => None,
             })
-            .map(|size| {
-                self.catalog()
-                    .cluster_replica_sizes()
-                    .0
-                    .get(size)
-                    .expect("location size is validated against the cluster replica sizes")
-                    .credits_per_hour
-            })
             .sum()
+    }
+
+    /// The credit rate of a managed replica, read from the size map by its billing size.
+    ///
+    /// An unknown billing size counts as free. DDL validates `SIZE` and `BILLED AS` against
+    /// the map at replica creation, but the map is external configuration and can lose a
+    /// size later. That case is a soft panic rather than a hard one, so that in production
+    /// such a replica can still be dropped from SQL.
+    fn replica_credits_per_hour(&self, location: &ManagedReplicaLocation) -> Numeric {
+        let size = location.size_for_billing();
+        match self.catalog().cluster_replica_sizes().0.get(size) {
+            Some(allocation) => allocation.credits_per_hour,
+            None => {
+                soft_panic_or_log!(
+                    "replica of size {:?} bills as unknown replica size {:?}, counting it as free",
+                    location.size,
+                    size,
+                );
+                Numeric::zero()
+            }
+        }
     }
 }
 

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1277,15 +1277,7 @@ impl Coordinator {
                     if cluster_id.is_user() {
                         *new_replicas_per_cluster.entry(*cluster_id).or_insert(0) += 1;
                         if let ReplicaLocation::Managed(location) = &config.location {
-                            let replica_allocation = self
-                                .catalog()
-                                .cluster_replica_sizes()
-                                .0
-                                .get(location.size_for_billing())
-                                .expect(
-                                    "location size is validated against the cluster replica sizes",
-                                );
-                            new_credit_consumption_rate += replica_allocation.credits_per_hour
+                            new_credit_consumption_rate += self.replica_credits_per_hour(location);
                         }
                     }
                 }
@@ -1348,16 +1340,8 @@ impl Coordinator {
                                     if let ReplicaLocation::Managed(location) =
                                         &cluster.config.location
                                     {
-                                        let replica_allocation = self
-                                            .catalog()
-                                            .cluster_replica_sizes()
-                                            .0
-                                            .get(location.size_for_billing())
-                                            .expect(
-                                                "location size is validated against the cluster replica sizes",
-                                            );
                                         new_credit_consumption_rate -=
-                                            replica_allocation.credits_per_hour
+                                            self.replica_credits_per_hour(location);
                                     }
                                 }
                             }

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -1599,6 +1599,11 @@ impl Coordinator {
                     if billed_as.is_some() && !internal {
                         coord_bail!("must specify INTERNAL when specifying BILLED AS");
                     }
+                    // Concretizing the location validates `SIZE` only, see
+                    // `ensure_valid_billed_as_size`.
+                    if let Some(billed_as) = &billed_as {
+                        self.ensure_valid_billed_as_size(billed_as)?;
+                    }
 
                     let location = mz_catalog::durable::ReplicaLocation::Managed {
                         // The user-pinned `AVAILABILITY ZONE`, if any, as a zero-
@@ -1777,6 +1782,20 @@ impl Coordinator {
         }
     }
 
+    /// Rejects a `BILLED AS` size that is not in the replica size map.
+    ///
+    /// Billing only reads the size's credit rate, so unlike `SIZE` the value
+    /// may be a disabled size and need not be in the role's allowed sizes.
+    /// The check lives here rather than in `concretize_replica_location`,
+    /// which catalog open also runs for every durable replica.
+    fn ensure_valid_billed_as_size(&self, size: &str) -> Result<(), AdapterError> {
+        if self.catalog().cluster_replica_sizes().0.contains_key(size) {
+            Ok(())
+        } else {
+            coord_bail!("unknown cluster replica size {size} in BILLED AS")
+        }
+    }
+
     #[mz_ore::instrument(level = "debug")]
     pub(crate) async fn sequence_create_cluster_replica(
         &mut self,
@@ -1874,6 +1893,11 @@ impl Coordinator {
             // BILLED AS implies the INTERNAL flag.
             if billed_as.is_some() && !*internal {
                 coord_bail!("must specify INTERNAL when specifying BILLED AS");
+            }
+            // Concretizing the location validated `SIZE` only, see
+            // `ensure_valid_billed_as_size`.
+            if let Some(billed_as) = billed_as {
+                self.ensure_valid_billed_as_size(billed_as)?;
             }
         }
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -38,7 +38,7 @@ from psycopg.errors import (
 )
 
 from materialize import buildkite, ui
-from materialize.mzcompose import sanitizer_enabled
+from materialize.mzcompose import cluster_replica_size_map, sanitizer_enabled
 from materialize.mzcompose.composition import (
     Composition,
     Service,
@@ -1293,6 +1293,77 @@ def workflow_test_notice_drop_restart(c: Composition) -> None:
         assert (
             notice_count() == 0
         ), "expected the notice to be retracted after DROP SCHEMA ... CASCADE"
+
+
+def workflow_test_billed_as_size_removed(c: Composition) -> None:
+    """
+    A replica whose BILLED AS size later disappears from the replica size
+    map must still be droppable, and other cluster DDL must keep working
+    (SQL-658). The size map is process configuration, so the removal is a
+    restart with a smaller map. Soft assertions are off for the restarted
+    process: the tolerant credit lookup soft-panics on the stale size by
+    design, and the production behavior is what is under test.
+    """
+    c.up("materialized")
+
+    c.sql(
+        """
+        CREATE CLUSTER billed_as_test SIZE 'scale=1,workers=1', REPLICATION FACTOR 0;
+        CREATE CLUSTER REPLICA billed_as_test.unbilled
+            SIZE 'scale=1,workers=1', INTERNAL, BILLED AS 'scale=2,workers=4';
+        """,
+        port=6877,
+        user="mz_system",
+    )
+
+    sizes = cluster_replica_size_map()
+    del sizes["scale=2,workers=4"]
+    with c.override(
+        Materialized(
+            propagate_crashes=False,
+            external_metadata_store=True,
+            additional_system_parameter_defaults={
+                "unsafe_enable_unsafe_functions": "true",
+                "unsafe_enable_unorchestrated_cluster_replicas": "true",
+            },
+            support_external_clusterd=True,
+            cluster_replica_size=sizes,
+            soft_assertions=False,
+        )
+    ):
+        c.kill("materialized")
+        c.up("materialized")
+
+        rows = c.sql_query("""
+            SELECT r.name, r.size
+            FROM mz_cluster_replicas r
+            JOIN mz_clusters cl ON r.cluster_id = cl.id
+            WHERE cl.name = 'billed_as_test'
+            """)
+        assert len(rows) == 1 and tuple(rows[0]) == (
+            "unbilled",
+            "scale=1,workers=1",
+        ), rows
+
+        # Every cluster DDL sums the credit rate of all existing replicas,
+        # including the one with the stale billing size.
+        c.sql(
+            """
+            CREATE CLUSTER billed_as_other SIZE 'scale=1,workers=1';
+            DROP CLUSTER REPLICA billed_as_test.unbilled;
+            CREATE CLUSTER REPLICA billed_as_test.unbilled2 SIZE 'scale=1,workers=1', INTERNAL;
+            DROP CLUSTER billed_as_other;
+            """,
+            port=6877,
+            user="mz_system",
+        )
+        rows = c.sql_query("""
+            SELECT r.name
+            FROM mz_cluster_replicas r
+            JOIN mz_clusters cl ON r.cluster_id = cl.id
+            WHERE cl.name = 'billed_as_test'
+            """)
+        assert [tuple(r) for r in rows] == [("unbilled2",)], rows
 
 
 def workflow_test_upsert(c: Composition) -> None:

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -1194,3 +1194,24 @@ DROP CLUSTER inem
 
 statement ok
 DROP CLUSTER iner
+
+# BILLED AS must name a configured size; an unknown one is an error rather
+# than a coordinator panic. A disabled size is accepted, which the
+# `t1.free` case above covers. These sit at the end of the file because a
+# failing CREATE CLUSTER still consumes a cluster id, which would shift the
+# hardcoded ids in the queries above.
+statement ok
+CREATE CLUSTER billed (SIZE 'scale=1,workers=1', REPLICATION FACTOR 0)
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA billed.typo SIZE 'scale=1,workers=1', INTERNAL, BILLED AS 'no-such-size'
+----
+db error: ERROR: unknown cluster replica size no-such-size in BILLED AS
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER typo REPLICAS (r1 (SIZE 'scale=1,workers=1', INTERNAL, BILLED AS 'no-such-size'))
+----
+db error: ERROR: unknown cluster replica size no-such-size in BILLED AS
+
+statement ok
+DROP CLUSTER billed


### PR DESCRIPTION
Creating an internal replica with a `BILLED AS` value that is not a configured replica size crashed environmentd instead of returning an error ([SQL-658](https://linear.app/materializeinc/issue/SQL-658)). This hit a production environment in [#incident-db-1257](https://materializeinc.slack.com/archives/C0BVC55TUDN): three coordinator panics from one statement retried twice, about twelve minutes of environmentd downtime across three restarts.

**Cause**
- `BILLED AS` was not validated when the replica location is concretized, only `SIZE` was validated.
- The credit-consumption check reads the size map by the billing size with an `expect`, so an unknown `BILLED AS` panicked the coordinator thread.

**Validation, `src/adapter/src/coord/sequencer/inner/cluster.rs`**
- `Coordinator::ensure_valid_billed_as_size` checks the value against the size map. In contrast to `SIZE`, this accepts disabled sizes and ignores the role's allowed sizes, since billing only reads the credit rate.
- Both DDL entry points call it: `CREATE CLUSTER REPLICA` and `CREATE CLUSTER ... REPLICAS (...)`. The statement now fails with `unknown cluster replica size <size> in BILLED AS`.
- It is deliberately not in `concretize_replica_location`, which catalog open also runs for every durable replica and `expect`s to succeed. A check there would turn a `BILLED AS` size removed from the map after the replica exists into a startup panic, whereas at DDL time the statement can simply fail.

**Tolerant credit lookups, `src/adapter/src/coord.rs` and `coord/ddl.rs`**
- The three lookups by billing size (replica create, replica drop, and the sum over all existing replicas) share `Coordinator::replica_credits_per_hour`, which counts a replica whose billing size has since left the map as free and raises `soft_panic_or_log!`.
- The sum over existing replicas only sees non-internal replicas, whose `SIZE` is validated at catalog open, so a stale billing size only reaches the drop site. Dropping such a replica used to panic the coordinator.

**Tests**
- `test/sqllogictest/cluster.slt`: `CREATE CLUSTER REPLICA` and `CREATE CLUSTER ... REPLICAS` with an unknown `BILLED AS` now expect the error. The existing `BILLED AS 'free'` case, a disabled size in the test map, keeps passing.
- `test/cluster/mzcompose.py`, workflow `test-billed-as-size-removed`: creates an internal `BILLED AS` replica, restarts environmentd with that size removed from the map and soft assertions off, then drops the replica and runs further cluster DDL.

**How this was verified**
- The cluster workflow fails on the v26.39.0 release image with the drop-site coordinator panic, and passes on this branch's CI image with the fallback logged once.

Closes: [SQL-658](https://linear.app/materializeinc/issue/SQL-658)
Closes: [CPU-236](https://linear.app/materializeinc/issue/CPU-236)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



