### PR TITLE
storage: do not re-sort decode output chunks in persist_source

### DIFF
--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -9,7 +9,6 @@
 
 //! A source that reads from an a persist shard.
 
-use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use std::convert::Infallible;
 use std::fmt::Debug;
 use std::future::Future;
@@ -595,12 +594,14 @@ impl PendingWork {
         map_filter_project: Option<&MfpPlan>,
         datum_vec: &mut DatumVec,
         row_builder: &mut Row,
+        // A plain capacity builder: parts arrive sorted and `next_with_storage` already sums
+        // adjacent duplicates, so re-sorting and consolidating each output chunk found nothing
+        // to fold and cost about 30ns per row. Consumers that need consolidated data (arrangements,
+        // the peek response) consolidate themselves.
         output: &mut OutputBuilderSession<
             '_,
             (mz_repr::Timestamp, Subtime),
-            ConsolidatingContainerBuilder<
-                Vec<(Result<Row, E>, (mz_repr::Timestamp, Subtime), Diff)>,
-            >,
+            CapacityContainerBuilder<Vec<(Result<Row, E>, (mz_repr::Timestamp, Subtime), Diff)>>,
         >,
     ) -> bool
     where


### PR DESCRIPTION
### Motivation

`persist_source::decode_and_mfp` pushed its output through a `ConsolidatingContainerBuilder`, which sorts every output chunk and folds equal `(row, time)` pairs before handing it on. Persist parts arrive sorted, and `FetchedPart::next_with_storage` already sums adjacent duplicates as it iterates a part, so the per-chunk sort found nothing to fold. It still cost about 30ns per row on every row read from persist, which is 37% of this operator's time on a two-column table.

### Change

The decode output uses a plain `CapacityContainerBuilder`. Consumers that need consolidated data, arrangements and the peek response, consolidate themselves; chunk boundaries were never a consolidation guarantee anyone could rely on. The builder came in with the 2024 switch to container builders across storage, not from a need specific to this operator.

The one thing the old builder did that this does not is shrink exchanged volume when a chunk holds duplicates that the source-level consolidation missed (duplicates that straddle a part boundary, or arrive through the filter-pushdown audit path). Those are rare and downstream handles them.

### Measurements

One worker, 10M rows, three repetitions, same tree with and without the change:

| shape | `decode_and_mfp` | hydration |
|---|---|---|
| index on `(k)` over `(k, v)` | 0.81s to 0.50s | 2.57s to 2.40s |
| index on `SELECT DISTINCT k, v` | 0.81s to 0.50s | 4.08s to 3.81s |
| fact join dim, pushed-down `IS NOT NULL` | 1.40s to 1.13s | 6.56s to 6.43s |
| `count(*), sum(v) GROUP BY k % G` | 0.82s to 0.52s | 6.80s to 6.56s |
| `DISTINCT ON` top-1 with a pushed-down `k % G` | 1.64s to 1.27s | 9.81s to 9.57s |

### Testing

Every sqllogictest and testdrive that reads a table or source through persist exercises this operator; `distinct_arrangements`, `joins`, `aggregates` and `table` pass locally with the CI defaults.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label.
- [x] If this PR includes major user-facing behavior changes, I have pinged the relevant PM to schedule a changelog post.

### Release notes

This release will not include user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
