### PR TITLE
deny: ignore RUSTSEC-2026-0275 (azure_core logs the authorization header)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -330,6 +330,11 @@ ignore = [
     # patched release, so this cannot be resolved by a version bump. That
     # client only talks to AWS endpoints, and the advisory is low severity.
     "RUSTSEC-2026-0258",
+    # `azure_core` 0.21 and earlier write the outgoing `authorization` header to
+    # the log at debug and trace level. It reaches us through `azure_identity`
+    # in `mz-persist`; the fix is moving to the new Azure SDK, tracked in
+    # SEC-619. The security team accepted ignoring the advisory until then.
+    "RUSTSEC-2026-0275",
 ]
 
 # Must be manually kept in sync with about.toml.


### PR DESCRIPTION
### Motivation

RUSTSEC-2026-0275 (`azure_core` 0.21 and earlier write the outgoing `authorization` header to the log at debug and trace level) has failed the nightly `Security advisories` step on every build since the advisory was published, including all v26.40.x and v26.41.0 RC nightlies. The crate reaches us through `azure_identity` in `mz-persist`, and the fix is the move to the new Azure SDK tracked in [SEC-619](https://linear.app/materializeinc/issue/SEC-619). The security team accepted ignoring the advisory until then.

### Description

Add the advisory to the `[advisories].ignore` list in `deny.toml`, with the reason and the tracking issue.

### Verification

`bin/ci-builder run stable cargo deny check advisories`, the nightly step's command, reports `advisories ok` with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
