### PR TITLE
compute: thin peek results by partitioning, not sorting

### DIFF
--- a/doc/user/data/metrics.yml
+++ b/doc/user/data/metrics.yml
@@ -1061,31 +1061,31 @@ metrics:
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_result_sort_rows_bucket
-  help: Number of intermediate result rows sorted during peek collection, summed across sort operations.
+  help: Number of intermediate result rows handed to thinning during peek collection, summed across the times it ran.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_result_sort_rows_count
-  help: Number of intermediate result rows sorted during peek collection, summed across sort operations.
+  help: Number of intermediate result rows handed to thinning during peek collection, summed across the times it ran.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_result_sort_rows_sum
-  help: Number of intermediate result rows sorted during peek collection, summed across sort operations.
+  help: Number of intermediate result rows handed to thinning during peek collection, summed across the times it ran.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_result_sort_seconds_bucket
-  help: Time sorting intermediate results during peek collection.
+  help: Time thinning intermediate results down to the rows a peek's finishing needs.
   labels:
   - le
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_result_sort_seconds_count
-  help: Time sorting intermediate results during peek collection.
+  help: Time thinning intermediate results down to the rows a peek's finishing needs.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_result_sort_seconds_sum
-  help: Time sorting intermediate results during peek collection.
+  help: Time thinning intermediate results down to the rows a peek's finishing needs.
   source: src/compute/src/metrics.rs
   visibility: internal
 - name: mz_index_peek_row_collection_seconds_bucket

--- a/src/compute/src/compute_state/peek_metrics.rs
+++ b/src/compute/src/compute_state/peek_metrics.rs
@@ -128,9 +128,9 @@ impl PeekWalkMetrics {
         self.row_iteration_rows
             .observe(f64::cast_lossy(phases.rows_processed));
         self.result_sort_seconds
-            .observe(phases.result_sort.as_secs_f64());
+            .observe(phases.thinning.as_secs_f64());
         self.result_sort_rows
-            .observe(f64::cast_lossy(phases.rows_sorted));
+            .observe(f64::cast_lossy(phases.rows_thinned));
     }
 
     /// Reports the time [`rows_response`](super::peek_scan::rows_response) took.

--- a/src/compute/src/compute_state/peek_scan.rs
+++ b/src/compute/src/compute_state/peek_scan.rs
@@ -83,14 +83,14 @@ pub(super) struct WalkPhases {
     /// Whether the error walk ended without finding an error. The two numbers above describe a
     /// finished phase only when it did.
     pub error_trace_clean: bool,
-    /// Worker time the ok walk spent, including the time thinning spent sorting.
+    /// Worker time the ok walk spent, including the time thinning spent.
     pub row_iteration: Duration,
     /// Cursor positions the ok walk evaluated.
     pub rows_processed: usize,
-    /// Worker time thinning spent sorting.
-    pub result_sort: Duration,
-    /// Rows handed to a sort, summed over the times thinning ran.
-    pub rows_sorted: usize,
+    /// Worker time thinning spent.
+    pub thinning: Duration,
+    /// Rows handed to thinning, summed over the times it ran.
+    pub rows_thinned: usize,
 }
 
 /// How a scan's rows may leave for the peek stash.
@@ -187,12 +187,12 @@ where
     /// Worker time spent opening the ok cursor.
     pub(super) cursor_setup_time: Duration,
     /// Worker time the ok walk spent, summed over the slices it was cut into. Includes the time
-    /// thinning spent sorting.
+    /// thinning spent.
     pub(super) row_iteration_time: Duration,
-    /// Worker time thinning spent sorting, summed over the times it ran.
-    pub(super) result_sort_time: Duration,
-    /// Rows handed to a sort, summed over the times thinning ran.
-    pub(super) rows_sorted: usize,
+    /// Worker time thinning spent, summed over the times it ran.
+    pub(super) thinning_time: Duration,
+    /// Rows handed to thinning, summed over the times it ran.
+    pub(super) rows_thinned: usize,
 }
 
 impl<Tr> PeekScan<Tr>
@@ -255,8 +255,8 @@ where
             error_scan_time,
             cursor_setup_time,
             row_iteration_time: Duration::ZERO,
-            result_sort_time: Duration::ZERO,
-            rows_sorted: 0,
+            thinning_time: Duration::ZERO,
+            rows_thinned: 0,
         }
     }
 
@@ -327,8 +327,8 @@ where
             error_trace_clean: self.error_trace_clean(),
             row_iteration: self.row_iteration_time,
             rows_processed: self.rows_processed(),
-            result_sort: self.result_sort_time,
-            rows_sorted: self.rows_sorted,
+            thinning: self.thinning_time,
+            rows_thinned: self.rows_thinned,
         }
     }
 
@@ -523,17 +523,28 @@ where
             return None;
         }
 
-        // We can sort `results` and then truncate to `max_results`. This has an effect similar to
-        // a priority queue, without its interactive dequeueing properties.
+        // Partitioned rather than sorted, because only which rows fall outside the first
+        // `max_results` matters here. The order among those that stay is established once, when
+        // the answer is collected.
+        //
+        // Partitioning is unstable, and entries carry counts, so which entry survives a tie
+        // across the cut changes the retained multiset. The client cannot tell: tied rows are
+        // byte-identical, since the tiebreaker compares the whole encoded row, and the
+        // `max_results` entries kept expand to at least `max_results` rows, of which the finishing
+        // reads `offset..offset + limit`.
+        //
+        // NOTE: a peek result must not be consumed without applying the finishing's limit.
+        //
         // TODO: Had we left these as `Vec<Datum>` we would avoid the unpacking; we should consider
         // doing that, although it will require a re-pivot of the code to branch on this inner test
         // (as we prefer not to maintain `Vec<Datum>` in the other case).
-        let sort_start = Instant::now();
-        self.rows_sorted = self.rows_sorted.saturating_add(self.results.len());
-        self.results.sort_by(|left, right| {
-            comparator.compare_rows(&left.0, &right.0, || left.0.cmp(&right.0))
-        });
-        self.result_sort_time += sort_start.elapsed();
+        let thinning_start = Instant::now();
+        self.rows_thinned = self.rows_thinned.saturating_add(self.results.len());
+        self.results
+            .select_nth_unstable_by(max_results, |left, right| {
+                comparator.compare_rows(&left.0, &right.0, || left.0.cmp(&right.0))
+            });
+        self.thinning_time += thinning_start.elapsed();
 
         let dropped = self.results.drain(max_results..);
         let (dropped_size, dropped_rows) = dropped.into_iter().fold(

--- a/src/compute/src/compute_state/peek_scan/tests.rs
+++ b/src/compute/src/compute_state/peek_scan/tests.rs
@@ -64,6 +64,21 @@ fn expected(values: impl IntoIterator<Item = u64>) -> RowBatch {
         .collect()
 }
 
+/// Asserts that a finished scan kept `values`, as a multiset.
+///
+/// Thinning partitions rather than sorts, so it does not order what it keeps. The answer's order
+/// is established when the rows are collected.
+fn assert_kept(outcome: ScanOutcome, values: impl IntoIterator<Item = u64>) {
+    let ScanOutcome::Finished(Ok(kept)) = outcome else {
+        panic!("the scan did not finish with rows: {outcome:?}");
+    };
+    let mut kept = kept;
+    let mut want = expected(values);
+    kept.sort();
+    want.sort();
+    assert_eq!(kept, want);
+}
+
 /// A walk over an ok trace holding `keys`, each once.
 fn ok_iterator(keys: &[Row]) -> PeekResultIterator<TestTrace> {
     ok_iterator_with_copies(keys, Diff::ONE)
@@ -132,8 +147,8 @@ fn scan(error_phase: ErrorPhase, keys: &[Row]) -> PeekScan<TestTrace> {
         error_scan_time: Duration::ZERO,
         cursor_setup_time: Duration::ZERO,
         row_iteration_time: Duration::ZERO,
-        result_sort_time: Duration::ZERO,
-        rows_sorted: 0,
+        thinning_time: Duration::ZERO,
+        rows_thinned: 0,
     }
 }
 
@@ -457,10 +472,7 @@ fn ordered_thinning_keeps_the_rows_the_ordering_ranks_first() {
     }]));
 
     let mut fuel = usize::MAX;
-    assert_eq!(
-        subject.step(None, &mut fuel),
-        ScanOutcome::Finished(Ok(expected([9, 8])))
-    );
+    assert_kept(subject.step(None, &mut fuel), [9, 8]);
     assert_eq!(
         subject.rows_processed(),
         keys.len(),
@@ -882,10 +894,7 @@ fn a_scan_thins_towards_the_rows_the_peeks_finishing_needs() {
     let mut subject = open(&mut bundle, &peek, u64::MAX, false, usize::MAX);
 
     let mut fuel = usize::MAX;
-    assert_eq!(
-        subject.step(None, &mut fuel),
-        ScanOutcome::Finished(Ok(expected([9, 8]))),
-    );
+    assert_kept(subject.step(None, &mut fuel), [9, 8]);
 }
 
 /// `entry_byte_len` is the per-entry half of `RowCollection::byte_len`, which is what the

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -245,12 +245,12 @@ impl ComputeMetrics {
             ), role)),
             index_peek_result_sort_seconds: registry.register(with_role(metric!(
                 name: "mz_index_peek_result_sort_seconds",
-                help: "Time sorting intermediate results during peek collection.",
+                help: "Time thinning intermediate results down to the rows a peek's finishing needs.",
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
             ), role)),
             index_peek_result_sort_rows: registry.register(with_role(metric!(
                 name: "mz_index_peek_result_sort_rows",
-                help: "Number of intermediate result rows sorted during peek collection, summed across sort operations.",
+                help: "Number of intermediate result rows handed to thinning during peek collection, summed across the times it ran.",
                 buckets: index_peek_row_buckets,
             ), role)),
             index_peek_frontier_check_seconds: registry.register(with_role(metric!(


### PR DESCRIPTION
Thinning only needs to know which rows fall outside the first `max_results`, not the order among those that stay. That order is established once anyway, when the answer is collected, so sorting here costs a log factor per row for an ordering that is then thrown away. Over a walk of N rows, thinning runs about N/max_results times on twice `max_results` rows each, which turns `O(N log max_results)` into `O(N)`. It is the walk these peeks spend their time in: a finishing that carries an ordering is never streamable, so such a peek never reaches the peek stash and accumulates until the walk ends.

Partitioning is unstable, so when rows tie across the cut it is unspecified which of them survives, and entries carry counts, so the retained multiset does depend on that choice. What the client reads does not, for three reasons together. A tie here means the rows are byte-identical, because the tiebreaker compares the whole encoded row. Exactly `max_results` entries stay, each with a count of at least one, so they expand to at least `max_results` rows. And `max_results` is `limit + offset`, which the finishing reads as `offset..offset + limit` of the merged answer, whose prefix depends only on the prefixes of the runs it merges. The second and third are why a peek result must not be consumed without applying the finishing's limit.

Two properties of the layers below make this safe here. The unordered early stop and the peek stash both require an absent ordering, while thinning requires one, so neither ever consumes a partitioned prefix. And `select_nth_unstable_by` is reached only after a row has been pushed and only when the prefix holds twice `max_results` entries, so its index is always below the length.

Thinning no longer orders what it keeps, so the two tests that asserted an exact order over a thinned result compare multisets instead. They passed on the partition's incidental output, which is not a property the implementation promises.

The phase's fields become `thinning_time` and `rows_thinned`, since neither measures a sort any more. The two metrics keep their names, which are already released, and their help text now describes thinning rather than sorting.

The reasoning here is Aljoscha's, from #38041, which is closed.

Co-authored-by: Aljoscha Krettek <aljoscha.krettek@gmail.com>
