### PR TITLE
docs: drop private preview caveat from MySQL snapshot parallelism

### DIFF
--- a/doc/user/content/headless/ingestion/snapshotting-parallelism.md
+++ b/doc/user/content/headless/ingestion/snapshotting-parallelism.md
@@ -13,7 +13,7 @@ hosting the source.
 - **MySQL sources** are parallelized by table, i.e., different tables are
   read concurrently by different workers. For tables that meet certain
   requirements, Materialize can additionally partition the table's read
-  across workers {{< private-preview-inline />}}. See [MySQL snapshot
+  across workers. See [MySQL snapshot
   parallelism](/ingest-data/mysql/snapshot-parallelism/).
 
 - **Kafka sources** are parallelized by topic partition, with partitions

--- a/doc/user/content/ingest-data/mysql/_index.md
+++ b/doc/user/content/ingest-data/mysql/_index.md
@@ -35,7 +35,7 @@ gives you the following benefits:
 
 When a source is created, Materialize parallelizes the initial snapshot
 across the cluster's workers and can split the read of large tables that meet
-certain requirements {{< private-preview-inline />}}. See [Snapshot
+certain requirements. See [Snapshot
 parallelism](/ingest-data/mysql/snapshot-parallelism/).
 
 ## Supported versions and services

--- a/doc/user/content/ingest-data/mysql/snapshot-parallelism.md
+++ b/doc/user/content/ingest-data/mysql/snapshot-parallelism.md
@@ -9,8 +9,6 @@ menu:
     weight: 70
 ---
 
-{{< private-preview />}}
-
 When you create a [MySQL source](/sql/create-source/mysql-v2/), Materialize
 performs an initial, snapshot-based sync of the selected tables before it
 starts ingesting change events from the binlog. For large tables, this


### PR DESCRIPTION
### Motivation

Primary-key based snapshot parallelism for MySQL sources is being enabled by default in https://github.com/MaterializeInc/materialize/pull/38656, so the docs should no longer mark it as a private preview feature.

Removes the `private-preview` shortcode from the MySQL snapshot parallelism page and the two inline `private-preview-inline` markers on the MySQL ingestion overview and the shared snapshotting parallelism headless snippet.

The historical v26.39 release note entry that described the feature as private preview is left as is, since it records what was true at the time of that release.

### Tips for reviewer

Docs only. Will defer to @kay-kim on when we want to merge. Should be enabled via launch darkly Monday and then enabled by default for self-managed with v26.41.


🤖 Generated with [Claude Code](https://claude.com/claude-code)