### PR TITLE
console: Add replica count filter to cluster usage table

### DIFF
--- a/console/src/components/Table/UniversalTable.tsx
+++ b/console/src/components/Table/UniversalTable.tsx
@@ -99,7 +99,7 @@ const ColumnFilterTrigger = <TData,>({
         motionProps={{ animate: false }}
         onClick={(e) => e.stopPropagation()}
       >
-        <Box width="280px">
+        <Box>
           {renderFilter(header.column, header.getContext().table)}
         </Box>
       </PopoverContent>

--- a/console/src/components/Table/UniversalTable.tsx
+++ b/console/src/components/Table/UniversalTable.tsx
@@ -99,9 +99,7 @@ const ColumnFilterTrigger = <TData,>({
         motionProps={{ animate: false }}
         onClick={(e) => e.stopPropagation()}
       >
-        <Box>
-          {renderFilter(header.column, header.getContext().table)}
-        </Box>
+        <Box>{renderFilter(header.column, header.getContext().table)}</Box>
       </PopoverContent>
     </Popover>
   );

--- a/console/src/platform/clusters/ClusterFilterChips.tsx
+++ b/console/src/platform/clusters/ClusterFilterChips.tsx
@@ -14,6 +14,10 @@ import React from "react";
 import { HydrationBucket } from "~/platform/maintained-objects/filters";
 
 import { HYDRATION_COLUMN_ID, hydrationFilterLabel } from "./hydrationFilters";
+import {
+  REPLICA_COLUMN_ID,
+  replicaCountFilterLabel,
+} from "./replicaCountFilters";
 import { utilizationFilterLabel } from "./utilizationFilters";
 
 interface Chip {
@@ -61,6 +65,25 @@ const hydrationChips = <TData,>(table: Table<TData>): Chip[] => {
   }));
 };
 
+/**
+ * The replica count minimum in force. Removing the chip drops the minimum
+ * entirely, which is the only way back to the clusters with no replicas once
+ * the default minimum has hidden them.
+ */
+const replicaCountChips = <TData,>(table: Table<TData>): Chip[] => {
+  const column = table.getColumn(REPLICA_COLUMN_ID);
+  const minimum = column?.getFilterValue() as number | undefined;
+  if (!column || minimum === undefined) return [];
+
+  return [
+    {
+      key: REPLICA_COLUMN_ID,
+      label: replicaCountFilterLabel(minimum),
+      onRemove: () => column.setFilterValue(undefined),
+    },
+  ];
+};
+
 export interface ClusterFilterChipsProps<TData> {
   table: Table<TData>;
   /** The utilization columns, in the order their chips should appear. */
@@ -80,6 +103,7 @@ export const ClusterFilterChips = <TData,>({
   utilizationColumns,
 }: ClusterFilterChipsProps<TData>) => {
   const chips = [
+    ...replicaCountChips(table),
     ...utilizationChips(table, utilizationColumns),
     ...hydrationChips(table),
   ];

--- a/console/src/platform/clusters/ClusterFilterChips.tsx
+++ b/console/src/platform/clusters/ClusterFilterChips.tsx
@@ -65,11 +65,6 @@ const hydrationChips = <TData,>(table: Table<TData>): Chip[] => {
   }));
 };
 
-/**
- * The replica count minimum in force. Removing the chip drops the minimum
- * entirely, which is the only way back to the clusters with no replicas once
- * the default minimum has hidden them.
- */
 const replicaCountChips = <TData,>(table: Table<TData>): Chip[] => {
   const column = table.getColumn(REPLICA_COLUMN_ID);
   const minimum = column?.getFilterValue() as number | undefined;

--- a/console/src/platform/clusters/ClusterUsageTable.tsx
+++ b/console/src/platform/clusters/ClusterUsageTable.tsx
@@ -111,8 +111,11 @@ const NO_UTILIZATION: ReplicaUtilizationValues = {
  * be looked up from table meta.
  *
  * `replica` is null for a cluster that currently has no replicas. Such a
- * cluster still gets a row, so the list stays a complete inventory of clusters
- * rather than silently hiding the ones with nothing running.
+ * cluster still gets a row, so every cluster is representable, but the replica
+ * count filter defaults to a minimum of one replica and so hides those rows
+ * until a reader asks for them. The row model stays complete because the filter
+ * is the reader's to remove: it is stated on a chip and is one click from off,
+ * which a dropped row could not be. See `replicaCountFilters`.
  *
  * `hydration` is null when the replica has no counted objects, which is not the
  * same as nothing being hydrated. See `buildReplicaHydrationQuery` for what the

--- a/console/src/platform/clusters/ClusterUsageTable.tsx
+++ b/console/src/platform/clusters/ClusterUsageTable.tsx
@@ -73,6 +73,14 @@ import {
   useReplicaHydration,
   useReplicaUtilization,
 } from "./queries";
+import { ReplicaCountFilterPanel } from "./ReplicaCountFilterPanel";
+import {
+  REPLICA_COLUMN_ID,
+  REPLICA_COUNT_URL_KEY,
+  replicaCountFilterFn,
+  replicaCountFilterFromUrl,
+  replicaCountFilterToUrl,
+} from "./replicaCountFilters";
 import { UtilizationFilterPanel } from "./UtilizationFilterPanel";
 import {
   utilizationFilterFn,
@@ -279,6 +287,13 @@ const columnFiltersFromSearch = (search: string): ColumnFiltersState => {
     filters.push({ id: HYDRATION_COLUMN_ID, value: buckets });
   }
 
+  const minimumReplicas = replicaCountFilterFromUrl(
+    params.get(REPLICA_COUNT_URL_KEY),
+  );
+  if (minimumReplicas !== undefined) {
+    filters.push({ id: REPLICA_COLUMN_ID, value: minimumReplicas });
+  }
+
   return filters;
 };
 
@@ -310,12 +325,16 @@ const columns = [
     },
   }),
   columnHelper.accessor((row) => row.replica?.name ?? null, {
-    id: "replica",
+    id: REPLICA_COLUMN_ID,
     header: "Replica",
     sortingFn: sortingFunctions.nullsLast,
     cell: (info) => info.getValue() ?? "-",
+    // The filter counts the row's cluster's replicas, so it hides the rows of
+    // whole clusters rather than individual replicas.
+    filterFn: replicaCountFilterFn,
     meta: {
       cellProps: truncateMaxWidth,
+      renderFilter: (column) => <ReplicaCountFilterPanel column={column} />,
     },
   }),
   columnHelper.accessor((row) => row.replica?.size ?? null, {
@@ -482,6 +501,15 @@ export const ClusterUsageTable = ({ clusters }: ClusterUsageTableProps) => {
     );
     if (hydrationFilter) {
       params[HYDRATION_URL_KEY] = hydrationFilter.value;
+    }
+    const replicaCountFilter = tableState.columnFilters.find(
+      (filter) => filter.id === REPLICA_COLUMN_ID,
+    );
+    const minimumReplicas = replicaCountFilterToUrl(
+      replicaCountFilter?.value as number | undefined,
+    );
+    if (minimumReplicas !== undefined) {
+      params[REPLICA_COUNT_URL_KEY] = minimumReplicas;
     }
     if (tableState.globalFilter) {
       params.q = tableState.globalFilter;

--- a/console/src/platform/clusters/ClustersList.test.tsx
+++ b/console/src/platform/clusters/ClustersList.test.tsx
@@ -173,16 +173,64 @@ const buildCluster = ({
   ...overrides,
 });
 
-const renderClustersList = async (clusters: Cluster[]) => {
+/**
+ * A URL turning the replica count filter off, so a test can see the rows the
+ * default minimum of one replica hides, or read the chips of the filter it is
+ * actually about. An absent parameter means the default, so saying "no
+ * minimum" takes an explicit `0`.
+ */
+const REPLICAS_UNFILTERED = "/?replicas=0";
+
+const renderClustersList = async (clusters: Cluster[], url = "/") => {
   getStore().set(allClusters, mockSubscribeState({ data: clusters }));
   const rendered = renderComponent(
     <RenderWithPathname>
       <ClustersListPage />
     </RenderWithPathname>,
+    { initialRouterEntries: [url] },
   );
   await screen.findByRole("table");
   return rendered;
 };
+
+/**
+ * Renders the router's query string, so what the table writes to the URL is
+ * assertable. Only the URL tests mount this: the rendered text would otherwise
+ * be one more place `getByText` could match a cluster or replica name.
+ */
+const RenderWithSearch = ({ children }: { children: React.ReactNode }) => {
+  const { search } = useLocation();
+  return (
+    <>
+      {children}
+      <div data-testid="search">{search}</div>
+    </>
+  );
+};
+
+/**
+ * Renders the list at `url`, so a bookmarked query string can be replayed.
+ * Settles on the table, or on the empty state when the URL's filters match
+ * nothing and there is no table to wait for.
+ */
+const renderAt = async (clusters: Cluster[], url = "/") => {
+  getStore().set(allClusters, mockSubscribeState({ data: clusters }));
+  const rendered = renderComponent(
+    <RenderWithSearch>
+      <ClustersListPage />
+    </RenderWithSearch>,
+    { initialRouterEntries: [url] },
+  );
+  await waitFor(() =>
+    expect(
+      screen.queryByRole("table") ?? screen.queryByText(NO_MATCHES_MESSAGE),
+    ).not.toBeNull(),
+  );
+  return rendered;
+};
+
+const currentSearch = () =>
+  new URLSearchParams(screen.getByTestId("search").textContent ?? "");
 
 /**
  * Position of each visible column, so assertions name what they read instead of
@@ -245,6 +293,7 @@ const rowOrderAfter = async (
  * the column id, so a test reaching for one has to know both.
  */
 const FILTER_COLUMN_IDS: Record<string, string> = {
+  Replica: "replica",
   CPU: "cpuPercent",
   Memory: "memoryPercent",
   Disk: "diskPercent",
@@ -425,7 +474,10 @@ describe("ClustersList replica rows", () => {
   });
 
   it("keeps a cluster with no replicas in the list", async () => {
-    await renderClustersList([buildCluster({ replicas: [] })]);
+    await renderClustersList(
+      [buildCluster({ replicas: [] })],
+      REPLICAS_UNFILTERED,
+    );
 
     // Dropping the row would hide the cluster from the clusters list entirely.
     const cells = cellsForRow("compute");
@@ -748,14 +800,19 @@ describe("ClustersList CPU sorting", () => {
 
   it("sorts a cluster with no replicas after the sampled ones", async () => {
     const user = userEvent.setup();
-    await renderClustersList([
-      buildCluster({ id: "u1", name: "alpha-empty", replicas: [] }),
-      buildCluster({
-        id: "u2",
-        name: "bravo-sampled",
-        replicas: [buildReplica({ id: "u20", name: "b-1", cpuPercent: 0.03 })],
-      }),
-    ]);
+    await renderClustersList(
+      [
+        buildCluster({ id: "u1", name: "alpha-empty", replicas: [] }),
+        buildCluster({
+          id: "u2",
+          name: "bravo-sampled",
+          replicas: [
+            buildReplica({ id: "u20", name: "b-1", cpuPercent: 0.03 }),
+          ],
+        }),
+      ],
+      REPLICAS_UNFILTERED,
+    );
 
     expect(await rowOrderAfter(sortByCpuAscending, user)).toEqual(["b-1", "-"]);
   });
@@ -1068,8 +1125,22 @@ describe("ClustersList keyboard navigation", () => {
     await user.tab();
     expect(screen.getByLabelText("Search clusters...")).toHaveFocus();
 
+    // The replica count filter is on by default, so its chip sits between the
+    // toolbar and the headers.
+    await user.tab();
+    expect(
+      screen.getByRole("button", { name: "Remove Replicas ≥ 1" }),
+    ).toHaveFocus();
+
     // One control per filterable column, in the order the table shows them.
-    for (const label of ["CPU", "Memory", "Disk", "Heap", "Hydration"]) {
+    for (const label of [
+      "Replica",
+      "CPU",
+      "Memory",
+      "Disk",
+      "Heap",
+      "Hydration",
+    ]) {
       await user.tab();
       expect(filterTrigger(label)).toHaveFocus();
     }
@@ -1540,21 +1611,6 @@ describe("ClustersList utilization filters", () => {
   });
 });
 
-/**
- * Renders the router's query string, so what the table writes to the URL is
- * assertable. Only the URL tests mount this: the rendered text would otherwise
- * be one more place `getByText` could match a cluster or replica name.
- */
-const RenderWithSearch = ({ children }: { children: React.ReactNode }) => {
-  const { search } = useLocation();
-  return (
-    <>
-      {children}
-      <div data-testid="search">{search}</div>
-    </>
-  );
-};
-
 describe("ClustersList filter URL state", () => {
   const twoClusters = () => [
     buildCluster({
@@ -1588,30 +1644,6 @@ describe("ClustersList filter URL state", () => {
       ],
     }),
   ];
-
-  /**
-   * Renders the list at `url`, so a bookmarked query string can be replayed.
-   * Settles on the table, or on the empty state when the URL's filters match
-   * nothing and there is no table to wait for.
-   */
-  const renderAt = async (clusters: Cluster[], url = "/") => {
-    getStore().set(allClusters, mockSubscribeState({ data: clusters }));
-    const rendered = renderComponent(
-      <RenderWithSearch>
-        <ClustersListPage />
-      </RenderWithSearch>,
-      { initialRouterEntries: [url] },
-    );
-    await waitFor(() =>
-      expect(
-        screen.queryByRole("table") ?? screen.queryByText(NO_MATCHES_MESSAGE),
-      ).not.toBeNull(),
-    );
-    return rendered;
-  };
-
-  const currentSearch = () =>
-    new URLSearchParams(screen.getByTestId("search").textContent ?? "");
 
   it("writes an applied filter to the URL", async () => {
     const user = userEvent.setup();
@@ -1880,7 +1912,7 @@ describe("ClustersList filter URL state", () => {
     it("restores every status a bookmark names", async () => {
       await renderAt(
         twoClusters(),
-        "/?hydration[]=hydrated&hydration[]=hydrating",
+        "/?hydration[]=hydrated&hydration[]=hydrating&replicas=0",
       );
 
       expect(rowOrder()).toEqual(["idle", "busy", "middling"]);
@@ -1892,7 +1924,7 @@ describe("ClustersList filter URL state", () => {
 
     describe("when the URL names a status that does not exist", () => {
       it("ignores it and leaves the table unfiltered", async () => {
-        await renderAt(twoClusters(), "/?hydration[]=lukewarm");
+        await renderAt(twoClusters(), "/?hydration[]=lukewarm&replicas=0");
 
         expect(rowOrder()).toEqual(["idle", "busy", "middling"]);
         expect(chipLabels()).toEqual([]);
@@ -1933,6 +1965,11 @@ describe("ClustersList filter chips", () => {
     }),
   ];
 
+  /*
+   * These render with the replica count filter off. Its chip is otherwise on
+   * screen from the first paint and would lead every expectation below, which
+   * is the subject of the replica count filter's own tests.
+   */
   const chips = () =>
     screen
       .queryAllByRole("button", { name: /^Remove / })
@@ -1941,14 +1978,14 @@ describe("ClustersList filter chips", () => {
       );
 
   it("shows no chip until a filter is applied", async () => {
-    await renderClustersList(twoClusters());
+    await renderClustersList(twoClusters(), REPLICAS_UNFILTERED);
 
     expect(chips()).toEqual([]);
   });
 
   it("states the applied condition on a chip", async () => {
     const user = userEvent.setup();
-    await renderClustersList(twoClusters());
+    await renderClustersList(twoClusters(), REPLICAS_UNFILTERED);
 
     await applyFilter(user, "CPU", "40");
 
@@ -1959,7 +1996,7 @@ describe("ClustersList filter chips", () => {
 
   it("carries one chip per filtered column, in column order", async () => {
     const user = userEvent.setup();
-    await renderClustersList(twoClusters());
+    await renderClustersList(twoClusters(), REPLICAS_UNFILTERED);
 
     await applyFilter(user, "Memory", "80");
     await applyFilter(user, "CPU", "40");
@@ -1971,7 +2008,7 @@ describe("ClustersList filter chips", () => {
 
   it("clears the filter when its chip is removed", async () => {
     const user = userEvent.setup();
-    await renderClustersList(twoClusters());
+    await renderClustersList(twoClusters(), REPLICAS_UNFILTERED);
 
     await applyFilter(user, "CPU", "40");
     expect(rowOrder()).toEqual(["busy", "hot-cpu"]);
@@ -1984,7 +2021,7 @@ describe("ClustersList filter chips", () => {
 
   it("removes one column's filter and leaves the rest", async () => {
     const user = userEvent.setup();
-    await renderClustersList(twoClusters());
+    await renderClustersList(twoClusters(), REPLICAS_UNFILTERED);
 
     await applyFilter(user, "CPU", "40");
     await applyFilter(user, "Memory", "80");
@@ -1996,7 +2033,7 @@ describe("ClustersList filter chips", () => {
 
   it("empties the panel of a filter removed by its chip", async () => {
     const user = userEvent.setup();
-    await renderClustersList(twoClusters());
+    await renderClustersList(twoClusters(), REPLICAS_UNFILTERED);
 
     await applyFilter(user, "CPU", "40");
     await user.click(screen.getByRole("button", { name: "Remove CPU ≥ 40%" }));
@@ -2010,7 +2047,7 @@ describe("ClustersList filter chips", () => {
   it("offers a chip for a filter restored from the URL", async () => {
     getStore().set(allClusters, mockSubscribeState({ data: twoClusters() }));
     renderComponent(<ClustersListPage />, {
-      initialRouterEntries: ["/?cpu=40"],
+      initialRouterEntries: ["/?cpu=40&replicas=0"],
     });
     await screen.findByRole("table");
 
@@ -2019,7 +2056,7 @@ describe("ClustersList filter chips", () => {
 
   it("keeps its chip when the filter empties the table", async () => {
     const user = userEvent.setup();
-    await renderClustersList(twoClusters());
+    await renderClustersList(twoClusters(), REPLICAS_UNFILTERED);
 
     await applyFilter(user, "CPU", "99");
 
@@ -2032,6 +2069,199 @@ describe("ClustersList filter chips", () => {
     await user.click(screen.getByRole("button", { name: "Remove CPU ≥ 99%" }));
 
     expect(rowOrder()).toEqual(["idle", "busy", "hot-cpu"]);
+  });
+});
+
+describe("ClustersList replica count filter", () => {
+  /**
+   * One cluster running two replicas, one running a single replica, and one
+   * running none, so a minimum of 0, 1, and 2 each cut the list differently.
+   *
+   * The default sort is by cluster name, which puts `empty`'s replica-less row
+   * first in every unfiltered assertion below.
+   */
+  const clustersByReplicaCount = () => [
+    buildCluster({
+      id: "u1",
+      name: "pair",
+      replicas: [
+        buildReplica({ id: "u10", name: "pair-1" }),
+        buildReplica({ id: "u11", name: "pair-2" }),
+      ],
+    }),
+    buildCluster({
+      id: "u2",
+      name: "single",
+      replicas: [buildReplica({ id: "u20", name: "single-1" })],
+    }),
+    buildCluster({ id: "u3", name: "empty", replicas: [] }),
+  ];
+
+  /** Sets `minimum` in the Replica panel and applies it, closing the panel. */
+  const applyMinimum = async (
+    user: ReturnType<typeof userEvent.setup>,
+    minimum: string,
+  ) => {
+    const apply = await openFilter(user, "Replica");
+    await user.clear(screen.getByLabelText("Minimum replica count"));
+    // `type` rejects an empty string, and an empty box is a real case: it is
+    // how the panel says "no minimum".
+    if (minimum !== "") {
+      await user.type(screen.getByLabelText("Minimum replica count"), minimum);
+    }
+    await user.click(apply);
+    const trigger = queryFilterTrigger("Replica");
+    if (trigger) await user.click(trigger);
+  };
+
+  it("hides the clusters running no replicas on a first visit", async () => {
+    await renderClustersList(clustersByReplicaCount());
+
+    expect(rowOrder()).toEqual(["pair-1", "pair-2", "single-1"]);
+  });
+
+  it("names the default minimum on a chip", async () => {
+    await renderClustersList(clustersByReplicaCount());
+
+    // Rows are missing from the first paint, so the reason has to be on screen
+    // rather than only inside a panel the reader has no cause to open.
+    expect(chipLabels()).toEqual(["Replicas ≥ 1"]);
+  });
+
+  it("shows every row at a minimum of 0", async () => {
+    const user = userEvent.setup();
+    await renderClustersList(clustersByReplicaCount());
+
+    await applyMinimum(user, "0");
+
+    expect(rowOrder()).toEqual(["-", "pair-1", "pair-2", "single-1"]);
+    expect(chipLabels()).toEqual([]);
+  });
+
+  it("counts the row's cluster's replicas, not the row itself", async () => {
+    const user = userEvent.setup();
+    await renderClustersList(clustersByReplicaCount());
+
+    await applyMinimum(user, "2");
+
+    // Every row carrying a replica counts as one on its own, so a minimum of
+    // two matching anything at all means the count is the cluster's.
+    expect(rowOrder()).toEqual(["pair-1", "pair-2"]);
+    expect(chipLabels()).toEqual(["Replicas ≥ 2"]);
+  });
+
+  it("restores the replica-less clusters when the chip is removed", async () => {
+    const user = userEvent.setup();
+    await renderClustersList(clustersByReplicaCount());
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove Replicas ≥ 1" }),
+    );
+
+    expect(rowOrder()).toEqual(["-", "pair-1", "pair-2", "single-1"]);
+  });
+
+  it("empties the panel of a minimum removed by its chip", async () => {
+    const user = userEvent.setup();
+    await renderClustersList(clustersByReplicaCount());
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove Replicas ≥ 1" }),
+    );
+    await openFilter(user, "Replica");
+
+    expect(screen.getByLabelText("Minimum replica count")).toHaveValue("");
+  });
+
+  it("narrows the search results rather than replacing them", async () => {
+    const user = userEvent.setup();
+    await renderClustersList(clustersByReplicaCount());
+
+    await applyMinimum(user, "2");
+    await user.type(screen.getByLabelText("Search clusters..."), "single");
+
+    // "single" names a cluster the minimum excludes, so the two conditions
+    // together leave nothing.
+    await waitFor(() =>
+      expect(screen.getByText(NO_MATCHES_MESSAGE)).toBeInTheDocument(),
+    );
+  });
+
+  it("stays recoverable when the minimum empties the table", async () => {
+    const user = userEvent.setup();
+    await renderClustersList(clustersByReplicaCount());
+
+    await applyMinimum(user, "3");
+
+    // The message replaces the table and takes the headers, and so the panel,
+    // with it. The chip is the only way back.
+    expect(screen.getByText(NO_MATCHES_MESSAGE)).toBeInTheDocument();
+    expect(chipLabels()).toEqual(["Replicas ≥ 3"]);
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove Replicas ≥ 3" }),
+    );
+
+    expect(rowOrder()).toEqual(["-", "pair-1", "pair-2", "single-1"]);
+  });
+
+  describe("URL state", () => {
+    it("leaves the default minimum out of the URL", async () => {
+      await renderAt(clustersByReplicaCount());
+
+      // A plain visit filters by the default, so writing it would put a
+      // parameter in the bar of every reader who never touched the filter.
+      await waitFor(() => expect(currentSearch().has("replicas")).toBe(false));
+    });
+
+    it("writes an applied minimum to the URL", async () => {
+      const user = userEvent.setup();
+      await renderAt(clustersByReplicaCount());
+
+      await applyMinimum(user, "2");
+
+      await waitFor(() => expect(currentSearch().get("replicas")).toBe("2"));
+    });
+
+    it("records a removed minimum as 0", async () => {
+      const user = userEvent.setup();
+      await renderAt(clustersByReplicaCount());
+
+      await user.click(
+        screen.getByRole("button", { name: "Remove Replicas ≥ 1" }),
+      );
+
+      // An absent parameter is the default, so a reader who asked for every
+      // cluster has to be given a URL that says so, or a reload would hide the
+      // rows again.
+      await waitFor(() => expect(currentSearch().get("replicas")).toBe("0"));
+    });
+
+    it("restores a bookmarked minimum, in the rows and in the panel", async () => {
+      const user = userEvent.setup();
+      await renderAt(clustersByReplicaCount(), "/?replicas=2");
+
+      expect(rowOrder()).toEqual(["pair-1", "pair-2"]);
+
+      await openFilter(user, "Replica");
+      expect(screen.getByLabelText("Minimum replica count")).toHaveValue("2");
+    });
+
+    it("leaves the table unfiltered for an explicit 0", async () => {
+      await renderAt(clustersByReplicaCount(), REPLICAS_UNFILTERED);
+
+      expect(rowOrder()).toEqual(["-", "pair-1", "pair-2", "single-1"]);
+      expect(chipLabels()).toEqual([]);
+    });
+
+    it("falls back to the default when the parameter is malformed", async () => {
+      // A hand-edited or stale link must not install a minimum the panel
+      // cannot show, and the default is the state the panel opens on.
+      await renderAt(clustersByReplicaCount(), "/?replicas=two");
+
+      expect(rowOrder()).toEqual(["pair-1", "pair-2", "single-1"]);
+      expect(chipLabels()).toEqual(["Replicas ≥ 1"]);
+    });
   });
 });
 
@@ -2097,9 +2327,10 @@ describe("ClustersList hydration", () => {
   });
 
   it("renders a dash for a cluster with no replicas", async () => {
-    await renderClustersList([
-      buildCluster({ id: "u1", name: "empty", replicas: [] }),
-    ]);
+    await renderClustersList(
+      [buildCluster({ id: "u1", name: "empty", replicas: [] })],
+      REPLICAS_UNFILTERED,
+    );
 
     expect(hydrationFor("empty")).toBe("-");
   });
@@ -2217,7 +2448,7 @@ describe("ClustersList hydration", () => {
 
     it("states each selected status on its own chip", async () => {
       const user = userEvent.setup();
-      await renderClustersList(mixedHydration());
+      await renderClustersList(mixedHydration(), REPLICAS_UNFILTERED);
 
       await toggleHydration(user, "Hydrating", "Not Hydrated");
 
@@ -2229,7 +2460,7 @@ describe("ClustersList hydration", () => {
 
     it("drops one status from its chip and keeps the rest", async () => {
       const user = userEvent.setup();
-      await renderClustersList(mixedHydration());
+      await renderClustersList(mixedHydration(), REPLICAS_UNFILTERED);
 
       await toggleHydration(user, "Hydrating", "Not Hydrated");
       await user.click(
@@ -2242,19 +2473,22 @@ describe("ClustersList hydration", () => {
 
     it("stays recoverable when the selection empties the table", async () => {
       const user = userEvent.setup();
-      await renderClustersList([
-        buildCluster({
-          id: "u1",
-          name: "compute",
-          replicas: [
-            buildReplica({
-              id: "u10",
-              name: "ready",
-              hydration: { hydratedObjects: 4, totalObjects: 4 },
-            }),
-          ],
-        }),
-      ]);
+      await renderClustersList(
+        [
+          buildCluster({
+            id: "u1",
+            name: "compute",
+            replicas: [
+              buildReplica({
+                id: "u10",
+                name: "ready",
+                hydration: { hydratedObjects: 4, totalObjects: 4 },
+              }),
+            ],
+          }),
+        ],
+        REPLICAS_UNFILTERED,
+      );
 
       await toggleHydration(user, "Not Hydrated");
 

--- a/console/src/platform/clusters/ClustersList.test.tsx
+++ b/console/src/platform/clusters/ClustersList.test.tsx
@@ -2138,6 +2138,28 @@ describe("ClustersList replica count filter", () => {
     expect(chipLabels()).toEqual([]);
   });
 
+  it("shows every row when the panel's Clear is pressed", async () => {
+    const user = userEvent.setup();
+    await renderClustersList(clustersByReplicaCount());
+
+    await clearFilter(user, "Replica");
+
+    expect(rowOrder()).toEqual(["-", "pair-1", "pair-2", "single-1"]);
+    expect(chipLabels()).toEqual([]);
+  });
+
+  it("treats an emptied box as no minimum", async () => {
+    const user = userEvent.setup();
+    await renderClustersList(clustersByReplicaCount());
+
+    await applyMinimum(user, "");
+
+    // Emptying the box and pressing Apply is a separate gesture from Clear and
+    // has to reach the same place: nothing in the box is no minimum.
+    expect(rowOrder()).toEqual(["-", "pair-1", "pair-2", "single-1"]);
+    expect(chipLabels()).toEqual([]);
+  });
+
   it("counts the row's cluster's replicas, not the row itself", async () => {
     const user = userEvent.setup();
     await renderClustersList(clustersByReplicaCount());
@@ -2203,6 +2225,29 @@ describe("ClustersList replica count filter", () => {
     );
 
     expect(rowOrder()).toEqual(["-", "pair-1", "pair-2", "single-1"]);
+  });
+
+  it("meets the empty state when no cluster has a replica", async () => {
+    const user = userEvent.setup();
+    await renderAt([
+      buildCluster({ id: "u1", name: "empty-one", replicas: [] }),
+      buildCluster({ id: "u2", name: "empty-two", replicas: [] }),
+    ]);
+
+    // A first visit filters by the default, so an account whose clusters all
+    // sit idle reaches this without having touched a filter. The page has to
+    // say why it is empty and offer the way back, or it reads as broken.
+    expect(screen.getByText(NO_MATCHES_MESSAGE)).toBeInTheDocument();
+    expect(chipLabels()).toEqual(["Replicas ≥ 1"]);
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove Replicas ≥ 1" }),
+    );
+
+    // The empty state replaced the table, so removing the chip mounts a fresh
+    // one rather than adding rows to a table already on screen.
+    await screen.findByRole("table");
+    expect(columnOrder(COLUMN.cluster)).toEqual(["empty-one", "empty-two"]);
   });
 
   describe("URL state", () => {

--- a/console/src/platform/clusters/ReplicaCountFilterPanel.tsx
+++ b/console/src/platform/clusters/ReplicaCountFilterPanel.tsx
@@ -1,0 +1,120 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Button,
+  HStack,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  Text,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
+import { Column } from "@tanstack/react-table";
+import React from "react";
+
+import { MaterializeTheme } from "~/theme";
+
+export interface ReplicaCountFilterPanelProps<TData> {
+  /** The column to filter, whose `filterFn` must be `replicaCountFilterFn`. */
+  column: Column<TData, unknown>;
+}
+
+/**
+ * Filters by how many replicas a row's cluster has, for the popover
+ * `UniversalTable` anchors on a column header.
+ *
+ * A minimum of 0 is a real choice rather than an empty one, so it is applied as
+ * an absent filter: clearing the panel and applying 0 both leave every row
+ * visible.
+ */
+export const ReplicaCountFilterPanel = <TData,>({
+  column,
+}: ReplicaCountFilterPanelProps<TData>) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const filterValue = column.getFilterValue() as number | undefined;
+
+  const [count, setCount] = React.useState(
+    filterValue ? String(filterValue) : "",
+  );
+
+  // The panel is remounted on each open, so the seed above is what an opening
+  // panel shows. This covers the filter changing while the panel is already
+  // open, which is what removing the column's chip does.
+  React.useEffect(() => {
+    setCount(filterValue ? String(filterValue) : "");
+  }, [filterValue]);
+
+  const apply = () => {
+    const parsed = parseInt(count, 10);
+    column.setFilterValue(parsed > 0 ? parsed : undefined);
+  };
+
+  const clearFilter = () => {
+    // Reset the draft as well as the filter. With nothing applied, clearing
+    // leaves the applied value as it was, `undefined`, so the sync effect has
+    // no change to react to and a minimum typed but never applied would stay on
+    // screen.
+    setCount("");
+    column.setFilterValue(undefined);
+  };
+
+  return (
+    <VStack alignItems="stretch" spacing={0}>
+      <HStack spacing={2} px={4} py={3}>
+        <Text textStyle="text-ui-reg" color={colors.foreground.secondary}>
+          Replica Count ≥
+        </Text>
+        <NumberInput
+          size="sm"
+          maxW="20"
+          min={0}
+          value={count}
+          focusBorderColor={colors.accent.brightPurple}
+          onChange={(next) => setCount(next)}
+        >
+          <NumberInputField
+            placeholder="0"
+            aria-label="Minimum replica count"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") apply();
+            }}
+          />
+          <NumberInputStepper>
+            <NumberIncrementStepper aria-label="Increase minimum replica count" />
+            <NumberDecrementStepper aria-label="Decrease minimum replica count" />
+          </NumberInputStepper>
+        </NumberInput>
+      </HStack>
+      <HStack
+        borderTopWidth="1px"
+        borderColor={colors.border.secondary}
+        justifyContent="space-between"
+        py={2}
+        px={4}
+      >
+        <Button
+          size="sm"
+          variant="secondary"
+          transition="none"
+          isDisabled={filterValue === undefined && count === ""}
+          onClick={clearFilter}
+        >
+          Clear
+        </Button>
+        <Button size="sm" variant="primary" transition="none" onClick={apply}>
+          Apply
+        </Button>
+      </HStack>
+    </VStack>
+  );
+};

--- a/console/src/platform/clusters/ReplicaCountFilterPanel.tsx
+++ b/console/src/platform/clusters/ReplicaCountFilterPanel.tsx
@@ -10,11 +10,8 @@
 import {
   Button,
   HStack,
-  NumberDecrementStepper,
-  NumberIncrementStepper,
   NumberInput,
   NumberInputField,
-  NumberInputStepper,
   Text,
   useTheme,
   VStack,
@@ -89,10 +86,6 @@ export const ReplicaCountFilterPanel = <TData,>({
               if (e.key === "Enter") apply();
             }}
           />
-          <NumberInputStepper>
-            <NumberIncrementStepper aria-label="Increase minimum replica count" />
-            <NumberDecrementStepper aria-label="Decrease minimum replica count" />
-          </NumberInputStepper>
         </NumberInput>
       </HStack>
       <HStack

--- a/console/src/platform/clusters/UtilizationFilterPanel.tsx
+++ b/console/src/platform/clusters/UtilizationFilterPanel.tsx
@@ -10,11 +10,8 @@
 import {
   Button,
   HStack,
-  NumberDecrementStepper,
-  NumberIncrementStepper,
   NumberInput,
   NumberInputField,
-  NumberInputStepper,
   Text,
   useTheme,
   VStack,
@@ -93,14 +90,6 @@ export const UtilizationFilterPanel = <TData,>({
               if (e.key === "Enter") apply();
             }}
           />
-          <NumberInputStepper>
-            <NumberIncrementStepper
-              aria-label={`Increase ${label} threshold`}
-            />
-            <NumberDecrementStepper
-              aria-label={`Decrease ${label} threshold`}
-            />
-          </NumberInputStepper>
         </NumberInput>
         <Text textStyle="text-ui-reg" color={colors.foreground.secondary}>
           %

--- a/console/src/platform/clusters/replicaCountFilters.test.ts
+++ b/console/src/platform/clusters/replicaCountFilters.test.ts
@@ -1,0 +1,167 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { Row } from "@tanstack/react-table";
+
+import {
+  DEFAULT_MINIMUM_REPLICAS,
+  replicaCountFilterFn,
+  replicaCountFilterFromUrl,
+  replicaCountFilterLabel,
+  replicaCountFilterToUrl,
+} from "./replicaCountFilters";
+
+type ReplicaCountRow = { cluster: { replicas: unknown[] } };
+
+/**
+ * A row belonging to a cluster running `count` replicas. The filter reads
+ * nothing else off the row, and nothing about the replicas themselves, so the
+ * rest of a `Row` is left out.
+ */
+const rowInClusterOf = (count: number) =>
+  ({
+    original: { cluster: { replicas: new Array(count).fill(null) } },
+  }) as Row<ReplicaCountRow>;
+
+const keeps = (clusterReplicas: number, minimum: number) =>
+  replicaCountFilterFn(rowInClusterOf(clusterReplicas), "replica", minimum);
+
+describe("replicaCountFilterFn", () => {
+  it("keeps a cluster with more replicas than the minimum", () => {
+    expect(keeps(3, 2)).toBe(true);
+  });
+
+  it("keeps a cluster sitting exactly on the minimum", () => {
+    // The minimum is a floor, so 2 satisfies "at least 2".
+    expect(keeps(2, 2)).toBe(true);
+  });
+
+  it("drops a cluster with fewer replicas than the minimum", () => {
+    expect(keeps(1, 2)).toBe(false);
+  });
+
+  it("drops a cluster running no replicas at the default minimum", () => {
+    // The replica-less cluster still gets a row, so the filter is what hides
+    // it rather than the row never being built.
+    expect(keeps(0, DEFAULT_MINIMUM_REPLICAS)).toBe(false);
+    expect(keeps(1, DEFAULT_MINIMUM_REPLICAS)).toBe(true);
+  });
+
+  it("counts the row's cluster, not the row's own replica", () => {
+    // The table shows one row per replica, so a row that has a replica always
+    // counts as one on its own. Reading the row instead of its cluster would
+    // make every minimum above 1 match nothing.
+    expect(keeps(2, 2)).toBe(true);
+    expect(keeps(5, 4)).toBe(true);
+  });
+
+  it("keeps every row at a minimum of zero", () => {
+    // Documents the contract rather than a reachable state: the panel and the
+    // URL both turn "no minimum" into undefined, which removes the filter.
+    expect(keeps(0, 0)).toBe(true);
+    expect(keeps(3, 0)).toBe(true);
+  });
+});
+
+describe("replicaCountFilterFromUrl", () => {
+  it("reads a well-formed minimum", () => {
+    expect(replicaCountFilterFromUrl("2")).toBe(2);
+    expect(replicaCountFilterFromUrl("10")).toBe(10);
+  });
+
+  it("reads the default stated explicitly", () => {
+    expect(replicaCountFilterFromUrl("1")).toBe(DEFAULT_MINIMUM_REPLICAS);
+  });
+
+  it("reads zero as no minimum at all", () => {
+    // The only way a URL can ask for every cluster, which is why clearing the
+    // filter writes the parameter rather than dropping it.
+    expect(replicaCountFilterFromUrl("0")).toBeUndefined();
+  });
+
+  it("ignores leading zeros", () => {
+    expect(replicaCountFilterFromUrl("007")).toBe(7);
+  });
+
+  // Absent or malformed means the *default*, not "unfiltered". A plain visit
+  // carries no parameter and has to land on the default, so there is no value
+  // left for a malformed parameter to mean. NOTE: this inverts how
+  // `utilizationFilterFromUrl` treats bad input, which is to filter nothing.
+  it.each([
+    ["absent", null],
+    ["empty", ""],
+    ["negative", "-1"],
+    ["fractional", "1.5"],
+    ["non-numeric", "abc"],
+    ["trailing junk", "2x"],
+    ["leading whitespace", " 2"],
+    ["a comparison prefix", "gte.2"],
+    ["a comma-joined list", "1,2"],
+  ])("falls back to the default when the parameter is %s", (_label, raw) => {
+    expect(replicaCountFilterFromUrl(raw)).toBe(DEFAULT_MINIMUM_REPLICAS);
+  });
+});
+
+describe("replicaCountFilterToUrl", () => {
+  it("leaves the default out of the URL", () => {
+    expect(replicaCountFilterToUrl(DEFAULT_MINIMUM_REPLICAS)).toBeUndefined();
+  });
+
+  it("writes a minimum that differs from the default", () => {
+    expect(replicaCountFilterToUrl(2)).toBe(2);
+    expect(replicaCountFilterToUrl(10)).toBe(10);
+  });
+
+  it("states no minimum as zero", () => {
+    // Dropping the parameter would read back as the default on the next visit,
+    // so "every cluster" has to be written down.
+    expect(replicaCountFilterToUrl(undefined)).toBe(0);
+    expect(replicaCountFilterToUrl(0)).toBe(0);
+  });
+});
+
+describe("a replica count round trip", () => {
+  /**
+   * The trip the table actually performs: write the minimum to the URL, then
+   * read it back. An undefined parameter is not written at all, so the read
+   * side sees `null`, which is what makes the default reachable.
+   */
+  const roundTrip = (minimum: number | undefined) => {
+    const written = replicaCountFilterToUrl(minimum);
+    return replicaCountFilterFromUrl(
+      written === undefined ? null : String(written),
+    );
+  };
+
+  it("survives for the default, which travels as no parameter", () => {
+    expect(roundTrip(DEFAULT_MINIMUM_REPLICAS)).toBe(DEFAULT_MINIMUM_REPLICAS);
+  });
+
+  it("survives for a minimum above the default", () => {
+    for (const minimum of [2, 3, 10, 99]) {
+      expect(roundTrip(minimum)).toBe(minimum);
+    }
+  });
+
+  it("survives for no minimum", () => {
+    expect(roundTrip(undefined)).toBeUndefined();
+  });
+
+  it("treats zero and no minimum as the same state", () => {
+    expect(roundTrip(0)).toBe(roundTrip(undefined));
+  });
+});
+
+describe("replicaCountFilterLabel", () => {
+  it("reads as the condition it applies", () => {
+    expect(replicaCountFilterLabel(1)).toBe("Replicas ≥ 1");
+    expect(replicaCountFilterLabel(2)).toBe("Replicas ≥ 2");
+    expect(replicaCountFilterLabel(10)).toBe("Replicas ≥ 10");
+  });
+});

--- a/console/src/platform/clusters/replicaCountFilters.ts
+++ b/console/src/platform/clusters/replicaCountFilters.ts
@@ -1,0 +1,73 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { Row } from "@tanstack/react-table";
+
+/** The replica column's id, shared by the column, its chip, and the URL. */
+export const REPLICA_COLUMN_ID = "replica";
+
+/** The URL parameter carrying the replica count filter. */
+export const REPLICA_COUNT_URL_KEY = "replicas";
+
+/**
+ * The minimum a visit with no parameter filters by. One replica is the fewest a
+ * cluster can have and still run anything, so the list opens on the clusters
+ * doing work and leaves reaching for the idle ones to the panel.
+ */
+export const DEFAULT_MINIMUM_REPLICAS = 1;
+
+/** As much of a row as the replica count filter reads. */
+type RowWithReplicas = { cluster: { replicas: unknown[] } };
+
+/**
+ * Keeps rows belonging to a cluster with at least `minimum` replicas. A
+ * `minimum` of 0 keeps every row, since no cluster has fewer.
+ *
+ * Counts the row's cluster's replicas, not the row's own replica. The table
+ * shows one row per replica, so a row that has a replica always counts as one
+ * on its own and a minimum above 1 would match nothing.
+ *
+ * NOTE: reads the count off the row rather than the column this hangs on, whose
+ * accessor returns the replica's name. The value compared is not the value the
+ * cell shows.
+ */
+export const replicaCountFilterFn = <TData extends RowWithReplicas>(
+  row: Row<TData>,
+  _columnId: string,
+  minimum: number,
+) => row.original.cluster.replicas.length >= minimum;
+
+/**
+ * The minimum a URL asks for, or undefined when it asks for no minimum.
+ *
+ * An absent or malformed parameter means the default rather than "unfiltered".
+ * The parameter is written only when the minimum differs from the default, so a
+ * plain visit, which carries no parameter, has to land on it. An explicit `0` is
+ * the only way a URL can say "every cluster", which is why clearing the filter
+ * writes the parameter instead of dropping it.
+ */
+export const replicaCountFilterFromUrl = (raw: string | null) => {
+  if (raw === null || !/^\d+$/.test(raw)) return DEFAULT_MINIMUM_REPLICAS;
+  const minimum = parseInt(raw, 10);
+  return minimum > 0 ? minimum : undefined;
+};
+
+/**
+ * A minimum as its URL parameter value, or undefined when it is the default and
+ * so needs no parameter. An undefined `minimum` is no minimum at all, which the
+ * URL states as `0`.
+ */
+export const replicaCountFilterToUrl = (minimum: number | undefined) => {
+  const value = minimum ?? 0;
+  return value === DEFAULT_MINIMUM_REPLICAS ? undefined : value;
+};
+
+/** A minimum stated for display, for example `Replicas ≥ 2`. */
+export const replicaCountFilterLabel = (minimum: number) =>
+  `Replicas ≥ ${minimum}`;

--- a/console/src/platform/maintained-objects/filterPanels.tsx
+++ b/console/src/platform/maintained-objects/filterPanels.tsx
@@ -144,7 +144,7 @@ export const MultiSelectFilterPanel = <
                 isChecked={selected.includes(item)}
                 onChange={() => toggle(item)}
               >
-                <Text textStyle="text-ui-reg" noOfLines={1}>
+                <Text textStyle="text-ui-reg" noOfLines={1} mr={4}>
                   {getLabel ? getLabel(item) : item}
                 </Text>
               </FilterCheckboxRow>


### PR DESCRIPTION
### Motivation

The cluster usage table lists one row per replica, and a cluster running no
replicas gets a row of dashes that pushes the clusters doing work down the
page. There was no way to ask for only the clusters running something, or only
the ones running redundant replicas.

### Description

Adds a replica count filter to the Replica column, in the same shape as the
existing utilization filters: a number input in the header popover labelled
`Replica Count ≥`, plus a removable chip above the table.

Three things the diff doesn't show:

- **On by default at 1**, so a first visit hides replica-less clusters. The
  `Replicas ≥ 1` chip says why and is the way back.
- **Clearing writes `?replicas=0`.** An absent parameter means the default, so
  without the explicit 0 a reload would re-hide those rows.
- **Counts the cluster's replicas, not the row's.** Each row represents one replica.

Reviewer note: most of the test file's deletions are a move, not lost coverage.
`renderAt` and `currentSearch` were lifted to module scope for the new URL
tests.


<img width="1587" height="745" alt="Screenshot 2026-09-02 at 4 56 01 PM" src="https://github.com/user-attachments/assets/38edaf54-6dcd-4883-ad26-1e86f9a7a56b" />
<img width="1604" height="822" alt="Screenshot 2026-09-02 at 4 56 14 PM" src="https://github.com/user-attachments/assets/8770e420-fdff-48be-9ca7-a06ecdf6d6ef" />

### Verification

New `ClustersList replica count filter` tests in
`console/src/platform/clusters/ClustersList.test.tsx` cover the default and its
chip, the three ways to reach "no minimum" (0, Clear, an emptied box), a
minimum of 2 keeping only redundant clusters, the empty state and recovering
from it, and the URL contract (default omitted, removal recorded as `0`, a
bookmark restored into rows and panel, malformed falling back).

Existing tests that asserted on replica-less rows or other filters' chips now
render with `?replicas=0`. `yarn test src/platform/clusters/` (262 tests),
`yarn typecheck`, and `yarn lint` pass locally.

