### PR TITLE
storage/mysql: enable primary-key snapshot parallelism by default

### DIFF
--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -234,7 +234,7 @@ pub const MYSQL_REPLICATION_HEARTBEAT_INTERVAL: Config<Duration> = Config::new(
 /// whole by a single worker.
 pub static MYSQL_SOURCE_SNAPSHOT_PARALLELISM: Config<bool> = Config::new(
     "mysql_source_snapshot_parallelism",
-    false,
+    true,
     "Whether to split MySQL snapshot reads across workers by primary-key ranges.",
     ParameterScope::Replica,
 );


### PR DESCRIPTION
### Motivation
Part of [SS-438](https://linear.app/materializeinc/issue/SS-438)


Flips the `mysql_source_snapshot_parallelism` dyncfg default from `false` to `true`, so MySQL source snapshots of tables with a supported single-column primary key are split into per-worker PK ranges out of the box. Tables without a suitable PK continue to fall back to a single-worker whole-table read.

CI has been exercising the enabled path via the mzcompose system parameter override (which also randomizes the flag so the fallback path stays covered). This brings the production default in line with what is tested. The flag remains available to disable splitting for a replica if needed.

### Tips for reviewer

One-line default change. The existing `test/mysql-cdc/mysql-cdc.td` coverage explicitly sets the flag to `false` for the fallback case and relies on the enabled path elsewhere, so no test changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)