### PR TITLE
INC-1252: Clean up adapter metrics keyed by clusters

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::future::Future;
@@ -2187,25 +2186,12 @@ impl RecordFirstRowStream {
         let session = client.session.as_ref().expect("session invariant");
         let isolation_level = *session.vars().transaction_isolation();
         let name_hint = ApplicationNameHint::from_str(session.application_name());
-        let instance = match instance_id {
-            Some(i) => Cow::Owned(i.to_string()),
-            None => Cow::Borrowed("none"),
-        };
-        let strategy = match strategy {
-            Some(s) => s.name(),
-            None => "none",
-        };
 
         client
             .inner()
             .metrics()
-            .time_to_first_row_seconds
-            .with_label_values(&[
-                instance.as_ref(),
-                isolation_level.as_variant_str(),
-                strategy,
-                name_hint.as_str(),
-            ])
+            .by_cluster
+            .time_to_first_row_seconds(instance_id, isolation_level, strategy, name_hint)
     }
 
     /// If you want to match [`RecordFirstRowStream`]'s logic but don't need

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -1030,6 +1030,10 @@ impl Coordinator {
                 self.drop_vpc_endpoints_in_background(vpc_endpoints_to_drop)
             }
 
+            let clusters_losing_replicas: BTreeSet<_> = cluster_replicas_to_drop
+                .iter()
+                .map(|(cluster_id, _)| *cluster_id)
+                .collect();
             if !cluster_replicas_to_drop.is_empty() {
                 fail::fail_point!("after_catalog_drop_replica");
 
@@ -1038,8 +1042,19 @@ impl Coordinator {
                 }
             }
             if !clusters_to_drop.is_empty() {
-                for cluster_id in clusters_to_drop {
-                    self.controller.drop_cluster(cluster_id);
+                for cluster_id in &clusters_to_drop {
+                    self.controller.drop_cluster(*cluster_id);
+                }
+            }
+            // A dropped cluster, or one left without replicas, cannot serve
+            // peeks, so its peek series are stale. They come back on the first
+            // peek once a cluster has a replica again.
+            for cluster_id in clusters_losing_replicas.into_iter().chain(clusters_to_drop) {
+                let has_replicas = self
+                    .catalog()
+                    .try_get_cluster(cluster_id)
+                    .is_some_and(|cluster| cluster.replicas().next().is_some());
+                if !has_replicas {
                     self.metrics.by_cluster.remove_cluster(cluster_id);
                 }
             }

--- a/src/adapter/src/coord/catalog_implications.rs
+++ b/src/adapter/src/coord/catalog_implications.rs
@@ -1040,6 +1040,7 @@ impl Coordinator {
             if !clusters_to_drop.is_empty() {
                 for cluster_id in clusters_to_drop {
                     self.controller.drop_cluster(cluster_id);
+                    self.metrics.by_cluster.remove_cluster(cluster_id);
                 }
             }
 

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -698,15 +698,12 @@ impl Coordinator {
             isolation_level,
         )?;
         self.metrics
-            .determine_timestamp
-            .with_label_values(&[
-                match det.respond_immediately() {
-                    true => "true",
-                    false => "false",
-                },
-                isolation_level.as_variant_str(),
-                &compute_instance.to_string(),
-            ])
+            .by_cluster
+            .determine_timestamp(
+                compute_instance,
+                det.respond_immediately(),
+                *isolation_level,
+            )
             .inc();
         if !det.respond_immediately()
             && isolation_level.is_bounded_staleness()
@@ -725,8 +722,8 @@ impl Coordinator {
                 )?;
                 if let Some(serializable) = serializable_det.timestamp_context.timestamp() {
                     self.metrics
-                        .timestamp_difference_for_bounded_staleness_ms
-                        .with_label_values(&[compute_instance.to_string().as_str()])
+                        .by_cluster
+                        .timestamp_difference_for_bounded_staleness_ms(compute_instance)
                         .observe(f64::cast_lossy(u64::from(
                             serializable.saturating_sub(*bs_ts),
                         )));

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -1532,14 +1532,12 @@ impl PeekClient {
 
         session
             .metrics()
-            .determine_timestamp(&[
-                match det.respond_immediately() {
-                    true => "true",
-                    false => "false",
-                },
-                isolation_level.as_variant_str(),
-                &compute_instance.to_string(),
-            ])
+            .by_cluster()
+            .determine_timestamp(
+                compute_instance,
+                det.respond_immediately(),
+                *isolation_level,
+            )
             .inc();
         if !det.respond_immediately()
             && isolation_level.is_bounded_staleness()
@@ -1562,9 +1560,8 @@ impl PeekClient {
                 if let Some(serializable) = serializable_det.timestamp_context.timestamp() {
                     session
                         .metrics()
-                        .timestamp_difference_for_bounded_staleness_ms(&[compute_instance
-                            .to_string()
-                            .as_ref()])
+                        .by_cluster()
+                        .timestamp_difference_for_bounded_staleness_ms(compute_instance)
                         .observe(f64::cast_lossy(u64::from(
                             serializable.saturating_sub(*bs_ts),
                         )));

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -7,14 +7,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
+
+use mz_controller_types::ClusterId;
 use mz_ore::metric;
-use mz_ore::metrics::{MetricTag, MetricVisibility, MetricsRegistry, UIntGauge};
+use mz_ore::metrics::{
+    MetricTag, MetricVisibility, MetricsRegistry, UIntGauge, remove_children_with_label,
+};
 use mz_ore::stats::{histogram_milliseconds_buckets, histogram_seconds_buckets};
 use mz_sql::ast::{AstInfo, Statement, StatementKind, SubscribeOutput};
+use mz_sql::session::hint::ApplicationNameHint;
 use mz_sql::session::user::User;
+use mz_sql::session::vars::IsolationLevel;
 use mz_sql_parser::ast::statement_kind_label_value;
 use prometheus::core::{AtomicU64, GenericCounter};
 use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec};
+
+use crate::statement_logging::StatementExecutionStrategy;
 
 pub(crate) const OCC_CALLER_SESSION: &str = "session";
 pub(crate) const OCC_CALLER_BACKGROUND: &str = "background";
@@ -27,8 +36,6 @@ pub struct Metrics {
     pub active_internal_subscribes: IntGaugeVec,
     pub active_copy_tos: IntGaugeVec,
     pub queue_busy_seconds: Histogram,
-    pub determine_timestamp: IntCounterVec,
-    pub timestamp_difference_for_bounded_staleness_ms: HistogramVec,
     pub commands: IntCounterVec,
     pub storage_usage_collection_time_seconds: Histogram,
     pub arrangement_sizes_collection_time_seconds: Histogram,
@@ -40,7 +47,6 @@ pub struct Metrics {
     pub subscribe_outputs: IntCounterVec,
     pub canceled_peeks: IntCounter,
     pub linearize_message_seconds: HistogramVec,
-    pub time_to_first_row_seconds: HistogramVec,
     pub statement_logging_records: IntCounterVec,
     pub statement_logging_unsampled_bytes: IntCounter,
     pub statement_logging_actual_bytes: IntCounter,
@@ -66,6 +72,7 @@ pub struct Metrics {
     pub apply_catalog_implications_seconds: Histogram,
     pub group_commit_catalog_upper_seconds: Histogram,
     pub occ_retry_count: HistogramVec,
+    pub by_cluster: ClusterLabeledMetrics,
 }
 
 impl Metrics {
@@ -106,17 +113,6 @@ impl Metrics {
                 name: "mz_coord_queue_busy_seconds",
                 help: "The number of seconds the coord queue was processing before it was empty. This is a sampled metric and does not measure the full coord queue wait/idle times.",
                 buckets: histogram_seconds_buckets(0.000_128, 32.0)
-            )),
-            determine_timestamp: registry.register(metric!(
-                name: "mz_determine_timestamp",
-                help: "The total number of calls to determine_timestamp.",
-                var_labels:["respond_immediately", "isolation_level", "compute_instance"],
-            )),
-            timestamp_difference_for_bounded_staleness_ms: registry.register(metric!(
-                name: "mz_timestamp_difference_for_bounded_staleness_ms",
-                help: "How much older bounded-staleness timestamps are compared to serializable, in milliseconds. Measures the actual staleness incurred.",
-                var_labels:["compute_instance"],
-                buckets: histogram_milliseconds_buckets(1., 8000.),
             )),
             commands: registry.register(metric!(
                 name: "mz_adapter_commands",
@@ -173,14 +169,6 @@ impl Metrics {
                 var_labels: ["type", "immediately_handled"],
                 buckets: histogram_seconds_buckets(0.000_128, 8.0),
             )),
-            time_to_first_row_seconds: registry.register(metric! {
-                name: "mz_time_to_first_row_seconds",
-                help: "Latency of an execute for a successful query from pgwire's perspective",
-                var_labels: ["instance_id", "isolation_level", "strategy", "application_name"],
-                // NOTE: Measurements below 512 microseconds are negligible, so omit those buckets.
-                // This histogram retains series for dropped `instance_id` label values.
-                buckets: histogram_seconds_buckets(0.000_512, 32.0)
-            }),
             statement_logging_records: registry.register(metric! {
                 name: "mz_statement_logging_record_count",
                 help: "The total number of SQL statements tagged with whether or not they were recorded.",
@@ -318,6 +306,7 @@ impl Metrics {
                     0., 1., 2., 3., 5., 10., 25., 50., 100., 200., 300., 500., 750., 1000.,
                 ],
             )),
+            by_cluster: ClusterLabeledMetrics::register_into(registry),
         }
     }
 
@@ -331,10 +320,7 @@ impl Metrics {
             session_startup_table_writes_seconds: self.session_startup_table_writes_seconds.clone(),
             query_total: self.query_total.clone(),
             subscribe_outputs: self.subscribe_outputs.clone(),
-            determine_timestamp: self.determine_timestamp.clone(),
-            timestamp_difference_for_bounded_staleness_ms: self
-                .timestamp_difference_for_bounded_staleness_ms
-                .clone(),
+            by_cluster: self.by_cluster.clone(),
             optimization_notices: self.optimization_notices.clone(),
             statement_logging_records: self.statement_logging_records.clone(),
             statement_logging_unsampled_bytes: self.statement_logging_unsampled_bytes.clone(),
@@ -350,8 +336,7 @@ pub struct SessionMetrics {
     session_startup_table_writes_seconds: Histogram,
     query_total: IntCounterVec,
     subscribe_outputs: IntCounterVec,
-    determine_timestamp: IntCounterVec,
-    timestamp_difference_for_bounded_staleness_ms: HistogramVec,
+    by_cluster: ClusterLabeledMetrics,
     optimization_notices: IntCounterVec,
     statement_logging_records: IntCounterVec,
     statement_logging_unsampled_bytes: IntCounter,
@@ -375,16 +360,8 @@ impl SessionMetrics {
         self.subscribe_outputs.with_label_values(label_values)
     }
 
-    pub(crate) fn determine_timestamp(&self, label_values: &[&str]) -> GenericCounter<AtomicU64> {
-        self.determine_timestamp.with_label_values(label_values)
-    }
-
-    pub(crate) fn timestamp_difference_for_bounded_staleness_ms(
-        &self,
-        label_values: &[&str],
-    ) -> Histogram {
-        self.timestamp_difference_for_bounded_staleness_ms
-            .with_label_values(label_values)
+    pub(crate) fn by_cluster(&self) -> &ClusterLabeledMetrics {
+        &self.by_cluster
     }
 
     pub(crate) fn optimization_notices(&self, label_values: &[&str]) -> GenericCounter<AtomicU64> {
@@ -431,5 +408,202 @@ where
         SubscribeOutput::WithinTimestampOrderBy { .. } => "within_timestamp_order_by",
         SubscribeOutput::EnvelopeUpsert { .. } => "envelope_upsert",
         SubscribeOutput::EnvelopeDebezium { .. } => "envelope_debezium",
+    }
+}
+
+/// Adapter metrics whose series carry a cluster id label.
+///
+/// Series are created on first observation, as for any labeled metric, and
+/// `remove_cluster` sweeps a dropped cluster's series out again.
+#[derive(Debug, Clone)]
+pub struct ClusterLabeledMetrics {
+    time_to_first_row_seconds: HistogramVec,
+    determine_timestamp: IntCounterVec,
+    timestamp_difference_for_bounded_staleness_ms: HistogramVec,
+}
+
+impl ClusterLabeledMetrics {
+    fn register_into(registry: &MetricsRegistry) -> Self {
+        Self {
+            time_to_first_row_seconds: registry.register(metric! {
+                name: "mz_time_to_first_row_seconds",
+                help: "Latency of an execute for a successful query from pgwire's perspective",
+                var_labels: ["instance_id", "isolation_level", "strategy", "application_name"],
+                // NOTE: Measurements below 512 microseconds are negligible, so omit those buckets.
+                buckets: histogram_seconds_buckets(0.000_512, 32.0)
+            }),
+            determine_timestamp: registry.register(metric!(
+                name: "mz_determine_timestamp",
+                help: "The total number of calls to determine_timestamp.",
+                var_labels: ["respond_immediately", "isolation_level", "compute_instance"],
+            )),
+            timestamp_difference_for_bounded_staleness_ms: registry.register(metric!(
+                name: "mz_timestamp_difference_for_bounded_staleness_ms",
+                help: "How much older bounded-staleness timestamps are compared to serializable, in milliseconds. Measures the actual staleness incurred.",
+                var_labels: ["compute_instance"],
+                buckets: histogram_milliseconds_buckets(1., 8000.),
+            )),
+        }
+    }
+
+    /// Deletes the series of `cluster_id`.
+    pub(crate) fn remove_cluster(&self, cluster_id: ClusterId) {
+        let cluster = cluster_id.to_string();
+        remove_children_with_label(&self.time_to_first_row_seconds, "instance_id", &cluster);
+        remove_children_with_label(&self.determine_timestamp, "compute_instance", &cluster);
+        remove_children_with_label(
+            &self.timestamp_difference_for_bounded_staleness_ms,
+            "compute_instance",
+            &cluster,
+        );
+    }
+
+    /// Statements without a cluster or strategy record under the "none" label value.
+    pub(crate) fn time_to_first_row_seconds(
+        &self,
+        cluster_id: Option<ClusterId>,
+        isolation_level: IsolationLevel,
+        strategy: Option<StatementExecutionStrategy>,
+        application_name: ApplicationNameHint,
+    ) -> Histogram {
+        let instance = match cluster_id {
+            Some(id) => Cow::Owned(id.to_string()),
+            None => Cow::Borrowed("none"),
+        };
+        self.time_to_first_row_seconds.with_label_values(&[
+            instance.as_ref(),
+            isolation_level.as_variant_str(),
+            strategy.map_or("none", |strategy| strategy.name()),
+            application_name.as_str(),
+        ])
+    }
+
+    pub(crate) fn determine_timestamp(
+        &self,
+        cluster_id: ClusterId,
+        respond_immediately: bool,
+        isolation_level: IsolationLevel,
+    ) -> GenericCounter<AtomicU64> {
+        self.determine_timestamp.with_label_values(&[
+            if respond_immediately { "true" } else { "false" },
+            isolation_level.as_variant_str(),
+            &cluster_id.to_string(),
+        ])
+    }
+
+    pub(crate) fn timestamp_difference_for_bounded_staleness_ms(
+        &self,
+        cluster_id: ClusterId,
+    ) -> Histogram {
+        self.timestamp_difference_for_bounded_staleness_ms
+            .with_label_values(&[&cluster_id.to_string()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use prometheus::proto::MetricFamily;
+
+    use super::*;
+
+    const U1: ClusterId = ClusterId::User(1);
+    const U2: ClusterId = ClusterId::User(2);
+
+    const CLUSTER_LABELED: [&str; 3] = [
+        "mz_time_to_first_row_seconds",
+        "mz_determine_timestamp",
+        "mz_timestamp_difference_for_bounded_staleness_ms",
+    ];
+
+    fn family(registry: &MetricsRegistry, name: &str) -> Option<MetricFamily> {
+        registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+    }
+
+    /// The cluster label values across the series of `name`.
+    fn clusters_in(registry: &MetricsRegistry, name: &str) -> BTreeSet<String> {
+        family(registry, name)
+            .map(|family| {
+                family
+                    .get_metric()
+                    .iter()
+                    .flat_map(|metric| metric.get_label())
+                    .filter(|label| ["instance_id", "compute_instance"].contains(&label.name()))
+                    .map(|label| label.value().to_string())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn observe_first_row(
+        metrics: &ClusterLabeledMetrics,
+        cluster_id: Option<ClusterId>,
+        strategy: Option<StatementExecutionStrategy>,
+    ) {
+        metrics
+            .time_to_first_row_seconds(
+                cluster_id,
+                IsolationLevel::StrictSerializable,
+                strategy,
+                ApplicationNameHint::from_str("psql"),
+            )
+            .observe(0.1);
+    }
+
+    #[mz_ore::test]
+    fn dropping_a_cluster_removes_its_series() {
+        let registry = MetricsRegistry::new();
+        let metrics = ClusterLabeledMetrics::register_into(&registry);
+
+        observe_first_row(&metrics, Some(U1), None);
+        observe_first_row(
+            &metrics,
+            Some(U1),
+            Some(StatementExecutionStrategy::FastPath),
+        );
+        observe_first_row(&metrics, Some(U2), None);
+        metrics
+            .determine_timestamp(U1, true, IsolationLevel::Serializable)
+            .inc();
+        metrics
+            .timestamp_difference_for_bounded_staleness_ms(U1)
+            .observe(5.0);
+        for name in CLUSTER_LABELED {
+            assert!(
+                clusters_in(&registry, name).contains("u1"),
+                "{name} has no u1 series before the drop"
+            );
+        }
+
+        metrics.remove_cluster(U1);
+
+        for name in CLUSTER_LABELED {
+            assert!(
+                !clusters_in(&registry, name).contains("u1"),
+                "{name} still has u1 series after the drop"
+            );
+        }
+        assert_eq!(
+            clusters_in(&registry, "mz_time_to_first_row_seconds"),
+            BTreeSet::from(["u2".to_string()]),
+            "the other cluster's series must be untouched"
+        );
+    }
+
+    #[mz_ore::test]
+    fn statements_without_a_cluster_are_unaffected_by_drops() {
+        let registry = MetricsRegistry::new();
+        let metrics = ClusterLabeledMetrics::register_into(&registry);
+        observe_first_row(&metrics, None, Some(StatementExecutionStrategy::Constant));
+        observe_first_row(&metrics, Some(U1), None);
+        metrics.remove_cluster(U1);
+        assert_eq!(
+            clusters_in(&registry, "mz_time_to_first_row_seconds"),
+            BTreeSet::from(["none".to_string()])
+        );
     }
 }

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -12,7 +12,8 @@ use std::borrow::Cow;
 use mz_controller_types::ClusterId;
 use mz_ore::metric;
 use mz_ore::metrics::{
-    MetricTag, MetricVisibility, MetricsRegistry, UIntGauge, remove_children_with_label,
+    MakeCollector, MakeCollectorOpts, MetricTag, MetricVisibility, MetricsRegistry, UIntGauge,
+    remove_children_with_label,
 };
 use mz_ore::stats::{histogram_milliseconds_buckets, histogram_seconds_buckets};
 use mz_sql::ast::{AstInfo, Statement, StatementKind, SubscribeOutput};
@@ -414,48 +415,110 @@ where
 /// Adapter metrics whose series carry a cluster id label.
 ///
 /// Series are created on first observation, as for any labeled metric, and
-/// `remove_cluster` sweeps a dropped cluster's series out again.
+/// `remove_cluster` deletes a dropped cluster's series from every vec that
+/// `register` put here.
 #[derive(Debug, Clone)]
 pub struct ClusterLabeledMetrics {
     time_to_first_row_seconds: HistogramVec,
     determine_timestamp: IntCounterVec,
     timestamp_difference_for_bounded_staleness_ms: HistogramVec,
+    /// Every vec above with the label that carries its cluster id. `register`
+    /// is the only way in, so a vec registered any other way is not swept.
+    delete_on_cluster_drop: Vec<ClusterLabeledVec>,
+}
+
+/// A metric vec with the name of the label that carries the cluster id.
+#[derive(Debug, Clone)]
+enum ClusterLabeledVec {
+    Histogram(HistogramVec, &'static str),
+    Counter(IntCounterVec, &'static str),
+}
+
+impl ClusterLabeledVec {
+    fn delete_cluster(&self, cluster: &str) {
+        match self {
+            Self::Histogram(vec, label) => remove_children_with_label(vec, label, cluster),
+            Self::Counter(vec, label) => remove_children_with_label(vec, label, cluster),
+        }
+    }
 }
 
 impl ClusterLabeledMetrics {
     fn register_into(registry: &MetricsRegistry) -> Self {
+        let mut vecs = Vec::new();
         Self {
-            time_to_first_row_seconds: registry.register(metric! {
-                name: "mz_time_to_first_row_seconds",
-                help: "Latency of an execute for a successful query from pgwire's perspective",
-                var_labels: ["instance_id", "isolation_level", "strategy", "application_name"],
-                // NOTE: Measurements below 512 microseconds are negligible, so omit those buckets.
-                buckets: histogram_seconds_buckets(0.000_512, 32.0)
-            }),
-            determine_timestamp: registry.register(metric!(
-                name: "mz_determine_timestamp",
-                help: "The total number of calls to determine_timestamp.",
-                var_labels: ["respond_immediately", "isolation_level", "compute_instance"],
-            )),
-            timestamp_difference_for_bounded_staleness_ms: registry.register(metric!(
-                name: "mz_timestamp_difference_for_bounded_staleness_ms",
-                help: "How much older bounded-staleness timestamps are compared to serializable, in milliseconds. Measures the actual staleness incurred.",
-                var_labels: ["compute_instance"],
-                buckets: histogram_milliseconds_buckets(1., 8000.),
-            )),
+            time_to_first_row_seconds: Self::register(
+                registry,
+                &mut vecs,
+                ClusterLabeledVec::Histogram,
+                "instance_id",
+                metric! {
+                    name: "mz_time_to_first_row_seconds",
+                    help: "Latency of an execute for a successful query from pgwire's perspective",
+                    var_labels: ["instance_id", "isolation_level", "strategy", "application_name"],
+                    // NOTE: Measurements below 512 microseconds are negligible, so omit those buckets.
+                    buckets: histogram_seconds_buckets(0.000_512, 32.0)
+                },
+            ),
+            determine_timestamp: Self::register(
+                registry,
+                &mut vecs,
+                ClusterLabeledVec::Counter,
+                "compute_instance",
+                metric!(
+                    name: "mz_determine_timestamp",
+                    help: "The total number of calls to determine_timestamp.",
+                    var_labels: ["respond_immediately", "isolation_level", "compute_instance"],
+                ),
+            ),
+            timestamp_difference_for_bounded_staleness_ms: Self::register(
+                registry,
+                &mut vecs,
+                ClusterLabeledVec::Histogram,
+                "compute_instance",
+                metric!(
+                    name: "mz_timestamp_difference_for_bounded_staleness_ms",
+                    help: "How much older bounded-staleness timestamps are compared to serializable, in milliseconds. Measures the actual staleness incurred.",
+                    var_labels: ["compute_instance"],
+                    buckets: histogram_milliseconds_buckets(1., 8000.),
+                ),
+            ),
+            delete_on_cluster_drop: vecs,
         }
+    }
+
+    /// Registers `opts` and records it, wrapped by `wrap`, with `cluster_label`
+    /// as the label carrying its cluster id, so `remove_cluster` covers it.
+    ///
+    /// Panics if `cluster_label` is not a variable label of `opts`.
+    fn register<M: MakeCollector>(
+        registry: &MetricsRegistry,
+        vecs: &mut Vec<ClusterLabeledVec>,
+        wrap: fn(M, &'static str) -> ClusterLabeledVec,
+        cluster_label: &'static str,
+        opts: MakeCollectorOpts,
+    ) -> M {
+        assert!(
+            opts.opts
+                .variable_labels
+                .iter()
+                .any(|label| label == cluster_label),
+            "{cluster_label} is not a label of {}",
+            opts.opts.name
+        );
+        let vec: M = registry.register(opts);
+        // A metric vec is a handle onto shared state, so the clone sees the
+        // same children as the field.
+        vecs.push(wrap(vec.clone(), cluster_label));
+        vec
     }
 
     /// Deletes the series of `cluster_id`.
     pub(crate) fn remove_cluster(&self, cluster_id: ClusterId) {
         let cluster = cluster_id.to_string();
-        remove_children_with_label(&self.time_to_first_row_seconds, "instance_id", &cluster);
-        remove_children_with_label(&self.determine_timestamp, "compute_instance", &cluster);
-        remove_children_with_label(
-            &self.timestamp_difference_for_bounded_staleness_ms,
-            "compute_instance",
-            &cluster,
-        );
+        for vec in &self.delete_on_cluster_drop {
+            vec.delete_cluster(&cluster);
+        }
     }
 
     /// Statements without a cluster or strategy record under the "none" label value.
@@ -504,39 +567,33 @@ impl ClusterLabeledMetrics {
 mod tests {
     use std::collections::BTreeSet;
 
-    use prometheus::proto::MetricFamily;
-
     use super::*;
 
     const U1: ClusterId = ClusterId::User(1);
     const U2: ClusterId = ClusterId::User(2);
 
-    const CLUSTER_LABELED: [&str; 3] = [
-        "mz_time_to_first_row_seconds",
-        "mz_determine_timestamp",
-        "mz_timestamp_difference_for_bounded_staleness_ms",
-    ];
-
-    fn family(registry: &MetricsRegistry, name: &str) -> Option<MetricFamily> {
+    fn families(registry: &MetricsRegistry) -> BTreeSet<String> {
         registry
             .gather()
             .into_iter()
-            .find(|family| family.name() == name)
+            .map(|family| family.name().to_string())
+            .collect()
     }
 
-    /// The cluster label values across the series of `name`.
-    fn clusters_in(registry: &MetricsRegistry, name: &str) -> BTreeSet<String> {
-        family(registry, name)
-            .map(|family| {
+    /// Names of the families with a series carrying `value` under any label.
+    fn families_with_label_value(registry: &MetricsRegistry, value: &str) -> BTreeSet<String> {
+        registry
+            .gather()
+            .into_iter()
+            .filter(|family| {
                 family
                     .get_metric()
                     .iter()
                     .flat_map(|metric| metric.get_label())
-                    .filter(|label| ["instance_id", "compute_instance"].contains(&label.name()))
-                    .map(|label| label.value().to_string())
-                    .collect()
+                    .any(|label| label.value() == value)
             })
-            .unwrap_or_default()
+            .map(|family| family.name().to_string())
+            .collect()
     }
 
     fn observe_first_row(
@@ -572,24 +629,22 @@ mod tests {
         metrics
             .timestamp_difference_for_bounded_staleness_ms(U1)
             .observe(5.0);
-        for name in CLUSTER_LABELED {
-            assert!(
-                clusters_in(&registry, name).contains("u1"),
-                "{name} has no u1 series before the drop"
-            );
-        }
+        assert_eq!(
+            families_with_label_value(&registry, "u1"),
+            families(&registry),
+            "every registered family needs a u1 series for the drop to be exercised"
+        );
 
         metrics.remove_cluster(U1);
 
-        for name in CLUSTER_LABELED {
-            assert!(
-                !clusters_in(&registry, name).contains("u1"),
-                "{name} still has u1 series after the drop"
-            );
-        }
         assert_eq!(
-            clusters_in(&registry, "mz_time_to_first_row_seconds"),
-            BTreeSet::from(["u2".to_string()]),
+            families_with_label_value(&registry, "u1"),
+            BTreeSet::new(),
+            "u1 series survived the drop"
+        );
+        assert_eq!(
+            families_with_label_value(&registry, "u2"),
+            BTreeSet::from(["mz_time_to_first_row_seconds".to_string()]),
             "the other cluster's series must be untouched"
         );
     }
@@ -601,9 +656,27 @@ mod tests {
         observe_first_row(&metrics, None, Some(StatementExecutionStrategy::Constant));
         observe_first_row(&metrics, Some(U1), None);
         metrics.remove_cluster(U1);
+        assert_eq!(families_with_label_value(&registry, "u1"), BTreeSet::new());
         assert_eq!(
-            clusters_in(&registry, "mz_time_to_first_row_seconds"),
-            BTreeSet::from(["none".to_string()])
+            families_with_label_value(&registry, "none"),
+            BTreeSet::from(["mz_time_to_first_row_seconds".to_string()])
+        );
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "is not a label of mz_test")]
+    fn registering_under_a_label_the_metric_lacks_panics() {
+        let registry = MetricsRegistry::new();
+        let _: IntCounterVec = ClusterLabeledMetrics::register(
+            &registry,
+            &mut Vec::new(),
+            ClusterLabeledVec::Counter,
+            "cluster_id",
+            metric!(
+                name: "mz_test",
+                help: "test",
+                var_labels: ["compute_instance"],
+            ),
         );
     }
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -7561,3 +7561,63 @@ fn test_startup_only_system_var_warns() {
         "RESET ALL warned without changing anything, notices: {notices:?}"
     );
 }
+
+/// The values of `label` across the series of the `family` metric.
+fn label_values(registry: &MetricsRegistry, family: &str, label: &str) -> BTreeSet<String> {
+    registry
+        .gather()
+        .into_iter()
+        .filter(|f| f.name() == family)
+        .flat_map(|f| f.get_metric().to_vec())
+        .flat_map(|metric| metric.get_label().to_vec())
+        .filter(|pair| pair.name() == label)
+        .map(|pair| pair.value().to_string())
+        .collect()
+}
+
+/// Metric families with a cluster id label, paired with that label's name.
+const CLUSTER_LABELED_METRICS: [(&str, &str); 2] = [
+    ("mz_time_to_first_row_seconds", "instance_id"),
+    ("mz_determine_timestamp", "compute_instance"),
+];
+
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_cluster_labeled_metrics_are_removed_on_cluster_drop() {
+    let server = test_util::TestHarness::default().start_blocking();
+    let mut client = server.connect(postgres::NoTls).unwrap();
+
+    client
+        .batch_execute("CREATE CLUSTER c REPLICAS (r1 (SIZE 'scale=1,workers=1'))")
+        .unwrap();
+    client.batch_execute("CREATE TABLE t (a int)").unwrap();
+    client.batch_execute("INSERT INTO t VALUES (1)").unwrap();
+    client
+        .batch_execute("CREATE INDEX t_idx IN CLUSTER c ON t (a)")
+        .unwrap();
+    let cluster_id: String = client
+        .query_one("SELECT id FROM mz_clusters WHERE name = 'c'", &[])
+        .unwrap()
+        .get(0);
+
+    // A peek served by the index on `c` records series labeled with its id.
+    client.batch_execute("SET cluster = c").unwrap();
+    client.query("SELECT * FROM t", &[]).unwrap();
+    for (family, label) in CLUSTER_LABELED_METRICS {
+        assert!(
+            label_values(server.metrics_registry(), family, label).contains(&cluster_id),
+            "peek on {cluster_id} recorded no {family} series"
+        );
+    }
+
+    // DROP CLUSTER applies its catalog implications, the metrics sweep among
+    // them, before it responds, so the series are gone once it returns.
+    client.batch_execute("SET cluster = quickstart").unwrap();
+    client.batch_execute("DROP CLUSTER c CASCADE").unwrap();
+    for (family, label) in CLUSTER_LABELED_METRICS {
+        assert!(
+            !label_values(server.metrics_registry(), family, label).contains(&cluster_id),
+            "{family} still has a {cluster_id} series after DROP CLUSTER"
+        );
+    }
+}

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -560,7 +560,8 @@ fn test_storage_usage_collection_interval() {
                     FROM mz_internal.mz_storage_usage_by_shard",
                     &[],
                 )?;
-                // mz_storage_usage_by_shard may not be populated yet, which would result in a NULL ts.
+                // mz_storage_usage_by_shard may not be populated yet, which would result in a NULL
+                // ts.
                 let ts = row.try_get::<_, DateTime<Utc>>("max")?;
                 if ts <= last_timestamp {
                     bail!("next collection has not yet occurred")
@@ -813,7 +814,8 @@ fn test_old_storage_usage_records_are_reaped_on_restart() {
         let server = harness.clone().start_blocking();
         let mut client = server.connect(postgres::NoTls).unwrap();
 
-        // Create a table with no data, which should have some overhead and therefore some storage usage
+        // Create a table with no data, which should have some overhead and therefore some storage
+        // usage
         client
             .batch_execute("CREATE TABLE usage_test (a int)")
             .unwrap();
@@ -852,7 +854,8 @@ fn test_old_storage_usage_records_are_reaped_on_restart() {
         initial_timestamp
     };
 
-    // Push time forward, start a new server, and assert that the previous storage records have been reaped
+    // Push time forward, start a new server, and assert that the previous storage records have been
+    // reaped
     *now.lock().expect("lock poisoned") = u64::try_from(initial_timestamp)
         .expect("negative timestamps are impossible")
         + u64::try_from(retention_period.as_millis()).expect("known to fit")
@@ -908,7 +911,8 @@ fn test_storage_usage_records_are_not_cleared_on_restart() {
     let (initial_timestamp, initial_storage_usage_records) = {
         let server = harness.clone().start_blocking();
         let mut client = server.connect(postgres::NoTls).unwrap();
-        // Create a table with no data, which should have some overhead and therefore some storage usage.
+        // Create a table with no data, which should have some overhead and therefore some storage
+        // usage.
         client
             .batch_execute("CREATE TABLE usage_test (a int)")
             .unwrap();
@@ -6463,8 +6467,9 @@ fn test_mcp_agent_with_data_product() {
         }),
     );
     assert_eq!(status, StatusCode::OK);
-    // The cluster name is escaped, so this should fail as an invalid cluster, not execute injection.
-    // It may be a query execution error (bad cluster name) which is fine - the key is no injection.
+    // The cluster name is escaped, so this should fail as an invalid cluster, not execute
+    // injection. It may be a query execution error (bad cluster name) which is fine - the key
+    // is no injection.
     assert!(
         body["error"].is_object(),
         "injection in cluster should produce an error, not succeed"
@@ -6913,9 +6918,8 @@ fn test_mcp_metrics() {
     // Exercise three distinct request shapes:
     //   1. `initialize`: succeeds.
     //   2. `tools/list`: succeeds.
-    //   3. `tools/call` for `read_data_product` with a nonexistent name:
-    //      the request itself completes with an MCP error
-    //      (`DataProductNotFound`), which both `requests_total` and
+    //   3. `tools/call` for `read_data_product` with a nonexistent name: the request itself
+    //      completes with an MCP error (`DataProductNotFound`), which both `requests_total` and
     //      `tool_calls_total` should reflect via the status label.
 
     let (status, _) = mcp_post(
@@ -7618,6 +7622,69 @@ fn test_cluster_labeled_metrics_are_removed_on_cluster_drop() {
         assert!(
             !label_values(server.metrics_registry(), family, label).contains(&cluster_id),
             "{family} still has a {cluster_id} series after DROP CLUSTER"
+        );
+    }
+}
+
+#[mz_ore::test]
+#[allow(clippy::disallowed_methods)]
+fn test_cluster_labeled_metrics_are_removed_at_zero_replicas() {
+    let server = test_util::TestHarness::default().start_blocking();
+    let mut client = server.connect(postgres::NoTls).unwrap();
+
+    client
+        .batch_execute("CREATE CLUSTER c SIZE 'scale=1,workers=1'")
+        .unwrap();
+    client.batch_execute("CREATE TABLE t (a int)").unwrap();
+    client.batch_execute("INSERT INTO t VALUES (1)").unwrap();
+    client
+        .batch_execute("CREATE INDEX t_idx IN CLUSTER c ON t (a)")
+        .unwrap();
+    let cluster_id: String = client
+        .query_one("SELECT id FROM mz_clusters WHERE name = 'c'", &[])
+        .unwrap()
+        .get(0);
+    client.batch_execute("SET cluster = c").unwrap();
+    client.query("SELECT * FROM t", &[]).unwrap();
+    for (family, label) in CLUSTER_LABELED_METRICS {
+        assert!(
+            label_values(server.metrics_registry(), family, label).contains(&cluster_id),
+            "peek on {cluster_id} recorded no {family} series"
+        );
+    }
+
+    // Losing the last replica sweeps the cluster's series like a drop does.
+    // Unlike DROP CLUSTER, a managed cluster's replication factor change
+    // applies its replica drop in a later coordinator stage, after the
+    // statement has responded, so the sweep has to be waited for.
+    client
+        .batch_execute("ALTER CLUSTER c SET (REPLICATION FACTOR 0)")
+        .unwrap();
+    Retry::default()
+        .max_duration(Duration::from_secs(30))
+        .retry(|_| {
+            for (family, label) in CLUSTER_LABELED_METRICS {
+                if label_values(server.metrics_registry(), family, label).contains(&cluster_id) {
+                    return Err(format!(
+                        "{family} still has a {cluster_id} series at zero replicas"
+                    ));
+                }
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    client
+        .batch_execute("ALTER CLUSTER c SET (REPLICATION FACTOR 1)")
+        .unwrap();
+    Retry::default()
+        .max_duration(Duration::from_secs(30))
+        .retry(|_| client.query("SELECT * FROM t", &[]).map(|_| ()))
+        .unwrap();
+    for (family, label) in CLUSTER_LABELED_METRICS {
+        assert!(
+            label_values(server.metrics_registry(), family, label).contains(&cluster_id),
+            "peek after scaling back up recorded no {family} series"
         );
     }
 }

--- a/src/ore/src/metrics.rs
+++ b/src/ore/src/metrics.rs
@@ -1054,9 +1054,9 @@ pub fn remove_children_with_label<V: MetricVec_ + Collector>(vec: &V, name: &str
                 .iter()
                 .map(|label| labels.get(label.as_str()).copied().unwrap_or_default())
                 .collect();
-            // `Err` means a concurrent removal got there first. The only other
-            // cause, a label count mismatch, cannot happen because the tuple is
-            // built from the vec's own desc.
+            // `remove_label_values` fails when the series is already gone, which happens
+            // if another caller removed it between the `collect` snapshot above and now.
+            // That is the state we wanted, so the error is ignored.
             let _ = vec.remove_label_values(&values);
         }
     }
@@ -1143,8 +1143,9 @@ mod tests {
 
         let exec_histogram = exec_metric[0].get_histogram();
         assert_eq!(exec_histogram.get_sample_count(), 1);
-        // This future will normally complete very quickly, but it's hard to guarantee any particular
-        // timing in an arbitrary test environment, so we don't assert on it here.
+        // This future will normally complete very quickly, but it's hard to guarantee any
+        // particular timing in an arbitrary test environment, so we don't assert on it
+        // here.
 
         let wall_family = reports
             .iter()

--- a/src/ore/src/metrics.rs
+++ b/src/ore/src/metrics.rs
@@ -42,6 +42,7 @@
 //! ```
 
 use std::any::Any;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::future::Future;
@@ -1027,10 +1028,45 @@ pub fn describe_runtime_metrics() -> Vec<(String, String, Vec<String>, &'static 
         .collect()
 }
 
+/// Removes every child of `vec` whose label `name` has the value `value`.
+///
+/// Prometheus removes children only by their full label tuple, so this learns
+/// the tuples by collecting the vec, which clones every child once. Meant for
+/// occasional cleanup such as dropping an object's series, not for hot paths.
+pub fn remove_children_with_label<V: MetricVec_ + Collector>(vec: &V, name: &str, value: &str) {
+    let descs = vec.desc();
+    // A metric vec has exactly one `Desc`.
+    let Some(desc) = descs.first() else {
+        return;
+    };
+    for family in vec.collect() {
+        for child in family.get_metric() {
+            let labels: BTreeMap<&str, &str> = child
+                .get_label()
+                .iter()
+                .map(|pair| (pair.name(), pair.value()))
+                .collect();
+            if labels.get(name) != Some(&value) {
+                continue;
+            }
+            let values: Vec<&str> = desc
+                .variable_labels
+                .iter()
+                .map(|label| labels.get(label.as_str()).copied().unwrap_or_default())
+                .collect();
+            // `Err` means a concurrent removal got there first. The only other
+            // cause, a label count mismatch, cannot happen because the tuple is
+            // built from the vec's own desc.
+            let _ = vec.remove_label_values(&values);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
+    use prometheus::core::Collector;
     use prometheus::{CounterVec, HistogramVec};
 
     use crate::stats::histogram_seconds_buckets;
@@ -1207,5 +1243,35 @@ mod tests {
 
         drop(handle);
         assert_eq!(registry.gather().len(), before);
+    }
+
+    #[crate::test]
+    fn remove_children_with_label_removes_only_matching_children() {
+        let registry = MetricsRegistry::new();
+        let vec: HistogramVec = registry.register(metric!(
+            name: "labeled_hist",
+            help: "help",
+            var_labels: ["cluster", "kind"],
+            buckets: histogram_seconds_buckets(0.000_128, 8.0),
+        ));
+        vec.with_label_values(&["u1", "a"]).observe(1.0);
+        vec.with_label_values(&["u1", "b"]).observe(1.0);
+        vec.with_label_values(&["u2", "a"]).observe(1.0);
+
+        super::remove_children_with_label(&vec, "cluster", "u1");
+
+        let remaining: Vec<Vec<String>> = vec
+            .collect()
+            .into_iter()
+            .flat_map(|family| family.get_metric().to_vec())
+            .map(|child| {
+                child
+                    .get_label()
+                    .iter()
+                    .map(|pair| pair.value().to_string())
+                    .collect()
+            })
+            .collect();
+        assert_eq!(remaining, vec![vec!["u2".to_string(), "a".to_string()]]);
     }
 }


### PR DESCRIPTION
For metrics like mz_time_to_first_row, we were tracking histograms keyed by clusters. However these would accumulate even when the cluster is gone. Thus we reclaim/cleanup the series on cluster drop, similar to other mz_compute_peek_duration_seconds.

The way we do this is when we drop the cluster, using the catalog implications framework we clean up the series keyed by that cluster.

### Motivation

Helps reduce `/metric` payload to solve Incident 1252

### Verification

I've created unit tests on the metrics functions and a server integration test. Also manually tested via starting 10 clusters, issuing peeks, observing the metrics, then dropping the clusters and observing the samples are gone. 

For the customer who this is an issue for, ran the following query to figure out cluster churn:
```sql
SELECT event_type, count(*) AS count
FROM mz_catalog.mz_audit_events
WHERE
    object_type = 'cluster'
        AND
    event_type IN ( 'create', 'drop' )
        AND
    occurred_at >= now() - INTERVAL '7 days'
GROUP BY event_type
ORDER BY event_type;
```
and got 1500 clusters created/dropped for a week. Their steady state is about 300. Given `mz_time_to_first_row` was our most expensive metric, and we have about 17 buckets for each label combination, we'd be substantially decreasing how much each scrape pulls.