### PR TITLE
console: WIP in-console MCP panels and `\ask` agent

### DIFF
--- a/console/.gitignore
+++ b/console/.gitignore
@@ -26,6 +26,8 @@ yarn-error.log
 .direnv
 .envrc
 .env
+.env.local
+.env.*.local
 
 .vscode
 

--- a/console/doc/ask-agent.md
+++ b/console/doc/ask-agent.md
@@ -1,0 +1,124 @@
+# `\ask` Agent and MCP Panels
+
+Work in progress, dev-server only. The `\ask` shell command and the MCP-backed
+panels are unreleased and ungated. Read "Before this can ship" before putting
+any of it in front of users.
+
+## What is wired
+
+| Surface                             | Location                                            | Backing endpoint                  |
+| ----------------------------------- | --------------------------------------------------- | --------------------------------- |
+| `\ask <question>` in the SQL Shell  | `src/platform/shell/Shell.tsx`                      | `/api/ask` + `/api/mcp/developer` |
+| `\health`, `\freshness`, `\sources` | `src/platform/shell/Shell.tsx`                      | `/api/mcp/developer`              |
+| `\products`                         | `src/platform/shell/Shell.tsx`                      | `/api/mcp/agent`                  |
+| Attention feed, Data products       | `src/platform/environment-overview/`                | both                              |
+| MV freshness panel                  | `src/platform/object-explorer/MvFreshnessPanel.tsx` | `/api/mcp/developer`              |
+| Cluster impact banner               | `src/platform/clusters/ClusterImpactBanner.tsx`     | `/api/mcp/developer`              |
+
+The agent loop is `src/api/materialize/consoleAgent.ts`. The MCP transport is
+`src/api/materialize/mcpClient.ts`.
+
+## How the key is handled
+
+The console is a client-only SPA, so it cannot hold an Anthropic key. The split:
+
+- The **browser** runs the tool-use loop. When the model calls
+  `query_system_catalog`, the browser runs that query itself through
+  `mcpClient`, using the logged-in user's own session. Catalog reads never
+  leave the user's authenticated session, so RBAC is preserved for free.
+- Only the **model completion** is proxied. `vite.config.ts` registers an
+  `/api/ask` dev middleware that injects `ANTHROPIC_API_KEY` server-side and
+  forwards the request body to `api.anthropic.com`. The key is read via
+  `loadEnv` and is never bundled or sent to the client.
+
+The middleware lives in `configureServer`, so it exists **only under
+`yarn start`**. A production build has no `/api/ask` and `\ask` will fail
+there. Shipping this needs a real key-holding endpoint, see below.
+
+## Running it locally
+
+1. Put your key in `console/.env.local` (git-ignored):
+
+   ```
+   ANTHROPIC_API_KEY=sk-ant-...
+   ```
+
+2. Start the dev server as usual:
+
+   ```
+   yarn start
+   ```
+
+3. Open the SQL Shell and ask a question:
+
+   ```
+   \ask why is my materialized view behind?
+   ```
+
+The shell prints each query the agent ran, then its answer. `\ask` with no
+argument prints usage. The other slash commands need no key, they are plain
+MCP calls.
+
+If the key is missing or still a placeholder, `/api/ask` returns a 500 whose
+message names the file to fix. `/api/ask` must be registered before Vite's
+internal `/api/` proxy, otherwise the request is forwarded to environmentd
+instead.
+
+## What the target environment must provide
+
+- `enable_mcp_developer` and `enable_mcp_agent`, both default `true`. When off,
+  the endpoints return 503 and `mcpClient` surfaces that as a disabled-endpoint
+  error.
+- The `mz_internal.mz_ontology_*` relations, which are built in. The system
+  prompt tells the model to query `mz_ontology_entity_types`,
+  `mz_ontology_link_types`, and `mz_ontology_properties` first so it discovers
+  real table and column names instead of guessing them. This ontology-first
+  step is what keeps the generated joins correct, so do not trim it from the
+  prompt.
+- A CORS-allowed origin for the dev host when pointing at a bare emulator.
+  environmentd rejects Basic-auth requests carrying an untrusted `Origin` as a
+  DNS-rebinding defense, which shows up as a browser 403 while the same request
+  succeeds under `curl`. Pass `--cors-allowed-origin=http://localhost:3000` as
+  an emulator CLI flag. The `CORS_ALLOWED_ORIGIN` environment variable does not
+  work for this.
+
+## Model
+
+`claude-opus-5`, pinned in two places that must agree: `MODEL` in
+`consoleAgent.ts`, and the fallback default in the `/api/ask` middleware in
+`vite.config.ts`.
+
+Opus 5 runs adaptive thinking by default, so no `thinking` parameter is sent.
+Thinking shares the output budget, which is why `max_tokens` is 16000 and not
+the couple of thousand a non-thinking model needs. Dropping it back down
+truncates answers mid-diagnosis. Reasoning is not surfaced in the shell: the
+default thinking display is `omitted`, so thinking blocks arrive with empty
+text and the shell renders only text blocks. The loop replays whole assistant
+`content` arrays, so those blocks are echoed back correctly across rounds.
+
+To trade cost against depth, add `output_config: { effort: ... }`, `low`
+through `max`, default `high`. Note that the middleware rebuilds the outgoing
+request from a fixed set of fields, currently `model`, `max_tokens`, `system`,
+`tools`, and `messages`. Anything else the client sends, `output_config` and
+`thinking` included, is dropped silently, so a tuning parameter has to be added
+in both files to take effect.
+
+`MAX_TOOL_ROUNDS` in `consoleAgent.ts` caps the loop at 8 rounds. On reaching
+it the agent returns a "stopped" answer rather than throwing.
+
+## Before this can ship
+
+- **No feature gating.** The panels render unconditionally on the environment
+  overview, cluster overview, and MV detail pages. Each needs a LaunchDarkly
+  flag before this merges for real.
+- **No production key path.** `/api/ask` is dev middleware. Cloud console is on
+  Vercel, so the shape there is a Vercel Function; self-managed console is
+  served by environmentd, so it needs its own key-holding sidecar. Note that
+  `vercel.json` currently carries only header rules, so an `/api/*` route is
+  not shadowed.
+- **No streaming.** `/api/ask` buffers the whole completion, so the shell shows
+  "Investigating..." until the full answer lands. Multi-round questions take a
+  while.
+- **No tests.** None of the agent loop, the proxy, or the panels are covered.
+- The MV freshness panel derives lag severity by string-matching the interval
+  text, which is brittle and should read a typed interval instead.

--- a/console/src/api/materialize/consoleAgent.ts
+++ b/console/src/api/materialize/consoleAgent.ts
@@ -1,0 +1,182 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/**
+ * In-console AI agent (the `\ask` shell command).
+ *
+ * The browser orchestrates a tool-use loop: it asks the model (via the
+ * dev-server `/api/ask` middleware, which injects the server-side Anthropic
+ * key), and when the model calls `query_system_catalog` we run that query
+ * ourselves through mcpClient — as the logged-in user, so RBAC is preserved.
+ * Only the LLM completion goes through the proxy; catalog reads never leave
+ * the user's authenticated session.
+ *
+ * The model is told to query the ontology (mz_internal.mz_ontology_*) FIRST so
+ * it discovers correct table/column names instead of hallucinating them.
+ */
+
+import { mcpQuerySystemCatalog } from "~/api/materialize/mcpClient";
+
+const MODEL = "claude-opus-5";
+const MAX_TOOL_ROUNDS = 8;
+
+const SYSTEM_PROMPT = `You are an operations assistant embedded in the Materialize console. You answer plain-English questions about the user's live Materialize environment by querying the system catalog.
+
+You have one tool: query_system_catalog(sql_query) — runs a READ-ONLY query (SELECT/SHOW/EXPLAIN only) against Materialize's mz_* system catalog and returns JSON array-of-arrays rows.
+
+Rules:
+1. DISCOVER THE SCHEMA FIRST. Before querying data, query the ontology to find the correct tables, columns, and join paths — never guess mz_* names:
+   - mz_internal.mz_ontology_entity_types(name, relation): entities and their backing mz_* table.
+   - mz_internal.mz_ontology_link_types(name, source_entity, target_entity): typed relationships between entities.
+   - mz_internal.mz_ontology_properties: column names/types per entity.
+2. For freshness/"why is X behind": object -> measures_global_lag_of / measures_materialization_lag (mz_internal.mz_materialization_lag has slowest_local_input / slowest_global_input columns that name the bottleneck input) -> hydration_of (mz_internal.mz_hydration_statuses) -> for sources, status_of_source (mz_internal.mz_source_statuses) + source statistics.
+3. Catalog gotchas: mz_source_statuses/mz_sink_statuses use last_status_change_at (not updated_at); join mz_cluster_replica_utilization via mz_cluster_replicas + mz_clusters to get names; do NOT query mz_introspection.mz_dataflow_arrangement_sizes.
+4. Read-only only. Never attempt INSERT/UPDATE/DELETE/CREATE/ALTER/DROP.
+5. Keep querying until you can answer, then STOP and reply with: a one-paragraph root-cause diagnosis naming the specific object, and (if relevant) a suggested SQL fix. Be terse, no preamble.`;
+
+const TOOLS = [
+  {
+    name: "query_system_catalog",
+    description:
+      "Run a read-only SQL query (SELECT/SHOW/EXPLAIN only) against Materialize's mz_* system catalog and ontology. Returns JSON array-of-arrays rows.",
+    input_schema: {
+      type: "object",
+      properties: {
+        sql_query: {
+          type: "string",
+          description:
+            "PostgreSQL-compatible read-only SQL referencing mz_* / pg_catalog / information_schema tables",
+        },
+      },
+      required: ["sql_query"],
+    },
+  },
+];
+
+interface ToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: { sql_query?: string };
+}
+interface TextBlock {
+  type: "text";
+  text: string;
+}
+type ContentBlock = ToolUseBlock | TextBlock | { type: string };
+
+interface MessageResponse {
+  stop_reason?: string;
+  content?: ContentBlock[];
+  error?: { message?: string };
+}
+
+interface AnthropicMessage {
+  role: "user" | "assistant";
+  content: string | ContentBlock[];
+}
+
+/** A single query the agent ran while investigating. */
+export interface AgentStep {
+  sql: string;
+  error?: string;
+}
+
+export interface AgentResult {
+  answer: string;
+  steps: AgentStep[];
+}
+
+const isToolUse = (b: ContentBlock): b is ToolUseBlock => b.type === "tool_use";
+const isText = (b: ContentBlock): b is TextBlock => b.type === "text";
+
+/** One round-trip to the model through the dev-server proxy. */
+async function callModel(
+  messages: AnthropicMessage[],
+): Promise<MessageResponse> {
+  const response = await fetch("/api/ask", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 16000,
+      system: SYSTEM_PROMPT,
+      tools: TOOLS,
+      messages,
+    }),
+  });
+  const raw = await response.text();
+  if (!response.ok) {
+    let message = raw || `HTTP ${response.status}`;
+    try {
+      const parsed = JSON.parse(raw);
+      message = parsed.error?.message ?? parsed.error ?? message;
+    } catch {
+      // not JSON
+    }
+    throw new Error(message);
+  }
+  return JSON.parse(raw) as MessageResponse;
+}
+
+/**
+ * Run the agent loop for a question: let the model query the catalog/ontology
+ * via the tool until it produces a final answer. Returns the answer plus the
+ * queries it ran (so the shell can show the investigation).
+ */
+export async function runConsoleAgent(question: string): Promise<AgentResult> {
+  const messages: AnthropicMessage[] = [{ role: "user", content: question }];
+  const steps: AgentStep[] = [];
+
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+    const response = await callModel(messages);
+    const blocks = response.content ?? [];
+    messages.push({ role: "assistant", content: blocks });
+
+    const toolUses = blocks.filter(isToolUse);
+    if (response.stop_reason !== "tool_use" || toolUses.length === 0) {
+      const answer = blocks
+        .filter(isText)
+        .map((b) => b.text)
+        .join("\n")
+        .trim();
+      return { answer: answer || "(no answer)", steps };
+    }
+
+    const toolResults = await Promise.all(
+      toolUses.map(async (toolUse) => {
+        const sql = toolUse.input.sql_query ?? "";
+        try {
+          const result = await mcpQuerySystemCatalog(sql);
+          steps.push({ sql });
+          return {
+            type: "tool_result" as const,
+            tool_use_id: toolUse.id,
+            content: result,
+          };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          steps.push({ sql, error: message });
+          return {
+            type: "tool_result" as const,
+            tool_use_id: toolUse.id,
+            content: `Error: ${message}`,
+            is_error: true,
+          };
+        }
+      }),
+    );
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  return {
+    answer: "(stopped: reached the maximum number of investigation steps)",
+    steps,
+  };
+}

--- a/console/src/api/materialize/mcpClient.ts
+++ b/console/src/api/materialize/mcpClient.ts
@@ -1,0 +1,173 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/**
+ * MCP (Model Context Protocol) client for Materialize's built-in MCP servers.
+ *
+ * Talks to the developer endpoint (`/api/mcp/developer`) for system catalog
+ * diagnostics, and the agent endpoint (`/api/mcp/agent`) for data product
+ * discovery. Uses the same auth as the SQL API.
+ */
+
+import { getStore } from "~/jotai";
+import { currentEnvironmentState } from "~/store/environments";
+import { assert } from "~/util";
+
+import { apiClient } from "../apiClient";
+
+// JSON-RPC 2.0 types
+
+interface McpRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface McpSuccessResponse {
+  jsonrpc: "2.0";
+  id: number;
+  result: {
+    content?: Array<{ type: string; text: string }>;
+    tools?: Array<{
+      name: string;
+      description: string;
+      inputSchema: Record<string, unknown>;
+    }>;
+    protocolVersion?: string;
+    capabilities?: Record<string, unknown>;
+    serverInfo?: { name: string; version: string };
+  };
+}
+
+interface McpErrorResponse {
+  jsonrpc: "2.0";
+  id: number;
+  error: {
+    code: number;
+    message: string;
+    data?: Record<string, unknown>;
+  };
+}
+
+type McpResponse = McpSuccessResponse | McpErrorResponse;
+
+export class McpError extends Error {
+  code: number;
+  constructor(code: number, message: string) {
+    super(message);
+    this.name = "McpError";
+    this.code = code;
+  }
+}
+
+type McpEndpoint = "developer" | "agent";
+
+let requestId = 0;
+
+async function getHttpAddress(): Promise<string> {
+  const environment = await getStore().get(currentEnvironmentState);
+  assert(environment && environment.state === "enabled");
+  return environment.httpAddress;
+}
+
+function buildMcpUrl(httpAddress: string, endpoint: McpEndpoint): string {
+  return `${apiClient.mzHttpUrlScheme}://${httpAddress}/api/mcp/${endpoint}`;
+}
+
+async function mcpRequest(
+  endpoint: McpEndpoint,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<McpSuccessResponse["result"]> {
+  const httpAddress = await getHttpAddress();
+  const url = buildMcpUrl(httpAddress, endpoint);
+
+  const body: McpRequest = {
+    jsonrpc: "2.0",
+    id: ++requestId,
+    method,
+    ...(params !== undefined && { params }),
+  };
+
+  const response = await apiClient.mzApiFetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  if (!response.ok) {
+    if (response.status === 503) {
+      throw new McpError(
+        -1,
+        "MCP endpoint is disabled. Enable it via system parameter.",
+      );
+    }
+    const text = await response.text();
+    throw new McpError(-1, text || `HTTP ${response.status}`);
+  }
+
+  const json: McpResponse = await response.json();
+
+  if ("error" in json && json.error) {
+    throw new McpError(json.error.code, json.error.message);
+  }
+
+  return (json as McpSuccessResponse).result;
+}
+
+// Developer tools
+
+/** Query system catalog tables (mz_*) via the developer MCP server. */
+export async function mcpQuerySystemCatalog(sqlQuery: string): Promise<string> {
+  const result = await mcpRequest("developer", "tools/call", {
+    name: "query_system_catalog",
+    arguments: { sql_query: sqlQuery },
+  });
+  const text = result.content?.[0]?.text;
+  if (!text) {
+    throw new McpError(-1, "Empty response from developer");
+  }
+  return text;
+}
+
+// Agent tools
+
+/** Discover available data products via the agents MCP server. */
+export async function mcpGetDataProducts(): Promise<string> {
+  const result = await mcpRequest("agent", "tools/call", {
+    name: "get_data_products",
+    arguments: {},
+  });
+  const text = result.content?.[0]?.text;
+  if (!text) {
+    throw new McpError(-1, "Empty response from agents endpoint");
+  }
+  return text;
+}
+
+/** Get detailed schema for a specific data product. */
+export async function mcpGetDataProductDetails(name: string): Promise<string> {
+  const result = await mcpRequest("agent", "tools/call", {
+    name: "get_data_product_details",
+    arguments: { name },
+  });
+  const text = result.content?.[0]?.text;
+  if (!text) {
+    throw new McpError(-1, "Empty response from agents endpoint");
+  }
+  return text;
+}
+
+/** List available tools on an MCP endpoint. */
+export async function mcpListTools(endpoint: McpEndpoint) {
+  const result = await mcpRequest(endpoint, "tools/list");
+  return result.tools ?? [];
+}

--- a/console/src/platform/clusters/ClusterImpactBanner.tsx
+++ b/console/src/platform/clusters/ClusterImpactBanner.tsx
@@ -1,0 +1,102 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import { Text, useTheme } from "@chakra-ui/react";
+import { useQuery } from "@tanstack/react-query";
+import React from "react";
+
+import {
+  buildQueryKeyPart,
+  buildRegionQueryKey,
+} from "~/api/buildQueryKeySchema";
+import { mcpQuerySystemCatalog } from "~/api/materialize/mcpClient";
+import Alert from "~/components/Alert";
+import { MaterializeTheme } from "~/theme";
+
+interface ClusterImpact {
+  affectedCount: number;
+  affectedNames: string;
+}
+
+function buildImpactQuery(clusterId: string) {
+  return `SELECT
+  count(DISTINCT dep.object_id)::text AS affected_count,
+  string_agg(DISTINCT o.name, ', ' ORDER BY o.name) AS affected_names
+FROM mz_internal.mz_object_dependencies dep
+JOIN mz_objects src ON src.id = dep.referenced_object_id
+JOIN mz_objects o ON o.id = dep.object_id AND o.cluster_id != src.cluster_id
+JOIN mz_internal.mz_materialization_lag lag ON lag.object_id = dep.object_id
+WHERE src.cluster_id = '${clusterId}'
+  AND lag.local_lag >= INTERVAL '10 seconds'`;
+}
+
+function parseImpactData(raw: string): ClusterImpact | null {
+  try {
+    const rows: unknown[][] = JSON.parse(raw);
+    if (rows.length === 0) return null;
+    const row = rows[0];
+    const count = parseInt(String(row[0] ?? "0"), 10);
+    if (count === 0) return null;
+    return {
+      affectedCount: count,
+      affectedNames: String(row[1] ?? ""),
+    };
+  } catch {
+    return null;
+  }
+}
+
+const clusterImpactQueryKeys = {
+  byId: (clusterId: string) =>
+    [
+      ...buildRegionQueryKey("clusterImpact"),
+      buildQueryKeyPart("clusterImpact", { clusterId }),
+    ] as const,
+};
+
+export interface ClusterImpactBannerProps {
+  clusterId: string;
+}
+
+const ClusterImpactBanner = ({ clusterId }: ClusterImpactBannerProps) => {
+  const { colors } = useTheme<MaterializeTheme>();
+
+  const { data: impact } = useQuery({
+    queryKey: clusterImpactQueryKeys.byId(clusterId),
+    queryFn: async () => {
+      const raw = await mcpQuerySystemCatalog(buildImpactQuery(clusterId));
+      return parseImpactData(raw);
+    },
+    refetchInterval: 30_000,
+  });
+
+  if (!impact) return null;
+
+  return (
+    <Alert
+      variant="warning"
+      width="100%"
+      message={
+        <Text>
+          This cluster has{" "}
+          <Text as="span" fontWeight="600">
+            {impact.affectedCount} materialized view
+            {impact.affectedCount !== 1 ? "s" : ""}
+          </Text>{" "}
+          on other clusters that are lagging as a result:{" "}
+          <Text as="span" color={colors.foreground.secondary}>
+            {impact.affectedNames}
+          </Text>
+        </Text>
+      }
+    />
+  );
+};
+
+export default ClusterImpactBanner;

--- a/console/src/platform/clusters/ClusterOverview.tsx
+++ b/console/src/platform/clusters/ClusterOverview.tsx
@@ -40,6 +40,7 @@ import { useAllClusters } from "~/store/allClusters";
 import { MaterializeTheme } from "~/theme";
 import { assert } from "~/util";
 
+import ClusterImpactBanner from "./ClusterImpactBanner";
 import ClusterFreshness from "./ClusterOverview/ClusterFreshness";
 import { DataPoint } from "./ClusterOverview/types";
 import {
@@ -146,6 +147,7 @@ const ClusterOverview = () => {
   return (
     <MainContentContainer mt="10">
       <VStack spacing="6">
+        <ClusterImpactBanner clusterId={clusterId} />
         {cluster && <ClusterInfoBox cluster={cluster} />}
         <Box
           border={`solid 1px ${colors.border.primary}`}

--- a/console/src/platform/environment-overview/AttentionFeed.tsx
+++ b/console/src/platform/environment-overview/AttentionFeed.tsx
@@ -1,0 +1,257 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Badge,
+  Box,
+  Circle,
+  HStack,
+  Text,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import React from "react";
+
+import {
+  buildQueryKeyPart,
+  buildRegionQueryKey,
+} from "~/api/buildQueryKeySchema";
+import { mcpQuerySystemCatalog } from "~/api/materialize/mcpClient";
+import { AppErrorBoundary } from "~/components/AppErrorBoundary";
+import { LoadingContainer } from "~/components/LoadingContainer";
+import { MaterializeTheme } from "~/theme";
+
+interface AttentionItem {
+  category: string;
+  objectName: string;
+  severity: "critical" | "warning" | "info";
+  detail: string;
+}
+
+const ATTENTION_QUERY = `SELECT * FROM (
+  SELECT
+    'Cluster' AS category,
+    c.name || '/' || cr.name AS object_name,
+    CASE
+      WHEN u.memory_percent > 90 THEN 'critical'
+      WHEN u.memory_percent > 70 THEN 'warning'
+      ELSE 'info'
+    END AS severity,
+    'Memory ' || round(u.memory_percent::numeric, 1) || '%, CPU ' || round(u.cpu_percent::numeric, 1) || '%' AS detail
+  FROM mz_cluster_replicas cr
+  JOIN mz_clusters c ON c.id = cr.cluster_id
+  JOIN mz_internal.mz_cluster_replica_utilization u ON u.replica_id = cr.id
+  WHERE c.id LIKE 'u%' AND u.memory_percent > 70
+
+  UNION ALL
+
+  SELECT
+    'MV Lag' AS category,
+    o.name AS object_name,
+    CASE
+      WHEN lag.local_lag >= INTERVAL '1 minute' THEN 'critical'
+      ELSE 'warning'
+    END AS severity,
+    'Lag: ' || lag.local_lag::text AS detail
+  FROM mz_internal.mz_materialization_lag lag
+  JOIN mz_objects o ON o.id = lag.object_id
+  WHERE o.id LIKE 'u%' AND lag.local_lag >= INTERVAL '10 seconds'
+
+  UNION ALL
+
+  SELECT
+    'Hydration' AS category,
+    o.name AS object_name,
+    'warning' AS severity,
+    'Not yet hydrated on replica ' || cr.name AS detail
+  FROM mz_internal.mz_hydration_statuses hs
+  JOIN mz_objects o ON o.id = hs.object_id
+  JOIN mz_cluster_replicas cr ON cr.id = hs.replica_id
+  WHERE hs.hydrated = false AND o.id LIKE 'u%'
+
+  UNION ALL
+
+  SELECT
+    'Source' AS category,
+    s.name AS object_name,
+    CASE s.status WHEN 'stalled' THEN 'critical' WHEN 'failed' THEN 'critical' ELSE 'warning' END AS severity,
+    COALESCE(s.error, 'Status: ' || s.status) AS detail
+  FROM mz_internal.mz_source_statuses s
+  WHERE s.id LIKE 'u%' AND s.status NOT IN ('running', 'created')
+) attention
+ORDER BY
+  CASE severity WHEN 'critical' THEN 0 WHEN 'warning' THEN 1 ELSE 2 END`;
+
+function parseAttentionItems(raw: string): AttentionItem[] {
+  try {
+    const rows: unknown[][] = JSON.parse(raw);
+    return rows.map((row) => ({
+      category: String(row[0] ?? ""),
+      objectName: String(row[1] ?? ""),
+      severity: String(row[2] ?? "info") as AttentionItem["severity"],
+      detail: String(row[3] ?? ""),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+const attentionQueryKeys = {
+  all: () =>
+    [
+      ...buildRegionQueryKey("attentionFeed"),
+      buildQueryKeyPart("attentionFeed"),
+    ] as const,
+};
+
+function useAttentionFeed() {
+  return useSuspenseQuery({
+    queryKey: attentionQueryKeys.all(),
+    queryFn: async () => {
+      const raw = await mcpQuerySystemCatalog(ATTENTION_QUERY);
+      return parseAttentionItems(raw);
+    },
+    refetchInterval: 30_000,
+  });
+}
+
+const severityColor = (
+  severity: AttentionItem["severity"],
+  colors: MaterializeTheme["colors"],
+) => {
+  switch (severity) {
+    case "critical":
+      return colors.accent.red;
+    case "warning":
+      return colors.accent.darkYellow;
+    case "info":
+      return colors.accent.green;
+  }
+};
+
+const severityBadgeScheme = (severity: AttentionItem["severity"]) => {
+  switch (severity) {
+    case "critical":
+      return "red";
+    case "warning":
+      return "yellow";
+    case "info":
+      return "green";
+  }
+};
+
+const AttentionFeedContent = () => {
+  const { data: items } = useAttentionFeed();
+  const { colors } = useTheme<MaterializeTheme>();
+
+  if (items.length === 0) {
+    return (
+      <HStack padding="4" spacing="3">
+        <Circle size="3" bg={colors.accent.green} />
+        <Text textStyle="text-ui-med" color={colors.foreground.primary}>
+          All systems healthy
+        </Text>
+      </HStack>
+    );
+  }
+
+  return (
+    <VStack
+      alignItems="stretch"
+      spacing="0"
+      divider={
+        <Box borderBottomWidth="1px" borderColor={colors.border.secondary} />
+      }
+    >
+      {items.map((item, idx) => (
+        <HStack key={idx} padding="4" spacing="3" alignItems="flex-start">
+          <Circle
+            size="3"
+            bg={severityColor(item.severity, colors)}
+            mt="1"
+            flexShrink={0}
+          />
+          <VStack alignItems="flex-start" spacing="0" minWidth="0">
+            <HStack spacing="2">
+              <Badge
+                colorScheme={severityBadgeScheme(item.severity)}
+                fontSize="xs"
+              >
+                {item.category}
+              </Badge>
+              <Text
+                textStyle="text-ui-med"
+                color={colors.foreground.primary}
+                noOfLines={1}
+              >
+                {item.objectName}
+              </Text>
+            </HStack>
+            <Text
+              textStyle="text-small"
+              color={colors.foreground.secondary}
+              noOfLines={2}
+            >
+              {item.detail}
+            </Text>
+          </VStack>
+        </HStack>
+      ))}
+    </VStack>
+  );
+};
+
+const AttentionFeed = () => {
+  const { colors } = useTheme<MaterializeTheme>();
+
+  return (
+    <VStack
+      alignItems="flex-start"
+      width="100%"
+      gap="0"
+      borderRadius="lg"
+      borderWidth="1px"
+      spacing="0"
+    >
+      <VStack
+        alignItems="flex-start"
+        gap="1"
+        width="100%"
+        borderBottomWidth="1px"
+        borderColor={colors.border.secondary}
+        padding="4"
+      >
+        <Text textStyle="heading-md" color={colors.foreground.primary}>
+          Needs attention
+        </Text>
+        <Text textStyle="text-small" color={colors.foreground.secondary}>
+          Issues detected across your environment via the MCP developer
+          endpoint. Auto-refreshes every 30 seconds.
+        </Text>
+      </VStack>
+      <AppErrorBoundary
+        message="Unable to fetch diagnostics from the MCP developer endpoint. The endpoint may be disabled."
+        containerProps={{ padding: "4" }}
+      >
+        <React.Suspense
+          fallback={
+            <Box height="120px" width="100%">
+              <LoadingContainer />
+            </Box>
+          }
+        >
+          <AttentionFeedContent />
+        </React.Suspense>
+      </AppErrorBoundary>
+    </VStack>
+  );
+};
+
+export default AttentionFeed;

--- a/console/src/platform/environment-overview/DataProducts.tsx
+++ b/console/src/platform/environment-overview/DataProducts.tsx
@@ -1,0 +1,181 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Box,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import React from "react";
+
+import {
+  buildQueryKeyPart,
+  buildRegionQueryKey,
+} from "~/api/buildQueryKeySchema";
+import { mcpQuerySystemCatalog } from "~/api/materialize/mcpClient";
+import { AppErrorBoundary } from "~/components/AppErrorBoundary";
+import { LoadingContainer } from "~/components/LoadingContainer";
+import { MaterializeTheme } from "~/theme";
+import { truncateMaxWidth } from "~/theme/components/Table";
+
+interface DataProduct {
+  objectName: string;
+  cluster: string;
+  description: string;
+}
+
+function parseDataProducts(raw: string): DataProduct[] {
+  try {
+    const rows: unknown[][] = JSON.parse(raw);
+    return rows.map((row) => ({
+      objectName: String(row[0] ?? ""),
+      cluster: String(row[1] ?? ""),
+      description: String(row[2] ?? ""),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+const dataProductsQueryKeys = {
+  all: () =>
+    [
+      ...buildRegionQueryKey("dataProducts"),
+      buildQueryKeyPart("dataProducts"),
+    ] as const,
+};
+
+function useDataProducts() {
+  return useSuspenseQuery({
+    queryKey: dataProductsQueryKeys.all(),
+    queryFn: async () => {
+      const raw = await mcpQuerySystemCatalog(
+        `SELECT object_name, cluster, description FROM mz_internal.mz_mcp_data_products ORDER BY object_name`,
+      );
+      return parseDataProducts(raw);
+    },
+    refetchInterval: 60_000,
+  });
+}
+
+const DataProductsContent = () => {
+  const { data: products } = useDataProducts();
+  const { colors } = useTheme<MaterializeTheme>();
+
+  if (products.length === 0) {
+    return (
+      <VStack padding="4" spacing="1" alignItems="flex-start">
+        <Text textStyle="text-ui-med" color={colors.foreground.secondary}>
+          No data products registered.
+        </Text>
+        <Text textStyle="text-small" color={colors.foreground.secondary}>
+          Add a COMMENT to an index to register it as an MCP data product.
+        </Text>
+      </VStack>
+    );
+  }
+
+  return (
+    <Box width="100%" overflowX="auto">
+      <Table variant="linkable" borderRadius="xl">
+        <Thead>
+          <Tr>
+            <Th>Data Product</Th>
+            <Th>Cluster</Th>
+            <Th>Description</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {products.map((product, idx) => (
+            <Tr key={idx}>
+              <Td {...truncateMaxWidth} py="2">
+                <Text textStyle="text-ui-med" noOfLines={1}>
+                  {product.objectName}
+                </Text>
+              </Td>
+              <Td py="2">
+                <Text
+                  textStyle="text-small"
+                  color={colors.foreground.secondary}
+                >
+                  {product.cluster}
+                </Text>
+              </Td>
+              <Td {...truncateMaxWidth} py="2">
+                <Text
+                  textStyle="text-small"
+                  color={colors.foreground.secondary}
+                  noOfLines={2}
+                >
+                  {product.description}
+                </Text>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+const DataProducts = () => {
+  const { colors } = useTheme<MaterializeTheme>();
+
+  return (
+    <VStack
+      alignItems="flex-start"
+      width="100%"
+      gap="0"
+      borderRadius="lg"
+      borderWidth="1px"
+      spacing="0"
+    >
+      <VStack
+        alignItems="flex-start"
+        gap="1"
+        width="100%"
+        borderBottomWidth="1px"
+        borderColor={colors.border.secondary}
+        padding="4"
+      >
+        <Text textStyle="heading-md" color={colors.foreground.primary}>
+          MCP Data Products
+        </Text>
+        <Text textStyle="text-small" color={colors.foreground.secondary}>
+          Materialized views registered as data products, accessible to AI
+          agents via the MCP server.
+        </Text>
+      </VStack>
+      <AppErrorBoundary
+        message="Unable to fetch data products from MCP agents endpoint. The endpoint may be disabled."
+        containerProps={{ padding: "4" }}
+      >
+        <React.Suspense
+          fallback={
+            <Box height="80px" width="100%">
+              <LoadingContainer />
+            </Box>
+          }
+        >
+          <DataProductsContent />
+        </React.Suspense>
+      </AppErrorBoundary>
+    </VStack>
+  );
+};
+
+export default DataProducts;

--- a/console/src/platform/environment-overview/EnvironmentOverview.tsx
+++ b/console/src/platform/environment-overview/EnvironmentOverview.tsx
@@ -17,7 +17,9 @@ import {
   PageHeading,
 } from "~/layouts/BaseLayout";
 
+import AttentionFeed from "./AttentionFeed";
 import ClusterFreshness from "./ClusterFreshness";
+import DataProducts from "./DataProducts";
 import MemDiskUtilization from "./MemDiskUtilization";
 
 export const EnvironmentOverview = () => {
@@ -30,8 +32,10 @@ export const EnvironmentOverview = () => {
         </HStack>
       </PageHeader>
       <VStack alignItems="flex-start" width="100%" gap="10" paddingBottom="10">
+        <AttentionFeed />
         <MemDiskUtilization />
         {flags["console-freshness-2855"] && <ClusterFreshness />}
+        <DataProducts />
       </VStack>
     </MainContentContainer>
   );

--- a/console/src/platform/object-explorer/MvFreshnessPanel.tsx
+++ b/console/src/platform/object-explorer/MvFreshnessPanel.tsx
@@ -1,0 +1,278 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import {
+  Box,
+  Code,
+  HStack,
+  IconButton,
+  Text,
+  Tooltip,
+  useTheme,
+  VStack,
+} from "@chakra-ui/react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import copyToClipboard from "copy-to-clipboard";
+import React from "react";
+
+import {
+  buildQueryKeyPart,
+  buildRegionQueryKey,
+} from "~/api/buildQueryKeySchema";
+import { mcpQuerySystemCatalog } from "~/api/materialize/mcpClient";
+import { AppErrorBoundary } from "~/components/AppErrorBoundary";
+import { LoadingContainer } from "~/components/LoadingContainer";
+import { useToast } from "~/hooks/useToast";
+import CopyIcon from "~/svg/CopyIcon";
+import { MaterializeTheme } from "~/theme";
+
+interface MvFreshnessData {
+  localLag: string;
+  globalLag: string;
+  hydrated: boolean | null;
+  bottleneckName: string | null;
+  bottleneckType: string | null;
+  bottleneckCluster: string | null;
+  mvCluster: string | null;
+}
+
+function buildFreshnessQuery(objectId: string) {
+  return `SELECT
+  lag.local_lag::text AS local_lag,
+  lag.global_lag::text AS global_lag,
+  hs.hydrated,
+  slowest_local.name AS bottleneck_name,
+  slowest_local.type AS bottleneck_type,
+  bc.name AS bottleneck_cluster,
+  mc.name AS mv_cluster
+FROM mz_internal.mz_materialization_lag lag
+LEFT JOIN mz_internal.mz_hydration_statuses hs ON hs.object_id = lag.object_id
+LEFT JOIN mz_objects slowest_local ON slowest_local.id = lag.slowest_local_input_id
+LEFT JOIN mz_clusters bc ON bc.id = slowest_local.cluster_id
+LEFT JOIN mz_objects mv ON mv.id = lag.object_id
+LEFT JOIN mz_clusters mc ON mc.id = mv.cluster_id
+WHERE lag.object_id = '${objectId}'
+LIMIT 1`;
+}
+
+function parseFreshnessData(raw: string): MvFreshnessData | null {
+  try {
+    const rows: unknown[][] = JSON.parse(raw);
+    if (rows.length === 0) return null;
+    const row = rows[0];
+    return {
+      localLag: String(row[0] ?? "unknown"),
+      globalLag: String(row[1] ?? "unknown"),
+      hydrated: row[2] === null ? null : row[2] === true || row[2] === "t",
+      bottleneckName: row[3] ? String(row[3]) : null,
+      bottleneckType: row[4] ? String(row[4]) : null,
+      bottleneckCluster: row[5] ? String(row[5]) : null,
+      mvCluster: row[6] ? String(row[6]) : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function lagSeverity(lag: string): "fresh" | "warning" | "critical" {
+  if (lag === "00:00:00" || lag.startsWith("00:00:0")) return "fresh";
+  // Anything over 1 minute is critical
+  if (!lag.startsWith("00:00:")) return "critical";
+  return "warning";
+}
+
+const mvFreshnessQueryKeys = {
+  byId: (objectId: string) =>
+    [
+      ...buildRegionQueryKey("mvFreshness"),
+      buildQueryKeyPart("mvFreshness", { objectId }),
+    ] as const,
+};
+
+const MvFreshnessPanelContent = ({ objectId }: { objectId: string }) => {
+  const { colors } = useTheme<MaterializeTheme>();
+  const toast = useToast();
+
+  const { data } = useSuspenseQuery({
+    queryKey: mvFreshnessQueryKeys.byId(objectId),
+    queryFn: async () => {
+      const raw = await mcpQuerySystemCatalog(buildFreshnessQuery(objectId));
+      return parseFreshnessData(raw);
+    },
+    refetchInterval: 10_000,
+  });
+
+  if (!data) return null;
+
+  const severity = lagSeverity(data.localLag);
+
+  const severityColors = {
+    fresh: colors.accent.green,
+    warning: colors.accent.darkYellow,
+    critical: colors.accent.red,
+  };
+
+  const severityLabels = {
+    fresh: "Fresh",
+    warning: "Lagging",
+    critical: "Lagging",
+  };
+
+  const suggestedFix =
+    data.bottleneckCluster && data.mvCluster !== data.bottleneckCluster
+      ? `-- Consider moving this MV closer to its bottleneck input\nALTER MATERIALIZED VIEW ... SET CLUSTER = '${data.bottleneckCluster}';`
+      : null;
+
+  return (
+    <VStack
+      alignItems="flex-start"
+      width="100%"
+      borderRadius="lg"
+      borderWidth="1px"
+      borderColor={
+        severity === "critical"
+          ? colors.accent.red
+          : severity === "warning"
+            ? colors.accent.darkYellow
+            : colors.border.secondary
+      }
+      spacing="0"
+    >
+      <VStack
+        alignItems="flex-start"
+        width="100%"
+        padding="4"
+        spacing="3"
+        bg={
+          severity === "critical"
+            ? "red.50"
+            : severity === "warning"
+              ? "yellow.50"
+              : undefined
+        }
+        borderTopRadius="lg"
+      >
+        <HStack spacing="3" width="100%">
+          <Box
+            width="3"
+            height="3"
+            borderRadius="full"
+            bg={severityColors[severity]}
+            flexShrink={0}
+          />
+          <Text textStyle="heading-sm" color={colors.foreground.primary}>
+            Freshness: {severityLabels[severity]}
+          </Text>
+          <Text textStyle="text-small" color={colors.foreground.secondary}>
+            via MCP
+          </Text>
+        </HStack>
+
+        <HStack spacing="6" flexWrap="wrap">
+          <VStack alignItems="flex-start" spacing="0">
+            <Text textStyle="text-small" color={colors.foreground.secondary}>
+              Local lag
+            </Text>
+            <Text textStyle="text-ui-med">{data.localLag}</Text>
+          </VStack>
+          <VStack alignItems="flex-start" spacing="0">
+            <Text textStyle="text-small" color={colors.foreground.secondary}>
+              Global lag
+            </Text>
+            <Text textStyle="text-ui-med">{data.globalLag}</Text>
+          </VStack>
+          <VStack alignItems="flex-start" spacing="0">
+            <Text textStyle="text-small" color={colors.foreground.secondary}>
+              Hydrated
+            </Text>
+            <Text textStyle="text-ui-med">
+              {data.hydrated === null
+                ? "Unknown"
+                : data.hydrated
+                  ? "Yes"
+                  : "No"}
+            </Text>
+          </VStack>
+        </HStack>
+
+        {data.bottleneckName && (
+          <VStack alignItems="flex-start" spacing="0">
+            <Text textStyle="text-small" color={colors.foreground.secondary}>
+              Slowest input (bottleneck)
+            </Text>
+            <Text textStyle="text-ui-med">
+              {data.bottleneckName}
+              {data.bottleneckType && ` (${data.bottleneckType})`}
+              {data.bottleneckCluster &&
+                ` on cluster ${data.bottleneckCluster}`}
+            </Text>
+          </VStack>
+        )}
+
+        {suggestedFix && severity !== "fresh" && (
+          <VStack alignItems="flex-start" spacing="1" width="100%">
+            <HStack spacing="2">
+              <Text textStyle="text-small" color={colors.foreground.secondary}>
+                Suggested fix
+              </Text>
+              <Tooltip label="Copy SQL" fontSize="xs">
+                <IconButton
+                  icon={<CopyIcon />}
+                  aria-label="Copy suggested fix"
+                  onClick={() => {
+                    copyToClipboard(suggestedFix);
+                    toast({ description: "SQL copied to clipboard" });
+                  }}
+                  variant="inline"
+                  size="xs"
+                />
+              </Tooltip>
+            </HStack>
+            <Code
+              display="block"
+              whiteSpace="pre"
+              px="3"
+              py="2"
+              borderRadius="md"
+              fontSize="sm"
+              width="100%"
+            >
+              {suggestedFix}
+            </Code>
+          </VStack>
+        )}
+      </VStack>
+    </VStack>
+  );
+};
+
+export interface MvFreshnessPanelProps {
+  objectId: string;
+}
+
+const MvFreshnessPanel = ({ objectId }: MvFreshnessPanelProps) => {
+  return (
+    <AppErrorBoundary
+      message="Unable to fetch freshness data from the MCP developer endpoint."
+      containerProps={{ padding: "4" }}
+    >
+      <React.Suspense
+        fallback={
+          <Box height="80px" width="100%">
+            <LoadingContainer />
+          </Box>
+        }
+      >
+        <MvFreshnessPanelContent objectId={objectId} />
+      </React.Suspense>
+    </AppErrorBoundary>
+  );
+};
+
+export default MvFreshnessPanel;

--- a/console/src/platform/object-explorer/SimpleObjectDetailRoutes.tsx
+++ b/console/src/platform/object-explorer/SimpleObjectDetailRoutes.tsx
@@ -26,6 +26,7 @@ import { SentryRoutes } from "~/sentry";
 import { useAllObjects } from "~/store/allObjects";
 
 import { ObjectDetailsContainer, ObjectDetailsStrip } from "./detailComponents";
+import MvFreshnessPanel from "./MvFreshnessPanel";
 import { ObjectColumns } from "./ObjectColumns";
 import { ObjectIndexes } from "./ObjectIndexes";
 import { useObjectDetails } from "./queries";
@@ -78,9 +79,14 @@ export const SimpleObjectDetailsContent = ({
     databaseObject.type as ShowCreateObjectType,
   );
 
+  const isMaterializedView = databaseObject.type === "materialized-view";
+
   return (
     <MainContentContainer>
       <ObjectDetailsContainer>
+        {isMaterializedView && (
+          <MvFreshnessPanel objectId={databaseObject.id} />
+        )}
         <ObjectDetailsStrip
           {...databaseObject}
           sourceType={object?.sourceType}

--- a/console/src/platform/shell/Shell.tsx
+++ b/console/src/platform/shell/Shell.tsx
@@ -16,6 +16,11 @@ import { RESET, useAtomCallback } from "jotai/utils";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { useSegment } from "~/analytics/segment";
+import { runConsoleAgent } from "~/api/materialize/consoleAgent";
+import {
+  mcpGetDataProducts,
+  mcpQuerySystemCatalog,
+} from "~/api/materialize/mcpClient";
 import { EditorCommand, EditorEvent } from "~/components/CommandBlock";
 import {
   useGetView,
@@ -185,6 +190,88 @@ const Shell = () => {
     display: boolean;
   };
 
+  /** Run an MCP query and commit the JSON result to shell history. */
+  const runMcpDiagnostic = useCallback(
+    async (command: string, mcpCall: () => Promise<string>) => {
+      commitToHistory(
+        createDefaultLocalCommandOutput({
+          command,
+          commandResults: [["Status", "Querying MCP server..."]],
+        }),
+      );
+      try {
+        const raw = await mcpCall();
+        const rows: unknown[][] = JSON.parse(raw);
+        if (!Array.isArray(rows) || rows.length === 0) {
+          commitToHistory(
+            createDefaultLocalCommandOutput({
+              command,
+              commandResults: [["Result", "No results"]],
+            }),
+          );
+          return;
+        }
+        // Format JSON array-of-arrays into key-value pairs for display
+        const formatted: Array<[string, string]> = rows.map(
+          (row: unknown[]) => {
+            const values = row.map((v) => (v === null ? "NULL" : String(v)));
+            return [values[0] ?? "", values.slice(1).join("  |  ")];
+          },
+        );
+        commitToHistory(
+          createDefaultLocalCommandOutput({
+            command,
+            commandResults: formatted,
+          }),
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        commitToHistory(
+          createDefaultLocalCommandOutput({
+            command,
+            commandResults: [["Error", message]],
+          }),
+        );
+      }
+    },
+    [commitToHistory],
+  );
+
+  /** Ask the in-console AI agent and commit its answer to shell history. */
+  const askAgent = useCallback(
+    async (question: string) => {
+      const command = `\\ask ${question}`;
+      commitToHistory(
+        createDefaultLocalCommandOutput({
+          command,
+          commandResults: [["Status", "Investigating..."]],
+        }),
+      );
+      try {
+        const { answer, steps } = await runConsoleAgent(question);
+        const stepRows: Array<[string, string]> = steps.map((step, i) => [
+          `Query ${i + 1}`,
+          step.error ? `${step.sql}  →  ERROR: ${step.error}` : step.sql,
+        ]);
+        commitToHistory(
+          createDefaultLocalCommandOutput({
+            command,
+            commandResults: [...stepRows, ["Answer", answer]],
+          }),
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        commitToHistory(
+          createDefaultLocalCommandOutput({
+            command,
+            commandResults: [["Error", message]],
+          }),
+        );
+      }
+    },
+    [commitToHistory],
+  );
+
   const slashCommands: Map<string, SlashCommandEntry> = useMemo(
     () =>
       new Map([
@@ -216,8 +303,97 @@ const Shell = () => {
             description: "Clear your displayed history",
           },
         ],
+        [
+          "health",
+          {
+            callback: () =>
+              runMcpDiagnostic("\\health", () =>
+                mcpQuerySystemCatalog(`SELECT c.name AS cluster, cr.name AS replica,
+  round(u.cpu_percent::numeric, 1) AS cpu_pct,
+  round(u.memory_percent::numeric, 1) AS mem_pct,
+  round(u.disk_percent::numeric, 1) AS disk_pct
+FROM mz_cluster_replicas cr
+JOIN mz_clusters c ON c.id = cr.cluster_id
+JOIN mz_internal.mz_cluster_replica_utilization u ON u.replica_id = cr.id
+WHERE c.id LIKE 'u%'
+ORDER BY u.memory_percent DESC`),
+              ),
+            display: true,
+            description:
+              "Show cluster health via MCP developer endpoint (CPU, memory, disk)",
+          },
+        ],
+        [
+          "freshness",
+          {
+            callback: () =>
+              runMcpDiagnostic("\\freshness", () =>
+                mcpQuerySystemCatalog(`SELECT o.name AS object, lag.local_lag::text AS lag,
+  CASE WHEN hs.hydrated = false THEN 'HYDRATING'
+       WHEN lag.local_lag >= INTERVAL '10 seconds' THEN 'LAGGING'
+       ELSE 'FRESH' END AS status,
+  slowest.name AS bottleneck
+FROM mz_internal.mz_materialization_lag lag
+JOIN mz_objects o ON o.id = lag.object_id
+LEFT JOIN mz_internal.mz_hydration_statuses hs ON hs.object_id = lag.object_id
+LEFT JOIN mz_objects slowest ON slowest.id = lag.slowest_local_input_id
+WHERE o.id LIKE 'u%'
+ORDER BY lag.local_lag DESC NULLS LAST
+LIMIT 20`),
+              ),
+            display: true,
+            description:
+              "Show materialized view freshness via MCP developer endpoint",
+          },
+        ],
+        [
+          "sources",
+          {
+            callback: () =>
+              runMcpDiagnostic("\\sources", () =>
+                mcpQuerySystemCatalog(`SELECT s.name, s.type, s.status, s.error
+FROM mz_internal.mz_source_statuses s
+WHERE s.id LIKE 'u%'
+ORDER BY CASE s.status WHEN 'stalled' THEN 0 WHEN 'failed' THEN 1 ELSE 2 END, s.name`),
+              ),
+            display: true,
+            description: "Show source health via MCP developer endpoint",
+          },
+        ],
+        [
+          "products",
+          {
+            callback: () =>
+              runMcpDiagnostic("\\products", () => mcpGetDataProducts()),
+            display: true,
+            description: "Show MCP data products available to agents",
+          },
+        ],
+        [
+          // The actual `\ask <question>` is dispatched in handlePromptInput
+          // (it takes an argument); this entry just lists it in \help and
+          // shows usage when `\ask` is run with no question.
+          "ask",
+          {
+            callback: () =>
+              commitToHistory(
+                createDefaultLocalCommandOutput({
+                  command: "\\ask",
+                  commandResults: [
+                    [
+                      "Usage",
+                      "\\ask <question> — ask the AI agent about your environment",
+                    ],
+                  ],
+                }),
+              ),
+            display: true,
+            description:
+              "Ask the AI agent about your environment (\\ask <question>)",
+          },
+        ],
       ]),
-    [clearHistory, setShellState, showHelp],
+    [clearHistory, commitToHistory, setShellState, showHelp, runMcpDiagnostic],
   );
 
   const {
@@ -250,6 +426,19 @@ const Shell = () => {
         if (text.startsWith("\\")) {
           setShouldAutoScroll(true);
 
+          // `\ask <question>` takes an argument, so it can't use the zero-arg
+          // exact-match map below. Route it explicitly. (Bare `\ask` with no
+          // question falls through to the map entry, which prints usage.)
+          if (text.startsWith("\\ask ")) {
+            const question = text.slice("\\ask".length).trim();
+            if (question) {
+              askAgent(question);
+              cacheCommand(text);
+              clearPrompt(dispatchReplacePrompt);
+              return true;
+            }
+          }
+
           const handler = slashCommands.get(text.substring(1));
           if (handler) {
             handler.callback();
@@ -270,6 +459,7 @@ const Shell = () => {
       runCommand,
       setShouldAutoScroll,
       slashCommands,
+      askAgent,
     ],
   );
 

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -10,7 +10,7 @@
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import react from "@vitejs/plugin-react";
 import browserslistToEsbuild from "browserslist-to-esbuild";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv, type PluginOption } from "vite";
 import { analyzer } from "vite-bundle-analyzer";
 import { createHtmlPlugin } from "vite-plugin-html";
 import svgr from "vite-plugin-svgr";
@@ -82,7 +82,75 @@ function buildDefinitions() {
   };
 }
 
+/**
+ * Dev-only middleware that proxies the in-console AI agent (`\ask`) to the
+ * Anthropic API. The browser POSTs an Anthropic Messages request body to
+ * `/api/ask`; this injects the server-side ANTHROPIC_API_KEY (read from
+ * .env.local via loadEnv, never exposed to the client) and forwards it.
+ *
+ * Registered inside `configureServer` (not the returned post-hook) so it runs
+ * BEFORE Vite's internal `/api/` proxy, which would otherwise forward `/api/ask`
+ * to environmentd. Dev-only: `configureServer` is not invoked in prod builds.
+ */
+const anthropicProxyPlugin: PluginOption = {
+  name: "mz-anthropic-proxy",
+  configureServer(server) {
+    const env = loadEnv(server.config.mode, server.config.root, "");
+    const apiKey = env.ANTHROPIC_API_KEY;
+
+    server.middlewares.use("/api/ask", async (req, res, next) => {
+      if (req.method !== "POST") {
+        next();
+        return;
+      }
+      const sendJson = (status: number, body: unknown) => {
+        res.statusCode = status;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify(body));
+      };
+      try {
+        if (!apiKey || apiKey.includes("REPLACE_ME")) {
+          sendJson(500, {
+            error: "ANTHROPIC_API_KEY is not set in console/.env.local",
+          });
+          return;
+        }
+        let raw = "";
+        for await (const chunk of req) raw += chunk;
+        const payload = raw ? JSON.parse(raw) : {};
+        const anthropicRes = await fetch(
+          "https://api.anthropic.com/v1/messages",
+          {
+            method: "POST",
+            headers: {
+              "x-api-key": apiKey,
+              "anthropic-version": "2023-06-01",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              model: payload.model ?? "claude-opus-5",
+              max_tokens: payload.max_tokens ?? 16000,
+              ...(payload.system ? { system: payload.system } : {}),
+              ...(payload.tools ? { tools: payload.tools } : {}),
+              messages: payload.messages ?? [],
+            }),
+          },
+        );
+        const text = await anthropicRes.text();
+        res.statusCode = anthropicRes.status;
+        res.setHeader("content-type", "application/json");
+        res.end(text);
+      } catch (err) {
+        sendJson(500, {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    });
+  },
+};
+
 const plugins = [
+  anthropicProxyPlugin,
   wasm(),
   createHtmlPlugin({
     minify: true,


### PR DESCRIPTION
**Draft, not for merge.** Dev-server only and ungated. Opening this for
visibility and to hand the work off.

## What this adds

An in-console AI agent plus the MCP-backed surfaces around it:

- `\ask <question>` in the SQL Shell, which runs a tool-use loop against the
  system catalog and answers in plain English, printing each query it ran.
- Four MCP-backed diagnostic slash commands: `\health`, `\freshness`,
  `\sources`, `\products`.
- Three MCP-backed panels: attention feed and data products on the environment
  overview, freshness on materialized view detail, and an impact banner on
  cluster overview.

## Architecture

The browser orchestrates the tool-use loop. This is the part worth reviewing,
because it is meant to be the production shape and not just a demo shortcut:

- **Catalog reads go straight from the browser** through the user's own
  authenticated session, hitting `/api/mcp/developer` and `/api/mcp/agent`.
  RBAC is preserved for free, with no server-side privilege model to build or
  to get wrong.
- **Only the model completion is proxied**, because a client-only SPA cannot
  hold an Anthropic key. Today that proxy is a Vite dev-server middleware that
  reads `ANTHROPIC_API_KEY` server-side and forwards to the Messages API.
- **The system prompt points the model at the built-in ontology relations
  first**, so it discovers real table and column names instead of guessing
  them. This is the piece that keeps generated joins correct, and it leans on
  catalog facts that are hard to replicate elsewhere, for instance
  `mz_materialization_lag` already naming the bottleneck input.

Model is `claude-opus-5`, pinned in both the agent and the proxy fallback.

## What blocks merging

- **No feature gating.** The three panels render unconditionally on the
  environment overview, cluster overview, and MV detail pages. Each needs a
  LaunchDarkly flag.
- **No production key path.** `/api/ask` is registered in `configureServer`,
  so it exists only under `yarn start`. A production build has no `/api/ask`
  and `\ask` fails there. Cloud console is on Vercel, so the shape there is a
  Vercel Function; self-managed console is served by environmentd and needs its
  own key-holding sidecar.
- **No streaming.** The proxy buffers the whole completion, so the shell sits
  on "Investigating..." until the full answer lands.
- **No tests.** Neither the agent loop, the proxy, nor the panels are covered.
- The MV freshness panel derives lag severity by string-matching interval text,
  which should read a typed interval instead.

## Docs

`console/doc/ask-agent.md` covers running it locally, how the key is handled,
what the target environment must provide (the MCP endpoint flags, the ontology
relations, and the CORS-allowed-origin requirement when pointing at a bare
emulator), and the same gap list above.

## Tests

None added. See the gap list.
