### PR TITLE
misc/scratch: move prod-like-arm to Graviton4

### DIFF
--- a/misc/scratch/prod-like-arm.json
+++ b/misc/scratch/prod-like-arm.json
@@ -1,7 +1,7 @@
 {
     "name": "production-like ARM",
     "launch_script": "true",
-    "instance_type": "r6g.4xlarge",
+    "instance_type": "r8g.4xlarge",
     "size_gb": 200,
     "tags": {}
 }


### PR DESCRIPTION
The `prod-like-arm` scratch config still launched an `r6g.4xlarge`, a Graviton2 box. Production's ARM node pools have moved on: the pools carrying weight today (`arm-swap`, `arm-jumbo-swap`) are all on the `r8gd` family, so a "production-like" scratch box was no longer on the microarchitecture production actually runs.

This moves the family to `r8g` and keeps the size at `4xlarge`, so the CPU generation tracks production while the footprint and cost of the box are unchanged.

Production uses the `d` variant for its local NVMe, which backs swap and the scratch filesystem. This config deliberately stays on plain `r8g`: nothing in `misc/scratch/provision.bash` mounts an instance store, so the extra disk would go unused. Wiring that up is a separate change.

No tests: `misc/scratch/*.json` are launch configs consumed by `bin/scratch`, with no test coverage.

### Release notes

None. Developer tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)