### PR TITLE
compute: let hinted TopK stages emit the rows they keep

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -97,6 +97,8 @@ def get_minimal_system_parameters(
         "enable_coalesce_case_transform": "true",
         "enable_columnation_lgalloc": "false",
         "enable_compute_correction_v2": "true",
+        # Off in production; on here so hinted TopK plans exercise kept-row stages.
+        "enable_compute_topk_retained_stages": "true",
         "enable_compute_logical_backpressure": "true",
         "enable_connection_validation_syntax": "true",
         "enable_create_table_from_source": "true",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3139,6 +3139,9 @@ class FlipFlagsAction(Action):
             BOOLEAN_FLAG_VALUES
         )
         self.flags_with_values["enable_compute_sync_mv_sink"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_compute_topk_retained_stages"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_column_paged_batcher"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_columnar_merge_batcher"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_column_paged_batcher_spill"] = (

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -262,6 +262,16 @@ pub const ENABLE_SYNC_MV_SINK: Config<bool> = Config::new(
     ParameterScope::Environment,
 );
 
+/// Whether a TopK stage may emit the rows it keeps instead of negations of the rows it drops,
+/// when the expected group size says the kept rows are fewer. Read at dataflow rendering time.
+pub const ENABLE_COMPUTE_TOPK_RETAINED_STAGES: Config<bool> = Config::new(
+    "enable_compute_topk_retained_stages",
+    false,
+    "Whether a TopK stage may emit the rows it keeps instead of negations of the rows it drops, \
+     when the expected group size says the kept rows are fewer.",
+    ParameterScope::Replica,
+);
+
 /// Whether rendering should use the new MV sink correction buffer implementation.
 pub const ENABLE_CORRECTION_V2: Config<bool> = Config::new(
     "enable_compute_correction_v2",
@@ -793,6 +803,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_ERROR_DISTINCT)
         .add(&ENABLE_MZ_JOIN_CORE)
         .add(&ENABLE_SYNC_MV_SINK)
+        .add(&ENABLE_COMPUTE_TOPK_RETAINED_STAGES)
         .add(&ENABLE_CORRECTION_V2)
         .add(&CORRECTION_V2_CHAIN_PROPORTIONALITY)
         .add(&CORRECTION_V2_CHUNK_SIZE)

--- a/src/compute-types/src/plan/top_k.rs
+++ b/src/compute-types/src/plan/top_k.rs
@@ -89,7 +89,6 @@ impl TopKPlan {
                 limit,
                 arity,
                 buckets: bucketing_of_expected_group_size(expected_group_size),
-                expected_group_size,
             })
         }
     }
@@ -150,7 +149,6 @@ impl TopKPlan {
                 arity: _,
                 offset: _,
                 buckets: _,
-                expected_group_size: _,
             }) => limit.as_ref(),
         }
     }
@@ -229,9 +227,8 @@ pub struct BasicTopKPlan {
     /// The number of columns in the input and output.
     pub arity: usize,
     /// Bucket sizes for hierarchical stages of TopK.  Should be decreasing.
+    ///
+    /// Empty when the query's group size hint is at most sixteen, the fan-in of one stage; the
+    /// renderer reads that as a promise that groups are small.
     pub buckets: Vec<u64>,
-    /// The expected number of rows per group, when the query gave a hint. The renderer uses it,
-    /// together with `limit` and `offset`, to decide per stage whether emitting the kept rows or
-    /// the dropped rows is cheaper.
-    pub expected_group_size: Option<u64>,
 }

--- a/src/compute-types/src/plan/top_k.rs
+++ b/src/compute-types/src/plan/top_k.rs
@@ -89,6 +89,7 @@ impl TopKPlan {
                 limit,
                 arity,
                 buckets: bucketing_of_expected_group_size(expected_group_size),
+                expected_group_size,
             })
         }
     }
@@ -149,6 +150,7 @@ impl TopKPlan {
                 arity: _,
                 offset: _,
                 buckets: _,
+                expected_group_size: _,
             }) => limit.as_ref(),
         }
     }
@@ -228,4 +230,8 @@ pub struct BasicTopKPlan {
     pub arity: usize,
     /// Bucket sizes for hierarchical stages of TopK.  Should be decreasing.
     pub buckets: Vec<u64>,
+    /// The expected number of rows per group, when the query gave a hint. The renderer uses it,
+    /// together with `limit` and `offset`, to decide per stage whether emitting the kept rows or
+    /// the dropped rows is cheaper.
+    pub expected_group_size: Option<u64>,
 }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -274,7 +274,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     let (result, errs) = self.build_topk_stage(
                         thinned,
                         order_key,
-                        1u64,
+                        Some(1),
                         0,
                         limit,
                         arity,
@@ -354,13 +354,20 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
     ) {
         let pairer = Pairer::new(1);
         let mut datum_vec = mz_repr::DatumVec::new();
+        // Key each row for the first stage directly: its bucket of the row hash, or zero when
+        // the only stage is the final one and the hash would be discarded anyway.
+        let first_modulus = buckets.first().copied().unwrap_or(1);
         let mut collection = collection.map({
             move |row| {
                 let group_row = {
-                    let row_hash = row.hashed();
+                    let bucket = if first_modulus == 1 {
+                        0
+                    } else {
+                        row.hashed() % first_modulus
+                    };
                     let datums = datum_vec.borrow_with(&row);
                     let iterator = group_key.iter().map(|i| datums[*i]);
-                    pairer.merge(std::iter::once(Datum::from(row_hash)), iterator)
+                    pairer.merge(std::iter::once(Datum::from(bucket)), iterator)
                 };
                 (group_row, row)
             }
@@ -388,6 +395,8 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                 StageOutput::Dropped
             }
         };
+        // The input arrives keyed for the first stage; later stages rekey it.
+        let mut first = true;
         let mut validating = true;
         let mut err_collection: Option<VecCollection<'s, T, _, _>> = None;
 
@@ -426,13 +435,14 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                 let (oks, errs) = self.build_topk_stage(
                     collection,
                     order_key.clone(),
-                    bucket,
+                    (!first).then_some(bucket),
                     0,
                     Some(limit.clone()),
                     arity,
                     validating,
                     stage_output(bucket),
                 );
+                first = false;
                 collection = oks;
                 if validating {
                     err_collection = errs;
@@ -448,7 +458,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         let (oks, errs) = self.build_topk_stage(
             collection,
             order_key,
-            1u64,
+            (!first).then_some(1),
             offset,
             limit,
             arity,
@@ -509,7 +519,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         &self,
         collection: VecCollection<'s, T, (Row, Row), Diff>,
         order_key: Vec<mz_expr::ColumnOrder>,
-        modulus: u64,
+        modulus: Option<u64>,
         offset: usize,
         limit: Option<LirScalarExpr>,
         arity: usize,
@@ -519,14 +529,17 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         VecCollection<'s, T, (Row, Row), Diff>,
         Option<VecCollection<'s, T, DataflowErrorSer, Diff>>,
     ) {
-        // Form appropriate input by updating the `hash` column (first datum in `hash_key`) by
-        // applying `modulus`.
-        let input = collection.map(move |(hash_key, row)| {
-            let mut hash_key_iter = hash_key.iter();
-            let hash = hash_key_iter.next().unwrap().unwrap_uint64() % modulus;
-            let hash_key = SharedRow::pack(std::iter::once(hash.into()).chain(hash_key_iter));
-            (hash_key, row)
-        });
+        // Rekey the input by applying `modulus` to the hash column (first datum in `hash_key`),
+        // unless the input already arrives keyed for this stage.
+        let input = match modulus {
+            Some(modulus) => collection.map(move |(hash_key, row)| {
+                let mut hash_key_iter = hash_key.iter();
+                let hash = hash_key_iter.next().unwrap().unwrap_uint64() % modulus;
+                let hash_key = SharedRow::pack(std::iter::once(hash.into()).chain(hash_key_iter));
+                (hash_key, row)
+            }),
+            None => collection,
+        };
 
         // If validating: demux errors, otherwise we cannot produce errors.
         let (input, oks, errs) = if validating {

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -357,17 +357,33 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         // Key each row for the first stage directly: its bucket of the row hash, or zero when
         // the only stage is the final one and the hash would be discarded anyway.
         let first_modulus = buckets.first().copied().unwrap_or(1);
+        // A group key that is the row's leading columns is a byte prefix of the row.
+        let prefix_len = group_key
+            .iter()
+            .enumerate()
+            .all(|(index, column)| *column == index)
+            .then_some(group_key.len());
         let mut collection = collection.map({
             move |row| {
-                let group_row = {
-                    let bucket = if first_modulus == 1 {
-                        0
-                    } else {
-                        row.hashed() % first_modulus
-                    };
-                    let datums = datum_vec.borrow_with(&row);
-                    let iterator = group_key.iter().map(|i| datums[*i]);
-                    pairer.merge(std::iter::once(Datum::from(bucket)), iterator)
+                let bucket = if first_modulus == 1 {
+                    0
+                } else {
+                    row.hashed() % first_modulus
+                };
+                let group_row = match prefix_len {
+                    Some(prefix_len) => {
+                        let (group, _) = row.split_at_datum(prefix_len);
+                        let mut group_row = Row::default();
+                        let mut packer = group_row.packer();
+                        packer.push(Datum::from(bucket));
+                        packer.extend_by_row_ref(group);
+                        group_row
+                    }
+                    None => {
+                        let datums = datum_vec.borrow_with(&row);
+                        let iterator = group_key.iter().map(|i| datums[*i]);
+                        pairer.merge(std::iter::once(Datum::from(bucket)), iterator)
+                    }
                 };
                 (group_row, row)
             }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -23,7 +23,10 @@ use differential_dataflow::operators::iterate::Variable as SemigroupVariable;
 use differential_dataflow::trace::cursor::{BatchCursor, BatchValOwn};
 use differential_dataflow::trace::{Builder, Cursor, Navigable, Trace};
 use differential_dataflow::{Data, VecCollection};
-use mz_compute_types::dyncfgs::{ENABLE_COMPUTE_TEMPORAL_BUCKETING, TEMPORAL_BUCKETING_SUMMARY};
+use mz_compute_types::dyncfgs::{
+    ENABLE_COMPUTE_TEMPORAL_BUCKETING, ENABLE_COMPUTE_TOPK_RETAINED_STAGES,
+    TEMPORAL_BUCKETING_SUMMARY,
+};
 use mz_compute_types::plan::ArrangementStrategy;
 use mz_compute_types::plan::scalar::LirScalarExpr;
 use mz_compute_types::plan::top_k::{
@@ -268,8 +271,16 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     // intra-ts thinning. The maximum number of records per timestamp is
                     // (num_workers * limit), which we expect to be a small number and so we render
                     // a single topk stage.
-                    let (result, errs) =
-                        self.build_topk_stage(thinned, order_key, 1u64, 0, limit, arity, false);
+                    let (result, errs) = self.build_topk_stage(
+                        thinned,
+                        order_key,
+                        1u64,
+                        0,
+                        limit,
+                        arity,
+                        false,
+                        StageOutput::Dropped,
+                    );
                     // Consolidate the output of `build_topk_stage` because it's not guaranteed to be.
                     let result = CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(
                         result,
@@ -293,6 +304,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     mut limit,
                     arity,
                     buckets,
+                    expected_group_size,
                 }) => {
                     // Must permute `limit` to reference `group_key` elements as if in order.
                     if let Some(expr) = limit.as_mut() {
@@ -304,7 +316,14 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     }
 
                     let (oks, errs) = self.build_topk(
-                        ok_input, group_key, order_key, offset, limit, arity, buckets,
+                        ok_input,
+                        group_key,
+                        order_key,
+                        offset,
+                        limit,
+                        arity,
+                        buckets,
+                        expected_group_size,
                     );
                     err_collection = err_collection.concat(errs);
                     CollectionBundle::from_collections(oks, err_collection)
@@ -328,6 +347,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         limit: Option<LirScalarExpr>,
         arity: usize,
         buckets: Vec<u64>,
+        expected_group_size: Option<u64>,
     ) -> (
         VecCollection<'s, T, Row, Diff>,
         VecCollection<'s, T, DataflowErrorSer, Diff>,
@@ -346,6 +366,28 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
             }
         });
 
+        // Rows a stage keeps per key: the literal limit plus the offset it must see past.
+        let kept_per_key = limit
+            .as_ref()
+            .and_then(|l| l.as_literal_int64())
+            .and_then(|l| u64::try_from(l).ok())
+            .map(|l| l.saturating_add(u64::cast_from(offset)));
+        let retain_allowed = ENABLE_COMPUTE_TOPK_RETAINED_STAGES.get(&self.config_set);
+        // Whether a stage emits kept rows or negated dropped rows. Kept rows cost less state when
+        // a key's group holds at least twice what the stage keeps, which only the hint can say:
+        // at a stage with modulus `m` a group spreads over `m` keys. Without a hint every stage
+        // emits dropped rows, since a kept-row stage whose keys hold a single row each would copy
+        // its whole input into its output arrangement.
+        let stage_output = |modulus: u64| -> StageOutput {
+            let (Some(kept), Some(group_size)) = (kept_per_key, expected_group_size) else {
+                return StageOutput::Dropped;
+            };
+            if retain_allowed && kept.saturating_mul(2) <= group_size / modulus.max(1) {
+                StageOutput::Kept
+            } else {
+                StageOutput::Dropped
+            }
+        };
         let mut validating = true;
         let mut err_collection: Option<VecCollection<'s, T, _, _>> = None;
 
@@ -389,6 +431,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     Some(limit.clone()),
                     arity,
                     validating,
+                    stage_output(bucket),
                 );
                 collection = oks;
                 if validating {
@@ -401,13 +444,26 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         // We do a final step, both to make sure that we complete the reduction, and to correctly
         // apply `offset` to the final group, as we have not yet been applying it to the partially
         // formed groups.
+        let final_output = stage_output(1);
         let (oks, errs) = self.build_topk_stage(
-            collection, order_key, 1u64, offset, limit, arity, validating,
+            collection,
+            order_key,
+            1u64,
+            offset,
+            limit,
+            arity,
+            validating,
+            final_output,
         );
-        // Consolidate the output of `build_topk_stage` because it's not guaranteed to be.
-        let oks =
-            CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(oks, "TopK final consolidate");
-        collection = oks;
+        // A stage that emits its input plus negations leaves cancellations behind; one that
+        // emits kept rows comes out of a reduce, already consolidated.
+        collection = match final_output {
+            StageOutput::Dropped => CollectionExt::consolidate_named::<KeyBatcher<_, _, _>>(
+                oks,
+                "TopK final consolidate",
+            ),
+            StageOutput::Kept => oks,
+        };
         if validating {
             err_collection = errs;
         }
@@ -458,6 +514,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         limit: Option<LirScalarExpr>,
         arity: usize,
         validating: bool,
+        output: StageOutput,
     ) -> (
         VecCollection<'s, T, (Row, Row), Diff>,
         Option<VecCollection<'s, T, DataflowErrorSer, Diff>>,
@@ -474,11 +531,11 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         // If validating: demux errors, otherwise we cannot produce errors.
         let (input, oks, errs) = if validating {
             // Build topk stage, produce errors for invalid multiplicities.
-            let (input, stage) = build_topk_negated_stage::<
+            let (input, stage) = build_topk_stage_arrangements::<
                 T,
                 RowValBuilder<_, _, _>,
                 RowValSpine<Result<Row, Row>, _, _>,
-            >(&input, order_key, offset, limit, arity);
+            >(&input, order_key, offset, limit, arity, output);
             let stage = stage.as_collection(|k, v| (k.to_row(), v.clone()));
 
             // Demux oks and errors.
@@ -502,16 +559,21 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         } else {
             // Build non-validating topk stage.
             let (input, stage) =
-                build_topk_negated_stage::<T, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
-                    &input, order_key, offset, limit, arity,
+                build_topk_stage_arrangements::<T, RowRowBuilder<_, _>, RowRowSpine<_, _>>(
+                    &input, order_key, offset, limit, arity, output,
                 );
             // Turn arrangement into collection.
             let stage = stage.as_collection(|k, v| (k.to_row(), v.to_row()));
 
             (input, stage, None)
         };
-        let input = input.as_collection(|k, v| (k.to_row(), v.to_row()));
-        (oks.concat(input), errs)
+        match output {
+            StageOutput::Kept => (oks, errs),
+            StageOutput::Dropped => {
+                let input = input.as_collection(|k, v| (k.to_row(), v.to_row()));
+                (oks.concat(input), errs)
+            }
+        }
     }
 
     fn render_top1_monotonic<'s>(
@@ -604,19 +666,29 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
     }
 }
 
-/// Build a stage of a topk reduction. Maintains the _retractions_ of the output instead of emitted
-/// rows. This has the benefit that we have to maintain state proportionally to size of the output
-/// instead of the size of the input.
+/// What a TopK stage's reduce emits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StageOutput {
+    /// The rows the stage keeps. The stage's result is the reduce output alone.
+    Kept,
+    /// Negations of the rows the stage drops. The stage's result is its input plus the
+    /// negations, so the maintained state is proportional to the rows dropped rather than kept,
+    /// which is smaller when groups are barely larger than the limit.
+    Dropped,
+}
+
+/// Build a stage of a topk reduction.
 ///
 /// Returns two arrangements:
 /// * The arranged input data without modifications, and
-/// * the maintained negated output data.
-fn build_topk_negated_stage<'s, T, Bu, Tr>(
+/// * the maintained output data, as `output` selects.
+fn build_topk_stage_arrangements<'s, T, Bu, Tr>(
     input: &VecCollection<'s, T, (Row, Row), Diff>,
     order_key: Vec<mz_expr::ColumnOrder>,
     offset: usize,
     limit: Option<LirScalarExpr>,
     arity: usize,
+    output: StageOutput,
 ) -> (
     Arranged<'s, TraceAgent<RowRowSpine<T, Diff>>>,
     Arranged<'s, TraceAgent<Tr>>,
@@ -702,16 +774,32 @@ where
                     || limit
                         .map(|l| source.iter().map(|(_, d)| *d).sum::<Diff>() > l)
                         .unwrap_or(false);
-                if !must_shrink {
-                    return;
-                }
-
-                // First go ahead and emit all records. Note that we ensure target
-                // has the capacity to hold at least these records, and avoid any
-                // dependencies on the user-provided (potentially unbounded) limit.
-                target.reserve(source.len());
-                for (datums, diff) in source.iter() {
-                    target.push((BatchValOwn::<Tr>::ok((*datums).to_row()), -diff));
+                match output {
+                    StageOutput::Dropped => {
+                        if !must_shrink {
+                            return;
+                        }
+                        // First go ahead and emit all records negated; the kept rows are emitted
+                        // again below and cancel. Note that we ensure target has the capacity to
+                        // hold at least these records, and avoid any dependencies on the
+                        // user-provided (potentially unbounded) limit.
+                        target.reserve(source.len());
+                        for (datums, diff) in source.iter() {
+                            target.push((BatchValOwn::<Tr>::ok((*datums).to_row()), -diff));
+                        }
+                    }
+                    StageOutput::Kept => {
+                        if !must_shrink {
+                            // Every row is kept.
+                            target.reserve(source.len());
+                            for (datums, diff) in source.iter() {
+                                if diff.is_positive() {
+                                    target.push((BatchValOwn::<Tr>::ok((*datums).to_row()), *diff));
+                                }
+                            }
+                            return;
+                        }
+                    }
                 }
                 // local copies that may count down to zero.
                 let mut offset = offset;
@@ -757,10 +845,9 @@ where
                         diff = std::cmp::min(diff, Diff::from(*limit));
                         *limit -= diff;
                     }
-                    // Output the indicated number of rows.
+                    // Output the indicated number of rows: the kept rows themselves, or, on
+                    // the dropped path, the positive counterparts that cancel their negations.
                     if diff.is_positive() {
-                        // Emit retractions for the elements actually part of
-                        // the set of TopK elements.
                         target.push((BatchValOwn::<Tr>::ok(datums.to_row()), diff));
                     }
                 }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -304,7 +304,6 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     mut limit,
                     arity,
                     buckets,
-                    expected_group_size,
                 }) => {
                     // Must permute `limit` to reference `group_key` elements as if in order.
                     if let Some(expr) = limit.as_mut() {
@@ -316,14 +315,7 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
                     }
 
                     let (oks, errs) = self.build_topk(
-                        ok_input,
-                        group_key,
-                        order_key,
-                        offset,
-                        limit,
-                        arity,
-                        buckets,
-                        expected_group_size,
+                        ok_input, group_key, order_key, offset, limit, arity, buckets,
                     );
                     err_collection = err_collection.concat(errs);
                     CollectionBundle::from_collections(oks, err_collection)
@@ -347,7 +339,6 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
         limit: Option<LirScalarExpr>,
         arity: usize,
         buckets: Vec<u64>,
-        expected_group_size: Option<u64>,
     ) -> (
         VecCollection<'s, T, Row, Diff>,
         VecCollection<'s, T, DataflowErrorSer, Diff>,
@@ -397,15 +388,19 @@ impl<'scope, T: crate::render::RenderTimestamp + crate::render::MaybeBucketByTim
             .map(|l| l.saturating_add(u64::cast_from(offset)));
         let retain_allowed = ENABLE_COMPUTE_TOPK_RETAINED_STAGES.get(&self.config_set);
         // Whether a stage emits kept rows or negated dropped rows. Kept rows cost less state when
-        // a key's group holds at least twice what the stage keeps, which only the hint can say:
-        // at a stage with modulus `m` a group spreads over `m` keys. Without a hint every stage
-        // emits dropped rows, since a kept-row stage whose keys hold a single row each would copy
-        // its whole input into its output arrangement.
-        let stage_output = |modulus: u64| -> StageOutput {
-            let (Some(kept), Some(group_size)) = (kept_per_key, expected_group_size) else {
+        // a key's group holds at least twice what the stage keeps. The plan carries the group
+        // size hint only as its bucket list: an empty list means the hint was at most sixteen,
+        // the fan-in of one stage, so the lone final stage keeps rows when twice its kept count
+        // fits in sixteen. With bucket stages the hint is unknown here (or absent, in which case
+        // the planner assumed billions), and every stage emits dropped rows, since a kept-row
+        // stage whose keys hold a single row each would copy its whole input into its output
+        // arrangement.
+        let single_stage = buckets.is_empty();
+        let stage_output = |_modulus: u64| -> StageOutput {
+            let Some(kept) = kept_per_key else {
                 return StageOutput::Dropped;
             };
-            if retain_allowed && kept.saturating_mul(2) <= group_size / modulus.max(1) {
+            if retain_allowed && single_stage && kept.saturating_mul(2) <= 16 {
                 StageOutput::Kept
             } else {
                 StageOutput::Dropped

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -753,6 +753,32 @@ impl RowRef {
         &self.0
     }
 
+    /// Splits the row after its first `n` datums into two rows: the first `n` datums and the
+    /// rest. Datums are encoded back to back, so both halves are complete row encodings and no
+    /// datum is re-encoded. Only the first `n` datums are decoded, to find the boundary.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the row has fewer than `n` datums.
+    pub fn split_at_datum(&self, n: usize) -> (&RowRef, &RowRef) {
+        let mut rest: &[u8] = &self.0;
+        for _ in 0..n {
+            assert!(!rest.is_empty(), "row has fewer than {n} datums");
+            // SAFETY: `rest` is a suffix of a valid row encoding at a datum boundary.
+            unsafe {
+                read_datum(&mut rest);
+            }
+        }
+        let boundary = self.0.len() - rest.len();
+        // SAFETY: both halves start and end at datum boundaries of a valid row encoding.
+        unsafe {
+            (
+                RowRef::from_slice(&self.0[..boundary]),
+                RowRef::from_slice(&self.0[boundary..]),
+            )
+        }
+    }
+
     /// True iff there is no data in this [`RowRef`].
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
@@ -4749,5 +4775,32 @@ mod tests {
 
         assert_eq!(map_1.cmp(&map_null), Ordering::Less);
         assert_eq!(map_null.cmp(&map_1), Ordering::Greater);
+    }
+
+    #[mz_ore::test]
+    fn split_at_datum_yields_whole_rows() {
+        let datums = [
+            Datum::Int64(7),
+            Datum::Null,
+            Datum::String("a longer string that is not inline"),
+            Datum::False,
+        ];
+        let row = Row::pack_slice(&datums);
+        for n in 0..=datums.len() {
+            let (head, tail) = row.split_at_datum(n);
+            assert_eq!(head.iter().collect::<Vec<_>>(), &datums[..n]);
+            assert_eq!(tail.iter().collect::<Vec<_>>(), &datums[n..]);
+            assert_eq!(
+                head.byte_len() + tail.byte_len(),
+                row.as_row_ref().byte_len()
+            );
+        }
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "fewer than")]
+    fn split_at_datum_past_the_end_panics() {
+        let row = Row::pack_slice(&[Datum::Int64(1)]);
+        let _ = row.split_at_datum(2);
     }
 }


### PR DESCRIPTION
A basic TopK stage emits negations of the rows it drops, and the stage's result is its input plus those negations. That keeps the reduce's state proportional to the dropped rows, which is small when groups are barely larger than the limit and large otherwise. For `DISTINCT ON` over groups of eight rows with an `EXPECTED GROUP SIZE` hint, the final stage's arrangement held 8.75M records for a 1.25M-row result, and the consolidate that cancels the negations processed 18.75M records and was the largest operator in the dataflow. Every hierarchical stage after the first is in the same position: it sees at most sixteen times the limit per key and drops most of it.

This change lets a stage emit the rows it keeps instead, chosen per stage:

- The renderer computes the rows a stage keeps per key (literal limit plus offset) and reads the hint through the plan's bucket list, which is empty exactly when the hint was at most sixteen, the fan-in of one stage. In that case the lone final stage emits kept rows when twice its kept count fits in sixteen; otherwise, and whenever there are bucket stages, stages emit negated dropped rows as before. A kept-row stage whose keys hold one row each would copy its whole input into its output arrangement, so the choice needs the hint's evidence. `BasicTopKPlan` is part of the durably stored LIR schema and is unchanged.
- A kept-row final stage comes out of a reduce already consolidated, so the final consolidate is skipped.
- The monotonic TopK path keeps the dropped-rows form, which its retraction loop relies on.

The behaviour is behind `enable_compute_topk_retained_stages`, default off in production and on in the CI configuration, and registered with the parallel workload's flag flipper.

Hydration of `SELECT DISTINCT ON (g) g, v FROM ... OPTIONS (DISTINCT ON INPUT GROUP SIZE = 8) ORDER BY g, v DESC` indexed by `g`, 10M rows in 1.25M groups, one worker, median of three:

| | before | after |
|---|---|---|
| hydration wall | 8.10s | 3.89s |
| `TopK final consolidate` | 2109ms | absent |
| `Reduced TopK input` | 1105ms | 640ms |
| reduce output arrangement | 8.75M records | 1.25M records |

Without a hint the plan is unchanged (25.0s before and after; that case is dominated by seven bucket stages that cannot shrink eight-row groups, a separate question about the default bucket schedule). Measured on a local build with the other hydration PRs in flight applied.

`test/sqllogictest/topk.slt` passes with the flag on; CI runs the whole suite with it on.


### Keying the input for the first stage once

The initial map hashed each row and packed `(hash, group)`, and the first stage's map immediately replaced the hash by `hash % modulus` and repacked. With a hint and no bucket stages the final stage's modulus is 1, so the hash was computed only to be replaced by zero. The initial map now keys rows for the first stage directly, and a stage rekeys only when its input is keyed for an earlier stage, as the min/max hierarchy already does. This is independent of the flag and removes one `FlatMap` operator (441ms on the measured shape) from every basic TopK dataflow; hinted topk goes from 4.73s to 4.21s.


### Byte slicing in the initial map

When the group key is a column prefix, the initial map now forms `(bucket, group)` by pushing the bucket and appending the row's leading bytes, instead of unpacking the row and packing the group datums; other group keys keep the datum path. The map goes from 532ms to 240ms on the measured shape; hinted topk from 4.21s to 3.89s.

This branch carries `RowRef::split_at_datum` from #38665 as its own commit so it builds on `main` alone; whichever PR lands first brings the helper.

