### PR TITLE
Enabled Cluster List with Usage Metrics for Self-Managed

### DIFF
--- a/console/src/config/flexibleDeploymentFlags.ts
+++ b/console/src/config/flexibleDeploymentFlags.ts
@@ -13,7 +13,6 @@
  * to disable.
  */
 export const disabledFlexibleDeploymentFlags: Record<string, boolean> = {
-  "usage-metrics-in-cluster-list-CNS121": false,
 };
 
 export const flexibleDeploymentFlags = new Proxy(

--- a/console/src/config/flexibleDeploymentFlags.ts
+++ b/console/src/config/flexibleDeploymentFlags.ts
@@ -12,8 +12,7 @@
  * is too big, we default all flags to true and specify the ones we want
  * to disable.
  */
-export const disabledFlexibleDeploymentFlags: Record<string, boolean> = {
-};
+export const disabledFlexibleDeploymentFlags: Record<string, boolean> = {};
 
 export const flexibleDeploymentFlags = new Proxy(
   {},


### PR DESCRIPTION
Removed feature flag `usage-metrics-in-cluster-list-CNS121` from list of flags that are disabled for flexible deployment mode.

