### PR TITLE
canary-load: keep going on any exception, fail at the end if any collected

### DIFF
--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -278,6 +278,20 @@ def fetch_token(user_name: str, password: str) -> str:
     )
 
 
+def http_status_failure(
+    status_code: int, text: str, query: str
+) -> FailedTestExecutionError:
+    return FailedTestExecutionError(
+        error_summary="HTTP SQL query failed",
+        errors=[
+            TestFailureDetails(
+                message=f"HTTP {status_code} from /api/sql: {text.strip()}",
+                details=f"Occurred at {datetime.datetime.now()}. Query: {query}",
+            )
+        ],
+    )
+
+
 def http_sql_query(
     host: str,
     query: str,
@@ -306,7 +320,15 @@ def http_sql_query(
         print("Got 401, refreshing token and retrying")
         new_token = refresh_token()
         return http_sql_query(host, query, new_token, retries, refresh_token=None)
-    assert r.status_code == 200, f"{r}\n{r.text}"
+    if r.status_code >= 500 and retries > 0:
+        # The balancer answers 502 "upstream server not available" while
+        # environmentd restarts, e.g. during a version cutover. Give it a
+        # moment; a persistent 5xx is a collected failure, not an abort.
+        print(f"Got {r.status_code}, retrying in 5s: {r.text.strip()}")
+        time.sleep(5)
+        return http_sql_query(host, query, token, retries - 1, refresh_token)
+    if r.status_code != 200:
+        raise http_status_failure(r.status_code, r.text, query)
     results = r.json()["results"]
     assert len(results) == 1, results
 

--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -56,6 +56,10 @@ CONNECTION_ERROR_STRINGS = [
     "consuming input failed: SSL SYSCALL error: EOF detected",
     "unexpected eof while reading",
     "consuming input failed: SSL connection has been closed unexpectedly",
+    # The agent's resolver, not the environment: seen as
+    # `NameResolutionError(... [Errno -3] Temporary failure in name resolution)`
+    # wrapped in a requests.ConnectionError.
+    "Temporary failure in name resolution",
 ]
 
 

--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -13,6 +13,7 @@ import json
 import os
 import threading
 import time
+import traceback
 import urllib.parse
 from collections.abc import Callable
 from textwrap import dedent
@@ -20,8 +21,6 @@ from textwrap import dedent
 import psycopg
 import requests
 from psycopg import Connection, Cursor
-from psycopg.errors import IdleInTransactionSessionTimeout, OperationalError
-from requests.exceptions import ConnectionError, ReadTimeout
 
 from materialize.cloudtest.util.jwt_key import fetch_jwt
 from materialize.mz_env_util import (
@@ -65,6 +64,21 @@ CONNECTION_ERROR_STRINGS = [
 
 def is_connection_error(msg: str) -> bool:
     return any(s in msg for s in CONNECTION_ERROR_STRINGS)
+
+
+def failure_messages(e: Exception) -> list[tuple[str, str | None]]:
+    """Every (message, details) pair an exception escaping a chunk stands for.
+
+    A FailedTestExecutionError carries one per testdrive error; anything else
+    is one entry, with the traceback as details for exception types the test
+    did not anticipate.
+    """
+    if isinstance(e, FailedTestExecutionError):
+        assert len(e.errors) > 0, "Exception contains no errors"
+        return [(error.message, error.details) for error in e.errors]
+    if isinstance(e, CommandFailureCausedUIError):
+        return [((e.stdout or "") + (e.stderr or ""), None)]
+    return [(f"{type(e).__name__}: {e}", traceback.format_exc())]
 
 
 class WebhookSender:
@@ -197,58 +211,32 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     )
                     close_connection_and_cursor(conn2, cursor_on_mv, "subscribe_mv")
 
-                except (
-                    OperationalError,
-                    ReadTimeout,
-                    ConnectionError,
-                    IdleInTransactionSessionTimeout,
-                ) as e:
-                    error_msg_str = str(e)
-                    if is_connection_error(error_msg_str):
+                except Exception as e:
+                    # Whatever escaped the chunk, the run keeps going: a
+                    # connection error restarts the chunk and stays out of the
+                    # verdict, anything else is collected and rethrown at the
+                    # end. Nothing aborts the run any more; an abort used to
+                    # skip the rethrow below and lose every failure collected
+                    # before it.
+                    for message, details in failure_messages(e):
+                        # TODO(def-): Remove when database-issues#6825 is fixed
+                        if "Non-positive multiplicity in DistinctBy" in message:
+                            continue
                         now = datetime.datetime.now(
                             tz=datetime.timezone.utc
                         ).isoformat()
-                        connection_failures.append((now, error_msg_str))
-                        print(f"Connection failure at {now}: {e}; retrying")
-                    else:
-                        raise
-                except FailedTestExecutionError as e:
-                    assert len(e.errors) > 0, "Exception contains no errors"
-                    for error in e.errors:
-                        # TODO(def-): Remove when database-issues#6825 is fixed
-                        if "Non-positive multiplicity in DistinctBy" in error.message:
-                            continue
-                        if is_connection_error(error.message):
-                            now = datetime.datetime.now(
-                                tz=datetime.timezone.utc
-                            ).isoformat()
-                            connection_failures.append((now, error.message))
+                        if is_connection_error(message):
+                            connection_failures.append((now, message))
                             print(
-                                f"Connection failure at {now}: {error.message}; continuing."
+                                f"Connection failure at {now}: {message}; restarting chunk."
                             )
                             continue
                         print(
-                            f"Test failure occurred ({error.message}), collecting it, and continuing."
+                            f"Test failure occurred ({message}), collecting it, and continuing."
                         )
-                        # collect, continue, and rethrow at the end
-                        failures.append(error)
-                except CommandFailureCausedUIError as e:
-                    msg = (e.stdout or "") + (e.stderr or "")
-                    # TODO(def-): Remove when database-issues#6825 is fixed
-                    if "Non-positive multiplicity in DistinctBy" in msg:
-                        continue
-                    if is_connection_error(msg):
-                        now = datetime.datetime.now(
-                            tz=datetime.timezone.utc
-                        ).isoformat()
-                        connection_failures.append((now, msg))
-                        print(f"Connection failure at {now}: {msg}; continuing.")
-                        continue
-                    print(
-                        f"Test failure occurred ({msg}), collecting it, and continuing."
-                    )
-                    # collect, continue, and rethrow at the end
-                    failures.append(TestFailureDetails(message=msg, details=None))
+                        failures.append(
+                            TestFailureDetails(message=message, details=details)
+                        )
         finally:
             webhook_sender.stop()
 


### PR DESCRIPTION
### Motivation

`test/canary-load` is the 23-hour validator the [qa-canary](https://buildkite.com/materialize/qa-canary) pipeline runs against the shared sandbox every night. Its chunk loop had three exception handlers, and anything they did not recognize propagated out of the loop. That did two things: it ended the run early, and, because the rethrow of collected failures sits after the loop, it dropped every failure collected before the abort from the annotation and the analytics DB. Two runs in the last week ended that way:

- [#986](https://buildkite.com/materialize/qa-canary/builds/986) aborted at 4h54m on `AssertionError: <Response [502]> upstream server not available`, the balancer's answer while environmentd restarted for the v26.40.1 cutover. `http_sql_query` asserted `status_code == 200`, and a bare `AssertionError` matched no handler.
- [#982](https://buildkite.com/materialize/qa-canary/builds/982) aborted at 7h on `Temporary failure in name resolution` from the agent's resolver. That arrives as a `requests.ConnectionError`, which the connection handler catches, but the message was not in `CONNECTION_ERROR_STRINGS`, so it re-raised.

### Description

Three commits, one per cause:

1. Add `Temporary failure in name resolution` to `CONNECTION_ERROR_STRINGS`, so the DNS blip restarts the chunk like the other transport failures.
2. In `http_sql_query`, retry a 5xx a few times with a short sleep, then turn any non-200 into a `FailedTestExecutionError` instead of asserting. The chunk loop collects it like a SQL failure.
3. Collapse the three handlers into one `except Exception` that classifies via a new `failure_messages` helper: connection errors restart the chunk and stay out of the verdict, testdrive errors yield one entry per error as before, and any other exception is collected with its traceback as `details`. The run always reaches the end of its runtime and goes red if anything was collected.

One behavior change beyond the two failure cases: a psycopg `OperationalError` whose message is not a connection error used to re-raise and now is collected. Connection failures are still stdout-only and still do not fail the build; that is unchanged.

### Verification

No test file covers `test/canary-load` and the workflow needs the canary credentials, so verification was a local harness against the module: `http_sql_query` with `requests.post` mocked to return 502/502/200, 502 forever, 403 once, and 200; and `failure_messages` plus the handler body against a multi-error `FailedTestExecutionError` mixing a connection error, a real error and the `DistinctBy` exclusion, a `CommandFailureCausedUIError`, psycopg `OperationalError` with and without a connection string, the DNS `ConnectionError`, the bare `AssertionError` from #986, and a `KeyError`. Each routed as described above. `ruff`, `black` and `pyright` are clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KamXNLq4ze5CGpai1mGmrF
