### PR TITLE
catalog: elide generated views inserted by other generators from mz_builtin_views

### DIFF
--- a/src/catalog/src/builtin/builtin.rs
+++ b/src/catalog/src/builtin/builtin.rs
@@ -58,17 +58,23 @@ pub(super) fn builtins(
         Box::leak(Box::new(make_builtin_materialized_views(mv_iter)));
     let tables: &'static BuiltinView = Box::leak(Box::new(make_builtin_tables(table_iter)));
 
-    // The generated views above, and `mz_builtin_views` itself, are listed in
-    // `mz_builtin_views` with placeholder SQL rather than their real
-    // definitions. See `make_builtin_views`.
+    // Generated views are listed in `mz_builtin_views` with placeholder SQL
+    // rather than their real definitions, which are `VALUES` lists of every
+    // builtin and would otherwise be embedded here a second time. That covers
+    // the three views above, `mz_builtin_views` itself, and the generated
+    // views that other parts of this crate insert into `builtin_items` before
+    // this runs, found by name. See `make_builtin_views`.
+    let mut generated: Vec<&'static BuiltinView> = vec![sources, materialized_views, tables];
+    generated.extend(builtin_items.iter().filter_map(|b| match b {
+        Builtin::View(x) if GENERATED_BUILTIN_VIEWS.contains(&x.name) => Some(*x),
+        _ => None,
+    }));
     let view_iter = builtin_items.iter().filter_map(|b| match b {
         Builtin::View(x) => Some(*x),
         _ => None,
     });
-    let views: &'static BuiltinView = Box::leak(Box::new(make_builtin_views(
-        view_iter,
-        [sources, materialized_views, tables],
-    )));
+    let views: &'static BuiltinView =
+        Box::leak(Box::new(make_builtin_views(view_iter, &generated)));
 
     [sources, materialized_views, tables, views]
         .into_iter()
@@ -250,9 +256,14 @@ FROM (VALUES {values}) AS v(oid, schema_name, name, privileges)"
 /// view. The placeholder also embeds the view's qualified name so that the
 /// `definition` and `create_sql` columns stay unique across rows, which the
 /// declared keys rely on.
+/// Names of generated `VALUES` views built elsewhere in this crate (see
+/// `make_mz_object_dependencies_raw`). Add a new generated view here so that
+/// `mz_builtin_views` elides its definition instead of embedding it.
+const GENERATED_BUILTIN_VIEWS: &[&str] = &["mz_object_dependencies_raw"];
+
 fn make_builtin_views<'a>(
     iter: impl Iterator<Item = &'a BuiltinView>,
-    generated: [&BuiltinView; 3],
+    generated: &[&BuiltinView],
 ) -> BuiltinView {
     let owner_priv = rbac::owner_privilege(ObjectType::View, MZ_SYSTEM_ROLE_ID);
 
@@ -308,7 +319,16 @@ fn make_builtin_views<'a>(
         ontology: None,
     };
 
-    let full_values = iter.map(|v| make_row(v.oid, v.schema, v.name, &v.access, &v.create_sql()));
+    // A generated view that other generators inserted into `builtin_items`
+    // is also yielded by `iter`; it must appear exactly once, as a placeholder.
+    let is_generated = |v: &BuiltinView| {
+        generated
+            .iter()
+            .any(|g| g.schema == v.schema && g.name == v.name)
+    };
+    let full_values = iter
+        .filter(|v| !is_generated(v))
+        .map(|v| make_row(v.oid, v.schema, v.name, &v.access, &v.create_sql()));
     let placeholder_values = generated.iter().copied().chain([&view]).map(|v| {
         let create_sql = format!(
             "CREATE VIEW {}.{} AS SELECT '<generated builtin view {}.{}: definition elided>'",

--- a/test/sqllogictest/mz_views.slt
+++ b/test/sqllogictest/mz_views.slt
@@ -193,6 +193,7 @@ mz_builtin_materialized_views
 mz_builtin_sources
 mz_builtin_tables
 mz_builtin_views
+mz_object_dependencies_raw
 
 query T multiline
 SELECT definition FROM mz_views WHERE name = 'mz_builtin_views'


### PR DESCRIPTION
### Motivation

`mz_builtin_views` embeds every builtin view's `definition` and `create_sql` as literals, and replaces the text of the generated `VALUES` views with a placeholder, since their SQL is a mechanically produced list of every builtin and would otherwise be embedded a second time. The elision list was hardcoded to the three views generated next to it, so `mz_object_dependencies_raw` (#38252), a generated view inserted by another generator before this one runs, was embedded verbatim: 1.9 MB of the compact catalog dump, larger than the view itself, and about half of the dump growth between v26.40.1 and v26.41.0-rc.4. Part of [SQL-689](https://linear.app/materializeinc/issue/SQL-689).

### Description

`make_builtin_views` takes a slice instead of a fixed-size array, and `builtins()` extends the elision list with every view in `builtin_items` whose name is in a new `GENERATED_BUILTIN_VIEWS` constant, currently `mz_object_dependencies_raw`. Unlike the three views generated next to it, such a view is also yielded by the iterator over `builtin_items`, so `make_builtin_views` now skips generated views when emitting the full-definition rows; each view appears exactly once. The elided view keeps its row in `mz_builtin_views`; only its `definition` and `create_sql` become the placeholder, as for the existing generated views. `test/sqllogictest/mz_views.slt` lists the elided views and now includes it.

### Verification

`bin/sqllogictest --optimized` on `mz_views.slt`, `mz_object_dependencies.slt`, `oid.slt`, `catalog_server_explain.slt`, `information_schema_tables.slt` and `mz_catalog_server_index_accounting.slt` passes (433 of 433 statements; the dependency counts, the 194-row constant plan and the oid list are the checks that would catch a duplicated or missing row). `cargo clippy -p mz-catalog --all-targets -- -D warnings` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

