### PR TITLE
docs: add historical freshness monitoring section

### DIFF
--- a/doc/user/content/transform-data/monitor-freshness.md
+++ b/doc/user/content/transform-data/monitor-freshness.md
@@ -54,22 +54,52 @@ healthy pattern for a lightly loaded object.
 
 {{< note >}}
 
-Materialize exposes wallclock lag history through two relations. Which one you
-query has a large impact on performance.
-
-- [`mz_internal.mz_wallclock_global_lag_recent_history`](/sql/system-catalog/mz_internal/#mz_wallclock_global_lag_recent_history)
-  is indexed and holds only the past 24 hours of data. Querying it is fast, so
-  it is the right choice for frequent or interactive monitoring and for
-  dashboards. Use this relation by default, as in the query above.
-
-- [`mz_internal.mz_wallclock_global_lag_history`](/sql/system-catalog/mz_internal/#mz_wallclock_global_lag_history)
-  covers the full retention window (at least 30 days) but is unindexed, so it
-  can be slow to query. A single query can occupy `mz_catalog_server` for
-  several seconds. Reach for this
-  relation only when you specifically need data older than 24 hours, and avoid
-  querying it frequently.
+[`mz_internal.mz_wallclock_global_lag_recent_history`](/sql/system-catalog/mz_internal/#mz_wallclock_global_lag_recent_history)
+is indexed and holds only the past 24 hours of data. Querying it is fast, so it
+is the right choice for frequent or interactive monitoring and for dashboards.
+Use this relation by default, as in the query above. For older data, see
+[Monitor historical freshness](#monitor-historical-freshness).
 
 {{< /note >}}
+
+## Monitor historical freshness
+
+`mz_wallclock_global_lag_recent_history` holds only the past 24 hours. To look
+further back, query
+[`mz_internal.mz_wallclock_global_lag_history`](/sql/system-catalog/mz_internal/#mz_wallclock_global_lag_history)
+instead, which covers the full retention window of at least 30 days. The
+columns are identical, so any query in this guide works against it by swapping
+the relation name and widening the time filter:
+
+```mzsql
+SELECT wl.occurred_at, wl.lag
+FROM mz_internal.mz_wallclock_global_lag_history wl
+JOIN mz_catalog.mz_objects o ON wl.object_id = o.id
+WHERE o.name = '<your_mv_name>'
+  AND wl.occurred_at > now() - INTERVAL '7 days'
+ORDER BY wl.occurred_at DESC;
+```
+
+Because the relation is unindexed, a single query can occupy
+`mz_catalog_server` for several seconds. Keep the `occurred_at` filter as
+narrow as the question allows, and aggregate in the query rather than pulling
+raw rows out for a longer window. For example, the following returns one
+maximum lag per day over the past 30 days:
+
+```mzsql
+SELECT
+    date_trunc('day', wl.occurred_at) AS day,
+    max(wl.lag) AS max_lag
+FROM mz_internal.mz_wallclock_global_lag_history wl
+JOIN mz_catalog.mz_objects o ON wl.object_id = o.id
+WHERE o.name = '<your_mv_name>'
+  AND wl.occurred_at > now() - INTERVAL '30 days'
+GROUP BY 1
+ORDER BY 1 DESC;
+```
+
+For recurring or dashboard queries, stay on
+`mz_wallclock_global_lag_recent_history`.
 
 ## Summarize freshness with a CCDF
 


### PR DESCRIPTION
### Motivation

The "Monitor freshness" guide only showed queries against
`mz_wallclock_global_lag_recent_history`, which retains just 24 hours. Readers
who need to look further back had nothing to follow beyond a passing mention in
a note.

### Description

Adds a "Monitor historical freshness" section to
`doc/user/content/transform-data/monitor-freshness.md` covering
`mz_internal.mz_wallclock_global_lag_history`:

- A syntax demo that swaps the relation name and widens the time filter to 7
  days, mirroring the existing "Track freshness over time" query.
- A per-day `max(lag)` aggregation over 30 days, as the pattern to use for
  longer windows given the relation is unindexed.
- A pointer back to the recent-history relation for recurring and dashboard
  queries.

The note above the new section previously restated the tradeoff between the two
relations in full. It is trimmed to describe the recent-history relation and
link to the new section, so the historical-relation guidance lives in one place.

### Verification

Docs-only prose change. `bin/format-docs` run clean; no code or generated
artifacts touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7oi5Tuw7aNdin7ZFhKeYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7oi5Tuw7aNdin7ZFhKeYZ)_