### PR TITLE
ci: disable RDS automated backups in the temporary Terraform test roots

### DIFF
--- a/test/terraform/aws-temporary/main.tf
+++ b/test/terraform/aws-temporary/main.tf
@@ -272,6 +272,12 @@ module "database" {
   node_security_group_id    = module.eks.node_security_group_id
   tags                      = var.tags
 
+  # A throwaway test database needs no point-in-time recovery, and the module
+  # default of 7 days makes every teardown wait on deleting a week of automated
+  # backups: nightly 18272's destroy was still on the RDS instance after 55
+  # minutes against a 90 minute step budget.
+  backup_retention_period = 0
+
   depends_on = [
     module.eks,
     module.networking,

--- a/test/terraform/aws-upgrade/main.tf
+++ b/test/terraform/aws-upgrade/main.tf
@@ -272,6 +272,12 @@ module "database" {
   node_security_group_id    = module.eks.node_security_group_id
   tags                      = var.tags
 
+  # A throwaway test database needs no point-in-time recovery, and the module
+  # default of 7 days makes every teardown wait on deleting a week of automated
+  # backups: nightly 18272's destroy was still on the RDS instance after 55
+  # minutes against a 90 minute step budget.
+  backup_retention_period = 0
+
   depends_on = [
     module.eks,
     module.networking,


### PR DESCRIPTION
The two temporary AWS roots inherit the database module's `backup_retention_period` default of 7 days, so each run's throwaway RDS instance keeps a week of automated backups that its teardown then has to delete. Nightly 18272's `terraform destroy` was still working on the RDS instance after 55 minutes against a 90 minute step budget, having taken 1m51s on 2026-08-24, and the step timed out with the cluster, VPC and KMS key still up. `skip_final_snapshot` was already true, so the final snapshot was not the cause. Setting the retention to 0 disables automated backups, which a test database that lives for under an hour has no use for, and drops the backup storage they were accruing.

`aws-persistent` is deliberately left alone: it is long-lived, so the trade-off there is not the same.

### Test plan

`terraform validate` passes on `aws-temporary` and `terraform fmt -check -recursive` is clean. Whether it actually shortens the teardown shows up in the two AWS nightlies' destroy timings, which is also the only place the previous 55 minute run was visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)