### PR TITLE
adapter: resolve optimizer features for a cluster in one place

### DIFF
--- a/ci/test/lint-main/checks/check-optimizer-feature-scope.sh
+++ b/ci/test/lint-main/checks/check-optimizer-feature-scope.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# check-optimizer-feature-scope.sh — keep env-wide optimizer features out of cluster-scoped plans.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../../../.."
+
+. misc/shlib/shlib.bash
+
+# `SystemVars::env_wide_optimizer_features` and `OptimizerConfig::env_wide` read
+# the base layer of the optimizer-feature stack: no `CLUSTER ... FEATURES(...)`
+# pin, no cluster-scoped system parameter. They are correct only for a plan that
+# runs on no cluster. Anything installed on or executed by a cluster must go
+# through `CatalogState::optimizer_{features,config}_for_cluster`, which layers
+# all three; assembling the layers at the call site is how one gets dropped.
+#
+# Every file below has been checked to plan on no cluster, or to define the
+# accessors themselves. Before adding one, confirm the code has no cluster in
+# scope. If it does, use the resolver instead.
+ALLOWED=(
+  src/adapter/src/catalog/state.rs
+  src/adapter/src/catalog/transact.rs
+  src/adapter/src/client.rs
+  src/adapter/src/coord/sequencer/inner.rs
+  src/adapter/src/coord/sequencer/inner/copy_from.rs
+  src/adapter/src/coord/sequencer/inner/create_view.rs
+  src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+  src/adapter/src/optimize.rs
+  src/adapter/src/optimize/metric_sink.rs
+  src/sql/src/session/vars/definitions.rs
+)
+
+MATCHES=$(git grep -n -E 'env_wide_optimizer_features\(|OptimizerConfig::env_wide\(' -- 'src/**/*.rs' \
+  | grep -v -F -f <(printf '%s:\n' "${ALLOWED[@]}") || true)
+
+if [ -n "$MATCHES" ]; then
+  echo "Env-wide optimizer features read outside the allowlist in check-optimizer-feature-scope.sh."
+  echo "If the code has a cluster in scope, resolve through CatalogState::optimizer_features_for_cluster"
+  echo "or CatalogState::optimizer_config_for_cluster instead. If it genuinely plans on no cluster,"
+  echo "add the file to ALLOWED with that justification."
+  echo "$MATCHES"
+  exit 1
+fi
+
+try_status_report

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2499,7 +2499,7 @@ mod tests {
     use std::{env, iter};
 
     use itertools::Itertools;
-    use mz_catalog::memory::objects::CatalogItem;
+    use mz_catalog::memory::objects::{CatalogItem, ClusterVariant};
     use mz_postgres_util::{query, sql};
     use tokio_postgres::NoTls;
     use tokio_postgres::types::Type;
@@ -2901,6 +2901,51 @@ mod tests {
                     .all(|id| !element_ids.contains(id)),
                 "{ARRAY_SUFFIX:?} recorded an element type id from {ELEMENT_TYPE:?}",
             );
+
+            catalog.expire().await;
+        })
+        .await;
+    }
+
+    /// The optimizer-feature stack for a cluster, weakest layer first: the
+    /// env-wide system vars, the cluster's `FEATURES` pin, then the
+    /// cluster-scoped system parameter. The scoped layer is last so a targeted
+    /// rollout is not defeated by a manual pin.
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn test_optimizer_features_for_cluster_layering() {
+        Catalog::with_debug(|mut catalog| async move {
+            let cluster_id = catalog
+                .resolve_cluster("quickstart")
+                .expect("quickstart cluster exists")
+                .id;
+            let resolved = |catalog: &Catalog| {
+                catalog
+                    .state()
+                    .optimizer_features_for_cluster(cluster_id)
+                    .enable_eager_delta_joins
+            };
+
+            assert!(!resolved(&catalog), "env-wide base");
+
+            let cluster = catalog
+                .state
+                .clusters_by_id
+                .get_mut(&cluster_id)
+                .expect("cluster exists");
+            match &mut cluster.config.variant {
+                ClusterVariant::Managed(managed) => {
+                    managed.optimizer_feature_overrides.enable_eager_delta_joins = Some(true);
+                }
+                ClusterVariant::Unmanaged => panic!("quickstart is a managed cluster"),
+            }
+            assert!(resolved(&catalog), "`FEATURES` pin beats the env-wide base");
+
+            catalog.state.scoped_system_parameters.cluster.insert(
+                cluster_id,
+                BTreeMap::from([("enable_eager_delta_joins".to_string(), "false".to_string())]),
+            );
+            assert!(!resolved(&catalog), "scoped parameter beats the pin");
 
             catalog.expire().await;
         })

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -551,7 +551,7 @@ impl CatalogState {
     /// copies (`scoped_system_parameters.{cluster,replica}`), keyed by object
     /// id. Mirrors the durable `{cluster,replica}_system_configurations`
     /// collections; the cluster copy is consumed at plan time via
-    /// [`CatalogState::cluster_scoped_optimizer_overrides`], the replica copy at
+    /// [`CatalogState::optimizer_features_for_cluster`], the replica copy at
     /// the compute controller's per-replica dyncfg push.
     ///
     /// Retraction is conditional on the value matching, so a value change
@@ -559,7 +559,7 @@ impl CatalogState {
     /// of the order the two updates are applied in. See the scoped feature flags
     /// design.
     ///
-    /// [`CatalogState::cluster_scoped_optimizer_overrides`]: crate::catalog::CatalogState::cluster_scoped_optimizer_overrides
+    /// [`CatalogState::optimizer_features_for_cluster`]: crate::catalog::CatalogState::optimizer_features_for_cluster
     fn apply_scoped_system_configuration_update<Id: Ord>(
         map: &mut BTreeMap<Id, BTreeMap<String, String>>,
         id: Id,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -143,7 +143,7 @@ pub struct CatalogState {
     /// In-memory mirror of the durable scoped (per-cluster and per-replica)
     /// system-parameter cache, maintained by `apply.rs` from the durable
     /// collections. Resolution reads from here: the optimizer's per-cluster
-    /// feature overrides (`cluster_scoped_optimizer_overrides`) and the
+    /// feature overrides (`optimizer_features_for_cluster`) and the
     /// coordinator's per-replica dyncfg push. See the scoped feature flags
     /// design. Skipped in the consistency-check snapshot because it is fully
     /// derived from the durable catalog.
@@ -1521,9 +1521,10 @@ impl CatalogState {
                 is_retained_metrics_object,
             }),
             Plan::CreateView(CreateViewPlan { view, .. }) => {
-                // Collect optimizer parameters.
+                // Collect optimizer parameters. A view is not installed on a
+                // cluster, so the env-wide layer is the whole stack here.
                 let optimizer_config =
-                    optimize::OptimizerConfig::from(session_catalog.system_vars());
+                    optimize::OptimizerConfig::env_wide(session_catalog.system_vars());
                 let previous_exprs = previous_item.map(|item| match item {
                     CatalogItem::View(view) => Some((view.raw_expr, view.locally_optimized_expr)),
                     _ => None,
@@ -1586,19 +1587,12 @@ impl CatalogState {
                     .chain([(RelationVersion::root(), global_id)].into_iter())
                     .collect();
 
-                // Collect optimizer parameters. The layering must match
-                // `sequence_create_materialized_view`: the cluster's own
-                // feature overrides, then the cluster-scoped system parameters,
-                // which win over a manual `FEATURES` pin. These features both
-                // key the local expression cache and drive re-optimization on a
-                // miss, so a divergence here rehydrates the view under features
-                // it was never created with.
-                let system_vars = session_catalog.system_vars();
-                let cluster_id = materialized_view.cluster_id;
-                let overrides = self.get_cluster(cluster_id).config.features();
-                let optimizer_config = optimize::OptimizerConfig::from(system_vars)
-                    .override_from(&overrides)
-                    .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id));
+                // Collect optimizer parameters. These features both key the
+                // local expression cache and drive re-optimization on a miss,
+                // so resolving them differently here than the sequencer did
+                // rehydrates the view under features it was never created with.
+                let optimizer_config =
+                    self.optimizer_config_for_cluster(materialized_view.cluster_id);
                 let previous_exprs = previous_item.map(|item| match item {
                     CatalogItem::MaterializedView(materialized_view) => (
                         materialized_view.raw_expr,
@@ -2514,7 +2508,11 @@ impl CatalogState {
     /// Returns the cluster-coherent scoped optimizer-feature overrides for
     /// `cluster_id` from the in-memory scoped-parameter working copy, or empty
     /// if the cluster has none.
-    pub fn cluster_scoped_optimizer_overrides(
+    ///
+    /// Private on purpose: this is one layer of the optimizer-feature stack,
+    /// and a caller holding it alone is a caller assembling the stack by hand.
+    /// Go through [`CatalogState::optimizer_features_for_cluster`].
+    fn cluster_scoped_optimizer_overrides(
         &self,
         cluster_id: ClusterId,
     ) -> OptimizerFeatureOverrides {
@@ -2524,6 +2522,36 @@ impl CatalogState {
             .cloned()
             .map(OptimizerFeatureOverrides::from)
             .unwrap_or_default()
+    }
+
+    /// Resolves the optimizer features for a plan that runs on `cluster_id`.
+    ///
+    /// The layers, weakest first: the environment-wide system variables, the
+    /// cluster's own `CLUSTER ... FEATURES(...)` pin, then the cluster-scoped
+    /// system parameters, which win so that a targeted rollout is not defeated
+    /// by a manual pin.
+    ///
+    /// Every plan installed on or executed by a cluster must resolve its
+    /// features through here or through
+    /// [`CatalogState::optimizer_config_for_cluster`]. Assembling the layers by
+    /// hand is how a layer gets dropped: the omission is invisible at the call
+    /// site and surfaces much later as a plan that differs between creation and
+    /// catalog rehydration.
+    pub fn optimizer_features_for_cluster(&self, cluster_id: ClusterId) -> OptimizerFeatures {
+        self.system_config()
+            .env_wide_optimizer_features()
+            .override_from(&self.get_cluster(cluster_id).config.features())
+            .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id))
+    }
+
+    /// Resolves the optimizer config for a plan that runs on `cluster_id`.
+    ///
+    /// See [`CatalogState::optimizer_features_for_cluster`] for the layering
+    /// and for why the layers must not be assembled at the call site.
+    pub fn optimizer_config_for_cluster(&self, cluster_id: ClusterId) -> optimize::OptimizerConfig {
+        let mut config = optimize::OptimizerConfig::env_wide(self.system_config());
+        config.features = self.optimizer_features_for_cluster(cluster_id);
+        config
     }
 
     /// Returns the entire scoped system-parameter working copy, read by the

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -50,7 +50,6 @@ use mz_persist_types::ShardId;
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap, merge_mz_acl_items};
 use mz_repr::network_policy_id::NetworkPolicyId;
-use mz_repr::optimize::OptimizerFeatures;
 use mz_repr::role_id::RoleId;
 use mz_repr::{CatalogItemId, ColumnName, GlobalId, SqlColumnType, strconv};
 use mz_sql::ast::RawDataType;
@@ -865,9 +864,14 @@ impl Catalog {
     /// Extracts optimized expressions from `Op::CreateItem` operations for views
     /// and materialized views. These can be used to populate a `LocalExpressionCache`
     /// to avoid re-optimization during `apply_updates`.
+    ///
+    /// Each expression is labelled with the features the sequencer optimized it
+    /// under, resolved the same way `apply_updates` will resolve them: env-wide
+    /// for a view, per-cluster for a materialized view. A label that does not
+    /// match costs a needless re-optimization inside the transaction.
     fn extract_expressions_from_ops(
+        state: &CatalogState,
         ops: &[Op],
-        optimizer_features: &OptimizerFeatures,
     ) -> BTreeMap<GlobalId, LocalExpressions> {
         let mut exprs = BTreeMap::new();
 
@@ -879,7 +883,9 @@ impl Catalog {
                             view.global_id,
                             LocalExpressions {
                                 local_mir: (*view.locally_optimized_expr).clone(),
-                                optimizer_features: optimizer_features.clone(),
+                                optimizer_features: state
+                                    .system_config()
+                                    .env_wide_optimizer_features(),
                             },
                         );
                     }
@@ -888,7 +894,8 @@ impl Catalog {
                             mv.global_id_writes(),
                             LocalExpressions {
                                 local_mir: (*mv.locally_optimized_expr).clone(),
-                                optimizer_features: optimizer_features.clone(),
+                                optimizer_features: state
+                                    .optimizer_features_for_cluster(mv.cluster_id),
                             },
                         );
                     }
@@ -967,8 +974,7 @@ impl Catalog {
 
         // Extract optimized expressions from CreateItem ops to avoid re-optimization
         // during apply_updates. We extract before the loop since `ops` is moved there.
-        let optimizer_features = OptimizerFeatures::from(state.system_config());
-        let cached_exprs = Self::extract_expressions_from_ops(&ops, &optimizer_features);
+        let cached_exprs = Self::extract_expressions_from_ops(&state, &ops);
 
         let mut storage_collections_to_create = BTreeSet::new();
         let mut storage_collections_to_drop = BTreeSet::new();

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -1863,7 +1863,7 @@ impl SessionClient {
                         // functions like current_user() are resolved before we
                         // decide whether this can use the blind-write path.
                         let optimizer_config =
-                            optimize::OptimizerConfig::from(catalog.system_config());
+                            optimize::OptimizerConfig::env_wide(catalog.system_config());
                         let session = self.session.as_ref().expect("SessionClient invariant");
                         let prep = ExprPrepOneShot {
                             logical_time: EvalTime::NotAvailable,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -144,7 +144,7 @@ use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::global_id::TransientIdGen;
-use mz_repr::optimize::{OptimizerFeatureOverrides, OptimizerFeatures, OverrideFrom};
+use mz_repr::optimize::OptimizerFeatures;
 use mz_repr::role_id::RoleId;
 use mz_repr::{CatalogItemId, Diff, GlobalId, RelationDesc, SqlRelationType, Timestamp};
 use mz_secrets::cache::CachingSecretsReader;
@@ -2290,10 +2290,10 @@ impl Coordinator {
     /// introspection relations. The `replica`-scoped overrides reach the compute
     /// controller's per-replica dyncfg layer through the catalog implication for
     /// the persisted change. The `cluster`-scoped layer is resolved at plan time
-    /// via [`CatalogState::cluster_scoped_optimizer_overrides`].
+    /// via [`CatalogState::optimizer_features_for_cluster`].
     ///
     /// [`CatalogState`]: crate::catalog::CatalogState
-    /// [`CatalogState::cluster_scoped_optimizer_overrides`]: crate::catalog::CatalogState::cluster_scoped_optimizer_overrides
+    /// [`CatalogState::optimizer_features_for_cluster`]: crate::catalog::CatalogState::optimizer_features_for_cluster
     pub(crate) async fn reconcile_scoped_system_parameters(
         &mut self,
         scoped: ScopedParameters,
@@ -2528,16 +2528,24 @@ impl Coordinator {
         self.controller.storage.update_parameters(storage_config);
     }
 
-    /// Returns the cluster-coherent scoped optimizer-feature overrides for
-    /// `cluster_id`. See
-    /// [`CatalogState::cluster_scoped_optimizer_overrides`](crate::catalog::CatalogState::cluster_scoped_optimizer_overrides).
-    pub(crate) fn cluster_scoped_optimizer_overrides(
+    /// Resolves the optimizer features for a plan that runs on `cluster_id`.
+    /// See
+    /// [`CatalogState::optimizer_features_for_cluster`](crate::catalog::CatalogState::optimizer_features_for_cluster).
+    pub(crate) fn optimizer_features_for_cluster(
         &self,
         cluster_id: ClusterId,
-    ) -> OptimizerFeatureOverrides {
+    ) -> OptimizerFeatures {
         self.catalog()
             .state()
-            .cluster_scoped_optimizer_overrides(cluster_id)
+            .optimizer_features_for_cluster(cluster_id)
+    }
+
+    /// Resolves the optimizer config for a plan that runs on `cluster_id`. See
+    /// [`CatalogState::optimizer_config_for_cluster`](crate::catalog::CatalogState::optimizer_config_for_cluster).
+    pub(crate) fn optimizer_config_for_cluster(&self, cluster_id: ClusterId) -> OptimizerConfig {
+        self.catalog()
+            .state()
+            .optimizer_config_for_cluster(cluster_id)
     }
 
     /// Initializes coordinator state based on the contained catalog. Must be
@@ -3739,17 +3747,7 @@ impl Coordinator {
         let mut uncached_expressions = BTreeMap::new();
 
         let optimizer_config = |catalog: &Catalog, cluster_id| {
-            let system_config = catalog.system_config();
-            let overrides = catalog.get_cluster(cluster_id).config.features();
-            OptimizerConfig::from(system_config)
-                .override_from(&overrides)
-                // A cluster-scoped LaunchDarkly rule beats a manual `FEATURES`
-                // pin.
-                .override_from(
-                    &catalog
-                        .state()
-                        .cluster_scoped_optimizer_overrides(cluster_id),
-                )
+            catalog.state().optimizer_config_for_cluster(cluster_id)
         };
 
         for entry in ordered_catalog_entries {

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -40,7 +40,6 @@ use mz_compute_client::protocol::response::SubscribeBatch;
 use mz_controller_types::ClusterId;
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_panic_or_log;
-use mz_repr::optimize::OverrideFrom;
 use mz_repr::{Datum, GlobalId, Row};
 use mz_sql::catalog::SessionCatalog;
 use mz_sql::plan::{Params, Plan, SubscribePlan};
@@ -221,11 +220,7 @@ impl Coordinator {
         let compute_instance = self.instance_snapshot(cluster_id).expect("must exist");
         let (_, view_id) = self.allocate_transient_id();
 
-        let vars = self.catalog().system_config();
-        let overrides = self.catalog.get_cluster(cluster_id).config.features();
-        let optimizer_config = optimize::OptimizerConfig::from(vars)
-            .override_from(&overrides)
-            .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id));
+        let optimizer_config = self.optimizer_config_for_cluster(cluster_id);
 
         let mut optimizer = optimize::subscribe::Optimizer::new(
             self.owned_catalog(),

--- a/src/adapter/src/coord/metric_sink.rs
+++ b/src/adapter/src/coord/metric_sink.rs
@@ -41,7 +41,6 @@ use mz_cluster_client::ReplicaId;
 use mz_controller_types::ClusterId;
 use mz_ore::collections::CollectionExt;
 use mz_ore::{instrument, soft_panic_or_log};
-use mz_repr::optimize::OverrideFrom;
 use mz_repr::{CatalogItemId, GlobalId, RelationDesc};
 use mz_sql::catalog::SessionCatalog;
 use mz_sql::plan::{
@@ -275,9 +274,7 @@ impl Coordinator {
         // dataflow. See `optimize::metric_sink::shape_metric_sink_source`.
         let (_, view_id) = self.allocate_transient_id();
 
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
-            .override_from(&self.catalog.get_cluster(cluster_id).config.features())
-            .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id));
+        let optimizer_config = self.optimizer_config_for_cluster(cluster_id);
 
         let mut optimizer = optimize::metric_sink::Optimizer::new(
             self.owned_catalog(),

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2678,7 +2678,8 @@ impl Coordinator {
             OptimizedMirRelationExpr(expr)
         } else {
             // Collect optimizer parameters.
-            let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+            let optimizer_config =
+                optimize::OptimizerConfig::env_wide(self.catalog().system_config());
 
             // (`optimize::view::Optimizer` has a special case for constant queries.)
             let mut optimizer = optimize::view::Optimizer::new(optimizer_config, None);

--- a/src/adapter/src/coord/sequencer/inner/copy_from.rs
+++ b/src/adapter/src/coord/sequencer/inner/copy_from.rs
@@ -337,7 +337,7 @@ impl Coordinator {
         let catalog = self.catalog().clone();
         let conn_catalog = catalog.for_session(session);
         let catalog_state = conn_catalog.state();
-        let optimizer_config = optimize::OptimizerConfig::from(conn_catalog.system_vars());
+        let optimizer_config = optimize::OptimizerConfig::env_wide(conn_catalog.system_vars());
 
         // Determine if we need column rewriting (defaults/reordering).
         let target_desc = catalog

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -14,7 +14,7 @@ use mz_catalog::memory::error::ErrorKind;
 use mz_catalog::memory::objects::{CatalogItem, Index};
 use mz_ore::instrument;
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
-use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
+use mz_repr::optimize::OverrideFrom;
 use mz_repr::{Datum, Row};
 use mz_sql::ast::ExplainStage;
 use mz_sql::catalog::CatalogError;
@@ -216,9 +216,8 @@ impl Coordinator {
 
         let target_cluster = self.catalog().get_cluster(index.cluster_id);
 
-        let features = OptimizerFeatures::from(self.catalog().system_config())
-            .override_from(&target_cluster.config.features())
-            .override_from(&self.cluster_scoped_optimizer_overrides(index.cluster_id))
+        let features = self
+            .optimizer_features_for_cluster(index.cluster_id)
             .override_from(&config.features);
 
         // TODO(mgree): calculate statistics (need a timestamp)
@@ -329,9 +328,8 @@ impl Coordinator {
             self.allocate_transient_id()
         };
 
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
-            .override_from(&self.catalog.get_cluster(*cluster_id).config.features())
-            .override_from(&self.cluster_scoped_optimizer_overrides(*cluster_id))
+        let optimizer_config = self
+            .optimizer_config_for_cluster(*cluster_id)
             .override_from(&explain_ctx);
         let optimizer_features = optimizer_config.features.clone();
 
@@ -598,9 +596,8 @@ impl Coordinator {
 
         let target_cluster = self.catalog().get_cluster(index.cluster_id);
 
-        let features = OptimizerFeatures::from(self.catalog().system_config())
-            .override_from(&target_cluster.config.features())
-            .override_from(&self.cluster_scoped_optimizer_overrides(index.cluster_id))
+        let features = self
+            .optimizer_features_for_cluster(index.cluster_id)
             .override_from(&config.features);
 
         let rows = optimizer_trace

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -18,7 +18,6 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::instrument;
 use mz_ore::soft_panic_or_log;
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
-use mz_repr::optimize::OptimizerFeatures;
 use mz_repr::optimize::OverrideFrom;
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{CatalogItemId, Datum, RelationVersion, Row, VersionedRelationDesc};
@@ -247,9 +246,8 @@ impl Coordinator {
 
         let target_cluster = self.catalog().get_cluster(view.cluster_id);
 
-        let features = OptimizerFeatures::from(self.catalog().system_config())
-            .override_from(&target_cluster.config.features())
-            .override_from(&self.cluster_scoped_optimizer_overrides(view.cluster_id))
+        let features = self
+            .optimizer_features_for_cluster(view.cluster_id)
             .override_from(&config.features);
 
         let cardinality_stats = BTreeMap::new();
@@ -452,9 +450,8 @@ impl Coordinator {
 
         let (_, view_id) = self.allocate_transient_id();
         let debug_name = self.catalog().resolve_full_name(name, None).to_string();
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
-            .override_from(&self.catalog.get_cluster(*cluster_id).config.features())
-            .override_from(&self.cluster_scoped_optimizer_overrides(*cluster_id))
+        let optimizer_config = self
+            .optimizer_config_for_cluster(*cluster_id)
             .override_from(&explain_ctx);
         let optimizer_features = optimizer_config.features.clone();
 
@@ -964,9 +961,8 @@ impl Coordinator {
 
         let target_cluster = self.catalog().get_cluster(cluster_id);
 
-        let features = OptimizerFeatures::from(self.catalog().system_config())
-            .override_from(&target_cluster.config.features())
-            .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id))
+        let features = self
+            .optimizer_features_for_cluster(cluster_id)
             .override_from(&config.features);
 
         let rows = optimizer_trace

--- a/src/adapter/src/coord/sequencer/inner/create_metric_sink.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_metric_sink.rs
@@ -17,7 +17,6 @@ use mz_catalog::memory::error::ErrorKind;
 use mz_catalog::memory::objects::{CatalogItem, MetricSink};
 use mz_controller_types::ClusterId;
 use mz_ore::instrument;
-use mz_repr::optimize::OverrideFrom;
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::{QualifiedItemName, ResolvedIds};
 use mz_sql::plan;
@@ -132,9 +131,7 @@ impl Coordinator {
         // `optimize::metric_sink::shape_metric_sink_source`); scoped to this dataflow, not durable.
         let (_, view_id) = self.allocate_transient_id();
 
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
-            .override_from(&self.catalog.get_cluster(cluster_id).config.features())
-            .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id));
+        let optimizer_config = self.optimizer_config_for_cluster(cluster_id);
         let optimizer_features = optimizer_config.features.clone();
         let debug_name = self
             .catalog()

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -15,7 +15,7 @@ use mz_catalog::memory::objects::{CatalogItem, View};
 use mz_expr::CollectionPlan;
 use mz_ore::instrument;
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
-use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
+use mz_repr::optimize::OverrideFrom;
 use mz_repr::{Datum, RelationDesc, Row};
 use mz_sql::ast::ExplainStage;
 use mz_sql::catalog::CatalogError;
@@ -208,8 +208,11 @@ impl Coordinator {
 
         let target_cluster = None; // Views don't have a target cluster.
 
-        let features =
-            OptimizerFeatures::from(self.catalog().system_config()).override_from(&config.features);
+        let features = self
+            .catalog()
+            .system_config()
+            .env_wide_optimizer_features()
+            .override_from(&config.features);
 
         let cardinality_stats = BTreeMap::new();
 
@@ -299,7 +302,7 @@ impl Coordinator {
         let (item_id, global_id) = self.allocate_user_id().await?;
 
         // Collect optimizer parameters.
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
+        let optimizer_config = optimize::OptimizerConfig::env_wide(self.catalog().system_config())
             .override_from(&explain_ctx);
 
         // Build an optimizer for this VIEW.
@@ -480,8 +483,11 @@ impl Coordinator {
             ExprHumanizerExt::new(transient_items, &session_catalog)
         };
 
-        let features =
-            OptimizerFeatures::from(self.catalog().system_config()).override_from(&config.features);
+        let features = self
+            .catalog()
+            .system_config()
+            .env_wide_optimizer_features()
+            .override_from(&config.features);
 
         let rows = optimizer_trace
             .into_rows(

--- a/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+++ b/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
@@ -137,7 +137,7 @@ impl Coordinator {
         }: ExplainTimestampOptimize,
     ) -> Result<StageResult<Box<ExplainTimestampStage>>, AdapterError> {
         // Collect optimizer parameters.
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+        let optimizer_config = optimize::OptimizerConfig::env_wide(self.catalog().system_config());
 
         let mut optimizer = optimize::view::Optimizer::new(optimizer_config, None);
 

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -16,7 +16,7 @@ use mz_controller_types::ClusterId;
 use mz_expr::{CollectionPlan, ResultSpec};
 use mz_ore::cast::CastFrom;
 use mz_ore::instrument;
-use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
+use mz_repr::optimize::OverrideFrom;
 use mz_repr::{Datum, GlobalId, Timestamp};
 use mz_sql::ast::{ExplainStage, Statement};
 use mz_sql::catalog::CatalogCluster;
@@ -253,9 +253,8 @@ impl Coordinator {
         let compute_instance = self
             .instance_snapshot(cluster.id())
             .expect("compute instance does not exist");
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
-            .override_from(&self.catalog.get_cluster(cluster.id()).config.features())
-            .override_from(&self.cluster_scoped_optimizer_overrides(cluster.id()))
+        let optimizer_config = self
+            .optimizer_config_for_cluster(cluster.id())
             .override_from(&explain_ctx);
 
         if cluster.replicas().next().is_none() && explain_ctx.needs_cluster() {
@@ -776,9 +775,7 @@ impl Coordinator {
 
         if let Some(trace) = plan_insights_optimizer_trace {
             let target_cluster = self.catalog().get_cluster(cluster_id);
-            let features = OptimizerFeatures::from(self.catalog().system_config())
-                .override_from(&target_cluster.config.features())
-                .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id));
+            let features = self.optimizer_features_for_cluster(cluster_id);
             let insights = trace
                 .into_plan_insights(
                     &features,

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -20,7 +20,7 @@ use mz_ore::instrument;
 use mz_repr::GlobalId;
 use mz_repr::Timestamp;
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
-use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
+use mz_repr::optimize::OverrideFrom;
 use mz_sql::plan::{self, QueryWhen, SubscribeFrom};
 use mz_sql::session::metadata::SessionMetadata;
 use std::collections::BTreeSet;
@@ -284,9 +284,8 @@ impl Coordinator {
         let (_, view_id) = self.allocate_transient_id();
         let (_, sink_id) = self.allocate_transient_id();
         let debug_name = format!("subscribe-{}", sink_id);
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config())
-            .override_from(&self.catalog.get_cluster(cluster_id).config.features())
-            .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id))
+        let optimizer_config = self
+            .optimizer_config_for_cluster(cluster_id)
             .override_from(&explain_ctx);
 
         // Build an optimizer for this SUBSCRIBE.
@@ -677,9 +676,8 @@ impl Coordinator {
 
         let target_cluster = self.catalog().get_cluster(cluster_id);
 
-        let features = OptimizerFeatures::from(self.catalog().system_config())
-            .override_from(&target_cluster.config.features())
-            .override_from(&self.cluster_scoped_optimizer_overrides(cluster_id))
+        let features = self
+            .optimizer_features_for_cluster(cluster_id)
             .override_from(&config.features);
 
         let rows = optimizer_trace

--- a/src/adapter/src/frontend_peek.rs
+++ b/src/adapter/src/frontend_peek.rs
@@ -23,7 +23,7 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::now::EpochMillis;
 use mz_ore::task::JoinHandle;
 use mz_ore::{soft_assert_eq_or_log, soft_assert_or_log, soft_panic_or_log};
-use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
+use mz_repr::optimize::OverrideFrom;
 use mz_repr::{Datum, GlobalId, IntoRowIterator, Timestamp};
 use mz_sql::ast::Raw;
 use mz_sql::catalog::CatalogCluster;
@@ -481,14 +481,9 @@ impl PeekClient {
         let compute_instance_snapshot =
             ComputeInstanceSnapshot::new_without_collections(cluster.id());
 
-        let optimizer_config = optimize::OptimizerConfig::from(catalog.system_config())
-            .override_from(&catalog.get_cluster(cluster.id()).config.features())
-            // A cluster-scoped LaunchDarkly rule beats a manual `FEATURES` pin.
-            .override_from(
-                &catalog
-                    .state()
-                    .cluster_scoped_optimizer_overrides(cluster.id()),
-            )
+        let optimizer_config = catalog
+            .state()
+            .optimizer_config_for_cluster(cluster.id())
             .override_from(&explain_ctx);
 
         if cluster.replicas().next().is_none() && explain_ctx.needs_cluster() {
@@ -1217,15 +1212,9 @@ impl PeekClient {
                 // Generate plan insights notice if needed
                 if let Some(trace) = plan_insights_optimizer_trace {
                     let target_cluster = catalog.get_cluster(target_cluster_id);
-                    let features = OptimizerFeatures::from(catalog.system_config())
-                        .override_from(&target_cluster.config.features())
-                        // A cluster-scoped LaunchDarkly rule beats a manual
-                        // `FEATURES` pin.
-                        .override_from(
-                            &catalog
-                                .state()
-                                .cluster_scoped_optimizer_overrides(target_cluster_id),
-                        );
+                    let features = catalog
+                        .state()
+                        .optimizer_features_for_cluster(target_cluster_id);
                     let insights = trace
                         .into_plan_insights(
                             &features,

--- a/src/adapter/src/frontend_read_then_write.rs
+++ b/src/adapter/src/frontend_read_then_write.rs
@@ -141,7 +141,6 @@ use mz_expr::row::RowCollection;
 use mz_expr::{CollectionPlan, Id, LocalId, MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::cast::CastFrom;
 use mz_ore::{soft_assert_or_log, soft_panic_or_log};
-use mz_repr::optimize::OverrideFrom;
 use mz_repr::{CatalogItemId, Diff, GlobalId, RelationDesc, Row, RowArena, Timestamp};
 use mz_sql::catalog::CatalogError;
 use mz_sql::plan::{self, MutationKind, QueryWhen};
@@ -1260,13 +1259,7 @@ impl PeekClient {
         let (_, view_id) = self.transient_id_gen.allocate_id();
         let (_, sink_id) = self.transient_id_gen.allocate_id();
         let debug_name = format!("frontend-read-then-write-subscribe-{}", sink_id);
-        let optimizer_config = optimize::OptimizerConfig::from(catalog.system_config())
-            .override_from(&catalog.get_cluster(cluster_id).config.features())
-            .override_from(
-                &catalog
-                    .state()
-                    .cluster_scoped_optimizer_overrides(cluster_id),
-            );
+        let optimizer_config = catalog.state().optimizer_config_for_cluster(cluster_id);
 
         let mut optimizer = optimize::subscribe::Optimizer::new(
             Arc::<Catalog>::clone(catalog),

--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -249,8 +249,8 @@ where
 /// 1. To make the flag available to all stages in our [`Optimize`] pipelines
 ///    and allow engineers to set a system-wide override:
 ///    1. Add the flag to the `optimizer_feature_flags!(...)` macro call.
-///    2. Add the flag to the `feature_flags!(...)` macro call and extend the
-///       `From<&SystemVars>` implementation for [`OptimizerFeatures`].
+///    2. Add the flag to the `feature_flags!(...)` macro call and extend
+///       `SystemVars::env_wide_optimizer_features`.
 ///
 /// 2. To enable `EXPLAIN ... WITH(...)` overrides which will allow engineers to
 ///    inspect plan differences before deploying the optimizer changes:
@@ -297,15 +297,26 @@ pub enum OptimizeMode {
     Explain,
 }
 
-impl From<&SystemVars> for OptimizerConfig {
-    fn from(vars: &SystemVars) -> Self {
+impl OptimizerConfig {
+    /// Builds a config from the environment-wide system variables, i.e. with
+    /// no cluster override applied.
+    ///
+    /// Correct only for a plan that runs on no cluster, such as a `CREATE
+    /// VIEW` or a constant-folded `INSERT ... VALUES`. A plan that is
+    /// installed on or executed by a cluster must instead use
+    /// [`CatalogState::optimizer_config_for_cluster`], which layers the
+    /// cluster's `FEATURES` pin and the cluster-scoped system parameters on
+    /// top of this.
+    ///
+    /// [`CatalogState::optimizer_config_for_cluster`]: crate::catalog::CatalogState::optimizer_config_for_cluster
+    pub fn env_wide(vars: &SystemVars) -> Self {
         Self {
             mode: OptimizeMode::Execute,
             replan: None,
             no_fast_path: false,
             persist_fast_path_order: PERSIST_FAST_PATH_ORDER.get(vars.dyncfgs()),
             subscribe_snapshot_optimization: SUBSCRIBE_SNAPSHOT_OPTIMIZATION.get(vars.dyncfgs()),
-            features: OptimizerFeatures::from(vars),
+            features: vars.env_wide_optimizer_features(),
         }
     }
 }

--- a/src/adapter/src/optimize/metric_sink.rs
+++ b/src/adapter/src/optimize/metric_sink.rs
@@ -747,7 +747,7 @@ mod tests {
         let catalog = Arc::new(SingleTableCatalog::new());
         let cluster_id = ClusterId::user(1).expect("valid cluster id");
         let compute_instance = ComputeInstanceSnapshot::new_without_collections(cluster_id);
-        let config = OptimizerConfig::from(&SystemVars::default());
+        let config = OptimizerConfig::env_wide(&SystemVars::default());
         let metrics = OptimizerMetrics::register_into(&MetricsRegistry::new(), Duration::MAX);
 
         let mut optimizer = Optimizer::new(

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2386,33 +2386,42 @@ feature_flags!(
     },
 );
 
-impl From<&super::SystemVars> for OptimizerFeatures {
-    fn from(vars: &super::SystemVars) -> Self {
-        Self {
-            enable_eager_delta_joins: vars.enable_eager_delta_joins(),
-            enable_new_outer_join_lowering: vars.enable_new_outer_join_lowering(),
-            enable_reduce_mfp_fusion: vars.enable_reduce_mfp_fusion(),
-            enable_variadic_left_join_lowering: vars.enable_variadic_left_join_lowering(),
-            enable_letrec_fixpoint_analysis: vars.enable_letrec_fixpoint_analysis(),
-            enable_cardinality_estimates: vars.enable_cardinality_estimates(),
-            persist_fast_path_limit: vars.persist_fast_path_limit(),
+impl super::SystemVars {
+    /// Reads the optimizer features from the environment-wide system
+    /// variables, i.e. the base layer with no cluster override applied.
+    ///
+    /// This is the weakest layer of the optimizer-feature stack and is the
+    /// correct value only for a plan that runs on no cluster, such as a
+    /// `CREATE VIEW` or a constant-folded `INSERT ... VALUES`. A plan that is
+    /// installed on or executed by a cluster must instead resolve its features
+    /// through the catalog's per-cluster resolver, which layers the cluster's
+    /// `FEATURES` pin and the cluster-scoped system parameters on top of this.
+    pub fn env_wide_optimizer_features(&self) -> OptimizerFeatures {
+        OptimizerFeatures {
+            enable_eager_delta_joins: self.enable_eager_delta_joins(),
+            enable_new_outer_join_lowering: self.enable_new_outer_join_lowering(),
+            enable_reduce_mfp_fusion: self.enable_reduce_mfp_fusion(),
+            enable_variadic_left_join_lowering: self.enable_variadic_left_join_lowering(),
+            enable_letrec_fixpoint_analysis: self.enable_letrec_fixpoint_analysis(),
+            enable_cardinality_estimates: self.enable_cardinality_estimates(),
+            persist_fast_path_limit: self.persist_fast_path_limit(),
             reoptimize_imported_views: false,
-            enable_join_prioritize_arranged: vars.enable_join_prioritize_arranged(),
-            enable_projection_pushdown_after_relation_cse: vars
+            enable_join_prioritize_arranged: self.enable_join_prioritize_arranged(),
+            enable_projection_pushdown_after_relation_cse: self
                 .enable_projection_pushdown_after_relation_cse(),
-            enable_union_cancellation_after_relation_cse: vars
+            enable_union_cancellation_after_relation_cse: self
                 .enable_union_cancellation_after_relation_cse(),
-            enable_less_reduce_in_eqprop: vars.enable_less_reduce_in_eqprop(),
-            enable_dequadratic_eqprop_map: vars.enable_dequadratic_eqprop_map(),
-            enable_eq_classes_withholding_errors: vars.enable_eq_classes_withholding_errors(),
-            enable_fast_path_plan_insights: vars.enable_fast_path_plan_insights(),
-            enable_cast_elimination: vars.enable_cast_elimination(),
-            enable_case_literal_transform: vars.enable_case_literal_transform(),
-            enable_simplify_quantified_comparisons: vars.enable_simplify_quantified_comparisons(),
-            enable_simplify_from_less_existence: vars.enable_simplify_from_less_existence(),
-            enable_coalesce_case_transform: vars.enable_coalesce_case_transform(),
-            enable_will_distinct_propagation: vars.enable_will_distinct_propagation(),
-            enable_fixed_correlated_cte_lowering: vars.enable_fixed_correlated_cte_lowering(),
+            enable_less_reduce_in_eqprop: self.enable_less_reduce_in_eqprop(),
+            enable_dequadratic_eqprop_map: self.enable_dequadratic_eqprop_map(),
+            enable_eq_classes_withholding_errors: self.enable_eq_classes_withholding_errors(),
+            enable_fast_path_plan_insights: self.enable_fast_path_plan_insights(),
+            enable_cast_elimination: self.enable_cast_elimination(),
+            enable_case_literal_transform: self.enable_case_literal_transform(),
+            enable_simplify_quantified_comparisons: self.enable_simplify_quantified_comparisons(),
+            enable_simplify_from_less_existence: self.enable_simplify_from_less_existence(),
+            enable_coalesce_case_transform: self.enable_coalesce_case_transform(),
+            enable_will_distinct_propagation: self.enable_will_distinct_propagation(),
+            enable_fixed_correlated_cte_lowering: self.enable_fixed_correlated_cte_lowering(),
         }
     }
 }
@@ -2500,7 +2509,7 @@ mod tests {
 
         // Enable for item parsing, then ensure we still get the same optimizer features.
         vars.enable_for_item_parsing();
-        let features_for_item_parsing = OptimizerFeatures::from(&vars);
+        let features_for_item_parsing = vars.env_wide_optimizer_features();
         assert_eq!(features_for_item_parsing, false_features);
     }
 }


### PR DESCRIPTION
Stacked on #38684, which is the base of this PR. Review that one first; the diff here is only the second commit.

The optimizer-feature stack has three layers: the env-wide system variables, the cluster's `CLUSTER ... FEATURES(...)` pin, and the cluster-scoped system parameters. Assembling them was a convention every call site with a cluster in scope had to remember, and the env-wide value was the easiest to reach for, being a `From<&SystemVars>` impl available from any `&SystemVars`. Nothing named or typed the difference between "resolved for a cluster" and "no override applied yet", so a site that dropped a layer looked like every other site. [SQL-629](https://linear.app/materializeinc/issue/SQL-629) was one such site.

Introduce `CatalogState::optimizer_{features,config}_for_cluster` as the single resolver, and convert every call site that has a cluster in scope. `cluster_scoped_optimizer_overrides` becomes private, so no caller can hold one layer on its own. The env-wide constructors are renamed to say what they are, `SystemVars::env_wide_optimizer_features` and `OptimizerConfig::env_wide`, and a lint restricts them to the files that plan on no cluster: a view, a constant-folded `INSERT ... VALUES`, a one-shot expression evaluation.

This also corrects `extract_expressions_from_ops`, which labelled a materialized view's cached local expression with env-wide features regardless of its cluster. The transact-time cache is discarded rather than persisted, so a wrong label only cost a re-optimization inside the transaction, but it was the same missing-resolver pattern.

Adds `ci/test/lint-main/checks/check-optimizer-feature-scope.sh` and a layering test in `src/adapter/src/catalog.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs6ehJaxwnL7r7nhqeTh47)_