### PR TITLE
adapter: Collect hydration history for system replicas

### DIFF
--- a/doc/developer/design/20260817_durable_object_hydration_history.md
+++ b/doc/developer/design/20260817_durable_object_hydration_history.md
@@ -44,7 +44,7 @@ the output frontier passes the as-of. See
 `doc/developer/design/20260817_compute_hydration_timestamps.md`. This design adds
 the history table and the sweep that writes those timestamps down.
 
-A coordinator task visits one user replica per interval, in a rotation, skipping
+A coordinator task visits one replica per interval, in a rotation, skipping
 replicas with introspection disabled, whose logs are installed but never populated.
 It installs an internal subscribe on that replica which aggregates every worker's
 completed rows, anti-joins them against the history table, and writes the missing
@@ -262,7 +262,7 @@ replica dataflow installs.
 **Background mutations take no OCC write permit.** The permits are one semaphore
 shared by every read-then-write in the process, not one per table. A session's wait
 is bounded by its statement timeout, a sweep's is not, and a sweep's subscribe has
-to hydrate a dataflow on a user replica first, so holding a permit would let
+to hydrate a dataflow on the selected replica first, so holding a permit would let
 background sampling stall user DML on any table for as long as that takes. Being
 single-flight, skipping the permit adds at most one concurrent read-then-write.
 

--- a/src/adapter/src/coord/hydration_history.rs
+++ b/src/adapter/src/coord/hydration_history.rs
@@ -9,7 +9,7 @@
 
 //! Durable history collection for completed object and replica hydration episodes.
 //!
-//! One sweep visits a single user replica, installs a replica-targeted
+//! One sweep visits a single replica, installs a replica-targeted
 //! subscribe that diffs that replica's live hydration timestamps against the
 //! durable history tables, and appends what is missing through the timestamped
 //! OCC write path. Including each history table in its read expression is what
@@ -198,7 +198,8 @@ impl Coordinator {
 
         let replicas = self
             .catalog()
-            .user_cluster_replicas()
+            .clusters()
+            .flat_map(|cluster| cluster.replicas())
             .filter(|replica| replica.config.compute.logging.enabled())
             .filter(|replica| match &replica.config.location {
                 ReplicaLocation::Managed(_) => {
@@ -295,7 +296,7 @@ impl Coordinator {
     }
 }
 
-/// A user replica eligible for one collection step.
+/// A replica eligible for one collection step.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct ReplicaTarget {
     cluster_id: ClusterId,

--- a/test/testdrive/hydration-status.td
+++ b/test/testdrive/hydration-status.td
@@ -78,6 +78,17 @@ si true
   LIMIT 1;
 hydrated true
 
+# System clusters participate in the collection rotation too.
+> SELECT count(*) > 0,
+         bool_and(h.status = 'hydrated'
+                  AND h.finished_at IS NOT NULL
+                  AND h.started_at <= h.finished_at)
+  FROM mz_internal.mz_replica_hydration_history AS h
+  JOIN mz_catalog.mz_cluster_replicas AS r ON r.id = h.replica_id
+  JOIN mz_catalog.mz_clusters AS c ON c.id = r.cluster_id AND c.id = h.cluster_id
+  WHERE c.name = 'mz_catalog_server';
+true true
+
 # Test adding new compute dataflows.
 
 > CREATE TABLE t (a int)


### PR DESCRIPTION
## Motivation
The hydration-history collector only visits user clusters, leaving system-cluster replica hydration absent from the history.

## Changes
Include all cluster replicas in the existing rotation, including system-cluster and internal support replicas. Keep the logging and readiness requirements.

Extend `hydration-status.td` to require a completed history episode for an `mz_catalog_server` replica, joined through the catalog and checked for valid timestamps. Existing user-replica and retention coverage remains in place.

Closes: [SQL-693](https://linear.app/materializeinc/issue/SQL-693)