### PR TITLE
docs: run historical freshness queries from a separate cluster

### DIFF
--- a/doc/user/content/transform-data/monitor-freshness.md
+++ b/doc/user/content/transform-data/monitor-freshness.md
@@ -98,8 +98,23 @@ GROUP BY 1
 ORDER BY 1 DESC;
 ```
 
-For recurring or dashboard queries, stay on
+For recurring or dashboard queries that fit within the last 24 hours, stay on
 `mz_wallclock_global_lag_recent_history`.
+
+If you need historical data on a recurring basis, run the query from a separate
+cluster instead of the default `mz_catalog_server`. A slow scan of the unindexed
+relation can tie up `mz_catalog_server` for seconds at a time, and because it
+also serves the `SHOW` commands and catalog lookups behind the Console and
+interactive tooling, that slows catalog queries across your whole environment.
+These queries read only system catalog relations, so Materialize routes them to
+`mz_catalog_server` by default. Point the session at your own cluster and turn
+off catalog auto-routing so the query actually runs there:
+
+```mzsql
+CREATE CLUSTER freshness_monitoring (SIZE = '25cc');
+SET cluster = freshness_monitoring;
+SET auto_route_catalog_queries = false;
+```
 
 ## Summarize freshness with a CCDF
 


### PR DESCRIPTION
### Motivation

Follow-up to #38744. On that PR, a reviewer noted that regularly querying the
unindexed `mz_wallclock_global_lag_history` can bog down `mz_catalog_server`,
which is risky because the catalog server also backs the Console and
`SHOW`/catalog queries across the whole environment.

Slack thread: https://materializeinc.slack.com/archives/CPNFV9CVB/p1789065229460309?thread_ts=1789064976.189309&cid=CPNFV9CVB

### Description

Adds guidance to the "Monitor historical freshness" section of
`doc/user/content/transform-data/monitor-freshness.md` to run recurring
historical freshness queries from a separate cluster instead of the default
`mz_catalog_server`. Because these queries read only system catalog relations,
they auto-route to `mz_catalog_server` regardless of the session's active
cluster, so the note also instructs disabling `auto_route_catalog_queries` so
the query actually runs on the dedicated cluster.

### Verification

- Docs-only prose change; `bin/format-docs` runs clean.
- Validated the documented flow against a local Materialize emulator
  (v26.41.0): `CREATE CLUSTER ... (SIZE = '25cc')`, `SET cluster = ...`,
  `SET auto_route_catalog_queries = false`, and both freshness queries all run
  without error. Confirmed via the statement activity log that with auto-routing
  left on the query executes on `mz_catalog_server`, and only with
  `auto_route_catalog_queries = false` does it execute on the separate cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vihj1JSR7cd8CW3SKhquoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vihj1JSR7cd8CW3SKhquoD)_