### PR TITLE
adapter: enable hydration history by default

### DIFF
--- a/doc/developer/design/20260817_durable_object_hydration_history.md
+++ b/doc/developer/design/20260817_durable_object_hydration_history.md
@@ -56,7 +56,8 @@ not-yet-recorded dataflow, and the OCC path rejects a result that exceeds
 only matters at millions of dataflows per replica.
 
 Two dyncfgs control it. `hydration_history_collection_interval` sets the sweep
-cadence and disables collection at zero, which is the production default.
+cadence, defaulting to 60 seconds. Setting it to zero prevents new collection and
+retention sweeps as a break-glass measure. An in-flight sweep is allowed to finish.
 `hydration_history_retention_period` bounds how long rows live, defaulting to 30
 days.
 
@@ -222,10 +223,8 @@ crash-looping replica must not be able to stop the table from shrinking. The
 dependency does not run the other way: a catalog server without a replica skips
 retention and leaves collection running.
 
-Disabling collection also suspends retention. The alternative is an always-on
-subscribe in the default configuration, where the table is empty and there is
-nothing to retain. Rows already collected are therefore kept while collection is
-off.
+Disabling collection also suspends retention once any in-flight sweep finishes.
+Rows already collected are therefore kept while collection is off.
 
 ## Durability is best effort
 
@@ -322,18 +321,12 @@ than wrong data. Because the symptom is otherwise hard to attribute, both a time
 and retry-budget exhaustion log that the replica's introspection frontier may be
 trailing.
 
-## Rollout
+## Operational control
 
-Collection is disabled by default, and the interval is runtime configurable, so
-enabling it needs no restart. The plan is to enable it in CI when this merges, then
-in staging, then in production, a week apart, so each step has a week of real
-traffic behind it before the next.
-
-CI enables it at a 60 second interval through the mzcompose configuration, which is
-what exercises the hydration, restart, retention, and catalog tests. It stays off in
-the sqllogictest runner defaults, against the usual preference for enabling new
-paths in tests: the collector installs subscribes and writes a builtin table, while
-those runs assert on catalog contents and plans.
+The collection interval is runtime configurable, so disabling or re-enabling the
+collector needs no restart. Standard mzcompose tests also set the 60 second interval
+explicitly so mixed-version tests exercise the collector when running binaries whose
+compiled default is zero.
 
 ## Future Work
 

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -421,11 +421,11 @@ pub const ARRANGEMENT_SIZE_HISTORY_RETENTION_PERIOD: Config<Duration> = Config::
     ParameterScope::Environment,
 );
 
-/// How often to sweep replicas for completed object hydration episodes.
+/// How often to sweep replicas for completed object and replica hydration episodes.
 pub const HYDRATION_HISTORY_COLLECTION_INTERVAL: Config<Duration> = Config::new(
     "hydration_history_collection_interval",
-    Duration::ZERO,
-    "How often to record completed object hydration episodes. A zero duration disables collection.",
+    Duration::from_secs(60),
+    "How often to record completed object and replica hydration episodes. A zero duration prevents new collection and retention sweeps.",
     ParameterScope::Environment,
 );
 

--- a/src/adapter/src/coord/hydration_history.rs
+++ b/src/adapter/src/coord/hydration_history.rs
@@ -68,8 +68,8 @@ const SCHEDULE_RECHECK_CAP: Duration = Duration::from_secs(5);
 
 /// How often a disabled collector rechecks whether it was enabled.
 ///
-/// This is the cadence of every environment in the default configuration, so it
-/// is much coarser than the enabled one: nothing is waiting on it.
+/// A disabled collector has no pending collection work, so this can be much
+/// coarser than the enabled scheduler's recheck cadence.
 const DISABLED_RECHECK_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Bound on one replica-targeted mutation.
@@ -187,10 +187,8 @@ impl Coordinator {
         };
         // Builtin tables are not writable in read-only mode, and a disabled
         // collector must do no background work at all. Retention is part of the
-        // sweep, so disabling collection also suspends it. That is deliberate:
-        // the table can only be non-empty if collection ran at some point, and
-        // the alternative is an always-on subscribe in the default (disabled)
-        // production configuration.
+        // sweep, so disabling collection also suspends it once any in-flight
+        // sweep finishes. This makes zero a break-glass setting for the subsystem.
         if collection_interval.is_zero() || self.controller.read_only() {
             self.schedule_hydration_history_collection();
             return;


### PR DESCRIPTION
### Motivation

The durable object and replica hydration history tables are currently empty unless collection is explicitly enabled. Standard mzcompose CI has exercised collection at a 60 second interval since the feature landed.

Enabling collection by default makes completed hydration episodes available for diagnosing object and replica hydration behavior without per-environment configuration.

### Description

This changes the compiled `hydration_history_collection_interval` default from zero to 60 seconds. Setting the interval to zero remains the runtime break-glass control. It prevents new collection and retention sweeps after any in-flight sweep finishes.

The parameter remains absent from LaunchDarkly. The explicit mzcompose default remains in place for mixed-version coverage. Standalone sqllogictest and Rust test harnesses are intentionally not pinned off, so CI exercises the production default and can expose interactions with background collection.

The design documentation and scheduler comments now describe the enabled default and break-glass behavior.

### Verification

Existing focused testdrive and restart coverage continues to use short explicit intervals to verify collection, retention, and durability. No test files are added or modified.
