### PR TITLE
compute: drop the unused bytesize dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7035,7 +7035,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-stream",
- "bytesize",
  "chrono",
  "columnar",
  "columnation",

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 async-stream.workspace = true
-bytesize.workspace = true
 chrono.workspace = true
 columnar.workspace = true
 columnation.workspace = true


### PR DESCRIPTION
### Motivation

The Nightly [Unused dependencies](https://buildkite.com/materialize/nightly/builds/18262#01a0790e-ec6b-48d6-850a-edf8666b4d41) job has been red on `main` since #38510 removed the last use of `bytesize` in `mz-compute`.

### Description

Drops `bytesize` from the `mz-compute` crate and syncs `Cargo.lock`. The workspace-level entry stays because ten other crates still use it.

### Verification

`cargo check -p mz-compute` and `bin/lint-cargo` pass locally. The Nightly `unused-deps` job is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
