### PR TITLE
console: let self-managed instances set a display name

### DIFF
--- a/console/src/config/AppConfig.ts
+++ b/console/src/config/AppConfig.ts
@@ -28,6 +28,7 @@ import {
   getEnvironmentdWebsocketScheme,
   getFronteggUrl,
 } from "./apiUrls";
+import { type ConsoleAppearance } from "./appearance";
 import { buildConstants } from "./buildConstants";
 import { getCloudRegions } from "./cloudRegions";
 import { getConsoleEnvironment } from "./consoleEnvironment";
@@ -95,6 +96,10 @@ interface IBaseAppConfig {
   environmentdWebsocketScheme: WebsocketScheme;
   // Whether query retries in react-query are enabled
   reactQueryRetriesEnabled: boolean;
+  // How this instance's console distinguishes itself from the consoles of
+  // other instances. Never set in cloud mode, which serves one console for all
+  // of an organization's regions.
+  appearance: ConsoleAppearance | undefined;
 }
 
 export class CloudAppConfig implements IBaseAppConfig {
@@ -200,6 +205,8 @@ export class CloudAppConfig implements IBaseAppConfig {
   // Whether the current environment requires user registration outside of the Console. This occurs in production
   // when the Console's 'sign up' button links to the Marketing site.
   requiresExternalRegistration = this.#consoleEnvironment === "production";
+
+  appearance = undefined;
 }
 
 export class SelfManagedAppConfig implements IBaseAppConfig {
@@ -208,6 +215,8 @@ export class SelfManagedAppConfig implements IBaseAppConfig {
   authMode: SelfManagedAuthMode = appConfigJson.auth.mode;
 
   balancerdDnsNames: string[] | undefined = appConfigJson.balancerdDnsNames;
+
+  appearance: ConsoleAppearance | undefined = appConfigJson.appearance;
 
   environmentdScheme = getEnvironmentdScheme({
     buildConstants,

--- a/console/src/config/appearance.test.ts
+++ b/console/src/config/appearance.test.ts
@@ -1,0 +1,42 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { documentTitle, parseConsoleAppearance } from "./appearance";
+
+describe("documentTitle", () => {
+  it("names the instance when it has a display name", () => {
+    expect(documentTitle({ displayName: "prod" })).toEqual(
+      "Materialize Console · prod",
+    );
+  });
+
+  it("falls back to the plain title", () => {
+    expect(documentTitle(undefined)).toEqual("Materialize Console");
+    expect(documentTitle({})).toEqual("Materialize Console");
+  });
+});
+
+describe("parseConsoleAppearance", () => {
+  it("returns undefined when unconfigured", () => {
+    expect(parseConsoleAppearance(undefined)).toBeUndefined();
+    expect(parseConsoleAppearance(null)).toBeUndefined();
+  });
+
+  it("keeps a display name", () => {
+    expect(parseConsoleAppearance({ displayName: "prod" })).toEqual({
+      displayName: "prod",
+    });
+  });
+
+  it("treats an empty display name as unset", () => {
+    expect(parseConsoleAppearance({ displayName: "" })).toEqual({
+      displayName: undefined,
+    });
+  });
+});

--- a/console/src/config/appearance.ts
+++ b/console/src/config/appearance.ts
@@ -1,0 +1,38 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/**
+ * @module
+ * Per-instance appearance, set on the Materialize resource and delivered to
+ * the browser in app-config.json. Self-managed only, since Cloud serves one
+ * console for all of a user's regions.
+ */
+
+export interface ConsoleAppearance {
+  /** A short name for the instance, such as "dev" or "prod". */
+  displayName?: string;
+}
+
+const BASE_DOCUMENT_TITLE = "Materialize Console";
+
+/** Builds the browser tab title, which names the instance when configured. */
+export const documentTitle = (appearance: ConsoleAppearance | undefined) =>
+  appearance?.displayName
+    ? `${BASE_DOCUMENT_TITLE} · ${appearance.displayName}`
+    : BASE_DOCUMENT_TITLE;
+
+/** Reads the appearance out of app-config.json. */
+export const parseConsoleAppearance = (
+  appearance: { displayName?: string } | null | undefined,
+): ConsoleAppearance | undefined => {
+  if (!appearance) {
+    return undefined;
+  }
+  return { displayName: appearance.displayName || undefined };
+};

--- a/console/src/config/importAppConfig.ts
+++ b/console/src/config/importAppConfig.ts
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 import { type SelfManagedAuthMode } from "./AppConfig";
+import { type ConsoleAppearance, parseConsoleAppearance } from "./appearance";
 
 const DEFAULT_APP_CONFIG = {
   auth: {
@@ -35,6 +36,7 @@ export function importAppConfig(): {
     mode: SelfManagedAuthMode;
   };
   balancerdDnsNames?: string[];
+  appearance?: ConsoleAppearance;
 } {
   if (process.env.NODE_ENV === "test") {
     return DEFAULT_APP_CONFIG;
@@ -45,9 +47,11 @@ export function importAppConfig(): {
       mode: SelfManagedAuthMode;
     };
     balancerd_dns_names?: string[];
+    appearance?: { displayName?: string };
   };
   return {
     auth: json.auth,
     balancerdDnsNames: json.balancerd_dns_names,
+    appearance: parseConsoleAppearance(json.appearance),
   };
 }

--- a/console/src/index.tsx
+++ b/console/src/index.tsx
@@ -22,9 +22,13 @@ import "~/sentry";
 import React from "react";
 import { createRoot } from "react-dom/client";
 
+import { appConfig } from "~/config/AppConfig";
+import { documentTitle } from "~/config/appearance";
 import { App } from "~/platform/App";
 
 import { addChunkLoadErrorListener } from "./utils/chunkLoadErrorHandler";
+
+document.title = documentTitle(appConfig.appearance);
 
 const rootEl = document.createElement("div");
 document.body.appendChild(rootEl);

--- a/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
+++ b/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
@@ -51,6 +51,14 @@
         "deprecated": false
       },
       {
+        "name": "consoleAppearance",
+        "type": "ConsoleAppearance",
+        "description": "Appearance overrides for this instance's console.\n\nThis field is excluded from the rollout hash and changes will not trigger a rollout.",
+        "default": null,
+        "required": false,
+        "deprecated": false
+      },
+      {
         "name": "consoleExternalCertificateSpec",
         "type": "MaterializeCertSpec",
         "description": "The configuration for generating an x509 certificate using cert-manager for the console\nto present to incoming connections.\nThe `dnsNames` and `issuerRef` fields are required.\nNot yet implemented.\n\nThis field is excluded from the rollout hash and changes will not trigger a rollout.",
@@ -325,6 +333,19 @@
         "name": "kind",
         "type": "String",
         "description": "Kind of the resource being referred to.",
+        "default": null,
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  ],
+  [
+    "ConsoleAppearance",
+    [
+      {
+        "name": "displayName",
+        "type": "String",
+        "description": "A short name for this instance, such as `dev` or `prod`. The console\nappends it to its browser tab title.",
         "default": null,
         "required": false,
         "deprecated": false

--- a/doc/user/data/self_managed/materialize_crd_descriptions_v1alpha1.json
+++ b/doc/user/data/self_managed/materialize_crd_descriptions_v1alpha1.json
@@ -51,6 +51,14 @@
         "deprecated": false
       },
       {
+        "name": "consoleAppearance",
+        "type": "ConsoleAppearance",
+        "description": "Appearance overrides for this instance's console.",
+        "default": null,
+        "required": false,
+        "deprecated": false
+      },
+      {
         "name": "consoleExternalCertificateSpec",
         "type": "MaterializeCertSpec",
         "description": "The configuration for generating an x509 certificate using cert-manager for the console\nto present to incoming connections.\nThe `dnsNames` and `issuerRef` fields are required.\nNot yet implemented.",
@@ -349,6 +357,19 @@
         "name": "kind",
         "type": "String",
         "description": "Kind of the resource being referred to.",
+        "default": null,
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  ],
+  [
+    "ConsoleAppearance",
+    [
+      {
+        "name": "displayName",
+        "type": "String",
+        "description": "A short name for this instance, such as `dev` or `prod`. The console\nappends it to its browser tab title.",
         "default": null,
         "required": false,
         "deprecated": false

--- a/src/cloud-resources/src/crd.rs
+++ b/src/cloud-resources/src/crd.rs
@@ -68,6 +68,20 @@ pub struct MaterializeCertSpec {
     pub private_key_size: Option<i64>,
 }
 
+/// Appearance overrides for an instance's console.
+///
+/// Consoles are otherwise identical, so an operator running several
+/// Materialize instances cannot tell from a browser tab which instance a
+/// console is pointed at.
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsoleAppearance {
+    /// A short name for this instance, such as `dev` or `prod`. The console
+    /// appends it to its browser tab title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
 pub trait ManagedResource: Resource<DynamicType = ()> + Sized {
     fn default_labels(&self) -> BTreeMap<String, String> {
         BTreeMap::new()

--- a/src/cloud-resources/src/crd/console.rs
+++ b/src/cloud-resources/src/crd/console.rs
@@ -16,7 +16,7 @@ use kube::{CustomResource, Resource, ResourceExt};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::crd::{ManagedResource, MaterializeCertSpec, new_resource_id};
+use crate::crd::{ConsoleAppearance, ManagedResource, MaterializeCertSpec, new_resource_id};
 use mz_server_core::listeners::AuthenticatorKind;
 
 pub mod v1alpha1 {
@@ -87,6 +87,10 @@ pub mod v1alpha1 {
         /// How to authenticate with Materialize.
         #[serde(default)]
         pub authenticator_kind: AuthenticatorKind,
+
+        /// Appearance overrides for this console.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub appearance: Option<ConsoleAppearance>,
 
         // This can be set to override the randomly chosen resource id
         pub resource_id: Option<String>,

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::crd::{ManagedResource, MaterializeCertSpec, new_resource_id};
+use crate::crd::{ConsoleAppearance, ManagedResource, MaterializeCertSpec, new_resource_id};
 use mz_server_core::listeners::AuthenticatorKind;
 
 pub const LAST_KNOWN_ACTIVE_GENERATION_ANNOTATION: &str =
@@ -174,6 +174,9 @@ pub mod v1alpha1 {
         pub balancerd_replicas: Option<i32>,
         /// Number of console pods to create.
         pub console_replicas: Option<i32>,
+        /// Appearance overrides for this instance's console.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub console_appearance: Option<ConsoleAppearance>,
 
         /// Name of the kubernetes service account to use.
         /// If not set, we will create one with the same name as this Materialize object.
@@ -862,6 +865,7 @@ pub mod v1alpha1 {
                     console_resource_requirements: value.spec.console_resource_requirements,
                     balancerd_replicas: value.spec.balancerd_replicas,
                     console_replicas: value.spec.console_replicas,
+                    console_appearance: value.spec.console_appearance,
                     service_account_name: value.spec.service_account_name,
                     service_account_annotations: value.spec.service_account_annotations,
                     service_account_labels: value.spec.service_account_labels,
@@ -982,6 +986,12 @@ pub mod v1alpha1 {
             skip_serializing_if = "Option::is_none"
         )]
         pub console_replicas: PartialField,
+        #[serde(
+            default,
+            with = "double_option",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub console_appearance: PartialField,
         #[serde(
             default,
             with = "double_option",
@@ -1182,6 +1192,7 @@ pub mod v1alpha1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -1216,6 +1227,7 @@ pub mod v1alpha1 {
                 console_resource_requirements: present_opt(console_resource_requirements),
                 balancerd_replicas: present_opt(balancerd_replicas),
                 console_replicas: present_opt(console_replicas),
+                console_appearance: present_opt(console_appearance),
                 service_account_name: present_opt(service_account_name),
                 service_account_annotations: present_opt(service_account_annotations),
                 service_account_labels: present_opt(service_account_labels),
@@ -1301,6 +1313,7 @@ pub mod v1alpha1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -1332,6 +1345,7 @@ pub mod v1alpha1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -1467,6 +1481,11 @@ pub mod v1 {
         ///
         /// This field is excluded from the rollout hash and changes will not trigger a rollout.
         pub console_replicas: Option<i32>,
+        /// Appearance overrides for this instance's console.
+        ///
+        /// This field is excluded from the rollout hash and changes will not trigger a rollout.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub console_appearance: Option<ConsoleAppearance>,
 
         /// Name of the kubernetes service account to use.
         /// If not set, we will create one with the same name as this Materialize object.
@@ -1603,6 +1622,7 @@ pub mod v1 {
                 console_resource_requirements: None,
                 balancerd_replicas: None,
                 console_replicas: None,
+                console_appearance: None,
                 service_account_name: self.spec.service_account_name.clone(),
                 service_account_annotations: self.spec.service_account_annotations.clone(),
                 service_account_labels: self.spec.service_account_labels.clone(),
@@ -2079,6 +2099,7 @@ pub mod v1 {
                     console_resource_requirements: value.spec.console_resource_requirements,
                     balancerd_replicas: value.spec.balancerd_replicas,
                     console_replicas: value.spec.console_replicas,
+                    console_appearance: value.spec.console_appearance,
                     service_account_name: value.spec.service_account_name,
                     service_account_annotations,
                     service_account_labels: value.spec.service_account_labels,
@@ -2222,6 +2243,12 @@ pub mod v1 {
             skip_serializing_if = "Option::is_none"
         )]
         pub console_replicas: PartialField,
+        #[serde(
+            default,
+            with = "double_option",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub console_appearance: PartialField,
         #[serde(
             default,
             with = "double_option",
@@ -2403,6 +2430,7 @@ pub mod v1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -2434,6 +2462,7 @@ pub mod v1 {
                 console_resource_requirements: present_opt(console_resource_requirements),
                 balancerd_replicas: present_opt(balancerd_replicas),
                 console_replicas: present_opt(console_replicas),
+                console_appearance: present_opt(console_appearance),
                 service_account_name: present_opt(service_account_name),
                 service_account_annotations: present_opt(service_account_annotations),
                 service_account_labels: present_opt(service_account_labels),
@@ -2516,6 +2545,7 @@ pub mod v1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -2558,6 +2588,7 @@ pub mod v1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -2793,6 +2824,7 @@ mod tests {
 
     use super::v1alpha1::{Materialize, MaterializeSpec, MaterializeStatus};
     use super::{DEFAULT_ROLLOUT_REQUEST_TIMEOUT, FORCE_ROLLOUT_ANNOTATION, RolloutRequestTimeout};
+    use crate::crd::ConsoleAppearance;
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // can't call foreign function `sha256_compress` on OS `linux`
@@ -3431,5 +3463,32 @@ mod tests {
             assert!(!field_value.is_null(), "unexpected null for {key}");
         }
         assert!(!value.as_object().unwrap().contains_key("status"));
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `sha256_compress` on OS `linux`
+    fn console_appearance_does_not_affect_the_rollout_hash() {
+        // Appearance reaches only the console deployment, so it must not roll
+        // environmentd.
+        let mut mz = super::v1::Materialize {
+            spec: super::v1::MaterializeSpec {
+                environmentd_image_ref: "materialize/environmentd:v26.0.0".to_owned(),
+                ..Default::default()
+            },
+            metadata: ObjectMeta::default(),
+            status: None,
+        };
+
+        // An unset appearance serializes away entirely, so instances that
+        // don't configure one hash the same as they did before the field
+        // existed and are not rolled by adopting a new operator.
+        let spec = serde_json::to_value(&mz.spec).unwrap();
+        assert!(!spec.as_object().unwrap().contains_key("consoleAppearance"));
+
+        let hash = mz.generate_rollout_hash();
+        mz.spec.console_appearance = Some(ConsoleAppearance {
+            display_name: Some("prod".to_owned()),
+        });
+        assert_eq!(mz.generate_rollout_hash(), hash);
     }
 }

--- a/src/orchestratord/src/controller/console.rs
+++ b/src/orchestratord/src/controller/console.rs
@@ -43,7 +43,7 @@ use crate::{
     tls::{DefaultCertificateSpecs, create_certificate, issuer_ref_defined},
 };
 use mz_cloud_resources::crd::{
-    ManagedResource,
+    ConsoleAppearance, ManagedResource,
     console::v1alpha1::{Console, HttpConnectionScheme},
     generated::cert_manager::certificates::{Certificate, CertificatePrivateKeyAlgorithm},
 };
@@ -77,6 +77,8 @@ struct AppConfig {
     auth: AppConfigAuth,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     balancerd_dns_names: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    appearance: Option<ConsoleAppearance>,
 }
 
 #[derive(Serialize)]
@@ -239,6 +241,7 @@ impl Context {
             auth: AppConfigAuth {
                 mode: console.spec.authenticator_kind,
             },
+            appearance: console.spec.appearance.clone(),
         })
         .expect("known valid");
         ConfigMap {

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -865,6 +865,7 @@ impl k8s_controller::Context for Context {
                     ),
                     resource_requirements: mz.spec.console_resource_requirements.clone(),
                     replicas: Some(mz.console_replicas()),
+                    appearance: mz.spec.console_appearance.clone(),
                     external_certificate_spec: mz.spec.console_external_certificate_spec.clone(),
                     pod_annotations: mz.spec.pod_annotations.clone(),
                     pod_labels: mz.spec.pod_labels.clone(),

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -1744,6 +1744,46 @@ class BalancerdExternalDnsNames(Modification):
         retry(check, 360)
 
 
+class ConsoleAppearance(Modification):
+    # The operator copies the Materialize CR's `consoleAppearance` into the
+    # console's `app-config.json`, which is how the console learns which
+    # instance it is pointed at.
+    APPEARANCE = {"displayName": "prod"}
+
+    @classmethod
+    def values(cls, version: MzVersion) -> list[Any]:
+        return [None, cls.APPEARANCE]
+
+    @classmethod
+    def default(cls) -> Any:
+        return None
+
+    def modify(self, definition: dict[str, Any]) -> None:
+        if self.value is not None:
+            definition["materialize"]["spec"]["consoleAppearance"] = self.value
+
+    def validate(self, mods: dict[type[Modification], Any]) -> None:
+        # `consoleAppearance` was added in v26.41; older orchestratord builds
+        # drop the field.
+        if MzVersion.parse_mz(mods[EnvironmentdImageRef]) < MzVersion.parse_mz(
+            "v26.41.0-dev.0"
+        ):
+            return
+        # Without a console there's no app config to inspect.
+        if not mods[ConsoleEnabled]:
+            return
+
+        def check() -> None:
+            app_config = get_console_app_config()
+            actual = app_config.get("appearance")
+            assert (
+                actual == self.value
+            ), f"Expected appearance {self.value}, but got {actual}: {app_config}"
+
+        # The console is reconciled last and the configmap update is async.
+        retry(check, 360)
+
+
 class RecommendedK8sLabels(Modification):
     @classmethod
     def values(cls, version: MzVersion) -> list[Any]:


### PR DESCRIPTION
## What

Adds an optional `spec.consoleAppearance` to the Materialize CRD so that each
self-managed instance's console can name itself:

```yaml
apiVersion: materialize.cloud/v1
kind: Materialize
spec:
  consoleAppearance:
    displayName: prod
```

The console appends the name to its browser tab title, e.g. `Materialize
Console · prod`. The field is optional, and has no effect in Materialize Cloud,
which serves a single console for all of an organization's regions.

Recoloring the console's accent was originally part of this change and has
moved to #38720 per review, so that it can be discussed on its own.

## Why

Every console looks identical, so an operator running more than one Materialize
instance cannot tell from a browser tab which instance a console is pointed at.
The only distinguishing signal today is the URL, which is easy to miss, so a
change intended for a dev instance is one tab away from landing on production.
The workarounds are per-instance browser profiles or a patched console image,
and neither survives an upgrade.

## How

The console already fetches an `app-config.json` that orchestratord renders
from the Console resource, so this reuses that channel instead of adding one:

`Materialize.spec.consoleAppearance` → `Console.spec.appearance` →
`app-config.json` → `appConfig.appearance` in the console.

The title is set from that config before the console authenticates, so the name
is on the login screen too.

`consoleAppearance` is a struct rather than a flat `consoleDisplayName` so that
further per-instance appearance settings can join it without another top-level
field.

`consoleAppearance` is excluded from the rollout hash and is skipped during
serialization when unset. Setting or changing it therefore reconciles only the
console's ConfigMap, which the console picks up on its next page load with no
pod restart, and adopting an operator version that knows the field does not
roll instances that leave it unset.

The CRD field reference under `doc/user/data/self_managed/` is regenerated with
the `crd-writer` step that `bin/bump-version` runs.

## Tests

* `console_appearance_does_not_affect_the_rollout_hash` in `mz-cloud-resources`
  covers both rollout-hash properties above.
* A `ConsoleAppearance` modification in `test/orchestratord/mzcompose.py`
  covers the passthrough from the Materialize CR to the console's
  `app-config.json`.
* Console unit tests cover the tab title and the app-config parsing.

## The subjective part: where this configuration belongs

The field sits on the Materialize CR and is exempt from the rollout hash. That
is the choice in this change I would most like a second opinion on, so here is
the reasoning and what it costs.

**Why the CR.** It is where every other per-instance console setting already
lives (`consoleReplicas`, `consoleResourceRequirements`,
`consoleExternalCertificateSpec`), so it is where an operator already looks.
It is declarative and versioned alongside the rest of the instance, and it
reaches the browser through the `app-config.json` the operator already writes,
so no new delivery mechanism has to be built or watched.

**What that costs.** A field on a versioned CRD is close to permanent: it has
to be carried through both CRD versions and the conversion webhook, which is
the bulk of the Rust in this diff, and withdrawing it later is a breaking API
change. It also puts presentation into an API whose every other field describes
infrastructure, which invites the follow-on requests (a logo, a favicon,
arbitrary CSS) that this deliberately does not open the door to.

The rollout-hash exemption is a smaller but real burden. Exclusion is enforced
by a hand-maintained struct literal in `generate_rollout_hash` plus a
`skip_serializing_if`, neither of which is visible from the field's type, and
getting it wrong means a cosmetic edit rolls production. Exempting it is not
optional though: a retitle that costs an environmentd rollout is a feature
nobody would use. The precedent is already set by `consoleReplicas` and both
services' resource requirements, so this follows an existing pattern rather
than inventing an exemption. If the pattern deserves a stronger mechanism than
prose plus a struct literal, that is worth its own change.

**Alternatives, and why I did not take them.**

* *The system parameter ConfigMap* (`systemParameterConfigmapName`). Wrong
  consumer, and too late in the boot sequence. Those are database settings that
  environmentd applies and `SHOW ALL` reports, and nothing in environmentd
  needs to know what the console calls itself. More decisively, the console
  fetches `app-config.json` before it authenticates, so the name is on the
  login screen. Anything sourced over SQL cannot be, because it would need a
  session first.
* *A ConfigMap of its own, watched by the operator.* This is the credible
  alternative if we would rather keep the CRD strictly about infrastructure.
  It keeps cosmetics out of a permanent API and cannot touch a
  rollout-relevant field by construction. It costs a second object to create
  and own, RBAC and orphan handling, no schema validation, and drift from the
  manifest that describes the rest of the instance. It is more machinery than
  a CRD field, not less.
* *A setting in the console UI, kept in the browser.* This is what the existing
  light and dark switcher does. It is per browser, so it protects whoever sets
  it and nobody else, which is the exact failure this feature exists to
  prevent. Worth having as a complement, wrong as the primary.
* *A setting in the console UI, persisted server side.* The console is static
  files behind nginx with no server of its own, so persistence would mean the
  catalog, which lands back on the first bullet and adds a write path and
  privileges to design.
* *An env var on the console Deployment, or an image per environment.* Both are
  the workarounds this replaces. The operator owns the Deployment and
  overwrites the env var, and a patched image has to be rebuilt on every
  upgrade.
* *Helm values on the operator.* Wrong scope: one operator manages many
  instances, and this is per instance.

## Notes for reviewers

* `displayName` could default to `metadata.name` rather than being configured
  at all, which would give every instance a useful tab title with no
  configuration. I kept it explicit because that name is often neither short
  nor human: the install docs name the CR
  `12345678-1234-1234-1234-123456789012`. But if we would rather have the
  zero-config version, this feature needs no new field at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
