### PR TITLE
docs: note network policies restrict Console (HTTP) access

### DIFF
--- a/doc/user/content/security/cloud/manage-network-policies.md
+++ b/doc/user/content/security/cloud/manage-network-policies.md
@@ -22,6 +22,10 @@ network-layer access control. As an **administrator** of a Materialize
 organization, you can configure network policies to restrict access to a
 Materialize region using IP-based rules.
 
+Network policies are enforced at the database layer and apply to both SQL
+(pgwire) and HTTP connections. Because the Materialize Console connects over
+HTTP, network policies restrict Console access in addition to SQL access.
+
 ## Create a network policy
 
 {{< note >}}


### PR DESCRIPTION
### Motivation

The "Manage network policies" guide described network policies only in terms of
SQL-level access restriction, leaving a gap: readers could not tell whether
network policies also cover the Materialize Console. Because the Console connects
over HTTP, users needed clarification that network policies restrict Console
access too.

Slack thread: https://materializeinc.slack.com/archives/CU7ELJ6E9/p1789048300549189?thread_ts=1789046448.477099&cid=CU7ELJ6E9

### Description

Adds a short paragraph to
`doc/user/content/security/cloud/manage-network-policies.md`, right after the
introductory paragraph, stating that network policies are enforced at the
database layer and apply to both SQL (pgwire) and HTTP connections, so they
restrict Console access in addition to SQL access. The text is plain inline
prose (no callout shortcode), so it reads as part of the guide's introduction.

### Verification

Docs-only change. Verified the rendered paragraph placement by reading the
surrounding Markdown and ran `bin/format-docs` on the file (no reformatting
needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWpUJNmngeaX8uMoboiY8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWpUJNmngeaX8uMoboiY8M)_