### PR TITLE
adapter: apply cluster-scoped optimizer overrides on rehydration

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2907,6 +2907,62 @@ mod tests {
         .await;
     }
 
+    /// Re-parsing a materialized view must resolve the same optimizer features
+    /// the sequencer resolved when the view was created, which includes the
+    /// cluster-scoped system parameters on top of the cluster's own feature
+    /// overrides. Dropping that layer both mis-keys the local expression cache
+    /// and re-derives the local plan under features the view was never
+    /// optimized with.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn test_parse_materialized_view_applies_cluster_scoped_overrides() {
+        Catalog::with_debug(|mut catalog| async move {
+            let cluster_id = catalog
+                .resolve_cluster("quickstart")
+                .expect("quickstart cluster exists")
+                .id;
+
+            // The scoped override below is only observable if it differs from
+            // the env-wide value.
+            assert!(!catalog.system_config().enable_eager_delta_joins());
+
+            let create_sql = r#"CREATE MATERIALIZED VIEW "materialize"."public"."mv" IN CLUSTER "quickstart" AS SELECT 1 AS "a""#;
+            let parse_features = |catalog: &Catalog| {
+                let (_item, uncached_expr) = catalog
+                    .state()
+                    .parse_item_inner(
+                        GlobalId::User(1),
+                        create_sql,
+                        &BTreeMap::new(),
+                        None,
+                        false,
+                        None,
+                        None,
+                        None,
+                    )
+                    .unwrap_or_else(|(err, _)| panic!("unable to parse materialized view: {err}"));
+                uncached_expr
+                    .expect("nothing was cached, so the expression was optimized")
+                    .1
+            };
+
+            assert!(!parse_features(&catalog).enable_eager_delta_joins);
+
+            catalog.state.scoped_system_parameters.cluster.insert(
+                cluster_id,
+                BTreeMap::from([(
+                    "enable_eager_delta_joins".to_string(),
+                    "true".to_string(),
+                )]),
+            );
+
+            assert!(parse_features(&catalog).enable_eager_delta_joins);
+
+            catalog.expire().await;
+        })
+        .await;
+    }
+
     // Test that if a large catalog item is somehow committed, then we can still load the catalog.
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // slow

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1586,14 +1586,19 @@ impl CatalogState {
                     .chain([(RelationVersion::root(), global_id)].into_iter())
                     .collect();
 
-                // Collect optimizer parameters.
+                // Collect optimizer parameters. The layering must match
+                // `sequence_create_materialized_view`: the cluster's own
+                // feature overrides, then the cluster-scoped system parameters,
+                // which win over a manual `FEATURES` pin. These features both
+                // key the local expression cache and drive re-optimization on a
+                // miss, so a divergence here rehydrates the view under features
+                // it was never created with.
                 let system_vars = session_catalog.system_vars();
-                let overrides = self
-                    .get_cluster(materialized_view.cluster_id)
-                    .config
-                    .features();
-                let optimizer_config =
-                    optimize::OptimizerConfig::from(system_vars).override_from(&overrides);
+                let cluster_id = materialized_view.cluster_id;
+                let overrides = self.get_cluster(cluster_id).config.features();
+                let optimizer_config = optimize::OptimizerConfig::from(system_vars)
+                    .override_from(&overrides)
+                    .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id));
                 let previous_exprs = previous_item.map(|item| match item {
                     CatalogItem::MaterializedView(materialized_view) => (
                         materialized_view.raw_expr,


### PR DESCRIPTION
`CatalogState::parse_item_inner` built a materialized view's `OptimizerConfig` from the system vars and the cluster's `FEATURES` pin, but omitted the cluster-scoped system parameters that `sequence_create_materialized_view` applies on top. A materialized view on a cluster carrying a scoped override was therefore optimized one way at creation and re-derived another way on rehydration.

Those features serve two purposes in that branch: they key the local expression cache, so a cached entry produced with the scoped layer was compared against features it was not optimized under, and they drive re-optimization on a miss, so the rehydrated local plan could differ from the one the view was created with.

Existing cache entries for materialized views on clusters with a scoped override now mismatch and are re-optimized once on the next boot, then rewritten with the correct features.

Adds a regression test in `src/adapter/src/catalog.rs` covering an MV on a cluster with a scoped override.

Closes: [SQL-629](https://linear.app/materializeinc/issue/SQL-629)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs6ehJaxwnL7r7nhqeTh47)_