### PR TITLE
mysql: drop keys over excluded columns from the table description

### DIFF
--- a/src/mysql-util/src/desc.rs
+++ b/src/mysql-util/src/desc.rs
@@ -153,7 +153,9 @@ impl MySqlTableDesc {
                 );
             }
         }
-        // Our keys are all still present in exactly the same shape.
+        // Our keys are all still present in exactly the same shape. Keys over an
+        // excluded column are skipped: they were never recorded as Materialize
+        // keys, and they cannot be re-verified once the column is gone upstream.
         // TODO: Implement a more relaxed key compatibility check:
         // We should check that for all keys that we know about there exists an upstream key whose
         // set of columns is a subset of the set of columns of the key we know about. For example
@@ -161,7 +163,22 @@ impl MySqlTableDesc {
         // up of columns (a, b) and key2 made up of columns (a, c) but now the table only has a
         // single unique key of just the column a then it's compatible because {a} ⊆ {a, b} and
         // {a} ⊆ {a, c}.
-        if self.keys.difference(&other.keys).next().is_some() {
+        let excluded_columns: BTreeSet<&str> = self
+            .columns
+            .iter()
+            .filter(|c| c.column_type.is_none())
+            .map(|c| c.name.as_str())
+            .collect();
+        let key_altered = self
+            .keys
+            .iter()
+            .filter(|k| {
+                !k.columns
+                    .iter()
+                    .any(|c| excluded_columns.contains(c.as_str()))
+            })
+            .any(|k| !other.keys.contains(k));
+        if key_altered {
             bail!(
                 "keys in table {} have been altered: self: {:?}, other: {:?}",
                 self.name,
@@ -358,5 +375,60 @@ impl RustType<ProtoMySqlKeyDesc> for MySqlKeyDesc {
             is_primary: proto.is_primary,
             columns: proto.columns,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_repr::SqlScalarType;
+
+    use super::{MySqlColumnDesc, MySqlKeyDesc, MySqlTableDesc};
+
+    fn column(name: &str, excluded: bool) -> MySqlColumnDesc {
+        MySqlColumnDesc {
+            name: name.into(),
+            column_type: (!excluded).then(|| SqlScalarType::Int32.nullable(false)),
+            meta: None,
+        }
+    }
+
+    fn key(name: &str, columns: &[&str]) -> MySqlKeyDesc {
+        MySqlKeyDesc {
+            name: name.into(),
+            is_primary: name == "PRIMARY",
+            columns: columns.iter().map(|c| c.to_string()).collect(),
+        }
+    }
+
+    fn desc(columns: Vec<MySqlColumnDesc>, keys: Vec<MySqlKeyDesc>) -> MySqlTableDesc {
+        MySqlTableDesc {
+            schema_name: "public".into(),
+            name: "t".into(),
+            columns,
+            keys: keys.into_iter().collect(),
+        }
+    }
+
+    #[mz_ore::test]
+    fn keys_over_excluded_columns_are_not_verified() {
+        let columns = || vec![column("f1", false), column("f2", true), column("f3", false)];
+        let recorded = desc(
+            columns(),
+            vec![
+                key("PRIMARY", &["f1"]),
+                key("uq_f2", &["f2"]),
+                key("uq_f1_f2", &["f1", "f2"]),
+            ],
+        );
+
+        // Upstream dropped both indexes over the excluded column.
+        let upstream = desc(columns(), vec![key("PRIMARY", &["f1"])]);
+        recorded
+            .determine_compatibility(&upstream, true)
+            .expect("keys over an excluded column are ignored");
+
+        // A key over included columns is still verified.
+        let upstream = desc(columns(), vec![key("uq_f2", &["f2"])]);
+        assert!(recorded.determine_compatibility(&upstream, true).is_err());
     }
 }

--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -181,11 +181,23 @@ impl MySqlTableSchema {
             })?;
         }
 
+        // A key over an excluded column cannot be re-verified against upstream
+        // once that column is gone, and planning would reject a constraint on
+        // a column the table does not have.
+        let keys = match &exclude_columns {
+            Some(excluded) => self
+                .keys
+                .into_iter()
+                .filter(|k| k.columns.iter().all(|c| !excluded.contains(&c.as_str())))
+                .collect(),
+            None => self.keys,
+        };
+
         Ok(MySqlTableDesc {
             schema_name: self.schema_name,
             name: self.name,
             columns,
-            keys: self.keys,
+            keys,
         })
     }
 }

--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -181,23 +181,11 @@ impl MySqlTableSchema {
             })?;
         }
 
-        // A key over an excluded column cannot be re-verified against upstream
-        // once that column is gone, and planning would reject a constraint on
-        // a column the table does not have.
-        let keys = match &exclude_columns {
-            Some(excluded) => self
-                .keys
-                .into_iter()
-                .filter(|k| k.columns.iter().all(|c| !excluded.contains(&c.as_str())))
-                .collect(),
-            None => self.keys,
-        };
-
         Ok(MySqlTableDesc {
             schema_name: self.schema_name,
             name: self.name,
             columns,
-            keys,
+            keys: self.keys,
         })
     }
 }

--- a/src/sql/src/pure/mysql.rs
+++ b/src/sql/src/pure/mysql.rs
@@ -166,8 +166,25 @@ pub(super) fn generate_source_export_statement_values(
         }
     }
 
+    // A key over an excluded column is not recorded as a Materialize key: the
+    // table has no such column, and the key cannot be re-verified once the
+    // column is dropped upstream. The key stays in the persisted description,
+    // where `determine_compatibility` skips it for the same reason.
+    let excluded_columns: BTreeSet<&str> = table
+        .columns
+        .iter()
+        .filter(|c| c.column_type.is_none())
+        .map(|c| c.name.as_str())
+        .collect();
     let mut constraints = vec![];
     for key in table.keys.iter() {
+        if key
+            .columns
+            .iter()
+            .any(|c| excluded_columns.contains(c.as_str()))
+        {
+            continue;
+        }
         let columns: Result<Vec<Ident>, _> = key.columns.iter().map(Ident::new).collect();
 
         let constraint = mz_sql_parser::ast::TableConstraint::Unique {

--- a/test/mysql-cdc/35-exclude-columns.td
+++ b/test/mysql-cdc/35-exclude-columns.td
@@ -108,8 +108,9 @@ ALTER TABLE t1 DROP COLUMN f2;
 1 "test"
 1 "test"
 
-# A key over an excluded column is dropped with the column, so the table can
-# be created and the upstream index can later be dropped without stalling it.
+# A key over an excluded column is not recorded as a Materialize key, so the
+# table can be created and the upstream index can later be dropped without
+# stalling it.
 $ mysql-execute name=mysql
 USE public;
 CREATE TABLE t2 (f1 INTEGER PRIMARY KEY, f2 INTEGER NOT NULL, f3 VARCHAR(64), UNIQUE KEY uq_f2 (f2), UNIQUE KEY uq_f1_f2 (f1, f2));
@@ -133,3 +134,28 @@ INSERT INTO t2 VALUES (2, 20, 'b');
 > SELECT * FROM t2;
 1 a
 2 b
+
+# The same holds when the key also spans a nullable included column, a shape
+# that constraint planning does not otherwise validate.
+$ mysql-execute name=mysql
+USE public;
+CREATE TABLE t3 (f1 INTEGER PRIMARY KEY, a INTEGER, b INTEGER NOT NULL, UNIQUE KEY uq_ab (a, b));
+INSERT INTO t3 VALUES (1, NULL, 10);
+
+> CREATE TABLE t3 FROM SOURCE da (REFERENCE public.t3) WITH (EXCLUDE COLUMNS (b));
+
+> SELECT * FROM t3;
+1 <null>
+
+> CREATE DEFAULT INDEX ON t3;
+> SELECT key FROM (SHOW INDEXES ON t3);
+{f1}
+
+$ mysql-execute name=mysql
+USE public;
+ALTER TABLE t3 DROP INDEX uq_ab;
+INSERT INTO t3 VALUES (2, NULL, 20);
+
+> SELECT * FROM t3;
+1 <null>
+2 <null>

--- a/test/mysql-cdc/35-exclude-columns.td
+++ b/test/mysql-cdc/35-exclude-columns.td
@@ -107,3 +107,29 @@ ALTER TABLE t1 DROP COLUMN f2;
 > select * from t1;
 1 "test"
 1 "test"
+
+# A key over an excluded column is dropped with the column, so the table can
+# be created and the upstream index can later be dropped without stalling it.
+$ mysql-execute name=mysql
+USE public;
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY, f2 INTEGER NOT NULL, f3 VARCHAR(64), UNIQUE KEY uq_f2 (f2), UNIQUE KEY uq_f1_f2 (f1, f2));
+INSERT INTO t2 VALUES (1, 10, 'a');
+
+> CREATE TABLE t2 FROM SOURCE da (REFERENCE public.t2) WITH (EXCLUDE COLUMNS (f2));
+
+> SELECT * FROM t2;
+1 a
+
+> CREATE DEFAULT INDEX ON t2;
+> SELECT key FROM (SHOW INDEXES ON t2);
+{f1}
+
+$ mysql-execute name=mysql
+USE public;
+ALTER TABLE t2 DROP INDEX uq_f2;
+ALTER TABLE t2 DROP INDEX uq_f1_f2;
+INSERT INTO t2 VALUES (2, 20, 'b');
+
+> SELECT * FROM t2;
+1 a
+2 b


### PR DESCRIPTION
### Motivation

`EXCLUDE COLUMNS` removed the column from a MySQL table description but left any unique index over it in `keys`. Planning then emitted a UNIQUE constraint on a column the table does not have and failed with "unknown column in constraint", so a table with a unique index on an excluded column could not be created. Where planning did admit it (an earlier nullable UNIQUE constraint short-circuits constraint validation), the retained key stalled the table once the excluded column or its index was dropped upstream, since schema verification could no longer find it.

### Description

Keys over an excluded column are handled where Postgres and SQL Server handle them, and the table description itself is left unchanged.

- Constraint emission in purification skips any key that spans an excluded column, so the table can be created and the key is not recorded as a Materialize key.
- `determine_compatibility` ignores keys in the recorded description that span a column the description marks as excluded, so dropping the excluded column or its index upstream is a non-event. This applies to existing tables too, whose persisted descriptions may already hold such keys.

Pruning inside `to_desc` was considered and rejected: `to_desc` also produces the upstream side of the runtime comparison, so pruning there would have made every persisted key over an excluded column look dropped on the next upstream DDL.

**User-visible effect**: a MySQL table with a unique index over a column listed in `EXCLUDE COLUMNS` can now be created, and dropping that index or column upstream no longer puts the table into an error state.

### Verification

`test/mysql-cdc/35-exclude-columns.td` creates such tables, checks the excluded key is not recorded, and drops the upstream indexes afterwards, including a key that also spans a nullable included column. `keys_over_excluded_columns_are_not_verified` unit tests the compatibility check directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
