### PR TITLE
v26.40.1 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -19,6 +19,16 @@ Starting with the v26.1.0 release, Materialize releases on a weekly schedule for
 both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for details.
 {{</ note >}}
 
+## v26.40.1
+*Released to Materialize Cloud: 2026-09-05* <br>
+*Released to Materialize Self-Managed: 2026-09-06* <br>
+
+### Improvements {#v26.40.1-improvements}
+- **Smaller Prometheus scrape payloads**: `environmentd` no longer exports the unused `mz_timestamp_difference_for_strict_serializable_ms` metric, which accounted for roughly 7% of one large environment's `/metrics` response, and `mz_time_to_first_row_seconds` drops two sub-millisecond buckets that held 12 observations out of 16.1 million in that same environment.
+
+### Bug Fixes {#v26.40.1-bug-fixes}
+- Fixed per-cluster `mz_time_to_first_row_seconds` series accumulating indefinitely for clusters that had already been dropped, which inflated `/metrics` responses in environments with high cluster churn; these series are now reclaimed when the cluster is dropped.
+
 ## v26.40.0
 *Released to Materialize Cloud: 2026-09-02* <br>
 *Released to Materialize Self-Managed: 2026-09-03* <br>

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -5,6 +5,11 @@ columns:
   - column: Release date
   - column: Notes
 rows:
+  - Materialize Operator: v26.40.1
+    orchestratord version: v26.40.1
+    environmentd version: v26.40.1
+    Release date: "2026-09-06"
+    Notes: "See [v26.40.1 release notes](/releases/#v26401)"
   - Materialize Operator: v26.40
     orchestratord version: v26.40
     environmentd version: v26.40


### PR DESCRIPTION
Release notes for v26.40.1, a three-commit hotfix train with no RC snapshots — `final` is its only snapshot, so this PR carries one commit and the dates set here are the real ones rather than provisional.

**Please confirm the dates before merging.** They were **inferred from the `v26.40.1` tag's commit date** (2026-09-05T01:54:28Z) plus one day, not supplied: Cloud 2026-09-05 / Self-Managed 2026-09-06. The tag was cut at 01:54 UTC on a Saturday, and a hotfix tagged in the small hours of a weekend does not typically reach Cloud the same day, so the real Cloud date may well be later.

**What this release is.** Both entries are metric-cardinality work: #38614 removes the `mz_timestamp_difference_for_strict_serializable_ms` metric (which the author declared in an explicit release note) and trims two `mz_time_to_first_row_seconds` buckets; #38640 (INC-1252) stops per-cluster series leaking for dropped clusters. The peek-path performance claim in #38614 is deliberately **not** published — the PR measures the metrics side only and reports no peek-latency number.

**Needs a decision — overlap with v26.41.0 (#38667).** These commits are cherry-picks, so they are also in the `v26.41.0` train, whose `rc.1` draft demoted #38614 to Borderline under the internal-observability rule. This PR departs from that on the evidence that the removed metric is listed on the published [Appendix: Metrics](/manage/monitor/appendix-metrics/) page (the shortcode there takes no `visibility` filter, so it lists internal metrics too). If these entries stay here, v26.41.0 should not restate #38614/#38640 — its snapshot directories currently omit both, which is the consistent outcome. If you prefer the `rc.1` treatment, cut these two entries here rather than adding them there. What must not ship is the metric being announced twice.

**Merge ordering:** `## v26.40.1` must stay **above** `## v26.40.0`. #38667 (v26.41.0) is also open against `main`; whichever of the two merges second needs its section placed relative to the other by hand.

Snapshot drafts (with PR links) in mz-skills:
- final: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.40.1/final/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.40.1/final/omitted.md)

**Borderline PRs omitted:** final: 1 — [review borderline calls](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.40.1/final/omitted.md#borderline)
