### PR TITLE
ci: delete failed EKS node groups before retrying terraform destroy

### DIFF
--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -583,9 +583,18 @@ class State:
                         f"terraform destroy failed (attempt {attempt + 1}/3), "
                         "waiting 60s for resources to be released..."
                     )
+                    self.unblock_destroy()
                     time.sleep(60)
                 else:
                     raise
+
+    def unblock_destroy(self) -> None:
+        """Clear state that a failed `terraform destroy` cannot clear itself.
+
+        Called between destroy attempts, so it must tolerate a partially
+        destroyed deployment and must never raise: whatever it cannot fix is
+        the next attempt's problem, not a new failure.
+        """
 
     def test(
         self, c: Composition, tag: str, run_testdrive_files: bool, files: list[str]
@@ -690,6 +699,69 @@ class AWS(State):
     def __init__(self, path: Path):
         super().__init__(path)
         self.base_vars = []
+
+    def _list_node_groups(self, cluster: str) -> list[str]:
+        """Node groups attached to `cluster`, empty if the cluster is gone."""
+        try:
+            return json.loads(
+                spawn.capture(
+                    [
+                        "aws",
+                        "eks",
+                        "list-nodegroups",
+                        "--cluster-name",
+                        cluster,
+                        "--region",
+                        "us-east-1",
+                        "--output",
+                        "json",
+                    ]
+                )
+            )["nodegroups"]
+        except (subprocess.CalledProcessError, json.JSONDecodeError):
+            return []
+
+    def unblock_destroy(self) -> None:
+        # A node group whose creation failed keeps its cluster undeletable
+        # ("ResourceInUseException: Cluster has nodegroups attached"), and
+        # Terraform does not retry the node group once the cluster delete
+        # fails, so every attempt hits the same wall. The cluster, its VPC and
+        # its KMS key then leak, and since each test root uses a fixed name
+        # prefix, the leak fails every later run on "already exists".
+        try:
+            cluster = spawn.capture(
+                ["terraform", "output", "-raw", "eks_cluster_name"], cwd=self.path
+            ).strip()
+        except subprocess.CalledProcessError:
+            cluster = ""
+        if not cluster:
+            # Nothing left in state to clean up after.
+            return
+
+        for node_group in self._list_node_groups(cluster):
+            print(f"Deleting EKS node group {node_group} to unblock the destroy")
+            run_ignore_error(
+                [
+                    "aws",
+                    "eks",
+                    "delete-nodegroup",
+                    "--cluster-name",
+                    cluster,
+                    "--nodegroup-name",
+                    node_group,
+                    "--region",
+                    "us-east-1",
+                ]
+            )
+
+        # Deletion is asynchronous and the cluster stays undeletable until it
+        # finishes, so wait rather than letting the next attempt fail again.
+        deadline = time.time() + 600
+        while node_groups := self._list_node_groups(cluster):
+            if time.time() > deadline:
+                print(f"EKS node groups still attached after 10m: {node_groups}")
+                break
+            time.sleep(15)
 
     def setup(
         self,

--- a/test/terraform/mzcompose.py
+++ b/test/terraform/mzcompose.py
@@ -755,11 +755,16 @@ class AWS(State):
             )
 
         # Deletion is asynchronous and the cluster stays undeletable until it
-        # finishes, so wait rather than letting the next attempt fail again.
-        deadline = time.time() + 600
+        # finishes, so give it a moment before the next attempt. Only best
+        # effort, and deliberately far shorter than the deletion can take: the
+        # next `terraform destroy` waits on a node group already in DELETING
+        # properly, while cleanup as a whole has ~30 minutes of step budget
+        # left, so overrunning here risks the timeout leaking the very cluster
+        # this is trying to free.
+        deadline = time.time() + 300
         while node_groups := self._list_node_groups(cluster):
             if time.time() > deadline:
-                print(f"EKS node groups still attached after 10m: {node_groups}")
+                print(f"EKS node groups still deleting, leaving them: {node_groups}")
                 break
             time.sleep(15)
 


### PR DESCRIPTION
An EKS node group whose creation fails keeps its cluster undeletable (`ResourceInUseException: Cluster has nodegroups attached`), and Terraform does not retry the node group once the cluster delete fails, so all three `terraform destroy` attempts hit the same wall and the run leaks its cluster, VPC, KMS key and log groups. Because each AWS test root uses a fixed name prefix and every run starts from empty state, that leak then fails every later nightly on "already exists" within minutes, which is how one bad apply in Nightly 18263 turned into an open-ended outage of both AWS Terraform nightlies. `State.destroy` now calls an `unblock_destroy` hook between attempts, which AWS overrides to delete any attached node groups and wait for them to go away before the next attempt.

### Test plan

The failure path needs a real EKS cluster with a `CREATE_FAILED` node group, so it is exercised by a Nightly on this branch (the branch name matches the two AWS jobs' `*terraform*` filter). The healthy path is unchanged: the hook only runs after a `terraform destroy` attempt has already failed, and the base implementation is a no-op, so GCP and Azure keep their current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)