### PR TITLE
ci: retry spurious 404s from the GitHub contents API in the orchestratord test

### DIFF
--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -498,7 +498,9 @@ def download_repo_file_at_tag(path: str, tag: str) -> bytes:
     requests/hour), which is what CI relies on. Falls back to anonymous
     raw.githubusercontent.com otherwise. Anonymous raw content throttles
     shared CI IPs with 429, so retry with backoff on rate-limit and 5xx
-    statuses, honoring Retry-After when present.
+    statuses, honoring Retry-After when present. The Contents API also
+    occasionally answers 404 for a path that exists at the tag, so 404 is
+    retried too; a genuine 404 surfaces after the full backoff.
     """
     token = os.getenv("GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN") or os.getenv(
         "GITHUB_TOKEN"
@@ -519,7 +521,7 @@ def download_repo_file_at_tag(path: str, tag: str) -> bytes:
         response = requests.get(url, headers=headers, timeout=30)
         if response.status_code == 200:
             return response.content
-        if response.status_code not in (429, 500, 502, 503, 504):
+        if response.status_code not in (404, 429, 500, 502, 503, 504):
             break
         wait = float(response.headers.get("Retry-After", delay))
         print(f"Got {response.status_code} for {url}, retrying in {wait}s")


### PR DESCRIPTION
### Motivation

`Orchestratord + documentation defaults 2` failed on the v26.41.0-rc.3 Nightly ([18238](https://buildkite.com/materialize/nightly/builds/18238#01a06e32-07ab-4c72-811d-39f8913ae2f0)) with

```
Failed to download misc/helm-charts/testing/postgres.yaml at v26.22.0 from https://api.github.com/repos/MaterializeInc/materialize/contents/misc/helm-charts/testing/postgres.yaml?ref=v26.22.0: 404
```

The file exists at that tag. Another build started one minute earlier ([18237](https://buildkite.com/materialize/nightly/builds/18237)) got a 404 for a different existing file at a different tag, so this is the contents API misbehaving briefly, not a bad tag or path. The same rc.3 job had already ridden out a 504 from the endpoint through the existing retry, which only covered 429 and 5xx.

### Description

Adds 404 to the retried statuses in `download_repo_file_at_tag` and says why in the docstring. The loop's eight attempts with backoff capped at 60 seconds are unchanged, so a genuine 404 (a tag that lacks the file) still fails with the same message, after about three minutes.

### Verification

No new tests; the change is to the retry set of a CI helper. The `orchestratord-defaults` Nightly steps exercise it. Nightly run: https://buildkite.com/materialize/nightly/builds/18264

🤖 Generated with [Claude Code](https://claude.com/claude-code)
