### PR TITLE
adapter: Align replica hydration history object counts

### DIFF
--- a/src/adapter/src/coord/hydration_history.rs
+++ b/src/adapter/src/coord/hydration_history.rs
@@ -388,10 +388,8 @@ fn object_collection_sql(cluster_id: ClusterId, replica_id: ReplicaId, cutoff: &
                 min(t.started_at) AS started_at,
                 max(t.hydrated_at) AS hydrated_at
             FROM mz_introspection.mz_compute_hydration_times_per_worker AS t
-            JOIN mz_internal.mz_object_global_ids AS ids ON ids.global_id = t.export_id
-            JOIN mz_catalog.mz_objects AS o ON o.id = ids.id
-            WHERE t.export_id LIKE 'u%'
-              AND o.type IN ('index', 'materialized-view')
+            WHERE t.export_id NOT LIKE 'si%'
+              AND t.export_id NOT LIKE 't%'
             GROUP BY t.export_id
             HAVING count(*) = count(t.hydrated_at)
         ) AS e
@@ -478,6 +476,7 @@ fn replica_collection_sql(target: ReplicaTarget, cutoff: &str) -> String {
         -- Each interval belongs to the latest episode start at or before it.
         labeled AS (
             SELECT
+                object_id,
                 installed_at,
                 hydrated_at,
                 max(CASE WHEN starts_episode THEN installed_at END) OVER (
@@ -491,7 +490,7 @@ fn replica_collection_sql(target: ReplicaTarget, cutoff: &str) -> String {
             SELECT
                 episode_started_at AS started_at,
                 max(hydrated_at) AS finished_at,
-                count(*)::uint8 AS object_count
+                count(*) FILTER (WHERE object_id NOT LIKE 'si%')::uint8 AS object_count
             FROM labeled
             GROUP BY episode_started_at
         ),

--- a/test/testdrive/hydration-status.td
+++ b/test/testdrive/hydration-status.td
@@ -61,22 +61,17 @@ si true
   JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   WHERE r.name LIKE 'hydrated_test%';
 
-# A system-only replica hydration episode covers every visible non-transient
-# export. Its existence also proves the collector excludes its own transient
+# A system-only replica hydration episode has no objects eligible for object
+# history. Its existence also proves the collector excludes its own transient
 # subscribe, whose intervals would otherwise show up as spurious episodes in
 # later snapshots.
-> SELECT h.status,
-         h.object_count = (
-             SELECT count(DISTINCT export_id)::uint8
-             FROM mz_introspection.mz_compute_hydration_times_per_worker
-             WHERE export_id NOT LIKE 't%'
-         )
+> SELECT h.status, h.object_count
   FROM mz_internal.mz_replica_hydration_history AS h
   JOIN mz_catalog.mz_cluster_replicas AS r ON r.id = h.replica_id
   WHERE r.name = 'hydrated_test_1'
   ORDER BY h.started_at DESC
   LIMIT 1;
-hydrated true
+hydrated 0
 
 # Test adding new compute dataflows.
 
@@ -131,7 +126,7 @@ mv  hydrated_test_1 hydrated true true
 # overlapped, so assert the stable properties here.
 > SELECT count(*) > 0,
          bool_and(h.status = 'hydrated' AND h.started_at <= h.finished_at),
-         bool_and(h.object_count > 0)
+         bool_or(h.object_count > 0)
   FROM mz_internal.mz_replica_hydration_history AS h
   JOIN mz_catalog.mz_cluster_replicas AS r ON r.id = h.replica_id
   WHERE r.name = 'hydrated_test_1';


### PR DESCRIPTION
## Motivation
Replica hydration history counts builtin introspection indexes that object hydration history excludes. This makes the two histories inconsistent.

## Changes
Exclude introspection-index (`si%`) and transient (`t%`) exports from both object history and replica episode counts, without catalog lookups. Ordinary system and user exports are included.

Keep all non-transient exports in episode construction, so introspection hydration still determines episode boundaries and completion. Introspection-only episodes remain visible with `object_count = 0`.

Adjust `hydration-status.td` to require a zero-count introspection-only episode while retaining the exact count and timing assertion for an isolated user-index episode.

Closes: [SQL-692](https://linear.app/materializeinc/issue/SQL-692)