### PR TITLE
ci: re-enable the nightly PreflightCheckRollback platform check

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1278,7 +1278,6 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=PreflightCheckRollback, "--seed=$BUILDKITE_JOB_ID"]
-        skip: "flaky due to https://linear.app/materializeinc/issue/DB-85"
 
       - id: checks-0dt-restart-entire-mz-forced-migrations
         topics: [0dt-migration, copy-to-s3, debezium, iceberg, kafka, kafka-sink, mysql, postgres, sql-server, ssh-tunnel]


### PR DESCRIPTION
The nightly job `checks-preflight-check-rollback` has been `skip:`-ped since 2026-02-23 (#35166) because of [DB-85](https://linear.app/materializeinc/issue/DB-85), where the 0dt preflight timed out waiting for the new environmentd to reach `ReadyToPromote`.

Evidence that the mechanism is fixed:

* #35634 (2026-03-26) stops the output frontier of read-only collections from being held back by the write frontier, which is the value controller hydration compares against.
* The sibling release-qualification scenario `PreflightCheckContinue`, which shares the scenario prefix and kept running, went from about 7 hits in 113 builds (February to April 2026) to 0 in 176 builds since 2026-04-12.

This PR only removes the `skip:` line so the rollback path gets the same confirmation on nightlies. [DB-85](https://linear.app/materializeinc/issue/DB-85) closes after a few green runs; if the timeout comes back, the job goes back to skipped and [DB-85](https://linear.app/materializeinc/issue/DB-85) gets the new build linked.

Part of: [DB-85](https://linear.app/materializeinc/issue/DB-85)

🤖 Generated with [Claude Code](https://claude.com/claude-code)