### PR TITLE
transform: complete partly-literal index keys using join equivalences

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -110,6 +110,7 @@ def get_minimal_system_parameters(
         "enable_logical_compaction_window": "true",
         "enable_metric_sink": "true",
         "enable_multi_worker_storage_persist_sink": "true",
+        "enable_partial_literal_index_lookups": "true",
         "enable_rbac_checks": "true",
         "enable_reduce_mfp_fusion": "true",
         "enable_refresh_every_mvs": "true",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -3095,6 +3095,9 @@ class FlipFlagsAction(Action):
         )
         self.flags_with_values["enable_upsert_v2"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_coalesce_case_transform"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["enable_partial_literal_index_lookups"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["enable_any_all_null_array_semantics"] = (
             BOOLEAN_FLAG_VALUES
         )

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -143,6 +143,8 @@ optimizer_feature_flags!({
     enable_will_distinct_propagation: bool,
     // See the feature flag of the same name.
     enable_fixed_correlated_cte_lowering: bool,
+    // See the feature flag of the same name.
+    enable_partial_literal_index_lookups: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5354,6 +5354,7 @@ pub fn unplan_create_cluster(
                 enable_coalesce_case_transform: _,
                 enable_will_distinct_propagation: _,
                 enable_fixed_correlated_cte_lowering: _,
+                enable_partial_literal_index_lookups: _,
             } = optimizer_feature_overrides;
             // The ones from above that don't occur below are not wired up to cluster features.
             let features_extracted = ClusterFeatureExtracted {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -649,6 +649,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_coalesce_case_transform: Default::default(),
                 enable_will_distinct_propagation: Default::default(),
                 enable_fixed_correlated_cte_lowering: v.enable_fixed_correlated_cte_lowering,
+                enable_partial_literal_index_lookups: Default::default(),
             },
         })
     }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2390,6 +2390,12 @@ feature_flags!(
         default: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_partial_literal_index_lookups,
+        desc: "Allow the optimizer to complete an index key that literal equalities cover only partly, using the enclosing join's equivalences to bind the rest.",
+        default: false,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {
@@ -2419,6 +2425,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_coalesce_case_transform: vars.enable_coalesce_case_transform(),
             enable_will_distinct_propagation: vars.enable_will_distinct_propagation(),
             enable_fixed_correlated_cte_lowering: vars.enable_fixed_correlated_cte_lowering(),
+            enable_partial_literal_index_lookups: vars.enable_partial_literal_index_lookups(),
         }
     }
 }
@@ -2470,6 +2477,7 @@ mod tests {
             enable_coalesce_case_transform,
             enable_will_distinct_propagation,
             enable_fixed_correlated_cte_lowering,
+            enable_partial_literal_index_lookups,
         } = false_features;
 
         let mut vars = SystemVars::new();
@@ -2503,6 +2511,7 @@ mod tests {
         set_var!(enable_coalesce_case_transform);
         set_var!(enable_will_distinct_propagation);
         set_var!(enable_fixed_correlated_cte_lowering);
+        set_var!(enable_partial_literal_index_lookups);
 
         // Enable for item parsing, then ensure we still get the same optimizer features.
         vars.enable_for_item_parsing();

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -615,7 +615,7 @@ mod delta_queries {
                 cardinalities,
                 filters,
                 input_mapper,
-                optimizer_features.enable_join_prioritize_arranged,
+                optimizer_features,
             )?;
 
             // Count new arrangements.
@@ -713,7 +713,7 @@ mod differential {
                 cardinalities,
                 filters,
                 input_mapper,
-                optimizer_features.enable_join_prioritize_arranged,
+                optimizer_features,
             )?;
 
             // Count new arrangements.
@@ -1014,7 +1014,7 @@ fn optimize_orders(
     cardinalities: &[Option<usize>],     // cardinalities of input relations
     filters: &[FilterCharacteristics],   // filter characteristics per input
     input_mapper: &JoinInputMapper,      // join helper
-    enable_join_prioritize_arranged: bool,
+    features: &OptimizerFeatures,
 ) -> Result<Vec<Vec<(JoinInputCharacteristics, Vec<MirScalarExpr>, usize)>>, TransformError> {
     let mut orderer = Orderer::new(
         equivalences,
@@ -1023,7 +1023,7 @@ fn optimize_orders(
         cardinalities,
         filters,
         input_mapper,
-        enable_join_prioritize_arranged,
+        features,
     );
     (0..available.len())
         .map(move |i| orderer.optimize_order_for(i))
@@ -1040,6 +1040,19 @@ struct Orderer<'a> {
     input_mapper: &'a JoinInputMapper,
     reverse_equivalences: Vec<Vec<(usize, usize)>>,
     unique_arrangement: Vec<Vec<bool>>,
+    /// Per input, the expressions (local to it) that an equivalence class pins
+    /// to a literal. Such an expression is bound whatever the order, so an
+    /// arrangement whose key the column equalities only partly cover can still
+    /// be viable. Kept apart from `bound`, which doubles as the key of an
+    /// arrangement the join would build: merging them would widen that key and
+    /// trade an existing arrangement for a new one.
+    ///
+    /// A key made viable by literals alone would probe with constants and leave
+    /// the real equalities as residual filters. That does not arise from SQL:
+    /// `LiteralConstraints` turns a fully literal key into an `IndexedFilter`
+    /// before the join is planned, and states a literal equivalence only next
+    /// to column equalities that bind the rest of the key.
+    literal_bound: Vec<Vec<MirScalarExpr>>,
 
     order: Vec<(JoinInputCharacteristics, Vec<MirScalarExpr>, usize)>,
     placed: Vec<bool>,
@@ -1060,7 +1073,7 @@ impl<'a> Orderer<'a> {
         cardinalities: &'a [Option<usize>],
         filters: &'a [FilterCharacteristics],
         input_mapper: &'a JoinInputMapper,
-        enable_join_prioritize_arranged: bool,
+        features: &OptimizerFeatures,
     ) -> Self {
         let inputs = arrangements.len();
         // A map from inputs to the equivalence classes in which they are referenced.
@@ -1083,6 +1096,21 @@ impl<'a> Orderer<'a> {
             }
         }
 
+        // See the doc on `literal_bound` for why this is kept apart from `bound`.
+        let mut literal_bound: Vec<Vec<MirScalarExpr>> = vec![Vec::new(); inputs];
+        if features.enable_partial_literal_index_lookups {
+            for equivalence in equivalences.iter() {
+                if !equivalence.iter().any(|e| e.is_literal()) {
+                    continue;
+                }
+                for expr in equivalence {
+                    if let Some(rel) = input_mapper.single_input(expr) {
+                        literal_bound[rel].push(input_mapper.map_expr_to_local(expr.clone()));
+                    }
+                }
+            }
+        }
+
         let order = Vec::with_capacity(inputs);
         let placed = vec![false; inputs];
         let bound = vec![Vec::new(); inputs];
@@ -1099,13 +1127,14 @@ impl<'a> Orderer<'a> {
             input_mapper,
             reverse_equivalences,
             unique_arrangement,
+            literal_bound,
             order,
             placed,
             bound,
             equivalences_active,
             arrangement_active,
             priority_queue,
-            enable_join_prioritize_arranged,
+            enable_join_prioritize_arranged: features.enable_join_prioritize_arranged,
         }
     }
 
@@ -1308,7 +1337,10 @@ impl<'a> Orderer<'a> {
 
                                         // Determine if the arrangement is viable,
                                         // which happens when all its key components are bound.
-                                        if key.iter().all(|k| self.bound[rel].contains(k)) {
+                                        if key.iter().all(|k| {
+                                            self.bound[rel].contains(k)
+                                                || self.literal_bound[rel].contains(k)
+                                        }) {
                                             self.arrangement_active[rel].push(pos);
                                             // TODO: This could be pre-computed, as it is independent of the order.
                                             let is_unique = self.unique_arrangement[rel][pos];

--- a/src/transform/src/literal_constraints.rs
+++ b/src/transform/src/literal_constraints.rs
@@ -17,20 +17,29 @@
 //! to
 //! `SELECT f1, f2, f3 FROM t, (SELECT * FROM (VALUES (lit1, lit2))) as filter_list
 //!  WHERE t.f1 = filter_list.column1 AND t.f2 = filter_list.column2`
+//!
+//! That rewrite needs the literals to cover every field of some index key. When
+//! they cover only part of one, and the `Get` sits inside a join whose
+//! equivalences bind the rest, we instead complete the key in place so that
+//! `JoinImplementation` can probe the index. See
+//! `LiteralConstraints::complete_join_index_key`.
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use itertools::Itertools;
-use mz_expr::JoinImplementation::IndexedFilter;
+use mz_expr::JoinImplementation::{IndexedFilter, Unimplemented};
 use mz_expr::canonicalize::canonicalize_predicates;
 use mz_expr::func::variadic::{And, Or};
 use mz_expr::visit::{Visit, VisitChildren};
-use mz_expr::{BinaryFunc, Id, MapFilterProject, MirRelationExpr, MirScalarExpr, VariadicFunc};
+use mz_expr::{
+    BinaryFunc, Columns, Id, JoinInputMapper, MapFilterProject, MirRelationExpr, MirScalarExpr,
+    VariadicFunc,
+};
 use mz_ore::collections::CollectionExt;
 use mz_ore::iter::IteratorExt;
 use mz_ore::stack::RecursionLimitError;
 use mz_ore::vec::swap_remove_multiple;
-use mz_repr::{Diff, GlobalId, ReprRelationType, Row};
+use mz_repr::{Diff, GlobalId, ReprColumnType, ReprRelationType, Row};
 
 use crate::TransformCtx;
 use crate::canonicalize_mfp::CanonicalizeMfp;
@@ -68,6 +77,21 @@ impl LiteralConstraints {
         transform_ctx: &mut TransformCtx,
     ) -> Result<(), crate::TransformError> {
         let mut mfp = MapFilterProject::extract_non_errors_from_expr_mut(relation);
+
+        // Has to happen before recursing: the rewrite needs the literal
+        // equalities as Filters on the join's inputs, which the `Get` case
+        // below may remove.
+        if transform_ctx.features.enable_partial_literal_index_lookups {
+            if let Some(restore) = Self::complete_join_index_key(relation, transform_ctx)? {
+                let (map, filter, project) = mfp.as_map_filter_project();
+                mfp = MapFilterProject::new(relation.arity())
+                    .project(restore)
+                    .map(map)
+                    .filter(filter)
+                    .project(project);
+            }
+        }
+
         relation.try_visit_mut_children(|e| self.action(e, transform_ctx))?;
 
         if let MirRelationExpr::Get {
@@ -285,16 +309,6 @@ impl LiteralConstraints {
         }
     }
 
-    /// Detects literal constraints in an MFP on top of a Get of `id`, and a matching index that can
-    /// be used to speed up the Filter of the MFP.
-    ///
-    /// For example, if there is an index on `(f1, f2)`, and the Filter is
-    /// `(f1 = 3 AND f2 = 5) OR (f1 = 7 AND f2 = 9)`, it returns `Some([f1, f2], [[3,5], [7,9]])`.
-    ///
-    /// We can use an index if each argument of the OR includes a literal constraint on each of the
-    /// key fields of the index. Extra predicates inside the OR arguments are ok.
-    ///
-    /// Returns (idx_id, idx_key, values to lookup in the index).
     fn detect_literal_constraints(
         mfp: &MapFilterProject,
         get_id: GlobalId,
@@ -752,6 +766,380 @@ impl LiteralConstraints {
         }
         sum
     }
+
+    /// Completes an index key that literal equalities cover only partly, when
+    /// `relation` is a join whose equivalences bind the rest of that key.
+    ///
+    /// An arrangement can only be probed with a complete key, so the `Get` case
+    /// of [LiteralConstraints::action] declines an index whose key the literals
+    /// cover only partly, leaving a full scan. Inside a join the missing key
+    /// fields are often bound anyway, through an equivalence with another
+    /// input, and then all that stands in the way is that the covered fields
+    /// are not stated in a form the join can see. This states them: the covered
+    /// fields become output columns of the indexed input, and the values they
+    /// are pinned to enter the join as equivalences. `JoinImplementation` then
+    /// finds every field of the key bound and can pick the index.
+    ///
+    /// Returns the projection that restores the join's original output columns.
+    /// `None` means the join was left alone.
+    ///
+    /// NOTE: Whether the index is actually probed is decided later, by
+    /// `JoinImplementation`. Should the order decline it, the rewrite has cost
+    /// a widened projection, for a lookup collection a replicated binder, and
+    /// the too-wide notice the `Get` case would otherwise have given.
+    fn complete_join_index_key(
+        relation: &mut MirRelationExpr,
+        transform_ctx: &TransformCtx,
+    ) -> Result<Option<Vec<usize>>, crate::TransformError> {
+        let MirRelationExpr::Join {
+            inputs,
+            equivalences,
+            implementation: Unimplemented,
+        } = relation
+        else {
+            return Ok(None);
+        };
+        // A single input has no equivalences that could bind the rest of a key.
+        if inputs.len() < 2 {
+            return Ok(None);
+        }
+
+        let input_types = inputs.iter().map(|i| i.typ()).collect_vec();
+        let input_mapper = JoinInputMapper::new_from_input_types(&input_types);
+
+        let mut candidates = Vec::new();
+        for i in 0..inputs.len() {
+            candidates.extend(Self::find_partial_key_lookup(
+                i,
+                inputs,
+                &input_mapper,
+                equivalences,
+                transform_ctx,
+            )?);
+        }
+        // The widest key is the most selective lookup.
+        // TODO: Only one input per join is completed, and this transform runs
+        // once, so a join with two eligible inputs only ever gets the first.
+        let Some(lookup) = candidates.into_iter().max_by_key(|lookup| lookup.key_len) else {
+            return Ok(None);
+        };
+
+        Ok(Some(Self::splice_in_key_bindings(
+            inputs,
+            equivalences,
+            &input_mapper,
+            &lookup,
+        )))
+    }
+
+    /// Looks for an index on join input `i` whose key is covered partly by
+    /// literal equalities in the input's own filter and partly by the join's
+    /// equivalences.
+    ///
+    /// Only plain-column key fields are considered. That is the shape user
+    /// indexes almost always have, and it keeps the correspondence between
+    /// `Get` columns and join columns a projection lookup rather than an
+    /// expression match.
+    fn find_partial_key_lookup(
+        i: usize,
+        inputs: &[MirRelationExpr],
+        input_mapper: &JoinInputMapper,
+        equivalences: &[Vec<MirScalarExpr>],
+        transform_ctx: &TransformCtx,
+    ) -> Result<Option<PartialKeyLookup>, crate::TransformError> {
+        let (mfp, inner) = MapFilterProject::extract_non_errors_from_expr(&inputs[i]);
+        let MirRelationExpr::Get {
+            id: Id::Global(get_id),
+            ..
+        } = inner
+        else {
+            return Ok(None);
+        };
+        let inner_typ = inner.typ();
+
+        // The same preparation the `Get` case does, for the same reasons.
+        let mut prepared = mfp.clone();
+        Self::inline_literal_constraints(&mut prepared);
+        Self::list_of_predicates_to_and_of_predicates(&mut prepared);
+        Self::distribute_and_over_or(&mut prepared)?;
+        Self::unary_and(&mut prepared);
+        let removed_contradicting_or_args = Self::remove_impossible_or_args(&mut prepared)?;
+        let or_args = Self::get_or_args(&prepared);
+        if or_args.is_empty() {
+            return Ok(None);
+        }
+
+        // Completing a key is only ever an improvement over a full scan. When
+        // some index *is* fully covered the `Get` case turns the input into an
+        // `IndexedFilter`, and re-arranging that by a wider key trades an
+        // existing arrangement for a new one. This is the same condition under
+        // which the `Get` case reports an index as too wide.
+        if transform_ctx
+            .indexes
+            .indexes_on(*get_id)
+            .any(|(_, key)| matches!(Self::match_index(key, &or_args), IndexMatch::Usable(..)))
+        {
+            return Ok(None);
+        }
+
+        let bound_by = Self::join_bound_columns(i, input_mapper, equivalences);
+        // Every other input that the join equates with any column of this one.
+        let all_binders: BTreeSet<usize> = bound_by.values().flatten().copied().collect();
+        // The output column of input `i` that carries `Get` column `c`, if any.
+        // Rewriting the input's MFP below preserves its output, so a position
+        // this reports stays valid for the rewritten MFP too.
+        let out_col = |c: usize| mfp.projection.iter().position(|p| *p == c);
+        let key_col = |e: &MirScalarExpr| match e {
+            MirScalarExpr::Column(c, _) => Some(*c),
+            _ => None,
+        };
+
+        let best = transform_ctx
+            .indexes
+            .indexes_on(*get_id)
+            .filter_map(|(_index_id, key)| {
+                let key_cols = key.iter().map(key_col).collect::<Option<Vec<_>>>()?;
+                // `Usable` is the `Get` case's own job, and `UnusableNoSubset`
+                // leaves nothing to complete.
+                let IndexMatch::UnusableTooWide(literal_key) = Self::match_index(key, &or_args)
+                else {
+                    return None;
+                };
+
+                // Every key field the literals do not cover has to be visible
+                // to the join and equated there with another input. `binders`
+                // ends up as the inputs that bind *all* of them.
+                let mut binders: Option<BTreeSet<usize>> = None;
+                for (pos, key_field) in key.iter().enumerate() {
+                    if literal_key.contains(key_field) {
+                        continue;
+                    }
+                    let binding = out_col(key_cols[pos]).and_then(|oc| bound_by.get(&oc))?;
+                    binders = Some(match binders {
+                        None => binding.clone(),
+                        Some(prev) => prev.intersection(binding).copied().collect(),
+                    });
+                }
+                let binders = binders?;
+                // An input that equates with this one but leaves some uncovered
+                // field unbound would still look it up by a key the index does
+                // not have, and `implement_arrangements` lifts an input's MFP
+                // only when every key it needs is on the index. See the NOTE on
+                // `complete_join_index_key` for what that costs.
+                if binders != all_binders {
+                    return None;
+                }
+
+                // `literal_key` came out of `UnusableTooWide`, so this matches
+                // by construction.
+                let IndexMatch::Usable(literal_values, _) =
+                    Self::match_index(&literal_key, &or_args)
+                else {
+                    return None;
+                };
+                // Contradicting constraints make the whole relation empty.
+                // Leave that rewrite to the `Get` case.
+                if literal_values.is_empty() {
+                    return None;
+                }
+
+                let values = if let Ok(row) = literal_values.iter().exactly_one() {
+                    LookupValues::Literals(
+                        row.iter()
+                            .zip_eq(literal_key.iter())
+                            .map(|(datum, key_field)| {
+                                MirScalarExpr::literal_ok(
+                                    datum,
+                                    key_field.typ(&inner_typ.column_types).scalar_type,
+                                )
+                            })
+                            .collect(),
+                    )
+                } else {
+                    // The values live only in the binder's cross product, so a
+                    // second equating input would still look this one up by a
+                    // partial key.
+                    // TODO: Bound the number of values, or weigh it against the
+                    // binder's cardinality, since the binder is replicated once
+                    // per value.
+                    let binder = *binders.iter().exactly_one().ok()?;
+                    LookupValues::Collection {
+                        binder,
+                        types: literal_key
+                            .iter()
+                            .map(|key_field| {
+                                key_field
+                                    .typ(&inner_typ.column_types)
+                                    .scalar_type
+                                    .nullable(false)
+                            })
+                            .collect(),
+                        rows: literal_values,
+                    }
+                };
+
+                // The equivalences added below pin the covered key fields to
+                // their values, so the input's own literal constraints become
+                // redundant and are dropped. This is also what keeps the `Get`
+                // case from reporting the index as too wide once recursion
+                // reaches it: there is no literal constraint left to report on.
+                let mut input_mfp = {
+                    let mut stripped = prepared.clone();
+                    if Self::remove_literal_constraints(&mut stripped, &literal_key)
+                        || removed_contradicting_or_args
+                    {
+                        Self::undo_preparation(&mut stripped, &mfp, inner, inner_typ.clone());
+                        stripped
+                    } else {
+                        mfp.clone()
+                    }
+                };
+
+                // Expose the covered key fields, in `literal_key` order so that
+                // they line up with the values.
+                let key_out_cols = literal_key
+                    .iter()
+                    .map(|key_field| {
+                        let c = key_col(key_field).expect("`literal_key` is a subset of `key`");
+                        out_col(c).unwrap_or_else(|| {
+                            input_mfp.projection.push(c);
+                            input_mfp.projection.len() - 1
+                        })
+                    })
+                    .collect();
+
+                Some(PartialKeyLookup {
+                    input: i,
+                    key_len: key.len(),
+                    values,
+                    input_mfp,
+                    key_out_cols,
+                })
+            })
+            .max_by_key(|lookup| lookup.key_len);
+        Ok(best)
+    }
+
+    /// For each output column of input `i` (local to it), the other inputs that
+    /// the join equates that column with.
+    fn join_bound_columns(
+        i: usize,
+        input_mapper: &JoinInputMapper,
+        equivalences: &[Vec<MirScalarExpr>],
+    ) -> BTreeMap<usize, BTreeSet<usize>> {
+        let mut bound: BTreeMap<usize, BTreeSet<usize>> = BTreeMap::new();
+        for class in equivalences {
+            let binders = class
+                .iter()
+                .filter_map(|e| input_mapper.single_input(e))
+                .filter(|j| *j != i)
+                .collect::<BTreeSet<_>>();
+            if binders.is_empty() {
+                continue;
+            }
+            for e in class {
+                if input_mapper.single_input(e) == Some(i) {
+                    if let MirScalarExpr::Column(c, _) = input_mapper.map_expr_to_local(e.clone()) {
+                        bound.entry(c).or_default().extend(binders.iter().copied());
+                    }
+                }
+            }
+        }
+        bound
+    }
+
+    /// Installs `lookup` into the join: widens the indexed input so that the
+    /// covered key fields are output columns, brings in the values those fields
+    /// are pinned to, and equates the two. Returns the projection that restores
+    /// the join's original output columns.
+    ///
+    /// A [LookupValues::Collection] is crossed *into* the binder rather than
+    /// added as a sibling input because a join order can only reach the
+    /// arrangement once a single placed input supplies every field of the key.
+    /// As a sibling the values would be reachable only through the indexed
+    /// input itself, so no order could bind the whole key before placing it.
+    /// The cost is that the binder is replicated once per lookup value.
+    fn splice_in_key_bindings(
+        inputs: &mut [MirRelationExpr],
+        equivalences: &mut Vec<Vec<MirScalarExpr>>,
+        input_mapper: &JoinInputMapper,
+        lookup: &PartialKeyLookup,
+    ) -> Vec<usize> {
+        let i = lookup.input;
+        let old_arity = |k: usize| input_mapper.input_arity(k);
+        let exposed = lookup.input_mfp.projection.len() - old_arity(i);
+        let (binder, values_width) = match &lookup.values {
+            LookupValues::Literals(_) => (None, 0),
+            LookupValues::Collection { binder, types, .. } => (Some(*binder), types.len()),
+        };
+
+        // Both inputs only grow by columns appended at their end, so every
+        // original column keeps its position local to its own input and only
+        // the input offsets move.
+        let new_start = (0..inputs.len())
+            .scan(0, |acc, k| {
+                let start = *acc;
+                *acc += old_arity(k)
+                    + if k == i { exposed } else { 0 }
+                    + if Some(k) == binder { values_width } else { 0 };
+                Some(start)
+            })
+            .collect_vec();
+        let relocate = |c: usize| {
+            let (local, k) = input_mapper.map_column_to_local(c);
+            new_start[k] + local
+        };
+
+        for expr in equivalences.iter_mut().flatten() {
+            expr.visit_columns(|c| *c = relocate(*c));
+        }
+
+        // With nothing to expose and nothing removed from the filter the MFP
+        // is unchanged, and rebuilding it would only reshuffle nodes.
+        if exposed > 0 || binder.is_some() {
+            let (_, inner) = MapFilterProject::extract_non_errors_from_expr(&inputs[i]);
+            let mut indexed_input = inner.clone();
+            CanonicalizeMfp::rebuild_mfp(lookup.input_mfp.clone(), &mut indexed_input);
+            inputs[i] = indexed_input;
+        }
+
+        if let LookupValues::Collection {
+            binder,
+            rows,
+            types,
+        } = &lookup.values
+        {
+            let lookup_values = MirRelationExpr::Constant {
+                rows: Ok(rows.iter().map(|row| (row.clone(), Diff::ONE)).collect()),
+                typ: ReprRelationType {
+                    column_types: types.clone(),
+                    // (See the note on the `filter_list` type in the `Get`
+                    // case for why the key is stated explicitly.)
+                    keys: vec![(0..types.len()).collect()],
+                },
+            };
+            inputs[*binder] = MirRelationExpr::Join {
+                inputs: vec![inputs[*binder].take_dangerous(), lookup_values],
+                equivalences: Vec::new(),
+                implementation: Unimplemented,
+            };
+        }
+
+        for (p, key_out_col) in lookup.key_out_cols.iter().enumerate() {
+            let value = match &lookup.values {
+                LookupValues::Literals(literals) => literals[p].clone(),
+                LookupValues::Collection { binder, .. } => {
+                    MirScalarExpr::column(new_start[*binder] + old_arity(*binder) + p)
+                }
+            };
+            equivalences.push(vec![
+                MirScalarExpr::column(new_start[i] + key_out_col),
+                value,
+            ]);
+        }
+
+        (0..input_mapper.total_columns()).map(relocate).collect()
+    }
 }
 
 /// Whether an index is usable to speed up a Filter with literal constraints.
@@ -775,4 +1163,41 @@ enum IndexMatch {
     /// The index is unusable. Moreover, none of its key fields could be used as an alternate index
     /// to speed up this filter.
     UnusableNoSubset,
+}
+
+/// An index on one join input whose key [LiteralConstraints::complete_join_index_key]
+/// can complete.
+#[derive(Debug)]
+struct PartialKeyLookup {
+    /// The join input holding the indexed `Get`.
+    input: usize,
+    /// Number of fields in the index key. Only used to prefer the widest key.
+    key_len: usize,
+    /// The values the literal-covered key fields are pinned to.
+    values: LookupValues,
+    /// Replacement MFP for `input`, exposing every key field the literals
+    /// cover. It only ever appends to the original projection, so the join's
+    /// existing columns keep their positions.
+    input_mfp: MapFilterProject,
+    /// For each value in `values`, in that order, the output column of `input`
+    /// under `input_mfp` that carries the key field it constrains.
+    key_out_cols: Vec<usize>,
+}
+
+/// How the values of the literal-covered key fields reach the join.
+#[derive(Debug)]
+enum LookupValues {
+    /// A single value per covered key field, so each one can go in as a join
+    /// equivalence with the literal itself.
+    Literals(Vec<MirScalarExpr>),
+    /// Several values, which cannot be one equivalence and so have to enter the
+    /// join as a collection crossed into `binder`.
+    Collection {
+        /// The input that binds every key field the literals do not cover.
+        /// Never the indexed input itself, so the two inputs that grow are
+        /// always distinct.
+        binder: usize,
+        rows: Vec<Row>,
+        types: Vec<ReprColumnType>,
+    },
 }

--- a/src/transform/src/literal_constraints.rs
+++ b/src/transform/src/literal_constraints.rs
@@ -869,18 +869,15 @@ impl LiteralConstraints {
             return Ok(None);
         }
 
-        // Completing a key is only ever an improvement over a full scan. When
-        // some index *is* fully covered the `Get` case turns the input into an
-        // `IndexedFilter`, and re-arranging that by a wider key trades an
-        // existing arrangement for a new one. This is the same condition under
-        // which the `Get` case reports an index as too wide.
-        if transform_ctx
+        // Indexes the literals cover fully. Those are the `Get` case's lookups,
+        // and a candidate below competes with them only under the conditions
+        // checked there.
+        let usable_keys = transform_ctx
             .indexes
             .indexes_on(*get_id)
-            .any(|(_, key)| matches!(Self::match_index(key, &or_args), IndexMatch::Usable(..)))
-        {
-            return Ok(None);
-        }
+            .filter(|(_, key)| matches!(Self::match_index(key, &or_args), IndexMatch::Usable(..)))
+            .map(|(_, key)| key.to_owned())
+            .collect_vec();
 
         let bound_by = Self::join_bound_columns(i, input_mapper, equivalences);
         // Every other input that the join equates with any column of this one.
@@ -905,6 +902,26 @@ impl LiteralConstraints {
                 else {
                     return None;
                 };
+
+                // Against a fully covered index this key wins only if it
+                // strictly extends every such index (stripping its literals
+                // then leaves the `Get` case nothing to act on) and contains a
+                // unique key. Ideally we would weigh |narrow lookup result|
+                // against |binder| x |literal values| with statistics, but none
+                // are available to estimate either. A unique key at least caps
+                // the wide probe at |binder| x |literal values|, one row per
+                // probe, and rules out the narrow index being a point lookup.
+                if !usable_keys.is_empty()
+                    && !(usable_keys
+                        .iter()
+                        .all(|u| u.len() < key.len() && u.iter().all(|f| key.contains(f)))
+                        && inner_typ
+                            .keys
+                            .iter()
+                            .any(|unique| unique.iter().all(|c| key_cols.contains(c))))
+                {
+                    return None;
+                }
 
                 // Every key field the literals do not cover has to be visible
                 // to the join and equated there with another input. `binders`

--- a/src/transform/src/literal_constraints.rs
+++ b/src/transform/src/literal_constraints.rs
@@ -84,30 +84,6 @@ impl LiteralConstraints {
             Self::distribute_and_over_or(&mut mfp)?;
             Self::unary_and(&mut mfp);
 
-            /// The above preparation might make the MFP more complicated, so we'll later want to
-            /// either undo the preparation transformations or get back to `orig_mfp`.
-            fn undo_preparation(
-                mfp: &mut MapFilterProject,
-                orig_mfp: &MapFilterProject,
-                relation: &MirRelationExpr,
-                relation_type: ReprRelationType,
-            ) {
-                // undo list_of_predicates_to_and_of_predicates, distribute_and_over_or, unary_and
-                // (It undoes the latter 2 through `MirScalarExp::reduce`.)
-                LiteralConstraints::canonicalize_predicates(mfp, relation, relation_type);
-                // undo inline_literal_constraints
-                mfp.optimize();
-                // We can usually undo, but sometimes not (see comment on `distribute_and_over_or`),
-                // so in those cases we might have a more complicated MFP than the original MFP
-                // (despite the removal of the literal constraints and/or contradicting OR args).
-                // So let's use the simpler one.
-                if LiteralConstraints::predicates_size(orig_mfp)
-                    < LiteralConstraints::predicates_size(mfp)
-                {
-                    *mfp = orig_mfp.clone();
-                }
-            }
-
             let removed_contradicting_or_args = Self::remove_impossible_or_args(&mut mfp)?;
 
             // todo: We might want to also call `canonicalize_equivalences`,
@@ -122,7 +98,7 @@ impl LiteralConstraints {
                     // We didn't find a usable index, so no chance to remove literal constraints.
                     // But, we might have removed contradicting OR args.
                     if removed_contradicting_or_args {
-                        undo_preparation(&mut mfp, &orig_mfp, relation, inp_typ);
+                        Self::undo_preparation(&mut mfp, &orig_mfp, relation, inp_typ);
                     } else {
                         // We didn't remove anything, so let's go with the original MFP.
                         mfp = orig_mfp;
@@ -136,7 +112,7 @@ impl LiteralConstraints {
                     {
                         // We were able to remove the literal constraints or contradicting OR args,
                         // so we would like to use this new MFP, so we try undoing the preparation.
-                        undo_preparation(&mut mfp, &orig_mfp, relation, inp_typ.clone());
+                        Self::undo_preparation(&mut mfp, &orig_mfp, relation, inp_typ.clone());
                     } else {
                         // We were not able to remove the literal constraint, so `mfp` is
                         // equivalent to `orig_mfp`, but `orig_mfp` is often simpler (or the same).
@@ -223,82 +199,113 @@ impl LiteralConstraints {
     /// key fields of the index. Extra predicates inside the OR arguments are ok.
     ///
     /// Returns (idx_id, idx_key, values to lookup in the index).
+    // Checks whether an index with the specified key can be used to speed up the given filter.
+    // See comment of `IndexMatch`.
+    fn match_index(key: &[MirScalarExpr], or_args: &Vec<MirScalarExpr>) -> IndexMatch {
+        if key.is_empty() {
+            // Nothing to do with an index that has an empty key.
+            return IndexMatch::UnusableNoSubset;
+        }
+        if !key.iter().all_unique() {
+            // This is a weird index. Why does it have duplicate key expressions?
+            return IndexMatch::UnusableNoSubset;
+        }
+        let mut literal_values = Vec::new();
+        let mut inv_cast_any = false;
+        // This starts with all key fields of the index.
+        // At the end, it will contain a subset S of index key fields such that if the index had
+        // only S as its key, then the index would be usable.
+        let mut usable_key_fields = key.iter().collect::<BTreeSet<_>>();
+        let mut usable = true;
+        for or_arg in or_args {
+            let mut row = Row::default();
+            let mut packer = row.packer();
+            for key_field in key {
+                let and_args = or_arg.and_or_args(And.into());
+                // Let's find a constraint for this key field
+                if let Some((literal, inv_cast)) = and_args
+                    .iter()
+                    .find_map(|and_arg| and_arg.expr_eq_literal(key_field))
+                {
+                    // (Note that the above find_map can find only 0 or 1 result, because
+                    // of `remove_impossible_or_args`.)
+                    packer.push(literal.unpack_first());
+                    inv_cast_any |= inv_cast;
+                } else {
+                    // There is an `or_arg` where we didn't find a constraint for a key field,
+                    // so the index is unusable. Throw out the field from the usable fields.
+                    usable = false;
+                    usable_key_fields.remove(key_field);
+                    if usable_key_fields.is_empty() {
+                        return IndexMatch::UnusableNoSubset;
+                    }
+                }
+            }
+            literal_values.push(row);
+        }
+        if usable {
+            // We should deduplicate, because a constraint can be duplicated by
+            // `distribute_and_over_or`. For example: `IN ('l1', 'l2') AND (a > 0 OR a < 5)`:
+            // the 2 args of the OR will cause the IN constraints to be duplicated. This doesn't
+            // alter the meaning of the expression when evaluated as a filter, but if we extract
+            // those literals 2 times into `literal_values` then the Peek code will look up
+            // those keys from the index 2 times, leading to duplicate results.
+            literal_values.sort();
+            literal_values.dedup();
+            IndexMatch::Usable(literal_values, inv_cast_any)
+        } else {
+            if usable_key_fields.is_empty() {
+                IndexMatch::UnusableNoSubset
+            } else {
+                IndexMatch::UnusableTooWide(usable_key_fields.into_iter().cloned().collect_vec())
+            }
+        }
+    }
+
+    /// The preparation that literal detection needs (see the `Get` case of
+    /// [LiteralConstraints::action]) might make the MFP more complicated, so
+    /// afterwards we want to either undo it or get back to `orig_mfp`.
+    fn undo_preparation(
+        mfp: &mut MapFilterProject,
+        orig_mfp: &MapFilterProject,
+        relation: &MirRelationExpr,
+        relation_type: ReprRelationType,
+    ) {
+        // undo list_of_predicates_to_and_of_predicates, distribute_and_over_or, unary_and
+        // (It undoes the latter 2 through `MirScalarExp::reduce`.)
+        Self::canonicalize_predicates(mfp, relation, relation_type);
+        // undo inline_literal_constraints
+        mfp.optimize();
+        // We can usually undo, but sometimes not (see comment on `distribute_and_over_or`),
+        // so in those cases we might have a more complicated MFP than the original MFP
+        // (despite the removal of the literal constraints and/or contradicting OR args).
+        // So let's use the simpler one.
+        if Self::predicates_size(orig_mfp) < Self::predicates_size(mfp) {
+            *mfp = orig_mfp.clone();
+        }
+    }
+
+    /// Detects literal constraints in an MFP on top of a Get of `id`, and a matching index that can
+    /// be used to speed up the Filter of the MFP.
+    ///
+    /// For example, if there is an index on `(f1, f2)`, and the Filter is
+    /// `(f1 = 3 AND f2 = 5) OR (f1 = 7 AND f2 = 9)`, it returns `Some([f1, f2], [[3,5], [7,9]])`.
+    ///
+    /// We can use an index if each argument of the OR includes a literal constraint on each of the
+    /// key fields of the index. Extra predicates inside the OR arguments are ok.
+    ///
+    /// Returns (idx_id, idx_key, values to lookup in the index).
     fn detect_literal_constraints(
         mfp: &MapFilterProject,
         get_id: GlobalId,
         transform_ctx: &mut TransformCtx,
     ) -> Option<(GlobalId, Vec<MirScalarExpr>, Vec<Row>)> {
-        // Checks whether an index with the specified key can be used to speed up the given filter.
-        // See comment of `IndexMatch`.
-        fn match_index(key: &[MirScalarExpr], or_args: &Vec<MirScalarExpr>) -> IndexMatch {
-            if key.is_empty() {
-                // Nothing to do with an index that has an empty key.
-                return IndexMatch::UnusableNoSubset;
-            }
-            if !key.iter().all_unique() {
-                // This is a weird index. Why does it have duplicate key expressions?
-                return IndexMatch::UnusableNoSubset;
-            }
-            let mut literal_values = Vec::new();
-            let mut inv_cast_any = false;
-            // This starts with all key fields of the index.
-            // At the end, it will contain a subset S of index key fields such that if the index had
-            // only S as its key, then the index would be usable.
-            let mut usable_key_fields = key.iter().collect::<BTreeSet<_>>();
-            let mut usable = true;
-            for or_arg in or_args {
-                let mut row = Row::default();
-                let mut packer = row.packer();
-                for key_field in key {
-                    let and_args = or_arg.and_or_args(And.into());
-                    // Let's find a constraint for this key field
-                    if let Some((literal, inv_cast)) = and_args
-                        .iter()
-                        .find_map(|and_arg| and_arg.expr_eq_literal(key_field))
-                    {
-                        // (Note that the above find_map can find only 0 or 1 result, because
-                        // of `remove_impossible_or_args`.)
-                        packer.push(literal.unpack_first());
-                        inv_cast_any |= inv_cast;
-                    } else {
-                        // There is an `or_arg` where we didn't find a constraint for a key field,
-                        // so the index is unusable. Throw out the field from the usable fields.
-                        usable = false;
-                        usable_key_fields.remove(key_field);
-                        if usable_key_fields.is_empty() {
-                            return IndexMatch::UnusableNoSubset;
-                        }
-                    }
-                }
-                literal_values.push(row);
-            }
-            if usable {
-                // We should deduplicate, because a constraint can be duplicated by
-                // `distribute_and_over_or`. For example: `IN ('l1', 'l2') AND (a > 0 OR a < 5)`:
-                // the 2 args of the OR will cause the IN constraints to be duplicated. This doesn't
-                // alter the meaning of the expression when evaluated as a filter, but if we extract
-                // those literals 2 times into `literal_values` then the Peek code will look up
-                // those keys from the index 2 times, leading to duplicate results.
-                literal_values.sort();
-                literal_values.dedup();
-                IndexMatch::Usable(literal_values, inv_cast_any)
-            } else {
-                if usable_key_fields.is_empty() {
-                    IndexMatch::UnusableNoSubset
-                } else {
-                    IndexMatch::UnusableTooWide(
-                        usable_key_fields.into_iter().cloned().collect_vec(),
-                    )
-                }
-            }
-        }
-
         let or_args = Self::get_or_args(mfp);
 
         let index_matches = transform_ctx
             .indexes
             .indexes_on(get_id)
-            .map(|(index_id, key)| (index_id, key.to_owned(), match_index(key, &or_args)))
+            .map(|(index_id, key)| (index_id, key.to_owned(), Self::match_index(key, &or_args)))
             .collect_vec();
 
         let result = index_matches
@@ -325,7 +332,7 @@ impl LiteralConstraints {
                             assert!(!usable_subset.is_empty());
                             // Determine literal values that we would get if the index was on
                             // `usable_subset`.
-                            let literal_values = match match_index(&usable_subset, &or_args) {
+                            let literal_values = match Self::match_index(&usable_subset, &or_args) {
                                 IndexMatch::Usable(literal_vals, _) => literal_vals,
                                 _ => unreachable!(), // `usable_subset` would make the index usable.
                             };

--- a/test/launchdarkly-flag-consistency/mzcompose.py
+++ b/test/launchdarkly-flag-consistency/mzcompose.py
@@ -269,6 +269,7 @@ KNOWN_MISSING_FROM_LD: set[str] = set("""
     enable_notices_for_index_already_exists
     enable_notices_for_index_empty_key
     enable_off_thread_optimization
+    enable_partial_literal_index_lookups
     enable_password_auth
     enable_paused_cluster_readhold_downgrade
     enable_persist_streaming_compaction

--- a/test/sqllogictest/catalog_server_explain.slt
+++ b/test/sqllogictest/catalog_server_explain.slt
@@ -14037,17 +14037,12 @@ EXPLAIN SELECT * FROM "mz_introspection"."mz_compute_error_counts";
 Explained Query:
   →With
     cte l0 =
-      →Differential Join %1:mz_compute_exports_per_worker[#0{export_id}] » %0:mz_compute_dependencies[#0{object_id}]
-        →Arrange (#0{object_id})
+      →Differential Join %0:mz_compute_dependencies[#0{object_id}, 0] » %1:mz_compute_exports_per_worker[#0, #1]
+        →Arrange (#0{object_id}, 0)
           →Fused with Parent Map/Filter/Project
             Project: #1, #0
             →Arranged mz_internal.mz_compute_dependencies
-        →Arrange (#0{export_id})
-          →Fused with Child Map/Filter/Project
-            Project: #0, #2
-            Filter: (#1{worker_id} = 0)
-              →Arranged mz_introspection.mz_compute_exports_per_worker
-                Key: (#0, #1)
+        →Arranged mz_introspection.mz_compute_exports_per_worker
     cte l1 =
       →Distinct GroupAggregate
         →Fused with Child Map/Filter/Project
@@ -14075,19 +14070,14 @@ Explained Query:
                           Key:
                             Project: #1
                             Map: list_index(#0{address}, 1)
-                          →Differential Join %0:mz_dataflow_addresses_per_worker[#0{id}] » %1:mz_dataflow_operators_per_worker[#0{id}]
-                            →Arrange (#0{id})
+                          →Differential Join %0:mz_dataflow_addresses_per_worker[#0{id}, 0] » %1:mz_dataflow_operators_per_worker[#0, #1]
+                            →Arrange (#0{id}, 0)
                               →Fused with Child Map/Filter/Project
                                 Project: #0, #2
                                 Filter: (#1{worker_id} = 0) AND (1 = list_length(#2{address})) AND (list_index(#2{address}, 1)) IS NOT NULL
                                   →Arranged mz_introspection.mz_dataflow_addresses_per_worker
                                     Key: (#0, #1)
-                            →Arrange (#0{id})
-                              →Fused with Child Map/Filter/Project
-                                Project: #0
-                                Filter: (#1{worker_id} = 0)
-                                  →Arranged mz_introspection.mz_dataflow_operators_per_worker
-                                    Key: (#0, #1)
+                            →Arranged mz_introspection.mz_dataflow_operators_per_worker
                     →Unarranged Raw Stream
                       →Arranged l1
     →Return
@@ -14103,20 +14093,16 @@ Explained Query:
 
 Used Indexes:
   - mz_internal.mz_compute_dependencies_ind (*** full scan ***)
-  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (*** full scan ***)
+  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (differential join)
   - mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx (*** full scan ***)
-  - mz_introspection.mz_compute_exports_per_worker_s2_primary_idx (*** full scan ***)
+  - mz_introspection.mz_compute_exports_per_worker_s2_primary_idx (differential join)
   - mz_introspection.mz_compute_error_counts_raw_s2_primary_idx (*** full scan ***)
 
 Target cluster: mz_catalog_server
 
 Notices:
-  - Notice: Index mz_introspection.mz_compute_exports_per_worker_s2_primary_idx on mz_compute_exports_per_worker(export_id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id).
   - Notice: Index mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx on mz_dataflow_addresses_per_worker(id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id, list_length(address)).
-  - Notice: Index mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx on mz_dataflow_operators_per_worker(id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id).
 
 EOF
 
@@ -14126,17 +14112,12 @@ EXPLAIN SELECT * FROM "mz_introspection"."mz_compute_error_counts_per_worker";
 Explained Query:
   →With
     cte l0 =
-      →Differential Join %1:mz_compute_exports_per_worker[#0{export_id}] » %0:mz_compute_dependencies[#0{object_id}]
-        →Arrange (#0{object_id})
+      →Differential Join %0:mz_compute_dependencies[#0{object_id}, 0] » %1:mz_compute_exports_per_worker[#0, #1]
+        →Arrange (#0{object_id}, 0)
           →Fused with Parent Map/Filter/Project
             Project: #1, #0
             →Arranged mz_internal.mz_compute_dependencies
-        →Arrange (#0{export_id})
-          →Fused with Child Map/Filter/Project
-            Project: #0, #2
-            Filter: (#1{worker_id} = 0)
-              →Arranged mz_introspection.mz_compute_exports_per_worker
-                Key: (#0, #1)
+        →Arranged mz_introspection.mz_compute_exports_per_worker
     cte l1 =
       →Distinct GroupAggregate
         →Fused with Child Map/Filter/Project
@@ -14164,19 +14145,14 @@ Explained Query:
                           Key:
                             Project: #1
                             Map: list_index(#0{address}, 1)
-                          →Differential Join %0:mz_dataflow_addresses_per_worker[#0{id}] » %1:mz_dataflow_operators_per_worker[#0{id}]
-                            →Arrange (#0{id})
+                          →Differential Join %0:mz_dataflow_addresses_per_worker[#0{id}, 0] » %1:mz_dataflow_operators_per_worker[#0, #1]
+                            →Arrange (#0{id}, 0)
                               →Fused with Child Map/Filter/Project
                                 Project: #0, #2
                                 Filter: (#1{worker_id} = 0) AND (1 = list_length(#2{address})) AND (list_index(#2{address}, 1)) IS NOT NULL
                                   →Arranged mz_introspection.mz_dataflow_addresses_per_worker
                                     Key: (#0, #1)
-                            →Arrange (#0{id})
-                              →Fused with Child Map/Filter/Project
-                                Project: #0
-                                Filter: (#1{worker_id} = 0)
-                                  →Arranged mz_introspection.mz_dataflow_operators_per_worker
-                                    Key: (#0, #1)
+                            →Arranged mz_introspection.mz_dataflow_operators_per_worker
                     →Unarranged Raw Stream
                       →Arranged l1
     →Return
@@ -14184,20 +14160,16 @@ Explained Query:
 
 Used Indexes:
   - mz_internal.mz_compute_dependencies_ind (*** full scan ***)
-  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (*** full scan ***)
+  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (differential join)
   - mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx (*** full scan ***)
-  - mz_introspection.mz_compute_exports_per_worker_s2_primary_idx (*** full scan ***)
+  - mz_introspection.mz_compute_exports_per_worker_s2_primary_idx (differential join)
   - mz_introspection.mz_compute_error_counts_raw_s2_primary_idx (*** full scan ***)
 
 Target cluster: mz_catalog_server
 
 Notices:
-  - Notice: Index mz_introspection.mz_compute_exports_per_worker_s2_primary_idx on mz_compute_exports_per_worker(export_id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id).
   - Notice: Index mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx on mz_dataflow_addresses_per_worker(id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id, list_length(address)).
-  - Notice: Index mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx on mz_dataflow_operators_per_worker(id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id).
 
 EOF
 
@@ -14359,13 +14331,9 @@ Explained Query:
         Simple aggregates: count(*)
         →Arranged mz_introspection.mz_arrangement_batcher_allocations_raw
     cte l9 =
-      →Fused with Child Map/Filter/Project
-        Project: #0, #2
-        Filter: (#1{worker_id} = 0)
-          →Arranged mz_introspection.mz_dataflow_operators_per_worker
-            Key: (#0, #1)
+      →Arranged mz_introspection.mz_dataflow_operators_per_worker
     cte l10 =
-      →One-Shot Delta Join [%0:l9 » %1:mz_dataflow_addresses_per_worker[#0{id}] » %2:mz_dataflow_addresses_per_worker[list_index(#1{address}, 1)] » %3:l9[#0{id}]]
+      →One-Shot Delta Join [%0:mz_dataflow_operators_per_worker » %1:mz_dataflow_addresses_per_worker[#0{id}] » %2:mz_dataflow_addresses_per_worker[list_index(#1{address}, 1)] » %3:l9[#0, #1]]
         path %0:
           after %1:
             Project: #0..=#2
@@ -14373,7 +14341,9 @@ Explained Query:
         →Unarranged Raw Stream
           →Fused with Child Map/Filter/Project
             Project: #0
-              →Read l9
+            Filter: (#1{worker_id} = 0)
+              →Arranged mz_introspection.mz_dataflow_operators_per_worker
+                Key: (#0, #1)
         →Arrange (#0{id}) (list_index(#1{address}, 1))
           →Fused with Child Map/Filter/Project
             Project: #0, #2
@@ -14386,8 +14356,7 @@ Explained Query:
             Filter: (#1{worker_id} = 0) AND (1 = list_length(#2{address})) AND (list_index(#2{address}, 1)) IS NOT NULL
               →Arranged mz_introspection.mz_dataflow_addresses_per_worker
                 Key: (#0, #1)
-        →Arrange (#0{id})
-          →Stream l9
+        →Arranged l9
     cte l11 =
       →Fused with Child Map/Filter/Project
         Project: #0, #1
@@ -14404,12 +14373,12 @@ Explained Query:
           Simple aggregates: sum(case when ((case when (#4) IS NULL then null else #3 end) IS NULL AND (case when (#12) IS NULL then null else #11 end) IS NULL) then null else (case when (#4) IS NULL then 0 else coalesce(#3, 0) end + case when (#12) IS NULL then 0 else coalesce(#11, 0) end) end), sum(case when (#2) IS NULL then null else #1 end), sum(case when ((case when (#6) IS NULL then null else #5 end) IS NULL AND (case when (#14) IS NULL then null else #13 end) IS NULL) then null else (case when (#6) IS NULL then 0 else coalesce(#5, 0) end + case when (#14) IS NULL then 0 else coalesce(#13, 0) end) end), sum(case when ((case when (#8) IS NULL then null else #7 end) IS NULL AND (case when (#16) IS NULL then null else #15 end) IS NULL) then null else (case when (#8) IS NULL then 0 else coalesce(#7, 0) end + case when (#16) IS NULL then 0 else coalesce(#15, 0) end) end), sum(case when ((case when (#10) IS NULL then null else #9 end) IS NULL AND (case when (#18) IS NULL then null else #17 end) IS NULL) then null else (case when (#10) IS NULL then 0 else coalesce(#9, 0) end + case when (#18) IS NULL then 0 else coalesce(#17, 0) end) end)
           Key:
             Project: #0
-          →One-Shot Delta Join [%0:mz_dataflow_operators_per_worker[#0, #1] » %1[#0, #1] » %2[#0, #1] » %3[#0, #1] » %4[#0, #1] » %5[#0, #1] » %6[#0, #1] » %7[#0, #1] » %8[#0, #1] » %9[#0, #1]]
+          →One-Shot Delta Join [%0:l9[#0, #1] » %1[#0, #1] » %2[#0, #1] » %3[#0, #1] » %4[#0, #1] » %5[#0, #1] » %6[#0, #1] » %7[#0, #1] » %8[#0, #1] » %9[#0, #1]]
             path %0:
               after %9:
                 Project: #0, #2..=#19
                 Filter: ((case when (#3) IS NULL then null else #2 end) IS NOT NULL OR (case when ((case when (#5) IS NULL then null else #4 end) IS NULL AND (case when (#13) IS NULL then null else #12 end) IS NULL) then null else (case when (#5) IS NULL then 0 else coalesce(#4, 0) end + case when (#13) IS NULL then 0 else coalesce(#12, 0) end) end) IS NOT NULL OR (case when ((case when (#7) IS NULL then null else #6 end) IS NULL AND (case when (#15) IS NULL then null else #14 end) IS NULL) then null else (case when (#7) IS NULL then 0 else coalesce(#6, 0) end + case when (#15) IS NULL then 0 else coalesce(#14, 0) end) end) IS NOT NULL OR (case when ((case when (#9) IS NULL then null else #8 end) IS NULL AND (case when (#17) IS NULL then null else #16 end) IS NULL) then null else (case when (#9) IS NULL then 0 else coalesce(#8, 0) end + case when (#17) IS NULL then 0 else coalesce(#16, 0) end) end) IS NOT NULL OR (case when ((case when (#11) IS NULL then null else #10 end) IS NULL AND (case when (#19) IS NULL then null else #18 end) IS NULL) then null else (case when (#11) IS NULL then 0 else coalesce(#10, 0) end + case when (#19) IS NULL then 0 else coalesce(#18, 0) end) end) IS NOT NULL)
-            →Arranged mz_introspection.mz_dataflow_operators_per_worker
+            →Arranged l9
             →Arrange (#0, #1)
               →Union
                 →Fused with Child Map/Filter/Project
@@ -14606,7 +14575,7 @@ Explained Query:
                 →Read l12
 
 Used Indexes:
-  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (*** full scan ***, delta join 1st input (full scan))
+  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (*** full scan ***, delta join lookup, delta join 1st input (full scan))
   - mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx (*** full scan ***)
   - mz_introspection.mz_arrangement_batches_raw_s2_primary_idx (*** full scan ***)
   - mz_introspection.mz_arrangement_records_raw_s2_primary_idx (*** full scan ***)
@@ -14636,47 +14605,37 @@ EXPLAIN SELECT * FROM "mz_introspection"."mz_dataflow_channel_operators";
 Explained Query:
   →With
     cte l0 =
-      →Fused with Child Map/Filter/Project
-        Filter: (#1 = 0)
-          →Arranged mz_introspection.mz_dataflow_addresses_per_worker
-            Key: (#0, #1)
-    cte l1 =
-      →Differential Join %0:l0[#0{id}] » %1:mz_dataflow_operators_per_worker[#0{id}]
-        →Arrange (#0{id})
-          →Stream l0
-        →Arrange (#0{id})
+      →Differential Join %0:mz_dataflow_addresses_per_worker[#0{id}, 0] » %1:mz_dataflow_operators_per_worker[#0, #1]
+        →Arrange (#0{id}, 0)
           →Fused with Child Map/Filter/Project
-            Project: #0
-            Filter: (#1{worker_id} = 0)
-              →Arranged mz_introspection.mz_dataflow_operators_per_worker
+            Filter: (#1 = 0)
+              →Arranged mz_introspection.mz_dataflow_addresses_per_worker
                 Key: (#0, #1)
-    cte l2 =
-      →Differential Join %0:mz_dataflow_channels_per_worker[#0{id}] » %1:l0[#0{id}]
+        →Arranged mz_introspection.mz_dataflow_operators_per_worker
+    cte l1 =
+      →Differential Join %0:mz_dataflow_channels_per_worker[#0{id}, 0] » %1:mz_dataflow_addresses_per_worker[#0, #1]
         after %1:
-          Project: #0, #3, #5, #6
-          Map: (#4{address} || #1{from_index}), (#4{address} || #2{to_index})
-        →Arrange (#0{id})
+          Project: #0, #4, #6, #7
+          Map: (#5{address} || #2{from_index}), (#5{address} || #3{to_index})
+        →Arrange (#0{id}, 0)
           →Fused with Child Map/Filter/Project
             Project: #0, #2, #4, #6
             Filter: (#1{worker_id} = 0)
               →Arranged mz_introspection.mz_dataflow_channels_per_worker
                 Key: (#0, #1)
-        →Arrange (#0{id})
-          →Fused with Child Map/Filter/Project
-            Project: #0, #2
-              →Read l0
-    cte l3 =
+        →Arranged mz_introspection.mz_dataflow_addresses_per_worker
+    cte l2 =
       →Negate Diffs
         →Fused with Child Map/Filter/Project
           Project: #1, #2
-            →Read l1
-    cte l4 =
+            →Read l0
+    cte l3 =
       →Fused with Child Map/Filter/Project
         Project: #0, #2, #3
         Map: true
-          →Read l1
+          →Read l0
   →Return
-    →One-Shot Delta Join [%0:l2 » %1[#1] » %2[#1]]
+    →One-Shot Delta Join [%0:l1 » %1[#1] » %2[#1]]
       path %0:
         after %1:
           Project: #1, #2, #0, #3, #6
@@ -14685,53 +14644,51 @@ Explained Query:
           Project: #1, #4, #3, #7, #0, #2
           Map: case when (#6) IS NULL then null else #5 end
       →Unarranged Raw Stream
-        →Stream l2
+        →Stream l1
       →Arrange (#1)
         →Union
-          →Stream l4
+          →Stream l3
           →Map/Filter/Project
             Project: #2, #1, #3
             Map: null, null
               →Threshold Diffs #0, #1
                 →Arrange (#0, #1)
                   →Union
-                    →Stream l3
+                    →Stream l2
                     →Map/Filter/Project
                       Project: #1, #0
                       Map: 0
                         →Distinct GroupAggregate
                           →Fused with Child Map/Filter/Project
                             Project: #2
-                              →Read l2
+                              →Read l1
       →Arrange (#1)
         →Union
-          →Stream l4
+          →Stream l3
           →Map/Filter/Project
             Project: #2, #1, #3
             Map: null, null
               →Threshold Diffs #0, #1
                 →Arrange (#0, #1)
                   →Union
-                    →Stream l3
+                    →Stream l2
                     →Map/Filter/Project
                       Project: #1, #0
                       Map: 0
                         →Distinct GroupAggregate
                           →Fused with Child Map/Filter/Project
                             Project: #3
-                              →Read l2
+                              →Read l1
 
 Used Indexes:
-  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (*** full scan ***)
+  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (differential join)
   - mz_introspection.mz_dataflow_channels_per_worker_s2_primary_idx (*** full scan ***)
-  - mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx (*** full scan ***)
+  - mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx (*** full scan ***, differential join)
 
 Target cluster: mz_catalog_server
 
 Notices:
   - Notice: Index mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx on mz_dataflow_addresses_per_worker(id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id).
-  - Notice: Index mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx on mz_dataflow_operators_per_worker(id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id).
   - Notice: Index mz_introspection.mz_dataflow_channels_per_worker_s2_primary_idx on mz_dataflow_channels_per_worker(id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id).
@@ -14861,37 +14818,33 @@ query T multiline
 EXPLAIN SELECT * FROM "mz_introspection"."mz_dataflow_operator_dataflows";
 ----
 Explained Query:
-  →With
-    cte l0 =
-      →Arrange (#0{id})
-        →Fused with Child Map/Filter/Project
-          Project: #0, #2
-          Filter: (#1{worker_id} = 0)
-            →Arranged mz_introspection.mz_dataflow_operators_per_worker
-              Key: (#0, #1)
-  →Return
-    →One-Shot Delta Join [%0:l0[#0{id}] » %1:mz_dataflow_addresses_per_worker[#0{id}] » %2:mz_dataflow_addresses_per_worker[list_index(#1{address}, 1)] » %3:l0[#0{id}]]
-      path %0:
-        after %1:
-          Project: #0..=#3
-          Map: list_index(#2{address}, 1)
-      →Arranged l0
-      →Arrange (#0{id}) (list_index(#1{address}, 1))
-        →Fused with Child Map/Filter/Project
-          Project: #0, #2
-          Filter: (#1{worker_id} = 0) AND (list_index(#2{address}, 1)) IS NOT NULL
-            →Arranged mz_introspection.mz_dataflow_addresses_per_worker
-              Key: (#0, #1)
-      →Arrange (#0{id}) (list_index(#1{address}, 1))
-        →Fused with Child Map/Filter/Project
-          Project: #0, #2
-          Filter: (#1{worker_id} = 0) AND (1 = list_length(#2{address})) AND (list_index(#2{address}, 1)) IS NOT NULL
-            →Arranged mz_introspection.mz_dataflow_addresses_per_worker
-              Key: (#0, #1)
-      →Arranged l0
+  →One-Shot Delta Join [%0:mz_dataflow_operators_per_worker » %1:mz_dataflow_addresses_per_worker[#0{id}] » %2:mz_dataflow_addresses_per_worker[list_index(#1{address}, 1)] » %3:mz_dataflow_operators_per_worker[#0, #1]]
+    path %0:
+      after %1:
+        Project: #0..=#3
+        Map: list_index(#2{address}, 1)
+    →Unarranged Raw Stream
+      →Fused with Child Map/Filter/Project
+        Project: #0, #2
+        Filter: (#1{worker_id} = 0)
+          →Arranged mz_introspection.mz_dataflow_operators_per_worker
+            Key: (#0, #1)
+    →Arrange (#0{id}) (list_index(#1{address}, 1))
+      →Fused with Child Map/Filter/Project
+        Project: #0, #2
+        Filter: (#1{worker_id} = 0) AND (list_index(#2{address}, 1)) IS NOT NULL
+          →Arranged mz_introspection.mz_dataflow_addresses_per_worker
+            Key: (#0, #1)
+    →Arrange (#0{id}) (list_index(#1{address}, 1))
+      →Fused with Child Map/Filter/Project
+        Project: #0, #2
+        Filter: (#1{worker_id} = 0) AND (1 = list_length(#2{address})) AND (list_index(#2{address}, 1)) IS NOT NULL
+          →Arranged mz_introspection.mz_dataflow_addresses_per_worker
+            Key: (#0, #1)
+    →Arranged mz_introspection.mz_dataflow_operators_per_worker
 
 Used Indexes:
-  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (*** full scan ***)
+  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (*** full scan ***, delta join lookup)
   - mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx (*** full scan ***)
 
 Target cluster: mz_catalog_server
@@ -14946,19 +14899,14 @@ EXPLAIN SELECT * FROM "mz_introspection"."mz_dataflow_operator_parents";
 Explained Query:
   →With
     cte l0 =
-      →Differential Join %0:mz_dataflow_addresses_per_worker[#0{id}] » %1:mz_dataflow_operators_per_worker[#0{id}]
-        →Arrange (#0{id})
+      →Differential Join %0:mz_dataflow_addresses_per_worker[#0{id}, 0] » %1:mz_dataflow_operators_per_worker[#0, #1]
+        →Arrange (#0{id}, 0)
           →Fused with Child Map/Filter/Project
             Project: #0, #2
             Filter: (#1{worker_id} = 0)
               →Arranged mz_introspection.mz_dataflow_addresses_per_worker
                 Key: (#0, #1)
-        →Arrange (#0{id})
-          →Fused with Child Map/Filter/Project
-            Project: #0
-            Filter: (#1{worker_id} = 0)
-              →Arranged mz_introspection.mz_dataflow_operators_per_worker
-                Key: (#0, #1)
+        →Arranged mz_introspection.mz_dataflow_operators_per_worker
   →Return
     →Differential Join %0:l0[#1{parent_address}] » %1:l0[#1{address}]
       →Arrange (#1{parent_address})
@@ -14970,15 +14918,13 @@ Explained Query:
         →Stream l0
 
 Used Indexes:
-  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (*** full scan ***)
+  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (differential join)
   - mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx (*** full scan ***)
 
 Target cluster: mz_catalog_server
 
 Notices:
   - Notice: Index mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx on mz_dataflow_addresses_per_worker(id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id).
-  - Notice: Index mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx on mz_dataflow_operators_per_worker(id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id).
 
 EOF
@@ -15086,25 +15032,20 @@ query T multiline
 EXPLAIN SELECT * FROM "mz_introspection"."mz_dataflows";
 ----
 Explained Query:
-  →Differential Join %0:mz_dataflow_addresses_per_worker[#0{id}] » %1:mz_dataflow_operators_per_worker[#0{id}]
+  →Differential Join %0:mz_dataflow_addresses_per_worker[#0{id}, 0] » %1:mz_dataflow_operators_per_worker[#0, #1]
     after %1:
-      Project: #3, #2
-      Map: list_index(#1{address}, 1)
-    →Arrange (#0{id})
+      Project: #4, #3
+      Map: list_index(#2{address}, 1)
+    →Arrange (#0{id}, 0)
       →Fused with Child Map/Filter/Project
         Project: #0, #2
         Filter: (#1{worker_id} = 0) AND (1 = list_length(#2{address}))
           →Arranged mz_introspection.mz_dataflow_addresses_per_worker
             Key: (#0, #1)
-    →Arrange (#0{id})
-      →Fused with Child Map/Filter/Project
-        Project: #0, #2
-        Filter: (#1{worker_id} = 0)
-          →Arranged mz_introspection.mz_dataflow_operators_per_worker
-            Key: (#0, #1)
+    →Arranged mz_introspection.mz_dataflow_operators_per_worker
 
 Used Indexes:
-  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (*** full scan ***)
+  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (differential join)
   - mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx (*** full scan ***)
 
 Target cluster: mz_catalog_server
@@ -15112,8 +15053,6 @@ Target cluster: mz_catalog_server
 Notices:
   - Notice: Index mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx on mz_dataflow_addresses_per_worker(id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id, list_length(address)).
-  - Notice: Index mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx on mz_dataflow_operators_per_worker(id, worker_id) is too wide to use for literal equalities `worker_id = 0`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (worker_id).
 
 EOF
 
@@ -15179,21 +15118,19 @@ Explained Query:
         Simple aggregates: count(*)
         →Arranged mz_introspection.mz_arrangement_batcher_allocations_raw
     cte l9 =
-      →Fused with Child Map/Filter/Project
-        Project: #0, #2
-        Filter: (#1{worker_id} = 0)
-          →Arranged mz_introspection.mz_dataflow_operators_per_worker
-            Key: (#0, #1)
+      →Arranged mz_introspection.mz_dataflow_operators_per_worker
     cte l10 =
-      →Arrange (#0{id})
-        →Stream l9
-    cte l11 =
-      →One-Shot Delta Join [%0:l10[#0{id}] » %1:mz_dataflow_addresses_per_worker[#0{id}] » %2:mz_dataflow_addresses_per_worker[list_index(#1{address}, 1)] » %3:l10[#0{id}]]
+      →One-Shot Delta Join [%0:mz_dataflow_operators_per_worker » %1:mz_dataflow_addresses_per_worker[#0{id}] » %2:mz_dataflow_addresses_per_worker[list_index(#1{address}, 1)] » %3:l9[#0, #1]]
         path %0:
           after %1:
             Project: #0..=#3
             Map: list_index(#2{address}, 1)
-        →Arranged l10
+        →Unarranged Raw Stream
+          →Fused with Child Map/Filter/Project
+            Project: #0, #2
+            Filter: (#1{worker_id} = 0)
+              →Arranged mz_introspection.mz_dataflow_operators_per_worker
+                Key: (#0, #1)
         →Arrange (#0{id}) (list_index(#1{address}, 1))
           →Fused with Child Map/Filter/Project
             Project: #0, #2
@@ -15206,20 +15143,20 @@ Explained Query:
             Filter: (#1{worker_id} = 0) AND (1 = list_length(#2{address})) AND (list_index(#2{address}, 1)) IS NOT NULL
               →Arranged mz_introspection.mz_dataflow_addresses_per_worker
                 Key: (#0, #1)
-        →Arranged l10
-    cte l12 =
+        →Arranged l9
+    cte l11 =
       →Fused with Child Map/Filter/Project
         Project: #0, #2
         Filter: (#1{worker_id} = 0)
           →Arranged mz_introspection.mz_dataflow_addresses_per_worker
             Key: (#0, #1)
-    cte l13 =
+    cte l12 =
       →Fused with Child Map/Filter/Project
         Project: #0, #1
           →Arranged mz_introspection.mz_dataflow_operators_per_worker
             Key: (#0, #1)
-    cte l14 =
-      →One-Shot Delta Join [%0:l11 » %4[#0] » %1:l12[#0{id}] » %2:l12[#1{address}] » %3:l9[#0{id}]]
+    cte l13 =
+      →One-Shot Delta Join [%0:l10 » %4[#0] » %1:l11[#0{id}] » %2:l11[#1{address}] » %3:l9[#0, #1]]
         path %0:
           after %4:
             Project: #0, #1, #4, #5
@@ -15228,25 +15165,22 @@ Explained Query:
           →Fused with Child Map/Filter/Project
             Project: #0, #3
             Filter: ((#1{name} = "Arranged TopK input") OR (#1{name} = "Arrange ReduceMinsMaxes") OR (#1{name} = "Arranged MinsMaxesHierarchical input"))
-              →Read l11
+              →Read l10
         →Arrange (#0{id}) (list_slice_linear(#1{address}, 1, integer_to_bigint((list_length(#1{address}) - 1))))
-          →Stream l12
+          →Stream l11
         →Arrange (#0{id}) (#1{address})
-          →Stream l12
-        →Arrange (#0{id})
-          →Fused with Child Map/Filter/Project
-            Project: #0
-              →Read l9
+          →Stream l11
+        →Arranged l9
         →Accumulable GroupAggregate
           Simple aggregates: sum(case when ((case when (#2) IS NULL then null else #1 end) IS NULL AND (case when (#6) IS NULL then null else #5 end) IS NULL) then null else (case when (#2) IS NULL then 0 else coalesce(#1, 0) end + case when (#6) IS NULL then 0 else coalesce(#5, 0) end) end), sum(case when ((case when (#4) IS NULL then null else #3 end) IS NULL AND (case when (#8) IS NULL then null else #7 end) IS NULL) then null else (case when (#4) IS NULL then 0 else coalesce(#3, 0) end + case when (#8) IS NULL then 0 else coalesce(#7, 0) end) end)
           Key:
             Project: #0
-          →One-Shot Delta Join [%0:mz_dataflow_operators_per_worker[#0, #1] » %1[#0, #1] » %2[#0, #1] » %3[#0, #1] » %4[#0, #1] » %5[#0, #1] » %6[#0, #1] » %7[#0, #1] » %8[#0, #1] » %9[#0, #1]]
+          →One-Shot Delta Join [%0:l9[#0, #1] » %1[#0, #1] » %2[#0, #1] » %3[#0, #1] » %4[#0, #1] » %5[#0, #1] » %6[#0, #1] » %7[#0, #1] » %8[#0, #1] » %9[#0, #1]]
             path %0:
               after %9:
                 Project: #0, #4..=#7, #12..=#15
                 Filter: ((case when (#3) IS NULL then null else #2 end) IS NOT NULL OR (case when ((case when (#5) IS NULL then null else #4 end) IS NULL AND (case when (#13) IS NULL then null else #12 end) IS NULL) then null else (case when (#5) IS NULL then 0 else coalesce(#4, 0) end + case when (#13) IS NULL then 0 else coalesce(#12, 0) end) end) IS NOT NULL OR (case when ((case when (#7) IS NULL then null else #6 end) IS NULL AND (case when (#15) IS NULL then null else #14 end) IS NULL) then null else (case when (#7) IS NULL then 0 else coalesce(#6, 0) end + case when (#15) IS NULL then 0 else coalesce(#14, 0) end) end) IS NOT NULL OR (case when ((case when (#9) IS NULL then null else #8 end) IS NULL AND (case when (#17) IS NULL then null else #16 end) IS NULL) then null else (case when (#9) IS NULL then 0 else coalesce(#8, 0) end + case when (#17) IS NULL then 0 else coalesce(#16, 0) end) end) IS NOT NULL OR (case when ((case when (#11) IS NULL then null else #10 end) IS NULL AND (case when (#19) IS NULL then null else #18 end) IS NULL) then null else (case when (#11) IS NULL then 0 else coalesce(#10, 0) end + case when (#19) IS NULL then 0 else coalesce(#18, 0) end) end) IS NOT NULL)
-            →Arranged mz_introspection.mz_dataflow_operators_per_worker
+            →Arranged l9
             →Arrange (#0, #1)
               →Union
                 →Fused with Child Map/Filter/Project
@@ -15265,7 +15199,7 @@ Explained Query:
                               Project: #0, #1
                                 →Arranged l0
                                   Key: (#0, #1)
-                          →Stream l13
+                          →Stream l12
             →Arrange (#0, #1)
               →Union
                 →Fused with Child Map/Filter/Project
@@ -15284,7 +15218,7 @@ Explained Query:
                               Project: #0, #1
                                 →Arranged l1
                                   Key: (#0, #1)
-                          →Stream l13
+                          →Stream l12
             →Arrange (#0, #1)
               →Union
                 →Fused with Child Map/Filter/Project
@@ -15303,7 +15237,7 @@ Explained Query:
                               Project: #0, #1
                                 →Arranged l2
                                   Key: (#0, #1)
-                          →Stream l13
+                          →Stream l12
             →Arrange (#0, #1)
               →Union
                 →Fused with Child Map/Filter/Project
@@ -15322,7 +15256,7 @@ Explained Query:
                               Project: #0, #1
                                 →Arranged l3
                                   Key: (#0, #1)
-                          →Stream l13
+                          →Stream l12
             →Arrange (#0, #1)
               →Union
                 →Fused with Child Map/Filter/Project
@@ -15341,7 +15275,7 @@ Explained Query:
                               Project: #0, #1
                                 →Arranged l4
                                   Key: (#0, #1)
-                          →Stream l13
+                          →Stream l12
             →Arrange (#0, #1)
               →Union
                 →Fused with Child Map/Filter/Project
@@ -15360,7 +15294,7 @@ Explained Query:
                               Project: #0, #1
                                 →Arranged l5
                                   Key: (#0, #1)
-                          →Stream l13
+                          →Stream l12
             →Arrange (#0, #1)
               →Union
                 →Fused with Child Map/Filter/Project
@@ -15379,7 +15313,7 @@ Explained Query:
                               Project: #0, #1
                                 →Arranged l6
                                   Key: (#0, #1)
-                          →Stream l13
+                          →Stream l12
             →Arrange (#0, #1)
               →Union
                 →Fused with Child Map/Filter/Project
@@ -15398,7 +15332,7 @@ Explained Query:
                               Project: #0, #1
                                 →Arranged l7
                                   Key: (#0, #1)
-                          →Stream l13
+                          →Stream l12
             →Arrange (#0, #1)
               →Union
                 →Fused with Child Map/Filter/Project
@@ -15417,9 +15351,9 @@ Explained Query:
                               Project: #0, #1
                                 →Arranged l8
                                   Key: (#0, #1)
-                          →Stream l13
+                          →Stream l12
   →Return
-    →One-Shot Delta Join [%0[#0, #1] » %1[#0, #1] » %2:l11[#0{id}, #3{dataflow_id}]]
+    →One-Shot Delta Join [%0[#0, #1] » %1[#0, #1] » %2:l10[#0{id}, #3{dataflow_id}]]
       path %0:
         after %1:
           Project: #0..=#5
@@ -15428,17 +15362,17 @@ Explained Query:
         Simple aggregates: count(*), sum(#2{size})
         Key:
           Project: #0, #1
-        →One-Shot Delta Join [%0:l14 » %2[#0, #1] » %1:l14[#0{id}..=#2{region_id}]]
+        →One-Shot Delta Join [%0:l13 » %2[#0, #1] » %1:l13[#0{id}..=#2{region_id}]]
           path %0:
             after %1:
               Project: #1, #2, #5
               Filter: (#3{id} != #0{id}) AND (bigint_to_numeric(#4{records}) >= (bigint_to_numeric(#6{records}) * 0.85))
           →Unarranged Raw Stream
-            →Stream l14
+            →Stream l13
           →Arrange (#0{id}..=#2{region_id})
             →Fused with Child Map/Filter/Project
               Project: #0..=#3
-                →Read l14
+                →Read l13
           →Arrange (#0..=#2)
             →Consolidating Monotonic GroupAggregate
               Aggregations: min
@@ -15446,17 +15380,17 @@ Explained Query:
                 Project: #1, #2
               →Fused with Child Map/Filter/Project
                 Project: #0..=#2
-                  →Read l14
+                  →Read l13
       →Accumulable GroupAggregate
         Simple aggregates: count(*)
         →Fused with Child Map/Filter/Project
           Project: #1, #2
-            →Read l14
+            →Read l13
       →Arrange (#0{id}, #3{dataflow_id})
-        →Stream l11
+        →Stream l10
 
 Used Indexes:
-  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (*** full scan ***, delta join 1st input (full scan))
+  - mz_introspection.mz_dataflow_operators_per_worker_s2_primary_idx (*** full scan ***, delta join lookup, delta join 1st input (full scan))
   - mz_introspection.mz_dataflow_addresses_per_worker_s2_primary_idx (*** full scan ***)
   - mz_introspection.mz_arrangement_batches_raw_s2_primary_idx (*** full scan ***)
   - mz_introspection.mz_arrangement_records_raw_s2_primary_idx (*** full scan ***)

--- a/test/sqllogictest/transform/join_literal_constraints.slt
+++ b/test/sqllogictest/transform/join_literal_constraints.slt
@@ -1,0 +1,445 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests for the join-level index key completion in LiteralConstraints: an index
+# key covered partly by literal equalities and partly by the enclosing join's
+# equivalences should still be usable as a lookup rather than degrading to a
+# full scan.
+
+mode cockroach
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_partial_literal_index_lookups TO true;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE t(a int, b int, v int);
+
+statement ok
+CREATE TABLE m(k int, a int);
+
+statement ok
+INSERT INTO t VALUES (1,7,10), (1,8,20), (1,9,30), (2,7,40), (1,7,5), (NULL,7,100), (1,NULL,50);
+
+statement ok
+INSERT INTO m VALUES (1,1), (2,2);
+
+# Results before any index exists, so the transform cannot fire. Every query
+# below is repeated once the indexes are in place and must agree.
+query II
+SELECT t.a, sum(t.v) FROM t
+WHERE t.a = (SELECT a FROM m WHERE m.k = 1) AND t.b IN (7, 8)
+GROUP BY t.a;
+----
+1  35
+
+query II
+SELECT t.a, sum(t.v) FROM t
+WHERE t.a = (SELECT a FROM m WHERE m.k = 1) AND t.b IN (7, 7)
+GROUP BY t.a;
+----
+1  15
+
+query II
+SELECT t.a, sum(t.v) FROM t
+WHERE t.a = (SELECT a FROM m WHERE m.k = 99) AND t.b IN (7, 8)
+GROUP BY t.a;
+----
+
+query II rowsort
+SELECT t.a, sum(t.v) FROM t, m
+WHERE t.a = m.a AND t.b IN (7, 8)
+GROUP BY t.a;
+----
+1  35
+2  40
+
+query II rowsort
+SELECT t.a, sum(t.v) FROM t, m
+WHERE t.a = m.a AND t.b = 7
+GROUP BY t.a;
+----
+1  15
+2  40
+
+statement ok
+CREATE INDEX t_a_b ON t(a, b);
+
+statement ok
+CREATE INDEX m_k ON m(k);
+
+query II
+SELECT t.a, sum(t.v) FROM t
+WHERE t.a = (SELECT a FROM m WHERE m.k = 1) AND t.b IN (7, 8)
+GROUP BY t.a;
+----
+1  35
+
+query II
+SELECT t.a, sum(t.v) FROM t
+WHERE t.a = (SELECT a FROM m WHERE m.k = 1) AND t.b IN (7, 7)
+GROUP BY t.a;
+----
+1  15
+
+query II
+SELECT t.a, sum(t.v) FROM t
+WHERE t.a = (SELECT a FROM m WHERE m.k = 99) AND t.b IN (7, 8)
+GROUP BY t.a;
+----
+
+# The lookup values are crossed into the binding input, so a non-unique join key
+# on that side must not multiply rows.
+query II rowsort
+SELECT t.a, sum(t.v) FROM t, m
+WHERE t.a = m.a AND t.b IN (7, 8)
+GROUP BY t.a;
+----
+1  35
+2  40
+
+query II rowsort
+SELECT t.a, sum(t.v) FROM t, m
+WHERE t.a = m.a AND t.b = 7
+GROUP BY t.a;
+----
+1  15
+2  40
+
+# A single literal needs no lookup collection: the value goes in as a join
+# equivalence, so the index is probed with no Constant and no CrossJoin.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT t.a, sum(t.v) FROM t, m
+WHERE t.a = m.a AND t.b = 7
+GROUP BY t.a;
+----
+Explained Query:
+  Reduce group_by=[#0{a}] aggregates=[sum(#1{v})]
+    Project (#0{a}, #2{v})
+      Join on=(#0{a} = #3{a} AND #1{b} = 7) type=differential
+        ArrangeBy keys=[[#0{a}, #1{b}]]
+          ReadIndex on=t t_a_b=[differential join]
+        ArrangeBy keys=[[#0{a}, 7]]
+          Project (#1{a})
+            Filter (#1{a}) IS NOT NULL
+              ReadIndex on=m m_k=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_b (differential join)
+  - materialize.public.m_k (*** full scan ***)
+
+Target cluster: quickstart
+
+EOF
+
+# The index is used with its full key, and the redundant filter on the literal
+# equalities is gone.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT t.a, sum(t.v) FROM t
+WHERE t.a = (SELECT a FROM m WHERE m.k = 1) AND t.b IN (7, 8)
+GROUP BY t.a;
+----
+Explained Query:
+  With
+    cte l0 =
+      Project (#1{a})
+        ReadIndex on=materialize.public.m m_k=[lookup value=(1)]
+  Return
+    Reduce group_by=[#0{a}] aggregates=[sum(#1{v})]
+      Project (#0{a}, #2{v})
+        Join on=(#0{a} = #3{a} AND #1{b} = #4) type=differential
+          ArrangeBy keys=[[#0{a}, #1{b}]]
+            ReadIndex on=t t_a_b=[differential join]
+          ArrangeBy keys=[[#0{a}, #1]]
+            CrossJoin type=differential
+              ArrangeBy keys=[[]]
+                Union
+                  Filter (#0{a}) IS NOT NULL
+                    Get l0
+                  Project (#1)
+                    FlatMap guard_subquery_size(#0{count})
+                      Reduce aggregates=[count(*)]
+                        Project ()
+                          Get l0
+              ArrangeBy keys=[[]]
+                Constant
+                  - (7)
+                  - (8)
+
+Used Indexes:
+  - materialize.public.t_a_b (differential join)
+  - materialize.public.m_k (lookup)
+
+Target cluster: quickstart
+
+EOF
+
+# With both key fields given as literals, the `Get` case handles it and the join
+# rewrite must stay out of the way.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT t.a, sum(t.v) FROM t WHERE t.a = 1 AND t.b IN (7, 8) GROUP BY t.a;
+----
+Explained Query:
+  Project (#1, #0{sum_v})
+    Map (1)
+      Reduce aggregates=[sum(#0{v})]
+        Project (#2{v})
+          ReadIndex on=materialize.public.t t_a_b=[lookup values=[(1, 7); (1, 8)]]
+
+Used Indexes:
+  - materialize.public.t_a_b (lookup)
+
+Target cluster: quickstart
+
+EOF
+
+# Nothing binds the remaining key field, so the full scan stands and the notice
+# is still the right advice.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT t.a, sum(t.v) FROM t WHERE t.b IN (7, 8) GROUP BY t.a;
+----
+Explained Query:
+  Reduce group_by=[#0{a}] aggregates=[sum(#1{v})]
+    Project (#0{a}, #2{v})
+      Filter ((#1{b} = 7) OR (#1{b} = 8))
+        ReadIndex on=t t_a_b=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.t_a_b (*** full scan ***)
+
+Target cluster: quickstart
+
+Notices:
+  - Notice: Index materialize.public.t_a_b on t(a, b) is too wide to use for literal equalities `b IN (7, 8)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (b).
+
+EOF
+
+statement ok
+CREATE TABLE u(a int, w int);
+
+statement ok
+INSERT INTO u VALUES (1, 100), (2, 200);
+
+# Three inputs, one literal. The literal enters as an equivalence, which every
+# delta path can see, so each lookup into `t` uses the completed key and the
+# index is probed from both directions.
+query II rowsort
+SELECT t.a, sum(t.v) FROM t, m, u
+WHERE t.a = m.a AND t.a = u.a AND t.b = 7
+GROUP BY t.a;
+----
+1  15
+2  40
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT t.a, sum(t.v) FROM t, m, u
+WHERE t.a = m.a AND t.a = u.a AND t.b = 7
+GROUP BY t.a;
+----
+Explained Query:
+  Reduce group_by=[#0{a}] aggregates=[sum(#1{v})]
+    Project (#0{a}, #2{v})
+      Join on=(#0{a} = #3{a} = #4{a} AND #1{b} = 7) type=delta
+        ArrangeBy keys=[[#0{a}, #1{b}]]
+          ReadIndex on=t t_a_b=[delta join 1st input (full scan)]
+        ArrangeBy keys=[[#0{a}]]
+          Project (#1{a})
+            Filter (#1{a}) IS NOT NULL
+              ReadIndex on=m m_k=[*** full scan ***]
+        ArrangeBy keys=[[#0{a}]]
+          Project (#0{a})
+            Filter (#0{a}) IS NOT NULL
+              ReadStorage materialize.public.u
+
+Source materialize.public.u
+  filter=((#0{a}) IS NOT NULL)
+
+Used Indexes:
+  - materialize.public.t_a_b (delta join 1st input (full scan))
+  - materialize.public.m_k (*** full scan ***)
+
+Target cluster: quickstart
+
+EOF
+
+# Three inputs, two values. The values would live only in the binder's cross
+# product, so the path from `u` would still look `t` up by `a` alone and the
+# index could not be lifted. The rewrite declines and the plan is the flag-off
+# one, notice included.
+query II rowsort
+SELECT t.a, sum(t.v) FROM t, m, u
+WHERE t.a = m.a AND t.a = u.a AND t.b IN (7, 8)
+GROUP BY t.a;
+----
+1  35
+2  40
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT t.a, sum(t.v) FROM t, m, u
+WHERE t.a = m.a AND t.a = u.a AND t.b IN (7, 8)
+GROUP BY t.a;
+----
+Explained Query:
+  Reduce group_by=[#0{a}] aggregates=[sum(#1{v})]
+    Project (#0{a}, #1{v})
+      Join on=(#0{a} = #2{a} = #3{a}) type=delta
+        ArrangeBy keys=[[#0{a}]]
+          Project (#0{a}, #2{v})
+            Filter (#0{a}) IS NOT NULL AND ((#1{b} = 7) OR (#1{b} = 8))
+              ReadIndex on=t t_a_b=[*** full scan ***]
+        ArrangeBy keys=[[#0{a}]]
+          Project (#1{a})
+            Filter (#1{a}) IS NOT NULL
+              ReadIndex on=m m_k=[*** full scan ***]
+        ArrangeBy keys=[[#0{a}]]
+          Project (#0{a})
+            Filter (#0{a}) IS NOT NULL
+              ReadStorage materialize.public.u
+
+Source materialize.public.u
+  filter=((#0{a}) IS NOT NULL)
+
+Used Indexes:
+  - materialize.public.t_a_b (*** full scan ***)
+  - materialize.public.m_k (*** full scan ***)
+
+Target cluster: quickstart
+
+Notices:
+  - Notice: Index materialize.public.t_a_b on t(a, b) is too wide to use for literal equalities `b IN (7, 8)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (b).
+
+EOF
+
+# With the flag off the original query is a full scan with the notice.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_partial_literal_index_lookups TO false;
+----
+COMPLETE 0
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT t.a, sum(t.v) FROM t
+WHERE t.a = (SELECT a FROM m WHERE m.k = 1) AND t.b IN (7, 8)
+GROUP BY t.a;
+----
+Explained Query:
+  With
+    cte l0 =
+      Project (#1{a})
+        ReadIndex on=materialize.public.m m_k=[lookup value=(1)]
+  Return
+    Reduce group_by=[#0{a}] aggregates=[sum(#1{v})]
+      Project (#0{a}, #1{v})
+        Join on=(#0{a} = #2{a}) type=differential
+          ArrangeBy keys=[[#0{a}]]
+            Project (#0{a}, #2{v})
+              Filter (#0{a}) IS NOT NULL AND ((#1{b} = 7) OR (#1{b} = 8))
+                ReadIndex on=t t_a_b=[*** full scan ***]
+          ArrangeBy keys=[[#0{a}]]
+            Union
+              Filter (#0{a}) IS NOT NULL
+                Get l0
+              Project (#1)
+                FlatMap guard_subquery_size(#0{count})
+                  Reduce aggregates=[count(*)]
+                    Project ()
+                      Get l0
+
+Used Indexes:
+  - materialize.public.t_a_b (*** full scan ***)
+  - materialize.public.m_k (lookup)
+
+Target cluster: quickstart
+
+Notices:
+  - Notice: Index materialize.public.t_a_b on t(a, b) is too wide to use for literal equalities `b IN (7, 8)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (b).
+
+EOF
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_partial_literal_index_lookups TO true;
+----
+COMPLETE 0
+
+# A maintained dataflow over a rewritten join, kept correct under updates. The
+# literal-bound input can be a delta path's source here, which lowering handles
+# through a different mechanism than a lookup key.
+statement ok
+CREATE VIEW v_partial AS
+SELECT t.a, sum(t.v) AS s FROM t
+WHERE t.a = (SELECT a FROM m WHERE m.k = 1) AND t.b IN (7, 8)
+GROUP BY t.a;
+
+statement ok
+CREATE INDEX v_partial_idx ON v_partial(a);
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR INDEX v_partial_idx;
+----
+materialize.public.v_partial_idx:
+  ArrangeBy keys=[[#0{a}]]
+    ReadGlobalFromSameDataflow materialize.public.v_partial
+
+materialize.public.v_partial:
+  With
+    cte l0 =
+      Project (#1{a})
+        ReadIndex on=materialize.public.m m_k=[lookup value=(1)]
+  Return
+    Reduce group_by=[#0{a}] aggregates=[sum(#1{v})]
+      Project (#0{a}, #2{v})
+        Join on=(#0{a} = #3{a} AND #1{b} = #4) type=differential
+          ArrangeBy keys=[[#0{a}, #1{b}]]
+            ReadIndex on=t t_a_b=[differential join]
+          ArrangeBy keys=[[#0{a}, #1]]
+            CrossJoin type=differential
+              ArrangeBy keys=[[]]
+                Union
+                  Filter (#0{a}) IS NOT NULL
+                    Get l0
+                  Project (#1)
+                    FlatMap guard_subquery_size(#0{count})
+                      Reduce aggregates=[count(*)]
+                        Project ()
+                          Get l0
+              ArrangeBy keys=[[]]
+                Constant
+                  - (7)
+                  - (8)
+
+Used Indexes:
+  - materialize.public.t_a_b (differential join)
+  - materialize.public.m_k (lookup)
+
+Target cluster: quickstart
+
+EOF
+
+query II
+SELECT * FROM v_partial;
+----
+1  35
+
+statement ok
+INSERT INTO t VALUES (1, 8, 1000);
+
+query II
+SELECT * FROM v_partial;
+----
+1  1035

--- a/test/sqllogictest/transform/join_literal_constraints.slt
+++ b/test/sqllogictest/transform/join_literal_constraints.slt
@@ -325,6 +325,134 @@ Notices:
 
 EOF
 
+# A narrower index that the literals cover fully is the `Get` case's lookup and
+# normally takes precedence. A wider key takes over only when it strictly
+# extends that index and contains a unique key of the relation, so that each
+# probe yields at most one row. `tk` is keyed by `(a, b)`.
+statement ok
+CREATE MATERIALIZED VIEW tk AS SELECT a, b, sum(v) AS v FROM t GROUP BY a, b;
+
+statement ok
+CREATE INDEX tk_b ON tk(b);
+
+statement ok
+CREATE INDEX tk_a_b ON tk(a, b);
+
+query II
+SELECT tk.a, sum(tk.v) FROM tk JOIN m ON tk.a = m.a
+WHERE tk.b IN (7, 8) AND m.k = 1
+GROUP BY tk.a;
+----
+1  35
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT tk.a, sum(tk.v) FROM tk JOIN m ON tk.a = m.a
+WHERE tk.b IN (7, 8) AND m.k = 1
+GROUP BY tk.a;
+----
+Explained Query:
+  Reduce group_by=[#0{a}] aggregates=[sum(#1{v})]
+    Project (#0{a}, #2{v})
+      Join on=(#0{a} = #3{a} AND #1{b} = #4) type=differential
+        ArrangeBy keys=[[#0{a}, #1{b}]]
+          ReadIndex on=tk tk_a_b=[differential join]
+        ArrangeBy keys=[[#0{a}, #1]]
+          CrossJoin type=differential
+            ArrangeBy keys=[[]]
+              Project (#1{a})
+                Filter (#1{a}) IS NOT NULL
+                  ReadIndex on=materialize.public.m m_k=[lookup value=(1)]
+            ArrangeBy keys=[[]]
+              Constant
+                - (7)
+                - (8)
+
+Used Indexes:
+  - materialize.public.m_k (lookup)
+  - materialize.public.tk_a_b (differential join)
+
+Target cluster: quickstart
+
+EOF
+
+# The rule does not look at the binder: the unique-key probe is preferred even
+# where `m(a)` would otherwise have served the join directly.
+statement ok
+CREATE INDEX m_a ON m(a);
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT tk.a, sum(tk.v) FROM tk JOIN m ON tk.a = m.a
+WHERE tk.b IN (7, 8)
+GROUP BY tk.a;
+----
+Explained Query:
+  Reduce group_by=[#0{a}] aggregates=[sum(#1{v})]
+    Project (#0{a}, #2{v})
+      Join on=(#0{a} = #3{a} AND #1{b} = #4) type=differential
+        ArrangeBy keys=[[#0{a}, #1{b}]]
+          ReadIndex on=tk tk_a_b=[differential join]
+        ArrangeBy keys=[[#0{a}, #1]]
+          CrossJoin type=differential
+            ArrangeBy keys=[[]]
+              Project (#1{a})
+                Filter (#1{a}) IS NOT NULL
+                  ReadIndex on=m m_k=[*** full scan ***]
+            ArrangeBy keys=[[]]
+              Constant
+                - (7)
+                - (8)
+
+Used Indexes:
+  - materialize.public.m_k (*** full scan ***)
+  - materialize.public.tk_a_b (differential join)
+
+Target cluster: quickstart
+
+EOF
+
+statement ok
+DROP INDEX m_a;
+
+# Without a unique key the fully covered index keeps its priority. `t` holds the
+# same data, but nothing bounds how many rows a probe of `t(a, b)` returns.
+statement ok
+CREATE INDEX t_b ON t(b);
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS VERBOSE TEXT FOR
+SELECT t.a, sum(t.v) FROM t JOIN m ON t.a = m.a
+WHERE t.b IN (7, 8) AND m.k = 1
+GROUP BY t.a;
+----
+Explained Query:
+  Reduce group_by=[#0{a}] aggregates=[sum(#1{v})]
+    Project (#0{a}, #1{v})
+      Join on=(#0{a} = #2{a}) type=differential
+        ArrangeBy keys=[[#0{a}]]
+          Project (#0{a}, #2{v})
+            Filter (#0{a}) IS NOT NULL
+              ReadIndex on=materialize.public.t t_b=[lookup values=[(7); (8)]]
+        ArrangeBy keys=[[#0{a}]]
+          Project (#1{a})
+            Filter (#1{a}) IS NOT NULL
+              ReadIndex on=materialize.public.m m_k=[lookup value=(1)]
+
+Used Indexes:
+  - materialize.public.m_k (lookup)
+  - materialize.public.t_b (lookup)
+
+Target cluster: quickstart
+
+EOF
+
+statement ok
+DROP INDEX t_b;
+
+statement ok
+DROP MATERIALIZED VIEW tk;
+
 # With the flag off the original query is a full scan with the notice.
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_partial_literal_index_lookups TO false;


### PR DESCRIPTION
**[Note: recommend reviewing the code via [this view of the second commit](https://github.com/MaterializeInc/materialize/pull/38724/commits/8fb0fa5b7ff723362aa78338c02578ff748f3f2a), as the first commit is just moving some code blocks around.]**

### Motivation

An arrangement can only be probed with its complete key. When literal equalities on a join input cover only some fields of an index key, `LiteralConstraints` declines the index and the plan degrades to a full scan, even though the enclosing join's equivalences bind the remaining fields. With an index on `t(a, b)`:

```sql
SELECT ... FROM t
WHERE t.a = (SELECT a FROM m WHERE m.k = 1) AND t.b IN (7, 8)
```

scans `t` and builds a fresh arrangement on `a`, and emits a "too wide" notice whose hint (index `(b)` alone) is usually bad advice. Passing `a` as a literal instead gives two point lookups. The optimizer has everything it needs to do that itself: the join already performs runtime-keyed probes, and `LiteralConstraints` already knows how to turn literals into a constant collection. The two passes just never combined.

Several `mz_introspection` views hit the same shape through `worker_id = 0` on `(id, worker_id)` indexes.

### Description

Two commits. The first is a pure move: `match_index` and `undo_preparation` become associated fns of `LiteralConstraints` so a second call site can reuse them. It has no behavior change and can be reviewed on its own.

The second adds a pre-order `Join` hook to `LiteralConstraints::action` (`complete_join_index_key`). It widens the indexed input's projection so the literal-covered key fields are visible to the join, then supplies their values one of two ways:

* **One literal per field** enters the join as an equivalence `{col, lit}`. The `JoinImplementation` orderer treats such a field as bound via a new `literal_bound` set. This is kept apart from `bound`, which doubles as the key of arrangements the join *builds*; merging them would widen those keys and trade existing indexes for new arrangements.
* **An `IN` list of two or more values** becomes a constant collection crossed into the one other input that binds the rest of the key, so a single input supplies the whole key. It cannot be a sibling join input: the orderer can only place an input once one of its equivalence classes is active, and a sibling constant only connects to the indexed input itself, so no order ever binds the whole key before placing it.

The literal constraints are removed from the input's MFP in both cases, so the `Get` case does not report the index as too wide for that read. This is per read: another read of the same index elsewhere in the plan that is still a full scan keeps its notice.

The rewrite pays off only if `JoinImplementation` can lift the input's MFP and reuse the index, which requires *every* key it needs on that input to be an index key. Without a guard, a third input reaching the indexed one by a non-index key would leave the MFP unlifted: two fresh arrangements over the now-unfiltered table plus a replicated binder. The rewrite therefore fires only when every input that equates with the indexed one binds all the uncovered key fields, and for a collection only when that input is unique. The `NOTE:` on `complete_join_index_key` states the residual cost when the order still declines the index.

Gated by `enable_partial_literal_index_lookups`, default off in production and on in CI per the project convention for new optimizer paths. Known limits are left as `TODO:`s: only one input per join is completed, and the number of `IN` values is not weighed against the binder's cardinality.

### Verification

New `test/sqllogictest/transform/join_literal_constraints.slt` covers both tiers with results asserted against the flag-off plans: NULLs in every key and join column, a duplicate-value `IN (7, 7)`, an empty scalar subquery, a non-unique join key on the binder side (the crossed-in values must not multiply rows), a 3-input delta join in both tiers (the single-literal one fires and drops an arrangement, the `IN`-list one is declined by the guard and keeps its notice), an explicit flag-off plan, and a maintained index over a rewritten join kept correct under an incremental insert.

`catalog_server_explain.slt` is rewritten: eight introspection views go from full scan to using their per-worker index as a join arrangement, with no `CrossJoin` or `Constant` introduced, since they are all the single-literal case.

No release note: off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
