### PR TITLE
adapter: track ALTER SOURCE's source in the purified statement's dependencies

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1614,7 +1614,14 @@ impl Coordinator {
                     )
                     .await;
                     let result = result.map_err(|e| e.into());
-                    let dependency_ids = resolved_ids.items().copied().collect();
+                    // `ALTER SOURCE` carries its target as an unresolved name, so name
+                    // resolution never records it and `resolved_ids` does not cover it.
+                    // Without it a source dropped while purification ran off-thread
+                    // passes the validity check below and then panics the coordinator
+                    // on the missing catalog entry ("catalog out of sync") during
+                    // planning.
+                    let mut dependency_ids: BTreeSet<_> = resolved_ids.items().copied().collect();
+                    dependency_ids.extend(statement_source.map(|source| source.id()));
                     let plan_validity = PlanValidity::new(
                         &catalog,
                         dependency_ids,


### PR DESCRIPTION
### Motivation

`ALTER SOURCE` is purified off the coordinator thread. Its target source is
carried in the AST as an `UnresolvedItemName`, so name resolution never records
it and the statement's `resolved_ids`, from which `PlanValidity`'s dependency
set is built, does not contain it.

A source dropped concurrently with that off-thread purification therefore
passed the validity check when the purified statement came back, and planning
then called `get_entry` on the missing id, panicking the coordinator with
"catalog out of sync" (`plan_purified_alter_source_add_subsource`,
`plan_purified_alter_source_refresh_references`).

### Description

Extend the purified statement's dependency ids with the source that
`mz_sql::pure::statement_source` resolves (introduced in #38564, where the same
resolution feeds the pre-purification authorization check). With the id
tracked, `PlanValidity::check` detects the drop and the coordinator repurifies
the original statement, ending in a clean unknown-item error instead of a
panic. For `CREATE TABLE ... FROM SOURCE` the source is already in
`resolved_ids`, so the extension is a no-op there.

### Verification

The race needs a drop landing between purification spawn and completion; there
is no deterministic hook for that in sqllogictest. Verified by code trace:
`PlanValidity::check` uses `try_get_entry` and returns
`ConcurrentDependencyDrop` for a missing id, and the `PurifiedStatementReady`
handler repurifies on validity failure. `ALTER SOURCE IF EXISTS` on a
never-resolving name contributes no phantom dependency (`statement_source`
returns `None`).

Stacked on #38564.

