### PR TITLE
parallel-workload: ignore the RTR timeout in ExplainFilterPushdownAction

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -6249,6 +6249,9 @@ class ExplainFilterPushdownAction(Action):
                 'is not allowed from the "mz_catalog_server" cluster',
                 # Scanning persist part stats can outrun statement_timeout.
                 "canceling statement due to statement timeout",
+                # Under real-time recency the EXPLAIN waits for the source
+                # like a SELECT does, and can hit the RTR timeout (SS-303).
+                "timed out before ingesting the source's visible frontier when real-time-recency query issued",
             ]
         )
         if exe.db.complexity == Complexity.DDL:


### PR DESCRIPTION
`SelectAction` already lists `timed out before ingesting the source's visible frontier when real-time-recency query issued` as an ignorable error, because a session with real-time recency enabled can legitimately hit the RTR timeout. `ExplainFilterPushdownAction` runs `EXPLAIN FILTER PUSHDOWN FOR SELECT ...` on the same sessions and waits for the source the same way, but did not list the error, so an RTR timeout there failed the whole workload: nightly 18001 and 18005 on 2026-08-09 (`Parallel Correctness + cancel`, `Parallel Correctness + 0dt deploy`).

One-line addition to the action's `errors_to_ignore`, mirroring `SelectAction`. Part of the CI-flake sweep under [SS-303](https://linear.app/materializeinc/issue/SS-303), which tracks the RTR timeout itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)