### PR TITLE
storage: pin session rendering GUCs on Postgres source connections

### DIFF
--- a/src/postgres-util/src/tunnel.rs
+++ b/src/postgres-util/src/tunnel.rs
@@ -14,6 +14,8 @@ use std::time::Duration;
 
 use mz_ore::future::{InTask, OreFutureExt};
 use mz_ore::option::OptionExt;
+use mz_ore::sql;
+use mz_ore::sql::Sql;
 use mz_ore::task::{self, AbortOnDropHandle};
 use mz_repr::CatalogItemId;
 use mz_ssh_util::tunnel::{SshTimeoutConfig, SshTunnelConfig};
@@ -24,6 +26,7 @@ use tokio_postgres::tls::MakeTlsConnect;
 use tracing::{info, warn};
 
 use crate::PostgresError;
+use crate::query::simple_query_opt;
 
 macro_rules! bail_generic {
     ($err:expr $(,)?) => {
@@ -57,6 +60,23 @@ pub enum TunnelConfig {
 
 pub const DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT: Duration = Duration::ZERO;
 
+/// Session settings every [`Config`] pins at connection startup, as
+/// `(name, value)`.
+///
+/// Source ingestion parses the text PostgreSQL renders, both for COPY
+/// snapshots and for before-images in the replication stream, and a
+/// retraction only cancels its insertion if both were rendered identically.
+/// These settings control that rendering and are otherwise inherited from
+/// server or database defaults that can change at any point in a source's
+/// life, so they are fixed here and verified after connecting.
+pub const PINNED_SESSION_SETTINGS: &[(&str, &str)] = &[
+    ("DateStyle", "ISO"),
+    ("IntervalStyle", "postgres"),
+    ("TimeZone", "UTC"),
+    // Any positive value selects shortest round-trip float rendering.
+    ("extra_float_digits", "3"),
+];
+
 /// A wrapper for [`tokio_postgres::Client`] that can report the server version.
 pub struct Client {
     inner: tokio_postgres::Client,
@@ -83,7 +103,10 @@ impl DerefMut for Client {
 /// Configuration for PostgreSQL connections.
 ///
 /// This wraps [`tokio_postgres::Config`] to allow the configuration of a
-/// tunnel via a [`TunnelConfig`].
+/// tunnel via a [`TunnelConfig`]. Every connection pins
+/// [`PINNED_SESSION_SETTINGS`] and fails if the server does not report them
+/// back, so a pooler or proxy that strips startup options is a connection
+/// error rather than a silent difference in rendering.
 #[derive(Clone, Debug)]
 pub struct Config {
     inner: tokio_postgres::Config,
@@ -99,6 +122,13 @@ impl Config {
         ssh_timeout_config: SshTimeoutConfig,
         in_task: InTask,
     ) -> Result<Self, PostgresError> {
+        let mut inner = inner;
+        let mut options = inner.get_options().unwrap_or_default().to_owned();
+        for (name, value) in PINNED_SESSION_SETTINGS {
+            options.push_str(&format!(" -c {name}={value}"));
+        }
+        inner.options(options.trim());
+
         let config = Self {
             inner,
             tunnel,
@@ -163,10 +193,14 @@ impl Config {
             self.get_dbname().display_or("<unknown-dbname>")
         );
         info!(%task_name, %address, "connecting");
-        match self
+        let connected = match self
             .connect_internal(task_name, configure, ssh_tunnel_manager)
             .await
         {
+            Ok(client) => verify_pinned_session_settings(client).await,
+            Err(e) => Err(e),
+        };
+        match connected {
             Ok(t) => {
                 let backend_pid = t.backend_pid();
                 info!(%task_name, %address, %backend_pid, "connected");
@@ -327,4 +361,29 @@ impl Config {
     pub fn get_dbname(&self) -> Option<&str> {
         self.inner.get_dbname()
     }
+}
+
+/// Confirms the server applied [`PINNED_SESSION_SETTINGS`], returning the
+/// client on success.
+async fn verify_pinned_session_settings(client: Client) -> Result<Client, PostgresError> {
+    for (name, expected) in PINNED_SESSION_SETTINGS {
+        let row = simple_query_opt(
+            &client,
+            sql!("SELECT current_setting({})", Sql::literal(name)),
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("no result for current_setting({name})"))?;
+        let actual = row.get(0).unwrap_or_default();
+        // DateStyle reports both the output format and the input field order,
+        // for example "ISO, MDY". Only the format is pinned.
+        let reported = actual.split(',').next().unwrap_or_default().trim();
+        if !reported.eq_ignore_ascii_case(expected) {
+            bail_generic!(
+                "PostgreSQL server did not apply session setting {name}={expected} \
+                 (reports {actual:?}); connection poolers that strip startup options \
+                 are not supported"
+            );
+        }
+    }
+    Ok(client)
 }

--- a/test/pg-cdc/session-guc-change.td
+++ b/test/pg-cdc/session-guc-change.td
@@ -1,0 +1,147 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Retractions of TEXT COLUMNS values compare the text PostgreSQL rendered for
+# the before-image against the text stored at insertion. That rendering follows
+# session GUCs that default from the database, so a database-level change picked
+# up by a fresh walsender makes the before-image differ from the stored row and
+# the retraction fails to cancel it. Materialize pins the rendering GUCs on its
+# connections, so each leg below must ingest cleanly.
+#
+# Each leg changes one GUC at the database level, terminates the walsender so
+# the next change is decoded by a session started after the change, then
+# updates a row and reads the table back through operators with multiplicity
+# checks. While the bug exists a leg fails with "Non-positive multiplicity in
+# DistinctBy".
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+ALTER DATABASE postgres RESET timezone;
+ALTER DATABASE postgres RESET datestyle;
+ALTER DATABASE postgres RESET intervalstyle;
+ALTER DATABASE postgres RESET extra_float_digits;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE SCHEMA public;
+CREATE TYPE audit_t AS (ts timestamptz, iv interval, f float8, note text);
+CREATE TABLE events (id int, val int, audit audit_t);
+ALTER TABLE events REPLICA IDENTITY FULL;
+INSERT INTO events VALUES (1, 0, ROW('2026-07-22 15:15:00+00'::timestamptz, '1 day 02:03:04'::interval, 0.1::float8 + 0.2::float8, 'a')::audit_t), (2, 0, ROW('2026-07-22 15:16:00+00'::timestamptz, '2 years 3 mons'::interval, 1e-7::float8, 'b')::audit_t);
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SECRET pgpass AS 'postgres'
+
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+
+> CREATE TABLE events FROM SOURCE mz_source (REFERENCE events)
+  WITH (TEXT COLUMNS (audit))
+
+> SELECT count(*) FROM events
+2
+
+# TimeZone leg.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER DATABASE postgres SET timezone = 'Europe/Berlin';
+SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE active_pid IS NOT NULL;
+
+# If the terminated walsender decodes the UPDATE before exiting, it still
+# renders with the old settings and nothing diverges. The corruption requires
+# the UPDATE to be decoded by a fresh session.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration="2s"
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE events SET val = 1 WHERE id = 2;
+
+# Ingestion barrier through a plan without multiplicity checks.
+> SELECT sum(val)::int FROM events
+1
+
+> SELECT count(*) FROM (SELECT DISTINCT id, val, audit FROM events)
+2
+
+> WITH t AS (SELECT * FROM events) SELECT count(*) FROM t GROUP BY row(t.*) HAVING count(*) < 0
+
+# DateStyle leg.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER DATABASE postgres SET datestyle = 'Postgres, MDY';
+SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE active_pid IS NOT NULL;
+
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration="2s"
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE events SET val = 1 WHERE id = 1;
+
+> SELECT sum(val)::int FROM events
+2
+
+> SELECT count(*) FROM (SELECT DISTINCT id, val, audit FROM events)
+2
+
+> WITH t AS (SELECT * FROM events) SELECT count(*) FROM t GROUP BY row(t.*) HAVING count(*) < 0
+
+# IntervalStyle leg.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER DATABASE postgres SET intervalstyle = 'sql_standard';
+SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE active_pid IS NOT NULL;
+
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration="2s"
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE events SET val = 2 WHERE id = 2;
+
+> SELECT sum(val)::int FROM events
+3
+
+> SELECT count(*) FROM (SELECT DISTINCT id, val, audit FROM events)
+2
+
+> WITH t AS (SELECT * FROM events) SELECT count(*) FROM t GROUP BY row(t.*) HAVING count(*) < 0
+
+# extra_float_digits leg. Zero rounds float8 to 15 significant digits, so
+# 0.30000000000000004 renders as 0.3.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER DATABASE postgres SET extra_float_digits = 0;
+SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE active_pid IS NOT NULL;
+
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration="2s"
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE events SET val = 2 WHERE id = 1;
+
+> SELECT sum(val)::int FROM events
+4
+
+> SELECT count(*) FROM (SELECT DISTINCT id, val, audit FROM events)
+2
+
+> WITH t AS (SELECT * FROM events) SELECT count(*) FROM t GROUP BY row(t.*) HAVING count(*) < 0
+
+> SELECT id, val, audit FROM events ORDER BY id
+1 2 "(\"2026-07-22 15:15:00+00\",\"1 day 02:03:04\",0.30000000000000004,a)"
+2 2 "(\"2026-07-22 15:16:00+00\",\"2 years 3 mons\",1e-07,b)"
+
+# Database-level settings outlive this file. Restore them for the rest of the
+# suite.
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER DATABASE postgres RESET timezone;
+ALTER DATABASE postgres RESET datestyle;
+ALTER DATABASE postgres RESET intervalstyle;
+ALTER DATABASE postgres RESET extra_float_digits;


### PR DESCRIPTION
Pin the PostgreSQL session settings that control text rendering on every connection a Postgres source makes, and fail the connection if the server does not honor them.

### Motivation

Source ingestion parses the text PostgreSQL renders, both in COPY snapshots and in the before-images of the replication stream, and a retraction only cancels its insertion if both were rendered identically. That rendering follows `DateStyle`, `IntervalStyle`, `TimeZone`, and `extra_float_digits`, which a source connection inherits from server or database defaults the customer can change at any point in a source's life. A change picked up by a fresh walsender, after a managed failover, a parameter-group apply, or `pg_terminate_backend`, renders the before-image differently from the stored row, and full-row reads fail with `Non-positive multiplicity in DistinctBy`, the signature of incident 1161. [SS-376](https://linear.app/materializeinc/issue/SS-376) confirmed the repro on the TimeZone leg with a `timestamptz` inside a `TEXT COLUMNS` composite.

### Change

`mz_postgres_util::Config` gains a `PINNED_SESSION_SETTINGS` constant (`DateStyle=ISO`, `IntervalStyle=postgres`, `TimeZone=UTC`, `extra_float_digits=3`). `Config::new` appends them to the startup `options` string, which already carries `wal_sender_timeout` and so is known to reach the walsender. After each connect, the settings are read back with `current_setting` over the simple-query protocol, and a mismatch fails the connection naming the setting and quoting what the server reported. That turns a pooler configured to strip startup options into a loud connection error instead of a silent rendering difference.

`PostgresConnection::config` in storage-types is the only constructor of this `Config`, so snapshot COPY, replication, and purification connections all get the pins. No call site changes.

Pins are instant-preserving for rows ingested before the pin: a `timestamptz` rendered as `17:15:00+02` under Europe/Berlin and as `15:15:00+00` under UTC parses to the same datum, so pre-pin rows still retract cleanly. Any positive `extra_float_digits` selects shortest round-trip float output.

### Tests

* `test/pg-cdc/session-guc-change.td` is the [SS-376](https://linear.app/materializeinc/issue/SS-376) repro extended to one leg per pinned setting. Each leg changes the setting at the database level, terminates the walsender so the next change is decoded by a fresh session, updates a row, and reads the table back through operators with multiplicity checks. It ends with an assertion on the exact rendered composite text and resets the database-level settings, which outlive the file. Without the pins each leg fails with the DistinctBy error: verified by running with progressively more pins enabled, so every pin has a leg that fails when it alone is removed. With all four pins the file passes, and so does the rest of the pg-cdc suite.

### Suggested review order

1. `src/postgres-util/src/tunnel.rs`: the constant and its doc comment, then `Config::new`, then `verify_pinned_session_settings`.
2. `test/pg-cdc/session-guc-change.td`.

### Release note

This release will pin `DateStyle`, `IntervalStyle`, `TimeZone`, and `extra_float_digits` on PostgreSQL source connections, so upstream session-default changes can no longer corrupt ingested rows. Connections through a pooler that strips startup options now fail with a clear error.

Closes: [SS-362](https://linear.app/materializeinc/issue/SS-362)
Closes: [SS-376](https://linear.app/materializeinc/issue/SS-376)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
