### PR TITLE
testdrive: skip the catalog dump when the catalog store is not validated

### DIFF
--- a/src/testdrive/src/action/consistency.rs
+++ b/src/testdrive/src/action/consistency.rs
@@ -196,6 +196,15 @@ async fn check_catalog_state(state: &State) -> Result<(), anyhow::Error> {
         storage_metadata: Option<StorageMetadata>,
     }
 
+    // The comparison below needs the on-disk catalog, which `with_catalog_copy`
+    // can only open when a catalog config was supplied
+    // (`--validate-catalog-store`). Without one it returns `None` and the
+    // check is skipped, so do not fetch and parse the dump (100+ MB) for
+    // nothing.
+    if state.materialize.catalog_config.is_none() {
+        return Ok(());
+    }
+
     // Dump the in-memory catalog state of the Materialize environment that we're
     // connected to.
     let memory_catalog = reqwest::get(&format!(


### PR DESCRIPTION
### Motivation

`check_catalog_state` runs after every testdrive file at the default consistency-check level. It fetched `/api/catalog/dump` from environmentd's internal HTTP listener and parsed the whole document, and only then called `with_catalog_copy`, which returns `None` and skips the comparison whenever no catalog config was supplied, which is every composition that does not pass `--validate-catalog-store` (about 170 of 175 call sites). The dump is 109 MB at v26.41.0-rc.4, so that was about 700 ms of waste per file, plus a transient allocation of a few hundred MB in environmentd, and it is what the parallel benchmark's `testdrive` row had been reporting as a regression ([QAR-159](https://linear.app/materializeinc/issue/QAR-159), [SQL-689](https://linear.app/materializeinc/issue/SQL-689)). Closes: [QAR-160](https://linear.app/materializeinc/issue/QAR-160)

### Description

Return early from `check_catalog_state` when the catalog config is absent, before the HTTP fetch. The fetched fields were only used to feed `with_catalog_copy` and the on-disk comparison, so nothing else depends on them. Compositions that pass `--validate-catalog-store` keep the full check.

### Verification

`cargo check -p mz-testdrive` and `cargo clippy -p mz-testdrive --all-targets -- -D warnings` are clean. The testdrive nightly with `--validate-catalog-store` still exercises the comparison path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
