### PR TITLE
console: fix stale catalog data across region switches

### DIFF
--- a/console/AGENTS.md
+++ b/console/AGENTS.md
@@ -77,7 +77,12 @@ Use `~/` for imports from src: `import { foo } from "~/api/materialize"`
 ### State Management
 
 - **Jotai** for global state (sparingly used - prefer component state)
-- **React Query** for server state
+- **React Query** for polled/one-shot server state (`useSql` hooks)
+- **Sync engine** for live catalog data: SUBSCRIBE-fed sessions reduce into
+  jotai atoms and TanStack DB collections (`useLiveQuery` consumers, scoped
+  instant-load cache). See `doc/design/20260902_sync_engine.md`. Wiring between
+  the engine's singletons belongs in session objects on the jotai store
+  (`store.sub`), not in React effects.
 - **Kysely** as query builder (NOT as database driver) for type-safe SQL against Materialize system catalog
 
 ### Stacks

--- a/console/doc/architecture.md
+++ b/console/doc/architecture.md
@@ -69,3 +69,11 @@ state is stored in components with the useState hook. Storing state globally
 can be tricky to get right, in particular when it comes to invalidating /
 cleaning up the state. With component state, we get that behavior for free
 because the component gets unmounted.
+
+Server state is split by shape. Request/response data (polled telemetry,
+one-shot queries, mutations) goes through React Query and the `useSql` hooks.
+Live catalog data goes through the sync engine: app-session `SUBSCRIBE`s feed
+subscribe sessions, which reduce into jotai atoms and TanStack DB collections,
+with a per-tenant localStorage cache for instant load. See
+[the sync engine design doc](design/20260902_sync_engine.md) for the full
+architecture and adoption recipes.

--- a/console/doc/design/20260902_sync_engine.md
+++ b/console/doc/design/20260902_sync_engine.md
@@ -91,11 +91,13 @@ unmount. Three kinds exist:
   changes, so no page serves another region's catalog.
 - `createCollectionSubscribeSession`: owns a socket, feeds a collection.
   Additionally holds a keep-alive subscriber so the collection is not garbage
-  collected while no component queries it, and hydrates the collection from
-  its scoped cache via the scope atom.
+  collected while no component queries it, clears the collection synchronously
+  on a region change, and hydrates it from its scoped cache via the scope atom.
 - `createAtomFedCollectionSession`: no socket. Bridges an already running
   subscribe atom into a collection, adding no upstream load, plus the same
-  scoped hydration. Region behavior comes from the source atom's own session.
+  region clear and scoped hydration. (The source atom's own reset reaches the
+  bridge as an empty pre-snapshot, which applySnapshot ignores, so the
+  collection must clear itself.)
 
 ```
                      +--------------------------------------+
@@ -128,6 +130,8 @@ The bridge also owns the instant-load cache:
   rows load into the collection and the loading gate opens immediately. A
   cached snapshot counts as complete for gating; the live snapshot replaces it
   when it arrives. Other scopes' cache entries are pruned on hydrate.
+- **Fail closed.** A scope resolution that errors suspends persistence
+  entirely rather than leaving writes aimed at the previous scope's key.
 - **Scope changes.** Re-hydrating under a new scope drops the in-memory rows
   and any pending persist first, so one tenant's rows are never shown as, or
   written under, another tenant's cache.

--- a/console/doc/design/20260902_sync_engine.md
+++ b/console/doc/design/20260902_sync_engine.md
@@ -1,0 +1,286 @@
+# The sync engine
+
+- Associated: MaterializeInc/materialize#38231, MaterializeInc/materialize#38631
+
+## Overview
+
+The console keeps a live, client-side replica of parts of the Materialize
+catalog. The sync engine is the stack that maintains that replica: a
+Materialize `SUBSCRIBE` feeds a reduction layer, plain session objects manage
+lifecycle, and the results land in one of two stores that pages read from. The
+newer of the two stores is TanStack DB, which adds incrementally maintained
+live queries and a per-tenant instant-load cache on top of the same feed.
+
+Pages never see the plumbing. They read a jotai atom or run a `useLiveQuery`
+against a collection, and the data is simply there, current, across
+reconnects and region switches.
+
+```
+   Materialize
+   SUBSCRIBE ... WITH (PROGRESS) ENVELOPE UPSERT        (one per data set)
+        |
+        v  WebSocket diff stream
+   SubscribeManager           folds diffs into the current row set,
+        |                     emits one snapshot per closed timestamp
+        v
+   subscribe session          plain object: lifecycle, region reset,
+        |                     cache hydration, sink writes
+        v
+   +----+---------------------------+
+   |                                |
+   v                                v
+ jotai atom                  TanStack DB collection <---> localStorage cache
+ (SubscribeState)            (rows diffed in)             (scoped, instant load)
+   |                                |
+   v                                v
+ useAtomValue                 useLiveQuery
+ consumers                    consumers (incremental)
+```
+
+## Why two stores
+
+The jotai atoms (`allObjects`, `allSchemas`, `allClusters`, `allRoles`) hold
+each data set as one array plus status. They are simple and fine for consumers
+that render the whole set or run a cheap filter.
+
+TanStack DB collections hold the same rows keyed, with a live-query engine on
+top. A collection is the right store when a surface needs any of:
+
+- **Incremental recomputation.** A live query (filters, joins, lookups)
+  recomputes from row deltas instead of re-scanning the full array on every
+  catalog tick. With atoms, every tick replaces the array and every consumer
+  re-filters and re-renders.
+- **Fine-grained re-renders.** A component watching one key re-renders only
+  when that row changes, not whenever anything in the set changes.
+- **Instant load.** Collections persist complete snapshots to a per-tenant
+  localStorage cache and seed from it on the next visit, so the surface
+  renders before the live snapshot arrives.
+
+Both stores are sinks of the same engine. Adopting a collection for a data set
+does not change what the server sees: within a tab, the upstream SUBSCRIBE
+count stays the same, and a collection can even be fed from an existing atom
+(see the atom-fed session below) at zero additional upstream cost.
+
+## The layers
+
+| Layer | File | Owns |
+| --- | --- | --- |
+| `MaterializeWebsocket` | `api/materialize/MaterializeWebsocket.ts` | The wire: one WebSocket to the SQL HTTP endpoint, one subscribe per connection. |
+| `SubscribeManager` | `api/materialize/SubscribeManager.ts` | The SUBSCRIBE protocol: buffers rows per timestamp, folds the upsert stream into the current row set, exposes snapshots via `onChange`/`getSnapshot`. Holds its last snapshot through a resubscribe so the UI does not flash empty. |
+| `WebsocketConnectionManager` | `api/materialize/WebsocketConnectionManager.ts` | Connection lifecycle: subscribes to environment health and the current region on the jotai store, connects when healthy, reconnects with backoff, reconnects when the region's address changes, and tears down a socket left pointing at a departed region. |
+| Subscribe sessions | `api/materialize/subscribeSession.ts` | Composition: one constructor wires the manager, the connection manager, the sink, the region reset, and cache hydration, in one defined order. |
+| Hooks | `api/materialize/useSubscribe.ts` | Lifecycle adapters: a single effect creates the session on mount and destroys it on unmount. |
+| Collection bridge | `api/materialize/subscribeCollection.ts` | `createSubscribeCollection`: turns manager snapshots into incremental insert/update/delete writes on a TanStack DB collection, owns the scoped localStorage cache, and mirrors status (error, snapshotComplete) into a companion atom. |
+| Cache scope | `store/syncEngineCache.ts` | Derives the cache scope `organizationId\|regionId` as an atom, so hydration can be driven from the store. |
+
+The design rule behind the split: reactive plumbing between module-level
+singletons belongs on the jotai store (`store.sub`), not in React effects.
+Effects impose ordering between independently registered callbacks, re-run
+under Suspense, and force every cross-cutting concern to be threaded into each
+hook variant separately. A session wires everything once, synchronously, and
+is testable without a DOM.
+
+## Subscribe sessions
+
+A session is a plain object created by a hook's single effect and destroyed on
+unmount. Three kinds exist:
+
+- `createAtomSubscribeSession`: owns a socket, reduces into a jotai atom.
+  Holds existing atom data through a fresh connection's empty pre-snapshot,
+  and resets the manager and the atom to the loading state when the region
+  changes, so no page serves another region's catalog.
+- `createCollectionSubscribeSession`: owns a socket, feeds a collection.
+  Additionally holds a keep-alive subscriber so the collection is not garbage
+  collected while no component queries it, and hydrates the collection from
+  its scoped cache via the scope atom.
+- `createAtomFedCollectionSession`: no socket. Bridges an already running
+  subscribe atom into a collection, adding no upstream load, plus the same
+  scoped hydration. Region behavior comes from the source atom's own session.
+
+```
+                     +--------------------------------------+
+  hook               |   subscribe session (plain object)   |
+  one effect:        |                                      |      +-----------+
+  create / destroy --+-> SubscribeManager <---- diff stream +----- | WebSocket |
+                     |   WebsocketConnectionManager --------+----> +-----------+
+                     |                     reconnect at addr|
+                     |   sink: atom | collection -----------+----> atoms / collections
+                     |                                      |            |
+                     |   store.sub(regionId)    -> reset    |            v
+                     |   store.sub(cacheScope)  -> hydrate  |     localStorage cache
+                     +--------------------------------------+     (scoped persist)
+```
+
+## The collection bridge
+
+`createSubscribeCollection` is the seam between the feed and TanStack DB. The
+manager already reduces the diff stream to the current row set, so the bridge
+diffs each snapshot against what the collection holds and writes only the
+delta as insert/update/delete operations. Live queries downstream therefore
+recompute incrementally.
+
+The bridge also owns the instant-load cache:
+
+- **Persist.** With a `persistName`, complete snapshots (never partial state)
+  are written to localStorage on a trailing throttle, under the key
+  `mz-console:sync-engine:<name>|<organizationId>|<regionId>|v<version>`.
+- **Hydrate.** Seeding is deferred until the scope is known, then the cached
+  rows load into the collection and the loading gate opens immediately. A
+  cached snapshot counts as complete for gating; the live snapshot replaces it
+  when it arrives. Other scopes' cache entries are pruned on hydrate.
+- **Scope changes.** Re-hydrating under a new scope drops the in-memory rows
+  and any pending persist first, so one tenant's rows are never shown as, or
+  written under, another tenant's cache.
+- **Status.** Error and snapshotComplete mirror into a companion jotai atom so
+  consumers keep the same loading/error semantics as atom-backed data.
+
+An empty pre-snapshot from a fresh connection carries no data: the bridge
+ignores it rather than clearing cache-seeded state or counting it as live
+data, except that it clears a stale error so the UI falls back to loading
+during reconnect backoff.
+
+## Data flow
+
+Steady state: the socket delivers the diff stream, the manager folds it and
+emits a snapshot per closed timestamp, the sink writes it into the atom or
+diffs it into the collection, and `useLiveQuery` consumers recompute
+incrementally.
+
+On a region switch:
+
+1. The region atom is written by the region selector.
+2. The connection manager sees the new address and reconnects the socket
+   there. Pausing on an unhealthy target tears the departed region's socket
+   down, so a later return to a healthy region always resumes. A health blip
+   within the current region leaves a working socket alone.
+3. Each session's region subscription fires synchronously: the manager drops
+   its held rows and atoms go back to loading.
+4. The cache scope atom recomputes. Collection sessions hydrate the new
+   scope's cache, dropping in-memory rows and any pending persist.
+5. The new region's snapshot arrives and flows through the sinks as usual.
+
+On a reconnect within one region, the manager keeps its last snapshot and
+re-emits it when the socket reopens, so the UI holds data through the
+resubscribe instead of flashing empty.
+
+## Boundaries
+
+What the engine is not:
+
+- **Not a server-load lever by itself.** It is a client store. Within one tab
+  the upstream SUBSCRIBE count is unchanged by adopting it. Its sessions and
+  sinks are transport-agnostic, which is the seam a shared upstream
+  (cross-tab or cross-client dedup) can plug into without touching surfaces,
+  but the engine alone does not provide that.
+- **Not for polled telemetry.** Expensive introspection queries
+  (utilization history, arrangement sizes) are react-query territory, with
+  polling intervals and its persistence tooling. The engine serves
+  catalog-shaped data that a SUBSCRIBE can maintain.
+- **Not for page-scoped, request-driven subscribes.** Those use
+  `useSubscribe`/`useSubscribeManager`, which tie a manager to a component
+  and expose state via `useSyncExternalStore`.
+
+## Adopting a collection for a surface
+
+A surface that moves from an atom read to a collection gets, without further
+code: incremental live queries, per-key re-render granularity, instant load
+from the scoped cache, keep-alive for the app session, and region-correct
+resets. The object explorer is the reference adoption: its tree runs live
+queries over the objects collection (fed from the app-wide `allObjects` atom)
+and the namespaces collection (its own subscribe), and renders from cache on
+revisit before the live snapshot lands.
+
+Declare configuration once at module scope. The hooks require a referentially
+stable options object, and a new object identity restarts the session, which
+makes accidental instability visible instead of masked.
+
+Atom-backed data set:
+
+```ts
+export const allWidgets = atom<SubscribeState<Widget>>({
+  data: [],
+  error: undefined,
+  snapshotComplete: false,
+});
+
+const ALL_WIDGETS_SUBSCRIBE_OPTIONS = {
+  atom: allWidgets,
+  subscribe: buildSubscribeQuery(buildWidgetsQuery(), { upsertKey: "id" }),
+  select: (row: SubscribeRow<Widget>) => row.data,
+  upsertKey: (row: SubscribeRow<Widget>) => row.data.id,
+};
+
+export function useSubscribeToAllWidgets() {
+  useGlobalUpsertSubscribe(ALL_WIDGETS_SUBSCRIBE_OPTIONS);
+}
+```
+
+Collection with its own subscribe and the instant-load cache:
+
+```ts
+export const widgetsCollection = createSubscribeCollection<Widget>({
+  id: "widgets",
+  getKey: (widget) => widget.id,
+  persistName: "widgets",
+});
+
+const WIDGETS_SUBSCRIBE_OPTIONS = {
+  target: widgetsCollection,
+  scopeAtom: syncEngineCacheScopeLoadableAtom,
+  subscribe: buildSubscribeQuery(buildWidgetsQuery(), { upsertKey: "id" }),
+  select: (row: SubscribeRow<Widget>) => row.data,
+  upsertKey: (row: SubscribeRow<Widget>) => row.data.id,
+};
+
+export function useSubscribeToWidgetsCollection() {
+  useGlobalSubscribeCollection(WIDGETS_SUBSCRIBE_OPTIONS);
+}
+```
+
+Collection fed from an existing atom, no second socket:
+
+```ts
+export const widgetsCollection = createSubscribeCollection<Widget>({
+  id: "widgets",
+  getKey: (widget) => widget.id,
+  persistName: "widgets",
+});
+
+export function useSubscribeToWidgetsCollection() {
+  const store = useStore();
+  React.useEffect(() => {
+    const session = createAtomFedCollectionSession({
+      store,
+      sourceAtom: allWidgets,
+      target: widgetsCollection,
+      scopeAtom: syncEngineCacheScopeLoadableAtom,
+    });
+    return session.destroy;
+  }, [store]);
+}
+```
+
+Consumers read collections through `useLiveQuery`, with status from the
+companion atom:
+
+```ts
+const { data } = useLiveQuery((q) => q.from({ widgets: widgetsCollection.collection }));
+const status = useAtomValue(widgetsCollection.statusAtom);
+```
+
+Mount the activator hook once: in `AppInitializer` for data the whole app
+reads, or in a route component for data one surface reads. Note that a route
+component keyed by a path pattern survives param-only navigation, including
+region switches, which is why region handling lives in the session rather
+than in mount/unmount.
+
+## Testing
+
+Sessions and the collection bridge are plain objects, so their behavior is
+asserted headlessly and synchronously: create them against `getStore()`,
+write the region or scope atoms or call `applySnapshot`, and assert on the
+sink in the same tick. No rendering, no Suspense, no `waitFor`. See
+`useSubscribe.test.tsx` and `subscribeCollection.test.ts`. jsdom-rendered
+tests of this stack are unreliable (sockets fail and produce error states,
+Suspense tears sessions down mid-switch), so prefer session-level tests plus
+component tests that mock the activator hooks.

--- a/console/package.json
+++ b/console/package.json
@@ -239,6 +239,17 @@
       "prettier/prettier": "error",
       "simple-import-sort/imports": "error",
       "simple-import-sort/exports": "error",
+      "no-restricted-syntax": [
+        "error",
+        {
+          "selector": "CallExpression[callee.name='useGlobalUpsertSubscribe'] > ObjectExpression",
+          "message": "Declare subscribe options at module scope; an inline object restarts the SUBSCRIBE session on every render."
+        },
+        {
+          "selector": "CallExpression[callee.name='useGlobalSubscribeCollection'] > ObjectExpression",
+          "message": "Declare subscribe options at module scope; an inline object restarts the SUBSCRIBE session on every render."
+        }
+      ],
       "@typescript-eslint/no-shadow": "error",
       "@typescript-eslint/ban-ts-comment": "off",
       "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/console/src/api/auth.tsx
+++ b/console/src/api/auth.tsx
@@ -14,6 +14,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 
+import { AppConfig } from "~/config/AppConfig";
 import { CloudRuntimeConfig } from "~/config/AppConfigSwitch";
 import { useAppConfig } from "~/config/useAppConfig";
 import {
@@ -170,6 +171,20 @@ export function useSelfManagedSubscription() {
   return { subscription, isLoading, isError, error };
 }
 
+/**
+ * Whether this deployment fetches the current organization at all. This also
+ * decides the organization half of the sync-engine cache key
+ * (store/syncEngineCache.ts), which isolates tenants' caches on a shared
+ * origin, so every caller must use this one predicate.
+ */
+export function isOrganizationFetchEnabled(appConfig: AppConfig): boolean {
+  const isLocalImpersonation =
+    appConfig.mode === "cloud" &&
+    appConfig.isImpersonating &&
+    appConfig.isLocalImpersonation;
+  return appConfig.mode !== "self-managed" && !isLocalImpersonation;
+}
+
 // Convenience hook for getting the current organization ID based on
 // the app's deployment mode. Although "organizations" don't really exist in
 // self managed environments, a lot of our code uses the organization ID as part of a key to cache
@@ -177,13 +192,8 @@ export function useSelfManagedSubscription() {
 // in deployment modes where the organization ID is not available.
 export function useMaybeCurrentOrganizationId() {
   const appConfig = useAppConfig();
-  const isLocalImpersonation =
-    appConfig.mode === "cloud" &&
-    appConfig.isImpersonating &&
-    appConfig.isLocalImpersonation;
-
   const isCurrentOrganizationFetchEnabled =
-    appConfig.mode !== "self-managed" && !isLocalImpersonation;
+    isOrganizationFetchEnabled(appConfig);
 
   const res = useQuery({
     queryKey: queryKeys.currentOrganization(),

--- a/console/src/api/materialize/WebsocketConnectionManager.test.ts
+++ b/console/src/api/materialize/WebsocketConnectionManager.test.ts
@@ -12,9 +12,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getStore } from "~/jotai";
 import {
+  currentRegionIdAtom,
   EnvironmentsWithHealth,
   environmentsWithHealth,
 } from "~/store/environments";
+import { defaultRegionId } from "~/test/utils";
 
 import {
   Connectable,
@@ -231,6 +233,169 @@ describe("WebsocketConnectionManager", () => {
       mockTarget.simulateOpen();
       manager.reconnect();
       expect(mockTarget.reconnect).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("region switch", () => {
+    const twoRegions = () =>
+      new Map([
+        [defaultRegionId, createHealthyEnvironment("addr-a:6876")],
+        ["aws/eu-west-1", createHealthyEnvironment("addr-b:6876")],
+      ]) as unknown as EnvironmentsWithHealth;
+
+    afterEach(() => {
+      getStore().set(currentRegionIdAtom, defaultRegionId);
+    });
+
+    it("reconnects at the new address when the region switches while connected", () => {
+      const store = getStore();
+      store.set(environmentsWithHealth, twoRegions());
+
+      manager = new WebsocketConnectionManager(
+        mockTarget,
+        store,
+        reconnectionStateAtom,
+      );
+      mockTarget.simulateOpen();
+      vi.mocked(mockTarget.reconnect).mockClear();
+
+      store.set(currentRegionIdAtom, "aws/eu-west-1");
+
+      expect(mockTarget.reconnect).toHaveBeenCalledTimes(1);
+      expect(mockTarget.reconnect).toHaveBeenCalledWith(
+        "addr-b:6876",
+        undefined,
+      );
+    });
+
+    it("reconnects after a round trip through an unhealthy region", () => {
+      const store = getStore();
+      const crashed = {
+        ...createHealthyEnvironment("addr-b:6876"),
+        status: { health: "crashed" as const, version: "0.0.0", errors: [] },
+      };
+      store.set(
+        environmentsWithHealth,
+        new Map<string, unknown>([
+          [defaultRegionId, createHealthyEnvironment("addr-a:6876")],
+          ["aws/eu-west-1", crashed],
+        ]) as unknown as EnvironmentsWithHealth,
+      );
+
+      manager = new WebsocketConnectionManager(
+        mockTarget,
+        store,
+        reconnectionStateAtom,
+      );
+      mockTarget.simulateOpen();
+      vi.mocked(mockTarget.reconnect).mockClear();
+
+      // Pausing on the unhealthy region tears the old region's socket down.
+      store.set(currentRegionIdAtom, "aws/eu-west-1");
+      expect(mockTarget.disconnect).toHaveBeenCalled();
+      expect(mockTarget.reconnect).not.toHaveBeenCalled();
+
+      // Returning to the healthy region reconnects rather than assuming the
+      // old socket still serves it.
+      store.set(currentRegionIdAtom, defaultRegionId);
+      expect(mockTarget.reconnect).toHaveBeenCalledWith(
+        "addr-a:6876",
+        undefined,
+      );
+    });
+
+    it("keeps the socket through a same-region health blip", () => {
+      const store = getStore();
+      store.set(environmentsWithHealth, twoRegions());
+      manager = new WebsocketConnectionManager(
+        mockTarget,
+        store,
+        reconnectionStateAtom,
+      );
+      mockTarget.simulateOpen();
+      vi.mocked(mockTarget.reconnect).mockClear();
+      vi.mocked(mockTarget.disconnect).mockClear();
+
+      // The current region's health check fails: the socket is left alone,
+      // so consumers like the Shell see no silent teardown.
+      store.set(
+        environmentsWithHealth,
+        new Map<string, unknown>([
+          [
+            defaultRegionId,
+            {
+              ...createHealthyEnvironment("addr-a:6876"),
+              status: {
+                health: "crashed" as const,
+                version: "0.0.0",
+                errors: [],
+              },
+            },
+          ],
+          ["aws/eu-west-1", createHealthyEnvironment("addr-b:6876")],
+        ]) as unknown as EnvironmentsWithHealth,
+      );
+      expect(mockTarget.disconnect).not.toHaveBeenCalled();
+
+      // Health recovers: the socket is still connected, so no churn either.
+      store.set(environmentsWithHealth, twoRegions());
+      expect(mockTarget.reconnect).not.toHaveBeenCalled();
+    });
+
+    it("reconnects after a round trip through a disabled region", () => {
+      const store = getStore();
+      store.set(
+        environmentsWithHealth,
+        new Map<string, unknown>([
+          [defaultRegionId, createHealthyEnvironment("addr-a:6876")],
+          ["aws/eu-west-1", { state: "disabled" as const }],
+        ]) as unknown as EnvironmentsWithHealth,
+      );
+      manager = new WebsocketConnectionManager(
+        mockTarget,
+        store,
+        reconnectionStateAtom,
+      );
+      mockTarget.simulateOpen();
+      vi.mocked(mockTarget.reconnect).mockClear();
+
+      // A disabled region never updates the address, so the teardown must key
+      // on the region, not the address.
+      store.set(currentRegionIdAtom, "aws/eu-west-1");
+      expect(mockTarget.disconnect).toHaveBeenCalled();
+
+      store.set(currentRegionIdAtom, defaultRegionId);
+      expect(mockTarget.reconnect).toHaveBeenCalledWith(
+        "addr-a:6876",
+        undefined,
+      );
+    });
+
+    it("reconnects after a region switch that lands mid-handshake", () => {
+      const store = getStore();
+      store.set(environmentsWithHealth, twoRegions());
+
+      // Constructor starts a connect to region A; handshake still in flight.
+      manager = new WebsocketConnectionManager(
+        mockTarget,
+        store,
+        reconnectionStateAtom,
+      );
+      expect(mockTarget.reconnect).toHaveBeenCalledWith(
+        "addr-a:6876",
+        undefined,
+      );
+      vi.mocked(mockTarget.reconnect).mockClear();
+
+      // Switch regions before the handshake completes: deferred, not dropped.
+      store.set(currentRegionIdAtom, "aws/eu-west-1");
+      expect(mockTarget.reconnect).not.toHaveBeenCalled();
+
+      mockTarget.simulateOpen();
+      expect(mockTarget.reconnect).toHaveBeenCalledWith(
+        "addr-b:6876",
+        undefined,
+      );
     });
   });
 

--- a/console/src/api/materialize/WebsocketConnectionManager.ts
+++ b/console/src/api/materialize/WebsocketConnectionManager.ts
@@ -77,6 +77,10 @@ export class WebsocketConnectionManager {
 
   private isHealthy = false;
   private currentHttpAddress?: string;
+  /** Address used for the most recent connection attempt. */
+  private attemptedHttpAddress?: string;
+  /** Region the most recent connection attempt was made for. */
+  private attemptedRegionId?: string | null;
   private retryAttempt = 0;
   private hasEverConnected = false;
   private retryTimer: ReturnType<typeof setTimeout> | undefined;
@@ -158,11 +162,20 @@ export class WebsocketConnectionManager {
     }
 
     if (nowHealthy) {
-      if (!this.target.isConnected()) {
+      // A connected socket may still stream from a previous region's address
+      // after a region switch; reconnect at the current one.
+      if (
+        !this.target.isConnected() ||
+        this.attemptedHttpAddress !== this.currentHttpAddress
+      ) {
         this.resumeConnection();
       }
     } else {
-      this.pauseConnection();
+      // Only tear down a socket pointing at a region the user has left; a
+      // health blip in the current region leaves a working socket alone
+      // (consumers like the Shell would get no close callback).
+      const regionId = this.store.get(currentRegionIdSyncAtom);
+      this.pauseConnection(regionId !== this.attemptedRegionId);
     }
   };
 
@@ -205,6 +218,14 @@ export class WebsocketConnectionManager {
     this.retryAttempt = 0;
     this.clearRetryTimer();
     this.notifyStateChange();
+    // The region may have switched while this handshake was in flight; the
+    // socket that just opened points at the old address.
+    if (
+      this.isHealthy &&
+      this.attemptedHttpAddress !== this.currentHttpAddress
+    ) {
+      this.attemptConnection();
+    }
   };
 
   /** Tear down and reopen the socket. Used on SQL request changes. */
@@ -239,6 +260,8 @@ export class WebsocketConnectionManager {
       hasEverConnected: this.hasEverConnected,
     });
     this.connectInFlight = true;
+    this.attemptedHttpAddress = this.currentHttpAddress;
+    this.attemptedRegionId = this.store.get(currentRegionIdSyncAtom);
     try {
       this.target.reconnect(this.currentHttpAddress, sessionVariables);
     } catch {
@@ -253,9 +276,15 @@ export class WebsocketConnectionManager {
     this.attemptConnection();
   }
 
-  private pauseConnection() {
+  private pauseConnection(disconnect: boolean) {
     this.clearRetryTimer();
     this.retryAttempt = 0;
+    if (disconnect) {
+      // Tear down so the resume path reconnects after an unhealthy round trip;
+      // clear connectInFlight since this socket gets no open/close callback.
+      this.connectInFlight = false;
+      this.target.disconnect();
+    }
     this.notifyStateChange();
   }
 

--- a/console/src/api/materialize/subscribeCollection.test.ts
+++ b/console/src/api/materialize/subscribeCollection.test.ts
@@ -190,6 +190,60 @@ describe("createSubscribeCollection", () => {
     expect(collection.get("9")?.name).toBe("region-b");
   });
 
+  it("reset drops rows, pending persistence, and the loading gate", async () => {
+    vi.useFakeTimers();
+    try {
+      const name = "reset";
+      const scope = "org|regionA";
+      const key = syncEngineCacheKey(name, scope);
+      const { collection, statusAtom, applySnapshot, hydrate, reset } =
+        freshCollection(name);
+      hydrate(scope);
+      applySnapshot(state([{ id: "1", name: "a" }]));
+
+      // Reset before the persist throttle fires: nothing may be written.
+      reset();
+      vi.advanceTimersByTime(1100);
+      expect(localStorage.getItem(key)).toBeNull();
+      expect(getStore().get(statusAtom).snapshotComplete).toBe(false);
+
+      vi.useRealTimers();
+      await flush();
+      expect(collection.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("suspendPersistence stops writes until a scope resolves again", () => {
+    vi.useFakeTimers();
+    try {
+      const name = "suspend";
+      const scope = "org|regionA";
+      const key = syncEngineCacheKey(name, scope);
+      const { applySnapshot, hydrate, suspendPersistence } =
+        freshCollection(name);
+      hydrate(scope);
+      applySnapshot(state([{ id: "1", name: "a" }]));
+
+      // Suspend cancels the pending write and later snapshots stay unpersisted.
+      suspendPersistence();
+      applySnapshot(state([{ id: "2", name: "b" }]));
+      vi.advanceTimersByTime(1100);
+      expect(localStorage.getItem(key)).toBeNull();
+
+      // A scope resolving again re-arms persistence, even the same scope.
+      hydrate(scope);
+      applySnapshot(state([{ id: "3", name: "c" }]));
+      vi.advanceTimersByTime(1100);
+      expect(JSON.parse(localStorage.getItem(key) ?? "[]")).toEqual([
+        { id: "3", name: "c" },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("clears a stale error when an empty pre-snapshot follows a reconnect", () => {
     const { applySnapshot, statusAtom } = freshCollection();
     const error = { code: "boom", message: "it failed" };

--- a/console/src/api/materialize/subscribeCollection.test.ts
+++ b/console/src/api/materialize/subscribeCollection.test.ts
@@ -105,9 +105,8 @@ describe("createSubscribeCollection", () => {
   });
 
   it("hydrates from cache after an empty pre-snapshot was applied", async () => {
-    // The mount effect pushes the atom's empty initial state before the async
-    // auth/region scope resolves, so hydrate always runs after it. The empty
-    // placeholder must not count as live data, or the cache is never read.
+    // The empty initial state is pushed before the async scope resolves, so
+    // hydrate always runs after it; it must not count as live data.
     const name = "late-hydrate";
     const scope = "org1|region1";
     localStorage.setItem(
@@ -141,6 +140,67 @@ describe("createSubscribeCollection", () => {
     applySnapshot(state([], false));
     await flush();
     expect(collection.size).toBe(1);
+  });
+
+  it("does not carry the previous scope's rows into a new scope", async () => {
+    const name = "scope-switch";
+    const keyB = syncEngineCacheKey(name, "org|regionB");
+    const { collection, statusAtom, applySnapshot, hydrate } =
+      freshCollection(name);
+
+    hydrate("org|regionA");
+    applySnapshot(state([{ id: "1", name: "region-a" }]));
+    await flush();
+    expect(collection.size).toBe(1);
+
+    vi.useFakeTimers();
+    try {
+      // A region switch re-hydrates with a new scope while region A's rows are
+      // still in memory. They must not be persisted under region B's key.
+      hydrate("org|regionB");
+      vi.advanceTimersByTime(1100);
+      expect(localStorage.getItem(keyB)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    // Nor served as region B data: the collection empties and the loading
+    // gate closes until region B's own snapshot arrives.
+    await flush();
+    expect(collection.size).toBe(0);
+    expect(getStore().get(statusAtom).snapshotComplete).toBe(false);
+  });
+
+  it("seeds the new scope from its own cache after a scope switch", async () => {
+    const name = "scope-switch-seed";
+    const keyB = syncEngineCacheKey(name, "org|regionB");
+    const { collection, applySnapshot, hydrate } = freshCollection(name);
+
+    hydrate("org|regionA");
+    applySnapshot(state([{ id: "1", name: "region-a" }]));
+    await flush();
+
+    // Written after region A's hydrate pruned other scopes, as another tab
+    // already on region B would.
+    localStorage.setItem(keyB, JSON.stringify([{ id: "9", name: "region-b" }]));
+    hydrate("org|regionB");
+    await flush();
+
+    expect(collection.has("1")).toBe(false);
+    expect(collection.get("9")?.name).toBe("region-b");
+  });
+
+  it("clears a stale error when an empty pre-snapshot follows a reconnect", () => {
+    const { applySnapshot, statusAtom } = freshCollection();
+    const error = { code: "boom", message: "it failed" };
+    applySnapshot(state([], false, error));
+    expect(getStore().get(statusAtom).error).toEqual(error);
+
+    // SubscribeManager re-emits an empty pre-snapshot when a reconnect opens;
+    // the status must fall back to loading, not hold the error.
+    applySnapshot(state([], false));
+    expect(getStore().get(statusAtom).error).toBeUndefined();
+    expect(getStore().get(statusAtom).snapshotComplete).toBe(false);
   });
 
   it("surfaces error and snapshotComplete on the status atom", () => {

--- a/console/src/api/materialize/subscribeCollection.ts
+++ b/console/src/api/materialize/subscribeCollection.ts
@@ -72,6 +72,14 @@ export interface SubscribeCollection<T extends object> {
    * tenant's catalog into another's session after an org or region switch. Only
    * the first call per scope seeds; later calls for the same scope no-op. */
   hydrate: (scope: string) => void;
+  /** Drop all rows and pending persistence and return to the loading state,
+   * for when the held rows belong to another region's catalog. A later
+   * hydrate may still seed the new scope from its cache. */
+  reset: () => void;
+  /** Stop persisting until a scope resolves again. Scope resolution failing
+   * must fail closed: writes aimed at a previous scope's key would store one
+   * tenant's rows under another's cache. */
+  suspendPersistence: () => void;
 }
 
 /**
@@ -291,5 +299,36 @@ export function createSubscribeCollection<T extends object>(options: {
     writeStatus({ error: undefined, snapshotComplete: lastSnapshotComplete });
   };
 
-  return { collection, statusAtom, applySnapshot, hydrate };
+  const clearPendingPersist = () => {
+    if (persistTimer) {
+      clearTimeout(persistTimer);
+      persistTimer = undefined;
+    }
+  };
+
+  const reset = () => {
+    clearPendingPersist();
+    desired = new Map();
+    lastSnapshotComplete = false;
+    liveSnapshotApplied = false;
+    materialize();
+    writeStatus({ error: undefined, snapshotComplete: false });
+  };
+
+  const suspendPersistence = () => {
+    clearPendingPersist();
+    persistKey = undefined;
+    // Allow a later successful resolution to hydrate again, even for the
+    // scope whose resolution just failed.
+    hydratedScope = undefined;
+  };
+
+  return {
+    collection,
+    statusAtom,
+    applySnapshot,
+    hydrate,
+    reset,
+    suspendPersistence,
+  };
 }

--- a/console/src/api/materialize/subscribeCollection.ts
+++ b/console/src/api/materialize/subscribeCollection.ts
@@ -213,14 +213,15 @@ export function createSubscribeCollection<T extends object>(options: {
   };
 
   const applySnapshot = (state: SubscribeState<T>) => {
-    // An empty pre-snapshot carries no information: ignore it entirely, so it
-    // neither clears cache-seeded state nor counts as live data. Marking it
-    // live would block a later hydrate (the scope resolves asynchronously, so
-    // hydrate always runs after the first empty push) and leave the cache
-    // permanently unread.
+    // An empty pre-snapshot carries no data: don't clear cache-seeded state or
+    // count it as live (that would block the later, async-scoped hydrate). It
+    // does clear a stale error so a reconnect falls back to loading.
     const isEmptyPreload =
       !state.snapshotComplete && state.data.length === 0 && !state.error;
-    if (isEmptyPreload) return;
+    if (isEmptyPreload) {
+      writeStatus({ error: undefined, snapshotComplete: lastSnapshotComplete });
+      return;
+    }
 
     liveSnapshotApplied = true;
     desired = new Map(state.data.map((row) => [getKey(row), row]));
@@ -254,9 +255,21 @@ export function createSubscribeCollection<T extends object>(options: {
 
   const hydrate = (scope: string) => {
     if (!persistName || hydratedScope === scope) return;
+    const scopeChanged = hydratedScope !== undefined;
     hydratedScope = scope;
     persistKey = syncEngineCacheKey(persistName, scope);
     pruneOtherScopes(persistKey);
+    if (scopeChanged) {
+      // The rows in memory belong to the previous scope: drop them and the
+      // pending persist (its timer reads `desired` at fire time).
+      if (persistTimer) {
+        clearTimeout(persistTimer);
+        persistTimer = undefined;
+      }
+      desired = new Map();
+      liveSnapshotApplied = false;
+      lastSnapshotComplete = false;
+    }
     if (liveSnapshotApplied) {
       // Live data already arrived; don't overwrite it with the cache, but do
       // persist it now that the scoped key is known.
@@ -264,13 +277,18 @@ export function createSubscribeCollection<T extends object>(options: {
       return;
     }
     const cached = readPersistedRows<T>(persistKey);
-    if (!cached.length) return;
-    desired = new Map(cached.map((row) => [getKey(row), row]));
-    // A cached full snapshot counts as complete for the loading gate; the live
-    // snapshot refreshes it once it arrives.
-    lastSnapshotComplete = true;
+    if (cached.length) {
+      desired = new Map(cached.map((row) => [getKey(row), row]));
+      // A cached full snapshot counts as complete for the loading gate; the
+      // live snapshot refreshes it once it arrives.
+      lastSnapshotComplete = true;
+    } else if (!scopeChanged) {
+      return;
+    }
+    // On a scope change this also flushes the emptied set, so the collection
+    // stops serving the previous scope's rows while the new snapshot loads.
     materialize();
-    writeStatus({ error: undefined, snapshotComplete: true });
+    writeStatus({ error: undefined, snapshotComplete: lastSnapshotComplete });
   };
 
   return { collection, statusAtom, applySnapshot, hydrate };

--- a/console/src/api/materialize/subscribeSession.ts
+++ b/console/src/api/materialize/subscribeSession.ts
@@ -1,0 +1,200 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { Atom, createStore, PrimitiveAtom } from "jotai";
+
+import { reconnectionStateAtom } from "~/hooks/useAutomaticallyConnectSocket";
+import { currentRegionIdSyncAtom } from "~/store/environments";
+
+import { SubscribeCollection } from "./subscribeCollection";
+import {
+  SelectFunction,
+  SubscribeManager,
+  SubscribeRow,
+  SubscribeState,
+  UpsertKeyFunction,
+} from "./SubscribeManager";
+import { SessionVariables, SqlRequest } from "./types";
+import { WebsocketConnectionManager } from "./WebsocketConnectionManager";
+
+type JotaiStore = ReturnType<typeof createStore>;
+
+/** The shape jotai's `loadable()` wraps an async atom into. */
+export type ScopeLoadableAtom = Atom<
+  | { state: "loading" }
+  | { state: "hasError"; error: unknown }
+  | { state: "hasData"; data: string | undefined }
+>;
+
+/** Hydrates `target` from its scoped cache whenever the scope settles or
+ * changes; hydrate itself handles both seeding and the scope-change reset. */
+function subscribeToScope(
+  store: JotaiStore,
+  scopeAtom: ScopeLoadableAtom,
+  hydrate: (scope: string) => void,
+) {
+  const applyScope = () => {
+    const value = store.get(scopeAtom);
+    if (value.state === "hasData" && value.data) hydrate(value.data);
+  };
+  applyScope();
+  return store.sub(scopeAtom, applyScope);
+}
+
+export interface SubscribeSessionOptions<T extends object, R> {
+  store: JotaiStore;
+  request: SqlRequest;
+  upsertKey: UpsertKeyFunction<T>;
+  select?: SelectFunction<T, R>;
+  sessionVariables?: SessionVariables;
+  closeSocketOnComplete?: boolean;
+}
+
+export interface SubscribeSession<T extends object, R> {
+  manager: SubscribeManager<T, R>;
+  destroy: () => void;
+}
+
+/**
+ * One app-session subscribe, wired outside React: a SubscribeManager kept
+ * connected by a WebsocketConnectionManager, snapshots pushed into `sink`, and
+ * a region-change reset subscribed directly on the store. Hooks only own the
+ * session's lifecycle; the composition is testable headlessly.
+ */
+function createSubscribeSession<T extends object, R>(
+  options: SubscribeSessionOptions<T, R>,
+  sink: {
+    apply: (snapshot: SubscribeState<R>) => void;
+    onRegionChange?: () => void;
+  },
+): SubscribeSession<T, R> {
+  const { store, request, upsertKey, select } = options;
+  const manager = new SubscribeManager<T, R>({
+    request,
+    // The connection manager supplies the address on every attempt.
+    httpAddress: "",
+    upsert: { key: upsertKey },
+    select,
+    sessionVariables: options.sessionVariables,
+    closeSocketOnComplete: options.closeSocketOnComplete,
+  });
+  const unsubscribeChange = manager.onChange(() =>
+    sink.apply(manager.getSnapshot()),
+  );
+  const connection = new WebsocketConnectionManager(
+    manager,
+    store,
+    reconnectionStateAtom,
+  );
+
+  // The held rows belong to the previous region's catalog: reset rather than
+  // serve or replay them while the socket re-subscribes at the new address.
+  let regionId = store.get(currentRegionIdSyncAtom);
+  const unsubscribeRegion = store.sub(currentRegionIdSyncAtom, () => {
+    const next = store.get(currentRegionIdSyncAtom);
+    if (next === regionId) return;
+    regionId = next;
+    manager.reset();
+    sink.onRegionChange?.();
+  });
+
+  return {
+    manager,
+    destroy() {
+      unsubscribeRegion();
+      unsubscribeChange();
+      connection.destroy();
+    },
+  };
+}
+
+/** A subscribe session that reduces into a jotai atom (allObjects et al.). */
+export function createAtomSubscribeSession<
+  T extends object,
+  R = SubscribeRow<T>,
+>(
+  options: SubscribeSessionOptions<T, R> & {
+    atom: PrimitiveAtom<SubscribeState<R>>;
+  },
+): SubscribeSession<T, R> {
+  const { store, atom } = options;
+  return createSubscribeSession(options, {
+    apply: (snapshot) => {
+      const current = store.get(atom);
+      if (current === snapshot) return;
+      // Hold cached atom data through a fresh manager's empty pre-snapshot state.
+      const snapshotIsEmptyPreload =
+        !snapshot.snapshotComplete && !snapshot.data.length && !snapshot.error;
+      if (snapshotIsEmptyPreload && current.data.length) return;
+      store.set(atom, snapshot);
+    },
+    onRegionChange: () =>
+      store.set(atom, { data: [], snapshotComplete: false, error: undefined }),
+  });
+}
+
+/** A subscribe session that feeds a TanStack DB collection (namespaces et al.).
+ * The manager reset on region change suffices for the sink: onOpen then
+ * replays an empty pre-snapshot, which applySnapshot ignores. */
+export function createCollectionSubscribeSession<
+  T extends object,
+  R extends object = SubscribeRow<T>,
+>(
+  options: SubscribeSessionOptions<T, R> & {
+    target: SubscribeCollection<R>;
+    scopeAtom?: ScopeLoadableAtom;
+  },
+): SubscribeSession<T, R> {
+  const { store, target, scopeAtom } = options;
+  // Hold a subscriber for the session so the collection doesn't pause/GC
+  // while no component is querying it.
+  const keepAlive = target.collection.subscribeChanges(() => {});
+  const unsubscribeScope = scopeAtom
+    ? subscribeToScope(store, scopeAtom, target.hydrate)
+    : undefined;
+  const session = createSubscribeSession(options, {
+    apply: (snapshot) => target.applySnapshot(snapshot),
+  });
+  target.applySnapshot(session.manager.getSnapshot());
+  return {
+    manager: session.manager,
+    destroy() {
+      unsubscribeScope?.();
+      keepAlive.unsubscribe();
+      session.destroy();
+    },
+  };
+}
+
+/**
+ * Feeds a collection from an already-running subscribe atom rather than its
+ * own socket, adding no upstream load. Region handling comes for free: the
+ * source atom's session resets it, and the scope hydration both seeds from
+ * and resets the collection's cache on a scope change.
+ */
+export function createAtomFedCollectionSession<R extends object>(options: {
+  store: JotaiStore;
+  sourceAtom: Atom<SubscribeState<R>>;
+  target: SubscribeCollection<R>;
+  scopeAtom?: ScopeLoadableAtom;
+}): { destroy: () => void } {
+  const { store, sourceAtom, target, scopeAtom } = options;
+  const unsubscribeScope = scopeAtom
+    ? subscribeToScope(store, scopeAtom, target.hydrate)
+    : undefined;
+  const apply = () => target.applySnapshot(store.get(sourceAtom));
+  apply();
+  const unsubscribeSource = store.sub(sourceAtom, apply);
+  return {
+    destroy() {
+      unsubscribeScope?.();
+      unsubscribeSource();
+    },
+  };
+}

--- a/console/src/api/materialize/subscribeSession.ts
+++ b/console/src/api/materialize/subscribeSession.ts
@@ -33,18 +33,38 @@ export type ScopeLoadableAtom = Atom<
 >;
 
 /** Hydrates `target` from its scoped cache whenever the scope settles or
- * changes; hydrate itself handles both seeding and the scope-change reset. */
+ * changes; hydrate itself handles both seeding and the scope-change reset. A
+ * failed scope resolution fails closed: persistence is suspended rather than
+ * left aimed at a previous scope's key. */
 function subscribeToScope(
   store: JotaiStore,
   scopeAtom: ScopeLoadableAtom,
-  hydrate: (scope: string) => void,
+  target: {
+    hydrate: (scope: string) => void;
+    suspendPersistence: () => void;
+  },
 ) {
   const applyScope = () => {
     const value = store.get(scopeAtom);
-    if (value.state === "hasData" && value.data) hydrate(value.data);
+    if (value.state === "hasData" && value.data) target.hydrate(value.data);
+    else if (value.state === "hasError") target.suspendPersistence();
   };
   applyScope();
   return store.sub(scopeAtom, applyScope);
+}
+
+/** Invokes `onRegionChange` when the current region changes. */
+function subscribeToRegionChange(
+  store: JotaiStore,
+  onRegionChange: () => void,
+) {
+  let regionId = store.get(currentRegionIdSyncAtom);
+  return store.sub(currentRegionIdSyncAtom, () => {
+    const next = store.get(currentRegionIdSyncAtom);
+    if (next === regionId) return;
+    regionId = next;
+    onRegionChange();
+  });
 }
 
 export interface SubscribeSessionOptions<T extends object, R> {
@@ -95,11 +115,7 @@ function createSubscribeSession<T extends object, R>(
 
   // The held rows belong to the previous region's catalog: reset rather than
   // serve or replay them while the socket re-subscribes at the new address.
-  let regionId = store.get(currentRegionIdSyncAtom);
-  const unsubscribeRegion = store.sub(currentRegionIdSyncAtom, () => {
-    const next = store.get(currentRegionIdSyncAtom);
-    if (next === regionId) return;
-    regionId = next;
+  const unsubscribeRegion = subscribeToRegionChange(store, () => {
     manager.reset();
     sink.onRegionChange?.();
   });
@@ -140,8 +156,8 @@ export function createAtomSubscribeSession<
 }
 
 /** A subscribe session that feeds a TanStack DB collection (namespaces et al.).
- * The manager reset on region change suffices for the sink: onOpen then
- * replays an empty pre-snapshot, which applySnapshot ignores. */
+ * The region change clears the collection synchronously; hydrate is
+ * responsible only for cache seeding. */
 export function createCollectionSubscribeSession<
   T extends object,
   R extends object = SubscribeRow<T>,
@@ -156,10 +172,11 @@ export function createCollectionSubscribeSession<
   // while no component is querying it.
   const keepAlive = target.collection.subscribeChanges(() => {});
   const unsubscribeScope = scopeAtom
-    ? subscribeToScope(store, scopeAtom, target.hydrate)
+    ? subscribeToScope(store, scopeAtom, target)
     : undefined;
   const session = createSubscribeSession(options, {
     apply: (snapshot) => target.applySnapshot(snapshot),
+    onRegionChange: () => target.reset(),
   });
   target.applySnapshot(session.manager.getSnapshot());
   return {
@@ -174,9 +191,10 @@ export function createCollectionSubscribeSession<
 
 /**
  * Feeds a collection from an already-running subscribe atom rather than its
- * own socket, adding no upstream load. Region handling comes for free: the
- * source atom's session resets it, and the scope hydration both seeds from
- * and resets the collection's cache on a scope change.
+ * own socket, adding no upstream load. The source atom's own session resets
+ * the atom on a region change, but that reaches this bridge as an empty
+ * pre-snapshot, which applySnapshot ignores, so the collection clears itself
+ * on the region change too.
  */
 export function createAtomFedCollectionSession<R extends object>(options: {
   store: JotaiStore;
@@ -186,14 +204,18 @@ export function createAtomFedCollectionSession<R extends object>(options: {
 }): { destroy: () => void } {
   const { store, sourceAtom, target, scopeAtom } = options;
   const unsubscribeScope = scopeAtom
-    ? subscribeToScope(store, scopeAtom, target.hydrate)
+    ? subscribeToScope(store, scopeAtom, target)
     : undefined;
+  const unsubscribeRegion = subscribeToRegionChange(store, () =>
+    target.reset(),
+  );
   const apply = () => target.applySnapshot(store.get(sourceAtom));
   apply();
   const unsubscribeSource = store.sub(sourceAtom, apply);
   return {
     destroy() {
       unsubscribeScope?.();
+      unsubscribeRegion();
       unsubscribeSource();
     },
   };

--- a/console/src/api/materialize/useSubscribe.test.tsx
+++ b/console/src/api/materialize/useSubscribe.test.tsx
@@ -20,9 +20,13 @@ import {
 } from "~/store/environments";
 import { defaultRegionId, healthyEnvironment } from "~/test/utils";
 
-import { createSubscribeCollection } from "./subscribeCollection";
+import {
+  createSubscribeCollection,
+  syncEngineCacheKey,
+} from "./subscribeCollection";
 import { SubscribeState } from "./SubscribeManager";
 import {
+  createAtomFedCollectionSession,
   createAtomSubscribeSession,
   createCollectionSubscribeSession,
 } from "./subscribeSession";
@@ -35,6 +39,9 @@ type Row = { id: string };
 
 const request = { queries: [{ query: "SELECT 1", params: [] }] };
 const upsertKey = (row: { data: Row }) => row.data.id;
+
+/** Let the collection's async sync writes settle before asserting. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 const loadingState: SubscribeState<Row> = {
   data: [],
@@ -117,7 +124,7 @@ describe("subscribeSession", () => {
     expect(store.get(testAtom).data).toEqual([{ id: "1" }]);
   });
 
-  it("resets the collection session's manager when the region switches", () => {
+  it("clears the collection when the region switches", async () => {
     const store = setTwoRegions();
     const target = createSubscribeCollection<Row>({
       id: "session-test-collection",
@@ -131,11 +138,100 @@ describe("subscribeSession", () => {
       target,
     });
     try {
-      const reset = vi.spyOn(session.manager, "reset");
+      // A completed snapshot from the previous region is in the collection.
+      target.applySnapshot({
+        data: [{ id: "1" }],
+        snapshotComplete: true,
+        error: undefined,
+      });
+      await flush();
+      expect(target.collection.size).toBe(1);
+
+      // The rows must be gone and the loading gate closed, not merely a
+      // manager reset invoked: that reset reaches applySnapshot as an empty
+      // pre-snapshot, which it ignores by design.
       store.set(currentRegionIdAtom, "aws/eu-west-1");
-      expect(reset).toHaveBeenCalledTimes(1);
+      await flush();
+      expect(target.collection.size).toBe(0);
+      expect(store.get(target.statusAtom).snapshotComplete).toBe(false);
     } finally {
       session.destroy();
+    }
+  });
+
+  it("clears an atom-fed collection when the region switches", async () => {
+    const store = setTwoRegions();
+    const sourceAtom = atom<SubscribeState<Row>>(loadingState);
+    const target = createSubscribeCollection<Row>({
+      id: "session-test-atom-fed",
+      getKey: (row) => row.id,
+    });
+    const session = createAtomFedCollectionSession({
+      store,
+      sourceAtom,
+      target,
+    });
+    try {
+      store.set(sourceAtom, {
+        data: [{ id: "1" }],
+        snapshotComplete: true,
+        error: undefined,
+      });
+      await flush();
+      expect(target.collection.size).toBe(1);
+
+      store.set(currentRegionIdAtom, "aws/eu-west-1");
+      await flush();
+      expect(target.collection.size).toBe(0);
+      expect(store.get(target.statusAtom).snapshotComplete).toBe(false);
+    } finally {
+      session.destroy();
+    }
+  });
+
+  it("suspends persistence when the scope fails to resolve", () => {
+    vi.useFakeTimers();
+    const store = setTwoRegions();
+    const scopeAtom = atom<
+      | { state: "loading" }
+      | { state: "hasError"; error: unknown }
+      | { state: "hasData"; data: string | undefined }
+    >({ state: "loading" });
+    const sourceAtom = atom<SubscribeState<Row>>(loadingState);
+    const target = createSubscribeCollection<Row>({
+      id: "session-test-scope-error",
+      getKey: (row) => row.id,
+      persistName: "session-scope-error",
+    });
+    const session = createAtomFedCollectionSession({
+      store,
+      sourceAtom,
+      target,
+      scopeAtom,
+    });
+    const key = syncEngineCacheKey("session-scope-error", "org|regionA");
+    try {
+      store.set(scopeAtom, { state: "hasData", data: "org|regionA" });
+      store.set(sourceAtom, {
+        data: [{ id: "1" }],
+        snapshotComplete: true,
+        error: undefined,
+      });
+
+      // Scope resolution fails before the persist throttle fires: nothing may
+      // be written under the last known scope's key.
+      store.set(scopeAtom, { state: "hasError", error: new Error("boom") });
+      store.set(sourceAtom, {
+        data: [{ id: "2" }],
+        snapshotComplete: true,
+        error: undefined,
+      });
+      vi.advanceTimersByTime(1100);
+      expect(localStorage.getItem(key)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+      session.destroy();
+      localStorage.clear();
     }
   });
 });

--- a/console/src/api/materialize/useSubscribe.test.tsx
+++ b/console/src/api/materialize/useSubscribe.test.tsx
@@ -1,0 +1,141 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { atom } from "jotai";
+import { ws } from "msw";
+
+import server from "~/api/mocks/server";
+import { getStore } from "~/jotai";
+import {
+  currentEnvironmentState,
+  currentRegionIdAtom,
+  EnvironmentsWithHealth,
+  environmentsWithHealth,
+} from "~/store/environments";
+import { defaultRegionId, healthyEnvironment } from "~/test/utils";
+
+import { createSubscribeCollection } from "./subscribeCollection";
+import { SubscribeState } from "./SubscribeManager";
+import {
+  createAtomSubscribeSession,
+  createCollectionSubscribeSession,
+} from "./subscribeSession";
+
+// Accept subscribe sockets and stay silent, so connections neither error nor
+// deliver data: the only thing that may then change state is the session.
+const subscribeSocket = ws.link("ws://*");
+
+type Row = { id: string };
+
+const request = { queries: [{ query: "SELECT 1", params: [] }] };
+const upsertKey = (row: { data: Row }) => row.data.id;
+
+const loadingState: SubscribeState<Row> = {
+  data: [],
+  snapshotComplete: false,
+  error: undefined,
+};
+
+function setTwoRegions() {
+  const store = getStore();
+  store.set(
+    environmentsWithHealth,
+    new Map<string, unknown>([
+      [defaultRegionId, { ...healthyEnvironment, httpAddress: "addr-a:6876" }],
+      ["aws/eu-west-1", { ...healthyEnvironment, httpAddress: "addr-b:6876" }],
+    ]) as unknown as EnvironmentsWithHealth,
+  );
+  return store;
+}
+
+describe("subscribeSession", () => {
+  beforeEach(() => {
+    server.use(subscribeSocket.addEventListener("connection", () => {}));
+  });
+
+  afterEach(async () => {
+    const store = getStore();
+    store.set(currentRegionIdAtom, defaultRegionId);
+    await store.get(currentEnvironmentState);
+  });
+
+  it("resets the atom to loading only when the region actually changes", () => {
+    const store = setTwoRegions();
+    const testAtom = atom<SubscribeState<Row>>(loadingState);
+    const session = createAtomSubscribeSession<Row, Row>({
+      store,
+      request,
+      upsertKey,
+      select: (row) => row.data,
+      atom: testAtom,
+    });
+    try {
+      // A completed snapshot from the previous region is in the atom.
+      store.set(testAtom, {
+        data: [{ id: "1" }],
+        snapshotComplete: true,
+        error: undefined,
+      });
+
+      // Re-setting the same region is not a change.
+      store.set(currentRegionIdAtom, defaultRegionId);
+      expect(store.get(testAtom).data).toEqual([{ id: "1" }]);
+
+      // The previous region's rows must not be served as the new region's data.
+      store.set(currentRegionIdAtom, "aws/eu-west-1");
+      expect(store.get(testAtom).data).toEqual([]);
+      expect(store.get(testAtom).snapshotComplete).toBe(false);
+    } finally {
+      session.destroy();
+    }
+  });
+
+  it("stops reacting to region changes after destroy", () => {
+    const store = setTwoRegions();
+    const testAtom = atom<SubscribeState<Row>>(loadingState);
+    const session = createAtomSubscribeSession<Row, Row>({
+      store,
+      request,
+      upsertKey,
+      select: (row) => row.data,
+      atom: testAtom,
+    });
+    session.destroy();
+
+    store.set(testAtom, {
+      data: [{ id: "1" }],
+      snapshotComplete: true,
+      error: undefined,
+    });
+    store.set(currentRegionIdAtom, "aws/eu-west-1");
+    expect(store.get(testAtom).data).toEqual([{ id: "1" }]);
+  });
+
+  it("resets the collection session's manager when the region switches", () => {
+    const store = setTwoRegions();
+    const target = createSubscribeCollection<Row>({
+      id: "session-test-collection",
+      getKey: (row) => row.id,
+    });
+    const session = createCollectionSubscribeSession<Row, Row>({
+      store,
+      request,
+      upsertKey,
+      select: (row) => row.data,
+      target,
+    });
+    try {
+      const reset = vi.spyOn(session.manager, "reset");
+      store.set(currentRegionIdAtom, "aws/eu-west-1");
+      expect(reset).toHaveBeenCalledTimes(1);
+    } finally {
+      session.destroy();
+    }
+  });
+});

--- a/console/src/api/materialize/useSubscribe.ts
+++ b/console/src/api/materialize/useSubscribe.ts
@@ -7,12 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-import { PrimitiveAtom, useSetAtom } from "jotai";
+import { PrimitiveAtom, useStore } from "jotai";
 import { RawBuilder } from "kysely";
 import React from "react";
 
 import { useAutomaticallyConnectSocket } from "~/hooks/useAutomaticallyConnectSocket";
-import { getStore } from "~/jotai";
 import { useCurrentEnvironmentHttpAddress } from "~/store/environments";
 
 import { queryBuilder } from "./db";
@@ -25,6 +24,11 @@ import {
   SubscribeState,
   UpsertKeyFunction,
 } from "./SubscribeManager";
+import {
+  createAtomSubscribeSession,
+  createCollectionSubscribeSession,
+  ScopeLoadableAtom,
+} from "./subscribeSession";
 
 export { buildSubscribeQuery } from "~/api/materialize/buildSubscribeQuery";
 
@@ -102,14 +106,14 @@ export function useSubscribe<T extends object, R = SubscribeRow<T>>(
 }
 
 /**
- * Executes a subscribe query, storing state in the provided atom.
- * All updates are reduced to the current set of values at latest closed timestamp.
+ * Runs an app-session subscribe that reduces into the provided atom, for as
+ * long as the calling component is mounted. All wiring (connection lifecycle,
+ * atom writes, region-change reset) lives in createAtomSubscribeSession.
+ *
+ * `options` must be referentially stable (declare it at module scope); a new
+ * object restarts the subscribe session.
  *
  * Note that the subscribe statement must have WITH (PROGRESS) and ENVELOPE UPSERT.
- *
- * The `select` and `upsertKey` functions are not expected to be stable, and new
- * function instances for these options will not restart the subscribe. On each render,
- * the socket will update the function reference.
  */
 export function useGlobalUpsertSubscribe<T extends object, R = SubscribeRow<T>>(
   options: UseSubscribeOptions<T, R> & {
@@ -117,54 +121,30 @@ export function useGlobalUpsertSubscribe<T extends object, R = SubscribeRow<T>>(
     atom: PrimitiveAtom<SubscribeState<R>>;
   },
 ) {
-  const setValue = useSetAtom(options.atom);
-  const httpAddress = useCurrentEnvironmentHttpAddress();
+  const store = useStore();
   const request = useSubscribeRequest(options.subscribe);
-  const [subscribe] = React.useState(
-    new SubscribeManager<T, R>({
-      request,
-      httpAddress,
-      upsert: {
-        key: options.upsertKey,
-      },
-      sessionVariables: {
-        cluster: options?.clusterName,
-      },
-      closeSocketOnComplete: options?.closeSocketOnComplete,
-      select: options.select,
-    }),
-  );
-  useAutomaticallyConnectSocket<T, R>({
-    target: subscribe,
-    subscribe,
-    request,
-  });
-
   React.useEffect(() => {
-    const cleanup = subscribe.onChange(() => {
-      const snapshot = subscribe.getSnapshot();
-      const current = getStore().get(options.atom);
-      if (current === snapshot) return;
-
-      // Hold cached atom data through a fresh manager's empty pre-snapshot state.
-      const snapshotIsEmptyPreload =
-        !snapshot.snapshotComplete && !snapshot.data.length && !snapshot.error;
-      if (snapshotIsEmptyPreload && current.data.length) return;
-
-      setValue(snapshot);
+    if (!request) return;
+    const session = createAtomSubscribeSession<T, R>({
+      store,
+      request,
+      atom: options.atom,
+      upsertKey: options.upsertKey,
+      select: options.select,
+      sessionVariables: { cluster: options.clusterName },
+      closeSocketOnComplete: options.closeSocketOnComplete,
     });
-    return cleanup;
-  }, [options.atom, setValue, subscribe]);
-
-  return {
-    subscribe,
-  };
+    return session.destroy;
+  }, [store, request, options]);
 }
 
 /**
- * Executes a subscribe query and feeds the upsert-reduced state into a TanStack DB
- * collection (via createSubscribeCollection). Mirrors useGlobalUpsertSubscribe but
- * targets a collection + status atom instead of a single SubscribeState atom.
+ * Runs an app-session subscribe that feeds a TanStack DB collection, for as
+ * long as the calling component is mounted. Mirrors useGlobalUpsertSubscribe
+ * with createCollectionSubscribeSession owning the wiring.
+ *
+ * `options` must be referentially stable (declare it at module scope); a new
+ * object restarts the subscribe session.
  *
  * Note that the subscribe statement must have WITH (PROGRESS) and ENVELOPE UPSERT.
  */
@@ -175,50 +155,25 @@ export function useGlobalSubscribeCollection<
   options: UseSubscribeOptions<T, R> & {
     upsertKey: UpsertKeyFunction<T>;
     target: SubscribeCollection<R>;
+    scopeAtom?: ScopeLoadableAtom;
   },
 ) {
-  const httpAddress = useCurrentEnvironmentHttpAddress();
+  const store = useStore();
   const request = useSubscribeRequest(options.subscribe);
-  const target = options.target;
-  const [subscribe] = React.useState(
-    new SubscribeManager<T, R>({
+  React.useEffect(() => {
+    if (!request) return;
+    const session = createCollectionSubscribeSession<T, R>({
+      store,
       request,
-      httpAddress,
-      upsert: {
-        key: options.upsertKey,
-      },
-      sessionVariables: {
-        cluster: options?.clusterName,
-      },
-      closeSocketOnComplete: options?.closeSocketOnComplete,
+      target: options.target,
+      scopeAtom: options.scopeAtom,
+      upsertKey: options.upsertKey,
       select: options.select,
-    }),
-  );
-  useAutomaticallyConnectSocket<T, R>({
-    target: subscribe,
-    subscribe,
-    request,
-  });
-
-  React.useEffect(() => {
-    // applySnapshot itself drops empty pre-snapshots when state already exists,
-    // so the manager can push every snapshot unconditionally.
-    const apply = () => target.applySnapshot(subscribe.getSnapshot());
-    const cleanup = subscribe.onChange(apply);
-    apply();
-    return cleanup;
-  }, [target, subscribe]);
-
-  // Keep the collection actively syncing for the app session by holding a
-  // subscriber, so it doesn't pause/GC when no component is querying it.
-  React.useEffect(() => {
-    const subscription = target.collection.subscribeChanges(() => {});
-    return () => subscription.unsubscribe();
-  }, [target]);
-
-  return {
-    subscribe,
-  };
+      sessionVariables: { cluster: options.clusterName },
+      closeSocketOnComplete: options.closeSocketOnComplete,
+    });
+    return session.destroy;
+  }, [store, request, options]);
 }
 
 /**

--- a/console/src/platform/object-explorer/allNamespacesCollection.ts
+++ b/console/src/platform/object-explorer/allNamespacesCollection.ts
@@ -9,7 +9,7 @@
 
 import { useLiveQuery } from "@tanstack/react-db";
 import { useAtomValue } from "jotai";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
 import { buildSubscribeQuery } from "~/api/materialize/buildSubscribeQuery";
 import {
@@ -19,7 +19,7 @@ import {
 import { createSubscribeCollection } from "~/api/materialize/subscribeCollection";
 import { SubscribeRow } from "~/api/materialize/SubscribeManager";
 import { useGlobalSubscribeCollection } from "~/api/materialize/useSubscribe";
-import { useSyncEngineCacheScope } from "~/store/syncEngineCache";
+import { syncEngineCacheScopeLoadableAtom } from "~/store/syncEngineCache";
 
 /** Subset of AllNamespaceItem stored per row, matching the existing atom's select. */
 export type NamespaceItem = Pick<
@@ -39,29 +39,23 @@ export const allNamespacesCollection = createSubscribeCollection<NamespaceItem>(
   },
 );
 
+const ALL_NAMESPACES_SUBSCRIBE_OPTIONS = {
+  target: allNamespacesCollection,
+  scopeAtom: syncEngineCacheScopeLoadableAtom,
+  subscribe: buildSubscribeQuery(buildAllNamespacesQuery(), {
+    upsertKey: ["schemaId", "databaseId"],
+  }),
+  select: (row: SubscribeRow<AllNamespaceItem>): NamespaceItem => ({
+    schemaId: row.data.schemaId,
+    schemaName: row.data.schemaName,
+    databaseId: row.data.databaseId,
+    databaseName: row.data.databaseName,
+  }),
+  upsertKey: (row: SubscribeRow<AllNamespaceItem>) => namespaceKey(row.data),
+};
+
 export function useSubscribeToAllNamespacesCollection() {
-  const scope = useSyncEngineCacheScope();
-  useEffect(() => {
-    if (scope) allNamespacesCollection.hydrate(scope);
-  }, [scope]);
-
-  const subscribe = useMemo(() => {
-    return buildSubscribeQuery(buildAllNamespacesQuery(), {
-      upsertKey: ["schemaId", "databaseId"],
-    });
-  }, []);
-
-  return useGlobalSubscribeCollection<AllNamespaceItem, NamespaceItem>({
-    target: allNamespacesCollection,
-    subscribe,
-    select: (row: SubscribeRow<AllNamespaceItem>) => ({
-      schemaId: row.data.schemaId,
-      schemaName: row.data.schemaName,
-      databaseId: row.data.databaseId,
-      databaseName: row.data.databaseName,
-    }),
-    upsertKey: (row: SubscribeRow<AllNamespaceItem>) => namespaceKey(row.data),
-  });
+  useGlobalSubscribeCollection(ALL_NAMESPACES_SUBSCRIBE_OPTIONS);
 }
 
 /** Returns the namespace items for the object explorer tree, from the collection. */

--- a/console/src/store/allClusters.ts
+++ b/console/src/store/allClusters.ts
@@ -14,7 +14,10 @@ import {
   buildClustersQuery,
   Cluster,
 } from "~/api/materialize/cluster/clusterList";
-import { SubscribeState } from "~/api/materialize/SubscribeManager";
+import {
+  SubscribeRow,
+  SubscribeState,
+} from "~/api/materialize/SubscribeManager";
 import {
   buildSubscribeQuery,
   useGlobalUpsertSubscribe,
@@ -26,22 +29,18 @@ export const allClusters = atom<SubscribeState<Cluster>>({
   snapshotComplete: false,
 });
 
-export function useSubscribeToAllClusters() {
-  const subscribe = React.useMemo(() => {
-    return buildSubscribeQuery(
-      buildClustersQuery({ queryOwnership: false, includeSystemObjects: true }),
-      {
-        upsertKey: "id",
-      },
-    );
-  }, []);
+const ALL_CLUSTERS_SUBSCRIBE_OPTIONS = {
+  atom: allClusters,
+  subscribe: buildSubscribeQuery(
+    buildClustersQuery({ queryOwnership: false, includeSystemObjects: true }),
+    { upsertKey: "id" },
+  ),
+  select: (row: SubscribeRow<Cluster>) => row.data,
+  upsertKey: (row: SubscribeRow<Cluster>) => row.data.id,
+};
 
-  return useGlobalUpsertSubscribe({
-    atom: allClusters,
-    subscribe,
-    select: (row) => row.data,
-    upsertKey: (row) => row.data.id,
-  });
+export function useSubscribeToAllClusters() {
+  useGlobalUpsertSubscribe(ALL_CLUSTERS_SUBSCRIBE_OPTIONS);
 }
 
 export function useAllClusters() {

--- a/console/src/store/allObjects.ts
+++ b/console/src/store/allObjects.ts
@@ -14,7 +14,10 @@ import {
   buildAllObjectsQuery,
   DatabaseObject,
 } from "~/api/materialize/objects";
-import { SubscribeState } from "~/api/materialize/SubscribeManager";
+import {
+  SubscribeRow,
+  SubscribeState,
+} from "~/api/materialize/SubscribeManager";
 import {
   buildSubscribeQuery,
   useGlobalUpsertSubscribe,
@@ -26,17 +29,15 @@ export const allObjects = atom<SubscribeState<DatabaseObject>>({
   snapshotComplete: false,
 });
 
-export function useSubscribeToAllObjects() {
-  const subscribe = React.useMemo(() => {
-    return buildSubscribeQuery(buildAllObjectsQuery(), { upsertKey: "id" });
-  }, []);
+const ALL_OBJECTS_SUBSCRIBE_OPTIONS = {
+  atom: allObjects,
+  subscribe: buildSubscribeQuery(buildAllObjectsQuery(), { upsertKey: "id" }),
+  select: (row: SubscribeRow<DatabaseObject>) => row.data,
+  upsertKey: (row: SubscribeRow<DatabaseObject>) => row.data.id,
+};
 
-  return useGlobalUpsertSubscribe({
-    atom: allObjects,
-    subscribe,
-    select: (row) => row.data,
-    upsertKey: (row) => row.data.id,
-  });
+export function useSubscribeToAllObjects() {
+  useGlobalUpsertSubscribe(ALL_OBJECTS_SUBSCRIBE_OPTIONS);
 }
 
 export function useAllObjects() {

--- a/console/src/store/allObjectsCollection.ts
+++ b/console/src/store/allObjectsCollection.ts
@@ -8,13 +8,14 @@
 // by the Apache License, Version 2.0.
 
 import { useLiveQuery } from "@tanstack/react-db";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useStore } from "jotai";
 import React from "react";
 
 import { DatabaseObject } from "~/api/materialize/objects";
 import { createSubscribeCollection } from "~/api/materialize/subscribeCollection";
+import { createAtomFedCollectionSession } from "~/api/materialize/subscribeSession";
 import { allObjects } from "~/store/allObjects";
-import { useSyncEngineCacheScope } from "~/store/syncEngineCache";
+import { syncEngineCacheScopeLoadableAtom } from "~/store/syncEngineCache";
 
 /**
  * TanStack DB-backed view of the `allObjects` jotai atom, so consumers can run
@@ -35,14 +36,16 @@ export const allObjectsCollection = createSubscribeCollection<DatabaseObject>({
  * tree is mounted, and sync re-seeds from the retained row set if it restarts.
  */
 export function useSubscribeToAllObjectsCollection() {
-  const state = useAtomValue(allObjects);
-  const scope = useSyncEngineCacheScope();
+  const store = useStore();
   React.useEffect(() => {
-    if (scope) allObjectsCollection.hydrate(scope);
-  }, [scope]);
-  React.useEffect(() => {
-    allObjectsCollection.applySnapshot(state);
-  }, [state]);
+    const session = createAtomFedCollectionSession({
+      store,
+      sourceAtom: allObjects,
+      target: allObjectsCollection,
+      scopeAtom: syncEngineCacheScopeLoadableAtom,
+    });
+    return session.destroy;
+  }, [store]);
 }
 
 /**

--- a/console/src/store/allRoles.ts
+++ b/console/src/store/allRoles.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 import { atom, useAtomValue } from "jotai";
-import React, { useMemo } from "react";
+import React from "react";
 
 import { buildSubscribeQuery } from "~/api/materialize/buildSubscribeQuery";
 import {
@@ -29,19 +29,17 @@ export const allRoles = atom<SubscribeState<RoleItem>>({
   snapshotComplete: false,
 });
 
-export function useSubscribeToAllRoles() {
-  const subscribe = useMemo(() => {
-    return buildSubscribeQuery(buildRolesListQuery(), {
-      upsertKey: ["roleName"],
-    });
-  }, []);
+const ALL_ROLES_SUBSCRIBE_OPTIONS = {
+  atom: allRoles,
+  subscribe: buildSubscribeQuery(buildRolesListQuery(), {
+    upsertKey: ["roleName"],
+  }),
+  select: (row: SubscribeRow<RoleItem>) => row.data,
+  upsertKey: (row: SubscribeRow<RoleItem>) => row.data.roleName,
+};
 
-  return useGlobalUpsertSubscribe({
-    atom: allRoles,
-    subscribe,
-    select: (row: SubscribeRow<RoleItem>) => row.data,
-    upsertKey: (row: SubscribeRow<RoleItem>) => row.data.roleName,
-  });
+export function useSubscribeToAllRoles() {
+  useGlobalUpsertSubscribe(ALL_ROLES_SUBSCRIBE_OPTIONS);
 }
 
 export function useAllRoles() {

--- a/console/src/store/allSchemas.ts
+++ b/console/src/store/allSchemas.ts
@@ -15,7 +15,10 @@ import {
   buildAllSchemaListQuery,
   SchemaWithOptionalDatabase,
 } from "~/api/materialize/schemaList";
-import { SubscribeState } from "~/api/materialize/SubscribeManager";
+import {
+  SubscribeRow,
+  SubscribeState,
+} from "~/api/materialize/SubscribeManager";
 import {
   buildSubscribeQuery,
   useGlobalUpsertSubscribe,
@@ -27,17 +30,17 @@ export const allSchemas = atom<SubscribeState<SchemaWithOptionalDatabase>>({
   snapshotComplete: false,
 });
 
-export function useSubscribeToAllSchemas() {
-  const subscribe = React.useMemo(() => {
-    return buildSubscribeQuery(buildAllSchemaListQuery(), { upsertKey: "id" });
-  }, []);
+const ALL_SCHEMAS_SUBSCRIBE_OPTIONS = {
+  atom: allSchemas,
+  subscribe: buildSubscribeQuery(buildAllSchemaListQuery(), {
+    upsertKey: "id",
+  }),
+  select: (row: SubscribeRow<SchemaWithOptionalDatabase>) => row.data,
+  upsertKey: (row: SubscribeRow<SchemaWithOptionalDatabase>) => row.data.id,
+};
 
-  return useGlobalUpsertSubscribe({
-    atom: allSchemas,
-    subscribe,
-    select: (row) => row.data,
-    upsertKey: (row) => row.data.id,
-  });
+export function useSubscribeToAllSchemas() {
+  useGlobalUpsertSubscribe(ALL_SCHEMAS_SUBSCRIBE_OPTIONS);
 }
 
 export function useAllSchemas(options?: { includeSystemSchemas?: boolean }) {

--- a/console/src/store/syncEngineCache.ts
+++ b/console/src/store/syncEngineCache.ts
@@ -7,26 +7,48 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-import { useAtomValue } from "jotai";
+import { atom } from "jotai";
+import { loadable } from "jotai/utils";
 
-import { useMaybeCurrentOrganizationId } from "~/api/auth";
+import {
+  fetchCurrentOrganization,
+  queryKeys as authQueryKeys,
+} from "~/api/auth";
+import { Organization } from "~/api/cloudGlobalApi";
+import { appConfigAtom } from "~/config/store";
+import { getQueryClient } from "~/queryClient";
 import { currentRegionIdSyncAtom } from "~/store/environments";
 
 /**
  * The auth/region scope for the sync-engine localStorage caches, as
- * `organizationId|regionId`. Returns undefined until both are known, so callers
- * defer seeding until the scope is settled and never share one tenant's cache
- * with another on the shared `console.materialize.com` origin.
+ * `organizationId|regionId`. Resolves to undefined until both are known, so
+ * consumers defer cache seeding until the scope is settled and never share one
+ * tenant's cache with another on a shared origin.
  */
-export function useSyncEngineCacheScope(): string | undefined {
-  const maybeOrganizationId = useMaybeCurrentOrganizationId();
-  const regionId = useAtomValue(currentRegionIdSyncAtom);
+export const syncEngineCacheScopeAtom = atom(async (get) => {
+  const regionId = get(currentRegionIdSyncAtom);
+  if (!regionId) return undefined;
 
-  const organizationIdLoading =
-    maybeOrganizationId !== null && maybeOrganizationId.isLoading;
-  if (organizationIdLoading || !regionId) return undefined;
+  const appConfig = get(appConfigAtom);
+  const isLocalImpersonation =
+    appConfig.mode === "cloud" &&
+    appConfig.isImpersonating &&
+    appConfig.isLocalImpersonation;
+  const organizationFetchEnabled =
+    appConfig.mode !== "self-managed" && !isLocalImpersonation;
 
-  const organizationId =
-    maybeOrganizationId !== null ? maybeOrganizationId.data : undefined;
+  const organizationId = organizationFetchEnabled
+    ? (
+        await getQueryClient().ensureQueryData<Organization>({
+          queryKey: authQueryKeys.currentOrganization(),
+          queryFn: fetchCurrentOrganization,
+        })
+      ).id
+    : undefined;
   return `${organizationId ?? ""}|${regionId}`;
-}
+});
+
+/** Synchronous view of the scope for store.sub consumers (subscribe sessions). */
+export const syncEngineCacheScopeLoadableAtom = loadable(
+  syncEngineCacheScopeAtom,
+);

--- a/console/src/store/syncEngineCache.ts
+++ b/console/src/store/syncEngineCache.ts
@@ -12,6 +12,7 @@ import { loadable } from "jotai/utils";
 
 import {
   fetchCurrentOrganization,
+  isOrganizationFetchEnabled,
   queryKeys as authQueryKeys,
 } from "~/api/auth";
 import { Organization } from "~/api/cloudGlobalApi";
@@ -29,15 +30,7 @@ export const syncEngineCacheScopeAtom = atom(async (get) => {
   const regionId = get(currentRegionIdSyncAtom);
   if (!regionId) return undefined;
 
-  const appConfig = get(appConfigAtom);
-  const isLocalImpersonation =
-    appConfig.mode === "cloud" &&
-    appConfig.isImpersonating &&
-    appConfig.isLocalImpersonation;
-  const organizationFetchEnabled =
-    appConfig.mode !== "self-managed" && !isLocalImpersonation;
-
-  const organizationId = organizationFetchEnabled
+  const organizationId = isOrganizationFetchEnabled(get(appConfigAtom))
     ? (
         await getQueryClient().ensureQueryData<Organization>({
           queryKey: authQueryKeys.currentOrganization(),


### PR DESCRIPTION
## Motivation

Switching regions in the console left pages fed by the app-wide SUBSCRIBEs (cluster list, object explorer) showing the previous region's catalog until a full page refresh, and the sync-engine localStorage cache could be poisoned with another region's rows. Fixing this properly also motivated restructuring how the subscribe stack is wired, and documenting the resulting architecture.

Fixes: [CNS-157 ](https://linear.app/materializeinc/issue/CNS-157/fix-sync-engine-reseeding-when-changing-regions)
Fixes: [CNS-155](https://linear.app/materializeinc/issue/CNS-155/clusters-do-not-update-when-switching-regions)
## The commits (one concern each; the branch squash-merges)

1. **Sync-engine cache scope fixes** (`subscribeCollection.ts`): a scope change drops in-memory rows and any pending persist before re-seeding, so one tenant's catalog is never written under another's cache key, and a reconnect's empty pre-snapshot clears a stale error so the UI falls back to loading during backoff. (Both flagged by the QA review on #38609.)

2. **Region-aware connection manager** (`WebsocketConnectionManager.ts`): tracks the address and region of the most recent connection attempt. Reconnects when the region's address changes (including mid-handshake), and tears down a paused socket only when it points at a region the user has left — keyed on region so disabled regions (whose address never updates) are covered, while a same-region health blip leaves a working socket alone (an intentional disconnect fires no close callback, so unconditional teardown would silently replace the SQL Shell's session).

3. **Subscribe sessions** (`subscribeSession.ts` + hooks + stores): the wiring that had accumulated as one React effect per concern moves into plain session objects that subscribe to the jotai store directly, the pattern the connection manager already used. Sessions reset their manager and sink on region change and hydrate collections from the scoped cache via a new cache-scope atom. Hooks keep a single lifecycle effect, cannot suspend, and take referentially stable module-scope options. The allObjects-to-collection bridge runs off a store subscription instead of re-renders.

4. **Documentation** (`doc/design/20260902_sync_engine.md`, `doc/architecture.md`, `AGENTS.md`): a design doc explaining the sync engine end to end (feed, sessions, both sinks, the collection bridge and its scoped instant-load cache, region-switch data flow, boundaries, adoption recipes), plus updates to the data-layer sections of the architecture doc and the agent guidance so they describe the server-state split: React Query for polled/one-shot data, the sync engine for live catalog data.

## Tips for reviewer

Every behavioral claim has a regression test that was verified to fail against the code it fixes: cache scope and error-clear tests in `subscribeCollection.test.ts`, the region round-trip / same-region-blip / disabled-region / mid-handshake tests in `WebsocketConnectionManager.test.ts`, and headless session tests in `useSubscribe.test.tsx`.

Known unrelated failure: `PlanDetails.test.tsx` (billing) fails identically on current main — it started failing on 2026-09-03 with no billing changes here, so it looks date-dependent and is not introduced by this branch.

## Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing $T ⇔ Proto$T mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
