### PR TITLE
pool: add a zstd extent codec and chunk codec flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8070,6 +8070,7 @@ dependencies = [
  "uuid",
  "yansi",
  "zeroize",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -572,6 +572,7 @@ which = "8"
 yansi = "1.0.1"
 zeroize = { version = "1.8.2", features = ["derive", "serde"] }
 zip = { version = "6.0.0", default-features = false, features = ["deflate-flate2"] }
+zstd = { version = "0.13.3", default-features = false }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -663,6 +663,8 @@ UNINTERESTING_SYSTEM_PARAMETERS = [
     "enable_column_paged_batcher",
     "enable_column_paged_batcher_spill",
     "column_chunk_compress_min_depth",
+    "column_chunk_codec",
+    "column_chunk_zstd_level",
     "column_paged_batcher_budget_fraction",
     "column_paged_batcher_lz4",
     "column_paged_batcher_swap_pageout",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3143,6 +3143,8 @@ class FlipFlagsAction(Action):
             "1",  # the default: fresh chunks store uncompressed
             "4",  # exempt several young generations
         ]
+        self.flags_with_values["column_chunk_codec"] = ["lz4", "zstd"]
+        self.flags_with_values["column_chunk_zstd_level"] = ["1", "3", "9"]
         # 0 forces the estimated-size path for every table, the default forces
         # the exact COUNT(*) path for workload-sized tables.
         self.flags_with_values["mysql_source_snapshot_exact_count_max_rows"] = [

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -129,8 +129,37 @@ pub const ENABLE_COLUMN_PAGED_BATCHER_SPILL: Config<bool> = Config::new(
 pub const COLUMN_CHUNK_COMPRESS_MIN_DEPTH: Config<u32> = Config::new(
     "column_chunk_compress_min_depth",
     1,
-    "The youngest chunk generation whose spilled bodies are lz4-compressed in the buffer \
-     pool; younger generations store uncompressed. 0 compresses every spilled body.",
+    "The youngest chunk generation whose spilled bodies are compressed in the buffer pool \
+     (codec per `column_chunk_codec`); younger generations store uncompressed. 0 compresses \
+     every spilled body.",
+    ParameterScope::Replica,
+);
+
+/// The codec spilled chunk bodies at or past [`COLUMN_CHUNK_COMPRESS_MIN_DEPTH`]
+/// compress with. `lz4` is one lz4 block per body. `zstd` is one zstd frame
+/// per body at zstd's fastest standard level, which stores denser than lz4
+/// for more encode CPU on the eviction path (spill threads, or the evicting
+/// worker when `column_paged_batcher_spill_worker_count` is 0). A body keeps
+/// the codec it spilled under, so a change applies to bodies spilled from
+/// then on and never migrates or invalidates existing extents. Unrecognized
+/// values are logged and leave the codec unchanged.
+pub const COLUMN_CHUNK_CODEC: Config<&'static str> = Config::new(
+    "column_chunk_codec",
+    "lz4",
+    "The codec compressing spilled chunk bodies in the buffer pool: `lz4` or `zstd`.",
+    ParameterScope::Replica,
+);
+
+/// The zstd level for `column_chunk_codec = zstd`, within zstd's standard
+/// levels 1 through 19. Higher levels store denser for more encode CPU,
+/// which lands on spill threads, or on the evicting worker when
+/// `column_paged_batcher_spill_worker_count` is 0. Out-of-range values are
+/// logged and leave the level unchanged. Decode does not depend on the
+/// level, so bodies spilled at earlier levels stay readable.
+pub const COLUMN_CHUNK_ZSTD_LEVEL: Config<u32> = Config::new(
+    "column_chunk_zstd_level",
+    1,
+    "The zstd level for spilled chunk bodies when `column_chunk_codec = zstd`, 1 through 19.",
     ParameterScope::Replica,
 );
 
@@ -759,4 +788,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COLUMN_PAGED_BATCHER_EAGER_BACKING)
         .add(&COLUMN_PAGED_BATCHER_POOL_RSS_TARGET_FRACTION)
         .add(&COLUMN_CHUNK_COMPRESS_MIN_DEPTH)
+        .add(&COLUMN_CHUNK_CODEC)
+        .add(&COLUMN_CHUNK_ZSTD_LEVEL)
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -516,6 +516,20 @@ impl ComputeState {
             let compress_min_depth =
                 u8::try_from(COLUMN_CHUNK_COMPRESS_MIN_DEPTH.get(config)).unwrap_or(u8::MAX);
             mz_timely_util::columnar::chunk::set_compress_min_depth(compress_min_depth);
+
+            let chunk_codec = COLUMN_CHUNK_CODEC.get(config);
+            match chunk_codec.parse() {
+                Ok(codec) => mz_timely_util::columnar::chunk::set_compress_codec(codec),
+                Err(err) => error!(err, chunk_codec, "Invalid value for column_chunk_codec"),
+            }
+
+            let zstd_level = COLUMN_CHUNK_ZSTD_LEVEL.get(config);
+            let applied = i32::try_from(zstd_level)
+                .map_err(|err| err.to_string())
+                .and_then(mz_timely_util::columnar::chunk::set_compress_zstd_level);
+            if let Err(err) = applied {
+                error!(err, zstd_level, "Invalid value for column_chunk_zstd_level");
+            }
         }
 
         // Remember the maintenance interval locally to avoid reading it from the config set on

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -69,6 +69,7 @@ tracing-subscriber = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true, features = ["v4", "v7"] }
 url = { workspace = true, features = ["serde"] }
 zeroize.workspace = true
+zstd = { workspace = true, optional = true }
 
 # For the `tracing` feature
 http = { workspace = true, optional = true }
@@ -154,7 +155,7 @@ assert = ["assert-no-tracing", "ctor", "tracing"]
 proptest = ["dep:proptest", "proptest-derive"]
 overflowing = ["assert"]
 pager = ["dep:bytemuck", "libc", "rand", "dep:tracing"]
-pool = ["dep:bytemuck", "libc", "dep:tracing"]
+pool = ["dep:bytemuck", "libc", "dep:tracing", "dep:zstd"]
 
 [[test]]
 name = "future"

--- a/src/ore/src/pool.rs
+++ b/src/ore/src/pool.rs
@@ -26,7 +26,7 @@
 //! chunk's state lock, so no reference into pool memory escapes the pool and
 //! a read leaves residency untouched. The backing is the swap-backed extent
 //! store of the design's Layer 1: a slot in a pool-owned anonymous-memory
-//! extent arena holding the chunk's lz4-compressed bytes.
+//! extent arena holding the chunk's compressed bytes.
 //!
 //! Memory descends a ladder of tiers, each with its own ceiling and each
 //! cheaper to vacate than the one above:
@@ -60,8 +60,9 @@
 mod extent;
 mod region;
 
+use std::cell::RefCell;
 use std::collections::VecDeque;
-use std::ops::Range;
+use std::ops::{Range, RangeInclusive};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, Weak};
 
@@ -130,14 +131,121 @@ impl ExtentCodec for IdentityCodec {
     }
 }
 
+/// The zstd [`ExtentCodec`]: a little-endian `u32` body-length prefix
+/// followed by one zstd frame.
+///
+/// Each thread that encodes or decodes keeps one zstd compression context
+/// and one decompression context for the life of the thread. A fresh
+/// context costs a workspace allocation and table setup, which on the
+/// eviction path would be paid once per spilled chunk, so the contexts are
+/// retained instead and the compression workspace settles at the size the
+/// level and the largest body seen require. One context per thread serves
+/// every `ZstdCodec` level, so the level is applied per call.
+#[derive(Debug, Clone, Copy)]
+pub struct ZstdCodec {
+    level: i32,
+}
+
+impl ZstdCodec {
+    /// A codec compressing at zstd `level`; `0` selects zstd's own default.
+    pub const fn new(level: i32) -> Self {
+        ZstdCodec { level }
+    }
+}
+
+/// The levels [`zstd_codec`] serves: zstd's standard levels. Levels 20 and
+/// above are zstd's ultra levels, whose windows exceed every chunk class.
+pub const ZSTD_LEVELS: RangeInclusive<i32> = 1..=19;
+
+const ZSTD_LEVEL_COUNT: usize = 19;
+
+/// One codec per level of [`ZSTD_LEVELS`], so a level chosen at runtime
+/// still reaches [`Pool::insert_with`] as a `'static` codec.
+static ZSTD_CODECS: [ZstdCodec; ZSTD_LEVEL_COUNT] = {
+    let mut table = [ZstdCodec::new(0); ZSTD_LEVEL_COUNT];
+    let mut level = *ZSTD_LEVELS.start();
+    let mut i = 0;
+    while i < ZSTD_LEVEL_COUNT {
+        table[i] = ZstdCodec::new(level);
+        level += 1;
+        i += 1;
+    }
+    assert!(
+        level - 1 == *ZSTD_LEVELS.end(),
+        "table covers exactly ZSTD_LEVELS"
+    );
+    table
+};
+
+/// The [`ZstdCodec`] for `level`, clamped into [`ZSTD_LEVELS`]. Callers that
+/// want to reject out-of-range levels check the range before calling.
+pub fn zstd_codec(level: i32) -> &'static ZstdCodec {
+    let clamped = level.clamp(*ZSTD_LEVELS.start(), *ZSTD_LEVELS.end());
+    let index = usize::try_from(clamped - *ZSTD_LEVELS.start()).expect("clamped into the table");
+    &ZSTD_CODECS[index]
+}
+
+thread_local! {
+    static ZSTD_COMPRESSOR: RefCell<Option<zstd::bulk::Compressor<'static>>> =
+        const { RefCell::new(None) };
+    static ZSTD_DECOMPRESSOR: RefCell<Option<zstd::bulk::Decompressor<'static>>> =
+        const { RefCell::new(None) };
+}
+
+impl ExtentCodec for ZstdCodec {
+    fn encode(&self, body: &[u8], out: &mut Vec<u8>) {
+        let bound = zstd::zstd_safe::compress_bound(body.len());
+        out.resize(4 + bound, 0);
+        let len = u32::try_from(body.len()).expect("chunk bodies are bounded by the size classes");
+        out[..4].copy_from_slice(&len.to_le_bytes());
+        let compressed = ZSTD_COMPRESSOR.with(|cell| {
+            let mut slot = cell.borrow_mut();
+            let compressor = slot.get_or_insert_with(|| {
+                zstd::bulk::Compressor::new(self.level).expect("zstd compression context")
+            });
+            compressor
+                .set_compression_level(self.level)
+                .expect("zstd accepts every level, clamping out-of-range ones");
+            compressor
+                .compress_to_buffer(body, &mut out[4..])
+                .expect("output sized to the compression bound")
+        });
+        out.truncate(4 + compressed);
+    }
+
+    fn decode(&self, stored: &[u8], body: &mut [u8]) {
+        let prefix: [u8; 4] = stored[..4].try_into().expect("prefix length");
+        let len = usize::try_from(u32::from_le_bytes(prefix)).expect("length fits usize");
+        assert_eq!(
+            len,
+            body.len(),
+            "destination must match the encoded body length"
+        );
+        let written = ZSTD_DECOMPRESSOR.with(|cell| {
+            let mut slot = cell.borrow_mut();
+            let decompressor = slot.get_or_insert_with(|| {
+                zstd::bulk::Decompressor::new().expect("zstd decompression context")
+            });
+            decompressor
+                .decompress_to_buffer(&stored[4..], body)
+                .expect("stored bytes hold a valid zstd frame")
+        });
+        assert_eq!(written, body.len(), "decoded length mismatch");
+    }
+}
+
 /// The largest stored form [`ExtentCodec::encode`] may produce for a
-/// `body_len`-byte body: an incompressible-input expansion matching lz4's
-/// worst case plus a four-byte length prefix. The extent store's size-class
-/// ladder is provisioned to this bound, so a codec that exceeds it can
-/// strand payloads with no class to hold them (they degrade to unpageable
-/// heap fallbacks).
+/// `body_len`-byte body: a four-byte length prefix plus the larger of lz4's
+/// and zstd's incompressible-input expansions. lz4 expands by at most
+/// `body_len / 255 + 16`. zstd's `ZSTD_COMPRESSBOUND` expands by
+/// `body_len / 256` plus block framing of up to 64 bytes that only exceeds
+/// lz4's slack below 128 KiB. The extent store's size-class ladder is
+/// provisioned to this bound, so a codec that exceeds it can strand payloads
+/// with no class to hold them (they degrade to unpageable heap fallbacks).
 pub fn max_stored_len(body_len: usize) -> usize {
-    4 + body_len + body_len / 255 + 16
+    let lz4 = body_len / 255 + 16;
+    let zstd = body_len / 256 + (128usize << 10).saturating_sub(body_len) / 2048;
+    4 + body_len + lz4.max(zstd)
 }
 
 /// Advisory placement hints for a chunk, supplied at insert and immutable
@@ -3638,6 +3746,73 @@ mod tests {
         let mut range = Vec::new();
         h.read_range_into(8..24, &mut range);
         assert_eq!(range, want[8..24], "range reads copy the range directly");
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: foreign function calls (zstd)
+    fn zstd_codec_round_trips() {
+        let pool = test_pool(usize::MAX);
+        let want = payload(SMALL, 602);
+        let h = pool.insert_with(SMALL, ChunkHints::default(), zstd_codec(1), |dst| {
+            dst.copy_from_slice(&want);
+        });
+        assert_eq!(read(&h), want);
+        pool.evict(&h);
+        assert_eq!(read(&h), want, "round-trips through the extent");
+        pool.evict(&h);
+        let mut range = Vec::new();
+        h.read_range_into(8..24, &mut range);
+        assert_eq!(range, want[8..24]);
+    }
+
+    /// The stored form is the body length followed by one frame, shrinks on
+    /// compressible input, stays within the extent-store bound, and one
+    /// thread's retained contexts serve codecs at different levels.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: foreign function calls (zstd)
+    fn zstd_codec_framing() {
+        let body: Vec<u8> = (0..100_000u32).flat_map(|i| i.to_le_bytes()).collect();
+        for codec in [zstd_codec(1), zstd_codec(19)] {
+            let mut stored = Vec::new();
+            codec.encode(&body, &mut stored);
+            let prefix: [u8; 4] = stored[..4].try_into().expect("prefix");
+            assert_eq!(u32::from_le_bytes(prefix), 400_000);
+            assert!(stored.len() < body.len(), "compressible input shrinks");
+            assert!(stored.len() <= max_stored_len(body.len()));
+            let mut round = vec![0u8; body.len()];
+            codec.decode(&stored, &mut round);
+            assert_eq!(round, body);
+        }
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: foreign function calls (zstd)
+    #[should_panic(expected = "destination must match")]
+    fn zstd_codec_decode_length_mismatch_panics() {
+        let mut stored = Vec::new();
+        zstd_codec(1).encode(&[7u8; 64], &mut stored);
+        let mut short = vec![0u8; 32];
+        zstd_codec(1).decode(&stored, &mut short);
+    }
+
+    #[mz_ore::test]
+    fn zstd_codec_table_clamps() {
+        assert_eq!(format!("{:?}", zstd_codec(-5)), "ZstdCodec { level: 1 }");
+        assert_eq!(format!("{:?}", zstd_codec(3)), "ZstdCodec { level: 3 }");
+        assert_eq!(format!("{:?}", zstd_codec(100)), "ZstdCodec { level: 19 }");
+    }
+
+    /// The extent-store bound covers zstd's documented worst case, including
+    /// the small-body range where zstd's block framing exceeds lz4's slack.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: foreign function calls (zstd)
+    fn max_stored_len_covers_zstd_bound() {
+        for body_len in (0..=(160 << 10)).chain(SIZE_CLASSES) {
+            assert!(
+                4 + zstd::zstd_safe::compress_bound(body_len) <= max_stored_len(body_len),
+                "zstd bound exceeds max_stored_len at {body_len}"
+            );
+        }
     }
 
     #[mz_ore::test]

--- a/src/timely-util/src/columnar/chunk.rs
+++ b/src/timely-util/src/columnar/chunk.rs
@@ -44,7 +44,7 @@ use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU8, Ordering};
 
 use columnar::bytes::indexed;
 use columnar::{Borrow, BorrowedOf, Columnar, Container as _, FromBytes, Index, Len, Push as _};
@@ -52,7 +52,9 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::chunk::Chunk;
 use mz_ore::cast::CastFrom;
-use mz_ore::pool::{ChunkHandle, ChunkHints, ExtentCodec, IDENTITY_CODEC, Pool};
+use mz_ore::pool::{
+    ChunkHandle, ChunkHints, ExtentCodec, IDENTITY_CODEC, Pool, ZSTD_LEVELS, zstd_codec,
+};
 use smallvec::SmallVec;
 use timely::Accountable;
 use timely::PartialOrder;
@@ -82,6 +84,16 @@ thread_local! {
     /// running tests on the process-global state.
     #[cfg(test)]
     static COMPRESS_MIN_DEPTH_OVERRIDE: Cell<Option<u8>> = const { Cell::new(None) };
+
+    /// A thread-scoped codec override, with the same purpose as the depth
+    /// floor override.
+    #[cfg(test)]
+    static COMPRESS_CODEC_OVERRIDE: Cell<Option<CompressCodec>> = const { Cell::new(None) };
+
+    /// A thread-scoped zstd level override, with the same purpose as the
+    /// depth floor override.
+    #[cfg(test)]
+    static COMPRESS_ZSTD_LEVEL_OVERRIDE: Cell<Option<i32>> = const { Cell::new(None) };
 
     /// Reusable staging for call-scoped reads of spilled bodies.
     static READ_SCRATCH: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) };
@@ -161,15 +173,143 @@ fn compress_min_depth() -> u8 {
     COMPRESS_MIN_DEPTH.load(Ordering::Relaxed)
 }
 
+/// The compressing codec choices for spilled bodies at or past the
+/// compression depth floor. See [`set_compress_codec`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompressCodec {
+    /// One lz4 block per body ([`LZ4_CODEC`]): the cheapest encode.
+    Lz4,
+    /// One zstd frame per body at the level [`set_compress_zstd_level`]
+    /// chose: denser than lz4 for more encode CPU on the eviction path.
+    Zstd,
+}
+
+impl CompressCodec {
+    const fn as_u8(self) -> u8 {
+        match self {
+            CompressCodec::Lz4 => 0,
+            CompressCodec::Zstd => 1,
+        }
+    }
+
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => CompressCodec::Zstd,
+            _ => CompressCodec::Lz4,
+        }
+    }
+
+    fn extent_codec(self, zstd_level: i32) -> &'static dyn ExtentCodec {
+        match self {
+            CompressCodec::Lz4 => &LZ4_CODEC,
+            CompressCodec::Zstd => zstd_codec(zstd_level),
+        }
+    }
+}
+
+impl std::str::FromStr for CompressCodec {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "lz4" => Ok(CompressCodec::Lz4),
+            "zstd" => Ok(CompressCodec::Zstd),
+            other => Err(format!(
+                "unknown chunk codec {other:?}; expected lz4 or zstd"
+            )),
+        }
+    }
+}
+
+const DEFAULT_COMPRESS_CODEC: CompressCodec = CompressCodec::Lz4;
+
+/// The codec spilled bodies at or past the depth floor store under. See
+/// [`set_compress_codec`].
+static COMPRESS_CODEC: AtomicU8 = AtomicU8::new(DEFAULT_COMPRESS_CODEC.as_u8());
+
+/// Set the codec spilled bodies at or past the compression depth floor
+/// store under.
+///
+/// Consulted at every commit, so bodies spilled from then on use the new
+/// codec. A body keeps the codec it was inserted under for its lifetime,
+/// since the pool decodes through the codec recorded at insert, so a change
+/// never migrates or invalidates bodies already spilled. They turn over as
+/// merges rewrite them.
+pub fn set_compress_codec(codec: CompressCodec) {
+    COMPRESS_CODEC.store(codec.as_u8(), Ordering::Relaxed);
+}
+
+/// Set or unset a thread-scoped codec override, taking precedence over
+/// [`set_compress_codec`]. Tests run concurrently and must not race on the
+/// process-global codec.
+#[cfg(test)]
+pub fn set_compress_codec_override(codec: Option<CompressCodec>) {
+    COMPRESS_CODEC_OVERRIDE.with(|cell| cell.set(codec));
+}
+
+/// The compressing codec in effect for this thread's commits.
+fn compress_codec() -> CompressCodec {
+    #[cfg(test)]
+    if let Some(codec) = COMPRESS_CODEC_OVERRIDE.with(|cell| cell.get()) {
+        return codec;
+    }
+    CompressCodec::from_u8(COMPRESS_CODEC.load(Ordering::Relaxed))
+}
+
+/// Level 1 because encode runs on the eviction path, inline on the evicting
+/// worker when spill threads are off, so encode throughput matters more than
+/// the ratio higher levels buy.
+const DEFAULT_COMPRESS_ZSTD_LEVEL: i32 = 1;
+
+/// The zstd level bodies spilled under [`CompressCodec::Zstd`] compress at.
+/// See [`set_compress_zstd_level`].
+static COMPRESS_ZSTD_LEVEL: AtomicI32 = AtomicI32::new(DEFAULT_COMPRESS_ZSTD_LEVEL);
+
+/// Set the zstd level bodies spilled under [`CompressCodec::Zstd`] compress
+/// at, within [`ZSTD_LEVELS`]. An out-of-range level is rejected and leaves
+/// the level unchanged.
+///
+/// Consulted at every commit. Decode does not depend on the level, so
+/// bodies spilled at earlier levels stay readable.
+pub fn set_compress_zstd_level(level: i32) -> Result<(), String> {
+    if !ZSTD_LEVELS.contains(&level) {
+        return Err(format!(
+            "zstd level {level} outside the supported range {}..={}",
+            ZSTD_LEVELS.start(),
+            ZSTD_LEVELS.end()
+        ));
+    }
+    COMPRESS_ZSTD_LEVEL.store(level, Ordering::Relaxed);
+    Ok(())
+}
+
+/// Set or unset a thread-scoped zstd level override, taking precedence over
+/// [`set_compress_zstd_level`]. Tests run concurrently and must not race on
+/// the process-global level.
+#[cfg(test)]
+pub fn set_compress_zstd_level_override(level: Option<i32>) {
+    COMPRESS_ZSTD_LEVEL_OVERRIDE.with(|cell| cell.set(level));
+}
+
+/// The zstd level in effect for this thread's commits.
+fn compress_zstd_level() -> i32 {
+    #[cfg(test)]
+    if let Some(level) = COMPRESS_ZSTD_LEVEL_OVERRIDE.with(|cell| cell.get()) {
+        return level;
+    }
+    COMPRESS_ZSTD_LEVEL.load(Ordering::Relaxed)
+}
+
 /// The codec a body at `depth` stores under, identity below the compression
-/// floor and lz4 at and past it, paired with whether that codec compresses.
-/// One read of the floor, so the pair cannot disagree with itself when the
-/// floor moves under a concurrent commit.
+/// floor and the configured compressing codec at and past it, paired with
+/// whether that codec compresses. One read of the floor, so the pair cannot
+/// disagree with itself when the floor moves under a concurrent commit.
 fn codec_for_depth(depth: u8) -> (&'static dyn ExtentCodec, bool) {
     if depth < compress_min_depth() {
         (&IDENTITY_CODEC, false)
     } else {
-        (&LZ4_CODEC, true)
+        let codec = compress_codec().extent_codec(compress_zstd_level());
+        (codec, true)
     }
 }
 
@@ -2007,6 +2147,53 @@ mod tests {
         assert_eq!(codec_name(0), "IdentityCodec");
         assert_eq!(codec_name(1), "Lz4Codec");
         set_compress_min_depth_override(None);
+    }
+
+    /// The codec and level flags pick what bodies at or past the floor store
+    /// under, the floor still exempts shallower generations, and bodies
+    /// round-trip through zstd at every depth.
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: foreign function calls (zstd)
+    fn spill_codec_flag_selects_zstd() {
+        set_spill_override(Some(test_pool()));
+        set_compress_min_depth_override(Some(1));
+        set_compress_codec_override(Some(CompressCodec::Zstd));
+        set_compress_zstd_level_override(Some(3));
+        let (codec, compressed) = codec_for_depth(0);
+        assert_eq!(format!("{:?}", codec), "IdentityCodec");
+        assert!(!compressed);
+        let (codec, compressed) = codec_for_depth(1);
+        assert_eq!(format!("{:?}", codec), "ZstdCodec { level: 3 }");
+        assert!(compressed);
+
+        let data: Vec<Tuple> = (0..20_000u64).map(|i| ((i, 0), 0, 1i64)).collect();
+        let data = consolidate(data);
+        let column = build_column(&data);
+        for depth in [0u8, 1, 3] {
+            let chunk = TestChunk::commit(column.clone(), depth);
+            assert!(chunk.is_spilled(), "depth {depth} must spill");
+            assert_eq!(collect_column(&chunk.into_column()), data);
+        }
+        set_spill_override(None);
+        set_compress_min_depth_override(None);
+        set_compress_codec_override(None);
+        set_compress_zstd_level_override(None);
+    }
+
+    #[mz_ore::test]
+    fn compress_codec_parses() {
+        assert_eq!("lz4".parse(), Ok(CompressCodec::Lz4));
+        assert_eq!("zstd".parse(), Ok(CompressCodec::Zstd));
+        assert!("gzip".parse::<CompressCodec>().is_err());
+    }
+
+    /// Rejected levels never reach the process-global, so this test cannot
+    /// race others on it.
+    #[mz_ore::test]
+    fn compress_zstd_level_rejects_out_of_range() {
+        assert!(set_compress_zstd_level(0).is_err());
+        assert!(set_compress_zstd_level(20).is_err());
+        assert!(set_compress_zstd_level(-1).is_err());
     }
 
     /// A chunk a merge carries forward untouched ages a generation, and a


### PR DESCRIPTION
### Motivation

The buffer pool compresses spilled chunk bodies at the eviction boundary, and until now the only compressing codec was lz4. To measure the ratio-versus-encode-CPU trade on real workloads without a rebuild, this adds a zstd codec to `mz_ore::pool` and two replica-scoped flags that pick the codec and its level for chunk spills. Internal, behind the off-by-default spill gates; no user-visible change.

### Description

`ZstdCodec` shares the lz4 framing: a little-endian u32 body length followed by one zstd frame. Each thread keeps one compression and one decompression context, since a fresh context per spilled chunk would pay a workspace allocation on the eviction path. A const table holds one codec per standard level (1 through 19) so a level chosen at runtime still reaches `Pool::insert_with` as a `'static` codec. Decode is level-agnostic, so mixed levels coexist in one pool.

`max_stored_len`, the bound the extent-store ladder is provisioned to, now takes the larger of lz4's and zstd's incompressible-input expansions. Below roughly 96 KiB zstd's block framing exceeds lz4's slack, so the lz4-only formula would have violated the codec contract for small bodies. The ladder itself is unchanged since lz4 dominates at the top class.

`column_chunk_codec` (`lz4`, the default, or `zstd`) and `column_chunk_zstd_level` (default 1) are applied alongside the depth floor in compute's config handler. A body keeps the codec it spilled under, since the pool decodes through the codec recorded at insert, so changing either flag never migrates or invalidates existing extents. Negative fast levels are out of reach because dyncfg has no signed integer type.

`zstd` is added to the workspace with default features off; the lock delta is the single new edge.

### Verification

New unit tests in `mz_ore::pool` cover zstd round-trips through eviction and range reads, the framing and the length-mismatch panic, `max_stored_len` against `zstd_safe::compress_bound` across the small-body range and every size class, and level-table clamping. New tests in `chunk.rs` cover the codec and level flags flowing through `codec_for_depth` with spills round-tripping through zstd at several depths, string parsing, and rejection of out-of-range levels. The two flags are listed in mzcompose's uninteresting set like their siblings and swept by parallel-workload.

Generated with Claude Code.