### PR TITLE
compute: form the min/max hierarchy's stage keys by byte slicing

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -871,17 +871,25 @@ impl<'scope, T: RenderTimestamp> Context<'scope, T> {
                 let first_mod = buckets.get(0).copied().unwrap_or(1);
                 let aggregations = aggr_funcs.len();
 
-                // Gather the relevant keys with their hashes along with values ordered by aggregation_index.
+                // Gather the relevant keys with their hashes along with values ordered by
+                // aggregation_index. The values are the row's leading datums and the key goes
+                // behind the hash unchanged, so both are byte copies rather than datum round
+                // trips.
                 let mut stage = input.map(move |(key, row)| {
-                    let mut row_builder = SharedRow::get();
-                    let mut row_packer = row_builder.packer();
-                    row_packer.extend(row.iter().take(aggregations));
-                    let values = row_builder.clone();
+                    let (values, _) = row.split_at_datum(aggregations);
+                    let values = values.to_owned();
 
-                    // Apply the initial mod here.
-                    let hash = values.hashed() % first_mod;
-                    let hash_key =
-                        row_builder.pack_using(std::iter::once(Datum::from(hash)).chain(&key));
+                    // Apply the initial mod here; a lone final stage keys everything by zero
+                    // and need not hash at all.
+                    let hash = if first_mod == 1 {
+                        0
+                    } else {
+                        values.hashed() % first_mod
+                    };
+                    let mut hash_key = Row::default();
+                    let mut packer = hash_key.packer();
+                    packer.push(Datum::from(hash));
+                    packer.extend_by_row_ref(&key);
                     (hash_key, values)
                 });
 

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -753,6 +753,32 @@ impl RowRef {
         &self.0
     }
 
+    /// Splits the row after its first `n` datums into two rows: the first `n` datums and the
+    /// rest. Datums are encoded back to back, so both halves are complete row encodings and no
+    /// datum is re-encoded. Only the first `n` datums are decoded, to find the boundary.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the row has fewer than `n` datums.
+    pub fn split_at_datum(&self, n: usize) -> (&RowRef, &RowRef) {
+        let mut rest: &[u8] = &self.0;
+        for _ in 0..n {
+            assert!(!rest.is_empty(), "row has fewer than {n} datums");
+            // SAFETY: `rest` is a suffix of a valid row encoding at a datum boundary.
+            unsafe {
+                read_datum(&mut rest);
+            }
+        }
+        let boundary = self.0.len() - rest.len();
+        // SAFETY: both halves start and end at datum boundaries of a valid row encoding.
+        unsafe {
+            (
+                RowRef::from_slice(&self.0[..boundary]),
+                RowRef::from_slice(&self.0[boundary..]),
+            )
+        }
+    }
+
     /// True iff there is no data in this [`RowRef`].
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
@@ -4749,5 +4775,32 @@ mod tests {
 
         assert_eq!(map_1.cmp(&map_null), Ordering::Less);
         assert_eq!(map_null.cmp(&map_1), Ordering::Greater);
+    }
+
+    #[mz_ore::test]
+    fn split_at_datum_yields_whole_rows() {
+        let datums = [
+            Datum::Int64(7),
+            Datum::Null,
+            Datum::String("a longer string that is not inline"),
+            Datum::False,
+        ];
+        let row = Row::pack_slice(&datums);
+        for n in 0..=datums.len() {
+            let (head, tail) = row.split_at_datum(n);
+            assert_eq!(head.iter().collect::<Vec<_>>(), &datums[..n]);
+            assert_eq!(tail.iter().collect::<Vec<_>>(), &datums[n..]);
+            assert_eq!(
+                head.byte_len() + tail.byte_len(),
+                row.as_row_ref().byte_len()
+            );
+        }
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "fewer than")]
+    fn split_at_datum_past_the_end_panics() {
+        let row = Row::pack_slice(&[Datum::Int64(1)]);
+        let _ = row.split_at_datum(2);
     }
 }


### PR DESCRIPTION
The hierarchical min/max reduction's initial map rebuilt each values row datum by datum from the input row and packed `(hash, key)` by iterating the key's datums. The values are the row's leading `aggregations` datums and the key goes behind the hash unchanged, so both are now byte copies: `split_at_datum` for the values, `extend_by_row_ref` for the key. When the group size hint leaves no bucket stages the first modulus is 1 and every hash is zero, so the row hash is skipped in that case.

Hydration of `SELECT k % g, max(v) ... GROUP BY 1 OPTIONS (AGGREGATE INPUT GROUP SIZE = 8)` indexed by the group, 10M rows in 1.25M groups, one worker, median of three: 4.72s to 4.50s, the initial map from 526ms to under 450ms.

No behaviour change; the rows produced are byte-identical. `aggregates.slt`, `aggregates_2.slt` and `group_size_hints.slt` pass.

This branch carries `RowRef::split_at_datum` from #38665 as its own commit so it builds on `main` alone; whichever PR lands first brings the helper.
