### PR TITLE
console: recolor the console's accent per instance

### DIFF
--- a/console/src/components/CommandBlock/ReadOnlyCommandBlock.tsx
+++ b/console/src/components/CommandBlock/ReadOnlyCommandBlock.tsx
@@ -71,7 +71,9 @@ export const ReadOnlyCommandBlock = ({
         EditorView.theme({
           ".highlight": {
             "background-color":
-              colorMode === "light" ? colors.purple[200] : colors.purple[700],
+              colorMode === "light"
+                ? colors.accentHue[200]
+                : colors.accentHue[700],
           },
         }),
       ];

--- a/console/src/components/SimpleSelect.tsx
+++ b/console/src/components/SimpleSelect.tsx
@@ -37,8 +37,7 @@ const SimpleSelect = forwardRef<SimpleSelectProps, "select">((props, ref) => {
         },
         _focus: {
           borderColor: colors.accent.brightPurple,
-          boxShadow:
-            "0px 0px 0px 0px hsla(0, 0%, 0%, 0), 0px 0px 0px 0px hsla(0, 0%, 0%, 0), 0px 0px 0px 2px hsla(257, 100%, 65%, 0.24)", // accent.brightPurple,
+          boxShadow: `0px 0px 0px 0px hsla(0, 0%, 0%, 0), 0px 0px 0px 0px hsla(0, 0%, 0%, 0), ${shadows.input.focus}`,
         },
         _invalid: {
           borderColor: colors.accent.red,

--- a/console/src/components/licenseComponents.tsx
+++ b/console/src/components/licenseComponents.tsx
@@ -312,7 +312,7 @@ export const LicenseKeyCTAContent = ({
       textAlign="left"
     >
       <HStack align="center" spacing={3}>
-        <BoxIcon color={colors.purple[500]} />
+        <BoxIcon color={colors.accentHue[500]} />
         <Text textStyle="heading-sm">
           {" "}
           {selfManagedMode === "enterprise"
@@ -353,7 +353,7 @@ export const LicenseKeyCTAContent = ({
         Want to learn more?{" "}
         <TextLink
           as="a"
-          color={colors.purple[400]}
+          color={colors.accentHue[400]}
           href={docUrls["/docs/installation/"]}
           target="_blank"
           rel="noreferrer"

--- a/console/src/config/AppConfig.ts
+++ b/console/src/config/AppConfig.ts
@@ -28,6 +28,7 @@ import {
   getEnvironmentdWebsocketScheme,
   getFronteggUrl,
 } from "./apiUrls";
+import { type ConsoleAppearance } from "./appearance";
 import { buildConstants } from "./buildConstants";
 import { getCloudRegions } from "./cloudRegions";
 import { getConsoleEnvironment } from "./consoleEnvironment";
@@ -95,6 +96,10 @@ interface IBaseAppConfig {
   environmentdWebsocketScheme: WebsocketScheme;
   // Whether query retries in react-query are enabled
   reactQueryRetriesEnabled: boolean;
+  // How this instance's console distinguishes itself from the consoles of
+  // other instances. Never set in cloud mode, which serves one console for all
+  // of an organization's regions.
+  appearance: ConsoleAppearance | undefined;
 }
 
 export class CloudAppConfig implements IBaseAppConfig {
@@ -200,6 +205,8 @@ export class CloudAppConfig implements IBaseAppConfig {
   // Whether the current environment requires user registration outside of the Console. This occurs in production
   // when the Console's 'sign up' button links to the Marketing site.
   requiresExternalRegistration = this.#consoleEnvironment === "production";
+
+  appearance = undefined;
 }
 
 export class SelfManagedAppConfig implements IBaseAppConfig {
@@ -208,6 +215,8 @@ export class SelfManagedAppConfig implements IBaseAppConfig {
   authMode: SelfManagedAuthMode = appConfigJson.auth.mode;
 
   balancerdDnsNames: string[] | undefined = appConfigJson.balancerdDnsNames;
+
+  appearance: ConsoleAppearance | undefined = appConfigJson.appearance;
 
   environmentdScheme = getEnvironmentdScheme({
     buildConstants,

--- a/console/src/config/appearance.test.ts
+++ b/console/src/config/appearance.test.ts
@@ -1,0 +1,42 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { documentTitle, parseConsoleAppearance } from "./appearance";
+
+describe("documentTitle", () => {
+  it("names the instance when it has a display name", () => {
+    expect(documentTitle({ displayName: "prod" })).toEqual(
+      "Materialize Console · prod",
+    );
+  });
+
+  it("falls back to the plain title", () => {
+    expect(documentTitle(undefined)).toEqual("Materialize Console");
+    expect(documentTitle({})).toEqual("Materialize Console");
+  });
+});
+
+describe("parseConsoleAppearance", () => {
+  it("returns undefined when unconfigured", () => {
+    expect(parseConsoleAppearance(undefined)).toBeUndefined();
+    expect(parseConsoleAppearance(null)).toBeUndefined();
+  });
+
+  it("keeps a display name", () => {
+    expect(parseConsoleAppearance({ displayName: "prod" })).toEqual({
+      displayName: "prod",
+    });
+  });
+
+  it("treats an empty display name as unset", () => {
+    expect(parseConsoleAppearance({ displayName: "" })).toEqual({
+      displayName: undefined,
+    });
+  });
+});

--- a/console/src/config/appearance.ts
+++ b/console/src/config/appearance.ts
@@ -1,0 +1,38 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/**
+ * @module
+ * Per-instance appearance, set on the Materialize resource and delivered to
+ * the browser in app-config.json. Self-managed only, since Cloud serves one
+ * console for all of a user's regions.
+ */
+
+export interface ConsoleAppearance {
+  /** A short name for the instance, such as "dev" or "prod". */
+  displayName?: string;
+}
+
+const BASE_DOCUMENT_TITLE = "Materialize Console";
+
+/** Builds the browser tab title, which names the instance when configured. */
+export const documentTitle = (appearance: ConsoleAppearance | undefined) =>
+  appearance?.displayName
+    ? `${BASE_DOCUMENT_TITLE} · ${appearance.displayName}`
+    : BASE_DOCUMENT_TITLE;
+
+/** Reads the appearance out of app-config.json. */
+export const parseConsoleAppearance = (
+  appearance: { displayName?: string } | null | undefined,
+): ConsoleAppearance | undefined => {
+  if (!appearance) {
+    return undefined;
+  }
+  return { displayName: appearance.displayName || undefined };
+};

--- a/console/src/config/appearance.ts
+++ b/console/src/config/appearance.ts
@@ -14,9 +14,19 @@
  * console for all of a user's regions.
  */
 
+/**
+ * The hues an instance may accent its console with. Each names a hue of the
+ * palette, which the theme reads the appropriate shades of. See
+ * `~/theme/accent`.
+ */
+export const ACCENT_COLORS = ["blue", "orange", "purple"] as const;
+
+export type AccentColor = (typeof ACCENT_COLORS)[number];
+
 export interface ConsoleAppearance {
   /** A short name for the instance, such as "dev" or "prod". */
   displayName?: string;
+  accentColor?: AccentColor;
 }
 
 const BASE_DOCUMENT_TITLE = "Materialize Console";
@@ -27,12 +37,26 @@ export const documentTitle = (appearance: ConsoleAppearance | undefined) =>
     ? `${BASE_DOCUMENT_TITLE} · ${appearance.displayName}`
     : BASE_DOCUMENT_TITLE;
 
-/** Reads the appearance out of app-config.json. */
+const isAccentColor = (value: unknown): value is AccentColor =>
+  ACCENT_COLORS.includes(value as AccentColor);
+
+/**
+ * Validates the appearance read out of app-config.json.
+ *
+ * Orchestratord writes that file and may be newer than the console it serves,
+ * so an accent color this build doesn't know is dropped rather than handed to
+ * the theme as an unresolvable color.
+ */
 export const parseConsoleAppearance = (
-  appearance: { displayName?: string } | null | undefined,
+  appearance: { displayName?: string; accentColor?: string } | null | undefined,
 ): ConsoleAppearance | undefined => {
   if (!appearance) {
     return undefined;
   }
-  return { displayName: appearance.displayName || undefined };
+  return {
+    displayName: appearance.displayName || undefined,
+    accentColor: isAccentColor(appearance.accentColor)
+      ? appearance.accentColor
+      : undefined,
+  };
 };

--- a/console/src/config/importAppConfig.ts
+++ b/console/src/config/importAppConfig.ts
@@ -47,7 +47,7 @@ export function importAppConfig(): {
       mode: SelfManagedAuthMode;
     };
     balancerd_dns_names?: string[];
-    appearance?: { displayName?: string };
+    appearance?: { displayName?: string; accentColor?: string };
   };
   return {
     auth: json.auth,

--- a/console/src/config/importAppConfig.ts
+++ b/console/src/config/importAppConfig.ts
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 import { type SelfManagedAuthMode } from "./AppConfig";
+import { type ConsoleAppearance, parseConsoleAppearance } from "./appearance";
 
 const DEFAULT_APP_CONFIG = {
   auth: {
@@ -35,6 +36,7 @@ export function importAppConfig(): {
     mode: SelfManagedAuthMode;
   };
   balancerdDnsNames?: string[];
+  appearance?: ConsoleAppearance;
 } {
   if (process.env.NODE_ENV === "test") {
     return DEFAULT_APP_CONFIG;
@@ -45,9 +47,11 @@ export function importAppConfig(): {
       mode: SelfManagedAuthMode;
     };
     balancerd_dns_names?: string[];
+    appearance?: { displayName?: string };
   };
   return {
     auth: json.auth,
     balancerdDnsNames: json.balancerd_dns_names,
+    appearance: parseConsoleAppearance(json.appearance),
   };
 }

--- a/console/src/index.tsx
+++ b/console/src/index.tsx
@@ -22,9 +22,13 @@ import "~/sentry";
 import React from "react";
 import { createRoot } from "react-dom/client";
 
+import { appConfig } from "~/config/AppConfig";
+import { documentTitle } from "~/config/appearance";
 import { App } from "~/platform/App";
 
 import { addChunkLoadErrorListener } from "./utils/chunkLoadErrorHandler";
+
+document.title = documentTitle(appConfig.appearance);
 
 const rootEl = document.createElement("div");
 document.body.appendChild(rootEl);

--- a/console/src/layouts/NavBar/NavItem.tsx
+++ b/console/src/layouts/NavBar/NavItem.tsx
@@ -67,8 +67,7 @@ export const NavItem = (props: NavItemProps) => {
             showActiveStyle
               ? {
                   ...NAV_HOVER_STYLES,
-                  // slightly more opaque than colors.background.accent
-                  bg: "rgba(90, 52, 203, 0.2)",
+                  bg: colors.background.accentActive,
                 }
               : undefined
           }

--- a/console/src/platform/shell/HistorySearchModal.tsx
+++ b/console/src/platform/shell/HistorySearchModal.tsx
@@ -63,7 +63,7 @@ const HistoryList = ({
   const { colors } = useTheme<MaterializeTheme>();
   const { colorMode } = useColorMode();
   const highlightBgColor =
-    colorMode === "light" ? colors.purple[200] : colors.purple[700];
+    colorMode === "light" ? colors.accentHue[200] : colors.accentHue[700];
   const highlightFgColor =
     colorMode === "light" ? "unset" : colors.foreground.primary;
 

--- a/console/src/theme/accent.test.ts
+++ b/console/src/theme/accent.test.ts
@@ -1,0 +1,109 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { ACCENT_COLORS } from "~/config/appearance";
+
+import { accentHueFor, buildAccentPalettes } from "./accent";
+import colors from "./colors";
+import { darkColors } from "./dark";
+import { lightColors } from "./light";
+
+describe("accentHueFor", () => {
+  it("defaults to Materialize purple", () => {
+    expect(accentHueFor(undefined)).toBe(colors.purple);
+  });
+
+  it("resolves a configured accent color to its hue", () => {
+    expect(accentHueFor("blue")).toBe(colors.blue);
+  });
+});
+
+describe("buildAccentPalettes", () => {
+  // An instance that configures nothing must render exactly as it did before
+  // the accent became configurable, so these pin the shades the themes used
+  // when they were hardcoded.
+  it("reproduces the original purple tokens by default", () => {
+    const { light, dark } = buildAccentPalettes(undefined);
+
+    expect(light).toEqual({
+      primary: "#472F85",
+      bright: "#5A34CB",
+      wash: "rgba(90, 52, 203, 0.08)",
+      focusRing: "0px 0px 0px 2px rgba(127, 78, 255, 0.24)",
+    });
+    expect(dark).toEqual({
+      primary: "#7F4EFF",
+      bright: "#B59AFF",
+      wash: "rgba(181, 154, 255, 0.08)",
+      focusRing: "0px 0px 0px 2px rgba(181, 154, 255, 0.4)",
+    });
+  });
+
+  it("washes the active navigation item the same in both themes", () => {
+    expect(buildAccentPalettes(undefined).activeWash).toEqual(
+      "rgba(90, 52, 203, 0.2)",
+    );
+  });
+
+  it("accents a configured hue with that hue's shades", () => {
+    const { light, dark } = buildAccentPalettes("orange");
+
+    expect(light.primary).toEqual(colors.orange[600]);
+    expect(light.bright).toEqual(colors.orange[600]);
+    expect(dark.primary).toEqual(colors.orange[500]);
+    expect(dark.bright).toEqual(colors.orange[300]);
+  });
+
+  it("washes the accent at the same opacity for any hue", () => {
+    const { light, dark } = buildAccentPalettes("blue");
+
+    expect(light.wash).toEqual("rgba(0, 114, 180, 0.08)");
+    expect(dark.wash).toEqual("rgba(89, 195, 255, 0.08)");
+  });
+});
+
+/** WCAG relative luminance of a `#rgb` or `#rrggbb` color. */
+const luminance = (hex: string) => {
+  const digits = hex.replace("#", "");
+  const width = digits.length / 3;
+  const channels = [0, 1, 2]
+    .map((i) => digits.slice(i * width, (i + 1) * width))
+    .map((channel) => (width === 1 ? channel.repeat(2) : channel))
+    .map((channel) => parseInt(channel, 16) / 255)
+    .map((c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+};
+
+const contrast = (a: string, b: string) => {
+  const [dimmer, brighter] = [luminance(a), luminance(b)].sort((x, y) => x - y);
+  return (brighter + 0.05) / (dimmer + 0.05);
+};
+
+describe("accent shades", () => {
+  // The shades are chosen by hand per hue, so hold them to the ratios that
+  // choice promises rather than trusting the table.
+  it.each(ACCENT_COLORS)("stay legible for %s", (accentColor) => {
+    const { light, dark } = buildAccentPalettes(accentColor);
+
+    // Drawn as text on the page, and as a surface behind a white label.
+    expect(
+      contrast(light.bright, lightColors.background.primary),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      contrast(light.primary, lightColors.foreground.primaryButtonLabel),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      contrast(dark.bright, darkColors.background.secondary),
+    ).toBeGreaterThanOrEqual(4.5);
+    // Large, bold button labels, which WCAG holds to 3:1.
+    expect(
+      contrast(dark.primary, darkColors.foreground.primaryButtonLabel),
+    ).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/console/src/theme/accent.ts
+++ b/console/src/theme/accent.ts
@@ -1,0 +1,147 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/**
+ * @module
+ * The hue the console accents itself with: the active navigation item, primary
+ * buttons, links, focus rings, selection highlights, and the like.
+ *
+ * Self-managed instances can point this at another hue so that their consoles
+ * are distinguishable. Colors that carry meaning are left alone, so an error
+ * stays red and a healthy object stays green whatever the accent.
+ */
+
+import { appConfig } from "~/config/AppConfig";
+import { type AccentColor } from "~/config/appearance";
+
+import colors from "./colors";
+
+/** Materialize purple, used when an instance configures nothing. */
+export const DEFAULT_ACCENT_COLOR: AccentColor = "purple";
+
+/**
+ * One hue of the palette, from its palest shade to its deepest.
+ *
+ * Every hue carries at least these shades, so a component can read the same
+ * position whichever hue is configured.
+ */
+export type AccentHue = typeof colors.purple;
+
+type Shade = keyof AccentHue;
+
+/**
+ * The shades each hue accents with.
+ *
+ * The palette's hues do not run parallel: a shade that is vivid in one hue is
+ * muted or washed out in another, so each hue names its own. `primary` is a
+ * surface behind white label text and `bright` is drawn as text on the page,
+ * so both are kept at 4.5:1 or better against what they sit against. Purple
+ * is the default, and names the shades the rest of the palette was designed
+ * around.
+ *
+ * TODO(#38691): a palette drawn as an even scale, rather than shades picked
+ * out of hues that were never meant to be interchangeable, would let this be
+ * a single rule instead of a table. That needs design input.
+ */
+const ACCENT_SHADES: Record<
+  AccentColor,
+  { light: { primary: Shade; bright: Shade }; dark: { primary: Shade } }
+> = {
+  purple: { light: { primary: 600, bright: 500 }, dark: { primary: 400 } },
+  orange: { light: { primary: 600, bright: 600 }, dark: { primary: 500 } },
+  blue: { light: { primary: 600, bright: 600 }, dark: { primary: 600 } },
+};
+
+/**
+ * The shade the dark theme draws accented text in.
+ *
+ * The dark themes accent against one background rather than the palette's
+ * whole range, so a single pale shade reads for every hue.
+ */
+const DARK_BRIGHT_SHADE: Shade = 300;
+
+/** The shade the light theme rings a focused input with. */
+const LIGHT_FOCUS_SHADE: Shade = 400;
+
+// Opacity of the wash behind hovered navigation items.
+const WASH_ALPHA = 0.08;
+// Opacity of the wash behind the active navigation item.
+const ACTIVE_WASH_ALPHA = 0.2;
+// Opacity of the ring around a focused input.
+const LIGHT_FOCUS_RING_ALPHA = 0.24;
+const DARK_FOCUS_RING_ALPHA = 0.4;
+
+/** `hex` at `alpha` opacity. */
+const withAlpha = (hex: string, alpha: number) => {
+  const [r, g, b] = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16));
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+/** The hue an accent color names. */
+export const accentHueFor = (accentColor: AccentColor | undefined): AccentHue =>
+  colors[accentColor ?? DEFAULT_ACCENT_COLOR];
+
+export interface AccentPalette {
+  /** Accented surfaces, such as a primary button's background. */
+  primary: string;
+  /** Accented detail against a page background: links, borders, icons. */
+  bright: string;
+  /** A wash of the accent, for accented backgrounds behind ordinary text. */
+  wash: string;
+  /** The ring drawn around a focused input. */
+  focusRing: string;
+}
+
+export interface AccentPalettes {
+  light: AccentPalette;
+  dark: AccentPalette;
+  /**
+   * The wash behind the active navigation item, stronger than `wash` and
+   * shared by both themes.
+   */
+  activeWash: string;
+}
+
+/** Both themes' accent tokens for an accent color. */
+export const buildAccentPalettes = (
+  accentColor: AccentColor | undefined,
+): AccentPalettes => {
+  const hue = accentHueFor(accentColor);
+  const shades = ACCENT_SHADES[accentColor ?? DEFAULT_ACCENT_COLOR];
+  const darkBright = hue[DARK_BRIGHT_SHADE];
+  const lightBright = hue[shades.light.bright];
+
+  return {
+    light: {
+      primary: hue[shades.light.primary],
+      bright: lightBright,
+      wash: withAlpha(lightBright, WASH_ALPHA),
+      focusRing: `0px 0px 0px 2px ${withAlpha(
+        hue[LIGHT_FOCUS_SHADE],
+        LIGHT_FOCUS_RING_ALPHA,
+      )}`,
+    },
+    dark: {
+      primary: hue[shades.dark.primary],
+      bright: darkBright,
+      wash: withAlpha(darkBright, WASH_ALPHA),
+      focusRing: `0px 0px 0px 2px ${withAlpha(
+        darkBright,
+        DARK_FOCUS_RING_ALPHA,
+      )}`,
+    },
+    activeWash: withAlpha(lightBright, ACTIVE_WASH_ALPHA),
+  };
+};
+
+export const accentHue = accentHueFor(appConfig.appearance?.accentColor);
+
+export const accentPalettes = buildAccentPalettes(
+  appConfig.appearance?.accentColor,
+);

--- a/console/src/theme/dark.ts
+++ b/console/src/theme/dark.ts
@@ -14,12 +14,14 @@
  */
 
 import { BasePalette, ComponentOverrides, ThemeColors, ThemeShadows } from ".";
+import { accentHue, accentPalettes } from "./accent";
 import colors from "./colors";
 
 const base: BasePalette = {
+  accentHue,
   accent: {
-    purple: colors.purple[400],
-    brightPurple: colors.purple[300],
+    purple: accentPalettes.dark.primary,
+    brightPurple: accentPalettes.dark.bright,
     green: colors.green[400],
     darkGreen: colors.green[450],
     indigo: colors.indigo[50],
@@ -38,7 +40,8 @@ const base: BasePalette = {
   background: {
     // robinclowers: I added this based on Parker's design for the new navigation hover
     // style. There may be a better / more idomatic way to fit it into our color system.
-    accent: "rgba(181, 154, 255, 0.08)",
+    accent: accentPalettes.dark.wash,
+    accentActive: accentPalettes.activeWash,
     primary: colors.gray[900],
     secondary: colors.gray[800],
     tertiary: colors.gray[700],
@@ -117,6 +120,6 @@ export const darkShadows: ThemeShadows = {
     0px 1px 0px 0px rgba(255, 255, 255, 0.08) inset`,
   input: {
     error: "0px 0px 0px 2px hsla(343, 95%, 46%, 0.24)",
-    focus: "0px 0px 0px 2px rgba(181, 154, 255, 0.40)",
+    focus: accentPalettes.dark.focusRing,
   },
 };

--- a/console/src/theme/index.tsx
+++ b/console/src/theme/index.tsx
@@ -35,13 +35,22 @@ import { SELECT_MENU_Z_INDEX } from "~/layouts/zIndex";
 import colors, { gradients } from "~/theme/colors";
 import * as components from "~/theme/components";
 
+import { type AccentHue } from "./accent";
 import { darkColors, darkShadows } from "./dark";
 import { lightColors, lightShadows } from "./light";
 import type { TextStyles } from "./typography";
 import { typographySystem } from "./typography";
 
 export interface BasePalette {
+  /**
+   * The hue the theme accents itself with, exposed whole for the few places
+   * that need a shade the `accent` tokens don't name.
+   */
+  accentHue: AccentHue;
   accent: {
+    // `purple` and `brightPurple` carry the configured accent, which is
+    // Materialize purple by default but need not be. Every other name here is
+    // literal.
     purple: string;
     brightPurple: string;
     green: string;
@@ -61,6 +70,7 @@ export interface BasePalette {
   };
   background: {
     accent: string;
+    accentActive: string;
     primary: string;
     secondary: string;
     tertiary: string;

--- a/console/src/theme/light.ts
+++ b/console/src/theme/light.ts
@@ -14,12 +14,14 @@
  */
 
 import { BasePalette, ComponentOverrides, ThemeColors, ThemeShadows } from ".";
+import { accentHue, accentPalettes } from "./accent";
 import colors from "./colors";
 
 const base: BasePalette = {
+  accentHue,
   accent: {
-    purple: colors.purple[600],
-    brightPurple: colors.purple[500],
+    purple: accentPalettes.light.primary,
+    brightPurple: accentPalettes.light.bright,
     darkGreen: colors.green[450],
     indigo: colors.indigo[50],
     green: colors.green[500],
@@ -38,7 +40,8 @@ const base: BasePalette = {
   background: {
     // robinclowers: I added this based on Parker's design for the new navigation hover
     // style. There may be a better / more idomatic way to fit it into our color system.
-    accent: "rgba(90, 52, 203, 0.08)",
+    accent: accentPalettes.light.wash,
+    accentActive: accentPalettes.activeWash,
     primary: colors.white,
     secondary: colors.gray[50],
     tertiary: colors.gray[100],
@@ -113,6 +116,6 @@ export const lightShadows: ThemeShadows = {
   `,
   input: {
     error: "0px 0px 0px 2px hsla(343, 95%, 46%, 0.24)",
-    focus: "0px 0px 0px 2px hsla(257, 100%, 65%, 0.24)",
+    focus: accentPalettes.light.focusRing,
   },
 };

--- a/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
+++ b/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
@@ -257,8 +257,8 @@
       },
       {
         "name": "privateKeyAlgorithm",
-        "type": "CertificatePrivateKeyAlgorithm",
-        "description": "Optional algorithm to use for the private key. If not specified, a recommended default will be chosen.",
+        "type": "Enum",
+        "description": "Optional algorithm to use for the private key. If not specified, a recommended default will be chosen.\n\nValid values:\n- `RSA`\n- `ECDSA`\n- `Ed25519`",
         "default": null,
         "required": false,
         "deprecated": false
@@ -342,6 +342,14 @@
   [
     "ConsoleAppearance",
     [
+      {
+        "name": "accentColor",
+        "type": "Enum",
+        "description": "The hue the console accents its interface with. This recolors accented\nelements such as the active navigation item, primary buttons, links and\nfocus rings. Colors that carry meaning, such as the red of an error or\nthe green of a healthy object, are left alone.\n\nDefaults to Materialize purple.\n\nValid values:\n- `blue`\n- `orange`\n- `purple`",
+        "default": null,
+        "required": false,
+        "deprecated": false
+      },
       {
         "name": "displayName",
         "type": "String",

--- a/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
+++ b/doc/user/data/self_managed/materialize_crd_descriptions_v1.json
@@ -51,6 +51,14 @@
         "deprecated": false
       },
       {
+        "name": "consoleAppearance",
+        "type": "ConsoleAppearance",
+        "description": "Appearance overrides for this instance's console.\n\nThis field is excluded from the rollout hash and changes will not trigger a rollout.",
+        "default": null,
+        "required": false,
+        "deprecated": false
+      },
+      {
         "name": "consoleExternalCertificateSpec",
         "type": "MaterializeCertSpec",
         "description": "The configuration for generating an x509 certificate using cert-manager for the console\nto present to incoming connections.\nThe `dnsNames` and `issuerRef` fields are required.\nNot yet implemented.\n\nThis field is excluded from the rollout hash and changes will not trigger a rollout.",
@@ -325,6 +333,19 @@
         "name": "kind",
         "type": "String",
         "description": "Kind of the resource being referred to.",
+        "default": null,
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  ],
+  [
+    "ConsoleAppearance",
+    [
+      {
+        "name": "displayName",
+        "type": "String",
+        "description": "A short name for this instance, such as `dev` or `prod`. The console\nappends it to its browser tab title.",
         "default": null,
         "required": false,
         "deprecated": false

--- a/doc/user/data/self_managed/materialize_crd_descriptions_v1alpha1.json
+++ b/doc/user/data/self_managed/materialize_crd_descriptions_v1alpha1.json
@@ -281,8 +281,8 @@
       },
       {
         "name": "privateKeyAlgorithm",
-        "type": "CertificatePrivateKeyAlgorithm",
-        "description": "Optional algorithm to use for the private key. If not specified, a recommended default will be chosen.",
+        "type": "Enum",
+        "description": "Optional algorithm to use for the private key. If not specified, a recommended default will be chosen.\n\nValid values:\n- `RSA`\n- `ECDSA`\n- `Ed25519`",
         "default": null,
         "required": false,
         "deprecated": false
@@ -366,6 +366,14 @@
   [
     "ConsoleAppearance",
     [
+      {
+        "name": "accentColor",
+        "type": "Enum",
+        "description": "The hue the console accents its interface with. This recolors accented\nelements such as the active navigation item, primary buttons, links and\nfocus rings. Colors that carry meaning, such as the red of an error or\nthe green of a healthy object, are left alone.\n\nDefaults to Materialize purple.\n\nValid values:\n- `blue`\n- `orange`\n- `purple`",
+        "default": null,
+        "required": false,
+        "deprecated": false
+      },
       {
         "name": "displayName",
         "type": "String",

--- a/doc/user/data/self_managed/materialize_crd_descriptions_v1alpha1.json
+++ b/doc/user/data/self_managed/materialize_crd_descriptions_v1alpha1.json
@@ -51,6 +51,14 @@
         "deprecated": false
       },
       {
+        "name": "consoleAppearance",
+        "type": "ConsoleAppearance",
+        "description": "Appearance overrides for this instance's console.",
+        "default": null,
+        "required": false,
+        "deprecated": false
+      },
+      {
         "name": "consoleExternalCertificateSpec",
         "type": "MaterializeCertSpec",
         "description": "The configuration for generating an x509 certificate using cert-manager for the console\nto present to incoming connections.\nThe `dnsNames` and `issuerRef` fields are required.\nNot yet implemented.",
@@ -349,6 +357,19 @@
         "name": "kind",
         "type": "String",
         "description": "Kind of the resource being referred to.",
+        "default": null,
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  ],
+  [
+    "ConsoleAppearance",
+    [
+      {
+        "name": "displayName",
+        "type": "String",
+        "description": "A short name for this instance, such as `dev` or `prod`. The console\nappends it to its browser tab title.",
         "default": null,
         "required": false,
         "deprecated": false

--- a/src/cloud-resources/src/bin/crd_writer.rs
+++ b/src/cloud-resources/src/bin/crd_writer.rs
@@ -113,20 +113,7 @@ impl DocsField {
         types_map: &mut IndexMap<String, Vec<DocsField>>,
         processed_types: &mut IndexSet<String>,
     ) -> String {
-        // Check for $ref first
-        let ref_str_opt = props.get("$ref").and_then(|r| r.as_str()).or_else(|| {
-            // We assume there is only one non-null type in anyOf
-            props
-                .get("oneOf")
-                .or_else(|| props.get("anyOf"))
-                .and_then(|o| o.as_array())
-                .and_then(|arr| {
-                    arr.iter()
-                        .find_map(|v| v.get("$ref").and_then(|r| r.as_str()))
-                })
-        });
-
-        if let Some(ref_str) = ref_str_opt {
+        if let Some(ref_str) = field_ref(props) {
             let type_name = ref_str
                 .split('/')
                 .next_back()
@@ -177,6 +164,22 @@ impl DocsField {
             unknown => panic!("found unexpected type: {unknown}"),
         }
     }
+}
+
+// The type a field refers to, either directly or as the non-null variant of an
+// optional field.
+fn field_ref(props: &serde_json::Value) -> Option<&str> {
+    props.get("$ref").and_then(|r| r.as_str()).or_else(|| {
+        // We assume there is only one non-null type in anyOf
+        props
+            .get("oneOf")
+            .or_else(|| props.get("anyOf"))
+            .and_then(|o| o.as_array())
+            .and_then(|arr| {
+                arr.iter()
+                    .find_map(|v| v.get("$ref").and_then(|r| r.as_str()))
+            })
+    })
 }
 
 // Get type string as reported by the JSON schema
@@ -247,7 +250,7 @@ fn extract_required_fields(props: &serde_json::Value) -> IndexSet<String> {
 
 // Check if a resolved schema is an enum
 fn is_enum_type(resolved: &serde_json::Value) -> bool {
-    resolved.get("oneOf").is_some()
+    resolved.get("oneOf").is_some() || resolved.get("enum").is_some()
 }
 
 // Get enum description text for a field
@@ -256,7 +259,7 @@ fn get_enum_description(
     root_schema: &serde_json::Value,
     default: &Option<serde_json::Value>,
 ) -> Option<String> {
-    let resolved = resolve_ref(root_schema, field_props.get("$ref")?.as_str()?)?;
+    let resolved = resolve_ref(root_schema, field_ref(field_props)?)?;
     if is_enum_type(resolved) {
         return Some(format_enum_variants_from_json(resolved, default));
     }
@@ -277,27 +280,42 @@ fn format_enum_variants_from_json(
         .and_then(|d| d.as_str())
         .map(|s| s.to_string());
 
-    // Enums use oneOf array containing variant descriptions
-    let variants: IndexMap<String, Option<String>> = schema_json
-        .get("oneOf")
-        .expect("schemars uses oneOf with const values for enums")
-        .as_array()
-        .expect("oneOf is always an array")
-        .into_iter()
-        .map(|variant| {
-            let name = variant
-                .get("const")
-                .expect("we only handle const enums currently")
-                .as_str()
-                .expect("enum const values should always be strings")
-                .to_owned();
-            let description = variant
-                .get("description")
-                .and_then(|d| d.as_str())
-                .map(|d| d.to_owned());
-            (name, description)
-        })
-        .collect();
+    // schemars describes an enum as a oneOf of const values when its variants
+    // carry doc comments, and as a plain array of the values when they don't.
+    let variants: IndexMap<String, Option<String>> = match schema_json.get("oneOf") {
+        Some(one_of) => one_of
+            .as_array()
+            .expect("oneOf is always an array")
+            .into_iter()
+            .map(|variant| {
+                let name = variant
+                    .get("const")
+                    .expect("we only handle const enums currently")
+                    .as_str()
+                    .expect("enum const values should always be strings")
+                    .to_owned();
+                let description = variant
+                    .get("description")
+                    .and_then(|d| d.as_str())
+                    .map(|d| d.to_owned());
+                (name, description)
+            })
+            .collect(),
+        None => schema_json
+            .get("enum")
+            .expect("is_enum_type checked for oneOf or enum")
+            .as_array()
+            .expect("enum is always an array")
+            .into_iter()
+            .map(|value| {
+                let name = value
+                    .as_str()
+                    .expect("enum values should always be strings")
+                    .to_owned();
+                (name, None)
+            })
+            .collect(),
+    };
 
     // Format variants
     for (variant_name, variant_description) in &variants {

--- a/src/cloud-resources/src/crd.rs
+++ b/src/cloud-resources/src/crd.rs
@@ -80,6 +80,28 @@ pub struct ConsoleAppearance {
     /// appends it to its browser tab title.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    /// The hue the console accents its interface with. This recolors accented
+    /// elements such as the active navigation item, primary buttons, links and
+    /// focus rings. Colors that carry meaning, such as the red of an error or
+    /// the green of a healthy object, are left alone.
+    ///
+    /// Defaults to Materialize purple.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accent_color: Option<ConsoleAccentColor>,
+}
+
+/// A hue of the console's palette. The console reads lighter or darker shades
+/// of it to suit the viewer's light or dark theme.
+///
+/// Hues that the console already spends on meaning are deliberately absent:
+/// accenting an instance in red or green would leave an error or an unhealthy
+/// object competing with the furniture for attention.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum ConsoleAccentColor {
+    Blue,
+    Orange,
+    Purple,
 }
 
 pub trait ManagedResource: Resource<DynamicType = ()> + Sized {

--- a/src/cloud-resources/src/crd.rs
+++ b/src/cloud-resources/src/crd.rs
@@ -68,6 +68,20 @@ pub struct MaterializeCertSpec {
     pub private_key_size: Option<i64>,
 }
 
+/// Appearance overrides for an instance's console.
+///
+/// Consoles are otherwise identical, so an operator running several
+/// Materialize instances cannot tell from a browser tab which instance a
+/// console is pointed at.
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsoleAppearance {
+    /// A short name for this instance, such as `dev` or `prod`. The console
+    /// appends it to its browser tab title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
 pub trait ManagedResource: Resource<DynamicType = ()> + Sized {
     fn default_labels(&self) -> BTreeMap<String, String> {
         BTreeMap::new()

--- a/src/cloud-resources/src/crd/console.rs
+++ b/src/cloud-resources/src/crd/console.rs
@@ -16,7 +16,7 @@ use kube::{CustomResource, Resource, ResourceExt};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::crd::{ManagedResource, MaterializeCertSpec, new_resource_id};
+use crate::crd::{ConsoleAppearance, ManagedResource, MaterializeCertSpec, new_resource_id};
 use mz_server_core::listeners::AuthenticatorKind;
 
 pub mod v1alpha1 {
@@ -87,6 +87,10 @@ pub mod v1alpha1 {
         /// How to authenticate with Materialize.
         #[serde(default)]
         pub authenticator_kind: AuthenticatorKind,
+
+        /// Appearance overrides for this console.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub appearance: Option<ConsoleAppearance>,
 
         // This can be set to override the randomly chosen resource id
         pub resource_id: Option<String>,

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -2824,7 +2824,7 @@ mod tests {
 
     use super::v1alpha1::{Materialize, MaterializeSpec, MaterializeStatus};
     use super::{DEFAULT_ROLLOUT_REQUEST_TIMEOUT, FORCE_ROLLOUT_ANNOTATION, RolloutRequestTimeout};
-    use crate::crd::ConsoleAppearance;
+    use crate::crd::{ConsoleAccentColor, ConsoleAppearance};
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // can't call foreign function `sha256_compress` on OS `linux`
@@ -3488,6 +3488,7 @@ mod tests {
         let hash = mz.generate_rollout_hash();
         mz.spec.console_appearance = Some(ConsoleAppearance {
             display_name: Some("prod".to_owned()),
+            accent_color: Some(ConsoleAccentColor::Orange),
         });
         assert_eq!(mz.generate_rollout_hash(), hash);
     }

--- a/src/cloud-resources/src/crd/materialize.rs
+++ b/src/cloud-resources/src/crd/materialize.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::crd::{ManagedResource, MaterializeCertSpec, new_resource_id};
+use crate::crd::{ConsoleAppearance, ManagedResource, MaterializeCertSpec, new_resource_id};
 use mz_server_core::listeners::AuthenticatorKind;
 
 pub const LAST_KNOWN_ACTIVE_GENERATION_ANNOTATION: &str =
@@ -174,6 +174,9 @@ pub mod v1alpha1 {
         pub balancerd_replicas: Option<i32>,
         /// Number of console pods to create.
         pub console_replicas: Option<i32>,
+        /// Appearance overrides for this instance's console.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub console_appearance: Option<ConsoleAppearance>,
 
         /// Name of the kubernetes service account to use.
         /// If not set, we will create one with the same name as this Materialize object.
@@ -862,6 +865,7 @@ pub mod v1alpha1 {
                     console_resource_requirements: value.spec.console_resource_requirements,
                     balancerd_replicas: value.spec.balancerd_replicas,
                     console_replicas: value.spec.console_replicas,
+                    console_appearance: value.spec.console_appearance,
                     service_account_name: value.spec.service_account_name,
                     service_account_annotations: value.spec.service_account_annotations,
                     service_account_labels: value.spec.service_account_labels,
@@ -982,6 +986,12 @@ pub mod v1alpha1 {
             skip_serializing_if = "Option::is_none"
         )]
         pub console_replicas: PartialField,
+        #[serde(
+            default,
+            with = "double_option",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub console_appearance: PartialField,
         #[serde(
             default,
             with = "double_option",
@@ -1182,6 +1192,7 @@ pub mod v1alpha1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -1216,6 +1227,7 @@ pub mod v1alpha1 {
                 console_resource_requirements: present_opt(console_resource_requirements),
                 balancerd_replicas: present_opt(balancerd_replicas),
                 console_replicas: present_opt(console_replicas),
+                console_appearance: present_opt(console_appearance),
                 service_account_name: present_opt(service_account_name),
                 service_account_annotations: present_opt(service_account_annotations),
                 service_account_labels: present_opt(service_account_labels),
@@ -1301,6 +1313,7 @@ pub mod v1alpha1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -1332,6 +1345,7 @@ pub mod v1alpha1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -1467,6 +1481,11 @@ pub mod v1 {
         ///
         /// This field is excluded from the rollout hash and changes will not trigger a rollout.
         pub console_replicas: Option<i32>,
+        /// Appearance overrides for this instance's console.
+        ///
+        /// This field is excluded from the rollout hash and changes will not trigger a rollout.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub console_appearance: Option<ConsoleAppearance>,
 
         /// Name of the kubernetes service account to use.
         /// If not set, we will create one with the same name as this Materialize object.
@@ -1603,6 +1622,7 @@ pub mod v1 {
                 console_resource_requirements: None,
                 balancerd_replicas: None,
                 console_replicas: None,
+                console_appearance: None,
                 service_account_name: self.spec.service_account_name.clone(),
                 service_account_annotations: self.spec.service_account_annotations.clone(),
                 service_account_labels: self.spec.service_account_labels.clone(),
@@ -2079,6 +2099,7 @@ pub mod v1 {
                     console_resource_requirements: value.spec.console_resource_requirements,
                     balancerd_replicas: value.spec.balancerd_replicas,
                     console_replicas: value.spec.console_replicas,
+                    console_appearance: value.spec.console_appearance,
                     service_account_name: value.spec.service_account_name,
                     service_account_annotations,
                     service_account_labels: value.spec.service_account_labels,
@@ -2222,6 +2243,12 @@ pub mod v1 {
             skip_serializing_if = "Option::is_none"
         )]
         pub console_replicas: PartialField,
+        #[serde(
+            default,
+            with = "double_option",
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub console_appearance: PartialField,
         #[serde(
             default,
             with = "double_option",
@@ -2403,6 +2430,7 @@ pub mod v1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -2434,6 +2462,7 @@ pub mod v1 {
                 console_resource_requirements: present_opt(console_resource_requirements),
                 balancerd_replicas: present_opt(balancerd_replicas),
                 console_replicas: present_opt(console_replicas),
+                console_appearance: present_opt(console_appearance),
                 service_account_name: present_opt(service_account_name),
                 service_account_annotations: present_opt(service_account_annotations),
                 service_account_labels: present_opt(service_account_labels),
@@ -2516,6 +2545,7 @@ pub mod v1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -2558,6 +2588,7 @@ pub mod v1 {
                 console_resource_requirements,
                 balancerd_replicas,
                 console_replicas,
+                console_appearance,
                 service_account_name,
                 service_account_annotations,
                 service_account_labels,
@@ -2793,6 +2824,7 @@ mod tests {
 
     use super::v1alpha1::{Materialize, MaterializeSpec, MaterializeStatus};
     use super::{DEFAULT_ROLLOUT_REQUEST_TIMEOUT, FORCE_ROLLOUT_ANNOTATION, RolloutRequestTimeout};
+    use crate::crd::ConsoleAppearance;
 
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // can't call foreign function `sha256_compress` on OS `linux`
@@ -3431,5 +3463,32 @@ mod tests {
             assert!(!field_value.is_null(), "unexpected null for {key}");
         }
         assert!(!value.as_object().unwrap().contains_key("status"));
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // can't call foreign function `sha256_compress` on OS `linux`
+    fn console_appearance_does_not_affect_the_rollout_hash() {
+        // Appearance reaches only the console deployment, so it must not roll
+        // environmentd.
+        let mut mz = super::v1::Materialize {
+            spec: super::v1::MaterializeSpec {
+                environmentd_image_ref: "materialize/environmentd:v26.0.0".to_owned(),
+                ..Default::default()
+            },
+            metadata: ObjectMeta::default(),
+            status: None,
+        };
+
+        // An unset appearance serializes away entirely, so instances that
+        // don't configure one hash the same as they did before the field
+        // existed and are not rolled by adopting a new operator.
+        let spec = serde_json::to_value(&mz.spec).unwrap();
+        assert!(!spec.as_object().unwrap().contains_key("consoleAppearance"));
+
+        let hash = mz.generate_rollout_hash();
+        mz.spec.console_appearance = Some(ConsoleAppearance {
+            display_name: Some("prod".to_owned()),
+        });
+        assert_eq!(mz.generate_rollout_hash(), hash);
     }
 }

--- a/src/orchestratord/src/controller/console.rs
+++ b/src/orchestratord/src/controller/console.rs
@@ -43,7 +43,7 @@ use crate::{
     tls::{DefaultCertificateSpecs, create_certificate, issuer_ref_defined},
 };
 use mz_cloud_resources::crd::{
-    ManagedResource,
+    ConsoleAppearance, ManagedResource,
     console::v1alpha1::{Console, HttpConnectionScheme},
     generated::cert_manager::certificates::{Certificate, CertificatePrivateKeyAlgorithm},
 };
@@ -77,6 +77,8 @@ struct AppConfig {
     auth: AppConfigAuth,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     balancerd_dns_names: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    appearance: Option<ConsoleAppearance>,
 }
 
 #[derive(Serialize)]
@@ -239,6 +241,7 @@ impl Context {
             auth: AppConfigAuth {
                 mode: console.spec.authenticator_kind,
             },
+            appearance: console.spec.appearance.clone(),
         })
         .expect("known valid");
         ConfigMap {

--- a/src/orchestratord/src/controller/materialize.rs
+++ b/src/orchestratord/src/controller/materialize.rs
@@ -865,6 +865,7 @@ impl k8s_controller::Context for Context {
                     ),
                     resource_requirements: mz.spec.console_resource_requirements.clone(),
                     replicas: Some(mz.console_replicas()),
+                    appearance: mz.spec.console_appearance.clone(),
                     external_certificate_spec: mz.spec.console_external_certificate_spec.clone(),
                     pod_annotations: mz.spec.pod_annotations.clone(),
                     pod_labels: mz.spec.pod_labels.clone(),

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -1744,6 +1744,46 @@ class BalancerdExternalDnsNames(Modification):
         retry(check, 360)
 
 
+class ConsoleAppearance(Modification):
+    # The operator copies the Materialize CR's `consoleAppearance` into the
+    # console's `app-config.json`, which is how the console learns which
+    # instance it is pointed at.
+    APPEARANCE = {"displayName": "prod"}
+
+    @classmethod
+    def values(cls, version: MzVersion) -> list[Any]:
+        return [None, cls.APPEARANCE]
+
+    @classmethod
+    def default(cls) -> Any:
+        return None
+
+    def modify(self, definition: dict[str, Any]) -> None:
+        if self.value is not None:
+            definition["materialize"]["spec"]["consoleAppearance"] = self.value
+
+    def validate(self, mods: dict[type[Modification], Any]) -> None:
+        # `consoleAppearance` was added in v26.41; older orchestratord builds
+        # drop the field.
+        if MzVersion.parse_mz(mods[EnvironmentdImageRef]) < MzVersion.parse_mz(
+            "v26.41.0-dev.0"
+        ):
+            return
+        # Without a console there's no app config to inspect.
+        if not mods[ConsoleEnabled]:
+            return
+
+        def check() -> None:
+            app_config = get_console_app_config()
+            actual = app_config.get("appearance")
+            assert (
+                actual == self.value
+            ), f"Expected appearance {self.value}, but got {actual}: {app_config}"
+
+        # The console is reconciled last and the configmap update is async.
+        retry(check, 360)
+
+
 class RecommendedK8sLabels(Modification):
     @classmethod
     def values(cls, version: MzVersion) -> list[Any]:

--- a/test/orchestratord/mzcompose.py
+++ b/test/orchestratord/mzcompose.py
@@ -1748,7 +1748,7 @@ class ConsoleAppearance(Modification):
     # The operator copies the Materialize CR's `consoleAppearance` into the
     # console's `app-config.json`, which is how the console learns which
     # instance it is pointed at.
-    APPEARANCE = {"displayName": "prod"}
+    APPEARANCE = {"displayName": "prod", "accentColor": "orange"}
 
     @classmethod
     def values(cls, version: MzVersion) -> list[Any]:


### PR DESCRIPTION
Stacked on #38691, which adds `spec.consoleAppearance.displayName`. This is
the other half of that change, split out per review so the palette question can
be settled on its own. **Draft until we have design direction on the palette**
(see the open question below).

GitHub diffs this against `main`, so the file view below includes #38691's
commit as well. The accent change on its own is the second commit:
https://github.com/MaterializeInc/materialize/pull/38720/commits/04f8b6a697d9661c6454ad19595da18d718871d1

## What

Adds `accentColor` to `spec.consoleAppearance`, which recolors what the console
accents in Materialize purple: the active navigation item, primary buttons,
links, focus rings, and selection highlights.

```yaml
spec:
  consoleAppearance:
    displayName: prod
    accentColor: orange
```

Colors that carry meaning are left alone, so an error stays red and a healthy
object stays green. The default is unchanged: an instance that configures
nothing renders exactly as it does today, which a test pins.

Red and green are not offered, per review: the console already spends both on
meaning, and an error is hard to find on a red page. That leaves `blue`,
`orange`, and `purple`, where purple lets an operator pin the default
explicitly.

## Open question: the palette

The palette's hues do not run parallel. A shade that is vivid in one hue is
muted or washed out in another, so reading purple's shade positions for every
hue would drop some link text below 4.5:1 against the page and would paint the
primary button in a muted brick rather than a vivid one. `theme/accent.ts`
therefore names the shades each hue accents with, and a test holds every hue to
4.5:1 for accented text and surfaces.

That table is the weakest part of this change, and it is a symptom rather than
a fix: `theme/colors.ts` was drawn for a purple product with semantic
accents, not as a set of interchangeable skins. An even scale designed for the
purpose, along the lines of the colorbrewer sequential or qualitative sets
raised in review, would let this be a single rule instead of a per-hue table,
and would give a wider set of hues than three. That needs design input, which
is why this is a draft. A `TODO` in `accent.ts` records the same thing.

## How

Both palettes read their accent tokens from `theme/accent.ts`, so every
consumer of `accent.purple`, `accent.brightPurple` and `background.accent`
follows automatically, including the theme's own `Button`, `Radio` and `Tabs`
overrides.

Accent values the themes had hardcoded become palette tokens so that they
follow the accent as well: the active navigation item's wash (an inline
`rgba(90, 52, 203, 0.2)` in `NavItem`, whose comment already wished it were a
token), both themes' input focus rings, and three components that read raw
`colors.purple[…]` shades. The light focus ring moves from
`hsla(257, 100%, 65%, 0.24)` to `purple[400]` at the same opacity, which the
`hsla` was approximating to within one unit of green.

`accentColor` names a hue rather than carrying a CSS color, so no arbitrary
value can reach the DOM, and an orchestratord newer than the console it serves
falls back to purple rather than rendering an unresolvable color.

## Also here: enum values in the generated field reference

`crd-writer` only listed an enum's values when its variants carried doc
comments, because schemars describes those with `oneOf` and a bare enum with a
plain array of values. It now reads both. So `accentColor` documents its own
values instead of repeating them in prose, which is what review asked for, and
`privateKeyAlgorithm` picks up the `RSA`/`ECDSA`/`Ed25519` list it was missing.
That second change is visible in the regenerated reference and is the only
behavior change outside this feature.

## Tests

* Console unit tests cover the accent color's app-config parsing (including a
  value the build does not know), the default palette reproducing the shades
  the themes hardcoded, and the contrast floor every hue's shades hold.
* The orchestratord modification and the rollout-hash test grow to cover the
  new field.

## Notes for reviewers

* `accent.purple` and `accent.brightPurple` now carry whatever hue is
  configured, which their names no longer describe. Renaming them to role names
  touches 112 call sites, so it is not in this change; the contract is
  documented on `BasePalette` instead. Happy to do the rename first if
  preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
