### PR TITLE
ci: recognize glibc heap-corruption aborts in ci-annotate-errors

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -83,6 +83,12 @@ ERROR_RE = re.compile(
     | cannot\ migrate\ from\ catalog
     | halting\ process: # Rust unwrap
     | fatal\ runtime\ error: # stack overflow
+    # glibc heap-consistency aborts: the process dies with SIGABRT and no
+    # Rust panic, so these lines are the only trace
+    | (malloc|free|realloc|munmap_chunk)\(\):
+    | double\ free\ or\ corruption
+    | corrupted\ (size\ vs\.\ prev_size|double-linked\ list)
+    | stack\ smashing\ detected
     | \[SQLsmith\] # Unknown errors are logged
     | \[SQLancer\] # Unknown errors are logged
     | \[SQLancer\+\+\] # Unknown errors are logged

--- a/misc/python/materialize/cli/ci_annotate_errors_test.py
+++ b/misc/python/materialize/cli/ci_annotate_errors_test.py
@@ -48,3 +48,20 @@ def test_log_start_marker_absent(tmp_path: Path) -> None:
             b"environmentd: fatal: setup failure", str(log_file)
         )
     ]
+
+
+def test_glibc_heap_abort_is_an_error(tmp_path: Path) -> None:
+    log_file = tmp_path / "run.log"
+    log_file.write_text(
+        "--- list.td\n"
+        "malloc(): unsorted double linked list corrupted\n"
+        "--- load-generator.td\n"
+    )
+
+    errors = ci_annotate_errors.get_errors([str(log_file)])
+
+    assert errors == [
+        ci_annotate_errors.ErrorLog(
+            b"malloc(): unsorted double linked list corrupted", str(log_file)
+        )
+    ]


### PR DESCRIPTION
### Motivation

Nightly 18265's `testdrive with FoundationDB 1` died with `malloc(): unsorted double linked list corrupted` on testdrive's stderr ([PER-82](https://linear.app/materializeinc/issue/PER-82)). `ERROR_RE` in `ci_annotate_errors.py` has no alternative for glibc's heap-consistency messages, so the job was annotated as "failed, but no error in logs found", no `ci-regexp` could attach to it, and the failure history has no record of the signature. Part of [QAR-158](https://linear.app/materializeinc/issue/QAR-158).

### Description

Add the glibc heap-abort messages to `ERROR_RE`: `malloc()/free()/realloc()/munmap_chunk():`, `double free or corruption`, `corrupted size vs. prev_size`, `corrupted double-linked list`, and `stack smashing detected`. Adds `test_glibc_heap_abort_is_an_error` to `ci_annotate_errors_test.py`; it fails without the pattern change.

### Verification

The new test and the existing annotator tests pass; black and ruff are clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
