### PR TITLE
persist: place each snapshot part on the least loaded worker

### DIFF
--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -20,7 +20,6 @@ use std::hash::{Hash, Hasher};
 use std::pin::pin;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::Instant;
 
 use anyhow::anyhow;
 use arrow::array::ArrayRef;
@@ -511,6 +510,9 @@ where
         let coalesce_target = u64::cast_from(SOURCE_HYDRATION_FRONTIER_COALESCE_BYTES.get(&cfg));
         // Encoded bytes emitted since the last forwarded progress.
         let mut coalesced_bytes: u64 = 0;
+        // Encoded bytes handed to each worker so far, so each part can go to the least
+        // loaded worker.
+        let mut worker_bytes: Vec<u64> = vec![0; num_workers];
 
         // If `until.less_equal(current_frontier)`, it means that all subsequent batches will contain only
         // times greater or equal to `until`, which means they can be dropped in their entirety.
@@ -598,15 +600,22 @@ where
                     }
                 }
 
-                // Give the part to a random worker. This isn't round robin in an attempt to avoid
-                // skew issues: if your parts alternate size large, small, then you'll end up only
-                // using half of your workers.
-                //
-                // There's certainly some other things we could be doing instead here, but this has
-                // seemed to work okay so far. Continue to revisit as necessary.
-                let worker_idx = usize::cast_from(Instant::now().hashed()) % num_workers;
-                batch_bytes =
-                    batch_bytes.saturating_add(u64::cast_from(part_desc.encoded_size_bytes()));
+                // Give the part to the worker that has received the fewest encoded bytes so
+                // far. Round robin fails when parts alternate large and small, leaving half the
+                // workers idle; random placement avoids that but accepts balls-in-bins
+                // imbalance, which with the tens of parts a snapshot typically has leaves the
+                // busiest worker with two to three times the bytes of the least busy one, and
+                // hydration waits for the busiest. Placing by load handles both, and is
+                // deterministic for a given part sequence.
+                let part_bytes = u64::cast_from(part_desc.encoded_size_bytes());
+                let worker_idx = worker_bytes
+                    .iter()
+                    .enumerate()
+                    .min_by_key(|(idx, bytes)| (**bytes, *idx))
+                    .map(|(idx, _)| idx)
+                    .expect("at least one worker");
+                worker_bytes[worker_idx] = worker_bytes[worker_idx].saturating_add(part_bytes);
+                batch_bytes = batch_bytes.saturating_add(part_bytes);
                 let (part, lease) = part_desc.into_exchangeable_part();
                 leases.borrow_mut().push_at(current_ts.clone(), lease);
                 descs_output.give(&session_cap, (worker_idx, part));
@@ -808,6 +817,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use super::*;
     use std::sync::Arc;
 


### PR DESCRIPTION
### Motivation

`shard_source` hands each persist part to a worker chosen at random. The comment explains why not round robin: parts that alternate large and small would leave half the workers idle. Random dodges that but accepts balls-in-bins imbalance, and with the tens of parts a typical snapshot has, that imbalance is large: hydrating an index over a 10M-row table on four workers, one worker carried 1.18s of the dataflow and another 0.35s, and the wall time follows the busiest worker.

### Change

Send each part to the worker that has received the fewest encoded bytes so far. `encoded_size_bytes` is already computed two lines earlier for the coalescing logic. This handles both failure modes: alternating sizes even out because placement follows load rather than position, and the placement is deterministic for a given part sequence.

### Measurements

Four workers, 10M rows written in 16 inserts, three repetitions, same tree with and without the change (on top of the other PRs of this series):

| shape | before | after | per-worker dataflow time after |
|---|---|---|---|
| index on `(k)` | 1.14s (1.10 to 1.25) | 0.90s (0.89 to 0.91) | 0.85, 0.55, 0.67, 0.60s (was 0.43, 0.60, 1.18, 0.35) |
| index on `SELECT DISTINCT k, v` | 1.07s (1.02 to 1.36) | 1.04s (1.02 to 1.05) | |
| fact join dim, index on output | 2.32s | 2.34s | unchanged: its skew is the 1M-row dimension table's few parts and the join exchange |

Single-worker numbers are unaffected. The August measurement in the same harness (4M rows, join shape, 64 parts) saw medians improve 16 to 21% at two and four workers with the repetition spread dropping from 28 to 37% to 2 to 17%, which matches: the change removes the bad draws rather than raising the best case.

### Testing

Existing tests cover the operator; placement is not observable in results, only in per-worker load.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label.
- [x] If this PR includes major user-facing behavior changes, I have pinged the relevant PM to schedule a changelog post.

### Release notes

This release will not include user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
