### PR TITLE
ci: pin the self-managed Terraform modules to a tag instead of main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,16 +72,11 @@ updates:
       update-types:
         - minor
         - patch
-# The `test/terraform` roots source the self-managed modules from a public git
-# repository, pinned to a tag rather than floating on `main`. An upstream merge
-# to `main` used to reach the nightly with no PR-time signal: DEP-200 moved the
-# modules to AWS provider v6 and EKS module v21, and the next nightly, 4h50m
-# later, failed at `terraform init` on an unsatisfiable provider constraint and
-# stayed red for two weeks. With a pin, a major bump arrives here as a PR that
-# someone has to look at, and the roots can be adapted in the same change.
-#
-# Pin to a tag, not a commit SHA: dependabot does not reliably bump SHA refs
-# (dependabot/dependabot-core#10787).
+# The `test/terraform` roots pin the self-managed modules to a tag rather than
+# floating on `main`, so an upstream release arrives here as a PR that can
+# adapt the roots in the same change, instead of breaking the nightly overnight
+# with no PR-time signal. Pin to a tag, not a commit SHA: dependabot does not
+# reliably bump SHA refs (dependabot/dependabot-core#10787).
 - package-ecosystem: terraform
   directories:
     - /test/terraform/aws-temporary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,6 +72,31 @@ updates:
       update-types:
         - minor
         - patch
+# The `test/terraform` roots source the self-managed modules from a public git
+# repository, pinned to a tag rather than floating on `main`. An upstream merge
+# to `main` used to reach the nightly with no PR-time signal: DEP-200 moved the
+# modules to AWS provider v6 and EKS module v21, and the next nightly, 4h50m
+# later, failed at `terraform init` on an unsatisfiable provider constraint and
+# stayed red for two weeks. With a pin, a major bump arrives here as a PR that
+# someone has to look at, and the roots can be adapted in the same change.
+#
+# Pin to a tag, not a commit SHA: dependabot does not reliably bump SHA refs
+# (dependabot/dependabot-core#10787).
+- package-ecosystem: terraform
+  directories:
+    - /test/terraform/aws-temporary
+    - /test/terraform/aws-upgrade
+    - /test/terraform/aws-persistent
+    - /test/terraform/gcp-temporary
+    - /test/terraform/azure-temporary
+  schedule:
+    interval: weekly
+    day: sunday
+    time: "22:00"
+  cooldown:
+    default-days: 3
+  open-pull-requests-limit: 50
+  labels: [A-dependencies]
 - package-ecosystem: pip
   directory: /misc/dbt-materialize
   schedule:

--- a/test/terraform/aws-persistent/main.tf
+++ b/test/terraform/aws-persistent/main.tf
@@ -15,7 +15,7 @@ resource "random_password" "db_password" {
 
 # 1. Create network infrastructure
 module "networking" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/networking?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/networking?ref=v13.2.1"
 
   name_prefix          = var.name_prefix
   vpc_cidr             = "10.0.0.0/16"
@@ -28,7 +28,7 @@ module "networking" {
 
 # 2. Create EKS cluster
 module "eks" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks?ref=v13.2.1"
 
   name_prefix                              = var.name_prefix
   cluster_version                          = "1.32"
@@ -50,7 +50,7 @@ module "eks" {
 # nodes cannot become Ready without one, so it must be installed before any
 # node group.
 module "vpc_cni" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/vpc-cni?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/vpc-cni?ref=v13.2.1"
 
   name_prefix       = var.name_prefix
   oidc_provider_arn = module.eks.oidc_provider_arn
@@ -74,7 +74,7 @@ module "vpc_cni" {
 }
 
 module "base_node_group" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks-node-group?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks-node-group?ref=v13.2.1"
 
   cluster_name                      = module.eks.cluster_name
   aws_region                        = var.aws_region
@@ -102,7 +102,7 @@ module "base_node_group" {
 # v21 clusters do not bootstrap CoreDNS either, so the deployment, its service
 # account and the kube-dns Service are created here.
 module "coredns" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/coredns?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/coredns?ref=v13.2.1"
 
   node_selector                      = local.base_node_labels
   disable_default_coredns_autoscaler = false
@@ -121,7 +121,7 @@ module "coredns" {
 }
 
 module "karpenter" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter?ref=v13.2.1"
 
   name_prefix             = var.name_prefix
   cluster_name            = module.eks.cluster_name
@@ -140,7 +140,7 @@ module "karpenter" {
 
 # Create a generic nodeclass and nodepool for system workloads
 module "ec2nodeclass_generic" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=v13.2.1"
 
   name               = local.nodeclass_name_generic
   ami_selector_terms = local.ami_selector_terms
@@ -158,7 +158,7 @@ module "ec2nodeclass_generic" {
 }
 
 module "nodepool_generic" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=v13.2.1"
 
   name            = local.nodeclass_name_generic
   nodeclass_name  = local.nodeclass_name_generic
@@ -175,7 +175,7 @@ module "nodepool_generic" {
 
 # Create a dedicated nodeclass and nodepool for Materialize pods
 module "ec2nodeclass_materialize" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=v13.2.1"
 
   name               = local.nodeclass_name_materialize
   ami_selector_terms = local.ami_selector_terms
@@ -192,7 +192,7 @@ module "ec2nodeclass_materialize" {
 }
 
 module "nodepool_materialize" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=v13.2.1"
 
   name            = local.nodeclass_name_materialize
   nodeclass_name  = local.nodeclass_name_materialize
@@ -210,7 +210,7 @@ module "nodepool_materialize" {
 
 # 3. Install AWS Load Balancer Controller
 module "aws_lbc" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/aws-lbc?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/aws-lbc?ref=v13.2.1"
 
   name_prefix       = var.name_prefix
   eks_cluster_name  = module.eks.cluster_name
@@ -230,7 +230,7 @@ module "aws_lbc" {
 
 # 4. Install Certificate Manager for TLS
 module "cert_manager" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/cert-manager?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/cert-manager?ref=v13.2.1"
 
   node_selector = local.generic_node_labels
 
@@ -243,7 +243,7 @@ module "cert_manager" {
 }
 
 module "self_signed_cluster_issuer" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/self-signed-cluster-issuer?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/self-signed-cluster-issuer?ref=v13.2.1"
 
   name_prefix = var.name_prefix
 
@@ -254,7 +254,7 @@ module "self_signed_cluster_issuer" {
 
 # 5. Setup dedicated database instance for Materialize
 module "database" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/database?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/database?ref=v13.2.1"
 
   name_prefix               = var.name_prefix
   postgres_version          = "15"
@@ -280,7 +280,7 @@ module "database" {
 
 # 6. Setup S3 bucket for Materialize
 module "storage" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/storage?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/storage?ref=v13.2.1"
 
   name_prefix            = var.name_prefix
   bucket_lifecycle_rules = []
@@ -305,7 +305,7 @@ module "storage" {
 
 # 7. Install Materialize Operator
 module "operator" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/operator?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/operator?ref=v13.2.1"
 
   name_prefix    = var.name_prefix
   aws_region     = var.aws_region
@@ -348,7 +348,7 @@ module "operator" {
 
 # 8. Setup Materialize instance
 module "materialize_instance" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/materialize-instance?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/materialize-instance?ref=v13.2.1"
 
   instance_name        = local.materialize_instance_name
   instance_namespace   = local.materialize_instance_namespace

--- a/test/terraform/aws-temporary/main.tf
+++ b/test/terraform/aws-temporary/main.tf
@@ -15,7 +15,7 @@ resource "random_password" "db_password" {
 
 # 1. Create network infrastructure
 module "networking" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/networking?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/networking?ref=v13.2.1"
 
   name_prefix          = var.name_prefix
   vpc_cidr             = "10.0.0.0/16"
@@ -28,7 +28,7 @@ module "networking" {
 
 # 2. Create EKS cluster
 module "eks" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks?ref=v13.2.1"
 
   name_prefix                              = var.name_prefix
   cluster_version                          = "1.34"
@@ -50,7 +50,7 @@ module "eks" {
 # nodes cannot become Ready without one, so it must be installed before any
 # node group.
 module "vpc_cni" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/vpc-cni?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/vpc-cni?ref=v13.2.1"
 
   name_prefix       = var.name_prefix
   oidc_provider_arn = module.eks.oidc_provider_arn
@@ -74,7 +74,7 @@ module "vpc_cni" {
 }
 
 module "base_node_group" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks-node-group?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks-node-group?ref=v13.2.1"
 
   cluster_name                      = module.eks.cluster_name
   aws_region                        = var.aws_region
@@ -102,7 +102,7 @@ module "base_node_group" {
 # v21 clusters do not bootstrap CoreDNS either, so the deployment, its service
 # account and the kube-dns Service are created here.
 module "coredns" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/coredns?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/coredns?ref=v13.2.1"
 
   node_selector                      = local.base_node_labels
   disable_default_coredns_autoscaler = false
@@ -121,7 +121,7 @@ module "coredns" {
 }
 
 module "karpenter" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter?ref=v13.2.1"
 
   name_prefix             = var.name_prefix
   cluster_name            = module.eks.cluster_name
@@ -140,7 +140,7 @@ module "karpenter" {
 
 # Create a generic nodeclass and nodepool for system workloads
 module "ec2nodeclass_generic" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=v13.2.1"
 
   name               = local.nodeclass_name_generic
   ami_selector_terms = local.ami_selector_terms
@@ -158,7 +158,7 @@ module "ec2nodeclass_generic" {
 }
 
 module "nodepool_generic" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=v13.2.1"
 
   name            = local.nodeclass_name_generic
   nodeclass_name  = local.nodeclass_name_generic
@@ -175,7 +175,7 @@ module "nodepool_generic" {
 
 # Create a dedicated nodeclass and nodepool for Materialize pods
 module "ec2nodeclass_materialize" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=v13.2.1"
 
   name               = local.nodeclass_name_materialize
   ami_selector_terms = local.ami_selector_terms
@@ -192,7 +192,7 @@ module "ec2nodeclass_materialize" {
 }
 
 module "nodepool_materialize" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=v13.2.1"
 
   name            = local.nodeclass_name_materialize
   nodeclass_name  = local.nodeclass_name_materialize
@@ -210,7 +210,7 @@ module "nodepool_materialize" {
 
 # 3. Install AWS Load Balancer Controller
 module "aws_lbc" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/aws-lbc?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/aws-lbc?ref=v13.2.1"
 
   name_prefix       = var.name_prefix
   eks_cluster_name  = module.eks.cluster_name
@@ -230,7 +230,7 @@ module "aws_lbc" {
 
 # 4. Install Certificate Manager for TLS
 module "cert_manager" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/cert-manager?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/cert-manager?ref=v13.2.1"
 
   node_selector = local.generic_node_labels
 
@@ -243,7 +243,7 @@ module "cert_manager" {
 }
 
 module "self_signed_cluster_issuer" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/self-signed-cluster-issuer?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/self-signed-cluster-issuer?ref=v13.2.1"
 
   name_prefix = var.name_prefix
 
@@ -254,7 +254,7 @@ module "self_signed_cluster_issuer" {
 
 # 5. Setup dedicated database instance for Materialize
 module "database" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/database?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/database?ref=v13.2.1"
 
   name_prefix               = var.name_prefix
   postgres_version          = "15"
@@ -280,7 +280,7 @@ module "database" {
 
 # 6. Setup S3 bucket for Materialize
 module "storage" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/storage?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/storage?ref=v13.2.1"
 
   name_prefix            = var.name_prefix
   bucket_lifecycle_rules = []
@@ -305,7 +305,7 @@ module "storage" {
 
 # 7. Install Materialize Operator
 module "operator" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/operator?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/operator?ref=v13.2.1"
 
   name_prefix    = var.name_prefix
   aws_region     = var.aws_region
@@ -348,7 +348,7 @@ module "operator" {
 
 # 8. Setup Materialize instance
 module "materialize_instance" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/materialize-instance?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/materialize-instance?ref=v13.2.1"
 
   instance_name        = local.materialize_instance_name
   instance_namespace   = local.materialize_instance_namespace

--- a/test/terraform/aws-upgrade/main.tf
+++ b/test/terraform/aws-upgrade/main.tf
@@ -15,7 +15,7 @@ resource "random_password" "db_password" {
 
 # 1. Create network infrastructure
 module "networking" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/networking?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/networking?ref=v13.2.1"
 
   name_prefix          = var.name_prefix
   vpc_cidr             = "10.0.0.0/16"
@@ -28,7 +28,7 @@ module "networking" {
 
 # 2. Create EKS cluster
 module "eks" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks?ref=v13.2.1"
 
   name_prefix                              = var.name_prefix
   cluster_version                          = "1.34"
@@ -50,7 +50,7 @@ module "eks" {
 # nodes cannot become Ready without one, so it must be installed before any
 # node group.
 module "vpc_cni" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/vpc-cni?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/vpc-cni?ref=v13.2.1"
 
   name_prefix       = var.name_prefix
   oidc_provider_arn = module.eks.oidc_provider_arn
@@ -74,7 +74,7 @@ module "vpc_cni" {
 }
 
 module "base_node_group" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks-node-group?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/eks-node-group?ref=v13.2.1"
 
   cluster_name                      = module.eks.cluster_name
   aws_region                        = var.aws_region
@@ -102,7 +102,7 @@ module "base_node_group" {
 # v21 clusters do not bootstrap CoreDNS either, so the deployment, its service
 # account and the kube-dns Service are created here.
 module "coredns" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/coredns?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/coredns?ref=v13.2.1"
 
   node_selector                      = local.base_node_labels
   disable_default_coredns_autoscaler = false
@@ -121,7 +121,7 @@ module "coredns" {
 }
 
 module "karpenter" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter?ref=v13.2.1"
 
   name_prefix             = var.name_prefix
   cluster_name            = module.eks.cluster_name
@@ -140,7 +140,7 @@ module "karpenter" {
 
 # Create a generic nodeclass and nodepool for system workloads
 module "ec2nodeclass_generic" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=v13.2.1"
 
   name               = local.nodeclass_name_generic
   ami_selector_terms = local.ami_selector_terms
@@ -158,7 +158,7 @@ module "ec2nodeclass_generic" {
 }
 
 module "nodepool_generic" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=v13.2.1"
 
   name            = local.nodeclass_name_generic
   nodeclass_name  = local.nodeclass_name_generic
@@ -175,7 +175,7 @@ module "nodepool_generic" {
 
 # Create a dedicated nodeclass and nodepool for Materialize pods
 module "ec2nodeclass_materialize" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-ec2nodeclass?ref=v13.2.1"
 
   name               = local.nodeclass_name_materialize
   ami_selector_terms = local.ami_selector_terms
@@ -192,7 +192,7 @@ module "ec2nodeclass_materialize" {
 }
 
 module "nodepool_materialize" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/karpenter-nodepool?ref=v13.2.1"
 
   name            = local.nodeclass_name_materialize
   nodeclass_name  = local.nodeclass_name_materialize
@@ -210,7 +210,7 @@ module "nodepool_materialize" {
 
 # 3. Install AWS Load Balancer Controller
 module "aws_lbc" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/aws-lbc?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/aws-lbc?ref=v13.2.1"
 
   name_prefix       = var.name_prefix
   eks_cluster_name  = module.eks.cluster_name
@@ -230,7 +230,7 @@ module "aws_lbc" {
 
 # 4. Install Certificate Manager for TLS
 module "cert_manager" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/cert-manager?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/cert-manager?ref=v13.2.1"
 
   node_selector = local.generic_node_labels
 
@@ -243,7 +243,7 @@ module "cert_manager" {
 }
 
 module "self_signed_cluster_issuer" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/self-signed-cluster-issuer?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/self-signed-cluster-issuer?ref=v13.2.1"
 
   name_prefix = var.name_prefix
 
@@ -254,7 +254,7 @@ module "self_signed_cluster_issuer" {
 
 # 5. Setup dedicated database instance for Materialize
 module "database" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/database?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/database?ref=v13.2.1"
 
   name_prefix               = var.name_prefix
   postgres_version          = "15"
@@ -280,7 +280,7 @@ module "database" {
 
 # 6. Setup S3 bucket for Materialize
 module "storage" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/storage?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/storage?ref=v13.2.1"
 
   name_prefix            = var.name_prefix
   bucket_lifecycle_rules = []
@@ -305,7 +305,7 @@ module "storage" {
 
 # 7. Install Materialize Operator
 module "operator" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/operator?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//aws/modules/operator?ref=v13.2.1"
 
   name_prefix    = var.name_prefix
   aws_region     = var.aws_region
@@ -348,7 +348,7 @@ module "operator" {
 
 # 8. Setup Materialize instance
 module "materialize_instance" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/materialize-instance?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/materialize-instance?ref=v13.2.1"
 
   instance_name        = local.materialize_instance_name
   instance_namespace   = local.materialize_instance_namespace

--- a/test/terraform/azure-temporary/main.tf
+++ b/test/terraform/azure-temporary/main.tf
@@ -102,7 +102,7 @@ resource "azurerm_resource_group" "materialize" {
 
 # 2. Create networking infrastructure
 module "networking" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/networking?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/networking?ref=v13.2.1"
 
   resource_group_name                = azurerm_resource_group.materialize.name
   location                           = var.location
@@ -120,7 +120,7 @@ module "networking" {
 
 # 3. Create AKS cluster with default node pool
 module "aks" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/aks?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/aks?ref=v13.2.1"
 
   resource_group_name = azurerm_resource_group.materialize.name
   kubernetes_version  = local.aks_config.kubernetes_version
@@ -153,7 +153,7 @@ module "aks" {
 
 # 3.1 Create Materialize-dedicated node pool with taints
 module "materialize_nodepool" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/nodepool?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/nodepool?ref=v13.2.1"
 
   prefix     = var.name_prefix
   cluster_id = module.aks.cluster_id
@@ -183,7 +183,7 @@ module "materialize_nodepool" {
 
 # 4. Create PostgreSQL database
 module "database" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/database?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/database?ref=v13.2.1"
 
   depends_on = [module.networking]
 
@@ -218,7 +218,7 @@ module "database" {
 
 # 5. Create Azure Blob Storage
 module "storage" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/storage?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/storage?ref=v13.2.1"
 
   resource_group_name            = azurerm_resource_group.materialize.name
   location                       = var.location
@@ -240,7 +240,7 @@ module "storage" {
 
 # 6. Install cert-manager for TLS
 module "cert_manager" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/cert-manager?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/cert-manager?ref=v13.2.1"
 
   node_selector = local.generic_node_labels
 
@@ -250,7 +250,7 @@ module "cert_manager" {
 }
 
 module "self_signed_cluster_issuer" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/self-signed-cluster-issuer?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/self-signed-cluster-issuer?ref=v13.2.1"
 
   name_prefix = var.name_prefix
 
@@ -261,7 +261,7 @@ module "self_signed_cluster_issuer" {
 
 # 7. Install Materialize Operator
 module "operator" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/operator?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//azure/modules/operator?ref=v13.2.1"
 
   name_prefix = var.name_prefix
   location    = var.location
@@ -301,7 +301,7 @@ module "operator" {
 
 # 8. Deploy Materialize instance
 module "materialize_instance" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/materialize-instance?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/materialize-instance?ref=v13.2.1"
 
   instance_name        = local.materialize_instance_name
   instance_namespace   = local.materialize_instance_namespace

--- a/test/terraform/gcp-temporary/main.tf
+++ b/test/terraform/gcp-temporary/main.tf
@@ -99,7 +99,7 @@ locals {
 
 # 1. Configure networking infrastructure including VPC, subnets, and CIDR blocks
 module "networking" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/networking?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/networking?ref=v13.2.1"
 
   project_id = var.project_id
   region     = var.region
@@ -110,7 +110,7 @@ module "networking" {
 
 # 2. Set up Google Kubernetes Engine (GKE) cluster
 module "gke" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/gke?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/gke?ref=v13.2.1"
 
   depends_on = [module.networking]
 
@@ -127,7 +127,7 @@ module "gke" {
 
 # 2.1 Create generic node pool for system workloads
 module "generic_nodepool" {
-  source     = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/nodepool?ref=main"
+  source     = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/nodepool?ref=v13.2.1"
   depends_on = [module.gke]
 
   prefix                = "${var.name_prefix}-generic"
@@ -147,7 +147,7 @@ module "generic_nodepool" {
 
 # 2.2 Create Materialize-dedicated node pool with taints
 module "materialize_nodepool" {
-  source     = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/nodepool?ref=main"
+  source     = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/nodepool?ref=v13.2.1"
   depends_on = [module.gke]
 
   prefix                = "${var.name_prefix}-mz"
@@ -170,7 +170,7 @@ module "materialize_nodepool" {
 
 # 3. Set up PostgreSQL database instance for Materialize metadata storage
 module "database" {
-  source     = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/database?ref=main"
+  source     = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/database?ref=v13.2.1"
   depends_on = [module.networking]
 
   databases = [local.database_config.database]
@@ -191,7 +191,7 @@ module "database" {
 
 # 4. Create Google Cloud Storage bucket for Materialize persistent data storage
 module "storage" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/storage?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/storage?ref=v13.2.1"
 
   project_id      = var.project_id
   region          = var.region
@@ -205,7 +205,7 @@ module "storage" {
 
 # 5. Install cert-manager for SSL certificate management and create cluster issuer
 module "cert_manager" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/cert-manager?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/cert-manager?ref=v13.2.1"
 
   node_selector = local.generic_node_labels
 
@@ -216,7 +216,7 @@ module "cert_manager" {
 }
 
 module "self_signed_cluster_issuer" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/self-signed-cluster-issuer?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/self-signed-cluster-issuer?ref=v13.2.1"
 
   name_prefix = var.name_prefix
 
@@ -227,7 +227,7 @@ module "self_signed_cluster_issuer" {
 
 # 6. Install Materialize Kubernetes operator for managing Materialize instances
 module "operator" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/operator?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//gcp/modules/operator?ref=v13.2.1"
 
   name_prefix = var.name_prefix
   region      = var.region
@@ -259,7 +259,7 @@ module "operator" {
 
 # 7. Deploy Materialize instance with configured backend connections
 module "materialize_instance" {
-  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/materialize-instance?ref=main"
+  source = "git::https://github.com/MaterializeInc/materialize-terraform-self-managed.git//kubernetes/modules/materialize-instance?ref=v13.2.1"
 
   instance_name        = local.materialize_instance_name
   instance_namespace   = local.materialize_instance_namespace


### PR DESCRIPTION
The `test/terraform` roots sourced every self-managed module at `ref=main`, so an upstream merge reached the nightly with no PR-time signal and no owner. [DEP-200](https://linear.app/materializeinc/issue/DEP-200) moved the modules to AWS provider v6 and EKS module v21, the next nightly 4h50m later failed at `terraform init` on an unsatisfiable provider constraint, and both AWS steps stayed red for two weeks ([DEP-245](https://linear.app/materializeinc/issue/DEP-245)). Pinning turns that into a dependabot PR someone has to look at, and lets the roots be adapted in the same change as the bump that requires it. All 70 `?ref=main` occurrences across the five roots move to `v13.2.1`, and a `terraform` ecosystem entry is added to dependabot so bumps keep arriving.

`v13.2.1` is the tag at upstream `main`'s current HEAD (`09ab1c9`), so this changes nothing about what the nightly runs today; it only changes how future upstream changes reach us. A tag rather than a commit SHA because dependabot does not reliably bump SHA refs (dependabot/dependabot-core#10787). The GCP and Azure roots are pinned too even though their nightlies are skipped, since leaving a floating ref behind just preserves the hazard for whenever they come back.

### Test plan

`terraform init -backend=false` and `terraform validate` pass on `aws-temporary` with the pinned refs, with every module resolving at `v13.2.1`, and `terraform fmt -check -recursive` is clean. Because the pin equals current `main`, the AWS nightlies are the same check they were before this change rather than a new one. One thing to watch on the first dependabot run: upstream carries monorepo tags such as `materialize-monitoring/v0.21.0` alongside the `vX.Y.Z` releases, and mixed tag namespaces on one repo have caused redundant PRs before (dependabot/dependabot-core#4616).

🤖 Generated with [Claude Code](https://claude.com/claude-code)