### PR TITLE
persist: arm the hedge sibling in the background, retrying its open

### DIFF
--- a/doc/developer/design/20260806_hedged_blob_gets.md
+++ b/doc/developer/design/20260806_hedged_blob_gets.md
@@ -194,10 +194,15 @@ success, for data that exists, winning races and reporting live batch
 parts as missing. Sharing the instance eliminates the hazard by
 construction while still exercising the race path in tests.
 
-Opening the sibling is best-effort. On failure, persist logs a warning and
-runs without hedging for the process lifetime, visible in metrics as
-`hedges_skipped{reason="unavailable"}` and as `hedge_armed` staying 0.
-Persist startup must not regress for this feature.
+Opening the sibling is best-effort and runs off the startup path: a
+background task makes one attempt regardless of the flag, retries with
+exponential backoff only while hedging is enabled, and arms hedging once
+an attempt succeeds. Until then hedging is unavailable, visible in metrics
+as `hedges_skipped{reason="unavailable"}` and as `hedge_armed` staying 0,
+with a warning logged per failed attempt. Retrying matters because a
+blob-store blip at process start would otherwise disarm hedging for the
+process lifetime, which is what happened to environments created during an
+S3 event.
 
 ### Keeping the sibling warm
 
@@ -206,9 +211,9 @@ timeout, and the burst evidence above shows fresh connects are sometimes
 slow exactly during the correlated events. So the sibling's pool must hold
 already-established connections. A background task issues concurrent
 liveness gets on the sibling (fetching a reserved key that never exists, so
-each ping is a cheap not-found response) immediately at startup and then
-every 20 seconds, well inside hyper's eviction of connections idle for 90
-seconds. (NOTE: that 90 is coincidentally equal to, and unrelated to, the
+each ping is a cheap not-found response) as soon as the sibling is armed and
+then every 20 seconds, well inside hyper's eviction of connections idle for
+90 seconds. (NOTE: that 90 is coincidentally equal to, and unrelated to, the
 SDK's 90 second attempt timeout.) The number of concurrent pings follows
 the hedge concurrency cap, because HTTP/1.1 allows one in-flight request
 per connection: N concurrent pings force N warm sockets, so hedges the cap
@@ -321,13 +326,15 @@ would-be fire rate at the candidate delay (the rate in Rollout is
 workload-dependent, dominated by part sizes and pod bandwidth).
 
 What the kill switch does not cover: `enabled = false` leaves the
-sibling idle (see Keeping the sibling warm), but its client and
-credential chain are constructed at process start regardless, which is
-what keeps enablement restart-free. The disabled standing costs are one
-extra SDK client's memory per process, one extra credential resolution,
-and a doubled blob-open (including the backend's own health-check get)
-at startup. Removing the sibling machinery is a rollback, not a flag
-flip.
+sibling idle, pending open retries included (see Pool isolation and
+Keeping the sibling warm; an attempt already in flight runs to completion,
+bounded by the blob client's timeouts), but its client and credential
+chain are constructed shortly after process start regardless, which is
+what keeps enablement restart-free. The disabled standing costs are at
+most one extra SDK client's memory per process, one extra credential
+resolution, and a doubled blob-open (including the backend's own
+health-check get), off the startup path. Removing the sibling machinery
+is a rollback, not a flag flip.
 
 ### Testing
 
@@ -342,7 +349,8 @@ Unit tests drive the race deterministically on tokio's paused test clock:
 - both legs failing, returning the primary's error verbatim,
 - budget exhaustion and refill, the concurrency cap, and release of the
   concurrency slot when a hedged get is dropped mid-race,
-- the warmer's cadence, and its absence for a same-instance sibling.
+- the warmer's cadence, and its absence for a same-instance sibling,
+- the sibling open retried until it succeeds, with hedging armed only then.
 
 The existing `Blob` conformance suite runs against `HedgedBlob` with the
 delay at zero and the primary's gets artificially slowed, so a hedge fires
@@ -399,7 +407,7 @@ New metrics, all prefixed `mz_persist_blob_` (elided in prose below):
 | `hedges_skipped` | counter, by `reason` | Hedges refused: `budget`, `concurrency`, or `unavailable`. |
 | `hedge_errors` | counter | Hedge legs (not primaries) that completed with an error. |
 | `hedge_warm_errors` | counter | Warm cycles that failed or timed out. |
-| `hedge_armed` | gauge | 1 if the process opened a sibling and can hedge. |
+| `hedge_armed` | gauge | 1 while the process has an open sibling and can hedge. |
 | `hedge_rtt_latency` | gauge | Round-trip time of the last successful warm cycle. |
 
 Enabling hedging makes the old detection signals go quiet. The hung
@@ -417,8 +425,8 @@ legs of a hedged get plus the warmer's pings, so they can exceed the logical
 `hedge_errors` are the signals that the sibling's independent credential
 chain has rotted, which would otherwise silently turn the feature into a
 no-op. Both only move while hedging is enabled, so expect any rot to
-surface within the first warm cycles after enablement. `hedge_armed` only certifies
-that the sibling opened at process start.
+surface within the first warm cycles after enablement. `hedge_armed`
+certifies only that the sibling is open, not that it is warm.
 
 ## Alternatives
 

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -25,7 +25,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::task::{AbortOnDropHandle, JoinHandle};
 use mz_ore::url::SensitiveUrl;
 use mz_persist::cfg::{BlobConfig, ConsensusConfig, open_hedge_sibling};
-use mz_persist::hedge::HedgedBlob;
+use mz_persist::hedge::{HedgeSiblingOpener, HedgedBlob};
 use mz_persist::location::{
     BLOB_GET_LIVENESS_KEY, Blob, CONSENSUS_HEAD_LIVENESS_KEY, Consensus, ExternalError, Tasked,
     VersionedData,
@@ -251,8 +251,9 @@ impl PersistClientCache {
                 })
                 .await;
                 // Hedged gets need a second handle on an isolated connection
-                // pool. Built unconditionally (best-effort): the wrapper
-                // reads its enable flag dynamically per call.
+                // pool. Built unconditionally (the wrapper reads its enable
+                // flag dynamically per call) and armed in the background, so
+                // the sibling open never runs under this lock.
                 //
                 // NOTE: HedgedBlob must stay below Tasked in this stack. Its
                 // race relies on dropping the losing future to cancel the
@@ -261,15 +262,20 @@ impl PersistClientCache {
                 // between HedgedBlob and the backend would break the former,
                 // and an aborting layer above would slowly leak budget
                 // tokens via the latter.
-                let sibling = open_hedge_sibling(
-                    x.key(),
-                    Box::new(self.cfg.clone()),
-                    self.metrics.s3_blob.clone(),
-                )
-                .await;
-                let blob = Arc::new(HedgedBlob::new(
+                let sibling_opener: HedgeSiblingOpener = {
+                    let url = x.key().clone();
+                    let cfg = self.cfg.clone();
+                    let metrics = self.metrics.s3_blob.clone();
+                    Box::new(move || {
+                        let (url, cfg, metrics) = (url.clone(), cfg.clone(), metrics.clone());
+                        Box::pin(
+                            async move { open_hedge_sibling(&url, Box::new(cfg), metrics).await },
+                        )
+                    })
+                };
+                let blob = Arc::new(HedgedBlob::new_arming(
                     blob,
-                    sibling,
+                    sibling_opener,
                     Arc::clone(&self.cfg.configs),
                     self.metrics.blob_hedge.clone(),
                 ));

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -59,9 +59,8 @@ pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
 ///
 /// Errors opening the sibling degrade to [HedgeSibling::Unavailable] with a
 /// warning rather than failing: persist must come up even if hedging cannot.
-/// A process that hits this keeps hedging unavailable until restart, visible
-/// as `mz_persist_blob_hedges_skipped{reason="unavailable"}` and
-/// `mz_persist_blob_hedge_armed` staying 0.
+/// What a caller does with that is its own contract, see
+/// [crate::hedge::HedgedBlob::new_arming].
 pub async fn open_hedge_sibling(
     url: &SensitiveUrl,
     knobs: Box<dyn BlobKnobs>,

--- a/src/persist/src/hedge.rs
+++ b/src/persist/src/hedge.rs
@@ -46,8 +46,10 @@
 //! connection-poisoning log lines), because the hung request is cancelled
 //! before they trigger. The `hedges_won` counter is the replacement signal.
 
-use std::sync::Arc;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -57,7 +59,7 @@ use mz_dyncfg::{Config, ConfigSet, ParameterScope};
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastLossy;
 use mz_ore::task::AbortOnDropHandle;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::location::{BLOB_GET_LIVENESS_KEY, Blob, BlobMetadata, ExternalError};
 use crate::metrics::BlobHedgeMetrics;
@@ -97,9 +99,10 @@ pub(crate) const BLOB_HEDGED_GET_BUDGET_RATIO: Config<f64> = Config::new(
     ParameterScope::Environment,
 );
 
-// NOTE: the warmer only runs while hedging is enabled, so `enabled` stops
-// its traffic too. Setting this knob to 0 additionally stops the warmer
-// while keeping hedging on, which is why it must be changeable at runtime.
+// NOTE: the warmer, and any retries of a failed sibling open, only run while
+// hedging is enabled, so `enabled` stops the sibling's traffic too. Setting
+// this knob to 0 additionally stops the warmer while keeping hedging on,
+// which is why it must be changeable at runtime.
 pub(crate) const BLOB_HEDGED_GET_WARM_INTERVAL: Config<Duration> = Config::new(
     "persist_blob_hedged_get_warm_interval",
     Duration::from_secs(20),
@@ -121,6 +124,12 @@ const HEDGE_COST_MICRO_TOKENS: u64 = 1_000_000;
 /// `budget_ratio = 0` still permits ~32 banked hedges before draining. It is
 /// not an instant stop, `enabled` is.
 const BUDGET_BURST_MICRO_TOKENS: u64 = 32 * HEDGE_COST_MICRO_TOKENS;
+
+/// Backoff between sibling open attempts. A failed open means the blob store
+/// or the credential chain was unhealthy, which heals on the order of seconds
+/// to minutes, so a one-minute ceiling loses little.
+const SIBLING_OPEN_RETRY_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const SIBLING_OPEN_RETRY_MAX_BACKOFF: Duration = Duration::from_secs(60);
 
 /// Why a hedge was not fired for a get that exceeded the delay.
 enum HedgeRefused {
@@ -210,22 +219,41 @@ pub enum HedgeSibling {
     /// would observe a different store): hedge on the primary instance
     /// itself, with nothing to warm.
     SharedWithPrimary,
-    /// Opening the sibling failed: hedging is unavailable for this process
-    /// lifetime.
+    /// Opening the sibling failed. Hedging stays unavailable until a later
+    /// attempt succeeds (see [HedgedBlob::new_arming]).
     Unavailable,
 }
+
+/// Opens the sibling handle for a store. A [HedgedBlob] built with
+/// [HedgedBlob::new_arming] calls it until it returns something other than
+/// [HedgeSibling::Unavailable]. See [crate::cfg::open_hedge_sibling].
+pub type HedgeSiblingOpener =
+    Box<dyn Fn() -> Pin<Box<dyn Future<Output = HedgeSibling> + Send>> + Send>;
 
 /// A [Blob] decorator that hedges slow `get` requests, per the module docs.
 #[derive(Debug)]
 pub struct HedgedBlob {
     primary: Arc<dyn Blob>,
-    /// The handle hedge requests run on. `None` = hedging unavailable,
-    /// visible as `hedges_skipped{reason="unavailable"}`.
-    hedge: Option<Arc<dyn Blob>>,
+    /// The handle hedge requests run on. Empty = hedging unavailable,
+    /// visible as `hedges_skipped{reason="unavailable"}`. Shared with the
+    /// sibling task, which installs the handle once the sibling is open.
+    hedge: Arc<OnceLock<Arc<dyn Blob>>>,
     cfg: Arc<ConfigSet>,
     metrics: BlobHedgeMetrics,
     budget: HedgeBudget,
-    _warmer: Option<AbortOnDropHandle<()>>,
+    /// Opens the sibling and keeps it warm. Absent when there is nothing to
+    /// warm: a sibling that is the primary itself, or none at all.
+    _sibling_task: Option<AbortOnDropHandle<()>>,
+}
+
+/// How often an idle sibling loop re-reads the dyncfgs, so a flip takes
+/// effect without a restart: the warm interval, or its default while
+/// warming is set to 0.
+fn recheck_interval(cfg: &ConfigSet) -> Duration {
+    match BLOB_HEDGED_GET_WARM_INTERVAL.get(cfg) {
+        Duration::ZERO => *BLOB_HEDGED_GET_WARM_INTERVAL.default(),
+        interval => interval,
+    }
 }
 
 /// Keeps the sibling's connection pool warm with periodic concurrent
@@ -235,90 +263,174 @@ pub struct HedgedBlob {
 /// and the sibling sees no traffic at all, so a freshly enabled flag can
 /// find a cold pool for up to one warm interval plus a handshake. Hedges
 /// in that window are merely no better than no hedge, never worse.
-fn spawn_warmer(
-    hedge: Arc<dyn Blob>,
+async fn warm(hedge: Arc<dyn Blob>, cfg: Arc<ConfigSet>, metrics: BlobHedgeMetrics) {
+    loop {
+        let interval = BLOB_HEDGED_GET_WARM_INTERVAL.get(&cfg);
+        if !BLOB_HEDGED_GET_ENABLED.get(&cfg) || interval == Duration::ZERO {
+            // Nothing to keep warm.
+            tokio::time::sleep(recheck_interval(&cfg)).await;
+            continue;
+        }
+        // Ping first, sleep second, so the pool is warm from process
+        // start. As many concurrent pings as hedges can run at once
+        // (HTTP/1.1 allows one in-flight request per connection, so N
+        // concurrent pings force N warm sockets).
+        let start = Instant::now();
+        let sockets = BLOB_HEDGED_GET_MAX_CONCURRENT.get(&cfg);
+        let pings = (0..sockets).map(|_| hedge.get(BLOB_GET_LIVENESS_KEY));
+        let pings = futures_util::future::join_all(pings);
+        // Bound the cycle: an unbounded hung ping would block warming
+        // past hyper's pool idle eviction, going cold exactly during the
+        // correlated events warming exists for. The timeout also drops
+        // the hung request, which closes its dying socket.
+        match tokio::time::timeout(interval, pings).await {
+            Ok(results) if results.iter().all(|r| r.is_ok()) => {
+                metrics.rtt_latency.set(start.elapsed().as_secs_f64());
+            }
+            Ok(_) | Err(_) => {
+                // A failing or hung warm path means hedges cannot be
+                // trusted to be fast. Surface it, and do not update the
+                // gauge: a fast failure must not report as a fast
+                // healthy path.
+                metrics.warm_errors.inc();
+            }
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// Installs the sibling into `slot` once `opener` yields one, then keeps it
+/// warm. See [HedgedBlob::new_arming] for the retry contract.
+async fn arm_then_warm(
+    primary: Arc<dyn Blob>,
+    opener: HedgeSiblingOpener,
+    slot: Arc<OnceLock<Arc<dyn Blob>>>,
     cfg: Arc<ConfigSet>,
     metrics: BlobHedgeMetrics,
-) -> AbortOnDropHandle<()> {
-    mz_ore::task::spawn(|| "persist::blob_hedge_warmer", async move {
-        loop {
-            let interval = BLOB_HEDGED_GET_WARM_INTERVAL.get(&cfg);
-            if !BLOB_HEDGED_GET_ENABLED.get(&cfg) || interval == Duration::ZERO {
-                // Nothing to keep warm. Re-check at the configured cadence
-                // (or its default while warming is set to 0), so a dyncfg
-                // flip takes effect without a restart.
-                let recheck = if interval == Duration::ZERO {
-                    *BLOB_HEDGED_GET_WARM_INTERVAL.default()
-                } else {
-                    interval
-                };
-                tokio::time::sleep(recheck).await;
-                continue;
+) {
+    let mut backoff = SIBLING_OPEN_RETRY_INITIAL_BACKOFF;
+    let mut attempts = 0u64;
+    let hedge = loop {
+        attempts += 1;
+        match opener().await {
+            HedgeSibling::Isolated(hedge) => break hedge,
+            HedgeSibling::SharedWithPrimary => {
+                install(&slot, &metrics, primary);
+                return;
             }
-            // Ping first, sleep second, so the pool is warm from process
-            // start. As many concurrent pings as hedges can run at once
-            // (HTTP/1.1 allows one in-flight request per connection, so N
-            // concurrent pings force N warm sockets).
-            let start = Instant::now();
-            let sockets = BLOB_HEDGED_GET_MAX_CONCURRENT.get(&cfg);
-            let pings = (0..sockets).map(|_| hedge.get(BLOB_GET_LIVENESS_KEY));
-            let pings = futures_util::future::join_all(pings);
-            // Bound the cycle: an unbounded hung ping would block warming
-            // past hyper's pool idle eviction, going cold exactly during the
-            // correlated events warming exists for. The timeout also drops
-            // the hung request, which closes its dying socket.
-            match tokio::time::timeout(interval, pings).await {
-                Ok(results) if results.iter().all(|r| r.is_ok()) => {
-                    metrics.rtt_latency.set(start.elapsed().as_secs_f64());
-                }
-                Ok(_) | Err(_) => {
-                    // A failing or hung warm path means hedges cannot be
-                    // trusted to be fast. Surface it, and do not update the
-                    // gauge: a fast failure must not report as a fast
-                    // healthy path.
-                    metrics.warm_errors.inc();
+            // The opener logs the cause of each failure.
+            HedgeSibling::Unavailable => {
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(SIBLING_OPEN_RETRY_MAX_BACKOFF);
+                // Retries are sibling traffic too, so `enabled` stops them
+                // like it stops the warmer. The first attempt above runs
+                // regardless, which is what keeps enablement restart-free.
+                while !BLOB_HEDGED_GET_ENABLED.get(&cfg) {
+                    tokio::time::sleep(recheck_interval(&cfg)).await;
                 }
             }
-            tokio::time::sleep(interval).await;
         }
-    })
-    .abort_on_drop()
+    };
+    if attempts > 1 {
+        info!(
+            attempts,
+            "hedged blob gets armed after retrying the sibling open"
+        );
+    }
+    install(&slot, &metrics, Arc::clone(&hedge));
+    warm(hedge, cfg, metrics).await
+}
+
+fn install(slot: &OnceLock<Arc<dyn Blob>>, metrics: &BlobHedgeMetrics, hedge: Arc<dyn Blob>) {
+    if slot.set(hedge).is_err() {
+        mz_ore::soft_panic_or_log!("hedge sibling installed twice");
+    }
+    metrics.armed.set(1);
 }
 
 impl HedgedBlob {
-    /// Returns a new [HedgedBlob].
+    /// Returns a new [HedgedBlob] from an already-open sibling, for tests that
+    /// need arming to be synchronous.
     ///
     /// Must be called from within a tokio runtime: it spawns the sibling
     /// warming task.
-    pub fn new(
+    #[cfg(test)]
+    pub(crate) fn new(
         primary: Arc<dyn Blob>,
         sibling: HedgeSibling,
         cfg: Arc<ConfigSet>,
         metrics: BlobHedgeMetrics,
     ) -> HedgedBlob {
-        let (hedge, warmer) = match sibling {
+        let slot = Arc::new(OnceLock::new());
+        let task = match sibling {
             HedgeSibling::Isolated(h) => {
-                let warmer = spawn_warmer(Arc::clone(&h), Arc::clone(&cfg), metrics.clone());
-                (Some(h), Some(warmer))
+                install(&slot, &metrics, Arc::clone(&h));
+                Some(
+                    mz_ore::task::spawn(
+                        || "persist::blob_hedge_warmer",
+                        warm(h, Arc::clone(&cfg), metrics.clone()),
+                    )
+                    .abort_on_drop(),
+                )
             }
-            HedgeSibling::SharedWithPrimary => (Some(Arc::clone(&primary)), None),
-            HedgeSibling::Unavailable => (None, None),
+            HedgeSibling::SharedWithPrimary => {
+                install(&slot, &metrics, Arc::clone(&primary));
+                None
+            }
+            HedgeSibling::Unavailable => None,
         };
-        metrics.armed.set(i64::from(hedge.is_some()));
         HedgedBlob {
             primary,
-            hedge,
+            hedge: slot,
             cfg,
             metrics,
             budget: HedgeBudget::new(),
-            _warmer: warmer,
+            _sibling_task: task,
+        }
+    }
+
+    /// Returns a new [HedgedBlob] whose sibling is opened in the background.
+    ///
+    /// `opener` is called from a spawned task, so this constructor never waits
+    /// on the blob store. While it returns [HedgeSibling::Unavailable] the task
+    /// retries with backoff, but only while hedging is enabled, so a disabled
+    /// process makes exactly one attempt until the flag flips. Until an attempt
+    /// succeeds gets are not hedged, visible as
+    /// `hedges_skipped{reason="unavailable"}` and `hedge_armed` at 0.
+    ///
+    /// Must be called from within a tokio runtime.
+    pub fn new_arming(
+        primary: Arc<dyn Blob>,
+        opener: HedgeSiblingOpener,
+        cfg: Arc<ConfigSet>,
+        metrics: BlobHedgeMetrics,
+    ) -> HedgedBlob {
+        let slot: Arc<OnceLock<Arc<dyn Blob>>> = Arc::new(OnceLock::new());
+        let task = mz_ore::task::spawn(
+            || "persist::blob_hedge_sibling",
+            arm_then_warm(
+                Arc::clone(&primary),
+                opener,
+                Arc::clone(&slot),
+                Arc::clone(&cfg),
+                metrics.clone(),
+            ),
+        )
+        .abort_on_drop();
+        HedgedBlob {
+            primary,
+            hedge: slot,
+            cfg,
+            metrics,
+            budget: HedgeBudget::new(),
+            _sibling_task: Some(task),
         }
     }
 
     /// Returns the sibling handle and a budget guard, or `None` (having
     /// already recorded why) if this get must not hedge.
     fn admit(&self) -> Option<(&Arc<dyn Blob>, HedgeGuard<'_>)> {
-        let Some(hedge_blob) = &self.hedge else {
+        let Some(hedge_blob) = self.hedge.get() else {
             self.metrics.skipped_unavailable.inc();
             return None;
         };
@@ -806,10 +918,110 @@ mod tests {
             test_cfg(|_| {}),
             metrics(),
         );
-        assert!(blob._warmer.is_none());
+        assert!(blob._sibling_task.is_none());
         assert_eq!(blob.metrics.armed.get(), 1);
         tokio::time::sleep(SECS(60)).await;
         assert_eq!(primary.gets.load(Ordering::SeqCst), 0);
+    }
+
+    /// An opener that reports the sibling unavailable `failures` times before
+    /// returning `hedge`, counting attempts.
+    fn flaky_opener(
+        hedge: &Arc<TestBlob>,
+        failures: usize,
+        attempts: &Arc<AtomicUsize>,
+    ) -> HedgeSiblingOpener {
+        let hedge: Arc<dyn Blob> = Arc::<TestBlob>::clone(hedge);
+        let attempts = Arc::clone(attempts);
+        Box::new(move || {
+            let hedge = Arc::clone(&hedge);
+            let attempts = Arc::clone(&attempts);
+            Box::pin(async move {
+                if attempts.fetch_add(1, Ordering::SeqCst) < failures {
+                    HedgeSibling::Unavailable
+                } else {
+                    HedgeSibling::Isolated(hedge)
+                }
+            })
+        })
+    }
+
+    #[mz_ore::test(tokio::test(start_paused = true))]
+    async fn arming_retries_until_sibling_opens() {
+        let primary = TestBlob::new(SECS(3), Ok(Some("primary")));
+        let hedge = TestBlob::new(SECS(0), Ok(Some("hedge")));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let cfg = test_cfg(|_| {});
+        let sockets = BLOB_HEDGED_GET_MAX_CONCURRENT.get(&cfg);
+        let primary_blob: Arc<dyn Blob> = Arc::<TestBlob>::clone(&primary);
+        let blob = HedgedBlob::new_arming(
+            primary_blob,
+            flaky_opener(&hedge, 3, &attempts),
+            cfg,
+            metrics(),
+        );
+        tokio::task::yield_now().await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(blob.metrics.armed.get(), 0);
+        // Unarmed: a slow get is not hedged, and says so.
+        let res = blob.get("k").await.unwrap().expect("some");
+        assert_eq!(res.into_contiguous(), b"primary".to_vec());
+        assert_eq!(blob.metrics.skipped_unavailable.get(), 1);
+        // Backoff 1s, 2s, 4s: the fourth attempt succeeds at 7s, and the get
+        // above already spent 3s of it.
+        tokio::time::sleep(SECS(5)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 4);
+        assert_eq!(blob.metrics.armed.get(), 1);
+        // Armed: the same slow get is hedged and the hedge wins.
+        let res = blob.get("k").await.unwrap().expect("some");
+        assert_eq!(res.into_contiguous(), b"hedge".to_vec());
+        assert_eq!(blob.metrics.won.get(), 1);
+        // The arming task continued into the warm loop: one ping per socket
+        // at install time, plus the winning hedge.
+        assert_eq!(hedge.gets.load(Ordering::SeqCst), sockets + 1);
+    }
+
+    #[mz_ore::test(tokio::test(start_paused = true))]
+    async fn arming_shared_with_primary() {
+        let primary = TestBlob::new(SECS(0), Ok(None));
+        let primary_blob: Arc<dyn Blob> = Arc::<TestBlob>::clone(&primary);
+        let opener: HedgeSiblingOpener =
+            Box::new(|| Box::pin(async { HedgeSibling::SharedWithPrimary }));
+        let blob = HedgedBlob::new_arming(primary_blob, opener, test_cfg(|_| {}), metrics());
+        tokio::task::yield_now().await;
+        assert_eq!(blob.metrics.armed.get(), 1);
+        // Nothing to warm: the primary sees no pings.
+        tokio::time::sleep(SECS(60)).await;
+        assert_eq!(primary.gets.load(Ordering::SeqCst), 0);
+    }
+
+    #[mz_ore::test(tokio::test(start_paused = true))]
+    async fn arming_retries_only_while_enabled() {
+        let primary = TestBlob::new(SECS(0), Ok(None));
+        let hedge = TestBlob::new(SECS(0), Ok(None));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let cfg = test_cfg(|u| u.add(&BLOB_HEDGED_GET_ENABLED, false));
+        let primary_blob: Arc<dyn Blob> = Arc::<TestBlob>::clone(&primary);
+        let blob = HedgedBlob::new_arming(
+            primary_blob,
+            flaky_opener(&hedge, 1, &attempts),
+            Arc::clone(&cfg),
+            metrics(),
+        );
+        // Disabled: the first attempt runs and fails, then nothing.
+        tokio::time::sleep(SECS(600)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(blob.metrics.armed.get(), 0);
+        // Enabling at runtime resumes the retries within one recheck.
+        let mut updates = ConfigUpdates::default();
+        updates.add(&BLOB_HEDGED_GET_ENABLED, true);
+        updates.apply(&cfg);
+        tokio::time::sleep(*BLOB_HEDGED_GET_WARM_INTERVAL.default() + SECS(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(blob.metrics.armed.get(), 1);
     }
 
     /// A test [Blob] that delays gets so the hedge (delay 0) fires and wins


### PR DESCRIPTION
### Motivation

The hedge sibling, the isolated S3 client that hedged blob gets run on, was opened once at process start, under the blob-cache lock, and any error left the process without hedging until its next restart (`hedge_armed` stuck at 0, `hedges_skipped{reason="unavailable"}` while enabled). The primary blob open under the same conditions retries until it succeeds, so the process itself comes up and serves normally; only the sibling open gave up on the first error. A blob-store or credential blip at startup therefore left exactly the processes that came up during trouble without hedging, and trouble is when hedging is needed.

This happened in production: during an S3 write-latency event in one region, every process of the environments created in that window logged `hedged blob gets unavailable, sibling open failed: indeterminate: s3 get meta err` and were still running disarmed 16 hours later, serving normally. Nowhere else in the week the code has been deployed did the open fail, so the failure needs S3 trouble at process start, and then it was permanent.

Closes: [PER-78](https://linear.app/materializeinc/issue/PER-78)

### The change

`HedgedBlob::new_arming` takes an opener closure (the existing `open_hedge_sibling`, wrapped at the call site in `PersistClientCache::open_blob`) and spawns one background task that

1. calls the opener, retrying with exponential backoff (1s doubling to a 60s ceiling) while it returns `HedgeSibling::Unavailable`. Retries run only while hedging is enabled; the first attempt runs regardless of the flag, which is what keeps enablement restart-free,
2. installs the resulting handle into the hedge slot and sets `hedge_armed` to 1 (logging at INFO if it took retries),
3. then runs the existing warm loop on it.

Consequences:

* Persist startup no longer waits on the sibling open at all, and the blob-cache lock is no longer held across it. Previously the open added one credential resolution plus a health-check get to every process start, bounded only by the SDK timeouts when S3 was slow.
* Until the open succeeds, gets are not hedged and the metrics read exactly as before (`hedge_armed` 0, `hedges_skipped{reason="unavailable"}`). The difference is that `hedge_armed` now becomes 1 once the store recovers, normally within the first second of the process.
* The hedge handle lives in a write-once `OnceLock` that is read only on the post-delay path (after a get has exceeded the hedge delay), so the per-get hot path is unchanged.
* `enabled = false` still stops all sibling traffic: a disabled process makes its single open attempt and, if that fails, waits for the flag before retrying.
* `HedgedBlob::new` with a pre-resolved `HedgeSibling` is now test-only; the `SharedWithPrimary` and `Unavailable` cases behave as before.

The design doc's "Pool isolation", "Keeping the sibling warm" and Observability sections are updated to describe the background arming and the new meaning of `hedge_armed`.

### Tests

* `arming_retries_until_sibling_opens`: an opener that fails three times; asserts the unarmed get is not hedged and counted as unavailable, that the fourth attempt at 7s (backoff 1s, 2s, 4s) arms the handle, and that a subsequent slow get is hedged and won while the warmer pings the sibling. Verified red when the retry loop is made to give up on the first failure.
* `arming_shared_with_primary`: the opener returns `SharedWithPrimary`; armed immediately, no warmer traffic.
* `arming_retries_only_while_enabled`: with the flag off, the failed first attempt is not retried for ten minutes; flipping the flag on resumes the retries within one recheck and arms the handle.
* Existing hedge tests unchanged apart from the renamed task handle.

### Rollout note

Processes currently running disarmed will arm on their next restart with this build; there is no runtime lever for them. The "disarmed while fetching" check (`hedge_armed == 0` on a process with blob gets in the last 30 minutes) should read 0 fleet-wide once this is deployed, S3 blips included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
