### PR TITLE
adapter: move a replacement's expression cache entries to its target on apply

### DIFF
--- a/misc/python/materialize/checks/all_checks/materialized_views.py
+++ b/misc/python/materialize/checks/all_checks/materialized_views.py
@@ -352,3 +352,69 @@ class MaterializedViewReplacement(Check):
                 # `validate` remains idempotent.
                 > DROP MATERIALIZED VIEW mv_replacement_replacement
             """))
+
+
+class MaterializedViewReplacementDropInput(Check):
+    """Applies a replacement and drops the old definition's input in the first
+    manipulate phase. The zero-downtime upgrade scenarios run that phase while
+    the next generation, built at a different version, is already booted
+    read-only, so its boot after promotion must not pair the new definition
+    with the expressions it cached before the apply. The tables retain history
+    so that a restart cannot hit CPU-95 (an input's read frontier overtaking
+    the output's write frontier).
+    """
+
+    def _can_run(self, e: Executor) -> bool:
+        # The first version whose expression cache records item versions. A
+        # generation of an earlier version that boots after the apply reuses
+        # the expressions cached for the old definition, and crash-loops on
+        # the dropped input.
+        return self.base_version >= MzVersion.parse_mz("v26.41.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(dedent("""
+                > CREATE TABLE mv_repl_drop_input_t1 (a INT) WITH (RETAIN HISTORY FOR '1 hour')
+                > INSERT INTO mv_repl_drop_input_t1 VALUES (1)
+                > CREATE VIEW mv_repl_drop_input_v1 AS SELECT a FROM mv_repl_drop_input_t1
+                > CREATE MATERIALIZED VIEW mv_repl_drop_input_mv AS SELECT a FROM mv_repl_drop_input_v1
+                > CREATE TABLE mv_repl_drop_input_t2 (a INT) WITH (RETAIN HISTORY FOR '1 hour')
+                > INSERT INTO mv_repl_drop_input_t2 VALUES (2)
+                > CREATE VIEW mv_repl_drop_input_v2 AS SELECT a FROM mv_repl_drop_input_t2
+                > CREATE REPLACEMENT MATERIALIZED VIEW mv_repl_drop_input_rp1 FOR mv_repl_drop_input_mv AS SELECT a FROM mv_repl_drop_input_v2
+                > SELECT * FROM mv_repl_drop_input_rp1
+                2
+                """))
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > ALTER MATERIALIZED VIEW mv_repl_drop_input_mv APPLY REPLACEMENT mv_repl_drop_input_rp1
+                > DROP VIEW mv_repl_drop_input_v1
+                > SELECT * FROM mv_repl_drop_input_mv
+                2
+                """,
+                """
+                > CREATE TABLE mv_repl_drop_input_t3 (a INT) WITH (RETAIN HISTORY FOR '1 hour')
+                > INSERT INTO mv_repl_drop_input_t3 VALUES (3)
+                > CREATE VIEW mv_repl_drop_input_v3 AS SELECT a FROM mv_repl_drop_input_t3
+                > CREATE REPLACEMENT MATERIALIZED VIEW mv_repl_drop_input_rp2 FOR mv_repl_drop_input_mv AS SELECT a FROM mv_repl_drop_input_v3
+                > SELECT * FROM mv_repl_drop_input_rp2
+                3
+                > ALTER MATERIALIZED VIEW mv_repl_drop_input_mv APPLY REPLACEMENT mv_repl_drop_input_rp2
+                > DROP VIEW mv_repl_drop_input_v2
+                > SELECT * FROM mv_repl_drop_input_mv
+                3
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(dedent("""
+                > SELECT * FROM mv_repl_drop_input_mv
+                3
+
+                > SELECT name FROM mz_materialized_views WHERE name LIKE 'mv_repl_drop_input_%'
+                mv_repl_drop_input_mv
+            """))

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1632,6 +1632,23 @@ impl Catalog {
         }
     }
 
+    /// See [`ExpressionCacheHandle::restamp`](mz_catalog::expr_cache::ExpressionCacheHandle::restamp).
+    pub(crate) fn restamp_expression_cache<'a, 'b>(
+        &'a self,
+        global_id: GlobalId,
+        local_id: GlobalId,
+        item_version: RelationVersion,
+        invalidate_ids: BTreeSet<GlobalId>,
+    ) -> BoxFuture<'b, ()> {
+        if let Some(expr_cache) = &self.expr_cache_handle {
+            expr_cache
+                .restamp(global_id, local_id, item_version, invalidate_ids)
+                .boxed()
+        } else {
+            async {}.boxed()
+        }
+    }
+
     /// Listen for and apply all unconsumed updates to the durable catalog state.
     // TODO(jkosh44) When this method is actually used outside of a test we can remove the
     // `#[cfg(test)]` annotation.

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -62,7 +62,9 @@ use mz_repr::explain::ExprHumanizer;
 use mz_repr::network_policy_id::NetworkPolicyId;
 use mz_repr::optimize::OptimizerFeatures;
 use mz_repr::role_id::RoleId;
-use mz_repr::{CatalogItemId, Diff, GlobalId, RelationVersionSelector, SqlScalarType};
+use mz_repr::{
+    CatalogItemId, Diff, GlobalId, RelationVersion, RelationVersionSelector, SqlScalarType,
+};
 use mz_secrets::InMemorySecretsController;
 use mz_sql::catalog::{
     CatalogCluster, CatalogClusterReplica, CatalogDatabase, CatalogError as SqlCatalogError,
@@ -1560,7 +1562,8 @@ impl Catalog {
     }
 
     /// Cache global and, optionally, local expressions for the given
-    /// `GlobalId`.
+    /// `GlobalId` of an item being created, whose only version is therefore
+    /// the root [`RelationVersion`].
     ///
     /// Takes the plans and metainfo directly as parameters (rather than
     /// fishing them out of catalog state), so this can be called **before**
@@ -1593,6 +1596,7 @@ impl Catalog {
                 LocalExpressions {
                     local_mir,
                     optimizer_features: optimizer_features.clone(),
+                    item_version: RelationVersion::root(),
                 },
             ));
         }
@@ -1603,6 +1607,7 @@ impl Catalog {
                 physical_plan,
                 dataflow_metainfos,
                 optimizer_features,
+                item_version: RelationVersion::root(),
             },
         )];
         self.update_expression_cache(local_exprs, global_exprs, Default::default())

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -1807,6 +1807,7 @@ impl CatalogState {
                             global_id,
                             uncached_expr,
                             optimizer_features,
+                            RelationVersion::root(),
                         );
                     }
                     // Add item to catalog.

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -39,6 +39,7 @@ use mz_catalog::durable::{
 };
 use mz_catalog::expr_cache::{
     ExpressionCacheConfig, ExpressionCacheHandle, GlobalExpressions, LocalExpressions,
+    latest_item_version,
 };
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
@@ -52,7 +53,7 @@ use mz_ore::now::{SYSTEM_TIME, to_datetime};
 use mz_ore::{instrument, soft_assert_no_log};
 use mz_repr::adt::mz_acl_item::PrivilegeMap;
 use mz_repr::namespaces::is_unstable_schema;
-use mz_repr::{CatalogItemId, Diff, GlobalId, Timestamp};
+use mz_repr::{CatalogItemId, Diff, GlobalId, RelationVersion, Timestamp};
 use mz_sql::catalog::{CatalogError as SqlCatalogError, CatalogItemType, RoleMembership, RoleVars};
 use mz_sql::func::OP_IMPLS;
 use mz_sql::names::CommentObjectId;
@@ -386,16 +387,17 @@ impl Catalog {
                 ?enable_expr_cache_dyncfg,
                 "using expression cache for startup"
             );
-            let current_ids = txn
+            let current_items = txn
                 .get_items()
                 .flat_map(|item| {
-                    let gid = item.global_id.clone();
-                    let gids: Vec<_> = item.extra_versions.values().cloned().collect();
-                    std::iter::once(gid).chain(gids)
+                    let item_version = latest_item_version(&item.extra_versions);
+                    std::iter::once(item.global_id)
+                        .chain(item.extra_versions.into_values())
+                        .map(move |gid| (gid, item_version))
                 })
                 .chain(
                     txn.get_system_object_mappings()
-                        .map(|som| som.unique_identifier.global_id),
+                        .map(|som| (som.unique_identifier.global_id, RelationVersion::root())),
                 )
                 .collect();
             let dyncfgs = config.persist_client.dyncfgs().clone();
@@ -415,7 +417,7 @@ impl Catalog {
                     .get_expression_cache_shard()
                     .expect("expression cache shard should exist for opened catalogs"),
                 persist: config.persist_client,
-                current_ids,
+                current_items,
                 remove_prior_versions: !config.read_only,
                 compact_shard: config.read_only,
                 dyncfgs,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -27,7 +27,7 @@ use mz_catalog::builtin::{
     BUILTINS, Builtin, BuiltinCluster, BuiltinLog, BuiltinSource, BuiltinTable, BuiltinType,
 };
 use mz_catalog::config::{AwsPrincipalContext, ClusterReplicaSizeMap};
-use mz_catalog::expr_cache::LocalExpressions;
+use mz_catalog::expr_cache::{LocalExpressions, latest_item_version};
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
     CatalogCollectionEntry, CatalogEntry, CatalogItem, Cluster, ClusterReplica, CommentsMap,
@@ -374,18 +374,20 @@ impl LocalExpressionCache {
     }
 
     /// Inform the cache that `id` was not found in the cache and that we should add it as
-    /// `local_mir` and `optimizer_features`.
+    /// `local_mir` and `optimizer_features`, recorded at `item_version`.
     pub(super) fn insert_uncached_expression(
         &mut self,
         id: GlobalId,
         local_mir: OptimizedMirRelationExpr,
         optimizer_features: OptimizerFeatures,
+        item_version: RelationVersion,
     ) {
         match self {
             LocalExpressionCache::Open { uncached_exprs, .. } => {
                 let local_expr = LocalExpressions {
                     local_mir,
                     optimizer_features,
+                    item_version,
                 };
                 // If we are trying to cache the same item a second time, with a different
                 // expression, then we must be migrating the object or doing something else weird.
@@ -1307,6 +1309,7 @@ impl CatalogState {
                         global_id,
                         uncached_expr,
                         optimizer_features,
+                        latest_item_version(extra_versions),
                     );
                 }
                 Ok(item)

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -35,7 +35,7 @@ use mz_audit_log::{
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_catalog::builtin::BuiltinLog;
 use mz_catalog::durable::{DryRunTransaction, NetworkPolicy, Snapshot, Transaction};
-use mz_catalog::expr_cache::LocalExpressions;
+use mz_catalog::expr_cache::{LocalExpressions, latest_item_version};
 use mz_catalog::memory::error::{AmbiguousRename, Error, ErrorKind};
 use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, ClusterConfig, ClusterVariant, DataSourceDesc, DefaultPrivileges,
@@ -52,7 +52,7 @@ use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap, merge_mz_acl_i
 use mz_repr::network_policy_id::NetworkPolicyId;
 use mz_repr::optimize::OptimizerFeatures;
 use mz_repr::role_id::RoleId;
-use mz_repr::{CatalogItemId, ColumnName, GlobalId, SqlColumnType, strconv};
+use mz_repr::{CatalogItemId, ColumnName, GlobalId, RelationVersion, SqlColumnType, strconv};
 use mz_sql::ast::RawDataType;
 use mz_sql::catalog::{
     AutoProvisionSource, CatalogDatabase, CatalogError as SqlCatalogError,
@@ -880,6 +880,7 @@ impl Catalog {
                             LocalExpressions {
                                 local_mir: (*view.locally_optimized_expr).clone(),
                                 optimizer_features: optimizer_features.clone(),
+                                item_version: RelationVersion::root(),
                             },
                         );
                     }
@@ -889,6 +890,7 @@ impl Catalog {
                             LocalExpressions {
                                 local_mir: (*mv.locally_optimized_expr).clone(),
                                 optimizer_features: optimizer_features.clone(),
+                                item_version: latest_item_version(&mv.collections),
                             },
                         );
                     }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -104,7 +104,7 @@ use mz_catalog::builtin::{
 };
 use mz_catalog::config::{AwsPrincipalContext, BuiltinItemMigrationConfig, ClusterReplicaSizeMap};
 use mz_catalog::durable::OpenableDurableCatalogState;
-use mz_catalog::expr_cache::{GlobalExpressions, LocalExpressions};
+use mz_catalog::expr_cache::{GlobalExpressions, LocalExpressions, latest_item_version};
 use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, ClusterReplicaProcessStatus, Connection, DataSourceDesc,
     ReconfigurationTarget, Table, TableDataSource,
@@ -146,7 +146,9 @@ use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::global_id::TransientIdGen;
 use mz_repr::optimize::{OptimizerFeatureOverrides, OptimizerFeatures, OverrideFrom};
 use mz_repr::role_id::RoleId;
-use mz_repr::{CatalogItemId, Diff, GlobalId, RelationDesc, SqlRelationType, Timestamp};
+use mz_repr::{
+    CatalogItemId, Diff, GlobalId, RelationDesc, RelationVersion, SqlRelationType, Timestamp,
+};
 use mz_secrets::cache::CachingSecretsReader;
 use mz_secrets::{SecretsController, SecretsReader};
 use mz_sql::ast::{Raw, Statement};
@@ -3832,6 +3834,7 @@ impl Coordinator {
                                         physical_plan: physical_plan.clone(),
                                         dataflow_metainfos: metainfo.clone(),
                                         optimizer_features: optimizer_config.features.clone(),
+                                        item_version: RelationVersion::root(),
                                     },
                                 );
                                 (optimized_plan, physical_plan, metainfo)
@@ -3930,6 +3933,7 @@ impl Coordinator {
                                     physical_plan: physical_plan.clone(),
                                     dataflow_metainfos: metainfo.clone(),
                                     optimizer_features: optimizer_config.features.clone(),
+                                    item_version: latest_item_version(&mv.collections),
                                 },
                             );
                             (optimized_plan, physical_plan, metainfo)
@@ -4024,6 +4028,7 @@ impl Coordinator {
                                     physical_plan: physical_plan.clone(),
                                     dataflow_metainfos: metainfo.clone(),
                                     optimizer_features: optimizer_config.features.clone(),
+                                    item_version: RelationVersion::root(),
                                 },
                             );
                             (optimized_plan, physical_plan, metainfo)

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -5052,15 +5052,11 @@ impl Coordinator {
             "finishing materialized view replacement application",
         );
 
-        // The durable expression cache is keyed by GlobalId and relies on the
-        // invariant that the definition behind a GlobalId never changes.
-        // Applying a replacement violates that for the target's existing
-        // GlobalIds: the item retains them as prior versions while its
-        // definition becomes the replacement's. Invalidate their cached
-        // expressions, and await the invalidation before the catalog
-        // transaction commits, so no subsequent bootstrap can pair the new
-        // definition with a stale cached expression whose dependencies may
-        // since have been dropped.
+        // Applying a replacement changes the target's definition while it
+        // keeps its GlobalIds, so the cached expressions under those ids are
+        // stale. Entries record the item's version and `ExpressionCache::open`
+        // drops them on the next boot; invalidating here only reclaims them
+        // eagerly.
         let invalidate_ids = self.catalog().get_entry(&id).global_ids().collect();
         self.catalog()
             .update_expression_cache(Vec::new(), Vec::new(), invalidate_ids)

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -25,6 +25,7 @@ use mz_adapter_types::dyncfgs::{
     ENABLE_EXPRESSION_CACHE, ENABLE_PASSWORD_AUTH, FRONTEND_READ_THEN_WRITE,
     READ_THEN_WRITE_MAX_DEPENDENCIES,
 };
+use mz_catalog::expr_cache::latest_item_version;
 use mz_catalog::memory::error::ErrorKind;
 use mz_catalog::memory::objects::{
     CatalogItem, Connection, DataSourceDesc, Sink, Source, Table, TableDataSource, Type,
@@ -38,6 +39,7 @@ use mz_expr::{
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::future::OreFutureExt;
+use mz_ore::soft_panic_or_log;
 use mz_ore::task::{self, JoinHandle, spawn};
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{assert_none, instrument};
@@ -5052,26 +5054,53 @@ impl Coordinator {
             "finishing materialized view replacement application",
         );
 
-        // Applying a replacement changes the target's definition while it
-        // keeps its GlobalIds, so the cached expressions under those ids are
-        // stale. Entries record the item's version and `ExpressionCache::open`
-        // drops them on the next boot; invalidating here only reclaims them
-        // eagerly.
-        let invalidate_ids = self.catalog().get_entry(&id).global_ids().collect();
-        self.catalog()
-            .update_expression_cache(Vec::new(), Vec::new(), invalidate_ids)
-            .await;
-
         let ops = vec![catalog::Op::AlterMaterializedViewApplyReplacement { id, replacement_id }];
         match self
             .catalog_transact(Some(ctx.ctx().session_mut()), ops)
             .await
         {
-            Ok(()) => ctx.retire(Ok(ExecuteResponse::AlteredObject(
-                ObjectType::MaterializedView,
-            ))),
+            Ok(()) => {
+                // The surviving item carries the replacement's item id and the
+                // target's global ids.
+                self.cache_applied_replacement_expressions(replacement_id)
+                    .await;
+                ctx.retire(Ok(ExecuteResponse::AlteredObject(
+                    ObjectType::MaterializedView,
+                )))
+            }
             Err(err) => ctx.retire(Err(err)),
         }
+    }
+
+    /// Moves the replacement's expression cache entries, which describe the
+    /// definition the surviving item holds now, to the item's ids at its new
+    /// version, and removes the item's other entries.
+    ///
+    /// The moved entries keep the optimizer features that produced them, so a
+    /// feature change between the replacement's creation and the apply makes
+    /// the next boot re-optimize the view, as for any other item.
+    ///
+    /// Nothing depends on the write landing: entries recorded before the apply
+    /// carry the old version, so the next open drops them either way.
+    async fn cache_applied_replacement_expressions(&self, id: CatalogItemId) {
+        let entry = self.catalog().get_entry(&id);
+        let Some(mv) = entry.materialized_view() else {
+            soft_panic_or_log!("replacement applied to a non-materialized-view item: {id}");
+            return;
+        };
+        // Local entries are keyed by the durable item's `global_id`, the root
+        // version's. Global entries are keyed by the writing id, which is the
+        // replacement's own id now.
+        self.catalog()
+            .restamp_expression_cache(
+                mv.global_id_writes(),
+                *mv.collections
+                    .get(&RelationVersion::root())
+                    .expect("materialized views have a root version"),
+                latest_item_version(&mv.collections),
+                entry.global_ids().collect(),
+            )
+            .await;
     }
 
     pub(super) async fn statistics_oracle(

--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -27,8 +27,8 @@ use mz_persist_client::cli::admin::{
 };
 use mz_persist_types::codec_impls::VecU8Schema;
 use mz_persist_types::{Codec, ShardId};
-use mz_repr::GlobalId;
 use mz_repr::optimize::OptimizerFeatures;
+use mz_repr::{GlobalId, RelationVersion};
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::notice::OptimizerNotice;
 use semver::Version;
@@ -57,6 +57,8 @@ enum ExpressionType {
 pub struct LocalExpressions {
     pub local_mir: OptimizedMirRelationExpr,
     pub optimizer_features: OptimizerFeatures,
+    /// The owning item's latest version, see [`ExpressionCache::open`].
+    pub item_version: RelationVersion,
 }
 
 /// The data that is cached per catalog object as a result of global optimizations.
@@ -66,6 +68,8 @@ pub struct GlobalExpressions {
     pub physical_plan: DataflowDescription<mz_compute_types::plan::LirRelationExpr>,
     pub dataflow_metainfos: DataflowMetainfo<Arc<OptimizerNotice>>,
     pub optimizer_features: OptimizerFeatures,
+    /// The owning item's latest version, see [`ExpressionCache::open`].
+    pub item_version: RelationVersion,
 }
 
 impl GlobalExpressions {
@@ -75,6 +79,13 @@ impl GlobalExpressions {
             .keys()
             .chain(self.physical_plan.index_imports.keys())
     }
+}
+
+/// The item version to record with an item's cached expressions, the latest of its `versions`.
+pub fn latest_item_version(versions: &BTreeMap<RelationVersion, GlobalId>) -> RelationVersion {
+    versions
+        .last_key_value()
+        .map_or_else(RelationVersion::root, |(version, _)| *version)
 }
 
 #[derive(
@@ -100,7 +111,7 @@ struct ExpressionCodec;
 impl DurableCacheCodec for ExpressionCodec {
     type Key = CacheKey;
     // We use a raw bytes instead of `Expressions` so that there is no backwards compatibility
-    // requirement on `Expressions` between versions.
+    // requirement on `Expressions` between build versions.
     type Val = Bytes;
     type KeyCodec = Bytes;
     type ValCodec = Bytes;
@@ -129,7 +140,11 @@ pub struct ExpressionCacheConfig {
     pub build_version: Version,
     pub persist: PersistClient,
     pub shard_id: ShardId,
-    pub current_ids: BTreeSet<GlobalId>,
+    /// Every `GlobalId` that may have entries, mapped to the latest version of the item it
+    /// belongs to. All ids of an item map to that same version, which is the one its entries
+    /// record, rather than the version the id itself denotes.
+    pub current_items: BTreeMap<GlobalId, RelationVersion>,
+    /// Whether to durably remove the entries of previous build versions.
     pub remove_prior_versions: bool,
     pub compact_shard: bool,
     pub dyncfgs: ConfigSet,
@@ -143,11 +158,24 @@ pub struct ExpressionCache {
 
 impl ExpressionCache {
     /// Creates a new [`ExpressionCache`] and reconciles all entries in current build version.
-    /// Reconciliation will remove all entries that are not in `current_ids` and remove all
-    /// entries that have optimizer features that are not equal to `optimizer_features`.
+    /// Reconciliation removes entries whose id is not in `current_items` or whose recorded
+    /// item version differs from the current one, and global entries that import an index
+    /// that is not in `current_items`.
     ///
-    /// If `remove_prior_versions` is `true`, then all previous versions are durably removed from the
-    /// cache.
+    /// An entry records the item version it was optimized for, because applying a materialized
+    /// view replacement changes an item's definition while the item keeps its `GlobalId`s and
+    /// bumps its [`RelationVersion`]. Dropping entries recorded at another version therefore
+    /// catches stale entries whichever process wrote them. That includes the replacement's own
+    /// entries: they are recorded at its root version, and the apply makes its id a later
+    /// version of the target.
+    ///
+    /// The apply also invalidates the target's entries, but that alone would not do: it only
+    /// reaches entries under the applying process's build version, while a 0dt deployment in
+    /// its read-only phase caches under its own build version and reads those entries again
+    /// when it reboots after promotion.
+    ///
+    /// If `remove_prior_versions` is `true`, then the entries of all previous build versions are
+    /// durably removed from the cache.
     ///
     /// If `compact_shard` is `true`, then this function will block on fully compacting the backing
     /// persist shard.
@@ -158,7 +186,7 @@ impl ExpressionCache {
             build_version,
             persist,
             shard_id,
-            current_ids,
+            current_items,
             remove_prior_versions,
             compact_shard,
             dyncfgs,
@@ -177,7 +205,12 @@ impl ExpressionCache {
         const RETRIES: usize = 100;
         for _ in 0..RETRIES {
             match cache
-                .try_open(&current_ids, remove_prior_versions, compact_shard, &dyncfgs)
+                .try_open(
+                    &current_items,
+                    remove_prior_versions,
+                    compact_shard,
+                    &dyncfgs,
+                )
                 .await
             {
                 Ok((local_expressions, global_expressions)) => {
@@ -192,7 +225,7 @@ impl ExpressionCache {
 
     async fn try_open(
         &mut self,
-        current_ids: &BTreeSet<GlobalId>,
+        current_items: &BTreeMap<GlobalId, RelationVersion>,
         remove_prior_versions: bool,
         compact_shard: bool,
         dyncfgs: &ConfigSet,
@@ -217,7 +250,7 @@ impl ExpressionCache {
                 }
             };
             if build_version == self.build_version {
-                // Only deserialize the current version.
+                // Only deserialize the current build version.
                 match key.expr_type {
                     ExpressionType::Local => {
                         let expressions: LocalExpressions = match bincode::deserialize(expressions)
@@ -230,8 +263,9 @@ impl ExpressionCache {
                                 continue;
                             }
                         };
-                        // Remove dropped IDs.
-                        if !current_ids.contains(&key.id) {
+                        // A missing id means the item is gone, a different item version means the
+                        // entry was optimized for another definition of it.
+                        if current_items.get(&key.id) != Some(&expressions.item_version) {
                             keys_to_remove.push((key.clone(), None));
                         } else {
                             local_expressions.insert(key.id, expressions);
@@ -248,11 +282,13 @@ impl ExpressionCache {
                                 continue;
                             }
                         };
-                        // Remove dropped IDs and expressions that rely on dropped indexes.
-                        let index_dependencies: BTreeSet<_> =
-                            expressions.index_imports().cloned().collect();
-                        if !current_ids.contains(&key.id)
-                            || !index_dependencies.is_subset(current_ids)
+                        // As above, plus expressions that import a dropped index: `DROP INDEX` is
+                        // allowed under a running consumer, whose plan then has to be re-optimized
+                        // at the next boot.
+                        if current_items.get(&key.id) != Some(&expressions.item_version)
+                            || !expressions
+                                .index_imports()
+                                .all(|id| current_items.contains_key(id))
                         {
                             keys_to_remove.push((key.clone(), None));
                         } else {
@@ -261,11 +297,10 @@ impl ExpressionCache {
                     }
                 }
             } else if remove_prior_versions {
-                // Remove expressions from previous versions.
+                // Remove expressions from previous build versions.
                 keys_to_remove.push((key.clone(), None));
             }
         }
-
         let keys_to_remove: Vec<_> = keys_to_remove
             .iter()
             .map(|(key, expressions)| (key, expressions.as_ref()))
@@ -273,7 +308,8 @@ impl ExpressionCache {
         self.durable_cache.try_set_many(&keys_to_remove).await?;
 
         if remove_prior_versions {
-            // We've purged old versions from the cache; upgrade the backing Persist version as well.
+            // We've purged old build versions from the cache. Upgrade the backing Persist version
+            // as well.
             self.durable_cache.upgrade_version().await;
         }
 
@@ -459,32 +495,36 @@ mod tests {
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn expression_cache() {
-        let first_version = Version::new(0, 1, 0);
-        let second_version = Version::new(0, 2, 0);
+        let first_build_version = Version::new(0, 1, 0);
+        let second_build_version = Version::new(0, 2, 0);
         let persist = PersistClient::new_for_tests().await;
         let shard_id = ShardId::new();
 
-        let mut current_ids = BTreeSet::new();
+        let mut current_items = BTreeMap::new();
         let mut remove_prior_versions = false;
         // Compacting the shard takes too long, so we leave it to integration tests.
         let compact_shard = false;
         let dyncfgs = &mz_persist_client::cfg::all_dyncfgs(ConfigSet::default());
+        let spawn = |build_version: &Version,
+                     current_items: &BTreeMap<GlobalId, RelationVersion>,
+                     remove_prior_versions: bool| {
+            ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
+                build_version: build_version.clone(),
+                persist: persist.clone(),
+                shard_id,
+                current_items: current_items.clone(),
+                remove_prior_versions,
+                compact_shard,
+                dyncfgs: dyncfgs.clone(),
+            })
+        };
 
         let mut next_id = 0;
 
         let (mut local_exps, mut global_exps) = {
             // Open a new empty cache.
             let (cache, local_exprs, global_exprs) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(local_exprs, BTreeMap::new(), "new cache should be empty");
             assert_eq!(global_exprs, BTreeMap::new(), "new cache should be empty");
 
@@ -504,8 +544,12 @@ mod tests {
                     )
                     .await;
 
-                current_ids.insert(id);
-                current_ids.extend(global_exp.index_imports());
+                current_items.insert(id, RelationVersion::root());
+                current_items.extend(
+                    global_exp
+                        .index_imports()
+                        .map(|id| (*id, RelationVersion::root())),
+                );
                 local_exps.insert(id, local_exp);
                 global_exps.insert(id, global_exp);
 
@@ -517,16 +561,7 @@ mod tests {
         {
             // Re-open the cache.
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries, local_exps,
                 "local expression with non-matching optimizer features should be removed during reconciliation"
@@ -540,22 +575,13 @@ mod tests {
         {
             // Simulate dropping an object.
             let id_to_remove = local_exps.keys().next().expect("not empty").clone();
-            current_ids.remove(&id_to_remove);
+            current_items.remove(&id_to_remove);
             let _removed_local_exp = local_exps.remove(&id_to_remove);
             let _removed_global_exp = global_exps.remove(&id_to_remove);
 
             // Re-open the cache.
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries, local_exps,
                 "dropped local objects should be removed during reconciliation"
@@ -563,6 +589,39 @@ mod tests {
             assert_eq!(
                 global_entries, global_exps,
                 "dropped global objects should be removed during reconciliation"
+            );
+        }
+
+        {
+            // Simulate applying a replacement: the item keeps its id at a bumped version.
+            let id_to_bump = global_exps.keys().next_back().expect("not empty").clone();
+            current_items.insert(id_to_bump, RelationVersion::root().bump());
+            let _removed_local_exp = local_exps.remove(&id_to_bump);
+            let _removed_global_exp = global_exps.remove(&id_to_bump);
+
+            // Re-open the cache.
+            let (_cache, local_entries, global_entries) =
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
+            assert_eq!(
+                local_entries, local_exps,
+                "local expressions of an earlier item version should be removed during reconciliation"
+            );
+            assert_eq!(
+                global_entries, global_exps,
+                "global expressions of an earlier item version should be removed during reconciliation"
+            );
+
+            // The removal is durable: restoring the item version does not bring the entries back.
+            current_items.insert(id_to_bump, RelationVersion::root());
+            let (_cache, local_entries, global_entries) =
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
+            assert_eq!(
+                local_entries, local_exps,
+                "local expressions of an earlier item version should be durably removed"
+            );
+            assert_eq!(
+                global_entries, global_exps,
+                "global expressions of an earlier item version should be durably removed"
             );
         }
 
@@ -576,7 +635,7 @@ mod tests {
                 .index_imports()
                 .next()
                 .expect("generator always makes non-empty index imports");
-            current_ids.remove(dependency_to_remove);
+            current_items.remove(dependency_to_remove);
 
             // If the dependency is also tracked in the cache remove it.
             let _removed_local_exp = local_exps.remove(dependency_to_remove);
@@ -589,16 +648,7 @@ mod tests {
 
             // Re-open the cache.
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries, local_exps,
                 "dropped object dependencies should NOT remove local expressions"
@@ -610,30 +660,21 @@ mod tests {
         }
 
         let (new_gen_local_exps, new_gen_global_exps) = {
-            // Open the cache at a new version.
+            // Open the cache at a new build version.
             let (cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: second_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&second_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries,
                 BTreeMap::new(),
-                "new version should be empty"
+                "new build version should be empty"
             );
             assert_eq!(
                 global_entries,
                 BTreeMap::new(),
-                "new version should be empty"
+                "new build version should be empty"
             );
 
-            // Insert some expressions at the new version.
+            // Insert some expressions at the new build version.
             let mut local_exps = BTreeMap::new();
             let mut global_exps = BTreeMap::new();
             for _ in 0..2 {
@@ -649,8 +690,12 @@ mod tests {
                     )
                     .await;
 
-                current_ids.insert(id);
-                current_ids.extend(global_exp.index_imports());
+                current_items.insert(id, RelationVersion::root());
+                current_items.extend(
+                    global_exp
+                        .index_imports()
+                        .map(|id| (*id, RelationVersion::root())),
+                );
                 local_exps.insert(id, local_exp);
                 global_exps.insert(id, global_exp);
 
@@ -660,74 +705,47 @@ mod tests {
         };
 
         {
-            // Re-open the cache at the first version.
+            // Re-open the cache at the first build version.
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries, local_exps,
-                "Previous version local expressions should still exist"
+                "Previous build version local expressions should still exist"
             );
             assert_eq!(
                 global_entries, global_exps,
-                "Previous version global expressions should still exist"
+                "Previous build version global expressions should still exist"
             );
         }
 
         {
-            // Open the cache at a new version and clear previous versions.
+            // Open the cache at a new build version and clear previous build versions.
             remove_prior_versions = true;
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: second_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&second_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries, new_gen_local_exps,
-                "new version local expressions should be persisted"
+                "new build version local expressions should be persisted"
             );
             assert_eq!(
                 global_entries, new_gen_global_exps,
-                "new version global expressions should be persisted"
+                "new build version global expressions should be persisted"
             );
         }
 
         {
-            // Re-open the cache at the first version.
+            // Re-open the cache at the first build version.
             let (_cache, local_entries, global_entries) =
-                ExpressionCacheHandle::spawn_expression_cache(ExpressionCacheConfig {
-                    build_version: first_version.clone(),
-                    persist: persist.clone(),
-                    shard_id,
-                    current_ids: current_ids.clone(),
-                    remove_prior_versions,
-                    compact_shard,
-                    dyncfgs: dyncfgs.clone(),
-                })
-                .await;
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
             assert_eq!(
                 local_entries,
                 BTreeMap::new(),
-                "Previous version local expressions should be cleared"
+                "Previous build version local expressions should be cleared"
             );
             assert_eq!(
                 global_entries,
                 BTreeMap::new(),
-                "Previous version global expressions should be cleared"
+                "Previous build version global expressions should be cleared"
             );
         }
     }
@@ -784,6 +802,7 @@ mod tests {
                 ReprRelationType::new(vec![ReprScalarType::UInt64.nullable(false)]),
             )),
             optimizer_features: Default::default(),
+            item_version: RelationVersion::root(),
         }
     }
 
@@ -819,6 +838,7 @@ mod tests {
             physical_plan,
             dataflow_metainfos: Default::default(),
             optimizer_features: Default::default(),
+            item_version: RelationVersion::root(),
         }
     }
 }

--- a/src/catalog/src/expr_cache.rs
+++ b/src/catalog/src/expr_cache.rs
@@ -34,7 +34,7 @@ use mz_transform::notice::OptimizerNotice;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 #[derive(
     Debug,
@@ -134,6 +134,16 @@ impl DurableCacheCodec for ExpressionCodec {
     }
 }
 
+/// Why [`ExpressionCache::open`] removed entries, for its reconciliation log line.
+#[derive(Debug, Default)]
+struct RemovedEntries {
+    unreadable: usize,
+    dropped_item: usize,
+    item_version_mismatch: usize,
+    dropped_index_import: usize,
+    prior_build_version: usize,
+}
+
 /// Configuration needed to initialize an [`ExpressionCache`].
 #[derive(Debug, Clone)]
 pub struct ExpressionCacheConfig {
@@ -169,10 +179,10 @@ impl ExpressionCache {
     /// entries: they are recorded at its root version, and the apply makes its id a later
     /// version of the target.
     ///
-    /// The apply also invalidates the target's entries, but that alone would not do: it only
-    /// reaches entries under the applying process's build version, while a 0dt deployment in
-    /// its read-only phase caches under its own build version and reads those entries again
-    /// when it reboots after promotion.
+    /// The apply also moves the replacement's entries to the target, but that alone would not
+    /// do: it only reaches entries under the applying process's build version, while a 0dt
+    /// deployment in its read-only phase caches under its own build version and reads those
+    /// entries again when it reboots after promotion.
     ///
     /// If `remove_prior_versions` is `true`, then the entries of all previous build versions are
     /// durably removed from the cache.
@@ -239,6 +249,7 @@ impl ExpressionCache {
         let mut keys_to_remove = Vec::new();
         let mut local_expressions = BTreeMap::new();
         let mut global_expressions = BTreeMap::new();
+        let mut removed = RemovedEntries::default();
 
         for (key, expressions) in self.durable_cache.entries_local() {
             let build_version = match key.build_version.parse::<Version>() {
@@ -260,15 +271,26 @@ impl ExpressionCache {
                                 soft_panic_or_log!(
                                     "unable to deserialize local expressions: ({key:?}, {expressions:?}): {err:?}"
                                 );
+                                // An entry this build cannot read is useless. Drop it rather
+                                // than report it on every boot.
+                                removed.unreadable += 1;
+                                keys_to_remove.push((key.clone(), None));
                                 continue;
                             }
                         };
-                        // A missing id means the item is gone, a different item version means the
-                        // entry was optimized for another definition of it.
-                        if current_items.get(&key.id) != Some(&expressions.item_version) {
-                            keys_to_remove.push((key.clone(), None));
-                        } else {
-                            local_expressions.insert(key.id, expressions);
+                        match current_items.get(&key.id) {
+                            None => {
+                                removed.dropped_item += 1;
+                                keys_to_remove.push((key.clone(), None));
+                            }
+                            // The entry was optimized for another definition of the item.
+                            Some(version) if *version != expressions.item_version => {
+                                removed.item_version_mismatch += 1;
+                                keys_to_remove.push((key.clone(), None));
+                            }
+                            Some(_) => {
+                                local_expressions.insert(key.id, expressions);
+                            }
                         }
                     }
                     ExpressionType::Global => {
@@ -279,25 +301,38 @@ impl ExpressionCache {
                                 soft_panic_or_log!(
                                     "unable to deserialize global expressions: ({key:?}, {expressions:?}): {err:?}"
                                 );
+                                removed.unreadable += 1;
+                                keys_to_remove.push((key.clone(), None));
                                 continue;
                             }
                         };
-                        // As above, plus expressions that import a dropped index: `DROP INDEX` is
-                        // allowed under a running consumer, whose plan then has to be re-optimized
-                        // at the next boot.
-                        if current_items.get(&key.id) != Some(&expressions.item_version)
-                            || !expressions
-                                .index_imports()
-                                .all(|id| current_items.contains_key(id))
-                        {
-                            keys_to_remove.push((key.clone(), None));
-                        } else {
-                            global_expressions.insert(key.id, expressions);
+                        match current_items.get(&key.id) {
+                            None => {
+                                removed.dropped_item += 1;
+                                keys_to_remove.push((key.clone(), None));
+                            }
+                            Some(version) if *version != expressions.item_version => {
+                                removed.item_version_mismatch += 1;
+                                keys_to_remove.push((key.clone(), None));
+                            }
+                            // `DROP INDEX` is allowed under a running consumer, whose plan then
+                            // has to be re-optimized at the next boot.
+                            Some(_)
+                                if !expressions
+                                    .index_imports()
+                                    .all(|id| current_items.contains_key(id)) =>
+                            {
+                                removed.dropped_index_import += 1;
+                                keys_to_remove.push((key.clone(), None));
+                            }
+                            Some(_) => {
+                                global_expressions.insert(key.id, expressions);
+                            }
                         }
                     }
                 }
             } else if remove_prior_versions {
-                // Remove expressions from previous build versions.
+                removed.prior_build_version += 1;
                 keys_to_remove.push((key.clone(), None));
             }
         }
@@ -306,6 +341,25 @@ impl ExpressionCache {
             .map(|(key, expressions)| (key, expressions.as_ref()))
             .collect();
         self.durable_cache.try_set_many(&keys_to_remove).await?;
+        let RemovedEntries {
+            unreadable,
+            dropped_item,
+            item_version_mismatch,
+            dropped_index_import,
+            prior_build_version,
+        } = removed;
+        info!(
+            build_version = %self.build_version,
+            remove_prior_versions,
+            kept_local = local_expressions.len(),
+            kept_global = global_expressions.len(),
+            removed_unreadable = unreadable,
+            removed_dropped_item = dropped_item,
+            removed_item_version_mismatch = item_version_mismatch,
+            removed_dropped_index_import = dropped_index_import,
+            removed_prior_build_version = prior_build_version,
+            "reconciled the expression cache"
+        );
 
         if remove_prior_versions {
             // We've purged old build versions from the cache. Upgrade the backing Persist version
@@ -401,6 +455,63 @@ impl ExpressionCache {
             .collect();
         self.durable_cache.set_many(&entries).await
     }
+
+    /// See [`ExpressionCacheHandle::restamp`].
+    async fn restamp(
+        &mut self,
+        global_id: GlobalId,
+        local_id: GlobalId,
+        item_version: RelationVersion,
+        invalidate_ids: BTreeSet<GlobalId>,
+    ) {
+        let build_version = self.build_version.to_string();
+        let key = |expr_type| CacheKey {
+            id: global_id,
+            build_version: build_version.clone(),
+            expr_type,
+        };
+        let local = self
+            .durable_cache
+            .get_local(&key(ExpressionType::Local))
+            .and_then(|expressions| bincode::deserialize::<LocalExpressions>(expressions).ok())
+            .map(|expressions| {
+                (
+                    local_id,
+                    LocalExpressions {
+                        item_version,
+                        ..expressions
+                    },
+                )
+            });
+        let global = self
+            .durable_cache
+            .get_local(&key(ExpressionType::Global))
+            .and_then(|expressions| bincode::deserialize::<GlobalExpressions>(expressions).ok())
+            .map(|expressions| {
+                (
+                    global_id,
+                    GlobalExpressions {
+                        item_version,
+                        ..expressions
+                    },
+                )
+            });
+        info!(
+            %global_id,
+            %local_id,
+            ?item_version,
+            moved_local = local.is_some(),
+            moved_global = global.is_some(),
+            invalidated = invalidate_ids.len(),
+            "restamped a replacement's expressions"
+        );
+        self.update(
+            local.into_iter().collect(),
+            global.into_iter().collect(),
+            invalidate_ids,
+        )
+        .await
+    }
 }
 
 /// Operations to perform on the cache.
@@ -409,6 +520,14 @@ enum CacheOperation {
     Update {
         new_local_expressions: Vec<(GlobalId, LocalExpressions)>,
         new_global_expressions: Vec<(GlobalId, GlobalExpressions)>,
+        invalidate_ids: BTreeSet<GlobalId>,
+        trigger: trigger::Trigger,
+    },
+    /// See [`ExpressionCache::restamp`].
+    Restamp {
+        global_id: GlobalId,
+        local_id: GlobalId,
+        item_version: RelationVersion,
         invalidate_ids: BTreeSet<GlobalId>,
         trigger: trigger::Trigger,
     },
@@ -450,6 +569,17 @@ impl ExpressionCacheHandle {
                             )
                             .await
                     }
+                    CacheOperation::Restamp {
+                        global_id,
+                        local_id,
+                        item_version,
+                        invalidate_ids,
+                        trigger: _trigger,
+                    } => {
+                        cache
+                            .restamp(global_id, local_id, item_version, invalidate_ids)
+                            .await
+                    }
                 }
             }
         });
@@ -467,6 +597,36 @@ impl ExpressionCacheHandle {
         let op = CacheOperation::Update {
             new_local_expressions,
             new_global_expressions,
+            invalidate_ids,
+            trigger,
+        };
+        // If the send fails, then we must be shutting down.
+        let _ = self.tx.send(op);
+        trigger_rx
+    }
+
+    /// Moves `global_id`'s entries in the current build version to `item_version`, the local one
+    /// under `local_id` and the global one under `global_id`, and removes every other entry of
+    /// `invalidate_ids`. An entry that is unreadable, or missing from this process's view of the
+    /// cache, is skipped and removed, leaving the next open to re-optimize what it would have
+    /// served.
+    ///
+    /// The read and the rewrite are not atomic against another process of the same build
+    /// version. That is safe because ids are never reused: whatever such a process writes under
+    /// `global_id` describes the definition this one is adopting, so at worst an older
+    /// optimization of it survives in place of a newer one.
+    pub fn restamp(
+        &self,
+        global_id: GlobalId,
+        local_id: GlobalId,
+        item_version: RelationVersion,
+        invalidate_ids: BTreeSet<GlobalId>,
+    ) -> impl Future<Output = ()> + use<> {
+        let (trigger, trigger_rx) = trigger::channel();
+        let op = CacheOperation::Restamp {
+            global_id,
+            local_id,
+            item_version,
             invalidate_ids,
             trigger,
         };
@@ -623,6 +783,77 @@ mod tests {
                 global_entries, global_exps,
                 "global expressions of an earlier item version should be durably removed"
             );
+        }
+
+        {
+            // Simulate applying a replacement with the cache open: the replacement's entries move
+            // to the target's ids at the bumped version, and the entries of the item's other ids
+            // are removed whether or not the version check would drop them.
+            let target = GlobalId::User(next_id);
+            let replacement = GlobalId::User(next_id + 1);
+            let other = GlobalId::User(next_id + 2);
+            next_id += 3;
+            let (cache, _, _) =
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
+            let mut exps = BTreeMap::new();
+            for id in [target, replacement, other] {
+                let local_exp = gen_local_expressions();
+                let global_exp = gen_global_expressions();
+                cache
+                    .update(
+                        vec![(id, local_exp.clone())],
+                        vec![(id, global_exp.clone())],
+                        BTreeSet::new(),
+                    )
+                    .await;
+                current_items.insert(id, RelationVersion::root());
+                exps.insert(id, (local_exp, global_exp));
+            }
+            let new_version = RelationVersion::root().bump();
+            cache
+                .restamp(
+                    replacement,
+                    target,
+                    new_version,
+                    [target, replacement, other].into_iter().collect(),
+                )
+                .await;
+            current_items.insert(target, new_version);
+            current_items.insert(replacement, new_version);
+            let (local_exp, global_exp) = exps.remove(&replacement).expect("inserted above");
+            local_exps.insert(
+                target,
+                LocalExpressions {
+                    item_version: new_version,
+                    ..local_exp
+                },
+            );
+            global_exps.insert(
+                replacement,
+                GlobalExpressions {
+                    item_version: new_version,
+                    ..global_exp
+                },
+            );
+
+            // Re-open the cache.
+            let (_cache, local_entries, global_entries) =
+                spawn(&first_build_version, &current_items, remove_prior_versions).await;
+            assert_eq!(
+                local_entries, local_exps,
+                "the replacement's local expressions should move to the target's root id"
+            );
+            assert_eq!(
+                global_entries, global_exps,
+                "the replacement's global expressions should stay under its id at the new version"
+            );
+
+            // Leave the later steps the ids they started with.
+            for id in [target, replacement, other] {
+                current_items.remove(&id);
+            }
+            local_exps.remove(&target);
+            global_exps.remove(&replacement);
         }
 
         {

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -4650,6 +4650,79 @@ fn test_replacement_materialized_view_invalidates_expression_cache() {
     }
 }
 
+// The boot after an apply reuses the replacement's cached plan. An index
+// created after the replacement was planned is therefore not adopted at boot,
+// while a re-optimization would read the input through it. That adoption is
+// what the assertion rests on: a cached plan installs with the imports it was
+// planned with.
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // too slow
+#[allow(clippy::disallowed_methods)]
+fn test_replacement_materialized_view_expression_cache_hit_after_apply() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let harness = test_util::TestHarness::default()
+        .data_directory(data_dir.path())
+        .with_system_parameter_default(
+            "enable_replacement_materialized_views".to_string(),
+            "true".to_string(),
+        )
+        .with_system_parameter_default(
+            "enable_logical_compaction_window".to_string(),
+            "true".to_string(),
+        );
+    // NOTE: user items get the same number as item id and global id, so the
+    // dataflow ids of `mz_compute_dependencies` join to the catalog ids.
+    let dependencies_query = "SELECT count(*), coalesce(bool_or(i.name = 't2_idx'), false) \
+        FROM mz_internal.mz_compute_dependencies d \
+        JOIN mz_catalog.mz_materialized_views mv ON d.object_id = mv.id \
+        LEFT JOIN mz_catalog.mz_indexes i ON d.dependency_id = i.id \
+        WHERE mv.name = 'mv'";
+    let reads_through_index = |client: &mut postgres::Client| -> bool {
+        Retry::default()
+            .max_duration(Duration::from_secs(60))
+            .clamp_backoff(Duration::from_secs(1))
+            .retry(|_| {
+                // An empty result means the dependencies are not recorded
+                // yet, not that the view reads no index.
+                let row = client.query_one(dependencies_query, &[]).unwrap();
+                let count: i64 = row.get(0);
+                if count == 0 {
+                    Err("no dependencies recorded yet")
+                } else {
+                    Ok(row.get::<_, bool>(1))
+                }
+            })
+            .unwrap()
+    };
+
+    {
+        let server = harness.clone().start_blocking();
+        let mut client = server.connect(postgres::NoTls).unwrap();
+        create_replacement_fixture(&mut client);
+        client
+            .batch_execute("CREATE INDEX t2_idx ON t2 (a)")
+            .unwrap();
+        client
+            .batch_execute("ALTER MATERIALIZED VIEW mv APPLY REPLACEMENT rp")
+            .unwrap();
+        assert!(
+            !reads_through_index(&mut client),
+            "the replacement was planned before the index"
+        );
+    }
+
+    {
+        let server = harness.start_blocking();
+        let mut client = server.connect(postgres::NoTls).unwrap();
+        let row = client.query_one("SELECT a FROM mv", &[]).unwrap();
+        assert_eq!(row.get::<_, i32>(0), 2);
+        assert!(
+            !reads_through_index(&mut client),
+            "the boot should reuse the cached plan"
+        );
+    }
+}
+
 // A process that applies the replacement with the expression cache disabled
 // neither reads nor invalidates the entries the first process wrote, standing
 // in for a writer the apply-time invalidation cannot reach (see

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -4590,14 +4590,30 @@ fn test_durable_oids() {
     }
 }
 
-// Applying a materialized view replacement retains the target's existing
-// GlobalIds as prior versions while swapping in the replacement's definition.
-// The durable expression cache is keyed by GlobalId under the invariant that
-// the definition behind a GlobalId never changes, so the apply must invalidate
-// the cached expressions of the retained GlobalIds. If it doesn't, the next
-// bootstrap installs the stale optimized expression for the item, and if the
-// old definition's dependencies have since been dropped, timeline resolution
-// panics with "catalog out of sync" on every startup.
+/// Creates `mv` over `v1`/`t1` plus an unapplied replacement `rp` over `v2`/`t2`.
+/// The inputs retain history so that a restart cannot trip the as-of hard
+/// constraint of CPU-95.
+#[allow(clippy::disallowed_methods)]
+fn create_replacement_fixture(client: &mut postgres::Client) {
+    for stmt in [
+        "CREATE TABLE t1 (a int) WITH (RETAIN HISTORY FOR '1 hour')",
+        "INSERT INTO t1 VALUES (1)",
+        "CREATE VIEW v1 AS SELECT a FROM t1",
+        "CREATE MATERIALIZED VIEW mv AS SELECT a FROM v1",
+        "CREATE TABLE t2 (a int) WITH (RETAIN HISTORY FOR '1 hour')",
+        "INSERT INTO t2 VALUES (2)",
+        "CREATE VIEW v2 AS SELECT a FROM t2",
+        "CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv AS SELECT a FROM v2",
+    ] {
+        client.batch_execute(stmt).unwrap();
+    }
+}
+
+// Applying a materialized view replacement changes the definition behind the
+// target's retained GlobalIds (see `mz_catalog::expr_cache::ExpressionCache::open`).
+// If the next bootstrap installs the expressions cached before the apply, and
+// the old definition's dependencies have since been dropped, timeline
+// resolution panics with "catalog out of sync" on every startup.
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // too slow
 #[allow(clippy::disallowed_methods)]
@@ -4608,27 +4624,68 @@ fn test_replacement_materialized_view_invalidates_expression_cache() {
         .with_system_parameter_default(
             "enable_replacement_materialized_views".to_string(),
             "true".to_string(),
+        )
+        .with_system_parameter_default(
+            "enable_logical_compaction_window".to_string(),
+            "true".to_string(),
         );
 
     {
         let server = harness.clone().start_blocking();
         let mut client = server.connect(postgres::NoTls).unwrap();
-        client.batch_execute("CREATE TABLE t1 (a int)").unwrap();
-        client.batch_execute("INSERT INTO t1 VALUES (1)").unwrap();
+        create_replacement_fixture(&mut client);
         client
-            .batch_execute("CREATE VIEW v1 AS SELECT a FROM t1")
+            .batch_execute("ALTER MATERIALIZED VIEW mv APPLY REPLACEMENT rp")
             .unwrap();
-        client
-            .batch_execute("CREATE MATERIALIZED VIEW mv AS SELECT a FROM v1")
-            .unwrap();
-        client.batch_execute("CREATE TABLE t2 (a int)").unwrap();
-        client.batch_execute("INSERT INTO t2 VALUES (2)").unwrap();
-        client
-            .batch_execute("CREATE VIEW v2 AS SELECT a FROM t2")
-            .unwrap();
-        client
-            .batch_execute("CREATE REPLACEMENT MATERIALIZED VIEW rp FOR mv AS SELECT a FROM v2")
-            .unwrap();
+        client.batch_execute("DROP VIEW v1").unwrap();
+        let row = client.query_one("SELECT a FROM mv", &[]).unwrap();
+        assert_eq!(row.get::<_, i32>(0), 2, "pre-restart");
+    }
+
+    {
+        let server = harness.start_blocking();
+        let mut client = server.connect(postgres::NoTls).unwrap();
+        let row = client.query_one("SELECT a FROM mv", &[]).unwrap();
+        assert_eq!(row.get::<_, i32>(0), 2);
+    }
+}
+
+// A process that applies the replacement with the expression cache disabled
+// neither reads nor invalidates the entries the first process wrote, standing
+// in for a writer the apply-time invalidation cannot reach (see
+// `mz_catalog::expr_cache::ExpressionCache::open`). The next boot with the cache
+// enabled must not use the entries recorded before the apply.
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // too slow
+#[allow(clippy::disallowed_methods)]
+fn test_replacement_materialized_view_stale_expression_cache_entry_dropped_on_open() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let harness = test_util::TestHarness::default()
+        .data_directory(data_dir.path())
+        .with_system_parameter_default(
+            "enable_replacement_materialized_views".to_string(),
+            "true".to_string(),
+        )
+        .with_system_parameter_default(
+            "enable_logical_compaction_window".to_string(),
+            "true".to_string(),
+        );
+
+    {
+        let server = harness.clone().start_blocking();
+        let mut client = server.connect(postgres::NoTls).unwrap();
+        create_replacement_fixture(&mut client);
+    }
+
+    {
+        let server = harness
+            .clone()
+            .with_system_parameter_default(
+                "enable_expression_cache".to_string(),
+                "false".to_string(),
+            )
+            .start_blocking();
+        let mut client = server.connect(postgres::NoTls).unwrap();
         client
             .batch_execute("ALTER MATERIALIZED VIEW mv APPLY REPLACEMENT rp")
             .unwrap();


### PR DESCRIPTION
This is on top of https://github.com/MaterializeInc/materialize/pull/38677, so please review the "adapter: record the item version in expression cache entries" commit there.

### Motivation

#38677 fixes [SQL-683](https://linear.app/materializeinc/issue/SQL-683) by having `ExpressionCache::open` drop entries recorded for an earlier definition of an item. After an `ALTER MATERIALIZED VIEW ... APPLY REPLACEMENT` that leaves the next boot re-optimizing the replaced materialized view once, and nothing in the logs says why an entry was dropped. This PR is stacked on #38677 (its first commit); review the second commit.

### Description

After a successful apply, the coordinator asks the cache to move the replacement's own entries to the surviving item: the local entry moves under the item's root id, the global entry stays under the writing id, both are recorded at the new version, and the item's other entries are removed. The moved entries keep the optimizer features that produced them, so a feature change between the replacement's creation and the apply makes the next boot re-optimize the view like any other item. Correctness does not rest on this write, the version check in #38677 does that; it only spares the boot after an apply one re-optimization per applied replacement.

The move runs inside the cache task (`ExpressionCache::restamp`), reading the replacement's entries from the durable cache's local mirror. An entry that is unreadable, or missing from this process's view of the cache, is skipped and removed, leaving the next open to re-optimize what it would have served. The read and the rewrite are not atomic against another process of the same build version, which is safe because ids are never reused: whatever such a process writes under the replacement's id describes the definition being adopted.

`ExpressionCache::open` now logs how many entries it kept and how many it removed, by reason (dropped item, item version mismatch, dropped index import, unreadable, prior build version), so a cache miss can be attributed after the fact. An entry the running build cannot read is dropped instead of being reported on every boot; entries are only ever read by the build version that wrote them, so this can only affect entries the same build wrote.

### Tests

* `expr_cache` unit test: the moved entries of an apply are returned under the target's ids at the new version, and the entries the move invalidates are gone even where the version check would have kept them.
* `test_replacement_materialized_view_expression_cache_hit_after_apply` (environmentd server tests): creates an index on the replacement's input after the replacement was planned, applies, restarts, and checks through `mz_compute_dependencies` that the view's dataflow still reads the input directly. A re-optimization at boot adopts the index, which is what happens without this change.

### Alternatives

Writing the surviving item's in-memory plans to the cache after the apply, stamped with the cluster's current optimizer features, would avoid the re-optimization without a new cache operation. But the apply moves the replacement's plans over without re-optimizing, so a feature change between the replacement's creation and the apply would stamp an old-feature plan with the new features, and every later boot would hit and reinstall it while re-optimizing everything else on the cluster. Moving the replacement's own entries keeps the features that produced each plan.

Part of [SQL-683](https://linear.app/materializeinc/issue/SQL-683).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
