### PR TITLE
release: bump to version v26.42.0-dev.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "mz-balancerd"
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6795,7 +6795,7 @@ dependencies = [
 
 [[package]]
 name = "mz-catalog-debug"
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6965,7 +6965,7 @@ dependencies = [
 
 [[package]]
 name = "mz-clusterd"
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -7337,7 +7337,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "mz-materialized"
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 dependencies = [
  "custom-labels",
  "mz-clusterd",
@@ -7960,7 +7960,7 @@ dependencies = [
 
 [[package]]
 name = "mz-orchestratord"
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8144,7 +8144,7 @@ dependencies = [
 
 [[package]]
 name = "mz-persist-client"
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.8",
@@ -9222,7 +9222,7 @@ dependencies = [
 
 [[package]]
 name = "mz-testdrive"
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 dependencies = [
  "anyhow",
  "arrow 58.4.0",

--- a/doc/user/content/releases/v26.42.md
+++ b/doc/user/content/releases/v26.42.md
@@ -1,0 +1,10 @@
+---
+title: Materialize v26.42
+date: 2026-09-16
+released: false
+patch: 0
+rc: 1
+publish_helm_chart: true
+build:
+  render: never
+---

--- a/doc/user/data/self_managed/materialize_operator_chart_parameter.yml
+++ b/doc/user/data/self_managed/materialize_operator_chart_parameter.yml
@@ -830,7 +830,7 @@
   type: string
   notationtype: ""
   autodefault: ""
-  default: '`"v26.39.0"`'
+  default: '`"v26.40.0"`'
   autodescription: The tag/version of the operator image to be used
   description: ""
   section: ""

--- a/misc/helm-charts/operator/Chart.yaml
+++ b/misc/helm-charts/operator/Chart.yaml
@@ -11,7 +11,7 @@ apiVersion: v2
 name: materialize-operator
 description: Materialize Kubernetes Operator Helm Chart
 type: application
-version: v26.41.0-dev.0
-appVersion: v26.41.0-dev.0
+version: v26.42.0-dev.0
+appVersion: v26.42.0-dev.0
 icon: https://materialize.com/favicon.ico
 home: https://materialize.com

--- a/misc/helm-charts/operator/README.md
+++ b/misc/helm-charts/operator/README.md
@@ -1,6 +1,6 @@
 # Materialize Kubernetes Operator Helm Chart
 
-![Version: v26.41.0-dev.0](https://img.shields.io/badge/Version-v26.41.0--dev.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.41.0-dev.0](https://img.shields.io/badge/AppVersion-v26.41.0--dev.0-informational?style=flat-square)
+![Version: v26.42.0-dev.0](https://img.shields.io/badge/Version-v26.42.0--dev.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.42.0-dev.0](https://img.shields.io/badge/AppVersion-v26.42.0--dev.0-informational?style=flat-square)
 
 Materialize Kubernetes Operator Helm Chart
 
@@ -176,7 +176,7 @@ The following table lists the configurable parameters of the Materialize operato
 | `operator.clusters.swap_enabled` | Configure sizes such that the pod QoS class is not Guaranteed, as is required for swap to be enabled. Disk doesn't make much sense with swap, as swap performs better than lgalloc, so it also gets disabled. | ``true`` |
 | `operator.image.pullPolicy` | Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images | ``"IfNotPresent"`` |
 | `operator.image.repository` | The Docker repository for the operator image | ``"materialize/orchestratord"`` |
-| `operator.image.tag` | The tag/version of the operator image to be used | ``"v26.39.0"`` |
+| `operator.image.tag` | The tag/version of the operator image to be used | ``"v26.40.0"`` |
 | `operator.nodeSelector` | Node selector to use for the operator pod | ``{}`` |
 | `operator.podDisruptionBudget.enabled` | Whether to create a PodDisruptionBudget for the operator. Only created when `replicas` is greater than 1, since a budget over a single replica either blocks node drains or protects nothing. | ``true`` |
 | `operator.podDisruptionBudget.maxUnavailable` | Maximum number of operator pods that may be unavailable at once during voluntary disruptions. Expressed as a maximum rather than a minimum so that node drains are never blocked outright, they are only serialized. | ``1`` |
@@ -206,7 +206,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```shell
 helm install my-materialize-operator \
-  --set operator.image.tag=v26.41.0-dev.0 \
+  --set operator.image.tag=v26.42.0-dev.0 \
   materialize/materialize-operator
 ```
 
@@ -241,7 +241,7 @@ metadata:
   name: 12345678-1234-1234-1234-123456789012
   namespace: materialize-environment
 spec:
-  environmentdImageRef: materialize/environmentd:v26.41.0-dev.0
+  environmentdImageRef: materialize/environmentd:v26.42.0-dev.0
   backendSecretName: materialize-backend
   environmentdResourceRequirements:
     limits:

--- a/misc/helm-charts/operator/tests/deployment_test.yaml
+++ b/misc/helm-charts/operator/tests/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
       of: Deployment
   - equal:
       path: spec.template.spec.containers[0].image
-      value: materialize/orchestratord:v26.39.0
+      value: materialize/orchestratord:v26.40.0
   - equal:
       path: spec.template.spec.containers[0].imagePullPolicy
       value: IfNotPresent
@@ -71,7 +71,7 @@ tests:
 
 - it: should omit the statement logging sample rate when unset
   set:
-    operator.args.statementLoggingMaxSampleRate: null
+    operator.args.statementLoggingMaxSampleRate:
   asserts:
   - notContains:
       path: spec.template.spec.containers[0].args

--- a/misc/helm-charts/operator/values.yaml
+++ b/misc/helm-charts/operator/values.yaml
@@ -13,7 +13,7 @@ operator:
     # -- The Docker repository for the operator image
     repository: materialize/orchestratord
     # -- The tag/version of the operator image to be used
-    tag: v26.39.0
+    tag: v26.40.0
     # -- Policy for pulling the image: "IfNotPresent" avoids unnecessary re-pulling of images
     pullPolicy: IfNotPresent
 

--- a/misc/helm-charts/testing/materialize.yaml
+++ b/misc/helm-charts/testing/materialize.yaml
@@ -29,7 +29,7 @@ metadata:
   name: 12345678-1234-1234-1234-123456789012
   namespace: materialize-environment
 spec:
-  environmentdImageRef: materialize/environmentd:v26.41.0-dev.0
+  environmentdImageRef: materialize/environmentd:v26.42.0-dev.0
   backendSecretName: materialize-backend
   authenticatorKind: None
   #balancerdExternalCertificateSpec:

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-balancerd"
 description = "Balancer service."
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-catalog-debug"
 description = "Durable metadata storage debug tool."
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-clusterd"
 description = "Materialize's cluster server."
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition.workspace = true

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-materialized"
 description = "Materialize's unified binary."
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/orchestratord/Cargo.toml
+++ b/src/orchestratord/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-orchestratord"
 description = "Kubernetes operator for Materialize regions"
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-testdrive"
 description = "Integration test driver for Materialize."
-version = "26.41.0-dev.0"
+version = "26.42.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
Reconstructs the `main`-side artifacts that [Cut release run 33828841947](https://github.com/MaterializeInc/release/actions/runs/33828841947) failed to push.

That run cut `v26.41.0-rc.1` and pushed its tag successfully, then died on the `main` bump:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
subprocess.CalledProcessError: Command '['git', 'push', 'origin', 'main']' returned non-zero exit status 1.
```

The `GH_TOKEN` secret on `MaterializeInc/release` is a personal access token on an account without branch-protection standing on `materialize` `main`. Tracked as [SEC-725](https://linear.app/materializeinc/issue/SEC-725/replace-gh-token-for-the-release-automation-currently-a-personal-pat); the same failure produced [#38567](https://github.com/MaterializeInc/materialize/pull/38567) a week ago, which this mirrors.

## What this contains

The two commits `misc/python/materialize/release/auto_cut_release.py` makes after tagging, in its order:

1. `release: bump to version v26.42.0-dev.0` — produced by `bin/ci-builder run stable bin/bump-version 26.42.0-dev.0`, not hand-edited.
2. `release: create doc file for v26.42` — the release page, with `date: 2026-09-16` from the run's own `next-date` argument.

Same 16 files as #38567.

## What this does not contain

- The staging and production bump PRs against `MaterializeInc/cloud` — the `open-cloud-prs` job was skipped after the failure, and they need their own PRs in that repo.
- A GitHub release object for `v26.41.0-rc.1`, which is absent while v26.40.0's RCs all have one.

The `v26.41.0-rc.1` tag itself is fine at `8dade2531f92` and needs nothing.