### PR TITLE
mz-deploy: render numeric type modifiers as precision and scale

### DIFF
--- a/src/mz-deploy/src/project/compiler/cache/schema.rs
+++ b/src/mz-deploy/src/project/compiler/cache/schema.rs
@@ -13,7 +13,7 @@
 //! dropped and recreated from [`CREATE_SQL`] — safe because nothing here is
 //! authoritative.
 
-pub(super) const SCHEMA_VERSION: i64 = 11;
+pub(super) const SCHEMA_VERSION: i64 = 12;
 
 pub(super) const DROP_SQL: &str = "
     DROP TABLE IF EXISTS meta;

--- a/src/mz-deploy/src/project/compiler/typecheck.rs
+++ b/src/mz-deploy/src/project/compiler/typecheck.rs
@@ -403,9 +403,9 @@ fn typecheck_node(
             .create_stub_table(dep_id, &dep_value.columns)
             .map_err(|err| {
                 ObjectTypeCheckError::internal(
-                    dep_id.clone(),
+                    node_id.clone(),
                     db_obj.path.clone(),
-                    format!("failed to stub dependency: {err}"),
+                    format!("internal: failed to stub dependency: {err}"),
                 )
             })?;
     }
@@ -504,6 +504,53 @@ mod run_tests {
             merged
                 .tables
                 .contains_key(&"materialize.storage.t1".parse::<ObjectId>().unwrap())
+        );
+    }
+
+    /// Needs three objects: `sum()` types as `Numeric { max_scale: Some(0) }`,
+    /// but that type only has to survive SQL round-tripping once a dependent
+    /// forces the aggregate to be stubbed.
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rust_psm_stack_pointer` on OS `linux`
+    #[mz_ore::test]
+    fn sum_of_integer_column_stubs_for_dependents() {
+        let temp = tempdir().unwrap();
+        let root = temp.path();
+        write_sql(
+            root,
+            "models/materialize/storage/t1.sql",
+            "CREATE TABLE t1 (u uint8, b bigint, g int)",
+        );
+        write_sql(
+            root,
+            "models/materialize/public/agg.sql",
+            "CREATE VIEW agg AS SELECT sum(u) AS su, sum(b) AS sb, g \
+             FROM materialize.storage.t1 GROUP BY g",
+        );
+        write_sql(
+            root,
+            "models/materialize/public/downstream.sql",
+            "CREATE VIEW downstream AS SELECT su, sb, g FROM materialize.public.agg",
+        );
+
+        let fs = crate::fs::FileSystem::new();
+        let project = compile_sync(&fs, root, None, None, &BTreeMap::new()).unwrap();
+        let (merged, _stats) = run(
+            root,
+            "default",
+            None,
+            &BTreeMap::new(),
+            &project,
+            Types::default(),
+        )
+        .unwrap();
+
+        let agg = &merged.tables[&"materialize.public.agg".parse::<ObjectId>().unwrap()];
+        assert_eq!(agg["su"].r#type, "numeric(39,0)");
+        assert_eq!(agg["sb"].r#type, "numeric(39,0)");
+        assert!(
+            merged
+                .tables
+                .contains_key(&"materialize.public.downstream".parse::<ObjectId>().unwrap())
         );
     }
 

--- a/src/mz-deploy/src/project/compiler/typecheck/convert.rs
+++ b/src/mz-deploy/src/project/compiler/typecheck/convert.rs
@@ -20,6 +20,7 @@ use crate::project::ir::compiled::FullyQualifiedName;
 use crate::project::ir::object_id::ObjectId;
 use crate::project::resolve::normalize::NormalizingVisitor;
 use crate::types::ColumnType;
+use mz_repr::adt::numeric::NUMERIC_DATUM_MAX_PRECISION;
 use mz_repr::{RelationDesc, SqlColumnType, SqlScalarType};
 use mz_sql_parser::ast::ColumnOption;
 use std::collections::BTreeMap;
@@ -172,7 +173,11 @@ fn sql_scalar_type_to_sql(scalar_type: &SqlScalarType) -> String {
         SqlScalarType::Float64 => "float8".into(),
         SqlScalarType::Numeric { max_scale } => match max_scale {
             None => "numeric".into(),
-            Some(max_scale) => format!("numeric({})", max_scale.into_u8()),
+            Some(max_scale) => format!(
+                "numeric({},{})",
+                NUMERIC_DATUM_MAX_PRECISION,
+                max_scale.into_u8()
+            ),
         },
         SqlScalarType::Date => "date".into(),
         SqlScalarType::Time => "time".into(),
@@ -224,6 +229,27 @@ fn sql_scalar_type_to_sql(scalar_type: &SqlScalarType) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mz_repr::adt::numeric::NumericMaxScale;
+
+    #[mz_ore::test]
+    fn numeric_renders_scale_in_the_scale_position() {
+        assert_eq!(
+            sql_scalar_type_to_sql(&SqlScalarType::Numeric { max_scale: None }),
+            "numeric"
+        );
+        assert_eq!(
+            sql_scalar_type_to_sql(&SqlScalarType::Numeric {
+                max_scale: Some(NumericMaxScale::ZERO)
+            }),
+            "numeric(39,0)"
+        );
+        assert_eq!(
+            sql_scalar_type_to_sql(&SqlScalarType::Numeric {
+                max_scale: Some(NumericMaxScale::try_from(2i64).unwrap())
+            }),
+            "numeric(39,2)"
+        );
+    }
 
     #[mz_ore::test]
     fn create_stub_table_sql_preserves_column_order() {


### PR DESCRIPTION
### Motivation

`mz-deploy compile` rejected valid SQL. A view aggregating a `bigint` or `uint8` column with `sum()`, read by another view in the same project, failed to compile:

```
error: failed to stub dependency: type check failed for 'db.public.t2': precision for type numeric must be between 1 and 39
       could not type check due to 1 previous error
```

Materialize accepts the same SQL and runs it in production, so this was purely an artifact of how the offline type checker round-trips a checked view's `RelationDesc` back into SQL.

Minimal repro, no profile or database connection needed:

```sql
-- models/db/public/t1.sql
create view db.public.t1 as select 1::uint8 as c, 1 as g;
-- models/db/public/t2.sql
create view db.public.t2 as select sum(c) as c, g from db.public.t1 group by g;
-- models/db/public/t3.sql
create view db.public.t3 as select c, g from db.public.t2;
```

### Root cause

`sql_scalar_type_to_sql` emitted the numeric **scale** in the single type-modifier position. SQL and the Materialize planner both read a lone modifier as a **precision**:

```rust
Some(max_scale) => format!("numeric({})", max_scale.into_u8()),
```

`sum(bigint)` and `sum(uint8)` type as `Numeric { max_scale: Some(0) }`, so stubbing that view for its dependents produced `CREATE TABLE db.public.t2 (c numeric(0), ...)` and planning the stub bailed on a precision of 0.

The bug was not limited to `sum()`. Any `Numeric { max_scale: Some(s) }` was mis-rendered, so a declared `numeric(10,2)` column stubbed as `numeric(2)` — silently precision 2 and scale 0 rather than failing.

### Changes

The scale now goes in the second position. `SqlScalarType::Numeric` carries no precision of its own, so `NUMERIC_DATUM_MAX_PRECISION` is the only faithful spelling. It matches how `mz-pgrepr` builds a numeric typmod, and `numeric(39, S)` parses back to `Numeric { max_scale: Some(S) }` exactly.

Bumping the compiler cache schema version is load-bearing here, not hygiene. `typecheck::run` persists validated columns even when the overall run errors, so the aggregating view already has a poisoned `numeric(0)` row in the build artifact. On a later run that view is clean — its own file and dependencies are unchanged, and the dirty set only walks dependents — so it skip-returns the cached string and the corrected renderer never runs. Without the bump, a fixed binary keeps failing on an already-compiled project until the user runs `clean`.

The stub failure also reported itself against the dependency's object id while carrying the dependent's file path, which is why the error named `t2` but pointed at `t3.sql`. It is now attributed to the object being checked, with the wrapped error naming the dependency.

### Tests

* `sum_of_integer_column_stubs_for_dependents` in the type checker's `run_tests`, covering the three-object shape from the report. Confirmed red without the fix, failing with the reported precision error.
* `numeric_renders_scale_in_the_scale_position` over the renderer, covering `None`, `Some(0)`, and `Some(2)`.

### Release notes

This release will fix an `mz-deploy compile` failure reporting `precision for type numeric must be between 1 and 39` when a view aggregating an integer column with `sum()` is read by another view in the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)