### PR TITLE
v26.40.2 release notes

### DIFF
--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -19,6 +19,13 @@ Starting with the v26.1.0 release, Materialize releases on a weekly schedule for
 both Cloud and Self-Managed. See [Release schedule](/releases/schedule) for details.
 {{</ note >}}
 
+## v26.40.2
+*Released to Materialize Cloud: 2026-09-07* <br>
+*Released to Materialize Self-Managed: 2026-09-08* <br>
+
+### Bug Fixes {#v26.40.2-bug-fixes}
+- Fixed `ALTER MATERIALIZED VIEW ... APPLY REPLACEMENT` run while a zero-downtime upgrade was in progress leaving the upgraded environment on the view's previous definition, which either put `environmentd` into a crash loop that restarting could not clear or left the view silently computing and serving the replaced definition.
+
 ## v26.40.0
 *Released to Materialize Cloud: 2026-09-02* <br>
 *Released to Materialize Self-Managed: 2026-09-03* <br>

--- a/doc/user/data/self_managed/self_managed_operator_compatibility.yml
+++ b/doc/user/data/self_managed/self_managed_operator_compatibility.yml
@@ -5,6 +5,11 @@ columns:
   - column: Release date
   - column: Notes
 rows:
+  - Materialize Operator: v26.40.2
+    orchestratord version: v26.40.2
+    environmentd version: v26.40.2
+    Release date: "2026-09-08"
+    Notes: "See [v26.40.2 release notes](/releases/#v26402)"
   - Materialize Operator: v26.40
     orchestratord version: v26.40
     environmentd version: v26.40


### PR DESCRIPTION
Release notes for `v26.40.2`, a patch release. One commit is added per snapshot; this train has no RC snapshots, so the single `final` commit carries the whole note with the real release dates.

Snapshot drafts (with PR links) in mz-skills:
- final: [release_notes.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.40.2/final/release_notes.md) / [omitted.md](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.40.2/final/omitted.md)

**Borderline PRs omitted:** final: 1 — [omitted.md#borderline](https://github.com/MaterializeInc/mz-skills/blob/main/data/mz-release-notes/v26.40.2/final/omitted.md#borderline)

### Two things for the reviewer

- **Release dates are inferred, not supplied.** Cloud 2026-09-07 / Self-Managed 2026-09-08, derived from the `v26.40.2` tag's commit date (2026-09-07T19:27:35Z) plus one day. The tag was cut Monday evening UTC, so a next-day Cloud rollout is at least as likely as a same-day one. Please confirm both dates before merging.
- **This section is the same increment as `v26.41.0-rc.4`.** Both trains took the same two `release-blocker` cherry-picks on 2026-09-07, so `#38677` is drafted as a Bug Fix in both #38667 and here. `v26.40.2` ships it to Cloud first, so if both merge as drafted the same fix is announced in consecutive releases. `v26.40.1` (#38675) raised the same question and answered it the other way. Worth settling once for both patches.

Merge ordering: `## v26.40.2` must sit above `## v26.40.1` (#38675), which must sit above `## v26.40.0`. #38675, #38667, and #38365 (v26.38.1) are all still open, so whichever merges last will need its section placed by hand relative to the others.
