### PR TITLE
cluster-controller: count oracle reads instead of timing reconciliation

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -21,7 +21,7 @@ import time
 from collections.abc import Callable
 from copy import copy
 from datetime import datetime, timedelta
-from statistics import median, quantiles
+from statistics import quantiles
 from textwrap import dedent
 from threading import Event, Thread
 
@@ -8315,145 +8315,79 @@ def workflow_test_metrics_null_label(c: Composition) -> None:
 def workflow_test_controller_oracle_stall(
     c: Composition, parser: WorkflowArgumentParser
 ) -> None:
-    """Scheduled-cluster count must not determine unrelated reconciliation latency."""
-    parser.add_argument("--latency-ms", type=int, default=500)
-    parser.add_argument("--scheduled-clusters", type=int, default=8)
+    """SQL-569: the cluster controller's timestamp-oracle reads must not grow
+    with the number of `ON REFRESH` clusters.
+
+    The controller gathers refresh-window inputs per scheduled cluster and then
+    performs one shared oracle read for the whole reconciliation-phase batch, so
+    a tick costs a bounded number of oracle round trips no matter how many
+    clusters are scheduled. This counts the oracle's own `read_ts` operations
+    over an idle window, first with `N` scheduled clusters and then with `2N`,
+    and requires the count not to scale with the cluster count.
+
+    The measurement counts operations rather than timing an unrelated cluster's
+    reconciliation under injected oracle latency. Reconciliation latency is the
+    per-tick oracle cost multiplied by however many controller ticks that
+    convergence happens to span, and no test controls the second factor, so a
+    latency measurement carries noise the size of the effect.
+    """
+    parser.add_argument("--scheduled-clusters", type=int, default=4)
+    parser.add_argument("--observation-seconds", type=float, default=10.0)
+    parser.add_argument("--tick-interval-ms", type=int, default=100)
     args = parser.parse_args()
-    if args.latency_ms < 100:
-        parser.error("--latency-ms must be at least 100")
-    if args.scheduled_clusters < 8:
-        parser.error("--scheduled-clusters must be at least 8")
-    oracle_port = 26258
+    if args.scheduled_clusters < 1:
+        parser.error("--scheduled-clusters must be at least 1")
+    if args.observation_seconds < 1:
+        parser.error("--observation-seconds must be at least 1")
 
-    def set_latency(toxi: str, latency_ms: int) -> None:
-        requests.delete(f"{toxi}/proxies/oracle/toxics/lat")
-        if latency_ms > 0:
-            response = requests.post(
-                f"{toxi}/proxies/oracle/toxics",
-                json={
-                    "name": "lat",
-                    "type": "latency",
-                    "attributes": {"latency": latency_ms, "jitter": 0},
-                },
-            )
-            assert response.status_code == 200, response.text
+    c.up("materialized")
+    c.sql(
+        "ALTER SYSTEM SET cluster_controller_tick_interval = "
+        f"'{args.tick_interval_ms}ms'",
+        port=6877,
+        user="mz_system",
+    )
+    mz = c.sql_cursor()
 
-    with c.override(
-        Materialized(
-            external_metadata_store=True,
-            options=[
-                f"--timestamp-oracle-url=postgres://root@toxiproxy:{oracle_port}"
-                "?options=--search_path=tsoracle",
-            ],
+    def oracle_read_ops() -> int:
+        """The oracle's `read_ts` operation count.
+
+        One operation is one round trip to the oracle's backing store. The
+        batching oracle coalesces only concurrent callers, and a controller that
+        awaited one read per scheduled cluster would await them serially, so the
+        per-cluster reads a batch replaces are individually counted here.
+        """
+        metric = 'mz_ts_oracle_started_count{op="read_ts"}'
+        result = c.exec(
+            "materialized",
+            "curl",
+            "-sf",
+            "http://localhost:6878/metrics",
+            capture=True,
         )
-    ):
-        c.up("toxiproxy")
-        toxi = f"http://localhost:{c.default_port('toxiproxy')}"
-        requests.delete(f"{toxi}/proxies/oracle")
-        response = requests.post(
-            f"{toxi}/proxies",
-            json={
-                "name": "oracle",
-                "listen": f"0.0.0.0:{oracle_port}",
-                "upstream": "postgres-metadata:26257",
-                "enabled": True,
-            },
-        )
-        assert response.status_code == 201, response.text
-        c.up("materialized")
+        assert (
+            result.returncode == 0
+        ), f"metrics endpoint failed (rc={result.returncode})"
+        for line in result.stdout.splitlines():
+            if line.startswith(metric):
+                return int(float(line.split()[-1]))
+        raise AssertionError(f"{metric} is not reported")
 
-        c.sql(
-            "ALTER SYSTEM SET cluster_controller_tick_interval = '100ms'",
-            port=6877,
-            user="mz_system",
-        )
-        mz = c.sql_cursor()
-        mz.execute("SET transaction_isolation = 'serializable'")
+    def reads_per_second() -> float:
+        """Oracle reads per second over an otherwise idle observation window.
 
-        def converge_ms(replication_factor: int) -> float:
-            start = time.monotonic()
-            mz.execute(
-                sql.SQL("ALTER CLUSTER cc_probe SET (REPLICATION FACTOR {})").format(
-                    sql.Literal(replication_factor)
-                )
-            )
-            while True:
-                mz.execute(
-                    "SELECT count(*) FROM mz_cluster_replicas r JOIN mz_clusters c "
-                    "ON r.cluster_id = c.id WHERE c.name = 'cc_probe'"
-                )
-                if mz.fetchall()[0][0] == replication_factor:
-                    return (time.monotonic() - start) * 1000
-                assert (
-                    time.monotonic() - start < 120
-                ), f"cc_probe never reached rf {replication_factor}"
-                time.sleep(0.05)
+        The window must stay free of SQL, which would contribute reads of its
+        own, so the counter is scraped over HTTP rather than queried.
+        """
+        before = oracle_read_ops()
+        before_at = time.monotonic()
+        time.sleep(args.observation_seconds)
+        after = oracle_read_ops()
+        after_at = time.monotonic()
+        return (after - before) / (after_at - before_at)
 
-        def convergence_samples() -> list[float]:
-            samples = []
-            replication_factor = 1
-            for _ in range(3):
-                samples.append(converge_ms(replication_factor))
-                replication_factor = 1 - replication_factor
-            return samples
-
-        def await_scheduled_replicas() -> None:
-            start = time.monotonic()
-            while True:
-                mz.execute(
-                    "SELECT count(DISTINCT c.id), count(*) "
-                    "FROM mz_clusters c JOIN mz_cluster_replicas r "
-                    "ON r.cluster_id = c.id "
-                    "WHERE c.name LIKE 'cc\\_sched%' ESCAPE '\\'"
-                )
-                cluster_count, replica_count = mz.fetchall()[0]
-                if (
-                    cluster_count == args.scheduled_clusters
-                    and replica_count == args.scheduled_clusters
-                ):
-                    return
-                if time.monotonic() - start >= 120:
-                    mz.execute(
-                        "SELECT c.name, count(r.id) "
-                        "FROM mz_clusters c LEFT JOIN mz_cluster_replicas r "
-                        "ON r.cluster_id = c.id "
-                        "WHERE c.name LIKE 'cc\\_sched%' ESCAPE '\\' "
-                        "GROUP BY c.name ORDER BY c.name"
-                    )
-                    replica_counts = mz.fetchall()
-                    raise AssertionError(
-                        "scheduled cluster replica counts after 120s: "
-                        f"{replica_counts}. Expected exactly "
-                        f"{args.scheduled_clusters} cc_sched clusters with "
-                        "exactly one replica each"
-                    )
-                time.sleep(0.05)
-
-        set_latency(toxi, 0)
-        mz.execute(
-            "CREATE CLUSTER cc_probe "
-            "(SIZE 'scale=1,workers=1', REPLICATION FACTOR 0)"
-        )
-
-        no_latency_samples = convergence_samples()
-        no_latency_ms = median(no_latency_samples)
-        converge_ms(0)
-
-        set_latency(toxi, args.latency_ms)
-        control_samples = convergence_samples()
-        control_ms = median(control_samples)
-        set_latency(toxi, 0)
-        latency_increase_ms = control_ms - no_latency_ms
-        minimum_increase_ms = args.latency_ms / 2
-        assert latency_increase_ms >= minimum_increase_ms, (
-            f"injecting {args.latency_ms}ms oracle latency increased the control "
-            f"measurement by only {latency_increase_ms:.0f}ms, expected at least "
-            f"{minimum_increase_ms:.0f}ms. The oracle may be bypassing toxiproxy"
-        )
-
-        converge_ms(0)
-        mz.execute("CREATE TABLE cc_sched_t (x int)")
-        for i in range(args.scheduled_clusters):
+    def create_scheduled_clusters(first: int, count: int) -> None:
+        for i in range(first, first + count):
             cluster_name = sql.Identifier(f"cc_sched{i}")
             mz.execute(
                 sql.SQL(
@@ -8470,24 +8404,74 @@ def workflow_test_controller_oracle_stall(
                 ).format(sql.Identifier(f"cc_sched{i}_mv"), cluster_name)
             )
 
-        await_scheduled_replicas()
-        set_latency(toxi, args.latency_ms)
-        stalled_samples = convergence_samples()
-        stalled_ms = median(stalled_samples)
-        set_latency(toxi, 0)
+    def await_scheduled_replicas(expected: int) -> None:
+        start = time.monotonic()
+        while True:
+            mz.execute(
+                "SELECT count(DISTINCT c.id), count(*) "
+                "FROM mz_clusters c JOIN mz_cluster_replicas r "
+                "ON r.cluster_id = c.id "
+                "WHERE c.name LIKE 'cc\\_sched%' ESCAPE '\\'"
+            )
+            cluster_count, replica_count = mz.fetchall()[0]
+            if cluster_count == expected and replica_count == expected:
+                return
+            if time.monotonic() - start >= 120:
+                mz.execute(
+                    "SELECT c.name, count(r.id) "
+                    "FROM mz_clusters c LEFT JOIN mz_cluster_replicas r "
+                    "ON r.cluster_id = c.id "
+                    "WHERE c.name LIKE 'cc\\_sched%' ESCAPE '\\' "
+                    "GROUP BY c.name ORDER BY c.name"
+                )
+                replica_counts = mz.fetchall()
+                raise AssertionError(
+                    "scheduled cluster replica counts after 120s: "
+                    f"{replica_counts}. Expected exactly {expected} cc_sched "
+                    "clusters with exactly one replica each"
+                )
+            time.sleep(0.05)
 
-    excess_ms = stalled_ms - control_ms
-    ceiling_ms = 4 * args.latency_ms
-    print(f"cc_probe 0 -> 1 replica at {args.latency_ms}ms oracle latency:")
-    print(f"  no injected latency : {no_latency_ms:.0f}ms")
-    print(f"  0 scheduled clusters : {control_ms:.0f}ms")
-    print(f"  {args.scheduled_clusters} scheduled clusters : {stalled_ms:.0f}ms")
-    print(
-        f"  excess : {excess_ms:.0f}ms (ceiling {ceiling_ms}ms, "
-        "expected bounded oracle round-trips per controller phase)"
+    mz.execute("CREATE TABLE cc_sched_t (x int)")
+
+    # The controller reads the oracle only for a refresh-window batch, so with no
+    # scheduled cluster this window carries whatever else in the system reads the
+    # oracle while idle. It is the baseline both measurements subtract.
+    idle_rps = reads_per_second()
+
+    create_scheduled_clusters(0, args.scheduled_clusters)
+    await_scheduled_replicas(args.scheduled_clusters)
+    single_rps = reads_per_second()
+
+    create_scheduled_clusters(args.scheduled_clusters, args.scheduled_clusters)
+    await_scheduled_replicas(2 * args.scheduled_clusters)
+    double_rps = reads_per_second()
+
+    single_excess = single_rps - idle_rps
+    double_excess = double_rps - idle_rps
+    print("oracle read_ts operations per second while idle:")
+    print(f"  0 scheduled clusters : {idle_rps:.1f}")
+    print(f"  {args.scheduled_clusters} scheduled clusters : {single_rps:.1f}")
+    print(f"  {2 * args.scheduled_clusters} scheduled clusters : {double_rps:.1f}")
+
+    # A tick reads the oracle once per refresh-window batch, so a reconciling
+    # scheduled cluster contributes on the order of one read per tick. The floor
+    # sits far below that because it only has to establish that the batch path
+    # runs at all: the tick interval is a floor on the cadence, not a promise,
+    # and a busy machine ticks slower than the configured interval.
+    minimum_excess = 0.25 * 1000 / args.tick_interval_ms
+    assert single_excess >= minimum_excess, (
+        f"{args.scheduled_clusters} scheduled clusters added only "
+        f"{single_excess:.1f} oracle reads per second over the idle baseline, "
+        f"expected at least {minimum_excess:.1f}. The controller may not be "
+        "reconciling them, which would leave this test measuring nothing"
     )
-    assert excess_ms < ceiling_ms, (
-        f"{args.scheduled_clusters} unrelated ON REFRESH clusters delayed the "
-        f"probe cluster's reconciliation by {excess_ms:.0f}ms "
-        f"(ceiling {ceiling_ms}ms)"
+    growth = double_excess / single_excess
+    ceiling = 1.5
+    print(f"  growth from doubling the cluster count : {growth:.2f}x")
+    assert growth < ceiling, (
+        f"doubling the scheduled cluster count from {args.scheduled_clusters} to "
+        f"{2 * args.scheduled_clusters} multiplied the controller's oracle reads "
+        f"by {growth:.2f}x (ceiling {ceiling}x), so the reads did not stay "
+        "bounded per reconciliation phase"
     )


### PR DESCRIPTION
## Motivation

`test-controller-oracle-stall` guards [SQL-569](https://linear.app/materializeinc/issue/SQL-569): the controller performs one shared timestamp-oracle read per reconciliation-phase batch, so its oracle cost is bounded per phase rather than proportional to the number of `ON REFRESH` clusters. It measured that by injecting 500ms of oracle latency through toxiproxy and comparing an unrelated probe cluster's convergence with zero and eight scheduled clusters, against a ceiling of four round trips. It flakes: [build 133473](https://buildkite.com/materialize/test/builds/133473) failed with `8 unrelated ON REFRESH clusters delayed the probe cluster's reconciliation by 3233ms (ceiling 2000ms)`.

Convergence latency is the per-tick oracle cost multiplied by however many controller ticks the convergence spans, and the test controls neither factor. A tick issues one refresh-window batch, or two when its first phase wrote, so the same bounded implementation lands anywhere from two to seven round trips depending on tick alignment. Recent runs cluster around 1025ms of excess and the failing one reached 3233ms. That spread also overlaps what eight unbatched per-cluster reads would cost, so no ceiling could both accommodate the implementation and detect its regression.

## Description

Count the oracle's own `read_ts` operations instead. The test scrapes `mz_ts_oracle_started_count{op="read_ts"}` over an idle window with `N` scheduled clusters and again with `2N`, and requires the rate not to grow with the cluster count. One operation is one round trip to the oracle's backing store, the batching oracle coalesces only concurrent callers, and per-cluster reads would be awaited serially, so the reads a batch replaces are individually counted.

Doubling the cluster count measures 0.99x to 1.11x across four local runs against a 1.5x ceiling, where per-cluster reads would measure 2.0x. No injected latency, no toxiproxy, and no dependence on tick alignment or machine speed. The floor assertion on the `N`-cluster rate replaces the old check that oracle traffic was reaching toxiproxy: both establish that the measurement observes the refresh path at all rather than passing vacuously.

Rewrites `workflow_test_controller_oracle_stall` in `test/cluster/mzcompose.py`. No production code changes.

Fixes [SQL-569](https://linear.app/materializeinc/issue/SQL-569) flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)