### PR TITLE
adapter: record the item version in expression cache entries

### DIFF
--- a/misc/python/materialize/checks/all_checks/materialized_views.py
+++ b/misc/python/materialize/checks/all_checks/materialized_views.py
@@ -352,3 +352,69 @@ class MaterializedViewReplacement(Check):
                 # `validate` remains idempotent.
                 > DROP MATERIALIZED VIEW mv_replacement_replacement
             """))
+
+
+class MaterializedViewReplacementDropInput(Check):
+    """Applies a replacement and drops the old definition's input in the first
+    manipulate phase. The zero-downtime upgrade scenarios run that phase while
+    the next generation, built at a different version, is already booted
+    read-only, so its boot after promotion must not pair the new definition
+    with the expressions it cached before the apply. The tables retain history
+    so that a restart cannot hit CPU-95 (an input's read frontier overtaking
+    the output's write frontier).
+    """
+
+    def _can_run(self, e: Executor) -> bool:
+        # The first version whose expression cache records item versions. A
+        # generation of an earlier version that boots after the apply reuses
+        # the expressions cached for the old definition, and crash-loops on
+        # the dropped input.
+        return self.base_version >= MzVersion.parse_mz("v26.41.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(dedent("""
+                > CREATE TABLE mv_repl_drop_input_t1 (a INT) WITH (RETAIN HISTORY FOR '1 hour')
+                > INSERT INTO mv_repl_drop_input_t1 VALUES (1)
+                > CREATE VIEW mv_repl_drop_input_v1 AS SELECT a FROM mv_repl_drop_input_t1
+                > CREATE MATERIALIZED VIEW mv_repl_drop_input_mv AS SELECT a FROM mv_repl_drop_input_v1
+                > CREATE TABLE mv_repl_drop_input_t2 (a INT) WITH (RETAIN HISTORY FOR '1 hour')
+                > INSERT INTO mv_repl_drop_input_t2 VALUES (2)
+                > CREATE VIEW mv_repl_drop_input_v2 AS SELECT a FROM mv_repl_drop_input_t2
+                > CREATE REPLACEMENT MATERIALIZED VIEW mv_repl_drop_input_rp1 FOR mv_repl_drop_input_mv AS SELECT a FROM mv_repl_drop_input_v2
+                > SELECT * FROM mv_repl_drop_input_rp1
+                2
+                """))
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > ALTER MATERIALIZED VIEW mv_repl_drop_input_mv APPLY REPLACEMENT mv_repl_drop_input_rp1
+                > DROP VIEW mv_repl_drop_input_v1
+                > SELECT * FROM mv_repl_drop_input_mv
+                2
+                """,
+                """
+                > CREATE TABLE mv_repl_drop_input_t3 (a INT) WITH (RETAIN HISTORY FOR '1 hour')
+                > INSERT INTO mv_repl_drop_input_t3 VALUES (3)
+                > CREATE VIEW mv_repl_drop_input_v3 AS SELECT a FROM mv_repl_drop_input_t3
+                > CREATE REPLACEMENT MATERIALIZED VIEW mv_repl_drop_input_rp2 FOR mv_repl_drop_input_mv AS SELECT a FROM mv_repl_drop_input_v3
+                > SELECT * FROM mv_repl_drop_input_rp2
+                3
+                > ALTER MATERIALIZED VIEW mv_repl_drop_input_mv APPLY REPLACEMENT mv_repl_drop_input_rp2
+                > DROP VIEW mv_repl_drop_input_v2
+                > SELECT * FROM mv_repl_drop_input_mv
+                3
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(dedent("""
+                > SELECT * FROM mv_repl_drop_input_mv
+                3
+
+                > SELECT name FROM mz_materialized_views WHERE name LIKE 'mv_repl_drop_input_%'
+                mv_repl_drop_input_mv
+            """))

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -62,7 +62,9 @@ use mz_repr::explain::ExprHumanizer;
 use mz_repr::network_policy_id::NetworkPolicyId;
 use mz_repr::optimize::OptimizerFeatures;
 use mz_repr::role_id::RoleId;
-use mz_repr::{CatalogItemId, Diff, GlobalId, RelationVersionSelector, SqlScalarType};
+use mz_repr::{
+    CatalogItemId, Diff, GlobalId, RelationVersion, RelationVersionSelector, SqlScalarType,
+};
 use mz_secrets::InMemorySecretsController;
 use mz_sql::catalog::{
     CatalogCluster, CatalogClusterReplica, CatalogDatabase, CatalogError as SqlCatalogError,
@@ -1560,7 +1562,8 @@ impl Catalog {
     }
 
     /// Cache global and, optionally, local expressions for the given
-    /// `GlobalId`.
+    /// `GlobalId` of an item being created, whose only version is therefore
+    /// the root [`RelationVersion`].
     ///
     /// Takes the plans and metainfo directly as parameters (rather than
     /// fishing them out of catalog state), so this can be called **before**
@@ -1593,6 +1596,7 @@ impl Catalog {
                 LocalExpressions {
                     local_mir,
                     optimizer_features: optimizer_features.clone(),
+                    item_version: RelationVersion::root(),
                 },
             ));
         }
@@ -1603,6 +1607,7 @@ impl Catalog {
                 physical_plan,
                 dataflow_metainfos,
                 optimizer_features,
+                item_version: RelationVersion::root(),
             },
         )];
         self.update_expression_cache(local_exprs, global_exprs, Default::default())

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -1807,6 +1807,7 @@ impl CatalogState {
                             global_id,
                             uncached_expr,
                             optimizer_features,
+                            RelationVersion::root(),
                         );
                     }
                     // Add item to catalog.

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -39,6 +39,7 @@ use mz_catalog::durable::{
 };
 use mz_catalog::expr_cache::{
     ExpressionCacheConfig, ExpressionCacheHandle, GlobalExpressions, LocalExpressions,
+    latest_item_version,
 };
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
@@ -52,7 +53,7 @@ use mz_ore::now::{SYSTEM_TIME, to_datetime};
 use mz_ore::{instrument, soft_assert_no_log};
 use mz_repr::adt::mz_acl_item::PrivilegeMap;
 use mz_repr::namespaces::is_unstable_schema;
-use mz_repr::{CatalogItemId, Diff, GlobalId, Timestamp};
+use mz_repr::{CatalogItemId, Diff, GlobalId, RelationVersion, Timestamp};
 use mz_sql::catalog::{CatalogError as SqlCatalogError, CatalogItemType, RoleMembership, RoleVars};
 use mz_sql::func::OP_IMPLS;
 use mz_sql::names::CommentObjectId;
@@ -386,16 +387,17 @@ impl Catalog {
                 ?enable_expr_cache_dyncfg,
                 "using expression cache for startup"
             );
-            let current_ids = txn
+            let current_items = txn
                 .get_items()
                 .flat_map(|item| {
-                    let gid = item.global_id.clone();
-                    let gids: Vec<_> = item.extra_versions.values().cloned().collect();
-                    std::iter::once(gid).chain(gids)
+                    let item_version = latest_item_version(&item.extra_versions);
+                    std::iter::once(item.global_id)
+                        .chain(item.extra_versions.into_values())
+                        .map(move |gid| (gid, item_version))
                 })
                 .chain(
                     txn.get_system_object_mappings()
-                        .map(|som| som.unique_identifier.global_id),
+                        .map(|som| (som.unique_identifier.global_id, RelationVersion::root())),
                 )
                 .collect();
             let dyncfgs = config.persist_client.dyncfgs().clone();
@@ -415,7 +417,7 @@ impl Catalog {
                     .get_expression_cache_shard()
                     .expect("expression cache shard should exist for opened catalogs"),
                 persist: config.persist_client,
-                current_ids,
+                current_items,
                 remove_prior_versions: !config.read_only,
                 compact_shard: config.read_only,
                 dyncfgs,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -27,7 +27,7 @@ use mz_catalog::builtin::{
     BUILTINS, Builtin, BuiltinCluster, BuiltinLog, BuiltinSource, BuiltinTable, BuiltinType,
 };
 use mz_catalog::config::{AwsPrincipalContext, ClusterReplicaSizeMap};
-use mz_catalog::expr_cache::LocalExpressions;
+use mz_catalog::expr_cache::{LocalExpressions, latest_item_version};
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
     CatalogCollectionEntry, CatalogEntry, CatalogItem, Cluster, ClusterReplica, CommentsMap,
@@ -374,18 +374,20 @@ impl LocalExpressionCache {
     }
 
     /// Inform the cache that `id` was not found in the cache and that we should add it as
-    /// `local_mir` and `optimizer_features`.
+    /// `local_mir` and `optimizer_features`, recorded at `item_version`.
     pub(super) fn insert_uncached_expression(
         &mut self,
         id: GlobalId,
         local_mir: OptimizedMirRelationExpr,
         optimizer_features: OptimizerFeatures,
+        item_version: RelationVersion,
     ) {
         match self {
             LocalExpressionCache::Open { uncached_exprs, .. } => {
                 let local_expr = LocalExpressions {
                     local_mir,
                     optimizer_features,
+                    item_version,
                 };
                 // If we are trying to cache the same item a second time, with a different
                 // expression, then we must be migrating the object or doing something else weird.
@@ -1307,6 +1309,7 @@ impl CatalogState {
                         global_id,
                         uncached_expr,
                         optimizer_features,
+                        latest_item_version(extra_versions),
                     );
                 }
                 Ok(item)

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -35,7 +35,7 @@ use mz_audit_log::{
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_catalog::builtin::BuiltinLog;
 use mz_catalog::durable::{DryRunTransaction, NetworkPolicy, Snapshot, Transaction};
-use mz_catalog::expr_cache::LocalExpressions;
+use mz_catalog::expr_cache::{LocalExpressions, latest_item_version};
 use mz_catalog::memory::error::{AmbiguousRename, Error, ErrorKind};
 use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, ClusterConfig, ClusterVariant, DataSourceDesc, DefaultPrivileges,
@@ -52,7 +52,7 @@ use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap, merge_mz_acl_i
 use mz_repr::network_policy_id::NetworkPolicyId;
 use mz_repr::optimize::OptimizerFeatures;
 use mz_repr::role_id::RoleId;
-use mz_repr::{CatalogItemId, ColumnName, GlobalId, SqlColumnType, strconv};
+use mz_repr::{CatalogItemId, ColumnName, GlobalId, RelationVersion, SqlColumnType, strconv};
 use mz_sql::ast::RawDataType;
 use mz_sql::catalog::{
     AutoProvisionSource, CatalogDatabase, CatalogError as SqlCatalogError,
@@ -880,6 +880,7 @@ impl Catalog {
                             LocalExpressions {
                                 local_mir: (*view.locally_optimized_expr).clone(),
                                 optimizer_features: optimizer_features.clone(),
+                                item_version: RelationVersion::root(),
                             },
                         );
                     }
@@ -889,6 +890,7 @@ impl Catalog {
                             LocalExpressions {
                                 local_mir: (*mv.locally_optimized_expr).clone(),
                                 optimizer_features: optimizer_features.clone(),
+                                item_version: latest_item_version(&mv.collections),
                             },
                         );
                     }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -104,7 +104,7 @@ use mz_catalog::builtin::{
 };
 use mz_catalog::config::{AwsPrincipalContext, BuiltinItemMigrationConfig, ClusterReplicaSizeMap};
 use mz_catalog::durable::OpenableDurableCatalogState;
-use mz_catalog::expr_cache::{GlobalExpressions, LocalExpressions};
+use mz_catalog::expr_cache::{GlobalExpressions, LocalExpressions, latest_item_version};
 use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, ClusterReplicaProcessStatus, Connection, DataSourceDesc,
     ReconfigurationTarget, Table, TableDataSource,
@@ -146,7 +146,9 @@ use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::global_id::TransientIdGen;
 use mz_repr::optimize::{OptimizerFeatureOverrides, OptimizerFeatures, OverrideFrom};
 use mz_repr::role_id::RoleId;
-use mz_repr::{CatalogItemId, Diff, GlobalId, RelationDesc, SqlRelationType, Timestamp};
+use mz_repr::{
+    CatalogItemId, Diff, GlobalId, RelationDesc, RelationVersion, SqlRelationType, Timestamp,
+};
 use mz_secrets::cache::CachingSecretsReader;
 use mz_secrets::{SecretsController, SecretsReader};
 use mz_sql::ast::{Raw, Statement};
@@ -3832,6 +3834,7 @@ impl Coordinator {
                                         physical_plan: physical_plan.clone(),
                                         dataflow_metainfos: metainfo.clone(),
                                         optimizer_features: optimizer_config.features.clone(),
+                                        item_version: RelationVersion::root(),
                                     },
                                 );
                                 (optimized_plan, physical_plan, metainfo)
@@ -3930,6 +3933,7 @@ impl Coordinator {
                                     physical_plan: physical_plan.clone(),
                                     dataflow_metainfos: metainfo.clone(),
                                     optimizer_features: optimizer_config.features.clone(),
+                                    item_version: latest_item_version(&mv.collections),
                                 },
                             );
                             (optimized_plan, physical_plan, metainfo)
@@ -4024,6 +4028,7 @@ impl Coordinator {
                                     physical_plan: physical_plan.clone(),
                                     dataflow_metainfos: metainfo.clone(),
                                     optimizer_features: optimizer_config.features.clone(),
+                                    item_version: RelationVersion::root(),
                                 },
                             );
                             (optimized_plan, physical_plan, metainfo)

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -5052,15 +5052,11 @@ impl Coordinator {
             "finishing materialized view replacement application",
         );
 
-        // The durable expression cache is keyed by GlobalId and relies on the
-        // invariant that the definition behind a GlobalId never changes.
-        // Applying a replacement violates that for the target's existing
-        // GlobalIds: the item retains them as prior versions while its
-        // definition becomes the replacement's. Invalidate their cached
-        // expressions, and await the invalidation before the catalog
-        // transaction commits, so no subsequent bootstrap can pair the new
-        // definition with a stale cached expression whose dependencies may
-        // since have been dropped.
+        // Applying a replacement changes the target's definition while it
+        // keeps its GlobalIds, so the cached expressions under those ids are
+        // stale. Entries record the item's version and `ExpressionCache::open`
+        // drops them on the next boot; invalidating here only reclaims them
+        // eagerly.
         let invalidate_ids = self.catalog().get_entry(&id).global_ids().collect();
         self.catalog()
             .update_expression_cache(Vec::new(), Vec::new(), invalidate_ids)

--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -27,8 +27,8 @@ use mz_persist_client::cli::admin::{
 };
 use mz_persist_types::codec_impls::VecU8Schema;
 use mz_persist_types::{Codec, ShardId};
-use mz_repr::GlobalId;
 use mz_repr::optimize::OptimizerFeatures;
+use mz_repr::{GlobalId, RelationVersion};
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::notice::OptimizerNotice;
 use semver::Version;
@@ -57,6 +57,8 @@ enum ExpressionType {
 pub struct LocalExpressions {
     pub local_mir: OptimizedMirRelationExpr,
     pub optimizer_features: OptimizerFeatures,
+    /// The owning item's latest version, see [`ExpressionCache::open`].
+    pub item_version: RelationVersion,
 }
 
 /// The data that is cached per catalog object as a result of global optimizations.
@@ -66,6 +68,8 @@ pub struct GlobalExpressions {
     pub physical_plan: DataflowDescription<mz_compute_types::plan::LirRelationExpr>,
     pub dataflow_metainfos: DataflowMetainfo<Arc<OptimizerNotice>>,
     pub optimizer_features: OptimizerFeatures,
+    /// The owning item's latest version, see [`ExpressionCache::open`].
+    pub item_version: RelationVersion,
 }
 
 impl GlobalExpressions {
@@ -75,6 +79,13 @@ impl GlobalExpressions {
             .keys()
             .chain(self.physical_plan.index_imports.keys())
     }
+}
+
+/// The item version to record with an item's cached expressions, the latest of its `versions`.
+pub fn latest_item_version(versions: &BTreeMap<RelationVersion, GlobalId>) -> RelationVersion {
+    versions
+        .last_key_value()
+        .map_or_else(RelationVersion::root, |(version, _)| *version)
 }
 
 #[derive(
@@ -100,7 +111,7 @@ struct ExpressionCodec;
 impl DurableCacheCodec for ExpressionCodec {
     type Key = CacheKey;
     // We use a raw bytes instead of `Expressions` so that there is no backwards compatibility
-    // requirement on `Expressions` between versions.
+    // requirement on `Expressions` between build versions.
     type Val = Bytes;
     type KeyCodec = Bytes;
     type ValCodec = Bytes;
@@ -129,7 +140,11 @@ pub struct ExpressionCacheConfig {
     pub build_version: Version,
     pub persist: PersistClient,
     pub shard_id: ShardId,
-    pub current_ids: BTreeSet<GlobalId>,
+    /// Every `GlobalId` that may have entries, mapped to the latest version of the item it
+    /// belongs to. All ids of an item map to that same version, which is the one its entries
+    /// record, rather than the version the id itself denotes.
+    pub current_items: BTreeMap<GlobalId, RelationVersion>,
+    /// Whether to durably remove the entries of previous build versions.
     pub remove_prior_versions: bool,
     pub compact_shard: bool,
     pub dyncfgs: ConfigSet,
@@ -143,11 +158,24 @@ pub struct ExpressionCache {
 
 impl ExpressionCache {
     /// Creates a new [`ExpressionCache`] and reconciles all entries in current build version.
-    /// Reconciliation will remove all entries that are not in `current_ids` and remove all
-    /// entries that have optimizer features that are not equal to `optimizer_features`.
+    /// Reconciliation removes entries whose id is not in `current_items` or whose recorded
+    /// item version differs from the current one, and global entries that import an index
+    /// that is not in `current_items`.
     ///
-    /// If `remove_prior_versions` is `true`, then all previous versions are durably removed from the
-    /// cache.
+    /// An entry records the item version it was optimized for, because applying a materialized
+    /// view replacement changes an item's definition while the item keeps its `GlobalId`s and
+    /// bumps its [`RelationVersion`]. Dropping entries recorded at another version therefore
+    /// catches stale entries whichever process wrote them. That includes the replacement's own
+    /// entries: they are recorded at its root version, and the apply makes its id a later
+    /// version of the target.
+    ///
+    /// The apply also invalidates the target's entries, but that alone would not do: it only
+    /// reaches entries under the applying process's build version, while a 0dt deployment in
+    /// its read-only phase caches under its own build version and reads those entries again
+    /// when it reboots after promotion.
+    ///
+    /// If `remove_prior_versions` is `true`, then the entries of all previous build versions are
+    /// durably removed from the cache.
     ///
     /// If `compact_shard` is `true`, then this function will block on fully compacting the backing
     /// persist shard.
@@ -158,7 +186,7 @@ impl ExpressionCache {
             build_version,
             persist,
             shard_id,
-            current_ids,
+            current_items,
             remove_prior_versions,
             compact_shard,
             dyncfgs,
@@ -177,7 +205,12 @@ impl ExpressionCache {
         const RETRIES: usize = 100;
         for _ in 0..RETRIES {
             match cache
-                .try_open(&current_ids, remove_prior_versions, compact_shard, &dyncfgs)
+                .try_open(
+                    &current_items,
+                    remove_prior_versions,
+                    compact_shard,
+                    &dyncfgs,
+                )
                 .await
             {
                 Ok((local_expressions, global_expressions)) => {
@@ -192,7 +225,7 @@ impl ExpressionCache {
 
     async fn try_open(
         &mut self,
-        current_ids: &BTreeSet<GlobalId>,
+        current_items: &BTreeMap<GlobalId, RelationVersion>,
         remove_prior_versions: bool,
         compact_shard: bool,
         dyncfgs: &ConfigSet,
@@ -217,7 +250,7 @@ impl ExpressionCache {
                 }
             };
             if build_version == self.build_version {
-                // Only deserialize the current version.
+                // Only deserialize the current build version.
                 match key.expr_type {
                     ExpressionType::Local => {
                         let expressions: LocalExpressions = match bincode::deserialize(expressions)
@@ -230,8 +263,9 @@ impl ExpressionCache {
                                 continue;
                             }
                         };
-                        // Remove dropped IDs.
-                        if !current_ids.contains(&key.id) {
+                        // A missing id means the item is gone, a different item version means the
+                        // entry was optimized for another definition of it.
+                        if current_items.get(&key.id) != Some(&expressions.item_version) {
                             keys_to_remove.push((key.clone(), None));
                         } else {
                             local_expressions.insert(key.id, expressions);
@@ -248,11 +282,13 @@ impl ExpressionCache {
                                 continue;
                             }
                         };
-                        // Remove dropped IDs and expressions that rely on dropped indexes.
-                        let index_dependencies: BTreeSet<_> =
-                            expressions.index_imports().cloned().collect();
-                        if !current_ids.contains(&key.id)
-                            || !index_dependencies.is_subset(current_ids)
+                        // As above, plus expressions that import a dropped index: `DROP INDEX` is
+                        // allowed under a running consumer, whose plan then has to be re-optimized
+                        // at the next boot.
+                        if current_items.get(&key.id) != Some(&expressions.item_version)
+                            || !expressions
+                                .index_imports()
+                                .all(|id| current_items.contains_key(id))
                         {
                             keys_to_remove.push((key.clone(), None));
                         } else {
@@ -261,11 +297,10 @@ impl ExpressionCache {
                     }
                 }
             } else if remove_prior_versions {
-                // Remove expressions from previous versions.
+                // Remove expressions from previous build versions.
                 keys_to_remove.push((key.clone(), None));
             }
         }
-
         let keys_to_remove: Vec<_> = keys_to_remove
             .iter()
             .map(|(key, expressions)| (key, expressions.as_ref()))
@@ -273,7 +308,8 @@ impl ExpressionCache {
         self.durable_cache.try_set_many(&keys_to_remove).await?;
 
         if remove_prior_versions {
-            // We've purged old versions from the cache; upgrade the backing Persist version as well.
+            // We've purged old build versions from the cache. Upgrade the backing Persist version
+            // as well.
             self.durable_cache.upgrade_version().await;
         }
 
@@ -459,32 +495,36 @@ mod tests {
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn expression_cache() {
-        let first_version = Version::new(0, 1, 0);
-        let second_version = Version::new(0, 2, 0);
+        let first_build_version = Version::new(0, 1, 0);
+        let second_build_version = Version::new(0, 2, 0);
         let persist = PersistClient::new_for_tests().await;
         let shard_id = ShardId::new();
 
-        let mut current_ids = BTreeSet::new();
+        let mut current_items = BTreeMap::new();
         let mut remove_prior_versions = false;
         // Compacting the shard takes too long, so we leave it to integration tests.
         let compact_shard = false;
         let dyncfgs = &mz_persist_client::cfg::all_dyncfgs(ConfigSet::default());
+        let spawn = |build_version: &Version,
+                     current_items: &BTreeMap<GlobalId, RelationVersion>,
+                     remove_prior_versions: bool| {
+            ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
+                build_version: build_version.clone(),
+                persist: persist.clone(),
+                shard_id,
+                current_items: current_items.clone(),
+                remove_prior_versions,
+                compact_shard,
+                dyncfgs: dyncfgs.clone(),
+            })
+        };
 
         let mut next_id = 0;
 
         let (mut local_exps, mut global_exps) = {
             // Open a new empty cache.
             let (cache, local_exprs, global_exprs) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(local_exprs, BTreeMap::new(), "new cache should be empty");
             assert_eq!(global_exprs, BTreeMap::new(), "new cache should be empty");
 
@@ -504,8 +544,12 @@ mod tests {
                     )
                     .await;
 
-                current_ids.insert(id);
-                current_ids.extend(global_exp.index_imports());
+                current_items.insert(id, RelationVersion::root());
+                current_items.extend(
+                    global_exp
+                        .index_imports()
+                        .map(|id| (*id, RelationVersion::root())),
+                );
                 local_exps.insert(id, local_exp);
                 global_exps.insert(id, global_exp);
 
@@ -517,16 +561,7 @@ mod tests {
         {
             // Re-open the cache.
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries, local_exps,
                 "local expression with non-matching optimizer features should be removed during reconciliation"
@@ -540,22 +575,13 @@ mod tests {
         {
             // Simulate dropping an object.
             let id_to_remove = local_exps.keys().next().expect("not empty").clone();
-            current_ids.remove(&id_to_remove);
+            current_items.remove(&id_to_remove);
             let _removed_local_exp = local_exps.remove(&id_to_remove);
             let _removed_global_exp = global_exps.remove(&id_to_remove);
 
             // Re-open the cache.
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries, local_exps,
                 "dropped local objects should be removed during reconciliation"
@@ -563,6 +589,39 @@ mod tests {
             assert_eq!(
                 global_entries, global_exps,
                 "dropped global objects should be removed during reconciliation"
+            );
+        }
+
+        {
+            // Simulate applying a replacement: the item keeps its id at a bumped version.
+            let id_to_bump = global_exps.keys().next_back().expect("not empty").clone();
+            current_items.insert(id_to_bump, RelationVersion::root().bump());
+            let _removed_local_exp = local_exps.remove(&id_to_bump);
+            let _removed_global_exp = global_exps.remove(&id_to_bump);
+
+            // Re-open the cache.
+            let (_cache, local_entries, global_entries) =
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
+            assert_eq!(
+                local_entries, local_exps,
+                "local expressions of an earlier item version should be removed during reconciliation"
+            );
+            assert_eq!(
+                global_entries, global_exps,
+                "global expressions of an earlier item version should be removed during reconciliation"
+            );
+
+            // The removal is durable: restoring the item version does not bring the entries back.
+            current_items.insert(id_to_bump, RelationVersion::root());
+            let (_cache, local_entries, global_entries) =
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
+            assert_eq!(
+                local_entries, local_exps,
+                "local expressions of an earlier item version should be durably removed"
+            );
+            assert_eq!(
+                global_entries, global_exps,
+                "global expressions of an earlier item version should be durably removed"
             );
         }
 
@@ -576,7 +635,7 @@ mod tests {
                 .index_imports()
                 .next()
                 .expect("generator always makes non-empty index imports");
-            current_ids.remove(dependency_to_remove);
+            current_items.remove(dependency_to_remove);
 
             // If the dependency is also tracked in the cache remove it.
             let _removed_local_exp = local_exps.remove(dependency_to_remove);
@@ -589,16 +648,7 @@ mod tests {
 
             // Re-open the cache.
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries, local_exps,
                 "dropped object dependencies should NOT remove local expressions"
@@ -610,30 +660,21 @@ mod tests {
         }
 
         let (new_gen_local_exps, new_gen_global_exps) = {
-            // Open the cache at a new version.
+            // Open the cache at a new build version.
             let (cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: second_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&second_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries,
                 BTreeMap::new(),
-                "new version should be empty"
+                "new build version should be empty"
             );
             assert_eq!(
                 global_entries,
                 BTreeMap::new(),
-                "new version should be empty"
+                "new build version should be empty"
             );
 
-            // Insert some expressions at the new version.
+            // Insert some expressions at the new build version.
             let mut local_exps = BTreeMap::new();
             let mut global_exps = BTreeMap::new();
             for _ in 0..2 {
@@ -649,8 +690,12 @@ mod tests {
                     )
                     .await;
 
-                current_ids.insert(id);
-                current_ids.extend(global_exp.index_imports());
+                current_items.insert(id, RelationVersion::root());
+                current_items.extend(
+                    global_exp
+                        .index_imports()
+                        .map(|id| (*id, RelationVersion::root())),
+                );
                 local_exps.insert(id, local_exp);
                 global_exps.insert(id, global_exp);
 
@@ -660,74 +705,47 @@ mod tests {
         };
 
         {
-            // Re-open the cache at the first version.
+            // Re-open the cache at the first build version.
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries, local_exps,
-                "Previous version local expressions should still exist"
+                "Previous build version local expressions should still exist"
             );
             assert_eq!(
                 global_entries, global_exps,
-                "Previous version global expressions should still exist"
+                "Previous build version global expressions should still exist"
             );
         }
 
         {
-            // Open the cache at a new version and clear previous versions.
+            // Open the cache at a new build version and clear previous build versions.
             remove_prior_versions = true;
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: second_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&second_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries, new_gen_local_exps,
-                "new version local expressions should be persisted"
+                "new build version local expressions should be persisted"
             );
             assert_eq!(
                 global_entries, new_gen_global_exps,
-                "new version global expressions should be persisted"
+                "new build version global expressions should be persisted"
             );
         }
 
         {
-            // Re-open the cache at the first version.
+            // Re-open the cache at the first build version.
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries,
                 BTreeMap::new(),
-                "Previous version local expressions should be cleared"
+                "Previous build version local expressions should be cleared"
             );
             assert_eq!(
                 global_entries,
                 BTreeMap::new(),
-                "Previous version global expressions should be cleared"
+                "Previous build version global expressions should be cleared"
             );
         }
     }
@@ -784,6 +802,7 @@ mod tests {
                 ReprRelationType::new(vec![ReprScalarType::UInt64.nullable(false)]),
             )),
             optimizer_features: Default::default(),
+            item_version: RelationVersion::root(),
         }
     }
 
@@ -819,6 +838,7 @@ mod tests {
             physical_plan,
             dataflow_metainfos: Default::default(),
             optimizer_features: Default::default(),
+            item_version: RelationVersion::root(),
         }
     }
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -4590,14 +4590,30 @@ fn test_durable_oids() {
     }
 }
 
-// Applying a materialized view replacement retains the target's existing
-// GlobalIds as prior versions while swapping in the replacement's definition.
-// The durable expression cache is keyed by GlobalId under the invariant that
-// the definition behind a GlobalId never changes, so the apply must invalidate
-// the cached expressions of the retained GlobalIds. If it doesn't, the next
-// bootstrap installs the stale optimized expression for the item, and if the
-// old definition's dependencies have since been dropped, timeline resolution
-// panics with "catalog out of sync" on every startup.
+/// Creates `mv` over `v1`/`t1` plus an unapplied replacement `rp` over `v2`/`t2`.
+/// The inputs retain history so that a restart cannot trip the as-of hard
+/// constraint of CPU-95.
+#[allow(clippy::disallowed_methods)]
+fn create_replacement_fixture(client: &mut postgres::Client) {
+    for stmt in [
+        "CREATE TABLE t1 (a int) WITH (RETAIN HISTORY FOR '1 hour')",
+        "INSERT INTO t1 VALUES (1)",
+        "CREATE VIEW v1 AS SELECT a FROM t1",
+        "CREATE MATERIALIZED VIEW mv AS SELECT a FROM v1",
+        "CREATE TABLE t2 (a int) WITH (RETAIN HISTORY FOR '1 hour')",
+        "INSERT INTO t2 VALUES (2)",
+        "CREATE VIEW v2 AS SELECT a FROM t2",
+        "CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv AS SELECT a FROM v2",
+    ] {
+        client.batch_execute(stmt).unwrap();
+    }
+}
+
+// Applying a materialized view replacement changes the definition behind the
+// target's retained GlobalIds (see `mz_catalog::expr_cache::ExpressionCache::open`).
+// If the next bootstrap installs the expressions cached before the apply, and
+// the old definition's dependencies have since been dropped, timeline
+// resolution panics with "catalog out of sync" on every startup.
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // too slow
 #[allow(clippy::disallowed_methods)]
@@ -4608,27 +4624,68 @@ fn test_replacement_materialized_view_invalidates_expression_cache() {
         .with_system_parameter_default(
             "enable_replacement_materialized_views".to_string(),
             "true".to_string(),
+        )
+        .with_system_parameter_default(
+            "enable_logical_compaction_window".to_string(),
+            "true".to_string(),
         );
 
     {
         let server = harness.clone().start_blocking();
         let mut client = server.connect(postgres::NoTls).unwrap();
-        client.batch_execute("CREATE TABLE t1 (a int)").unwrap();
-        client.batch_execute("INSERT INTO t1 VALUES (1)").unwrap();
+        create_replacement_fixture(&mut client);
         client
-            .batch_execute("CREATE VIEW v1 AS SELECT a FROM t1")
+            .batch_execute("ALTER MATERIALIZED VIEW mv APPLY REPLACEMENT rp")
             .unwrap();
-        client
-            .batch_execute("CREATE MATERIALIZED VIEW mv AS SELECT a FROM v1")
-            .unwrap();
-        client.batch_execute("CREATE TABLE t2 (a int)").unwrap();
-        client.batch_execute("INSERT INTO t2 VALUES (2)").unwrap();
-        client
-            .batch_execute("CREATE VIEW v2 AS SELECT a FROM t2")
-            .unwrap();
-        client
-            .batch_execute("CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv AS SELECT a FROM v2")
-            .unwrap();
+        client.batch_execute("DROP VIEW v1").unwrap();
+        let row = client.query_one("SELECT a FROM mv", &[]).unwrap();
+        assert_eq!(row.get::<_, i32>(0), 2, "pre-restart");
+    }
+
+    {
+        let server = harness.start_blocking();
+        let mut client = server.connect(postgres::NoTls).unwrap();
+        let row = client.query_one("SELECT a FROM mv", &[]).unwrap();
+        assert_eq!(row.get::<_, i32>(0), 2);
+    }
+}
+
+// A process that applies the replacement with the expression cache disabled
+// neither reads nor invalidates the entries the first process wrote, standing
+// in for a writer the apply-time invalidation cannot reach (see
+// `mz_catalog::expr_cache::ExpressionCache::open`). The next boot with the cache
+// enabled must not use the entries recorded before the apply.
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // too slow
+#[allow(clippy::disallowed_methods)]
+fn test_replacement_materialized_view_stale_expression_cache_entry_dropped_on_open() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let harness = test_util::TestHarness::default()
+        .data_directory(data_dir.path())
+        .with_system_parameter_default(
+            "enable_replacement_materialized_views".to_string(),
+            "true".to_string(),
+        )
+        .with_system_parameter_default(
+            "enable_logical_compaction_window".to_string(),
+            "true".to_string(),
+        );
+
+    {
+        let server = harness.clone().start_blocking();
+        let mut client = server.connect(postgres::NoTls).unwrap();
+        create_replacement_fixture(&mut client);
+    }
+
+    {
+        let server = harness
+            .clone()
+            .with_system_parameter_default(
+                "enable_expression_cache".to_string(),
+                "false".to_string(),
+            )
+            .start_blocking();
+        let mut client = server.connect(postgres::NoTls).unwrap();
         client
             .batch_execute("ALTER MATERIALIZED VIEW mv APPLY REPLACEMENT rp")
             .unwrap();


### PR DESCRIPTION
### Motivation

`ALTER MATERIALIZED VIEW ... APPLY REPLACEMENT` changes an item's definition while the item keeps its `GlobalId`s. #38545 made the apply invalidate the cached expressions under those ids, but only under the applying process's build version. That is not enough during a 0dt rollout. The new generation's read-only boot optimizes everything it sees and writes the results under its own build version, DDL keeps running on the old generation, and the new generation reads its own entries again when it reboots after promotion. An apply in that window leaves the promoted leader with the old definition's plan:

* If a dependency of the old definition was dropped, bootstrap panics with `catalog out of sync, missing id` on every start, with the old generation already fenced.
* Otherwise the materialized view computes and serves the old definition, with nothing in the logs. This variant needs a shorter window: the replacement has to be created after the new generation's last DDL check, because creating it earlier makes that check reboot the read-only generation, which then caches the replacement's plan. The promoted leader then installs the old definition's local plan for the target, finds no cached global plan under the replacement's `GlobalId`, and `bootstrap_dataflow_plans` re-optimizes from the stale local plan.

Both reproduce with release images on every shipped version, including between two versions that carry #38545 (v26.40.1 -> v26.41.0-rc.3). The mechanism and the reproduction are in [SQL-683](https://linear.app/materializeinc/issue/SQL-683).

### Description

Cache entries now record the latest `RelationVersion` of the item they were optimized for, and `ExpressionCache::open` drops entries whose recorded version differs from the item's current one. Applying a replacement bumps the target's version, so entries optimized for the old definition are dropped whoever wrote them and however the apply was ordered relative to the writer. The invalidation on apply from #38545 stays as eager cleanup. Correctness no longer rests on it.

Entries are only ever read by the build version that wrote them, so the changed entry format needs no migration.

This PR is kept to the fix so that it can be cherry-picked into a release candidate. #38682 builds on it: after an apply it moves the replacement's own cache entries to the target, so the next boot does not re-optimize the view, and it adds a reconciliation log line to the cache open.

### Tests

* `expr_cache` unit test: entries recorded at another item version are removed on open.
* `test_replacement_materialized_view_stale_expression_cache_entry_dropped_on_open` (environmentd server tests): a process applies the replacement with the expression cache disabled, standing in for a writer the apply-time invalidation cannot reach. The next boot with the cache enabled must not use the entries recorded before the apply. Without the fix it reproduces the bootstrap panic.
* `MaterializedViewReplacementDropInput` (platform checks): applies a replacement and drops the old definition's input in the first manipulate phase, and applies a second replacement in the second phase. The zero-downtime upgrade scenarios run the first phase on the old generation while the new one, built at a different version, is already booted read-only. The existing replacement check only applies after promotion, so it never reached the window. Run manually with pinned images in `ZeroDowntimeUpgradeEntireMzOnce` from v26.40.1, the check fails on `main` with the bootstrap panic after "rebooting as leader" and passes with this change. In CI the check is gated on every version in the scenario being at least v26.41.0-dev, because a released generation without this fix that boots after the apply crash-loops. Nightly 18253 showed that with v26.40.1 as the read-only generation and with a same-version restart of v26.18.0. The cross-version scenarios pick the check up once v26.41.0 is a released version.

The two server tests share a fixture whose tables retain history, which keeps a restart from tripping the as-of check of [CPU-95](https://linear.app/materializeinc/issue/CPU-95).

### Alternatives

Invalidating the target's ids under every build version present in the cache shard on apply (option 1 in [SQL-683](https://linear.app/materializeinc/issue/SQL-683)) is not sufficient on its own. The new generation takes its catalog snapshot at read-only open but writes its cache entries only after optimizing everything, so an apply that commits in that gap finds nothing to remove yet, and the stale entries are written afterwards. Recording the item version moves the check to read time, against the durable catalog as it is then, so the order of the apply relative to the writer does not matter.

Recording a hash of `create_sql` instead of the item version would also catch the apply. It would be content-based rather than relying on the version bump, so it would also cover a hypothetical future path that changes a definition in place without bumping the version. No such path exists today; the definition-changing ALTERs were traced. It was rejected for the spurious misses. `create_sql` is rewritten in cases that don't change what was optimized: renames of the item or of anything it references, cluster changes, and above all AST migrations at open. A new generation parses the migrated SQL in memory and would record its hash, while the durable SQL stays unmigrated until the leader commits, so at the promotion reboot every migrated item would miss. That is the cache failing on exactly the boot it exists for, on exactly the releases that carry migrations. The version is untouched by all of these, and the one operation that changes a definition under kept GlobalIds bumps it unconditionally in `MaterializedView::apply_replacement`.

### Release note

This release will no longer crash-loop or serve a materialized view's previous definition when a replacement is applied while a zero-downtime rollout is in progress.

Closes: [SQL-683](https://linear.app/materializeinc/issue/SQL-683)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Nightly:
- https://buildkite.com/materialize/nightly/builds/18255 (head 43091f9476, which differs from the final head only in comments; the only failures are the fleet-wide Unused dependencies and Security advisories of that day)
