### PR TITLE
ci: run cargo benches against an ancestor in nightly

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -304,6 +304,7 @@ steps:
         # Annotation-only while the noise floor on this hardware is being
         # calibrated. Remove after 2026-09-18 so regressions fail the build.
         soft_fail: true
+        parallelism: 9
         inputs:
           - Cargo.lock
           - Cargo.toml
@@ -314,9 +315,10 @@ steps:
               composition: cargo-bench
               ci-builder: stable
         agents:
-          # Dedicated hardware for stable timings. 48 cores because the step
-          # builds the bench targets twice in the bench profile.
-          queue: hetzner-x86-64-dedi-48cpu-192gb
+          # Dedicated hardware for stable timings, one shard per package with
+          # bench targets, so `parallelism` should track that package count.
+          # Extra shards exit as no-ops, fewer shards double up packages.
+          queue: hetzner-x86-64-dedi-8cpu-32gb
 
       - id: workload-replay
         topics: [iceberg, kafka, mysql, postgres, sql-server, ssh-tunnel]

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -296,6 +296,28 @@ steps:
                 - --other-tag
                 - common-ancestor
 
+      - id: cargo-bench
+        label: ":rust: Cargo bench against ancestor"
+        sanitizer: skip
+        depends_on: []
+        timeout_in_minutes: 180
+        # Annotation-only while the noise floor on this hardware is being
+        # calibrated. Remove after 2026-09-18 so regressions fail the build.
+        soft_fail: true
+        inputs:
+          - Cargo.lock
+          - Cargo.toml
+          - "**/Cargo.toml"
+          - "**/*.rs"
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: cargo-bench
+              ci-builder: stable
+        agents:
+          # Dedicated hardware for stable timings. 48 cores because the step
+          # builds the bench targets twice in the bench profile.
+          queue: hetzner-x86-64-dedi-48cpu-192gb
+
       - id: workload-replay
         topics: [iceberg, kafka, mysql, postgres, sql-server, ssh-tunnel]
         label: "Workload Replay (1% initial data)"

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -300,7 +300,7 @@ steps:
         label: ":rust: Cargo bench against ancestor"
         sanitizer: skip
         depends_on: []
-        timeout_in_minutes: 180
+        timeout_in_minutes: 480
         # Annotation-only while the noise floor on this hardware is being
         # calibrated. Remove after 2026-09-18 so regressions fail the build.
         soft_fail: true

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -302,8 +302,10 @@ steps:
         depends_on: []
         timeout_in_minutes: 480
         # Annotation-only while the noise floor on this hardware is being
-        # calibrated. Remove after 2026-09-18 so regressions fail the build.
+        # calibrated. Remove after 2026-09-25 so regressions fail the build.
         soft_fail: true
+        # One shard per package with bench targets, so this should track that
+        # package count. Extra shards exit as no-ops, fewer shards double up.
         parallelism: 9
         inputs:
           - Cargo.lock
@@ -315,9 +317,7 @@ steps:
               composition: cargo-bench
               ci-builder: stable
         agents:
-          # Dedicated hardware for stable timings, one shard per package with
-          # bench targets, so `parallelism` should track that package count.
-          # Extra shards exit as no-ops, fewer shards double up packages.
+          # Dedicated hardware for stable timings.
           queue: hetzner-x86-64-dedi-8cpu-32gb
 
       - id: workload-replay

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -300,9 +300,12 @@ steps:
         label: ":rust: Cargo bench against ancestor"
         sanitizer: skip
         depends_on: []
-        timeout_in_minutes: 480
+        # Measured: 48 minutes for the largest closure built twice on the
+        # 8-core queue, 73 minutes for a shard that also ran its benchmarks.
+        timeout_in_minutes: 240
         # Annotation-only while the noise floor on this hardware is being
-        # calibrated. Remove after 2026-09-25 so regressions fail the build.
+        # calibrated. QAR-162 covers dropping `soft_fail` so regressions and
+        # HEAD build failures fail the build.
         soft_fail: true
         # One shard per package with bench targets, so this should track that
         # package count. Extra shards exit as no-ops, fewer shards double up.

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -400,6 +400,7 @@ cleanup() {
 
   if [ ! -s services.log ] \
     && [ "$BUILDKITE_LABEL" != ":rust: cargo-fuzz" ] \
+    && [ "$BUILDKITE_LABEL" != ":rust: Cargo bench against ancestor" ] \
     && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of persist" ] \
     && [ "$BUILDKITE_LABEL" != "Long single-node Maelstrom coverage of persist" ] \
     && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of txn-wal" ] \

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -400,7 +400,6 @@ cleanup() {
 
   if [ ! -s services.log ] \
     && [ "$BUILDKITE_LABEL" != ":rust: cargo-fuzz" ] \
-    && [ "$BUILDKITE_LABEL" != ":rust: Cargo bench against ancestor" ] \
     && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of persist" ] \
     && [ "$BUILDKITE_LABEL" != "Long single-node Maelstrom coverage of persist" ] \
     && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of txn-wal" ] \
@@ -413,7 +412,8 @@ cleanup() {
     && [ "$BUILDKITE_LABEL" != ":rust: Miri test (full)" ] \
     && [[ ! "$BUILDKITE_LABEL" =~ Terraform\ .* ]] \
     && [[ ! "$BUILDKITE_LABEL" =~ Orchestratord\ .* ]] \
-    && [[ ! "$BUILDKITE_LABEL" =~ Cluster\ spec\ sheet.* ]]; then
+    && [[ ! "$BUILDKITE_LABEL" =~ Cluster\ spec\ sheet.* ]] \
+    && [[ ! "$BUILDKITE_LABEL" =~ ^:rust:\ Cargo\ bench\ against\ ancestor ]]; then
       echo "+++ services.log is empty, failing"
       if [[ $CI_ANNOTATE_ERRORS_RESULT -ne 0 ]]; then
         # Keep the retryable code (128 for GHCR/DockerHub trouble, 199 for a

--- a/misc/python/materialize/cargo_bench/__init__.py
+++ b/misc/python/materialize/cargo_bench/__init__.py
@@ -1,0 +1,8 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.

--- a/misc/python/materialize/cargo_bench/compare.py
+++ b/misc/python/materialize/cargo_bench/compare.py
@@ -159,7 +159,11 @@ def render_markdown(report: CompareReport) -> str:
         "| --- | --- | --- | --- | --- | --- |",
     ]
     for r in report.results:
-        ancestor = format_duration(r.ancestor_mean_ns) if r.ancestor_mean_ns is not None else ""
+        ancestor = (
+            format_duration(r.ancestor_mean_ns)
+            if r.ancestor_mean_ns is not None
+            else ""
+        )
         change = _pct(r.change_mean) if r.change_mean is not None else ""
         ci = (
             f"[{_pct(r.change_lower)}, {_pct(r.change_upper)}]"

--- a/misc/python/materialize/cargo_bench/compare.py
+++ b/misc/python/materialize/cargo_bench/compare.py
@@ -1,0 +1,175 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Comparison of criterion results between an ancestor baseline and the current run.
+
+Reads the JSON files criterion writes under its output directory. Criterion
+itself never fails a run on a regression, so the verdict logic lives here.
+"""
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class Verdict(Enum):
+    REGRESSION = "regression"
+    IMPROVEMENT = "improvement"
+    UNCHANGED = "unchanged"
+    NEW = "new"
+
+
+@dataclass(frozen=True)
+class BenchResult:
+    """Outcome for one criterion benchmark id.
+
+    Means are in nanoseconds. Change fields are relative to the ancestor mean,
+    so 0.1 is a 10% slowdown. They are `None` when there is no ancestor
+    measurement to compare against.
+    """
+
+    id: str
+    current_mean_ns: float
+    ancestor_mean_ns: float | None
+    change_mean: float | None
+    change_lower: float | None
+    change_upper: float | None
+    verdict: Verdict
+
+
+@dataclass(frozen=True)
+class CompareReport:
+    results: list[BenchResult]
+    warnings: list[str]
+
+    @property
+    def has_regressions(self) -> bool:
+        return any(r.verdict == Verdict.REGRESSION for r in self.results)
+
+
+_VERDICT_ORDER = {
+    Verdict.REGRESSION: 0,
+    Verdict.IMPROVEMENT: 1,
+    Verdict.UNCHANGED: 2,
+    Verdict.NEW: 3,
+}
+
+
+def _load(path: Path) -> Any:
+    with path.open() as f:
+        return json.load(f)
+
+
+def compare(criterion_dir: Path, threshold: float) -> CompareReport:
+    """Compare every benchmark under `criterion_dir` against its `ancestor` baseline.
+
+    A benchmark is a regression when the lower bound of criterion's 95%
+    confidence interval on the relative mean change exceeds `threshold`, and
+    an improvement when the upper bound is below `-threshold`. A benchmark
+    with no ancestor baseline is reported as new.
+    """
+    results: list[BenchResult] = []
+    warnings: list[str] = []
+
+    # Criterion's own discovery rule: a benchmark.json inside a directory
+    # named "new". Baseline directories never hold a benchmark.json.
+    for benchmark_json in sorted(criterion_dir.rglob("benchmark.json")):
+        new_dir = benchmark_json.parent
+        if new_dir.name != "new":
+            continue
+        bench_dir = new_dir.parent
+        full_id = _load(benchmark_json)["full_id"]
+        current_mean = _load(new_dir / "estimates.json")["mean"]["point_estimate"]
+
+        ancestor_estimates = bench_dir / "ancestor" / "estimates.json"
+        change_estimates = bench_dir / "change" / "estimates.json"
+        # A change file is only meaningful when the ancestor baseline it was
+        # computed against is present. A stale change file from an earlier
+        # run must not produce a verdict.
+        if not ancestor_estimates.exists():
+            results.append(
+                BenchResult(full_id, current_mean, None, None, None, None, Verdict.NEW)
+            )
+            continue
+        ancestor_mean = _load(ancestor_estimates)["mean"]["point_estimate"]
+        if not change_estimates.exists():
+            warnings.append(
+                f"{full_id}: ancestor baseline exists but criterion wrote no change estimate, treating as new"
+            )
+            results.append(
+                BenchResult(
+                    full_id, current_mean, ancestor_mean, None, None, None, Verdict.NEW
+                )
+            )
+            continue
+
+        change = _load(change_estimates)["mean"]
+        lower = change["confidence_interval"]["lower_bound"]
+        upper = change["confidence_interval"]["upper_bound"]
+        if lower > threshold:
+            verdict = Verdict.REGRESSION
+        elif upper < -threshold:
+            verdict = Verdict.IMPROVEMENT
+        else:
+            verdict = Verdict.UNCHANGED
+        results.append(
+            BenchResult(
+                full_id,
+                current_mean,
+                ancestor_mean,
+                change["point_estimate"],
+                lower,
+                upper,
+                verdict,
+            )
+        )
+
+    def sort_key(r: BenchResult) -> tuple[int, float, str]:
+        change = r.change_mean if r.change_mean is not None else 0.0
+        return (_VERDICT_ORDER[r.verdict], -change, r.id)
+
+    results.sort(key=sort_key)
+    return CompareReport(results, warnings)
+
+
+def format_duration(ns: float) -> str:
+    """Format nanoseconds with the largest unit that keeps the value below 1000."""
+    for unit, scale in (("s", 1e9), ("ms", 1e6), ("µs", 1e3)):
+        if ns >= scale:
+            return f"{ns / scale:.2f} {unit}"
+    return f"{ns:.2f} ns"
+
+
+def _pct(value: float) -> str:
+    return f"{value * 100:+.1f}%"
+
+
+def render_markdown(report: CompareReport) -> str:
+    """Render the results as a markdown table, one row per benchmark."""
+    lines = [
+        "| Benchmark | Ancestor | Current | Change | 95% CI | Verdict |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for r in report.results:
+        ancestor = format_duration(r.ancestor_mean_ns) if r.ancestor_mean_ns is not None else ""
+        change = _pct(r.change_mean) if r.change_mean is not None else ""
+        ci = (
+            f"[{_pct(r.change_lower)}, {_pct(r.change_upper)}]"
+            if r.change_lower is not None and r.change_upper is not None
+            else ""
+        )
+        verdict = r.verdict.value
+        if r.verdict == Verdict.REGRESSION:
+            verdict = f"**{verdict}**"
+        lines.append(
+            f"| {r.id} | {ancestor} | {format_duration(r.current_mean_ns)} | {change} | {ci} | {verdict} |"
+        )
+    return "\n".join(lines)

--- a/misc/python/materialize/cargo_bench/compare.py
+++ b/misc/python/materialize/cargo_bench/compare.py
@@ -79,8 +79,10 @@ def compare(criterion_dir: Path, threshold: float) -> CompareReport:
     results: list[BenchResult] = []
     warnings: list[str] = []
 
-    # Criterion's own discovery rule: a benchmark.json inside a directory
-    # named "new". Baseline directories never hold a benchmark.json.
+    # Criterion copies benchmark.json into every saved baseline directory,
+    # not just "new/", so the guard on new_dir.name below is what identifies
+    # the current result and prevents counting a benchmark once per baseline
+    # it has been copied into.
     for benchmark_json in sorted(criterion_dir.rglob("benchmark.json")):
         new_dir = benchmark_json.parent
         if new_dir.name != "new":

--- a/misc/python/materialize/cargo_bench/targets.py
+++ b/misc/python/materialize/cargo_bench/targets.py
@@ -1,0 +1,54 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Enumeration of criterion bench targets from `cargo metadata` output."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, order=True)
+class BenchTarget:
+    """One `[[bench]]` target of a workspace package."""
+
+    package: str
+    name: str
+    required_features: tuple[str, ...]
+
+
+def bench_targets(metadata: dict[str, Any]) -> list[BenchTarget]:
+    """Return every bench target in a `cargo metadata --no-deps` document, sorted by package and name."""
+    targets = []
+    for package in metadata["packages"]:
+        for target in package["targets"]:
+            if "bench" not in target["kind"]:
+                continue
+            targets.append(
+                BenchTarget(
+                    package=package["name"],
+                    name=target["name"],
+                    required_features=tuple(target.get("required-features", [])),
+                )
+            )
+    return sorted(targets)
+
+
+def cargo_bench_args(
+    target: BenchTarget, criterion_args: Sequence[str]
+) -> list[str]:
+    """Build the `cargo bench` argv for one target, passing `criterion_args` through to the bench binary."""
+    args = ["cargo", "bench", "--package", target.package, "--bench", target.name]
+    # Cargo silently skips a target whose required features are off, so they
+    # must be enabled explicitly for the target to run at all.
+    if target.required_features:
+        args += ["--features", ",".join(target.required_features)]
+    args.append("--")
+    args.extend(criterion_args)
+    return args

--- a/misc/python/materialize/cargo_bench/targets.py
+++ b/misc/python/materialize/cargo_bench/targets.py
@@ -70,10 +70,12 @@ def cargo_build_args(targets: Sequence[BenchTarget]) -> list[str]:
     package is selected. Output is `--message-format=json` so the caller can
     recover executable paths.
     """
+    if not targets:
+        raise ValueError("no bench targets to build")
     packages = sorted({t.package for t in targets})
     names = sorted({t.name for t in targets})
     features = sorted(
-        f"{t.package}/{feature}" for t in targets for feature in t.required_features
+        {f"{t.package}/{feature}" for t in targets for feature in t.required_features}
     )
     args = ["cargo", "bench", "--no-run", "--message-format=json"]
     for package in packages:

--- a/misc/python/materialize/cargo_bench/targets.py
+++ b/misc/python/materialize/cargo_bench/targets.py
@@ -7,10 +7,14 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-"""Enumeration of criterion bench targets from `cargo metadata` output."""
+"""Enumeration of criterion bench targets from `cargo metadata` output, and the
+argv and JSON-artifact parsing needed to build all of them in one `cargo bench
+--no-run` invocation."""
 
-from collections.abc import Sequence
+import json
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 
@@ -40,13 +44,79 @@ def bench_targets(metadata: dict[str, Any]) -> list[BenchTarget]:
     return sorted(targets)
 
 
-def cargo_bench_args(target: BenchTarget, criterion_args: Sequence[str]) -> list[str]:
-    """Build the `cargo bench` argv for one target, passing `criterion_args` through to the bench binary."""
-    args = ["cargo", "bench", "--package", target.package, "--bench", target.name]
-    # An explicitly named bench target whose required features are not enabled
-    # makes cargo fail instead of skipping it, so the features must be passed through.
-    if target.required_features:
-        args += ["--features", ",".join(target.required_features)]
-    args.append("--")
-    args.extend(criterion_args)
+@dataclass(frozen=True)
+class BuiltBench:
+    """A compiled bench binary and the directory cargo would run it from."""
+
+    package: str
+    name: str
+    executable: Path
+    manifest_dir: Path
+
+
+def package_manifests(metadata: dict[str, Any]) -> dict[str, str]:
+    """Map each workspace package's manifest path to its package name."""
+    return {
+        package["manifest_path"]: package["name"] for package in metadata["packages"]
+    }
+
+
+def cargo_build_args(targets: Sequence[BenchTarget]) -> list[str]:
+    """Build the `cargo bench --no-run` argv that compiles every given target in one invocation.
+
+    Emits `--package` once per distinct package, `--bench` once per distinct
+    target name, and required features as `package/feature` entries of a single
+    `--features` flag, which is the only spelling cargo accepts when more than one
+    package is selected. Output is `--message-format=json` so the caller can
+    recover executable paths.
+    """
+    packages = sorted({t.package for t in targets})
+    names = sorted({t.name for t in targets})
+    features = sorted(
+        f"{t.package}/{feature}" for t in targets for feature in t.required_features
+    )
+    args = ["cargo", "bench", "--no-run", "--message-format=json"]
+    for package in packages:
+        args += ["--package", package]
+    for name in names:
+        args += ["--bench", name]
+    if features:
+        args += ["--features", ",".join(features)]
     return args
+
+
+def bench_executables(
+    lines: Iterable[str], manifests: dict[str, str]
+) -> list[BuiltBench]:
+    """Extract bench binaries from `cargo --message-format=json` output.
+
+    Keeps `compiler-artifact` messages whose target kind contains `bench` and
+    that carry an `executable`. The package is resolved through `manifests`
+    because bench target names are only unique within a package (`row` exists
+    in both mz-repr and mz-storage-types). Lines that are not JSON or not
+    artifacts are ignored. Sorted by (package, name).
+    """
+    built = []
+    for line in lines:
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if message.get("reason") != "compiler-artifact":
+            continue
+        target = message["target"]
+        if "bench" not in target["kind"]:
+            continue
+        executable = message.get("executable")
+        if executable is None:
+            continue
+        manifest_path = message["manifest_path"]
+        built.append(
+            BuiltBench(
+                package=manifests[manifest_path],
+                name=target["name"],
+                executable=Path(executable),
+                manifest_dir=Path(manifest_path).parent,
+            )
+        )
+    return sorted(built, key=lambda b: (b.package, b.name))

--- a/misc/python/materialize/cargo_bench/targets.py
+++ b/misc/python/materialize/cargo_bench/targets.py
@@ -40,13 +40,11 @@ def bench_targets(metadata: dict[str, Any]) -> list[BenchTarget]:
     return sorted(targets)
 
 
-def cargo_bench_args(
-    target: BenchTarget, criterion_args: Sequence[str]
-) -> list[str]:
+def cargo_bench_args(target: BenchTarget, criterion_args: Sequence[str]) -> list[str]:
     """Build the `cargo bench` argv for one target, passing `criterion_args` through to the bench binary."""
     args = ["cargo", "bench", "--package", target.package, "--bench", target.name]
-    # Cargo silently skips a target whose required features are off, so they
-    # must be enabled explicitly for the target to run at all.
+    # An explicitly named bench target whose required features are not enabled
+    # makes cargo fail instead of skipping it, so the features must be passed through.
     if target.required_features:
         args += ["--features", ",".join(target.required_features)]
     args.append("--")

--- a/misc/python/materialize/cargo_bench/targets.py
+++ b/misc/python/materialize/cargo_bench/targets.py
@@ -98,6 +98,16 @@ def cargo_build_args(targets: Sequence[BenchTarget]) -> list[str]:
     `--features` flag, which is the only spelling cargo accepts when more than one
     package is selected. Output is `--message-format=json` so the caller can
     recover executable paths.
+
+    NOTE: the features are a union over the whole selection, so a target that
+    requires none is still built against a lib with every other selected
+    target's features enabled. Both sides of a comparison are built the same
+    way, so verdicts hold, but absolute numbers can differ from a single
+    `cargo bench --bench <name>` run.
+
+    Callers must select whole packages. A partial selection within a package
+    would build targets absent from the caller's target list, because
+    `--bench` names are matched across every selected package.
     """
     if not targets:
         raise ValueError("no bench targets to build")

--- a/misc/python/materialize/cargo_bench/targets.py
+++ b/misc/python/materialize/cargo_bench/targets.py
@@ -54,6 +54,35 @@ class BuiltBench:
     manifest_dir: Path
 
 
+def closure_dirs(metadata: dict[str, Any], package: str) -> list[Path]:
+    """Return the manifest directories of workspace package `package` and of every path dependency in its transitive closure, sorted.
+
+    Needs a full `cargo metadata` document, one with a `resolve` section.
+    Dependencies of every kind count, since a bench target links the
+    package's dev-dependencies as well.
+    """
+    packages = {p["id"]: p for p in metadata["packages"]}
+    nodes = {n["id"]: n for n in metadata["resolve"]["nodes"]}
+    roots = [i for i in metadata["workspace_members"] if packages[i]["name"] == package]
+    if not roots:
+        raise ValueError(f"{package} is not a workspace member")
+    seen: set[str] = set()
+    stack = list(roots)
+    while stack:
+        i = stack.pop()
+        if i in seen:
+            continue
+        seen.add(i)
+        stack.extend(d["pkg"] for d in nodes[i]["deps"])
+    return sorted(
+        {
+            Path(packages[i]["manifest_path"]).parent
+            for i in seen
+            if packages[i]["source"] is None
+        }
+    )
+
+
 def package_manifests(metadata: dict[str, Any]) -> dict[str, str]:
     """Map each workspace package's manifest path to its package name."""
     return {

--- a/misc/python/materialize/cargo_bench/test_compare.py
+++ b/misc/python/materialize/cargo_bench/test_compare.py
@@ -1,0 +1,158 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import json
+from pathlib import Path
+
+from materialize.cargo_bench.compare import (
+    Verdict,
+    compare,
+    format_duration,
+    render_markdown,
+)
+
+
+def _estimate(point: float, lower: float, upper: float) -> dict:
+    return {
+        "confidence_interval": {
+            "confidence_level": 0.95,
+            "lower_bound": lower,
+            "upper_bound": upper,
+        },
+        "point_estimate": point,
+        "standard_error": 0.0,
+    }
+
+
+def _estimates(mean_ns: float) -> dict:
+    e = _estimate(mean_ns, mean_ns * 0.99, mean_ns * 1.01)
+    return {
+        "mean": e,
+        "median": e,
+        "median_abs_dev": e,
+        "slope": None,
+        "std_dev": e,
+    }
+
+
+def _write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def _bench(
+    root: Path,
+    directory: str,
+    full_id: str,
+    current_ns: float,
+    ancestor_ns: float | None = None,
+    change: tuple[float, float, float] | None = None,
+) -> None:
+    d = root / directory
+    _write(d / "new" / "benchmark.json", {"full_id": full_id})
+    _write(d / "new" / "estimates.json", _estimates(current_ns))
+    if ancestor_ns is not None:
+        _write(d / "ancestor" / "estimates.json", _estimates(ancestor_ns))
+    if change is not None:
+        point, lower, upper = change
+        e = _estimate(point, lower, upper)
+        _write(d / "change" / "estimates.json", {"mean": e, "median": e})
+
+
+def test_verdicts(tmp_path: Path) -> None:
+    _bench(tmp_path, "g/regressed", "g/regressed", 120.0, 100.0, (0.20, 0.15, 0.25))
+    _bench(tmp_path, "g/noisy", "g/noisy", 115.0, 100.0, (0.15, 0.05, 0.25))
+    _bench(tmp_path, "g/faster", "g/faster", 80.0, 100.0, (-0.20, -0.25, -0.15))
+    _bench(tmp_path, "g/same", "g/same", 101.0, 100.0, (0.01, -0.01, 0.03))
+    _bench(tmp_path, "g/brand_new", "g/brand_new", 50.0)
+
+    report = compare(tmp_path, threshold=0.10)
+
+    verdicts = {r.id: r.verdict for r in report.results}
+    assert verdicts == {
+        "g/regressed": Verdict.REGRESSION,
+        "g/noisy": Verdict.UNCHANGED,
+        "g/faster": Verdict.IMPROVEMENT,
+        "g/same": Verdict.UNCHANGED,
+        "g/brand_new": Verdict.NEW,
+    }
+    assert report.has_regressions
+    assert report.warnings == []
+
+
+def test_ordering_regressions_first(tmp_path: Path) -> None:
+    _bench(tmp_path, "a", "a", 50.0)
+    _bench(tmp_path, "b", "b", 101.0, 100.0, (0.01, -0.01, 0.03))
+    _bench(tmp_path, "c", "c", 80.0, 100.0, (-0.20, -0.25, -0.15))
+    _bench(tmp_path, "d", "d", 120.0, 100.0, (0.20, 0.15, 0.25))
+    _bench(tmp_path, "e", "e", 150.0, 100.0, (0.50, 0.45, 0.55))
+
+    report = compare(tmp_path, threshold=0.10)
+
+    assert [r.id for r in report.results] == ["e", "d", "c", "b", "a"]
+
+
+def test_new_benchmark_has_no_ancestor_fields(tmp_path: Path) -> None:
+    _bench(tmp_path, "n", "n", 50.0)
+
+    [result] = compare(tmp_path, threshold=0.10).results
+
+    assert result.verdict == Verdict.NEW
+    assert result.current_mean_ns == 50.0
+    assert result.ancestor_mean_ns is None
+    assert result.change_mean is None
+
+
+def test_missing_change_with_ancestor_warns_and_is_new(tmp_path: Path) -> None:
+    _bench(tmp_path, "m", "m", 50.0, ancestor_ns=40.0)
+
+    report = compare(tmp_path, threshold=0.10)
+
+    [result] = report.results
+    assert result.verdict == Verdict.NEW
+    assert result.ancestor_mean_ns == 40.0
+    assert len(report.warnings) == 1
+    assert "m" in report.warnings[0]
+
+
+def test_stale_change_without_ancestor_is_ignored(tmp_path: Path) -> None:
+    _bench(tmp_path, "s", "s", 50.0, change=(0.5, 0.4, 0.6))
+
+    [result] = compare(tmp_path, threshold=0.10).results
+
+    assert result.verdict == Verdict.NEW
+
+
+def test_no_regressions(tmp_path: Path) -> None:
+    _bench(tmp_path, "b", "b", 101.0, 100.0, (0.01, -0.01, 0.03))
+
+    assert not compare(tmp_path, threshold=0.10).has_regressions
+
+
+def test_format_duration() -> None:
+    assert format_duration(999.4) == "999.40 ns"
+    assert format_duration(1_500.0) == "1.50 µs"
+    assert format_duration(2_500_000.0) == "2.50 ms"
+    assert format_duration(3_000_000_000.0) == "3.00 s"
+
+
+def test_render_markdown(tmp_path: Path) -> None:
+    _bench(tmp_path, "g/regressed", "g/regressed", 120.0, 100.0, (0.20, 0.15, 0.25))
+    _bench(tmp_path, "g/brand_new", "g/brand_new", 50.0)
+    report = compare(tmp_path, threshold=0.10)
+
+    markdown = render_markdown(report)
+
+    lines = markdown.splitlines()
+    assert lines[0] == "| Benchmark | Ancestor | Current | Change | 95% CI | Verdict |"
+    assert lines[1] == "| --- | --- | --- | --- | --- | --- |"
+    assert lines[2] == (
+        "| g/regressed | 100.00 ns | 120.00 ns | +20.0% | [+15.0%, +25.0%] | **regression** |"
+    )
+    assert lines[3] == "| g/brand_new |  | 50.00 ns |  |  | new |"

--- a/misc/python/materialize/cargo_bench/test_compare.py
+++ b/misc/python/materialize/cargo_bench/test_compare.py
@@ -129,6 +129,18 @@ def test_stale_change_without_ancestor_is_ignored(tmp_path: Path) -> None:
     assert result.verdict == Verdict.NEW
 
 
+def test_ancestor_benchmark_json_not_double_counted(tmp_path: Path) -> None:
+    _bench(tmp_path, "d", "d", 110.0, 100.0, (0.10, 0.05, 0.15))
+    # Criterion copies benchmark.json into the baseline directory it saves,
+    # not just into "new/". A discovery loop keyed on "any benchmark.json"
+    # rather than the "new" directory name would count this id twice.
+    _write(tmp_path / "d" / "ancestor" / "benchmark.json", {"full_id": "d"})
+
+    report = compare(tmp_path, threshold=0.10)
+
+    assert len(report.results) == 1
+
+
 def test_no_regressions(tmp_path: Path) -> None:
     _bench(tmp_path, "b", "b", 101.0, 100.0, (0.01, -0.01, 0.03))
 

--- a/misc/python/materialize/cargo_bench/test_targets.py
+++ b/misc/python/materialize/cargo_bench/test_targets.py
@@ -7,10 +7,16 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import json
+from pathlib import Path
+
 from materialize.cargo_bench.targets import (
     BenchTarget,
+    BuiltBench,
+    bench_executables,
     bench_targets,
-    cargo_bench_args,
+    cargo_build_args,
+    package_manifests,
 )
 
 METADATA = {
@@ -57,31 +63,113 @@ def test_bench_targets_tolerates_missing_required_features_key() -> None:
     assert bench_targets(metadata) == [BenchTarget("p", "b", ())]
 
 
-def test_cargo_bench_args_without_features() -> None:
-    target = BenchTarget("mz-ore", "id_gen", ())
-    assert cargo_bench_args(target, ["--save-baseline", "ancestor"]) == [
+def test_cargo_build_args_single_package_no_features() -> None:
+    targets = [
+        BenchTarget("mz-ore", "a", ()),
+        BenchTarget("mz-ore", "b", ()),
+    ]
+    assert cargo_build_args(targets) == [
         "cargo",
         "bench",
+        "--no-run",
+        "--message-format=json",
         "--package",
         "mz-ore",
         "--bench",
-        "id_gen",
-        "--",
-        "--save-baseline",
-        "ancestor",
+        "a",
+        "--bench",
+        "b",
     ]
 
 
-def test_cargo_bench_args_with_features() -> None:
-    target = BenchTarget("mz-ore", "bytes", ("bytes", "region", "tracing"))
-    assert cargo_bench_args(target, []) == [
+def test_cargo_build_args_multi_package_features() -> None:
+    # Given in a deliberately unsorted order: the output must sort packages,
+    # bench names, and features regardless of input order.
+    targets = [
+        BenchTarget("mz-ore", "pager", ("pager",)),
+        BenchTarget("mz-compute", "correction", ("bench",)),
+        BenchTarget("mz-ore", "bytes", ("bytes", "region", "tracing")),
+        BenchTarget("mz-ore", "id_gen", ()),
+    ]
+    assert cargo_build_args(targets) == [
         "cargo",
         "bench",
+        "--no-run",
+        "--message-format=json",
+        "--package",
+        "mz-compute",
         "--package",
         "mz-ore",
         "--bench",
         "bytes",
+        "--bench",
+        "correction",
+        "--bench",
+        "id_gen",
+        "--bench",
+        "pager",
         "--features",
-        "bytes,region,tracing",
-        "--",
+        "mz-compute/bench,mz-ore/bytes,mz-ore/pager,mz-ore/region,mz-ore/tracing",
     ]
+
+
+def test_bench_executables_filters_and_resolves_package() -> None:
+    manifests = {
+        "/ws/src/repr/Cargo.toml": "mz-repr",
+        "/ws/src/storage-types/Cargo.toml": "mz-storage-types",
+    }
+    lines = [
+        json.dumps(
+            {
+                "reason": "compiler-artifact",
+                "manifest_path": "/ws/src/repr/Cargo.toml",
+                "target": {"kind": ["lib"], "name": "mz_repr"},
+                "executable": None,
+            }
+        ),
+        json.dumps(
+            {
+                "reason": "compiler-artifact",
+                "manifest_path": "/ws/src/repr/Cargo.toml",
+                "target": {"kind": ["bench"], "name": "row"},
+                "executable": "/ws/target/release/deps/row-aaa",
+            }
+        ),
+        json.dumps(
+            {
+                "reason": "compiler-artifact",
+                "manifest_path": "/ws/src/storage-types/Cargo.toml",
+                "target": {"kind": ["bench"], "name": "row"},
+                "executable": "/ws/target/release/deps/row-bbb",
+            }
+        ),
+        json.dumps({"reason": "build-script-executed"}),
+        "warning: unused import",
+    ]
+    assert bench_executables(lines, manifests) == [
+        BuiltBench(
+            package="mz-repr",
+            name="row",
+            executable=Path("/ws/target/release/deps/row-aaa"),
+            manifest_dir=Path("/ws/src/repr"),
+        ),
+        BuiltBench(
+            package="mz-storage-types",
+            name="row",
+            executable=Path("/ws/target/release/deps/row-bbb"),
+            manifest_dir=Path("/ws/src/storage-types"),
+        ),
+    ]
+
+
+def test_package_manifests() -> None:
+    metadata = {
+        "packages": [
+            {"name": "mz-ore", "manifest_path": "/ws/src/ore/Cargo.toml"},
+            {"name": "mz-repr", "manifest_path": "/ws/src/repr/Cargo.toml"},
+        ]
+    }
+    assert package_manifests(metadata) == {
+        "/ws/src/ore/Cargo.toml": "mz-ore",
+        "/ws/src/repr/Cargo.toml": "mz-repr",
+    }

--- a/misc/python/materialize/cargo_bench/test_targets.py
+++ b/misc/python/materialize/cargo_bench/test_targets.py
@@ -10,6 +10,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from materialize.cargo_bench.targets import (
     BenchTarget,
     BuiltBench,
@@ -84,11 +86,14 @@ def test_cargo_build_args_single_package_no_features() -> None:
 
 def test_cargo_build_args_multi_package_features() -> None:
     # Given in a deliberately unsorted order: the output must sort packages,
-    # bench names, and features regardless of input order.
+    # bench names, and features regardless of input order. "region" is
+    # required by both "bytes" and "region_probe" in mz-ore, so "mz-ore/region"
+    # must still appear exactly once in the output.
     targets = [
         BenchTarget("mz-ore", "pager", ("pager",)),
         BenchTarget("mz-compute", "correction", ("bench",)),
         BenchTarget("mz-ore", "bytes", ("bytes", "region", "tracing")),
+        BenchTarget("mz-ore", "region_probe", ("region",)),
         BenchTarget("mz-ore", "id_gen", ()),
     ]
     assert cargo_build_args(targets) == [
@@ -108,9 +113,16 @@ def test_cargo_build_args_multi_package_features() -> None:
         "id_gen",
         "--bench",
         "pager",
+        "--bench",
+        "region_probe",
         "--features",
         "mz-compute/bench,mz-ore/bytes,mz-ore/pager,mz-ore/region,mz-ore/tracing",
     ]
+
+
+def test_cargo_build_args_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="no bench targets to build"):
+        cargo_build_args([])
 
 
 def test_bench_executables_filters_and_resolves_package() -> None:

--- a/misc/python/materialize/cargo_bench/test_targets.py
+++ b/misc/python/materialize/cargo_bench/test_targets.py
@@ -1,0 +1,89 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.cargo_bench.targets import (
+    BenchTarget,
+    bench_targets,
+    cargo_bench_args,
+)
+
+METADATA = {
+    "packages": [
+        {
+            "name": "mz-ore",
+            "targets": [
+                {"name": "mz_ore", "kind": ["lib"], "required-features": []},
+                {"name": "id_gen", "kind": ["bench"], "required-features": []},
+                {
+                    "name": "pager",
+                    "kind": ["bench"],
+                    "required-features": ["pager"],
+                },
+            ],
+        },
+        {
+            "name": "mz-compute",
+            "targets": [
+                {
+                    "name": "correction",
+                    "kind": ["bench"],
+                    "required-features": ["bench"],
+                },
+                {"name": "some_test", "kind": ["test"], "required-features": []},
+            ],
+        },
+    ]
+}
+
+
+def test_bench_targets_filters_kind_and_sorts() -> None:
+    assert bench_targets(METADATA) == [
+        BenchTarget("mz-compute", "correction", ("bench",)),
+        BenchTarget("mz-ore", "id_gen", ()),
+        BenchTarget("mz-ore", "pager", ("pager",)),
+    ]
+
+
+def test_bench_targets_tolerates_missing_required_features_key() -> None:
+    metadata = {
+        "packages": [
+            {"name": "p", "targets": [{"name": "b", "kind": ["bench"]}]}
+        ]
+    }
+    assert bench_targets(metadata) == [BenchTarget("p", "b", ())]
+
+
+def test_cargo_bench_args_without_features() -> None:
+    target = BenchTarget("mz-ore", "id_gen", ())
+    assert cargo_bench_args(target, ["--save-baseline", "ancestor"]) == [
+        "cargo",
+        "bench",
+        "--package",
+        "mz-ore",
+        "--bench",
+        "id_gen",
+        "--",
+        "--save-baseline",
+        "ancestor",
+    ]
+
+
+def test_cargo_bench_args_with_features() -> None:
+    target = BenchTarget("mz-ore", "bytes", ("bytes", "region", "tracing"))
+    assert cargo_bench_args(target, []) == [
+        "cargo",
+        "bench",
+        "--package",
+        "mz-ore",
+        "--bench",
+        "bytes",
+        "--features",
+        "bytes,region,tracing",
+        "--",
+    ]

--- a/misc/python/materialize/cargo_bench/test_targets.py
+++ b/misc/python/materialize/cargo_bench/test_targets.py
@@ -52,9 +52,7 @@ def test_bench_targets_filters_kind_and_sorts() -> None:
 
 def test_bench_targets_tolerates_missing_required_features_key() -> None:
     metadata = {
-        "packages": [
-            {"name": "p", "targets": [{"name": "b", "kind": ["bench"]}]}
-        ]
+        "packages": [{"name": "p", "targets": [{"name": "b", "kind": ["bench"]}]}]
     }
     assert bench_targets(metadata) == [BenchTarget("p", "b", ())]
 

--- a/misc/python/materialize/cargo_bench/test_targets.py
+++ b/misc/python/materialize/cargo_bench/test_targets.py
@@ -18,6 +18,7 @@ from materialize.cargo_bench.targets import (
     bench_executables,
     bench_targets,
     cargo_build_args,
+    closure_dirs,
     package_manifests,
 )
 
@@ -185,3 +186,52 @@ def test_package_manifests() -> None:
         "/ws/src/ore/Cargo.toml": "mz-ore",
         "/ws/src/repr/Cargo.toml": "mz-repr",
     }
+
+
+def _resolve_package(id: str, name: str, manifest: str, source: str | None) -> dict:
+    return {"id": id, "name": name, "manifest_path": manifest, "source": source}
+
+
+def _node(id: str, deps: list[str]) -> dict:
+    return {"id": id, "deps": [{"name": d, "pkg": d} for d in deps]}
+
+
+# mz-a depends on mz-b (dev-dependency) and anyhow, mz-b depends on anyhow,
+# mz-c depends on mz-a and is not in mz-a's closure.
+RESOLVE_METADATA = {
+    "packages": [
+        _resolve_package("a", "mz-a", "/ws/src/a/Cargo.toml", None),
+        _resolve_package("b", "mz-b", "/ws/src/b/Cargo.toml", None),
+        _resolve_package("c", "mz-c", "/ws/src/c/Cargo.toml", None),
+        _resolve_package(
+            "anyhow", "anyhow", "/registry/anyhow/Cargo.toml", "registry+https://x"
+        ),
+    ],
+    "workspace_members": ["a", "b", "c"],
+    "resolve": {
+        "nodes": [
+            _node("a", ["b", "anyhow"]),
+            _node("b", ["anyhow"]),
+            _node("c", ["a"]),
+            _node("anyhow", []),
+        ]
+    },
+}
+
+
+def test_closure_dirs_transitive_path_crates_only() -> None:
+    assert closure_dirs(RESOLVE_METADATA, "mz-a") == [
+        Path("/ws/src/a"),
+        Path("/ws/src/b"),
+    ]
+    assert closure_dirs(RESOLVE_METADATA, "mz-b") == [Path("/ws/src/b")]
+    assert closure_dirs(RESOLVE_METADATA, "mz-c") == [
+        Path("/ws/src/a"),
+        Path("/ws/src/b"),
+        Path("/ws/src/c"),
+    ]
+
+
+def test_closure_dirs_rejects_unknown_package() -> None:
+    with pytest.raises(ValueError, match="mz-missing"):
+        closure_dirs(RESOLVE_METADATA, "mz-missing")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@
 
 [tool.black]
 target_version = ["py310"]
-# DEFAULT_EXCLUDES from https://github.com/psf/black/blob/main/src/black/const.py but without "build" directory since we use it in our source code. Instead exclude target and target-xcompile
-exclude = "(\\.direnv|\\.eggs|\\.git|\\.hg|\\.ipynb_checkpoints|\\.mypy_cache|\\.nox|\\.pytest_cache|\\.ruff_cache|\\.tox|\\.svn|\\.venv|\\.vscode|__pypackages__|_build|buck-out|dist|venv|target|target-xcompile|\\.terraform)"
+# DEFAULT_EXCLUDES from https://github.com/psf/black/blob/main/src/black/const.py but without "build" directory since we use it in our source code. Instead exclude target and target-xcompile. The alternation is anchored on path components so file names containing an excluded word are not skipped.
+exclude = "/(\\.direnv|\\.eggs|\\.git|\\.hg|\\.ipynb_checkpoints|\\.mypy_cache|\\.nox|\\.pytest_cache|\\.ruff_cache|\\.tox|\\.svn|\\.venv|\\.vscode|__pypackages__|_build|buck-out|dist|venv|target[^/]*|\\.terraform)/"
 
 [tool.ruff]
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 [tool.black]
 target_version = ["py310"]
 # DEFAULT_EXCLUDES from https://github.com/psf/black/blob/main/src/black/const.py but without "build" directory since we use it in our source code. Instead exclude target and target-xcompile. The alternation is anchored on path components so file names containing an excluded word are not skipped.
-exclude = "/(\\.direnv|\\.eggs|\\.git|\\.hg|\\.ipynb_checkpoints|\\.mypy_cache|\\.nox|\\.pytest_cache|\\.ruff_cache|\\.tox|\\.svn|\\.venv|\\.vscode|__pypackages__|_build|buck-out|dist|venv|target[^/]*|\\.terraform)/"
+exclude = "/(\\.direnv|\\.eggs|\\.git|\\.hg|\\.ipynb_checkpoints|\\.mypy_cache|\\.nox|\\.pytest_cache|\\.ruff_cache|\\.tox|\\.svn|\\.venv|\\.vscode|__pypackages__|_build|buck-out|dist|venv|target|target-xcompile|\\.terraform)/"
 
 [tool.ruff]
 target-version = "py310"

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false
+autobenches = false
 
 [lints]
 workspace = true

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -98,15 +98,24 @@ def run_ancestor(
     env: dict[str, str],
 ) -> tuple[list[BenchTarget], list[TargetFailure]]:
     worktree = Path(tempfile.mkdtemp(prefix="cargo-bench-ancestor-"))
-    spawn.runv(
-        ["git", "worktree", "add", "--detach", str(worktree), ancestor], cwd=MZ_ROOT
-    )
+    added = False
     try:
+        # `git worktree add` can fail on a bad ancestor ref, in which case
+        # there is no worktree to remove, only the scratch directory to clean up.
+        spawn.runv(
+            ["git", "worktree", "add", "--detach", str(worktree), ancestor],
+            cwd=MZ_ROOT,
+        )
+        added = True
         targets = load_targets(worktree, packages)
         failures = run_targets(targets, worktree, env, ["--save-baseline", BASELINE])
         return targets, failures
     finally:
-        spawn.runv(["git", "worktree", "remove", "--force", str(worktree)], cwd=MZ_ROOT)
+        if added:
+            spawn.runv(
+                ["git", "worktree", "remove", "--force", str(worktree)], cwd=MZ_ROOT
+            )
+        shutil.rmtree(worktree, ignore_errors=True)
 
 
 def render_report(
@@ -183,13 +192,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ancestor: str | None = None
     ancestor_failures: list[TargetFailure] = []
     if not args.skip_ancestor:
-        # Annotated `str`, not `str | None`: `args.ancestor` is `Any`, and
-        # assigning an `Any` value into `ancestor` would otherwise narrow to
-        # its declared `str | None`, which `run_ancestor` below rejects.
-        resolved_ancestor: str = args.ancestor or resolve_ancestor()
-        ancestor = resolved_ancestor
-        print(f"--- Comparing against ancestor {resolved_ancestor}")
-        _, ancestor_failures = run_ancestor(resolved_ancestor, args.package, env)
+        ancestor = args.ancestor or resolve_ancestor()
+        assert ancestor is not None
+        print(f"--- Comparing against ancestor {ancestor}")
+        _, ancestor_failures = run_ancestor(ancestor, args.package, env)
 
     current_targets = load_targets(MZ_ROOT, args.package)
     if not current_targets:
@@ -209,18 +215,21 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         buildkite.add_annotation(
             "error" if failed else "info", "Cargo bench results", markdown
         )
-        spawn.runv(
-            [
-                "tar",
-                "-caf",
-                REPORTS_ARTIFACT,
-                "-C",
-                str(criterion_home.parent),
-                criterion_home.name,
-            ],
-            cwd=MZ_ROOT,
-        )
-        buildkite.upload_artifact(REPORTS_ARTIFACT, cwd=MZ_ROOT)
+        try:
+            spawn.runv(
+                [
+                    "tar",
+                    "-caf",
+                    REPORTS_ARTIFACT,
+                    "-C",
+                    str(criterion_home.parent),
+                    criterion_home.name,
+                ],
+                cwd=MZ_ROOT,
+            )
+            buildkite.upload_artifact(REPORTS_ARTIFACT, cwd=MZ_ROOT)
+        except subprocess.CalledProcessError as e:
+            print(f"^^^ +++ uploading criterion reports failed: {e}")
 
     if current_failures:
         raise RuntimeError(

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -422,6 +422,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     # or S3 endpoint is configured. This step measures code, not network
     # storage, so the benches run as they do locally and skip those variants.
     env.pop("CI", None)
+    # A vendored C dependency such as OpenSSL embeds its own build timestamp
+    # unless SOURCE_DATE_EPOCH is set, and a timestamp difference alone would
+    # defeat the identical-binary skip below even when the compiled source is
+    # otherwise byte-for-byte the same between the ancestor and current build.
+    env["SOURCE_DATE_EPOCH"] = "0"
 
     # Cargo derives a unit's hash from absolute paths, so the ancestor and
     # current checkouts must build at the same checkout path and the same

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -12,6 +12,7 @@ Runs every criterion benchmark at an ancestor commit and at the current commit,
 then fails when a benchmark regressed beyond a threshold.
 """
 
+import hashlib
 import json
 import os
 import shutil
@@ -138,6 +139,7 @@ def run_bench(
     env: dict[str, str],
     target_home: Path,
     label: str,
+    header_suffix: str = "",
 ) -> int | None:
     """Run one compiled bench binary directly and return its exit code on failure, else `None`.
 
@@ -149,7 +151,7 @@ def run_bench(
     also what `CARGO_MANIFEST_DIR` would otherwise expand to at build time,
     so both are set here for a binary that inspects either at runtime.
     """
-    print(f"--- Benchmarking {built.package}/{built.name} ({label})")
+    print(f"--- Benchmarking {built.package}/{built.name} ({label}){header_suffix}")
     target_env = dict(
         env,
         CARGO_MANIFEST_DIR=str(built.manifest_dir),
@@ -167,6 +169,31 @@ def run_bench(
         return e.returncode
 
 
+def loaded_image_digest(executable: Path, scratch: Path) -> str:
+    """Return the sha256 hex digest of the bytes a loader actually maps for `executable`.
+
+    Two builds of identical source from different checkouts still differ in
+    debug info, symbol names, and the build-id note, none of which the loader
+    maps into memory. Stripping those out before hashing judges identity on
+    the loaded program rather than on incidental build-location bytes.
+    """
+    stripped = scratch / executable.name
+    spawn.runv(
+        [
+            "strip",
+            "--strip-all",
+            "--remove-section=.note.gnu.build-id",
+            "-o",
+            str(stripped),
+            str(executable),
+        ]
+    )
+    try:
+        return hashlib.sha256(stripped.read_bytes()).hexdigest()
+    finally:
+        stripped.unlink(missing_ok=True)
+
+
 def run_benches(
     head_built: list[BuiltBench],
     ancestor_built: list[BuiltBench],
@@ -174,7 +201,7 @@ def run_benches(
     ancestor_targets: list[BenchTarget],
     env: dict[str, str],
     criterion_home: Path,
-) -> tuple[list[TargetFailure], list[TargetFailure]]:
+) -> tuple[list[TargetFailure], list[TargetFailure], list[BuiltBench]]:
     """Run every HEAD bench binary, its ancestor counterpart first when one was built for the same target.
 
     Interleaving ancestor and HEAD per target, rather than running every
@@ -188,9 +215,12 @@ def run_benches(
     ancestor_by_key = {(b.package, b.name): b for b in ancestor_built}
     ancestor_target_by_key = {(t.package, t.name): t for t in ancestor_targets}
     head_target_by_key = {(t.package, t.name): t for t in head_targets}
+    scratch = criterion_home / "stripped"
+    scratch.mkdir(parents=True, exist_ok=True)
 
     ancestor_failures: list[TargetFailure] = []
     current_failures: list[TargetFailure] = []
+    identical: list[BuiltBench] = []
     for head_bin in sorted(head_built, key=lambda b: (b.package, b.name)):
         key = (head_bin.package, head_bin.name)
         # Benchmark ids are only unique within a target, so a collision
@@ -198,12 +228,28 @@ def run_benches(
         # unrelated benchmarks.
         target_home = criterion_home / head_bin.package / head_bin.name
         ancestor_bin = ancestor_by_key.get(key)
+        header_suffix = ""
         if ancestor_bin is not None:
             if ancestor_bin.executable == head_bin.executable:
                 raise RuntimeError(
                     f"{head_bin.package}/{head_bin.name}: ancestor and current bench "
                     f"binaries resolve to the same file {head_bin.executable}"
                 )
+            # A target whose loaded program is identical between ancestor and
+            # current cannot have changed in any way that affects the
+            # benchmark, and running it anyway only costs time and risks a
+            # false regression from shared CI hardware.
+            ancestor_digest = loaded_image_digest(ancestor_bin.executable, scratch)
+            head_digest = loaded_image_digest(head_bin.executable, scratch)
+            if ancestor_digest == head_digest:
+                print(
+                    f"--- Skipping {head_bin.package}/{head_bin.name}: identical binaries"
+                )
+                identical.append(head_bin)
+                continue
+            header_suffix = (
+                f" ancestor={ancestor_digest[:12]} current={head_digest[:12]}"
+            )
             rc = run_bench(
                 ancestor_bin,
                 ["--save-baseline", BASELINE],
@@ -224,11 +270,16 @@ def run_benches(
                 if d.is_dir():
                     shutil.rmtree(d)
         rc = run_bench(
-            head_bin, ["--baseline-lenient", BASELINE], env, target_home, "current"
+            head_bin,
+            ["--baseline-lenient", BASELINE],
+            env,
+            target_home,
+            "current",
+            header_suffix,
         )
         if rc is not None:
             current_failures.append(TargetFailure(head_target_by_key[key], rc))
-    return ancestor_failures, current_failures
+    return ancestor_failures, current_failures, identical
 
 
 def render_report(
@@ -237,6 +288,7 @@ def render_report(
     report: CompareReport,
     ancestor_failures: list[TargetFailure],
     current_failures: list[TargetFailure],
+    identical: list[BuiltBench],
 ) -> str:
     sections = []
     if ancestor is not None:
@@ -263,6 +315,11 @@ def render_report(
         )
     if report.warnings:
         sections.append("Warnings:\n" + "\n".join(f"* {w}" for w in report.warnings))
+    if identical:
+        sections.append(
+            "Bench targets with identical binaries at ancestor and current (not run):\n"
+            + "\n".join(f"* `{b.package}/{b.name}`" for b in identical)
+        )
     sections.append(render_markdown(report))
     return "\n\n".join(sections)
 
@@ -323,7 +380,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         head_built, current_build_failures = build_benches(
             MZ_ROOT, head_targets, head_manifests, env
         )
-        ancestor_run_failures, current_run_failures = run_benches(
+        ancestor_run_failures, current_run_failures, identical = run_benches(
             head_built, [], head_targets, [], env, criterion_home
         )
         ancestor_failures = ancestor_run_failures
@@ -375,7 +432,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             head_built, current_build_failures = build_benches(
                 MZ_ROOT, head_targets, head_manifests, env
             )
-            ancestor_run_failures, current_run_failures = run_benches(
+            ancestor_run_failures, current_run_failures, identical = run_benches(
                 head_built,
                 ancestor_built,
                 head_targets,
@@ -400,7 +457,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     report = compare(criterion_home, args.threshold)
     markdown = render_report(
-        ancestor, args.threshold, report, ancestor_failures, current_failures
+        ancestor,
+        args.threshold,
+        report,
+        ancestor_failures,
+        current_failures,
+        identical,
     )
     print(markdown)
 

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -173,9 +173,13 @@ def loaded_image_digest(executable: Path, scratch: Path) -> str:
     """Return the sha256 hex digest of the bytes a loader actually maps for `executable`.
 
     Two builds of identical source from different checkouts still differ in
-    debug info, symbol names, and the build-id note, none of which the loader
-    maps into memory. Stripping those out before hashing judges identity on
-    the loaded program rather than on incidental build-location bytes.
+    debug info, symbol names, the build-id note, and `.comment` (compiler and
+    linker version strings, which vary if the system's C toolchain changed
+    between builds), none of which the loader maps into memory. Stripping
+    those out before hashing judges identity on the loaded program rather
+    than on incidental build-environment bytes. `--strip-all` removes symbol
+    tables and debug info but leaves `.comment` behind, so it is named
+    explicitly.
     """
     stripped = scratch / executable.name
     spawn.runv(
@@ -183,6 +187,7 @@ def loaded_image_digest(executable: Path, scratch: Path) -> str:
             "strip",
             "--strip-all",
             "--remove-section=.note.gnu.build-id",
+            "--remove-section=.comment",
             "-o",
             str(stripped),
             str(executable),

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -29,8 +29,11 @@ from materialize.cargo_bench.compare import (
 )
 from materialize.cargo_bench.targets import (
     BenchTarget,
+    BuiltBench,
+    bench_executables,
     bench_targets,
-    cargo_bench_args,
+    cargo_build_args,
+    package_manifests,
 )
 from materialize.mz_version import MzVersion
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
@@ -75,79 +78,146 @@ def target_dir() -> Path:
     return value if value.is_absolute() else MZ_ROOT / value
 
 
-def load_targets(cwd: Path, packages: list[str]) -> list[BenchTarget]:
+def load_targets(
+    cwd: Path, packages: list[str]
+) -> tuple[list[BenchTarget], dict[str, str]]:
+    """Enumerate bench targets and package manifest paths for one checkout via `cargo metadata`."""
     metadata = json.loads(
         spawn.capture(["cargo", "metadata", "--no-deps", "--format-version=1"], cwd=cwd)
     )
     targets = bench_targets(metadata)
     if packages:
         targets = [t for t in targets if t.package in packages]
-    return targets
+    return targets, package_manifests(metadata)
 
 
-def run_targets(
-    targets: list[BenchTarget],
+def build_benches(
     cwd: Path,
+    targets: list[BenchTarget],
+    manifests: dict[str, str],
     env: dict[str, str],
-    criterion_args: list[str],
-) -> list[TargetFailure]:
-    """Run each target on its own so one failure does not take down the rest. Returns the failures."""
-    failures = []
-    base_criterion_home = Path(env["CRITERION_HOME"])
+) -> tuple[list[BuiltBench], list[TargetFailure]]:
+    """Compile every bench target of one checkout in as few `cargo bench --no-run` invocations as possible.
+
+    A single invocation covering every target builds with full core
+    parallelism, but cargo's message stream gives no way to tell which target
+    broke when the invocation itself exits non-zero. The fallback isolates
+    the failing targets with one invocation each; cargo's incremental cache
+    makes recompiling the targets that already succeeded cheap.
+    """
+    print(f"--- Building {len(targets)} bench targets in {cwd}")
+    try:
+        output = spawn.capture(cargo_build_args(targets), cwd=cwd, env=env)
+        return bench_executables(output.splitlines(), manifests), []
+    except subprocess.CalledProcessError:
+        pass
+
+    built: list[BuiltBench] = []
+    failures: list[TargetFailure] = []
     for target in targets:
-        print(f"--- Benchmarking {target.package}/{target.name} in {cwd}")
+        try:
+            output = spawn.capture(cargo_build_args([target]), cwd=cwd, env=env)
+            built.extend(bench_executables(output.splitlines(), manifests))
+        except subprocess.CalledProcessError as e:
+            print(
+                f"^^^ +++ {target.package}/{target.name} failed to build with {e.returncode}"
+            )
+            failures.append(TargetFailure(target, e.returncode))
+    return built, failures
+
+
+def run_bench(
+    built: BuiltBench,
+    criterion_args: list[str],
+    env: dict[str, str],
+    target_home: Path,
+    label: str,
+) -> int | None:
+    """Run one compiled bench binary directly and return its exit code on failure, else `None`.
+
+    The binary is invoked directly rather than through `cargo bench` again,
+    since cargo has already compiled it and re-running cargo would recheck
+    the whole workspace for no benefit. `--bench` is required: a criterion
+    binary invoked without it runs in test mode and measures nothing. Cargo
+    itself runs bench binaries with the package directory as cwd, which is
+    also what `CARGO_MANIFEST_DIR` would otherwise expand to at build time,
+    so both are set here for a binary that inspects either at runtime.
+    """
+    print(f"--- Benchmarking {built.package}/{built.name} ({label})")
+    target_env = dict(
+        env,
+        CARGO_MANIFEST_DIR=str(built.manifest_dir),
+        CRITERION_HOME=str(target_home),
+    )
+    try:
+        spawn.runv(
+            [str(built.executable), "--bench", *criterion_args],
+            cwd=built.manifest_dir,
+            env=target_env,
+        )
+        return None
+    except subprocess.CalledProcessError as e:
+        print(f"^^^ +++ {built.package}/{built.name} failed with {e.returncode}")
+        return e.returncode
+
+
+def run_benches(
+    head_built: list[BuiltBench],
+    ancestor_built: list[BuiltBench],
+    head_targets: list[BenchTarget],
+    ancestor_targets: list[BenchTarget],
+    env: dict[str, str],
+    criterion_home: Path,
+) -> tuple[list[TargetFailure], list[TargetFailure]]:
+    """Run every HEAD bench binary, its ancestor counterpart first when one was built for the same target.
+
+    Interleaving ancestor and HEAD per target, rather than running every
+    ancestor target and then every HEAD target, keeps the machine's page
+    cache and thermal state close between the two runs of a benchmark, which
+    is what produced repeatable false regressions in the I/O-bound
+    mz-ore/pager benches when the two phases ran far apart. A target present
+    only in the ancestor is never run, since there is no HEAD result to
+    compare it against.
+    """
+    ancestor_by_key = {(b.package, b.name): b for b in ancestor_built}
+    ancestor_target_by_key = {(t.package, t.name): t for t in ancestor_targets}
+    head_target_by_key = {(t.package, t.name): t for t in head_targets}
+
+    ancestor_failures: list[TargetFailure] = []
+    current_failures: list[TargetFailure] = []
+    for head_bin in sorted(head_built, key=lambda b: (b.package, b.name)):
+        key = (head_bin.package, head_bin.name)
         # Benchmark ids are only unique within a target, so a collision
         # across targets sharing one criterion home would silently merge two
         # unrelated benchmarks.
-        target_env = dict(
-            env,
-            CRITERION_HOME=str(base_criterion_home / target.package / target.name),
-        )
-        try:
-            spawn.runv(
-                cargo_bench_args(target, criterion_args), cwd=cwd, env=target_env
+        target_home = criterion_home / head_bin.package / head_bin.name
+        ancestor_bin = ancestor_by_key.get(key)
+        if ancestor_bin is not None:
+            rc = run_bench(
+                ancestor_bin,
+                ["--save-baseline", BASELINE],
+                env,
+                target_home,
+                "ancestor",
             )
-        except subprocess.CalledProcessError as e:
-            print(f"^^^ +++ {target.package}/{target.name} failed with {e.returncode}")
-            failures.append(TargetFailure(target, e.returncode))
-    return failures
-
-
-def run_ancestor(
-    ancestor: str,
-    packages: list[str],
-    env: dict[str, str],
-) -> list[TargetFailure]:
-    """Build and bench every target at `ancestor` in a scratch worktree. Returns the failures."""
-    worktree = Path(tempfile.mkdtemp(prefix="cargo-bench-ancestor-"))
-    added = False
-    try:
-        # A cancelled or timed-out job destroys the container's /tmp worktree
-        # before the `finally` block below runs to remove it, and CI agents
-        # reuse their checkout across jobs, so stale registrations would
-        # otherwise accumulate in `.git/worktrees`.
-        spawn.runv(["git", "worktree", "prune"], cwd=MZ_ROOT)
-        # `git worktree add` can fail on a bad ancestor ref, in which case
-        # there is no worktree to remove, only the scratch directory to clean up.
-        spawn.runv(
-            ["git", "worktree", "add", "--detach", str(worktree), ancestor],
-            cwd=MZ_ROOT,
+            if rc is not None:
+                ancestor_failures.append(TargetFailure(ancestor_target_by_key[key], rc))
+            # Criterion's --save-baseline leaves a `new/` copy of the
+            # ancestor run behind in addition to the baseline it saves. An id
+            # absent at HEAD would otherwise keep that copy and get reported
+            # as a HEAD result carrying the ancestor's numbers. Criterion
+            # recreates `new/` on the HEAD run and only reads
+            # `ancestor/estimates.json` and `ancestor/sample.json` for
+            # comparison, so removing it here is safe.
+            for d in target_home.rglob("new"):
+                if d.is_dir():
+                    shutil.rmtree(d)
+        rc = run_bench(
+            head_bin, ["--baseline-lenient", BASELINE], env, target_home, "current"
         )
-        added = True
-        targets = load_targets(worktree, packages)
-        return run_targets(targets, worktree, env, ["--save-baseline", BASELINE])
-    finally:
-        if added:
-            try:
-                spawn.runv(
-                    ["git", "worktree", "remove", "--force", str(worktree)],
-                    cwd=MZ_ROOT,
-                )
-            except subprocess.CalledProcessError as e:
-                # A failing remove must not mask an in-flight exception from
-                # the try block above.
-                print(f"^^^ +++ removing worktree {worktree} failed: {e}")
-        shutil.rmtree(worktree, ignore_errors=True)
+        if rc is not None:
+            current_failures.append(TargetFailure(head_target_by_key[key], rc))
+    return ancestor_failures, current_failures
 
 
 def render_report(
@@ -212,8 +282,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if args.skip_ancestor and args.ancestor:
         parser.error("--ancestor has no effect with --skip-ancestor")
 
-    current_targets = load_targets(MZ_ROOT, args.package)
-    if not current_targets:
+    head_targets, head_manifests = load_targets(MZ_ROOT, args.package)
+    if not head_targets:
         raise RuntimeError("no bench targets found")
 
     criterion_home = target_dir() / "criterion-compare"
@@ -221,37 +291,77 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     # comparison target, so start from an empty directory every time.
     shutil.rmtree(criterion_home, ignore_errors=True)
     criterion_home.mkdir(parents=True)
-    env = dict(
-        os.environ,
-        CARGO_TARGET_DIR=str(target_dir()),
-        CRITERION_HOME=str(criterion_home),
-    )
+    env = dict(os.environ, CARGO_TARGET_DIR=str(target_dir()))
     # Persist's test storage configs panic under CI when no external Postgres
     # or S3 endpoint is configured. This step measures code, not network
     # storage, so the benches run as they do locally and skip those variants.
     env.pop("CI", None)
 
     ancestor: str | None = None
-    ancestor_failures: list[TargetFailure] = []
-    if not args.skip_ancestor:
+    if args.skip_ancestor:
+        head_built, current_build_failures = build_benches(
+            MZ_ROOT, head_targets, head_manifests, env
+        )
+        ancestor_run_failures, current_run_failures = run_benches(
+            head_built, [], head_targets, [], env, criterion_home
+        )
+        ancestor_failures = ancestor_run_failures
+        current_failures = current_build_failures + current_run_failures
+    else:
         ancestor = args.ancestor or resolve_ancestor()
         assert ancestor is not None
         print(f"--- Comparing against ancestor {ancestor}")
-        ancestor_failures = run_ancestor(ancestor, args.package, env)
-
-        # Criterion's --save-baseline leaves a `new/` copy of the ancestor
-        # run behind in addition to the baseline it saves. An id absent at
-        # HEAD would otherwise keep that copy and get reported as a HEAD
-        # result carrying the ancestor's numbers. Criterion recreates `new/`
-        # on the HEAD run and only reads `ancestor/estimates.json` and
-        # `ancestor/sample.json` for comparison, so removing it here is safe.
-        for d in criterion_home.rglob("new"):
-            if d.is_dir():
-                shutil.rmtree(d)
-
-    current_failures = run_targets(
-        current_targets, MZ_ROOT, env, ["--baseline-lenient", BASELINE]
-    )
+        worktree = Path(tempfile.mkdtemp(prefix="cargo-bench-ancestor-"))
+        added = False
+        try:
+            # A cancelled or timed-out job destroys the container's /tmp
+            # worktree before the `finally` block below runs to remove it,
+            # and CI agents reuse their checkout across jobs, so stale
+            # registrations would otherwise accumulate in `.git/worktrees`.
+            spawn.runv(["git", "worktree", "prune"], cwd=MZ_ROOT)
+            # `git worktree add` can fail on a bad ancestor ref, in which
+            # case there is no worktree to remove, only the scratch
+            # directory to clean up.
+            spawn.runv(
+                ["git", "worktree", "add", "--detach", str(worktree), ancestor],
+                cwd=MZ_ROOT,
+            )
+            added = True
+            ancestor_targets, ancestor_manifests = load_targets(worktree, args.package)
+            # Building ancestor before HEAD lets both build phases run at
+            # full core parallelism back to back, then the run phase below
+            # benchmarks matching targets ancestor then HEAD while the
+            # worktree the ancestor binaries were compiled against is still
+            # present. Bench binaries read fixtures relative to their
+            # manifest dir, so the worktree must outlive the run phase.
+            ancestor_built, ancestor_build_failures = build_benches(
+                worktree, ancestor_targets, ancestor_manifests, env
+            )
+            head_built, current_build_failures = build_benches(
+                MZ_ROOT, head_targets, head_manifests, env
+            )
+            ancestor_run_failures, current_run_failures = run_benches(
+                head_built,
+                ancestor_built,
+                head_targets,
+                ancestor_targets,
+                env,
+                criterion_home,
+            )
+            ancestor_failures = ancestor_build_failures + ancestor_run_failures
+            current_failures = current_build_failures + current_run_failures
+        finally:
+            if added:
+                try:
+                    spawn.runv(
+                        ["git", "worktree", "remove", "--force", str(worktree)],
+                        cwd=MZ_ROOT,
+                    )
+                except subprocess.CalledProcessError as e:
+                    # A failing remove must not mask an in-flight exception
+                    # from the try block above.
+                    print(f"^^^ +++ removing worktree {worktree} failed: {e}")
+            shutil.rmtree(worktree, ignore_errors=True)
 
     report = compare(criterion_home, args.threshold)
     markdown = render_report(

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -66,9 +66,7 @@ def target_dir() -> Path:
 
 def load_targets(cwd: Path, packages: list[str]) -> list[BenchTarget]:
     metadata = json.loads(
-        spawn.capture(
-            ["cargo", "metadata", "--no-deps", "--format-version=1"], cwd=cwd
-        )
+        spawn.capture(["cargo", "metadata", "--no-deps", "--format-version=1"], cwd=cwd)
     )
     targets = bench_targets(metadata)
     if packages:
@@ -105,14 +103,10 @@ def run_ancestor(
     )
     try:
         targets = load_targets(worktree, packages)
-        failures = run_targets(
-            targets, worktree, env, ["--save-baseline", BASELINE]
-        )
+        failures = run_targets(targets, worktree, env, ["--save-baseline", BASELINE])
         return targets, failures
     finally:
-        spawn.runv(
-            ["git", "worktree", "remove", "--force", str(worktree)], cwd=MZ_ROOT
-        )
+        spawn.runv(["git", "worktree", "remove", "--force", str(worktree)], cwd=MZ_ROOT)
 
 
 def render_report(
@@ -124,7 +118,9 @@ def render_report(
 ) -> str:
     sections = []
     if ancestor is not None:
-        sections.append(f"Ancestor: `{ancestor}`, regression threshold: {threshold:.0%}")
+        sections.append(
+            f"Ancestor: `{ancestor}`, regression threshold: {threshold:.0%}"
+        )
     else:
         sections.append("Ancestor run skipped, no comparison performed")
     if current_failures:
@@ -187,9 +183,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ancestor: str | None = None
     ancestor_failures: list[TargetFailure] = []
     if not args.skip_ancestor:
-        ancestor = args.ancestor or resolve_ancestor()
-        print(f"--- Comparing against ancestor {ancestor}")
-        _, ancestor_failures = run_ancestor(ancestor, args.package, env)
+        # Annotated `str`, not `str | None`: `args.ancestor` is `Any`, and
+        # assigning an `Any` value into `ancestor` would otherwise narrow to
+        # its declared `str | None`, which `run_ancestor` below rejects.
+        resolved_ancestor: str = args.ancestor or resolve_ancestor()
+        ancestor = resolved_ancestor
+        print(f"--- Comparing against ancestor {resolved_ancestor}")
+        _, ancestor_failures = run_ancestor(resolved_ancestor, args.package, env)
 
     current_targets = load_targets(MZ_ROOT, args.package)
     if not current_targets:

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -433,8 +433,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     # Cargo derives a unit's hash from absolute paths, so the ancestor and
     # current checkouts must build at the same checkout path and the same
-    # target dir path for identical source to produce identical binaries;
-    # the identical-binary skip in `run_benches` depends on that. Both sides
+    # target dir path for identical source to produce identical binaries.
+    # The identical-binary skip in `run_benches` depends on that. Both sides
     # therefore build one after another at these fixed paths instead of at a
     # fresh temporary worktree each, and each side's target dir and checkout
     # are parked under a side-specific name between runs so cargo's caches
@@ -447,13 +447,20 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ancestor_src = root / "ancestor-src"
 
     # A cancelled or timed-out job can leave a previous run's worktrees
-    # registered and their directories in place; clear both before reusing
+    # registered and their directories in place. Clear both before reusing
     # the fixed paths.
     spawn.runv(["git", "worktree", "prune"], cwd=MZ_ROOT)
     for leftover in (src, ancestor_src):
         if leftover.exists():
             remove_worktree(leftover)
             shutil.rmtree(leftover, ignore_errors=True)
+    # A hard kill (OOM, SIGKILL) skips the `finally` below and can leave
+    # `target` populated with whichever side's build was in flight. Which
+    # side that was is no longer known, and the next rename onto this path
+    # would fail with the destination already existing, so discarding the
+    # cache is the only safe option.
+    if target.exists():
+        shutil.rmtree(target)
 
     ancestor: str | None = None
     ancestor_targets: list[BenchTarget] = []
@@ -500,7 +507,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 for b in ancestor_built_raw
             ]
 
-        # Only the committed HEAD is measured here; uncommitted local changes
+        # Only the committed HEAD is measured here. Uncommitted local changes
         # in MZ_ROOT are not part of the checkout built below.
         head = spawn.capture(["git", "rev-parse", "HEAD"], cwd=MZ_ROOT).strip()
         spawn.runv(["git", "worktree", "add", "--detach", str(src), head], cwd=MZ_ROOT)
@@ -531,13 +538,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         if args.skip_ancestor:
             ancestor_run_failures, current_run_failures, identical = run_benches(
-                head_built, [], head_targets, [], env, criterion_home
+                head_built, [], current_targets, [], env, criterion_home
             )
         else:
             ancestor_run_failures, current_run_failures, identical = run_benches(
                 head_built,
                 ancestor_built,
-                head_targets,
+                current_targets,
                 ancestor_targets,
                 env,
                 criterion_home,

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -1,0 +1,231 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""
+Runs every criterion benchmark at an ancestor commit and at the current commit,
+then fails when a benchmark regressed beyond a threshold.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from materialize import MZ_ROOT, buildkite, git, spawn
+from materialize.cargo_bench.compare import CompareReport, compare, render_markdown
+from materialize.cargo_bench.targets import (
+    BenchTarget,
+    bench_targets,
+    cargo_bench_args,
+)
+from materialize.mz_version import MzVersion
+from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+
+SERVICES = []
+
+BASELINE = "ancestor"
+
+REPORTS_ARTIFACT = "criterion-reports.tar.zst"
+
+
+@dataclass(frozen=True)
+class TargetFailure:
+    target: BenchTarget
+    returncode: int
+
+
+def resolve_ancestor() -> str:
+    """Pick the commit to compare against: the merge base in a pull request, else the latest release tag."""
+    if buildkite.is_in_pull_request():
+        return buildkite.get_merge_base()
+    current = MzVersion.parse_cargo()
+    # Release candidates carry a semver prerelease and would otherwise win
+    # over the release they precede.
+    releases = [
+        v
+        for v in git.get_version_tags(version_type=MzVersion)
+        if v.prerelease is None and v < current
+    ]
+    if not releases:
+        raise RuntimeError(f"no release tag older than {current} found")
+    return git.rev_parse(f"{max(releases)}^{{commit}}")
+
+
+def target_dir() -> Path:
+    return Path(os.getenv("CARGO_TARGET_DIR", str(MZ_ROOT / "target"))).absolute()
+
+
+def load_targets(cwd: Path, packages: list[str]) -> list[BenchTarget]:
+    metadata = json.loads(
+        spawn.capture(
+            ["cargo", "metadata", "--no-deps", "--format-version=1"], cwd=cwd
+        )
+    )
+    targets = bench_targets(metadata)
+    if packages:
+        targets = [t for t in targets if t.package in packages]
+    return targets
+
+
+def run_targets(
+    targets: list[BenchTarget],
+    cwd: Path,
+    env: dict[str, str],
+    criterion_args: list[str],
+) -> list[TargetFailure]:
+    """Run each target on its own so one failure does not take down the rest. Returns the failures."""
+    failures = []
+    for target in targets:
+        print(f"--- Benchmarking {target.package}/{target.name} in {cwd}")
+        try:
+            spawn.runv(cargo_bench_args(target, criterion_args), cwd=cwd, env=env)
+        except subprocess.CalledProcessError as e:
+            print(f"^^^ +++ {target.package}/{target.name} failed with {e.returncode}")
+            failures.append(TargetFailure(target, e.returncode))
+    return failures
+
+
+def run_ancestor(
+    ancestor: str,
+    packages: list[str],
+    env: dict[str, str],
+) -> tuple[list[BenchTarget], list[TargetFailure]]:
+    worktree = Path(tempfile.mkdtemp(prefix="cargo-bench-ancestor-"))
+    spawn.runv(
+        ["git", "worktree", "add", "--detach", str(worktree), ancestor], cwd=MZ_ROOT
+    )
+    try:
+        targets = load_targets(worktree, packages)
+        failures = run_targets(
+            targets, worktree, env, ["--save-baseline", BASELINE]
+        )
+        return targets, failures
+    finally:
+        spawn.runv(
+            ["git", "worktree", "remove", "--force", str(worktree)], cwd=MZ_ROOT
+        )
+
+
+def render_report(
+    ancestor: str | None,
+    threshold: float,
+    report: CompareReport,
+    ancestor_failures: list[TargetFailure],
+    current_failures: list[TargetFailure],
+) -> str:
+    sections = []
+    if ancestor is not None:
+        sections.append(f"Ancestor: `{ancestor}`, regression threshold: {threshold:.0%}")
+    else:
+        sections.append("Ancestor run skipped, no comparison performed")
+    if current_failures:
+        sections.append(
+            "Bench targets failing on the current commit:\n"
+            + "\n".join(
+                f"* `{f.target.package}/{f.target.name}` exited with {f.returncode}"
+                for f in current_failures
+            )
+        )
+    if ancestor_failures:
+        sections.append(
+            "Bench targets skipped on the ancestor (their benchmarks show as new):\n"
+            + "\n".join(
+                f"* `{f.target.package}/{f.target.name}` exited with {f.returncode}"
+                for f in ancestor_failures
+            )
+        )
+    if report.warnings:
+        sections.append("Warnings:\n" + "\n".join(f"* {w}" for w in report.warnings))
+    sections.append(render_markdown(report))
+    return "\n\n".join(sections)
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    parser.add_argument(
+        "--ancestor",
+        help="commit to compare against, defaults to the merge base in a PR and the latest release tag otherwise",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.10,
+        help="relative mean slowdown that counts as a regression",
+    )
+    parser.add_argument(
+        "--package",
+        action="append",
+        default=[],
+        help="only run bench targets of this package, repeatable",
+    )
+    parser.add_argument(
+        "--skip-ancestor",
+        action="store_true",
+        help="run only the current commit, no comparison",
+    )
+    args = parser.parse_args()
+
+    criterion_home = target_dir() / "criterion-compare"
+    # Stale baselines from an earlier run would silently become the
+    # comparison target, so start from an empty directory every time.
+    shutil.rmtree(criterion_home, ignore_errors=True)
+    criterion_home.mkdir(parents=True)
+    env = dict(
+        os.environ,
+        CARGO_TARGET_DIR=str(target_dir()),
+        CRITERION_HOME=str(criterion_home),
+    )
+
+    ancestor: str | None = None
+    ancestor_failures: list[TargetFailure] = []
+    if not args.skip_ancestor:
+        ancestor = args.ancestor or resolve_ancestor()
+        print(f"--- Comparing against ancestor {ancestor}")
+        _, ancestor_failures = run_ancestor(ancestor, args.package, env)
+
+    current_targets = load_targets(MZ_ROOT, args.package)
+    if not current_targets:
+        raise RuntimeError("no bench targets found")
+    current_failures = run_targets(
+        current_targets, MZ_ROOT, env, ["--baseline-lenient", BASELINE]
+    )
+
+    report = compare(criterion_home, args.threshold)
+    markdown = render_report(
+        ancestor, args.threshold, report, ancestor_failures, current_failures
+    )
+    print(markdown)
+
+    failed = report.has_regressions or bool(current_failures)
+    if buildkite.is_in_buildkite():
+        buildkite.add_annotation(
+            "error" if failed else "info", "Cargo bench results", markdown
+        )
+        spawn.runv(
+            [
+                "tar",
+                "-caf",
+                REPORTS_ARTIFACT,
+                "-C",
+                str(criterion_home.parent),
+                criterion_home.name,
+            ],
+            cwd=MZ_ROOT,
+        )
+        buildkite.upload_artifact(REPORTS_ARTIFACT, cwd=MZ_ROOT)
+
+    if current_failures:
+        raise RuntimeError(
+            f"{len(current_failures)} bench target(s) failed on the current commit"
+        )
+    if report.has_regressions:
+        regressions = [r.id for r in report.results if r.verdict.value == "regression"]
+        raise RuntimeError(f"benchmark regressions: {', '.join(regressions)}")

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -106,6 +106,10 @@ def build_benches(
     makes recompiling the targets that already succeeded cheap.
     """
     print(f"--- Building {len(targets)} bench targets in {cwd}")
+    if not targets:
+        # An unrestricted `cargo bench --no-run` would build every bench
+        # target in the whole workspace instead of nothing.
+        return [], []
     try:
         output = spawn.capture(cargo_build_args(targets), cwd=cwd, env=env)
         return bench_executables(output.splitlines(), manifests), []

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -79,11 +79,13 @@ def target_dir() -> Path:
 
 
 def load_targets(
-    cwd: Path, packages: list[str]
+    cwd: Path, packages: list[str], env: dict[str, str] | None = None
 ) -> tuple[list[BenchTarget], dict[str, str]]:
     """Enumerate bench targets and package manifest paths for one checkout via `cargo metadata`."""
     metadata = json.loads(
-        spawn.capture(["cargo", "metadata", "--no-deps", "--format-version=1"], cwd=cwd)
+        spawn.capture(
+            ["cargo", "metadata", "--no-deps", "--format-version=1"], cwd=cwd, env=env
+        )
     )
     targets = bench_targets(metadata)
     if packages:
@@ -197,6 +199,11 @@ def run_benches(
         target_home = criterion_home / head_bin.package / head_bin.name
         ancestor_bin = ancestor_by_key.get(key)
         if ancestor_bin is not None:
+            if ancestor_bin.executable == head_bin.executable:
+                raise RuntimeError(
+                    f"{head_bin.package}/{head_bin.name}: ancestor and current bench "
+                    f"binaries resolve to the same file {head_bin.executable}"
+                )
             rc = run_bench(
                 ancestor_bin,
                 ["--save-baseline", BASELINE],
@@ -331,7 +338,21 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 cwd=MZ_ROOT,
             )
             added = True
-            ancestor_targets, ancestor_manifests = load_targets(worktree, args.package)
+            # Cargo hashes workspace members by their path relative to the
+            # workspace root, so the ancestor worktree and the HEAD checkout,
+            # being two copies of the same workspace at different paths,
+            # would alias each other's units and fingerprints in a shared
+            # target dir. That is what let a build script binary compiled for
+            # the ancestor worktree's manifest directory get reused when
+            # building HEAD, and it failed once the ancestor worktree was
+            # removed. Building the ancestor into its own target dir avoids
+            # the aliasing.
+            ancestor_env = dict(
+                env, CARGO_TARGET_DIR=str(target_dir() / "cargo-bench-ancestor")
+            )
+            ancestor_targets, ancestor_manifests = load_targets(
+                worktree, args.package, ancestor_env
+            )
             # Building ancestor before HEAD lets both build phases run at
             # full core parallelism back to back, then the run phase below
             # benchmarks matching targets ancestor then HEAD while the
@@ -339,7 +360,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             # present. Bench binaries read fixtures relative to their
             # manifest dir, so the worktree must outlive the run phase.
             ancestor_built, ancestor_build_failures = build_benches(
-                worktree, ancestor_targets, ancestor_manifests, env
+                worktree, ancestor_targets, ancestor_manifests, ancestor_env
             )
             head_built, current_build_failures = build_benches(
                 MZ_ROOT, head_targets, head_manifests, env

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -21,7 +21,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from materialize import MZ_ROOT, buildkite, git, spawn
-from materialize.cargo_bench.compare import CompareReport, compare, render_markdown
+from materialize.cargo_bench.compare import (
+    CompareReport,
+    Verdict,
+    compare,
+    render_markdown,
+)
 from materialize.cargo_bench.targets import (
     BenchTarget,
     bench_targets,
@@ -61,7 +66,13 @@ def resolve_ancestor() -> str:
 
 
 def target_dir() -> Path:
-    return Path(os.getenv("CARGO_TARGET_DIR", str(MZ_ROOT / "target"))).absolute()
+    """Resolve `CARGO_TARGET_DIR`, defaulting to `<MZ_ROOT>/target`.
+
+    A relative override is resolved against `MZ_ROOT`, not the process cwd,
+    since mzcompose workflows can be invoked from any directory.
+    """
+    value = Path(os.getenv("CARGO_TARGET_DIR", str(MZ_ROOT / "target")))
+    return value if value.is_absolute() else MZ_ROOT / value
 
 
 def load_targets(cwd: Path, packages: list[str]) -> list[BenchTarget]:
@@ -82,10 +93,20 @@ def run_targets(
 ) -> list[TargetFailure]:
     """Run each target on its own so one failure does not take down the rest. Returns the failures."""
     failures = []
+    base_criterion_home = Path(env["CRITERION_HOME"])
     for target in targets:
         print(f"--- Benchmarking {target.package}/{target.name} in {cwd}")
+        # Benchmark ids are only unique within a target, so a collision
+        # across targets sharing one criterion home would silently merge two
+        # unrelated benchmarks.
+        target_env = dict(
+            env,
+            CRITERION_HOME=str(base_criterion_home / target.package / target.name),
+        )
         try:
-            spawn.runv(cargo_bench_args(target, criterion_args), cwd=cwd, env=env)
+            spawn.runv(
+                cargo_bench_args(target, criterion_args), cwd=cwd, env=target_env
+            )
         except subprocess.CalledProcessError as e:
             print(f"^^^ +++ {target.package}/{target.name} failed with {e.returncode}")
             failures.append(TargetFailure(target, e.returncode))
@@ -96,10 +117,16 @@ def run_ancestor(
     ancestor: str,
     packages: list[str],
     env: dict[str, str],
-) -> tuple[list[BenchTarget], list[TargetFailure]]:
+) -> list[TargetFailure]:
+    """Build and bench every target at `ancestor` in a scratch worktree. Returns the failures."""
     worktree = Path(tempfile.mkdtemp(prefix="cargo-bench-ancestor-"))
     added = False
     try:
+        # A cancelled or timed-out job destroys the container's /tmp worktree
+        # before the `finally` block below runs to remove it, and CI agents
+        # reuse their checkout across jobs, so stale registrations would
+        # otherwise accumulate in `.git/worktrees`.
+        spawn.runv(["git", "worktree", "prune"], cwd=MZ_ROOT)
         # `git worktree add` can fail on a bad ancestor ref, in which case
         # there is no worktree to remove, only the scratch directory to clean up.
         spawn.runv(
@@ -108,13 +135,18 @@ def run_ancestor(
         )
         added = True
         targets = load_targets(worktree, packages)
-        failures = run_targets(targets, worktree, env, ["--save-baseline", BASELINE])
-        return targets, failures
+        return run_targets(targets, worktree, env, ["--save-baseline", BASELINE])
     finally:
         if added:
-            spawn.runv(
-                ["git", "worktree", "remove", "--force", str(worktree)], cwd=MZ_ROOT
-            )
+            try:
+                spawn.runv(
+                    ["git", "worktree", "remove", "--force", str(worktree)],
+                    cwd=MZ_ROOT,
+                )
+            except subprocess.CalledProcessError as e:
+                # A failing remove must not mask an in-flight exception from
+                # the try block above.
+                print(f"^^^ +++ removing worktree {worktree} failed: {e}")
         shutil.rmtree(worktree, ignore_errors=True)
 
 
@@ -177,6 +209,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="run only the current commit, no comparison",
     )
     args = parser.parse_args()
+    if args.skip_ancestor and args.ancestor:
+        parser.error("--ancestor has no effect with --skip-ancestor")
+
+    current_targets = load_targets(MZ_ROOT, args.package)
+    if not current_targets:
+        raise RuntimeError("no bench targets found")
 
     criterion_home = target_dir() / "criterion-compare"
     # Stale baselines from an earlier run would silently become the
@@ -195,11 +233,18 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         ancestor = args.ancestor or resolve_ancestor()
         assert ancestor is not None
         print(f"--- Comparing against ancestor {ancestor}")
-        _, ancestor_failures = run_ancestor(ancestor, args.package, env)
+        ancestor_failures = run_ancestor(ancestor, args.package, env)
 
-    current_targets = load_targets(MZ_ROOT, args.package)
-    if not current_targets:
-        raise RuntimeError("no bench targets found")
+        # Criterion's --save-baseline leaves a `new/` copy of the ancestor
+        # run behind in addition to the baseline it saves. An id absent at
+        # HEAD would otherwise keep that copy and get reported as a HEAD
+        # result carrying the ancestor's numbers. Criterion recreates `new/`
+        # on the HEAD run and only reads `ancestor/estimates.json` and
+        # `ancestor/sample.json` for comparison, so removing it here is safe.
+        for d in criterion_home.rglob("new"):
+            if d.is_dir():
+                shutil.rmtree(d)
+
     current_failures = run_targets(
         current_targets, MZ_ROOT, env, ["--baseline-lenient", BASELINE]
     )
@@ -228,6 +273,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 cwd=MZ_ROOT,
             )
             buildkite.upload_artifact(REPORTS_ARTIFACT, cwd=MZ_ROOT)
+            (MZ_ROOT / REPORTS_ARTIFACT).unlink(missing_ok=True)
         except subprocess.CalledProcessError as e:
             print(f"^^^ +++ uploading criterion reports failed: {e}")
 
@@ -236,5 +282,5 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             f"{len(current_failures)} bench target(s) failed on the current commit"
         )
     if report.has_regressions:
-        regressions = [r.id for r in report.results if r.verdict.value == "regression"]
+        regressions = [r.id for r in report.results if r.verdict == Verdict.REGRESSION]
         raise RuntimeError(f"benchmark regressions: {', '.join(regressions)}")

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -169,8 +169,8 @@ def run_bench(
         return e.returncode
 
 
-def loaded_image_digest(executable: Path, scratch: Path) -> str:
-    """Return the sha256 hex digest of the bytes a loader actually maps for `executable`.
+def loaded_image_digest(executable: Path, scratch: Path) -> str | None:
+    """Return the sha256 hex digest of the bytes a loader actually maps for `executable`, or `None` if `strip` fails.
 
     Two builds of identical source from different checkouts still differ in
     debug info, symbol names, the build-id note, and `.comment` (compiler and
@@ -179,22 +179,27 @@ def loaded_image_digest(executable: Path, scratch: Path) -> str:
     those out before hashing judges identity on the loaded program rather
     than on incidental build-environment bytes. `--strip-all` removes symbol
     tables and debug info but leaves `.comment` behind, so it is named
-    explicitly.
+    explicitly. A `None` return means "unknown", not "identical": the caller
+    must never treat two `None`s as a match, or a broken `strip` would skip
+    every benchmark instead of running them.
     """
     stripped = scratch / executable.name
-    spawn.runv(
-        [
-            "strip",
-            "--strip-all",
-            "--remove-section=.note.gnu.build-id",
-            "--remove-section=.comment",
-            "-o",
-            str(stripped),
-            str(executable),
-        ]
-    )
     try:
+        spawn.runv(
+            [
+                "strip",
+                "--strip-all",
+                "--remove-section=.note.gnu.build-id",
+                "--remove-section=.comment",
+                "-o",
+                str(stripped),
+                str(executable),
+            ]
+        )
         return hashlib.sha256(stripped.read_bytes()).hexdigest()
+    except subprocess.CalledProcessError as e:
+        print(f"^^^ +++ stripping {executable} failed: {e}")
+        return None
     finally:
         stripped.unlink(missing_ok=True)
 
@@ -246,15 +251,19 @@ def run_benches(
             # false regression from shared CI hardware.
             ancestor_digest = loaded_image_digest(ancestor_bin.executable, scratch)
             head_digest = loaded_image_digest(head_bin.executable, scratch)
-            if ancestor_digest == head_digest:
+            if (
+                ancestor_digest is not None
+                and head_digest is not None
+                and ancestor_digest == head_digest
+            ):
                 print(
                     f"--- Skipping {head_bin.package}/{head_bin.name}: identical binaries"
                 )
                 identical.append(head_bin)
                 continue
-            header_suffix = (
-                f" ancestor={ancestor_digest[:12]} current={head_digest[:12]}"
-            )
+            ancestor_label = ancestor_digest[:12] if ancestor_digest else "unknown"
+            head_label = head_digest[:12] if head_digest else "unknown"
+            header_suffix = f" ancestor={ancestor_label} current={head_label}"
             rc = run_bench(
                 ancestor_bin,
                 ["--save-baseline", BASELINE],

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -297,6 +297,16 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if not head_targets:
         raise RuntimeError("no bench targets found")
 
+    packages = sorted({t.package for t in head_targets})
+    # Sharding by package rather than by target keeps each shard to one
+    # dependency closure per checkout.
+    shard_packages = buildkite.shard_list(packages, lambda p: p)
+    if not shard_packages:
+        print("--- No bench packages assigned to this shard")
+        return
+    print(f"--- Bench packages in this shard: {', '.join(shard_packages)}")
+    head_targets = [t for t in head_targets if t.package in shard_packages]
+
     criterion_home = target_dir() / "criterion-compare"
     # Stale baselines from an earlier run would silently become the
     # comparison target, so start from an empty directory every time.
@@ -351,7 +361,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 env, CARGO_TARGET_DIR=str(target_dir() / "cargo-bench-ancestor")
             )
             ancestor_targets, ancestor_manifests = load_targets(
-                worktree, args.package, ancestor_env
+                worktree, shard_packages, ancestor_env
             )
             # Building ancestor before HEAD lets both build phases run at
             # full core parallelism back to back, then the run phase below
@@ -397,7 +407,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     failed = report.has_regressions or bool(current_failures)
     if buildkite.is_in_buildkite():
         buildkite.add_annotation(
-            "error" if failed else "info", "Cargo bench results", markdown
+            "error" if failed else "info",
+            f"Cargo bench results ({', '.join(shard_packages)})",
+            markdown,
         )
         try:
             spawn.runv(

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -426,7 +426,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     # unless SOURCE_DATE_EPOCH is set, and a timestamp difference alone would
     # defeat the identical-binary skip below even when the compiled source is
     # otherwise byte-for-byte the same between the ancestor and current build.
-    env["SOURCE_DATE_EPOCH"] = "0"
+    # The value must not be "0": the OpenSSL version this workspace resolves
+    # reads it with Perl's `||`, which treats the string "0" as false and
+    # falls back to the real time, so any other fixed non-zero value is used.
+    env["SOURCE_DATE_EPOCH"] = "1"
 
     # Cargo derives a unit's hash from absolute paths, so the ancestor and
     # current checkouts must build at the same checkout path and the same

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -226,6 +226,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         CARGO_TARGET_DIR=str(target_dir()),
         CRITERION_HOME=str(criterion_home),
     )
+    # Persist's test storage configs panic under CI when no external Postgres
+    # or S3 endpoint is configured. This step measures code, not network
+    # storage, so the benches run as they do locally and skip those variants.
+    env.pop("CI", None)
 
     ancestor: str | None = None
     ancestor_failures: list[TargetFailure] = []

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -10,6 +10,14 @@
 """
 Runs every criterion benchmark at an ancestor commit and at the current commit,
 then fails when a benchmark regressed beyond a threshold.
+
+The ancestor and current checkouts both build at the same fixed checkout path
+and the same fixed `CARGO_TARGET_DIR`, one after the other, because cargo
+derives a unit's hash from absolute paths and two builds at different paths
+produce different bytes even from identical source. Locally this means the
+current-commit build does not reuse the developer's own `target/` cache; the
+first run compiles it from scratch into a parked target dir and later runs
+reuse that.
 """
 
 import hashlib
@@ -17,7 +25,6 @@ import json
 import os
 import shutil
 import subprocess
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -77,6 +84,29 @@ def target_dir() -> Path:
     """
     value = Path(os.getenv("CARGO_TARGET_DIR", str(MZ_ROOT / "target")))
     return value if value.is_absolute() else MZ_ROOT / value
+
+
+def cargo_bench_dir() -> Path:
+    """Directory holding every checkout and target dir this workflow builds at.
+
+    It sits under `target_dir()` so parking a target dir between runs (a
+    rename between `target` and `ancestor-target` or `current-target`) stays
+    on one filesystem instead of copying.
+    """
+    return target_dir() / "cargo-bench"
+
+
+def remove_worktree(path: Path) -> None:
+    """Remove the git worktree at `path`, tolerating and logging failure.
+
+    Used both for leftover cleanup from a crashed prior run, where `path` may
+    not be a registered worktree at all, and in a `finally` block, where a
+    failure here must not mask an exception already in flight.
+    """
+    try:
+        spawn.runv(["git", "worktree", "remove", "--force", str(path)], cwd=MZ_ROOT)
+    except subprocess.CalledProcessError as e:
+        print(f"^^^ +++ removing worktree {path} failed: {e}")
 
 
 def load_targets(
@@ -364,7 +394,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if args.skip_ancestor and args.ancestor:
         parser.error("--ancestor has no effect with --skip-ancestor")
 
-    head_targets, head_manifests = load_targets(MZ_ROOT, args.package)
+    # Manifests are re-enumerated from `src` below, once the checkout that
+    # will actually be built exists at its fixed path, so cargo's build
+    # output (which reports manifest paths under that checkout) can be
+    # resolved back to package names.
+    head_targets, _ = load_targets(MZ_ROOT, args.package)
     if not head_targets:
         raise RuntimeError("no bench targets found")
 
@@ -389,63 +423,109 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     # storage, so the benches run as they do locally and skip those variants.
     env.pop("CI", None)
 
+    # Cargo derives a unit's hash from absolute paths, so the ancestor and
+    # current checkouts must build at the same checkout path and the same
+    # target dir path for identical source to produce identical binaries;
+    # the identical-binary skip in `run_benches` depends on that. Both sides
+    # therefore build one after another at these fixed paths instead of at a
+    # fresh temporary worktree each, and each side's target dir and checkout
+    # are parked under a side-specific name between runs so cargo's caches
+    # and the ancestor's fixtures survive across invocations of this workflow.
+    root = cargo_bench_dir()
+    src = root / "src"
+    target = root / "target"
+    ancestor_target = root / "ancestor-target"
+    current_target = root / "current-target"
+    ancestor_src = root / "ancestor-src"
+
+    # A cancelled or timed-out job can leave a previous run's worktrees
+    # registered and their directories in place; clear both before reusing
+    # the fixed paths.
+    spawn.runv(["git", "worktree", "prune"], cwd=MZ_ROOT)
+    for leftover in (src, ancestor_src):
+        if leftover.exists():
+            remove_worktree(leftover)
+            shutil.rmtree(leftover, ignore_errors=True)
+
     ancestor: str | None = None
-    if args.skip_ancestor:
-        head_built, current_build_failures = build_benches(
-            MZ_ROOT, head_targets, head_manifests, env
-        )
-        ancestor_run_failures, current_run_failures, identical = run_benches(
-            head_built, [], head_targets, [], env, criterion_home
-        )
-        ancestor_failures = ancestor_run_failures
-        current_failures = current_build_failures + current_run_failures
-    else:
-        ancestor = args.ancestor or resolve_ancestor()
-        assert ancestor is not None
-        print(f"--- Comparing against ancestor {ancestor}")
-        worktree = Path(tempfile.mkdtemp(prefix="cargo-bench-ancestor-"))
-        added = False
-        try:
-            # A cancelled or timed-out job destroys the container's /tmp
-            # worktree before the `finally` block below runs to remove it,
-            # and CI agents reuse their checkout across jobs, so stale
-            # registrations would otherwise accumulate in `.git/worktrees`.
-            spawn.runv(["git", "worktree", "prune"], cwd=MZ_ROOT)
-            # `git worktree add` can fail on a bad ancestor ref, in which
-            # case there is no worktree to remove, only the scratch
-            # directory to clean up.
+    ancestor_targets: list[BenchTarget] = []
+    ancestor_built: list[BuiltBench] = []
+    ancestor_build_failures: list[TargetFailure] = []
+    # Tracks which parked target dir currently owns `target`, so the
+    # `finally` below can park it back even if a build raises partway through.
+    target_owner: str | None = None
+    try:
+        if not args.skip_ancestor:
+            ancestor = args.ancestor or resolve_ancestor()
+            assert ancestor is not None
+            print(f"--- Comparing against ancestor {ancestor}")
             spawn.runv(
-                ["git", "worktree", "add", "--detach", str(worktree), ancestor],
+                ["git", "worktree", "add", "--detach", str(src), ancestor],
                 cwd=MZ_ROOT,
             )
-            added = True
-            # Cargo hashes workspace members by their path relative to the
-            # workspace root, so the ancestor worktree and the HEAD checkout,
-            # being two copies of the same workspace at different paths,
-            # would alias each other's units and fingerprints in a shared
-            # target dir. That is what let a build script binary compiled for
-            # the ancestor worktree's manifest directory get reused when
-            # building HEAD, and it failed once the ancestor worktree was
-            # removed. Building the ancestor into its own target dir avoids
-            # the aliasing.
-            ancestor_env = dict(
-                env, CARGO_TARGET_DIR=str(target_dir() / "cargo-bench-ancestor")
-            )
+            if ancestor_target.exists():
+                ancestor_target.rename(target)
+            target_owner = "ancestor"
+            ancestor_env = dict(env, CARGO_TARGET_DIR=str(target))
             ancestor_targets, ancestor_manifests = load_targets(
-                worktree, shard_packages, ancestor_env
+                src, shard_packages, ancestor_env
             )
-            # Building ancestor before HEAD lets both build phases run at
-            # full core parallelism back to back, then the run phase below
-            # benchmarks matching targets ancestor then HEAD while the
-            # worktree the ancestor binaries were compiled against is still
-            # present. Bench binaries read fixtures relative to their
-            # manifest dir, so the worktree must outlive the run phase.
-            ancestor_built, ancestor_build_failures = build_benches(
-                worktree, ancestor_targets, ancestor_manifests, ancestor_env
+            ancestor_built_raw, ancestor_build_failures = build_benches(
+                src, ancestor_targets, ancestor_manifests, ancestor_env
             )
-            head_built, current_build_failures = build_benches(
-                MZ_ROOT, head_targets, head_manifests, env
+            target.rename(ancestor_target)
+            target_owner = None
+            # Keeps the checkout registered and valid so its bench binaries,
+            # which read fixtures relative to their manifest dir, keep
+            # running against those fixtures once `src` is reused below.
+            spawn.runv(
+                ["git", "worktree", "move", str(src), str(ancestor_src)],
+                cwd=MZ_ROOT,
             )
+            ancestor_built = [
+                BuiltBench(
+                    package=b.package,
+                    name=b.name,
+                    executable=ancestor_target / b.executable.relative_to(target),
+                    manifest_dir=ancestor_src / b.manifest_dir.relative_to(src),
+                )
+                for b in ancestor_built_raw
+            ]
+
+        # Only the committed HEAD is measured here; uncommitted local changes
+        # in MZ_ROOT are not part of the checkout built below.
+        head = spawn.capture(["git", "rev-parse", "HEAD"], cwd=MZ_ROOT).strip()
+        spawn.runv(["git", "worktree", "add", "--detach", str(src), head], cwd=MZ_ROOT)
+        if current_target.exists():
+            current_target.rename(target)
+        target_owner = "current"
+        current_env = dict(env, CARGO_TARGET_DIR=str(target))
+        # Enumerated from `src`, not MZ_ROOT, so the manifest paths this
+        # returns match the paths cargo reports for the build below, even
+        # though both are the same commit.
+        current_targets, current_manifests = load_targets(
+            src, shard_packages, current_env
+        )
+        head_built_raw, current_build_failures = build_benches(
+            src, current_targets, current_manifests, current_env
+        )
+        target.rename(current_target)
+        target_owner = None
+        head_built = [
+            BuiltBench(
+                package=b.package,
+                name=b.name,
+                executable=current_target / b.executable.relative_to(target),
+                manifest_dir=b.manifest_dir,
+            )
+            for b in head_built_raw
+        ]
+
+        if args.skip_ancestor:
+            ancestor_run_failures, current_run_failures, identical = run_benches(
+                head_built, [], head_targets, [], env, criterion_home
+            )
+        else:
             ancestor_run_failures, current_run_failures, identical = run_benches(
                 head_built,
                 ancestor_built,
@@ -454,20 +534,18 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 env,
                 criterion_home,
             )
-            ancestor_failures = ancestor_build_failures + ancestor_run_failures
-            current_failures = current_build_failures + current_run_failures
-        finally:
-            if added:
-                try:
-                    spawn.runv(
-                        ["git", "worktree", "remove", "--force", str(worktree)],
-                        cwd=MZ_ROOT,
-                    )
-                except subprocess.CalledProcessError as e:
-                    # A failing remove must not mask an in-flight exception
-                    # from the try block above.
-                    print(f"^^^ +++ removing worktree {worktree} failed: {e}")
-            shutil.rmtree(worktree, ignore_errors=True)
+        ancestor_failures = ancestor_build_failures + ancestor_run_failures
+        current_failures = current_build_failures + current_run_failures
+    finally:
+        if target_owner is not None and target.exists():
+            target.rename(
+                ancestor_target if target_owner == "ancestor" else current_target
+            )
+        for path in (src, ancestor_src):
+            if path.exists():
+                remove_worktree(path)
+        shutil.rmtree(src, ignore_errors=True)
+        shutil.rmtree(ancestor_src, ignore_errors=True)
 
     report = compare(criterion_home, args.threshold)
     markdown = render_report(

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -430,6 +430,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     # reads it with Perl's `||`, which treats the string "0" as false and
     # falls back to the real time, so any other fixed non-zero value is used.
     env["SOURCE_DATE_EPOCH"] = "1"
+    # `build_info!()` shells out to `git rev-parse HEAD` at compile time and
+    # embeds the result, so without a fixed value the two checkouts always
+    # differ, which also defeats the skip. The dummy build info uses all zeros.
+    env["MZ_DEV_BUILD_SHA"] = "0" * 40
 
     # Cargo derives a unit's hash from absolute paths, so the ancestor and
     # current checkouts must build at the same checkout path and the same

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -22,8 +22,13 @@ reuse that.
 A package whose dependency closure has no committed change between the ancestor
 and the current commit is not built at all: identical source at identical paths
 would only reproduce the identical-binary skip below at the cost of two builds.
+That prediction is unchecked by construction, so scheduled runs build those
+packages anyway and fail when a predicted-unchanged package yields differing
+binaries, which points at a hole in the closure or an unpinned compile-time
+input.
 """
 
+import argparse
 import hashlib
 import json
 import os
@@ -82,7 +87,12 @@ def resolve_ancestor() -> str:
     ]
     if not releases:
         raise RuntimeError(f"no release tag older than {current} found")
-    return git.rev_parse(f"{max(releases)}^{{commit}}")
+    tag = spawn.capture(
+        ["git", "rev-parse", f"{max(releases)}^{{commit}}"], cwd=MZ_ROOT
+    ).strip()
+    # The tag sits on its release branch and carries backports that main
+    # lacks, so the comparison point is where that branch left main.
+    return spawn.capture(["git", "merge-base", tag, "HEAD"], cwd=MZ_ROOT).strip()
 
 
 def target_dir() -> Path:
@@ -305,7 +315,9 @@ def run_benches(
     ancestor_by_key = {(b.package, b.name): b for b in ancestor_built}
     ancestor_target_by_key = {(t.package, t.name): t for t in ancestor_targets}
     head_target_by_key = {(t.package, t.name): t for t in head_targets}
-    scratch = criterion_home / "stripped"
+    # Outside `criterion_home`, which is uploaded as an artifact, so a hard
+    # kill mid-strip cannot leave a full bench binary in the upload.
+    scratch = cargo_bench_dir() / "stripped"
     scratch.mkdir(parents=True, exist_ok=True)
 
     ancestor_failures: list[TargetFailure] = []
@@ -384,6 +396,8 @@ def render_report(
     current_failures: list[TargetFailure],
     identical: list[BuiltBench],
     unchanged: list[str],
+    unchanged_built: bool,
+    mispredicted: list[str],
 ) -> str:
     sections = []
     if ancestor is not None:
@@ -410,9 +424,19 @@ def render_report(
         )
     if report.warnings:
         sections.append("Warnings:\n" + "\n".join(f"* {w}" for w in report.warnings))
-    if unchanged:
+    if mispredicted:
         sections.append(
-            "Bench packages with no change in their dependency closure since the ancestor (not built):\n"
+            "Bench packages the closure prefilter predicted unchanged whose binaries differ, a hole in the closure or an unpinned compile-time input:\n"
+            + "\n".join(f"* `{p}`" for p in mispredicted)
+        )
+    if unchanged:
+        suffix = (
+            "(built anyway to verify the prediction)"
+            if unchanged_built
+            else "(not built)"
+        )
+        sections.append(
+            f"Bench packages with no change in their dependency closure since the ancestor {suffix}:\n"
             + "\n".join(f"* `{p}`" for p in unchanged)
         )
     if identical:
@@ -446,6 +470,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         action="store_true",
         help="run only the current commit, no comparison",
     )
+    parser.add_argument(
+        "--verify-closure",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="build packages the closure prefilter predicts unchanged and fail when their binaries differ, defaults to on in scheduled CI runs and off in pull requests and locally",
+    )
     args = parser.parse_args()
     if args.skip_ancestor and args.ancestor:
         parser.error("--ancestor has no effect with --skip-ancestor")
@@ -469,7 +499,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     # Only the committed HEAD is measured here. Uncommitted local changes
     # in MZ_ROOT are not part of the checkout built below.
-    head = git.rev_parse("HEAD")
+    head = spawn.capture(["git", "rev-parse", "HEAD"], cwd=MZ_ROOT).strip()
     ancestor: str | None = None
     unchanged: list[str] = []
     if not args.skip_ancestor:
@@ -477,11 +507,23 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         assert ancestor is not None
         print(f"--- Comparing against ancestor {ancestor}")
         unchanged = unchanged_packages(ancestor, head, shard_packages)
-        if unchanged:
-            print(
-                f"--- Unchanged since the ancestor, not built: {', '.join(unchanged)}"
-            )
-    build_packages = [p for p in shard_packages if p not in unchanged]
+    # The prefilter is a prediction the identical-binary check can confirm or
+    # refute, but only if the predicted-unchanged packages get built. Pull
+    # requests and local runs take the saving, scheduled runs pay for the
+    # check so a wrong prediction surfaces before it hides a regression.
+    verify_closure = (
+        args.verify_closure
+        if args.verify_closure is not None
+        else buildkite.is_in_buildkite() and not buildkite.is_in_pull_request()
+    )
+    if unchanged:
+        action = "built to verify" if verify_closure else "not built"
+        print(f"--- Unchanged since the ancestor, {action}: {', '.join(unchanged)}")
+    build_packages = (
+        shard_packages
+        if verify_closure
+        else [p for p in shard_packages if p not in unchanged]
+    )
 
     criterion_home = target_dir() / "criterion-compare"
     # Stale baselines from an earlier run would silently become the
@@ -523,12 +565,15 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     # A cancelled or timed-out job can leave a previous run's worktrees
     # registered and their directories in place. Clear both before reusing
-    # the fixed paths.
-    spawn.runv(["git", "worktree", "prune"], cwd=MZ_ROOT)
+    # the fixed paths. The prune runs after the removals: `remove_worktree`
+    # tolerates failure, so the rmtree can leave a registration whose
+    # directory is gone, and `git worktree add` refuses such a path as a
+    # "missing but already registered worktree".
     for leftover in (src, ancestor_src):
         if leftover.exists():
             remove_worktree(leftover)
             shutil.rmtree(leftover, ignore_errors=True)
+    spawn.runv(["git", "worktree", "prune"], cwd=MZ_ROOT)
     # A hard kill (OOM, SIGKILL) skips the `finally` below and can leave
     # `target` populated with whichever side's build was in flight. Which
     # side that was is no longer known, and the next rename onto this path
@@ -543,6 +588,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ancestor_failures: list[TargetFailure] = []
     current_failures: list[TargetFailure] = []
     identical: list[BuiltBench] = []
+    current_targets: list[BenchTarget] = []
     # Tracks which parked target dir currently owns `target`, so the
     # `finally` below can park it back even if a build raises partway through.
     target_owner: str | None = None
@@ -631,6 +677,14 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         shutil.rmtree(src, ignore_errors=True)
         shutil.rmtree(ancestor_src, ignore_errors=True)
 
+    mispredicted: list[str] = []
+    if verify_closure:
+        identical_keys = {(b.package, b.name) for b in identical}
+        for package in unchanged:
+            targets = [t for t in current_targets if t.package == package]
+            if any((t.package, t.name) not in identical_keys for t in targets):
+                mispredicted.append(package)
+
     report = compare(criterion_home, args.threshold)
     markdown = render_report(
         ancestor,
@@ -640,10 +694,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         current_failures,
         identical,
         unchanged,
+        verify_closure,
+        mispredicted,
     )
     print(markdown)
 
-    failed = report.has_regressions or bool(current_failures)
+    failed = report.has_regressions or bool(current_failures) or bool(mispredicted)
     if buildkite.is_in_buildkite():
         buildkite.add_annotation(
             "error" if failed else "info",
@@ -674,3 +730,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if report.has_regressions:
         regressions = [r.id for r in report.results if r.verdict == Verdict.REGRESSION]
         raise RuntimeError(f"benchmark regressions: {', '.join(regressions)}")
+    if mispredicted:
+        raise RuntimeError(
+            f"closure prefilter predicted unchanged but binaries differ: {', '.join(mispredicted)}"
+        )

--- a/test/cargo-bench/mzcompose.py
+++ b/test/cargo-bench/mzcompose.py
@@ -18,6 +18,10 @@ produce different bytes even from identical source. Locally this means the
 current-commit build does not reuse the developer's own `target/` cache; the
 first run compiles it from scratch into a parked target dir and later runs
 reuse that.
+
+A package whose dependency closure has no committed change between the ancestor
+and the current commit is not built at all: identical source at identical paths
+would only reproduce the identical-binary skip below at the cost of two builds.
 """
 
 import hashlib
@@ -41,6 +45,7 @@ from materialize.cargo_bench.targets import (
     bench_executables,
     bench_targets,
     cargo_build_args,
+    closure_dirs,
     package_manifests,
 )
 from materialize.mz_version import MzVersion
@@ -51,6 +56,10 @@ SERVICES = []
 BASELINE = "ancestor"
 
 REPORTS_ARTIFACT = "criterion-reports.tar.zst"
+
+# Repo-relative paths outside any crate directory that feed every build:
+# dependency versions, workspace profiles, and the rustflags cargo applies.
+BUILD_INPUTS = ("Cargo.lock", "Cargo.toml", ".cargo")
 
 
 @dataclass(frozen=True)
@@ -122,6 +131,47 @@ def load_targets(
     if packages:
         targets = [t for t in targets if t.package in packages]
     return targets, package_manifests(metadata)
+
+
+def unchanged_packages(ancestor: str, head: str, packages: list[str]) -> list[str]:
+    """Return the members of `packages` with no committed change in their dependency closure between `ancestor` and `head`.
+
+    The closure comes from `head`'s metadata. A dependency added or removed
+    since the ancestor changes the dependent's manifest, which is inside the
+    closure either way, so one side's closure suffices. Build scripts that
+    read files outside their crate directory are not covered.
+    """
+    # The resolve honours only the features cargo would enable by default,
+    # while a bench's `required-features` can pull in optional path
+    # dependencies, so the superset over all features is used.
+    metadata = json.loads(
+        spawn.capture(
+            ["cargo", "metadata", "--format-version=1", "--all-features"],
+            cwd=MZ_ROOT,
+        )
+    )
+    unchanged = []
+    for package in packages:
+        dirs = [str(d.relative_to(MZ_ROOT)) for d in closure_dirs(metadata, package)]
+        # Without `--no-renames` a file moved across the closure boundary
+        # would only be listed under its destination path.
+        changed = spawn.capture(
+            [
+                "git",
+                "diff",
+                "--name-only",
+                "--no-renames",
+                ancestor,
+                head,
+                "--",
+                *BUILD_INPUTS,
+                *dirs,
+            ],
+            cwd=MZ_ROOT,
+        )
+        if not changed.strip():
+            unchanged.append(package)
+    return unchanged
 
 
 def build_benches(
@@ -333,6 +383,7 @@ def render_report(
     ancestor_failures: list[TargetFailure],
     current_failures: list[TargetFailure],
     identical: list[BuiltBench],
+    unchanged: list[str],
 ) -> str:
     sections = []
     if ancestor is not None:
@@ -359,6 +410,11 @@ def render_report(
         )
     if report.warnings:
         sections.append("Warnings:\n" + "\n".join(f"* {w}" for w in report.warnings))
+    if unchanged:
+        sections.append(
+            "Bench packages with no change in their dependency closure since the ancestor (not built):\n"
+            + "\n".join(f"* `{p}`" for p in unchanged)
+        )
     if identical:
         sections.append(
             "Bench targets with identical binaries at ancestor and current (not run):\n"
@@ -410,7 +466,22 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         print("--- No bench packages assigned to this shard")
         return
     print(f"--- Bench packages in this shard: {', '.join(shard_packages)}")
-    head_targets = [t for t in head_targets if t.package in shard_packages]
+
+    # Only the committed HEAD is measured here. Uncommitted local changes
+    # in MZ_ROOT are not part of the checkout built below.
+    head = git.rev_parse("HEAD")
+    ancestor: str | None = None
+    unchanged: list[str] = []
+    if not args.skip_ancestor:
+        ancestor = args.ancestor or resolve_ancestor()
+        assert ancestor is not None
+        print(f"--- Comparing against ancestor {ancestor}")
+        unchanged = unchanged_packages(ancestor, head, shard_packages)
+        if unchanged:
+            print(
+                f"--- Unchanged since the ancestor, not built: {', '.join(unchanged)}"
+            )
+    build_packages = [p for p in shard_packages if p not in unchanged]
 
     criterion_home = target_dir() / "criterion-compare"
     # Stale baselines from an earlier run would silently become the
@@ -466,18 +537,17 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if target.exists():
         shutil.rmtree(target)
 
-    ancestor: str | None = None
     ancestor_targets: list[BenchTarget] = []
     ancestor_built: list[BuiltBench] = []
     ancestor_build_failures: list[TargetFailure] = []
+    ancestor_failures: list[TargetFailure] = []
+    current_failures: list[TargetFailure] = []
+    identical: list[BuiltBench] = []
     # Tracks which parked target dir currently owns `target`, so the
     # `finally` below can park it back even if a build raises partway through.
     target_owner: str | None = None
     try:
-        if not args.skip_ancestor:
-            ancestor = args.ancestor or resolve_ancestor()
-            assert ancestor is not None
-            print(f"--- Comparing against ancestor {ancestor}")
+        if ancestor is not None and build_packages:
             spawn.runv(
                 ["git", "worktree", "add", "--detach", str(src), ancestor],
                 cwd=MZ_ROOT,
@@ -487,7 +557,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             target_owner = "ancestor"
             ancestor_env = dict(env, CARGO_TARGET_DIR=str(target))
             ancestor_targets, ancestor_manifests = load_targets(
-                src, shard_packages, ancestor_env
+                src, build_packages, ancestor_env
             )
             ancestor_built_raw, ancestor_build_failures = build_benches(
                 src, ancestor_targets, ancestor_manifests, ancestor_env
@@ -511,40 +581,35 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 for b in ancestor_built_raw
             ]
 
-        # Only the committed HEAD is measured here. Uncommitted local changes
-        # in MZ_ROOT are not part of the checkout built below.
-        head = spawn.capture(["git", "rev-parse", "HEAD"], cwd=MZ_ROOT).strip()
-        spawn.runv(["git", "worktree", "add", "--detach", str(src), head], cwd=MZ_ROOT)
-        if current_target.exists():
-            current_target.rename(target)
-        target_owner = "current"
-        current_env = dict(env, CARGO_TARGET_DIR=str(target))
-        # Enumerated from `src`, not MZ_ROOT, so the manifest paths this
-        # returns match the paths cargo reports for the build below, even
-        # though both are the same commit.
-        current_targets, current_manifests = load_targets(
-            src, shard_packages, current_env
-        )
-        head_built_raw, current_build_failures = build_benches(
-            src, current_targets, current_manifests, current_env
-        )
-        target.rename(current_target)
-        target_owner = None
-        head_built = [
-            BuiltBench(
-                package=b.package,
-                name=b.name,
-                executable=current_target / b.executable.relative_to(target),
-                manifest_dir=b.manifest_dir,
+        if build_packages:
+            spawn.runv(
+                ["git", "worktree", "add", "--detach", str(src), head], cwd=MZ_ROOT
             )
-            for b in head_built_raw
-        ]
+            if current_target.exists():
+                current_target.rename(target)
+            target_owner = "current"
+            current_env = dict(env, CARGO_TARGET_DIR=str(target))
+            # Enumerated from `src`, not MZ_ROOT, so the manifest paths this
+            # returns match the paths cargo reports for the build below, even
+            # though both are the same commit.
+            current_targets, current_manifests = load_targets(
+                src, build_packages, current_env
+            )
+            head_built_raw, current_build_failures = build_benches(
+                src, current_targets, current_manifests, current_env
+            )
+            target.rename(current_target)
+            target_owner = None
+            head_built = [
+                BuiltBench(
+                    package=b.package,
+                    name=b.name,
+                    executable=current_target / b.executable.relative_to(target),
+                    manifest_dir=b.manifest_dir,
+                )
+                for b in head_built_raw
+            ]
 
-        if args.skip_ancestor:
-            ancestor_run_failures, current_run_failures, identical = run_benches(
-                head_built, [], current_targets, [], env, criterion_home
-            )
-        else:
             ancestor_run_failures, current_run_failures, identical = run_benches(
                 head_built,
                 ancestor_built,
@@ -553,8 +618,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 env,
                 criterion_home,
             )
-        ancestor_failures = ancestor_build_failures + ancestor_run_failures
-        current_failures = current_build_failures + current_run_failures
+            ancestor_failures = ancestor_build_failures + ancestor_run_failures
+            current_failures = current_build_failures + current_run_failures
     finally:
         if target_owner is not None and target.exists():
             target.rename(
@@ -574,6 +639,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         ancestor_failures,
         current_failures,
         identical,
+        unchanged,
     )
     print(markdown)
 


### PR DESCRIPTION
### Motivation

The nightly `Benchmarks` group covers mzcompose-level benchmarks only. The
criterion benchmarks in the Rust crates (`cargo bench`, 22 targets across 9
crates) never run in CI, so a regression in one of them goes unnoticed until
someone runs the bench locally.

### Description

Adds a `cargo-bench` nightly step that builds and runs every `[[bench]]` target
at an ancestor commit and at HEAD, then fails when a benchmark regressed.

* The ancestor is the merge base in a pull request and, on `main`, the merge
  base of the latest release tag (prereleases excluded) and HEAD, since the
  tag itself sits on a release branch with backports main lacks. `--ancestor`
  overrides it for local runs.
* Bench targets come from `cargo metadata`. Each checkout's bench binaries are
  built in one `cargo bench --no-run --message-format=json` invocation, with
  `required-features` passed as `package/feature`, so all targets compile with
  full parallelism and the run phase starts with a quiet machine. A target that
  fails to build or run at the ancestor is skipped and reported. A target that
  fails at HEAD fails the step.
* A package whose dependency closure has no committed change between the
  ancestor and HEAD is not built at all. The closure is every path crate
  reachable from the package in `cargo metadata --all-features`, and the
  check is `git diff --name-only` over those crate directories plus
  `Cargo.lock`, the root `Cargo.toml`, and `.cargo`. Build scripts reading
  files outside their crate are not covered by this prefilter. Scheduled runs
  build predicted-unchanged packages anyway and fail when the identical-binary
  check disagrees, so a hole in the closure or a new unpinned compile-time
  input surfaces on main instead of hiding a regression. Pull requests and
  local runs take the saving, `--verify-closure` overrides the default.
* A target whose ancestor and HEAD binaries are identical is not run. Cargo
  derives unit hashes from absolute paths, so both checkouts build at one
  fixed path under `target/cargo-bench/` with one fixed target dir path, each
  side's target dir parked between builds as its cache. With
  `SOURCE_DATE_EPOCH` pinned so the vendored OpenSSL build stops embedding a
  timestamp, identical source then gives binaries that differ only in debug
  info, symbol names, the build-id note, and toolchain banners, none of which
  is loaded at run time, so identity is judged on a stripped copy. Unchanged
  crates cost a build and nothing else, and cannot produce a false regression.
  A dependency bump runs everything that depends on it. Only the committed
  HEAD is measured.
* Benchmarks that do run go interleaved per target, ancestor then HEAD, which
  keeps the two measurements of one target close in time. The ancestor run
  saves a criterion baseline, the HEAD run compares against it in lenient mode
  so a benchmark added since the ancestor simply runs without a baseline and is
  reported as new.
* Benches run without the `CI` marker in their environment. Persist's test
  storage configs panic under `CI` when no Postgres or S3 endpoint is
  configured, and this step measures code rather than network storage, so the
  external-storage variants skip as they do locally.
* A benchmark counts as a regression when the lower bound of criterion's 95%
  confidence interval on the relative mean change exceeds the threshold
  (default 10%). Results land in a Buildkite annotation and the criterion
  reports are uploaded as an artifact.
* The step runs as parallel jobs on small dedicated agents, sharded by
  package, so each shard builds one package's dependency closure per checkout
  and runs that package's targets. `parallelism` tracks the number of packages
  with bench targets. Extra shards exit as no-ops, fewer shards double up.
* The step ships with `soft_fail: true` so the noise floor on the dedicated
  runners can be calibrated before regressions turn the build red. [QAR-162](https://linear.app/materializeinc/issue/QAR-162)
  tracks dropping it.

Calibration notes from the PR's own nightly runs on identical Rust code: the
first sequential flow (one `cargo bench` per target, shared target dir, one
48-core agent) reported regressions of up to +465% in the merge benchmarks.
The sharded interleaved flow reduced that to a handful of rows between +12%
and +29% per shard, with confidence intervals of a fraction of a percent, on
binaries identical up to debug info. Those are run-to-run environment effects
on shared hardware. With the fixed-path builds, nightly build 18239 skipped
every target as identical in eight of nine shards and passed, with shard wall
times between 6 and 54 minutes. The `mz-adapter` shard still ran its
benchmark: `build_info!()` embeds the checkout's commit at compile time, so
`MZ_DEV_BUILD_SHA` is now pinned alongside `SOURCE_DATE_EPOCH`. For changed
code the run-to-run effects remain the noise floor the threshold has to clear.

Two side fixes the step depends on: `src/interchange` gets `autobenches =
false` because cargo auto-discovered its `benches/avro.rs` and `protobuf.rs`
modules as libtest bench targets that reject criterion flags, and the mzcompose
plugin's empty `services.log` allowlist learns the new step's label since the
composition starts no services.

Also fixes the black `exclude` regex in `pyproject.toml`, which was unanchored
and silently skipped any Python file whose name contains `target`.

### Verification

Unit tests for bench target enumeration, cargo argv and artifact parsing, and
result comparison in `misc/python/materialize/cargo_bench/`. Local smoke runs
of the composition against `HEAD~1` for `mz-ore`, `mz-repr`, and
`mz-storage-types`, including simulated shard assignment and the
identical-binary skip. Nightly builds 18234, 18237, 18239, and 18281 on this
PR, the last one skipping every target in all nine shards as identical.

---
Posted by Claude Code.
