### PR TITLE
ci: label the staging spec-sheet step by what it runs

### DIFF
--- a/ci/spec-sheet/pipeline.template.yml
+++ b/ci/spec-sheet/pipeline.template.yml
@@ -111,7 +111,7 @@ steps:
       queue: linux-aarch64-small
 
   - id: cluster-spec-sheet-staging
-    label: "Cluster spec sheet: Staging"
+    label: "Cluster spec sheet: envd Scalability + Cluster Object Count Limits (against Staging)"
     timeout_in_minutes: 3600
     depends_on: devel-docker-tags
     parallelism: 7


### PR DESCRIPTION
### Motivation

The three spec-sheet steps were labeled inconsistently. The two production steps read "what runs (against where)", while the staging step said only where it runs.

### Description

* The staging step is now labeled `Cluster spec sheet: envd Scalability + Cluster Object Count Limits (against Staging)`. It runs the `envd_qps_scalability`, `envd_objects_scalability`, and `cluster_object_limits` scenario groups. "Object count" is spelled out so the limit is not mistaken for a size limit.
* The `Cluster spec sheet` prefix stays. It is what the mzcompose plugin's services.log check matches on.
* Side effect: Buildkite Test Analytics starts a new suite history under the new name.

Independent of #38681, which touches other files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
