### PR TITLE
doc/user: add LibreDB Studio to SQL clients

### DIFF
--- a/doc/user/content/integrations/sql-clients.md
+++ b/doc/user/content/integrations/sql-clients.md
@@ -181,6 +181,8 @@ an open-source, browser-based SQL IDE, choose the **PostgreSQL** driver in the
 connection dialog and use the credentials from the Materialize console (host,
 port **6875**, your app password, SSL mode **Require**).
 
+<img width="1440" alt="Connect using the credentials provided in the Materialize console" src="https://github.com/user-attachments/assets/55212af8-66e0-4add-a7df-ea6eeb13d190">
+
 ### `psql`
 
 {{< warning >}}

--- a/doc/user/content/integrations/sql-clients.md
+++ b/doc/user/content/integrations/sql-clients.md
@@ -164,6 +164,23 @@ Materialize console.
 
 <img width="1440" alt="Screenshot 2023-12-28 at 18 45 11" src="https://github.com/MaterializeInc/materialize/assets/23521087/c530769e-3445-49c8-8f36-9f7166352ac4">
 
+### LibreDB Studio
+
+{{< warning >}}
+Only the SQL editor is fully supported today. The object/schema browser and the
+monitoring dashboard both depend on PostgreSQL catalog objects Materialize does
+not have: `MATERIALIZED` is a reserved keyword that breaks LibreDB Studio's
+schema-introspection query, and `pg_stat_activity`/`pg_statio_user_tables` do
+not exist, so the monitoring panel reports a connection error rather than
+data. Running queries, including Materialize-specific statements like `SHOW
+MATERIALIZED VIEWS` and `SHOW SOURCES`, works normally.
+{{< /warning >}}
+
+To connect to Materialize using [LibreDB Studio](https://github.com/libredb/libredb-studio),
+an open-source, browser-based SQL IDE, choose the **PostgreSQL** driver in the
+connection dialog and use the credentials from the Materialize console (host,
+port **6875**, your app password, SSL mode **Require**).
+
 ### `psql`
 
 {{< warning >}}


### PR DESCRIPTION
### Motivation

LibreDB Studio is an open source, browser-based SQL IDE that connects to Materialize over the PostgreSQL wire protocol. This adds it to the SQL clients page alongside DataGrip, DBeaver and TablePlus.

### Description

Added a `### LibreDB Studio` section after TablePlus. The SQL editor works fully, including Materialize specific statements like `SHOW MATERIALIZED VIEWS` and `SHOW SOURCES`. The object browser and monitoring dashboard both fail, called out honestly in a warning block: `MATERIALIZED` is a reserved keyword that breaks the schema introspection query, and `pg_stat_activity`/`pg_statio_user_tables` do not exist, so the monitoring panel cannot read them.