### PR TITLE
ci: run a composition's ci-cleanup workflow after every mzcompose job

### DIFF
--- a/ci/plugins/mzcompose/README.md
+++ b/ci/plugins/mzcompose/README.md
@@ -24,4 +24,18 @@ at the last occurrence of the marker. Logs without the marker are scanned in
 full. This is useful for workflows that exercise historical binaries before
 testing the current build.
 
+## Cleaning up resources outside of Docker
+
+A composition that creates resources outside of Docker, such as a Cloud
+region, can define a workflow named `ci-cleanup`. The command hook runs it
+after the main workflow has exited, however it exited, and passes it the same
+`args`. Cancelling or timing out a job ends the main workflow with SIGTERM,
+which does not run Python `finally` blocks, so a composition must not rely on
+its own cleanup path for those cases. Before the workflow runs, the hook kills
+the main workflow's containers, so nothing left over from the main run can
+race the cleanup; the Docker teardown proper happens afterwards. The workflow
+must be idempotent: it also runs after a successful run that already cleaned
+up. It writes no JUnit report, so the main workflow's report survives. Its
+failure is recorded in the error annotation and fails an otherwise green job.
+
 [Buildkite plugin]: https://buildkite.com/docs/agent/v3/plugins

--- a/ci/plugins/mzcompose/README.md
+++ b/ci/plugins/mzcompose/README.md
@@ -28,14 +28,27 @@ testing the current build.
 
 A composition that creates resources outside of Docker, such as a Cloud
 region, can define a workflow named `ci-cleanup`. The command hook runs it
-after the main workflow has exited, however it exited, and passes it the same
-`args`. Cancelling or timing out a job ends the main workflow with SIGTERM,
-which does not run Python `finally` blocks, so a composition must not rely on
-its own cleanup path for those cases. Before the workflow runs, the hook kills
-the main workflow's containers, so nothing left over from the main run can
-race the cleanup; the Docker teardown proper happens afterwards. The workflow
-must be idempotent: it also runs after a successful run that already cleaned
-up. It writes no JUnit report, so the main workflow's report survives. Its
-failure is recorded in the error annotation and fails an otherwise green job.
+after the main workflow has exited, however it exited, and passes it the main
+workflow's full argument list: the step's `args` plus any `CI_EXTRA_ARGS`. The
+workflow must therefore parse with `parse_known_args` and find its target from
+those arguments alone. Cancelling or timing out a job ends the main workflow
+with SIGTERM, which does not run Python `finally` blocks, so a composition
+must not rely on its own cleanup path for those cases.
+
+Before the workflow runs, the hook kills (SIGKILL) the containers of the main
+run's compose project, so that a command still in flight from the main run,
+such as an `mz region enable` that outlived the cancelled process, cannot undo
+the cleanup after it has finished; the Docker teardown proper happens
+afterwards. The kill is skipped under `CI_COVERAGE_ENABLED`, where the Docker
+teardown is deliberately graceful. The workflow must be idempotent: it also
+runs after a successful run that already cleaned up. It has 15 minutes, so
+that a hung cleanup cannot eat the cancel grace period before the artifacts
+are uploaded. It writes no JUnit report, so the main workflow's report
+survives. Its failure is recorded in the error annotation and fails an
+otherwise green job.
+
+The mzcompose-files lint does not count `ci-cleanup` as a workflow, so a
+composition with a single main workflow can add it without looping over
+`c.workflows`; a `default` that does loop must skip `ci-cleanup`.
 
 [Buildkite plugin]: https://buildkite.com/docs/agent/v3/plugins

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -167,7 +167,7 @@ cleanup() {
     # period before the artifacts and the error annotation. Normal disables
     # take about 30 s. The output also goes to run.log so that the artifact
     # shows why a cleanup failed.
-    if ! bin/ci-builder run "$builder" timeout 15m bin/mzcompose --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" run ci-cleanup "${run_args[@]:1}" |& sed -u -r 's/\x1B\[[0-9;]*[A-Za-z]//g' | tee -a run.log; then
+    if ! bin/ci-builder run "$builder" timeout --signal=TERM --kill-after=30s 15m bin/mzcompose --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" run ci-cleanup "${run_args[@]:1}" |& sed -u -r 's/\x1B\[[0-9;]*[A-Za-z]//g' | tee -a run.log; then
       printf "\n%s" "$BUILDKITE_LABEL: ci-cleanup workflow failed" >> run.log
     fi
   fi

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -157,11 +157,12 @@ cleanup() {
     # The main workflow's containers can outlive its process: SIGTERM ends
     # mzcompose, but a `docker compose run` container it started keeps going,
     # and an in-flight `mz region enable` could re-create the region after the
-    # cleanup deleted it. Only compose-managed containers, so that containers
-    # a composition drives through other means, such as kind nodes, keep
-    # running for the log collection below. Killed containers keep their logs
-    # for services.log; `mzcompose down` removes them.
-    docker ps --quiet --filter label=com.docker.compose.project | xargs --no-run-if-empty docker kill > /dev/null || true
+    # cleanup deleted it. Only this composition's compose project (named after
+    # the composition): other jobs' containers, and containers a composition
+    # drives outside compose, such as kind nodes, keep running for the log
+    # collection below. Killed containers keep their logs for services.log;
+    # `mzcompose down` removes them.
+    docker ps --quiet --filter "label=com.docker.compose.project=$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" | xargs --no-run-if-empty docker kill > /dev/null || true
     # 15m keeps a hung cleanup from eating the agents' 40-minute cancel grace
     # period before the artifacts and the error annotation. Normal disables
     # take about 30 s. The output also goes to run.log so that the artifact

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -161,8 +161,12 @@ cleanup() {
     # the composition): other jobs' containers, and containers a composition
     # drives outside compose, such as kind nodes, keep running for the log
     # collection below. Killed containers keep their logs for services.log;
-    # `mzcompose down` removes them.
-    docker ps --quiet --filter "label=com.docker.compose.project=$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" | xargs --no-run-if-empty docker kill > /dev/null || true
+    # `mzcompose down` removes them. Skipped under coverage: the coverage
+    # teardown below stops containers gracefully on purpose, and a kill here
+    # would defeat it.
+    if [ -z "${CI_COVERAGE_ENABLED:-}" ]; then
+      docker ps --quiet --filter "label=com.docker.compose.project=$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" | xargs --no-run-if-empty docker kill > /dev/null || true
+    fi
     # 15m keeps a hung cleanup from eating the agents' 40-minute cancel grace
     # period before the artifacts and the error annotation. Normal disables
     # take about 30 s. The output also goes to run.log so that the artifact

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -145,6 +145,32 @@ cleanup() {
     printf "\n%s" "$BUILDKITE_LABEL: test timed out" >> run.log
   fi
 
+  # A composition that holds resources outside of Docker, such as a Cloud
+  # region, can declare a `ci-cleanup` workflow. It runs here, before the Docker
+  # teardown, with the arguments of the main workflow. A cancelled or timed-out
+  # job reaches this trap through SIGTERM, which ends the mzcompose process
+  # without running the composition's own cleanup path, so this is the only
+  # cleanup such a run gets. A failure goes to run.log, where ci-annotate-errors
+  # turns it into an error annotation and fails an otherwise green job.
+  if echo "$workflows" | grep -x "ci-cleanup" > /dev/null; then
+    ci_unimportant_heading ":docker: Running the composition's ci-cleanup workflow"
+    # The main workflow's containers can outlive its process: SIGTERM ends
+    # mzcompose, but a `docker compose run` container it started keeps going,
+    # and an in-flight `mz region enable` could re-create the region after the
+    # cleanup deleted it. Only compose-managed containers, so that containers
+    # a composition drives through other means, such as kind nodes, keep
+    # running for the log collection below. Killed containers keep their logs
+    # for services.log; `mzcompose down` removes them.
+    docker ps --quiet --filter label=com.docker.compose.project | xargs --no-run-if-empty docker kill > /dev/null || true
+    # 15m keeps a hung cleanup from eating the agents' 40-minute cancel grace
+    # period before the artifacts and the error annotation. Normal disables
+    # take about 30 s. The output also goes to run.log so that the artifact
+    # shows why a cleanup failed.
+    if ! bin/ci-builder run "$builder" timeout 15m bin/mzcompose --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" run ci-cleanup "${run_args[@]:1}" |& sed -u -r 's/\x1B\[[0-9;]*[A-Za-z]//g' | tee -a run.log; then
+      printf "\n%s" "$BUILDKITE_LABEL: ci-cleanup workflow failed" >> run.log
+    fi
+  fi
+
   ci_unimportant_heading "Post command steps"
   # Run before potential "run down" in coverage
   docker ps --all --quiet | xargs --no-run-if-empty docker inspect | jq '

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -142,7 +142,7 @@ cleanup() {
   END_TIME=$(date +%s)
   ELAPSED=$((END_TIME - START_TIME))
   if [ $ELAPSED -ge $((BUILDKITE_TIMEOUT * 60)) ]; then
-    printf "\n%s" "$BUILDKITE_LABEL: test timed out" >> run.log
+    printf "\n%s\n" "$BUILDKITE_LABEL: test timed out" >> run.log
   fi
 
   # A composition that holds resources outside of Docker, such as a Cloud
@@ -168,7 +168,7 @@ cleanup() {
     # take about 30 s. The output also goes to run.log so that the artifact
     # shows why a cleanup failed.
     if ! bin/ci-builder run "$builder" timeout --signal=TERM --kill-after=30s 15m bin/mzcompose --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" run ci-cleanup "${run_args[@]:1}" |& sed -u -r 's/\x1B\[[0-9;]*[A-Za-z]//g' | tee -a run.log; then
-      printf "\n%s" "$BUILDKITE_LABEL: ci-cleanup workflow failed" >> run.log
+      printf "\n%s\n" "$BUILDKITE_LABEL: ci-cleanup workflow failed" >> run.log
     fi
   fi
 

--- a/ci/spec-sheet/pipeline.template.yml
+++ b/ci/spec-sheet/pipeline.template.yml
@@ -111,7 +111,7 @@ steps:
       queue: linux-aarch64-small
 
   - id: cluster-spec-sheet-staging
-    label: "Cluster spec sheet: Staging"
+    label: "Cluster spec sheet: envd Scalability + Cluster Object Count Limits (against Staging)"
     timeout_in_minutes: 3600
     depends_on: devel-docker-tags
     parallelism: 7

--- a/ci/test/lint-main/checks/check-mzcompose-files.sh
+++ b/ci/test/lint-main/checks/check-mzcompose-files.sh
@@ -59,7 +59,8 @@ check_default_workflow_references_others() {
     )
 
     for file in "${MZCOMPOSE_TEST_FILES[@]}"; do
-      MATCHES_COUNT=$(grep "def workflow_" "$file" -c)
+      # `ci-cleanup` is run by the mzcompose plugin's hook, never by `default`.
+      MATCHES_COUNT=$(grep "def workflow_" "$file" | grep -vc "def workflow_ci_cleanup" || true)
 
       if (( MATCHES_COUNT > 1 )); then
         # mzcompose file contains more than one workflow

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -94,6 +94,7 @@ ERROR_RE = re.compile(
     | SUMMARY:\ .*Sanitizer
     | primary\ source\ \w+\ seemingly\ dropped\ before\ subsource
     | :\ test\ timed\ out
+    | :\ ci-cleanup\ workflow\ failed
     | very\ slow\ coordinator\ message
     # Only notifying on unexpected failures. INT, TRAP, BUS, FPE, SEGV, PIPE
     | \ ANOM_ABEND\ .*\ sig=(2|5|7|8|11|13)

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -869,7 +869,7 @@ To see the available workflows, run:
                     workflow_name, *args.unknown_subargs[1:], *extra_args
                 )
 
-            if self.shall_generate_junit_report(args.find, composition):
+            if self.shall_generate_junit_report(args.find, workflow_name, composition):
                 junit_suite = self.generate_junit_suite(composition)
                 self.write_junit_report_to_file(junit_suite)
 
@@ -880,8 +880,16 @@ To see the available workflows, run:
                 raise UIError("at least one test case failed")
 
     def shall_generate_junit_report(
-        self, composition_name: str | None, composition: Composition
+        self,
+        composition_name: str | None,
+        workflow_name: str | None,
+        composition: Composition,
     ) -> bool:
+        if workflow_name == "ci-cleanup":
+            # Runs from the CI plugin's exit trap after the main workflow, under
+            # the same BUILDKITE_JOB_ID, so its report would overwrite the main
+            # run's. Its outcome is reported through run.log instead.
+            return False
         if composition.has_testdrive_junit:
             # Testdrive already produced a junit.xml with detailed errors;
             # skip the mzcompose-level junit to avoid duplicate annotations.

--- a/test/cluster-spec-sheet/README.md
+++ b/test/cluster-spec-sheet/README.md
@@ -27,7 +27,7 @@ regions behind.
 
 ## Running manually in Cloud
 
-To run the cloud canary test manually, you can specify either `--target=cloud-production` (which is hardcoded to aws/us-east-1) or `--target=cloud-staging` (which is hardcoded to aws/eu-west-1). For production, you need to set the environment variables `NIGHTLY_MZ_USERNAME` and `MZ_CLI_APP_PASSWORD`. For staging, the run uses one account from the E2E database pool: set `E2E_STAGING_TEST_FRONTEGG_DATABASE_APP_PASSWORD_<n>` for the pool index `<n>` and select it with `CI_CONCURRENCY_POOL_SLOT=<n>` (outside CI, index 0 is used when the slot is unset); the username is derived from the index.
+To run the cloud canary test manually, you can specify either `--target=cloud-production` (which is hardcoded to aws/us-east-1) or `--target=cloud-staging` (which is hardcoded to aws/eu-west-1). For production, you need to set the environment variables `NIGHTLY_MZ_USERNAME` and `MZ_CLI_APP_PASSWORD`. For staging, the run uses one account from the E2E database pool: set `E2E_STAGING_TEST_FRONTEGG_DATABASE_APP_PASSWORD_<n>` for the pool index `<n>` and select it with `CI_CONCURRENCY_POOL_SLOT=<n>` (outside CI, index 0 is used when the slot is unset); the username is derived from the index. Staging runs also need `BUILDKITE_COMMIT`, which selects the image version to enable.
 
 The username is an email address, the app password is a password generated in the cloud console (something like `mzp_...`).
 

--- a/test/cluster-spec-sheet/README.md
+++ b/test/cluster-spec-sheet/README.md
@@ -27,7 +27,7 @@ regions behind.
 
 ## Running manually in Cloud
 
-To run the cloud canary test manually, you can specify either `--target=cloud-production` (which is hardcoded to aws/us-east-1) or `--target=cloud-staging` (which is hardcoded to aws/eu-west-1). For production, you need to set the environment variables `NIGHTLY_MZ_USERNAME` and `MZ_CLI_APP_PASSWORD`. For staging, you need to set the environment variables `NIGHTLY_CANARY_USERNAME` and `NIGHTLY_CANARY_APP_PASSWORD`.
+To run the cloud canary test manually, you can specify either `--target=cloud-production` (which is hardcoded to aws/us-east-1) or `--target=cloud-staging` (which is hardcoded to aws/eu-west-1). For production, you need to set the environment variables `NIGHTLY_MZ_USERNAME` and `MZ_CLI_APP_PASSWORD`. For staging, the run uses one account from the E2E database pool: set `E2E_STAGING_TEST_FRONTEGG_DATABASE_APP_PASSWORD_<n>` for the pool index `<n>` and select it with `CI_CONCURRENCY_POOL_SLOT=<n>` (outside CI, index 0 is used when the slot is unset); the username is derived from the index.
 
 The username is an email address, the app password is a password generated in the cloud console (something like `mzp_...`).
 

--- a/test/cluster-spec-sheet/README.md
+++ b/test/cluster-spec-sheet/README.md
@@ -4,9 +4,12 @@ Reproduce data for the cluster spec sheet effort.
 
 # Usage
 
-`bin/mzcompose --find cluster-spec-sheet run default`
+`bin/mzcompose --find cluster-spec-sheet run default --target=<target>`
 
 This will run all scenarios currently defined for the cluster spec sheet.
+`--target` is required: `cloud-production`, `cloud-staging`, or `docker`.
+There is deliberately no default, because the CI cleanup below destroys the
+target's region unattended.
 
 Pass `--cleanup` to disable the region after the test.
 
@@ -15,7 +18,12 @@ Pass `--cleanup` to disable the region after the test.
 
 ## Running via Buildkite
 
-The workload runs as part of the release qualification pipeline in Buildkite.
+The workload runs in the `spec-sheet` Buildkite pipeline. After a CI job
+ends, however it ends, the mzcompose plugin runs the `ci-cleanup` workflow
+with the job's arguments; for a Cloud target started with `--cleanup` it
+disables the region. A canceled or timed-out job never reaches the
+composition's own cleanup, so this is what keeps canceled runs from leaving
+regions behind.
 
 ## Running manually in Cloud
 
@@ -27,7 +35,7 @@ Once the environment variables have been set, you can run:
 
 ```
 cd test/cluster-spec-sheet
-./mzcompose run default
+./mzcompose run default --target=cloud-production
 ```
 
 ## Running in Docker
@@ -55,11 +63,11 @@ bin/mzcompose --find cluster-spec-sheet run default envd_qps_scalability  --targ
 ```
 or
 ```
-bin/mzcompose --find cluster-spec-sheet run default cluster
+bin/mzcompose --find cluster-spec-sheet run default cluster --target=cloud-production
 ```
 or
 ```
-bin/mzcompose --find cluster-spec-sheet run default envd_objects_scalability
+bin/mzcompose --find cluster-spec-sheet run default envd_objects_scalability --target=cloud-production
 ```
 or
 ```

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -3404,24 +3404,30 @@ def verify_region_disabled(composition: Composition, region: str) -> None:
     or failing API, and a region that survives a cleanup keeps costing money
     and load until someone notices. "disabled" also covers a region whose
     deletion is still pending, so the check proves that no enabled region is
-    left, not that the deletion has completed. The check runs after every
-    cleanup, including the unattended one from the CI plugin's exit trap.
+    left, not that the deletion has completed.
     """
     output = composition.run(
         "mz", "region", "list", "--format", "json", rm=True, capture_and_print=True
     ).stdout
-    # The JSON array is the last line: `mz region list` reports a cloud provider
-    # whose lookup failed as an `Error: ...` line on stdout before it.
+    # `mz region list` reports a cloud provider whose lookup failed as an
+    # `Error: ...` line on stdout before the JSON array, so parsing the whole
+    # output would fail on an unrelated provider's hiccup.
+    lines = output.strip().splitlines()
+    start = next((i for i, line in enumerate(lines) if line.startswith("[")), None)
     try:
-        regions = json.loads(output.strip().splitlines()[-1])
-    except (ValueError, IndexError) as e:
+        if start is None:
+            raise ValueError("no JSON array in the output")
+        statuses = {
+            entry["region"]: entry["status"]
+            for entry in json.loads("\n".join(lines[start:]))
+        }
+    except (ValueError, KeyError, TypeError) as e:
         raise UIError(f"unexpected `mz region list` output: {output!r}") from e
-    for entry in regions:
-        if entry["region"] == region:
-            if entry["status"] == "disabled":
-                return
-            raise UIError(f"region {region} is still {entry['status']} after disable")
-    raise UIError(f"region {region} missing from `mz region list` output")
+    status = statuses.get(region)
+    if status is None:
+        raise UIError(f"region {region} missing from `mz region list` output")
+    if status != "disabled":
+        raise UIError(f"region {region} is still {status} after disable")
 
 
 def enable_region(target: "CloudTarget", envd_cpus: int | None = None) -> None:

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -3791,7 +3791,7 @@ def add_target_arguments(parser: argparse.ArgumentParser) -> None:
         "--cleanup",
         default=False,
         action=argparse.BooleanOptionalAction,
-        help="Destroy the region at the end of the workflow.",
+        help="Destroy the region when the workflow ends, and from CI's ci-cleanup after a cancel or timeout.",
     )
     # Required rather than defaulting to cloud-production: `ci-cleanup` runs
     # unattended from the CI plugin's exit trap and destroys the target's

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -3748,16 +3748,60 @@ def log_environment_info(target: "BenchTarget") -> None:
             pass
 
 
-def workflow_default(composition: Composition, parser: WorkflowArgumentParser) -> None:
-    """
-    Run the bench workflow by default
-    """
+def add_target_arguments(parser: argparse.ArgumentParser) -> None:
+    """The arguments of a workflow that constructs a bench target."""
     parser.add_argument(
         "--cleanup",
         default=False,
         action=argparse.BooleanOptionalAction,
         help="Destroy the region at the end of the workflow.",
     )
+    parser.add_argument(
+        "--target",
+        default="cloud-production",
+        choices=["cloud-production", "cloud-staging", "docker"],
+        help="Target to deploy to (default: cloud-production).",
+    )
+
+
+def make_target(composition: Composition, target: str) -> tuple["BenchTarget", Mz]:
+    """The bench target for `--target`, with the `mz` service configured for it."""
+    if target == "cloud-production":
+        bench_target: BenchTarget = CloudTarget(
+            composition, PRODUCTION_USERNAME, PRODUCTION_APP_PASSWORD or ""
+        )
+        mz = Mz(
+            region=PRODUCTION_REGION,
+            environment=PRODUCTION_ENVIRONMENT,
+            app_password=PRODUCTION_APP_PASSWORD or "",
+        )
+    elif target == "cloud-staging":
+        staging_username, staging_app_password = staging_credentials()
+        bench_target = CloudTarget(
+            composition,
+            staging_username,
+            staging_app_password,
+            is_staging=True,
+            version=staging_version(),
+        )
+        mz = Mz(
+            region=STAGING_REGION,
+            environment=STAGING_ENVIRONMENT,
+            app_password=staging_app_password,
+        )
+    elif target == "docker":
+        bench_target = DockerTarget(composition)
+        mz = Mz(app_password="")
+    else:
+        raise ValueError(f"Unknown target: {target}")
+    return bench_target, mz
+
+
+def workflow_default(composition: Composition, parser: WorkflowArgumentParser) -> None:
+    """
+    Run the bench workflow by default
+    """
+    add_target_arguments(parser)
     parser.add_argument(
         "--record",
         default=f"results_{int(time.time())}.csv",
@@ -3768,12 +3812,6 @@ def workflow_default(composition: Composition, parser: WorkflowArgumentParser) -
         default=True,
         action=argparse.BooleanOptionalAction,
         help="Analyze results after completing test. Dispatches to cluster-scale or envd-scale focused analyses based on the file suffix: `.cluster.csv` or `.envd.csv`.",
-    )
-    parser.add_argument(
-        "--target",
-        default="cloud-production",
-        choices=["cloud-production", "cloud-staging", "docker"],
-        help="Target to deploy to (default: cloud-production).",
     )
     parser.add_argument(
         "--max-scale",
@@ -3865,34 +3903,7 @@ def workflow_default(composition: Composition, parser: WorkflowArgumentParser) -
             f"{', '.join(sorted(cluster_object_limits_requested))}."
         )
 
-    if args.target == "cloud-production":
-        target: BenchTarget = CloudTarget(
-            composition, PRODUCTION_USERNAME, PRODUCTION_APP_PASSWORD or ""
-        )
-        mz = Mz(
-            region=PRODUCTION_REGION,
-            environment=PRODUCTION_ENVIRONMENT,
-            app_password=PRODUCTION_APP_PASSWORD or "",
-        )
-    elif args.target == "cloud-staging":
-        staging_username, staging_app_password = staging_credentials()
-        target: BenchTarget = CloudTarget(
-            composition,
-            staging_username,
-            staging_app_password,
-            is_staging=True,
-            version=staging_version(),
-        )
-        mz = Mz(
-            region=STAGING_REGION,
-            environment=STAGING_ENVIRONMENT,
-            app_password=staging_app_password,
-        )
-    elif args.target == "docker":
-        target = DockerTarget(composition)
-        mz = Mz(app_password="")
-    else:
-        raise ValueError(f"Unknown target: {args.target}")
+    target, mz = make_target(composition, args.target)
 
     with composition.override(mz):
         target_max = target.max_scale()

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -3449,11 +3449,12 @@ def enable_region(target: "CloudTarget", envd_cpus: int | None = None) -> None:
         # Production Cloud forbids callers from injecting environmentd args and rejects
         # `--environmentd-extra-arg` with a 403 Forbidden, so this is staging-only.
         args += [
-            "--environmentd-extra-arg=--system-parameter-default=with_0dt_caught_up_check_stability_period=0s"
+            "--environmentd-extra-arg=--system-parameter-default=with_0dt_caught_up_check_stability_period=0s",
+            # Pin the image built for this PR. Production does not accept a
+            # custom version.
+            "--version",
+            staging_version(),
         ]
-
-    if target.version is not None:
-        args += ["--version", target.version]
 
     target.composition.run("mz", "region", "enable", *args, rm=True)
 
@@ -3822,7 +3823,6 @@ def make_target(composition: Composition, target: str) -> tuple["BenchTarget", M
             staging_app_password,
             region=STAGING_REGION,
             is_staging=True,
-            version=staging_version(),
         )
         mz = Mz(
             region=STAGING_REGION,
@@ -4093,7 +4093,6 @@ class CloudTarget(BenchTarget):
         app_password: str,
         region: str,
         is_staging: bool = False,
-        version: str | None = None,
     ) -> None:
         self.composition = composition
         self.username = username
@@ -4101,11 +4100,6 @@ class CloudTarget(BenchTarget):
         self.app_password = app_password
         self.new_app_password: str | None = None
         self.is_staging = is_staging
-        # Set for staging runs so `mz region enable --version <version>` pins the
-        # exact image built for this PR. Must be None for production (production
-        # doesn't accept a custom version).
-        self.version = version
-        assert (version is not None) == is_staging
 
     def dbbench_connection_flags(self) -> list[str]:
         assert self.new_app_password is not None

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -15,6 +15,7 @@ import argparse
 import csv
 import glob
 import itertools
+import json
 import os
 import re
 import shlex
@@ -3386,16 +3387,40 @@ class EnvdObjectsSweep(Scenario):
 # TODO: We should factor the region helpers below out into a separate module.
 # (Similar `disable_region` functions also occur in other tests.)
 def disable_region(composition: Composition, hard: bool) -> None:
+    # `mz region disable` treats an already-disabled region as success, so any
+    # failure here is a real one (auth, API error) and must surface.
     print("Shutting down region ...")
+    if hard:
+        composition.run("mz", "region", "disable", "--hard", rm=True)
+    else:
+        composition.run("mz", "region", "disable", rm=True)
 
+
+def verify_region_disabled(composition: Composition, region: str) -> None:
+    """Fail unless `mz region list` reports `region` as disabled.
+
+    `mz region disable` returning is not proof: it can be answered by a stale
+    or failing API, and a region that survives a cleanup keeps costing money
+    and load until someone notices. "disabled" also covers a region whose
+    deletion is still pending, so the check proves that no enabled region is
+    left, not that the deletion has completed. The check runs after every
+    cleanup, including the unattended one from the CI plugin's exit trap.
+    """
+    output = composition.run(
+        "mz", "region", "list", "--format", "json", rm=True, capture_and_print=True
+    ).stdout
+    # The JSON array is the last line: `mz region list` reports a cloud provider
+    # whose lookup failed as an `Error: ...` line on stdout before it.
     try:
-        if hard:
-            composition.run("mz", "region", "disable", "--hard", rm=True)
-        else:
-            composition.run("mz", "region", "disable", rm=True)
-    except UIError:
-        # Can return: status 404 Not Found
-        pass
+        regions = json.loads(output.strip().splitlines()[-1])
+    except (ValueError, IndexError) as e:
+        raise UIError(f"unexpected `mz region list` output: {output!r}") from e
+    for entry in regions:
+        if entry["region"] == region:
+            if entry["status"] == "disabled":
+                return
+            raise UIError(f"region {region} is still {entry['status']} after disable")
+    raise UIError(f"region {region} missing from `mz region list` output")
 
 
 def enable_region(target: "CloudTarget", envd_cpus: int | None = None) -> None:
@@ -3772,7 +3797,10 @@ def make_target(composition: Composition, target: str) -> tuple["BenchTarget", M
     """The bench target for `--target`, with the `mz` service configured for it."""
     if target == "cloud-production":
         bench_target: BenchTarget = CloudTarget(
-            composition, PRODUCTION_USERNAME, PRODUCTION_APP_PASSWORD or ""
+            composition,
+            PRODUCTION_USERNAME,
+            PRODUCTION_APP_PASSWORD or "",
+            region=PRODUCTION_REGION,
         )
         mz = Mz(
             region=PRODUCTION_REGION,
@@ -3785,6 +3813,7 @@ def make_target(composition: Composition, target: str) -> tuple["BenchTarget", M
             composition,
             staging_username,
             staging_app_password,
+            region=STAGING_REGION,
             is_staging=True,
             version=staging_version(),
         )
@@ -4055,11 +4084,13 @@ class CloudTarget(BenchTarget):
         composition: Composition,
         username: str,
         app_password: str,
+        region: str,
         is_staging: bool = False,
         version: str | None = None,
     ) -> None:
         self.composition = composition
         self.username = username
+        self.region = region
         self.app_password = app_password
         self.new_app_password: str | None = None
         self.is_staging = is_staging
@@ -4122,6 +4153,7 @@ class CloudTarget(BenchTarget):
 
     def cleanup(self) -> None:
         disable_region(self.composition, hard=True)
+        verify_region_disabled(self.composition, self.region)
 
     # M.1 size with the same worker count as the {scale}00cc size. Scales
     # above 8 have no available M.1 equivalent.

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -3505,19 +3505,19 @@ def cloud_recreate_region_with_envd_cpus(
     soon as it has booted, in about a minute.
     """
     for attempt in range(1, attempts + 1):
-        disable_region(target.composition, hard=True)
         try:
+            disable_region(target.composition, hard=True)
             enable_region(target, envd_cpus=envd_cpus)
             break
         except UIError as e:
             # A sweep does a dozen of these calls and the staging Cloud API returns the
-            # occasional 502, which `mz region enable` does not retry on its own. We
-            # disable again before retrying, so that a half-finished enable can't leave
-            # the region running with the previous allocation.
+            # occasional 502 that surfaces despite the CLI's own retries. A retry starts
+            # over with the disable, so that a half-finished enable can't leave the
+            # region running with the previous allocation.
             if attempt == attempts:
                 raise
             print(
-                f"WARNING: 'mz region enable' failed (attempt {attempt}/{attempts}): {e}"
+                f"WARNING: recreating the region failed (attempt {attempt}/{attempts}): {e}"
             )
             time.sleep(30)
 

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -4016,32 +4016,40 @@ def workflow_default(composition: Composition, parser: WorkflowArgumentParser) -
 
         test_failed = True
         try:
-            scenarios_list = buildkite.shard_list(sorted(list(scenarios)), lambda s: s)
-            composition.test_parts(scenarios_list, process)
-            test_failed = False
-        finally:
+            try:
+                scenarios_list = buildkite.shard_list(
+                    sorted(list(scenarios)), lambda s: s
+                )
+                composition.test_parts(scenarios_list, process)
+                test_failed = False
+            finally:
+                for stream in streams.values():
+                    stream.file.close()
+
+            # Upload, archive, and analyze each result stream uniformly. The
+            # cluster_object_limits stream's extra `healthy` / `failure_mode`
+            # columns are silently dropped on upload (CSV writer uses
+            # extrasaction="ignore"); to recover them, consult the artifact
+            # CSV directly.
             for stream in streams.values():
-                stream.file.close()
+                stream.spec.upload(composition, stream.path, not test_failed)
+
+            assert not test_failed
+
+            if buildkite.is_in_buildkite():
+                for stream in streams.values():
+                    buildkite.upload_artifact(stream.path, cwd=MZ_ROOT, quiet=True)
+
+            if args.analyze:
+                for stream in streams.values():
+                    stream.spec.analyze(stream.path)
+        finally:
+            # Only after the results are out: the teardown can fail (a slow
+            # hard delete, a transient API error in its verify) and must not
+            # cost a multi-hour run its data. The CI plugin's `ci-cleanup`
+            # repeats the teardown after the workflow, however it ended.
             if args.cleanup:
                 target.cleanup()
-
-        # Upload, archive, and analyze each result stream uniformly. The
-        # cluster_object_limits stream's extra `healthy` / `failure_mode`
-        # columns are silently dropped on upload (CSV writer uses
-        # extrasaction="ignore"); to recover them, consult the artifact
-        # CSV directly.
-        for stream in streams.values():
-            stream.spec.upload(composition, stream.path, not test_failed)
-
-        assert not test_failed
-
-        if buildkite.is_in_buildkite():
-            for stream in streams.values():
-                buildkite.upload_artifact(stream.path, cwd=MZ_ROOT, quiet=True)
-
-        if args.analyze:
-            for stream in streams.values():
-                stream.spec.analyze(stream.path)
 
 
 class BenchTarget:

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -3749,18 +3749,22 @@ def log_environment_info(target: "BenchTarget") -> None:
 
 
 def add_target_arguments(parser: argparse.ArgumentParser) -> None:
-    """The arguments of a workflow that constructs a bench target."""
+    """The arguments `workflow_default` and `workflow_ci_cleanup` share."""
     parser.add_argument(
         "--cleanup",
         default=False,
         action=argparse.BooleanOptionalAction,
         help="Destroy the region at the end of the workflow.",
     )
+    # Required rather than defaulting to cloud-production: `ci-cleanup` runs
+    # unattended from the CI plugin's exit trap and destroys the target's
+    # region, so a missing or malformed target must fail loudly instead of
+    # quietly selecting production. Every CI step passes it explicitly.
     parser.add_argument(
         "--target",
-        default="cloud-production",
+        required=True,
         choices=["cloud-production", "cloud-staging", "docker"],
-        help="Target to deploy to (default: cloud-production).",
+        help="Target to deploy to.",
     )
 
 
@@ -3795,6 +3799,30 @@ def make_target(composition: Composition, target: str) -> tuple["BenchTarget", M
     else:
         raise ValueError(f"Unknown target: {target}")
     return bench_target, mz
+
+
+def workflow_ci_cleanup(
+    composition: Composition, parser: WorkflowArgumentParser
+) -> None:
+    """
+    Destroy the Cloud region of a run that did not get to its own cleanup.
+
+    The CI mzcompose plugin runs this workflow after `default` has exited, however
+    it exited, with the same arguments. A cancelled or timed-out job ends `default`
+    with SIGTERM, which skips its `finally` block, so for such a run this is the
+    only region cleanup there is. Only `--cleanup` and `--target` are read.
+    """
+    add_target_arguments(parser)
+    args, _ = parser.parse_known_args()
+    if not args.cleanup:
+        print("Not destroying the region: the run was started without --cleanup")
+        return
+    target, mz = make_target(composition, args.target)
+    if not isinstance(target, CloudTarget):
+        print(f"Nothing to clean up for --target={args.target}")
+        return
+    with composition.override(mz):
+        target.cleanup()
 
 
 def workflow_default(composition: Composition, parser: WorkflowArgumentParser) -> None:

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -13,6 +13,7 @@ Reproduces cluster spec sheet results on Materialize Cloud (or local Docker).
 
 import argparse
 import csv
+import functools
 import glob
 import itertools
 import json
@@ -105,7 +106,10 @@ MATERIALIZED_ADDITIONAL_SYSTEM_PARAMETER_DEFAULTS = ADDITIONAL_BENCHMARKING_SYST
 }
 
 
+@functools.cache
 def staging_version() -> str:
+    # Cached: the version cannot change within a run, and `parse_cargo` shells
+    # out to cargo, whose failure must not surface inside a region retry loop.
     return f"{MzVersion.parse_cargo()}--pr.g{os.environ['BUILDKITE_COMMIT']}"
 
 

--- a/test/cluster-spec-sheet/mzcompose.py
+++ b/test/cluster-spec-sheet/mzcompose.py
@@ -3387,8 +3387,9 @@ class EnvdObjectsSweep(Scenario):
 # TODO: We should factor the region helpers below out into a separate module.
 # (Similar `disable_region` functions also occur in other tests.)
 def disable_region(composition: Composition, hard: bool) -> None:
-    # `mz region disable` treats an already-disabled region as success, so any
-    # failure here is a real one (auth, API error) and must surface.
+    # `mz region disable` reports a region that does not exist as success (its
+    # `disable` maps the API's 404 to "Region already disabled"), so any failure
+    # here is a real one (auth, API error) and must surface.
     print("Shutting down region ...")
     if hard:
         composition.run("mz", "region", "disable", "--hard", rm=True)


### PR DESCRIPTION
### Motivation

Cancelling or timing out a Cluster spec sheet job leaves its Cloud region running. Buildkite ends the job with SIGTERM, which kills the mzcompose process without running the composition's `finally` block, so `mz region disable --hard` never happens. The region survives until the next run on the same account disables it at its start: for the production steps that is the next weekly run, for a staging shard it is when the same E2E account comes up again in the 7-of-20 rotation, which can take weeks.

On 2026-09-03 two cancelled builds ([37](https://buildkite.com/materialize/spec-sheet/builds/37) and [38](https://buildkite.com/materialize/spec-sheet/builds/38)) left nine staging regions behind ([slack](https://materializeinc.slack.com/archives/CTESPM7FU/p1788631756670729?thread_ts=1788563743.586529&cid=CTESPM7FU)). One of them, cancelled at 20,000 materialized views, kept the staging eu-west-1 CockroachDB cluster at 75-85% CPU for over two days and stalled the v26.41.0-rc.3 staging rollout. [Build 17](https://buildkite.com/materialize/spec-sheet/builds/17) did the same on a smaller scale on 2026-07-08.

### Description

Best reviewed commit by commit; each commit is one concern.

* **Plugin mechanism.** The mzcompose Buildkite plugin runs a composition's `ci-cleanup` workflow, if it defines one, from its exit trap: after the main workflow has exited for any reason, before the Docker teardown, with the main workflow's arguments. Before it runs, the hook kills the containers of the main run's compose project: SIGTERM ends the mzcompose process, but a `docker compose run` container it started keeps going, and an in-flight `mz region enable` could otherwise re-create the region after the cleanup deleted it. The cleanup run writes no JUnit report, since it runs under the same job id and would overwrite the main run's report, which for a normally failing job is the only source of the failure annotation. A cleanup failure is written to run.log, where a new `ci-annotate-errors` pattern turns it into an error annotation even for a cancelled job, and fails an otherwise green job. Documented in the plugin README.
* **`cluster-spec-sheet` defines `ci-cleanup`.** For a Cloud target started with `--cleanup` it destroys the region, otherwise it does nothing. It is idempotent: after a successful run the region is already gone, which `mz region disable` reports as success. The target construction shared with `default` moves into `make_target`.
* **`--target` is now required** instead of defaulting to `cloud-production`. `ci-cleanup` runs unattended and reads the main workflow's arguments with `parse_known_args`, so a mistyped target used to fall through to production with cleanup enabled. All CI steps pass the target explicitly.
* **Cleanup is verified.** `CloudTarget.cleanup` checks with `mz region list --format json` that the region is reported disabled (which also covers a deletion still in progress) and fails otherwise, and `disable_region` no longer swallows errors. A surviving region therefore shows up as a failed `ci-cleanup` in the error annotation, however the job ended. Because the end-of-run teardown can now fail, it runs after the result uploads and the analysis, so a teardown failure fails the run without discarding its data.
* **README.** Every command passes `--target`, and the staging credentials paragraph describes the E2E pool accounts the composition actually uses.
* **Staging step label.** `Cluster spec sheet: envd Scalability + Cluster Object Count Limits (against Staging)`, following the "what runs (against where)" pattern of the two production steps. The `Cluster spec sheet` prefix, which the plugin's services.log check matches on, stays. Buildkite Test Analytics starts a new suite history under the new name.
* **Review fixes.** Twelve more commits, one per review point; what they change is listed under build 44 in Verification below.

Not covered: a job that dies from outside (agent loss, host termination). The start-of-run disable on the next use of the account remains the backstop for that. A SIGTERM handler in Python was considered and dropped: it would race the plugin's container kill and `mzcompose down`, which end the container the disable runs in.

### Verification

* 2026-09-05, spec-sheet builds 40 to 42, against the nine real leftover regions: dry runs where the trap declined to destroy, then the nine disables, then idempotent reruns of the trap.
* 2026-09-06, [spec-sheet build 43](https://buildkite.com/materialize/spec-sheet/builds/43), the staging step of this branch, cancelled once six shards had their regions up (the seventh never got an agent). All six SIGTERMed shards ran `ci-cleanup` from the trap, each disable took about 30 seconds and was reported disabled, and staging eu-west-1 was back to its four permanent environments within two minutes. That build correctly has no error annotation; checking how a failure would have surfaced is what found the missing `ci-annotate-errors` pattern. A review pass after that build found the JUnit overwrite (reproduced locally, and visible in build 43's uploaded reports) and the orphaned-container race.
* 2026-09-06, [spec-sheet build 44](https://buildkite.com/materialize/spec-sheet/builds/44), with all fixes: cancelled eleven seconds into one shard's `mz region enable` during its QPS sweep, i.e. with a live enable container. All six shards cleaned up (the seventh was still waiting for an agent), the JSON check reported the region disabled, no shard uploaded a JUnit report, run.log carries the cleanup output, there is no error annotation, and staging was back to its four permanent environments 80 seconds after the cancel and still ten minutes later. Changes since that build: an unbuffered `sed` so the cleanup output streams to the job log, and the review fixes (the container kill scoped to the job's composition, `--kill-after` on the cleanup's timeout, the QPS sweep's disable inside its retry loop, sturdier `mz region list` parsing, the staging image version computed on use, the results uploaded before the teardown, the run.log marker lines ending with a newline, the container kill skipped under coverage, the plugin README spelling out the `ci-cleanup` contract and the mzcompose-files lint accepting the workflow, the staging version cached per run, and two doc lines).
* 2026-09-06, [spec-sheet build 45](https://buildkite.com/materialize/spec-sheet/builds/45), with the review fixes: cancelled 23 seconds into the one shard that had an agent, during its first `mz region enable`. The trap's cleanup disabled and verified the region in 18 seconds, no error annotation, no JUnit artifact, and staging was back to its four permanent environments 92 seconds after the cancel and still ten minutes later.
* Locally: with `--target=docker` or without `--cleanup` the workflow is a no-op, `default --help` still parses, and shellcheck, pyright and `bin/fmt` are clean.

### Out of scope

`cloud-canary` and `mz-e2e` disable their Cloud region from a `try/finally` too, so a cancelled job leaves it up the same way. They stay as they are for now: the risk is much lower, since the next Nightly's start-of-run disable cleans up within a day rather than a week, their environments are far cheaper, and their runs last minutes rather than hours, so the window for a bad cancel is short. Historically it has not bitten: in the last two months of metrics, no cancel left either region up for more than 20 minutes, and `cloud-canary` has not been cancelled or timed out at all since December 2025. They can adopt `ci-cleanup` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)










