### PR TITLE
doc/user: add LibreDB Studio to SQL clients

### DIFF
--- a/doc/user/content/serve-results/sql-clients.md
+++ b/doc/user/content/serve-results/sql-clients.md
@@ -165,6 +165,23 @@ Materialize console.
 
 <img width="1440" alt="Screenshot 2023-12-28 at 18 45 11" src="https://github.com/MaterializeInc/materialize/assets/23521087/c530769e-3445-49c8-8f36-9f7166352ac4">
 
+### LibreDB Studio
+
+{{< warning >}}
+Only the SQL editor is fully supported today. The object/schema browser and the
+monitoring dashboard both depend on PostgreSQL catalog objects Materialize does
+not have: `MATERIALIZED` is a reserved keyword that breaks LibreDB Studio's
+schema-introspection query, and `pg_stat_activity`/`pg_statio_user_tables` do
+not exist, so the monitoring panel reports a connection error rather than
+data. Running queries, including Materialize-specific statements like `SHOW
+MATERIALIZED VIEWS` and `SHOW SOURCES`, works normally.
+{{< /warning >}}
+
+To connect to Materialize using [LibreDB Studio](https://github.com/libredb/libredb-studio),
+an open-source, browser-based SQL IDE, choose the **PostgreSQL** driver in the
+connection dialog and use the credentials from the Materialize console (host,
+port **6875**, your app password, SSL mode **Require**).
+
 ### `psql`
 
 {{< warning >}}

--- a/doc/user/content/serve-results/sql-clients.md
+++ b/doc/user/content/serve-results/sql-clients.md
@@ -182,6 +182,8 @@ an open-source, browser-based SQL IDE, choose the **PostgreSQL** driver in the
 connection dialog and use the credentials from the Materialize console (host,
 port **6875**, your app password, SSL mode **Require**).
 
+<img width="1440" alt="Connect using the credentials provided in the Materialize console" src="https://github.com/user-attachments/assets/55212af8-66e0-4add-a7df-ea6eeb13d190">
+
 ### `psql`
 
 {{< warning >}}

--- a/doc/user/content/serve-results/sql-clients.md
+++ b/doc/user/content/serve-results/sql-clients.md
@@ -167,15 +167,11 @@ Materialize console.
 
 ### LibreDB Studio
 
-{{< warning >}}
-Only the SQL editor is fully supported today. The object/schema browser and the
-monitoring dashboard both depend on PostgreSQL catalog objects Materialize does
-not have: `MATERIALIZED` is a reserved keyword that breaks LibreDB Studio's
-schema-introspection query, and `pg_stat_activity`/`pg_statio_user_tables` do
-not exist, so the monitoring panel reports a connection error rather than
-data. Running queries, including Materialize-specific statements like `SHOW
-MATERIALIZED VIEWS` and `SHOW SOURCES`, works normally.
-{{< /warning >}}
+{{< tip >}}
+The object browser lists Materialize's tables, views, and materialized views
+along with their columns, and the SQL editor supports Materialize-specific
+statements like `SHOW MATERIALIZED VIEWS` and `SHOW SOURCES`.
+{{< /tip >}}
 
 To connect to Materialize using [LibreDB Studio](https://github.com/libredb/libredb-studio),
 an open-source, browser-based SQL IDE, choose the **PostgreSQL** driver in the


### PR DESCRIPTION
### Motivation

LibreDB Studio is an open source, browser-based SQL IDE that connects to Materialize over the PostgreSQL wire protocol. This adds it to the SQL clients page alongside DataGrip, DBeaver and TablePlus.

This reopens #38680, which I could not reopen directly through GitHub (the API rejected the reopen and no reopen button showed up for me either). Same branch, with the fix described below on top.

### Description

Added a `### LibreDB Studio` section after TablePlus. The SQL editor works fully, including Materialize specific statements like `SHOW MATERIALIZED VIEWS` and `SHOW SOURCES`. The object browser lists real tables, views and materialized views with their columns.

@sjwiesman closed #38680 because the object browser and monitoring dashboard both failed outright. That turned out to be a bug in LibreDB Studio, not a gap in Materialize: `MATERIALIZED` is a reserved keyword that broke the schema introspection query, and the monitoring dashboard errored on connect instead of degrading. Both are fixed in libredb/libredb-studio#578, and the tip in this PR is updated to describe current behavior instead of the old restrictions.