### PR TITLE
docs: note Iceberg sinks cannot target an existing table

### DIFF
--- a/doc/user/content/headless/iceberg-sinks/limitations-list.md
+++ b/doc/user/content/headless/iceberg-sinks/limitations-list.md
@@ -3,6 +3,9 @@ headless: true
 ---
 
 - {{< include-from-yaml data="examples/create_sink_iceberg"
+  name="restrictions-limitations-existing-table" >}}
+
+- {{< include-from-yaml data="examples/create_sink_iceberg"
   name="restrictions-limitations-partitioned-tables" >}}
 
 - {{< include-from-yaml data="examples/create_sink_iceberg"

--- a/doc/user/data/examples/create_sink_iceberg.yml
+++ b/doc/user/data/examples/create_sink_iceberg.yml
@@ -187,6 +187,10 @@
     Your S3 Tables bucket must be in the same AWS region as your Materialize
     deployment.
 
+- name: "restrictions-limitations-existing-table"
+  content: |
+    You cannot create an Iceberg sink into an existing Iceberg table. Materialize creates and manages the target Iceberg table itself, so the table named by the sink must not already exist.
+
 - name: "restrictions-limitations-partitioned-tables"
   content: |
     Partitioned tables are not supported.


### PR DESCRIPTION
### Motivation

Documents that a user cannot create an Iceberg sink into an existing Iceberg
table. Materialize creates and manages the target Iceberg table itself.

Slack thread: https://materializeinc.slack.com/archives/C08A7H11KP0/p1788531786276499?thread_ts=1788531628.127999&cid=C08A7H11KP0

### Description

This is added once in the shared single-source location so it applies to all
Iceberg sink pages (Databricks / Unity Catalog, GCP BigLake, AWS S3 Tables, and
the generic REST catalog page):

- New limitation entry `restrictions-limitations-existing-table` in
  `doc/user/data/examples/create_sink_iceberg.yml`.
- Referenced from the shared headless fragment
  `doc/user/content/headless/iceberg-sinks/limitations-list.md`, which every
  Iceberg sink page already includes in its Limitations section.

### Verification

Docs-only change. The new limitation renders on all Iceberg sink pages through
the shared headless fragment they already include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3iJBWnxMheEJ1Wui8dhgj

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3iJBWnxMheEJ1Wui8dhgj)_