### PR TITLE
ci: keep the cargo-fuzz workspace's crate patches in sync with the root

### DIFF
--- a/misc/python/materialize/cli/lint-cargo.py
+++ b/misc/python/materialize/cli/lint-cargo.py
@@ -146,6 +146,51 @@ def check_fuzz_versions_mirror_root(workspace: Workspace) -> bool:
     return success
 
 
+def check_fuzz_patches_mirror_root(workspace: Workspace) -> bool:
+    """Checks that the `[patch.crates-io]` entries of the cargo-fuzz workspace
+    (test/cargo-fuzz) match the root workspace's.
+
+    A patch that does not apply is not an error to cargo: it lands in
+    `[[patch.unused]]` and the crate resolves from crates.io instead, with only
+    a warning. So a fork revision that drifts from the root here silently builds
+    the fuzz targets against a different crate than production, and fails
+    whenever the fork carries API the published crate lacks.
+
+    The fuzz workspace may omit a root entry that nothing in its graph depends
+    on, since cargo warns about patches it cannot apply, but it may not carry an
+    entry the root does not have, and every entry it shares with the root must
+    be identical."""
+
+    with open(MZ_ROOT / "Cargo.toml") as f:
+        root_patches = toml.load(f).get("patch", {}).get("crates-io", {})
+    with open(MZ_ROOT / "test" / "cargo-fuzz" / "Cargo.toml") as f:
+        fuzz_patches = toml.load(f).get("patch", {}).get("crates-io", {})
+
+    success = True
+    for name, spec in sorted(fuzz_patches.items()):
+        if name not in root_patches:
+            print(
+                f"test/cargo-fuzz/Cargo.toml: {name} is patched here but not in "
+                f"the root Cargo.toml",
+                file=sys.stderr,
+            )
+            success = False
+        elif spec != root_patches[name]:
+            print(
+                f"test/cargo-fuzz/Cargo.toml: {name} = {spec} must match the "
+                f"root Cargo.toml's {name} = {root_patches[name]}",
+                file=sys.stderr,
+            )
+            success = False
+    if not success:
+        print(
+            "\nhint: copy the entry from the root `[patch.crates-io]` verbatim, "
+            "or drop it here if the root no longer patches that crate.",
+            file=sys.stderr,
+        )
+    return success
+
+
 def main() -> None:
     workspace = Workspace(MZ_ROOT)
     lints = [
@@ -153,6 +198,7 @@ def main() -> None:
         check_default_members,
         check_workspace_dependencies,
         check_fuzz_versions_mirror_root,
+        check_fuzz_patches_mirror_root,
     ]
     # Run every lint, then combine. `success and lint(...)` would short-circuit
     # and skip the remaining lints after the first failure, under-reporting.

--- a/test/cargo-fuzz/Cargo.toml
+++ b/test/cargo-fuzz/Cargo.toml
@@ -14,8 +14,9 @@
 # the fuzz crates' dependency graph actually uses (root entries with no consumer
 # here, currently `duckdb` and `postgres_array`, are omitted to avoid cargo's
 # "patch was not used in the crate graph" warnings). Every entry that IS present
-# must match the root's rev/version verbatim. If a fuzz crate gains a dependency
-# that needs another patched crate, copy that entry from the root.
+# must match the root's rev/version verbatim, which `bin/lint-cargo` enforces.
+# If a fuzz crate gains a dependency that needs another patched crate, copy that
+# entry from the root.
 
 [workspace]
 resolver = "2"
@@ -51,9 +52,6 @@ postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 # Waiting on https://github.com/MaterializeInc/serde-value/pull/35.
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 
-# Waiting for resolution of https://github.com/launchdarkly/rust-server-sdk/issues/116
-launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk", rev = "3e0a0b98b09a2970f292577a07e1c9382b65b5da" }
-
 # Waiting on https://github.com/edenhill/librdkafka/pull/4051.
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }
@@ -69,7 +67,7 @@ tiberius = { git = "https://github.com/MaterializeInc/tiberius", rev="64ca594cc2
 async-compression = { git = "https://github.com/MaterializeInc/async-compression.git", rev = "fe7411eb6104a02a89e2c3a76ab326dd6594214d" }
 
 # Custom iceberg features for mz
-# All changes should go to the `mz_v0.9.0` branch.
-iceberg = { git = "https://github.com/MaterializeInc/iceberg-rust.git", rev = "dedd9231ee88ee979b648e14792878b40e74c20a" }
-iceberg-catalog-rest = { git = "https://github.com/MaterializeInc/iceberg-rust.git", rev = "dedd9231ee88ee979b648e14792878b40e74c20a" }
-iceberg-storage-opendal = { git = "https://github.com/MaterializeInc/iceberg-rust.git", rev = "dedd9231ee88ee979b648e14792878b40e74c20a" }
+# All changes should go to the `mz_v0.10.x` branch.
+iceberg = { git = "https://github.com/MaterializeInc/iceberg-rust.git", rev = "958ac5b3c318026aeb362485c593e4956aeabe95" }
+iceberg-catalog-rest = { git = "https://github.com/MaterializeInc/iceberg-rust.git", rev = "958ac5b3c318026aeb362485c593e4956aeabe95" }
+iceberg-storage-opendal = { git = "https://github.com/MaterializeInc/iceberg-rust.git", rev = "958ac5b3c318026aeb362485c593e4956aeabe95" }


### PR DESCRIPTION
### Motivation

The `:rust: cargo-fuzz` job has failed on every Nightly and release-qualification run since 2026-08-28 with `build FAILED for src/transform/fuzz`: `mz-storage-types` fails to compile with unresolved imports of `TokenProvider`, `OAuth2TokenProvider`, `RequestAuthenticator` and `BearerTokenAuthenticator` from `iceberg_catalog_rest`. Fuzzing has been dark for two releases.

The fuzz crates build in their own workspace, `test/cargo-fuzz`, which carries a copy of the root's `[patch.crates-io]` table. Its three iceberg-rust entries were still pinned to the fork revision for 0.9.0 after #38471 moved the root to the 0.10.1 revision. A patch that no longer satisfies the version requirement is not an error to Cargo: it lands in `[[patch.unused]]` with a warning and the crate resolves from crates.io, which lacks the fork API that #38475 started using two seconds later. The `launchdarkly-server-sdk` patch in the same table had drifted the same way after the root dropped it in #37026.

### Description

- `test/cargo-fuzz/Cargo.toml`: repin the three iceberg entries to the root's revision and drop the stale LaunchDarkly patch.
- `bin/lint-cargo` (run by CI's lint step): a new check that fails when the fuzz workspace's patch table carries an entry the root does not have, or one that differs from the root's. It fails on the pre-fix manifest naming all four drifted entries, and passes after. The fuzz workspace may still omit root entries nothing in its graph needs; Cargo warns about those.

Alternatives considered: per-crate fuzz workspaces (more duplication), symlinking or generating the manifest (Cargo has no include mechanism; a generated file for a table that changes a few times a year is not worth the tooling), repinning without the lint (guarantees the same outage on the next root patch bump).

### Verification

`cargo check` passes for `src/transform/fuzz` and for the whole `test/cargo-fuzz` workspace (17 crates), resolving iceberg from the fork; `cargo metadata` shows zero `[[patch.unused]]` entries. `bin/lint-cargo` exits 1 on the old manifest and 0 on the new one; black, ruff and pyright are clean. Not run locally: the release build with sanitizer-coverage flags and `cargo fuzz build` itself. The errors were unresolved imports, which `cargo check` exercises fully; the Nightly `cargo-fuzz` step is the end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
